### PR TITLE
fix(backfill): track shutdown, persist marker early, survive FullScan panic

### DIFF
--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 
 package server
@@ -46,7 +46,14 @@ func (s *Server) runEmbeddingBackfill() {
 	}
 	log.Printf("[INFO] Starting embedding backfill (%s)...", backfillVersionMarker)
 
-	ctx := context.Background()
+	// Use the server's background context so Shutdown can cancel this
+	// goroutine instead of leaving it iterating Pebble while CloseStore
+	// tries to tear down the database. If bgCtx is nil (e.g. unit tests
+	// instantiating Server without NewServer), fall back to Background.
+	ctx := s.bgCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	offset := 0
 
 	// Honest counters: the previous version of this loop reported
@@ -69,11 +76,23 @@ func (s *Server) runEmbeddingBackfill() {
 
 	// Backfill books in batches
 	for {
+		// Honor shutdown — if the server is stopping, bail out fast so
+		// we're not holding iterators / DB connections when CloseStore
+		// runs. The marker stays unset on cancel, which is the right
+		// thing: we want the next startup to resume the backfill.
+		if ctx.Err() != nil {
+			log.Printf("[INFO] Embedding backfill canceled during book loop at offset %d: %v", offset, ctx.Err())
+			return
+		}
 		books, err := store.GetAllBooks(100, offset)
 		if err != nil || len(books) == 0 {
 			break
 		}
 		for _, book := range books {
+			if ctx.Err() != nil {
+				log.Printf("[INFO] Embedding backfill canceled mid-batch at offset %d", offset)
+				return
+			}
 			status, err := s.dedupEngine.EmbedBook(ctx, book.ID)
 			if err != nil {
 				log.Printf("[WARN] backfill embed book %s: %v", book.ID, err)
@@ -112,6 +131,10 @@ func (s *Server) runEmbeddingBackfill() {
 		log.Printf("[WARN] backfill: failed to get authors: %v", err)
 	} else {
 		for _, author := range authors {
+			if ctx.Err() != nil {
+				log.Printf("[INFO] Embedding backfill canceled during author loop after %d authors", authorCount)
+				return
+			}
 			if err := s.dedupEngine.EmbedAuthor(ctx, author.ID); err != nil {
 				log.Printf("[WARN] backfill embed author %d: %v", author.ID, err)
 			} else {
@@ -123,6 +146,23 @@ func (s *Server) runEmbeddingBackfill() {
 
 	log.Printf("[INFO] Embedding backfill complete: %d books (embedded=%d, cached=%d), %d authors",
 		visited, statEmbedded, statCached, authorCount)
+
+	// Persist the backfill marker NOW, before FullScan runs. The embedding
+	// work itself is complete; FullScan is a follow-up exact-match/similarity
+	// pass that happens to live in the same function. It used to come right
+	// before the SetSetting call, which meant any crash or panic during
+	// FullScan — and we've been hitting a Pebble "element has outstanding
+	// references" panic pretty reliably — would leave the marker unset and
+	// the next restart would pointlessly re-embed 24K books from the cached
+	// text_hash (fast but not free, and it blocks the API while it runs).
+	// Writing the marker here makes the expensive part idempotent across
+	// crashes. If FullScan fails, the user can still trigger a Re-scan from
+	// the UI; they just won't re-pay for embedding work that's already done.
+	if err := store.SetSetting(backfillVersionMarker, "true", "bool", false); err != nil {
+		log.Printf("[WARN] failed to persist backfill marker: %v — backfill will re-run next startup", err)
+	} else {
+		log.Printf("[INFO] Embedding backfill marker persisted (%s)", backfillVersionMarker)
+	}
 
 	// Purge stale candidates from any previous scan before running a new
 	// one. This is what cleans up the 16K+ non-primary / same-group rows
@@ -136,15 +176,26 @@ func (s *Server) runEmbeddingBackfill() {
 
 	// Run full dedup scan with a bucket-crossing progress logger (see
 	// newDedupScanProgressLogger for why a naive `done%N == 0` check fails).
+	// Wrapped in defer/recover because this is the block that has been
+	// panicking with a Pebble ref-count error mid-scan. A panic here should
+	// leave the process running — the marker is already set above, the
+	// dedup queue is usable, and the crash was killing the whole server on
+	// startup which meant the user couldn't even reach the UI to investigate.
 	log.Printf("[INFO] Running initial dedup scan...")
-	progressFn := newDedupScanProgressLogger(1000, func(format string, args ...any) {
-		log.Printf(format, args...)
-	})
-	if err := s.dedupEngine.FullScan(ctx, progressFn); err != nil {
-		log.Printf("[WARN] Initial dedup scan failed: %v", err)
-	}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[ERROR] Initial dedup scan panicked: %v — backfill marker is already set, server will continue", r)
+			}
+		}()
+		progressFn := newDedupScanProgressLogger(1000, func(format string, args ...any) {
+			log.Printf(format, args...)
+		})
+		if err := s.dedupEngine.FullScan(ctx, progressFn); err != nil {
+			log.Printf("[WARN] Initial dedup scan failed: %v", err)
+		}
+	}()
 
-	_ = store.SetSetting(backfillVersionMarker, "true", "bool", false)
 	log.Printf("[INFO] Embedding backfill and initial dedup scan complete (%s)", backfillVersionMarker)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.155.0
+// version: 1.156.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -706,6 +706,19 @@ type Server struct {
 	dedupEngine            *DedupEngine
 	activityWriter         *activityWriter
 	http3Server            *http3.Server
+
+	// Shutdown coordination. bgCtx is canceled when Shutdown() runs, and
+	// bgWG tracks every fire-and-forget background goroutine (embedding
+	// backfill, async dedup scans, etc.) so Shutdown can wait for them to
+	// finish BEFORE the database is closed. Without this the embedding
+	// backfill goroutine would still be holding Pebble iterators when
+	// database.CloseStore() ran, and Pebble would panic with "element has
+	// outstanding references" during FileCache.Unref. Every goroutine that
+	// touches the store must: (1) call bgWG.Add(1) before starting,
+	// (2) defer bgWG.Done(), (3) honor bgCtx.Done() for cancellation.
+	bgCtx    context.Context
+	bgCancel context.CancelFunc
+	bgWG     sync.WaitGroup
 }
 
 // ServerConfig holds server configuration
@@ -736,7 +749,10 @@ func NewServer() *Server {
 	metrics.Register()
 
 	store := database.GetGlobalStore()
+	bgCtx, bgCancel := context.WithCancel(context.Background())
 	server := &Server{
+		bgCtx:                  bgCtx,
+		bgCancel:               bgCancel,
 		router:                 router,
 		audiobookService:       NewAudiobookService(store),
 		audiobookUpdateService: NewAudiobookUpdateService(store),
@@ -875,9 +891,17 @@ func NewServer() *Server {
 		}
 	}
 
-	// Start embedding backfill if dedup engine is ready
+	// Start embedding backfill if dedup engine is ready. Tracked via
+	// bgWG so Shutdown() can wait for it to finish before the database
+	// closes — without this, a backfill still iterating Pebble when the
+	// server stops will leave iterators open and panic inside Pebble's
+	// FileCache.Unref during Close().
 	if server.dedupEngine != nil {
-		go server.runEmbeddingBackfill()
+		server.bgWG.Add(1)
+		go func() {
+			defer server.bgWG.Done()
+			server.runEmbeddingBackfill()
+		}()
 	}
 
 	// Wire activity log dual-write hooks
@@ -1167,8 +1191,14 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// Resume interrupted metadata candidate fetch operations
 	s.resumeInterruptedMetadataFetch()
 
-	// Backfill external ID mappings from existing iTunes PIDs (one-time, idempotent)
-	go s.backfillExternalIDs()
+	// Backfill external ID mappings from existing iTunes PIDs (one-time,
+	// idempotent). Tracked via bgWG for the same reason as the embedding
+	// backfill: we can't let it hold Pebble iterators while CloseStore runs.
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		s.backfillExternalIDs()
+	}()
 
 	// Start periodic cleanup of stale transcode temp files
 	if database.GlobalStore != nil {
@@ -1361,6 +1391,29 @@ func (s *Server) Start(cfg ServerConfig) error {
 	}
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		log.Printf("[WARN] HTTP server forced shutdown: %v", err)
+	}
+
+	// Cancel fire-and-forget background work (embedding backfill, async
+	// dedup scans) and wait for it to return. This MUST happen before
+	// embeddingStore.Close() and before Start() returns (which triggers
+	// the deferred closeStore() in cmd/root.go). Without it, the backfill
+	// goroutine keeps iterating Pebble while CloseStore runs, and Pebble's
+	// FileCache.Unref panics with "element has outstanding references"
+	// during shutdown — which has been killing every restart mid-cycle.
+	if s.bgCancel != nil {
+		log.Println("[INFO] Canceling background goroutines...")
+		s.bgCancel()
+	}
+	bgDone := make(chan struct{})
+	go func() {
+		s.bgWG.Wait()
+		close(bgDone)
+	}()
+	select {
+	case <-bgDone:
+		log.Println("[INFO] Background goroutines stopped")
+	case <-time.After(30 * time.Second):
+		log.Println("[WARN] Background goroutines did not stop within 30s — proceeding with shutdown anyway")
 	}
 
 	// Stop the file I/O pool — waits for in-flight jobs to finish


### PR DESCRIPTION
## Summary

Three interlocking fixes for "backfill runs every restart and keeps panicking":

1. **Root cause — iterator leak during shutdown.** Fire-and-forget goroutines (embedding backfill, external-ID backfill) held Pebble iterators while the shutdown path called \`CloseStore\`. Pebble's \`FileCache.Unref\` panicked with \`element has outstanding references\` on every single restart. Fixed with a server-level \`bgCtx\`/\`bgCancel\`/\`bgWG\`: cancel → Wait → Close DB, the standard Go pattern.

2. **Backfill marker persisted early.** Marker \`embedding_backfill_v5_done\` used to be written AFTER \`FullScan\` returned. Because \`FullScan\` kept panicking (via the iterator leak above), the marker never got written, and every restart re-embedded 24K books (cached, but still ~60s of iteration blocking the API). Now the marker is written right after the embed loop — \`FullScan\` is a follow-up pass.

3. **FullScan wrapped in recover.** If the follow-up scan panics for any other reason, the server survives and the user can still reach the UI to trigger a Re-scan.

## Evidence from prod logs

\`\`\`
17:47:24 panic: element has outstanding references
17:47:26 [INFO] Starting embedding backfill (v3_done)...
18:35:54 panic: element has outstanding references  
18:35:55 [INFO] Starting embedding backfill (v4_done)...
...repeating every 10-60 minutes, never completing
\`\`\`

Stack trace roots at \`PebbleStore.Close → FileCache.Unref → genericcache.shard.Close\` — 100% a shutdown-time cache-refcount issue, not a FullScan bug.

## Test plan

- [ ] Deploy, verify first run completes backfill + sets marker
- [ ] Restart the service — verify it logs \`Embedding backfill already complete (v5_done), skipping\`
- [ ] SIGTERM mid-backfill — verify graceful shutdown, no panic
- [ ] Confirm no \`element has outstanding references\` panics in journalctl

🤖 Generated with [Claude Code](https://claude.com/claude-code)