### PR TITLE
feat(ai): content-hash cache for OpenAI embedding calls (quota emergency fix)

### DIFF
--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package ai
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -16,14 +17,46 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
-// EmbeddingClient handles OpenAI embedding generation
+// EmbeddingCache is the minimal surface EmbeddingClient needs from
+// a content-hash cache layer. It's an interface (not a concrete
+// type) so internal/ai doesn't need to import internal/database,
+// which would create a circular dependency. Production wires the
+// *database.EmbeddingStore implementation at server startup.
+//
+// Get returns (nil, nil) on a cache miss so callers can use the
+// two-valued result without needing a sentinel error constant.
+// Put is called with the newly-embedded vectors after a successful
+// API call; a Put failure is logged but never fatal because the
+// cache is an optimization, not a correctness requirement.
+//
+// Added after the 2026-04-11 OpenAI quota incident: the metadata
+// scorer was re-embedding every candidate on every fetch — no
+// content-hash cache existed — and burned the entire monthly
+// budget in minutes.
+type EmbeddingCache interface {
+	GetCachedEmbedding(textHash, model string) ([]float32, error)
+	PutCachedEmbedding(textHash, model string, vector []float32) error
+}
+
+// EmbeddingClient handles OpenAI embedding generation. Optional
+// content-hash cache (see EmbeddingCache) short-circuits repeat
+// embeds of identical text so a bulk fetch of 10K books only
+// hits the API for unique title+author+narrator combinations.
 type EmbeddingClient struct {
 	client *openai.Client
 	model  string
+	cache  EmbeddingCache
+
+	// rawEmbed is the underlying API-call function. It defaults
+	// to c.embedBatchRaw which hits OpenAI; tests override it
+	// with a fake so the cache-partitioning logic can be
+	// exercised without a real API key.
+	rawEmbed func(ctx context.Context, texts []string) ([][]float32, error)
 }
 
 // NewEmbeddingClient creates a new embedding client using the given API key.
-// Default model is text-embedding-3-large.
+// Default model is text-embedding-3-large. The returned client has no cache
+// wired up — call WithCache after construction to enable content-hash caching.
 func NewEmbeddingClient(apiKey string) *EmbeddingClient {
 	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
 	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
@@ -31,16 +64,118 @@ func NewEmbeddingClient(apiKey string) *EmbeddingClient {
 	}
 
 	client := openai.NewClient(clientOptions...)
-	return &EmbeddingClient{
+	c := &EmbeddingClient{
 		client: &client,
 		model:  "text-embedding-3-large",
 	}
+	c.rawEmbed = c.embedBatchRaw
+	return c
 }
 
-// EmbedBatch sends up to 100 texts to the OpenAI Embeddings API and returns one
-// []float32 per input in the same order. Retries up to 3 times with exponential
-// backoff (1s, 4s).
+// WithCache attaches a content-hash cache to the client. Safe to
+// call at any time — subsequent EmbedBatch calls start using the
+// cache immediately. Pass nil to disable caching (reverts to
+// uncached behavior).
+func (c *EmbeddingClient) WithCache(cache EmbeddingCache) *EmbeddingClient {
+	c.cache = cache
+	return c
+}
+
+// Model returns the embedding model name this client is pinned
+// to. Used by cache-aware callers that need to compose cache
+// keys.
+func (c *EmbeddingClient) Model() string {
+	return c.model
+}
+
+// EmbedBatch returns one []float32 per input text in the same
+// order. If a content-hash cache is attached (see WithCache),
+// inputs are partitioned into cache hits and misses: hits are
+// served from the cache with zero API cost, misses are sent to
+// OpenAI in a single batch and the results are written back to
+// the cache before being returned.
+//
+// Retries up to 3 times with exponential backoff (1s, 4s) on
+// API errors. Cache I/O errors are logged but never fail the
+// call — the cache is an optimization, not a correctness layer.
 func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	// Partition texts into cache hits and misses. `results` keeps
+	// the original order; `missIndices` remembers which slots in
+	// `results` are still empty and need an API call. `missTexts`
+	// is the compact list we actually send to OpenAI.
+	results := make([][]float32, len(texts))
+	var missIndices []int
+	var missTexts []string
+	hits := 0
+
+	if c.cache != nil {
+		for i, text := range texts {
+			hash := TextHash(text)
+			vec, err := c.cache.GetCachedEmbedding(hash, c.model)
+			if err != nil {
+				// Cache read failure — treat as miss, log once.
+				log.Printf("[WARN] embedding cache get failed (hash=%s): %v", hash[:8], err)
+			}
+			if err == nil && vec != nil {
+				results[i] = vec
+				hits++
+				continue
+			}
+			missIndices = append(missIndices, i)
+			missTexts = append(missTexts, text)
+		}
+	} else {
+		missIndices = make([]int, len(texts))
+		missTexts = texts
+		for i := range texts {
+			missIndices[i] = i
+		}
+	}
+
+	// All cache hits? Return without touching the API at all.
+	if len(missTexts) == 0 {
+		log.Printf("[DEBUG] embedding cache: %d/%d hits, 0 API calls", hits, len(texts))
+		return results, nil
+	}
+
+	if c.cache != nil {
+		log.Printf("[DEBUG] embedding cache: %d/%d hits, %d misses sent to API",
+			hits, len(texts), len(missTexts))
+	}
+
+	apiResults, err := c.rawEmbed(ctx, missTexts)
+	if err != nil {
+		return nil, err
+	}
+	if len(apiResults) != len(missTexts) {
+		return nil, fmt.Errorf("embedding API returned %d results for %d inputs",
+			len(apiResults), len(missTexts))
+	}
+
+	// Stitch API results back into the original positions and
+	// write them to the cache for next time.
+	for j, vec := range apiResults {
+		origIdx := missIndices[j]
+		results[origIdx] = vec
+		if c.cache != nil {
+			hash := TextHash(missTexts[j])
+			if putErr := c.cache.PutCachedEmbedding(hash, c.model, vec); putErr != nil {
+				log.Printf("[WARN] embedding cache put failed (hash=%s): %v",
+					hash[:8], putErr)
+			}
+		}
+	}
+	return results, nil
+}
+
+// embedBatchRaw is the actual OpenAI API call with retries —
+// EmbedBatch handles the cache partitioning around it. Split out
+// so the caching logic can call it with just the miss set.
+func (c *EmbeddingClient) embedBatchRaw(ctx context.Context, texts []string) ([][]float32, error) {
 	var lastErr error
 	delays := []time.Duration{1 * time.Second, 4 * time.Second}
 

--- a/internal/ai/embedding_client_test.go
+++ b/internal/ai/embedding_client_test.go
@@ -1,13 +1,17 @@
 // file: internal/ai/embedding_client_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 package ai
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildEmbeddingText_Book(t *testing.T) {
@@ -33,4 +37,143 @@ func TestTextHash(t *testing.T) {
 	assert.Equal(t, h1, h2, "same input should produce same hash")
 	assert.NotEqual(t, h1, h3, "different input should produce different hash")
 	assert.Len(t, h1, 64, "SHA-256 hex digest should be 64 characters")
+}
+
+// fakeEmbeddingCache is a thread-safe in-memory EmbeddingCache
+// for tests. Records every Get/Put so tests can assert call
+// counts and keys.
+type fakeEmbeddingCache struct {
+	mu       sync.Mutex
+	entries  map[string][]float32
+	getCalls int
+	putCalls int
+	getErr   error
+}
+
+func newFakeCache() *fakeEmbeddingCache {
+	return &fakeEmbeddingCache{entries: make(map[string][]float32)}
+}
+
+func (f *fakeEmbeddingCache) key(hash, model string) string { return model + ":" + hash }
+
+func (f *fakeEmbeddingCache) GetCachedEmbedding(hash, model string) ([]float32, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getCalls++
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.entries[f.key(hash, model)], nil
+}
+
+func (f *fakeEmbeddingCache) PutCachedEmbedding(hash, model string, vec []float32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.putCalls++
+	if f.entries == nil {
+		f.entries = make(map[string][]float32)
+	}
+	f.entries[f.key(hash, model)] = vec
+	return nil
+}
+
+// newClientWithFakeAPI returns an EmbeddingClient whose API seam
+// is replaced with a fake that returns one deterministic vector
+// per input and counts calls. Model is "test" so cache keys
+// stay isolated from production entries.
+func newClientWithFakeAPI() (*EmbeddingClient, *int) {
+	calls := 0
+	c := &EmbeddingClient{model: "test"}
+	c.rawEmbed = func(ctx context.Context, texts []string) ([][]float32, error) {
+		calls++
+		out := make([][]float32, len(texts))
+		for i, text := range texts {
+			// Return a trivially-unique vector per text so the
+			// test can verify the right vectors reached the
+			// right slots without depending on real embedding
+			// math.
+			out[i] = []float32{float32(len(text)), float32(i)}
+		}
+		return out, nil
+	}
+	return c, &calls
+}
+
+func TestEmbedBatch_NoCache_CallsAPIOnce(t *testing.T) {
+	c, apiCalls := newClientWithFakeAPI()
+
+	results, err := c.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, 1, *apiCalls, "no cache → one API call")
+}
+
+func TestEmbedBatch_AllHits_ZeroAPICalls(t *testing.T) {
+	c, apiCalls := newClientWithFakeAPI()
+	cache := newFakeCache()
+	// Pre-populate the cache for every input.
+	cache.entries[cache.key(TextHash("a"), "test")] = []float32{1, 2, 3}
+	cache.entries[cache.key(TextHash("b"), "test")] = []float32{4, 5, 6}
+	c.WithCache(cache)
+
+	results, err := c.EmbedBatch(context.Background(), []string{"a", "b"})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, []float32{1, 2, 3}, results[0])
+	assert.Equal(t, []float32{4, 5, 6}, results[1])
+	assert.Equal(t, 0, *apiCalls, "all cache hits → zero API calls")
+	assert.Equal(t, 0, cache.putCalls, "hits should not trigger puts")
+}
+
+func TestEmbedBatch_MixedHitsAndMisses_APICalledOnceForMisses(t *testing.T) {
+	c, apiCalls := newClientWithFakeAPI()
+	cache := newFakeCache()
+	// Pre-populate the cache for inputs 0 and 2 but not 1 and 3.
+	cache.entries[cache.key(TextHash("hit-0"), "test")] = []float32{10}
+	cache.entries[cache.key(TextHash("hit-2"), "test")] = []float32{20}
+	c.WithCache(cache)
+
+	inputs := []string{"hit-0", "miss-1", "hit-2", "miss-3"}
+	results, err := c.EmbedBatch(context.Background(), inputs)
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+	// Hits were served from the cache at their original positions.
+	assert.Equal(t, []float32{10}, results[0])
+	assert.Equal(t, []float32{20}, results[2])
+	// Misses got fresh vectors from the fake API seam.
+	assert.NotNil(t, results[1])
+	assert.NotNil(t, results[3])
+	// Exactly one batched API call for the two misses.
+	assert.Equal(t, 1, *apiCalls)
+	// Both misses got written back to the cache.
+	assert.Equal(t, 2, cache.putCalls)
+	_, got1 := cache.entries[cache.key(TextHash("miss-1"), "test")]
+	_, got3 := cache.entries[cache.key(TextHash("miss-3"), "test")]
+	assert.True(t, got1, "miss-1 should be cached after API call")
+	assert.True(t, got3, "miss-3 should be cached after API call")
+}
+
+func TestEmbedBatch_CacheGetError_FallsBackToAPI(t *testing.T) {
+	// A cache read failure should never fail the call — the client
+	// treats it as a miss and proceeds to the API. Production
+	// behavior: cache is an optimization, not a correctness layer.
+	c, apiCalls := newClientWithFakeAPI()
+	cache := newFakeCache()
+	cache.getErr = errors.New("simulated cache read failure")
+	c.WithCache(cache)
+
+	results, err := c.EmbedBatch(context.Background(), []string{"a", "b"})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, 1, *apiCalls)
+}
+
+func TestEmbedBatch_EmptyInput_NoAPICallNoError(t *testing.T) {
+	c, apiCalls := newClientWithFakeAPI()
+	c.WithCache(newFakeCache())
+
+	results, err := c.EmbedBatch(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+	assert.Equal(t, 0, *apiCalls)
 }

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -173,6 +173,70 @@ ON CONFLICT(id) DO UPDATE SET
 	return err
 }
 
+// cacheEntityID composes the per-row entity_id for cache entries.
+// The primary key on the embeddings table is entity_type:entity_id,
+// so to keep different models for the same text hash in separate
+// rows we embed the model name into the entity_id itself. Format:
+// "<model>:<textHash>". This keeps the existing table schema and
+// its text_hash index untouched while giving each (hash, model)
+// pair its own row.
+func cacheEntityID(textHash, model string) string {
+	return model + ":" + textHash
+}
+
+// GetCachedEmbedding looks up a cached embedding by its text hash
+// and model. Content-hash caching reuses the existing embeddings
+// table under an `entity_type='cache'` keyspace so every caller
+// that embeds the same text string — Foundation by Isaac Asimov,
+// for example — gets the same vector back with zero API cost
+// after the first successful embed.
+//
+// Returns nil, nil on a cache miss. Errors are only for real I/O
+// problems — callers should treat nil+nil as "proceed to embed".
+//
+// Added after a production incident where the metadata scorer
+// re-embedded every candidate on every fetch and burned the
+// entire monthly OpenAI quota in minutes.
+func (s *EmbeddingStore) GetCachedEmbedding(textHash, model string) ([]float32, error) {
+	if textHash == "" || model == "" {
+		return nil, nil
+	}
+	id := compositeKey("cache", cacheEntityID(textHash, model))
+	row := s.db.QueryRow(`SELECT vector FROM embeddings WHERE id = ?`, id)
+	var vectorBlob []byte
+	err := row.Scan(&vectorBlob)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cached embedding: %w", err)
+	}
+	return decodeVector(vectorBlob), nil
+}
+
+// PutCachedEmbedding stores a vector keyed by its text hash and
+// model under the `entity_type='cache'` keyspace so future
+// GetCachedEmbedding lookups hit. Errors are logged by the
+// caller — a cache-put failure is never fatal.
+//
+// Reuses the existing embeddings table rather than a new one
+// because the schema already has an index on text_hash and the
+// user's "SQLite for specific things only" directive applies:
+// the embedding store is already a SQLite sidecar and we don't
+// want another one.
+func (s *EmbeddingStore) PutCachedEmbedding(textHash, model string, vector []float32) error {
+	if textHash == "" || model == "" || len(vector) == 0 {
+		return nil
+	}
+	return s.Upsert(Embedding{
+		EntityType: "cache",
+		EntityID:   cacheEntityID(textHash, model),
+		TextHash:   textHash,
+		Vector:     vector,
+		Model:      model,
+	})
+}
+
 // Get retrieves an embedding by entity type and ID. Returns nil, nil when not found.
 func (s *EmbeddingStore) Get(entityType, entityID string) (*Embedding, error) {
 	id := compositeKey(entityType, entityID)

--- a/internal/database/embedding_store_test.go
+++ b/internal/database/embedding_store_test.go
@@ -23,6 +23,49 @@ func newTestEmbeddingStore(t *testing.T) *EmbeddingStore {
 	return store
 }
 
+// TestEmbeddingStore_ContentHashCache locks in the contract that
+// GetCachedEmbedding returns (nil, nil) on a miss, PutCachedEmbedding
+// round-trips a vector by text hash + model, and different models
+// for the same hash are isolated. This is the cache path that
+// EmbedBatch relies on to avoid burning the OpenAI quota on
+// identical-content re-embeds.
+func TestEmbeddingStore_ContentHashCache(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	const hash = "deadbeef"
+	const model = "text-embedding-3-large"
+
+	// Miss on a fresh store.
+	got, err := store.GetCachedEmbedding(hash, model)
+	require.NoError(t, err)
+	assert.Nil(t, got, "miss should return nil, nil")
+
+	// Round-trip a vector.
+	want := []float32{0.1, 0.2, 0.3, 0.4}
+	require.NoError(t, store.PutCachedEmbedding(hash, model, want))
+	got, err = store.GetCachedEmbedding(hash, model)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	// Same hash, different model → separate row.
+	smaller := []float32{1, 2}
+	require.NoError(t, store.PutCachedEmbedding(hash, "text-embedding-3-small", smaller))
+	got, err = store.GetCachedEmbedding(hash, "text-embedding-3-small")
+	require.NoError(t, err)
+	assert.Equal(t, smaller, got)
+	// The original entry at the original model is still intact.
+	got, err = store.GetCachedEmbedding(hash, model)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	// Empty arguments short-circuit cleanly.
+	got, err = store.GetCachedEmbedding("", model)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	require.NoError(t, store.PutCachedEmbedding("", model, want))
+	require.NoError(t, store.PutCachedEmbedding(hash, model, nil))
+}
+
 func TestEmbeddingStore_UpsertAndGet(t *testing.T) {
 	store := newTestEmbeddingStore(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -836,7 +836,16 @@ func NewServer() *Server {
 		} else {
 			server.embeddingStore = embeddingStore
 			if config.AppConfig.OpenAIAPIKey != "" && config.AppConfig.EmbeddingEnabled {
-				embedClient := ai.NewEmbeddingClient(config.AppConfig.OpenAIAPIKey)
+				// Wire the embedding store as a content-hash cache so
+				// repeated embeds of identical text (e.g. "Foundation
+				// by Isaac Asimov" appearing as a candidate across
+				// many metadata fetches) return instantly without
+				// re-hitting OpenAI. Added after the 2026-04-11 quota
+				// incident where a single bulk fetch burned the
+				// entire monthly budget by re-embedding every
+				// candidate on every fetch.
+				embedClient := ai.NewEmbeddingClient(config.AppConfig.OpenAIAPIKey).
+					WithCache(embeddingStore)
 				// Dedup Layer 3 uses a dedicated chat parser so it can call
 				// OpenAIParser.ReviewDedupPairs during maintenance runs.
 				llmParser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)


### PR DESCRIPTION
## Summary

**Urgent fix for the OpenAI quota incident on 2026-04-11.** The metadata scorer was re-embedding every candidate on every metadata fetch — no content-hash cache existed, so \"Foundation by Isaac Asimov\" appearing as a candidate across 20 different fetches cost 20 separate OpenAI API calls. On 2026-04-11 this burned the entire monthly OpenAI budget in minutes on a single bulk fetch.

This PR adds a content-hash cache layer so repeat embeds of identical text return instantly with zero API cost.

## What shipped

### \`internal/database/embedding_store.go\` — cache persistence
- \`GetCachedEmbedding(textHash, model) → []float32, error\`
- \`PutCachedEmbedding(textHash, model, vec) error\`
- Reuses the existing \`embeddings\` table under an \`entity_type='cache'\` keyspace (no new sidecar per the \"SQLite for specific things only\" directive)
- Primary key composes \`cache:<model>:<textHash>\` so different models for the same text live in separate rows
- Schema already had \`idx_embeddings_hash\` so lookups are fast

### \`internal/ai/embedding_client.go\` — cache integration
- New \`EmbeddingCache\` interface (minimal surface, no import of \`internal/database\` — avoids the circular dependency)
- \`EmbeddingClient.WithCache(cache)\` attaches a cache to an existing client
- \`EmbedBatch\` partitions inputs into cache hits and misses:
  - Hits are served from the cache at **zero API cost**
  - Misses are batched into a **single OpenAI call**
  - New vectors are written back to the cache before returning
- All cache I/O errors are logged but non-fatal — cache is an optimization, not a correctness layer
- Extracted \`embedBatchRaw\` as a function-valued field (\`rawEmbed\`) so tests can inject a fake API without a real OpenAI key

### \`internal/server/server.go\` — wiring
- \`ai.NewEmbeddingClient(...).WithCache(embeddingStore)\` at startup

## Expected impact

- **First fetch of a new title:** same cost as before (1 API call for the batch of candidates).
- **Every subsequent fetch with ANY overlap:** overlapping candidates cost zero API calls.
- **Bulk \"find all 8000 books\" re-runs:** after the first pass, near-zero API cost on re-runs because every candidate has already been embedded.

The production server currently has \`MetadataEmbeddingScoringEnabled=false\` as an emergency stop. **After this deploys, the flag can be flipped back on** — future scoring will use the cache and the quota stays protected.

## Tests

- \`TestEmbeddingStore_ContentHashCache\` — round-trip, model isolation (same hash across two models → two rows), empty-arg short-circuit
- \`TestEmbedBatch_NoCache_CallsAPIOnce\` — baseline
- \`TestEmbedBatch_AllHits_ZeroAPICalls\` — happy path
- \`TestEmbedBatch_MixedHitsAndMisses_APICalledOnceForMisses\` — verifies result-order preservation across the cache-vs-API partition
- \`TestEmbedBatch_CacheGetError_FallsBackToAPI\` — cache read failure must never fail the call
- \`TestEmbedBatch_EmptyInput_NoAPICallNoError\` — edge case

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/ai/ ./internal/database/ ./internal/server/...\` all green
- [ ] **Deploy to prod**
- [ ] **Flip \`metadata_embedding_scoring_enabled\` back to true** via Settings or API
- [ ] Run a small metadata fetch (~10 books) and confirm log line shows \`embedding cache: 0/10 hits, 10 misses sent to API\`
- [ ] Re-run the same fetch and confirm log line shows \`embedding cache: 10/10 hits, 0 API calls\` — this is the success signal

## Follow-up (not in this PR)

- **§7.5 Metadata fetch caching** — the OTHER kind of caching: cache the raw Hardcover/Audible API responses, not just the embeddings. Complements this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)