### PR TITLE
feat(tags): visual distinction for user vs system tags

### DIFF
--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -911,6 +911,33 @@ func (s *Server) getBookUserTags(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"tags": tags})
 }
 
+// getBookTagsDetailed returns a book's tags with their source
+// attribution ('user' vs 'system'), so the frontend can render
+// user-applied and system-applied tags differently. System tags
+// follow the namespace from migrations 47/48 — dedup:*,
+// metadata:source:*, metadata:language:*, etc. — and should be
+// shown as outlined, non-deletable chips by default.
+//
+// Backlog 7.8. Separate endpoint from /user-tags so existing
+// callers that only want the string list don't pay for the
+// source lookup.
+func (s *Server) getBookTagsDetailed(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		return
+	}
+	tags, err := database.GlobalStore.GetBookTagsDetailed(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if tags == nil {
+		tags = []database.BookTag{}
+	}
+	c.JSON(http.StatusOK, gin.H{"tags": tags})
+}
+
 // getBookAlternativeTitles handles GET /audiobooks/:id/alternative-titles.
 // Returns the list of alt titles for a book along with source/language
 // metadata so the UI can show where each came from.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1690,6 +1690,10 @@ func (s *Server) setupRoutes() {
 			// User tag routes
 			protected.GET("/tags", s.listAllUserTags)
 			protected.GET("/audiobooks/:id/user-tags", s.getBookUserTags)
+			// Detailed tag route: returns tag+source pairs so the
+			// UI can render system-applied tags (dedup:*,
+			// metadata:source:*, etc.) differently from user tags.
+			protected.GET("/audiobooks/:id/tags-detailed", s.getBookTagsDetailed)
 			protected.POST("/audiobooks/batch-tags", s.batchUpdateTags)
 
 			// Book alternative titles

--- a/web/src/components/audiobooks/TagEditor.tsx
+++ b/web/src/components/audiobooks/TagEditor.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/TagEditor.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: b3c4d5e6-f7a8-4b9c-0d1e-2f3a4b5c6d7e
 
 import React, { useState, useRef } from 'react';
@@ -11,6 +11,7 @@ import {
   Popover,
   Button,
   Stack,
+  Tooltip,
 } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import * as api from '../../services/api';
@@ -18,15 +19,56 @@ import * as api from '../../services/api';
 interface TagEditorProps {
   bookId: string;
   tags: string[];
+  // detailedTags, when provided, carries per-tag source
+  // attribution so user and system tags render differently.
+  // Takes precedence over `tags` for display; `tags` is still
+  // used for dedup/normalization checks during add.
+  detailedTags?: api.DetailedBookTag[];
   allTags?: string[];
   onTagsChange?: (tags: string[]) => void;
   readOnly?: boolean;
   compact?: boolean;
 }
 
+// isSystemTag checks whether a tag's source marks it as
+// server-applied provenance (not user-editable by default).
+function isSystemTag(source: string | undefined): boolean {
+  return source === 'system';
+}
+
+// systemTagCategory returns the top-level namespace of a system
+// tag (e.g. "dedup", "metadata") so we can color-code by
+// category. Unknown namespaces fall through to "default".
+function systemTagCategory(tag: string): 'dedup' | 'metadata' | 'import' | 'organize' | 'default' {
+  if (tag.startsWith('dedup:')) return 'dedup';
+  if (tag.startsWith('metadata:')) return 'metadata';
+  if (tag.startsWith('import:')) return 'import';
+  if (tag.startsWith('organize:')) return 'organize';
+  return 'default';
+}
+
+// systemTagColor maps a category to a MUI chip color. Soft
+// outlined chips so system tags feel like "info" rather than
+// "actions I can take".
+function systemTagColor(tag: string): 'default' | 'primary' | 'secondary' | 'info' | 'warning' {
+  switch (systemTagCategory(tag)) {
+    case 'dedup':
+      return 'warning';
+    case 'metadata':
+      return 'info';
+    case 'import':
+      return 'secondary';
+    case 'organize':
+      return 'primary';
+    default:
+      return 'default';
+  }
+}
+
 export const TagEditor: React.FC<TagEditorProps> = ({
   bookId,
   tags,
+  detailedTags,
   allTags = [],
   onTagsChange,
   readOnly = false,
@@ -35,6 +77,17 @@ export const TagEditor: React.FC<TagEditorProps> = ({
   const [inputValue, setInputValue] = useState('');
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Build the render list — detailedTags when available, else
+  // fall back to string-only tags (rendered as user tags).
+  // Split into system and user groups so we can render them in
+  // two rows with different styling.
+  const effectiveTags: api.DetailedBookTag[] = detailedTags
+    ? detailedTags
+    : tags.map((t) => ({ tag: t, source: 'user', created_at: '' }));
+
+  const userTags = effectiveTags.filter((t) => !isSystemTag(t.source));
+  const systemTags = effectiveTags.filter((t) => isSystemTag(t.source));
 
   const availableSuggestions = allTags.filter(
     (t) => !tags.includes(t.toLowerCase())
@@ -61,20 +114,42 @@ export const TagEditor: React.FC<TagEditorProps> = ({
     }
   };
 
+  // renderSystemChip and renderUserChip keep the two styles
+  // separate. System chips are outlined, color-coded by
+  // namespace, and have no delete action — the user can't
+  // accidentally remove server-applied provenance.
+  const renderSystemChip = (bt: api.DetailedBookTag) => (
+    <Tooltip
+      key={`sys:${bt.tag}`}
+      title={`System tag (${bt.source}) — applied automatically by the server`}
+    >
+      <Chip
+        label={bt.tag}
+        size="small"
+        variant="outlined"
+        color={systemTagColor(bt.tag)}
+        sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}
+      />
+    </Tooltip>
+  );
+
+  const renderUserChip = (bt: api.DetailedBookTag) => (
+    <Chip
+      key={`usr:${bt.tag}`}
+      label={bt.tag}
+      size="small"
+      variant="outlined"
+      onDelete={readOnly ? undefined : () => handleRemoveTag(bt.tag)}
+    />
+  );
+
   const popoverOpen = Boolean(anchorEl);
 
   if (compact) {
     return (
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
-        {tags.map((tag) => (
-          <Chip
-            key={tag}
-            label={tag}
-            size="small"
-            variant="outlined"
-            onDelete={readOnly ? undefined : () => handleRemoveTag(tag)}
-          />
-        ))}
+        {userTags.map(renderUserChip)}
+        {systemTags.map(renderSystemChip)}
         {!readOnly && (
           <>
             <Button
@@ -135,16 +210,13 @@ export const TagEditor: React.FC<TagEditorProps> = ({
   return (
     <Stack spacing={1}>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-        {tags.map((tag) => (
-          <Chip
-            key={tag}
-            label={tag}
-            size="small"
-            variant="outlined"
-            onDelete={readOnly ? undefined : () => handleRemoveTag(tag)}
-          />
-        ))}
+        {userTags.map(renderUserChip)}
       </Box>
+      {systemTags.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {systemTags.map(renderSystemChip)}
+        </Box>
+      )}
       {!readOnly && (
         <Autocomplete
           freeSolo

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -3512,6 +3512,34 @@ export async function removeBookUserTag(
   return data.tags;
 }
 
+// DetailedBookTag carries the source attribution alongside the
+// tag string. `source='user'` is a human-applied label; everything
+// else (`system`, potentially future sources) is server-applied
+// provenance and should be rendered as non-deletable in the UI.
+export interface DetailedBookTag {
+  tag: string;
+  source: string;
+  created_at: string;
+}
+
+// getBookTagsDetailed returns tags with their source attribution
+// so the frontend can render user-applied and system-applied
+// tags differently. System tags follow the namespace from
+// migrations 47/48 — dedup:*, metadata:source:*, metadata:language:*,
+// etc. — and are the result of automatic server-side actions.
+export async function getBookTagsDetailed(
+  bookId: string
+): Promise<DetailedBookTag[]> {
+  const response = await fetch(
+    `${API_BASE}/audiobooks/${bookId}/tags-detailed`
+  );
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to get detailed tags');
+  }
+  const data = await response.json();
+  return (data.tags || []) as DetailedBookTag[];
+}
+
 export async function bulkUpdateTags(
   bookIds: string[],
   addTags: string[],


### PR DESCRIPTION
## Summary

Adds the data path for rendering user-applied and system-applied tags differently in the UI. System tags (\`dedup:*\`, \`metadata:source:*\`, \`metadata:language:*\`) are shown as outlined color-coded chips without a delete affordance, so users can't accidentally remove server-applied provenance.

## Backend
- New \`GET /audiobooks/:id/tags-detailed\` returns \`[]BookTag\` (tag + source + created_at) — separate from \`/user-tags\` so the string-list callers don't pay for the source lookup.

## Frontend
- \`DetailedBookTag\` TypeScript interface + \`getBookTagsDetailed()\` fetcher
- \`TagEditor\` gains a \`detailedTags\` prop (backward compatible). System tags render as outlined, color-coded monospace chips with a tooltip, no delete action. Category colors: dedup=warning, metadata=info, import=secondary, organize=primary.

## Not in this PR (follow-up)

Wiring \`TagEditor\` into BookDetail — it was orphan code before this PR and BookDetail doesn't currently show book-level user tags at all. The component is ready to drop in.

Refs: backlog 7.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)