### PR TITLE
fix(backups): gate .bak-* creation behind opt-in flag + cleanup endpoint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.33.0
+// version: 1.34.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 package config
@@ -154,6 +154,24 @@ type Config struct {
 	MetadataLLMScoringEnabled bool    `json:"metadata_llm_scoring_enabled"` // default false — opt-in, costs money
 	MetadataLLMRerankEpsilon  float64 `json:"metadata_llm_rerank_epsilon"`  // default 0.01
 	MetadataLLMRerankTopK     int     `json:"metadata_llm_rerank_top_k"`    // default 5
+
+	// Tag-write backup policy.
+	//
+	// When enabled, metadata_fetch_service creates a .bak-<timestamp>
+	// hardlink next to every audio file it's about to write tags to.
+	// Historically this was always on and accumulated tens of thousands
+	// of stale backup files across the library, filling terabytes of
+	// disk. It's also of questionable value — TagLib writes tags
+	// in-place, which means a hardlink snapshot DOES NOT preserve
+	// pre-write content if the writer modifies the inode's data. The
+	// hardlinks only survive as real backups when the writer happens
+	// to use a rename-dance, which is not guaranteed across formats.
+	//
+	// Default is false: don't create the backups at all. Users who
+	// want belt-and-suspenders recovery can turn it on, but they
+	// should pair it with the cleanup-backups maintenance endpoint
+	// to keep the library from growing unbounded.
+	WriteBackupBeforeTagWrite bool `json:"write_backup_before_tag_write"` // default false
 
 	// API limits
 	APIRateLimitPerMinute  int  `json:"api_rate_limit_per_minute"`
@@ -590,6 +608,7 @@ func InitConfig() {
 	AppConfig.MetadataLLMScoringEnabled = false
 	AppConfig.MetadataLLMRerankEpsilon = 0.01
 	AppConfig.MetadataLLMRerankTopK = 5
+	AppConfig.WriteBackupBeforeTagWrite = false
 
 	// Default Open Library dump dir to {RootDir}/openlibrary-dumps if not set
 	if AppConfig.OpenLibraryDumpDir == "" && AppConfig.RootDir != "" {
@@ -897,6 +916,11 @@ func ResetToDefaults() {
 		MetadataLLMScoringEnabled: false,
 		MetadataLLMRerankEpsilon:  0.01,
 		MetadataLLMRerankTopK:     5,
+
+		// Tag-write backup default OFF — old default was always-on and
+		// accumulated tens of thousands of stale backup files across
+		// the library (multi-TB apparent size). Opt-in if you want it.
+		WriteBackupBeforeTagWrite: false,
 
 		// Logging
 		LogLevel:          "info",

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -3522,4 +3522,133 @@ func (s *Server) handleGenerateITLTests(c *gin.Context) {
 		"book_files": len(allBookFiles),
 		"message":    fmt.Sprintf("Generated ITL test suite in %s with %d books and %d book_files", outputDir, len(allBooks), len(allBookFiles)),
 	})
+}
+
+// backupCleanupResult summarizes a cleanup-backups run.
+type backupCleanupResult struct {
+	DryRun       bool     `json:"dry_run"`
+	RootDir      string   `json:"root_dir"`
+	FilesFound   int      `json:"files_found"`
+	FilesRemoved int      `json:"files_removed"`
+	BytesFreed   int64    `json:"bytes_freed"`
+	Errors       []string `json:"errors,omitempty"`
+}
+
+// handleCleanupBackups sweeps the library for stale tag-write backup files
+// and deletes them. Two patterns are matched:
+//
+//  1. `*.backup` and `*.backup.*.backup` — created by the older
+//     fileops.FileOperation.Execute() path, which retains 5 per file but
+//     never garbage-collects when a file stops being written.
+//  2. `*.bak-YYYYMMDD-HHMMSS` — created by the write-back path in
+//     metadata_fetch_service.backupFileBeforeWrite. That function is now
+//     gated on the WriteBackupBeforeTagWrite config flag (default off)
+//     so new backups stop accumulating, but the historical pile (tens of
+//     thousands of files, multi-TB apparent size) still needs sweeping.
+//
+// Protected paths:
+//   - Every directory whose name starts with `.` is skipped via
+//     filepath.SkipDir. This covers the iTunes writeback folder
+//     (.itunes-writeback) and the cover dedup store (.covers).
+//   - The iTunes Media tree outside the managed library is not walked
+//     because we only scan under config.AppConfig.RootDir.
+//
+// Query params:
+//   - dry_run=true  (default) — report what would be removed
+//   - dry_run=false — actually delete
+func (s *Server) handleCleanupBackups(c *gin.Context) {
+	dryRun := c.DefaultQuery("dry_run", "true") == "true"
+	rootDir := config.AppConfig.RootDir
+	if rootDir == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "root_dir is not configured"})
+		return
+	}
+	if _, err := os.Stat(rootDir); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("root_dir not accessible: %v", err)})
+		return
+	}
+
+	result := backupCleanupResult{
+		DryRun:  dryRun,
+		RootDir: rootDir,
+	}
+
+	// Regex matches a timestamped .bak-YYYYMMDD-HHMMSS suffix anywhere in
+	// the filename. Anchored at end-of-string so it doesn't accidentally
+	// eat filenames that happen to contain `.bak-1` earlier.
+	bakTimestampRe := regexp.MustCompile(`\.bak-[0-9]{8}-[0-9]{6}$`)
+
+	walkErr := filepath.Walk(rootDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// Non-fatal, keep going — record and continue.
+			result.Errors = append(result.Errors, fmt.Sprintf("walk %q: %v", path, walkErr))
+			return nil
+		}
+		if info.IsDir() {
+			// Skip any hidden directory. This intentionally catches
+			// .itunes-writeback, .covers, and any other dotfolder a user
+			// might add later — explicit deny-list is fragile, prefix
+			// check is robust. The root itself never starts with `.`
+			// so we don't have to guard against skipping it.
+			if path != rootDir && strings.HasPrefix(filepath.Base(path), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		name := filepath.Base(path)
+		isBackupCopy := strings.HasSuffix(name, ".backup")
+		isBakTimestamp := bakTimestampRe.MatchString(name)
+		if !isBackupCopy && !isBakTimestamp {
+			return nil
+		}
+
+		result.FilesFound++
+		size := info.Size()
+
+		if dryRun {
+			result.BytesFreed += size
+			return nil
+		}
+
+		if removeErr := os.Remove(path); removeErr != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("remove %q: %v", path, removeErr))
+			log.Printf("[WARN] cleanup-backups: failed to remove %q: %v", path, removeErr)
+			return nil
+		}
+		result.FilesRemoved++
+		result.BytesFreed += size
+		return nil
+	})
+	if walkErr != nil {
+		internalError(c, "failed to walk root directory", walkErr)
+		return
+	}
+
+	log.Printf("[INFO] cleanup-backups: dry_run=%v found=%d removed=%d bytes=%d errors=%d",
+		dryRun, result.FilesFound, result.FilesRemoved, result.BytesFreed, len(result.Errors))
+
+	c.JSON(http.StatusOK, gin.H{
+		"dry_run":       result.DryRun,
+		"root_dir":      result.RootDir,
+		"files_found":   result.FilesFound,
+		"files_removed": result.FilesRemoved,
+		"bytes_freed":   result.BytesFreed,
+		"human_freed":   humanizeBytes(result.BytesFreed),
+		"errors":        result.Errors,
+	})
+}
+
+// humanizeBytes turns a byte count into a short "1.23 GB" style string.
+func humanizeBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_fetch_service.go
-// version: 4.46.0
+// version: 4.47.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package server
@@ -2647,9 +2647,30 @@ func audioFilesInDir(dir string) []string {
 	return files
 }
 
-// backupFileBeforeWrite creates a timestamped .bak copy of a file before writing tags.
+// backupFileBeforeWrite creates a timestamped .bak copy of a file before
+// writing tags — IF the WriteBackupBeforeTagWrite config flag is enabled.
+//
+// Default is OFF. Historically this function ran unconditionally on every
+// tag write and used os.Link (hardlink) for "no disk space cost". Two
+// problems with that:
+//
+//  1. Tens of thousands of stale backup files accumulated across the
+//     library (43K+ files, multi-TB apparent size in production) because
+//     nothing ever cleaned them up.
+//  2. Hardlinks don't actually preserve pre-write content when the
+//     writer modifies the inode in place (which TagLib does for some
+//     formats). The "backup" could be a hardlink to the same now-modified
+//     data, providing false safety.
+//
+// The flag is opt-in. Users who turn it on should also run the
+// cleanup-backups maintenance endpoint periodically to keep the library
+// from growing unbounded.
+//
 // Failures are logged but non-fatal — the write-back proceeds regardless.
 func backupFileBeforeWrite(filePath string) {
+	if !config.AppConfig.WriteBackupBeforeTagWrite {
+		return
+	}
 	if filePath == "" {
 		return
 	}
@@ -2657,8 +2678,6 @@ func backupFileBeforeWrite(filePath string) {
 		return
 	}
 	backupPath := filePath + ".bak-" + time.Now().Format("20060102-150405")
-	// Use hardlink — same data, no disk space cost. Falls back to copy if
-	// hardlink fails (cross-device, unsupported filesystem).
 	if err := os.Link(filePath, backupPath); err != nil {
 		// Hardlink failed — fall back to copy
 		if err := fileops.SafeCopy(filePath, backupPath, fileops.OperationConfig{}); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.159.0
+// version: 1.160.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1797,6 +1797,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/cleanup-series", s.handleCleanupSeries)
 			protected.POST("/maintenance/backfill-book-files", s.handleBackfillBookFiles)
 			protected.POST("/maintenance/cleanup-empty-folders", s.handleCleanupEmptyFolders)
+			protected.POST("/maintenance/cleanup-backups", s.handleCleanupBackups)
 			protected.POST("/maintenance/cleanup-organize-mess", s.handleCleanupOrganizeMess)
 			protected.POST("/maintenance/fix-author-narrator-swap", s.handleFixAuthorNarratorSwap)
 			protected.POST("/maintenance/fix-version-groups", s.handleFixVersionGroups)


### PR DESCRIPTION
## Summary

Two interlocking fixes. Prod just hit 82% full on the library zpool — the proximate cause was tens of thousands of stale tag-write backup files that were never cleaned up.

### 1. Gate backup creation on a config flag (default OFF)

\`metadata_fetch_service.backupFileBeforeWrite\` no longer runs unconditionally. New config key: \`write_backup_before_tag_write\` (default \`false\`). When off (the new default), tag writes don't leave \`.bak-YYYYMMDD-HHMMSS\` droppings next to audio files. When on (opt-in), the old behavior returns.

Two problems with the old always-on path:

- **Leak**: nothing ever cleaned up those files. 43K+ hardlinks across the library at multi-TB apparent size.
- **Questionable value**: TagLib writes tags in-place for some formats. A hardlink \"backup\" immediately shares an inode with the post-write file and preserves nothing. The hardlinks were only real backups when the writer happened to use a rename-dance, which isn't guaranteed.

Users who want belt-and-suspenders safety can turn it back on. Default off stops the leak with a single deploy.

### 2. New cleanup-backups maintenance endpoint

\`POST /api/v1/maintenance/cleanup-backups\` walks the library under \`root_dir\` and removes every file matching:

- \`*.backup\` — from the older \`fileops.FileOperation.Execute()\` path
- \`*.bak-YYYYMMDD-HHMMSS\` — from the tag write path above

**Protected paths**: every directory whose base name starts with \`.\` gets \`filepath.SkipDir\`. This covers \`.itunes-writeback\`, \`.covers\`, and any future dotfolder — explicit deny-list is fragile, prefix check is robust.

Supports \`dry_run=true\` (default) so you can preview before committing. Returns counts, bytes freed, and a human-readable size.

### Already fixed in prod

Ran the equivalent find-and-delete manually before shipping this:
- **~43,684 files deleted**
- **~500 GB freed** (5.2T → 5.7T available, 82% → 80% used)

A handful of stragglers (files created mid-delete by in-flight tag writes) remain. After merging this, the config flag stops new ones and the endpoint can sweep the stragglers.

## Test plan

- [ ] Deploy, verify \`write_backup_before_tag_write\` defaults to false
- [ ] Trigger a metadata-apply on a book, verify no \`.bak-*\` file is created next to it
- [ ] \`curl -X POST https://.../api/v1/maintenance/cleanup-backups?dry_run=true\` — preview should show a small count (just the stragglers)
- [ ] \`curl -X POST https://.../api/v1/maintenance/cleanup-backups?dry_run=false\` — actual cleanup, verify zero remaining
- [ ] Flip the config flag to \`true\` in the Settings JSON, do another metadata-apply, verify \`.bak-*\` files come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)