### PR TITLE
feat(metadata): TagLib fallback reader when dhowden/tag fails

### DIFF
--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/metadata.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
 
 package metadata
@@ -127,7 +127,22 @@ func ExtractMetadata(filePath string, metaLog logger.Logger) (Metadata, error) {
 
 	m, err := tag.ReadFrom(f)
 	if err != nil {
-		metaLog.Warn("failed to read tags for %s: %v; falling back to filename parsing", filePath, err)
+		// dhowden/tag choked on this file. Before giving up and falling
+		// back to filename parsing, try TagLib — it understands more
+		// variants (M4B with unusual atoms, certain DRM-scrubbed files,
+		// Vorbis-with-non-standard-comment layouts) and we already link
+		// its static libs for tag writing. TagLib's output is folded
+		// into a Metadata via BuildMetadataFromTaglibMap so everything
+		// downstream sees the same shape.
+		metaLog.Warn("dhowden/tag failed for %s: %v; trying taglib fallback", filePath, err)
+		if tagMap, tlErr := readTagsWithTaglib(filePath); tlErr == nil && len(tagMap) > 0 {
+			result := BuildMetadataFromTaglibMap(tagMap, filePath, metaLog)
+			metaLog.Info("taglib fallback succeeded for %s (%d keys)", filePath, len(tagMap))
+			return result, nil
+		} else if tlErr != nil {
+			metaLog.Warn("taglib fallback also failed for %s: %v", filePath, tlErr)
+		}
+		metaLog.Warn("both parsers failed for %s; falling back to filename parsing", filePath)
 		metadata = extractFromFilename(filePath)
 		metadata.UsedFilenameFallback = true
 		if metadata.SeriesIndex == 0 {

--- a/internal/metadata/taglib_cgo.go
+++ b/internal/metadata/taglib_cgo.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_cgo.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 //
 // Native CGO bindings to TagLib C API for high-performance tag writing.
@@ -100,4 +100,69 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, c
 	}
 
 	return nil
+}
+
+// readTagsWithTaglib reads tags from a file via native TagLib (CGO).
+// Returns a flat key → list-of-values map, matching the shape of the
+// WASM fallback in taglib_support.go so callers can use one code path.
+// Used by ExtractMetadata when dhowden/tag fails to parse a file.
+func readTagsWithTaglib(filePath string) (map[string][]string, error) {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("taglib read abs: %w", err)
+	}
+
+	cPath := C.CString(abs)
+	defer C.free(unsafe.Pointer(cPath))
+
+	file := C.taglib_file_new(cPath)
+	if file == nil {
+		return nil, fmt.Errorf("taglib: failed to open %s", abs)
+	}
+	defer C.taglib_file_free(file)
+
+	if C.taglib_file_is_valid(file) == 0 {
+		return nil, fmt.Errorf("taglib: file not valid/supported: %s", abs)
+	}
+
+	// taglib_property_keys returns a NULL-terminated array of C strings.
+	// The array AND each string are owned by taglib and must be freed via
+	// taglib_property_free.
+	keys := C.taglib_property_keys(file)
+	if keys == nil {
+		// No properties — not an error, just an empty tag set.
+		return map[string][]string{}, nil
+	}
+	defer C.taglib_property_free(keys)
+
+	tags := map[string][]string{}
+	// Walk the NULL-terminated key array.
+	keyPtr := unsafe.Pointer(keys)
+	for {
+		cKey := *(**C.char)(keyPtr)
+		if cKey == nil {
+			break
+		}
+		key := C.GoString(cKey)
+
+		// taglib_property_get returns a NULL-terminated value array, also
+		// owned by taglib and freed via taglib_property_free.
+		values := C.taglib_property_get(file, cKey)
+		if values != nil {
+			valPtr := unsafe.Pointer(values)
+			for {
+				cVal := *(**C.char)(valPtr)
+				if cVal == nil {
+					break
+				}
+				tags[key] = append(tags[key], C.GoString(cVal))
+				valPtr = unsafe.Pointer(uintptr(valPtr) + unsafe.Sizeof(cVal))
+			}
+			C.taglib_property_free(values)
+		}
+
+		keyPtr = unsafe.Pointer(uintptr(keyPtr) + unsafe.Sizeof(cKey))
+	}
+
+	return tags, nil
 }

--- a/internal/metadata/taglib_reader.go
+++ b/internal/metadata/taglib_reader.go
@@ -1,0 +1,175 @@
+// file: internal/metadata/taglib_reader.go
+// version: 1.0.0
+// guid: 9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f
+
+package metadata
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/logger"
+)
+
+// BuildMetadataFromTaglibMap takes the flat key → values map returned by
+// TagLib (both the CGO and WASM paths produce the same shape) and folds
+// it into a Metadata struct using the same field-priority rules as the
+// dhowden-based BuildMetadataFromTag. This exists so the taglib fallback
+// path in ExtractMetadata can produce a result compatible with everything
+// downstream — scanner, dedup, organize — without anyone needing to know
+// which parser ultimately read the file.
+//
+// The key matching is intentionally forgiving: TagLib emits uppercase keys
+// by default but individual formats can deliver lowercase or mixed-case
+// variants (Vorbis comments especially), so we normalize to uppercase on
+// lookup.
+func BuildMetadataFromTaglibMap(tags map[string][]string, filePath string, metaLog logger.Logger) Metadata {
+	if metaLog == nil {
+		metaLog = logger.New("metadata")
+	}
+	// Normalize all keys to uppercase so lookups are case-insensitive.
+	norm := make(map[string][]string, len(tags))
+	for k, v := range tags {
+		norm[strings.ToUpper(k)] = v
+	}
+	get := func(keys ...string) string {
+		for _, k := range keys {
+			if vs, ok := norm[strings.ToUpper(k)]; ok {
+				for _, v := range vs {
+					if cleaned := cleanTagValue(v); cleaned != "" {
+						return cleaned
+					}
+				}
+			}
+		}
+		return ""
+	}
+
+	var metadata Metadata
+
+	metadata.Album = get("ALBUM")
+	metadata.Title = get("TITLE")
+	if metadata.Title == "" && metadata.Album != "" {
+		metadata.Title = metadata.Album
+	}
+	if metadata.Title == "" {
+		metadata.Title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	}
+
+	// Author priority: ALBUMARTIST > ARTIST > COMPOSER (composer is
+	// narrator in audiobooks, so it's a last-ditch fallback).
+	albumArtist := get("ALBUMARTIST", "ALBUM_ARTIST", "ALBUM ARTIST")
+	artist := get("ARTIST")
+	composer := get("COMPOSER")
+	authorFromArtist := false
+	switch {
+	case albumArtist != "":
+		metadata.Artist = albumArtist
+		metadata.AuthorSource = "taglib.albumartist"
+	case artist != "":
+		metadata.Artist = artist
+		metadata.AuthorSource = "taglib.artist"
+		authorFromArtist = true
+	case composer != "":
+		metadata.Artist = composer
+		metadata.AuthorSource = "taglib.composer"
+	}
+
+	metadata.Genre = get("GENRE")
+
+	// Narrator: dedicated fields first, then fall back to artist if
+	// artist wasn't already used for the author slot.
+	metadata.Narrator = get("NARRATOR", "PERFORMER", "READER", "TXXX:NARRATOR", "TXXX:PERFORMER")
+	if metadata.Narrator == "" && !authorFromArtist && artist != "" && artist != metadata.Artist {
+		metadata.Narrator = artist
+	}
+
+	metadata.Language = get("LANGUAGE")
+	metadata.Publisher = get("PUBLISHER", "LABEL")
+	metadata.Comments = get("DESCRIPTION", "COMMENT")
+
+	// Year. TagLib gives a DATE property; the dhowden path understands
+	// "YYYY", "YYYY-MM-DD", and year-in-noise formats, so mirror that.
+	if dateStr := get("DATE", "YEAR", "ORIGINALDATE"); dateStr != "" {
+		if y, err := strconv.Atoi(extractYearDigits(dateStr)); err == nil {
+			metadata.Year = y
+		}
+	}
+
+	// Series and series index. Custom audiobook tags come first, then
+	// the movement tags iTunes uses, then fall back to splitting the
+	// album name on " - ".
+	metadata.Series = get("SERIES", "SERIESNAME", "SERIES_NAME", "TXXX:SERIES", "MOVEMENTNAME", "MOVEMENT")
+	if idxStr := get("SERIES_INDEX", "SERIESINDEX", "TXXX:SERIES_INDEX", "MOVEMENTNUMBER", "MOVEMENT_NUMBER"); idxStr != "" {
+		if idx, err := strconv.Atoi(strings.TrimSpace(idxStr)); err == nil && idx > 0 {
+			metadata.SeriesIndex = idx
+		}
+	}
+	if metadata.Series == "" && strings.Contains(metadata.Album, " - ") {
+		parts := strings.Split(metadata.Album, " - ")
+		if len(parts) > 1 {
+			metadata.Series = strings.TrimSpace(parts[0])
+		}
+	}
+	if metadata.Series == "" && metadata.Comments != "" {
+		if extracted := extractSeriesFromComments(metadata.Comments); extracted != "" {
+			metadata.Series = extracted
+		}
+	}
+	if metadata.Series == "" {
+		if series, idx := extractSeriesFromVolumeString(metadata.Album); series != "" {
+			metadata.Series = series
+			if metadata.SeriesIndex == 0 && idx > 0 {
+				metadata.SeriesIndex = idx
+			}
+		}
+	}
+	if metadata.Series == "" {
+		if series, idx := extractSeriesFromVolumeString(metadata.Title); series != "" {
+			metadata.Series = series
+			if metadata.SeriesIndex == 0 && idx > 0 {
+				metadata.SeriesIndex = idx
+			}
+		}
+	}
+	if metadata.SeriesIndex == 0 {
+		metadata.SeriesIndex = DetectVolumeNumber(metadata.Title)
+	}
+
+	// External IDs.
+	metadata.ISBN10 = normalizeISBN(get("ISBN10", "TXXX:ISBN10"))
+	metadata.ISBN13 = normalizeISBN(get("ISBN13", "TXXX:ISBN13", "ISBN"))
+	metadata.ASIN = get("ASIN", "TXXX:ASIN")
+	metadata.OpenLibraryID = get("OPEN_LIBRARY_ID", "OPENLIBRARYID", "TXXX:OPEN_LIBRARY_ID")
+	metadata.HardcoverID = get("HARDCOVER_ID", "HARDCOVERID", "TXXX:HARDCOVER_ID")
+	metadata.GoogleBooksID = get("GOOGLE_BOOKS_ID", "GOOGLEBOOKSID", "TXXX:GOOGLE_BOOKS_ID")
+
+	// Custom AUDIOBOOK_ORGANIZER_* round-trip tags.
+	metadata.BookOrganizerID = get("AUDIOBOOK_ORGANIZER_BOOK_ID", "TXXX:AUDIOBOOK_ORGANIZER_BOOK_ID")
+	metadata.OrganizerTagVersion = get("AUDIOBOOK_ORGANIZER_TAG_VERSION", "TXXX:AUDIOBOOK_ORGANIZER_TAG_VERSION")
+	metadata.Edition = get("EDITION", "TXXX:EDITION")
+	metadata.PrintYear = get("PRINT_YEAR", "PRINTYEAR", "TXXX:PRINT_YEAR")
+
+	metaLog.Debug("taglib fallback read %d tag keys from %s", len(norm), filePath)
+	return metadata
+}
+
+// normalizeISBN strips hyphens and whitespace from an ISBN-like string.
+// Returns "" if the result isn't 10 or 13 digits (optionally with trailing X).
+func normalizeISBN(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= '0' && r <= '9') || r == 'X' || r == 'x' {
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if len(out) != 10 && len(out) != 13 {
+		return ""
+	}
+	return out
+}

--- a/internal/metadata/taglib_reader_test.go
+++ b/internal/metadata/taglib_reader_test.go
@@ -1,0 +1,231 @@
+// file: internal/metadata/taglib_reader_test.go
+// version: 1.0.0
+// guid: b1a2c3d4-e5f6-7890-1234-567890abcdef
+
+package metadata
+
+import (
+	"testing"
+)
+
+// TestBuildMetadataFromTaglibMap covers the common shapes TagLib emits
+// when reading from an audiobook file. This is the fallback path used
+// when dhowden/tag can't parse a file — we need it to produce a usable
+// Metadata for every format the scanner actually cares about.
+func TestBuildMetadataFromTaglibMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     map[string][]string
+		filePath string
+		check    func(t *testing.T, m Metadata)
+	}{
+		{
+			name: "basic m4b tags",
+			tags: map[string][]string{
+				"TITLE":       {"Foundation and Empire"},
+				"ARTIST":      {"Isaac Asimov"},
+				"ALBUMARTIST": {"Isaac Asimov"},
+				"ALBUM":       {"Foundation 4 - Foundation and Empire"},
+				"GENRE":       {"Science Fiction"},
+				"DATE":        {"1952"},
+			},
+			filePath: "/tmp/foundation-and-empire.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Title != "Foundation and Empire" {
+					t.Errorf("title = %q, want Foundation and Empire", m.Title)
+				}
+				if m.Artist != "Isaac Asimov" {
+					t.Errorf("artist = %q, want Isaac Asimov", m.Artist)
+				}
+				if m.Year != 1952 {
+					t.Errorf("year = %d, want 1952", m.Year)
+				}
+				if m.Genre != "Science Fiction" {
+					t.Errorf("genre = %q", m.Genre)
+				}
+			},
+		},
+		{
+			name: "case insensitive keys",
+			tags: map[string][]string{
+				// Vorbis comments can come through lowercase
+				"title":  {"The Hobbit"},
+				"artist": {"J.R.R. Tolkien"},
+				"album":  {"The Hobbit"},
+			},
+			filePath: "/tmp/hobbit.ogg",
+			check: func(t *testing.T, m Metadata) {
+				if m.Title != "The Hobbit" {
+					t.Errorf("title = %q, want The Hobbit", m.Title)
+				}
+				if m.Artist != "J.R.R. Tolkien" {
+					t.Errorf("artist = %q", m.Artist)
+				}
+			},
+		},
+		{
+			name: "album_artist beats artist",
+			tags: map[string][]string{
+				"TITLE":        {"Foundation"},
+				"ARTIST":       {"Scott Brick"},  // narrator
+				"ALBUMARTIST":  {"Isaac Asimov"}, // author
+			},
+			filePath: "/tmp/foundation.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Artist != "Isaac Asimov" {
+					t.Errorf("expected ALBUMARTIST to win, got %q", m.Artist)
+				}
+				// ARTIST should fall through to Narrator since it wasn't used
+				if m.Narrator != "Scott Brick" {
+					t.Errorf("narrator = %q, want Scott Brick", m.Narrator)
+				}
+			},
+		},
+		{
+			name: "composer fallback when neither artist nor album_artist set",
+			tags: map[string][]string{
+				"TITLE":    {"Mystery"},
+				"COMPOSER": {"Fallback Author"},
+			},
+			filePath: "/tmp/mystery.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Artist != "Fallback Author" {
+					t.Errorf("expected composer fallback, got %q", m.Artist)
+				}
+			},
+		},
+		{
+			name: "explicit NARRATOR property",
+			tags: map[string][]string{
+				"TITLE":    {"Book"},
+				"ARTIST":   {"Author Name"},
+				"NARRATOR": {"Narrator Name"},
+			},
+			filePath: "/tmp/book.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Narrator != "Narrator Name" {
+					t.Errorf("narrator = %q, want Narrator Name", m.Narrator)
+				}
+			},
+		},
+		{
+			name: "series and series_index",
+			tags: map[string][]string{
+				"TITLE":        {"Foundation and Empire"},
+				"ARTIST":       {"Isaac Asimov"},
+				"SERIES":       {"Foundation"},
+				"SERIES_INDEX": {"4"},
+			},
+			filePath: "/tmp/foundation-4.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Series != "Foundation" {
+					t.Errorf("series = %q", m.Series)
+				}
+				if m.SeriesIndex != 4 {
+					t.Errorf("series_index = %d, want 4", m.SeriesIndex)
+				}
+			},
+		},
+		{
+			name: "AUDIOBOOK_ORGANIZER custom tags round-trip",
+			tags: map[string][]string{
+				"TITLE":                          {"Book"},
+				"ARTIST":                         {"Author"},
+				"AUDIOBOOK_ORGANIZER_BOOK_ID":    {"01KNDB000000000000000000"},
+				"AUDIOBOOK_ORGANIZER_TAG_VERSION": {"3"},
+				"EDITION":                        {"Unabridged"},
+			},
+			filePath: "/tmp/book.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.BookOrganizerID != "01KNDB000000000000000000" {
+					t.Errorf("BookOrganizerID = %q", m.BookOrganizerID)
+				}
+				if m.OrganizerTagVersion != "3" {
+					t.Errorf("OrganizerTagVersion = %q", m.OrganizerTagVersion)
+				}
+				if m.Edition != "Unabridged" {
+					t.Errorf("Edition = %q", m.Edition)
+				}
+			},
+		},
+		{
+			name: "ISBN normalization",
+			tags: map[string][]string{
+				"TITLE":  {"Book"},
+				"ARTIST": {"Author"},
+				"ISBN13": {"978-0-553-29335-0"},
+				"ISBN10": {"0-553-29335-4"},
+				"ASIN":   {"B00MW8EZJU"},
+			},
+			filePath: "/tmp/book.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.ISBN13 != "9780553293350" {
+					t.Errorf("ISBN13 = %q, want 9780553293350", m.ISBN13)
+				}
+				if m.ISBN10 != "0553293354" {
+					t.Errorf("ISBN10 = %q, want 0553293354", m.ISBN10)
+				}
+				if m.ASIN != "B00MW8EZJU" {
+					t.Errorf("ASIN = %q", m.ASIN)
+				}
+			},
+		},
+		{
+			name: "missing title falls back to album then filename",
+			tags: map[string][]string{
+				"ARTIST": {"Author"},
+				"ALBUM":  {"Album Fallback"},
+			},
+			filePath: "/tmp/book.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Title != "Album Fallback" {
+					t.Errorf("title = %q, want Album Fallback (album fallback)", m.Title)
+				}
+			},
+		},
+		{
+			name:     "empty tag map falls back to filename basename for title",
+			tags:     map[string][]string{},
+			filePath: "/tmp/some-audiobook-file.m4b",
+			check: func(t *testing.T, m Metadata) {
+				if m.Title != "some-audiobook-file" {
+					t.Errorf("title = %q, want basename", m.Title)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := BuildMetadataFromTaglibMap(tc.tags, tc.filePath, nil)
+			tc.check(t, m)
+		})
+	}
+}
+
+// TestNormalizeISBN covers the hyphen/whitespace-stripping logic that
+// turns raw tag values into canonical ISBN strings, plus the length
+// validation that rejects anything that isn't 10 or 13 digits.
+func TestNormalizeISBN(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"978-0-553-29335-0", "9780553293350"},
+		{"9780553293350", "9780553293350"},
+		{"0553293354", "0553293354"},
+		{"0-553-29335-4", "0553293354"},
+		{"  978 0 553 29335 0  ", "9780553293350"},
+		{"12345", ""},                  // too short
+		{"12345678901234567", ""},      // too long
+		{"978055329335X", "978055329335X"},
+		{"garbage-string", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := normalizeISBN(tc.in); got != tc.want {
+				t.Errorf("normalizeISBN(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metadata/taglib_support.go
+++ b/internal/metadata/taglib_support.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_support.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 //
 // TagLib WASM writer (default, no CGO required).
@@ -54,4 +54,23 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, c
 	}
 
 	return nil
+}
+
+// readTagsWithTaglib reads tags from a file via the TagLib WASM runtime.
+// Returns a flat key → list-of-values map exactly like TagLib's property
+// interface: "TITLE" → ["Foundation and Empire"], "ARTIST" → ["Isaac
+// Asimov"], plus any custom properties the file has (AUDIOBOOK_ORGANIZER_*,
+// SERIES, SERIES_INDEX, NARRATOR, etc.). Used as a fallback by
+// ExtractMetadata when dhowden/tag can't parse a file — typically happens
+// on unusual M4B variants, DRM-touched files, or edge-case Vorbis comments.
+func readTagsWithTaglib(filePath string) (map[string][]string, error) {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("taglib read abs: %w", err)
+	}
+	tags, err := taglib.ReadTags(abs)
+	if err != nil {
+		return nil, fmt.Errorf("taglib read: %w", err)
+	}
+	return tags, nil
 }


### PR DESCRIPTION
## Summary

Adds TagLib as a middle-tier fallback between dhowden/tag and filename parsing in \`ExtractMetadata\`. When dhowden chokes on a file, we try TagLib (which we already link statically for the write path), fold its flat key-value output into a \`Metadata\` via \`BuildMetadataFromTaglibMap\`, and return that. Only if TagLib also fails do we fall back to filename parsing.

## Read paths

- **WASM (default build)** — wraps \`go.senan.xyz/taglib.ReadTags\`, returns \`map[string][]string\`.
- **Native CGO (-tags native_taglib)** — walks \`taglib_property_keys\` + \`taglib_property_get\` by hand and returns the same shape. Uses the same static \`libtag.a\` already in \`third_party/taglib/lib/\`.

Both routes feed a single \`BuildMetadataFromTaglibMap\` helper that applies the same field-priority rules as the dhowden path:
- album_artist > artist > composer (composer = narrator fallback)
- narrator from dedicated field, artist fallback when unused
- series chain: custom → album-split → comment-extract → volume-string → fallback
- AUDIOBOOK_ORGANIZER_* round-trip tags
- normalizeISBN for ISBN10/13 with hyphens and whitespace

## Why

dhowden/tag is solid for common cases but doesn't handle every M4B variant, some Vorbis layouts, or DRM-scrubbed files. \"Fall back to filename parsing\" on a book titled \`Chapter-12.m4b\` produces garbage metadata. TagLib understands more formats; we already link it for writing; no reason not to use it as a read fallback.

## Test plan

- [x] \`TestBuildMetadataFromTaglibMap\` — 10 subtests covering basic tags, case-insensitive keys, album_artist precedence, composer fallback, NARRATOR property, series+index, custom round-trip tags, ISBN normalization, title-from-album fallback, empty-map-to-filename fallback
- [x] \`TestNormalizeISBN\` — 10 subtests including length validation (rejects non-10/13)
- [x] Full build with \`-tags native_taglib\` for linux-amd64 (CGO path compiles)
- [x] Full build without tag (WASM path compiles)
- [ ] Deploy and watch for \"taglib fallback succeeded\" log lines on files dhowden was previously losing

🤖 Generated with [Claude Code](https://claude.com/claude-code)