### PR TITLE
chore(ci): update ghcommon SHA — strip GoReleaser metadata from assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   ci:
     name: Run CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@6b32d2084fd33ddd27931bed912bf2ab05795680 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,7 +48,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@6b32d2084fd33ddd27931bed912bf2ab05795680 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@6b32d2084fd33ddd27931bed912bf2ab05795680 # latest
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@659c291cd2c9df49d392dcb49ee289023896ea21 # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@6b32d2084fd33ddd27931bed912bf2ab05795680 # latest
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false


### PR DESCRIPTION
Updates ghcommon to latest (6b32d20) which also strips artifacts.json, metadata.json, and config.yaml from release assets.