### PR TITLE
feat: implement Layer 3 LLM review for dedup candidates

### DIFF
--- a/internal/ai/dedup_review.go
+++ b/internal/ai/dedup_review.go
@@ -1,0 +1,159 @@
+// file: internal/ai/dedup_review.go
+// version: 1.0.0
+// guid: b2e7c3d1-4a58-4f96-9e0b-7d3a1c8f5b24
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/shared"
+)
+
+// DedupEntity describes one side of a duplicate-pair candidate for LLM review.
+// Fields are optional — empty strings are elided from the prompt.
+type DedupEntity struct {
+	ID       string `json:"id"`
+	Title    string `json:"title,omitempty"`
+	Author   string `json:"author,omitempty"`
+	Narrator string `json:"narrator,omitempty"`
+	Series   string `json:"series,omitempty"`
+	ISBN     string `json:"isbn,omitempty"`
+	ASIN     string `json:"asin,omitempty"`
+	// For author entities, Title holds the author name and other fields are empty.
+}
+
+// DedupPairInput is one pair (A, B) the caller wants the LLM to adjudicate.
+// The caller assigns Index so responses can be matched back.
+type DedupPairInput struct {
+	Index      int         `json:"index"`
+	EntityType string      `json:"entity_type"` // "book" or "author"
+	A          DedupEntity `json:"a"`
+	B          DedupEntity `json:"b"`
+	Similarity float64     `json:"similarity"`
+}
+
+// DedupPairVerdict is the LLM's judgment for a single pair.
+type DedupPairVerdict struct {
+	Index       int    `json:"index"`
+	IsDuplicate bool   `json:"is_duplicate"`
+	Confidence  string `json:"confidence"` // "high" | "medium" | "low"
+	Reason      string `json:"reason"`
+}
+
+// dedupReviewBatchSize is the maximum number of pairs sent in one chat request.
+// Chosen to stay well under output-token limits with typical per-pair payloads.
+const dedupReviewBatchSize = 25
+
+// ReviewDedupPairs sends batches of candidate pairs to OpenAI and returns a
+// verdict for each. Results are keyed by Index so the caller can reassemble them
+// in any order. Inputs are chunked internally; the caller passes all pairs at once.
+func (p *OpenAIParser) ReviewDedupPairs(ctx context.Context, inputs []DedupPairInput) ([]DedupPairVerdict, error) {
+	if !p.enabled {
+		return nil, fmt.Errorf("OpenAI parser is not enabled")
+	}
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	var all []DedupPairVerdict
+	for start := 0; start < len(inputs); start += dedupReviewBatchSize {
+		end := start + dedupReviewBatchSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		batch := inputs[start:end]
+
+		verdicts, err := p.reviewDedupBatch(ctx, batch)
+		if err != nil {
+			return all, fmt.Errorf("dedup review batch [%d:%d]: %w", start, end, err)
+		}
+		all = append(all, verdicts...)
+	}
+	return all, nil
+}
+
+func (p *OpenAIParser) reviewDedupBatch(ctx context.Context, batch []DedupPairInput) ([]DedupPairVerdict, error) {
+	systemPrompt := `You are an expert audiobook metadata reviewer. You will receive a batch of candidate duplicate pairs (either book pairs or author pairs). For each pair, decide whether A and B describe the same thing.
+
+Rules for BOOK pairs:
+- Same book: same title (allowing minor punctuation/subtitle differences), same primary author. Narrator differences are allowed — different editions or re-recordings of the same book are still the same book.
+- Examples of SAME book: "The Way of Kings" vs "Stormlight Archive 1 - The Way of Kings"; "Dune" vs "Dune (Unabridged)"; same ISBN or ASIN.
+- Examples of DIFFERENT books: same series but different volumes; same title but different authors; "Dune" vs "Dune Messiah".
+
+Rules for AUTHOR pairs:
+- Same author: the same real person with a name variant (initial spacing, suffix, pen name, case folding).
+- Examples of SAME author: "J.R.R. Tolkien" vs "J. R. R. Tolkien"; "Mark Twain" vs "Samuel Clemens" (pen name, same person).
+- Examples of DIFFERENT authors: two real people who happen to share initials; a compound entry like "V. A. Lewis, Azrie" is NOT a duplicate of "V. A. Lewis" — it's a compound that needs splitting, but for THIS task, mark it as not a duplicate.
+
+Confidence:
+- "high": obvious match or obvious non-match
+- "medium": likely but some ambiguity
+- "low": genuinely unsure
+
+Return ONLY valid JSON in this exact shape:
+{"verdicts": [{"index": N, "is_duplicate": true|false, "confidence": "high|medium|low", "reason": "brief one-sentence explanation"}]}
+
+Include one verdict per input pair, using the same index as the input.`
+
+	batchJSON, err := json.Marshal(batch)
+	if err != nil {
+		return nil, fmt.Errorf("marshal batch: %w", err)
+	}
+
+	userPrompt := fmt.Sprintf("Review these candidate duplicate pairs:\n\n%s", string(batchJSON))
+
+	jsonObjectFormat := shared.NewResponseFormatJSONObjectParam()
+
+	var lastErr error
+	for attempt := 0; attempt <= p.maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt*attempt) * 2 * time.Second
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		completion, err := p.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+			Messages: []openai.ChatCompletionMessageParamUnion{
+				openai.SystemMessage(systemPrompt),
+				openai.UserMessage(userPrompt),
+			},
+			Model:               shared.ChatModel(p.model),
+			MaxCompletionTokens: param.NewOpt[int64](8000),
+			PromptCacheKey:      param.NewOpt("audiobook-dedup-pair-review-v1"),
+			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONObject: &jsonObjectFormat,
+			},
+		})
+
+		if err != nil {
+			lastErr = fmt.Errorf("OpenAI API call failed (attempt %d): %w", attempt+1, err)
+			continue
+		}
+
+		if len(completion.Choices) == 0 {
+			lastErr = fmt.Errorf("no response from OpenAI (attempt %d)", attempt+1)
+			continue
+		}
+
+		content := completion.Choices[0].Message.Content
+		var result struct {
+			Verdicts []DedupPairVerdict `json:"verdicts"`
+		}
+		if err := json.Unmarshal([]byte(content), &result); err != nil {
+			lastErr = fmt.Errorf("parse response (attempt %d): %w", attempt+1, err)
+			continue
+		}
+		return result.Verdicts, nil
+	}
+
+	return nil, lastErr
+}

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -54,6 +54,7 @@ type CandidateFilter struct {
 	Status        string
 	Layer         string
 	MinSimilarity *float64
+	MaxSimilarity *float64
 	Limit         int
 	Offset        int
 }
@@ -435,6 +436,10 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 	if f.MinSimilarity != nil {
 		clauses = append(clauses, "similarity >= ?")
 		args = append(args, *f.MinSimilarity)
+	}
+	if f.MaxSimilarity != nil {
+		clauses = append(clauses, "similarity <= ?")
+		args = append(args, *f.MaxSimilarity)
 	}
 
 	where := ""

--- a/internal/server/dedup_engine.go
+++ b/internal/server/dedup_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 
 package server
@@ -23,6 +23,7 @@ type DedupEngine struct {
 	embedStore   *database.EmbeddingStore
 	bookStore    database.Store
 	embedClient  *ai.EmbeddingClient
+	llmParser    *ai.OpenAIParser
 	mergeService *MergeService
 
 	// Thresholds (read from config or set directly)
@@ -31,25 +32,44 @@ type DedupEngine struct {
 	AuthorHighThreshold float64
 	AuthorLowThreshold  float64
 	AutoMergeEnabled    bool
+
+	// Layer 3 ambiguous zones — candidates whose similarity falls inside these
+	// ranges (inclusive) are sent to the LLM during RunLLMReview.
+	LLMBookLow    float64
+	LLMBookHigh   float64
+	LLMAuthorLow  float64
+	LLMAuthorHigh float64
+
+	// LLMMaxPairsPerRun caps how many pairs a single RunLLMReview invocation will
+	// send to the LLM. Zero means "all pending ambiguous candidates".
+	LLMMaxPairsPerRun int
 }
 
 // NewDedupEngine creates a DedupEngine with sensible defaults.
+// llmParser may be nil if Layer 3 LLM review should be disabled.
 func NewDedupEngine(
 	embedStore *database.EmbeddingStore,
 	bookStore database.Store,
 	embedClient *ai.EmbeddingClient,
+	llmParser *ai.OpenAIParser,
 	mergeService *MergeService,
 ) *DedupEngine {
 	return &DedupEngine{
 		embedStore:          embedStore,
 		bookStore:           bookStore,
 		embedClient:         embedClient,
+		llmParser:           llmParser,
 		mergeService:        mergeService,
 		BookHighThreshold:   0.95,
 		BookLowThreshold:    0.85,
 		AuthorHighThreshold: 0.92,
 		AuthorLowThreshold:  0.80,
 		AutoMergeEnabled:    false,
+		LLMBookLow:          0.80,
+		LLMBookHigh:         0.92,
+		LLMAuthorLow:        0.75,
+		LLMAuthorHigh:       0.85,
+		LLMMaxPairsPerRun:   200,
 	}
 }
 
@@ -488,10 +508,186 @@ func (de *DedupEngine) getAllBooks() ([]database.Book, error) {
 }
 
 // RunLLMReview processes ambiguous candidates through LLM review (Layer 3).
-// TODO: Implement full LLM review using OpenAI chat completion.
+// Pending book candidates whose similarity falls in [LLMBookLow, LLMBookHigh] and
+// pending author candidates in [LLMAuthorLow, LLMAuthorHigh] are fetched, enriched
+// with entity metadata, batched, and sent to the OpenAI chat LLM. The verdict is
+// persisted via UpdateCandidateLLM (which also sets layer='llm').
+//
+// Candidates that are already at layer='llm' are skipped — rerunning is cheap in
+// bookkeeping but expensive in API calls, so callers should use UpsertCandidate to
+// clear the layer back to 'embedding' if they want a re-review.
 func (de *DedupEngine) RunLLMReview(ctx context.Context) error {
-	log.Println("dedup: LLM review not yet implemented")
+	if de.llmParser == nil || !de.llmParser.IsEnabled() {
+		log.Println("dedup: LLM review skipped — llmParser not configured")
+		return nil
+	}
+	if de.embedStore == nil {
+		return fmt.Errorf("dedup: LLM review requires embedStore")
+	}
+
+	bookCandidates, err := de.listAmbiguousCandidates("book", de.LLMBookLow, de.LLMBookHigh)
+	if err != nil {
+		return fmt.Errorf("list ambiguous book candidates: %w", err)
+	}
+	authorCandidates, err := de.listAmbiguousCandidates("author", de.LLMAuthorLow, de.LLMAuthorHigh)
+	if err != nil {
+		return fmt.Errorf("list ambiguous author candidates: %w", err)
+	}
+
+	allCandidates := append(bookCandidates, authorCandidates...)
+	if de.LLMMaxPairsPerRun > 0 && len(allCandidates) > de.LLMMaxPairsPerRun {
+		allCandidates = allCandidates[:de.LLMMaxPairsPerRun]
+	}
+	if len(allCandidates) == 0 {
+		log.Println("dedup: LLM review found no pending ambiguous candidates")
+		return nil
+	}
+	log.Printf("dedup: LLM review starting — %d pair(s) queued", len(allCandidates))
+
+	// Build inputs alongside an index→candidate map for verdict routing.
+	inputs := make([]ai.DedupPairInput, 0, len(allCandidates))
+	byIndex := make(map[int]database.DedupCandidate, len(allCandidates))
+	for i, c := range allCandidates {
+		input, ok := de.buildPairInput(i, c)
+		if !ok {
+			log.Printf("dedup: skipping candidate %d — could not load entities", c.ID)
+			continue
+		}
+		inputs = append(inputs, input)
+		byIndex[i] = c
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	verdicts, err := de.llmParser.ReviewDedupPairs(ctx, inputs)
+	if err != nil {
+		// Persist whatever we did get before surfacing the error.
+		de.applyVerdicts(verdicts, byIndex)
+		return fmt.Errorf("LLM review call: %w", err)
+	}
+	applied := de.applyVerdicts(verdicts, byIndex)
+	log.Printf("dedup: LLM review complete — %d verdict(s) applied", applied)
 	return nil
+}
+
+// listAmbiguousCandidates returns pending embedding-layer candidates whose
+// similarity falls inside [low, high].
+func (de *DedupEngine) listAmbiguousCandidates(entityType string, low, high float64) ([]database.DedupCandidate, error) {
+	filter := database.CandidateFilter{
+		EntityType:    entityType,
+		Status:        "pending",
+		Layer:         "embedding",
+		MinSimilarity: &low,
+		MaxSimilarity: &high,
+		Limit:         10000,
+	}
+	candidates, _, err := de.embedStore.ListCandidates(filter)
+	return candidates, err
+}
+
+// buildPairInput enriches a stored candidate with entity details suitable for
+// the LLM prompt. Returns false if either entity could not be loaded.
+func (de *DedupEngine) buildPairInput(index int, c database.DedupCandidate) (ai.DedupPairInput, bool) {
+	input := ai.DedupPairInput{
+		Index:      index,
+		EntityType: c.EntityType,
+	}
+	if c.Similarity != nil {
+		input.Similarity = *c.Similarity
+	}
+
+	switch c.EntityType {
+	case "book":
+		a, aOK := de.loadBookEntity(c.EntityAID)
+		b, bOK := de.loadBookEntity(c.EntityBID)
+		if !aOK || !bOK {
+			return input, false
+		}
+		input.A = a
+		input.B = b
+	case "author":
+		a, aOK := de.loadAuthorEntity(c.EntityAID)
+		b, bOK := de.loadAuthorEntity(c.EntityBID)
+		if !aOK || !bOK {
+			return input, false
+		}
+		input.A = a
+		input.B = b
+	default:
+		return input, false
+	}
+	return input, true
+}
+
+// loadBookEntity fetches a book and converts it into a DedupEntity. The caller
+// may rely on ID always being populated when the second return value is true.
+func (de *DedupEngine) loadBookEntity(bookID string) (ai.DedupEntity, bool) {
+	book, err := de.bookStore.GetBookByID(bookID)
+	if err != nil || book == nil {
+		return ai.DedupEntity{}, false
+	}
+	entity := ai.DedupEntity{ID: book.ID, Title: book.Title}
+	if book.AuthorID != nil {
+		if author, aerr := de.bookStore.GetAuthorByID(*book.AuthorID); aerr == nil && author != nil {
+			entity.Author = author.Name
+		}
+	}
+	if book.Narrator != nil {
+		entity.Narrator = *book.Narrator
+	}
+	if book.ISBN13 != nil && *book.ISBN13 != "" {
+		entity.ISBN = *book.ISBN13
+	} else if book.ISBN10 != nil {
+		entity.ISBN = *book.ISBN10
+	}
+	if book.ASIN != nil {
+		entity.ASIN = *book.ASIN
+	}
+	return entity, true
+}
+
+// loadAuthorEntity fetches an author and converts it into a DedupEntity. The
+// Title field carries the author name so the prompt treats both entity types
+// uniformly.
+func (de *DedupEngine) loadAuthorEntity(entityID string) (ai.DedupEntity, bool) {
+	id, err := strconv.Atoi(entityID)
+	if err != nil {
+		return ai.DedupEntity{}, false
+	}
+	author, err := de.bookStore.GetAuthorByID(id)
+	if err != nil || author == nil {
+		return ai.DedupEntity{}, false
+	}
+	return ai.DedupEntity{ID: entityID, Title: author.Name}, true
+}
+
+// applyVerdicts persists each verdict via UpdateCandidateLLM and returns the
+// number of rows successfully updated. Errors are logged and skipped so one
+// bad row does not abort the whole batch.
+func (de *DedupEngine) applyVerdicts(verdicts []ai.DedupPairVerdict, byIndex map[int]database.DedupCandidate) int {
+	applied := 0
+	for _, v := range verdicts {
+		candidate, ok := byIndex[v.Index]
+		if !ok {
+			log.Printf("dedup: LLM returned unknown index %d", v.Index)
+			continue
+		}
+		verdict := "not_duplicate"
+		if v.IsDuplicate {
+			verdict = "duplicate"
+		}
+		reason := v.Reason
+		if v.Confidence != "" {
+			reason = fmt.Sprintf("[%s] %s", v.Confidence, reason)
+		}
+		if err := de.embedStore.UpdateCandidateLLM(candidate.ID, verdict, reason); err != nil {
+			log.Printf("dedup: failed to update candidate %d: %v", candidate.ID, err)
+			continue
+		}
+		applied++
+	}
+	return applied
 }
 
 // levenshteinDistance computes the Levenshtein edit distance between two strings.

--- a/internal/server/dedup_engine_test.go
+++ b/internal/server/dedup_engine_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
 
 package server
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
@@ -27,7 +28,7 @@ func setupTestEngine(t *testing.T) (*DedupEngine, *database.MockStore, *database
 
 	mock := &database.MockStore{}
 	ms := NewMergeService(mock)
-	engine := NewDedupEngine(es, mock, nil, ms)
+	engine := NewDedupEngine(es, mock, nil, nil, ms)
 
 	return engine, mock, es
 }
@@ -335,5 +336,204 @@ func TestDerefStr(t *testing.T) {
 	}
 	if got := derefStr(nil); got != "" {
 		t.Errorf("derefStr(nil) = %q, want empty", got)
+	}
+}
+
+// --- Layer 3 LLM review tests ---
+
+// seedCandidate inserts a pending embedding-layer candidate directly into the store.
+func seedCandidate(t *testing.T, es *database.EmbeddingStore, entityType, aID, bID string, similarity float64) {
+	t.Helper()
+	if err := es.UpsertCandidate(database.DedupCandidate{
+		EntityType: entityType,
+		EntityAID:  aID,
+		EntityBID:  bID,
+		Layer:      "embedding",
+		Similarity: &similarity,
+		Status:     "pending",
+	}); err != nil {
+		t.Fatalf("UpsertCandidate: %v", err)
+	}
+}
+
+func TestListAmbiguousCandidates_FiltersByRange(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	// Seed candidates across the whole book similarity spectrum.
+	seedCandidate(t, es, "book", "B1", "B2", 0.70) // below zone
+	seedCandidate(t, es, "book", "B3", "B4", 0.82) // in zone
+	seedCandidate(t, es, "book", "B5", "B6", 0.88) // in zone
+	seedCandidate(t, es, "book", "B7", "B8", 0.95) // above zone
+	// Same-range authors should be ignored when we query for books.
+	seedCandidate(t, es, "author", "1", "2", 0.85)
+
+	got, err := engine.listAmbiguousCandidates("book", 0.80, 0.92)
+	if err != nil {
+		t.Fatalf("listAmbiguousCandidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 book candidates in zone, got %d", len(got))
+	}
+	for _, c := range got {
+		if c.EntityType != "book" {
+			t.Errorf("unexpected entity_type %q", c.EntityType)
+		}
+		if c.Similarity == nil || *c.Similarity < 0.80 || *c.Similarity > 0.92 {
+			t.Errorf("candidate %d similarity %v outside [0.80, 0.92]", c.ID, c.Similarity)
+		}
+	}
+}
+
+func TestBuildPairInput_Book(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	authorID := 42
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "BOOK_A":
+			return &database.Book{ID: "BOOK_A", Title: "Dune", AuthorID: &authorID,
+				Narrator: strPtr("Scott Brick"), ISBN13: strPtr("9780441013593")}, nil
+		case "BOOK_B":
+			return &database.Book{ID: "BOOK_B", Title: "Dune (Unabridged)", AuthorID: &authorID,
+				ASIN: strPtr("B002V1OHSU")}, nil
+		}
+		return nil, nil
+	}
+	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
+		return &database.Author{ID: 42, Name: "Frank Herbert"}, nil
+	}
+
+	sim := 0.87
+	c := database.DedupCandidate{
+		ID: 1, EntityType: "book", EntityAID: "BOOK_A", EntityBID: "BOOK_B",
+		Similarity: &sim,
+	}
+	input, ok := engine.buildPairInput(0, c)
+	if !ok {
+		t.Fatal("buildPairInput returned !ok")
+	}
+	if input.EntityType != "book" {
+		t.Errorf("entity_type = %q", input.EntityType)
+	}
+	if input.A.Title != "Dune" || input.A.Author != "Frank Herbert" || input.A.Narrator != "Scott Brick" {
+		t.Errorf("unexpected A: %+v", input.A)
+	}
+	if input.A.ISBN != "9780441013593" {
+		t.Errorf("ISBN13 should populate ISBN, got %q", input.A.ISBN)
+	}
+	if input.B.Title != "Dune (Unabridged)" || input.B.ASIN != "B002V1OHSU" {
+		t.Errorf("unexpected B: %+v", input.B)
+	}
+	if input.Similarity != 0.87 {
+		t.Errorf("similarity = %v", input.Similarity)
+	}
+}
+
+func TestBuildPairInput_Author(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
+		switch id {
+		case 1:
+			return &database.Author{ID: 1, Name: "J.R.R. Tolkien"}, nil
+		case 2:
+			return &database.Author{ID: 2, Name: "J. R. R. Tolkien"}, nil
+		}
+		return nil, nil
+	}
+
+	c := database.DedupCandidate{
+		ID: 5, EntityType: "author", EntityAID: "1", EntityBID: "2",
+	}
+	input, ok := engine.buildPairInput(3, c)
+	if !ok {
+		t.Fatal("buildPairInput returned !ok")
+	}
+	if input.Index != 3 {
+		t.Errorf("index = %d, want 3", input.Index)
+	}
+	if input.A.Title != "J.R.R. Tolkien" || input.B.Title != "J. R. R. Tolkien" {
+		t.Errorf("unexpected entities: A=%q B=%q", input.A.Title, input.B.Title)
+	}
+}
+
+func TestBuildPairInput_MissingEntityReturnsFalse(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "GOOD" {
+			return &database.Book{ID: "GOOD", Title: "Good Book"}, nil
+		}
+		return nil, nil // Missing book
+	}
+
+	c := database.DedupCandidate{
+		EntityType: "book", EntityAID: "GOOD", EntityBID: "MISSING",
+	}
+	if _, ok := engine.buildPairInput(0, c); ok {
+		t.Error("expected !ok when one entity is missing")
+	}
+}
+
+func TestApplyVerdicts_PersistsAndRoutes(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	// Seed two candidates and get their IDs back.
+	sim := 0.85
+	_ = es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "A1", EntityBID: "A2",
+		Layer: "embedding", Similarity: &sim, Status: "pending",
+	})
+	_ = es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "B1", EntityBID: "B2",
+		Layer: "embedding", Similarity: &sim, Status: "pending",
+	})
+	candidates, _, _ := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 seeded candidates, got %d", len(candidates))
+	}
+
+	byIndex := map[int]database.DedupCandidate{
+		0: candidates[0],
+		1: candidates[1],
+	}
+	verdicts := []ai.DedupPairVerdict{
+		{Index: 0, IsDuplicate: true, Confidence: "high", Reason: "identical"},
+		{Index: 1, IsDuplicate: false, Confidence: "medium", Reason: "different editions"},
+		{Index: 99, IsDuplicate: true, Reason: "unknown index — should be ignored"},
+	}
+
+	applied := engine.applyVerdicts(verdicts, byIndex)
+	if applied != 2 {
+		t.Errorf("applied = %d, want 2", applied)
+	}
+
+	got, _, _ := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	for _, c := range got {
+		if c.Layer != "llm" {
+			t.Errorf("candidate %d layer = %q, want 'llm'", c.ID, c.Layer)
+		}
+		if c.LLMVerdict != "duplicate" && c.LLMVerdict != "not_duplicate" {
+			t.Errorf("candidate %d verdict = %q", c.ID, c.LLMVerdict)
+		}
+		if c.LLMReason == "" {
+			t.Errorf("candidate %d has empty reason", c.ID)
+		}
+	}
+}
+
+func TestRunLLMReview_NilParserSkipsGracefully(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+	// Leave engine.llmParser = nil (setupTestEngine constructs without a parser).
+
+	seedCandidate(t, es, "book", "X", "Y", 0.85)
+
+	if err := engine.RunLLMReview(context.Background()); err != nil {
+		t.Fatalf("RunLLMReview with nil parser: %v", err)
+	}
+	// Candidate should remain unchanged at layer='embedding'.
+	got, _, _ := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	if len(got) != 1 || got[0].Layer != "embedding" {
+		t.Errorf("candidate should be untouched when parser is nil: %+v", got)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -826,17 +826,21 @@ func NewServer() *Server {
 			server.embeddingStore = embeddingStore
 			if config.AppConfig.OpenAIAPIKey != "" && config.AppConfig.EmbeddingEnabled {
 				embedClient := ai.NewEmbeddingClient(config.AppConfig.OpenAIAPIKey)
-				server.dedupEngine = &DedupEngine{
-					embedStore:          embeddingStore,
-					bookStore:           database.GlobalStore,
-					embedClient:         embedClient,
-					mergeService:        server.mergeService,
-					BookHighThreshold:   config.AppConfig.DedupBookHighThreshold,
-					BookLowThreshold:    config.AppConfig.DedupBookLowThreshold,
-					AuthorHighThreshold: config.AppConfig.DedupAuthorHighThreshold,
-					AuthorLowThreshold:  config.AppConfig.DedupAuthorLowThreshold,
-					AutoMergeEnabled:    config.AppConfig.DedupAutoMergeEnabled,
-				}
+				// Dedup Layer 3 uses a dedicated chat parser so it can call
+				// OpenAIParser.ReviewDedupPairs during maintenance runs.
+				llmParser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
+				server.dedupEngine = NewDedupEngine(
+					embeddingStore,
+					database.GlobalStore,
+					embedClient,
+					llmParser,
+					server.mergeService,
+				)
+				server.dedupEngine.BookHighThreshold = config.AppConfig.DedupBookHighThreshold
+				server.dedupEngine.BookLowThreshold = config.AppConfig.DedupBookLowThreshold
+				server.dedupEngine.AuthorHighThreshold = config.AppConfig.DedupAuthorHighThreshold
+				server.dedupEngine.AuthorLowThreshold = config.AppConfig.DedupAuthorLowThreshold
+				server.dedupEngine.AutoMergeEnabled = config.AppConfig.DedupAutoMergeEnabled
 				log.Println("[INFO] Embedding store and dedup engine initialized")
 				server.metadataFetchService.SetDedupEngine(server.dedupEngine)
 			} else {


### PR DESCRIPTION
## Summary

Replaces the \`RunLLMReview\` stub with a real gpt-5-mini-backed review. Pending embedding-layer candidates in the ambiguous zone (books 0.80-0.92, authors 0.75-0.85) are batched, enriched with entity metadata, sent to the chat LLM, and persisted as \`layer='llm'\` with verdict + reason.

## How it works

1. \`DedupEngine.RunLLMReview\` queries pending embedding-layer candidates via the new \`CandidateFilter.MaxSimilarity\` field
2. For each candidate, it fetches both entities (book or author) through the main store and packages them as \`ai.DedupPairInput\` with index routing
3. \`OpenAIParser.ReviewDedupPairs\` (new in \`internal/ai/dedup_review.go\`) chunks pairs into batches of 25, calls \`client.Chat.Completions.New\` with a structured JSON response format, and returns one \`DedupPairVerdict\` per input
4. Verdicts are persisted via \`UpdateCandidateLLM\` which flips the layer to \`llm\` and writes \`duplicate\`/\`not_duplicate\` + \`[confidence] reason\`

## Config knobs (defaults on \`DedupEngine\`)

- \`LLMBookLow=0.80\`, \`LLMBookHigh=0.92\`
- \`LLMAuthorLow=0.75\`, \`LLMAuthorHigh=0.85\`
- \`LLMMaxPairsPerRun=200\` — safety cap on per-run cost

These are set in \`NewDedupEngine\`; the scheduler task from PR #203 calls \`RunLLMReview\` during the maintenance window.

## Tests

5 new unit tests exercise the logic without hitting the real API:
- \`TestListAmbiguousCandidates_FiltersByRange\` — range + entity type filtering
- \`TestBuildPairInput_Book\` — book entity enrichment (title, author, narrator, ISBN/ASIN)
- \`TestBuildPairInput_Author\` — author entity enrichment
- \`TestBuildPairInput_MissingEntityReturnsFalse\` — skips rows with missing entities
- \`TestApplyVerdicts_PersistsAndRoutes\` — verdicts route by index, unknown indices skipped
- \`TestRunLLMReview_NilParserSkipsGracefully\` — safe no-op when parser is not configured

## Test plan
- [x] \`go test ./internal/server/ ./internal/database/ ./internal/ai/\` all green
- [x] Full build clean
- [ ] Deploy to prod, verify scheduler triggers LLM review during maintenance window
- [ ] Manually POST \`/api/v1/dedup/scan-llm\` on prod, verify candidates transition to \`layer=llm\` with verdict populated
- [ ] Inspect a handful of verdicts for sanity

🤖 Generated with [Claude Code](https://claude.com/claude-code)