### PR TITLE
feat(dedup): vertical layout for 5+ way + iTunes-ghost primary bias

### DIFF
--- a/internal/server/merge_service_test.go
+++ b/internal/server/merge_service_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/merge_service_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8e847d3e-f1a0-41be-a05c-1b18cd3fb7af
 
 package server
@@ -102,6 +102,78 @@ func TestMergeService_MergeBooks_TooFew(t *testing.T) {
 	_, err := ms.MergeBooks([]string{"one"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least 2")
+}
+
+// TestMergeService_MergeBooks_PrefersOrganizedOverITunesGhost verifies that
+// when a cluster mixes books under the managed library with books still
+// pointing at the iTunes Media folder, the organized copy wins the primary
+// slot even if the iTunes one has a "better" format. Without this bias a
+// M4B iTunes ghost would steal primary from an MP3 that's already been
+// organized into our library — that's the opposite of what we want.
+func TestMergeService_MergeBooks_PrefersOrganizedOverITunesGhost(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+	_ = server
+
+	store := database.GlobalStore
+
+	// iTunes ghost — better format on paper (M4B, higher bitrate)
+	ghost := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Foundation and Empire",
+		Format:   "m4b",
+		FilePath: "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Isaac Asimov/Foundation and Empire.m4b",
+	}
+	bitrate := 128
+	ghost.Bitrate = &bitrate
+
+	// Organized library copy — worse format on paper but this is the one
+	// the user actually owns and manages.
+	organized := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Foundation and Empire",
+		Format:   "mp3",
+		FilePath: "/mnt/bigdata/books/audiobook-organizer/Isaac Asimov/Foundation and Empire/Foundation and Empire.mp3",
+	}
+	lowBitrate := 64
+	organized.Bitrate = &lowBitrate
+
+	_, err := store.CreateBook(ghost)
+	require.NoError(t, err)
+	_, err = store.CreateBook(organized)
+	require.NoError(t, err)
+
+	ms := NewMergeService(store)
+	result, err := ms.MergeBooks([]string{ghost.ID, organized.ID}, "")
+	require.NoError(t, err)
+
+	// The organized MP3 must win even though the iTunes ghost is M4B +
+	// higher bitrate — path origin is the strongest tiebreaker.
+	assert.Equal(t, organized.ID, result.PrimaryID,
+		"organized library path should beat iTunes ghost regardless of format")
+}
+
+// TestIsITunesGhostPath sanity-checks the path classifier against the
+// shapes we see in production. Exhaustive because the classifier is the
+// load-bearing piece of the primary-pick bias above.
+func TestIsITunesGhostPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"itunes media absolute", "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/x.m4b", true},
+		{"itunes media mixed case", "/mnt/bigdata/books/iTunes/iTunes Media/x.m4b", true},
+		{"organized library", "/mnt/bigdata/books/audiobook-organizer/author/book.mp3", false},
+		{"empty", "", false},
+		{"relative", "itunes/iTunes Media/x.m4b", true},
+		{"generic linux tmp", "/tmp/x.mp3", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isITunesGhostPath(tc.path))
+		})
+	}
 }
 
 func TestMergeService_MergeBooks_NotFound(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.154.0
+// version: 1.155.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2214,9 +2214,33 @@ func isProtectedPath(filePath string) bool {
 	return false
 }
 
+// isITunesGhostPath reports whether a book's file path points at the
+// iTunes media folder rather than the managed audiobook-organizer library.
+// Such books are "ghost" references — iTunes knows about them but they
+// live outside the library we actually manage, so they should never be
+// chosen as the primary version of a merge.
+func isITunesGhostPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	lower := strings.ToLower(p)
+	return strings.Contains(lower, "/itunes media/") || strings.Contains(lower, "/itunes/itunes")
+}
+
 // bookIsBetter returns true if a is a "better" primary version than b.
-// Preference: M4B > other formats, higher bitrate, larger file.
+// Preference: managed library path > iTunes-ghost path, M4B > other formats,
+// higher bitrate, larger file.
 func bookIsBetter(a, b *database.Book) bool {
+	// Path origin trumps everything else — an organized-library copy is
+	// always a better primary than an iTunes ghost, regardless of format or
+	// bitrate. Otherwise a high-bitrate iTunes import would steal the
+	// primary slot from the file the user has actually organized.
+	aGhost := isITunesGhostPath(a.FilePath)
+	bGhost := isITunesGhostPath(b.FilePath)
+	if aGhost != bGhost {
+		return !aGhost
+	}
+
 	aM4B := strings.EqualFold(a.Format, "m4b")
 	bM4B := strings.EqualFold(b.Format, "m4b")
 	if aM4B != bM4B {

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.8.0
+// version: 3.9.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -2915,6 +2915,12 @@ function EmbeddingDedupTab() {
             {clusters.map((cluster) => {
               const busy = actionLoading === cluster.key;
               const isMultiWay = cluster.bookIds.length > 2;
+              // Horizontal cramming stops being readable around 4 sides —
+              // dividing the card width by 5+ produces columns too narrow
+              // to fit a full title. Switch to a stacked vertical layout
+              // (one book per row, full-width file paths) for large
+              // clusters so every side stays legible.
+              const isLargeCluster = cluster.bookIds.length >= 5;
               return (
                 <Card key={cluster.key} variant="outlined">
                   <CardContent sx={{ pb: 1 }}>
@@ -2947,18 +2953,29 @@ function EmbeddingDedupTab() {
                       <MergeIcon color="action" fontSize="small" />
                     </Stack>
 
-                    {/* Book sides laid out horizontally with vertical dividers */}
+                    {/* Book sides — horizontal for small clusters (2-4 sides
+                        fit comfortably side-by-side), vertical for large ones
+                        so a 19-way cluster is still mergeable. */}
                     <Stack
-                      direction="row"
-                      spacing={2}
+                      direction={isLargeCluster ? 'column' : 'row'}
+                      spacing={isLargeCluster ? 1 : 2}
                       alignItems="stretch"
-                      divider={<Divider orientation="vertical" flexItem />}
-                      sx={{ overflowX: 'auto' }}
+                      divider={
+                        <Divider
+                          orientation={isLargeCluster ? 'horizontal' : 'vertical'}
+                          flexItem
+                        />
+                      }
+                      sx={isLargeCluster ? undefined : { overflowX: 'auto' }}
                     >
                       {cluster.bookIds.map((bookId) => (
                         <Box
                           key={bookId}
-                          sx={{ flex: 1, minWidth: 0, maxWidth: `${100 / cluster.bookIds.length}%` }}
+                          sx={
+                            isLargeCluster
+                              ? { minWidth: 0 }
+                              : { flex: 1, minWidth: 0, maxWidth: `${100 / cluster.bookIds.length}%` }
+                          }
                         >
                           {renderBookSide(bookId)}
                         </Box>


### PR DESCRIPTION
## Summary

- 5+ way clusters render vertically (one book per row, full-width paths) instead of 5+ narrow columns — makes the 18-way and 19-way clusters mergeable
- \`bookIsBetter\` now picks a managed-library path over an iTunes-ghost path as the strongest tiebreaker, regardless of format or bitrate

## Why

Horizontal cluster layout became unreadable above ~4 sides. In production there's currently a 2+5+1+1+3+2+2+1+1 distribution of 5+way clusters, including an 18-way and 19-way. Vertical layout keeps every side legible.

When a cluster mixes an iTunes-ghost entry (file_path under /iTunes Media/) with an organized copy (file_path under audiobook-organizer/), the organized copy should always win the primary slot. Previously a high-bitrate M4B ghost could steal primary from a lower-bitrate organized MP3 — the opposite of what we want.

## Test plan

- [x] New unit tests: \`TestIsITunesGhostPath\`, \`TestMergeService_MergeBooks_PrefersOrganizedOverITunesGhost\`
- [ ] Eyeball the 18-way Foundation cluster on prod and verify it renders stacked
- [ ] Merge a mixed iTunes/organized pair and confirm the organized book is primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)