### PR TITLE
feat(metadata): cache external API fetches by (book, source)

### DIFF
--- a/internal/database/metadata_fetch_cache.go
+++ b/internal/database/metadata_fetch_cache.go
@@ -1,0 +1,140 @@
+// file: internal/database/metadata_fetch_cache.go
+// version: 1.0.0
+// guid: 9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MetadataFetchCache caches external metadata API responses
+// keyed by (book_id, source_name). Added after the 2026-04-11
+// OpenAI quota incident and subsequent user complaint that
+// re-fetching 8000 books re-hit every external API for every
+// book even when the result was identical — books don't change
+// meaningfully between fetches, so repeat API calls are just
+// wasted quota and user review time.
+//
+// The cache sits INSIDE the metadata fetch path: before any
+// Search* call on a MetadataSource, the service asks the cache
+// for a hit; on hit, the cached results are returned; on miss,
+// the external API is called and the results are written back
+// to the cache.
+//
+// Storage uses the Store's raw key-value methods (SetRaw /
+// GetRaw / DeleteRaw) so the cache works against whichever
+// primary store the user picked — Pebble today, possibly
+// Postgres or CockroachDB in the future — without needing
+// backend-specific migrations.
+//
+// Cache keys are namespaced under "metadata_fetch_cache:" so
+// a ScanPrefix can list every cached entry for diagnostics
+// or wholesale invalidation.
+
+// CachedMetadataEntry is the serialized shape of a cache row.
+// The CachedAt timestamp exists so an optional TTL policy can
+// filter stale entries; the current implementation never
+// expires, but the timestamp is recorded for future use and
+// for the diagnostics surface.
+type CachedMetadataEntry struct {
+	BookID    string            `json:"book_id"`
+	Source    string            `json:"source"`
+	Results   json.RawMessage   `json:"results"`         // []metadata.BookMetadata, left as RawMessage so this package doesn't need to import internal/metadata
+	BestScore float64           `json:"best_score"`
+	CachedAt  time.Time         `json:"cached_at"`
+	Extra     map[string]string `json:"extra,omitempty"` // reserved for future use (language tag, TTL override, etc.)
+}
+
+// metadataFetchCacheKey formats the storage key for a
+// (bookID, source) pair. Kept stable so cache entries survive
+// across restarts. Source names are lowercased to avoid
+// "Hardcover" vs "hardcover" drift.
+func metadataFetchCacheKey(bookID, source string) string {
+	return "metadata_fetch_cache:" + bookID + ":" + strings.ToLower(strings.TrimSpace(source))
+}
+
+// GetCachedMetadataFetch looks up a cache entry. Returns nil
+// on miss (not an error). The returned Results slice is the
+// raw JSON payload the caller originally stored — the caller
+// is responsible for unmarshalling it into its own type.
+func GetCachedMetadataFetch(store Store, bookID, source string) (*CachedMetadataEntry, error) {
+	if bookID == "" || source == "" {
+		return nil, nil
+	}
+	blob, err := store.GetRaw(metadataFetchCacheKey(bookID, source))
+	if err != nil {
+		return nil, fmt.Errorf("cache get: %w", err)
+	}
+	if blob == nil {
+		return nil, nil
+	}
+	var entry CachedMetadataEntry
+	if err := json.Unmarshal(blob, &entry); err != nil {
+		// Corrupt entry — treat as a miss and delete it so
+		// the next call writes a fresh row.
+		_ = store.DeleteRaw(metadataFetchCacheKey(bookID, source))
+		return nil, nil
+	}
+	return &entry, nil
+}
+
+// PutCachedMetadataFetch writes a cache entry. The `results`
+// parameter is pre-marshalled JSON so this package doesn't
+// need to depend on internal/metadata for the type.
+//
+// Writes are best-effort — a cache put failure is logged by
+// the caller but never fails the outer fetch, per the same
+// principle as the embedding cache: the cache is an
+// optimization, not a correctness layer.
+func PutCachedMetadataFetch(store Store, bookID, source string, results json.RawMessage, bestScore float64) error {
+	if bookID == "" || source == "" {
+		return nil
+	}
+	entry := CachedMetadataEntry{
+		BookID:    bookID,
+		Source:    strings.ToLower(strings.TrimSpace(source)),
+		Results:   results,
+		BestScore: bestScore,
+		CachedAt:  time.Now().UTC(),
+	}
+	blob, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("cache marshal: %w", err)
+	}
+	return store.SetRaw(metadataFetchCacheKey(bookID, source), blob)
+}
+
+// InvalidateCachedMetadataFetch removes the cache entry for
+// a single (bookID, source) pair. Called after a metadata
+// apply so the next fetch refreshes from the source.
+func InvalidateCachedMetadataFetch(store Store, bookID, source string) error {
+	if bookID == "" || source == "" {
+		return nil
+	}
+	return store.DeleteRaw(metadataFetchCacheKey(bookID, source))
+}
+
+// InvalidateAllCachedMetadataFetchesForBook wipes every source's
+// cache entry for a single book. Called when the book's title
+// or author changes — any cached candidate is now stale because
+// it was queried against different search terms.
+func InvalidateAllCachedMetadataFetchesForBook(store Store, bookID string) error {
+	if bookID == "" {
+		return nil
+	}
+	prefix := "metadata_fetch_cache:" + bookID + ":"
+	pairs, err := store.ScanPrefix(prefix)
+	if err != nil {
+		return fmt.Errorf("cache scan: %w", err)
+	}
+	for _, kv := range pairs {
+		if err := store.DeleteRaw(kv.Key); err != nil {
+			return fmt.Errorf("cache delete %s: %w", kv.Key, err)
+		}
+	}
+	return nil
+}

--- a/internal/database/metadata_fetch_cache_test.go
+++ b/internal/database/metadata_fetch_cache_test.go
@@ -1,0 +1,150 @@
+// file: internal/database/metadata_fetch_cache_test.go
+// version: 1.1.0
+// guid: 6f5e4d3c-2b1a-0f9e-8d7c-6b5a4f3e2d1c
+
+package database
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newCacheTestStore returns a :memory: SQLiteStore for the
+// metadata fetch cache tests. The cache only needs the raw
+// kv_store table (created lazily by SetRaw/GetRaw), so we
+// don't need to run migrations.
+func newCacheTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestMetadataFetchCache_RoundTrip verifies basic put/get
+// semantics. Put a payload, read it back, compare.
+func TestMetadataFetchCache_RoundTrip(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	payload := json.RawMessage(`[{"title":"Dune","author":"Frank Herbert"}]`)
+	if err := PutCachedMetadataFetch(store, "book-1", "Hardcover", payload, 0.95); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	entry, err := GetCachedMetadataFetch(store, "book-1", "Hardcover")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected cache hit, got nil")
+	}
+	if string(entry.Results) != string(payload) {
+		t.Errorf("results = %s, want %s", entry.Results, payload)
+	}
+	if entry.BestScore != 0.95 {
+		t.Errorf("best_score = %v, want 0.95", entry.BestScore)
+	}
+	// Source is stored lowercased.
+	if entry.Source != "hardcover" {
+		t.Errorf("source = %q, want 'hardcover'", entry.Source)
+	}
+}
+
+// TestMetadataFetchCache_Miss confirms nil+nil on miss so
+// callers can branch without a sentinel error.
+func TestMetadataFetchCache_Miss(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	entry, err := GetCachedMetadataFetch(store, "book-unknown", "Hardcover")
+	if err != nil {
+		t.Fatalf("unexpected error on miss: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("expected nil entry on miss, got %+v", entry)
+	}
+}
+
+// TestMetadataFetchCache_CaseInsensitiveSource locks in that
+// "Hardcover" and "hardcover" resolve to the same cache row.
+// Drift here would silently duplicate cache entries.
+func TestMetadataFetchCache_CaseInsensitiveSource(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	payload := json.RawMessage(`[]`)
+	if err := PutCachedMetadataFetch(store, "book-1", "Hardcover", payload, 0); err != nil {
+		t.Fatal(err)
+	}
+	entry, err := GetCachedMetadataFetch(store, "book-1", "hardcover")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry == nil {
+		t.Fatal("expected hit when source case differs")
+	}
+}
+
+// TestMetadataFetchCache_Invalidate confirms per-(book, source)
+// invalidation works.
+func TestMetadataFetchCache_Invalidate(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	_ = PutCachedMetadataFetch(store, "book-1", "Hardcover", json.RawMessage(`[]`), 0)
+	if err := InvalidateCachedMetadataFetch(store, "book-1", "Hardcover"); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	entry, _ := GetCachedMetadataFetch(store, "book-1", "Hardcover")
+	if entry != nil {
+		t.Errorf("expected miss after invalidate, got hit")
+	}
+}
+
+// TestMetadataFetchCache_InvalidateAllForBook wipes every
+// source entry for a book without touching other books.
+func TestMetadataFetchCache_InvalidateAllForBook(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	_ = PutCachedMetadataFetch(store, "book-1", "Hardcover", json.RawMessage(`[]`), 0)
+	_ = PutCachedMetadataFetch(store, "book-1", "Audible", json.RawMessage(`[]`), 0)
+	_ = PutCachedMetadataFetch(store, "book-2", "Hardcover", json.RawMessage(`[]`), 0)
+
+	if err := InvalidateAllCachedMetadataFetchesForBook(store, "book-1"); err != nil {
+		t.Fatalf("invalidate all: %v", err)
+	}
+
+	// book-1 entries gone.
+	if e, _ := GetCachedMetadataFetch(store, "book-1", "Hardcover"); e != nil {
+		t.Error("book-1 Hardcover should be gone")
+	}
+	if e, _ := GetCachedMetadataFetch(store, "book-1", "Audible"); e != nil {
+		t.Error("book-1 Audible should be gone")
+	}
+	// book-2 entry still there.
+	if e, _ := GetCachedMetadataFetch(store, "book-2", "Hardcover"); e == nil {
+		t.Error("book-2 Hardcover should have survived")
+	}
+}
+
+// TestMetadataFetchCache_CorruptEntry_TreatedAsMiss verifies
+// that a garbage cache value is transparently treated as a
+// miss instead of a hard error, and the corrupt row is
+// cleaned up so the next write lands in a clean slot.
+func TestMetadataFetchCache_CorruptEntry_TreatedAsMiss(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	// Hand-poison a cache key with non-JSON bytes.
+	_ = store.SetRaw(metadataFetchCacheKey("book-1", "Hardcover"), []byte("not json"))
+
+	entry, err := GetCachedMetadataFetch(store, "book-1", "Hardcover")
+	if err != nil {
+		t.Fatalf("unexpected error on corrupt entry: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("expected nil entry on corrupt row, got %+v", entry)
+	}
+	// The corrupt row should have been cleaned up during the read.
+	raw, _ := store.GetRaw(metadataFetchCacheKey("book-1", "Hardcover"))
+	if raw != nil {
+		t.Errorf("expected corrupt entry to be cleaned up, still got %d bytes", len(raw))
+	}
+}

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1471,6 +1471,7 @@ func (m *MockStore) GetRemovedExternalIDs(source string) ([]ExternalIDMapping, e
 }
 
 func (m *MockStore) SetRaw(key string, value []byte) error      { return nil }
+func (m *MockStore) GetRaw(key string) ([]byte, error)          { return nil, nil }
 func (m *MockStore) DeleteRaw(key string) error                 { return nil }
 func (m *MockStore) ScanPrefix(prefix string) ([]KVPair, error) { return nil, nil }
 func (m *MockStore) CreateOperationResult(result *OperationResult) error       { return nil }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -8461,6 +8461,68 @@ func (_c *MockStore_GetPlaylistItems_Call) RunAndReturn(run func(playlistID int)
 	return _c
 }
 
+// GetRaw provides a mock function for the type MockStore
+func (_mock *MockStore) GetRaw(key string) ([]byte, error) {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRaw")
+	}
+
+	var r0 []byte
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
+		return returnFunc(key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = returnFunc(key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRaw'
+type MockStore_GetRaw_Call struct {
+	*mock.Call
+}
+
+// GetRaw is a helper method to define mock.On call
+//   - key string
+func (_e *MockStore_Expecter) GetRaw(key interface{}) *MockStore_GetRaw_Call {
+	return &MockStore_GetRaw_Call{Call: _e.mock.On("GetRaw", key)}
+}
+
+func (_c *MockStore_GetRaw_Call) Run(run func(key string)) *MockStore_GetRaw_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetRaw_Call) Return(bytes []byte, err error) *MockStore_GetRaw_Call {
+	_c.Call.Return(bytes, err)
+	return _c
+}
+
+func (_c *MockStore_GetRaw_Call) RunAndReturn(run func(key string) ([]byte, error)) *MockStore_GetRaw_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRecentCompletedOperations provides a mock function for the type MockStore
 func (_mock *MockStore) GetRecentCompletedOperations(limit int) ([]database.Operation, error) {
 	ret := _mock.Called(limit)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -4272,6 +4272,24 @@ func (p *PebbleStore) SetRaw(key string, value []byte) error {
 	return p.db.Set([]byte(key), value, pebble.Sync)
 }
 
+// GetRaw reads a single key. Returns (nil, nil) on miss so callers
+// can handle cache-style lookups with a two-valued result instead
+// of a sentinel error.
+func (p *PebbleStore) GetRaw(key string) ([]byte, error) {
+	val, closer, err := p.db.Get([]byte(key))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	// Copy because the closer frees the underlying bytes.
+	out := make([]byte, len(val))
+	copy(out, val)
+	return out, nil
+}
+
 func (p *PebbleStore) DeleteRaw(key string) error {
 	return p.db.Delete([]byte(key), pebble.Sync)
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -3267,6 +3267,22 @@ func (s *SQLiteStore) SetRaw(key string, value []byte) error {
 	return err
 }
 
+// GetRaw reads a single kv_store row. Returns (nil, nil) on miss so
+// callers can handle cache-style lookups with a two-valued result
+// rather than a sentinel error.
+func (s *SQLiteStore) GetRaw(key string) ([]byte, error) {
+	s.db.Exec(`CREATE TABLE IF NOT EXISTS kv_store (key TEXT PRIMARY KEY, value BLOB)`)
+	var value []byte
+	err := s.db.QueryRow(`SELECT value FROM kv_store WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
 func (s *SQLiteStore) DeleteRaw(key string) error {
 	_, err := s.db.Exec(`DELETE FROM kv_store WHERE key = ?`, key)
 	return err

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -349,6 +349,12 @@ type Store interface {
 
 	// Low-level key-value operations (for persistent tracking)
 	SetRaw(key string, value []byte) error
+	// GetRaw reads a single key. Returns (nil, nil) on miss —
+	// callers should treat a nil value + nil error as "not found"
+	// so they don't need a sentinel error constant. Used by
+	// cache layers and anywhere else that needs a lightweight
+	// key-value lookup against the primary store.
+	GetRaw(key string) ([]byte, error)
 	DeleteRaw(key string) error
 	ScanPrefix(prefix string) ([]KVPair, error)
 

--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -2003,50 +2003,86 @@ func (mfs *MetadataFetchService) SearchMetadataForBookWithOptions(
 		var allResults []metadata.BookMetadata
 		var lastErr error
 		sourcesTried = append(sourcesTried, src.Name())
+		cacheHit := false
 
-		// If author hint provided, use title+author search for better results
-		if searchAuthor != "" {
-			if results, serr := src.SearchByTitleAndAuthor(searchTitle, searchAuthor); serr == nil {
+		// Check the metadata fetch cache before hitting the
+		// external API. Cache key is (bookID, source name) —
+		// on hit, we use the cached results as-is and skip the
+		// Search* calls entirely. On miss we fall through to
+		// the API path and write the result back at the end
+		// of the per-source block.
+		//
+		// Added 2026-04-11 after the OpenAI quota incident
+		// where re-fetching 8000 books hit every external API
+		// 8000 times even for books we'd already matched with
+		// high confidence.
+		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
+			var cachedResults []metadata.BookMetadata
+			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
+				allResults = cachedResults
+				cacheHit = true
+				log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
+					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+			}
+		}
+
+		if !cacheHit {
+			// If author hint provided, use title+author search for better results
+			if searchAuthor != "" {
+				if results, serr := src.SearchByTitleAndAuthor(searchTitle, searchAuthor); serr == nil {
+					allResults = append(allResults, results...)
+				} else {
+					lastErr = serr
+					log.Printf("[DEBUG] metadata-search: %s SearchByTitleAndAuthor(%q, %q) error: %v", src.Name(), searchTitle, searchAuthor, serr)
+				}
+			}
+
+			// Narrator-as-author fallback: author/narrator fields are frequently
+			// swapped in audiobook metadata. Try searching with the narrator as
+			// author to catch these cases.
+			if bookNarrator != "" && bookNarrator != searchAuthor {
+				if results, serr := src.SearchByTitleAndAuthor(searchTitle, bookNarrator); serr == nil {
+					allResults = append(allResults, results...)
+				} else {
+					log.Printf("[DEBUG] metadata-search: %s narrator-as-author fallback(%q, %q) error: %v", src.Name(), searchTitle, bookNarrator, serr)
+				}
+			}
+
+			// Always also search by title only to get broader results
+			if results, serr := src.SearchByTitle(searchTitle); serr == nil {
 				allResults = append(allResults, results...)
 			} else {
 				lastErr = serr
-				log.Printf("[DEBUG] metadata-search: %s SearchByTitleAndAuthor(%q, %q) error: %v", src.Name(), searchTitle, searchAuthor, serr)
+				log.Printf("[DEBUG] metadata-search: %s SearchByTitle(%q) error: %v", src.Name(), searchTitle, serr)
+			}
+			// SearchByTitle with original title if different
+			if searchTitle != book.Title {
+				if results, serr := src.SearchByTitle(book.Title); serr == nil {
+					allResults = append(allResults, results...)
+				} else {
+					lastErr = serr
+				}
+			}
+
+			// If all calls failed (no results and there was an error), record it
+			if len(allResults) == 0 && lastErr != nil {
+				sourcesFailed[src.Name()] = lastErr.Error()
+			}
+
+			log.Printf("[DEBUG] metadata-search: %s returned %d raw results for %q", src.Name(), len(allResults), searchTitle)
+
+			// Write to cache on a successful non-empty fetch.
+			// Empty and error cases are not cached so they can
+			// be retried. Cache is best-effort — a Put failure
+			// is logged but doesn't fail the outer search.
+			if len(allResults) > 0 {
+				if blob, merr := json.Marshal(allResults); merr == nil {
+					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
+						log.Printf("[WARN] metadata-search: cache put failed for (%s, %s): %v", id, src.Name(), perr)
+					}
+				}
 			}
 		}
-
-		// Narrator-as-author fallback: author/narrator fields are frequently
-		// swapped in audiobook metadata. Try searching with the narrator as
-		// author to catch these cases.
-		if bookNarrator != "" && bookNarrator != searchAuthor {
-			if results, serr := src.SearchByTitleAndAuthor(searchTitle, bookNarrator); serr == nil {
-				allResults = append(allResults, results...)
-			} else {
-				log.Printf("[DEBUG] metadata-search: %s narrator-as-author fallback(%q, %q) error: %v", src.Name(), searchTitle, bookNarrator, serr)
-			}
-		}
-
-		// Always also search by title only to get broader results
-		if results, serr := src.SearchByTitle(searchTitle); serr == nil {
-			allResults = append(allResults, results...)
-		} else {
-			lastErr = serr
-			log.Printf("[DEBUG] metadata-search: %s SearchByTitle(%q) error: %v", src.Name(), searchTitle, serr)
-		}
-		// SearchByTitle with original title if different
-		if searchTitle != book.Title {
-			if results, serr := src.SearchByTitle(book.Title); serr == nil {
-				allResults = append(allResults, results...)
-			} else {
-				lastErr = serr
-			}
-		}
-
-		// If all calls failed (no results and there was an error), record it
-		if len(allResults) == 0 && lastErr != nil {
-			sourcesFailed[src.Name()] = lastErr.Error()
-		}
-
-		log.Printf("[DEBUG] metadata-search: %s returned %d raw results for %q", src.Name(), len(allResults), searchTitle)
 
 		baseScores, baseTier := mfs.scoreBaseCandidates(context.Background(), book, allResults, searchWords)
 		log.Printf("[DEBUG] metadata-search: scored %d results from %s with tier %s", len(allResults), src.Name(), baseTier)
@@ -2389,6 +2425,15 @@ func (mfs *MetadataFetchService) ApplyMetadataCandidate(id string, candidate Met
 	// a true no-op at the tag layer (no wasted writes). Done after
 	// UpdateBook so a failed update never leaves stale tags behind.
 	mfs.applyMetadataSystemTags(id, candidate.Source, meta.Language)
+
+	// Invalidate the metadata fetch cache for this book. After a
+	// successful apply the book's title/author may have changed,
+	// which means any cached candidates from the per-source cache
+	// were queried against stale search terms and should be
+	// re-fetched next time the user asks.
+	if cerr := database.InvalidateAllCachedMetadataFetchesForBook(mfs.db, id); cerr != nil {
+		log.Printf("[WARN] metadata apply: failed to invalidate fetch cache for %s: %v", id, cerr)
+	}
 
 	return &FetchMetadataResponse{
 		Message: "metadata candidate applied",


### PR DESCRIPTION
## Summary

Second phase of the API-cost fight. [#247](https://github.com/jdfalk/audiobook-organizer/pull/247) stopped re-embedding identical text in the OpenAI scorer; this PR stops re-fetching identical candidates from **Hardcover / Audible / Audnexus / Open Library / Google Books** for a book we've already looked up.

## How it works

- \`Store.GetRaw(key)\` added for symmetry with \`SetRaw\`/\`DeleteRaw\`/\`ScanPrefix\`. Returns \`(nil, nil)\` on miss. Implemented in PebbleStore, SQLiteStore, and MockStore.
- New \`internal/database/metadata_fetch_cache.go\` with four top-level helpers that take a \`Store\`:
  - \`GetCachedMetadataFetch\`
  - \`PutCachedMetadataFetch\`
  - \`InvalidateCachedMetadataFetch\`
  - \`InvalidateAllCachedMetadataFetchesForBook\`
- Cache keys: \`metadata_fetch_cache:<bookID>:<source>\` (source lowercased).
- Corrupt entries (non-JSON bytes) are transparently treated as a miss **and** cleaned up during the read.
- \`SearchMetadataForBookWithOptions\` per-source loop wraps the \`Search*\` calls: **cache check → skip API on hit → cache write on miss**.
- \`ApplyMetadataCandidate\` invalidates the book's whole cache after a successful apply (title/author may have changed, so cached candidates are stale).

## Expected impact

| Scenario | Before | After |
|---|---|---|
| First fetch of a book | N API calls | N API calls |
| Second fetch of the same book | N API calls | **0 API calls** |
| Bulk re-fetch of 8K books | 8K × N calls | ~0 calls |
| Fetch after metadata apply | cached stale data | invalidated, fresh API call |

## Test plan

- [x] \`go build\` + \`go vet\` clean
- [x] New tests: RoundTrip, Miss, CaseInsensitiveSource, Invalidate, InvalidateAllForBook, CorruptEntry_TreatedAsMiss
- [x] Full server test sweep green
- [ ] **Deploy and flip \`metadata_embedding_scoring_enabled=true\` back on** (was disabled as emergency stop)
- [ ] Run a small bulk fetch (~10 books), observe log line \`metadata-search: cache HIT for (bookID, source) — N results, age=Xs\` on the second run

## Follow-ups (not in this PR)

- TTL/stale policy (currently indefinite cache)
- User-facing \"clear cache\" button
- Per-source cache metrics

Refs: backlog 7.5, [#247](https://github.com/jdfalk/audiobook-organizer/pull/247) (embedding cache sister PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)