### PR TITLE
docs: prioritized backlog from 2026-04-10 dedup session

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,0 +1,905 @@
+<!-- file: docs/backlog-2026-04-10.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
+<!-- last-edited: 2026-04-10 -->
+
+# Backlog — 2026-04-10
+
+Generated after a long session landing the embedding dedup stack, cluster
+UI, shutdown fixes, and collision handling. This is a brain-dump of
+everything that surfaced along the way plus ideas for what should come
+next, ranked within category and with rationale per item.
+
+## Top 10 (do these first)
+
+Quick scan for tomorrow — the highest-value items across all categories.
+
+| # | Item | Category | Why | Effort |
+|---|---|---|---|---|
+| 1 | **Library centralization / `.versions/` layout** | Architecture | Currently only iTunes-ghost entries are outside the managed library. Every other "duplicate" sits wherever it was imported, and merging doesn't move files. Centralizing all non-iTunes content under one tree with deluge path updates is the foundation for everything else. | L |
+| 2 | **Dedup scan as a real Operation** | Bug/UX | Clicking Re-scan fires a goroutine with zero UI visibility — no progress bar, no completion message, no ability to see what it's doing. Users have no idea if it finished or how long it'll take. Wrap it in the operations queue. | S |
+| 3 | **Activity log compact "Everything (now)" bug** | Bug | Choosing "Now" returns 0 entries even when thousands of uncompacted debug rows exist. Earlier investigation found the SQL path returns 0 but direct queries show rows — root cause not identified. | S |
+| 4 | **`book_alternative_titles` schema + CRUD** | Feature | Was specced earlier in the session. Would let the dedup engine catch manga romaji vs English, subtitle variants, and other variants the normalizer can't auto-derive. Now that import runs dedup, adding alt titles compounds the win. | M |
+| 5 | **Duration-based dedup similarity signal** | Feature | Two audio files with the same title + author + ±2% duration are almost certainly the same book. Cheap to compute, strong signal, would let the exact layer auto-merge confidently. | S |
+| 6 | **Import-time collision preview** | UX | The organize endpoint now returns ErrTargetOccupied properly, but the scanner + auto-organize flow just logs it. Surfacing "N books would collide with existing content" in a pre-scan dry-run dialog would prevent surprises. | M |
+| 7 | **Side-by-side metadata diff in cluster card** | UX | Cluster card shows title/author/path. Doesn't show ISBN, duration, bitrate, narrator, year. Those are exactly the fields that tell "same book, different release" apart from "different book, same title". | M |
+| 8 | **Pebble → PostgreSQL migration (investigate)** | Architecture | The Pebble v2.1.4 shutdown panic is a known library bug we're defensive-coding around. Memory already recommends PostgreSQL. This is a multi-week project but the payoff is stable shutdowns, real transactions, and downstream access to CockroachDB/YugabyteDB if we ever want that. | XL |
+| 9 | **LLM verdict auto-apply above confidence threshold** | Feature | AI Review annotates ambiguous pairs but never acts. A "if LLM says `[high] duplicate`, auto-mark as mergeable" setting would let trusted users pipeline the ambiguous band without clicking through each one. Opt-in via config. | S |
+| 10 | **Bulk organize undo via operation_changes** | Feature | `operation_changes` table exists and records field-level diffs. No UI to roll back. "Undo last organize" would save users from disasters. | M |
+
+Effort key: **S** = <1 day, **M** = 1-3 days, **L** = 1-2 weeks,
+**XL** = multi-week project.
+
+---
+
+## 1. Dedup & Library Integrity
+
+Things that directly improve the dedup system I just spent the session
+on. Ranked by impact.
+
+### 1.1 `book_alternative_titles` schema + engine integration (**M**)
+
+**What:** New `book_alternative_titles` table (book_id, title, source,
+language). Store methods for add/list/remove. Book struct grows a
+transient `AlternativeTitles []string` field populated on demand. Dedup
+Layer 1 iterates every alt title on both sides when running
+`checkExactTitle`. Auto-populate from `&`/`and` variants on book
+create/update; manual entry via a new REST endpoint and a simple
+BookDetail panel.
+
+**Why:** `normalizeTitle` now handles `&` ↔ `and`, punctuation, and
+leading articles, which catches Foundation-and-Empire-class cases. But
+it can't catch:
+
+- Manga/light novel romaji vs translated English
+- Subtitle reordering ("Foo: The Bar" vs "The Bar: A Foo Novel")
+- Rebrands ("The Darkest Part of the Forest" vs "Foxheart")
+- Translations where the translator changed the title outright
+
+These are real in the user's library and the embedding layer is too
+fuzzy to reliably catch them — it produces false positives alongside
+the true matches. Explicit user-curated alt titles give the exact layer
+a second chance at every comparison.
+
+**Dependencies:** None. Schema migration, store methods, engine tweak.
+
+**Risks:** Small. Auto-populate logic needs to avoid infinite loops
+(add "Foundation and Empire" on create → scan sees it, adds "Foundation
+& Empire" back → ...). One-shot on create is fine.
+
+---
+
+### 1.2 Duration-based similarity signal (**S**)
+
+**What:** Add a `DurationDelta` check to Layer 1. Two books with the
+same normalized title, same author, and duration within ±2% (configurable)
+are near-certain duplicates — auto-merge or flag as exact candidate.
+Cheap to compute from existing `duration_seconds` column; no API calls,
+no new dependencies.
+
+**Why:** Duration is one of the strongest physical signals that two
+audio files represent the same content. Bitrate, format, and even file
+size can vary wildly between rips of the same book, but duration
+shouldn't drift more than a couple percent unless chapters were added
+or removed. Currently the engine doesn't use duration at all, even
+though every book has it.
+
+**Dependencies:** None.
+
+**Risks:** Abridged vs unabridged editions legitimately differ in
+duration. The rule should ONLY upgrade confidence, never downgrade —
+if titles match but duration differs 20%, still surface as a candidate
+but mark "abridged?" in the reason.
+
+---
+
+### 1.3 Dedup scan as a real Operation (**S**)
+
+**What:** Currently `triggerDedupScan` fires `go func() { FullScan }`
+and immediately returns `{"status": "started"}`. No progress, no
+cancel, no row in `operations`. Wrap it in the existing operations
+queue so it shows up in the Operations panel like every other
+long-running task, with live progress reporting and a kill switch.
+
+**Why:** Users (the current one, verbatim) have no idea if the scan is
+running, how far along it is, or whether it finished. Clicking Re-scan
+is a black box. The operations queue already handles this for scans,
+organize, metadata fetch, etc. — dedup is the odd one out.
+
+**Dependencies:** None. Touches `dedup_handlers.go`,
+`FullScan` to accept a `ProgressReporter`.
+
+**Risks:** None — purely wrapping existing logic in a cancelable
+context + progress callback.
+
+---
+
+### 1.4 LLM verdict auto-apply (**S**)
+
+**What:** New config flag `DedupLLMAutoMergeHighConfidence = false`
+(default). When `true`, AI Review's `[high] duplicate` verdicts
+auto-update the candidate to `layer=llm, status=merged` and actually
+fire `MergeBooks` for the pair. `[low]` and `[medium]` stay pending for
+human review. `not_duplicate` high-confidence auto-dismisses.
+
+**Why:** AI Review is currently advisory-only — it annotates but never
+acts. For users (me) who trust gpt-5-mini's `[high]` confidence calls,
+that's extra clicking for no judgement gain. Making it opt-in means
+people who don't trust it can keep the old flow.
+
+**Dependencies:** None.
+
+**Risks:** Medium. A false-positive `[high]` verdict merges the wrong
+books silently. Mitigations: keep it opt-in, log every auto-merge to
+the activity log with "llm:[high]" source, surface a "recent AI
+auto-merges" pane for quick undo, and require `operation_changes`
+to be written so bulk undo works.
+
+---
+
+### 1.5 Side-by-side metadata diff in cluster card (**M**)
+
+**What:** Expand the cluster card to show a compact table of the
+fields that matter for "is this really the same book": ISBN, duration,
+bitrate, narrator, publisher, year, language, file hash. Color cells
+red when they differ, green when they match. Put this behind a "show
+details" toggle so the default view stays compact.
+
+**Why:** The current card shows title, author, truncated file path. If
+both sides say "Foundation" by "Asimov" at close-looking paths, there's
+no way to tell them apart without clicking through to each book's
+detail page. The fields that distinguish versions (narrator, duration,
+publisher, year) are right there in the DB — just not rendered.
+
+**Dependencies:** None. Pure frontend.
+
+**Risks:** Low. Could bloat the card when expanded.
+
+---
+
+### 1.6 Import-time collision preview (**M**)
+
+**What:** Before an import or scan commits, run a dry-run against the
+organized path tree. Surface a dialog: "N books would collide with
+existing content — resolve before continuing?" with a list and
+per-row "merge" / "skip" / "rename" / "force" actions.
+
+**Why:** Organize now returns `ErrTargetOccupied` cleanly (PR #218),
+but the scanner just logs the error and the user has to dig into logs
+or the dedup tab to find out what happened. A preview gives them a
+chance to resolve up front instead of retroactively.
+
+**Dependencies:** `GenerateTargetPath` already exists for dry runs.
+Needs a batch variant that checks every source file against the current
+library state without committing.
+
+**Risks:** Small. The check is read-only.
+
+---
+
+### 1.7 Per-side "merge into this" quick action (**S**)
+
+**What:** In addition to the existing cluster-level merge (auto-picks
+primary via `bookIsBetter`) and per-side × remove button, add a "★"
+button that says "merge the others into this one — keep this as
+primary". Currently the only way to override the auto-pick is to use
+the per-candidate merge endpoint which targets by candidate ID, not
+book ID.
+
+**Why:** `bookIsBetter` is right most of the time but not always. When
+the user has already curated book B's metadata but book A happens to
+have a slightly better format, the curation tiebreaker helps — but
+sometimes the user just wants direct control.
+
+**Dependencies:** `MergeBooks` already accepts an explicit
+`primaryID`. New endpoint + UI.
+
+**Risks:** Low.
+
+---
+
+### 1.8 Smarter "split cluster" with edge preview (**M**)
+
+**What:** When the user wants to split a 5-way cluster into two
+sub-clusters (e.g., "these 3 are the same book, those 2 are a
+different book"), the current × button can only remove ONE book at a
+time. A "split" mode would let the user select a subset and separate
+them into their own cluster with one action.
+
+**Why:** Multi-book series often produce clusters like:
+`Foundation, Foundation, Foundation II, Foundation II, Foundation III`.
+Removing each wrong book individually is tedious. Split mode is one
+click per split.
+
+**Dependencies:** None. New endpoint + UI state.
+
+**Risks:** Medium. Clustering semantics get fuzzy — splitting by
+"select these, remove edges between the two sets" works but is
+harder to explain than "this one is wrong, × it".
+
+---
+
+### 1.9 Series-aware bulk merge (**M**)
+
+**What:** "Merge every cluster in this series" action. Filters
+clusters where every book belongs to the same series, then merges
+them in one click. Useful after rescanning a full collection and
+seeing Book 1 as a cluster, Book 2 as a cluster, etc. — all
+independently confirmed but needing one-click action each.
+
+**Why:** Right now Merge Filtered is all-or-nothing. Merge Page helps
+but series-scoped is the most natural scope for a re-rip pass.
+
+**Dependencies:** None.
+
+**Risks:** Low.
+
+---
+
+### 1.10 Export dedup state (**S**)
+
+**What:** "Export" button that downloads the current filtered
+candidate view as CSV or JSON. Columns: candidate_id, status, layer,
+similarity, entity_a_id, entity_a_title, entity_b_id, entity_b_title,
+llm_verdict, llm_reason.
+
+**Why:** Users sometimes want to audit the dedup state outside the
+UI, or review it on another machine, or drop it into a spreadsheet
+for manual sorting. Small feature, zero-risk, saves a bunch of
+one-off grunt work.
+
+**Dependencies:** None.
+
+**Risks:** None.
+
+---
+
+## 2. Known Bugs
+
+Things we already know are broken but haven't fixed.
+
+### 2.1 Activity log compact "Everything (now)" returns 0 (**S**)
+
+**Symptom:** User selects "Now" (older_than_days=0) in the Compact
+Activity Log dialog and the server returns `{compacted: 0, days: 0}`
+even though thousands of uncompacted debug-tier entries exist for the
+current day.
+
+**Evidence:** Prior investigation (from context summary) found the
+SQL query `WHERE tier IN ('change','debug') AND compacted=0 AND
+timestamp < ?` should work, but the handler computes `cutoff =
+time.Now()` when days=0 and nothing matches. Manually querying the
+activity DB showed 4768 uncompacted debug entries for today.
+
+**Hypothesis:** The `timestamp < ?` comparison is using microseconds
+and `time.Now()` is slightly ahead of the most recent write, so the
+"now" cutoff excludes everything written in the same millisecond.
+Or the SQL prepared statement is binding `cutoff` as a string and
+SQLite's comparison is lexical.
+
+**Fix direction:** Instrument the handler, log the exact cutoff
+value passed to the query, run the query manually against the live DB.
+Root-cause before patching.
+
+---
+
+### 2.2 Dedup scan isn't tracked in Operations (**S**)
+
+Listed as item 1.3 above. Same bug from a different angle.
+
+---
+
+### 2.3 Dedup scan has no completion messages (**S**)
+
+**Symptom:** User clicks Re-scan, gets a "started" toast (now a
+Snackbar after PR #221), and then... nothing. No "scan complete",
+no "found N new candidates", no way to know it finished other than
+seeing the candidate count change eventually.
+
+**Fix direction:** Either (a) have the goroutine broadcast a
+realtime event when FullScan returns, or (b) fold into item 2.2 —
+if the scan is an operation, operations already emit completion
+events via the realtime hub.
+
+---
+
+### 2.4 Pebble "element has outstanding references" root cause (**M**)
+
+**Symptom:** Fixed at the shutdown level (PR #214) by tracking
+background goroutines in a WaitGroup and canceling before
+`db.Close()`. But the root cause in Pebble v2.1.4 is unknown — it's
+a ref-count bug in `genericcache/shard.go:385` that triggers when
+a FileCache element has outstanding references at the moment Close
+fires. We work around it; we don't understand it.
+
+**Why it matters:** The workaround is correct but fragile. If any
+new goroutine forgets to register with `bgWG`, the panic comes back.
+A real fix would be: upgrade Pebble to a version with the bug fixed,
+OR find a Pebble option that makes Close wait for outstanding refs.
+
+**Fix direction:**
+1. Check if a newer Pebble release (v2.2.x or v3.x) fixed the
+   specific ref-count issue — scan the changelog.
+2. If yes, upgrade + remove the `bgCtx`/`bgWG` workaround.
+3. If no, file an upstream issue with a minimal repro.
+
+---
+
+### 2.5 Directory organize has no cleanup on partial failure (**S**)
+
+**Symptom:** In `createOrganizedVersion`, if `CreateBook` fails for a
+directory-based (multi-file) book, the files have already been moved
+to the target directory but the new DB row was never created. The
+single-file path has `os.Remove(newPath)` as cleanup; the directory
+path has no equivalent `os.RemoveAll`.
+
+**Consequence:** An orphan directory at the organized path with no DB
+row pointing at it. Next scan will either pick it up (creating a
+duplicate row) or ignore it (if the scan path doesn't cover the org
+output).
+
+**Fix direction:** Add `os.RemoveAll(newPath)` for the directory case,
+gated on "the new path is under `RootDir`" as a safety check. Or
+reflink-first so the source files still exist and the cleanup is
+lossless.
+
+---
+
+### 2.6 Scanner may double-count iTunes path + organized path as separate books (**M**)
+
+**Symptom:** `Foundation & Empire` has both `/mnt/.../itunes/iTunes
+Media/.../Foundation & Empire.m4b` AND
+`/mnt/.../audiobook-organizer/Isaac Asimov/Foundation & Empire/Foundation
+& Empire.m4b` as distinct Book rows. The iTunes one was imported via
+iTunes sync, the organized one via a scan of the library.
+
+**Root cause:** `GetBookByFilePath` is keyed on exact path string, so
+the same file content at two paths gets two rows. External ID mapping
+links them but `book.file_path` is still different per row.
+
+**Fix direction:** During iTunes sync, if the file hash matches an
+existing organized book, mark the iTunes record as a "reference" that
+points to the organized book's row instead of creating a parallel row.
+Or: rely on the centralization project (item A) to eliminate the
+duplication entirely.
+
+---
+
+### 2.7 `GetAllBooks` is O(n²) when called in a loop (**S**)
+
+**Symptom:** `DedupEngine.getAllBooks` calls `bookStore.GetAllBooks(500,
+offset)` in a loop. Each call opens a new Pebble iterator and skips
+`offset` entries before yielding results. For 24K books × 48 batches
+× 24K iterator reads per batch = ~30M iterator ops per full-library
+scan.
+
+**Fix direction:** Return a channel or callback-based iterator that
+reads once and streams results. Or: expose `ListBooksStream` that
+opens one iterator and yields pages cooperatively.
+
+**Impact:** Scans take longer than they should. Not catastrophic but
+wastes 10-30 seconds on every FullScan.
+
+---
+
+### 2.8 Auto-scan file watcher only watches one import path (**S**)
+
+**Symptom:** `server.go:1305` starts the watcher against
+`watchPaths[0]` — first enabled import path only. If the user has
+multiple import paths, only the first gets live auto-scan.
+
+**Fix direction:** Loop over `watchPaths` and start one watcher per
+path, shutdown them all cleanly.
+
+---
+
+## 3. Features
+
+### 3.1 Library centralization / `.versions/` layout (**L**)
+
+**What:** Full design is already stashed in
+`project_centralization_backlog.md` (user's memory). Short version:
+
+- Primary version at the natural path (`Author/Book/Book.m4b`)
+- Alt versions under `Author/Book/.versions/{version-id}/`
+- Manifest in `.versions/versions.json` tracks per-version metadata
+  (format, bitrate, source, torrent_hash, deluge_path, sha256)
+- Reflinks on ZFS for O(1) primary swaps
+- Deluge integration calls `move_storage` when a seeded torrent
+  swaps position between primary and `.versions/`
+- Purged versions keep their fingerprints forever so re-downloading
+  a previously-deleted version can be detected and paused for
+  manual approval
+
+**Why:** The biggest remaining gap in the dedup workflow. Every
+other fix we've shipped assumes "the duplicate file exists somewhere,
+we just need to link it to the right book row". Centralization is
+what makes that physically true — every non-iTunes version lives
+under the managed tree, every primary swap is a reflink rename, and
+the deluge integration keeps torrents seeding from their new location.
+
+**Dependencies:** Brainstorming session first (per the memory file's
+"open questions"). Then schema migration for versions table, merge
+service refactor, file I/O wrapper, deluge integration, migration
+script for the big-bang move, UI.
+
+**Risks:** High complexity. Touches dedup, merge, file I/O, torrent
+client, UI. Worth it because every other feature becomes cleaner once
+this is in place.
+
+---
+
+### 3.2 Bulk organize undo via operation_changes (**M**)
+
+**What:** `operation_changes` already records field-level diffs for
+every organize operation. Add a "Recent Operations" panel with an
+"Undo" button that reverses every change in an operation (reassign
+paths, restore old field values). Bounded by a time window so you
+can't undo something from 3 months ago.
+
+**Why:** Bulk organize is irreversible right now. A single bad
+metadata fetch followed by organize means hundreds of files moved to
+wrong paths. "Undo last organize" is the escape hatch.
+
+**Dependencies:** `operation_changes` table (exists). File I/O needs
+to know how to move files BACK (reflink makes this cheap on ZFS).
+
+**Risks:** Medium. Files may have been edited since; the undo needs
+to detect "current state doesn't match the OldValue we recorded" and
+refuse to undo that row.
+
+---
+
+### 3.3 Bulk edit metadata across selected books (**S**)
+
+**What:** In the library view, multi-select books, click "Edit",
+set fields once, apply to all selected. Currently you edit one at a
+time.
+
+**Why:** Standard library-management workflow. Saves hours when
+fixing batch mistakes (wrong narrator on a whole series, wrong
+publisher).
+
+**Dependencies:** None. API endpoint exists
+(`/api/v1/audiobooks/batch-operations`), UI doesn't expose it.
+
+**Risks:** None.
+
+---
+
+### 3.4 Smart playlists (**M**)
+
+**What:** Playlists generated by query rather than explicit membership.
+"All unread books by Brandon Sanderson in the Stormlight Archive
+series, ordered by series sequence" → dynamic playlist that updates
+as you add/read books.
+
+**Why:** The static playlist table already exists. Smart playlists
+are how people actually browse large libraries.
+
+**Dependencies:** Saved-search primitive (doesn't exist). Playlist
+rendering that re-runs the query each time it's viewed.
+
+**Risks:** Query complexity, performance on large libraries.
+
+---
+
+### 3.5 Cover art browse/restore UI (**S**)
+
+**What:** Cover history is already deduped to
+`covers/dedup/{hash}.{ext}` with SHA-256 per image (from memory).
+What doesn't exist: a UI to browse past covers for a book and click
+"restore this one". Currently only the latest cover is visible.
+
+**Why:** Users sometimes prefer the old cover after an auto-update.
+The data is already there; the UI is missing.
+
+**Dependencies:** None. Frontend only.
+
+**Risks:** None.
+
+---
+
+### 3.6 Read/unread tracking beyond iTunes play count (**M**)
+
+**What:** First-class read/unread status on books, independent of
+iTunes sync. Integrates with playback events (if/when we have a
+player), but also manually settable via the UI. Add progress tracking
+(last position, % complete).
+
+**Why:** iTunes play count is a heuristic, not a source of truth.
+Multi-device listening and non-iTunes workflows need a dedicated
+store.
+
+**Dependencies:** New columns or new `reading_progress` table.
+
+**Risks:** Low. Schema migration + UI.
+
+---
+
+### 3.7 Multi-user support (**L**)
+
+**What:** The `users` and `sessions` tables already exist but are
+not really wired up for multi-user workflows. Proper multi-user means
+per-user progress, per-user preferences, per-user dedup state, with
+shared library content but isolated read state.
+
+**Why:** If the library is ever shared (family, friends), single-user
+state is a blocker.
+
+**Dependencies:** Session-aware queries everywhere. Activity log
+needs a user_id dimension. Auth middleware needs to actually
+authenticate.
+
+**Risks:** High. Cuts across every query path.
+
+---
+
+### 3.8 Plex-style HTTP media server API (**L**)
+
+**What:** Expose the library via a standardized API (OPDS? custom?)
+that media players can browse and stream from. Turn
+audiobook-organizer into a backend for Prologue, BookPlayer, Voice,
+etc.
+
+**Why:** Makes the library actually playable on devices without
+syncing to iTunes.
+
+**Dependencies:** Streaming endpoint with range requests (mostly
+exists). Playlist/catalog format selection. Auth for remote devices.
+
+**Risks:** Medium. Lots of protocol details.
+
+---
+
+### 3.9 LLM-based series detection and ordering (**M**)
+
+**What:** When a book has no series metadata, send its title + author
++ description to an LLM that returns `{series, position, confidence}`.
+Apply high-confidence results automatically, surface low-confidence
+ones for review.
+
+**Why:** Books imported from incomplete sources (iTunes especially)
+often have no series info even when the series is obvious to a
+human. Current fallback is manual editing one at a time.
+
+**Dependencies:** LLM parser is already wired for metadata + dedup;
+extending it for series detection reuses the same pipeline.
+
+**Risks:** LLM hallucinations. Needs a confidence gate and easy undo.
+
+---
+
+### 3.10 AI-generated cover art when none exists (**S**)
+
+**What:** When a book has no cover after exhausting Open Library,
+Hardcover, Google Books, and Audible lookups, generate one via DALL-E
+or similar using title + author + genre as the prompt.
+
+**Why:** Filler covers are ugly. AI-generated ones are passable and
+free of licensing concerns.
+
+**Dependencies:** Image generation API (OpenAI image endpoint already
+has an API key).
+
+**Risks:** Cost per image, quality varies, some users hate
+AI-generated art.
+
+---
+
+## 4. Architecture / Future-Proofing
+
+### 4.1 Pebble → PostgreSQL migration (**XL**)
+
+**What:** Replace PebbleDB with PostgreSQL as the primary store.
+Keep SQLite sidecars for activity log and embedding vectors (or
+migrate those too).
+
+**Why:** Memory already marks this as "recommended next". Pebble is
+embedded and fast, but:
+
+- Shutdown panic (item 2.4) is a known Pebble bug we work around
+- No real transactions across multiple keys
+- No ad-hoc queries without writing Go code
+- No out-of-process tooling (pgAdmin, direct psql) for debugging
+- Upgrade to CockroachDB/YugabyteDB for HA is a drop-in if we're
+  already on PostgreSQL
+- Tooling ecosystem is larger (migrations, backups, replication)
+
+**Dependencies:** Migration layer that reads Pebble + writes
+PostgreSQL. Schema translation from the current Pebble key format to
+proper relational tables (most of the SQLite sidecar schema is
+already close to what we want).
+
+**Risks:** High effort. Touches every query path. Must preserve the
+current hash/filepath/external ID indexes. Migration has to be
+idempotent and resumable.
+
+---
+
+### 4.2 Split the monolithic `server.go` (**M**)
+
+**What:** `server.go` is ~10K lines of mixed handlers. Split by
+domain: `handlers_audiobooks.go`, `handlers_organize.go`,
+`handlers_dedup.go` (exists), `handlers_metadata.go`,
+`handlers_system.go`, etc.
+
+**Why:** File is hard to navigate, harder to review, and every commit
+that touches it conflicts with every other commit that touches it.
+
+**Dependencies:** None. Pure refactor.
+
+**Risks:** Rebase hell during the split itself. Low afterward.
+
+---
+
+### 4.3 Move write-back queue to a durable outbox (**M**)
+
+**What:** Currently `GlobalWriteBackBatcher` queues iTunes XML
+write-backs in memory. Crash = queue lost. Move to an `outbox` table
+with claim-and-process semantics.
+
+**Why:** Durability under crash. Also makes the queue inspectable
+via the activity log / operations panel.
+
+**Dependencies:** None.
+
+**Risks:** Low.
+
+---
+
+### 4.4 Replace `database.GlobalStore` package var with DI (**L**)
+
+**What:** Most of the codebase reaches for `database.GlobalStore`
+directly instead of receiving it as a dependency. This makes tests
+harder (every test has to save/restore the global) and couples
+everything to a single instance.
+
+**Why:** Testability, hermetic builds, easier to run two stores
+side by side during migration.
+
+**Dependencies:** None, just grunt work.
+
+**Risks:** Low but massive diff.
+
+---
+
+### 4.5 Property-based tests for dedup engine (**M**)
+
+**What:** `pgregory.net/rapid` is already in use for tag invariants.
+Extend to dedup: property tests for `normalizeTitle` idempotence,
+candidate canonicalization round-trip, cluster union-find
+correctness, merge primary selection stability under permutation.
+
+**Why:** The dedup engine has grown a LOT of edge cases (iTunes
+ghost, non-primary filter, series-number fallback, digit-only-diff
+fallback, empty title guard, canonicalization). Property tests would
+catch regressions that example-based tests can't.
+
+**Dependencies:** None.
+
+**Risks:** None.
+
+---
+
+### 4.6 Chaos tests for the embedding store under shutdown (**M**)
+
+**What:** Random-kill tests that start a FullScan + import + merge
+workload, then SIGTERM the process mid-operation and verify the
+database comes back up cleanly on restart.
+
+**Why:** The Pebble ref-count panic came from this exact scenario
+but we only caught it in production. A chaos harness would catch
+the next equivalent bug before deploy.
+
+**Dependencies:** None. Go has `os.Kill` and the test framework
+can spin up a real server binary.
+
+**Risks:** Slow tests. Gate behind `-tags chaos`.
+
+---
+
+## 5. UX / DX Polish
+
+### 5.1 Search inside the dedup tab (**S**)
+
+**What:** Filter candidates by substring match on title or author,
+live as you type. Server-side filter is better than client-side for
+large candidate counts.
+
+**Why:** With 500+ pending candidates, scrolling for "the Foundation
+ones" is tedious. A search box is the standard affordance.
+
+**Dependencies:** `ListCandidates` needs a search parameter. Needs
+a JOIN to books to search titles.
+
+**Risks:** Low.
+
+---
+
+### 5.2 "Similar books" lookup on BookDetail page (**S**)
+
+**What:** On the BookDetail page, add a "Similar books" panel that
+runs an embedding similarity query against the current book and
+shows the top 10. One-click to create a manual dedup candidate for
+any of them.
+
+**Why:** Helps find duplicates that the scanner missed (similar but
+below the similarity threshold, or not yet embedded).
+
+**Dependencies:** `findSimilarBooks` already exists; just needs a
+REST endpoint and a UI panel.
+
+**Risks:** None.
+
+---
+
+### 5.3 Batch select in library view (**S**)
+
+**What:** Checkbox column in the library table. "Select all on
+page", "select all matching filter", bulk delete / bulk edit /
+bulk merge buttons in the toolbar.
+
+**Why:** Standard library-management workflow. Required to make item
+3.3 (bulk edit) usable.
+
+**Dependencies:** None. Frontend only.
+
+**Risks:** None.
+
+---
+
+### 5.4 Better error messages on organize failures (**S**)
+
+**What:** `internalError` wraps errors generically. The user sees
+"failed to organize book" with the real error buried. Surface the
+actual error class (collision, disk full, permission denied) with
+actionable guidance.
+
+**Why:** Organize errors are the #1 support burden. "It didn't work"
+is the entirety of user feedback when the error message is useless.
+
+**Dependencies:** None. Handler-level polish.
+
+**Risks:** None.
+
+---
+
+### 5.5 Dev mode "seed library" command (**S**)
+
+**What:** `audiobook-organizer seed --count 1000 --with-dupes` creates
+a fake library on disk with N random books, some of which are
+guaranteed duplicates. Useful for testing dedup, organize, search,
+etc. without needing a real library.
+
+**Why:** New developers (including future-me) need a test corpus.
+Currently everyone either uses their own library or nothing.
+
+**Dependencies:** None.
+
+**Risks:** None.
+
+---
+
+### 5.6 Frontend test coverage baseline (**M**)
+
+**What:** Playwright e2e tests exist but are thin. Pick 5 critical
+user flows (dedup merge, library search, organize one book, apply
+metadata, merge cluster) and write thorough e2e for each.
+
+**Why:** Every frontend change currently lands without e2e coverage
+of the feature it touches. Regressions ship and are found by the
+user.
+
+**Dependencies:** None.
+
+**Risks:** Test flakiness in CI.
+
+---
+
+### 5.7 API documentation (**M**)
+
+**What:** Generate OpenAPI spec from the gin routes. Host at
+`/api/docs`. Add example requests/responses.
+
+**Why:** `docs/API.md` is stale. The real API surface has grown to
+hundreds of endpoints; nobody (including me) knows them all.
+OpenAPI generation would bring docs up to date automatically.
+
+**Dependencies:** A gin → OpenAPI generator library, or manual spec.
+
+**Risks:** Generator tools have varying quality.
+
+---
+
+## 6. Integration / Ecosystem
+
+### 6.1 Deluge move_storage integration (**M**)
+
+**What:** Part of the centralization work (item 3.1) but can be built
+ahead of time as a standalone capability. When a book's file path
+changes, update the torrent client's tracking so it keeps seeding from
+the new location without re-hashing.
+
+**Why:** Enables the centralization layout. Also solves the current
+pain point where organizing a seeded book breaks the seed.
+
+**Dependencies:** Deluge JSON-RPC API (already have partial
+integration).
+
+**Risks:** Low. Move-storage is a well-supported deluge operation.
+
+---
+
+### 6.2 Audnexus + Hardcover full integration (**M**)
+
+**What:** Both are partially wired up. Finish the integration: use
+Audnexus for narrator-accurate matching, Hardcover for
+community-curated series info.
+
+**Why:** Open Library is inconsistent, Google Books is shallow.
+Audnexus knows audiobooks specifically; Hardcover has better series
+data than anyone.
+
+**Dependencies:** Existing metadata fetch service.
+
+**Risks:** Low.
+
+---
+
+### 6.3 Tag writeback to iTunes via ITL updates (**M**)
+
+**What:** Already partially exists (GlobalWriteBackBatcher). Finish:
+support multi-field updates, verify ITL integrity after write,
+handle iTunes running vs not running on the Windows host.
+
+**Why:** Users edit metadata in audiobook-organizer but iTunes shows
+stale data unless they manually re-add.
+
+**Dependencies:** Existing ITL parser.
+
+**Risks:** ITL file corruption — needs solid backup/restore flow
+(partially exists).
+
+---
+
+## 7. Out of scope / decide later
+
+Brain-dump of things that came up but probably shouldn't be touched
+soon without more thought.
+
+- **iOS/Android companion app** — scope explosion
+- **WebDAV browse of the library** — niche
+- **RSS/Atom feed of new additions** — niche
+- **Notification system** (Slack/Discord when scan completes) — nice
+  but rabbit hole
+- **Cross-library federation** — architecturally premature
+- **Voice control / Alexa skill** — fun but out of focus
+- **Audio preview in dedup tab** (play first 30 seconds) — nice but
+  requires streaming infra
+- **"Recommended for you"** based on listening history — premature,
+  no listening history store yet
+- **Book recommendation engine** — same
+
+---
+
+## Appendix: How I'd sequence the next month
+
+If I had to pick five things to do in order, starting tomorrow, this
+is the sequence:
+
+1. **#2.1 Activity log compact bug** (half a day, unblocks the
+   activity log UX)
+2. **#1.3 Dedup scan as an Operation** (half a day, stops users
+   wondering if their rescan is running)
+3. **#1.1 `book_alternative_titles`** (2-3 days, compounds the
+   import-time dedup win)
+4. **#1.5 Side-by-side diff in cluster card** (1 day, makes the
+   merge decision actually informed)
+5. **#3.1 Library centralization brainstorming session** (half a
+   day talking + half a day spec writing), then kick off the full
+   implementation plan
+
+That's a week to ten days of work that shores up the dedup stack
+we just built and sets up the centralization project with a real
+design behind it.


### PR DESCRIPTION
Saves a comprehensive ranked backlog to \`docs/backlog-2026-04-10.md\` for review in the morning. Captures everything that came up during the session plus forward-looking ideas, organized into:

1. **Dedup & Library Integrity** (10 items — directly builds on the work we just shipped)
2. **Known Bugs** (8 items — stuff we already know is broken)
3. **Features** (10 items — new capabilities)
4. **Architecture / Future-Proofing** (6 items — longer-term)
5. **UX / DX Polish** (7 items — quality of life)
6. **Integration / Ecosystem** (3 items — deluge, metadata sources)
7. **Out of scope / decide later**

Top 10 ranked across all categories at the top. Each item has what / why / dependencies / risks / effort (S/M/L/XL). Final section suggests a 5-item sequence for the next 1-2 weeks of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)