### PR TITLE
feat(tags): source-aware tag infrastructure for books / authors / series

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -316,6 +316,18 @@ var migrations = []Migration{
 		Up:          migration046Up,
 		Down:        nil,
 	},
+	{
+		Version:     47,
+		Description: "Add source column to book_tags so system-applied tags can be distinguished from user tags",
+		Up:          migration047Up,
+		Down:        nil,
+	},
+	{
+		Version:     48,
+		Description: "Add author_tags and series_tags tables for author/series-level tagging",
+		Up:          migration048Up,
+		Down:        nil,
+	},
 }
 
 // RunMigrations applies all pending migrations
@@ -2380,3 +2392,100 @@ func migration046Up(store Store) error {
 	log.Println("  - Created book_alternative_titles table")
 	return nil
 }
+
+// migration047Up adds a `source` column to book_tags so system-
+// applied tags (dedup:merge-survivor:llm-auto, metadata:source:*,
+// ...) can be distinguished from user-applied tags. PebbleStore
+// stores the same field in the serialized value; this migration
+// keeps SQLite as a first-class store option in sync.
+//
+// Example sources and the tags they emit:
+//
+//	source='user'   — tag was added via the UI or API by a human
+//	source='system' — tag was added automatically by the server:
+//	    dedup:merge-survivor[:auto-hash|auto-isbn|llm-auto]
+//	    dedup:duration-match
+//	    dedup:duration-abridged
+//	    metadata:source:{audible,hardcover,google_books,openlibrary,audnexus}
+//	    metadata:language:{en,es,fr,...} (from applied metadata)
+//	    import:scan (future), organize:applied (future), ...
+//
+// The column defaults to 'user' so every existing row stays valid
+// without a data migration, and existing AddBookTag callers don't
+// need to be touched — they just keep writing user-sourced tags.
+//
+// An index on source lets "tag:metadata:source:google_books AND
+// source=system" filter cheaply for the metadata-upgrade workflow.
+func migration047Up(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil
+	}
+	stmts := []string{
+		`ALTER TABLE book_tags ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`,
+		`CREATE INDEX IF NOT EXISTS idx_book_tags_source ON book_tags(source)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			// ALTER TABLE ADD COLUMN fails if the column already
+			// exists — SQLite has no IF NOT EXISTS for ALTER. Log
+			// and continue so a re-run is idempotent.
+			log.Printf("  - [WARN] migration 47: %v (continuing)", err)
+		}
+	}
+	log.Println("  - Added source column to book_tags")
+	return nil
+}
+
+// migration048Up adds parallel `author_tags` and `series_tags`
+// tables so tagging works at every entity level, not just books.
+// Motivating use cases:
+//
+//   - Mark an author as language-locked: tag with `language:en`,
+//     then the metadata fetcher and dedup engine skip candidates
+//     in other languages without inspecting every book.
+//   - Mark a series as `completed` / `on-hold` / `dropped` for
+//     read-list management.
+//   - Future "policy" tags: `policy:english-only` on an author or
+//     series binds a named settings bundle to every book that
+//     inherits through the author/series hierarchy.
+//   - System-applied provenance tags on authors/series after a
+//     merge or metadata apply — same namespace as book_tags.
+//
+// Schema mirrors book_tags after migration 47: primary key on
+// (entity_id, tag), `source` column defaulting to 'user', plus
+// indexes on tag and source for reverse lookup and filtering.
+func migration048Up(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil
+	}
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS author_tags (
+            author_id INTEGER NOT NULL,
+            tag TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'user',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (author_id, tag)
+        )`,
+		`CREATE INDEX IF NOT EXISTS idx_author_tags_tag ON author_tags(tag)`,
+		`CREATE INDEX IF NOT EXISTS idx_author_tags_source ON author_tags(source)`,
+		`CREATE TABLE IF NOT EXISTS series_tags (
+            series_id INTEGER NOT NULL,
+            tag TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'user',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (series_id, tag)
+        )`,
+		`CREATE INDEX IF NOT EXISTS idx_series_tags_tag ON series_tags(tag)`,
+		`CREATE INDEX IF NOT EXISTS idx_series_tags_source ON series_tags(source)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			log.Printf("  - [WARN] migration 48: %v (continuing)", err)
+		}
+	}
+	log.Println("  - Created author_tags and series_tags tables")
+	return nil
+}
+

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -250,13 +250,38 @@ type MockStore struct {
 	RecordPathChangeFunc   func(change *BookPathChange) error
 	GetBookPathHistoryFunc func(bookID string) ([]BookPathChange, error)
 
-	// Book User Tags
-	AddBookTagFunc    func(bookID, tag string) error
-	RemoveBookTagFunc func(bookID, tag string) error
-	GetBookTagsFunc   func(bookID string) ([]string, error)
-	SetBookTagsFunc   func(bookID string, tags []string) error
-	ListAllTagsFunc   func() ([]TagWithCount, error)
-	GetBooksByTagFunc func(tag string) ([]string, error)
+	// Book Tags
+	AddBookTagFunc              func(bookID, tag string) error
+	AddBookTagWithSourceFunc    func(bookID, tag, source string) error
+	RemoveBookTagFunc           func(bookID, tag string) error
+	RemoveBookTagsByPrefixFunc  func(bookID, prefix, source string) error
+	GetBookTagsFunc             func(bookID string) ([]string, error)
+	GetBookTagsDetailedFunc     func(bookID string) ([]BookTag, error)
+	SetBookTagsFunc             func(bookID string, tags []string) error
+	ListAllTagsFunc             func() ([]TagWithCount, error)
+	GetBooksByTagFunc           func(tag string) ([]string, error)
+
+	// Author Tags
+	AddAuthorTagFunc              func(authorID int, tag string) error
+	AddAuthorTagWithSourceFunc    func(authorID int, tag, source string) error
+	RemoveAuthorTagFunc           func(authorID int, tag string) error
+	RemoveAuthorTagsByPrefixFunc  func(authorID int, prefix, source string) error
+	GetAuthorTagsFunc             func(authorID int) ([]string, error)
+	GetAuthorTagsDetailedFunc     func(authorID int) ([]BookTag, error)
+	SetAuthorTagsFunc             func(authorID int, tags []string) error
+	ListAllAuthorTagsFunc         func() ([]TagWithCount, error)
+	GetAuthorsByTagFunc           func(tag string) ([]int, error)
+
+	// Series Tags
+	AddSeriesTagFunc              func(seriesID int, tag string) error
+	AddSeriesTagWithSourceFunc    func(seriesID int, tag, source string) error
+	RemoveSeriesTagFunc           func(seriesID int, tag string) error
+	RemoveSeriesTagsByPrefixFunc  func(seriesID int, prefix, source string) error
+	GetSeriesTagsFunc             func(seriesID int) ([]string, error)
+	GetSeriesTagsDetailedFunc     func(seriesID int) ([]BookTag, error)
+	SetSeriesTagsFunc             func(seriesID int, tags []string) error
+	ListAllSeriesTagsFunc         func() ([]TagWithCount, error)
+	GetSeriesByTagFunc            func(tag string) ([]int, error)
 
 	// Lifecycle
 	CloseFunc func() error
@@ -1522,6 +1547,166 @@ func (m *MockStore) ListAllTags() ([]TagWithCount, error) {
 func (m *MockStore) GetBooksByTag(tag string) ([]string, error) {
 	if m.GetBooksByTagFunc != nil {
 		return m.GetBooksByTagFunc(tag)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) AddBookTagWithSource(bookID, tag, source string) error {
+	if m.AddBookTagWithSourceFunc != nil {
+		return m.AddBookTagWithSourceFunc(bookID, tag, source)
+	}
+	if m.AddBookTagFunc != nil {
+		return m.AddBookTagFunc(bookID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) RemoveBookTagsByPrefix(bookID, prefix, source string) error {
+	if m.RemoveBookTagsByPrefixFunc != nil {
+		return m.RemoveBookTagsByPrefixFunc(bookID, prefix, source)
+	}
+	return nil
+}
+
+func (m *MockStore) GetBookTagsDetailed(bookID string) ([]BookTag, error) {
+	if m.GetBookTagsDetailedFunc != nil {
+		return m.GetBookTagsDetailedFunc(bookID)
+	}
+	return nil, nil
+}
+
+// ---- Author tag methods ----
+
+func (m *MockStore) AddAuthorTag(authorID int, tag string) error {
+	if m.AddAuthorTagFunc != nil {
+		return m.AddAuthorTagFunc(authorID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) AddAuthorTagWithSource(authorID int, tag, source string) error {
+	if m.AddAuthorTagWithSourceFunc != nil {
+		return m.AddAuthorTagWithSourceFunc(authorID, tag, source)
+	}
+	if m.AddAuthorTagFunc != nil {
+		return m.AddAuthorTagFunc(authorID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) RemoveAuthorTag(authorID int, tag string) error {
+	if m.RemoveAuthorTagFunc != nil {
+		return m.RemoveAuthorTagFunc(authorID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) RemoveAuthorTagsByPrefix(authorID int, prefix, source string) error {
+	if m.RemoveAuthorTagsByPrefixFunc != nil {
+		return m.RemoveAuthorTagsByPrefixFunc(authorID, prefix, source)
+	}
+	return nil
+}
+
+func (m *MockStore) GetAuthorTags(authorID int) ([]string, error) {
+	if m.GetAuthorTagsFunc != nil {
+		return m.GetAuthorTagsFunc(authorID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetAuthorTagsDetailed(authorID int) ([]BookTag, error) {
+	if m.GetAuthorTagsDetailedFunc != nil {
+		return m.GetAuthorTagsDetailedFunc(authorID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) SetAuthorTags(authorID int, tags []string) error {
+	if m.SetAuthorTagsFunc != nil {
+		return m.SetAuthorTagsFunc(authorID, tags)
+	}
+	return nil
+}
+
+func (m *MockStore) ListAllAuthorTags() ([]TagWithCount, error) {
+	if m.ListAllAuthorTagsFunc != nil {
+		return m.ListAllAuthorTagsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetAuthorsByTag(tag string) ([]int, error) {
+	if m.GetAuthorsByTagFunc != nil {
+		return m.GetAuthorsByTagFunc(tag)
+	}
+	return nil, nil
+}
+
+// ---- Series tag methods ----
+
+func (m *MockStore) AddSeriesTag(seriesID int, tag string) error {
+	if m.AddSeriesTagFunc != nil {
+		return m.AddSeriesTagFunc(seriesID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) AddSeriesTagWithSource(seriesID int, tag, source string) error {
+	if m.AddSeriesTagWithSourceFunc != nil {
+		return m.AddSeriesTagWithSourceFunc(seriesID, tag, source)
+	}
+	if m.AddSeriesTagFunc != nil {
+		return m.AddSeriesTagFunc(seriesID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) RemoveSeriesTag(seriesID int, tag string) error {
+	if m.RemoveSeriesTagFunc != nil {
+		return m.RemoveSeriesTagFunc(seriesID, tag)
+	}
+	return nil
+}
+
+func (m *MockStore) RemoveSeriesTagsByPrefix(seriesID int, prefix, source string) error {
+	if m.RemoveSeriesTagsByPrefixFunc != nil {
+		return m.RemoveSeriesTagsByPrefixFunc(seriesID, prefix, source)
+	}
+	return nil
+}
+
+func (m *MockStore) GetSeriesTags(seriesID int) ([]string, error) {
+	if m.GetSeriesTagsFunc != nil {
+		return m.GetSeriesTagsFunc(seriesID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetSeriesTagsDetailed(seriesID int) ([]BookTag, error) {
+	if m.GetSeriesTagsDetailedFunc != nil {
+		return m.GetSeriesTagsDetailedFunc(seriesID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) SetSeriesTags(seriesID int, tags []string) error {
+	if m.SetSeriesTagsFunc != nil {
+		return m.SetSeriesTagsFunc(seriesID, tags)
+	}
+	return nil
+}
+
+func (m *MockStore) ListAllSeriesTags() ([]TagWithCount, error) {
+	if m.ListAllSeriesTagsFunc != nil {
+		return m.ListAllSeriesTagsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetSeriesByTag(tag string) ([]int, error) {
+	if m.GetSeriesByTagFunc != nil {
+		return m.GetSeriesByTagFunc(tag)
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -38,6 +38,126 @@ func (_m *MockStore) EXPECT() *MockStore_Expecter {
 	return &MockStore_Expecter{mock: &_m.Mock}
 }
 
+// AddAuthorTag provides a mock function for the type MockStore
+func (_mock *MockStore) AddAuthorTag(authorID int, tag string) error {
+	ret := _mock.Called(authorID, tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddAuthorTag")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string) error); ok {
+		r0 = returnFunc(authorID, tag)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddAuthorTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddAuthorTag'
+type MockStore_AddAuthorTag_Call struct {
+	*mock.Call
+}
+
+// AddAuthorTag is a helper method to define mock.On call
+//   - authorID int
+//   - tag string
+func (_e *MockStore_Expecter) AddAuthorTag(authorID interface{}, tag interface{}) *MockStore_AddAuthorTag_Call {
+	return &MockStore_AddAuthorTag_Call{Call: _e.mock.On("AddAuthorTag", authorID, tag)}
+}
+
+func (_c *MockStore_AddAuthorTag_Call) Run(run func(authorID int, tag string)) *MockStore_AddAuthorTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddAuthorTag_Call) Return(err error) *MockStore_AddAuthorTag_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddAuthorTag_Call) RunAndReturn(run func(authorID int, tag string) error) *MockStore_AddAuthorTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddAuthorTagWithSource provides a mock function for the type MockStore
+func (_mock *MockStore) AddAuthorTagWithSource(authorID int, tag string, source string) error {
+	ret := _mock.Called(authorID, tag, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddAuthorTagWithSource")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string, string) error); ok {
+		r0 = returnFunc(authorID, tag, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddAuthorTagWithSource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddAuthorTagWithSource'
+type MockStore_AddAuthorTagWithSource_Call struct {
+	*mock.Call
+}
+
+// AddAuthorTagWithSource is a helper method to define mock.On call
+//   - authorID int
+//   - tag string
+//   - source string
+func (_e *MockStore_Expecter) AddAuthorTagWithSource(authorID interface{}, tag interface{}, source interface{}) *MockStore_AddAuthorTagWithSource_Call {
+	return &MockStore_AddAuthorTagWithSource_Call{Call: _e.mock.On("AddAuthorTagWithSource", authorID, tag, source)}
+}
+
+func (_c *MockStore_AddAuthorTagWithSource_Call) Run(run func(authorID int, tag string, source string)) *MockStore_AddAuthorTagWithSource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddAuthorTagWithSource_Call) Return(err error) *MockStore_AddAuthorTagWithSource_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddAuthorTagWithSource_Call) RunAndReturn(run func(authorID int, tag string, source string) error) *MockStore_AddAuthorTagWithSource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AddBlockedHash provides a mock function for the type MockStore
 func (_mock *MockStore) AddBlockedHash(hash string, reason string) error {
 	ret := _mock.Called(hash, reason)
@@ -217,6 +337,69 @@ func (_c *MockStore_AddBookTag_Call) Return(err error) *MockStore_AddBookTag_Cal
 }
 
 func (_c *MockStore_AddBookTag_Call) RunAndReturn(run func(bookID string, tag string) error) *MockStore_AddBookTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddBookTagWithSource provides a mock function for the type MockStore
+func (_mock *MockStore) AddBookTagWithSource(bookID string, tag string, source string) error {
+	ret := _mock.Called(bookID, tag, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddBookTagWithSource")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = returnFunc(bookID, tag, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddBookTagWithSource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddBookTagWithSource'
+type MockStore_AddBookTagWithSource_Call struct {
+	*mock.Call
+}
+
+// AddBookTagWithSource is a helper method to define mock.On call
+//   - bookID string
+//   - tag string
+//   - source string
+func (_e *MockStore_Expecter) AddBookTagWithSource(bookID interface{}, tag interface{}, source interface{}) *MockStore_AddBookTagWithSource_Call {
+	return &MockStore_AddBookTagWithSource_Call{Call: _e.mock.On("AddBookTagWithSource", bookID, tag, source)}
+}
+
+func (_c *MockStore_AddBookTagWithSource_Call) Run(run func(bookID string, tag string, source string)) *MockStore_AddBookTagWithSource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddBookTagWithSource_Call) Return(err error) *MockStore_AddBookTagWithSource_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddBookTagWithSource_Call) RunAndReturn(run func(bookID string, tag string, source string) error) *MockStore_AddBookTagWithSource_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -457,6 +640,126 @@ func (_c *MockStore_AddPlaylistItem_Call) Return(err error) *MockStore_AddPlayli
 }
 
 func (_c *MockStore_AddPlaylistItem_Call) RunAndReturn(run func(playlistID int, bookID int, position int) error) *MockStore_AddPlaylistItem_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddSeriesTag provides a mock function for the type MockStore
+func (_mock *MockStore) AddSeriesTag(seriesID int, tag string) error {
+	ret := _mock.Called(seriesID, tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddSeriesTag")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string) error); ok {
+		r0 = returnFunc(seriesID, tag)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddSeriesTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddSeriesTag'
+type MockStore_AddSeriesTag_Call struct {
+	*mock.Call
+}
+
+// AddSeriesTag is a helper method to define mock.On call
+//   - seriesID int
+//   - tag string
+func (_e *MockStore_Expecter) AddSeriesTag(seriesID interface{}, tag interface{}) *MockStore_AddSeriesTag_Call {
+	return &MockStore_AddSeriesTag_Call{Call: _e.mock.On("AddSeriesTag", seriesID, tag)}
+}
+
+func (_c *MockStore_AddSeriesTag_Call) Run(run func(seriesID int, tag string)) *MockStore_AddSeriesTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddSeriesTag_Call) Return(err error) *MockStore_AddSeriesTag_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddSeriesTag_Call) RunAndReturn(run func(seriesID int, tag string) error) *MockStore_AddSeriesTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddSeriesTagWithSource provides a mock function for the type MockStore
+func (_mock *MockStore) AddSeriesTagWithSource(seriesID int, tag string, source string) error {
+	ret := _mock.Called(seriesID, tag, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddSeriesTagWithSource")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string, string) error); ok {
+		r0 = returnFunc(seriesID, tag, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddSeriesTagWithSource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddSeriesTagWithSource'
+type MockStore_AddSeriesTagWithSource_Call struct {
+	*mock.Call
+}
+
+// AddSeriesTagWithSource is a helper method to define mock.On call
+//   - seriesID int
+//   - tag string
+//   - source string
+func (_e *MockStore_Expecter) AddSeriesTagWithSource(seriesID interface{}, tag interface{}, source interface{}) *MockStore_AddSeriesTagWithSource_Call {
+	return &MockStore_AddSeriesTagWithSource_Call{Call: _e.mock.On("AddSeriesTagWithSource", seriesID, tag, source)}
+}
+
+func (_c *MockStore_AddSeriesTagWithSource_Call) Run(run func(seriesID int, tag string, source string)) *MockStore_AddSeriesTagWithSource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddSeriesTagWithSource_Call) Return(err error) *MockStore_AddSeriesTagWithSource_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddSeriesTagWithSource_Call) RunAndReturn(run func(seriesID int, tag string, source string) error) *MockStore_AddSeriesTagWithSource_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3995,6 +4298,130 @@ func (_c *MockStore_GetAuthorByName_Call) RunAndReturn(run func(name string) (*d
 	return _c
 }
 
+// GetAuthorTags provides a mock function for the type MockStore
+func (_mock *MockStore) GetAuthorTags(authorID int) ([]string, error) {
+	ret := _mock.Called(authorID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthorTags")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]string, error)); ok {
+		return returnFunc(authorID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []string); ok {
+		r0 = returnFunc(authorID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(authorID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAuthorTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAuthorTags'
+type MockStore_GetAuthorTags_Call struct {
+	*mock.Call
+}
+
+// GetAuthorTags is a helper method to define mock.On call
+//   - authorID int
+func (_e *MockStore_Expecter) GetAuthorTags(authorID interface{}) *MockStore_GetAuthorTags_Call {
+	return &MockStore_GetAuthorTags_Call{Call: _e.mock.On("GetAuthorTags", authorID)}
+}
+
+func (_c *MockStore_GetAuthorTags_Call) Run(run func(authorID int)) *MockStore_GetAuthorTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAuthorTags_Call) Return(strings []string, err error) *MockStore_GetAuthorTags_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockStore_GetAuthorTags_Call) RunAndReturn(run func(authorID int) ([]string, error)) *MockStore_GetAuthorTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAuthorTagsDetailed provides a mock function for the type MockStore
+func (_mock *MockStore) GetAuthorTagsDetailed(authorID int) ([]database.BookTag, error) {
+	ret := _mock.Called(authorID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthorTagsDetailed")
+	}
+
+	var r0 []database.BookTag
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookTag, error)); ok {
+		return returnFunc(authorID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookTag); ok {
+		r0 = returnFunc(authorID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookTag)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(authorID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAuthorTagsDetailed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAuthorTagsDetailed'
+type MockStore_GetAuthorTagsDetailed_Call struct {
+	*mock.Call
+}
+
+// GetAuthorTagsDetailed is a helper method to define mock.On call
+//   - authorID int
+func (_e *MockStore_Expecter) GetAuthorTagsDetailed(authorID interface{}) *MockStore_GetAuthorTagsDetailed_Call {
+	return &MockStore_GetAuthorTagsDetailed_Call{Call: _e.mock.On("GetAuthorTagsDetailed", authorID)}
+}
+
+func (_c *MockStore_GetAuthorTagsDetailed_Call) Run(run func(authorID int)) *MockStore_GetAuthorTagsDetailed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAuthorTagsDetailed_Call) Return(bookTags []database.BookTag, err error) *MockStore_GetAuthorTagsDetailed_Call {
+	_c.Call.Return(bookTags, err)
+	return _c
+}
+
+func (_c *MockStore_GetAuthorTagsDetailed_Call) RunAndReturn(run func(authorID int) ([]database.BookTag, error)) *MockStore_GetAuthorTagsDetailed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAuthorTombstone provides a mock function for the type MockStore
 func (_mock *MockStore) GetAuthorTombstone(oldID int) (int, error) {
 	ret := _mock.Called(oldID)
@@ -4051,6 +4478,68 @@ func (_c *MockStore_GetAuthorTombstone_Call) Return(n int, err error) *MockStore
 }
 
 func (_c *MockStore_GetAuthorTombstone_Call) RunAndReturn(run func(oldID int) (int, error)) *MockStore_GetAuthorTombstone_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAuthorsByTag provides a mock function for the type MockStore
+func (_mock *MockStore) GetAuthorsByTag(tag string) ([]int, error) {
+	ret := _mock.Called(tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthorsByTag")
+	}
+
+	var r0 []int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]int, error)); ok {
+		return returnFunc(tag)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []int); ok {
+		r0 = returnFunc(tag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(tag)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAuthorsByTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAuthorsByTag'
+type MockStore_GetAuthorsByTag_Call struct {
+	*mock.Call
+}
+
+// GetAuthorsByTag is a helper method to define mock.On call
+//   - tag string
+func (_e *MockStore_Expecter) GetAuthorsByTag(tag interface{}) *MockStore_GetAuthorsByTag_Call {
+	return &MockStore_GetAuthorsByTag_Call{Call: _e.mock.On("GetAuthorsByTag", tag)}
+}
+
+func (_c *MockStore_GetAuthorsByTag_Call) Run(run func(tag string)) *MockStore_GetAuthorsByTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAuthorsByTag_Call) Return(ints []int, err error) *MockStore_GetAuthorsByTag_Call {
+	_c.Call.Return(ints, err)
+	return _c
+}
+
+func (_c *MockStore_GetAuthorsByTag_Call) RunAndReturn(run func(tag string) ([]int, error)) *MockStore_GetAuthorsByTag_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5569,6 +6058,68 @@ func (_c *MockStore_GetBookTags_Call) Return(strings []string, err error) *MockS
 }
 
 func (_c *MockStore_GetBookTags_Call) RunAndReturn(run func(bookID string) ([]string, error)) *MockStore_GetBookTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookTagsDetailed provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookTagsDetailed(bookID string) ([]database.BookTag, error) {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookTagsDetailed")
+	}
+
+	var r0 []database.BookTag
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BookTag, error)); ok {
+		return returnFunc(bookID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.BookTag); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookTag)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(bookID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookTagsDetailed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookTagsDetailed'
+type MockStore_GetBookTagsDetailed_Call struct {
+	*mock.Call
+}
+
+// GetBookTagsDetailed is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockStore_Expecter) GetBookTagsDetailed(bookID interface{}) *MockStore_GetBookTagsDetailed_Call {
+	return &MockStore_GetBookTagsDetailed_Call{Call: _e.mock.On("GetBookTagsDetailed", bookID)}
+}
+
+func (_c *MockStore_GetBookTagsDetailed_Call) Run(run func(bookID string)) *MockStore_GetBookTagsDetailed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookTagsDetailed_Call) Return(bookTags []database.BookTag, err error) *MockStore_GetBookTagsDetailed_Call {
+	_c.Call.Return(bookTags, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookTagsDetailed_Call) RunAndReturn(run func(bookID string) ([]database.BookTag, error)) *MockStore_GetBookTagsDetailed_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -8281,6 +8832,192 @@ func (_c *MockStore_GetSeriesByName_Call) RunAndReturn(run func(name string, aut
 	return _c
 }
 
+// GetSeriesByTag provides a mock function for the type MockStore
+func (_mock *MockStore) GetSeriesByTag(tag string) ([]int, error) {
+	ret := _mock.Called(tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSeriesByTag")
+	}
+
+	var r0 []int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]int, error)); ok {
+		return returnFunc(tag)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []int); ok {
+		r0 = returnFunc(tag)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(tag)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetSeriesByTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSeriesByTag'
+type MockStore_GetSeriesByTag_Call struct {
+	*mock.Call
+}
+
+// GetSeriesByTag is a helper method to define mock.On call
+//   - tag string
+func (_e *MockStore_Expecter) GetSeriesByTag(tag interface{}) *MockStore_GetSeriesByTag_Call {
+	return &MockStore_GetSeriesByTag_Call{Call: _e.mock.On("GetSeriesByTag", tag)}
+}
+
+func (_c *MockStore_GetSeriesByTag_Call) Run(run func(tag string)) *MockStore_GetSeriesByTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetSeriesByTag_Call) Return(ints []int, err error) *MockStore_GetSeriesByTag_Call {
+	_c.Call.Return(ints, err)
+	return _c
+}
+
+func (_c *MockStore_GetSeriesByTag_Call) RunAndReturn(run func(tag string) ([]int, error)) *MockStore_GetSeriesByTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSeriesTags provides a mock function for the type MockStore
+func (_mock *MockStore) GetSeriesTags(seriesID int) ([]string, error) {
+	ret := _mock.Called(seriesID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSeriesTags")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]string, error)); ok {
+		return returnFunc(seriesID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []string); ok {
+		r0 = returnFunc(seriesID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(seriesID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetSeriesTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSeriesTags'
+type MockStore_GetSeriesTags_Call struct {
+	*mock.Call
+}
+
+// GetSeriesTags is a helper method to define mock.On call
+//   - seriesID int
+func (_e *MockStore_Expecter) GetSeriesTags(seriesID interface{}) *MockStore_GetSeriesTags_Call {
+	return &MockStore_GetSeriesTags_Call{Call: _e.mock.On("GetSeriesTags", seriesID)}
+}
+
+func (_c *MockStore_GetSeriesTags_Call) Run(run func(seriesID int)) *MockStore_GetSeriesTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetSeriesTags_Call) Return(strings []string, err error) *MockStore_GetSeriesTags_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockStore_GetSeriesTags_Call) RunAndReturn(run func(seriesID int) ([]string, error)) *MockStore_GetSeriesTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSeriesTagsDetailed provides a mock function for the type MockStore
+func (_mock *MockStore) GetSeriesTagsDetailed(seriesID int) ([]database.BookTag, error) {
+	ret := _mock.Called(seriesID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSeriesTagsDetailed")
+	}
+
+	var r0 []database.BookTag
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookTag, error)); ok {
+		return returnFunc(seriesID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookTag); ok {
+		r0 = returnFunc(seriesID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookTag)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(seriesID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetSeriesTagsDetailed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSeriesTagsDetailed'
+type MockStore_GetSeriesTagsDetailed_Call struct {
+	*mock.Call
+}
+
+// GetSeriesTagsDetailed is a helper method to define mock.On call
+//   - seriesID int
+func (_e *MockStore_Expecter) GetSeriesTagsDetailed(seriesID interface{}) *MockStore_GetSeriesTagsDetailed_Call {
+	return &MockStore_GetSeriesTagsDetailed_Call{Call: _e.mock.On("GetSeriesTagsDetailed", seriesID)}
+}
+
+func (_c *MockStore_GetSeriesTagsDetailed_Call) Run(run func(seriesID int)) *MockStore_GetSeriesTagsDetailed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetSeriesTagsDetailed_Call) Return(bookTags []database.BookTag, err error) *MockStore_GetSeriesTagsDetailed_Call {
+	_c.Call.Return(bookTags, err)
+	return _c
+}
+
+func (_c *MockStore_GetSeriesTagsDetailed_Call) RunAndReturn(run func(seriesID int) ([]database.BookTag, error)) *MockStore_GetSeriesTagsDetailed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSession provides a mock function for the type MockStore
 func (_mock *MockStore) GetSession(id string) (*database.Session, error) {
 	ret := _mock.Called(id)
@@ -9149,6 +9886,116 @@ func (_c *MockStore_IsHashBlocked_Call) Return(b bool, err error) *MockStore_IsH
 }
 
 func (_c *MockStore_IsHashBlocked_Call) RunAndReturn(run func(hash string) (bool, error)) *MockStore_IsHashBlocked_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListAllAuthorTags provides a mock function for the type MockStore
+func (_mock *MockStore) ListAllAuthorTags() ([]database.TagWithCount, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAllAuthorTags")
+	}
+
+	var r0 []database.TagWithCount
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.TagWithCount, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.TagWithCount); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.TagWithCount)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListAllAuthorTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAllAuthorTags'
+type MockStore_ListAllAuthorTags_Call struct {
+	*mock.Call
+}
+
+// ListAllAuthorTags is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ListAllAuthorTags() *MockStore_ListAllAuthorTags_Call {
+	return &MockStore_ListAllAuthorTags_Call{Call: _e.mock.On("ListAllAuthorTags")}
+}
+
+func (_c *MockStore_ListAllAuthorTags_Call) Run(run func()) *MockStore_ListAllAuthorTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ListAllAuthorTags_Call) Return(tagWithCounts []database.TagWithCount, err error) *MockStore_ListAllAuthorTags_Call {
+	_c.Call.Return(tagWithCounts, err)
+	return _c
+}
+
+func (_c *MockStore_ListAllAuthorTags_Call) RunAndReturn(run func() ([]database.TagWithCount, error)) *MockStore_ListAllAuthorTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListAllSeriesTags provides a mock function for the type MockStore
+func (_mock *MockStore) ListAllSeriesTags() ([]database.TagWithCount, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAllSeriesTags")
+	}
+
+	var r0 []database.TagWithCount
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.TagWithCount, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.TagWithCount); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.TagWithCount)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListAllSeriesTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAllSeriesTags'
+type MockStore_ListAllSeriesTags_Call struct {
+	*mock.Call
+}
+
+// ListAllSeriesTags is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ListAllSeriesTags() *MockStore_ListAllSeriesTags_Call {
+	return &MockStore_ListAllSeriesTags_Call{Call: _e.mock.On("ListAllSeriesTags")}
+}
+
+func (_c *MockStore_ListAllSeriesTags_Call) Run(run func()) *MockStore_ListAllSeriesTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ListAllSeriesTags_Call) Return(tagWithCounts []database.TagWithCount, err error) *MockStore_ListAllSeriesTags_Call {
+	_c.Call.Return(tagWithCounts, err)
+	return _c
+}
+
+func (_c *MockStore_ListAllSeriesTags_Call) RunAndReturn(run func() ([]database.TagWithCount, error)) *MockStore_ListAllSeriesTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -10590,6 +11437,126 @@ func (_c *MockStore_RecordPathChange_Call) RunAndReturn(run func(change *databas
 	return _c
 }
 
+// RemoveAuthorTag provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveAuthorTag(authorID int, tag string) error {
+	ret := _mock.Called(authorID, tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAuthorTag")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string) error); ok {
+		r0 = returnFunc(authorID, tag)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveAuthorTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveAuthorTag'
+type MockStore_RemoveAuthorTag_Call struct {
+	*mock.Call
+}
+
+// RemoveAuthorTag is a helper method to define mock.On call
+//   - authorID int
+//   - tag string
+func (_e *MockStore_Expecter) RemoveAuthorTag(authorID interface{}, tag interface{}) *MockStore_RemoveAuthorTag_Call {
+	return &MockStore_RemoveAuthorTag_Call{Call: _e.mock.On("RemoveAuthorTag", authorID, tag)}
+}
+
+func (_c *MockStore_RemoveAuthorTag_Call) Run(run func(authorID int, tag string)) *MockStore_RemoveAuthorTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveAuthorTag_Call) Return(err error) *MockStore_RemoveAuthorTag_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveAuthorTag_Call) RunAndReturn(run func(authorID int, tag string) error) *MockStore_RemoveAuthorTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveAuthorTagsByPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveAuthorTagsByPrefix(authorID int, prefix string, source string) error {
+	ret := _mock.Called(authorID, prefix, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAuthorTagsByPrefix")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string, string) error); ok {
+		r0 = returnFunc(authorID, prefix, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveAuthorTagsByPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveAuthorTagsByPrefix'
+type MockStore_RemoveAuthorTagsByPrefix_Call struct {
+	*mock.Call
+}
+
+// RemoveAuthorTagsByPrefix is a helper method to define mock.On call
+//   - authorID int
+//   - prefix string
+//   - source string
+func (_e *MockStore_Expecter) RemoveAuthorTagsByPrefix(authorID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveAuthorTagsByPrefix_Call {
+	return &MockStore_RemoveAuthorTagsByPrefix_Call{Call: _e.mock.On("RemoveAuthorTagsByPrefix", authorID, prefix, source)}
+}
+
+func (_c *MockStore_RemoveAuthorTagsByPrefix_Call) Run(run func(authorID int, prefix string, source string)) *MockStore_RemoveAuthorTagsByPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveAuthorTagsByPrefix_Call) Return(err error) *MockStore_RemoveAuthorTagsByPrefix_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveAuthorTagsByPrefix_Call) RunAndReturn(run func(authorID int, prefix string, source string) error) *MockStore_RemoveAuthorTagsByPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveBlockedHash provides a mock function for the type MockStore
 func (_mock *MockStore) RemoveBlockedHash(hash string) error {
 	ret := _mock.Called(hash)
@@ -10755,6 +11722,69 @@ func (_c *MockStore_RemoveBookTag_Call) RunAndReturn(run func(bookID string, tag
 	return _c
 }
 
+// RemoveBookTagsByPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveBookTagsByPrefix(bookID string, prefix string, source string) error {
+	ret := _mock.Called(bookID, prefix, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveBookTagsByPrefix")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = returnFunc(bookID, prefix, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveBookTagsByPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveBookTagsByPrefix'
+type MockStore_RemoveBookTagsByPrefix_Call struct {
+	*mock.Call
+}
+
+// RemoveBookTagsByPrefix is a helper method to define mock.On call
+//   - bookID string
+//   - prefix string
+//   - source string
+func (_e *MockStore_Expecter) RemoveBookTagsByPrefix(bookID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveBookTagsByPrefix_Call {
+	return &MockStore_RemoveBookTagsByPrefix_Call{Call: _e.mock.On("RemoveBookTagsByPrefix", bookID, prefix, source)}
+}
+
+func (_c *MockStore_RemoveBookTagsByPrefix_Call) Run(run func(bookID string, prefix string, source string)) *MockStore_RemoveBookTagsByPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveBookTagsByPrefix_Call) Return(err error) *MockStore_RemoveBookTagsByPrefix_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveBookTagsByPrefix_Call) RunAndReturn(run func(bookID string, prefix string, source string) error) *MockStore_RemoveBookTagsByPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveBookUserTag provides a mock function for the type MockStore
 func (_mock *MockStore) RemoveBookUserTag(bookID string, tag string) error {
 	ret := _mock.Called(bookID, tag)
@@ -10808,6 +11838,126 @@ func (_c *MockStore_RemoveBookUserTag_Call) Return(err error) *MockStore_RemoveB
 }
 
 func (_c *MockStore_RemoveBookUserTag_Call) RunAndReturn(run func(bookID string, tag string) error) *MockStore_RemoveBookUserTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveSeriesTag provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveSeriesTag(seriesID int, tag string) error {
+	ret := _mock.Called(seriesID, tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveSeriesTag")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string) error); ok {
+		r0 = returnFunc(seriesID, tag)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveSeriesTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveSeriesTag'
+type MockStore_RemoveSeriesTag_Call struct {
+	*mock.Call
+}
+
+// RemoveSeriesTag is a helper method to define mock.On call
+//   - seriesID int
+//   - tag string
+func (_e *MockStore_Expecter) RemoveSeriesTag(seriesID interface{}, tag interface{}) *MockStore_RemoveSeriesTag_Call {
+	return &MockStore_RemoveSeriesTag_Call{Call: _e.mock.On("RemoveSeriesTag", seriesID, tag)}
+}
+
+func (_c *MockStore_RemoveSeriesTag_Call) Run(run func(seriesID int, tag string)) *MockStore_RemoveSeriesTag_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveSeriesTag_Call) Return(err error) *MockStore_RemoveSeriesTag_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveSeriesTag_Call) RunAndReturn(run func(seriesID int, tag string) error) *MockStore_RemoveSeriesTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveSeriesTagsByPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) RemoveSeriesTagsByPrefix(seriesID int, prefix string, source string) error {
+	ret := _mock.Called(seriesID, prefix, source)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveSeriesTagsByPrefix")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, string, string) error); ok {
+		r0 = returnFunc(seriesID, prefix, source)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RemoveSeriesTagsByPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveSeriesTagsByPrefix'
+type MockStore_RemoveSeriesTagsByPrefix_Call struct {
+	*mock.Call
+}
+
+// RemoveSeriesTagsByPrefix is a helper method to define mock.On call
+//   - seriesID int
+//   - prefix string
+//   - source string
+func (_e *MockStore_Expecter) RemoveSeriesTagsByPrefix(seriesID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveSeriesTagsByPrefix_Call {
+	return &MockStore_RemoveSeriesTagsByPrefix_Call{Call: _e.mock.On("RemoveSeriesTagsByPrefix", seriesID, prefix, source)}
+}
+
+func (_c *MockStore_RemoveSeriesTagsByPrefix_Call) Run(run func(seriesID int, prefix string, source string)) *MockStore_RemoveSeriesTagsByPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RemoveSeriesTagsByPrefix_Call) Return(err error) *MockStore_RemoveSeriesTagsByPrefix_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RemoveSeriesTagsByPrefix_Call) RunAndReturn(run func(seriesID int, prefix string, source string) error) *MockStore_RemoveSeriesTagsByPrefix_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -11449,6 +12599,63 @@ func (_c *MockStore_SearchBooks_Call) RunAndReturn(run func(query string, limit 
 	return _c
 }
 
+// SetAuthorTags provides a mock function for the type MockStore
+func (_mock *MockStore) SetAuthorTags(authorID int, tags []string) error {
+	ret := _mock.Called(authorID, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAuthorTags")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, []string) error); ok {
+		r0 = returnFunc(authorID, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetAuthorTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAuthorTags'
+type MockStore_SetAuthorTags_Call struct {
+	*mock.Call
+}
+
+// SetAuthorTags is a helper method to define mock.On call
+//   - authorID int
+//   - tags []string
+func (_e *MockStore_Expecter) SetAuthorTags(authorID interface{}, tags interface{}) *MockStore_SetAuthorTags_Call {
+	return &MockStore_SetAuthorTags_Call{Call: _e.mock.On("SetAuthorTags", authorID, tags)}
+}
+
+func (_c *MockStore_SetAuthorTags_Call) Run(run func(authorID int, tags []string)) *MockStore_SetAuthorTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetAuthorTags_Call) Return(err error) *MockStore_SetAuthorTags_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetAuthorTags_Call) RunAndReturn(run func(authorID int, tags []string) error) *MockStore_SetAuthorTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetBookAlternativeTitles provides a mock function for the type MockStore
 func (_mock *MockStore) SetBookAlternativeTitles(bookID string, titles []database.BookAlternativeTitle) error {
 	ret := _mock.Called(bookID, titles)
@@ -11907,6 +13114,63 @@ func (_c *MockStore_SetRaw_Call) Return(err error) *MockStore_SetRaw_Call {
 }
 
 func (_c *MockStore_SetRaw_Call) RunAndReturn(run func(key string, value []byte) error) *MockStore_SetRaw_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetSeriesTags provides a mock function for the type MockStore
+func (_mock *MockStore) SetSeriesTags(seriesID int, tags []string) error {
+	ret := _mock.Called(seriesID, tags)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetSeriesTags")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, []string) error); ok {
+		r0 = returnFunc(seriesID, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetSeriesTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetSeriesTags'
+type MockStore_SetSeriesTags_Call struct {
+	*mock.Call
+}
+
+// SetSeriesTags is a helper method to define mock.On call
+//   - seriesID int
+//   - tags []string
+func (_e *MockStore_Expecter) SetSeriesTags(seriesID interface{}, tags interface{}) *MockStore_SetSeriesTags_Call {
+	return &MockStore_SetSeriesTags_Call{Call: _e.mock.On("SetSeriesTags", seriesID, tags)}
+}
+
+func (_c *MockStore_SetSeriesTags_Call) Run(run func(seriesID int, tags []string)) *MockStore_SetSeriesTags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetSeriesTags_Call) Return(err error) *MockStore_SetSeriesTags_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetSeriesTags_Call) RunAndReturn(run func(seriesID int, tags []string) error) *MockStore_SetSeriesTags_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -5069,16 +5069,31 @@ func (p *PebbleStore) GetBookPathHistory(bookID string) ([]BookPathChange, error
 	return results, nil
 }
 
-// AddBookTag adds a tag to a book (idempotent — no error if already exists).
+// AddBookTag adds a user-sourced tag to a book. Server code that
+// auto-applies tags should use AddBookTagWithSource so provenance
+// is preserved.
 func (p *PebbleStore) AddBookTag(bookID, tag string) error {
+	return p.AddBookTagWithSource(bookID, tag, "user")
+}
+
+// AddBookTagWithSource adds a tag with an explicit source. Typical
+// sources: "user" (default), "system" (auto-applied by the server).
+// Upserts when the row already exists — later writes overwrite the
+// source field so a user-claimed tag can promote to system or vice
+// versa without needing a delete-first step.
+func (p *PebbleStore) AddBookTagWithSource(bookID, tag, source string) error {
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
+	}
+	if source == "" {
+		source = "user"
 	}
 
 	bt := BookTag{
 		BookID:    bookID,
 		Tag:       tag,
+		Source:    source,
 		CreatedAt: time.Now(),
 	}
 	data, err := json.Marshal(bt)
@@ -5097,7 +5112,7 @@ func (p *PebbleStore) AddBookTag(bookID, tag string) error {
 	return p.db.Set(tagIdxKey, []byte{}, pebble.Sync)
 }
 
-// RemoveBookTag removes a tag from a book.
+// RemoveBookTag removes a tag from a book regardless of source.
 func (p *PebbleStore) RemoveBookTag(bookID, tag string) error {
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if tag == "" {
@@ -5117,7 +5132,39 @@ func (p *PebbleStore) RemoveBookTag(bookID, tag string) error {
 	return nil
 }
 
-// GetBookTags returns all tags for a book, sorted alphabetically.
+// RemoveBookTagsByPrefix removes every tag on a book whose name
+// begins with `prefix`, optionally scoped to a specific source.
+// Used to clear a namespace before writing a fresh system tag —
+// e.g., re-applying metadata from a new source removes any
+// existing `metadata:source:*` system tags first so each book has
+// exactly one source tag at a time.
+//
+// If `source` is empty, all sources match.
+func (p *PebbleStore) RemoveBookTagsByPrefix(bookID, prefix, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" {
+		return fmt.Errorf("prefix cannot be empty")
+	}
+
+	detailed, err := p.GetBookTagsDetailed(bookID)
+	if err != nil {
+		return err
+	}
+	for _, bt := range detailed {
+		if !strings.HasPrefix(bt.Tag, prefix) {
+			continue
+		}
+		if source != "" && bt.Source != source {
+			continue
+		}
+		if err := p.RemoveBookTag(bookID, bt.Tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetBookTags returns all tag strings for a book, sorted alphabetically.
 func (p *PebbleStore) GetBookTags(bookID string) ([]string, error) {
 	prefix := []byte(fmt.Sprintf("book_tag:%s:", bookID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
@@ -5141,14 +5188,51 @@ func (p *PebbleStore) GetBookTags(bookID string) ([]string, error) {
 	return tags, nil
 }
 
-// SetBookTags replaces all tags on a book with the given set.
+// GetBookTagsDetailed returns tags with their source attribution.
+// Rows written before migration 47 deserialize with source="" which
+// we promote to "user" so downstream filters treat them as user
+// tags (the sensible default for legacy data).
+func (p *PebbleStore) GetBookTagsDetailed(bookID string) ([]BookTag, error) {
+	prefix := []byte(fmt.Sprintf("book_tag:%s:", bookID))
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var out []BookTag
+	for iter.First(); iter.Valid(); iter.Next() {
+		var bt BookTag
+		if err := json.Unmarshal(iter.Value(), &bt); err != nil {
+			continue
+		}
+		if bt.Source == "" {
+			bt.Source = "user"
+		}
+		out = append(out, bt)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Tag < out[j].Tag
+	})
+	return out, nil
+}
+
+// SetBookTags replaces all USER tags on a book with the given set.
+// System tags (dedup:*, metadata:source:*, ...) are preserved so the
+// user-facing bulk-replace doesn't clobber server-applied provenance.
 func (p *PebbleStore) SetBookTags(bookID string, tags []string) error {
-	existing, err := p.GetBookTags(bookID)
+	detailed, err := p.GetBookTagsDetailed(bookID)
 	if err != nil {
 		return err
 	}
 
-	// Normalize incoming tags
+	// Normalize incoming tags.
 	normalized := make(map[string]bool)
 	for _, t := range tags {
 		t = strings.ToLower(strings.TrimSpace(t))
@@ -5157,14 +5241,16 @@ func (p *PebbleStore) SetBookTags(bookID string, tags []string) error {
 		}
 	}
 
-	// Build set of existing
-	existingSet := make(map[string]bool)
-	for _, t := range existing {
-		existingSet[t] = true
+	// Existing user tags we may need to drop.
+	existingUser := make(map[string]bool)
+	for _, bt := range detailed {
+		if bt.Source == "user" || bt.Source == "" {
+			existingUser[bt.Tag] = true
+		}
 	}
 
-	// Remove tags not in new set
-	for _, t := range existing {
+	// Remove user tags not in new set.
+	for t := range existingUser {
 		if !normalized[t] {
 			if err := p.RemoveBookTag(bookID, t); err != nil {
 				return err
@@ -5172,10 +5258,10 @@ func (p *PebbleStore) SetBookTags(bookID string, tags []string) error {
 		}
 	}
 
-	// Add tags not in existing set
+	// Add user tags not already present.
 	for t := range normalized {
-		if !existingSet[t] {
-			if err := p.AddBookTag(bookID, t); err != nil {
+		if !existingUser[t] {
+			if err := p.AddBookTagWithSource(bookID, t, "user"); err != nil {
 				return err
 			}
 		}
@@ -5243,6 +5329,343 @@ func (p *PebbleStore) GetBooksByTag(tag string) ([]string, error) {
 		}
 	}
 	return bookIDs, nil
+}
+
+// ---------- Author / Series tag storage ----------
+//
+// Authors and series follow the same tag shape as books. Pebble
+// keys are parameterized by a keyspace prefix so the same helper
+// functions serve all three entity types:
+//
+//	Books:   book_tag:<bookID>:<tag>       tag_idx:<tag>:<bookID>
+//	Authors: author_tag:<authorID>:<tag>   author_tag_idx:<tag>:<authorID>
+//	Series:  series_tag:<seriesID>:<tag>   series_tag_idx:<tag>:<seriesID>
+//
+// Entity IDs are string-formatted for author/series (integer → string)
+// because Pebble keys are flat bytes — the caller provides the ID
+// formatting and the helper never has to care about the type.
+
+// pebbleTagKeyspace bundles the prefixes for one entity type.
+type pebbleTagKeyspace struct {
+	tagPrefix    string // e.g. "author_tag:"
+	indexPrefix  string // e.g. "author_tag_idx:"
+	entityLabel  string // for error messages / logging
+}
+
+var (
+	bookTagKeyspace = pebbleTagKeyspace{
+		tagPrefix:   "book_tag:",
+		indexPrefix: "tag_idx:",
+		entityLabel: "book",
+	}
+	authorTagKeyspace = pebbleTagKeyspace{
+		tagPrefix:   "author_tag:",
+		indexPrefix: "author_tag_idx:",
+		entityLabel: "author",
+	}
+	seriesTagKeyspace = pebbleTagKeyspace{
+		tagPrefix:   "series_tag:",
+		indexPrefix: "series_tag_idx:",
+		entityLabel: "series",
+	}
+)
+
+// pebbleAddTag upserts a tag for any entity type. Serializes a
+// BookTag with the source field so it survives round-trips.
+func (p *PebbleStore) pebbleAddTag(ks pebbleTagKeyspace, entityID, tag, source string) error {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return fmt.Errorf("tag cannot be empty")
+	}
+	if source == "" {
+		source = "user"
+	}
+	bt := BookTag{
+		BookID:    entityID, // reused as the generic entity ID
+		Tag:       tag,
+		Source:    source,
+		CreatedAt: time.Now(),
+	}
+	data, err := json.Marshal(bt)
+	if err != nil {
+		return err
+	}
+	primary := []byte(fmt.Sprintf("%s%s:%s", ks.tagPrefix, entityID, tag))
+	if err := p.db.Set(primary, data, pebble.Sync); err != nil {
+		return err
+	}
+	idx := []byte(fmt.Sprintf("%s%s:%s", ks.indexPrefix, tag, entityID))
+	return p.db.Set(idx, []byte{}, pebble.Sync)
+}
+
+func (p *PebbleStore) pebbleRemoveTag(ks pebbleTagKeyspace, entityID, tag string) error {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return fmt.Errorf("tag cannot be empty")
+	}
+	primary := []byte(fmt.Sprintf("%s%s:%s", ks.tagPrefix, entityID, tag))
+	if err := p.db.Delete(primary, pebble.Sync); err != nil && err != pebble.ErrNotFound {
+		return err
+	}
+	idx := []byte(fmt.Sprintf("%s%s:%s", ks.indexPrefix, tag, entityID))
+	if err := p.db.Delete(idx, pebble.Sync); err != nil && err != pebble.ErrNotFound {
+		return err
+	}
+	return nil
+}
+
+func (p *PebbleStore) pebbleGetTags(ks pebbleTagKeyspace, entityID string) ([]string, error) {
+	prefix := []byte(fmt.Sprintf("%s%s:", ks.tagPrefix, entityID))
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var tags []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		var bt BookTag
+		if err := json.Unmarshal(iter.Value(), &bt); err != nil {
+			continue
+		}
+		tags = append(tags, bt.Tag)
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+func (p *PebbleStore) pebbleGetTagsDetailed(ks pebbleTagKeyspace, entityID string) ([]BookTag, error) {
+	prefix := []byte(fmt.Sprintf("%s%s:", ks.tagPrefix, entityID))
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var out []BookTag
+	for iter.First(); iter.Valid(); iter.Next() {
+		var bt BookTag
+		if err := json.Unmarshal(iter.Value(), &bt); err != nil {
+			continue
+		}
+		if bt.Source == "" {
+			bt.Source = "user"
+		}
+		out = append(out, bt)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Tag < out[j].Tag
+	})
+	return out, nil
+}
+
+func (p *PebbleStore) pebbleRemoveTagsByPrefix(ks pebbleTagKeyspace, entityID, prefix, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" {
+		return fmt.Errorf("prefix cannot be empty")
+	}
+	detailed, err := p.pebbleGetTagsDetailed(ks, entityID)
+	if err != nil {
+		return err
+	}
+	for _, bt := range detailed {
+		if !strings.HasPrefix(bt.Tag, prefix) {
+			continue
+		}
+		if source != "" && bt.Source != source {
+			continue
+		}
+		if err := p.pebbleRemoveTag(ks, entityID, bt.Tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PebbleStore) pebbleSetTags(ks pebbleTagKeyspace, entityID string, tags []string) error {
+	detailed, err := p.pebbleGetTagsDetailed(ks, entityID)
+	if err != nil {
+		return err
+	}
+	normalized := make(map[string]bool)
+	for _, t := range tags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t != "" {
+			normalized[t] = true
+		}
+	}
+	existingUser := make(map[string]bool)
+	for _, bt := range detailed {
+		if bt.Source == "user" || bt.Source == "" {
+			existingUser[bt.Tag] = true
+		}
+	}
+	for t := range existingUser {
+		if !normalized[t] {
+			if err := p.pebbleRemoveTag(ks, entityID, t); err != nil {
+				return err
+			}
+		}
+	}
+	for t := range normalized {
+		if !existingUser[t] {
+			if err := p.pebbleAddTag(ks, entityID, t, "user"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *PebbleStore) pebbleListAllTags(ks pebbleTagKeyspace) ([]TagWithCount, error) {
+	prefix := []byte(ks.indexPrefix)
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	counts := make(map[string]int)
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Key format: <indexPrefix><tag>:<entityID>
+		key := string(iter.Key())
+		rest := strings.TrimPrefix(key, ks.indexPrefix)
+		parts := strings.SplitN(rest, ":", 2)
+		if len(parts) >= 1 {
+			counts[parts[0]]++
+		}
+	}
+
+	result := make([]TagWithCount, 0, len(counts))
+	for tag, count := range counts {
+		result = append(result, TagWithCount{Tag: tag, Count: count})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Tag < result[j].Tag
+	})
+	return result, nil
+}
+
+func (p *PebbleStore) pebbleEntitiesByTag(ks pebbleTagKeyspace, tag string) ([]string, error) {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return nil, fmt.Errorf("tag cannot be empty")
+	}
+	prefix := []byte(fmt.Sprintf("%s%s:", ks.indexPrefix, tag))
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var ids []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		rest := strings.TrimPrefix(key, fmt.Sprintf("%s%s:", ks.indexPrefix, tag))
+		if rest != "" {
+			ids = append(ids, rest)
+		}
+	}
+	return ids, nil
+}
+
+// ---------- Author tag wrappers (PebbleStore) ----------
+
+func (p *PebbleStore) AddAuthorTag(authorID int, tag string) error {
+	return p.pebbleAddTag(authorTagKeyspace, strconv.Itoa(authorID), tag, "user")
+}
+func (p *PebbleStore) AddAuthorTagWithSource(authorID int, tag, source string) error {
+	return p.pebbleAddTag(authorTagKeyspace, strconv.Itoa(authorID), tag, source)
+}
+func (p *PebbleStore) RemoveAuthorTag(authorID int, tag string) error {
+	return p.pebbleRemoveTag(authorTagKeyspace, strconv.Itoa(authorID), tag)
+}
+func (p *PebbleStore) RemoveAuthorTagsByPrefix(authorID int, prefix, source string) error {
+	return p.pebbleRemoveTagsByPrefix(authorTagKeyspace, strconv.Itoa(authorID), prefix, source)
+}
+func (p *PebbleStore) GetAuthorTags(authorID int) ([]string, error) {
+	return p.pebbleGetTags(authorTagKeyspace, strconv.Itoa(authorID))
+}
+func (p *PebbleStore) GetAuthorTagsDetailed(authorID int) ([]BookTag, error) {
+	return p.pebbleGetTagsDetailed(authorTagKeyspace, strconv.Itoa(authorID))
+}
+func (p *PebbleStore) SetAuthorTags(authorID int, tags []string) error {
+	return p.pebbleSetTags(authorTagKeyspace, strconv.Itoa(authorID), tags)
+}
+func (p *PebbleStore) ListAllAuthorTags() ([]TagWithCount, error) {
+	return p.pebbleListAllTags(authorTagKeyspace)
+}
+func (p *PebbleStore) GetAuthorsByTag(tag string) ([]int, error) {
+	raw, err := p.pebbleEntitiesByTag(authorTagKeyspace, tag)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, 0, len(raw))
+	for _, s := range raw {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			continue // skip malformed entries
+		}
+		ids = append(ids, n)
+	}
+	return ids, nil
+}
+
+// ---------- Series tag wrappers (PebbleStore) ----------
+
+func (p *PebbleStore) AddSeriesTag(seriesID int, tag string) error {
+	return p.pebbleAddTag(seriesTagKeyspace, strconv.Itoa(seriesID), tag, "user")
+}
+func (p *PebbleStore) AddSeriesTagWithSource(seriesID int, tag, source string) error {
+	return p.pebbleAddTag(seriesTagKeyspace, strconv.Itoa(seriesID), tag, source)
+}
+func (p *PebbleStore) RemoveSeriesTag(seriesID int, tag string) error {
+	return p.pebbleRemoveTag(seriesTagKeyspace, strconv.Itoa(seriesID), tag)
+}
+func (p *PebbleStore) RemoveSeriesTagsByPrefix(seriesID int, prefix, source string) error {
+	return p.pebbleRemoveTagsByPrefix(seriesTagKeyspace, strconv.Itoa(seriesID), prefix, source)
+}
+func (p *PebbleStore) GetSeriesTags(seriesID int) ([]string, error) {
+	return p.pebbleGetTags(seriesTagKeyspace, strconv.Itoa(seriesID))
+}
+func (p *PebbleStore) GetSeriesTagsDetailed(seriesID int) ([]BookTag, error) {
+	return p.pebbleGetTagsDetailed(seriesTagKeyspace, strconv.Itoa(seriesID))
+}
+func (p *PebbleStore) SetSeriesTags(seriesID int, tags []string) error {
+	return p.pebbleSetTags(seriesTagKeyspace, strconv.Itoa(seriesID), tags)
+}
+func (p *PebbleStore) ListAllSeriesTags() ([]TagWithCount, error) {
+	return p.pebbleListAllTags(seriesTagKeyspace)
+}
+func (p *PebbleStore) GetSeriesByTag(tag string) ([]int, error) {
+	raw, err := p.pebbleEntitiesByTag(seriesTagKeyspace, tag)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, 0, len(raw))
+	for _, s := range raw {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, n)
+	}
+	return ids, nil
 }
 
 // ---- BookFile CRUD ----

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -4559,20 +4559,33 @@ func (s *SQLiteStore) GetBookPathHistory(bookID string) ([]BookPathChange, error
 	return results, rows.Err()
 }
 
-// AddBookTag adds a tag to a book (idempotent — no error if already exists).
+// AddBookTag adds a user-sourced tag to a book. Server code that
+// auto-applies tags should call AddBookTagWithSource so provenance
+// is preserved (see migration 47 namespace notes).
 func (s *SQLiteStore) AddBookTag(bookID, tag string) error {
+	return s.AddBookTagWithSource(bookID, tag, "user")
+}
+
+// AddBookTagWithSource upserts a tag on a book with an explicit
+// source ("user" or "system"). Later writes overwrite the source
+// so a user can claim a system tag or vice versa.
+func (s *SQLiteStore) AddBookTagWithSource(bookID, tag, source string) error {
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
+	if source == "" {
+		source = "user"
+	}
 	_, err := s.db.Exec(
-		`INSERT OR IGNORE INTO book_tags (book_id, tag) VALUES (?, ?)`,
-		bookID, tag,
+		`INSERT INTO book_tags (book_id, tag, source) VALUES (?, ?, ?)
+		 ON CONFLICT(book_id, tag) DO UPDATE SET source = excluded.source`,
+		bookID, tag, source,
 	)
 	return err
 }
 
-// RemoveBookTag removes a tag from a book.
+// RemoveBookTag removes a tag from a book regardless of source.
 func (s *SQLiteStore) RemoveBookTag(bookID, tag string) error {
 	tag = strings.ToLower(strings.TrimSpace(tag))
 	if tag == "" {
@@ -4585,7 +4598,34 @@ func (s *SQLiteStore) RemoveBookTag(bookID, tag string) error {
 	return err
 }
 
-// GetBookTags returns all tags for a book, sorted alphabetically.
+// RemoveBookTagsByPrefix removes every tag on a book whose name
+// begins with `prefix`, optionally scoped to a specific source.
+// Used to clear a namespace before writing a fresh system tag —
+// e.g., re-applying metadata from a new source clears any existing
+// `metadata:source:*` system tags first so each book has exactly
+// one source tag at a time. Empty `source` matches all sources.
+func (s *SQLiteStore) RemoveBookTagsByPrefix(bookID, prefix, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" {
+		return fmt.Errorf("prefix cannot be empty")
+	}
+	if source == "" {
+		_, err := s.db.Exec(
+			`DELETE FROM book_tags WHERE book_id = ? AND tag LIKE ?`,
+			bookID, prefix+"%",
+		)
+		return err
+	}
+	_, err := s.db.Exec(
+		`DELETE FROM book_tags WHERE book_id = ? AND tag LIKE ? AND source = ?`,
+		bookID, prefix+"%", source,
+	)
+	return err
+}
+
+// GetBookTags returns all tag strings for a book, sorted
+// alphabetically. Both user and system tags are returned —
+// callers that need provenance should use GetBookTagsDetailed.
 func (s *SQLiteStore) GetBookTags(bookID string) ([]string, error) {
 	rows, err := s.db.Query(
 		`SELECT tag FROM book_tags WHERE book_id = ? ORDER BY tag`,
@@ -4607,7 +4647,35 @@ func (s *SQLiteStore) GetBookTags(bookID string) ([]string, error) {
 	return tags, rows.Err()
 }
 
-// SetBookTags replaces all tags on a book with the given set.
+// GetBookTagsDetailed returns tags with source and creation time.
+// Used by the frontend to render system tags differently from
+// user tags (outlined chip + not-deletable by default).
+func (s *SQLiteStore) GetBookTagsDetailed(bookID string) ([]BookTag, error) {
+	rows, err := s.db.Query(
+		`SELECT tag, source, created_at FROM book_tags WHERE book_id = ? ORDER BY source, tag`,
+		bookID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []BookTag
+	for rows.Next() {
+		var bt BookTag
+		if err := rows.Scan(&bt.Tag, &bt.Source, &bt.CreatedAt); err != nil {
+			return nil, err
+		}
+		bt.BookID = bookID
+		out = append(out, bt)
+	}
+	return out, rows.Err()
+}
+
+// SetBookTags replaces all USER tags on a book with the given set.
+// System tags (dedup:*, metadata:source:*, ...) survive the bulk
+// replace so the user-facing operation doesn't clobber server-
+// applied provenance.
 func (s *SQLiteStore) SetBookTags(bookID string, tags []string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -4615,19 +4683,21 @@ func (s *SQLiteStore) SetBookTags(bookID string, tags []string) error {
 	}
 	defer tx.Rollback()
 
-	// Remove all existing tags
-	if _, err := tx.Exec(`DELETE FROM book_tags WHERE book_id = ?`, bookID); err != nil {
+	// Only delete user-sourced tags so system tags survive.
+	if _, err := tx.Exec(
+		`DELETE FROM book_tags WHERE book_id = ? AND source = 'user'`,
+		bookID,
+	); err != nil {
 		return err
 	}
 
-	// Insert new tags
 	for _, tag := range tags {
 		tag = strings.ToLower(strings.TrimSpace(tag))
 		if tag == "" {
 			continue
 		}
 		if _, err := tx.Exec(
-			`INSERT OR IGNORE INTO book_tags (book_id, tag) VALUES (?, ?)`,
+			`INSERT OR IGNORE INTO book_tags (book_id, tag, source) VALUES (?, ?, 'user')`,
 			bookID, tag,
 		); err != nil {
 			return err
@@ -4637,10 +4707,17 @@ func (s *SQLiteStore) SetBookTags(bookID string, tags []string) error {
 	return tx.Commit()
 }
 
-// ListAllTags returns all unique tags with their usage counts.
+// ListAllTags returns all unique book tags with their usage counts.
+// `source` is populated only when every row sharing the tag string
+// has the same source — otherwise it's empty (mixed provenance).
 func (s *SQLiteStore) ListAllTags() ([]TagWithCount, error) {
 	rows, err := s.db.Query(
-		`SELECT tag, COUNT(*) as count FROM book_tags GROUP BY tag ORDER BY tag`,
+		`SELECT tag,
+		        COUNT(*) AS count,
+		        CASE WHEN COUNT(DISTINCT source) = 1 THEN MAX(source) ELSE '' END AS source
+		 FROM book_tags
+		 GROUP BY tag
+		 ORDER BY tag`,
 	)
 	if err != nil {
 		return nil, err
@@ -4650,7 +4727,7 @@ func (s *SQLiteStore) ListAllTags() ([]TagWithCount, error) {
 	var result []TagWithCount
 	for rows.Next() {
 		var tc TagWithCount
-		if err := rows.Scan(&tc.Tag, &tc.Count); err != nil {
+		if err := rows.Scan(&tc.Tag, &tc.Count, &tc.Source); err != nil {
 			return nil, err
 		}
 		result = append(result, tc)
@@ -4683,6 +4760,246 @@ func (s *SQLiteStore) GetBooksByTag(tag string) ([]string, error) {
 		bookIDs = append(bookIDs, id)
 	}
 	return bookIDs, rows.Err()
+}
+
+// ---------- Author / Series tag helpers ----------
+//
+// Author and series tags share the exact same shape as book_tags
+// (see migrations 47 and 48), so instead of duplicating SQL across
+// 18 parallel methods we parameterize by table name and ID column.
+// `idCol` is "author_id" or "series_id"; the caller passes the
+// integer ID directly. Helpers stay unexported — the Store
+// interface exposes typed wrappers below.
+
+func (s *SQLiteStore) addTagGeneric(table, idCol string, id any, tag, source string) error {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return fmt.Errorf("tag cannot be empty")
+	}
+	if source == "" {
+		source = "user"
+	}
+	stmt := fmt.Sprintf(
+		`INSERT INTO %s (%s, tag, source) VALUES (?, ?, ?)
+		 ON CONFLICT(%s, tag) DO UPDATE SET source = excluded.source`,
+		table, idCol, idCol,
+	)
+	_, err := s.db.Exec(stmt, id, tag, source)
+	return err
+}
+
+func (s *SQLiteStore) removeTagGeneric(table, idCol string, id any, tag string) error {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return fmt.Errorf("tag cannot be empty")
+	}
+	stmt := fmt.Sprintf(`DELETE FROM %s WHERE %s = ? AND tag = ?`, table, idCol)
+	_, err := s.db.Exec(stmt, id, tag)
+	return err
+}
+
+func (s *SQLiteStore) removeTagsByPrefixGeneric(table, idCol string, id any, prefix, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" {
+		return fmt.Errorf("prefix cannot be empty")
+	}
+	if source == "" {
+		stmt := fmt.Sprintf(`DELETE FROM %s WHERE %s = ? AND tag LIKE ?`, table, idCol)
+		_, err := s.db.Exec(stmt, id, prefix+"%")
+		return err
+	}
+	stmt := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s = ? AND tag LIKE ? AND source = ?`,
+		table, idCol,
+	)
+	_, err := s.db.Exec(stmt, id, prefix+"%", source)
+	return err
+}
+
+func (s *SQLiteStore) getTagsGeneric(table, idCol string, id any) ([]string, error) {
+	stmt := fmt.Sprintf(`SELECT tag FROM %s WHERE %s = ? ORDER BY tag`, table, idCol)
+	rows, err := s.db.Query(stmt, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var tags []string
+	for rows.Next() {
+		var tag string
+		if err := rows.Scan(&tag); err != nil {
+			return nil, err
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
+}
+
+func (s *SQLiteStore) getTagsDetailedGeneric(table, idCol string, id any) ([]BookTag, error) {
+	stmt := fmt.Sprintf(
+		`SELECT tag, source, created_at FROM %s WHERE %s = ? ORDER BY source, tag`,
+		table, idCol,
+	)
+	rows, err := s.db.Query(stmt, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []BookTag
+	for rows.Next() {
+		var bt BookTag
+		if err := rows.Scan(&bt.Tag, &bt.Source, &bt.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, bt)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteStore) setTagsGeneric(table, idCol string, id any, tags []string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	delStmt := fmt.Sprintf(`DELETE FROM %s WHERE %s = ? AND source = 'user'`, table, idCol)
+	if _, err := tx.Exec(delStmt, id); err != nil {
+		return err
+	}
+
+	insStmt := fmt.Sprintf(
+		`INSERT OR IGNORE INTO %s (%s, tag, source) VALUES (?, ?, 'user')`,
+		table, idCol,
+	)
+	for _, tag := range tags {
+		tag = strings.ToLower(strings.TrimSpace(tag))
+		if tag == "" {
+			continue
+		}
+		if _, err := tx.Exec(insStmt, id, tag); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *SQLiteStore) listAllTagsGeneric(table string) ([]TagWithCount, error) {
+	stmt := fmt.Sprintf(
+		`SELECT tag, COUNT(*) AS count,
+		        CASE WHEN COUNT(DISTINCT source) = 1 THEN MAX(source) ELSE '' END AS source
+		 FROM %s
+		 GROUP BY tag
+		 ORDER BY tag`,
+		table,
+	)
+	rows, err := s.db.Query(stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []TagWithCount
+	for rows.Next() {
+		var tc TagWithCount
+		if err := rows.Scan(&tc.Tag, &tc.Count, &tc.Source); err != nil {
+			return nil, err
+		}
+		result = append(result, tc)
+	}
+	return result, rows.Err()
+}
+
+// ---------- Author tag wrappers ----------
+
+func (s *SQLiteStore) AddAuthorTag(authorID int, tag string) error {
+	return s.addTagGeneric("author_tags", "author_id", authorID, tag, "user")
+}
+func (s *SQLiteStore) AddAuthorTagWithSource(authorID int, tag, source string) error {
+	return s.addTagGeneric("author_tags", "author_id", authorID, tag, source)
+}
+func (s *SQLiteStore) RemoveAuthorTag(authorID int, tag string) error {
+	return s.removeTagGeneric("author_tags", "author_id", authorID, tag)
+}
+func (s *SQLiteStore) RemoveAuthorTagsByPrefix(authorID int, prefix, source string) error {
+	return s.removeTagsByPrefixGeneric("author_tags", "author_id", authorID, prefix, source)
+}
+func (s *SQLiteStore) GetAuthorTags(authorID int) ([]string, error) {
+	return s.getTagsGeneric("author_tags", "author_id", authorID)
+}
+func (s *SQLiteStore) GetAuthorTagsDetailed(authorID int) ([]BookTag, error) {
+	return s.getTagsDetailedGeneric("author_tags", "author_id", authorID)
+}
+func (s *SQLiteStore) SetAuthorTags(authorID int, tags []string) error {
+	return s.setTagsGeneric("author_tags", "author_id", authorID, tags)
+}
+func (s *SQLiteStore) ListAllAuthorTags() ([]TagWithCount, error) {
+	return s.listAllTagsGeneric("author_tags")
+}
+func (s *SQLiteStore) GetAuthorsByTag(tag string) ([]int, error) {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return nil, fmt.Errorf("tag cannot be empty")
+	}
+	rows, err := s.db.Query(`SELECT author_id FROM author_tags WHERE tag = ?`, tag)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// ---------- Series tag wrappers ----------
+
+func (s *SQLiteStore) AddSeriesTag(seriesID int, tag string) error {
+	return s.addTagGeneric("series_tags", "series_id", seriesID, tag, "user")
+}
+func (s *SQLiteStore) AddSeriesTagWithSource(seriesID int, tag, source string) error {
+	return s.addTagGeneric("series_tags", "series_id", seriesID, tag, source)
+}
+func (s *SQLiteStore) RemoveSeriesTag(seriesID int, tag string) error {
+	return s.removeTagGeneric("series_tags", "series_id", seriesID, tag)
+}
+func (s *SQLiteStore) RemoveSeriesTagsByPrefix(seriesID int, prefix, source string) error {
+	return s.removeTagsByPrefixGeneric("series_tags", "series_id", seriesID, prefix, source)
+}
+func (s *SQLiteStore) GetSeriesTags(seriesID int) ([]string, error) {
+	return s.getTagsGeneric("series_tags", "series_id", seriesID)
+}
+func (s *SQLiteStore) GetSeriesTagsDetailed(seriesID int) ([]BookTag, error) {
+	return s.getTagsDetailedGeneric("series_tags", "series_id", seriesID)
+}
+func (s *SQLiteStore) SetSeriesTags(seriesID int, tags []string) error {
+	return s.setTagsGeneric("series_tags", "series_id", seriesID, tags)
+}
+func (s *SQLiteStore) ListAllSeriesTags() ([]TagWithCount, error) {
+	return s.listAllTagsGeneric("series_tags")
+}
+func (s *SQLiteStore) GetSeriesByTag(tag string) ([]int, error) {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return nil, fmt.Errorf("tag cannot be empty")
+	}
+	rows, err := s.db.Query(`SELECT series_id FROM series_tags WHERE tag = ?`, tag)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 func scanOperationChanges(rows *sql.Rows) ([]*OperationChange, error) {

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -287,13 +287,53 @@ type Store interface {
 	RecordPathChange(change *BookPathChange) error
 	GetBookPathHistory(bookID string) ([]BookPathChange, error)
 
-	// Book User Tags (user-defined labels like "litrpg", "scifi", etc.)
+	// Tags (user-defined labels + system-applied provenance).
+	//
+	// Tags exist on three entity types (books / authors / series)
+	// and share the same shape: (entity_id, tag, source, created_at).
+	// The `source` column distinguishes user-applied tags ('user')
+	// from auto-applied system tags ('system'). System tags follow
+	// a `category:subcategory[:detail]` naming convention — see
+	// migrations 47 and 48 for the current namespace.
+	//
+	// The string-list methods (AddBookTag / GetBookTags / ...) are
+	// the user-facing surface — they default to source='user' and
+	// are what the UI edits. Server code that auto-applies tags
+	// should call the *WithSource variants so provenance is
+	// preserved and system tags can be filtered separately.
+
+	// Book tags
 	AddBookTag(bookID, tag string) error
+	AddBookTagWithSource(bookID, tag, source string) error
 	RemoveBookTag(bookID, tag string) error
+	RemoveBookTagsByPrefix(bookID, prefix, source string) error // clear a namespace
 	GetBookTags(bookID string) ([]string, error)
-	SetBookTags(bookID string, tags []string) error // bulk replace
+	GetBookTagsDetailed(bookID string) ([]BookTag, error)
+	SetBookTags(bookID string, tags []string) error // bulk replace (user source)
 	ListAllTags() ([]TagWithCount, error)
 	GetBooksByTag(tag string) ([]string, error) // returns book IDs
+
+	// Author tags (mirror of book tags, keyed by author integer ID)
+	AddAuthorTag(authorID int, tag string) error
+	AddAuthorTagWithSource(authorID int, tag, source string) error
+	RemoveAuthorTag(authorID int, tag string) error
+	RemoveAuthorTagsByPrefix(authorID int, prefix, source string) error
+	GetAuthorTags(authorID int) ([]string, error)
+	GetAuthorTagsDetailed(authorID int) ([]BookTag, error)
+	SetAuthorTags(authorID int, tags []string) error
+	ListAllAuthorTags() ([]TagWithCount, error)
+	GetAuthorsByTag(tag string) ([]int, error)
+
+	// Series tags (mirror of book tags, keyed by series integer ID)
+	AddSeriesTag(seriesID int, tag string) error
+	AddSeriesTagWithSource(seriesID int, tag, source string) error
+	RemoveSeriesTag(seriesID int, tag string) error
+	RemoveSeriesTagsByPrefix(seriesID int, prefix, source string) error
+	GetSeriesTags(seriesID int) ([]string, error)
+	GetSeriesTagsDetailed(seriesID int) ([]BookTag, error)
+	SetSeriesTags(seriesID int, tags []string) error
+	ListAllSeriesTags() ([]TagWithCount, error)
+	GetSeriesByTag(tag string) ([]int, error)
 
 	// External ID mapping (PID map for iTunes, Audible, etc.)
 	CreateExternalIDMapping(mapping *ExternalIDMapping) error
@@ -822,17 +862,25 @@ type BookPathChange struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
-// BookTag represents a user-defined tag on a book
+// BookTag represents one tag row on a book. Source distinguishes
+// user-applied tags ("user") from system-applied provenance tags
+// ("system", e.g. dedup:merge-survivor:llm-auto, metadata:source:*).
+// BookID is populated on reads that need to identify the owning book
+// (historically PebbleStore serialized it into the JSON value); for
+// the per-book read path it's left empty since the caller already
+// has the ID.
 type BookTag struct {
-	BookID    string    `json:"book_id"`
+	BookID    string    `json:"book_id,omitempty"`
 	Tag       string    `json:"tag"`
+	Source    string    `json:"source,omitempty"` // "user" | "system"
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// TagWithCount represents a tag with its usage count
+// TagWithCount represents a tag with its usage count.
 type TagWithCount struct {
-	Tag   string `json:"tag"`
-	Count int    `json:"count"`
+	Tag    string `json:"tag"`
+	Count  int    `json:"count"`
+	Source string `json:"source,omitempty"` // "user" or "system" — empty when mixed
 }
 
 // ScanCacheEntry holds mtime/size for incremental scan skip checks.

--- a/internal/database/tag_helpers.go
+++ b/internal/database/tag_helpers.go
@@ -1,0 +1,179 @@
+// file: internal/database/tag_helpers.go
+// version: 1.0.0
+// guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
+
+package database
+
+import "strings"
+
+// Tag helpers for the "exactly one tag in this namespace" idiom.
+//
+// Several system tag namespaces are semantically singletons — a
+// book (or author / series) should have exactly one value at a
+// time. Examples:
+//
+//	metadata:source:<name>    — last metadata apply provenance
+//	metadata:language:<code>  — language of the applied metadata
+//	dedup:merge-survivor:<method> — how the last merge happened
+//
+// The naive approach "delete prefix + add tag" does wasteful
+// writes on every apply even when the value hasn't changed. These
+// helpers read current state first and short-circuit when the
+// desired tag is already in place, so a re-apply of identical
+// metadata is a true no-op at the tag layer.
+
+// EnsureSingletonBookTag makes sure exactly one book_tag row
+// matches `prefix` at the given `source`, and it equals `fullTag`.
+// If `fullTag` is already present at `source`, does nothing.
+// Otherwise removes any conflicting tags with that prefix and
+// adds the new one.
+//
+// `fullTag` must start with `prefix` — the helper enforces this
+// because mismatched prefix/tag combinations are almost always
+// programmer bugs ("metadata:source:audible" with prefix
+// "metadata:language:" would delete every language tag).
+func EnsureSingletonBookTag(store Store, bookID, prefix, fullTag, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	if prefix == "" || fullTag == "" {
+		return nil
+	}
+	if !strings.HasPrefix(fullTag, prefix) {
+		return errInvalidSingletonTag
+	}
+
+	detailed, err := store.GetBookTagsDetailed(bookID)
+	if err != nil {
+		return err
+	}
+
+	// Scan for conflicts + short-circuit hit.
+	alreadyCorrect := false
+	hasConflict := false
+	for _, bt := range detailed {
+		if !strings.HasPrefix(bt.Tag, prefix) {
+			continue
+		}
+		if bt.Source != source {
+			continue
+		}
+		if bt.Tag == fullTag {
+			alreadyCorrect = true
+			continue
+		}
+		hasConflict = true
+	}
+
+	// Fast path: exactly the right tag is already present and
+	// nothing else in the namespace needs to go.
+	if alreadyCorrect && !hasConflict {
+		return nil
+	}
+
+	// Clear everything in the namespace (at this source), then
+	// write the target value. Done in two steps rather than one
+	// so an interrupted apply never leaves zero tags in a
+	// namespace that should always have exactly one.
+	if hasConflict {
+		if err := store.RemoveBookTagsByPrefix(bookID, prefix, source); err != nil {
+			return err
+		}
+	}
+	return store.AddBookTagWithSource(bookID, fullTag, source)
+}
+
+// EnsureSingletonAuthorTag mirrors EnsureSingletonBookTag for
+// authors — same semantics, keyed by author integer ID.
+func EnsureSingletonAuthorTag(store Store, authorID int, prefix, fullTag, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	if prefix == "" || fullTag == "" {
+		return nil
+	}
+	if !strings.HasPrefix(fullTag, prefix) {
+		return errInvalidSingletonTag
+	}
+
+	detailed, err := store.GetAuthorTagsDetailed(authorID)
+	if err != nil {
+		return err
+	}
+
+	alreadyCorrect := false
+	hasConflict := false
+	for _, bt := range detailed {
+		if !strings.HasPrefix(bt.Tag, prefix) {
+			continue
+		}
+		if bt.Source != source {
+			continue
+		}
+		if bt.Tag == fullTag {
+			alreadyCorrect = true
+			continue
+		}
+		hasConflict = true
+	}
+	if alreadyCorrect && !hasConflict {
+		return nil
+	}
+	if hasConflict {
+		if err := store.RemoveAuthorTagsByPrefix(authorID, prefix, source); err != nil {
+			return err
+		}
+	}
+	return store.AddAuthorTagWithSource(authorID, fullTag, source)
+}
+
+// EnsureSingletonSeriesTag mirrors EnsureSingletonBookTag for
+// series — same semantics, keyed by series integer ID.
+func EnsureSingletonSeriesTag(store Store, seriesID int, prefix, fullTag, source string) error {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	if prefix == "" || fullTag == "" {
+		return nil
+	}
+	if !strings.HasPrefix(fullTag, prefix) {
+		return errInvalidSingletonTag
+	}
+
+	detailed, err := store.GetSeriesTagsDetailed(seriesID)
+	if err != nil {
+		return err
+	}
+
+	alreadyCorrect := false
+	hasConflict := false
+	for _, bt := range detailed {
+		if !strings.HasPrefix(bt.Tag, prefix) {
+			continue
+		}
+		if bt.Source != source {
+			continue
+		}
+		if bt.Tag == fullTag {
+			alreadyCorrect = true
+			continue
+		}
+		hasConflict = true
+	}
+	if alreadyCorrect && !hasConflict {
+		return nil
+	}
+	if hasConflict {
+		if err := store.RemoveSeriesTagsByPrefix(seriesID, prefix, source); err != nil {
+			return err
+		}
+	}
+	return store.AddSeriesTagWithSource(seriesID, fullTag, source)
+}
+
+// errInvalidSingletonTag signals that a caller passed a fullTag
+// that doesn't start with the given prefix. Kept as a package-
+// level sentinel so tests can assert on it without string
+// matching.
+var errInvalidSingletonTag = &tagError{"singleton tag does not match prefix"}
+
+type tagError struct{ msg string }
+
+func (e *tagError) Error() string { return e.msg }


### PR DESCRIPTION
## Summary

Lays the storage-level foundation for using tags as first-class infrastructure across books, authors, and series, with a \`source\` column that distinguishes user-applied tags from system-applied provenance tags (\`dedup:merge-survivor:*\`, \`metadata:source:*\`, etc.).

This is **PR A of a stack** — pure infrastructure, no call sites use it yet. Follow-up PRs will wire system tag application at metadata-apply time, add the language filter in the review dialog (the motivating Spanish/English screenshot), and capture the new backlog items that surfaced during the design conversation.

## What shipped

### Schema — migrations 47 + 48
- **47** adds \`source TEXT NOT NULL DEFAULT 'user'\` to \`book_tags\` (idempotent via ALTER+log-and-continue)
- **48** creates \`author_tags\` and \`series_tags\` tables with the same shape as \`book_tags\`: \`(entity_id, tag, source, created_at)\` + indexes on tag and source

### Store interface — 21 new methods
Nine methods per entity type: \`Add\` / \`AddWithSource\` / \`Remove\` / \`RemoveByPrefix\` / \`Get\` / \`GetDetailed\` / \`Set\` / \`ListAll\` / \`GetByTag\`. Book methods grew three new entries (\`AddBookTagWithSource\`, \`RemoveBookTagsByPrefix\`, \`GetBookTagsDetailed\`); author and series methods are entirely new.

### Implementations (full parity across backends)
- **\`PebbleStore\`** — generic helper functions parameterized by \`pebbleTagKeyspace\` (prefix bundle) so all three entity types share one code path. Keys: \`book_tag:<id>:<tag>\`, \`author_tag:<id>:<tag>\`, \`series_tag:<id>:<tag>\` with parallel \`*_idx:\` reverse indexes.
- **\`SQLiteStore\`** — generic helpers parameterized by \`(table, idCol)\` to avoid duplicating the same SQL 18 times.
- **\`MockStore\`** (hand-written) — every new method has a matching \`XxxFunc\` field and a default no-op implementation.
- **\`mocks.MockStore\`** (mockery-generated) — regenerated via \`make mocks\`.

### Singleton tag helpers — \`tag_helpers.go\`
\`EnsureSingletonBookTag\` / \`EnsureSingletonAuthorTag\` / \`EnsureSingletonSeriesTag\` implement the "exactly one tag in this namespace" idiom. The naive "remove prefix + add" is wasteful when the new value equals the existing one; these helpers short-circuit when the desired tag is already in place. Used for \`metadata:source:*\`, \`metadata:language:*\`, and any future singleton namespace.

Prefix validation catches programmer bugs — calling \`EnsureSingletonBookTag(store, id, "metadata:language:", "metadata:source:audible", "system")\` would otherwise silently wipe every language tag on the book.

### Namespace convention
All system tags use \`<category>:<subcategory>[:<detail>]\` with \`:\` separator. Current set documented in migration 47 comment:

- \`dedup:merge-survivor[:auto-hash|auto-isbn|llm-auto]\`
- \`dedup:duration-match\` | \`dedup:duration-abridged\`
- \`metadata:source:{audible,hardcover,google_books,openlibrary,audnexus}\`
- \`metadata:language:{en,es,fr,...}\`
- \`import:scan\` | \`import:itunes\`
- \`organize:applied\` | \`transcode:applied\`

### Drift protection worked
The \`var _ Store = (*MockStore)(nil)\` compile-time assertion added in #242 caught all 21 missing methods on the hand-written \`MockStore\` immediately — no runtime surprise, no shipped drift.

### \`BookTag\` type unified
The existing PebbleStore \`BookTag\` struct and my new \`BookTag\` were merged into a single type with \`Source\` added and \`BookID\` now \`omitempty\` so it can represent rows from any of the three entity tables.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`make mocks-check\` clean
- [x] \`go test ./internal/database/...\` — all green
- [ ] Deploy and verify migrations 47/48 run cleanly on the production SQLite (Pebble doesn't need migrations — new keys just appear)

## Not in this PR (deliberate)
- System tag application at call sites (metadata apply, dedup merge) — PR C
- Language filter in MetadataReviewDialog — PR D
- HTTP endpoints for author/series tags — later PR
- Backlog updates capturing new items from this design session — PR B

🤖 Generated with [Claude Code](https://claude.com/claude-code)