### PR TITLE
feat(metadata-review): language filter — hide cross-language candidates

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -34,6 +34,14 @@ type CandidateBookInfo struct {
 	Format     string `json:"format,omitempty"`
 	Duration   int    `json:"duration_seconds,omitempty"`
 	FileSize   int64  `json:"file_size_bytes,omitempty"`
+	// Language is the book's current language as stored on the
+	// Book row (ISO code or full name, whatever was last applied).
+	// Used by the review dialog's language filter to hide
+	// candidates whose language disagrees with the book's — the
+	// motivating Spanish/English "Ancillary Sword" screenshot fix.
+	// Empty when the book has no language set, in which case the
+	// filter is a no-op for that row.
+	Language string `json:"language,omitempty"`
 }
 
 // CandidateResult holds the metadata candidate search result for a single book.
@@ -299,6 +307,9 @@ func buildCandidateBookInfo(book *database.Book) CandidateBookInfo {
 	}
 	if book.FileSize != nil {
 		info.FileSize = *book.FileSize
+	}
+	if book.Language != nil {
+		info.Language = *book.Language
 	}
 	return info
 }

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -53,6 +53,66 @@ const SOURCE_COLORS: Record<string, 'primary' | 'secondary' | 'success' | 'warni
 // across pagination controls.
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250];
 
+// Language filter: when enabled (default), candidates whose
+// language disagrees with the book's are hidden. Preference
+// persists in localStorage so users don't re-enable it on
+// every dialog open.
+const LANGUAGE_FILTER_KEY = 'metadata-review-language-filter';
+
+function loadLanguageFilter(): boolean {
+  if (typeof window === 'undefined') return true;
+  const raw = window.localStorage.getItem(LANGUAGE_FILTER_KEY);
+  return raw === null ? true : raw === 'true';
+}
+
+// Normalizes a language string to an ISO 639-1 2-letter code
+// for comparison. Mirrors the server-side metadataLanguageTag
+// logic — the review dialog filter compares book.language
+// against candidate.language, and both sides might come from
+// different source APIs that return the language in different
+// formats (full name, 2-letter code, 3-letter code).
+//
+// Returns the lowercased input for unknown languages so the
+// filter still works via string equality.
+function normalizeLanguage(lang: string | undefined | null): string {
+  if (!lang) return '';
+  const s = lang.trim().toLowerCase();
+  if (!s) return '';
+  const canonical: Record<string, string> = {
+    english: 'en',
+    eng: 'en',
+    spanish: 'es',
+    spa: 'es',
+    french: 'fr',
+    fre: 'fr',
+    fra: 'fr',
+    german: 'de',
+    ger: 'de',
+    deu: 'de',
+    italian: 'it',
+    ita: 'it',
+    japanese: 'ja',
+    jpn: 'ja',
+    chinese: 'zh',
+    chi: 'zh',
+    zho: 'zh',
+    mandarin: 'zh',
+    portuguese: 'pt',
+    por: 'pt',
+    russian: 'ru',
+    rus: 'ru',
+    dutch: 'nl',
+    nld: 'nl',
+    korean: 'ko',
+    kor: 'ko',
+    arabic: 'ar',
+    ara: 'ar',
+  };
+  if (canonical[s]) return canonical[s];
+  if (s.length === 2) return s;
+  return s;
+}
+
 // Persist the review page size in localStorage so users don't have
 // to re-select it every time they open the dialog. The activity log
 // uses session-only state, but the review dialog is opened ad-hoc
@@ -104,6 +164,7 @@ export function MetadataReviewDialog({
   const [hideApplied, setHideApplied] = useState(true);
   const [hideRejected, setHideRejected] = useState(true);
   const [hideNoMatch, setHideNoMatch] = useState(true);
+  const [matchLanguage, setMatchLanguage] = useState<boolean>(loadLanguageFilter);
 
   useEffect(() => {
     if (!open || !operationId) return;
@@ -180,12 +241,26 @@ export function MetadataReviewDialog({
     )
     .filter((r) => !hideApplied || rowStates.get(r.book.id) !== 'applied')
     .filter((r) => !hideRejected || rowStates.get(r.book.id) !== 'rejected')
-    .filter((r) => !hideNoMatch || (r.status !== 'no_match' && r.status !== 'error'));
+    .filter((r) => !hideNoMatch || (r.status !== 'no_match' && r.status !== 'error'))
+    .filter((r) => {
+      // Language filter: hide candidates whose language
+      // doesn't match the book's. Only active when the toggle
+      // is on AND both the book and candidate have a language
+      // set — an unknown language on either side is a
+      // no-op (show the row) so new books without metadata
+      // still get candidates offered to them.
+      if (!matchLanguage) return true;
+      if (!r.candidate) return true;
+      const bookLang = normalizeLanguage(r.book.language);
+      const candLang = normalizeLanguage(r.candidate.language);
+      if (!bookLang || !candLang) return true;
+      return bookLang === candLang;
+    });
 
   // Reset page when filters change
   useEffect(() => {
     setReviewPage(1);
-  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideNoMatch]);
+  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideNoMatch, matchLanguage]);
 
   // Coalesce rapid Apply clicks into one batched API call
   const applyQueueRef = useRef<string[]>([]);
@@ -904,6 +979,27 @@ export function MetadataReviewDialog({
                   }
                   label={<Typography variant="body2">Hide No Match</Typography>}
                 />
+                <Tooltip title="Hide candidates whose language doesn't match the book's current language. Books without a language set still show all candidates.">
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        size="small"
+                        checked={matchLanguage}
+                        onChange={(e) => {
+                          const next = e.target.checked;
+                          setMatchLanguage(next);
+                          if (typeof window !== 'undefined') {
+                            window.localStorage.setItem(
+                              LANGUAGE_FILTER_KEY,
+                              String(next)
+                            );
+                          }
+                        }}
+                      />
+                    }
+                    label={<Typography variant="body2">Match Language</Typography>}
+                  />
+                </Tooltip>
               </Stack>
 
               {/* Smart action buttons */}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2623,6 +2623,11 @@ export interface CandidateBookInfo {
   format?: string;
   duration_seconds?: number;
   file_size_bytes?: number;
+  // Book's current language (ISO code or full name). Used by
+  // the review dialog's language filter to hide candidates
+  // whose language disagrees with the book's. Empty means
+  // "unknown" — filter is a no-op for that row.
+  language?: string;
 }
 
 export interface CandidateResult {


### PR DESCRIPTION
## Summary

Motivating fix for the Spanish/English \"Ancillary Sword\" screenshot from earlier in the session. The review dialog now has a **Match Language** toggle (default on, persisted in localStorage) that hides candidates whose language disagrees with the book's current language.

Depends on [#246](https://github.com/jdfalk/audiobook-organizer/pull/246) (metadata-apply tagging) so books actually have a language set to compare against.

## Backend

\`CandidateBookInfo\` gains a \`Language\` field populated from \`book.Language\` in \`buildCandidateBookInfo\`. The dialog has the data it needs without a second fetch.

## Frontend

- \`CandidateBookInfo\` TypeScript type gains \`language?: string\`
- New \`normalizeLanguage()\` helper mirrors the server-side \`metadataLanguageTag()\` logic — handles ISO-639-1 codes, ISO-639-2 codes, and English names
- Filter chain gains a language predicate: allow when toggle is off, either side has no language, or the normalized codes match
- New \"Match Language\" \`Switch\` in the filter row with a tooltip explaining the \"show everything when unknown\" behavior

## Behavior matrix

| Book language | Candidate language | Filter | Result |
|---|---|---|---|
| en | en | on | show |
| en | es | on | **hide** |
| en | es | off | show |
| (none) | es | on | show (unknown book) |
| en | (none) | on | show (unknown candidate) |

## Test plan

- [x] Backend builds + vet clean
- [x] \`tsc --noEmit\` clean, \`eslint\` clean
- [ ] Deploy, open review dialog with a mix of Spanish/English candidates, verify the Spanish row disappears when Match Language is on and reappears when off

Refs: backlog 7.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)