### PR TITLE
fix(author-merge): sync denormalized book.AuthorID after reassignment

### DIFF
--- a/internal/server/entities_handlers.go
+++ b/internal/server/entities_handlers.go
@@ -11,6 +11,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -453,6 +454,36 @@ func (s *Server) mergeAuthors(c *gin.Context) {
 						OldValue:    fmt.Sprintf("author_id:%d (%s)", mergeID, mergeAuthorName),
 						NewValue:    fmt.Sprintf("author_id:%d (%s)", keepID, keepName),
 					})
+				}
+
+				// Sync the denormalized `book.AuthorID` pointer
+				// on the Book row itself. SetBookAuthors above
+				// updates the join table, but callers that read
+				// the Book struct directly — organize path,
+				// metadata fetcher, search indexer — expect
+				// book.AuthorID to match the primary author in
+				// the join table. Without this sync, the field
+				// still points at the losing author ID, which
+				// has been hard-deleted on the next iteration.
+				//
+				// Tombstones cover most lookups (GetAuthorByID
+				// follows the tombstone chain), but any code that
+				// uses book.AuthorID as a map key or as an equality
+				// check without going through the lookup helpers
+				// sees the stale ID. This closes that gap.
+				//
+				// Backlog 7.11 — found while investigating the
+				// merge ITL cleanup bug (#251).
+				current, gbErr := store.GetBookByID(book.ID)
+				if gbErr != nil || current == nil {
+					continue
+				}
+				if current.AuthorID != nil && *current.AuthorID == mergeID {
+					newID := keepID
+					current.AuthorID = &newID
+					if _, upErr := store.UpdateBook(book.ID, current); upErr != nil {
+						log.Printf("[WARN] author merge: failed to sync denormalized AuthorID on book %s: %v", book.ID, upErr)
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Backlog 7.11 — latent bug found while investigating #251.

\`mergeAuthors\` updates the \`book_authors\` join table via \`SetBookAuthors\` but never syncs the denormalized \`book.AuthorID\` pointer on the Book row. After merging author 5 into author 3, \`book.AuthorID\` still said 5, and author 5 was hard-deleted at the end of the same loop — leaving a dangling pointer that only the tombstone chain in \`GetAuthorByID\` papered over.

Any code that used \`book.AuthorID\` as a map key or compared against it directly (without going through the lookup helpers) saw the stale ID.

## Fix

After \`SetBookAuthors\`, fetch the book and — if its \`AuthorID\` still points at the losing \`mergeID\` — update it to \`keepID\` and persist via \`UpdateBook\`. Surgical: only touches books whose denormalized pointer needs updating.

## No new test

\`mergeAuthors\` runs in the operation queue and is exercised via existing integration tests. The condition being fixed is latent and never had a reproduction in the suite.

Refs: backlog 7.11, #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)