### PR TITLE
feat(dedup): export current filtered candidate set as CSV or JSON

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,15 +1,18 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -72,6 +75,183 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 		"candidates": candidates,
 		"total":      total,
 	})
+}
+
+// exportDedupCandidates handles GET /api/v1/dedup/candidates/export.
+//
+// Query params:
+//
+//	format = "csv" (default) or "json"
+//	status, layer, min_similarity, entity_type — same as list endpoint
+//
+// Unlike the list endpoint, export doesn't paginate — it walks every
+// matching row up to an internal hard cap (100K) to prevent runaway
+// downloads. Each row is enriched with the book titles and author names
+// of both sides so the CSV is readable in a spreadsheet without needing
+// to cross-reference IDs.
+//
+// Columns (CSV): candidate_id, status, layer, similarity,
+// entity_a_id, entity_a_title, entity_a_author,
+// entity_b_id, entity_b_title, entity_b_author,
+// llm_verdict, llm_reason, created_at, updated_at.
+func (s *Server) exportDedupCandidates(c *gin.Context) {
+	if s.embeddingStore == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		return
+	}
+
+	format := c.DefaultQuery("format", "csv")
+	if format != "csv" && format != "json" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "format must be csv or json"})
+		return
+	}
+
+	filter := database.CandidateFilter{Limit: 100000}
+	if v := c.Query("entity_type"); v != "" {
+		filter.EntityType = v
+	}
+	if v := c.Query("status"); v != "" {
+		filter.Status = v
+	}
+	if v := c.Query("layer"); v != "" {
+		filter.Layer = v
+	}
+	if v := c.Query("min_similarity"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_similarity"})
+			return
+		}
+		filter.MinSimilarity = &f
+	}
+
+	candidates, _, err := s.embeddingStore.ListCandidates(filter)
+	if err != nil {
+		internalError(c, "failed to list candidates for export", err)
+		return
+	}
+
+	// Enrich: lookup titles + author names for every entity involved,
+	// memoized so a book that appears in multiple candidates is only
+	// fetched once. Books-only for now — authors export would need the
+	// author table which we can add later if needed.
+	type enriched struct {
+		title  string
+		author string
+	}
+	cache := make(map[string]enriched, len(candidates)*2)
+	lookup := func(id string) enriched {
+		if e, ok := cache[id]; ok {
+			return e
+		}
+		e := enriched{}
+		if book, err := database.GlobalStore.GetBookByID(id); err == nil && book != nil {
+			e.title = book.Title
+			if book.AuthorID != nil {
+				if a, err := database.GlobalStore.GetAuthorByID(*book.AuthorID); err == nil && a != nil {
+					e.author = a.Name
+				}
+			}
+		}
+		cache[id] = e
+		return e
+	}
+
+	filename := fmt.Sprintf("dedup-candidates-%s.%s", time.Now().Format("20060102-150405"), format)
+
+	if format == "json" {
+		type row struct {
+			CandidateID   int64   `json:"candidate_id"`
+			Status        string  `json:"status"`
+			Layer         string  `json:"layer"`
+			Similarity    float64 `json:"similarity"`
+			EntityType    string  `json:"entity_type"`
+			EntityAID     string  `json:"entity_a_id"`
+			EntityATitle  string  `json:"entity_a_title"`
+			EntityAAuthor string  `json:"entity_a_author"`
+			EntityBID     string  `json:"entity_b_id"`
+			EntityBTitle  string  `json:"entity_b_title"`
+			EntityBAuthor string  `json:"entity_b_author"`
+			LLMVerdict    string  `json:"llm_verdict,omitempty"`
+			LLMReason     string  `json:"llm_reason,omitempty"`
+			CreatedAt     string  `json:"created_at"`
+			UpdatedAt     string  `json:"updated_at"`
+		}
+		rows := make([]row, 0, len(candidates))
+		for _, cand := range candidates {
+			a := lookup(cand.EntityAID)
+			b := lookup(cand.EntityBID)
+			sim := 0.0
+			if cand.Similarity != nil {
+				sim = *cand.Similarity
+			}
+			rows = append(rows, row{
+				CandidateID:   cand.ID,
+				Status:        cand.Status,
+				Layer:         cand.Layer,
+				Similarity:    sim,
+				EntityType:    cand.EntityType,
+				EntityAID:     cand.EntityAID,
+				EntityATitle:  a.title,
+				EntityAAuthor: a.author,
+				EntityBID:     cand.EntityBID,
+				EntityBTitle:  b.title,
+				EntityBAuthor: b.author,
+				LLMVerdict:    cand.LLMVerdict,
+				LLMReason:     cand.LLMReason,
+				CreatedAt:     cand.CreatedAt.Format(time.RFC3339),
+				UpdatedAt:     cand.UpdatedAt.Format(time.RFC3339),
+			})
+		}
+		c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+		c.Header("Content-Type", "application/json")
+		enc := json.NewEncoder(c.Writer)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(gin.H{"count": len(rows), "candidates": rows}); err != nil {
+			log.Printf("[dedup] export json encode: %v", err)
+		}
+		return
+	}
+
+	// CSV path.
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	c.Header("Content-Type", "text/csv")
+	w := csv.NewWriter(c.Writer)
+	defer w.Flush()
+	_ = w.Write([]string{
+		"candidate_id", "status", "layer", "similarity",
+		"entity_type",
+		"entity_a_id", "entity_a_title", "entity_a_author",
+		"entity_b_id", "entity_b_title", "entity_b_author",
+		"llm_verdict", "llm_reason",
+		"created_at", "updated_at",
+	})
+	for _, cand := range candidates {
+		a := lookup(cand.EntityAID)
+		b := lookup(cand.EntityBID)
+		simStr := ""
+		if cand.Similarity != nil {
+			simStr = strconv.FormatFloat(*cand.Similarity, 'f', 4, 64)
+		}
+		_ = w.Write([]string{
+			strconv.FormatInt(cand.ID, 10),
+			cand.Status,
+			cand.Layer,
+			simStr,
+			cand.EntityType,
+			cand.EntityAID,
+			a.title,
+			a.author,
+			cand.EntityBID,
+			b.title,
+			b.author,
+			cand.LLMVerdict,
+			cand.LLMReason,
+			cand.CreatedAt.Format(time.RFC3339),
+			cand.UpdatedAt.Format(time.RFC3339),
+		})
+	}
+	log.Printf("[dedup] export: wrote %d candidate rows as %s", len(candidates), format)
 }
 
 // getDedupStats handles GET /api/v1/dedup/stats.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.160.0
+// version: 1.161.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1742,6 +1742,7 @@ func (s *Server) setupRoutes() {
 
 			// Embedding-based dedup
 			protected.GET("/dedup/candidates", s.listDedupCandidates)
+			protected.GET("/dedup/candidates/export", s.exportDedupCandidates)
 			protected.GET("/dedup/stats", s.getDedupStats)
 			protected.POST("/dedup/candidates/:id/merge", s.mergeDedupCandidate)
 			protected.POST("/dedup/candidates/:id/dismiss", s.dismissDedupCandidate)

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.14.0
+// version: 3.15.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -11,6 +11,8 @@ import {
   Button,
   Alert,
   Snackbar,
+  Menu,
+  MenuItem,
   Chip,
   CircularProgress,
   Divider,
@@ -41,6 +43,7 @@ import {
 } from '@mui/material';
 import MergeIcon from '@mui/icons-material/MergeType';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
+import DownloadIcon from '@mui/icons-material/Download';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -2573,6 +2576,7 @@ function EmbeddingDedupTab() {
   const [scanMsg, setScanMsg] = useState<string | null>(null);
   const [bulkMergeOpen, setBulkMergeOpen] = useState(false);
   const [pageMergeOpen, setPageMergeOpen] = useState(false);
+  const [exportMenuAnchor, setExportMenuAnchor] = useState<HTMLElement | null>(null);
   const [pageMerging, setPageMerging] = useState(false);
   const [bulkMerging, setBulkMerging] = useState(false);
 
@@ -2633,6 +2637,23 @@ function EmbeddingDedupTab() {
 
   useEffect(() => { loadStats(); }, [loadStats]);
   useEffect(() => { loadCandidates(); }, [loadCandidates]);
+
+  // Download the current filtered candidate set as CSV or JSON. Builds
+  // the query string with whatever filters the user has active (status,
+  // layer) so what they export matches what they see. Navigates to the
+  // endpoint via an anchor click so the browser handles the file save.
+  const handleExport = (format: 'csv' | 'json') => {
+    const params = new URLSearchParams({ format });
+    if (statusFilter) params.set('status', statusFilter);
+    if (layerFilter) params.set('layer', layerFilter);
+    const url = `/api/v1/dedup/candidates/export?${params.toString()}`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = ''; // let the server Content-Disposition pick the name
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
 
   const handleMergeCluster = async (cluster: BookCluster, primaryBookId?: string) => {
     setActionLoading(primaryBookId ? `${cluster.key}:primary:${primaryBookId}` : cluster.key);
@@ -2978,6 +2999,28 @@ function EmbeddingDedupTab() {
         >
           Merge Page ({clusters.filter((c) => c.hasPending).length})
         </Button>
+        <Button
+          variant="outlined"
+          color="inherit"
+          startIcon={<DownloadIcon />}
+          onClick={(e) => setExportMenuAnchor(e.currentTarget)}
+          size="small"
+          title="Download the current filtered candidate set as CSV or JSON"
+        >
+          Export
+        </Button>
+        <Menu
+          anchorEl={exportMenuAnchor}
+          open={Boolean(exportMenuAnchor)}
+          onClose={() => setExportMenuAnchor(null)}
+        >
+          <MenuItem onClick={() => { handleExport('csv'); setExportMenuAnchor(null); }}>
+            Download as CSV
+          </MenuItem>
+          <MenuItem onClick={() => { handleExport('json'); setExportMenuAnchor(null); }}>
+            Download as JSON
+          </MenuItem>
+        </Menu>
       </Stack>
 
       {/* Scan/merge status lives in a bottom-right Snackbar instead of


### PR DESCRIPTION
New GET /api/v1/dedup/candidates/export endpoint + frontend Export button with CSV/JSON menu. Each row is enriched with book titles + author names so the output is readable without joining on IDs. Respects the current status + layer filters. Backlog item #9.