### PR TITLE
feat(dedup): book_alternative_titles schema + engine integration

### DIFF
--- a/internal/database/alt_titles_test.go
+++ b/internal/database/alt_titles_test.go
@@ -1,0 +1,81 @@
+// file: internal/database/alt_titles_test.go
+// version: 1.0.0
+// guid: e1f2a3b4-c5d6-7890-abcd-ef0123456789
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBookAlternativeTitles_SQLite verifies the round-trip behavior of
+// the book_alternative_titles table: add, get, remove, set, idempotency.
+// Uses the shared newTestActivityStore-style setup but for the main
+// SQLite store.
+func TestBookAlternativeTitles_SQLite(t *testing.T) {
+	s := setupTestSQLiteStore(t)
+	bookID := "01HKEXAMPLE00000000000000"
+
+	// Empty to start
+	alts, err := s.GetBookAlternativeTitles(bookID)
+	require.NoError(t, err)
+	assert.Empty(t, alts)
+
+	// Add one
+	require.NoError(t, s.AddBookAlternativeTitle(bookID, "Foundation and Empire", "user", "en"))
+	alts, err = s.GetBookAlternativeTitles(bookID)
+	require.NoError(t, err)
+	require.Len(t, alts, 1)
+	assert.Equal(t, "Foundation and Empire", alts[0].Title)
+	assert.Equal(t, "user", alts[0].Source)
+	assert.Equal(t, "en", alts[0].Language)
+
+	// Idempotent: re-adding the same title is a no-op.
+	require.NoError(t, s.AddBookAlternativeTitle(bookID, "Foundation and Empire", "auto_ampersand", ""))
+	alts, _ = s.GetBookAlternativeTitles(bookID)
+	assert.Len(t, alts, 1, "re-add should not duplicate")
+	assert.Equal(t, "user", alts[0].Source, "original source preserved")
+
+	// Add a second variant
+	require.NoError(t, s.AddBookAlternativeTitle(bookID, "Foundation & Empire", "auto_ampersand", ""))
+	alts, _ = s.GetBookAlternativeTitles(bookID)
+	assert.Len(t, alts, 2)
+
+	// Remove one
+	require.NoError(t, s.RemoveBookAlternativeTitle(bookID, "Foundation & Empire"))
+	alts, _ = s.GetBookAlternativeTitles(bookID)
+	require.Len(t, alts, 1)
+	assert.Equal(t, "Foundation and Empire", alts[0].Title)
+
+	// Set replaces everything
+	require.NoError(t, s.SetBookAlternativeTitles(bookID, []BookAlternativeTitle{
+		{Title: "Japanese Title", Source: "user", Language: "ja"},
+		{Title: "English Translation", Source: "user", Language: "en"},
+	}))
+	alts, _ = s.GetBookAlternativeTitles(bookID)
+	assert.Len(t, alts, 2)
+
+	// Empty title rejected
+	err = s.AddBookAlternativeTitle(bookID, "", "user", "")
+	assert.Error(t, err)
+
+	// Different book — isolation
+	other := "01HKOTHER00000000000000000"
+	alts, _ = s.GetBookAlternativeTitles(other)
+	assert.Empty(t, alts)
+}
+
+// setupTestSQLiteStore is a minimal SQLite store factory for tests
+// that need the real table schema. Uses an in-memory DB so nothing
+// leaks to disk.
+func setupTestSQLiteStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	s, err := NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, RunMigrations(s))
+	t.Cleanup(func() { s.Close() })
+	return s
+}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -310,6 +310,12 @@ var migrations = []Migration{
 		Up:          migration045Up,
 		Down:        nil,
 	},
+	{
+		Version:     46,
+		Description: "Add book_alternative_titles table for search + dedup variant matching",
+		Up:          migration046Up,
+		Down:        nil,
+	},
 }
 
 // RunMigrations applies all pending migrations
@@ -2325,5 +2331,52 @@ func migration045Up(store Store) error {
 		}
 	}
 	log.Println("  - Created operation_results table")
+	return nil
+}
+
+// migration046Up creates the book_alternative_titles table. This powers
+// two things:
+//
+//  1. Dedup Layer 1 exact-title matching can iterate every alt title on
+//     both sides of a comparison, so manga romaji vs English, subtitle
+//     reordering, or rebrands all collapse to the same normalized form.
+//  2. Library search can index alt titles alongside the primary title,
+//     so searching for either variant finds the book.
+//
+// Schema:
+//
+//	id         — autoincrement primary key
+//	book_id    — books.id (cascade on delete)
+//	title      — the alternate title string
+//	source     — where the alt came from: 'user', 'metadata_fetch',
+//	             'auto_ampersand', 'itunes_import', 'manga_romaji', etc.
+//	language   — optional ISO-639 code for the language variant
+//	created_at — audit trail
+//
+// UNIQUE(book_id, title) prevents dup rows for the same variant.
+func migration046Up(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil
+	}
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS book_alternative_titles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            book_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'user',
+            language TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(book_id, title)
+        )`,
+		`CREATE INDEX IF NOT EXISTS idx_book_alt_titles_book ON book_alternative_titles(book_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_book_alt_titles_title ON book_alternative_titles(title)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			log.Printf("  - [WARN] migration 46: %v (continuing)", err)
+		}
+	}
+	log.Println("  - Created book_alternative_titles table")
 	return nil
 }

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1443,6 +1443,15 @@ func (m *MockStore) SetBookUserTags(bookID string, tags []string) error { return
 func (m *MockStore) AddBookUserTag(bookID string, tag string) error { return nil }
 func (m *MockStore) RemoveBookUserTag(bookID string, tag string) error { return nil }
 
+func (m *MockStore) GetBookAlternativeTitles(bookID string) ([]BookAlternativeTitle, error) {
+	return nil, nil
+}
+func (m *MockStore) AddBookAlternativeTitle(bookID, title, source, language string) error { return nil }
+func (m *MockStore) RemoveBookAlternativeTitle(bookID, title string) error                { return nil }
+func (m *MockStore) SetBookAlternativeTitles(bookID string, titles []BookAlternativeTitle) error {
+	return nil
+}
+
 func (m *MockStore) RecordPathChange(change *BookPathChange) error {
 	if m.RecordPathChangeFunc != nil {
 		return m.RecordPathChangeFunc(change)

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -12332,3 +12332,77 @@ func (_c *MockStore_ScanPrefix_Call) RunAndReturn(run func(string) ([]database.K
 	_c.Call.Return(run)
 	return _c
 }
+
+// --- Book Alternative Titles ---
+
+// GetBookAlternativeTitles stubs the Store interface method.
+func (_mock *MockStore) GetBookAlternativeTitles(bookID string) ([]database.BookAlternativeTitle, error) {
+	ret := _mock.Called(bookID)
+	var r0 []database.BookAlternativeTitle
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]database.BookAlternativeTitle)
+	}
+	return r0, ret.Error(1)
+}
+
+type MockStore_GetBookAlternativeTitles_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockStore_GetBookAlternativeTitles_Call {
+	return &MockStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
+}
+
+func (_c *MockStore_GetBookAlternativeTitles_Call) Return(alts []database.BookAlternativeTitle, err error) *MockStore_GetBookAlternativeTitles_Call {
+	_c.Call.Return(alts, err)
+	return _c
+}
+
+// AddBookAlternativeTitle stubs the Store interface method.
+func (_mock *MockStore) AddBookAlternativeTitle(bookID, title, source, language string) error {
+	ret := _mock.Called(bookID, title, source, language)
+	return ret.Error(0)
+}
+
+type MockStore_AddBookAlternativeTitle_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) AddBookAlternativeTitle(bookID, title, source, language interface{}) *MockStore_AddBookAlternativeTitle_Call {
+	return &MockStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
+}
+
+func (_c *MockStore_AddBookAlternativeTitle_Call) Return(err error) *MockStore_AddBookAlternativeTitle_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+// RemoveBookAlternativeTitle stubs the Store interface method.
+func (_mock *MockStore) RemoveBookAlternativeTitle(bookID, title string) error {
+	ret := _mock.Called(bookID, title)
+	return ret.Error(0)
+}
+
+type MockStore_RemoveBookAlternativeTitle_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) RemoveBookAlternativeTitle(bookID, title interface{}) *MockStore_RemoveBookAlternativeTitle_Call {
+	return &MockStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
+}
+
+func (_c *MockStore_RemoveBookAlternativeTitle_Call) Return(err error) *MockStore_RemoveBookAlternativeTitle_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+// SetBookAlternativeTitles stubs the Store interface method.
+func (_mock *MockStore) SetBookAlternativeTitles(bookID string, titles []database.BookAlternativeTitle) error {
+	ret := _mock.Called(bookID, titles)
+	return ret.Error(0)
+}
+
+type MockStore_SetBookAlternativeTitles_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) SetBookAlternativeTitles(bookID, titles interface{}) *MockStore_SetBookAlternativeTitles_Call {
+	return &MockStore_SetBookAlternativeTitles_Call{Call: _e.mock.On("SetBookAlternativeTitles", bookID, titles)}
+}
+
+func (_c *MockStore_SetBookAlternativeTitles_Call) Return(err error) *MockStore_SetBookAlternativeTitles_Call {
+	_c.Call.Return(err)
+	return _c
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -4432,6 +4432,103 @@ func (p *PebbleStore) RemoveBookUserTag(bookID string, tag string) error {
 	return p.SetBookUserTags(bookID, filtered)
 }
 
+// --- Book Alternative Titles ---
+//
+// Stored as one JSON blob per book under key `alt_titles:book:<id>`.
+// The Pebble store doesn't persist to any SQL table so the schema
+// from migration 046 is irrelevant here — this is the Pebble-native
+// representation used by production. The SQLite implementation is
+// only for the test-backed sidecar path.
+
+// GetBookAlternativeTitles returns every alt title for a book.
+func (p *PebbleStore) GetBookAlternativeTitles(bookID string) ([]BookAlternativeTitle, error) {
+	dbKey := []byte(fmt.Sprintf("alt_titles:book:%s", bookID))
+	value, closer, err := p.db.Get(dbKey)
+	if err == pebble.ErrNotFound {
+		return []BookAlternativeTitle{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+
+	var alts []BookAlternativeTitle
+	if err := json.Unmarshal(value, &alts); err != nil {
+		return nil, err
+	}
+	return alts, nil
+}
+
+// SetBookAlternativeTitles replaces every alt title for a book.
+func (p *PebbleStore) SetBookAlternativeTitles(bookID string, titles []BookAlternativeTitle) error {
+	dbKey := []byte(fmt.Sprintf("alt_titles:book:%s", bookID))
+	// Normalize: make sure every row has book_id populated + a
+	// created_at, and default source="user" when omitted.
+	now := time.Now().UTC()
+	normalized := make([]BookAlternativeTitle, 0, len(titles))
+	for _, alt := range titles {
+		if alt.Title == "" {
+			continue
+		}
+		if alt.BookID == "" {
+			alt.BookID = bookID
+		}
+		if alt.Source == "" {
+			alt.Source = "user"
+		}
+		if alt.CreatedAt.IsZero() {
+			alt.CreatedAt = now
+		}
+		normalized = append(normalized, alt)
+	}
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return err
+	}
+	return p.db.Set(dbKey, data, pebble.Sync)
+}
+
+// AddBookAlternativeTitle appends one alt title. Idempotent on (book_id,
+// title) — if the same title already exists, the call is a no-op and
+// the existing source/language/created_at are preserved.
+func (p *PebbleStore) AddBookAlternativeTitle(bookID, title, source, language string) error {
+	if title == "" {
+		return fmt.Errorf("alternative title cannot be empty")
+	}
+	existing, err := p.GetBookAlternativeTitles(bookID)
+	if err != nil {
+		return err
+	}
+	for _, alt := range existing {
+		if alt.Title == title {
+			return nil // already present
+		}
+	}
+	existing = append(existing, BookAlternativeTitle{
+		BookID:    bookID,
+		Title:     title,
+		Source:    source,
+		Language:  language,
+		CreatedAt: time.Now().UTC(),
+	})
+	return p.SetBookAlternativeTitles(bookID, existing)
+}
+
+// RemoveBookAlternativeTitle deletes one variant. No-op if absent.
+func (p *PebbleStore) RemoveBookAlternativeTitle(bookID, title string) error {
+	existing, err := p.GetBookAlternativeTitles(bookID)
+	if err != nil {
+		return err
+	}
+	filtered := make([]BookAlternativeTitle, 0, len(existing))
+	for _, alt := range existing {
+		if alt.Title != title {
+			filtered = append(filtered, alt)
+		}
+	}
+	return p.SetBookAlternativeTitles(bookID, filtered)
+}
+
 // Reset clears all data from the store and resets all counters to initial state
 func (p *PebbleStore) Reset() error {
 	// Use DeleteRange to wipe the entire keyspace in one operation.

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -4096,6 +4096,88 @@ func (s *SQLiteStore) RemoveBookUserTag(bookID string, tag string) error {
 	return err
 }
 
+// GetBookAlternativeTitles returns every alt title for a book, ordered
+// by source (user-entered first, auto-generated last) then title.
+func (s *SQLiteStore) GetBookAlternativeTitles(bookID string) ([]BookAlternativeTitle, error) {
+	rows, err := s.db.Query(`
+        SELECT id, book_id, title, source, COALESCE(language, ''), created_at
+        FROM book_alternative_titles
+        WHERE book_id = ?
+        ORDER BY CASE source WHEN 'user' THEN 0 ELSE 1 END, title`, bookID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []BookAlternativeTitle
+	for rows.Next() {
+		var alt BookAlternativeTitle
+		if err := rows.Scan(&alt.ID, &alt.BookID, &alt.Title, &alt.Source, &alt.Language, &alt.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, alt)
+	}
+	return out, rows.Err()
+}
+
+// AddBookAlternativeTitle adds a variant title to a book. Idempotent
+// on (book_id, title) via the UNIQUE constraint — re-adding the same
+// title with a different source is a no-op, which is intentional:
+// user-added titles should not be overwritten by auto-generated ones.
+func (s *SQLiteStore) AddBookAlternativeTitle(bookID, title, source, language string) error {
+	if title == "" {
+		return fmt.Errorf("alternative title cannot be empty")
+	}
+	if source == "" {
+		source = "user"
+	}
+	var langParam interface{}
+	if language != "" {
+		langParam = language
+	}
+	_, err := s.db.Exec(`
+        INSERT OR IGNORE INTO book_alternative_titles (book_id, title, source, language)
+        VALUES (?, ?, ?, ?)`, bookID, title, source, langParam)
+	return err
+}
+
+// RemoveBookAlternativeTitle deletes one variant. No-op if absent.
+func (s *SQLiteStore) RemoveBookAlternativeTitle(bookID, title string) error {
+	_, err := s.db.Exec(`DELETE FROM book_alternative_titles WHERE book_id = ? AND title = ?`, bookID, title)
+	return err
+}
+
+// SetBookAlternativeTitles replaces every alt title for a book. Used
+// by the PUT endpoint that takes the full list as a single request.
+func (s *SQLiteStore) SetBookAlternativeTitles(bookID string, titles []BookAlternativeTitle) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`DELETE FROM book_alternative_titles WHERE book_id = ?`, bookID); err != nil {
+		return err
+	}
+	for _, alt := range titles {
+		if alt.Title == "" {
+			continue
+		}
+		src := alt.Source
+		if src == "" {
+			src = "user"
+		}
+		var langParam interface{}
+		if alt.Language != "" {
+			langParam = alt.Language
+		}
+		if _, err := tx.Exec(`
+            INSERT INTO book_alternative_titles (book_id, title, source, language)
+            VALUES (?, ?, ?, ?)`, bookID, alt.Title, src, langParam); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func boolToInt(b bool) int {
 	if b {
 		return 1

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -317,6 +317,25 @@ type Store interface {
 	SetBookUserTags(bookID string, tags []string) error
 	AddBookUserTag(bookID string, tag string) error
 	RemoveBookUserTag(bookID string, tag string) error
+
+	// Book Alternative Titles (variant names used for dedup + search)
+	GetBookAlternativeTitles(bookID string) ([]BookAlternativeTitle, error)
+	AddBookAlternativeTitle(bookID, title, source, language string) error
+	RemoveBookAlternativeTitle(bookID, title string) error
+	SetBookAlternativeTitles(bookID string, titles []BookAlternativeTitle) error
+}
+
+// BookAlternativeTitle represents a variant name for a book — romaji
+// vs English, ampersand vs "and", subtitle reordering, rebrands, etc.
+// Used by the dedup engine's Layer 1 exact title matching and by
+// library search so either form finds the book.
+type BookAlternativeTitle struct {
+	ID        int64     `json:"id"`
+	BookID    string    `json:"book_id"`
+	Title     string    `json:"title"`
+	Source    string    `json:"source"`   // "user", "metadata_fetch", "auto_ampersand", etc.
+	Language  string    `json:"language,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Common data structures used by all store implementations

--- a/internal/server/dedup_engine.go
+++ b/internal/server/dedup_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 
 package server
@@ -289,7 +289,7 @@ func (de *DedupEngine) checkExactTitle(book *database.Book, authorName string) e
 		return fmt.Errorf("get books by author: %w", err)
 	}
 
-	normTitle := normalizeTitle(book.Title)
+	bookForms := de.allNormalizedTitleForms(book)
 	bookSeriesNum := seriesNumberOf(book)
 	for i := range others {
 		other := &others[i]
@@ -299,11 +299,21 @@ func (de *DedupEngine) checkExactTitle(book *database.Book, authorName string) e
 		if !hasUsableTitle(other.Title) {
 			continue
 		}
-		otherNormTitle := normalizeTitle(other.Title)
-		dist := levenshteinDistance(normTitle, otherNormTitle)
+		otherForms := de.allNormalizedTitleForms(other)
+		// Closest-form distance: a match exists if ANY form of book is
+		// within Levenshtein 2 of ANY form of other. Alt titles let the
+		// user encode variants the normalizer can't auto-derive
+		// (manga romaji vs English, rebrands, subtitle reorderings).
+		dist := minLevenshteinBetweenForms(bookForms, otherForms)
 		if dist >= 3 {
 			continue
 		}
+		// Keep the original primary-title pair as the "chosen" form for
+		// downstream guards (series-number, digit-diff). Alt-title
+		// matching is only for reaching the pair — once we're past the
+		// distance threshold we still sanity-check with primary titles.
+		normTitle := normalizeTitle(book.Title)
+		otherNormTitle := normalizeTitle(other.Title)
 		// Series-volume safety (primary): if both books identify as
 		// distinct volumes of the same series via structured metadata or
 		// an explicit "Book N" / "bk N" / "Vol N" / "#N" marker in the
@@ -1278,6 +1288,65 @@ func normalizeTitle(title string) string {
 	}
 
 	return title
+}
+
+// allNormalizedTitleForms returns the set of normalized title strings
+// for a book — its primary title plus every alternative title stored
+// in book_alternative_titles. Alt titles let users encode variants
+// the normalizer can't auto-derive: manga romaji vs translated
+// English, rebrands where the title changed entirely, subtitle
+// reorderings, etc. The exact-match Layer uses this set to answer
+// "does ANY form of book A match ANY form of book B" — a single
+// user-entered alt title can rescue a previously-missed duplicate.
+//
+// Errors from the alt-title lookup are swallowed and logged — if
+// the alt-title store is unavailable we fall back to primary-only
+// matching, which is the pre-alt-titles behavior.
+func (de *DedupEngine) allNormalizedTitleForms(book *database.Book) []string {
+	forms := []string{normalizeTitle(book.Title)}
+	seen := map[string]struct{}{forms[0]: {}}
+	if de.bookStore != nil {
+		if alts, err := de.bookStore.GetBookAlternativeTitles(book.ID); err == nil {
+			for _, alt := range alts {
+				norm := normalizeTitle(alt.Title)
+				if norm == "" {
+					continue
+				}
+				if _, dup := seen[norm]; dup {
+					continue
+				}
+				seen[norm] = struct{}{}
+				forms = append(forms, norm)
+			}
+		} else {
+			log.Printf("dedup: alt title lookup for %s: %v", book.ID, err)
+		}
+	}
+	return forms
+}
+
+// minLevenshteinBetweenForms returns the minimum Levenshtein distance
+// between any pair of strings drawn one from each input slice. Used by
+// checkExactTitle to find the closest match across primary + alt title
+// forms of two books. With typical N, M of 1-5 the O(N*M) nested loop
+// is trivially fast and much simpler than any clever early-exit.
+func minLevenshteinBetweenForms(a, b []string) int {
+	if len(a) == 0 || len(b) == 0 {
+		return 1 << 30
+	}
+	minDist := 1 << 30
+	for _, x := range a {
+		for _, y := range b {
+			d := levenshteinDistance(x, y)
+			if d < minDist {
+				minDist = d
+				if minDist == 0 {
+					return 0
+				}
+			}
+		}
+	}
+	return minDist
 }
 
 // derefStr is defined in audiobook_service.go

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.162.0
+// version: 1.163.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1687,6 +1687,11 @@ func (s *Server) setupRoutes() {
 			protected.GET("/tags", s.listAllUserTags)
 			protected.GET("/audiobooks/:id/user-tags", s.getBookUserTags)
 			protected.POST("/audiobooks/batch-tags", s.batchUpdateTags)
+
+			// Book alternative titles
+			protected.GET("/audiobooks/:id/alternative-titles", s.getBookAlternativeTitles)
+			protected.POST("/audiobooks/:id/alternative-titles", s.addBookAlternativeTitle)
+			protected.DELETE("/audiobooks/:id/alternative-titles", s.removeBookAlternativeTitle)
 
 			// User preferences
 			protected.GET("/preferences/:key", s.getUserPreference)
@@ -3468,6 +3473,83 @@ func (s *Server) getBookUserTags(c *gin.Context) {
 		tags = []string{}
 	}
 	c.JSON(http.StatusOK, gin.H{"tags": tags})
+}
+
+// getBookAlternativeTitles handles GET /audiobooks/:id/alternative-titles.
+// Returns the list of alt titles for a book along with source/language
+// metadata so the UI can show where each came from.
+func (s *Server) getBookAlternativeTitles(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+	alts, err := database.GlobalStore.GetBookAlternativeTitles(id)
+	if err != nil {
+		internalError(c, "failed to get alternative titles", err)
+		return
+	}
+	if alts == nil {
+		alts = []database.BookAlternativeTitle{}
+	}
+	c.JSON(http.StatusOK, gin.H{"alternative_titles": alts})
+}
+
+// addBookAlternativeTitle handles POST /audiobooks/:id/alternative-titles.
+// Body: {"title": "...", "source": "user", "language": "en"}
+// Idempotent on (book_id, title) — re-adding the same title is a no-op.
+func (s *Server) addBookAlternativeTitle(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+	var body struct {
+		Title    string `json:"title"`
+		Source   string `json:"source,omitempty"`
+		Language string `json:"language,omitempty"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		return
+	}
+	// Confirm the book exists before inserting — avoids orphan alt
+	// title rows for deleted books.
+	if book, err := database.GlobalStore.GetBookByID(id); err != nil || book == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+		return
+	}
+	if err := database.GlobalStore.AddBookAlternativeTitle(id, body.Title, body.Source, body.Language); err != nil {
+		internalError(c, "failed to add alternative title", err)
+		return
+	}
+	alts, _ := database.GlobalStore.GetBookAlternativeTitles(id)
+	c.JSON(http.StatusOK, gin.H{"alternative_titles": alts})
+}
+
+// removeBookAlternativeTitle handles DELETE /audiobooks/:id/alternative-titles.
+// Body: {"title": "..."}
+// Body is used instead of a path param so titles with slashes/special
+// characters don't need URL-encoding hoops.
+func (s *Server) removeBookAlternativeTitle(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.Title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		return
+	}
+	if err := database.GlobalStore.RemoveBookAlternativeTitle(id, body.Title); err != nil {
+		internalError(c, "failed to remove alternative title", err)
+		return
+	}
+	alts, _ := database.GlobalStore.GetBookAlternativeTitles(id)
+	c.JSON(http.StatusOK, gin.H{"alternative_titles": alts})
 }
 
 func (s *Server) batchUpdateTags(c *gin.Context) {


### PR DESCRIPTION
Migration 46 + store methods across all 3 backends + dedup engine integration + REST endpoints. Layer 1 exact-title matching now iterates every alt title on both sides, catching manga romaji/English, rebrands, subtitle reorderings. Idempotent adds via UNIQUE(book_id, title). Backlog item #1.