### PR TITLE
chore: align dependabot labels with repository conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# file: .github/dependabot.yml
+# version: 1.0.0
+# guid: c2815597-017f-46ab-93d9-92a36143d6bc
+#
 # Smart Dependabot configuration for audiobook-organizer
 # Audiobook organization and management tool
 # Automatically detected: Go, GitHub Actions, Python scripts
@@ -17,7 +21,8 @@ updates:
       prefix: "go"
       include: "scope"
     labels:
-      - "dependencies"
+      - "type:maintenance"
+      - "module:config"
     allow:
       - dependency-type: "direct"
     ignore:
@@ -37,7 +42,8 @@ updates:
       prefix: "python"
       include: "scope"
     labels:
-      - "dependencies"
+      - "type:maintenance"
+      - "tech:python"
     allow:
       - dependency-type: "direct"
     ignore:
@@ -57,8 +63,9 @@ updates:
       prefix: "actions"
       include: "scope"
     labels:
-      - "dependencies"
-      - "ci/cd"
+      - "type:maintenance"
+      - "workflow:github-actions"
+      - "workflow:ci-cd"
     groups:
       ci-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- align dependabot labels with existing repository conventions
- add file metadata header to dependabot configuration

## Issues Addressed

### chore(dependabot): align labels with repo conventions

**Description:** Replaced deprecated labels with official colon-based labels and added required file metadata header.

**Files Modified:**
- [`.github/dependabot.yml`](./.github/dependabot.yml) - added file header and replaced labels with `type:maintenance`, `module:config`, `tech:python`, `workflow:github-actions`, `workflow:ci-cd`

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...` *(no test output; command terminated)*

## Breaking Changes
- None

## Additional Notes
- None

## Related Issues
- None

------
https://chatgpt.com/codex/tasks/task_e_688e20c794c08321906062ee7b42ba19