### PR TITLE
feat(dedup): per-side "not a duplicate" button on 3+ way clusters

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -318,6 +318,101 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":    "dismissed",
+		"dismissed": dismissed,
+	})
+}
+
+// removeFromDedupCluster handles POST /api/v1/dedup/candidates/remove-from-cluster.
+//
+// Body: {"cluster_book_ids": [...], "remove_book_id": "X"}
+//
+// Dismisses every pending candidate whose pair is one-side-X and other-side
+// in (cluster \ X). In other words: "this one book is NOT a duplicate of
+// the other books in this cluster". Pairs involving X that point to books
+// OUTSIDE the cluster are left alone — this is a scoped split, not a
+// global ban on the book.
+//
+// The effect on the UI: a 3-way cluster (A, B, C) where the user removes
+// C drops the (A,C) and (B,C) edges but leaves (A,B). On the next page
+// load the union-find produces a 2-way cluster (A, B) and C disappears
+// from the pending view. C can still show up in future dedup scans if
+// something new hits it.
+func (s *Server) removeFromDedupCluster(c *gin.Context) {
+	if s.embeddingStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		return
+	}
+
+	var body struct {
+		ClusterBookIDs []string `json:"cluster_book_ids"`
+		RemoveBookID   string   `json:"remove_book_id"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	if body.RemoveBookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "remove_book_id is required"})
+		return
+	}
+	if len(body.ClusterBookIDs) < 2 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster_book_ids must contain at least 2 entries"})
+		return
+	}
+
+	// Build the set of "other books in this cluster" — everything in the
+	// cluster except the one being removed.
+	others := make(map[string]struct{}, len(body.ClusterBookIDs))
+	for _, id := range body.ClusterBookIDs {
+		if id != body.RemoveBookID {
+			others[id] = struct{}{}
+		}
+	}
+	if len(others) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster must contain at least one book other than remove_book_id"})
+		return
+	}
+
+	candidates, _, err := s.embeddingStore.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Limit:      100000,
+	})
+	if err != nil {
+		internalError(c, "failed to list candidates for cluster remove", err)
+		return
+	}
+
+	dismissed := 0
+	for _, cand := range candidates {
+		// The pair must involve the removed book on one side and an
+		// "other cluster member" on the opposite side. Pairs where the
+		// removed book touches a book OUTSIDE the cluster are deliberately
+		// skipped — those represent different clusters that the user
+		// hasn't expressed an opinion on.
+		var otherID string
+		switch {
+		case cand.EntityAID == body.RemoveBookID:
+			otherID = cand.EntityBID
+		case cand.EntityBID == body.RemoveBookID:
+			otherID = cand.EntityAID
+		default:
+			continue
+		}
+		if _, ok := others[otherID]; !ok {
+			continue
+		}
+		if err := s.embeddingStore.UpdateCandidateStatus(cand.ID, "dismissed"); err != nil {
+			log.Printf("[dedup] remove-from-cluster: status update %d: %v", cand.ID, err)
+			continue
+		}
+		dismissed++
+	}
+	log.Printf("[dedup] remove-from-cluster: dismissed %d edge(s) between %s and %d other cluster member(s)",
+		dismissed, body.RemoveBookID, len(others))
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "removed",
 		"dismissed": dismissed,
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.157.0
+// version: 1.158.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1675,6 +1675,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/candidates/bulk-merge", s.bulkMergeDedupCandidates)
 			protected.POST("/dedup/candidates/merge-cluster", s.mergeDedupCluster)
 			protected.POST("/dedup/candidates/dismiss-cluster", s.dismissDedupCluster)
+			protected.POST("/dedup/candidates/remove-from-cluster", s.removeFromDedupCluster)
 			protected.POST("/dedup/scan", s.triggerDedupScan)
 			protected.POST("/dedup/scan-llm", s.triggerDedupLLM)
 			protected.POST("/dedup/refresh", s.triggerDedupRefresh)

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.9.0
+// version: 3.10.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -2656,6 +2656,25 @@ function EmbeddingDedupTab() {
     }
   };
 
+  // Remove a single book from a 3+ way cluster. Dismisses just the edges
+  // between this book and the other cluster members, leaving the rest as
+  // a smaller cluster the user can still merge. This is the "one of these
+  // is actually a different book" escape hatch — e.g. a 3-way cluster with
+  // "Monster Trainer Academy I" twice plus "Monster Trainer Academy II"
+  // where the user wants to merge the two I's and kick out the II.
+  const handleRemoveFromCluster = async (cluster: BookCluster, bookId: string) => {
+    setActionLoading(`${cluster.key}:${bookId}`);
+    try {
+      await api.removeFromDedupCluster(cluster.bookIds, bookId);
+      loadCandidates();
+      loadStats();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Remove from cluster failed');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleScan = async () => {
     setScanning(true);
     setScanMsg(null);
@@ -2713,7 +2732,12 @@ function EmbeddingDedupTab() {
   const embeddingCount = stats.filter(s => s.layer === 'embedding').reduce((sum, s) => sum + s.count, 0);
   const llmCount = stats.filter(s => s.layer === 'llm').reduce((sum, s) => sum + s.count, 0);
 
-  const renderBookSide = (id: string) => {
+  // renderBookSide takes the cluster it belongs to so the per-side
+  // "Not a duplicate" button can scope its dismiss to that cluster's
+  // pairs only. The button only appears for 3+ way clusters — in a 2-way
+  // cluster, removing one side is the same as dismissing the whole
+  // cluster, so we show the existing cluster-level Dismiss button instead.
+  const renderBookSide = (id: string, cluster: BookCluster) => {
     const book = bookDetails.get(id);
     if (!book) {
       return (
@@ -2722,6 +2746,9 @@ function EmbeddingDedupTab() {
         </Typography>
       );
     }
+    const isMultiWay = cluster.bookIds.length > 2;
+    const removeBusy = actionLoading === `${cluster.key}:${id}`;
+    const anyActionBusy = actionLoading != null;
     const allFiles = bookFiles.get(id) ?? [];
     // Prefer the full file list (book_files table) over the Book.file_path
     // column because multi-file audiobooks only track the first file on the
@@ -2757,45 +2784,72 @@ function EmbeddingDedupTab() {
         </Typography>
       );
     return (
-      <Box
-        sx={{ cursor: 'pointer', minWidth: 0, '&:hover .dedup-side-title': { textDecoration: 'underline' } }}
-        onClick={() => navigate(`/books/${book.id}`)}
-      >
-        <Typography
-          className="dedup-side-title"
-          variant="body2"
-          fontWeight="medium"
-          noWrap
-          title={book.title}
+      <Box sx={{ minWidth: 0, position: 'relative' }}>
+        <Box
+          sx={{ cursor: 'pointer', minWidth: 0, '&:hover .dedup-side-title': { textDecoration: 'underline' } }}
+          onClick={() => navigate(`/books/${book.id}`)}
         >
-          {cleanDisplayTitle(book.title)}
-        </Typography>
-        {book.author_name && (
-          <Typography variant="caption" color="text.secondary" noWrap title={book.author_name}>
-            {book.author_name}
-          </Typography>
-        )}
-        {shortPath && (
-          <Tooltip
-            title={tooltipContent}
-            enterDelay={300}
-            placement="bottom-start"
-            componentsProps={{ tooltip: { sx: { maxWidth: 'none' } } }}
+          <Typography
+            className="dedup-side-title"
+            variant="body2"
+            fontWeight="medium"
+            noWrap
+            title={book.title}
+            sx={{ pr: isMultiWay ? 3 : 0 }} // leave room for the button
           >
-            <Typography
-              variant="caption"
-              color="text.disabled"
-              noWrap
-              sx={{ display: 'block', fontFamily: 'monospace', fontSize: '0.7rem' }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              {shortPath}
-              {extraCount > 0 && (
-                <Box component="span" sx={{ ml: 0.5, color: 'primary.main', fontWeight: 600 }}>
-                  +{extraCount} more
-                </Box>
-              )}
+            {cleanDisplayTitle(book.title)}
+          </Typography>
+          {book.author_name && (
+            <Typography variant="caption" color="text.secondary" noWrap title={book.author_name}>
+              {book.author_name}
             </Typography>
+          )}
+          {shortPath && (
+            <Tooltip
+              title={tooltipContent}
+              enterDelay={300}
+              placement="bottom-start"
+              componentsProps={{ tooltip: { sx: { maxWidth: 'none' } } }}
+            >
+              <Typography
+                variant="caption"
+                color="text.disabled"
+                noWrap
+                sx={{ display: 'block', fontFamily: 'monospace', fontSize: '0.7rem' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {shortPath}
+                {extraCount > 0 && (
+                  <Box component="span" sx={{ ml: 0.5, color: 'primary.main', fontWeight: 600 }}>
+                    +{extraCount} more
+                  </Box>
+                )}
+              </Typography>
+            </Tooltip>
+          )}
+        </Box>
+        {isMultiWay && cluster.hasPending && (
+          <Tooltip title="Not a duplicate — remove this book from the cluster">
+            <span>
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveFromCluster(cluster, id);
+                }}
+                disabled={anyActionBusy}
+                sx={{
+                  position: 'absolute',
+                  top: -4,
+                  right: -4,
+                  padding: '2px',
+                  color: 'text.disabled',
+                  '&:hover': { color: 'error.main' },
+                }}
+              >
+                {removeBusy ? <CircularProgress size={14} /> : <CloseIcon sx={{ fontSize: 16 }} />}
+              </IconButton>
+            </span>
           </Tooltip>
         )}
       </Box>
@@ -2977,7 +3031,7 @@ function EmbeddingDedupTab() {
                               : { flex: 1, minWidth: 0, maxWidth: `${100 / cluster.bookIds.length}%` }
                           }
                         >
-                          {renderBookSide(bookId)}
+                          {renderBookSide(bookId, cluster)}
                         </Box>
                       ))}
                     </Stack>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 1.68.0
+// version: 1.69.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -3694,6 +3694,29 @@ export async function dismissDedupCluster(bookIds: string[]): Promise<{ status: 
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to dismiss dedup cluster');
+  }
+  return response.json();
+}
+
+// Remove a single book from a cluster by dismissing only the edges between
+// it and the other cluster members. Pairs involving the book with books
+// OUTSIDE the cluster are left alone. Used by the per-side "not a
+// duplicate" button when one book in a 3+ way cluster is wrong but the
+// rest are real duplicates.
+export async function removeFromDedupCluster(
+  clusterBookIds: string[],
+  removeBookId: string
+): Promise<{ status: string; dismissed: number }> {
+  const response = await fetch(`${API_BASE}/dedup/candidates/remove-from-cluster`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      cluster_book_ids: clusterBookIds,
+      remove_book_id: removeBookId,
+    }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to remove book from dedup cluster');
   }
   return response.json();
 }


### PR DESCRIPTION
## Summary

When a 3+ way dedup cluster contains one entry that doesn't belong (e.g. \"Monster Trainer Academy I\" × 2 plus \"Monster Trainer Academy II\" — the II is a different book), the user previously had two bad options: merge all three or dismiss the whole cluster. This PR adds a third option: remove just the wrong entry.

- **Small × button** in the top-right of each book side, visible only on 3+ way clusters
- **New backend endpoint** \`POST /api/v1/dedup/candidates/remove-from-cluster\` dismisses only the edges between the removed book and the OTHER cluster members
- **Cluster re-renders** after the call — a 3-way cluster with one book removed becomes a 2-way cluster the user can then merge cleanly

## Scope guarantee

Pairs involving the removed book that point to books OUTSIDE the cluster are deliberately **not** touched. Removing a book from cluster A doesn't express any opinion about cluster B. The scoped dismiss is implemented server-side — the client sends \`{cluster_book_ids, remove_book_id}\` and the server iterates pending candidates, only touching rows where one side is the removed book and the other is an \"other cluster member\".

## UI rules

- 2-way clusters: no × button (the existing cluster Dismiss already covers it)
- 3+ way horizontal layout: × in the top-right of each book card
- 5+ way vertical layout: same × position, stays absolute-positioned so it doesn't disturb the stacked list

## Test plan

- [ ] Eyeball the current Monster Trainer Academy cluster on prod, click × on the II entry, verify it becomes a 2-way (I+I) cluster
- [ ] Merge the remaining 2-way pair and verify the whole thing clears
- [ ] Verify × does NOT appear on 2-way clusters
- [ ] Verify × stays functional in the 5+ way vertical layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)