### PR TITLE
feat(metadata): Resume Review picker for back-to-back fetches

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
@@ -344,45 +345,89 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 	})
 }
 
-// handleGetLatestMetadataFetch returns the most recently-created
-// metadata_candidate_fetch operation that has persisted results. Used
-// by the "Resume Last Review" button in the library: after a fetch
-// completes the user may close the tab, reload, or otherwise lose the
-// in-memory reviewOp state, and they need a way to get back to the
-// review dialog without re-running the fetch. Returns 404 if no such
-// operation exists.
+// handleListMetadataFetchOperations returns recent completed
+// metadata_candidate_fetch operations that have persisted results.
+//
+// Returns up to the last 10 operations where:
+//   - type = metadata_candidate_fetch
+//   - status = completed
+//   - at least one persisted result row exists
+//
+// The frontend Resume Review dialog displays these so the user can
+// pick which fetch to review. Without this, firing two fetches
+// back-to-back without reviewing the first leaves the first's
+// results invisible in the UI — the operation id is only held in
+// React state, and only the latest gets tracked.
+//
+// 10 is a soft cap chosen as "enough to cover back-to-back fetches
+// plus a review backlog without overwhelming the dialog".
 func (s *Server) handleGetLatestMetadataFetch(c *gin.Context) {
+	const maxOps = 10
 	store := database.GlobalStore
-	ops, err := store.GetRecentOperations(50)
+	// Scan more than maxOps from recent history because the filter
+	// (type + completed + non-empty results) can reject many rows.
+	ops, err := store.GetRecentOperations(200)
 	if err != nil {
 		internalError(c, "failed to list recent operations", err)
 		return
 	}
+	type fetchOpSummary struct {
+		ID           string    `json:"id"`
+		Type         string    `json:"type"`
+		Status       string    `json:"status"`
+		CreatedAt    time.Time `json:"created_at"`
+		CompletedAt  time.Time `json:"completed_at,omitempty"`
+		ResultCount  int       `json:"result_count"`
+		MatchedCount int       `json:"matched_count"`
+		NoMatchCount int       `json:"no_match_count"`
+		ErrorCount   int       `json:"error_count"`
+	}
+	var out []fetchOpSummary
 	for _, op := range ops {
+		if len(out) >= maxOps {
+			break
+		}
 		if op.Type != "metadata_candidate_fetch" {
 			continue
 		}
 		if op.Status != "completed" {
 			continue
 		}
-		// Confirm it actually has persisted results — an operation
-		// can "complete" with zero results if every book's fetch
-		// failed, and there's nothing to review in that case.
 		results, err := store.GetOperationResults(op.ID)
 		if err != nil {
-			log.Printf("[WARN] resume-review: get results for %s: %v", op.ID, err)
+			log.Printf("[WARN] list-metadata-fetches: get results for %s: %v", op.ID, err)
 			continue
 		}
 		if len(results) == 0 {
 			continue
 		}
-		c.JSON(http.StatusOK, gin.H{
-			"operation":    op,
-			"result_count": len(results),
-		})
-		return
+		var matched, noMatch, errCount int
+		for _, r := range results {
+			switch r.Status {
+			case "matched":
+				matched++
+			case "no_match":
+				noMatch++
+			case "error":
+				errCount++
+			}
+		}
+		summary := fetchOpSummary{
+			ID:           op.ID,
+			Type:         op.Type,
+			Status:       op.Status,
+			CreatedAt:    op.CreatedAt,
+			ResultCount:  len(results),
+			MatchedCount: matched,
+			NoMatchCount: noMatch,
+			ErrorCount:   errCount,
+		}
+		if op.CompletedAt != nil {
+			summary.CompletedAt = *op.CompletedAt
+		}
+		out = append(out, summary)
 	}
-	c.JSON(http.StatusNotFound, gin.H{"error": "no completed metadata fetch operations with results found"})
+	c.JSON(http.StatusOK, gin.H{"operations": out, "count": len(out)})
 }
 
 // countByStatus counts CandidateResults with the given status.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1884,7 +1884,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/metadata/fields", s.getMetadataFields)
 			protected.POST("/metadata/bulk-fetch", s.bulkFetchMetadata)
 			protected.POST("/metadata/batch-fetch-candidates", s.handleBatchFetchCandidates)
-			protected.GET("/metadata/latest-fetch", s.handleGetLatestMetadataFetch)
+			protected.GET("/metadata/recent-fetches", s.handleGetLatestMetadataFetch)
 			protected.POST("/metadata/batch-apply-candidates", s.handleBatchApplyCandidates)
 			protected.POST("/metadata/batch-reject-candidates", s.handleRejectCandidates)
 			protected.POST("/metadata/batch-unreject-candidates", s.handleUnrejectCandidates)

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -17,6 +17,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogContentText,
   DialogActions,
   TextField,
   IconButton,
@@ -288,6 +289,8 @@ export const Library = () => {
     searchParams.get('reviewOp')
   );
   const [metadataReviewOpen, setMetadataReviewOpen] = useState(!!searchParams.get('reviewOp'));
+  const [resumeReviewPickerOpen, setResumeReviewPickerOpen] = useState(false);
+  const [recentFetches, setRecentFetches] = useState<api.MetadataFetchSummary[]>([]);
   const [mergeInProgress, setMergeInProgress] = useState(false);
   const sseStatusRef = useRef<EventSourceStatus['state'] | null>(null);
 
@@ -1757,21 +1760,20 @@ export const Library = () => {
               variant="outlined"
               onClick={async () => {
                 try {
-                  const latest = await api.getLatestMetadataFetch();
-                  if (!latest) {
+                  const list = await api.getRecentMetadataFetches();
+                  if (list.length === 0) {
                     toast('No recent metadata fetch with results found. Start a Fetch & Review first.', 'info');
                     return;
                   }
-                  setMetadataReviewOpId(latest.operation.id);
-                  setMetadataReviewOpen(true);
-                  toast(`Resumed review for ${latest.result_count} book(s)`, 'success');
+                  setRecentFetches(list);
+                  setResumeReviewPickerOpen(true);
                 } catch {
-                  toast('Failed to load latest metadata fetch', 'error');
+                  toast('Failed to load recent metadata fetches', 'error');
                 }
               }}
-              title="Open the review dialog with the most recent completed fetch results — useful after a page reload or accidental dialog close"
+              title="Pick a recent fetch operation to review — useful when multiple fetches completed without review or after a page reload"
             >
-              Resume Last Review
+              Resume Review
             </Button>
             <Button size="small" variant="outlined" onClick={() => setBulkSearchOpen(true)} disabled={!hasSelection}>Search Metadata</Button>
             <Box sx={{ borderLeft: 1, borderColor: 'divider', height: 24 }} />
@@ -2955,6 +2957,72 @@ export const Library = () => {
             toast={toast}
           />
         )}
+
+        {/* Resume Review picker: lists recent completed
+            metadata_candidate_fetch ops with their result counts.
+            Click a row to open the MetadataReviewDialog for that
+            specific operation. Solves the "fired two fetches, first
+            one's results are lost in the UI" scenario. */}
+        <Dialog
+          open={resumeReviewPickerOpen}
+          onClose={() => setResumeReviewPickerOpen(false)}
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle>Resume metadata review</DialogTitle>
+          <DialogContent>
+            <DialogContentText sx={{ mb: 2 }}>
+              Pick a completed metadata fetch to review. Results stay in
+              the operation log until you review them, so even older
+              fetches can still be opened if you never got around to it.
+            </DialogContentText>
+            {recentFetches.length === 0 ? (
+              <Typography color="text.secondary">No recent fetches found.</Typography>
+            ) : (
+              <Stack spacing={1}>
+                {recentFetches.map((op) => (
+                  <Box
+                    key={op.id}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      p: 1.5,
+                      border: 1,
+                      borderColor: 'divider',
+                      borderRadius: 1,
+                      cursor: 'pointer',
+                      '&:hover': { borderColor: 'primary.main' },
+                    }}
+                    onClick={() => {
+                      setMetadataReviewOpId(op.id);
+                      setMetadataReviewOpen(true);
+                      setResumeReviewPickerOpen(false);
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Typography variant="body2" fontWeight="medium" noWrap>
+                        {new Date(op.completed_at || op.created_at).toLocaleString()}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {op.matched_count} matched ·{' '}
+                        {op.no_match_count} no match ·{' '}
+                        {op.error_count} error{' '}
+                        ({op.result_count} total)
+                      </Typography>
+                    </Box>
+                    <Button size="small" variant="contained">
+                      Review
+                    </Button>
+                  </Box>
+                ))}
+              </Stack>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setResumeReviewPickerOpen(false)}>Close</Button>
+          </DialogActions>
+        </Dialog>
 
         <VersionManagement
           audiobookId={versionManagingAudiobook?.id || ''}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2656,19 +2656,32 @@ export async function getOperationResults(operationId: string): Promise<BatchFet
   return response.json();
 }
 
-// getLatestMetadataFetch returns the most recent completed metadata
-// batch-fetch operation that has persisted results, or null if none
-// exists. Used by the "Resume Last Review" button in the library so a
-// user who lost the reviewOp state (page reload, tab close) can get
-// back to the review dialog without re-running the fetch.
-export async function getLatestMetadataFetch(): Promise<{
-  operation: { id: string; type: string; status: string; created_at: string };
+// MetadataFetchSummary is one row in the Resume Review picker —
+// a completed metadata_candidate_fetch operation with its result
+// breakdown so the user knows what they're about to review.
+export interface MetadataFetchSummary {
+  id: string;
+  type: string;
+  status: string;
+  created_at: string;
+  completed_at?: string;
   result_count: number;
-} | null> {
-  const response = await fetch(`${API_BASE}/metadata/latest-fetch`);
-  if (response.status === 404) return null;
-  if (!response.ok) throw await buildApiError(response, 'Failed to get latest metadata fetch');
-  return response.json();
+  matched_count: number;
+  no_match_count: number;
+  error_count: number;
+}
+
+// getRecentMetadataFetches returns up to the last 10 completed
+// metadata batch-fetch operations that have persisted results,
+// newest first. Used by the Resume Review picker dialog so users
+// can pick which fetch to review when multiple are outstanding —
+// solves the scenario where someone fires a second fetch before
+// reviewing the first.
+export async function getRecentMetadataFetches(): Promise<MetadataFetchSummary[]> {
+  const response = await fetch(`${API_BASE}/metadata/recent-fetches`);
+  if (!response.ok) throw await buildApiError(response, 'Failed to list recent metadata fetches');
+  const data = await response.json();
+  return data.operations || [];
 }
 
 export async function batchApplyCandidates(operationId: string, bookIds: string[]): Promise<{ applied: number }> {


### PR DESCRIPTION
Follow-up to #235. User scenario: select page 1 → Fetch & Review → skip review → select page 2 → Fetch & Review → previous Resume Last Review only found the latest. The first fetch's results were invisible in the UI.

Rewritten as a picker dialog listing up to 10 recent completed fetches with matched/no_match/error counts and timestamps. Click a row to open MetadataReviewDialog for that specific op. Endpoint renamed /metadata/latest-fetch → /metadata/recent-fetches (plural). Button renamed Resume Last Review → Resume Review.