### PR TITLE
feat(dedup): per-side "merge as primary" star button

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -208,7 +208,8 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 	}
 
 	var body struct {
-		BookIDs []string `json:"book_ids"`
+		BookIDs       []string `json:"book_ids"`
+		PrimaryBookID string   `json:"primary_book_id,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -218,8 +219,23 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids must contain at least 2 entries"})
 		return
 	}
+	// If primary_book_id is set, it must be one of the books in the
+	// cluster. Empty means "let bookIsBetter auto-pick".
+	if body.PrimaryBookID != "" {
+		found := false
+		for _, id := range body.BookIDs {
+			if id == body.PrimaryBookID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "primary_book_id must be one of book_ids"})
+			return
+		}
+	}
 
-	mergeResult, err := s.mergeService.MergeBooks(body.BookIDs, "")
+	mergeResult, err := s.mergeService.MergeBooks(body.BookIDs, body.PrimaryBookID)
 	if err != nil {
 		internalError(c, "failed to merge books in cluster", err)
 		return

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.13.0
+// version: 3.14.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -40,6 +40,7 @@ import {
   Switch,
 } from '@mui/material';
 import MergeIcon from '@mui/icons-material/MergeType';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -2633,10 +2634,10 @@ function EmbeddingDedupTab() {
   useEffect(() => { loadStats(); }, [loadStats]);
   useEffect(() => { loadCandidates(); }, [loadCandidates]);
 
-  const handleMergeCluster = async (cluster: BookCluster) => {
-    setActionLoading(cluster.key);
+  const handleMergeCluster = async (cluster: BookCluster, primaryBookId?: string) => {
+    setActionLoading(primaryBookId ? `${cluster.key}:primary:${primaryBookId}` : cluster.key);
     try {
-      await api.mergeDedupCluster(cluster.bookIds);
+      await api.mergeDedupCluster(cluster.bookIds, primaryBookId);
       loadCandidates();
       loadStats();
     } catch (err) {
@@ -2877,6 +2878,34 @@ function EmbeddingDedupTab() {
             </Tooltip>
           )}
         </Box>
+        {cluster.hasPending && (
+          <Tooltip title="Merge cluster — keep THIS book as primary (overrides auto-pick)">
+            <span>
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleMergeCluster(cluster, id);
+                }}
+                disabled={anyActionBusy}
+                sx={{
+                  position: 'absolute',
+                  top: -4,
+                  right: isMultiWay ? 22 : -4,
+                  padding: '2px',
+                  color: 'text.disabled',
+                  '&:hover': { color: 'warning.main' },
+                }}
+              >
+                {actionLoading === `${cluster.key}:primary:${id}` ? (
+                  <CircularProgress size={14} />
+                ) : (
+                  <StarBorderIcon sx={{ fontSize: 16 }} />
+                )}
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
         {isMultiWay && cluster.hasPending && (
           <Tooltip title="Not a duplicate — remove this book from the cluster">
             <span>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 1.69.0
+// version: 1.70.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -3674,11 +3674,22 @@ export interface ClusterMergeResult {
   result?: unknown;
 }
 
-export async function mergeDedupCluster(bookIds: string[]): Promise<ClusterMergeResult> {
+// mergeDedupCluster merges a set of book IDs into one version group.
+// If primaryBookId is provided, that book is forced as the version-group
+// primary (overrides the bookIsBetter auto-pick based on path origin,
+// curation, format, bitrate, size). If omitted, the backend auto-picks.
+export async function mergeDedupCluster(
+  bookIds: string[],
+  primaryBookId?: string
+): Promise<ClusterMergeResult> {
+  const body: Record<string, unknown> = { book_ids: bookIds };
+  if (primaryBookId) {
+    body.primary_book_id = primaryBookId;
+  }
   const response = await fetch(`${API_BASE}/dedup/candidates/merge-cluster`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ book_ids: bookIds }),
+    body: JSON.stringify(body),
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge dedup cluster');


### PR DESCRIPTION
Cluster merges auto-pick the primary via \`bookIsBetter\` (organized-path > curation > format > bitrate > size). Usually right, not always. Adds a ★ button in the top-right of each book in a pending cluster that forces that book as the explicit primary.

- Backend: \`mergeDedupCluster\` takes optional \`primary_book_id\`, validated to be in \`book_ids\`, passed through to \`MergeBooks\` which already supports it.
- Frontend: ★ next to × on 3+ way clusters, alone on 2-way clusters. Cluster-level Merge button still auto-picks.

Backlog item #6 of the 12 queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)