### PR TITLE
fix: clear outstanding bugs from backlog section 2

### DIFF
--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_compact_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package database
@@ -210,4 +210,100 @@ func TestCompactByDay_TruncatesLargeDays(t *testing.T) {
 	assert.True(t, dd.Truncated, "Truncated should be true")
 	assert.Equal(t, 100, dd.TruncatedCount, "100 items should have been truncated")
 	assert.Equal(t, 600, dd.OriginalCount)
+}
+
+// TestCompactByDay_MergesIntoExistingDigest is the regression test for the
+// "compact Everything (now) returns 0" bug. When a daily digest already
+// exists for a date AND more uncompacted change/debug entries have been
+// written for that same date (late imports, background tasks, etc.), a
+// second compact run used to `continue` past the day and leave the new
+// entries permanently uncompacted. This test proves that's fixed: the
+// second run merges new entries into the existing digest and deletes the
+// originals.
+func TestCompactByDay_MergesIntoExistingDigest(t *testing.T) {
+	s := newTestActivityStore(t)
+
+	// Day 1: three initial entries at 08:00 on 2025-05-15.
+	day := time.Date(2025, 5, 15, 8, 0, 0, 0, time.UTC)
+	// olderThan is set to "1 hour after the latest entry we'll add",
+	// so every run compacts everything written so far.
+	initialCutoff := time.Date(2025, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "change",
+			Type:      "metadata_applied",
+			Level:     "info",
+			Source:    "test",
+			Summary:   "initial entry",
+			Timestamp: day,
+			Details:   map[string]any{"book_title": "Initial Book"},
+		})
+		require.NoError(t, err)
+	}
+
+	// First compaction — 3 entries compacted into 1 digest.
+	r1, err := s.CompactByDay(initialCutoff)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.DaysCompacted, "first run should create 1 digest")
+	assert.Equal(t, 3, r1.EntriesDeleted)
+
+	// Late-arriving entries: 5 more entries for the SAME day, written
+	// AFTER the first compact ran. This is the real-world scenario —
+	// background imports, deferred tasks, crash recovery.
+	lateDay := time.Date(2025, 5, 15, 11, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "change",
+			Type:      "tag_written",
+			Level:     "info",
+			Source:    "test",
+			Summary:   "late entry",
+			Timestamp: lateDay,
+			Details:   map[string]any{"book_title": "Late Book", "tag_count": float64(4), "file_count": float64(1)},
+		})
+		require.NoError(t, err)
+	}
+
+	// Second compaction — must MERGE the 5 late entries into the
+	// existing digest, not skip them.
+	r2, err := s.CompactByDay(initialCutoff)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r2.DaysCompacted, "second run should merge into existing digest (counted as 1 day compacted)")
+	assert.Equal(t, 5, r2.EntriesDeleted, "all 5 late entries must be deleted")
+
+	// Exactly one digest row for 2025-05-15 (old one deleted, new one
+	// inserted with combined data).
+	var digestCount int
+	err = s.db.QueryRow(`
+		SELECT COUNT(*) FROM activity_log
+		WHERE tier = 'digest' AND type = 'daily_digest'
+		  AND date(timestamp) = '2025-05-15'`).Scan(&digestCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, digestCount, "must be exactly one digest per day")
+
+	// Zero uncompacted change/debug rows remaining for 2025-05-15.
+	var remaining int
+	err = s.db.QueryRow(`
+		SELECT COUNT(*) FROM activity_log
+		WHERE tier IN ('change','debug') AND compacted = 0
+		  AND date(timestamp) = '2025-05-15'`).Scan(&remaining)
+	require.NoError(t, err)
+	assert.Equal(t, 0, remaining, "no stragglers should remain")
+
+	// Unmarshal the merged digest and verify it contains both old and new counts.
+	var detailsJSON []byte
+	err = s.db.QueryRow(`
+		SELECT details FROM activity_log
+		WHERE tier = 'digest' AND type = 'daily_digest'
+		  AND date(timestamp) = '2025-05-15'`).Scan(&detailsJSON)
+	require.NoError(t, err)
+	var dd DigestDetails
+	err = json.Unmarshal(detailsJSON, &dd)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8, dd.OriginalCount, "merged digest should cover all 8 entries (3 old + 5 new)")
+	assert.Equal(t, 3, dd.Counts["metadata_applied"], "old counts preserved")
+	assert.Equal(t, 5, dd.Counts["tag_written"], "new counts added")
+	assert.Len(t, dd.Items, 8, "all 8 items present")
 }

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -626,32 +626,86 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 			return result, fmt.Errorf("activity_store: compact parse date %q: %w", dateKey, err)
 		}
 
-		// Transaction: idempotency check + insert digest + delete originals.
+		// Transaction: merge-or-insert digest + delete originals.
 		tx, err := s.db.Begin()
 		if err != nil {
 			return result, fmt.Errorf("activity_store: compact begin tx: %w", err)
 		}
 
-		// Idempotency: skip if digest already exists for this date (inside tx).
-		var exists int
+		// Merge semantics: if a digest already exists for this date
+		// (because a previous compact ran and then more entries were
+		// written for the same day — background imports, late tasks,
+		// etc.), fold its counts/items into the new digest and DELETE
+		// the old row inside this transaction. Then INSERT a single
+		// combined digest below.
+		//
+		// Previous behavior was to `continue` on existing digest, which
+		// left every late-arriving entry permanently uncompacted. A
+		// library that ran compact once a day would accumulate tens of
+		// thousands of stragglers forever.
+		var (
+			existingID          int64
+			existingDetailsJSON sql.NullString
+		)
 		err = tx.QueryRow(`
-			SELECT COUNT(*) FROM activity_log
+			SELECT id, details FROM activity_log
 			WHERE tier = 'digest' AND type = 'daily_digest'
-			  AND date(timestamp) = ?`, dateKey).Scan(&exists)
-		if err != nil {
+			  AND date(timestamp) = ?
+			ORDER BY id ASC
+			LIMIT 1`, dateKey).Scan(&existingID, &existingDetailsJSON)
+		if err != nil && err != sql.ErrNoRows {
 			tx.Rollback()
 			return result, fmt.Errorf("activity_store: compact check digest: %w", err)
 		}
-		if exists > 0 {
-			tx.Rollback()
-			continue
+		if existingID > 0 {
+			// Fold existing digest's counts + items into the new digest
+			// we just built, then delete the old row.
+			if existingDetailsJSON.Valid && existingDetailsJSON.String != "" {
+				var existing DigestDetails
+				if jsonErr := json.Unmarshal([]byte(existingDetailsJSON.String), &existing); jsonErr == nil {
+					// Merge counts.
+					for k, v := range existing.Counts {
+						dd.Counts[k] += v
+					}
+					dd.OriginalCount += existing.OriginalCount
+					// Merge items — old items first so new errors/warnings
+					// still sort to the front. Cap at maxDigestItems.
+					// Existing digests may already have been truncated; we
+					// preserve that signal in the combined row.
+					combined := append(existing.Items, dd.Items...)
+					if existing.Truncated {
+						// Keep the truncation flag since older data was lost.
+						dd.Truncated = true
+						dd.TruncatedCount += existing.TruncatedCount
+					}
+					if len(combined) > maxDigestItems {
+						dd.TruncatedCount += len(combined) - maxDigestItems
+						combined = combined[:maxDigestItems]
+						dd.Truncated = true
+					}
+					dd.Items = combined
+				}
+			}
+			// Re-marshal the merged digest for insertion below.
+			merged, mErr := json.Marshal(dd)
+			if mErr != nil {
+				tx.Rollback()
+				return result, fmt.Errorf("activity_store: compact remarshal merged digest: %w", mErr)
+			}
+			detailsBytes = merged
+
+			// Delete the old digest row — we'll insert the combined one below.
+			if _, delErr := tx.Exec(`DELETE FROM activity_log WHERE id = ?`, existingID); delErr != nil {
+				tx.Rollback()
+				return result, fmt.Errorf("activity_store: compact delete old digest: %w", delErr)
+			}
 		}
 
 		_, err = tx.Exec(`
 			INSERT INTO activity_log
 				(timestamp, tier, type, level, source, summary, details, compacted)
 			VALUES (?, 'digest', 'daily_digest', 'info', 'compaction', ?, ?, 1)`,
-			startOfDay, fmt.Sprintf("Daily digest for %s (%d entries)", dateKey, len(dg.entries)),
+			startOfDay, fmt.Sprintf("Daily digest for %s (%d entries)", dateKey, dd.OriginalCount),
 			string(detailsBytes),
 		)
 		if err != nil {

--- a/internal/server/dedup_engine.go
+++ b/internal/server/dedup_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 
 package server
@@ -954,31 +954,32 @@ func (de *DedupEngine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 	return deleted, nil
 }
 
-// getAllBooks fetches all PRIMARY-version books in batches. Non-primary
-// version-group members are filtered out so FullScan never processes them
-// (their identity is owned by the primary) and similarity scanning only
-// produces primary-vs-primary candidate pairs.
+// getAllBooks fetches all PRIMARY-version books in a single pass.
+// Non-primary version-group members are filtered out so FullScan never
+// processes them (their identity is owned by the primary) and similarity
+// scanning only produces primary-vs-primary candidate pairs.
+//
+// Previously this used batched pagination (500 per page, ~48 batches for
+// a 24K-book library). Each batch re-opened a Pebble iterator and walked
+// from the start to the target offset before yielding results, producing
+// O(n²) iterator ops per FullScan — ~576K reads for a 24K-book library.
+// Passing limit=0 tells the store to return everything in one iteration,
+// which is O(n). The memory cost is ~50MB for 24K Book structs — same
+// order of magnitude as the old cumulative batch allocation and far
+// cheaper than the wasted CPU on re-walked iterators.
 func (de *DedupEngine) getAllBooks() ([]database.Book, error) {
-	var all []database.Book
-	const batchSize = 500
-	offset := 0
-	for {
-		batch, err := de.bookStore.GetAllBooks(batchSize, offset)
-		if err != nil {
-			return nil, err
-		}
-		for _, b := range batch {
-			if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
-				continue
-			}
-			all = append(all, b)
-		}
-		if len(batch) < batchSize {
-			break
-		}
-		offset += batchSize
+	batch, err := de.bookStore.GetAllBooks(0, 0)
+	if err != nil {
+		return nil, err
 	}
-	return all, nil
+	filtered := make([]database.Book, 0, len(batch))
+	for _, b := range batch {
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered, nil
 }
 
 // RunLLMReview processes ambiguous candidates through LLM review (Layer 3).

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,17 +1,20 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	ulid "github.com/oklog/ulid/v2"
 )
 
 // listDedupCandidates handles GET /api/v1/dedup/candidates.
@@ -482,72 +485,121 @@ func (s *Server) dismissDedupCandidate(c *gin.Context) {
 }
 
 // triggerDedupScan handles POST /api/v1/dedup/scan.
-// Starts a background full embedding-based dedup scan. Before scanning,
-// any stale candidates (non-primary versions, same-group pairs, orphaned
-// book IDs) are purged so the scan starts from a clean slate.
+// Runs a full embedding-based dedup scan as a tracked Operation so the
+// UI can show progress and completion. Before scanning, stale candidates
+// (non-primary versions, same-group pairs, orphaned book IDs) are purged.
+//
+// Previously this fired a fire-and-forget goroutine and returned
+// {"status": "started"} with no way for the UI to see progress or
+// completion. Now the operation shows up in the Operations panel with
+// live progress updates and final-completion messages.
 func (s *Server) triggerDedupScan(c *gin.Context) {
 	if s.dedupEngine == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
 		return
 	}
+	if operations.GlobalQueue == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		return
+	}
 
-	go func() {
-		ctx := context.Background()
+	opID := ulid.Make().String()
+	op, err := database.GlobalStore.CreateOperation(opID, "dedup-scan", nil)
+	if err != nil {
+		internalError(c, "failed to create dedup-scan operation", err)
+		return
+	}
+
+	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		_ = progress.UpdateProgress(0, 100, "Purging stale candidates...")
 		if deleted, err := s.dedupEngine.PurgeStaleCandidates(ctx); err != nil {
 			log.Printf("[dedup] purge stale candidates error: %v", err)
 		} else if deleted > 0 {
 			log.Printf("[dedup] purged %d stale candidate(s) before scan", deleted)
 		}
-		if err := s.dedupEngine.FullScan(ctx, func(done, total int) {
-			log.Printf("[dedup] scan progress: %d/%d", done, total)
-		}); err != nil {
-			log.Printf("[dedup] FullScan error: %v", err)
-		}
-	}()
 
-	c.JSON(http.StatusOK, gin.H{"status": "started"})
+		// FullScan reports progress via a callback (done, total). Translate
+		// that into ProgressReporter updates, reserving 5% at the start for
+		// the purge pass and 5% at the end for the "complete" line so the
+		// bar actually moves all the way to 100.
+		var lastPct int
+		fullScanErr := s.dedupEngine.FullScan(ctx, func(done, total int) {
+			if total <= 0 {
+				return
+			}
+			pct := 5 + (90 * done / total)
+			if pct == lastPct {
+				return
+			}
+			lastPct = pct
+			_ = progress.UpdateProgress(pct, 100, fmt.Sprintf("Scanning books: %d / %d", done, total))
+		})
+		if fullScanErr != nil {
+			log.Printf("[dedup] FullScan error: %v", fullScanErr)
+			return fmt.Errorf("dedup scan: %w", fullScanErr)
+		}
+
+		// Fetch final candidate counts for the completion message.
+		pendingCount := 0
+		if s.embeddingStore != nil {
+			filter := database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1}
+			if _, total, listErr := s.embeddingStore.ListCandidates(filter); listErr == nil {
+				pendingCount = total
+			}
+		}
+		_ = progress.UpdateProgress(100, 100,
+			fmt.Sprintf("Dedup scan complete — %d pending candidates", pendingCount))
+		return nil
+	}
+
+	if err := operations.GlobalQueue.Enqueue(opID, "dedup-scan", operations.PriorityLow, opFunc); err != nil {
+		internalError(c, "failed to enqueue dedup scan", err)
+		return
+	}
+
+	c.JSON(http.StatusAccepted, op)
 }
 
 // triggerDedupLLM handles POST /api/v1/dedup/scan-llm.
-// Starts a background LLM review pass over existing candidates.
+// Runs an LLM review pass over ambiguous embedding-layer candidates as a
+// tracked Operation so the UI can display progress and completion.
 func (s *Server) triggerDedupLLM(c *gin.Context) {
 	if s.dedupEngine == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
 		return
 	}
-
-	go func() {
-		ctx := context.Background()
-		if err := s.dedupEngine.RunLLMReview(ctx); err != nil {
-			log.Printf("[dedup] RunLLMReview error: %v", err)
-		}
-	}()
-
-	c.JSON(http.StatusOK, gin.H{"status": "started"})
-}
-
-// triggerDedupRefresh handles POST /api/v1/dedup/refresh.
-// Re-runs the full scan (re-embeds stale entries then scans for candidates).
-// Purges stale candidates first so the refresh starts clean.
-func (s *Server) triggerDedupRefresh(c *gin.Context) {
-	if s.dedupEngine == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
+	if operations.GlobalQueue == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
 		return
 	}
 
-	go func() {
-		ctx := context.Background()
-		if deleted, err := s.dedupEngine.PurgeStaleCandidates(ctx); err != nil {
-			log.Printf("[dedup] purge stale candidates error: %v", err)
-		} else if deleted > 0 {
-			log.Printf("[dedup] purged %d stale candidate(s) before refresh", deleted)
-		}
-		if err := s.dedupEngine.FullScan(ctx, func(done, total int) {
-			log.Printf("[dedup] refresh progress: %d/%d", done, total)
-		}); err != nil {
-			log.Printf("[dedup] refresh FullScan error: %v", err)
-		}
-	}()
+	opID := ulid.Make().String()
+	op, err := database.GlobalStore.CreateOperation(opID, "dedup-llm-review", nil)
+	if err != nil {
+		internalError(c, "failed to create dedup-llm-review operation", err)
+		return
+	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "started"})
+	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		_ = progress.UpdateProgress(0, 100, "Starting LLM review of ambiguous candidates...")
+		if err := s.dedupEngine.RunLLMReview(ctx); err != nil {
+			return fmt.Errorf("LLM review: %w", err)
+		}
+		_ = progress.UpdateProgress(100, 100, "LLM review complete")
+		return nil
+	}
+
+	if err := operations.GlobalQueue.Enqueue(opID, "dedup-llm-review", operations.PriorityLow, opFunc); err != nil {
+		internalError(c, "failed to enqueue LLM review", err)
+		return
+	}
+
+	c.JSON(http.StatusAccepted, op)
+}
+
+// triggerDedupRefresh handles POST /api/v1/dedup/refresh.
+// Re-runs the full scan as a tracked Operation. Identical behavior to
+// triggerDedupScan — kept as a separate endpoint for backwards compatibility.
+func (s *Server) triggerDedupRefresh(c *gin.Context) {
+	s.triggerDedupScan(c)
 }

--- a/internal/server/itunes.go
+++ b/internal/server/itunes.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes.go
-// version: 2.21.0
+// version: 2.22.0
 // guid: 719912e9-7b5f-48e1-afa6-1b0b7f57c2fa
 
 package server
@@ -1068,6 +1068,15 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 			log.Error("Failed to save '%s': %v", book.Title, err)
 			updateITunesProgress(log, status, processed, totalGroups)
 			continue
+		}
+
+		// Fire dedup-on-import so iTunes ghost entries get checked
+		// against the organized library. Layer 1 hash match will
+		// surface any parallel row for the same file content that's
+		// already under audiobook-organizer/, instead of quietly
+		// coexisting as two rows pointing at the same audio.
+		if globalServer != nil {
+			globalServer.fireDedupOnImport(created.ID)
 		}
 
 		updateITunesImported(status)
@@ -2315,6 +2324,11 @@ func executeITunesSync(ctx context.Context, log logger.Logger, libraryPath strin
 				log.Error("Failed to create '%s': %v", book.Title, err)
 			} else {
 				newBooks++
+				// Dedup-on-import: catch iTunes ghost entries that
+				// overlap with existing organized-library books.
+				if globalServer != nil {
+					globalServer.fireDedupOnImport(created.ID)
+				}
 				// Set up book_authors junction table
 				if created.AuthorID != nil && len(book.Authors) > 0 {
 					for i := range book.Authors {

--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package server
@@ -736,8 +736,23 @@ func (orgSvc *OrganizeService) createOrganizedVersion(org *organizer.Organizer, 
 	createdBook, err := orgSvc.db.CreateBook(&newBook)
 	if err != nil {
 		log.Error("Failed to create organized book record for %s: %v", book.Title, err)
-		if !isDir {
-			os.Remove(newPath)
+		// Best-effort cleanup of the files we just placed at newPath so
+		// we don't leak orphan files (single-file) or orphan directories
+		// (multi-file) with no DB row pointing at them. Every removal is
+		// safety-gated on newPath being under RootDir so a broken newPath
+		// can't accidentally rm something outside the managed library.
+		if newPath != "" && config.AppConfig.RootDir != "" && strings.HasPrefix(newPath, config.AppConfig.RootDir) {
+			if isDir {
+				if rmErr := os.RemoveAll(newPath); rmErr != nil {
+					log.Warn("organize: cleanup of partial directory organize failed (%s): %v", newPath, rmErr)
+				} else {
+					log.Warn("organize: cleaned up partial directory organize at %s after CreateBook failure", newPath)
+				}
+			} else {
+				if rmErr := os.Remove(newPath); rmErr != nil {
+					log.Warn("organize: cleanup of partial single-file organize failed (%s): %v", newPath, rmErr)
+				}
+			}
 		}
 		return nil, err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -870,18 +870,7 @@ func NewServer() *Server {
 				// Re-scan before dedup ever saw it — which meant a
 				// "Foundation & Empire" re-import would stay invisible to
 				// the cluster tab for hours or days.
-				scanner.DedupOnImportHook = func(bookID string) {
-					if server.dedupEngine == nil {
-						return
-					}
-					server.bgWG.Add(1)
-					go func() {
-						defer server.bgWG.Done()
-						if _, err := server.dedupEngine.CheckBook(server.bgCtx, bookID); err != nil {
-							log.Printf("[WARN] dedup-on-import CheckBook(%s): %v", bookID, err)
-						}
-					}()
-				}
+				scanner.DedupOnImportHook = server.fireDedupOnImport
 				log.Println("[INFO] Dedup-on-import hook wired")
 
 				// Wire the organize collision hook. When OrganizeBook
@@ -1031,6 +1020,35 @@ func NewServer() *Server {
 	InitFileIOPool()
 
 	return server
+}
+
+// fireDedupOnImport runs the dedup engine's Layer 1 + Layer 2 checks for
+// a freshly created book, in a bgWG-tracked goroutine so it doesn't
+// block the caller and shutdown drains it before closing Pebble.
+//
+// This is the single entry point used by every CreateBook path —
+// scanner imports (via scanner.DedupOnImportHook), iTunes sync, manual
+// book creation, etc. Having every create path fire the hook means new
+// books get exact-match hash/ISBN/title checks against the whole
+// library immediately, instead of waiting for a user-triggered Re-scan.
+//
+// In particular this catches the "iTunes sync creates a parallel row
+// for a book we already have under audiobook-organizer/" bug — the
+// Layer 1 file-hash check fires inside CheckBook, sees the match, and
+// records a pending dedup candidate that surfaces in the UI.
+//
+// Safe to call even when the dedup engine is disabled — it's a no-op.
+func (s *Server) fireDedupOnImport(bookID string) {
+	if s.dedupEngine == nil || bookID == "" {
+		return
+	}
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		if _, err := s.dedupEngine.CheckBook(s.bgCtx, bookID); err != nil {
+			log.Printf("[WARN] dedup-on-import CheckBook(%s): %v", bookID, err)
+		}
+	}()
 }
 
 // resumeInterruptedOperations checks for operations left in running/queued state
@@ -1332,8 +1350,11 @@ func (s *Server) Start(cfg ServerConfig) error {
 		}
 	}()
 
-	// Start auto-scan file watcher if enabled
-	var fileWatcher *watcher.Watcher
+	// Start auto-scan file watchers if enabled. ONE watcher per enabled
+	// import path — previously only the first enabled path was watched,
+	// so users with multiple import locations had silent blind spots on
+	// every path after the first.
+	var fileWatchers []*watcher.Watcher
 	if config.AppConfig.AutoScanEnabled && database.GlobalStore != nil {
 		importPaths, err := database.GlobalStore.GetAllImportPaths()
 		if err == nil && len(importPaths) > 0 {
@@ -1349,7 +1370,10 @@ func (s *Server) Start(cfg ServerConfig) error {
 					debounce = time.Duration(config.AppConfig.AutoScanDebounceSeconds) * time.Second
 				}
 				watchLog := logger.NewWithActivityLog("auto-scan", database.GlobalStore)
-				fileWatcher = watcher.New(func(path string) {
+				// The same callback is reused across watchers because
+				// each watcher invokes it with its own root path, so
+				// the scan target is correct per event.
+				cb := func(path string) {
 					watchLog.Info("Auto-scan triggered for: %s", path)
 					if hub := realtime.GetGlobalHub(); hub != nil {
 						hub.Broadcast(&realtime.Event{
@@ -1375,13 +1399,15 @@ func (s *Server) Start(cfg ServerConfig) error {
 							}
 						}()
 					}
-				}, debounce)
-				// Start watching the first import path (primary)
-				if startErr := fileWatcher.Start(watchPaths[0]); startErr != nil {
-					watchLog.Warn("Failed to start file watcher: %v", startErr)
-					fileWatcher = nil
-				} else {
-					watchLog.Info("Auto-scan file watcher started for %s", watchPaths[0])
+				}
+				for _, wp := range watchPaths {
+					fw := watcher.New(cb, debounce)
+					if startErr := fw.Start(wp); startErr != nil {
+						watchLog.Warn("Failed to start file watcher for %s: %v", wp, startErr)
+						continue
+					}
+					fileWatchers = append(fileWatchers, fw)
+					watchLog.Info("Auto-scan file watcher started for %s", wp)
 				}
 			}
 		}
@@ -1511,10 +1537,12 @@ func (s *Server) Start(cfg ServerConfig) error {
 		}
 	}
 
-	// Stop file watcher
-	if fileWatcher != nil {
-		fileWatcher.Stop()
-		log.Println("[INFO] File watcher stopped")
+	// Stop every file watcher (one per import path).
+	for _, fw := range fileWatchers {
+		fw.Stop()
+	}
+	if len(fileWatchers) > 0 {
+		log.Printf("[INFO] File watchers stopped (%d)", len(fileWatchers))
 	}
 
 	// Close embedding store


### PR DESCRIPTION
Six fixes bundled from the Known Bugs section of \`docs/backlog-2026-04-10.md\`.

## 2.1 Activity log compact \"Everything (now)\" returns 0

\`CompactByDay\` used to \`continue\` past any day where a digest already existed, which meant late entries written for that same day (background imports, deferred tasks, crash recovery) stayed uncompacted forever. Prod had 152,045 stragglers over 4 days. Fix: merge the existing digest's counts/items/original_count into the new digest, delete the old row, insert the combined row — all in the same tx. Covered by new \`TestCompactByDay_MergesIntoExistingDigest\`.

## 2.2 Dedup scan isn't tracked in Operations + 2.3 No completion messages

\`triggerDedupScan\`, \`triggerDedupLLM\`, and \`triggerDedupRefresh\` now go through \`operations.GlobalQueue.Enqueue\` with real Operation rows, \`ProgressReporter\`-based updates (\"Scanning books: N / total\"), and a final \"Dedup scan complete — N pending candidates\" message. They show up in the Operations panel like every other long-running task.

## 2.4 Directory organize has no cleanup on partial failure

\`createOrganizedVersion\` only cleaned up single-file failures. Directory (multi-file) failures left an orphan directory at the target with no DB row. Added \`os.RemoveAll\` for the directory case, gated on newPath being under \`RootDir\`.

## 2.5 Scanner double-counts iTunes + organized paths

iTunes sync created books via \`database.GlobalStore.CreateBook\` without going through \`scanner.DedupOnImportHook\`, so iTunes ghost entries for books already under \`audiobook-organizer/\` never got checked for exact-match duplicates. Added a server method \`fireDedupOnImport\` that every \`CreateBook\` path can call; wired it into the two iTunes CreateBook sites that create new books (skipped \`linkAsVersion\` and \`splitSegmentsToBooks\` which create known siblings). The existing scanner hook now routes through the same helper.

## 2.6 GetAllBooks O(n²) in a loop

\`DedupEngine.getAllBooks\` paginated via 500-at-a-time \`GetAllBooks\` calls. Each call re-opened a Pebble iterator and walked past \`offset\` entries — O(n²) total, ~576K reads for 24K books. Changed to a single \`GetAllBooks(0, 0)\` call. ~50MB memory for the full list, same order as the cumulative batch allocation, far cheaper than the wasted CPU.

## 2.7 Auto-scan watcher only watched first import path

\`server.Start\` started a single watcher for \`watchPaths[0]\`. Users with multiple import paths had silent blind spots. Changed to one watcher per enabled path, tracked as a slice, stopped en masse in shutdown.

## Test plan

- [x] \`TestCompactByDay_MergesIntoExistingDigest\` — regression test for 2.1
- [x] All existing \`TestCompactByDay_*\` still pass
- [x] All existing dedup, organize, merge tests pass
- [x] Full suite green across server, database, organizer, scanner, metadata
- [ ] Deploy and verify:
  - [ ] Click Compact Activity Log \"Now\" — expect the merge behavior, stragglers folded into existing digests
  - [ ] Click Re-scan in dedup tab — expect an Operation row to appear with live progress + final completion message
  - [ ] Import a new book on an import path that isn't \`[0]\` — expect auto-scan to fire
  - [ ] Trigger an iTunes sync and verify new iTunes rows get dedup-on-import processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)