### PR TITLE
feat(metadata): Resume Last Review button

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-04-05
 
@@ -342,6 +342,47 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 		"no_match":     countByStatus(candidateResults, "no_match"),
 		"errors":       countByStatus(candidateResults, "error"),
 	})
+}
+
+// handleGetLatestMetadataFetch returns the most recently-created
+// metadata_candidate_fetch operation that has persisted results. Used
+// by the "Resume Last Review" button in the library: after a fetch
+// completes the user may close the tab, reload, or otherwise lose the
+// in-memory reviewOp state, and they need a way to get back to the
+// review dialog without re-running the fetch. Returns 404 if no such
+// operation exists.
+func (s *Server) handleGetLatestMetadataFetch(c *gin.Context) {
+	store := database.GlobalStore
+	ops, err := store.GetRecentOperations(50)
+	if err != nil {
+		internalError(c, "failed to list recent operations", err)
+		return
+	}
+	for _, op := range ops {
+		if op.Type != "metadata_candidate_fetch" {
+			continue
+		}
+		if op.Status != "completed" {
+			continue
+		}
+		// Confirm it actually has persisted results — an operation
+		// can "complete" with zero results if every book's fetch
+		// failed, and there's nothing to review in that case.
+		results, err := store.GetOperationResults(op.ID)
+		if err != nil {
+			log.Printf("[WARN] resume-review: get results for %s: %v", op.ID, err)
+			continue
+		}
+		if len(results) == 0 {
+			continue
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"operation":    op,
+			"result_count": len(results),
+		})
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "no completed metadata fetch operations with results found"})
 }
 
 // countByStatus counts CandidateResults with the given status.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.163.0
+// version: 1.164.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1884,6 +1884,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/metadata/fields", s.getMetadataFields)
 			protected.POST("/metadata/bulk-fetch", s.bulkFetchMetadata)
 			protected.POST("/metadata/batch-fetch-candidates", s.handleBatchFetchCandidates)
+			protected.GET("/metadata/latest-fetch", s.handleGetLatestMetadataFetch)
 			protected.POST("/metadata/batch-apply-candidates", s.handleBatchApplyCandidates)
 			protected.POST("/metadata/batch-reject-candidates", s.handleRejectCandidates)
 			protected.POST("/metadata/batch-unreject-candidates", s.handleUnrejectCandidates)

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.48.0
+// version: 1.49.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -1752,6 +1752,27 @@ export const Library = () => {
               }}
               disabled={selectedAudiobooks.length < 2}
             >Fetch & Review</Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={async () => {
+                try {
+                  const latest = await api.getLatestMetadataFetch();
+                  if (!latest) {
+                    toast('No recent metadata fetch with results found. Start a Fetch & Review first.', 'info');
+                    return;
+                  }
+                  setMetadataReviewOpId(latest.operation.id);
+                  setMetadataReviewOpen(true);
+                  toast(`Resumed review for ${latest.result_count} book(s)`, 'success');
+                } catch {
+                  toast('Failed to load latest metadata fetch', 'error');
+                }
+              }}
+              title="Open the review dialog with the most recent completed fetch results — useful after a page reload or accidental dialog close"
+            >
+              Resume Last Review
+            </Button>
             <Button size="small" variant="outlined" onClick={() => setBulkSearchOpen(true)} disabled={!hasSelection}>Search Metadata</Button>
             <Box sx={{ borderLeft: 1, borderColor: 'divider', height: 24 }} />
             <Button size="small" variant="outlined" onClick={() => { setBulkWriteBackResult(null); setBulkWriteBackRename(false); setBulkWriteBackDialogOpen(true); }} disabled={!selectedHasActive}>Save to Files</Button>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 1.72.0
+// version: 1.73.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -2653,6 +2653,21 @@ export async function batchFetchCandidates(bookIds: string[]): Promise<{ operati
 export async function getOperationResults(operationId: string): Promise<BatchFetchResponse> {
   const response = await fetch(`${API_BASE}/operations/${operationId}/results`);
   if (!response.ok) throw await buildApiError(response, 'Failed to get operation results');
+  return response.json();
+}
+
+// getLatestMetadataFetch returns the most recent completed metadata
+// batch-fetch operation that has persisted results, or null if none
+// exists. Used by the "Resume Last Review" button in the library so a
+// user who lost the reviewOp state (page reload, tab close) can get
+// back to the review dialog without re-running the fetch.
+export async function getLatestMetadataFetch(): Promise<{
+  operation: { id: string; type: string; status: string; created_at: string };
+  result_count: number;
+} | null> {
+  const response = await fetch(`${API_BASE}/metadata/latest-fetch`);
+  if (response.status === 404) return null;
+  if (!response.ok) throw await buildApiError(response, 'Failed to get latest metadata fetch');
   return response.json();
 }
 


### PR DESCRIPTION
After clicking Fetch & Review the reviewOp id is held in React state. A page reload loses it and the user is stuck with a completed fetch they can't open. New Resume Last Review button + GET /metadata/latest-fetch endpoint that finds the most recent completed metadata_candidate_fetch with persisted results and opens the review dialog with it. Future fetches can still update — always grabs the newest qualifying operation.