### PR TITLE
docs(backlog): CGO is a tiebreaker not a gate in DB eval

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,5 +1,5 @@
 <!-- file: docs/backlog-2026-04-10.md -->
-<!-- version: 1.3.0 -->
+<!-- version: 1.4.0 -->
 <!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
 <!-- last-edited: 2026-04-11 -->
 
@@ -825,8 +825,12 @@ simple.
 
 **Criteria for inclusion in the actual evaluation:**
 
-1. Pure Go or at least a stable Go client (no mandatory CGO we
-   don't already have)
+1. **Pure Go preferred, CGO acceptable.** The bar is "Go-native or a
+   stable Go client". CGO is fine when the upside is worth it — we
+   already ship CGO for TagLib and SQLite, so one more CGO dep is not
+   a dealbreaker. A pure-Go alternative that's close in performance
+   should be picked over a CGO one when it exists, but don't
+   auto-reject a CGO candidate just because it's CGO.
 2. Actively maintained (commits in the last 12 months, reasonable
    issue response time)
 3. Production users in the wild (somebody other than us is
@@ -836,8 +840,10 @@ simple.
    current store by enough to justify the switch OR offer a
    feature we can't get cheaply from the current stack
 
-Candidates that fail any of the first four should be noted and
-dropped without further measurement.
+Candidates that fail any of criteria 2-4 should be noted and dropped
+without further measurement. Criterion 1 is a tiebreaker, not a
+gate — a CGO candidate that wins on benchmark and feature gets the
+slot over a pure-Go one that loses.
 
 **Why:** The top-level instinct "migrate to PostgreSQL" is wrong.
 Pebble's bulk-write performance during organize/scan/backfill is a


### PR DESCRIPTION
Softens criterion 1 in backlog item 4.7's DB evaluation. Original wording implied pure-Go was a hard requirement; in reality we already ship CGO for TagLib and SQLite, so one more CGO dep is not a dealbreaker. Pure Go is preferred when candidates are otherwise close, but a CGO candidate that wins on benchmark + feature shouldn't get auto-rejected for being CGO.

Criteria 2-4 (maintenance, production use, license) remain hard gates. Criteria 1 (Go-nativeness) and 5 (benchmark win) are judgment calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)