### PR TITLE
feat(dedup): multi-select split-cluster workflow

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -797,19 +797,24 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 
 // removeFromDedupCluster handles POST /api/v1/dedup/candidates/remove-from-cluster.
 //
-// Body: {"cluster_book_ids": [...], "remove_book_id": "X"}
+// Body: {
+//   "cluster_book_ids": [...],
+//   "remove_book_id": "X"      // singular, backwards-compat
+//   "remove_book_ids": [...]   // plural, preferred
+// }
 //
-// Dismisses every pending candidate whose pair is one-side-X and other-side
-// in (cluster \ X). In other words: "this one book is NOT a duplicate of
-// the other books in this cluster". Pairs involving X that point to books
-// OUTSIDE the cluster are left alone — this is a scoped split, not a
-// global ban on the book.
+// Dismisses every pending candidate whose pair is one-side-in-remove-set
+// and other-side in (cluster \ remove-set). In other words: "these books
+// are NOT duplicates of the remaining books in this cluster". Pairs where
+// both sides are in the remove set are ALSO dismissed — removing two
+// wrong-books from a cluster means neither should stay paired with
+// anything that was in the original cluster.
 //
-// The effect on the UI: a 3-way cluster (A, B, C) where the user removes
-// C drops the (A,C) and (B,C) edges but leaves (A,B). On the next page
-// load the union-find produces a 2-way cluster (A, B) and C disappears
-// from the pending view. C can still show up in future dedup scans if
-// something new hits it.
+// Pairs involving a removed book with books OUTSIDE the cluster are
+// left alone — this is a scoped split, not a global ban.
+//
+// Accepts both singular and plural forms for backwards compatibility.
+// If both are provided, they're merged into a single set.
 func (s *Server) removeFromDedupCluster(c *gin.Context) {
 	if s.embeddingStore == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
@@ -818,14 +823,28 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 
 	var body struct {
 		ClusterBookIDs []string `json:"cluster_book_ids"`
-		RemoveBookID   string   `json:"remove_book_id"`
+		RemoveBookID   string   `json:"remove_book_id,omitempty"`
+		RemoveBookIDs  []string `json:"remove_book_ids,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}
-	if body.RemoveBookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "remove_book_id is required"})
+
+	// Normalize into one remove set. Singular and plural both supported
+	// so the existing × button (singular) keeps working while the new
+	// multi-select UI sends the plural.
+	removeSet := make(map[string]struct{})
+	if body.RemoveBookID != "" {
+		removeSet[body.RemoveBookID] = struct{}{}
+	}
+	for _, id := range body.RemoveBookIDs {
+		if id != "" {
+			removeSet[id] = struct{}{}
+		}
+	}
+	if len(removeSet) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "remove_book_id or remove_book_ids is required"})
 		return
 	}
 	if len(body.ClusterBookIDs) < 2 {
@@ -833,16 +852,17 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 		return
 	}
 
-	// Build the set of "other books in this cluster" — everything in the
-	// cluster except the one being removed.
-	others := make(map[string]struct{}, len(body.ClusterBookIDs))
+	// Build the set of "remaining books in this cluster" — cluster
+	// minus the remove set.
+	remaining := make(map[string]struct{}, len(body.ClusterBookIDs))
 	for _, id := range body.ClusterBookIDs {
-		if id != body.RemoveBookID {
-			others[id] = struct{}{}
+		if _, removed := removeSet[id]; removed {
+			continue
 		}
+		remaining[id] = struct{}{}
 	}
-	if len(others) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster must contain at least one book other than remove_book_id"})
+	if len(remaining) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster must contain at least one book that is not in remove set"})
 		return
 	}
 
@@ -858,35 +878,43 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 
 	dismissed := 0
 	for _, cand := range candidates {
-		// The pair must involve the removed book on one side and an
-		// "other cluster member" on the opposite side. Pairs where the
-		// removed book touches a book OUTSIDE the cluster are deliberately
-		// skipped — those represent different clusters that the user
-		// hasn't expressed an opinion on.
-		var otherID string
+		// A pair is dismissible if at least one side is in the remove
+		// set AND the other side is either also in the remove set or in
+		// the remaining cluster. Pairs where a removed book touches a
+		// book OUTSIDE the cluster are not touched — those are
+		// different clusters.
+		_, aRemoved := removeSet[cand.EntityAID]
+		_, bRemoved := removeSet[cand.EntityBID]
+		if !aRemoved && !bRemoved {
+			continue
+		}
+		_, aRemaining := remaining[cand.EntityAID]
+		_, bRemaining := remaining[cand.EntityBID]
+
+		touchesCluster := false
 		switch {
-		case cand.EntityAID == body.RemoveBookID:
-			otherID = cand.EntityBID
-		case cand.EntityBID == body.RemoveBookID:
-			otherID = cand.EntityAID
-		default:
+		case aRemoved && (bRemaining || bRemoved):
+			touchesCluster = true
+		case bRemoved && (aRemaining || aRemoved):
+			touchesCluster = true
+		}
+		if !touchesCluster {
 			continue
 		}
-		if _, ok := others[otherID]; !ok {
-			continue
-		}
+
 		if err := s.embeddingStore.UpdateCandidateStatus(cand.ID, "dismissed"); err != nil {
 			log.Printf("[dedup] remove-from-cluster: status update %d: %v", cand.ID, err)
 			continue
 		}
 		dismissed++
 	}
-	log.Printf("[dedup] remove-from-cluster: dismissed %d edge(s) between %s and %d other cluster member(s)",
-		dismissed, body.RemoveBookID, len(others))
+	log.Printf("[dedup] remove-from-cluster: dismissed %d edge(s), removed %d book(s) from cluster of %d",
+		dismissed, len(removeSet), len(body.ClusterBookIDs))
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":    "removed",
 		"dismissed": dismissed,
+		"removed":   len(removeSet),
 	})
 }
 

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.16.0
+// version: 3.17.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -2581,6 +2581,11 @@ function EmbeddingDedupTab() {
   const [seriesMergeLoading, setSeriesMergeLoading] = useState(false);
   const [seriesSummary, setSeriesSummary] = useState<api.DedupSeriesSummary[]>([]);
   const [seriesMergeRunning, setSeriesMergeRunning] = useState<number | null>(null);
+  // Per-cluster multi-select state for the split-cluster workflow.
+  // Key: cluster.key → set of selected bookIds. When at least one
+  // book is selected for a cluster, the split-cluster action bar
+  // appears at the bottom of that card.
+  const [splitSelections, setSplitSelections] = useState<Map<string, Set<string>>>(new Map());
   const [pageMerging, setPageMerging] = useState(false);
   const [bulkMerging, setBulkMerging] = useState(false);
 
@@ -2724,14 +2729,58 @@ function EmbeddingDedupTab() {
 
   // Remove a single book from a 3+ way cluster. Dismisses just the edges
   // between this book and the other cluster members, leaving the rest as
-  // a smaller cluster the user can still merge. This is the "one of these
-  // is actually a different book" escape hatch — e.g. a 3-way cluster with
-  // "Monster Trainer Academy I" twice plus "Monster Trainer Academy II"
-  // where the user wants to merge the two I's and kick out the II.
+  // a smaller cluster the user can still merge.
   const handleRemoveFromCluster = async (cluster: BookCluster, bookId: string) => {
     setActionLoading(`${cluster.key}:${bookId}`);
     try {
       await api.removeFromDedupCluster(cluster.bookIds, bookId);
+      loadCandidates();
+      loadStats();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Remove from cluster failed');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // Toggle whether a specific book is selected for multi-select split
+  // on a given cluster. Immutable map update so React re-renders the
+  // cluster card.
+  const toggleSplitSelection = (cluster: BookCluster, bookId: string) => {
+    setSplitSelections((prev) => {
+      const next = new Map(prev);
+      const current = new Set(next.get(cluster.key) ?? []);
+      if (current.has(bookId)) {
+        current.delete(bookId);
+      } else {
+        current.add(bookId);
+      }
+      if (current.size === 0) {
+        next.delete(cluster.key);
+      } else {
+        next.set(cluster.key, current);
+      }
+      return next;
+    });
+  };
+
+  // Remove every selected book from a cluster in one backend call.
+  // This is what the split-cluster multi-select workflow commits:
+  // "this 6-way cluster is really two groups, let me kick out three
+  // of the books in one action instead of clicking × three times".
+  const handleRemoveSelectedFromCluster = async (cluster: BookCluster) => {
+    const selected = splitSelections.get(cluster.key);
+    if (!selected || selected.size === 0) return;
+    const removeIds = Array.from(selected);
+    setActionLoading(`${cluster.key}:split`);
+    try {
+      await api.removeFromDedupCluster(cluster.bookIds, removeIds);
+      // Clear selection for this cluster on success.
+      setSplitSelections((prev) => {
+        const next = new Map(prev);
+        next.delete(cluster.key);
+        return next;
+      });
       loadCandidates();
       loadStats();
     } catch (err) {
@@ -2990,6 +3039,23 @@ function EmbeddingDedupTab() {
                 {removeBusy ? <CircularProgress size={14} /> : <CloseIcon sx={{ fontSize: 16 }} />}
               </IconButton>
             </span>
+          </Tooltip>
+        )}
+        {isMultiWay && cluster.hasPending && (
+          <Tooltip title="Select for multi-remove">
+            <Checkbox
+              size="small"
+              checked={splitSelections.get(cluster.key)?.has(id) ?? false}
+              onClick={(e) => e.stopPropagation()}
+              onChange={() => toggleSplitSelection(cluster, id)}
+              disabled={anyActionBusy}
+              sx={{
+                position: 'absolute',
+                top: -8,
+                left: -8,
+                padding: '4px',
+              }}
+            />
           </Tooltip>
         )}
       </Box>
@@ -3374,6 +3440,23 @@ function EmbeddingDedupTab() {
                         >
                           Dismiss
                         </Button>
+                        {(splitSelections.get(cluster.key)?.size ?? 0) > 0 && (
+                          <Button
+                            size="small"
+                            color="error"
+                            variant="outlined"
+                            startIcon={
+                              actionLoading === `${cluster.key}:split`
+                                ? <CircularProgress size={14} />
+                                : <CloseIcon />
+                            }
+                            onClick={() => handleRemoveSelectedFromCluster(cluster)}
+                            disabled={actionLoading != null}
+                            sx={{ ml: 'auto' }}
+                          >
+                            Remove {splitSelections.get(cluster.key)?.size ?? 0} Selected
+                          </Button>
+                        )}
                       </>
                     ) : (
                       <Chip

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 1.71.0
+// version: 1.72.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -3746,22 +3746,27 @@ export async function dismissDedupCluster(bookIds: string[]): Promise<{ status: 
   return response.json();
 }
 
-// Remove a single book from a cluster by dismissing only the edges between
-// it and the other cluster members. Pairs involving the book with books
-// OUTSIDE the cluster are left alone. Used by the per-side "not a
-// duplicate" button when one book in a 3+ way cluster is wrong but the
-// rest are real duplicates.
+// Remove one or more books from a cluster by dismissing only the
+// edges between them and the remaining cluster members. Pairs
+// involving a removed book with books OUTSIDE the cluster are left
+// alone. Accepts either a single book ID (× button) or a list of
+// IDs (multi-select split).
 export async function removeFromDedupCluster(
   clusterBookIds: string[],
-  removeBookId: string
-): Promise<{ status: string; dismissed: number }> {
+  removeBookIds: string | string[]
+): Promise<{ status: string; dismissed: number; removed: number }> {
+  const body: Record<string, unknown> = {
+    cluster_book_ids: clusterBookIds,
+  };
+  if (Array.isArray(removeBookIds)) {
+    body.remove_book_ids = removeBookIds;
+  } else {
+    body.remove_book_id = removeBookIds;
+  }
   const response = await fetch(`${API_BASE}/dedup/candidates/remove-from-cluster`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      cluster_book_ids: clusterBookIds,
-      remove_book_id: removeBookId,
-    }),
+    body: JSON.stringify(body),
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to remove book from dedup cluster');


### PR DESCRIPTION
Checkboxes on each book in 3+ way clusters. When at least one is selected, a Remove N Selected button fires a batch endpoint. Backend extended to accept remove_book_ids plural alongside the existing singular form. Backlog item #7.