### PR TITLE
fix(ci): changelog diffs against previous stable + strip frontend from assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   ci:
     name: Run CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@7d1de69939871d95024c649cf5214b137bb64fb7 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,7 +48,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@7d1de69939871d95024c649cf5214b137bb64fb7 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@7d1de69939871d95024c649cf5214b137bb64fb7 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@7d1de69939871d95024c649cf5214b137bb64fb7 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false


### PR DESCRIPTION
Points at updated ghcommon (ea8b522) which fixes:

1. **Changelog**: diffs against previous stable release (v0.205.0) not the tag being created (v0.206.0)
2. **Assets**: strips frontend JS chunks/maps (73 → ~15 meaningful assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)