### PR TITLE
feat(library): upgrade bulk edit to batch API + series auto-increment

### DIFF
--- a/web/src/components/audiobooks/BatchEditDialog.tsx
+++ b/web/src/components/audiobooks/BatchEditDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/BatchEditDialog.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5b6c7d8e-9f0a-1b2c-3d4e-5f6a7b8c9d0e
 
 import React, { useState } from 'react';
@@ -15,6 +15,8 @@ import {
   Alert,
   FormControlLabel,
   Checkbox,
+  Tooltip,
+  Typography,
 } from '@mui/material';
 import type { Audiobook } from '../../types';
 
@@ -22,7 +24,15 @@ interface BatchEditDialogProps {
   open: boolean;
   audiobooks: Audiobook[];
   onClose: () => void;
+  // onSave is called ONCE with the common updates (same values
+  // for all books). When series_position auto-increment is on,
+  // the dialog calls onSavePerBook instead — one call per book
+  // with a different series_position each time.
   onSave: (updates: Partial<Audiobook>) => Promise<void>;
+  // onSavePerBook is optional — when absent and auto-increment
+  // is needed, the dialog falls back to calling onSave multiple
+  // times (less efficient but always works).
+  onSavePerBook?: (bookId: string, updates: Partial<Audiobook>) => Promise<void>;
 }
 
 interface FieldUpdate {
@@ -35,16 +45,24 @@ export const BatchEditDialog: React.FC<BatchEditDialogProps> = ({
   audiobooks,
   onClose,
   onSave,
+  onSavePerBook,
 }) => {
   const [updates, setUpdates] = useState<Record<string, FieldUpdate>>({
     author: { enabled: false, value: '' },
     narrator: { enabled: false, value: '' },
     series: { enabled: false, value: '' },
+    series_position: { enabled: false, value: 1 },
     genre: { enabled: false, value: '' },
     language: { enabled: false, value: '' },
     publisher: { enabled: false, value: '' },
     year: { enabled: false, value: '' },
   });
+  // Auto-increment: when series_position is enabled AND this is
+  // checked, each book gets an incrementing series_position
+  // starting from the value in the field. Typical use: select 10
+  // books in a series, set starting position to 1, check
+  // auto-increment, and all 10 get positions 1–10.
+  const [autoIncrement, setAutoIncrement] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -67,14 +85,39 @@ export const BatchEditDialog: React.FC<BatchEditDialogProps> = ({
     setError(null);
 
     try {
+      // Build the common (non-auto-incrementing) field set.
       const changedFields: Partial<Audiobook> = {};
       Object.entries(updates).forEach(([field, update]) => {
         if (update.enabled) {
+          // Skip series_position if auto-increment is on — it
+          // gets handled per-book below.
+          if (field === 'series_position' && autoIncrement) return;
           changedFields[field as keyof Audiobook] = update.value as never;
         }
       });
 
-      await onSave(changedFields);
+      // Auto-increment path: each book gets a different
+      // series_position. Uses onSavePerBook when available
+      // (single PUT per book) or falls back to onSave in
+      // a loop (batch endpoint can't do per-book values).
+      if (
+        updates.series_position.enabled &&
+        autoIncrement
+      ) {
+        const start = Number(updates.series_position.value) || 1;
+        const saveFn = onSavePerBook || (async (_id: string, u: Partial<Audiobook>) => onSave(u));
+        let i = 0;
+        for (const ab of audiobooks) {
+          const perBook = {
+            ...changedFields,
+            series_position: start + i,
+          } as Partial<Audiobook>;
+          await saveFn(ab.id, perBook);
+          i++;
+        }
+      } else {
+        await onSave(changedFields);
+      }
       onClose();
     } catch (err) {
       setError(
@@ -163,6 +206,48 @@ export const BatchEditDialog: React.FC<BatchEditDialogProps> = ({
                 disabled={!updates.series.enabled}
                 sx={{ mt: 1 }}
               />
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={updates.series_position.enabled}
+                    onChange={() => handleToggle('series_position')}
+                  />
+                }
+                label="Series Position"
+              />
+              <TextField
+                fullWidth
+                type="number"
+                placeholder="Starting position"
+                value={updates.series_position.value}
+                onChange={(e) =>
+                  handleChange('series_position', parseInt(e.target.value) || 1)
+                }
+                disabled={!updates.series_position.enabled}
+                sx={{ mt: 1 }}
+              />
+              {updates.series_position.enabled && (
+                <Tooltip title="Each book gets an incrementing position starting from the value above. Books are numbered in the order they appear in the selection.">
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={autoIncrement}
+                        onChange={(e) => setAutoIncrement(e.target.checked)}
+                        size="small"
+                      />
+                    }
+                    label={
+                      <Typography variant="body2">
+                        Auto-increment (1, 2, 3, …)
+                      </Typography>
+                    }
+                    sx={{ mt: 0.5 }}
+                  />
+                </Tooltip>
+              )}
             </Grid>
 
             <Grid item xs={12} sm={6}>

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1080,16 +1080,23 @@ export const Library = () => {
 
   const handleBatchSave = async (updates: Partial<Audiobook>) => {
     try {
-      const results = await Promise.allSettled(
-        selectedAudiobooks.map((ab) => api.updateBook(ab.id, updates))
-      );
-      const failed = results.filter((r) => r.status === 'rejected').length;
-      if (failed > 0) {
-        toast(`Updated ${results.length - failed} audiobooks, ${failed} failed.`, 'warning');
+      // Use the single-call batch API instead of N individual
+      // PUT requests. One round trip, one DB write loop. The
+      // old path did Promise.allSettled(N × updateBook) which
+      // was both slower and noisier in the activity log.
+      const ids = selectedAudiobooks.map((ab) => ab.id);
+      const result = await api.batchUpdateBooks(ids, updates as Record<string, unknown>);
+      if (result.failed > 0) {
+        toast(
+          `Updated ${result.updated} audiobooks, ${result.failed} failed.`,
+          'warning'
+        );
       } else {
-        toast(`Updated metadata for ${selectedAudiobooks.length} audiobooks.`, 'success');
+        toast(
+          `Updated metadata for ${result.updated} audiobooks.`,
+          'success'
+        );
       }
-      // Reload to get server state
       loadAudiobooks();
       setSelectedAudiobooks([]);
       setBatchEditOpen(false);
@@ -2508,6 +2515,9 @@ export const Library = () => {
           audiobooks={selectedAudiobooks}
           onClose={() => setBatchEditOpen(false)}
           onSave={handleBatchSave}
+          onSavePerBook={async (bookId, updates) => {
+            await api.updateBook(bookId, updates as Record<string, unknown> & Partial<import('../services/api').Book>);
+          }}
         />
 
         <BulkTagDialog

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -764,6 +764,31 @@ export async function updateBook(
   return response.json();
 }
 
+// batchUpdateBooks applies the same metadata updates to every
+// book in `ids` via a single API call. Much faster than N
+// individual updateBook calls — one round trip and one DB
+// write loop instead of N of each.
+export interface BatchUpdateResult {
+  updated: number;
+  failed: number;
+  errors?: string[];
+}
+
+export async function batchUpdateBooks(
+  ids: string[],
+  updates: Record<string, unknown>
+): Promise<BatchUpdateResult> {
+  const response = await fetch(`${API_BASE}/audiobooks/batch`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids, updates }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to batch update audiobooks');
+  }
+  return response.json();
+}
+
 export async function getBookTags(
   bookId: string,
   compareId?: string,


### PR DESCRIPTION
## Summary

Backlog 3.3. Two improvements to the existing BatchEditDialog:

1. **Single batch API call** — switches from N individual \`updateBook()\` PUT calls to one \`batchUpdateBooks()\` POST against \`/audiobooks/batch\`. One round trip instead of N.

2. **Series position auto-increment** — new field + checkbox. Select 10 books, set starting position to 1, check \"Auto-increment\", and all 10 get positions 1-10.

## Test plan

- [x] \`tsc --noEmit\` + \`go build\` clean
- [ ] Select 5 books, batch-set author → single API call
- [ ] Select 5 books, enable auto-increment from 1 → positions 1-5

Refs: backlog 3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)