### PR TITLE
fix(itunes): enqueue iTunes writeback on organize + rename; add backfill op

### DIFF
--- a/internal/server/itunes_path_reconcile.go
+++ b/internal/server/itunes_path_reconcile.go
@@ -1,0 +1,181 @@
+// file: internal/server/itunes_path_reconcile.go
+// version: 1.0.0
+// guid: 9e3b7a1d-4c2f-4a60-b8d5-2f1e8c0d9a47
+//
+// One-time (repeatable) backfill that walks every book with an
+// iTunes persistent ID, recomputes book.ITunesPath and
+// book_files.ITunesPath from the current FilePath, and enqueues the
+// writeback batcher. Fixes libraries where organize ran before the
+// path-update bug was patched and iTunes now shows "missing files"
+// for books that were moved under the hood.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+type iTunesPathReconcileResult struct {
+	Scanned            int `json:"scanned"`
+	ITunesTracked      int `json:"itunes_tracked"`
+	PathsUpdated       int `json:"paths_updated"`
+	FilePathsUpdated   int `json:"file_paths_updated"`
+	EnqueuedForWrite   int `json:"enqueued_for_write"`
+	Errors             int `json:"errors"`
+}
+
+// startITunesPathReconcile kicks off a tracked operation that walks the
+// library and re-enqueues every iTunes-tracked book so the batcher
+// pushes updated locations + metadata back to the ITL.
+func (s *Server) startITunesPathReconcile(c *gin.Context) {
+	store := database.GlobalStore
+	if store == nil {
+		c.JSON(500, gin.H{"error": "database not initialized"})
+		return
+	}
+	if operations.GlobalQueue == nil {
+		c.JSON(500, gin.H{"error": "operation queue not initialized"})
+		return
+	}
+
+	id := ulid.Make().String()
+	op, err := store.CreateOperation(id, "itunes_path_reconcile", nil)
+	if err != nil {
+		internalError(c, "failed to create operation", err)
+		return
+	}
+
+	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		return s.runITunesPathReconcile(ctx, id, progress)
+	}
+
+	if err := operations.GlobalQueue.Enqueue(op.ID, "itunes_path_reconcile", operations.PriorityNormal, operationFunc); err != nil {
+		internalError(c, "failed to enqueue operation", err)
+		return
+	}
+
+	c.JSON(202, op)
+}
+
+// runITunesPathReconcile is the operation body. Read-only over iTunes
+// PIDs (PIDs are not changed), read-write over ITunesPath fields.
+// Idempotent — safe to re-run. Skips books without an iTunes PID.
+func (s *Server) runITunesPathReconcile(ctx context.Context, opID string, progress operations.ProgressReporter) error {
+	store := database.GlobalStore
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	_ = progress.Log("info", "Starting iTunes path reconcile", nil)
+
+	// Load all books — 100k is the same cap other maintenance ops use.
+	books, err := store.GetAllBooks(100000, 0)
+	if err != nil {
+		return fmt.Errorf("load books: %w", err)
+	}
+
+	result := iTunesPathReconcileResult{Scanned: len(books)}
+	_ = progress.Log("info", fmt.Sprintf("Reconciling iTunes paths for %d books", len(books)), nil)
+	_ = progress.UpdateProgress(0, len(books), "Scanning books for iTunes PID coverage")
+
+	for i := range books {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		b := &books[i]
+
+		// Skip books with no iTunes connection at any level.
+		hasITunesBook := b.ITunesPersistentID != nil && *b.ITunesPersistentID != ""
+
+		bookFiles, _ := store.GetBookFiles(b.ID)
+		hasITunesFile := false
+		for _, bf := range bookFiles {
+			if bf.ITunesPersistentID != "" {
+				hasITunesFile = true
+				break
+			}
+		}
+
+		if !hasITunesBook && !hasITunesFile {
+			continue
+		}
+		result.ITunesTracked++
+
+		// Recompute book.ITunesPath from the current FilePath if needed.
+		if b.FilePath != "" {
+			wantBookITunesPath := computeITunesPath(b.FilePath)
+			if wantBookITunesPath != "" {
+				current := ""
+				if b.ITunesPath != nil {
+					current = *b.ITunesPath
+				}
+				if current != wantBookITunesPath {
+					b.ITunesPath = &wantBookITunesPath
+					if _, err := store.UpdateBook(b.ID, b); err != nil {
+						result.Errors++
+						_ = progress.Log("warn", fmt.Sprintf("update book %s: %v", b.ID, err), nil)
+					} else {
+						result.PathsUpdated++
+					}
+				}
+			}
+		}
+
+		// Recompute book_files.ITunesPath per file.
+		for _, bf := range bookFiles {
+			if bf.ITunesPersistentID == "" || bf.FilePath == "" {
+				continue
+			}
+			want := computeITunesPath(bf.FilePath)
+			if want == "" || want == bf.ITunesPath {
+				continue
+			}
+			bf.ITunesPath = want
+			if err := store.UpdateBookFile(bf.ID, &bf); err != nil {
+				result.Errors++
+				_ = progress.Log("warn", fmt.Sprintf("update book_file %s: %v", bf.ID, err), nil)
+				continue
+			}
+			result.FilePathsUpdated++
+		}
+
+		// Enqueue the batcher so the next flush pushes both location
+		// and metadata updates to iTunes for this book.
+		if GlobalWriteBackBatcher != nil {
+			GlobalWriteBackBatcher.Enqueue(b.ID)
+			result.EnqueuedForWrite++
+		}
+
+		if (i+1)%500 == 0 {
+			_ = progress.UpdateProgress(i+1, len(books),
+				fmt.Sprintf("reconciled %d/%d (%d iTunes-tracked, %d paths fixed, %d files fixed)",
+					i+1, len(books), result.ITunesTracked, result.PathsUpdated, result.FilePathsUpdated))
+			_ = operations.SaveCheckpoint(store, opID, "itunes_path_reconcile", "scanning", i+1, len(books))
+		}
+	}
+
+	// Nudge the batcher to flush sooner rather than waiting out its
+	// maxDelay. Give it a brief grace window so log output stays
+	// ordered with the flush INFO line.
+	if GlobalWriteBackBatcher != nil && result.EnqueuedForWrite > 0 {
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	_ = operations.ClearState(store, opID)
+	summary := fmt.Sprintf(
+		"iTunes path reconcile complete: scanned=%d iTunes-tracked=%d book-paths-updated=%d file-paths-updated=%d enqueued=%d errors=%d",
+		result.Scanned, result.ITunesTracked, result.PathsUpdated, result.FilePathsUpdated, result.EnqueuedForWrite, result.Errors,
+	)
+	_ = progress.Log("info", summary, nil)
+	_ = progress.UpdateProgress(len(books), len(books), summary)
+	return nil
+}

--- a/internal/server/itunes_writeback_batcher.go
+++ b/internal/server/itunes_writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_writeback_batcher.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -257,6 +257,18 @@ func (b *WriteBackBatcher) flush() {
 	if err := safeWriteITL(itlPath, ops); err != nil {
 		log.Printf("[WARN] iTunes write-back failed: %v", err)
 		return
+	}
+
+	// Mark the books we wrote as iTunes-synced so downstream UI /
+	// filters reflect current state. Only books with at least one
+	// update (location or metadata) count — pendingBooks may include
+	// IDs whose PIDs weren't found in the DB, those stay unmarked.
+	if len(bookIDs) > 0 {
+		if n, markErr := store.MarkITunesSynced(bookIDs); markErr != nil {
+			log.Printf("[WARN] iTunes write-back: MarkITunesSynced failed: %v", markErr)
+		} else if n > 0 {
+			log.Printf("[INFO] iTunes write-back: marked %d books as iTunes-synced", n)
+		}
 	}
 }
 

--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_fetch_service.go
-// version: 4.49.0
+// version: 4.50.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package server
@@ -3281,6 +3281,14 @@ func (mfs *MetadataFetchService) runApplyPipeline(id string, book *database.Book
 		}
 	}
 
+	// Enqueue iTunes writeback so the batcher picks up both location
+	// (if the file was renamed) and metadata changes. The apply
+	// handler also enqueues after this returns; the batcher dedupes
+	// on book ID so the duplicate is harmless.
+	if GlobalWriteBackBatcher != nil {
+		GlobalWriteBackBatcher.Enqueue(id)
+	}
+
 	return nil
 }
 
@@ -3453,6 +3461,13 @@ func (mfs *MetadataFetchService) RunApplyPipelineRenameOnly(id string, book *dat
 				log.Printf("[WARN] dedup re-check failed for book %s after metadata apply: %v", id, err)
 			}
 		}()
+	}
+
+	// Enqueue iTunes writeback so location changes from the rename
+	// propagate to iTunes. Callers (bulk write-back) also enqueue,
+	// the batcher dedupes.
+	if GlobalWriteBackBatcher != nil {
+		GlobalWriteBackBatcher.Enqueue(id)
 	}
 
 	return nil

--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service.go
-// version: 1.23.0
+// version: 1.24.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package server
@@ -18,7 +18,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/backup"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
@@ -144,34 +143,20 @@ func (orgSvc *OrganizeService) PerformOrganize(ctx context.Context, req *Organiz
 	// Perform organization
 	stats := orgSvc.organizeBooks(ctx, booksToOrganize, alreadyCorrect, log, req.OperationID)
 
-	// Auto write-back and post-organize tasks
+	// Post-organize auto write-back now rides the batcher.
+	// Previously this ran a bulk location-only write via
+	// collectITLUpdatesWithBookIDs + UpdateITLLocations inline.
+	// That path (a) skipped metadata refresh, (b) only read
+	// book.ITunesPath (stale for older organize runs), and
+	// (c) raced with the batcher writing to the same file.
+	// Each organize worker now calls GlobalWriteBackBatcher.Enqueue
+	// per book; the batcher flushes once after its debounce with
+	// both location + metadata updates and calls MarkITunesSynced
+	// on success.
 	if stats.Organized > 0 || stats.ReOrganized > 0 {
 		// Note: auto-rescan disabled — organize already updates all paths and book_files.
 		// A rescan after organize can trigger another organize, creating an infinite loop.
 		// If a rescan is needed, trigger it manually.
-
-		// Auto write-back to ITL after organize (paths have changed)
-		if writePath := config.AppConfig.ITunesLibraryWritePath; writePath != "" {
-			log.Info("Auto write-back: writing organized paths to ITL")
-			itlUpdates, bookIDs := collectITLUpdatesWithBookIDs(orgSvc.db)
-			if len(itlUpdates) > 0 {
-				result, err := itunes.UpdateITLLocations(writePath, writePath+".tmp", itlUpdates)
-				if err != nil {
-					log.Warn("Auto write-back failed: %v", err)
-				} else {
-					if renameErr := itunes.RenameITLFile(writePath+".tmp", writePath); renameErr != nil {
-						log.Warn("Auto write-back rename failed: %v", renameErr)
-					} else {
-						recordITLReadTime() // mark our write as the latest known state
-						log.Info("Auto write-back: updated %d tracks in ITL", result.UpdatedCount)
-						// Mark written books as synced with iTunes
-						if n, markErr := orgSvc.db.MarkITunesSynced(bookIDs); markErr == nil && n > 0 {
-							log.Info("Auto write-back: marked %d books as iTunes-synced", n)
-						}
-					}
-				}
-			}
-		}
 	}
 
 	return nil
@@ -382,8 +367,13 @@ func (orgSvc *OrganizeService) reOrganizeInPlace(book *database.Book, log logger
 		return "", fmt.Errorf("cannot move %s -> %s: %w (verify both paths exist, target not in use, same filesystem, write permission)", oldPath, targetPath, err)
 	}
 
-	// Update the book record — set path and mark as organized
+	// Update the book record — set path and mark as organized.
+	// ITunesPath is kept in sync so iTunes writeback sends the new
+	// location. Without this, iTunes keeps pointing at the old path
+	// and shows "file missing."
 	book.FilePath = targetPath
+	newITunesPath := computeITunesPath(targetPath)
+	book.ITunesPath = &newITunesPath
 	organizedState := "organized"
 	book.LibraryState = &organizedState
 	now := time.Now()
@@ -436,9 +426,7 @@ func (orgSvc *OrganizeService) organizeBooks(ctx context.Context, booksToOrganiz
 
 	// Thread-safe counters and collectors
 	var statsMu sync.Mutex
-	var itlMu sync.Mutex
 	var progressCounter int64
-	var itlUpdates []itunes.ITLLocationUpdate
 
 	const numWorkers = 8
 	jobs := make(chan int, numWorkers*2)
@@ -565,14 +553,13 @@ func (orgSvc *OrganizeService) organizeBooks(ctx context.Context, booksToOrganiz
 					statsMu.Unlock()
 				}
 
-				// --- Step 3: Collect ITL updates ---
-				if err == nil && oldPath != newPath && book.ITunesPersistentID != nil {
-					itlMu.Lock()
-					itlUpdates = append(itlUpdates, itunes.ITLLocationUpdate{
-						PersistentID: *book.ITunesPersistentID,
-						NewLocation:  newPath,
-					})
-					itlMu.Unlock()
+				// --- Step 3: Enqueue iTunes writeback ---
+				// Route through the global batcher so location + metadata
+				// updates ride together. The batcher iterates book_files to
+				// pick up per-segment PIDs (multi-file books), falling back
+				// to book.ITunesPersistentID for single-file books.
+				if err == nil && oldPath != newPath && GlobalWriteBackBatcher != nil {
+					GlobalWriteBackBatcher.Enqueue(book.ID)
 				}
 
 			progress:
@@ -611,10 +598,10 @@ func (orgSvc *OrganizeService) organizeBooks(ctx context.Context, booksToOrganiz
 		stats.AlreadyCorrect += len(alreadyCorrect)
 	}
 
-	// Write back location changes to iTunes Library.itl
-	if len(itlUpdates) > 0 && config.AppConfig.ITLWriteBackEnabled && config.AppConfig.ITunesLibraryWritePath != "" {
-		orgSvc.writeBackITLLocations(itlUpdates, log)
-	}
+	// iTunes writeback happens via GlobalWriteBackBatcher (enqueued per
+	// book inside the worker loop above). The batcher handles both
+	// location and metadata updates and correctly iterates book_files
+	// to pick up per-segment PIDs for multi-file books.
 
 	summary := fmt.Sprintf("Organize complete: %d organized, %d re-organized, %d already correct (stamped), %d skipped",
 		stats.Organized, stats.ReOrganized, stats.AlreadyCorrect, stats.Skipped)
@@ -845,44 +832,6 @@ func (orgSvc *OrganizeService) createOrganizedVersion(org *organizer.Organizer, 
 	}
 
 	return createdBook, nil
-}
-
-func (orgSvc *OrganizeService) writeBackITLLocations(updates []itunes.ITLLocationUpdate, log logger.Logger) {
-	itlPath := config.AppConfig.ITunesLibraryWritePath
-
-	// Create backup before modifying
-	backupPath := itlPath + ".bak"
-	srcData, err := os.ReadFile(itlPath)
-	if err != nil {
-		log.Warn("ITL write-back: failed to read %s: %s", itlPath, err.Error())
-		return
-	}
-	if err := os.WriteFile(backupPath, srcData, 0644); err != nil {
-		log.Warn("ITL write-back: failed to create backup: %s", err.Error())
-		return
-	}
-
-	result, err := itunes.UpdateITLLocations(itlPath, itlPath, updates)
-	if err != nil {
-		log.Warn("ITL write-back failed: %s", err.Error())
-		// Restore backup on failure
-		if restoreErr := os.WriteFile(itlPath, srcData, 0644); restoreErr != nil {
-			log.Error("ITL restore from backup also failed: %s", restoreErr.Error())
-		}
-		return
-	}
-
-	// Validate the written file
-	if err := itunes.ValidateITL(itlPath); err != nil {
-		log.Warn("ITL validation failed after write-back: %s", err.Error())
-		// Restore backup
-		if restoreErr := os.WriteFile(itlPath, srcData, 0644); restoreErr != nil {
-			log.Error("ITL restore from backup also failed: %s", restoreErr.Error())
-		}
-		return
-	}
-
-	log.Info("ITL write-back: updated %d/%d locations in %s", result.UpdatedCount, len(updates), itlPath)
 }
 
 func (orgSvc *OrganizeService) triggerAutomaticRescan(ctx context.Context, log logger.Logger) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.166.0
+// version: 1.167.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1155,6 +1155,11 @@ func (s *Server) resumeInterruptedOperations() {
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
 				return s.runReconcileScan(ctx, scanOpID, progress)
 			}
+		case "itunes_path_reconcile":
+			reconcileOpID := opID
+			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+				return s.runITunesPathReconcile(ctx, reconcileOpID, progress)
+			}
 		case "transcode", "diagnostics_export", "diagnostics_ai",
 			"cleanup_activity_log", "purge_old_logs",
 			"purge-deleted", "tombstone-cleanup",
@@ -1828,6 +1833,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/operations/reconcile", s.startReconcile)
 			protected.POST("/operations/reconcile/scan", s.startReconcileScan)
 			protected.GET("/operations/reconcile/scan/latest", s.latestReconcileScan)
+			protected.POST("/operations/itunes-path-reconcile", s.startITunesPathReconcile)
 			protected.POST("/operations/cleanup-version-groups", s.cleanupDuplicateVersionGroupsHandler)
 			protected.POST("/operations/mark-broken-segments", s.markBrokenSegmentBooksHandler)
 			protected.POST("/operations/merge-novg-duplicates", s.mergeNoVGDuplicatesHandler)


### PR DESCRIPTION
## Root cause

iTunes showed "missing files" after organize because:

1. \`organize_service.go\` had its own bulk writeback path that wrote locations only (no metadata refresh), and raced with \`GlobalWriteBackBatcher\` on the same ITL file.
2. \`reOrganizeInPlace\` updated \`book.FilePath\` but not \`book.ITunesPath\` for single-file books — so the bulk path wrote stale locations anyway.
3. \`runApplyPipeline\` never enqueued the batcher itself; the apply handler did it after the fact, but the bulk-write-back path didn't.

## Fix

- \`reOrganizeInPlace\` now sets \`book.ITunesPath\` alongside \`book.FilePath\` on every rename.
- Organize worker replaces per-book ITL collection with \`GlobalWriteBackBatcher.Enqueue(bookID)\`. The batcher iterates \`book_files\` to catch per-segment PIDs (multi-file books) and pushes location + metadata together.
- Bulk auto-writeback block in \`PerformOrganize\` removed — the batcher is the single writeback path.
- Stale \`writeBackITLLocations\` method deleted.
- \`runApplyPipeline\` / \`RunApplyPipelineRenameOnly\` now enqueue the batcher too (safe double-enqueue; batcher dedupes by book ID).
- Batcher flush calls \`MarkITunesSynced\` for books it wrote.

## Backfill

New tracked operation \`itunes_path_reconcile\` (endpoint \`POST /api/v1/operations/itunes-path-reconcile\`). Walks every book with an iTunes PID, recomputes \`book.ITunesPath\` + \`book_files.ITunesPath\` from current \`FilePath\`, enqueues the batcher. Idempotent, resumable. Run once after deploy to heal existing libraries.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/server/...\` clean
- [x] \`go test ./internal/server/\` — all pass (43.9s)
- [ ] Manual post-deploy: \`curl -X POST http://server/api/v1/operations/itunes-path-reconcile\`, verify iTunes no longer shows missing files for previously organized books
- [ ] Manual: run a new organize, verify iTunes receives location + metadata updates via batcher flush (check server logs for \`iTunes write-back: flushing N location updates, M metadata updates\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)