### PR TITLE
chore(ci): update checkout SHAs + fix test timeouts

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load frontend configuration
         id: frontend-config

--- a/.github/workflows/test-action-integration.yml
+++ b/.github/workflows/test-action-integration.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get frontend configuration
         id: frontend-config

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -18,7 +18,7 @@ jobs:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -34,7 +34,7 @@ jobs:
     name: NPM Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,5 +1,5 @@
 // file: vitest.config.ts
-// version: 1.0.1
+// version: 1.1.0
 // guid: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
 
 import { defineConfig } from 'vitest/config';
@@ -10,5 +10,11 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
     globals: true,
     exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+    // CI runners are slower than local dev machines. The default
+    // 5000ms timeout was causing false failures on tests that
+    // render complex components (Library, BookDetail) with
+    // multiple async operations. 30s is generous enough for CI
+    // while still catching genuinely hung tests.
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Summary

Fixes two CI blockers:

1. **Updated checkout SHA** — three workflows were pinned to \`actions/checkout@0c366fd\` (v4.3.1). Updated to \`@de0fac2\` (v6.0.2). All other action SHAs were already at their latest versions.

2. **Vitest test timeout** — increased global \`testTimeout\` from 5000ms (default) to 30000ms. CI runners are slower than local dev and complex async tests (Library.importFile, Library.bulkFetch, BookDetail.unlock) were failing at the default.

**Note:** The Node.js 20 deprecation warnings in the release workflow come from docker/\* and setup-\* actions inside \`jdfalk/ghcommon\` reusable workflows — those need updating in that repo, not this one.

## Test plan
- [ ] CI passes on this PR
- [ ] Frontend tests no longer timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)