### PR TITLE
feat(release): add previous-version override for changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   ci:
     name: Run CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,7 +48,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      previous-version:
+        description: 'Override previous version for changelog (e.g. v0.205.0). Leave empty for auto-detect.'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: release-${{ github.ref }}
@@ -36,7 +41,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@ea8b522079207f1cb0f3fd5145def8c317fee14a # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false
@@ -48,4 +53,5 @@ jobs:
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'
+      previous-version: ${{ github.event.inputs.previous-version }}
     secrets: inherit


### PR DESCRIPTION
Adds \`previous-version\` input to the production release workflow. When set, the changelog diffs against that tag instead of auto-detecting. Passes through to ghcommon's reusable workflow.

Also updates ghcommon SHA to latest (659c291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)