### PR TITLE
fix(organize): stop silent no-op when target path is occupied

### DIFF
--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,10 +1,11 @@
 // file: internal/organizer/organizer.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package organizer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,6 +18,29 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
+
+// ErrTargetOccupied is returned from OrganizeBook when the computed
+// target path already exists on disk and is a DIFFERENT file than the
+// book's current source. This is the "two books with identical metadata
+// want the same destination" case — e.g. two different audio files both
+// tagged as "Asimov / Foundation". Previously OrganizeBook silently
+// returned (target, "", nil) here, which caused the caller to update
+// the DB file_path to the occupant's file — two rows pointed at the
+// same file on disk and the second book's audio was orphaned.
+//
+// Callers that can usefully act on this (e.g. the manual organize
+// endpoint) should detect the error via errors.Is, look up the occupant
+// via GetBookByFilePath, and either create a dedup candidate or ask
+// the user to resolve the collision before retrying.
+var ErrTargetOccupied = errors.New("organize: target path already occupied by a different file")
+
+// OrganizeCollisionHook is an optional package-level hook fired when
+// OrganizeBook hits ErrTargetOccupied. The server package wires it to
+// create a pending dedup candidate between the current book and the
+// occupant, so the collision surfaces in the dedup tab instead of
+// becoming an invisible data-integrity problem. nil-safe — the
+// organizer runs fine in tests or CLI contexts where no hook is set.
+var OrganizeCollisionHook func(currentBookID, occupantPath string)
 
 // Organizer handles file organization operations
 type Organizer struct {
@@ -79,29 +103,62 @@ func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
 		return targetPath, "", nil
 	}
 
-	// Check if file already exists at target path
-	if targetInfo, err := os.Stat(targetPath); err == nil {
-		// Target exists — check if it's the same inode (already hardlinked)
-		if srcInfo, srcErr := os.Stat(book.FilePath); srcErr == nil {
-			if os.SameFile(srcInfo, targetInfo) {
-				return targetPath, "", nil // Already the same file (hardlink/reflink)
-			}
-		}
-		return targetPath, "", nil // Target already exists with different content; don't overwrite
-	}
-
-	// Check for duplicate files by hash (if hash is available in book metadata)
-	// This prevents copying the same file multiple times during re-organization
-	if book.FileHash != nil && *book.FileHash != "" {
-		// Check if a file with this hash already exists in the database
+	// Same-hash dedup check runs FIRST so a true content-duplicate (same
+	// bytes, two DB rows) gets a proper error before we get to the
+	// target-exists check. Otherwise a re-organize of a book whose
+	// content already exists at another path under root would hit the
+	// target-exists branch first (seeing the OLD organized version) and
+	// silently no-op. Order matters.
+	if book.FileHash != nil && *book.FileHash != "" && database.GlobalStore != nil {
 		existingBook, err := database.GlobalStore.GetBookByFileHash(*book.FileHash)
 		if err == nil && existingBook != nil && existingBook.ID != book.ID {
-			// Another book with same hash exists - check if it's in the output directory
 			if strings.HasPrefix(existingBook.FilePath, o.config.RootDir) {
-				// File already organized under different metadata
+				// Content-identical book already organized under a
+				// different row. This is a true duplicate — fire the
+				// collision hook so the dedup tab picks it up.
+				if OrganizeCollisionHook != nil {
+					OrganizeCollisionHook(book.ID, existingBook.FilePath)
+				}
 				return existingBook.FilePath, "", fmt.Errorf("duplicate file already organized at: %s", existingBook.FilePath)
 			}
 		}
+	}
+
+	// Check if file already exists at target path. Four cases:
+	//   1. SameFile (hardlink/reflink): already organized, success no-op.
+	//   2. Different inode but the DB says this exact book owns the
+	//      target path: it's a previous copy-based organize of the same
+	//      book (re-organize where the caller didn't refresh book.FilePath
+	//      before the retry). Success no-op.
+	//   3. Different inode and the DB says another book owns the target:
+	//      real collision, fire hook, return ErrTargetOccupied.
+	//   4. Different inode and no DB row at the target (e.g. orphaned
+	//      file from a previous partial organize): treat as collision
+	//      too — refuse to overwrite, let the user resolve it.
+	if targetInfo, err := os.Stat(targetPath); err == nil {
+		if srcInfo, srcErr := os.Stat(book.FilePath); srcErr == nil {
+			if os.SameFile(srcInfo, targetInfo) {
+				return targetPath, "", nil
+			}
+		}
+		// Case 2: ask the DB who owns the target. If it's the current
+		// book, this is a re-organize no-op — don't panic, don't fire
+		// the collision hook, just return the target.
+		if database.GlobalStore != nil && book.ID != "" {
+			if owner, lookupErr := database.GlobalStore.GetBookByFilePath(targetPath); lookupErr == nil && owner != nil && owner.ID == book.ID {
+				return targetPath, "", nil
+			}
+		}
+		// Case 3/4: collision. Fire the hook so the server can create a
+		// pending dedup candidate between this book and whoever owns
+		// the target, then return the explicit error. The old code
+		// silently returned nil here, which caused the caller to set
+		// this book's file_path to the occupant's file — two DB rows
+		// pointing at one file on disk.
+		if OrganizeCollisionHook != nil {
+			OrganizeCollisionHook(book.ID, targetPath)
+		}
+		return targetPath, "", fmt.Errorf("%w: %s", ErrTargetOccupied, targetPath)
 	}
 
 	// Perform the organization based on strategy

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -1,10 +1,11 @@
 // file: internal/organizer/organizer_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package organizer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -295,7 +296,10 @@ func TestOrganizeBook_Copy(t *testing.T) {
 		t.Error("content mismatch")
 	}
 
-	// Verify calling again with same book returns same path
+	// Verify re-organize is idempotent: production updates book.FilePath
+	// to the new path after a successful organize, so the next call hits
+	// the source==target fast-path and returns the same path.
+	book.FilePath = targetPath
 	targetPath2, _, err := org.OrganizeBook(book)
 	if err != nil {
 		t.Fatalf("second OrganizeBook failed: %v", err)
@@ -820,5 +824,156 @@ func TestCopyFile_IOCopyError(t *testing.T) {
 	err = org.copyFile(srcPath, dstPath)
 	if err == nil {
 		t.Log("Expected error for read-only destination, but got none (may be OS-specific)")
+	}
+}
+
+// TestOrganizeBook_TargetOccupiedByDifferentFile is the regression test
+// for the silent-no-op bug: two books with identical metadata produce
+// the same target path, the first organizes successfully, the second
+// used to return (target, "", nil) and the caller would update the
+// second book's file_path to the first book's file — two DB rows
+// pointing at one file on disk. Now the second call must return
+// ErrTargetOccupied so the caller knows the organize didn't happen.
+func TestOrganizeBook_TargetOccupiedByDifferentFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "source")
+	dstDir := filepath.Join(tmpDir, "output")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+
+	// Two DIFFERENT source files with the same metadata.
+	srcA := filepath.Join(srcDir, "a.m4b")
+	srcB := filepath.Join(srcDir, "b.m4b")
+	if err := os.WriteFile(srcA, []byte("content A"), 0644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := os.WriteFile(srcB, []byte("content B - totally different"), 0644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	cfg := &config.Config{
+		RootDir:              dstDir,
+		FolderNamingPattern:  "{author}",
+		FileNamingPattern:    "{title}",
+		OrganizationStrategy: "copy",
+	}
+	org := NewOrganizer(cfg)
+
+	bookA := &database.Book{
+		ID:       "book-a",
+		Title:    "Foundation",
+		FilePath: srcA,
+		Author:   &database.Author{Name: "Asimov"},
+	}
+	bookB := &database.Book{
+		ID:       "book-b",
+		Title:    "Foundation",
+		FilePath: srcB,
+		Author:   &database.Author{Name: "Asimov"},
+	}
+
+	// Organize A - should succeed.
+	targetA, _, err := org.OrganizeBook(bookA)
+	if err != nil {
+		t.Fatalf("OrganizeBook(A) failed: %v", err)
+	}
+	if _, err := os.Stat(targetA); err != nil {
+		t.Fatalf("target A missing after organize: %v", err)
+	}
+
+	// Organize B - target is now A's file, different inode. Must return
+	// ErrTargetOccupied, NOT silently succeed.
+	_, _, err = org.OrganizeBook(bookB)
+	if err == nil {
+		t.Fatal("expected ErrTargetOccupied, got nil - silent no-op regression")
+	}
+	if !errors.Is(err, ErrTargetOccupied) {
+		t.Errorf("expected ErrTargetOccupied, got %v", err)
+	}
+
+	// B's source file must still exist and be unchanged.
+	bContent, err := os.ReadFile(srcB)
+	if err != nil {
+		t.Fatalf("read B source: %v", err)
+	}
+	if string(bContent) != "content B - totally different" {
+		t.Errorf("B source was modified: %q", bContent)
+	}
+
+	// Target file's content must still be A's, not B's.
+	aContent, err := os.ReadFile(targetA)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(aContent) != "content A" {
+		t.Errorf("target was overwritten by B: %q", aContent)
+	}
+}
+
+// TestOrganizeBook_CollisionHookFires verifies the collision hook is
+// called with the current book's ID and the occupant's path when the
+// target-exists branch fires. This is the wiring the server relies on
+// to create a pending dedup candidate for user resolution.
+func TestOrganizeBook_CollisionHookFires(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "source")
+	dstDir := filepath.Join(tmpDir, "output")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+
+	srcA := filepath.Join(srcDir, "a.m4b")
+	srcB := filepath.Join(srcDir, "b.m4b")
+	if err := os.WriteFile(srcA, []byte("A"), 0644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := os.WriteFile(srcB, []byte("B"), 0644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	cfg := &config.Config{
+		RootDir:              dstDir,
+		FolderNamingPattern:  "{author}",
+		FileNamingPattern:    "{title}",
+		OrganizationStrategy: "copy",
+	}
+	org := NewOrganizer(cfg)
+
+	type call struct{ bookID, occupant string }
+	var calls []call
+	prev := OrganizeCollisionHook
+	OrganizeCollisionHook = func(bookID, occupant string) {
+		calls = append(calls, call{bookID, occupant})
+	}
+	t.Cleanup(func() { OrganizeCollisionHook = prev })
+
+	bookA := &database.Book{
+		ID: "book-a", Title: "Foundation", FilePath: srcA,
+		Author: &database.Author{Name: "Asimov"},
+	}
+	bookB := &database.Book{
+		ID: "book-b", Title: "Foundation", FilePath: srcB,
+		Author: &database.Author{Name: "Asimov"},
+	}
+
+	if _, _, err := org.OrganizeBook(bookA); err != nil {
+		t.Fatalf("OrganizeBook(A): %v", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("hook fired for successful organize: %v", calls)
+	}
+
+	if _, _, err := org.OrganizeBook(bookB); err == nil {
+		t.Fatal("expected error for B")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 hook call, got %d: %v", len(calls), calls)
+	}
+	if calls[0].bookID != "book-b" {
+		t.Errorf("hook bookID = %q, want book-b", calls[0].bookID)
+	}
+	if !strings.HasSuffix(calls[0].occupant, "Foundation.m4b") {
+		t.Errorf("hook occupant = %q, want ...Foundation.m4b", calls[0].occupant)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.158.0
+// version: 1.159.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -883,6 +883,51 @@ func NewServer() *Server {
 					}()
 				}
 				log.Println("[INFO] Dedup-on-import hook wired")
+
+				// Wire the organize collision hook. When OrganizeBook
+				// hits ErrTargetOccupied (two books with identical
+				// metadata producing the same target path, or a re-organize
+				// of a content-duplicate), this hook creates a pending
+				// "exact" dedup candidate between the current book and the
+				// book that already owns the target. Without it, the
+				// collision would surface only as an opaque error and the
+				// user would have no trail to follow.
+				//
+				// Runs inside a bgWG-tracked goroutine so it doesn't block
+				// the organize caller and shutdown drains it cleanly.
+				organizer.OrganizeCollisionHook = func(currentBookID, occupantPath string) {
+					if server.embeddingStore == nil || database.GlobalStore == nil {
+						return
+					}
+					server.bgWG.Add(1)
+					go func() {
+						defer server.bgWG.Done()
+						occupant, err := database.GlobalStore.GetBookByFilePath(occupantPath)
+						if err != nil {
+							log.Printf("[WARN] organize-collision hook: lookup %s failed: %v", occupantPath, err)
+							return
+						}
+						if occupant == nil || occupant.ID == currentBookID {
+							return
+						}
+						sim := 1.0
+						if err := server.embeddingStore.UpsertCandidate(database.DedupCandidate{
+							EntityType: "book",
+							EntityAID:  currentBookID,
+							EntityBID:  occupant.ID,
+							Layer:      "exact",
+							Similarity: &sim,
+							Status:     "pending",
+						}); err != nil {
+							log.Printf("[WARN] organize-collision hook: upsert candidate %s/%s failed: %v",
+								currentBookID, occupant.ID, err)
+							return
+						}
+						log.Printf("[INFO] organize-collision: created dedup candidate between %s and %s (occupant of %s)",
+							currentBookID, occupant.ID, occupantPath)
+					}()
+				}
+				log.Println("[INFO] Organize collision hook wired")
 
 				// Wire the embedding-based metadata candidate scorer. The
 				// scorer reuses the same embedClient + embeddingStore as the


### PR DESCRIPTION
## Summary

Organizing two books with identical metadata used to silently corrupt the DB — the second organize would no-op but the caller still wrote a new \"organized\" row pointing at the FIRST book's file. Two rows, one file on disk, and the second book's audio was effectively lost from the organized view.

This PR:

1. **\`OrganizeBook\` returns \`ErrTargetOccupied\`** when the target exists with a different inode. Callers detect it with \`errors.Is\`.
2. **Re-organize safety net:** if the target inode differs but the DB says the current book owns the target, it's a re-organize where the caller didn't refresh \`book.FilePath\`. Treat as no-op.
3. **Hash-dedup check runs first** so true content-duplicates return a proper error instead of getting masked by the target-exists branch.
4. **\`OrganizeCollisionHook\`** package-level hook — server wires it to upsert a pending \`exact\` dedup candidate between the current book and the occupant. Collisions surface in the dedup tab instead of becoming invisible orphans.

## The old broken sequence

\`\`\`
1. Book A organized → /organized/Asimov/Foundation.m4b holds A's audio
2. OrganizeBook(B) → target exists, SameFile=false → return (target, \"\", nil)
3. createOrganizedVersion(B) inserts new row with FilePath=target
4. /organized/Asimov/Foundation.m4b has TWO DB rows pointing at it
5. Playing \"organized B\" row plays A's audio. No error anywhere.
\`\`\`

## New sequence

\`\`\`
1. Book A organized → ok
2. OrganizeBook(B) → target exists, not owned by B → ErrTargetOccupied
3. Hook fires → upserts exact dedup candidate between A and B
4. Caller sees error, surfaces \"target path occupied\" to user
5. User resolves in dedup tab (merge or dismiss)
\`\`\`

## Test plan

- [x] \`TestOrganizeBook_TargetOccupiedByDifferentFile\` — regression test for the silent no-op
- [x] \`TestOrganizeBook_CollisionHookFires\` — hook fires once with correct arguments
- [x] \`TestOrganizeBook_Copy\` updated to reflect real production flow (book.FilePath refreshed after first organize)
- [ ] Apply metadata + organize on two matching books on prod, verify second errors out and a pending candidate appears in the dedup tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)