### PR TITLE
fix(merge): soft-delete losers + remove from ITL on book merge

### DIFF
--- a/internal/server/merge_service.go
+++ b/internal/server/merge_service.go
@@ -1,11 +1,12 @@
 // file: internal/server/merge_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
 
 package server
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	ulid "github.com/oklog/ulid/v2"
@@ -29,8 +30,32 @@ func NewMergeService(db database.Store) *MergeService {
 }
 
 // MergeBooks merges a set of books into a single version group.
-// If primaryID is empty, the best book is auto-selected (M4B preferred, then highest bitrate, then largest file).
-// If primaryID is provided, that book is set as the primary version.
+//
+// Semantics (confirmed 2026-04-11 after an investigation into
+// orphaned ITL entries):
+//
+//  1. Winner is chosen (user-supplied primaryID or auto-picked
+//     via bookIsBetter) and given IsPrimaryVersion=true. Losers
+//     get IsPrimaryVersion=false and are soft-deleted.
+//  2. External IDs (iTunes PIDs, Audible ASINs, etc.) are
+//     reassigned from losers to the winner so lookups still
+//     resolve to the surviving entity.
+//  3. **iTunes ITL cleanup**: before reassignment, we collect
+//     each loser's iTunes PIDs and enqueue them for removal via
+//     GlobalWriteBackBatcher.EnqueueRemove. This matches the
+//     behavior of maintenance_fixups.mergeDuplicateBook — the
+//     UI merge path used to skip this step, which left the
+//     losers' tracks alive in the iTunes library forever.
+//  4. Loser DB rows are soft-deleted (MarkedForDeletion=true).
+//     They stay recoverable via the existing soft-delete
+//     restore flow for at least the retention window.
+//  5. Loser files on disk are NOT touched — they remain
+//     playable until an archive sweep (not yet implemented)
+//     cleans them up.
+//
+// If primaryID is empty, the best book is auto-selected (M4B
+// preferred, then highest bitrate, then largest file).
+// If primaryID is provided, that book is set as the primary.
 func (ms *MergeService) MergeBooks(bookIDs []string, primaryID string) (*MergeResult, error) {
 	if len(bookIDs) < 2 {
 		return nil, fmt.Errorf("need at least 2 book IDs to merge")
@@ -81,7 +106,11 @@ func (ms *MergeService) MergeBooks(bookIDs []string, primaryID string) (*MergeRe
 		versionGroupID = ulid.Make().String()
 	}
 
-	// Update all books
+	// Update all books to share the version group. Winner is
+	// marked primary; losers are marked non-primary. We still
+	// persist the flag on losers here so the version group is
+	// queryable and the relationship survives through the
+	// soft-delete call below.
 	resolvedPrimaryID := books[bestIdx].ID
 	for i, book := range books {
 		book.VersionGroupID = &versionGroupID
@@ -92,12 +121,58 @@ func (ms *MergeService) MergeBooks(bookIDs []string, primaryID string) (*MergeRe
 		}
 	}
 
-	// Reassign external IDs from merged books to the primary book
-	if eidStore := asExternalIDStore(ms.db); eidStore != nil {
-		for _, book := range books {
-			if book.ID != resolvedPrimaryID {
-				_ = eidStore.ReassignExternalIDs(book.ID, resolvedPrimaryID)
+	// --- Per-loser cleanup ---
+	//
+	// For each non-primary book we:
+	//  (a) collect its iTunes PIDs BEFORE reassignment so we
+	//      know which tracks to remove from the ITL,
+	//  (b) reassign all external IDs to the winner so future
+	//      lookups resolve,
+	//  (c) enqueue ITL removals for the collected PIDs so
+	//      iTunes no longer shows duplicate tracks for this
+	//      version group,
+	//  (d) soft-delete the loser so it drops off the default
+	//      library view. Files on disk are left alone for the
+	//      archive sweep to handle later.
+	eidStore := asExternalIDStore(ms.db)
+	for _, book := range books {
+		if book.ID == resolvedPrimaryID {
+			continue
+		}
+
+		// (a) Collect PIDs before reassignment.
+		var dupPIDs []string
+		if mappings, err := ms.db.GetExternalIDsForBook(book.ID); err == nil {
+			for _, m := range mappings {
+				if m.Source == "itunes" && m.ExternalID != "" && !m.Tombstoned {
+					dupPIDs = append(dupPIDs, m.ExternalID)
+				}
 			}
+		}
+
+		// (b) Reassign external IDs to the winner.
+		if eidStore != nil {
+			if err := eidStore.ReassignExternalIDs(book.ID, resolvedPrimaryID); err != nil {
+				log.Printf("[WARN] merge: ReassignExternalIDs %s → %s: %v", book.ID, resolvedPrimaryID, err)
+			}
+		}
+
+		// (c) Queue iTunes removals for the loser's tracks so
+		// the ITL stops showing them. Best-effort — a nil
+		// batcher (e.g. tests, or iTunes write-back disabled)
+		// means we just skip.
+		if GlobalWriteBackBatcher != nil && len(dupPIDs) > 0 {
+			for _, pid := range dupPIDs {
+				GlobalWriteBackBatcher.EnqueueRemove(pid)
+			}
+			log.Printf("[INFO] merge: queued %d ITL removals for loser %s", len(dupPIDs), book.ID)
+		}
+
+		// (d) Soft-delete the loser. If UpdateBook fails inside
+		// softDeleteBook it falls back to hard delete, so we
+		// never leave a zombie non-primary row behind.
+		if err := softDeleteBook(ms.db, book.ID); err != nil {
+			log.Printf("[WARN] merge: soft-delete %s: %v", book.ID, err)
 		}
 	}
 

--- a/internal/server/merge_service_test.go
+++ b/internal/server/merge_service_test.go
@@ -105,6 +105,66 @@ func TestMergeService_MergeBooks_TooFew(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least 2")
 }
 
+// TestMergeService_MergeBooks_SoftDeletesLosers verifies the
+// post-2026-04-11 merge semantics: losers get soft-deleted
+// (MarkedForDeletion=true) after merge so they drop off the
+// default library view, while the winner stays active with
+// the version group pointing at all of them.
+func TestMergeService_MergeBooks_SoftDeletesLosers(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+	_ = server
+
+	store := database.GlobalStore
+
+	book1 := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Loser MP3",
+		Format:   "mp3",
+		FilePath: "/tmp/loser.mp3",
+	}
+	book2 := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Winner M4B",
+		Format:   "m4b",
+		FilePath: "/tmp/winner.m4b",
+	}
+
+	_, err := store.CreateBook(book1)
+	require.NoError(t, err)
+	_, err = store.CreateBook(book2)
+	require.NoError(t, err)
+
+	ms := NewMergeService(store)
+	result, err := ms.MergeBooks([]string{book1.ID, book2.ID}, "")
+	require.NoError(t, err)
+	require.Equal(t, book2.ID, result.PrimaryID, "M4B should auto-win")
+
+	// Winner is NOT soft-deleted.
+	winner, err := store.GetBookByID(book2.ID)
+	require.NoError(t, err)
+	require.NotNil(t, winner)
+	require.NotNil(t, winner.IsPrimaryVersion)
+	assert.True(t, *winner.IsPrimaryVersion)
+	if winner.MarkedForDeletion != nil {
+		assert.False(t, *winner.MarkedForDeletion, "winner must not be soft-deleted")
+	}
+
+	// Loser IS soft-deleted, with the version group still pointing
+	// at it so the relationship survives for recovery.
+	loser, err := store.GetBookByID(book1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, loser)
+	require.NotNil(t, loser.IsPrimaryVersion)
+	assert.False(t, *loser.IsPrimaryVersion)
+	require.NotNil(t, loser.MarkedForDeletion, "loser must be soft-deleted")
+	assert.True(t, *loser.MarkedForDeletion)
+	require.NotNil(t, loser.MarkedForDeletionAt, "loser must have deletion timestamp")
+	assert.WithinDuration(t, time.Now(), *loser.MarkedForDeletionAt, 5*time.Second)
+	require.NotNil(t, loser.VersionGroupID)
+	assert.Equal(t, result.VersionGroupID, *loser.VersionGroupID)
+}
+
 // TestMergeService_MergeBooks_PrefersCuratedOverPristine verifies that a
 // book the user has curated (metadata match accepted, tags written back)
 // wins the primary slot over a duplicate with a better format or bitrate.


### PR DESCRIPTION
## Summary

Closes the UI dedup merge path's gap vs the maintenance \`dedup-books\` path. Before this fix, clicking Merge in the dedup cluster UI left losers alive as non-primary versions **and** left their iTunes tracks in the library — duplicate entries accumulated forever.

## The two paths before this PR

| Path | ITL cleanup | Soft-delete losers |
|---|---|---|
| UI dedup merge (\`MergeBooks\`) | ❌ | ❌ |
| Maintenance \`mergeDuplicateBook\` | ✅ | ✅ |

Now both paths match.

## What the UI merge does now

For each non-primary book:
1. Collect iTunes PIDs **before** reassignment via \`GetExternalIDsForBook\`
2. Reassign external IDs to the winner (unchanged)
3. Enqueue \`GlobalWriteBackBatcher.EnqueueRemove(pid)\` for each PID so iTunes drops the duplicate track on the next write-back flush
4. \`softDeleteBook(store, loser.ID)\` so the loser row drops off the default library view but stays recoverable

**Files on disk are intentionally NOT touched.** The soft-deleted row still references its files; an archive sweep (backlog, not yet built) will eventually physically remove them.

## Out of scope (tracked for follow-up)

- **Author and series merge paths**: don't touch ITL at all — they re-parent books via \`SetBookAuthors\` and rely on the next metadata write-back. They don't suffer from this particular bug, but they do have a latent issue where \`mergeAuthors\` updates the join table without syncing the denormalized \`book.AuthorID\`. Tombstones paper over it; flagging for a follow-up.
- **Full iTunes library regeneration feature** (user request during investigation) — complementary escape hatch for cleaning up existing accumulated cruft. Separate PR.

## Test plan

- [x] Existing \`TestMergeService_MergeBooks\` still passes (assertions on VersionGroupID / IsPrimaryVersion unchanged)
- [x] New \`TestMergeService_MergeBooks_SoftDeletesLosers\` verifies:
  - loser has \`MarkedForDeletion=true\` with a recent \`MarkedForDeletionAt\`
  - winner is untouched
  - version group still points at both
- [ ] Deploy, merge a known-duplicate cluster, confirm:
  - Loser drops off default library view
  - Next ITL write-back flush removes loser's tracks from iTunes
  - Winner's tracks stay intact
  - Soft-deleted book can be restored via the existing maintenance API if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)