### PR TITLE
docs(backlog): remove bogus "Pebble known bug" item

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,7 +1,7 @@
 <!-- file: docs/backlog-2026-04-10.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
-<!-- last-edited: 2026-04-10 -->
+<!-- last-edited: 2026-04-11 -->
 
 # Backlog — 2026-04-10
 
@@ -23,7 +23,7 @@ Quick scan for tomorrow — the highest-value items across all categories.
 | 5 | **Duration-based dedup similarity signal** | Feature | Two audio files with the same title + author + ±2% duration are almost certainly the same book. Cheap to compute, strong signal, would let the exact layer auto-merge confidently. | S |
 | 6 | **Import-time collision preview** | UX | The organize endpoint now returns ErrTargetOccupied properly, but the scanner + auto-organize flow just logs it. Surfacing "N books would collide with existing content" in a pre-scan dry-run dialog would prevent surprises. | M |
 | 7 | **Side-by-side metadata diff in cluster card** | UX | Cluster card shows title/author/path. Doesn't show ISBN, duration, bitrate, narrator, year. Those are exactly the fields that tell "same book, different release" apart from "different book, same title". | M |
-| 8 | **Pebble → PostgreSQL migration (investigate)** | Architecture | The Pebble v2.1.4 shutdown panic is a known library bug we're defensive-coding around. Memory already recommends PostgreSQL. This is a multi-week project but the payoff is stable shutdowns, real transactions, and downstream access to CockroachDB/YugabyteDB if we ever want that. | XL |
+| 8 | **Pebble → PostgreSQL migration (investigate)** | Architecture | Memory already recommends PostgreSQL. This is a multi-week project but the payoff is real transactions, ad-hoc SQL, out-of-process tooling (pgAdmin, psql), and a drop-in upgrade path to CockroachDB/YugabyteDB if we ever want HA. | XL |
 | 9 | **LLM verdict auto-apply above confidence threshold** | Feature | AI Review annotates ambiguous pairs but never acts. A "if LLM says `[high] duplicate`, auto-mark as mergeable" setting would let trusted users pipeline the ambiguous band without clicking through each one. Opt-in via config. | S |
 | 10 | **Bulk organize undo via operation_changes** | Feature | `operation_changes` table exists and records field-level diffs. No UI to roll back. "Undo last organize" would save users from disasters. | M |
 
@@ -303,29 +303,7 @@ events via the realtime hub.
 
 ---
 
-### 2.4 Pebble "element has outstanding references" root cause (**M**)
-
-**Symptom:** Fixed at the shutdown level (PR #214) by tracking
-background goroutines in a WaitGroup and canceling before
-`db.Close()`. But the root cause in Pebble v2.1.4 is unknown — it's
-a ref-count bug in `genericcache/shard.go:385` that triggers when
-a FileCache element has outstanding references at the moment Close
-fires. We work around it; we don't understand it.
-
-**Why it matters:** The workaround is correct but fragile. If any
-new goroutine forgets to register with `bgWG`, the panic comes back.
-A real fix would be: upgrade Pebble to a version with the bug fixed,
-OR find a Pebble option that makes Close wait for outstanding refs.
-
-**Fix direction:**
-1. Check if a newer Pebble release (v2.2.x or v3.x) fixed the
-   specific ref-count issue — scan the changelog.
-2. If yes, upgrade + remove the `bgCtx`/`bgWG` workaround.
-3. If no, file an upstream issue with a minimal repro.
-
----
-
-### 2.5 Directory organize has no cleanup on partial failure (**S**)
+### 2.4 Directory organize has no cleanup on partial failure (**S**)
 
 **Symptom:** In `createOrganizedVersion`, if `CreateBook` fails for a
 directory-based (multi-file) book, the files have already been moved
@@ -345,7 +323,7 @@ lossless.
 
 ---
 
-### 2.6 Scanner may double-count iTunes path + organized path as separate books (**M**)
+### 2.5 Scanner may double-count iTunes path + organized path as separate books (**M**)
 
 **Symptom:** `Foundation & Empire` has both `/mnt/.../itunes/iTunes
 Media/.../Foundation & Empire.m4b` AND
@@ -365,7 +343,7 @@ duplication entirely.
 
 ---
 
-### 2.7 `GetAllBooks` is O(n²) when called in a loop (**S**)
+### 2.6 `GetAllBooks` is O(n²) when called in a loop (**S**)
 
 **Symptom:** `DedupEngine.getAllBooks` calls `bookStore.GetAllBooks(500,
 offset)` in a loop. Each call opens a new Pebble iterator and skips
@@ -382,7 +360,7 @@ wastes 10-30 seconds on every FullScan.
 
 ---
 
-### 2.8 Auto-scan file watcher only watches one import path (**S**)
+### 2.7 Auto-scan file watcher only watches one import path (**S**)
 
 **Symptom:** `server.go:1305` starts the watcher against
 `watchPaths[0]` — first enabled import path only. If the user has
@@ -598,13 +576,21 @@ migrate those too).
 **Why:** Memory already marks this as "recommended next". Pebble is
 embedded and fast, but:
 
-- Shutdown panic (item 2.4) is a known Pebble bug we work around
-- No real transactions across multiple keys
-- No ad-hoc queries without writing Go code
+- No real transactions across multiple keys (every multi-step write
+  can partially fail, which is why we keep rewriting idempotent
+  migration loops)
+- No ad-hoc queries without writing Go code — every investigation
+  requires a new CLI subcommand
 - No out-of-process tooling (pgAdmin, direct psql) for debugging
+  a broken prod DB
 - Upgrade to CockroachDB/YugabyteDB for HA is a drop-in if we're
   already on PostgreSQL
-- Tooling ecosystem is larger (migrations, backups, replication)
+- Tooling ecosystem is larger (migrations, backups, replication,
+  point-in-time recovery)
+- Pebble has strict `Close()` contract ("no outstanding references")
+  that we have to manually satisfy with a background-goroutine
+  WaitGroup; a relational DB with a connection pool handles this
+  automatically
 
 **Dependencies:** Migration layer that reads Pebble + writes
 PostgreSQL. Schema translation from the current Pebble key format to


### PR DESCRIPTION
Item 2.4 claimed \`element has outstanding references\` was a known Pebble v2.1.4 bug. I was wrong — it's Pebble's intentional invariant check. The \`Close()\` doc-comment in \`internal/genericcache/shard.go:377\` says verbatim:

> There must not be any outstanding references on any of the values.

Our shutdown ordering was the actual bug. PR #214 correctly fixed it by tracking background goroutines with a WaitGroup and waiting for them before \`CloseStore\`. Just misframed as "working around Pebble."

Changes:
- Deleted item 2.4 entirely (nothing to root-cause upstream)
- Renumbered 2.5–2.8 → 2.4–2.7
- Top-10 entry #8 (Pebble → PostgreSQL) — dropped "known bug" framing
- Section 4.1 — replaced the false bullet with an accurate note about \`Close()\` contract + manual goroutine tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)