### PR TITLE
docs(backlog): expand 4.7 with Go-native NoSQL candidates to evaluate

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,5 +1,5 @@
 <!-- file: docs/backlog-2026-04-10.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
 <!-- last-edited: 2026-04-11 -->
 
@@ -738,6 +738,107 @@ theoretical strengths. Current split lives in:
   measurement (book_files relationships, operation_changes, maybe
   settings)
 
+**Other Go-native candidates to evaluate (non-exhaustive):**
+
+The audit should NOT assume Pebble/SQLite/PostgreSQL are the only
+options. Several Go-native stores exist that might be a better fit
+for specific workloads. Goal: don't skip past a meaningful win just
+because it isn't on the current radar. Preference for NoSQL /
+embedded / pure-Go where possible so the operational story stays
+simple.
+
+**Embedded K/V (direct Pebble alternatives):**
+
+- **BadgerDB** — LSM-based like Pebble, pure Go (no CGO), has
+  native TTL support, value-log separation for large blobs,
+  managed transactions. Dgraph uses it in production. The most
+  direct Pebble competitor. Worth a head-to-head benchmark on our
+  bulk-write hot paths.
+- **bbolt** (`go.etcd.io/bbolt`) — B+tree, pure Go, single-writer
+  multi-reader, ACID transactions, memory-mapped. Simpler than
+  Pebble, used by etcd and Consul. Better for read-heavy workloads
+  with occasional writes; worse for concurrent writes or bulk
+  scans. Could fit small reference tables (settings, blocked
+  hashes, import paths) where simplicity beats throughput.
+- **NutsDB** — embedded K/V with native data structures (list,
+  set, sorted set, hash) on top of a log-structured engine. Less
+  mature, smaller community, but richer primitives out of the box.
+- **Pogreb** — log-structured K/V optimized for write-heavy
+  append-only workloads. Interesting for the activity log if we
+  wanted to get away from SQLite.
+
+**Embedded document / NoSQL:**
+
+- **clover** — MongoDB-like embedded document DB in pure Go.
+  JSON-ish documents, indexes, query DSL. Interesting for
+  workloads where schema evolves a lot (operation history,
+  metadata snapshots, the AI scan results store).
+- **genji** — combines SQL + document model, can use Pebble,
+  BoltDB, or Badger as the underlying storage engine. Gives us SQL
+  query flexibility without the operational cost of a relational
+  server. Worth serious investigation for the activity log +
+  dedup candidate workloads currently on SQLite.
+- **tiedot** — pure Go document DB with query language. Older,
+  less maintained, but simple.
+
+**Vector / embedding stores:**
+
+- **chromem-go** — pure Go embedded vector DB, Chroma-compatible
+  query semantics. Native similarity search, metadata filters,
+  collections. Our current embedding store stores vectors as
+  SQLite blobs and computes cosine similarity in Go — chromem-go
+  would replace both with a purpose-built engine. Potentially a
+  big win for the dedup similarity queries, especially as the
+  library grows.
+- **milvus-lite** / **qdrant** — not Go-native, evaluate only if
+  chromem-go proves insufficient.
+
+**Full-text search (complementary, not replacement):**
+
+- **bleve** — Go-native FTS, mature, used by Couchbase. Faceting,
+  highlighting, relevance scoring beyond SQLite FTS5. Could
+  supercharge the library search feature without replacing the
+  primary store. Index is a separate artifact, rebuildable.
+
+**Time-series (for metrics + operation history):**
+
+- **VictoriaMetrics (embedded)** — Go-native TSDB, embeddable via
+  its Go packages. Overkill for current needs but worth a look if
+  we ever want to retain operation-duration / queue-depth /
+  scan-throughput metrics over long windows.
+- **InfluxDB** — not embedded, but Go-native. Heavier.
+
+**Distributed / HA (future-future):**
+
+- **dqlite** (`canonical/go-dqlite`) — SQLite replicated via
+  Raft. Pure Go client bindings. Would give us HA without
+  changing query patterns if we ever need it.
+- **rqlite** — similar but runs as a separate daemon.
+- **CockroachDB** — already noted as a PostgreSQL upgrade path.
+
+**Immutable / audit trail:**
+
+- **immuDB** — cryptographically verifiable immutable DB. Native
+  Go client. Overkill for current needs but interesting if we
+  ever want tamper-evident operation history (legal / compliance
+  angle, probably never relevant here).
+
+**Criteria for inclusion in the actual evaluation:**
+
+1. Pure Go or at least a stable Go client (no mandatory CGO we
+   don't already have)
+2. Actively maintained (commits in the last 12 months, reasonable
+   issue response time)
+3. Production users in the wild (somebody other than us is
+   relying on it)
+4. License compatible with our own (MIT/Apache/BSD preferred)
+5. Benchmarks on at least one of our hot workloads beat the
+   current store by enough to justify the switch OR offer a
+   feature we can't get cheaply from the current stack
+
+Candidates that fail any of the first four should be noted and
+dropped without further measurement.
+
 **Why:** The top-level instinct "migrate to PostgreSQL" is wrong.
 Pebble's bulk-write performance during organize/scan/backfill is a
 real advantage we would lose. But some workloads in Pebble right now
@@ -752,10 +853,18 @@ that this approach works.
 1. Lists every table / key-space with classification
 2. Measures current performance on prod data (read latency, write
    throughput, scan time) for representative queries
-3. Proposes per-workload assignments with justification
-4. Identifies migration order (start with workloads that gain the
+3. For each candidate store in the list above, runs the same
+   benchmarks against a representative snapshot of the library
+   and records results in a comparison table
+4. Proposes per-workload assignments with justification — which
+   store wins which workload and why
+5. Identifies migration order (start with workloads that gain the
    most with the least risk)
-5. Explicitly marks workloads that should NOT move
+6. Explicitly marks workloads that should NOT move
+7. Explicitly marks candidate stores we're NOT going to use, with
+   a one-line reason per rejection (maintenance, maturity,
+   performance, licensing) — so a future reviewer doesn't have to
+   re-evaluate something we already dismissed
 
 **Dependencies:** Requires representative prod-scale test data to
 measure against. Can use a snapshot of the current library for


### PR DESCRIPTION
The original 4.7 only framed the DB evaluation as Pebble vs SQLite vs PostgreSQL. That's too narrow — there are several Go-native NoSQL / document / vector / search databases that could be a better fit for specific workloads, and skipping them means a real opportunity cost.

Added a catalog of candidates grouped by category:

- **Embedded K/V** — BadgerDB, bbolt, NutsDB, Pogreb
- **Embedded document / NoSQL** — clover, genji, tiedot
- **Vector / embedding** — chromem-go (headline candidate for replacing our SQLite embedding store)
- **Full-text search** — bleve (complementary, could supercharge library search)
- **Time-series** — VictoriaMetrics embedded, InfluxDB (speculative)
- **Distributed / HA** — dqlite, rqlite, CockroachDB
- **Immutable / audit** — immuDB

Plus inclusion criteria (pure Go / stable Go client, actively maintained, production users, compatible license, measurable benchmark win) so the evaluation can reject candidates without a full benchmark run.

Output section now requires:
- Per-candidate benchmarks on our hot workloads
- Explicit rejection list with reasons so a future reviewer doesn't re-evaluate what we already dismissed

The point isn't that we'll adopt any of these — it's that we shouldn't skip past a meaningful win just because it wasn't on the current radar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)