### PR TITLE
fix(dedup): stop deleting merged rows on rescan + move banner to snackbar

### DIFF
--- a/internal/server/dedup_engine.go
+++ b/internal/server/dedup_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 
 package server
@@ -854,8 +854,16 @@ func (de *DedupEngine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 			rewritten, deleted)
 	}
 
+	// CRITICAL: Only purge PENDING candidates. Merged and dismissed rows
+	// are historical records the user explicitly wants to keep — they're
+	// what populates the Merged / Dismissed tabs and lets the user see
+	// what they've already actioned. Without this filter, every rescan
+	// would delete every previously-merged candidate (because merged
+	// books share a version_group_id, which is one of the stale-rule
+	// conditions below), making the Merged tab useless.
 	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
 		EntityType: "book",
+		Status:     "pending",
 		Limit:      100000,
 	})
 	if err != nil {

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.12.0
+// version: 3.13.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -10,6 +10,7 @@ import {
   Paper,
   Button,
   Alert,
+  Snackbar,
   Chip,
   CircularProgress,
   Divider,
@@ -2948,12 +2949,30 @@ function EmbeddingDedupTab() {
         >
           Merge Page ({clusters.filter((c) => c.hasPending).length})
         </Button>
-        {scanMsg && (
-          <Alert severity="info" sx={{ py: 0, flexGrow: 1 }} onClose={() => setScanMsg(null)}>
-            {scanMsg}
-          </Alert>
-        )}
       </Stack>
+
+      {/* Scan/merge status lives in a bottom-right Snackbar instead of
+          shoving an inline Alert into the toolbar. The inline version
+          squeezed the toolbar and made the whole row look busted when
+          a status fired. */}
+      <Snackbar
+        open={scanMsg !== null}
+        autoHideDuration={6000}
+        onClose={(_, reason) => {
+          if (reason === 'clickaway') return;
+          setScanMsg(null);
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert
+          severity="info"
+          variant="filled"
+          onClose={() => setScanMsg(null)}
+          sx={{ minWidth: 280 }}
+        >
+          {scanMsg}
+        </Alert>
+      </Snackbar>
 
       {/* Bulk merge confirmation dialog */}
       <Dialog open={bulkMergeOpen} onClose={() => setBulkMergeOpen(false)}>


### PR DESCRIPTION
## Summary

Three fixes bundled — all in response to \"why does my Merged tab keep emptying out after a rescan\".

1. **Root cause — PurgeStaleCandidates was nuking merged rows.** The function iterated every candidate regardless of status and deleted any where both sides shared a \`version_group_id\`. But merged books *always* share a version group (that's what merge means), so the merged candidate row itself matched the stale rule and got deleted on the next rescan. The user's merge history evaporated every time they clicked Re-scan. Fix: filter to \`Status: \"pending\"\` so only pending rows are candidates for purge.
2. **Scan status banner** moved from inline-in-the-toolbar to a bottom-right Snackbar (6s autoHide, filled variant). The inline Alert was shoving the toolbar around whenever a status fired.
3. **Tab counts verified present.** The PR #220 counts were correctly wired — the missing counts in your screenshot were browser-cache staleness against the previous deploy. This rebuild busts the cache.

## What merging actually does (answering the Q)

- \`MergeService.MergeBooks\` creates (or reuses) a \`version_group_id\` and stamps every merged book with it
- Picks one book as \`is_primary_version=true\` based on the \`bookIsBetter\` score (organized-path > curated-metadata > M4B > higher bitrate > larger file)
- Reassigns external IDs (iTunes PID, OL, Hardcover, Google Books) from non-primary books to the primary
- **No files are deleted or moved.** Every book's audio stays where it is on disk.
- **No book records are deleted.** The non-primary books stay in the DB, just marked as non-primary siblings of the version group.
- In the Library view, a version group shows up as one entry (the primary) with a badge saying how many versions exist; drilling in shows all siblings.

The dedup \"merge\" is purely a DB/relationship operation. The Merged tab is the *history* of which candidates you've actioned — now it'll actually persist.

## Test plan

- [ ] Merge a candidate, click Re-scan, verify the merged row is still in the Merged tab afterward
- [ ] Verify the bottom-right Snackbar shows scan status, autohides after 6s, can be dismissed
- [ ] Verify tab labels show counts: Pending (N) / Merged (N) / Dismissed (N) / All (N)
- [ ] Hard-refresh the page to bust any browser cache before testing counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)