### PR TITLE
feat(organize): richer error messages with paths and remediation hints

### DIFF
--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package organizer
@@ -77,13 +77,16 @@ func NewOrganizer(cfg *config.Config) *Organizer {
 // OrganizeBook organizes a book file according to the configured patterns
 // Returns (targetPath, method, error) where method is "reflink", "hardlink", "copy", or "symlink"
 func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
-	if book == nil || book.FilePath == "" {
-		return "", "", fmt.Errorf("invalid book or file path")
+	if book == nil {
+		return "", "", fmt.Errorf("cannot organize: book is nil")
+	}
+	if book.FilePath == "" {
+		return "", "", fmt.Errorf("cannot organize %q (id=%s): file_path is empty — book has no tracked file", book.Title, book.ID)
 	}
 
 	// Skip directories — only organize individual files
 	if info, err := os.Stat(book.FilePath); err == nil && info.IsDir() {
-		return "", "", fmt.Errorf("source path is a directory, not a file: %s", book.FilePath)
+		return "", "", fmt.Errorf("cannot organize %q (id=%s): file_path %s is a directory but single-file organize was requested — use organizeDirectoryBook for multi-file books", book.Title, book.ID, book.FilePath)
 	}
 
 	// Generate target path
@@ -326,7 +329,8 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 
 	result = cleanupPattern(result)
 	if leftoverPlaceholderRegex.MatchString(result) {
-		return "", fmt.Errorf("unresolved placeholders in pattern result: %s", result)
+		leftover := leftoverPlaceholderRegex.FindAllString(result, -1)
+		return "", fmt.Errorf("naming pattern produced %q with unresolved placeholders %v — book is missing values for these fields, or the pattern references unknown placeholders", result, leftover)
 	}
 	return result, nil
 }
@@ -413,7 +417,7 @@ func ensureUnderRoot(fullPath, rootDir string) error {
 	cleanTarget := filepath.Clean(fullPath)
 	cleanRoot := filepath.Clean(rootDir)
 	if !strings.HasPrefix(cleanTarget, cleanRoot+string(filepath.Separator)) && cleanTarget != cleanRoot {
-		return fmt.Errorf("generated path %q escapes root directory %q", cleanTarget, cleanRoot)
+		return fmt.Errorf("generated path %q escapes the configured root %q — likely caused by special characters in author/title metadata or a malformed naming pattern", cleanTarget, cleanRoot)
 	}
 	return nil
 }
@@ -430,7 +434,7 @@ func stringOrEmpty(s *string) string {
 func (o *Organizer) copyFile(src, dst string) error {
 	sourceFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("failed to open source file: %w", err)
+		return fmt.Errorf("cannot read source file %s: %w", src, err)
 	}
 	defer sourceFile.Close()
 
@@ -439,7 +443,7 @@ func (o *Organizer) copyFile(src, dst string) error {
 
 	destFile, err := os.Create(tempPath)
 	if err != nil {
-		return fmt.Errorf("failed to create destination file: %w", err)
+		return fmt.Errorf("cannot create destination file %s: %w (check parent directory permissions and disk space)", tempPath, err)
 	}
 	defer func() {
 		_ = destFile.Close()

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -235,7 +235,7 @@ func TestOrganizeBook_NilBook(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil book")
 	}
-	if err.Error() != "invalid book or file path" {
+	if !strings.Contains(err.Error(), "book is nil") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -247,7 +247,7 @@ func TestOrganizeBook_EmptyFilePath(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty file path")
 	}
-	if err.Error() != "invalid book or file path" {
+	if !strings.Contains(err.Error(), "file_path is empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -675,7 +675,7 @@ func TestCopyFile_ErrorCases(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for nonexistent source")
 		}
-		if !strings.Contains(err.Error(), "failed to open source file") {
+		if !strings.Contains(err.Error(), "cannot read source file") {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -690,7 +690,7 @@ func TestCopyFile_ErrorCases(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for invalid destination")
 		}
-		if !strings.Contains(err.Error(), "failed to create destination file") {
+		if !strings.Contains(err.Error(), "cannot create destination file") {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})

--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service.go
-// version: 1.22.0
+// version: 1.23.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package server
@@ -342,7 +342,13 @@ func (orgSvc *OrganizeService) reOrganizeInPlace(book *database.Book, log logger
 
 	info, err := os.Stat(oldPath)
 	if err != nil {
-		return "", fmt.Errorf("cannot stat %s: %w", oldPath, err)
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("source path no longer exists: %s — re-scan the library to update tracking", oldPath)
+		}
+		if os.IsPermission(err) {
+			return "", fmt.Errorf("permission denied reading source: %s — check filesystem permissions and ACLs", oldPath)
+		}
+		return "", fmt.Errorf("cannot access source %s: %w", oldPath, err)
 	}
 
 	var targetPath string
@@ -366,13 +372,14 @@ func (orgSvc *OrganizeService) reOrganizeInPlace(book *database.Book, log logger
 	}
 
 	// Create parent directory for target
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0775); err != nil {
-		return "", fmt.Errorf("failed to create target directory: %w", err)
+	parentDir := filepath.Dir(targetPath)
+	if err := os.MkdirAll(parentDir, 0775); err != nil {
+		return "", fmt.Errorf("cannot create target directory %s: %w (check parent permissions and disk space)", parentDir, err)
 	}
 
 	// Rename (move) the file or directory
 	if err := os.Rename(oldPath, targetPath); err != nil {
-		return "", fmt.Errorf("failed to rename %s -> %s: %w", oldPath, targetPath, err)
+		return "", fmt.Errorf("cannot move %s -> %s: %w (verify both paths exist, target not in use, same filesystem, write permission)", oldPath, targetPath, err)
 	}
 
 	// Update the book record — set path and mark as organized
@@ -635,19 +642,28 @@ func (orgSvc *OrganizeService) organizeBooks(ctx context.Context, booksToOrganiz
 // Returns the target directory path.
 func (orgSvc *OrganizeService) organizeDirectoryBook(org *organizer.Organizer, book *database.Book, log logger.Logger) (string, error) {
 	bookFiles, err := orgSvc.db.GetBookFiles(book.ID)
-	if err != nil || len(bookFiles) == 0 {
-		return "", fmt.Errorf("no book_files for %s — cannot organize without known files", book.ID)
+	if err != nil {
+		return "", fmt.Errorf("cannot load segments for %s (%s): %w", book.Title, book.ID, err)
+	}
+	if len(bookFiles) == 0 {
+		return "", fmt.Errorf("no segments tracked for %q (id=%s) — run a library scan to detect files in %s", book.Title, book.ID, book.FilePath)
 	}
 
 	var segmentPaths []string
+	missingCount := 0
 	for _, bf := range bookFiles {
-		if bf.FilePath != "" && !bf.Missing {
-			segmentPaths = append(segmentPaths, bf.FilePath)
+		if bf.FilePath == "" {
+			continue
 		}
+		if bf.Missing {
+			missingCount++
+			continue
+		}
+		segmentPaths = append(segmentPaths, bf.FilePath)
 	}
 
 	if len(segmentPaths) == 0 {
-		return "", fmt.Errorf("all book_files for %s are marked missing — skipping", book.ID)
+		return "", fmt.Errorf("all %d segments for %q (id=%s) marked missing on disk — re-scan to verify, or restore from backup", missingCount, book.Title, book.ID)
 	}
 
 	log.Info("Organizing %d segment file(s) for %s (from book_files)", len(segmentPaths), book.Title)

--- a/internal/server/organize_service_regression_test.go
+++ b/internal/server/organize_service_regression_test.go
@@ -89,7 +89,7 @@ func TestOrganizeDirectoryBook_NoBookFiles(t *testing.T) {
 
 	_, err := svc.organizeDirectoryBook(org, book, testLog)
 	assert.Error(t, err, "should fail with no book_files")
-	assert.Contains(t, err.Error(), "no book_files")
+	assert.Contains(t, err.Error(), "no segments tracked")
 }
 
 func TestOrganizeDirectoryBook_AllBookFilesMarkedMissing(t *testing.T) {


### PR DESCRIPTION
## Summary

Surveyed the organize execution path and updated terse errors to include the book identifier, the offending path, and a hint about likely cause / what to try next. Closes backlog item **5.4**.

Eight error sites updated across \`organize_service.go\` and \`organizer.go\`. Tests assertions updated to match.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/server/ ./internal/organizer/\` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)