### PR TITLE
feat(operations): per-op file I/O tracking + resumable bulk ops

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.41.0
+// version: 1.42.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -2543,15 +2543,9 @@ func (p *PebbleStore) GetRecentOperations(limit int) ([]Operation, error) {
 		operations = append(operations, op)
 	}
 
-	// Sort by created_at descending (most recent first)
-	// In production, you'd want a better indexing strategy
-	for i := 0; i < len(operations)-1; i++ {
-		for j := i + 1; j < len(operations); j++ {
-			if operations[j].CreatedAt.After(operations[i].CreatedAt) {
-				operations[i], operations[j] = operations[j], operations[i]
-			}
-		}
-	}
+	sort.Slice(operations, func(i, j int) bool {
+		return operations[i].CreatedAt.After(operations[j].CreatedAt)
+	})
 
 	if len(operations) > limit {
 		operations = operations[:limit]
@@ -2579,14 +2573,9 @@ func (p *PebbleStore) ListOperations(limit, offset int) ([]Operation, int, error
 		operations = append(operations, op)
 	}
 
-	// Sort by created_at descending
-	for i := 0; i < len(operations)-1; i++ {
-		for j := i + 1; j < len(operations); j++ {
-			if operations[j].CreatedAt.After(operations[i].CreatedAt) {
-				operations[i], operations[j] = operations[j], operations[i]
-			}
-		}
-	}
+	sort.Slice(operations, func(i, j int) bool {
+		return operations[i].CreatedAt.After(operations[j].CreatedAt)
+	})
 
 	total := len(operations)
 	if offset >= len(operations) {

--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -1,5 +1,5 @@
 // file: internal/operations/state.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package operations
@@ -42,6 +42,25 @@ type ScanParams struct {
 // OrganizeParams stores the immutable parameters for an organize operation.
 type OrganizeParams struct {
 	Strategy string `json:"strategy,omitempty"`
+}
+
+// BulkWriteBackParams stores the immutable parameters for a bulk write-back operation.
+// Resume diffs the book IDs against the operation's checkpoint PhaseIndex.
+type BulkWriteBackParams struct {
+	BookIDs []string `json:"book_ids"`
+	Rename  bool     `json:"rename"`
+}
+
+// IsbnEnrichmentParams stores the immutable parameters for an ISBN enrichment operation.
+// BookIDs is the list to enrich; on resume, the checkpoint PhaseIndex is the next index.
+type IsbnEnrichmentParams struct {
+	BookIDs []string `json:"book_ids"`
+}
+
+// MetadataRefreshParams stores the immutable parameters for a metadata refresh operation.
+type MetadataRefreshParams struct {
+	BookIDs []string `json:"book_ids"`
+	Source  string   `json:"source,omitempty"`
 }
 
 // SaveCheckpoint persists an operation's progress checkpoint.

--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -1,16 +1,20 @@
 // file: internal/server/file_io_pool.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f
 //
 // Bounded worker pool for file I/O operations (cover embed, tag write,
 // rename). Tracks pending jobs in PebbleDB so they survive restarts.
+//
+// Tracking key schema: pending_file_op:{bookID}:{opType}. Multiple op
+// types for the same book coexist without clobbering. Recovery looks
+// each opType up in recoveryDispatch.
 
 package server
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,10 +22,12 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+const pendingFileOpPrefix = "pending_file_op:"
+
 // FileIOJob tracks a pending file I/O operation persistently.
 type FileIOJob struct {
 	BookID    string    `json:"book_id"`
-	OpType    string    `json:"op_type"` // "apply_metadata", "write_back", etc.
+	OpType    string    `json:"op_type"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -31,7 +37,7 @@ type FileIOPool struct {
 	ch       chan fileIOJobEntry
 	wg       sync.WaitGroup
 	stopped  int32
-	pending  sync.Map // bookID -> true, for in-memory tracking
+	pending  sync.Map      // "{bookID}:{opType}" -> FileIOJob, for in-memory tracking
 	overflow chan struct{} // semaphore to limit overflow goroutines
 }
 
@@ -41,12 +47,34 @@ type fileIOJobEntry struct {
 	fn     func()
 }
 
-// GlobalFileIOPool is the singleton pool.
-var GlobalFileIOPool *FileIOPool
-var globalFileIOPoolMu sync.Mutex
+var (
+	GlobalFileIOPool   *FileIOPool
+	globalFileIOPoolMu sync.Mutex
 
-// globalServer holds a reference to the Server for recovery of interrupted file ops.
-var globalServer *Server
+	// globalServer holds a Server reference used by the default recovery handler.
+	globalServer *Server
+
+	recoveryDispatch   = map[string]FileOpRecoveryFunc{}
+	recoveryDispatchMu sync.RWMutex
+)
+
+// FileOpRecoveryFunc re-runs a specific file-op type for one book.
+type FileOpRecoveryFunc func(bookID string)
+
+// RegisterFileOpRecovery registers a recovery handler for a given op type.
+// Overwrites any previous registration for the same type.
+func RegisterFileOpRecovery(opType string, fn FileOpRecoveryFunc) {
+	recoveryDispatchMu.Lock()
+	recoveryDispatch[opType] = fn
+	recoveryDispatchMu.Unlock()
+}
+
+func lookupFileOpRecovery(opType string) (FileOpRecoveryFunc, bool) {
+	recoveryDispatchMu.RLock()
+	fn, ok := recoveryDispatch[opType]
+	recoveryDispatchMu.RUnlock()
+	return fn, ok
+}
 
 // GetGlobalFileIOPool returns the pool safely.
 func GetGlobalFileIOPool() *FileIOPool {
@@ -67,7 +95,7 @@ func SetGlobalFileIOPool(p *FileIOPool) {
 func NewFileIOPool(workers int) *FileIOPool {
 	p := &FileIOPool{
 		ch:       make(chan fileIOJobEntry, 500),
-		overflow: make(chan struct{}, workers), // cap overflow goroutines at worker count
+		overflow: make(chan struct{}, workers),
 	}
 	for i := 0; i < workers; i++ {
 		p.wg.Add(1)
@@ -83,18 +111,17 @@ func (p *FileIOPool) worker(id int) {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Printf("[ERROR] file I/O worker %d panicked on book %s: %v", id, job.bookID, r)
+					log.Printf("[ERROR] file I/O worker %d panicked on book %s (op=%s): %v", id, job.bookID, job.opType, r)
 				}
 			}()
 			job.fn()
-			// Mark completed — remove from persistent store
-			p.pending.Delete(job.bookID)
-			removePendingFileOp(job.bookID)
+			p.pending.Delete(pendingKey(job.bookID, job.opType))
+			removePendingFileOp(job.bookID, job.opType)
 		}()
 	}
 }
 
-// Submit queues a file I/O job with persistent tracking.
+// Submit queues a file I/O job with the default "apply_metadata" op type.
 func (p *FileIOPool) Submit(bookID string, fn func()) {
 	p.SubmitTyped(bookID, "apply_metadata", fn)
 }
@@ -102,40 +129,58 @@ func (p *FileIOPool) Submit(bookID string, fn func()) {
 // SubmitTyped queues a file I/O job with a specific operation type.
 func (p *FileIOPool) SubmitTyped(bookID, opType string, fn func()) {
 	if atomic.LoadInt32(&p.stopped) == 1 {
-		log.Printf("[WARN] file I/O pool stopped, dropping job for book %s", bookID)
+		log.Printf("[WARN] file I/O pool stopped, dropping job for book %s (op=%s)", bookID, opType)
 		return
 	}
-	// Track persistently so we can recover on restart
-	p.pending.Store(bookID, true)
-	storePendingFileOp(bookID, opType)
+	job := FileIOJob{BookID: bookID, OpType: opType, CreatedAt: time.Now()}
+	p.pending.Store(pendingKey(bookID, opType), job)
+	storePendingFileOp(job)
 
 	select {
 	case p.ch <- fileIOJobEntry{bookID: bookID, opType: opType, fn: fn}:
 	default:
-		// Buffer full — use semaphore to limit overflow concurrency
-		p.overflow <- struct{}{} // blocks if too many overflow goroutines
-		log.Printf("[WARN] file I/O pool buffer full, running overflow for book %s", bookID)
+		p.overflow <- struct{}{}
+		log.Printf("[WARN] file I/O pool buffer full, running overflow for book %s (op=%s)", bookID, opType)
 		go func() {
 			defer func() { <-p.overflow }()
 			fn()
-			p.pending.Delete(bookID)
-			removePendingFileOp(bookID)
+			p.pending.Delete(pendingKey(bookID, opType))
+			removePendingFileOp(bookID, opType)
 		}()
 	}
 }
 
-// Pending returns the number of queued + in-flight jobs.
+// Pending returns the number of queued jobs.
 func (p *FileIOPool) Pending() int {
 	return len(p.ch)
 }
 
-// PendingBookIDs returns all book IDs with pending file operations.
-func (p *FileIOPool) PendingBookIDs() []string {
-	var ids []string
-	p.pending.Range(func(key, _ any) bool {
-		ids = append(ids, key.(string))
+// PendingJobs returns all in-flight / queued jobs for observability.
+func (p *FileIOPool) PendingJobs() []FileIOJob {
+	var jobs []FileIOJob
+	p.pending.Range(func(_, v any) bool {
+		if job, ok := v.(FileIOJob); ok {
+			jobs = append(jobs, job)
+		}
 		return true
 	})
+	return jobs
+}
+
+// PendingBookIDs returns all book IDs with at least one pending file op.
+// Deduped across op types.
+func (p *FileIOPool) PendingBookIDs() []string {
+	seen := map[string]struct{}{}
+	p.pending.Range(func(_, v any) bool {
+		if job, ok := v.(FileIOJob); ok {
+			seen[job.BookID] = struct{}{}
+		}
+		return true
+	})
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
 	return ids
 }
 
@@ -144,7 +189,7 @@ func (p *FileIOPool) PendingBookIDs() []string {
 // Safe to call multiple times.
 func (p *FileIOPool) Stop() {
 	if !atomic.CompareAndSwapInt32(&p.stopped, 0, 1) {
-		return // already stopped
+		return
 	}
 	close(p.ch)
 
@@ -162,37 +207,72 @@ func (p *FileIOPool) Stop() {
 	}
 }
 
-// InitFileIOPool creates the global pool.
+// InitFileIOPool creates the global pool and registers the default recovery handler.
 func InitFileIOPool() {
 	GlobalFileIOPool = NewFileIOPool(4)
+	RegisterFileOpRecovery("apply_metadata", func(bookID string) {
+		srv := globalServer
+		if srv == nil || srv.metadataFetchService == nil {
+			log.Printf("[WARN] no server instance for apply_metadata recovery of book %s", bookID)
+			return
+		}
+		srv.metadataFetchService.ApplyMetadataFileIO(bookID)
+		if _, err := srv.metadataFetchService.WriteBackMetadataForBook(bookID); err != nil {
+			log.Printf("[WARN] recovery write-back for %s: %v", bookID, err)
+		}
+		if GlobalWriteBackBatcher != nil {
+			GlobalWriteBackBatcher.Enqueue(bookID)
+		}
+	})
 }
 
 // RecoverInterruptedFileOps re-queues any interrupted file I/O jobs.
-// Called explicitly from the server startup sequence, after all services are ready.
+// Called from the server startup sequence after services are ready.
 func RecoverInterruptedFileOps() {
 	recoverInterruptedFileOps()
 }
 
 // --- Persistent tracking via PebbleDB ---
 
-func storePendingFileOp(bookID, opType string) {
-	store := database.GetGlobalStore()
-	if store == nil {
-		return
-	}
-	job := FileIOJob{BookID: bookID, OpType: opType, CreatedAt: time.Now()}
-	data, _ := json.Marshal(job)
-	key := fmt.Sprintf("pending_file_op:%s", bookID)
-	_ = store.SetRaw(key, data)
+func pendingKey(bookID, opType string) string {
+	return bookID + ":" + opType
 }
 
-func removePendingFileOp(bookID string) {
+func pebbleKey(bookID, opType string) string {
+	return pendingFileOpPrefix + bookID + ":" + opType
+}
+
+// parsePebbleKey splits a stored key back into (bookID, opType).
+// Accepts legacy keys without opType ("pending_file_op:{bookID}"), treating them as apply_metadata.
+func parsePebbleKey(key string) (bookID, opType string, ok bool) {
+	rest := strings.TrimPrefix(key, pendingFileOpPrefix)
+	if rest == key {
+		return "", "", false
+	}
+	// Last ":" separates bookID from opType. Book IDs shouldn't contain ":"
+	// but be defensive: split on the last colon only.
+	idx := strings.LastIndex(rest, ":")
+	if idx < 0 {
+		return rest, "apply_metadata", true
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+func storePendingFileOp(job FileIOJob) {
 	store := database.GetGlobalStore()
 	if store == nil {
 		return
 	}
-	key := fmt.Sprintf("pending_file_op:%s", bookID)
-	_ = store.DeleteRaw(key)
+	data, _ := json.Marshal(job)
+	_ = store.SetRaw(pebbleKey(job.BookID, job.OpType), data)
+}
+
+func removePendingFileOp(bookID, opType string) {
+	store := database.GetGlobalStore()
+	if store == nil {
+		return
+	}
+	_ = store.DeleteRaw(pebbleKey(bookID, opType))
 }
 
 // recoverInterruptedFileOps re-queues any file I/O jobs that were in-flight
@@ -203,9 +283,8 @@ func recoverInterruptedFileOps() {
 		return
 	}
 
-	keys, err := store.ScanPrefix("pending_file_op:")
+	keys, err := store.ScanPrefix(pendingFileOpPrefix)
 	if err != nil || len(keys) == 0 {
-		// No interrupted ops or store doesn't support ScanPrefix (e.g. in tests)
 		return
 	}
 
@@ -218,23 +297,35 @@ func recoverInterruptedFileOps() {
 			continue
 		}
 
-		bookID := job.BookID
-		log.Printf("[INFO] re-queuing file I/O for book %s (type=%s, started=%s)", bookID, job.OpType, job.CreatedAt.Format(time.RFC3339))
+		// Backfill fields for legacy entries that predate the opType split.
+		if job.BookID == "" || job.OpType == "" {
+			if bid, op, ok := parsePebbleKey(kv.Key); ok {
+				if job.BookID == "" {
+					job.BookID = bid
+				}
+				if job.OpType == "" {
+					job.OpType = op
+				}
+			}
+		}
+		if job.OpType == "" {
+			job.OpType = "apply_metadata"
+		}
+		if job.BookID == "" {
+			_ = store.DeleteRaw(kv.Key)
+			continue
+		}
 
-		GlobalFileIOPool.SubmitTyped(bookID, job.OpType, func() {
-			// Re-run the full apply pipeline
-			srv := globalServer
-			if srv == nil {
-				log.Printf("[WARN] no server instance for recovery of book %s", bookID)
-				return
-			}
-			srv.metadataFetchService.ApplyMetadataFileIO(bookID)
-			if _, wbErr := srv.metadataFetchService.WriteBackMetadataForBook(bookID); wbErr != nil {
-				log.Printf("[WARN] recovery write-back for %s: %v", bookID, wbErr)
-			}
-			if GlobalWriteBackBatcher != nil {
-				GlobalWriteBackBatcher.Enqueue(bookID)
-			}
-		})
+		fn, ok := lookupFileOpRecovery(job.OpType)
+		if !ok {
+			log.Printf("[WARN] no recovery handler for op type %q (book %s), removing stale key", job.OpType, job.BookID)
+			_ = store.DeleteRaw(kv.Key)
+			continue
+		}
+
+		bookID := job.BookID
+		opType := job.OpType
+		log.Printf("[INFO] re-queuing file I/O for book %s (type=%s, started=%s)", bookID, opType, job.CreatedAt.Format(time.RFC3339))
+		GlobalFileIOPool.SubmitTyped(bookID, opType, func() { fn(bookID) })
 	}
 }

--- a/internal/server/file_io_pool_test.go
+++ b/internal/server/file_io_pool_test.go
@@ -1,0 +1,85 @@
+// file: internal/server/file_io_pool_test.go
+// version: 1.0.0
+// guid: 9d4e2a8f-1b6c-4f70-a3d1-7e5b9c2f8a04
+
+package server
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParsePebbleKey_ModernFormat(t *testing.T) {
+	bookID, opType, ok := parsePebbleKey("pending_file_op:abc123:apply_metadata")
+	if !ok || bookID != "abc123" || opType != "apply_metadata" {
+		t.Fatalf("got (%q, %q, %v), want (\"abc123\", \"apply_metadata\", true)", bookID, opType, ok)
+	}
+}
+
+func TestParsePebbleKey_LegacyFormat(t *testing.T) {
+	// Legacy keys (pre-2.2.0) had no opType — should default to apply_metadata.
+	bookID, opType, ok := parsePebbleKey("pending_file_op:abc123")
+	if !ok || bookID != "abc123" || opType != "apply_metadata" {
+		t.Fatalf("got (%q, %q, %v), want (\"abc123\", \"apply_metadata\", true)", bookID, opType, ok)
+	}
+}
+
+func TestParsePebbleKey_UnrelatedKey(t *testing.T) {
+	if _, _, ok := parsePebbleKey("operation:xyz"); ok {
+		t.Fatal("parsePebbleKey accepted a non-pending_file_op key")
+	}
+}
+
+func TestPendingKey_Composite(t *testing.T) {
+	if got := pendingKey("book1", "tag_writeback"); got != "book1:tag_writeback" {
+		t.Fatalf("pendingKey = %q, want \"book1:tag_writeback\"", got)
+	}
+}
+
+func TestRecoveryDispatch_RegisterAndLookup(t *testing.T) {
+	const opType = "test_op_type_recovery_dispatch"
+	defer func() {
+		recoveryDispatchMu.Lock()
+		delete(recoveryDispatch, opType)
+		recoveryDispatchMu.Unlock()
+	}()
+
+	var called atomic.Int32
+	RegisterFileOpRecovery(opType, func(string) {
+		called.Add(1)
+	})
+
+	fn, ok := lookupFileOpRecovery(opType)
+	if !ok {
+		t.Fatal("lookupFileOpRecovery returned !ok for registered op type")
+	}
+	fn("book123")
+	if called.Load() != 1 {
+		t.Fatalf("recovery handler not invoked, called = %d", called.Load())
+	}
+
+	if _, ok := lookupFileOpRecovery("unregistered_op_type"); ok {
+		t.Fatal("lookupFileOpRecovery returned ok for unregistered op type")
+	}
+}
+
+func TestPendingJobs_DistinctOpTypesPerBook(t *testing.T) {
+	// Two different op types for the same book should both be tracked
+	// — this is what motivated the per-op key schema change.
+	pool := NewFileIOPool(2)
+	defer pool.Stop()
+
+	done := make(chan struct{}, 2)
+	pool.SubmitTyped("book1", "op_a", func() { done <- struct{}{} })
+	pool.SubmitTyped("book1", "op_b", func() { done <- struct{}{} })
+
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-deadline:
+			t.Fatal("timed out waiting for both jobs to run")
+		}
+	}
+}

--- a/internal/server/file_ops_handlers.go
+++ b/internal/server/file_ops_handlers.go
@@ -1,0 +1,58 @@
+// file: internal/server/file_ops_handlers.go
+// version: 1.0.0
+// guid: 5a2e0c6b-1d4f-4a9e-9c3b-6f1a2d7e8b01
+//
+// HTTP handlers for in-flight file I/O operations. Exposes the
+// FileIOPool's pending jobs so the UI can display a "N books writing
+// tags..." indicator and list per-book progress.
+
+package server
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+type pendingFileOp struct {
+	BookID    string    `json:"book_id"`
+	OpType    string    `json:"op_type"`
+	StartedAt time.Time `json:"started_at"`
+	BookTitle string    `json:"book_title,omitempty"`
+}
+
+// handleListPendingFileOps returns currently-queued + in-flight file I/O jobs.
+// Used by the frontend toast + Operations page + Activity Log page.
+func (s *Server) handleListPendingFileOps(c *gin.Context) {
+	pool := GetGlobalFileIOPool()
+	if pool == nil {
+		c.JSON(http.StatusOK, gin.H{"operations": []pendingFileOp{}, "count": 0})
+		return
+	}
+
+	jobs := pool.PendingJobs()
+	out := make([]pendingFileOp, 0, len(jobs))
+	store := database.GlobalStore
+	for _, j := range jobs {
+		op := pendingFileOp{
+			BookID:    j.BookID,
+			OpType:    j.OpType,
+			StartedAt: j.CreatedAt,
+		}
+		if store != nil {
+			if b, err := store.GetBookByID(j.BookID); err == nil && b != nil {
+				op.BookTitle = b.Title
+			}
+		}
+		out = append(out, op)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].StartedAt.Before(out[j].StartedAt)
+	})
+
+	c.JSON(http.StatusOK, gin.H{"operations": out, "count": len(out)})
+}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -855,78 +855,18 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 	}
 
 	doRename := req.Rename
-	mfs := s.metadataFetchService
 	bookIDs := make([]string, len(filtered))
 	for i, b := range filtered {
 		bookIDs[i] = b.ID
 	}
 
+	// Persist params so the operation can be resumed across a restart.
+	if err := operations.SaveParams(store, op.ID, operations.BulkWriteBackParams{BookIDs: bookIDs, Rename: doRename}); err != nil {
+		log.Printf("[WARN] failed to save bulk_write_back params for %s: %v", op.ID, err)
+	}
+
 	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		total := len(bookIDs)
-		written := 0
-		failed := 0
-
-		for i, bookID := range bookIDs {
-			if progress.IsCanceled() {
-				msg := fmt.Sprintf("canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
-				_ = progress.Log("info", msg, nil)
-				return nil
-			}
-
-			// Check context cancellation
-			select {
-			case <-ctx.Done():
-				msg := fmt.Sprintf("context canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
-				_ = progress.Log("info", msg, nil)
-				return ctx.Err()
-			default:
-			}
-
-			book, err := store.GetBookByID(bookID)
-			if err != nil || book == nil {
-				failed++
-				detail := fmt.Sprintf("book %s: not found", bookID)
-				_ = progress.Log("warn", detail, nil)
-				_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: not found)", i+1, total))
-				continue
-			}
-
-			// Skip protected paths (re-check in case data changed)
-			if isProtectedPath(book.FilePath) {
-				detail := fmt.Sprintf("book %s: skipping protected path %s", bookID, book.FilePath)
-				_ = progress.Log("info", detail, nil)
-				_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: protected)", i+1, total))
-				continue
-			}
-
-			// Step 1: Rename if requested
-			if doRename {
-				if renameErr := mfs.RunApplyPipelineRenameOnly(bookID, book); renameErr != nil {
-					detail := fmt.Sprintf("book %s: rename failed: %v", bookID, renameErr)
-					_ = progress.Log("warn", detail, nil)
-				}
-			}
-
-			// Step 2: Write tags
-			count, writeErr := mfs.WriteBackMetadataForBook(bookID)
-			if writeErr != nil {
-				failed++
-				detail := fmt.Sprintf("book %s: write-back failed: %v", bookID, writeErr)
-				_ = progress.Log("warn", detail, nil)
-			} else {
-				written++
-				if count > 0 {
-					detail := fmt.Sprintf("book %s: wrote %d file(s)", bookID, count)
-					_ = progress.Log("debug", detail, nil)
-				}
-			}
-
-			_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (%d written, %d failed)", i+1, total, written, failed))
-		}
-
-		summary := fmt.Sprintf("bulk write-back complete: %d written, %d failed out of %d", written, failed, total)
-		_ = progress.Log("info", summary, nil)
-		return nil
+		return s.runBulkWriteBack(ctx, op.ID, bookIDs, doRename, 0, progress)
 	}
 
 	if err := operations.GlobalQueue.Enqueue(op.ID, "bulk_write_back", operations.PriorityNormal, operationFunc); err != nil {
@@ -938,6 +878,142 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 		"operation_id":    op.ID,
 		"estimated_books": estimatedBooks,
 	})
+}
+
+// runBulkWriteBack iterates the provided bookIDs starting at startIdx, writing
+// tags (and optionally renaming first) for each. Used by both the fresh-launch
+// path and the resume path. Checkpoints progress every 10 books so a restart
+// can pick up near where it left off.
+func (s *Server) runBulkWriteBack(
+	ctx context.Context,
+	opID string,
+	bookIDs []string,
+	doRename bool,
+	startIdx int,
+	progress operations.ProgressReporter,
+) error {
+	store := database.GlobalStore
+	mfs := s.metadataFetchService
+	total := len(bookIDs)
+	written := 0
+	failed := 0
+
+	if startIdx > 0 {
+		_ = progress.Log("info", fmt.Sprintf("resuming bulk write-back from index %d/%d", startIdx, total), nil)
+	}
+
+	for i := startIdx; i < total; i++ {
+		bookID := bookIDs[i]
+		if progress.IsCanceled() {
+			msg := fmt.Sprintf("canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
+			_ = progress.Log("info", msg, nil)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			msg := fmt.Sprintf("context canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
+			_ = progress.Log("info", msg, nil)
+			return ctx.Err()
+		default:
+		}
+
+		book, err := store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			failed++
+			_ = progress.Log("warn", fmt.Sprintf("book %s: not found", bookID), nil)
+			_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: not found)", i+1, total))
+			continue
+		}
+
+		if isProtectedPath(book.FilePath) {
+			_ = progress.Log("info", fmt.Sprintf("book %s: skipping protected path %s", bookID, book.FilePath), nil)
+			_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: protected)", i+1, total))
+			continue
+		}
+
+		if doRename {
+			if renameErr := mfs.RunApplyPipelineRenameOnly(bookID, book); renameErr != nil {
+				_ = progress.Log("warn", fmt.Sprintf("book %s: rename failed: %v", bookID, renameErr), nil)
+			}
+		}
+
+		count, writeErr := mfs.WriteBackMetadataForBook(bookID)
+		if writeErr != nil {
+			failed++
+			_ = progress.Log("warn", fmt.Sprintf("book %s: write-back failed: %v", bookID, writeErr), nil)
+		} else {
+			written++
+			if count > 0 {
+				_ = progress.Log("debug", fmt.Sprintf("book %s: wrote %d file(s)", bookID, count), nil)
+			}
+		}
+
+		_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (%d written, %d failed)", i+1, total, written, failed))
+
+		if (i+1)%10 == 0 {
+			_ = operations.SaveCheckpoint(store, opID, "bulk_write_back", "writing", i+1, total)
+		}
+	}
+
+	_ = operations.ClearState(store, opID)
+	summary := fmt.Sprintf("bulk write-back complete: %d written, %d failed out of %d", written, failed, total)
+	_ = progress.Log("info", summary, nil)
+	return nil
+}
+
+// runIsbnEnrichment enriches missing ISBN identifiers from external sources.
+// Idempotent — books that already have an ISBN are skipped, so a restart
+// safely re-runs from scratch (no checkpoint needed).
+func (s *Server) runIsbnEnrichment(ctx context.Context, progress operations.ProgressReporter) error {
+	if s.metadataFetchService == nil || s.metadataFetchService.isbnEnrichment == nil {
+		_ = progress.Log("info", "ISBN enrichment service is not configured, skipping", nil)
+		return nil
+	}
+	_ = progress.Log("info", "Scanning for books missing ISBN identifiers", nil)
+	checked, updated, err := s.metadataFetchService.isbnEnrichment.EnrichMissingISBNs(ctx, 100)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("ISBN enrichment complete: checked %d candidate book(s), updated %d", checked, updated)
+	_ = progress.Log("info", msg, nil)
+	_ = progress.UpdateProgress(100, 100, msg)
+	return nil
+}
+
+// runMetadataRefreshScan reports books with incomplete metadata. Read-only,
+// safe to re-run on restart with no state.
+func (s *Server) runMetadataRefreshScan(ctx context.Context, progress operations.ProgressReporter) error {
+	store := database.GlobalStore
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	_ = progress.Log("info", "Starting metadata refresh scan", nil)
+	_ = progress.UpdateProgress(0, 100, "Scanning books for incomplete metadata...")
+	books, err := store.GetAllBooks(10000, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get books: %w", err)
+	}
+	_ = progress.Log("info", fmt.Sprintf("Checking %d books for incomplete metadata", len(books)), nil)
+	incomplete := 0
+	for i, book := range books {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if book.AuthorID == nil || book.Title == "" {
+			incomplete++
+			_ = progress.Log("debug", fmt.Sprintf("Incomplete: %q (id=%s)", book.Title, book.ID), nil)
+		}
+		if (i+1)%200 == 0 {
+			_ = progress.UpdateProgress(i+1, len(books), fmt.Sprintf("Checked %d/%d books", i+1, len(books)))
+		}
+	}
+	resultMsg := fmt.Sprintf("Found %d books with incomplete metadata out of %d total", incomplete, len(books))
+	_ = progress.Log("info", resultMsg, nil)
+	_ = progress.UpdateProgress(len(books), len(books), resultMsg)
+	return nil
 }
 
 func (s *Server) batchWriteBackAudiobooks(c *gin.Context) {

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -286,21 +286,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Enrich missing ISBN identifiers from external metadata sources",
 		Category:    "maintenance",
 		TriggerFn: func() (*database.Operation, error) {
-			return ts.triggerOperation("isbn-enrichment", func(ctx context.Context, progress operations.ProgressReporter) error {
-				if s.metadataFetchService == nil || s.metadataFetchService.isbnEnrichment == nil {
-					_ = progress.Log("info", "ISBN enrichment service is not configured, skipping", nil)
-					return nil
-				}
-				_ = progress.Log("info", "Scanning for books missing ISBN identifiers", nil)
-				checked, updated, err := s.metadataFetchService.isbnEnrichment.EnrichMissingISBNs(ctx, 100)
-				if err != nil {
-					return err
-				}
-				msg := fmt.Sprintf("ISBN enrichment complete: checked %d candidate book(s), updated %d", checked, updated)
-				_ = progress.Log("info", msg, nil)
-				_ = progress.UpdateProgress(100, 100, msg)
-				return nil
-			})
+			return ts.triggerOperation("isbn-enrichment", s.runIsbnEnrichment)
 		},
 		IsEnabled:              func() bool { return s.metadataFetchService != nil && s.metadataFetchService.isbnEnrichment != nil },
 		GetInterval:            func() time.Duration { return 0 },
@@ -738,33 +724,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Re-fetch metadata for incomplete books",
 		Category:    "maintenance",
 		TriggerFn: func() (*database.Operation, error) {
-			return ts.triggerOperation("metadata-refresh", func(ctx context.Context, progress operations.ProgressReporter) error {
-				store := database.GlobalStore
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				_ = progress.Log("info", "Starting metadata refresh scan", nil)
-				_ = progress.UpdateProgress(0, 100, "Scanning books for incomplete metadata...")
-				books, err := store.GetAllBooks(10000, 0)
-				if err != nil {
-					return fmt.Errorf("failed to get books: %w", err)
-				}
-				_ = progress.Log("info", fmt.Sprintf("Checking %d books for incomplete metadata", len(books)), nil)
-				incomplete := 0
-				for i, book := range books {
-					if book.AuthorID == nil || book.Title == "" {
-						incomplete++
-						_ = progress.Log("debug", fmt.Sprintf("Incomplete: %q (id=%s)", book.Title, book.ID), nil)
-					}
-					if (i+1)%200 == 0 {
-						_ = progress.UpdateProgress(i+1, len(books), fmt.Sprintf("Checked %d/%d books", i+1, len(books)))
-					}
-				}
-				resultMsg := fmt.Sprintf("Found %d books with incomplete metadata out of %d total", incomplete, len(books))
-				_ = progress.Log("info", resultMsg, nil)
-				_ = progress.UpdateProgress(len(books), len(books), resultMsg)
-				return nil
-			})
+			return ts.triggerOperation("metadata-refresh", s.runMetadataRefreshScan)
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledMetadataRefreshEnabled },
 		GetInterval: func() time.Duration {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1130,12 +1130,32 @@ func (s *Server) resumeInterruptedOperations() {
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
 				return s.organizeService.PerformOrganizeWithID(ctx, opID, &OrganizeRequest{}, operations.LoggerFromReporter(progress))
 			}
+		case "bulk_write_back":
+			params, _ := operations.LoadParams[operations.BulkWriteBackParams](store, opID)
+			if params == nil {
+				log.Printf("[WARN] No params for interrupted bulk_write_back %s, marking failed", opID)
+				_ = store.UpdateOperationError(opID, "no saved params, cannot resume")
+				continue
+			}
+			startIdx := 0
+			if checkpoint != nil {
+				startIdx = checkpoint.PhaseIndex
+			}
+			bookIDs := params.BookIDs
+			doRename := params.Rename
+			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+				return s.runBulkWriteBack(ctx, opID, bookIDs, doRename, startIdx, progress)
+			}
+		case "isbn-enrichment":
+			resumeFn = s.runIsbnEnrichment
+		case "metadata-refresh":
+			resumeFn = s.runMetadataRefreshScan
 		case "reconcile_scan", "transcode", "diagnostics_export", "diagnostics_ai",
-			"bulk_write_back", "cleanup_activity_log", "purge_old_logs",
-			"purge-deleted", "tombstone-cleanup", "isbn-enrichment",
+			"cleanup_activity_log", "purge_old_logs",
+			"purge-deleted", "tombstone-cleanup",
 			"author-dedup-scan", "author-split-scan", "series-prune",
 			"db-optimize", "cleanup-old-backups", "batch_poller",
-			"itunes_sync", "metadata-refresh":
+			"itunes_sync":
 			// These are not resumable — mark as failed silently
 			_ = store.UpdateOperationError(opID, fmt.Sprintf("interrupted during %s, please retry", opType))
 			_ = operations.ClearState(store, opID)
@@ -1788,6 +1808,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/operations/organize", s.startOrganize)
 			protected.POST("/operations/transcode", s.startTranscode)
 			protected.GET("/operations/recent", s.handleGetRecentOperations)
+			protected.GET("/file-ops/pending", s.handleListPendingFileOps)
 			protected.GET("/operations/:id/results", s.handleGetOperationResults)
 			protected.GET("/operations/:id/status", s.getOperationStatus)
 			protected.GET("/operations/:id/logs", s.getOperationLogs)

--- a/web/src/components/PendingFileOpsBanner.tsx
+++ b/web/src/components/PendingFileOpsBanner.tsx
@@ -1,0 +1,102 @@
+// file: web/src/components/PendingFileOpsBanner.tsx
+// version: 1.0.0
+// guid: 6c1e8b3d-2a47-4f5d-9e0c-b8a4d2f6e7a3
+//
+// Banner shown when background file operations (tag write, cover embed,
+// rename) are in flight. Mounted at the top of the Activity Log so users
+// can see what's still happening before the activity entries are written.
+
+import { useState } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  LinearProgress,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess.js';
+import type { PendingFileOp } from '../services/fileOpsApi';
+
+interface Props {
+  operations: PendingFileOp[];
+}
+
+function formatOpType(t: string): string {
+  switch (t) {
+    case 'apply_metadata':
+      return 'Writing tags & cover';
+    case 'tag_writeback':
+      return 'Writing tags';
+    case 'cover_embed':
+      return 'Embedding cover';
+    case 'rename':
+      return 'Renaming files';
+    default:
+      return t.replace(/_/g, ' ');
+  }
+}
+
+function timeAgo(iso: string): string {
+  const sec = Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+}
+
+export function PendingFileOpsBanner({ operations }: Props): JSX.Element | null {
+  const [expanded, setExpanded] = useState(false);
+  if (operations.length === 0) return null;
+
+  const count = operations.length;
+
+  return (
+    <Paper variant="outlined" sx={{ mb: 2, borderColor: 'info.main' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 2,
+          py: 1.25,
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <CircularProgress size={18} thickness={5} />
+        <Typography variant="body2" sx={{ flex: 1 }}>
+          Writing files for <strong>{count}</strong> book{count === 1 ? '' : 's'}
+          {count > 1 && '...'}
+        </Typography>
+        <IconButton size="small">
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+      <LinearProgress sx={{ height: 2 }} />
+      <Collapse in={expanded}>
+        <Stack divider={<Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }} />}>
+          {operations.map((op) => (
+            <Box
+              key={`${op.book_id}:${op.op_type}`}
+              sx={{ px: 2, py: 0.75, display: 'flex', alignItems: 'center', gap: 1.5 }}
+            >
+              <Typography variant="body2" sx={{ flex: 1 }} noWrap>
+                {op.book_title || op.book_id}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatOpType(op.op_type)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ minWidth: 32, textAlign: 'right' }}>
+                {timeAgo(op.started_at)}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </Collapse>
+    </Paper>
+  );
+}

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -1,11 +1,12 @@
 // file: web/src/components/layout/MainLayout.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
 
 import { useState, ReactNode } from 'react';
 import { Box } from '@mui/material';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
+import { usePendingFileOps } from '../../hooks/usePendingFileOps';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -15,6 +16,10 @@ const DRAWER_WIDTH = 240;
 
 export function MainLayout({ children }: MainLayoutProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Global poller — fires the "All tag writes complete" toast on every page
+  // even if the user is not on Activity Log.
+  usePendingFileOps({ fireToasts: true });
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);

--- a/web/src/hooks/usePendingFileOps.ts
+++ b/web/src/hooks/usePendingFileOps.ts
@@ -1,0 +1,74 @@
+// file: web/src/hooks/usePendingFileOps.ts
+// version: 1.0.0
+// guid: 8f4a2b9c-5e1d-4f70-a8c3-2b6e9d1a0f45
+
+import { useEffect, useRef, useState } from 'react';
+import { fetchPendingFileOps, type PendingFileOp } from '../services/fileOpsApi';
+import { useToast } from '../components/toast/ToastProvider';
+
+const POLL_INTERVAL_MS = 4000;
+
+export interface UsePendingFileOpsOptions {
+  enabled?: boolean;
+  /** Fire a toast when count drops from N to 0. Should only be true on one mount per app. */
+  fireToasts?: boolean;
+}
+
+export interface UsePendingFileOpsResult {
+  operations: PendingFileOp[];
+  count: number;
+  loading: boolean;
+}
+
+/**
+ * Polls /api/v1/file-ops/pending. When fireToasts is true, fires a single
+ * "All tag writes complete" toast when the count drops from N to 0 (rising
+ * edge is suppressed since the user already knows they kicked off an apply).
+ */
+export function usePendingFileOps(options: UsePendingFileOpsOptions = {}): UsePendingFileOpsResult {
+  const { enabled = true, fireToasts = false } = options;
+  const [operations, setOperations] = useState<PendingFileOp[]>([]);
+  const [loading, setLoading] = useState<boolean>(enabled);
+  const { toast } = useToast();
+  const previousCountRef = useRef<number>(0);
+  const initialLoadRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    if (!enabled) {
+      setOperations([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const resp = await fetchPendingFileOps();
+        if (cancelled) return;
+        setOperations(resp.operations || []);
+        setLoading(false);
+
+        if (fireToasts) {
+          const prev = previousCountRef.current;
+          const next = resp.count;
+          if (!initialLoadRef.current && prev > 0 && next === 0) {
+            toast('All tag writes complete', 'success');
+          }
+          previousCountRef.current = next;
+          initialLoadRef.current = false;
+        }
+      } catch {
+        // Silent — transient network error shouldn't spam the user
+      }
+    };
+
+    void poll();
+    const interval = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [enabled, fireToasts, toast]);
+
+  return { operations, count: operations.length, loading };
+}

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.2.0
+// version: 2.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -42,6 +42,8 @@ import FilterListIcon from '@mui/icons-material/FilterList.js';
 import { fetchActivity, fetchActivitySources, compactActivityLog } from '../services/activityApi';
 import type { ActivityEntry, SourceCount } from '../services/activityApi';
 import * as api from '../services/api';
+import { PendingFileOpsBanner } from '../components/PendingFileOpsBanner';
+import { usePendingFileOps } from '../hooks/usePendingFileOps';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250];
 
@@ -128,6 +130,9 @@ export default function ActivityLog() {
 
   // Mobile filter collapse
   const [filtersExpanded, setFiltersExpanded] = useState(false);
+
+  // Pending background file operations (cover embed, tag write, rename)
+  const { operations: pendingFileOps } = usePendingFileOps();
 
   // Active ops
   const [activeOps, setActiveOps] = useState<api.ActiveOperationSummary[]>([]);
@@ -556,6 +561,9 @@ export default function ActivityLog() {
           <RefreshIcon />
         </IconButton>
       </Stack>
+
+      {/* In-flight background file operations */}
+      <PendingFileOpsBanner operations={pendingFileOps} />
 
       {/* Pinned Operations Section */}
       {showOpsSection && (

--- a/web/src/services/fileOpsApi.ts
+++ b/web/src/services/fileOpsApi.ts
@@ -1,0 +1,25 @@
+// file: web/src/services/fileOpsApi.ts
+// version: 1.0.0
+// guid: 7b3d5a1e-9c2f-4e80-b1a4-3d8c6e0f4a12
+
+const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
+
+export interface PendingFileOp {
+  book_id: string;
+  op_type: string;
+  started_at: string;
+  book_title?: string;
+}
+
+export interface PendingFileOpsResponse {
+  operations: PendingFileOp[];
+  count: number;
+}
+
+export async function fetchPendingFileOps(): Promise<PendingFileOpsResponse> {
+  const res = await fetch(`${API_BASE}/file-ops/pending`, { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`fetchPendingFileOps failed: ${res.status}`);
+  }
+  return res.json() as Promise<PendingFileOpsResponse>;
+}


### PR DESCRIPTION
## Summary

- **Per-op file I/O tracking** — `pending_file_op:{bookID}:{opType}` keys instead of one-key-per-book, so two distinct file ops on the same book no longer clobber each other. Recovery dispatches by op type via a registered handler map; legacy single-segment keys back-compat to `apply_metadata`.
- **`GET /api/v1/file-ops/pending`** — exposes in-flight pool jobs to the frontend. Global poller in `MainLayout` fires \"All tag writes complete\" toast on falling edge; `PendingFileOpsBanner` on Activity Log shows per-book progress with elapsed time.
- **Three op types now resumable** — `bulk_write_back` (saves params + checkpoints every 10 books, resumes from checkpoint), `isbn-enrichment` (idempotent — skips books already enriched), `metadata-refresh` (read-only scan). Previously all three silently failed on restart.
- **Sort fix** — `PebbleStore.GetRecentOperations`/`ListOperations` were doing O(N²) bubble sort; replaced with `sort.Slice`. Fixes the ~900ms cache-miss latency on `/api/v1/operations/recent`. Existing 10s listCache still covers repeat hits.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/server/ ./internal/database/ ./internal/operations/` all pass
- [x] New unit tests: `TestParsePebbleKey_*`, `TestPendingKey_Composite`, `TestRecoveryDispatch_RegisterAndLookup`, `TestPendingJobs_DistinctOpTypesPerBook`
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 86 / 86 pass
- [ ] Manual: apply metadata to several books, observe banner on `/activity` and toast on completion
- [ ] Manual: kick off bulk write-back, restart server mid-flight, verify it resumes from checkpoint

## Notes

- Skipped a side-index for `recent_ops`: the `sort.Slice` fix should be a ~1000× improvement (10K ops: 100M→130K comparisons) so an index is premature. Add one if production benchmarks show this isn't enough.
- Apply pipeline stays atomic (cover embed + tag write + ITL update bundled under `apply_metadata`); per-op granularity is for *future* op types that aren't part of that bundle. The split would require phase checkpoints in the apply pipeline for marginal payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)