### PR TITLE
fix(dedup): canonicalize pairs + catch 'title' vs 'title N' false positives

### DIFF
--- a/internal/database/embedding_candidates_test.go
+++ b/internal/database/embedding_candidates_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_candidates_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f3e2d1c0-b9a8-4765-8e7d-6f5c4b3a2190
 
 package database
@@ -251,4 +251,96 @@ func TestDedupCandidates_LayerUpgrade(t *testing.T) {
 	got, _, _ = store.ListCandidates(CandidateFilter{EntityType: "book"})
 	require.Len(t, got, 1)
 	assert.Equal(t, "exact", got[0].Layer, "exact should upgrade over llm")
+}
+
+// TestDedupCandidates_UpsertCanonicalizes verifies that inserting the same
+// logical pair with swapped entity IDs produces exactly one row (in
+// canonical form: smaller ID first). Before this fix, FullScan would
+// discover a pair once as (A,B) while processing book A, then again as
+// (B,A) while processing book B, and each went into its own row because
+// the UNIQUE constraint treats (A,B) and (B,A) as distinct — which is
+// why the UI showed the same "Foundation and Empire" pair twice.
+func TestDedupCandidates_UpsertCanonicalizes(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Insert the pair as (book_z, book_a) — non-canonical direction.
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book",
+		EntityAID:  "book_z",
+		EntityBID:  "book_a",
+		Layer:      "embedding",
+		Similarity: floatPtr(0.92),
+		Status:     "pending",
+	}))
+	// Insert the same pair in canonical direction — should update the
+	// existing row, not create a new one.
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book",
+		EntityAID:  "book_a",
+		EntityBID:  "book_z",
+		Layer:      "embedding",
+		Similarity: floatPtr(0.93),
+		Status:     "pending",
+	}))
+
+	got, total, err := store.ListCandidates(CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "exactly one row should exist for the pair")
+	require.Len(t, got, 1)
+	// Canonical form: smaller ID first
+	assert.Equal(t, "book_a", got[0].EntityAID)
+	assert.Equal(t, "book_z", got[0].EntityBID)
+	// Second upsert's similarity should have taken effect.
+	require.NotNil(t, got[0].Similarity)
+	assert.InDelta(t, 0.93, *got[0].Similarity, 0.0001)
+}
+
+// TestCanonicalizeCandidates_Cleanup verifies the one-time cleanup that
+// removes duplicate (A,B)/(B,A) rows from deployments that accumulated
+// them before UpsertCandidate started canonicalizing on insert. The
+// cleanup must (a) swap non-canonical rows in place when no canonical
+// sibling exists, and (b) delete the non-canonical row when a canonical
+// sibling already exists.
+func TestCanonicalizeCandidates_Cleanup(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Bypass the upsert canonicalization by using raw SQL so we can
+	// simulate a pre-fix database state.
+	rawInsert := func(typ, a, b, layer string) {
+		t.Helper()
+		_, err := store.db.Exec(`
+			INSERT INTO dedup_candidates
+				(entity_type, entity_a_id, entity_b_id, layer, status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, 'pending', '2026-04-10', '2026-04-10')
+		`, typ, a, b, layer)
+		require.NoError(t, err)
+	}
+
+	// Case A: non-canonical row with no canonical sibling — should be
+	// swapped in place.
+	rawInsert("book", "zebra", "apple", "embedding")
+
+	// Case B: canonical row already exists alongside a non-canonical
+	// duplicate — the non-canonical duplicate should be deleted.
+	rawInsert("book", "hello", "world", "embedding") // canonical (h < w)
+	rawInsert("book", "world", "hello", "exact")     // non-canonical duplicate
+
+	// Case C: pair already in canonical form — untouched.
+	rawInsert("book", "aaa", "bbb", "embedding")
+
+	rewritten, deleted, err := store.CanonicalizeCandidates()
+	require.NoError(t, err)
+	assert.Equal(t, 1, rewritten, "case A should be swapped in place")
+	assert.Equal(t, 1, deleted, "case B's non-canonical duplicate should be deleted")
+
+	// Verify final state: 3 rows, all in canonical order.
+	got, total, err := store.ListCandidates(CandidateFilter{EntityType: "book", Limit: 100})
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	require.Len(t, got, 3)
+	for _, c := range got {
+		assert.LessOrEqual(t, c.EntityAID, c.EntityBID,
+			"all rows should have entity_a_id <= entity_b_id after canonicalize, got (%s, %s)",
+			c.EntityAID, c.EntityBID)
+	}
 }

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -342,7 +342,21 @@ func joinAnd(clauses []string) string {
 // The `similarity` column is paired with `layer` — it only makes sense on
 // the embedding path — so we only overwrite similarity when we're also
 // overwriting (or newly inserting) the layer.
+//
+// Pairs are canonicalized before insert so each logical pair has exactly
+// one row regardless of which direction it was discovered from. Without
+// this, FullScan would emit both (A, B) when processing book A and (B, A)
+// when processing book B, and each would go into its own row because the
+// UNIQUE constraint on (entity_type, entity_a_id, entity_b_id) treats the
+// two orderings as distinct. The UI then shows the same logical pair
+// twice, which is exactly the "Foundation and Empire appears twice" bug
+// from PR #208 follow-up. Canonical order: the lexicographically smaller
+// ID is always EntityAID.
 func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
+	if c.EntityAID > c.EntityBID {
+		c.EntityAID, c.EntityBID = c.EntityBID, c.EntityAID
+	}
+
 	now := time.Now().UTC()
 
 	// Preserve created_at for existing rows.
@@ -545,6 +559,77 @@ func (s *EmbeddingStore) RemoveCandidatesForEntity(entityType, entityID string) 
 func (s *EmbeddingStore) DeleteCandidate(id int64) error {
 	_, err := s.db.Exec(`DELETE FROM dedup_candidates WHERE id=?`, id)
 	return err
+}
+
+// CanonicalizeCandidates rewrites existing rows so each logical pair has
+// exactly one entry with entity_a_id < entity_b_id lexicographically. This
+// is a one-time cleanup for deployments that accumulated duplicate rows
+// before UpsertCandidate started canonicalizing on insert.
+//
+// Algorithm:
+//  1. Find every row where entity_a_id > entity_b_id (non-canonical order).
+//  2. For each such row, check whether a canonical row already exists for
+//     the same pair. If yes, delete the non-canonical row (the canonical
+//     one already carries the evidence). If no, update the non-canonical
+//     row in place to swap the two IDs.
+//
+// Returns (rewritten, deleted) counts for logging.
+func (s *EmbeddingStore) CanonicalizeCandidates() (rewritten, deleted int, err error) {
+	rows, err := s.db.Query(`
+SELECT id, entity_type, entity_a_id, entity_b_id
+FROM dedup_candidates
+WHERE entity_a_id > entity_b_id
+`)
+	if err != nil {
+		return 0, 0, fmt.Errorf("canonicalize: list non-canonical: %w", err)
+	}
+	type nonCanon struct {
+		id         int64
+		entityType string
+		a, b       string
+	}
+	var targets []nonCanon
+	for rows.Next() {
+		var n nonCanon
+		if err := rows.Scan(&n.id, &n.entityType, &n.a, &n.b); err != nil {
+			rows.Close()
+			return 0, 0, fmt.Errorf("canonicalize: scan: %w", err)
+		}
+		targets = append(targets, n)
+	}
+	rows.Close()
+
+	for _, n := range targets {
+		// Canonical form has the smaller ID first.
+		canonicalA, canonicalB := n.b, n.a
+
+		var existingID int64
+		err := s.db.QueryRow(
+			`SELECT id FROM dedup_candidates WHERE entity_type=? AND entity_a_id=? AND entity_b_id=?`,
+			n.entityType, canonicalA, canonicalB,
+		).Scan(&existingID)
+		switch {
+		case err == sql.ErrNoRows:
+			// No canonical row exists — swap the fields in place.
+			if _, err := s.db.Exec(
+				`UPDATE dedup_candidates SET entity_a_id=?, entity_b_id=?, updated_at=? WHERE id=?`,
+				canonicalA, canonicalB, time.Now().UTC().Format(time.RFC3339Nano), n.id,
+			); err != nil {
+				return rewritten, deleted, fmt.Errorf("canonicalize: swap row %d: %w", n.id, err)
+			}
+			rewritten++
+		case err != nil:
+			return rewritten, deleted, fmt.Errorf("canonicalize: check existing %d: %w", n.id, err)
+		default:
+			// Canonical row already exists — the non-canonical one is
+			// redundant, delete it.
+			if _, err := s.db.Exec(`DELETE FROM dedup_candidates WHERE id=?`, n.id); err != nil {
+				return rewritten, deleted, fmt.Errorf("canonicalize: delete row %d: %w", n.id, err)
+			}
+			deleted++
+		}
+	}
+	return rewritten, deleted, nil
 }
 
 // GetCandidateStats returns row counts grouped by entity_type, layer, and status.

--- a/internal/server/dedup_engine.go
+++ b/internal/server/dedup_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 
 package server
@@ -402,32 +402,44 @@ func extractSeriesNumberFromTitle(title string) string {
 // non-digit content (e.g. two books titled "Untitled" — no digits, so
 // the function returns false and the pair is allowed through).
 func titlesDifferOnlyInDigits(a, b string) bool {
-	stripDigits := func(s string) (stripped string, hadDigit bool) {
+	// Normalize: replace each digit with a space, then collapse runs of
+	// whitespace, then trim. Replacing (rather than dropping) digits
+	// avoids "title12" and "title" producing different strippeds when
+	// one is "title12sub" and the other is "title sub" — both collapse
+	// to "title sub" the right way. Collapsing whitespace handles
+	// "title 2" -> "title " -> "title" vs plain "title".
+	normalize := func(s string) string {
 		var sb strings.Builder
 		for _, r := range s {
 			if r >= '0' && r <= '9' {
-				hadDigit = true
+				sb.WriteRune(' ')
 				continue
 			}
 			sb.WriteRune(r)
 		}
-		return sb.String(), hadDigit
+		return strings.Join(strings.Fields(sb.String()), " ")
 	}
-	strippedA, aHadDigit := stripDigits(a)
-	strippedB, bHadDigit := stripDigits(b)
-	if !aHadDigit || !bHadDigit {
+	normA := normalize(a)
+	normB := normalize(b)
+	if normA != normB {
 		return false
 	}
-	if strippedA != strippedB {
-		return false
-	}
-	// Both had digits and the non-digit content is identical — they
-	// differ only in number tokens. But if the digit strings are ALSO
-	// identical (e.g. both titles contain "2024" in the same position),
-	// this isn't a series-volume difference, it's the same title.
+	// Non-digit content is identical (ignoring whitespace differences
+	// where digits used to be). For this to count as a series-volume
+	// diff, the digit strings must differ. If both digit strings are
+	// identical, it's the same title (e.g. both "Foundation 1" — same
+	// book, not a series difference). If one side has no digits and the
+	// other has a digit, that's a "Backyard Dungeon" vs "Backyard Dungeon
+	// 2" pattern where the first book is volume 1 and the second is
+	// volume 2 — a real series-volume diff.
 	digitsA := extractDigits(a)
 	digitsB := extractDigits(b)
-	return digitsA != digitsB
+	if digitsA == digitsB {
+		return false
+	}
+	// At least one side must have a digit; otherwise both digit strings
+	// are "" and the == check above would have caught it.
+	return true
 }
 
 // extractDigits returns all digit characters from s concatenated in
@@ -823,6 +835,18 @@ func (de *DedupEngine) FullScan(ctx context.Context, progress func(done, total i
 func (de *DedupEngine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 	if de.embedStore == nil || de.bookStore == nil {
 		return 0, nil
+	}
+
+	// First, canonicalize existing rows so duplicate-direction pairs
+	// collapse into a single logical row. This has to run BEFORE the
+	// stale-rule sweep below because otherwise we'd list the same pair
+	// twice (once as (A,B), once as (B,A)) and maybe delete one copy
+	// based on one rule and leave the other copy to cause confusion.
+	if rewritten, deleted, err := de.embedStore.CanonicalizeCandidates(); err != nil {
+		log.Printf("dedup: canonicalize candidates: %v", err)
+	} else if rewritten > 0 || deleted > 0 {
+		log.Printf("dedup: canonicalized %d candidate pair(s), deleted %d duplicate(s)",
+			rewritten, deleted)
 	}
 
 	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{

--- a/internal/server/dedup_engine_test.go
+++ b/internal/server/dedup_engine_test.go
@@ -616,8 +616,11 @@ func TestTitlesDifferOnlyInDigits(t *testing.T) {
 		// Different non-digit content — not a series-volume pair.
 		{"title one", "title two", false},
 		{"reclaiming honor", "restoring honor", false},
-		// One has a number, the other doesn't — structure differs.
-		{"title", "title 3", false},
+		// One has a number, the other doesn't — this IS a series pair
+		// now. "Backyard Dungeon" vs "Backyard Dungeon 2" is the
+		// canonical example: book 1 (unnumbered) vs book 2 (numbered).
+		{"title", "title 3", true},
+		{"backyard dungeon", "backyard dungeon 2", true},
 		// Both numbers but different non-digit content.
 		{"title 3", "book 3", false},
 		// Empty strings.

--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 
 package server
@@ -29,7 +29,7 @@ import (
 // cached text_hash — so re-running it just pays a few seconds of DB reads
 // plus a purge pass to delete candidates that the new rules would have
 // rejected.
-const backfillVersionMarker = "embedding_backfill_v4_done"
+const backfillVersionMarker = "embedding_backfill_v5_done"
 
 // runEmbeddingBackfill embeds all books and authors on first startup and
 // re-runs once after each backfill version bump.


### PR DESCRIPTION
## Summary

Two user-reported bugs after PR #208 merged. Both are classes of false positive in the Embedding Dedup tab.

## Bug 1 — same logical pair stored twice

User saw "Foundation and Empire" by Isaac Asimov appear **twice** in the pending candidates list, with both rows showing the same pair at 100% exact. Root cause: the \`dedup_candidates\` UNIQUE constraint is directional — \`(entity_type, entity_a_id, entity_b_id)\` — so (A, B) and (B, A) are treated as distinct rows. FullScan walks every book and calls \`findSimilarBooks\` per book, so when book A discovers book B we insert (A, B), and when book B later discovers book A we insert (B, A). Two rows, one logical pair.

**Fix:**
- \`UpsertCandidate\` now canonicalizes before insert: if \`EntityAID > EntityBID\` lexicographically, swap them. New rows always have the smaller ID first.
- New \`EmbeddingStore.CanonicalizeCandidates\` method does a one-time cleanup for existing deployments: for every non-canonical row, either swap it in place (if no canonical sibling exists) or delete it (if a canonical sibling already exists, which preserves that one).
- \`PurgeStaleCandidates\` calls \`CanonicalizeCandidates\` as its first step, so the cleanup runs automatically on every backfill, Re-scan, and Refresh.

## Bug 2 — "Backyard Dungeon" vs "Backyard Dungeon 2"

User saw two books by Logan Jacobs flagged as exact 100%: "Backyard Dungeon 2" and "Backyard Dungeon" (book 1 without a number suffix). The PR #208 \`titlesDifferOnlyInDigits\` fallback required BOTH sides to have at least one digit, so this "book 1 is unnumbered, book 2 has a 2" pattern fell through the guard.

**Fix:** \`titlesDifferOnlyInDigits\` now:
1. Replaces each digit with a space (preserves word boundaries)
2. Collapses runs of whitespace
3. Trims
4. Compares the normalized forms

\`"backyard dungeon 2"\` → \`"backyard dungeon"\`, \`"backyard dungeon"\` → \`"backyard dungeon"\` — they match structurally. The digit strings still have to differ (otherwise it's just the same title), so identical titles with identical digits (\`"Foundation 1"\` vs \`"Foundation 1"\`) correctly return false.

## Changes

- \`internal/database/embedding_store.go\` — \`UpsertCandidate\` canonicalization + new \`CanonicalizeCandidates\` cleanup method
- \`internal/database/embedding_candidates_test.go\` — \`TestDedupCandidates_UpsertCanonicalizes\` + \`TestCanonicalizeCandidates_Cleanup\` (swap-in-place + delete-dup paths)
- \`internal/server/dedup_engine.go\` — rewrote \`titlesDifferOnlyInDigits\` to handle the one-side-has-no-digits case; \`PurgeStaleCandidates\` calls canonicalize first
- \`internal/server/dedup_engine_test.go\` — updated \`TestTitlesDifferOnlyInDigits\` cases (the old "title" vs "title 3" case now correctly returns true; added "backyard dungeon" vs "backyard dungeon 2")
- \`internal/server/embedding_backfill.go\` — \`backfillVersionMarker\` v4 → v5 so the canonicalize + re-purge runs on existing deployments

## Tests

- 2 new database tests (canonicalization behavior, both insert-path and cleanup-path)
- 2 updated server tests (titlesDifferOnlyInDigits cases covering the new behavior)
- Full \`internal/server/\` + \`internal/database/\` suites pass

## Prod deployment

Deployed to 172.16.2.30. v5 backfill is running now. The canonicalize + purge pass will run after the embed phase completes (~1 minute since everything's cached) and will:
1. Delete any duplicate \`(B, A)\` rows created before UpsertCandidate started canonicalizing — fixing "Foundation and Empire appears twice"
2. Delete any candidate pair where the titles differ only in digits (incl. one side having no digits) — fixing "Backyard Dungeon" vs "Backyard Dungeon 2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)