### PR TITLE
fix: dedup scan progress log now fires on bucket crossings

### DIFF
--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 
 package server
@@ -69,15 +69,41 @@ func (s *Server) runEmbeddingBackfill() {
 	totalEmbedded := embedded + authorCount
 	log.Printf("[INFO] Embedding backfill complete: %d total entities", totalEmbedded)
 
-	// Run full dedup scan
-	if err := s.dedupEngine.FullScan(ctx, func(done, total int) {
-		if done%1000 == 0 && done > 0 {
-			log.Printf("[INFO] Dedup scan progress: %d/%d", done, total)
-		}
-	}); err != nil {
+	// Run full dedup scan with a bucket-crossing progress logger (see
+	// newDedupScanProgressLogger for why a naive `done%N == 0` check fails).
+	log.Printf("[INFO] Running initial dedup scan...")
+	progressFn := newDedupScanProgressLogger(1000, func(format string, args ...any) {
+		log.Printf(format, args...)
+	})
+	if err := s.dedupEngine.FullScan(ctx, progressFn); err != nil {
 		log.Printf("[WARN] Initial dedup scan failed: %v", err)
 	}
 
 	_ = store.SetSetting("embedding_backfill_done", "true", "bool", false)
 	log.Printf("[INFO] Embedding backfill and initial dedup scan complete")
+}
+
+// newDedupScanProgressLogger returns a progress callback suitable for
+// DedupEngine.FullScan that logs once every `interval` books processed (plus
+// one final line at completion).
+//
+// It exists because FullScan passes `done = i+1` at a step of 10, so values
+// are 1, 11, 21, ... which never satisfy `done % interval == 0` for interval
+// ≥ 11. This previously hid all scan progress. The returned closure tracks
+// the next threshold internally and advances past it on each bucket crossing,
+// so progress lines appear at ~interval granularity regardless of the caller's
+// step size.
+func newDedupScanProgressLogger(interval int, logf func(format string, args ...any)) func(done, total int) {
+	if interval <= 0 {
+		interval = 1
+	}
+	nextLog := interval
+	return func(done, total int) {
+		if done >= nextLog || (total > 0 && done == total) {
+			logf("[INFO] Dedup scan progress: %d/%d", done, total)
+			for nextLog <= done {
+				nextLog += interval
+			}
+		}
+	}
 }

--- a/internal/server/embedding_backfill_test.go
+++ b/internal/server/embedding_backfill_test.go
@@ -1,0 +1,111 @@
+// file: internal/server/embedding_backfill_test.go
+// version: 1.0.0
+// guid: 4f81c2ae-6b39-47d5-9ae1-3c5d8b12f7a4
+
+package server
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestDedupScanProgressLogger_BucketCrossings verifies that a callback driven
+// at FullScan's actual step size (done = i+1 with i%10 == 0) emits a log line
+// approximately every `interval` books — the scenario the original
+// `done%interval == 0` check silently broke.
+func TestDedupScanProgressLogger_BucketCrossings(t *testing.T) {
+	var lines []string
+	logf := func(format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+
+	progress := newDedupScanProgressLogger(1000, logf)
+
+	// Simulate FullScan calling progress(i+1, total) on every i where i%10 == 0.
+	const total = 2500
+	for i := 0; i < total; i++ {
+		if i%10 == 0 || i == total-1 {
+			progress(i+1, total)
+		}
+	}
+
+	// Expected log lines: one at the first crossing of 1000, one at 2000, and
+	// one at total completion (2500). None of those satisfy the buggy
+	// `done%1000 == 0` check since done values are always of the form 10k+1.
+	if got, want := len(lines), 3; got != want {
+		t.Fatalf("expected %d log lines, got %d: %v", want, got, lines)
+	}
+	// First two should be at bucket crossings near 1000 and 2000.
+	if lines[0] != "[INFO] Dedup scan progress: 1001/2500" {
+		t.Errorf("first log line = %q", lines[0])
+	}
+	if lines[1] != "[INFO] Dedup scan progress: 2001/2500" {
+		t.Errorf("second log line = %q", lines[1])
+	}
+	// Last one is the completion line.
+	if lines[2] != "[INFO] Dedup scan progress: 2500/2500" {
+		t.Errorf("final log line = %q", lines[2])
+	}
+}
+
+// TestDedupScanProgressLogger_EveryItem exercises the closure against a caller
+// that invokes progress for every single item, not just on a 10-step. The
+// logger should still only fire once per bucket.
+func TestDedupScanProgressLogger_EveryItem(t *testing.T) {
+	var lines []string
+	logf := func(format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	progress := newDedupScanProgressLogger(100, logf)
+
+	const total = 350
+	for i := 0; i < total; i++ {
+		progress(i+1, total)
+	}
+
+	// Expected: one log line at each of done=100, 200, 300, and the completion
+	// line at done=350 — four lines total.
+	if got, want := len(lines), 4; got != want {
+		t.Fatalf("expected %d log lines, got %d: %v", want, got, lines)
+	}
+}
+
+// TestDedupScanProgressLogger_SmallTotal verifies that a scan smaller than the
+// interval still emits the final completion line.
+func TestDedupScanProgressLogger_SmallTotal(t *testing.T) {
+	var lines []string
+	progress := newDedupScanProgressLogger(1000, func(format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	})
+
+	const total = 42
+	for i := 0; i < total; i++ {
+		if i%10 == 0 || i == total-1 {
+			progress(i+1, total)
+		}
+	}
+
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 log line (completion only), got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "[INFO] Dedup scan progress: 42/42" {
+		t.Errorf("completion line = %q", lines[0])
+	}
+}
+
+// TestDedupScanProgressLogger_NonPositiveInterval defends against a caller
+// passing 0 or a negative interval — the logger should degrade gracefully by
+// treating the interval as 1 (log every call) rather than div-by-zero or loop
+// forever.
+func TestDedupScanProgressLogger_NonPositiveInterval(t *testing.T) {
+	count := 0
+	progress := newDedupScanProgressLogger(0, func(format string, args ...any) {
+		count++
+	})
+	for i := 0; i < 5; i++ {
+		progress(i+1, 5)
+	}
+	if count != 5 {
+		t.Errorf("interval=0 should log every call; got %d calls", count)
+	}
+}


### PR DESCRIPTION
## Why

The initial dedup scan after the embedding backfill runs \`DedupEngine.FullScan\`, which invokes its progress callback as \`progress(i+1, total)\` on every \`i%10 == 0\`. The backfill closure checked \`done%1000 == 0\`, which can never match — done values are always 10k+1, so the condition is silently dead.

Fallout: during the Layer 3 rollout the scan ran for ~50 minutes with zero log output, which I misread as \"scan must be done\" and deployed on top of a still-running scan. The \`embedding_backfill_done\` setting never got written, so the next restart kicked off another full backfill and scan.

## Fix

Replace the inline closure with \`newDedupScanProgressLogger(interval, logf)\`. It tracks the next bucket threshold in the closure state and advances past it on each crossing, so log lines appear every \`interval\` books plus one final line at completion — regardless of how the caller steps through \`done\`.

Also added an explicit \"Running initial dedup scan...\" line so operators can tell the embed phase finished and the scan phase started.

## Tests

- \`TestDedupScanProgressLogger_BucketCrossings\` — simulates FullScan's exact 10-step pattern, verifies lines fire at ~1000, ~2000, and at completion
- \`TestDedupScanProgressLogger_EveryItem\` — caller pattern that invokes progress for every item (1 line per bucket, still correct)
- \`TestDedupScanProgressLogger_SmallTotal\` — total smaller than the interval (only the completion line fires)
- \`TestDedupScanProgressLogger_NonPositiveInterval\` — defensive path, caller passes 0/negative

No behavior change to the scan itself — this is purely observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)