### PR TITLE
docs(backlog): add per-workload DB evaluation + soften PG migration

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,5 +1,5 @@
 <!-- file: docs/backlog-2026-04-10.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
 <!-- last-edited: 2026-04-11 -->
 
@@ -567,39 +567,45 @@ AI-generated art.
 
 ## 4. Architecture / Future-Proofing
 
-### 4.1 Pebble → PostgreSQL migration (**XL**)
+### 4.1 PostgreSQL research track (**XL**)
 
-**What:** Replace PebbleDB with PostgreSQL as the primary store.
-Keep SQLite sidecars for activity log and embedding vectors (or
-migrate those too).
+**What:** Investigate whether PostgreSQL should become the primary
+relational store alongside (not instead of) PebbleDB. Memory already
+notes PostgreSQL as "recommended next", but the real decision is
+per-workload, not all-or-nothing — see item 4.7.
 
-**Why:** Memory already marks this as "recommended next". Pebble is
-embedded and fast, but:
+**Why PostgreSQL might earn a slot:**
 
-- No real transactions across multiple keys (every multi-step write
-  can partially fail, which is why we keep rewriting idempotent
-  migration loops)
-- No ad-hoc queries without writing Go code — every investigation
-  requires a new CLI subcommand
-- No out-of-process tooling (pgAdmin, direct psql) for debugging
-  a broken prod DB
-- Upgrade to CockroachDB/YugabyteDB for HA is a drop-in if we're
-  already on PostgreSQL
-- Tooling ecosystem is larger (migrations, backups, replication,
-  point-in-time recovery)
-- Pebble has strict `Close()` contract ("no outstanding references")
-  that we have to manually satisfy with a background-goroutine
-  WaitGroup; a relational DB with a connection pool handles this
-  automatically
+- Real multi-key transactions. Pebble batches give us atomic writes
+  within a single batch but cross-table consistency requires
+  idempotent loop patterns.
+- Ad-hoc queries without writing Go. Every investigation on prod
+  currently requires a new CLI subcommand or a one-shot script.
+- Out-of-process tooling (pgAdmin, psql) when the service is down
+  and we need to poke at the DB directly.
+- Drop-in upgrade path to CockroachDB / YugabyteDB if we ever want
+  HA or geo-replication.
+- Mature ecosystem: point-in-time recovery, logical replication,
+  foreign data wrappers, mature migration tools (goose, atlas).
 
-**Dependencies:** Migration layer that reads Pebble + writes
-PostgreSQL. Schema translation from the current Pebble key format to
-proper relational tables (most of the SQLite sidecar schema is
-already close to what we want).
+**Why we'd keep Pebble:**
 
-**Risks:** High effort. Touches every query path. Must preserve the
-current hash/filepath/external ID indexes. Migration has to be
-idempotent and resumable.
+- Multi-write throughput is excellent — the observed speed on bulk
+  operations (metadata apply, organize, backfill) is a real win we
+  don't want to give up.
+- Zero operational overhead — embedded, no daemon to manage.
+- Key-range scans on book IDs / filepaths / hashes are where Pebble
+  earns its keep.
+
+**Dependencies:** Item 4.7 (per-workload evaluation) comes first.
+Then schema translation for whichever tables move, migration layer
+that reads Pebble + writes PostgreSQL, dual-write bridge during
+cutover.
+
+**Risks:** High effort. A naive "replace Pebble entirely" loses
+the multi-write throughput advantage. Splitting workloads across
+two stores adds operational complexity. Any answer here should come
+out of 4.7 with data, not instinct.
 
 ---
 
@@ -682,6 +688,88 @@ the next equivalent bug before deploy.
 can spin up a real server binary.
 
 **Risks:** Slow tests. Gate behind `-tags chaos`.
+
+---
+
+### 4.7 Per-workload store evaluation: Pebble vs SQLite vs PostgreSQL (**L, far-future research**)
+
+**What:** Treat this as a research + measurement task, not an
+implementation task. Audit every table / key-space we currently
+store and classify each by workload characteristics:
+
+- **Read shape**: point lookup by ID, range scan, full-table iteration,
+  complex join, fuzzy search
+- **Write shape**: high-throughput bulk (scan/organize/backfill),
+  single-row edit, append-only log, blob/vector
+- **Consistency needs**: single-key atomic, cross-key transactional,
+  eventual
+- **Access pattern**: from Go code only, from ad-hoc queries, from
+  out-of-process tools
+- **Durability**: critical, recoverable-from-files, ephemeral cache
+
+Then map each workload to the store that best fits it based on
+measured performance on the current production data, not on
+theoretical strengths. Current split lives in:
+
+- PebbleDB: `books`, `authors`, `series`, `book_files`, filepath
+  indexes, external_id_map, settings, operation_changes,
+  `scan_cache`, etc. — the bulk of the application state
+- SQLite: `activity.db` (activity log + compact), `embeddings.db`
+  (vectors + dedup candidates), `ai_scans.db` (AI scan sessions)
+
+**What the audit should surface:**
+
+- Where PebbleDB is clearly winning (bulk writes during
+  backfill/organize — the observed multi-write throughput is
+  noticeably better than SQLite would be for the same pattern,
+  confirmed empirically during the embedding backfill work)
+- Where SQLite's query flexibility matters more than Pebble's
+  throughput (user-facing filters, activity log timeline queries,
+  dedup candidate filtering by layer/status/similarity — the
+  embedding store is already SQLite for exactly this reason)
+- Where PostgreSQL would actually move the needle vs incremental
+  SQLite improvements (likely: multi-user, operations history,
+  deduplication state that needs transactional consistency across
+  book + candidate + operation tables)
+- Workloads that should stay on Pebble forever (point lookups by
+  book ID, filepath index, external ID map — hot paths where the
+  LSM tree's read speed is the right answer)
+- Workloads that might benefit from a migration but only after
+  measurement (book_files relationships, operation_changes, maybe
+  settings)
+
+**Why:** The top-level instinct "migrate to PostgreSQL" is wrong.
+Pebble's bulk-write performance during organize/scan/backfill is a
+real advantage we would lose. But some workloads in Pebble right now
+would be much happier in a store with joins, ad-hoc SQL, and
+out-of-process tooling. The right answer is probably a two- or
+three-store setup where each workload lives in the store that fits
+it best — and the current SQLite sidecars are already evidence
+that this approach works.
+
+**Output:** A design doc in `docs/superpowers/specs/` that:
+
+1. Lists every table / key-space with classification
+2. Measures current performance on prod data (read latency, write
+   throughput, scan time) for representative queries
+3. Proposes per-workload assignments with justification
+4. Identifies migration order (start with workloads that gain the
+   most with the least risk)
+5. Explicitly marks workloads that should NOT move
+
+**Dependencies:** Requires representative prod-scale test data to
+measure against. Can use a snapshot of the current library for
+benchmarking.
+
+**Risks:** Research projects can spiral. Time-box to ~1 week of
+investigation + 1 week of measurement + 1 week of writing. Don't
+start implementation until the doc is reviewed.
+
+**Why "far-future":** Item 3.1 (centralization) is more immediately
+valuable. Item 4.1 (PostgreSQL migration) depends on this one and
+should not be started without it. Nothing in the user-visible
+dedup/organize flow is blocked by the current store arrangement —
+this is a foundation-strengthening exercise, not a user-facing win.
 
 ---
 


### PR DESCRIPTION
Two changes to section 4 of the backlog:

1. **Reframe 4.1** from \"Pebble → PostgreSQL migration\" to \"PostgreSQL research track\". The old framing assumed full replacement and treated Pebble as pure downside. In reality Pebble's multi-write throughput during organize/scan/backfill is a real, observed win we don't want to give up. Item 4.1 now lists Pebble's strengths alongside Postgres's and explicitly depends on item 4.7.

2. **Add 4.7** — far-future research task to audit every table/keyspace and classify by workload characteristics (read shape, write shape, consistency needs, access pattern, durability). Map each to the best-fit store based on measured prod performance. Output is a design doc, not code. The current SQLite sidecars already prove per-workload store selection works; 4.7 formalizes it.

The gist: don't assume \"migrate to PostgreSQL\" is the answer. Measure first, pick per-workload, keep what's working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)