### PR TITLE
docs(backlog): add 4 items from the merge/cache investigation

### DIFF
--- a/docs/backlog-2026-04-10.md
+++ b/docs/backlog-2026-04-10.md
@@ -1,5 +1,5 @@
 <!-- file: docs/backlog-2026-04-10.md -->
-<!-- version: 1.9.0 -->
+<!-- version: 1.10.0 -->
 <!-- guid: a1b2c3d4-e5f6-7890-1234-567890abcdef -->
 <!-- last-edited: 2026-04-11 -->
 
@@ -1487,6 +1487,175 @@ use case that motivates policy inheritance (8.1).
 **Dependencies:** [#244](https://github.com/jdfalk/audiobook-organizer/pull/244).
 
 **Risks:** Low. Parallel to existing book-tag surface.
+
+### 7.9 Full iTunes library regenerate / rebuild (**L**) — NEW
+
+**What:** A new maintenance action that rebuilds the entire
+iTunes `.itl` library from the current DB state. Two modes:
+
+1. **Rebuild from scratch:** wipe the existing ITL (backup
+   first) and construct a fresh one with one track per
+   primary book. Preserves nothing iTunes-side (play counts,
+   ratings, etc.). Intended for the case where ITL has
+   accumulated too much cruft to untangle incrementally.
+2. **Diff and batch:** walk the DB + the current ITL,
+   compute the diff (tracks to add / remove / update), and
+   apply the whole diff in one `ApplyITLOperations` call.
+   Preserves iTunes-side metadata that's not in our DB
+   (play counts, ratings, last-played timestamps).
+
+Mode 2 is the preferred default; mode 1 is the nuclear
+escape hatch for when the current ITL is beyond repair.
+
+**Why:** User request after the merge-ITL-cleanup investigation
+(#251): "with all these weird entries, duplicates and other
+stuff, it would be better once we know our database and
+everything is right to just sync a fresh library over, or
+batch all the changes so we can quickly process all the adds
+and removals". The incremental write-back batcher works well
+for ongoing changes, but it can't cleanly reconcile
+historical drift accumulated before merge cleanup was wired
+in. A rebuild gives users a single "reset button" that makes
+iTunes match the DB.
+
+**Where:**
+- Backend: new `internal/itunes/rebuild.go` with two functions:
+  `BuildITLFromScratch(books, destPath)` and
+  `DiffAndApplyITLUpdates(currentITL, books)`
+- New handler under `/api/v1/itunes/rebuild` (POST) with a
+  mode parameter and a dry-run flag
+- Frontend: button under Settings → iTunes with
+  "Rebuild iTunes library" and a confirmation dialog
+  (destructive, especially mode 1) plus a preview of what
+  the diff would apply
+
+**Dependencies:**
+- Existing ITL write path via `safeWriteITL` / backup-restore
+  (#238)
+- `ApplyITLOperations` batch API for mode 2
+- Mode 1 needs a "build ITL from nothing" code path that
+  doesn't currently exist — the writer has always edited an
+  existing file
+
+**Risks:**
+- Mode 1 loses iTunes-side metadata not in our DB. Must be
+  gated behind a strong confirmation and documented.
+- Both modes write the entire library file at once — lots
+  of work per call, needs to run as a real Operation with
+  progress reporting.
+- The built ITL needs to round-trip through iTunes without
+  corruption; golden-test coverage from item 5.8
+  (regenerate ITL fixtures) becomes a hard dependency.
+
+### 7.10 Archive sweep for soft-deleted books (**M**) — NEW
+
+**What:** A background task that physically removes files
+belonging to books soft-deleted longer than N days (default
+30). Currently `softDeleteBook` sets `MarkedForDeletion=true`
+and `MarkedForDeletionAt=now()` but nothing ever hard-deletes
+the row or cleans up the files — soft-deletes accumulate
+forever.
+
+**Why:** The book merge fix in #251 soft-deletes losers
+instead of hard-deleting, which is correct for recoverability
+but means disk usage keeps growing. A sweep that moves old
+soft-deletes to an archive folder (or just hard-deletes
+after a retention period) closes the loop.
+
+Related user comment: "we were going to move all the deleted
+or removed ones into an archive or something or set an
+inactive state, can't remember but don't worry about it now".
+
+**Where:**
+- New periodic task in the existing maintenance scheduler
+- Gated on a config flag `ArchiveSweepEnabled` + retention
+  days `ArchiveRetentionDays`
+- Optional archive path: move files to
+  `{RootDir}/.archive/{bookID}/` before hard-deleting the DB
+  row, or just `os.RemoveAll` if archive is disabled
+- Maintenance UI surface: "Pending archive" count, "Archive
+  now" button
+
+**Dependencies:**
+- Existing soft-delete columns (`MarkedForDeletion`,
+  `MarkedForDeletionAt`)
+- `ListSoftDeletedBooks` store method (exists)
+- `DeleteBook` for the final hard-delete
+
+**Risks:** Low with a conservative default retention window.
+Any file that isn't intentional can be recovered during the
+retention period via the existing restore API.
+
+### 7.11 Author/series merge — sync denormalized book.AuthorID (**S**) — NEW
+
+**What:** `mergeAuthors` in `entities_handlers.go` reassigns
+books via `SetBookAuthors(bookID, newAuthors)` (updates the
+join table) but never calls `UpdateBook` to sync the book's
+denormalized `book.AuthorID` pointer. After merging author 5
+into author 3, `book.AuthorID` still says 5, and author 5
+has been hard-deleted. Tombstones paper over most lookups
+but the stale pointer is a latent bug.
+
+**Why:** Found while investigating the merge-ITL-cleanup bug
+(#251). Not currently causing visible problems because
+`GetAuthorByID` consults the tombstone table, but any code
+path that reads `book.AuthorID` directly without going
+through the lookup layer will see a dead ID.
+
+**Fix direction:**
+1. In `mergeAuthors`, after `SetBookAuthors`, fetch the book
+   and if its denormalized `AuthorID` matched the losing
+   author, update it to the keep author and `UpdateBook`.
+2. Add a compile-time invariant / lint that flags direct
+   reads of `book.AuthorID` outside the lookup helpers.
+
+**Dependencies:** None.
+
+**Risks:** None — strictly a consistency fix.
+
+### 7.12 Organize rewrites file tags on every run even when unchanged (**S**) — NEW
+
+**What:** User reported concern that every organize pass may
+be rewriting audio file tags even when the DB state is
+identical to what's already on disk. If true, this is a
+wasted I/O operation per book per organize run, and worse:
+every rewrite invalidates file mtime and may poison hash
+comparisons in the scanner.
+
+**Investigation needed** (not yet done — deferred behind the
+caching stack):
+1. Trace the organize → runApplyPipeline → tag writeback
+   path
+2. Confirm whether there's a "skip if unchanged" check
+   (`filterUnchangedTags` exists somewhere — verify it
+   actually runs)
+3. Measure: run organize twice on the same book and diff
+   the audio file bytes; if they differ, the tag path is
+   rewriting pointlessly
+4. Add a content-hash check if missing: if the target tag
+   set is byte-for-byte identical to what's already in the
+   file, skip the write
+
+**Why:** Direct user quote: "are we writing metadata to
+files every time we organize even if they don't need it?".
+Pointless rewrites waste disk I/O, invalidate file mtimes
+(breaking the scanner's mtime-based skip optimization),
+potentially corrupt media players that cache based on file
+timestamps, and produce unnecessary churn in any backup or
+sync system watching the library.
+
+**Where:**
+- Investigation lives in `internal/server/metadata_fetch_service.go`
+  (runApplyPipeline) and `internal/organizer/organizer.go`
+- Fix direction: ensure `filterUnchangedTags` (if it exists)
+  runs before tag write, or add a pre-write check comparing
+  target vs existing tags
+
+**Dependencies:** None — pure investigation + fix.
+
+**Risks:** Minimal. If the check is added too strict, we
+might skip a legitimate rewrite — easy to fix with targeted
+tests.
 
 ### 7.8 System tag UX — visual distinction + non-deletable by default (**S**)
 


### PR DESCRIPTION
## Summary

Four new items surfaced during the merge-ITL-cleanup investigation (#251) and the OpenAI quota fight:

- **7.9 Full iTunes library regenerate/rebuild (L)** — user request for a nuclear rebuild button + a smarter "diff and batch" mode that preserves iTunes-side metadata (play counts, ratings).
- **7.10 Archive sweep for soft-deleted books (M)** — closes the loop on #251's soft-delete by adding a periodic archive sweep with retention window.
- **7.11 Author/series merge — sync denormalized book.AuthorID (S)** — latent bug: the join table gets updated but the denormalized pointer stays stale. Tombstones cover it but it's a sharp edge.
- **7.12 Organize rewrites file tags on every run even when unchanged (S)** — user-reported: pointless rewrites waste I/O, invalidate mtimes, poison the scanner skip cache. Needs measurement first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)