### PR TITLE
fix(metadata): normalize "Series, Book N" out of Audible candidates

### DIFF
--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_fetch_service.go
-// version: 4.48.0
+// version: 4.49.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package server
@@ -360,22 +360,7 @@ func (mfs *MetadataFetchService) FetchMetadataForBook(id string) (*FetchMetadata
 				}
 			}
 			meta := scored[0]
-
-			// Parse series string if present (e.g. "(Long Earth 05) The Long Cosmos")
-			parsedSeries, parsedPosition, parsedTitle := parseSeriesFromTitle(meta.Title)
-			if parsedSeries == "" && meta.Series != "" {
-				parsedSeries, parsedPosition, parsedTitle = parseSeriesFromTitle(meta.Series)
-				if parsedTitle == "" {
-					parsedTitle = meta.Title
-				}
-			}
-			if parsedSeries != "" {
-				meta.Series = parsedSeries
-				meta.SeriesPosition = parsedPosition
-				if parsedTitle != "" {
-					meta.Title = parsedTitle
-				}
-			}
+			normalizeMetaSeries(&meta)
 
 			// Safety: never apply empty/untitled metadata
 			if meta.Title == "" || strings.ToLower(meta.Title) == "untitled" {
@@ -501,21 +486,7 @@ func (mfs *MetadataFetchService) FetchMetadataForBookByTitle(id string) (*FetchM
 			continue
 		}
 		meta := scored[0]
-
-		parsedSeries, parsedPosition, parsedTitle := parseSeriesFromTitle(meta.Title)
-		if parsedSeries == "" && meta.Series != "" {
-			parsedSeries, parsedPosition, parsedTitle = parseSeriesFromTitle(meta.Series)
-			if parsedTitle == "" {
-				parsedTitle = meta.Title
-			}
-		}
-		if parsedSeries != "" {
-			meta.Series = parsedSeries
-			meta.SeriesPosition = parsedPosition
-			if parsedTitle != "" {
-				meta.Title = parsedTitle
-			}
-		}
+		normalizeMetaSeries(&meta)
 
 		mfs.recordChangeHistory(book, meta, src.Name())
 		mfs.applyMetadataToBook(book, meta)
@@ -780,6 +751,35 @@ func derefIntAsString(p *int) string {
 func jsonEncodeString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+// normalizeMetaSeries splits an embedded "Series Name, Book N" pattern
+// out of meta.Title or meta.Series into separate Series + SeriesPosition
+// fields. Audible/Audnexus sometimes return the series name with the
+// book number baked in (e.g. "Mistborn, Book 3") instead of using their
+// own Sequence field, which leaves us with a series row named
+// "Mistborn, Book 3" if we apply the candidate as-is.
+//
+// Safe to call multiple times: a no-match leaves meta untouched, and an
+// already-split series field will not match Pattern 3.
+func normalizeMetaSeries(meta *metadata.BookMetadata) {
+	parsedSeries, parsedPosition, parsedTitle := parseSeriesFromTitle(meta.Title)
+	if parsedSeries == "" && meta.Series != "" {
+		parsedSeries, parsedPosition, parsedTitle = parseSeriesFromTitle(meta.Series)
+		if parsedTitle == "" {
+			parsedTitle = meta.Title
+		}
+	}
+	if parsedSeries == "" {
+		return
+	}
+	meta.Series = parsedSeries
+	if parsedPosition != "" {
+		meta.SeriesPosition = parsedPosition
+	}
+	if parsedTitle != "" {
+		meta.Title = parsedTitle
+	}
 }
 
 // parseSeriesFromTitle extracts series name, position, and title from strings like:
@@ -2375,6 +2375,11 @@ func (mfs *MetadataFetchService) ApplyMetadataCandidate(id string, candidate Met
 			meta.Language = ""
 		}
 	}
+
+	// Strip embedded "Series Name, Book N" before persisting — protects
+	// against Audible/Audnexus candidates where the book number is baked
+	// into the series name. Same normalization the auto-fetch paths run.
+	normalizeMetaSeries(&meta)
 
 	// Record history BEFORE applying changes so old values are correct
 	mfs.recordChangeHistory(book, meta, candidate.Source)

--- a/internal/server/metadata_normalize_test.go
+++ b/internal/server/metadata_normalize_test.go
@@ -1,0 +1,98 @@
+// file: internal/server/metadata_normalize_test.go
+// version: 1.0.0
+// guid: 4f7c2b8d-3a91-4e5f-b6c0-1d8e7a9f3c45
+
+package server
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+)
+
+func TestNormalizeMetaSeries_AlreadySplit(t *testing.T) {
+	meta := metadata.BookMetadata{
+		Title:          "The Final Empire",
+		Series:         "Mistborn",
+		SeriesPosition: "1",
+	}
+	normalizeMetaSeries(&meta)
+	if meta.Series != "Mistborn" || meta.SeriesPosition != "1" || meta.Title != "The Final Empire" {
+		t.Fatalf("clean fields should not be modified, got %+v", meta)
+	}
+}
+
+func TestNormalizeMetaSeries_BookNumberInSeries(t *testing.T) {
+	// The actual BMR-1 case: Audible returned the series field with the book
+	// number baked in. The title is fine. Without normalization we'd create
+	// a series named "Mistborn, Book 3".
+	meta := metadata.BookMetadata{
+		Title:  "The Hero of Ages",
+		Series: "Mistborn, Book 3",
+	}
+	normalizeMetaSeries(&meta)
+	if meta.Series != "Mistborn" {
+		t.Errorf("Series = %q, want %q", meta.Series, "Mistborn")
+	}
+	if meta.SeriesPosition != "3" {
+		t.Errorf("SeriesPosition = %q, want %q", meta.SeriesPosition, "3")
+	}
+	if meta.Title != "The Hero of Ages" {
+		t.Errorf("Title = %q, want %q (Pattern 3 has no title — keep original)", meta.Title, "The Hero of Ages")
+	}
+}
+
+func TestNormalizeMetaSeries_BookNumberInTitle(t *testing.T) {
+	// Pattern 1 in title: extract series + position + new title.
+	meta := metadata.BookMetadata{
+		Title: "(Long Earth 5) The Long Cosmos",
+	}
+	normalizeMetaSeries(&meta)
+	if meta.Series != "Long Earth" {
+		t.Errorf("Series = %q, want %q", meta.Series, "Long Earth")
+	}
+	if meta.SeriesPosition != "5" {
+		t.Errorf("SeriesPosition = %q, want %q", meta.SeriesPosition, "5")
+	}
+	if meta.Title != "The Long Cosmos" {
+		t.Errorf("Title = %q, want %q", meta.Title, "The Long Cosmos")
+	}
+}
+
+func TestNormalizeMetaSeries_NoMatch(t *testing.T) {
+	meta := metadata.BookMetadata{
+		Title:  "Some Standalone Book",
+		Series: "",
+	}
+	normalizeMetaSeries(&meta)
+	if meta.Title != "Some Standalone Book" || meta.Series != "" {
+		t.Fatalf("non-matching input should be untouched, got %+v", meta)
+	}
+}
+
+func TestNormalizeMetaSeries_PreservesExistingPositionWhenSeriesUnchanged(t *testing.T) {
+	// If the series field doesn't match a pattern AND is non-empty, we keep
+	// whatever the upstream gave us — do not clobber SeriesPosition.
+	meta := metadata.BookMetadata{
+		Title:          "Wind and Truth",
+		Series:         "The Stormlight Archive",
+		SeriesPosition: "5",
+	}
+	normalizeMetaSeries(&meta)
+	if meta.SeriesPosition != "5" {
+		t.Errorf("SeriesPosition lost, got %q", meta.SeriesPosition)
+	}
+}
+
+func TestNormalizeMetaSeries_Idempotent(t *testing.T) {
+	meta := metadata.BookMetadata{
+		Title:  "The Hero of Ages",
+		Series: "Mistborn, Book 3",
+	}
+	normalizeMetaSeries(&meta)
+	first := meta
+	normalizeMetaSeries(&meta)
+	if meta != first {
+		t.Errorf("second call mutated meta; before=%+v after=%+v", first, meta)
+	}
+}


### PR DESCRIPTION
## Summary

When metadata is applied from an Audible/Audnexus candidate where the series field has the book number baked in (e.g. \`\"Mistborn, Book 3\"\`), the database ends up with a series row named exactly \`\"Mistborn, Book 3\"\` and \`series_sequence\` left null.

The auto-fetch paths already normalized this via \`parseSeriesFromTitle\`, but the user-facing \`ApplyMetadataCandidate\` path didn't — it called \`applyMetadataToBook\` directly with the raw candidate fields.

Extracts the parse-and-assign logic into \`normalizeMetaSeries(*BookMetadata)\` so all three call sites run the same code. Idempotent: a second call on already-clean fields is a no-op.

## Test plan

- [x] \`go build ./...\`
- [x] New unit tests in \`internal/server/metadata_normalize_test.go\` cover: clean fields, baked-in series, paren-pattern title, no-match, position preservation, idempotency
- [x] \`go test ./internal/server/ -run TestNormalizeMetaSeries\` — 6 / 6 pass
- [ ] Manual: apply an Audible candidate where \`series = \"Series Name, Book 7\"\`, verify DB stores \`series.name = \"Series Name\"\` and \`book.series_sequence = 7\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)