### PR TITLE
fix(test): add BookAlternativeTitle methods to stubStore

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -367,6 +367,16 @@ func (s *stubStore) GetBookTags(bookID string) ([]string, error)                
 func (s *stubStore) SetBookTags(bookID string, tags []string) error              { return nil }
 func (s *stubStore) ListAllTags() ([]database.TagWithCount, error)               { return nil, nil }
 func (s *stubStore) GetBooksByTag(tag string) ([]string, error)                  { return nil, nil }
+func (s *stubStore) GetBookAlternativeTitles(bookID string) ([]database.BookAlternativeTitle, error) {
+	return nil, nil
+}
+func (s *stubStore) AddBookAlternativeTitle(bookID, title, source, language string) error {
+	return nil
+}
+func (s *stubStore) RemoveBookAlternativeTitle(bookID, title string) error { return nil }
+func (s *stubStore) SetBookAlternativeTitles(bookID string, titles []database.BookAlternativeTitle) error {
+	return nil
+}
 func (s *stubStore) MarkExternalIDRemoved(source, externalID string) error       { return nil }
 func (s *stubStore) SetExternalIDProvenance(source, externalID, provenance string) error {
 	return nil


### PR DESCRIPTION
## Summary

- Adds zero-value stub implementations of the four new
  `BookAlternativeTitle` Store methods to `stubStore` in
  `cmd/commands_test.go`.
- Fixes `go vet` failure on main introduced when the interface
  grew in #234 but this stub wasn't updated.

## Error being fixed

```
vet: cmd/commands_test.go:410:26: cannot use &stubStore{} (value
of type *stubStore) as database.Store value in assignment:
*stubStore does not implement database.Store (missing method
AddBookAlternativeTitle)
```

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./cmd/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)