### PR TITLE
feat(metadata): system-tag books with source + language on every apply

### DIFF
--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -527,6 +527,11 @@ func (mfs *MetadataFetchService) FetchMetadataForBookByTitle(id string) (*FetchM
 
 		mfs.persistFetchedMetadata(id, meta)
 
+		// Mirror of ApplyMetadataCandidate: tag the book with the
+		// source and language so downstream filters (review dialog,
+		// upgrade jobs) have provenance to key on.
+		mfs.applyMetadataSystemTags(id, src.Name(), meta.Language)
+
 		return &FetchMetadataResponse{
 			Message: "metadata fetched by title only",
 			Book:    updatedBook,
@@ -2378,11 +2383,129 @@ func (mfs *MetadataFetchService) ApplyMetadataCandidate(id string, candidate Met
 		mfs.queueISBNEnrichment(id, updatedBook)
 	}
 
+	// Tag the book with metadata:source:* and metadata:language:*
+	// as system-applied provenance tags. Uses the singleton
+	// helpers so a no-op re-apply of the same source/language is
+	// a true no-op at the tag layer (no wasted writes). Done after
+	// UpdateBook so a failed update never leaves stale tags behind.
+	mfs.applyMetadataSystemTags(id, candidate.Source, meta.Language)
+
 	return &FetchMetadataResponse{
 		Message: "metadata candidate applied",
 		Book:    updatedBook,
 		Source:  candidate.Source,
 	}, nil
+}
+
+// applyMetadataSystemTags writes the metadata:source:* and
+// metadata:language:* system tags for a book. Logs but doesn't
+// propagate errors — tagging is provenance metadata, not part
+// of the apply transaction, so a tag write failure shouldn't
+// fail the apply itself.
+func (mfs *MetadataFetchService) applyMetadataSystemTags(bookID, sourceName, language string) {
+	sourceTag := metadataSourceTag(sourceName)
+	if sourceTag != "" {
+		if err := database.EnsureSingletonBookTag(
+			mfs.db, bookID, "metadata:source:", sourceTag, "system",
+		); err != nil {
+			log.Printf("[WARN] failed to tag book %s with %s: %v", bookID, sourceTag, err)
+		}
+	}
+	langTag := metadataLanguageTag(language)
+	if langTag != "" {
+		if err := database.EnsureSingletonBookTag(
+			mfs.db, bookID, "metadata:language:", langTag, "system",
+		); err != nil {
+			log.Printf("[WARN] failed to tag book %s with %s: %v", bookID, langTag, err)
+		}
+	}
+}
+
+// metadataSourceTag turns a human-readable source name from
+// metadata.MetadataSource.Name() into a tag-safe slug under the
+// metadata:source:* namespace. Returns "" for empty inputs so
+// the caller can skip the tag write.
+//
+//	"Hardcover"          → "metadata:source:hardcover"
+//	"Open Library"       → "metadata:source:open_library"
+//	"Google Books"       → "metadata:source:google_books"
+//	"Audnexus (Audible)" → "metadata:source:audnexus"
+//	"Audible"            → "metadata:source:audible"
+func metadataSourceTag(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	// Special case: drop the "(Audible)" parenthetical on Audnexus
+	// so the tag cleanly identifies the source provider, not its
+	// upstream. We still have metadata:source:audible for the
+	// direct Audible path.
+	if strings.HasPrefix(name, "Audnexus") {
+		return "metadata:source:audnexus"
+	}
+	slug := strings.ToLower(name)
+	slug = strings.ReplaceAll(slug, " ", "_")
+	slug = strings.ReplaceAll(slug, "(", "")
+	slug = strings.ReplaceAll(slug, ")", "")
+	slug = strings.ReplaceAll(slug, "-", "_")
+	return "metadata:source:" + slug
+}
+
+// metadataLanguageTag turns a language string from a metadata
+// source into a tag under the metadata:language:* namespace.
+// Accepts ISO 639-1 codes ("en"), ISO 639-2 codes ("eng"), and
+// full English names ("English"); normalizes to the 2-letter
+// form where recognized and lowercases everything else. Returns
+// "" for empty inputs so the caller can skip the tag write.
+func metadataLanguageTag(lang string) string {
+	lang = strings.ToLower(strings.TrimSpace(lang))
+	if lang == "" {
+		return ""
+	}
+	// Short list of ISO 639-2 / English-name variants we see
+	// across the real sources. Unknown languages fall through
+	// to the lowercased input so we never drop data — worst
+	// case the tag looks weird but it's still filterable.
+	canonical := map[string]string{
+		"english":    "en",
+		"eng":        "en",
+		"spanish":    "es",
+		"spa":        "es",
+		"french":     "fr",
+		"fre":        "fr",
+		"fra":        "fr",
+		"german":     "de",
+		"ger":        "de",
+		"deu":        "de",
+		"italian":    "it",
+		"ita":        "it",
+		"japanese":   "ja",
+		"jpn":        "ja",
+		"chinese":    "zh",
+		"chi":        "zh",
+		"zho":        "zh",
+		"mandarin":   "zh",
+		"portuguese": "pt",
+		"por":        "pt",
+		"russian":    "ru",
+		"rus":        "ru",
+		"dutch":      "nl",
+		"nld":        "nl",
+		"korean":     "ko",
+		"kor":        "ko",
+		"arabic":     "ar",
+		"ara":        "ar",
+	}
+	if code, ok := canonical[lang]; ok {
+		return "metadata:language:" + code
+	}
+	// Already a 2-letter code? Keep it.
+	if len(lang) == 2 {
+		return "metadata:language:" + lang
+	}
+	// Unknown — slugify and pass through.
+	slug := strings.ReplaceAll(lang, " ", "_")
+	return "metadata:language:" + slug
 }
 
 // ApplyMetadataFileIO runs the slow file operations after metadata is applied:

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -732,6 +732,10 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 			}
 			updatedCount++
 			result.Status = "updated"
+
+			// System tag the source and language so the review UI
+			// and future upgrade jobs know where this came from.
+			s.metadataFetchService.applyMetadataSystemTags(bookID, sourceName, meta.Language)
 		} else if len(fetchedValues) > 0 {
 			result.Status = "fetched"
 		}

--- a/internal/server/metadata_system_tags_test.go
+++ b/internal/server/metadata_system_tags_test.go
@@ -1,0 +1,80 @@
+// file: internal/server/metadata_system_tags_test.go
+// version: 1.0.0
+// guid: 8e9f0a1b-2c3d-4e5f-6a7b-8c9d0e1f2a3b
+
+package server
+
+import "testing"
+
+// TestMetadataSourceTag locks in the slug format for the
+// metadata:source:* namespace. Every metadata source's Name()
+// string gets passed through this helper, and the resulting tag
+// is what downstream filters (review dialog, upgrade jobs) key
+// on — so drift here would silently break filters.
+func TestMetadataSourceTag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace", "   ", ""},
+		{"hardcover", "Hardcover", "metadata:source:hardcover"},
+		{"open library", "Open Library", "metadata:source:open_library"},
+		{"google books", "Google Books", "metadata:source:google_books"},
+		{"audible", "Audible", "metadata:source:audible"},
+		// Audnexus wraps Audible upstream — we strip the
+		// "(Audible)" parenthetical so the tag cleanly names
+		// the source provider rather than its upstream.
+		{"audnexus", "Audnexus (Audible)", "metadata:source:audnexus"},
+		{"audnexus_bare", "Audnexus", "metadata:source:audnexus"},
+		{"wikipedia", "Wikipedia", "metadata:source:wikipedia"},
+		{"hyphens", "Some-Source", "metadata:source:some_source"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := metadataSourceTag(tt.in)
+			if got != tt.want {
+				t.Errorf("metadataSourceTag(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMetadataLanguageTag locks in the canonicalization from
+// the grab-bag of formats real sources return (ISO-639-1,
+// ISO-639-2, English names) to the lowercase 2-letter code the
+// review-dialog filter expects. Unknowns fall through to a
+// slugified tag so we never drop data.
+func TestMetadataLanguageTag(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"en", "metadata:language:en"},
+		{"EN", "metadata:language:en"},
+		{"English", "metadata:language:en"},
+		{"eng", "metadata:language:en"},
+		{"Spanish", "metadata:language:es"},
+		{"spa", "metadata:language:es"},
+		{"Mandarin", "metadata:language:zh"},
+		{"zho", "metadata:language:zh"},
+		{"Chinese", "metadata:language:zh"},
+		{"de", "metadata:language:de"},
+		{"German", "metadata:language:de"},
+		{"Portuguese", "metadata:language:pt"},
+		// Unknown: slugified fallthrough, never dropped.
+		{"Klingon", "metadata:language:klingon"},
+		{"Old English", "metadata:language:old_english"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := metadataLanguageTag(tt.in)
+			if got != tt.want {
+				t.Errorf("metadataLanguageTag(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Every metadata apply path now tags the book with two system tags so provenance is queryable via the tag system from [#244](https://github.com/jdfalk/audiobook-organizer/pull/244):

- \`metadata:source:<slug>\` — where the metadata came from (hardcover, audible, open_library, google_books, audnexus, ...)
- \`metadata:language:<code>\` — 2-letter ISO code of the applied language data

This is the minimum data-model change that makes the §7 follow-up PRs possible (language filter, Google Books → Audible upgrade, system-tag UX).

## Apply sites covered

1. \`ApplyMetadataCandidate\` (\`metadata_fetch_service.go\`) — single user-selected candidate via the review dialog
2. \`FetchMetadataForBook\` title-only fallback (same file) — auto-fetch when no candidate is selected
3. \`bulkFetchMetadata\` (\`metadata_handlers.go\`) — the bulk fetch-and-apply path used by the Library bulk action

All three call a new \`applyMetadataSystemTags\` helper on the service, which in turn uses \`database.EnsureSingletonBookTag\` from #244 — no wasted writes when the tag already has the correct value.

## New helpers with unit tests

- \`metadataSourceTag(name string) string\` — normalizes a source's \`Name()\` into a tag-safe slug. \"Hardcover\" → hardcover, \"Open Library\" → open_library, \"Audnexus (Audible)\" → audnexus (strips the parenthetical), etc.
- \`metadataLanguageTag(lang string) string\` — canonicalizes ISO-639-1/2 codes and English names into the 2-letter form. \"English\" → en, \"spa\" → es, \"Mandarin\" → zh. Unknowns fall through to a slugified tag so we never drop data.

\`metadata_system_tags_test.go\` locks both helpers' output formats so drift fails CI before downstream filters silently start missing.

## Test plan
- [x] New unit tests pass (\`go test ./internal/server/ -run \"TestMetadataSourceTag|TestMetadataLanguageTag\"\`)
- [x] Full server test suite still green (\`go test ./internal/server/...\`)
- [x] \`go vet ./...\` clean
- [ ] Deploy, apply metadata to one book via each path, verify tags appear on the book via \`GET /audiobooks/:id/tags\`

## Not in this PR (intentional)

- **Language filter in MetadataReviewDialog** — needed the tag data to exist on books first; this PR makes that happen. Follow-up is a small frontend change.
- **Metadata fetch caching** (§7.5) — urgent but larger scope, separate PR.
- **Embedding scorer caching** — acute OpenAI quota fix, getting its own PR right after this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)