### PR TITLE
feat(itunes): finish ITL write-back — backup, validate, restore, narrator

### DIFF
--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -95,6 +95,75 @@ func (_c *MockStore_AddBlockedHash_Call) RunAndReturn(run func(hash string, reas
 	return _c
 }
 
+// AddBookAlternativeTitle provides a mock function for the type MockStore
+func (_mock *MockStore) AddBookAlternativeTitle(bookID string, title string, source string, language string) error {
+	ret := _mock.Called(bookID, title, source, language)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddBookAlternativeTitle")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string, string) error); ok {
+		r0 = returnFunc(bookID, title, source, language)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddBookAlternativeTitle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddBookAlternativeTitle'
+type MockStore_AddBookAlternativeTitle_Call struct {
+	*mock.Call
+}
+
+// AddBookAlternativeTitle is a helper method to define mock.On call
+//   - bookID string
+//   - title string
+//   - source string
+//   - language string
+func (_e *MockStore_Expecter) AddBookAlternativeTitle(bookID interface{}, title interface{}, source interface{}, language interface{}) *MockStore_AddBookAlternativeTitle_Call {
+	return &MockStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
+}
+
+func (_c *MockStore_AddBookAlternativeTitle_Call) Run(run func(bookID string, title string, source string, language string)) *MockStore_AddBookAlternativeTitle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddBookAlternativeTitle_Call) Return(err error) *MockStore_AddBookAlternativeTitle_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddBookAlternativeTitle_Call) RunAndReturn(run func(bookID string, title string, source string, language string) error) *MockStore_AddBookAlternativeTitle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddBookTag provides a mock function for the type MockStore
 func (_mock *MockStore) AddBookTag(bookID string, tag string) error {
 	ret := _mock.Called(bookID, tag)
@@ -451,6 +520,57 @@ func (_c *MockStore_AddSystemActivityLog_Call) Return(err error) *MockStore_AddS
 }
 
 func (_c *MockStore_AddSystemActivityLog_Call) RunAndReturn(run func(source string, level string, message string) error) *MockStore_AddSystemActivityLog_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// BatchUpsertBookFiles provides a mock function for the type MockStore
+func (_mock *MockStore) BatchUpsertBookFiles(files []*database.BookFile) error {
+	ret := _mock.Called(files)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BatchUpsertBookFiles")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func([]*database.BookFile) error); ok {
+		r0 = returnFunc(files)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_BatchUpsertBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BatchUpsertBookFiles'
+type MockStore_BatchUpsertBookFiles_Call struct {
+	*mock.Call
+}
+
+// BatchUpsertBookFiles is a helper method to define mock.On call
+//   - files []*database.BookFile
+func (_e *MockStore_Expecter) BatchUpsertBookFiles(files interface{}) *MockStore_BatchUpsertBookFiles_Call {
+	return &MockStore_BatchUpsertBookFiles_Call{Call: _e.mock.On("BatchUpsertBookFiles", files)}
+}
+
+func (_c *MockStore_BatchUpsertBookFiles_Call) Run(run func(files []*database.BookFile)) *MockStore_BatchUpsertBookFiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []*database.BookFile
+		if args[0] != nil {
+			arg0 = args[0].([]*database.BookFile)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_BatchUpsertBookFiles_Call) Return(err error) *MockStore_BatchUpsertBookFiles_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_BatchUpsertBookFiles_Call) RunAndReturn(run func(files []*database.BookFile) error) *MockStore_BatchUpsertBookFiles_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1070,6 +1190,57 @@ func (_c *MockStore_CreateBook_Call) RunAndReturn(run func(book *database.Book) 
 	return _c
 }
 
+// CreateBookFile provides a mock function for the type MockStore
+func (_mock *MockStore) CreateBookFile(file *database.BookFile) error {
+	ret := _mock.Called(file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBookFile")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*database.BookFile) error); ok {
+		r0 = returnFunc(file)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_CreateBookFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateBookFile'
+type MockStore_CreateBookFile_Call struct {
+	*mock.Call
+}
+
+// CreateBookFile is a helper method to define mock.On call
+//   - file *database.BookFile
+func (_e *MockStore_Expecter) CreateBookFile(file interface{}) *MockStore_CreateBookFile_Call {
+	return &MockStore_CreateBookFile_Call{Call: _e.mock.On("CreateBookFile", file)}
+}
+
+func (_c *MockStore_CreateBookFile_Call) Run(run func(file *database.BookFile)) *MockStore_CreateBookFile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.BookFile
+		if args[0] != nil {
+			arg0 = args[0].(*database.BookFile)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CreateBookFile_Call) Return(err error) *MockStore_CreateBookFile_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_CreateBookFile_Call) RunAndReturn(run func(file *database.BookFile) error) *MockStore_CreateBookFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateBookSegment provides a mock function for the type MockStore
 func (_mock *MockStore) CreateBookSegment(bookNumericID int, segment *database.BookSegment) (*database.BookSegment, error) {
 	ret := _mock.Called(bookNumericID, segment)
@@ -1566,6 +1737,57 @@ func (_c *MockStore_CreateOperationChange_Call) Return(err error) *MockStore_Cre
 }
 
 func (_c *MockStore_CreateOperationChange_Call) RunAndReturn(run func(change *database.OperationChange) error) *MockStore_CreateOperationChange_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateOperationResult provides a mock function for the type MockStore
+func (_mock *MockStore) CreateOperationResult(result *database.OperationResult) error {
+	ret := _mock.Called(result)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateOperationResult")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*database.OperationResult) error); ok {
+		r0 = returnFunc(result)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_CreateOperationResult_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateOperationResult'
+type MockStore_CreateOperationResult_Call struct {
+	*mock.Call
+}
+
+// CreateOperationResult is a helper method to define mock.On call
+//   - result *database.OperationResult
+func (_e *MockStore_Expecter) CreateOperationResult(result interface{}) *MockStore_CreateOperationResult_Call {
+	return &MockStore_CreateOperationResult_Call{Call: _e.mock.On("CreateOperationResult", result)}
+}
+
+func (_c *MockStore_CreateOperationResult_Call) Run(run func(result *database.OperationResult)) *MockStore_CreateOperationResult_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.OperationResult
+		if args[0] != nil {
+			arg0 = args[0].(*database.OperationResult)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CreateOperationResult_Call) Return(err error) *MockStore_CreateOperationResult_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_CreateOperationResult_Call) RunAndReturn(run func(result *database.OperationResult) error) *MockStore_CreateOperationResult_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2099,6 +2321,108 @@ func (_c *MockStore_DeleteBook_Call) RunAndReturn(run func(id string) error) *Mo
 	return _c
 }
 
+// DeleteBookFile provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteBookFile(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBookFile")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteBookFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBookFile'
+type MockStore_DeleteBookFile_Call struct {
+	*mock.Call
+}
+
+// DeleteBookFile is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) DeleteBookFile(id interface{}) *MockStore_DeleteBookFile_Call {
+	return &MockStore_DeleteBookFile_Call{Call: _e.mock.On("DeleteBookFile", id)}
+}
+
+func (_c *MockStore_DeleteBookFile_Call) Run(run func(id string)) *MockStore_DeleteBookFile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFile_Call) Return(err error) *MockStore_DeleteBookFile_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFile_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteBookFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteBookFilesForBook provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteBookFilesForBook(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBookFilesForBook")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteBookFilesForBook_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBookFilesForBook'
+type MockStore_DeleteBookFilesForBook_Call struct {
+	*mock.Call
+}
+
+// DeleteBookFilesForBook is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockStore_Expecter) DeleteBookFilesForBook(bookID interface{}) *MockStore_DeleteBookFilesForBook_Call {
+	return &MockStore_DeleteBookFilesForBook_Call{Call: _e.mock.On("DeleteBookFilesForBook", bookID)}
+}
+
+func (_c *MockStore_DeleteBookFilesForBook_Call) Run(run func(bookID string)) *MockStore_DeleteBookFilesForBook_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFilesForBook_Call) Return(err error) *MockStore_DeleteBookFilesForBook_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFilesForBook_Call) RunAndReturn(run func(bookID string) error) *MockStore_DeleteBookFilesForBook_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteBookTombstone provides a mock function for the type MockStore
 func (_mock *MockStore) DeleteBookTombstone(id string) error {
 	ret := _mock.Called(id)
@@ -2425,6 +2749,57 @@ func (_c *MockStore_DeleteOperationsByStatus_Call) Return(n int, err error) *Moc
 }
 
 func (_c *MockStore_DeleteOperationsByStatus_Call) RunAndReturn(run func(statuses []string) (int, error)) *MockStore_DeleteOperationsByStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteRaw provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteRaw(key string) error {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRaw")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRaw'
+type MockStore_DeleteRaw_Call struct {
+	*mock.Call
+}
+
+// DeleteRaw is a helper method to define mock.On call
+//   - key string
+func (_e *MockStore_Expecter) DeleteRaw(key interface{}) *MockStore_DeleteRaw_Call {
+	return &MockStore_DeleteRaw_Call{Call: _e.mock.On("DeleteRaw", key)}
+}
+
+func (_c *MockStore_DeleteRaw_Call) Run(run func(key string)) *MockStore_DeleteRaw_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteRaw_Call) Return(err error) *MockStore_DeleteRaw_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteRaw_Call) RunAndReturn(run func(key string) error) *MockStore_DeleteRaw_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3742,6 +4117,68 @@ func (_c *MockStore_GetBlockedHashByHash_Call) RunAndReturn(run func(hash string
 	return _c
 }
 
+// GetBookAlternativeTitles provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookAlternativeTitles(bookID string) ([]database.BookAlternativeTitle, error) {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookAlternativeTitles")
+	}
+
+	var r0 []database.BookAlternativeTitle
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BookAlternativeTitle, error)); ok {
+		return returnFunc(bookID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.BookAlternativeTitle); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookAlternativeTitle)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(bookID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookAlternativeTitles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookAlternativeTitles'
+type MockStore_GetBookAlternativeTitles_Call struct {
+	*mock.Call
+}
+
+// GetBookAlternativeTitles is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockStore_GetBookAlternativeTitles_Call {
+	return &MockStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
+}
+
+func (_c *MockStore_GetBookAlternativeTitles_Call) Run(run func(bookID string)) *MockStore_GetBookAlternativeTitles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookAlternativeTitles_Call) Return(bookAlternativeTitles []database.BookAlternativeTitle, err error) *MockStore_GetBookAlternativeTitles_Call {
+	_c.Call.Return(bookAlternativeTitles, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookAlternativeTitles_Call) RunAndReturn(run func(bookID string) ([]database.BookAlternativeTitle, error)) *MockStore_GetBookAlternativeTitles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookAtVersion provides a mock function for the type MockStore
 func (_mock *MockStore) GetBookAtVersion(id string, ts time.Time) (*database.Book, error) {
 	ret := _mock.Called(id, ts)
@@ -4502,6 +4939,260 @@ func (_c *MockStore_GetBookCountsByLocation_Call) Return(library int, import_ in
 }
 
 func (_c *MockStore_GetBookCountsByLocation_Call) RunAndReturn(run func(rootDir string) (int, int, error)) *MockStore_GetBookCountsByLocation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookFileByID provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFileByID(bookID string, fileID string) (*database.BookFile, error) {
+	ret := _mock.Called(bookID, fileID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookFileByID")
+	}
+
+	var r0 *database.BookFile
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) (*database.BookFile, error)); ok {
+		return returnFunc(bookID, fileID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string) *database.BookFile); ok {
+		r0 = returnFunc(bookID, fileID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = returnFunc(bookID, fileID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookFileByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFileByID'
+type MockStore_GetBookFileByID_Call struct {
+	*mock.Call
+}
+
+// GetBookFileByID is a helper method to define mock.On call
+//   - bookID string
+//   - fileID string
+func (_e *MockStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockStore_GetBookFileByID_Call {
+	return &MockStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
+}
+
+func (_c *MockStore_GetBookFileByID_Call) Run(run func(bookID string, fileID string)) *MockStore_GetBookFileByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByID_Call) Return(bookFile *database.BookFile, err error) *MockStore_GetBookFileByID_Call {
+	_c.Call.Return(bookFile, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByID_Call) RunAndReturn(run func(bookID string, fileID string) (*database.BookFile, error)) *MockStore_GetBookFileByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookFileByPID provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFileByPID(itunesPID string) (*database.BookFile, error) {
+	ret := _mock.Called(itunesPID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookFileByPID")
+	}
+
+	var r0 *database.BookFile
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.BookFile, error)); ok {
+		return returnFunc(itunesPID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.BookFile); ok {
+		r0 = returnFunc(itunesPID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(itunesPID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookFileByPID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFileByPID'
+type MockStore_GetBookFileByPID_Call struct {
+	*mock.Call
+}
+
+// GetBookFileByPID is a helper method to define mock.On call
+//   - itunesPID string
+func (_e *MockStore_Expecter) GetBookFileByPID(itunesPID interface{}) *MockStore_GetBookFileByPID_Call {
+	return &MockStore_GetBookFileByPID_Call{Call: _e.mock.On("GetBookFileByPID", itunesPID)}
+}
+
+func (_c *MockStore_GetBookFileByPID_Call) Run(run func(itunesPID string)) *MockStore_GetBookFileByPID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByPID_Call) Return(bookFile *database.BookFile, err error) *MockStore_GetBookFileByPID_Call {
+	_c.Call.Return(bookFile, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByPID_Call) RunAndReturn(run func(itunesPID string) (*database.BookFile, error)) *MockStore_GetBookFileByPID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookFileByPath provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFileByPath(filePath string) (*database.BookFile, error) {
+	ret := _mock.Called(filePath)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookFileByPath")
+	}
+
+	var r0 *database.BookFile
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.BookFile, error)); ok {
+		return returnFunc(filePath)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.BookFile); ok {
+		r0 = returnFunc(filePath)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(filePath)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookFileByPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFileByPath'
+type MockStore_GetBookFileByPath_Call struct {
+	*mock.Call
+}
+
+// GetBookFileByPath is a helper method to define mock.On call
+//   - filePath string
+func (_e *MockStore_Expecter) GetBookFileByPath(filePath interface{}) *MockStore_GetBookFileByPath_Call {
+	return &MockStore_GetBookFileByPath_Call{Call: _e.mock.On("GetBookFileByPath", filePath)}
+}
+
+func (_c *MockStore_GetBookFileByPath_Call) Run(run func(filePath string)) *MockStore_GetBookFileByPath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByPath_Call) Return(bookFile *database.BookFile, err error) *MockStore_GetBookFileByPath_Call {
+	_c.Call.Return(bookFile, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookFileByPath_Call) RunAndReturn(run func(filePath string) (*database.BookFile, error)) *MockStore_GetBookFileByPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookFiles provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookFiles")
+	}
+
+	var r0 []database.BookFile
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BookFile, error)); ok {
+		return returnFunc(bookID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.BookFile); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(bookID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFiles'
+type MockStore_GetBookFiles_Call struct {
+	*mock.Call
+}
+
+// GetBookFiles is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockStore_Expecter) GetBookFiles(bookID interface{}) *MockStore_GetBookFiles_Call {
+	return &MockStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
+}
+
+func (_c *MockStore_GetBookFiles_Call) Run(run func(bookID string)) *MockStore_GetBookFiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookFiles_Call) Return(bookFiles []database.BookFile, err error) *MockStore_GetBookFiles_Call {
+	_c.Call.Return(bookFiles, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookFiles_Call) RunAndReturn(run func(bookID string) ([]database.BookFile, error)) *MockStore_GetBookFiles_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5920,6 +6611,61 @@ func (_c *MockStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]datab
 	return _c
 }
 
+// GetITunesDirtyBooks provides a mock function for the type MockStore
+func (_mock *MockStore) GetITunesDirtyBooks() ([]database.Book, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetITunesDirtyBooks")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.Book, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.Book); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetITunesDirtyBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetITunesDirtyBooks'
+type MockStore_GetITunesDirtyBooks_Call struct {
+	*mock.Call
+}
+
+// GetITunesDirtyBooks is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetITunesDirtyBooks() *MockStore_GetITunesDirtyBooks_Call {
+	return &MockStore_GetITunesDirtyBooks_Call{Call: _e.mock.On("GetITunesDirtyBooks")}
+}
+
+func (_c *MockStore_GetITunesDirtyBooks_Call) Run(run func()) *MockStore_GetITunesDirtyBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_GetITunesDirtyBooks_Call) Return(books []database.Book, err error) *MockStore_GetITunesDirtyBooks_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockStore_GetITunesDirtyBooks_Call) RunAndReturn(run func() ([]database.Book, error)) *MockStore_GetITunesDirtyBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetImportPathByID provides a mock function for the type MockStore
 func (_mock *MockStore) GetImportPathByID(id int) (*database.ImportPath, error) {
 	ret := _mock.Called(id)
@@ -6669,6 +7415,68 @@ func (_c *MockStore_GetOperationParams_Call) RunAndReturn(run func(opID string) 
 	return _c
 }
 
+// GetOperationResults provides a mock function for the type MockStore
+func (_mock *MockStore) GetOperationResults(operationID string) ([]database.OperationResult, error) {
+	ret := _mock.Called(operationID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOperationResults")
+	}
+
+	var r0 []database.OperationResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.OperationResult, error)); ok {
+		return returnFunc(operationID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.OperationResult); ok {
+		r0 = returnFunc(operationID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.OperationResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(operationID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetOperationResults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOperationResults'
+type MockStore_GetOperationResults_Call struct {
+	*mock.Call
+}
+
+// GetOperationResults is a helper method to define mock.On call
+//   - operationID string
+func (_e *MockStore_Expecter) GetOperationResults(operationID interface{}) *MockStore_GetOperationResults_Call {
+	return &MockStore_GetOperationResults_Call{Call: _e.mock.On("GetOperationResults", operationID)}
+}
+
+func (_c *MockStore_GetOperationResults_Call) Run(run func(operationID string)) *MockStore_GetOperationResults_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetOperationResults_Call) Return(operationResults []database.OperationResult, err error) *MockStore_GetOperationResults_Call {
+	_c.Call.Return(operationResults, err)
+	return _c
+}
+
+func (_c *MockStore_GetOperationResults_Call) RunAndReturn(run func(operationID string) ([]database.OperationResult, error)) *MockStore_GetOperationResults_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOperationState provides a mock function for the type MockStore
 func (_mock *MockStore) GetOperationState(opID string) ([]byte, error) {
 	ret := _mock.Called(opID)
@@ -7102,6 +7910,68 @@ func (_c *MockStore_GetPlaylistItems_Call) RunAndReturn(run func(playlistID int)
 	return _c
 }
 
+// GetRecentCompletedOperations provides a mock function for the type MockStore
+func (_mock *MockStore) GetRecentCompletedOperations(limit int) ([]database.Operation, error) {
+	ret := _mock.Called(limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRecentCompletedOperations")
+	}
+
+	var r0 []database.Operation
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Operation, error)); ok {
+		return returnFunc(limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []database.Operation); ok {
+		r0 = returnFunc(limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Operation)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetRecentCompletedOperations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRecentCompletedOperations'
+type MockStore_GetRecentCompletedOperations_Call struct {
+	*mock.Call
+}
+
+// GetRecentCompletedOperations is a helper method to define mock.On call
+//   - limit int
+func (_e *MockStore_Expecter) GetRecentCompletedOperations(limit interface{}) *MockStore_GetRecentCompletedOperations_Call {
+	return &MockStore_GetRecentCompletedOperations_Call{Call: _e.mock.On("GetRecentCompletedOperations", limit)}
+}
+
+func (_c *MockStore_GetRecentCompletedOperations_Call) Run(run func(limit int)) *MockStore_GetRecentCompletedOperations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetRecentCompletedOperations_Call) Return(operations []database.Operation, err error) *MockStore_GetRecentCompletedOperations_Call {
+	_c.Call.Return(operations, err)
+	return _c
+}
+
+func (_c *MockStore_GetRecentCompletedOperations_Call) RunAndReturn(run func(limit int) ([]database.Operation, error)) *MockStore_GetRecentCompletedOperations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRecentOperations provides a mock function for the type MockStore
 func (_mock *MockStore) GetRecentOperations(limit int) ([]database.Operation, error) {
 	ret := _mock.Called(limit)
@@ -7160,6 +8030,68 @@ func (_c *MockStore_GetRecentOperations_Call) Return(operations []database.Opera
 }
 
 func (_c *MockStore_GetRecentOperations_Call) RunAndReturn(run func(limit int) ([]database.Operation, error)) *MockStore_GetRecentOperations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRemovedExternalIDs provides a mock function for the type MockStore
+func (_mock *MockStore) GetRemovedExternalIDs(source string) ([]database.ExternalIDMapping, error) {
+	ret := _mock.Called(source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRemovedExternalIDs")
+	}
+
+	var r0 []database.ExternalIDMapping
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.ExternalIDMapping, error)); ok {
+		return returnFunc(source)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.ExternalIDMapping); ok {
+		r0 = returnFunc(source)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.ExternalIDMapping)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(source)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetRemovedExternalIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRemovedExternalIDs'
+type MockStore_GetRemovedExternalIDs_Call struct {
+	*mock.Call
+}
+
+// GetRemovedExternalIDs is a helper method to define mock.On call
+//   - source string
+func (_e *MockStore_Expecter) GetRemovedExternalIDs(source interface{}) *MockStore_GetRemovedExternalIDs_Call {
+	return &MockStore_GetRemovedExternalIDs_Call{Call: _e.mock.On("GetRemovedExternalIDs", source)}
+}
+
+func (_c *MockStore_GetRemovedExternalIDs_Call) Run(run func(source string)) *MockStore_GetRemovedExternalIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetRemovedExternalIDs_Call) Return(externalIDMappings []database.ExternalIDMapping, err error) *MockStore_GetRemovedExternalIDs_Call {
+	_c.Call.Return(externalIDMappings, err)
+	return _c
+}
+
+func (_c *MockStore_GetRemovedExternalIDs_Call) RunAndReturn(run func(source string) ([]database.ExternalIDMapping, error)) *MockStore_GetRemovedExternalIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -8858,6 +9790,123 @@ func (_c *MockStore_MarkDeferredITunesUpdateApplied_Call) RunAndReturn(run func(
 	return _c
 }
 
+// MarkExternalIDRemoved provides a mock function for the type MockStore
+func (_mock *MockStore) MarkExternalIDRemoved(source string, externalID string) error {
+	ret := _mock.Called(source, externalID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkExternalIDRemoved")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(source, externalID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_MarkExternalIDRemoved_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkExternalIDRemoved'
+type MockStore_MarkExternalIDRemoved_Call struct {
+	*mock.Call
+}
+
+// MarkExternalIDRemoved is a helper method to define mock.On call
+//   - source string
+//   - externalID string
+func (_e *MockStore_Expecter) MarkExternalIDRemoved(source interface{}, externalID interface{}) *MockStore_MarkExternalIDRemoved_Call {
+	return &MockStore_MarkExternalIDRemoved_Call{Call: _e.mock.On("MarkExternalIDRemoved", source, externalID)}
+}
+
+func (_c *MockStore_MarkExternalIDRemoved_Call) Run(run func(source string, externalID string)) *MockStore_MarkExternalIDRemoved_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_MarkExternalIDRemoved_Call) Return(err error) *MockStore_MarkExternalIDRemoved_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_MarkExternalIDRemoved_Call) RunAndReturn(run func(source string, externalID string) error) *MockStore_MarkExternalIDRemoved_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MarkITunesSynced provides a mock function for the type MockStore
+func (_mock *MockStore) MarkITunesSynced(bookIDs []string) (int64, error) {
+	ret := _mock.Called(bookIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkITunesSynced")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) (int64, error)); ok {
+		return returnFunc(bookIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) int64); ok {
+		r0 = returnFunc(bookIDs)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(bookIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_MarkITunesSynced_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkITunesSynced'
+type MockStore_MarkITunesSynced_Call struct {
+	*mock.Call
+}
+
+// MarkITunesSynced is a helper method to define mock.On call
+//   - bookIDs []string
+func (_e *MockStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockStore_MarkITunesSynced_Call {
+	return &MockStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
+}
+
+func (_c *MockStore_MarkITunesSynced_Call) Run(run func(bookIDs []string)) *MockStore_MarkITunesSynced_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_MarkITunesSynced_Call) Return(n int64, err error) *MockStore_MarkITunesSynced_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_MarkITunesSynced_Call) RunAndReturn(run func(bookIDs []string) (int64, error)) *MockStore_MarkITunesSynced_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarkNeedsRescan provides a mock function for the type MockStore
 func (_mock *MockStore) MarkNeedsRescan(bookID string) error {
 	ret := _mock.Called(bookID)
@@ -8968,6 +10017,69 @@ func (_c *MockStore_MergeBookSegments_Call) Return(err error) *MockStore_MergeBo
 }
 
 func (_c *MockStore_MergeBookSegments_Call) RunAndReturn(run func(bookNumericID int, newSegment *database.BookSegment, supersedeIDs []string) error) *MockStore_MergeBookSegments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MoveBookFilesToBook provides a mock function for the type MockStore
+func (_mock *MockStore) MoveBookFilesToBook(fileIDs []string, sourceBookID string, targetBookID string) error {
+	ret := _mock.Called(fileIDs, sourceBookID, targetBookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MoveBookFilesToBook")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func([]string, string, string) error); ok {
+		r0 = returnFunc(fileIDs, sourceBookID, targetBookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_MoveBookFilesToBook_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MoveBookFilesToBook'
+type MockStore_MoveBookFilesToBook_Call struct {
+	*mock.Call
+}
+
+// MoveBookFilesToBook is a helper method to define mock.On call
+//   - fileIDs []string
+//   - sourceBookID string
+//   - targetBookID string
+func (_e *MockStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockStore_MoveBookFilesToBook_Call {
+	return &MockStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
+}
+
+func (_c *MockStore_MoveBookFilesToBook_Call) Run(run func(fileIDs []string, sourceBookID string, targetBookID string)) *MockStore_MoveBookFilesToBook_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_MoveBookFilesToBook_Call) Return(err error) *MockStore_MoveBookFilesToBook_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_MoveBookFilesToBook_Call) RunAndReturn(run func(fileIDs []string, sourceBookID string, targetBookID string) error) *MockStore_MoveBookFilesToBook_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -9525,6 +10637,63 @@ func (_c *MockStore_RemoveBlockedHash_Call) Return(err error) *MockStore_RemoveB
 }
 
 func (_c *MockStore_RemoveBlockedHash_Call) RunAndReturn(run func(hash string) error) *MockStore_RemoveBlockedHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveBookAlternativeTitle provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveBookAlternativeTitle(bookID string, title string) error {
+	ret := _mock.Called(bookID, title)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveBookAlternativeTitle")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(bookID, title)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveBookAlternativeTitle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveBookAlternativeTitle'
+type MockStore_RemoveBookAlternativeTitle_Call struct {
+	*mock.Call
+}
+
+// RemoveBookAlternativeTitle is a helper method to define mock.On call
+//   - bookID string
+//   - title string
+func (_e *MockStore_Expecter) RemoveBookAlternativeTitle(bookID interface{}, title interface{}) *MockStore_RemoveBookAlternativeTitle_Call {
+	return &MockStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
+}
+
+func (_c *MockStore_RemoveBookAlternativeTitle_Call) Run(run func(bookID string, title string)) *MockStore_RemoveBookAlternativeTitle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveBookAlternativeTitle_Call) Return(err error) *MockStore_RemoveBookAlternativeTitle_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveBookAlternativeTitle_Call) RunAndReturn(run func(bookID string, title string) error) *MockStore_RemoveBookAlternativeTitle_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -10144,6 +11313,68 @@ func (_c *MockStore_SaveOperationSummaryLog_Call) RunAndReturn(run func(op *data
 	return _c
 }
 
+// ScanPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) ScanPrefix(prefix string) ([]database.KVPair, error) {
+	ret := _mock.Called(prefix)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ScanPrefix")
+	}
+
+	var r0 []database.KVPair
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.KVPair, error)); ok {
+		return returnFunc(prefix)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.KVPair); ok {
+		r0 = returnFunc(prefix)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.KVPair)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(prefix)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ScanPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ScanPrefix'
+type MockStore_ScanPrefix_Call struct {
+	*mock.Call
+}
+
+// ScanPrefix is a helper method to define mock.On call
+//   - prefix string
+func (_e *MockStore_Expecter) ScanPrefix(prefix interface{}) *MockStore_ScanPrefix_Call {
+	return &MockStore_ScanPrefix_Call{Call: _e.mock.On("ScanPrefix", prefix)}
+}
+
+func (_c *MockStore_ScanPrefix_Call) Run(run func(prefix string)) *MockStore_ScanPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ScanPrefix_Call) Return(kVPairs []database.KVPair, err error) *MockStore_ScanPrefix_Call {
+	_c.Call.Return(kVPairs, err)
+	return _c
+}
+
+func (_c *MockStore_ScanPrefix_Call) RunAndReturn(run func(prefix string) ([]database.KVPair, error)) *MockStore_ScanPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SearchBooks provides a mock function for the type MockStore
 func (_mock *MockStore) SearchBooks(query string, limit int, offset int) ([]database.Book, error) {
 	ret := _mock.Called(query, limit, offset)
@@ -10214,6 +11445,63 @@ func (_c *MockStore_SearchBooks_Call) Return(books []database.Book, err error) *
 }
 
 func (_c *MockStore_SearchBooks_Call) RunAndReturn(run func(query string, limit int, offset int) ([]database.Book, error)) *MockStore_SearchBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetBookAlternativeTitles provides a mock function for the type MockStore
+func (_mock *MockStore) SetBookAlternativeTitles(bookID string, titles []database.BookAlternativeTitle) error {
+	ret := _mock.Called(bookID, titles)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetBookAlternativeTitles")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []database.BookAlternativeTitle) error); ok {
+		r0 = returnFunc(bookID, titles)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetBookAlternativeTitles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetBookAlternativeTitles'
+type MockStore_SetBookAlternativeTitles_Call struct {
+	*mock.Call
+}
+
+// SetBookAlternativeTitles is a helper method to define mock.On call
+//   - bookID string
+//   - titles []database.BookAlternativeTitle
+func (_e *MockStore_Expecter) SetBookAlternativeTitles(bookID interface{}, titles interface{}) *MockStore_SetBookAlternativeTitles_Call {
+	return &MockStore_SetBookAlternativeTitles_Call{Call: _e.mock.On("SetBookAlternativeTitles", bookID, titles)}
+}
+
+func (_c *MockStore_SetBookAlternativeTitles_Call) Run(run func(bookID string, titles []database.BookAlternativeTitle)) *MockStore_SetBookAlternativeTitles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []database.BookAlternativeTitle
+		if args[1] != nil {
+			arg1 = args[1].([]database.BookAlternativeTitle)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetBookAlternativeTitles_Call) Return(err error) *MockStore_SetBookAlternativeTitles_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetBookAlternativeTitles_Call) RunAndReturn(run func(bookID string, titles []database.BookAlternativeTitle) error) *MockStore_SetBookAlternativeTitles_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -10446,6 +11734,69 @@ func (_c *MockStore_SetBookUserTags_Call) RunAndReturn(run func(bookID string, t
 	return _c
 }
 
+// SetExternalIDProvenance provides a mock function for the type MockStore
+func (_mock *MockStore) SetExternalIDProvenance(source string, externalID string, provenance string) error {
+	ret := _mock.Called(source, externalID, provenance)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetExternalIDProvenance")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = returnFunc(source, externalID, provenance)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetExternalIDProvenance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetExternalIDProvenance'
+type MockStore_SetExternalIDProvenance_Call struct {
+	*mock.Call
+}
+
+// SetExternalIDProvenance is a helper method to define mock.On call
+//   - source string
+//   - externalID string
+//   - provenance string
+func (_e *MockStore_Expecter) SetExternalIDProvenance(source interface{}, externalID interface{}, provenance interface{}) *MockStore_SetExternalIDProvenance_Call {
+	return &MockStore_SetExternalIDProvenance_Call{Call: _e.mock.On("SetExternalIDProvenance", source, externalID, provenance)}
+}
+
+func (_c *MockStore_SetExternalIDProvenance_Call) Run(run func(source string, externalID string, provenance string)) *MockStore_SetExternalIDProvenance_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetExternalIDProvenance_Call) Return(err error) *MockStore_SetExternalIDProvenance_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetExternalIDProvenance_Call) RunAndReturn(run func(source string, externalID string, provenance string) error) *MockStore_SetExternalIDProvenance_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetLastWrittenAt provides a mock function for the type MockStore
 func (_mock *MockStore) SetLastWrittenAt(id string, t time.Time) error {
 	ret := _mock.Called(id, t)
@@ -10503,98 +11854,59 @@ func (_c *MockStore_SetLastWrittenAt_Call) RunAndReturn(run func(id string, t ti
 	return _c
 }
 
-// MarkITunesSynced provides a mock function for the type MockStore
-func (_mock *MockStore) MarkITunesSynced(bookIDs []string) (int64, error) {
-	ret := _mock.Called(bookIDs)
+// SetRaw provides a mock function for the type MockStore
+func (_mock *MockStore) SetRaw(key string, value []byte) error {
+	ret := _mock.Called(key, value)
+
 	if len(ret) == 0 {
-		panic("no return value specified for MarkITunesSynced")
+		panic("no return value specified for SetRaw")
 	}
-	var r0 int64
-	if returnFunc, ok := ret.Get(0).(func([]string) (int64, error)); ok {
-		return returnFunc(bookIDs)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) int64); ok {
-		r0 = returnFunc(bookIDs)
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = returnFunc(key, value)
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Error(0)
 	}
-	var r1 error
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(bookIDs)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+	return r0
 }
 
-// MockStore_MarkITunesSynced_Call is a *mock.Call
-type MockStore_MarkITunesSynced_Call struct {
+// MockStore_SetRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetRaw'
+type MockStore_SetRaw_Call struct {
 	*mock.Call
 }
 
-func (_e *MockStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockStore_MarkITunesSynced_Call {
-	return &MockStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
+// SetRaw is a helper method to define mock.On call
+//   - key string
+//   - value []byte
+func (_e *MockStore_Expecter) SetRaw(key interface{}, value interface{}) *MockStore_SetRaw_Call {
+	return &MockStore_SetRaw_Call{Call: _e.mock.On("SetRaw", key, value)}
 }
 
-func (_c *MockStore_MarkITunesSynced_Call) Run(run func(bookIDs []string)) *MockStore_MarkITunesSynced_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].([]string)) })
+func (_c *MockStore_SetRaw_Call) Run(run func(key string, value []byte)) *MockStore_SetRaw_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
 	return _c
 }
 
-func (_c *MockStore_MarkITunesSynced_Call) Return(n int64, err error) *MockStore_MarkITunesSynced_Call {
-	_c.Call.Return(n, err)
+func (_c *MockStore_SetRaw_Call) Return(err error) *MockStore_SetRaw_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockStore_MarkITunesSynced_Call) RunAndReturn(run func([]string) (int64, error)) *MockStore_MarkITunesSynced_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetITunesDirtyBooks provides a mock function for the type MockStore
-func (_mock *MockStore) GetITunesDirtyBooks() ([]database.Book, error) {
-	ret := _mock.Called()
-	if len(ret) == 0 {
-		panic("no return value specified for GetITunesDirtyBooks")
-	}
-	var r0 []database.Book
-	if returnFunc, ok := ret.Get(0).(func() ([]database.Book, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []database.Book); ok {
-		r0 = returnFunc()
-	} else if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.Book)
-	}
-	var r1 error
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_GetITunesDirtyBooks_Call is a *mock.Call
-type MockStore_GetITunesDirtyBooks_Call struct {
-	*mock.Call
-}
-
-func (_e *MockStore_Expecter) GetITunesDirtyBooks() *MockStore_GetITunesDirtyBooks_Call {
-	return &MockStore_GetITunesDirtyBooks_Call{Call: _e.mock.On("GetITunesDirtyBooks")}
-}
-
-func (_c *MockStore_GetITunesDirtyBooks_Call) Run(run func()) *MockStore_GetITunesDirtyBooks_Call {
-	_c.Call.Run(func(args mock.Arguments) { run() })
-	return _c
-}
-
-func (_c *MockStore_GetITunesDirtyBooks_Call) Return(books []database.Book, err error) *MockStore_GetITunesDirtyBooks_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockStore_GetITunesDirtyBooks_Call) RunAndReturn(run func() ([]database.Book, error)) *MockStore_GetITunesDirtyBooks_Call {
+func (_c *MockStore_SetRaw_Call) RunAndReturn(run func(key string, value []byte) error) *MockStore_SetRaw_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -10966,6 +12278,63 @@ func (_c *MockStore_UpdateBook_Call) Return(book1 *database.Book, err error) *Mo
 }
 
 func (_c *MockStore_UpdateBook_Call) RunAndReturn(run func(id string, book *database.Book) (*database.Book, error)) *MockStore_UpdateBook_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateBookFile provides a mock function for the type MockStore
+func (_mock *MockStore) UpdateBookFile(id string, file *database.BookFile) error {
+	ret := _mock.Called(id, file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateBookFile")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, *database.BookFile) error); ok {
+		r0 = returnFunc(id, file)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_UpdateBookFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBookFile'
+type MockStore_UpdateBookFile_Call struct {
+	*mock.Call
+}
+
+// UpdateBookFile is a helper method to define mock.On call
+//   - id string
+//   - file *database.BookFile
+func (_e *MockStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockStore_UpdateBookFile_Call {
+	return &MockStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
+}
+
+func (_c *MockStore_UpdateBookFile_Call) Run(run func(id string, file *database.BookFile)) *MockStore_UpdateBookFile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 *database.BookFile
+		if args[1] != nil {
+			arg1 = args[1].(*database.BookFile)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_UpdateBookFile_Call) Return(err error) *MockStore_UpdateBookFile_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_UpdateBookFile_Call) RunAndReturn(run func(id string, file *database.BookFile) error) *MockStore_UpdateBookFile_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -11557,6 +12926,57 @@ func (_c *MockStore_UpdateWork_Call) RunAndReturn(run func(id string, work *data
 	return _c
 }
 
+// UpsertBookFile provides a mock function for the type MockStore
+func (_mock *MockStore) UpsertBookFile(file *database.BookFile) error {
+	ret := _mock.Called(file)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertBookFile")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*database.BookFile) error); ok {
+		r0 = returnFunc(file)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_UpsertBookFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertBookFile'
+type MockStore_UpsertBookFile_Call struct {
+	*mock.Call
+}
+
+// UpsertBookFile is a helper method to define mock.On call
+//   - file *database.BookFile
+func (_e *MockStore_Expecter) UpsertBookFile(file interface{}) *MockStore_UpsertBookFile_Call {
+	return &MockStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
+}
+
+func (_c *MockStore_UpsertBookFile_Call) Run(run func(file *database.BookFile)) *MockStore_UpsertBookFile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.BookFile
+		if args[0] != nil {
+			arg0 = args[0].(*database.BookFile)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_UpsertBookFile_Call) Return(err error) *MockStore_UpsertBookFile_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_UpsertBookFile_Call) RunAndReturn(run func(file *database.BookFile) error) *MockStore_UpsertBookFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpsertMetadataFieldState provides a mock function for the type MockStore
 func (_mock *MockStore) UpsertMetadataFieldState(state *database.MetadataFieldState) error {
 	ret := _mock.Called(state)
@@ -11605,804 +13025,5 @@ func (_c *MockStore_UpsertMetadataFieldState_Call) Return(err error) *MockStore_
 
 func (_c *MockStore_UpsertMetadataFieldState_Call) RunAndReturn(run func(state *database.MetadataFieldState) error) *MockStore_UpsertMetadataFieldState_Call {
 	_c.Call.Return(run)
-	return _c
-}
-
-// ---- BookFile mock methods (Task 1 placeholder — generated pattern) ----
-
-// CreateBookFile provides a mock function for the type MockStore
-func (_mock *MockStore) CreateBookFile(file *database.BookFile) error {
-	ret := _mock.Called(file)
-	if len(ret) == 0 {
-		panic("no return value specified for CreateBookFile")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*database.BookFile) error); ok {
-		r0 = returnFunc(file)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_CreateBookFile_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) CreateBookFile(file interface{}) *MockStore_CreateBookFile_Call {
-	return &MockStore_CreateBookFile_Call{Call: _e.mock.On("CreateBookFile", file)}
-}
-
-func (_c *MockStore_CreateBookFile_Call) Run(run func(file *database.BookFile)) *MockStore_CreateBookFile_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *database.BookFile
-		if args[0] != nil {
-			arg0 = args[0].(*database.BookFile)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_CreateBookFile_Call) Return(err error) *MockStore_CreateBookFile_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_CreateBookFile_Call) RunAndReturn(run func(*database.BookFile) error) *MockStore_CreateBookFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateBookFile provides a mock function for the type MockStore
-func (_mock *MockStore) UpdateBookFile(id string, file *database.BookFile) error {
-	ret := _mock.Called(id, file)
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateBookFile")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, *database.BookFile) error); ok {
-		r0 = returnFunc(id, file)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_UpdateBookFile_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockStore_UpdateBookFile_Call {
-	return &MockStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
-}
-
-func (_c *MockStore_UpdateBookFile_Call) Run(run func(id string, file *database.BookFile)) *MockStore_UpdateBookFile_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 *database.BookFile
-		if args[1] != nil {
-			arg1 = args[1].(*database.BookFile)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_UpdateBookFile_Call) Return(err error) *MockStore_UpdateBookFile_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_UpdateBookFile_Call) RunAndReturn(run func(string, *database.BookFile) error) *MockStore_UpdateBookFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookFiles provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
-	ret := _mock.Called(bookID)
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookFiles")
-	}
-	var r0 []database.BookFile
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BookFile, error)); ok {
-		return returnFunc(bookID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) []database.BookFile); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(bookID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockStore_GetBookFiles_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetBookFiles(bookID interface{}) *MockStore_GetBookFiles_Call {
-	return &MockStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
-}
-
-func (_c *MockStore_GetBookFiles_Call) Run(run func(bookID string)) *MockStore_GetBookFiles_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBookFiles_Call) Return(files []database.BookFile, err error) *MockStore_GetBookFiles_Call {
-	_c.Call.Return(files, err)
-	return _c
-}
-
-func (_c *MockStore_GetBookFiles_Call) RunAndReturn(run func(string) ([]database.BookFile, error)) *MockStore_GetBookFiles_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookFileByPID provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookFileByPID(itunesPID string) (*database.BookFile, error) {
-	ret := _mock.Called(itunesPID)
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookFileByPID")
-	}
-	var r0 *database.BookFile
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*database.BookFile, error)); ok {
-		return returnFunc(itunesPID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *database.BookFile); ok {
-		r0 = returnFunc(itunesPID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*database.BookFile)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(itunesPID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockStore_GetBookFileByPID_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetBookFileByPID(itunesPID interface{}) *MockStore_GetBookFileByPID_Call {
-	return &MockStore_GetBookFileByPID_Call{Call: _e.mock.On("GetBookFileByPID", itunesPID)}
-}
-
-func (_c *MockStore_GetBookFileByPID_Call) Run(run func(itunesPID string)) *MockStore_GetBookFileByPID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByPID_Call) Return(file *database.BookFile, err error) *MockStore_GetBookFileByPID_Call {
-	_c.Call.Return(file, err)
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByPID_Call) RunAndReturn(run func(string) (*database.BookFile, error)) *MockStore_GetBookFileByPID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookFileByPath provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookFileByPath(filePath string) (*database.BookFile, error) {
-	ret := _mock.Called(filePath)
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookFileByPath")
-	}
-	var r0 *database.BookFile
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*database.BookFile, error)); ok {
-		return returnFunc(filePath)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) *database.BookFile); ok {
-		r0 = returnFunc(filePath)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*database.BookFile)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(filePath)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockStore_GetBookFileByPath_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetBookFileByPath(filePath interface{}) *MockStore_GetBookFileByPath_Call {
-	return &MockStore_GetBookFileByPath_Call{Call: _e.mock.On("GetBookFileByPath", filePath)}
-}
-
-func (_c *MockStore_GetBookFileByPath_Call) Run(run func(filePath string)) *MockStore_GetBookFileByPath_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByPath_Call) Return(file *database.BookFile, err error) *MockStore_GetBookFileByPath_Call {
-	_c.Call.Return(file, err)
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByPath_Call) RunAndReturn(run func(string) (*database.BookFile, error)) *MockStore_GetBookFileByPath_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteBookFile provides a mock function for the type MockStore
-func (_mock *MockStore) DeleteBookFile(id string) error {
-	ret := _mock.Called(id)
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteBookFile")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_DeleteBookFile_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) DeleteBookFile(id interface{}) *MockStore_DeleteBookFile_Call {
-	return &MockStore_DeleteBookFile_Call{Call: _e.mock.On("DeleteBookFile", id)}
-}
-
-func (_c *MockStore_DeleteBookFile_Call) Run(run func(id string)) *MockStore_DeleteBookFile_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_DeleteBookFile_Call) Return(err error) *MockStore_DeleteBookFile_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_DeleteBookFile_Call) RunAndReturn(run func(string) error) *MockStore_DeleteBookFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteBookFilesForBook provides a mock function for the type MockStore
-func (_mock *MockStore) DeleteBookFilesForBook(bookID string) error {
-	ret := _mock.Called(bookID)
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteBookFilesForBook")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_DeleteBookFilesForBook_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) DeleteBookFilesForBook(bookID interface{}) *MockStore_DeleteBookFilesForBook_Call {
-	return &MockStore_DeleteBookFilesForBook_Call{Call: _e.mock.On("DeleteBookFilesForBook", bookID)}
-}
-
-func (_c *MockStore_DeleteBookFilesForBook_Call) Run(run func(bookID string)) *MockStore_DeleteBookFilesForBook_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_DeleteBookFilesForBook_Call) Return(err error) *MockStore_DeleteBookFilesForBook_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_DeleteBookFilesForBook_Call) RunAndReturn(run func(string) error) *MockStore_DeleteBookFilesForBook_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// BatchUpsertBookFiles provides a mock function for the type MockStore
-func (_mock *MockStore) BatchUpsertBookFiles(files []*database.BookFile) error {
-	ret := _mock.Called(files)
-	if len(ret) == 0 {
-		panic("no return value specified for BatchUpsertBookFiles")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func([]*database.BookFile) error); ok {
-		r0 = returnFunc(files)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_BatchUpsertBookFiles_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) BatchUpsertBookFiles(files interface{}) *MockStore_BatchUpsertBookFiles_Call {
-	return &MockStore_BatchUpsertBookFiles_Call{Call: _e.mock.On("BatchUpsertBookFiles", files)}
-}
-
-func (_c *MockStore_BatchUpsertBookFiles_Call) Run(run func(files []*database.BookFile)) *MockStore_BatchUpsertBookFiles_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]*database.BookFile))
-	})
-	return _c
-}
-
-func (_c *MockStore_BatchUpsertBookFiles_Call) Return(err error) *MockStore_BatchUpsertBookFiles_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_BatchUpsertBookFiles_Call) RunAndReturn(run func([]*database.BookFile) error) *MockStore_BatchUpsertBookFiles_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpsertBookFile provides a mock function for the type MockStore
-func (_mock *MockStore) UpsertBookFile(file *database.BookFile) error {
-	ret := _mock.Called(file)
-	if len(ret) == 0 {
-		panic("no return value specified for UpsertBookFile")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*database.BookFile) error); ok {
-		r0 = returnFunc(file)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_UpsertBookFile_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) UpsertBookFile(file interface{}) *MockStore_UpsertBookFile_Call {
-	return &MockStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
-}
-
-func (_c *MockStore_UpsertBookFile_Call) Run(run func(file *database.BookFile)) *MockStore_UpsertBookFile_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *database.BookFile
-		if args[0] != nil {
-			arg0 = args[0].(*database.BookFile)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_UpsertBookFile_Call) Return(err error) *MockStore_UpsertBookFile_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_UpsertBookFile_Call) RunAndReturn(run func(*database.BookFile) error) *MockStore_UpsertBookFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookFileByID provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookFileByID(bookID string, fileID string) (*database.BookFile, error) {
-	ret := _mock.Called(bookID, fileID)
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookFileByID")
-	}
-	var r0 *database.BookFile
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (*database.BookFile, error)); ok {
-		r0, r1 = returnFunc(bookID, fileID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*database.BookFile)
-		}
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockStore_GetBookFileByID_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockStore_GetBookFileByID_Call {
-	return &MockStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
-}
-
-func (_c *MockStore_GetBookFileByID_Call) Run(run func(bookID string, fileID string)) *MockStore_GetBookFileByID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByID_Call) Return(file *database.BookFile, err error) *MockStore_GetBookFileByID_Call {
-	_c.Call.Return(file, err)
-	return _c
-}
-
-func (_c *MockStore_GetBookFileByID_Call) RunAndReturn(run func(string, string) (*database.BookFile, error)) *MockStore_GetBookFileByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// MoveBookFilesToBook provides a mock function for the type MockStore
-func (_mock *MockStore) MoveBookFilesToBook(fileIDs []string, sourceBookID string, targetBookID string) error {
-	ret := _mock.Called(fileIDs, sourceBookID, targetBookID)
-	if len(ret) == 0 {
-		panic("no return value specified for MoveBookFilesToBook")
-	}
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func([]string, string, string) error); ok {
-		r0 = returnFunc(fileIDs, sourceBookID, targetBookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-type MockStore_MoveBookFilesToBook_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockStore_MoveBookFilesToBook_Call {
-	return &MockStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
-}
-
-func (_c *MockStore_MoveBookFilesToBook_Call) Run(run func(fileIDs []string, sourceBookID string, targetBookID string)) *MockStore_MoveBookFilesToBook_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]string), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockStore_MoveBookFilesToBook_Call) Return(err error) *MockStore_MoveBookFilesToBook_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_MoveBookFilesToBook_Call) RunAndReturn(run func([]string, string, string) error) *MockStore_MoveBookFilesToBook_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// MarkExternalIDRemoved stubs the Store interface method.
-func (_mock *MockStore) MarkExternalIDRemoved(source string, externalID string) error {
-	ret := _mock.Called(source, externalID)
-	return ret.Error(0)
-}
-
-type MockStore_MarkExternalIDRemoved_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) MarkExternalIDRemoved(source interface{}, externalID interface{}) *MockStore_MarkExternalIDRemoved_Call {
-	return &MockStore_MarkExternalIDRemoved_Call{Call: _e.mock.On("MarkExternalIDRemoved", source, externalID)}
-}
-func (_c *MockStore_MarkExternalIDRemoved_Call) Run(run func(string, string)) *MockStore_MarkExternalIDRemoved_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(string)) })
-	return _c
-}
-func (_c *MockStore_MarkExternalIDRemoved_Call) Return(err error) *MockStore_MarkExternalIDRemoved_Call {
-	_c.Call.Return(err)
-	return _c
-}
-func (_c *MockStore_MarkExternalIDRemoved_Call) RunAndReturn(run func(string, string) error) *MockStore_MarkExternalIDRemoved_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetExternalIDProvenance stubs the Store interface method.
-func (_mock *MockStore) SetExternalIDProvenance(source string, externalID string, provenance string) error {
-	ret := _mock.Called(source, externalID, provenance)
-	return ret.Error(0)
-}
-
-type MockStore_SetExternalIDProvenance_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) SetExternalIDProvenance(source interface{}, externalID interface{}, provenance interface{}) *MockStore_SetExternalIDProvenance_Call {
-	return &MockStore_SetExternalIDProvenance_Call{Call: _e.mock.On("SetExternalIDProvenance", source, externalID, provenance)}
-}
-func (_c *MockStore_SetExternalIDProvenance_Call) Run(run func(string, string, string)) *MockStore_SetExternalIDProvenance_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(string), args[2].(string)) })
-	return _c
-}
-func (_c *MockStore_SetExternalIDProvenance_Call) Return(err error) *MockStore_SetExternalIDProvenance_Call {
-	_c.Call.Return(err)
-	return _c
-}
-func (_c *MockStore_SetExternalIDProvenance_Call) RunAndReturn(run func(string, string, string) error) *MockStore_SetExternalIDProvenance_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetRemovedExternalIDs stubs the Store interface method.
-func (_mock *MockStore) GetRemovedExternalIDs(source string) ([]database.ExternalIDMapping, error) {
-	ret := _mock.Called(source)
-	var r0 []database.ExternalIDMapping
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.ExternalIDMapping)
-	}
-	return r0, ret.Error(1)
-}
-
-type MockStore_GetRemovedExternalIDs_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetRemovedExternalIDs(source interface{}) *MockStore_GetRemovedExternalIDs_Call {
-	return &MockStore_GetRemovedExternalIDs_Call{Call: _e.mock.On("GetRemovedExternalIDs", source)}
-}
-func (_c *MockStore_GetRemovedExternalIDs_Call) Run(run func(string)) *MockStore_GetRemovedExternalIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
-	return _c
-}
-func (_c *MockStore_GetRemovedExternalIDs_Call) Return(mappings []database.ExternalIDMapping, err error) *MockStore_GetRemovedExternalIDs_Call {
-	_c.Call.Return(mappings, err)
-	return _c
-}
-func (_c *MockStore_GetRemovedExternalIDs_Call) RunAndReturn(run func(string) ([]database.ExternalIDMapping, error)) *MockStore_GetRemovedExternalIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateOperationResult stubs the Store interface method.
-func (_mock *MockStore) CreateOperationResult(result *database.OperationResult) error {
-	ret := _mock.Called(result)
-	return ret.Error(0)
-}
-
-type MockStore_CreateOperationResult_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) CreateOperationResult(result interface{}) *MockStore_CreateOperationResult_Call {
-	return &MockStore_CreateOperationResult_Call{Call: _e.mock.On("CreateOperationResult", result)}
-}
-func (_c *MockStore_CreateOperationResult_Call) Run(run func(result *database.OperationResult)) *MockStore_CreateOperationResult_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(*database.OperationResult)) })
-	return _c
-}
-func (_c *MockStore_CreateOperationResult_Call) Return(err error) *MockStore_CreateOperationResult_Call {
-	_c.Call.Return(err)
-	return _c
-}
-func (_c *MockStore_CreateOperationResult_Call) RunAndReturn(run func(*database.OperationResult) error) *MockStore_CreateOperationResult_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOperationResults stubs the Store interface method.
-func (_mock *MockStore) GetOperationResults(operationID string) ([]database.OperationResult, error) {
-	ret := _mock.Called(operationID)
-	var r0 []database.OperationResult
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.OperationResult)
-	}
-	return r0, ret.Error(1)
-}
-
-type MockStore_GetOperationResults_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetOperationResults(operationID interface{}) *MockStore_GetOperationResults_Call {
-	return &MockStore_GetOperationResults_Call{Call: _e.mock.On("GetOperationResults", operationID)}
-}
-func (_c *MockStore_GetOperationResults_Call) Run(run func(string)) *MockStore_GetOperationResults_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
-	return _c
-}
-func (_c *MockStore_GetOperationResults_Call) Return(results []database.OperationResult, err error) *MockStore_GetOperationResults_Call {
-	_c.Call.Return(results, err)
-	return _c
-}
-func (_c *MockStore_GetOperationResults_Call) RunAndReturn(run func(string) ([]database.OperationResult, error)) *MockStore_GetOperationResults_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetRecentCompletedOperations stubs the Store interface method.
-func (_mock *MockStore) GetRecentCompletedOperations(limit int) ([]database.Operation, error) {
-	ret := _mock.Called(limit)
-	var r0 []database.Operation
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.Operation)
-	}
-	return r0, ret.Error(1)
-}
-
-type MockStore_GetRecentCompletedOperations_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetRecentCompletedOperations(limit interface{}) *MockStore_GetRecentCompletedOperations_Call {
-	return &MockStore_GetRecentCompletedOperations_Call{Call: _e.mock.On("GetRecentCompletedOperations", limit)}
-}
-func (_c *MockStore_GetRecentCompletedOperations_Call) Run(run func(int)) *MockStore_GetRecentCompletedOperations_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(int)) })
-	return _c
-}
-func (_c *MockStore_GetRecentCompletedOperations_Call) Return(ops []database.Operation, err error) *MockStore_GetRecentCompletedOperations_Call {
-	_c.Call.Return(ops, err)
-	return _c
-}
-func (_c *MockStore_GetRecentCompletedOperations_Call) RunAndReturn(run func(int) ([]database.Operation, error)) *MockStore_GetRecentCompletedOperations_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetRaw stubs the Store interface method.
-func (_mock *MockStore) SetRaw(key string, value []byte) error {
-	ret := _mock.Called(key, value)
-	return ret.Error(0)
-}
-
-type MockStore_SetRaw_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) SetRaw(key interface{}, value interface{}) *MockStore_SetRaw_Call {
-	return &MockStore_SetRaw_Call{Call: _e.mock.On("SetRaw", key, value)}
-}
-func (_c *MockStore_SetRaw_Call) Run(run func(string, []byte)) *MockStore_SetRaw_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].([]byte)) })
-	return _c
-}
-func (_c *MockStore_SetRaw_Call) Return(err error) *MockStore_SetRaw_Call {
-	_c.Call.Return(err)
-	return _c
-}
-func (_c *MockStore_SetRaw_Call) RunAndReturn(run func(string, []byte) error) *MockStore_SetRaw_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteRaw stubs the Store interface method.
-func (_mock *MockStore) DeleteRaw(key string) error {
-	ret := _mock.Called(key)
-	return ret.Error(0)
-}
-
-type MockStore_DeleteRaw_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) DeleteRaw(key interface{}) *MockStore_DeleteRaw_Call {
-	return &MockStore_DeleteRaw_Call{Call: _e.mock.On("DeleteRaw", key)}
-}
-func (_c *MockStore_DeleteRaw_Call) Run(run func(string)) *MockStore_DeleteRaw_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
-	return _c
-}
-func (_c *MockStore_DeleteRaw_Call) Return(err error) *MockStore_DeleteRaw_Call {
-	_c.Call.Return(err)
-	return _c
-}
-func (_c *MockStore_DeleteRaw_Call) RunAndReturn(run func(string) error) *MockStore_DeleteRaw_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ScanPrefix stubs the Store interface method.
-func (_mock *MockStore) ScanPrefix(prefix string) ([]database.KVPair, error) {
-	ret := _mock.Called(prefix)
-	var r0 []database.KVPair
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.KVPair)
-	}
-	return r0, ret.Error(1)
-}
-
-type MockStore_ScanPrefix_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) ScanPrefix(prefix interface{}) *MockStore_ScanPrefix_Call {
-	return &MockStore_ScanPrefix_Call{Call: _e.mock.On("ScanPrefix", prefix)}
-}
-func (_c *MockStore_ScanPrefix_Call) Run(run func(string)) *MockStore_ScanPrefix_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
-	return _c
-}
-func (_c *MockStore_ScanPrefix_Call) Return(pairs []database.KVPair, err error) *MockStore_ScanPrefix_Call {
-	_c.Call.Return(pairs, err)
-	return _c
-}
-func (_c *MockStore_ScanPrefix_Call) RunAndReturn(run func(string) ([]database.KVPair, error)) *MockStore_ScanPrefix_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// --- Book Alternative Titles ---
-
-// GetBookAlternativeTitles stubs the Store interface method.
-func (_mock *MockStore) GetBookAlternativeTitles(bookID string) ([]database.BookAlternativeTitle, error) {
-	ret := _mock.Called(bookID)
-	var r0 []database.BookAlternativeTitle
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).([]database.BookAlternativeTitle)
-	}
-	return r0, ret.Error(1)
-}
-
-type MockStore_GetBookAlternativeTitles_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockStore_GetBookAlternativeTitles_Call {
-	return &MockStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
-}
-
-func (_c *MockStore_GetBookAlternativeTitles_Call) Return(alts []database.BookAlternativeTitle, err error) *MockStore_GetBookAlternativeTitles_Call {
-	_c.Call.Return(alts, err)
-	return _c
-}
-
-// AddBookAlternativeTitle stubs the Store interface method.
-func (_mock *MockStore) AddBookAlternativeTitle(bookID, title, source, language string) error {
-	ret := _mock.Called(bookID, title, source, language)
-	return ret.Error(0)
-}
-
-type MockStore_AddBookAlternativeTitle_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) AddBookAlternativeTitle(bookID, title, source, language interface{}) *MockStore_AddBookAlternativeTitle_Call {
-	return &MockStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
-}
-
-func (_c *MockStore_AddBookAlternativeTitle_Call) Return(err error) *MockStore_AddBookAlternativeTitle_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-// RemoveBookAlternativeTitle stubs the Store interface method.
-func (_mock *MockStore) RemoveBookAlternativeTitle(bookID, title string) error {
-	ret := _mock.Called(bookID, title)
-	return ret.Error(0)
-}
-
-type MockStore_RemoveBookAlternativeTitle_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) RemoveBookAlternativeTitle(bookID, title interface{}) *MockStore_RemoveBookAlternativeTitle_Call {
-	return &MockStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
-}
-
-func (_c *MockStore_RemoveBookAlternativeTitle_Call) Return(err error) *MockStore_RemoveBookAlternativeTitle_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-// SetBookAlternativeTitles stubs the Store interface method.
-func (_mock *MockStore) SetBookAlternativeTitles(bookID string, titles []database.BookAlternativeTitle) error {
-	ret := _mock.Called(bookID, titles)
-	return ret.Error(0)
-}
-
-type MockStore_SetBookAlternativeTitles_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) SetBookAlternativeTitles(bookID, titles interface{}) *MockStore_SetBookAlternativeTitles_Call {
-	return &MockStore_SetBookAlternativeTitles_Call{Call: _e.mock.On("SetBookAlternativeTitles", bookID, titles)}
-}
-
-func (_c *MockStore_SetBookAlternativeTitles_Call) Return(err error) *MockStore_SetBookAlternativeTitles_Call {
-	_c.Call.Return(err)
 	return _c
 }

--- a/internal/server/itunes_writeback_batcher.go
+++ b/internal/server/itunes_writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_writeback_batcher.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -8,8 +8,11 @@
 package server
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -180,6 +183,21 @@ func (b *WriteBackBatcher) flush() {
 				authorName = author.Name
 			}
 		}
+		// Narrator ends up in the Composer field for audiobooks —
+		// Apple Music shows it there and most audiobook workflows
+		// (scanners, converters, players) key on that mapping.
+		narrator := ""
+		if book.Narrator != nil {
+			narrator = *book.Narrator
+		}
+		// Genre: prefer the book's own genre when set, fall back to
+		// "Audiobook" so iTunes classifies correctly. Previously
+		// every write hardcoded "Audiobook" even when the user had
+		// set a more specific value.
+		genre := "Audiobook"
+		if book.Genre != nil && *book.Genre != "" {
+			genre = *book.Genre
+		}
 
 		files, _ := store.GetBookFiles(id)
 		if len(files) > 0 {
@@ -199,7 +217,8 @@ func (b *WriteBackBatcher) flush() {
 					Name:         f.Title,
 					Album:        book.Title,
 					Artist:       authorName,
-					Genre:        "Audiobook",
+					Composer:     narrator,
+					Genre:        genre,
 				})
 			}
 		} else if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
@@ -214,7 +233,8 @@ func (b *WriteBackBatcher) flush() {
 				Name:         book.Title,
 				Album:        book.Title,
 				Artist:       authorName,
-				Genre:        "Audiobook",
+				Composer:     narrator,
+				Genre:        genre,
 			})
 		}
 	}
@@ -230,21 +250,178 @@ func (b *WriteBackBatcher) flush() {
 		return
 	}
 
-	log.Printf("[INFO] iTunes write-back: flushing %d location updates, %d adds, %d removes",
-		len(locationUpdates), len(adds), len(removes))
+	log.Printf("[INFO] iTunes write-back: flushing %d location updates, %d metadata updates, %d adds, %d removes",
+		len(locationUpdates), len(metadataUpdates), len(adds), len(removes))
 
 	itlPath := config.AppConfig.ITunesLibraryWritePath
-	result, err := itunes.ApplyITLOperations(itlPath, itlPath+".tmp", ops)
-	if err != nil {
+	if err := safeWriteITL(itlPath, ops); err != nil {
 		log.Printf("[WARN] iTunes write-back failed: %v", err)
 		return
 	}
+}
 
-	if renameErr := renameFile(itlPath+".tmp", itlPath); renameErr != nil {
-		log.Printf("[WARN] iTunes write-back rename failed: %v", renameErr)
-	} else {
-		log.Printf("[INFO] iTunes write-back: %d operations applied", result.UpdatedCount)
+// Test hooks. Production code wires these to the real itunes
+// package functions at package init. Tests override them so the
+// safe-write cycle can be unit-tested without needing a valid
+// ITL fixture on disk — the fixture itself is fragile, format
+// changes have broken it before, and mocking the two external
+// calls lets us test the logic in isolation.
+var (
+	itlValidateFn           = itunes.ValidateITL
+	itlApplyOperationsFn    = itunes.ApplyITLOperations
+)
+
+// safeWriteITL performs a backup → write-temp → validate-temp →
+// rename → validate-final → cleanup cycle for ITL write-back. At
+// every failure point the original ITL is either untouched or
+// restored from the backup, so a corrupted write can never leave
+// the user with an unreadable library file.
+//
+// Sequence:
+//  1. Ensure the source ITL currently parses (pre-condition check).
+//     If it doesn't, abort — we won't compound an existing problem.
+//  2. Copy itlPath → itlPath+".bak-YYYYMMDD-HHMMSS" as the rollback
+//     anchor. Prune older backups to keep the last `itlBackupRetention`.
+//  3. Run ApplyITLOperations to produce itlPath+".tmp".
+//  4. Validate the .tmp file. If invalid, remove .tmp and abort — the
+//     original itlPath is still intact.
+//  5. Rename .tmp over itlPath.
+//  6. Validate the renamed itlPath. If invalid (the rename itself
+//     produced corruption, or the write was partial), copy the
+//     backup back over itlPath.
+//  7. Log the result.
+func safeWriteITL(itlPath string, ops itunes.ITLOperationSet) error {
+	// Step 1: sanity-check the source. If the ITL we're about to
+	// write over is ALREADY corrupted, the write has nothing to
+	// validate against and a rollback wouldn't help anyway.
+	if err := itlValidateFn(itlPath); err != nil {
+		return fmt.Errorf("source ITL validation failed (refusing to write to a broken file): %w", err)
 	}
+
+	// Step 2: backup-before-write.
+	backupPath, backupErr := writeITLBackup(itlPath)
+	if backupErr != nil {
+		// A failing backup isn't fatal for the write — the user can
+		// still recover from the next successful run — but we log
+		// prominently so they know the safety net was missing.
+		log.Printf("[WARN] iTunes write-back: backup failed (%v); proceeding without a rollback anchor", backupErr)
+		backupPath = ""
+	} else {
+		if pruneErr := pruneITLBackups(itlPath, itlBackupRetention); pruneErr != nil {
+			log.Printf("[WARN] iTunes write-back: backup prune failed: %v", pruneErr)
+		}
+	}
+
+	// Step 3: write the updated ITL to a temp file.
+	tmpPath := itlPath + ".tmp"
+	result, err := itlApplyOperationsFn(itlPath, tmpPath, ops)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("ApplyITLOperations: %w", err)
+	}
+
+	// Step 4: validate the temp BEFORE renaming. If the write
+	// produced a file iTunes can't read, the original is still
+	// intact at itlPath and we abort cleanly.
+	if err := itlValidateFn(tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("validation of temp ITL failed (original preserved): %w", err)
+	}
+
+	// Step 5: rename .tmp over the original.
+	if err := renameFile(tmpPath, itlPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename .tmp → itl: %w", err)
+	}
+
+	// Step 6: validate the final file. On paranoid-filesystem
+	// failures or weird permission issues the rename can land but
+	// the result is still corrupt. Catch that and roll back.
+	if err := itlValidateFn(itlPath); err != nil {
+		log.Printf("[ERROR] iTunes write-back: post-rename validation failed (%v)", err)
+		if backupPath != "" {
+			if rbErr := copyFileContents(backupPath, itlPath); rbErr != nil {
+				return fmt.Errorf("post-rename validation failed AND backup restore failed: validation=%v restore=%v", err, rbErr)
+			}
+			log.Printf("[INFO] iTunes write-back: restored from backup %s after corrupted write", backupPath)
+			return fmt.Errorf("post-rename validation failed (restored from backup): %w", err)
+		}
+		return fmt.Errorf("post-rename validation failed (no backup available): %w", err)
+	}
+
+	log.Printf("[INFO] iTunes write-back: %d operations applied and validated", result.UpdatedCount)
+	return nil
+}
+
+// itlBackupRetention is how many rotating .bak-YYYYMMDD-HHMMSS
+// files to keep per ITL file. Balances "enough history to
+// investigate a regression" vs "don't fill the disk". Five is
+// typical for config-file backup schemes.
+const itlBackupRetention = 5
+
+// writeITLBackup copies itlPath to a timestamped sibling and
+// returns the new path. Uses time.Now with seconds precision so
+// rapid-fire backups in the same millisecond collide by design —
+// the per-run batcher's debounce makes that effectively
+// impossible, but documenting the assumption.
+func writeITLBackup(itlPath string) (string, error) {
+	stamp := time.Now().Format("20060102-150405")
+	backupPath := fmt.Sprintf("%s.bak-%s", itlPath, stamp)
+	if err := copyFileContents(itlPath, backupPath); err != nil {
+		return "", err
+	}
+	return backupPath, nil
+}
+
+// copyFileContents duplicates src to dst by reading the whole file
+// into memory and writing it out. Small enough for ITL files
+// (typically < 100 MB) and avoids needing io.Copy's dance.
+func copyFileContents(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+// pruneITLBackups deletes rotating backups beyond the keep limit.
+// Sorts siblings by name (lexicographic on the timestamp suffix,
+// which is monotonic) and removes the oldest excess.
+func pruneITLBackups(itlPath string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	dir := filepath.Dir(itlPath)
+	base := filepath.Base(itlPath) + ".bak-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var backups []string
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if !strings.HasPrefix(name, base) {
+			continue
+		}
+		backups = append(backups, filepath.Join(dir, name))
+	}
+	if len(backups) <= keep {
+		return nil
+	}
+	sort.Strings(backups) // oldest first (lex sort on timestamp)
+	toRemove := backups[:len(backups)-keep]
+	for _, p := range toRemove {
+		if err := os.Remove(p); err != nil {
+			log.Printf("[WARN] iTunes write-back: prune %s: %v", p, err)
+		}
+	}
+	return nil
 }
 
 // renameFile is a helper for os.Rename.

--- a/internal/server/itunes_writeback_batcher_test.go
+++ b/internal/server/itunes_writeback_batcher_test.go
@@ -1,0 +1,306 @@
+// file: internal/server/itunes_writeback_batcher_test.go
+// version: 1.1.0
+// guid: d4e5f6a7-b8c9-0123-def4-56789abcdef0
+
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+)
+
+// withFakeITLHooks replaces the package-level itunes hooks with
+// test doubles and restores them on cleanup. Lets every safeWriteITL
+// test drive the validate + apply paths without needing a real ITL
+// fixture on disk — the fixture is fragile and format changes have
+// broken it before.
+func withFakeITLHooks(t *testing.T, validate func(string) error, apply func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error)) {
+	t.Helper()
+	prevValidate := itlValidateFn
+	prevApply := itlApplyOperationsFn
+	itlValidateFn = validate
+	itlApplyOperationsFn = apply
+	t.Cleanup(func() {
+		itlValidateFn = prevValidate
+		itlApplyOperationsFn = prevApply
+	})
+}
+
+// makeITL writes a placeholder "ITL" file for tests. Since our
+// ValidateITL hook is mocked, the contents don't need to parse —
+// they just need to exist so os.ReadFile succeeds during backup.
+func makeITL(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("makeITL: %v", err)
+	}
+	return p
+}
+
+// TestSafeWriteITL_HappyPath covers the full success cycle:
+// source validates, backup is written, apply produces a temp,
+// temp validates, rename lands, final validates. End state: the
+// original is replaced, one backup exists, no temp remains.
+func TestSafeWriteITL_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "original-content")
+
+	applyCalls := 0
+	withFakeITLHooks(t,
+		func(path string) error {
+			// Every validate call passes.
+			return nil
+		},
+		func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			applyCalls++
+			// Simulate the real function: read in, transform, write out.
+			data, err := os.ReadFile(in)
+			if err != nil {
+				return nil, err
+			}
+			if err := os.WriteFile(out, append(data, '!'), 0o644); err != nil {
+				return nil, err
+			}
+			return &itunes.ITLWriteBackResult{UpdatedCount: 1, OutputPath: out}, nil
+		},
+	)
+
+	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("safeWriteITL happy path failed: %v", err)
+	}
+	if applyCalls != 1 {
+		t.Errorf("expected 1 apply call, got %d", applyCalls)
+	}
+
+	// Original file now has the transform applied.
+	out, _ := os.ReadFile(itlPath)
+	if string(out) != "original-content!" {
+		t.Errorf("final file content = %q, want %q", string(out), "original-content!")
+	}
+
+	// Exactly one backup exists.
+	backups, _ := filepath.Glob(itlPath + ".bak-*")
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 backup, got %d", len(backups))
+	}
+	// Backup contains the pre-write bytes.
+	backup, _ := os.ReadFile(backups[0])
+	if string(backup) != "original-content" {
+		t.Errorf("backup content = %q, want %q", string(backup), "original-content")
+	}
+
+	// No .tmp left over.
+	if _, err := os.Stat(itlPath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("expected .tmp to be cleaned up")
+	}
+}
+
+// TestSafeWriteITL_RefusesBrokenSource is the regression test for
+// rule #1: never write to an ITL that's already corrupted. The
+// validate call for the source path fails, and safeWriteITL must
+// abort without creating a backup or touching the file.
+func TestSafeWriteITL_RefusesBrokenSource(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "corrupted")
+
+	withFakeITLHooks(t,
+		func(path string) error {
+			return errors.New("bad magic bytes")
+		},
+		func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			t.Fatal("apply must not be called when source validation fails")
+			return nil, nil
+		},
+	)
+
+	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error on broken source")
+	}
+	if !strings.Contains(err.Error(), "source ITL validation failed") {
+		t.Errorf("expected source-validation error, got: %v", err)
+	}
+
+	// No backup created for a broken source.
+	backups, _ := filepath.Glob(itlPath + ".bak-*")
+	if len(backups) != 0 {
+		t.Errorf("expected 0 backups for broken source, got %d", len(backups))
+	}
+
+	// Source is untouched.
+	if data, _ := os.ReadFile(itlPath); string(data) != "corrupted" {
+		t.Errorf("source modified despite validation failure: %q", string(data))
+	}
+}
+
+// TestSafeWriteITL_TempValidationFailure verifies that when the
+// post-write temp file doesn't validate, we delete the temp and
+// abort cleanly with the original intact. This catches the case
+// where ApplyITLOperations succeeds byte-wise but produces
+// something iTunes can't read.
+func TestSafeWriteITL_TempValidationFailure(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "original")
+
+	// Validate passes for the source, fails for the temp.
+	validateCalls := 0
+	withFakeITLHooks(t,
+		func(path string) error {
+			validateCalls++
+			if strings.HasSuffix(path, ".tmp") {
+				return errors.New("temp file malformed")
+			}
+			return nil
+		},
+		func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			return &itunes.ITLWriteBackResult{UpdatedCount: 1}, os.WriteFile(out, []byte("garbage"), 0o644)
+		},
+	)
+
+	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error on temp validation failure")
+	}
+	if !strings.Contains(err.Error(), "validation of temp ITL failed") {
+		t.Errorf("expected temp-validation error, got: %v", err)
+	}
+
+	// Temp file was cleaned up.
+	if _, err := os.Stat(itlPath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("expected .tmp to be cleaned up after validation failure")
+	}
+
+	// Original still has pre-write content.
+	if data, _ := os.ReadFile(itlPath); string(data) != "original" {
+		t.Errorf("original modified despite temp validation failure: %q", string(data))
+	}
+}
+
+// TestSafeWriteITL_PostRenameRestore verifies the restore path:
+// temp validates, rename lands, then post-rename validation fails
+// (e.g., the filesystem corrupted it during the rename). We must
+// restore from the backup we took before the write.
+func TestSafeWriteITL_PostRenameRestore(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "original-bytes")
+
+	// Validate passes for source, passes for temp, fails for the
+	// final file after rename.
+	validateCount := 0
+	withFakeITLHooks(t,
+		func(path string) error {
+			validateCount++
+			// Source (call 1) + temp (call 2) pass. The third call is
+			// the post-rename validation on itlPath — fail that.
+			if validateCount == 3 {
+				return errors.New("corrupted after rename")
+			}
+			return nil
+		},
+		func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			// Write the new content.
+			return &itunes.ITLWriteBackResult{UpdatedCount: 1}, os.WriteFile(out, []byte("new-bytes"), 0o644)
+		},
+	)
+
+	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error on post-rename validation failure")
+	}
+	if !strings.Contains(err.Error(), "restored from backup") {
+		t.Errorf("expected restore message in error, got: %v", err)
+	}
+
+	// The final file should contain the ORIGINAL bytes (restored
+	// from backup), not the new ones (written and then rolled back).
+	data, _ := os.ReadFile(itlPath)
+	if string(data) != "original-bytes" {
+		t.Errorf("file not restored: got %q, want %q", string(data), "original-bytes")
+	}
+}
+
+// TestPruneITLBackups verifies backup rotation: given N+1 backup
+// files, pruneITLBackups keeps the N newest (by lex sort on the
+// timestamp suffix) and removes the oldest.
+func TestPruneITLBackups(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := filepath.Join(dir, "test.itl")
+	if err := os.WriteFile(itlPath, []byte("live"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stamps := []string{
+		"20260101-000000", "20260102-000000", "20260103-000000",
+		"20260104-000000", "20260105-000000", "20260106-000000",
+		"20260107-000000", "20260108-000000",
+	}
+	for _, s := range stamps {
+		if err := os.WriteFile(itlPath+".bak-"+s, []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := pruneITLBackups(itlPath, 5); err != nil {
+		t.Fatalf("pruneITLBackups: %v", err)
+	}
+
+	remaining, _ := filepath.Glob(itlPath + ".bak-*")
+	if len(remaining) != 5 {
+		t.Fatalf("expected 5 remaining, got %d: %v", len(remaining), remaining)
+	}
+
+	survivors := map[string]bool{}
+	for _, p := range remaining {
+		survivors[filepath.Base(p)] = true
+	}
+	for _, want := range []string{
+		"test.itl.bak-20260104-000000",
+		"test.itl.bak-20260105-000000",
+		"test.itl.bak-20260106-000000",
+		"test.itl.bak-20260107-000000",
+		"test.itl.bak-20260108-000000",
+	} {
+		if !survivors[want] {
+			t.Errorf("expected survivor %s, not found", want)
+		}
+	}
+	for _, gone := range []string{
+		"test.itl.bak-20260101-000000",
+		"test.itl.bak-20260102-000000",
+		"test.itl.bak-20260103-000000",
+	} {
+		if survivors[gone] {
+			t.Errorf("expected %s to be pruned, still present", gone)
+		}
+	}
+}
+
+// TestPruneITLBackups_KeepZero is a no-op by contract: passing
+// keep=0 means "don't prune". Callers that want to delete
+// everything pass a very large keep and use Remove directly.
+func TestPruneITLBackups_KeepZero(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := filepath.Join(dir, "test.itl")
+	_ = os.WriteFile(itlPath+".bak-20260101-000000", []byte("x"), 0o644)
+	if err := pruneITLBackups(itlPath, 0); err != nil {
+		t.Fatalf("pruneITLBackups: %v", err)
+	}
+	if _, err := os.Stat(itlPath + ".bak-20260101-000000"); err != nil {
+		t.Error("backup was removed despite keep=0")
+	}
+}


### PR DESCRIPTION
## Summary

Three gaps closed in the ITL write-back batcher:

1. **Narrator (Composer) field** now pushed on every metadata update. The \`ITLMetadataUpdate\` struct already supported it — the batcher just wasn't populating the field. iTunes was showing the wrong Composer value after users corrected narrators in audiobook-organizer. Also fixed Genre: previously hardcoded to \"Audiobook\" even when the book had a more specific genre set.

2. **\`safeWriteITL\` safe-write cycle** wraps the flush path with:
   - **Backup-before-write:** copy \`itlPath\` → \`itlPath.bak-YYYYMMDD-HHMMSS\` before any write. Rotates to last 5 per ITL.
   - **Pre-condition validation:** abort if the source ITL is already corrupted — we don't compound existing problems.
   - **Temp validation:** validate the \`.tmp\` BEFORE renaming. If invalid, delete \`.tmp\` and abort — original is still intact.
   - **Post-rename validation:** validate the renamed final file. If invalid (filesystem oddity, partial write), restore from backup.
   - Every failure path either leaves the original untouched or restores it.

3. **Mockable hooks:** \`itlValidateFn\` and \`itlApplyOperationsFn\` are package-level function vars so tests can swap them. Tests now cover all four code paths (happy, broken-source, temp-validation-fail, post-rename-restore) without needing a real ITL fixture on disk — the fixture has broken before on format changes, and we don't want future format work to invalidate the test suite.

## Test coverage

6 new unit tests, all passing:
- \`TestSafeWriteITL_HappyPath\` — full success cycle + backup contents check
- \`TestSafeWriteITL_RefusesBrokenSource\` — pre-condition failure
- \`TestSafeWriteITL_TempValidationFailure\` — post-write temp invalid
- \`TestSafeWriteITL_PostRenameRestore\` — restore-from-backup path
- \`TestPruneITLBackups\` — rotation to last N (8 → 5, oldest removed)
- \`TestPruneITLBackups_KeepZero\` — \`keep=0\` is a no-op by contract

Plus existing \`itunes\`, \`metadata\`, and \`server\` suites all still green.

Backlog item #36 of the 12 queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)