### PR TITLE
fix(organize): stop rewriting file tags when already unchanged

### DIFF
--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -2733,9 +2733,13 @@ func (mfs *MetadataFetchService) WriteBackMetadataForBook(id string, segmentFilt
 			skippedProtected++
 		} else {
 			fullTagMap := mfs.buildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
-			// Always write all tags — taglib fork handles custom MP4 atoms natively.
-			// The filter previously skipped writes when standard tags matched,
-			// but custom tags (NARRATOR, SERIES, etc.) need writing too.
+			// Filter out tags whose current on-disk value already
+			// matches the DB state, so a re-run of bulk write-back
+			// is near-free when nothing actually changed.
+			// filterUnchangedTags now covers album_artist and
+			// composer (both narrator-sourced in our convention),
+			// so the filter correctly no-ops on unchanged books
+			// instead of always-writing because of those keys.
 			dirFiles := audioFilesInDir(book.FilePath)
 			if len(dirFiles) > 0 {
 				// book.FilePath is a directory — write to each audio file found inside.
@@ -2746,8 +2750,13 @@ func (mfs *MetadataFetchService) WriteBackMetadataForBook(id string, segmentFilt
 						skippedProtected++
 						continue
 					}
+					fm := filterUnchangedTags(f, fullTagMap)
+					if len(fm) == 0 {
+						log.Printf("[DEBUG] write-back: all tags match, skipping %s", f)
+						continue
+					}
 					backupFileBeforeWrite(f)
-					if err := metadata.WriteMetadataToFile(f, fullTagMap, opConfig); err != nil {
+					if err := metadata.WriteMetadataToFile(f, fm, opConfig); err != nil {
 						log.Printf("[WARN] write-back failed for %s: %v", f, err)
 					} else {
 						log.Printf("[INFO] wrote metadata back to %s", f)
@@ -2755,11 +2764,16 @@ func (mfs *MetadataFetchService) WriteBackMetadataForBook(id string, segmentFilt
 					}
 				}
 			} else {
-				backupFileBeforeWrite(book.FilePath)
-				if err := metadata.WriteMetadataToFile(book.FilePath, fullTagMap, opConfig); err != nil {
-					log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
+				fm := filterUnchangedTags(book.FilePath, fullTagMap)
+				if len(fm) == 0 {
+					log.Printf("[DEBUG] write-back: all tags match, skipping %s", book.FilePath)
 				} else {
-					writtenCount++
+					backupFileBeforeWrite(book.FilePath)
+					if err := metadata.WriteMetadataToFile(book.FilePath, fm, opConfig); err != nil {
+						log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
+					} else {
+						writtenCount++
+					}
 				}
 			}
 		}
@@ -2997,9 +3011,20 @@ func filterUnchangedTags(filePath string, tagMap map[string]interface{}) map[str
 	}
 
 	currentVals := map[string]string{
-		"title":           current.Title,
-		"album":           current.Album,
-		"artist":          current.Artist,
+		"title": current.Title,
+		"album": current.Album,
+		"artist": current.Artist,
+		// album_artist and composer both hold the narrator in our
+		// audiobook tag convention (album_artist > artist > composer
+		// is the read priority). RenameService writes them as two
+		// separate keys, so filterUnchangedTags needs to know they
+		// compare against current.Narrator too — otherwise every
+		// organize pass sees album_artist/composer as "unknown
+		// field → always write" and falls through to a real write,
+		// which was the root cause of the "organize rewrites tags
+		// every time even when unchanged" investigation.
+		"album_artist":    current.Narrator,
+		"composer":        current.Narrator,
 		"narrator":        current.Narrator,
 		"genre":           current.Genre,
 		"year":            fmt.Sprintf("%d", current.Year),

--- a/internal/server/rename_service.go
+++ b/internal/server/rename_service.go
@@ -119,25 +119,40 @@ func (rs *RenameService) ApplyRename(bookID, operationID string) (*RenameApplyRe
 		tagWriteTarget = proposedPath // Write tags to the copy, not the original
 	}
 
-	// Write tags to the target file (never the protected source)
+	// Write tags to the target file (never the protected source).
+	//
+	// Only write fields that actually changed. Without this filter,
+	// every organize pass would rewrite every tag on every file
+	// regardless of whether the DB value and the on-disk value
+	// already match — wasted disk I/O, wasted mtime churn (which
+	// poisons the scanner's mtime skip cache), and unnecessary
+	// noise in any backup/sync watcher. The filter reads the
+	// current file's tags, compares each key, and drops matches.
+	// When nothing remains we skip the write entirely.
 	if len(tagMeta) > 0 && !isProtectedPath(tagWriteTarget) {
-		opConfig := fileops.OperationConfig{VerifyChecksums: true}
-		if err := enhanced.WriteMetadataToFile(tagWriteTarget, tagMeta, opConfig); err != nil {
-			log.Printf("[WARN] rename: tag write failed for %s: %v", bookID, err)
-			// Tag write failure is non-fatal; continue with rename
+		filtered := filterUnchangedTags(tagWriteTarget, tagMeta)
+		if len(filtered) == 0 {
+			log.Printf("[DEBUG] rename: all tags match, skipping write for %s", tagWriteTarget)
 		} else {
-			tagsWritten = len(tagMeta)
-			// Record tag write changes for undo
-			if operationID != "" {
-				for field, val := range tagMeta {
-					_ = rs.db.CreateOperationChange(&database.OperationChange{
-						OperationID: operationID,
-						BookID:      bookID,
-						ChangeType:  "tag_write",
-						FieldName:   field,
-						OldValue:    "", // original tag values not easily recoverable
-						NewValue:    fmt.Sprintf("%v", val),
-					})
+			opConfig := fileops.OperationConfig{VerifyChecksums: true}
+			if err := enhanced.WriteMetadataToFile(tagWriteTarget, filtered, opConfig); err != nil {
+				log.Printf("[WARN] rename: tag write failed for %s: %v", bookID, err)
+				// Tag write failure is non-fatal; continue with rename
+			} else {
+				tagsWritten = len(filtered)
+				// Record tag write changes for undo (only the
+				// fields we actually wrote).
+				if operationID != "" {
+					for field, val := range filtered {
+						_ = rs.db.CreateOperationChange(&database.OperationChange{
+							OperationID: operationID,
+							BookID:      bookID,
+							ChangeType:  "tag_write",
+							FieldName:   field,
+							OldValue:    "", // original tag values not easily recoverable
+							NewValue:    fmt.Sprintf("%v", val),
+						})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Investigation question from the session: \"are we writing metadata to files every time we organize even if they don't need it?\" **Answer: yes, on two separate paths, for two different reasons.** This PR fixes both.

## Root causes

**1. \`rename_service.go\` had no filter at all.** The rename half of the organize pipeline was calling \`WriteMetadataToFile\` unconditionally on every pass.

**2. Bulk write-back had the filter intentionally disabled.** The comment said:

> Always write all tags — taglib fork handles custom MP4 atoms natively. The filter previously skipped writes when standard tags matched, but custom tags (NARRATOR, SERIES, etc.) need writing too.

The concern was that \`filterUnchangedTags\` only compared standard audio tags. The \"fix\" was to nuke the filter, trading correctness for perpetual rewrites.

## The real missing piece

\`filterUnchangedTags\`' \`currentVals\` map was missing two keys that both writers actually produce:
- \`album_artist\` (narrator, by our convention)
- \`composer\` (narrator, same convention)

Without those keys, the filter treated them as \"unknown field → always write\", preventing \`len == 0\` from ever short-circuiting. Adding them — both sourced from \`current.Narrator\` — lets the filter correctly no-op on unchanged books.

## What changed

- \`filterUnchangedTags\` \`currentVals\` gains \`album_artist\` and \`composer\` (both = \`current.Narrator\`)
- Bulk write-back single-file + directory-of-files branches now call \`filterUnchangedTags\` + skip when empty
- \`rename_service.go\` calls \`filterUnchangedTags\` before \`WriteMetadataToFile\`, logs \`[DEBUG] rename: all tags match, skipping\` when nothing changed, and only writes \`operation_change\` rows for fields that actually got written

## Why this matters

Pointless rewrites were causing:
- Wasted disk I/O (every organize pass touched every file)
- Invalidated scanner mtime skip cache → every rescan redid more work
- Backup/sync churn (every organize was a \"new version of every file\" event)
- Unnecessary taglib copy-on-write backup noise

## Test plan

- [x] Build + vet clean
- [x] Existing rename/metadata tests pass
- [ ] Deploy, run organize on an already-organized book, confirm \`[DEBUG] skip\` messages and that file mtimes don't advance
- [ ] Run bulk write-back twice on the same book, confirm the second run skips

Closes backlog 7.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)