### PR TITLE
docs(specs): 7 design specs from Apr 15 brainstorm session

### DIFF
--- a/docs/superpowers/specs/2026-04-11-bleve-library-search.md
+++ b/docs/superpowers/specs/2026-04-11-bleve-library-search.md
@@ -1,15 +1,181 @@
 <!-- file: docs/superpowers/specs/2026-04-11-bleve-library-search.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: d2e3f4a5-b6c7-8901-2345-67890abcdef1 -->
-<!-- last-edited: 2026-04-11 -->
+<!-- last-edited: 2026-04-15 -->
 
 # bleve Library Search Design
 
-**Status:** Design spec — not yet implemented.
+**Status:** Design spec — not yet implemented. v1.1 folds in decisions from the 2026-04-15 brainstorm (DSL integration, query usage map, new operators, default match mode, perf targets, per-user indexing future-work).
 **Owner:** TBD.
-**Parent task:** Backlog item 4.7 (per-workload DB evaluation).
-**Depends on:** Nothing. Standalone replacement for the current
-SQLite FTS5 + LIKE + Go-rerank search path.
+**Parent tasks:** TODO.md DES-1 (primary); pairs with 3.4 playlists (shares the DSL) and 3.6 read/unread tracking (Go-side post-filter for per-user fields).
+**Depends on:** Nothing. Standalone replacement for the current SQLite FTS5 + LIKE + Go-rerank search path.
+
+## v1.1 summary of additions (2026-04-15)
+
+Bleve becomes **THE engine** driving the library search bar and smart-playlist query evaluation — not a side-index used only for free-text. Our locked DSL (from §3.4 design) compiles to Bleve `query.Query` objects so one engine serves everything user-facing. New sections added below:
+
+- **§ Integration with our query DSL** — translator from our AST to Bleve programmatic queries
+- **§ Where Bleve drives behavior** — usage map, explicit "where Bleve does NOT run"
+- **§ Syntax comparison table** — our DSL vs Bleve native string syntax, differences called out
+- **§ Default match mode change** — substring → tokenized + stemmed, plus the UI auto-append-`*` workaround to preserve typeahead UX
+- **§ New operators added to our DSL** — `*` (prefix/wildcard), `~` (fuzzy), `^N` (boost), consistent `field:<op>value` placement (e.g. `year:>2022`, not `year>2022`)
+- **§ Perf targets** — concrete per-query-type timings at 24K-book scale, typeahead budget
+- **§ Per-user indexing (deferred)** — shared-library index + Go post-filter for per-user fields (`read_status`, `progress_pct`, `last_played`); shard model documented as future work if scale demands it
+
+The v1.0 document model, field boosts, index lifecycle, concurrency model, migration phases, and risks all stand.
+
+## Integration with our query DSL
+
+Our DSL (defined in the 3.4 playlists spec) is the user-facing query language. Bleve is the backend evaluator. Users don't see Bleve's native syntax — it's an implementation detail.
+
+Translation pipeline:
+
+```
+User input ──▶ DSL parser ──▶ AST ──▶ translator ──▶ Bleve query.Query ──▶ Bleve index
+                               │
+                               └─▶ Go post-filter pass for per-user fields
+```
+
+Translator rules:
+
+| Our AST node | Bleve query |
+|---|---|
+| `AND` | `ConjunctionQuery` |
+| `OR` | `DisjunctionQuery` |
+| `NOT` | `BooleanQuery{MustNot: [...]}` |
+| Field leaf (single term) | `MatchQuery{Field, Term}` (tokenized + analyzed) |
+| Field leaf (quoted, multi-word) | `MatchPhraseQuery{Field, Text}` |
+| Field leaf with `*` wildcard | `WildcardQuery` (or `PrefixQuery` for trailing `*`) |
+| Field leaf with `~` fuzzy | `FuzzyQuery{Field, Term, Fuzziness}` |
+| Field leaf with `^N` boost | any above, with `boost` parameter |
+| Within-field alt `field:(a\|b\|c)` | `DisjunctionQuery` of `MatchQuery`s |
+| Numeric `field:>N` | `NumericRangeQuery{Min: N, Min: false}` (exclusive) |
+| Numeric `field:>=N` | `NumericRangeQuery{Min: N, Min: true}` (inclusive) |
+| Numeric `field:<N` / `field:<=N` | `NumericRangeQuery{Max: N, ...}` |
+| Numeric `field:[A TO B]` | `NumericRangeQuery{Min: A, Max: B, both inclusive}` |
+| Date range | `DateRangeQuery` |
+| Per-user field (`read_status`, `progress_pct`, `last_played`) | **Not sent to Bleve.** Added to the Go post-filter list. Bleve returns a larger candidate set; Go narrows to matches for the calling user. |
+
+Per-user post-filter:
+
+1. Bleve evaluates the index-backed portion, returns scored candidate book IDs
+2. Go pass applies per-user filters using the calling user's state from the `user_book_state` / `user_position` PebbleDB keys
+3. Intersection returned, preserving Bleve's score order so relevance is honored
+
+## Where Bleve drives behavior
+
+| Surface | Uses Bleve | Notes |
+|---|---|---|
+| Library search bar (free-text + field:value) | **Yes** | Primary use. TF-IDF scoring, stemmed match, highlights. |
+| Smart playlist query evaluation | **Yes** | Shares DSL + engine with search bar. Results preserve Bleve score ordering. |
+| Quick filter autocomplete (typeahead on authors, series, tags) | **Yes** | `PrefixQuery` on indexed fields. Search bar auto-appends `*` to the last typed token. |
+| "Similar books" on BookDetail (future 5.2) | **Yes** | Bleve's `more-like-this` / `SimilarQuery` fits naturally. |
+| Book dedup candidate matching | No | Separate engine (embedding + heuristic) already in place. Different problem — similarity, not retrieval. |
+| BookDetail direct lookup by book ID | No | PebbleDB point lookup is 10-20× faster than routing through Bleve. |
+| Full-library paginated list (no search term, page 47 of everything) | No | PebbleDB prefix scan with cursor is the right tool; scoring irrelevant. |
+| Activity log search | Later | Existing FTS works; migrate post-MVP if Bleve replaces the shared search infra. |
+| Per-user filter fields (`read_status`, `progress_pct`, `last_played`) | No | Go post-filter over the current user's state; see integration section above. |
+
+## Syntax comparison
+
+Users write our DSL. Bleve syntax shown for reference (useful if we ever expose a "raw Bleve" advanced mode).
+
+| Operation | Our DSL | Bleve native string | Notes |
+|---|---|---|---|
+| AND | space, `&&`, `AND` | space, `AND` | Bleve has no `&&` — our parser accepts both |
+| OR | `OR`, `||` (double pipe) | `OR` only | Bleve has no `||` — our parser accepts both |
+| NOT | `-`, `NOT` | `-`, `NOT` | Same |
+| Within-field alt | `title:(a|b|c)` | `title:(a OR b OR c)` | Our `|` is sugar; translates to `DisjunctionQuery` of `MatchQuery`s |
+| Range open | `year:>2000` | `year:>2000` | Colon before comparator on both sides |
+| Range closed (inclusive) | `year:[2000 TO 2010]` | `year:[2000 TO 2010]` | Same |
+| Prefix | `title:vamp*` | `title:vamp*` | Same |
+| Wildcard | `title:*vamp*` | `title:*vamp*` | Same; slower than prefix on both sides |
+| Fuzzy | `author:smith~` | `author:smith~` | Same |
+| Boost | `title:vampire^3` | `title:vampire^3` | Same |
+| Exact (reserved, future) | `title:=value` | (use Term query programmatically) | Bleve's string DSL has no exact operator — reserved in ours for later |
+| Phrase | `title:"New Dawn"` | `title:"New Dawn"` | Same |
+
+## Default match mode change (semantics)
+
+v1.0 design implied field matches were tokenized. Making it explicit here as a locked-in semantic choice in v1.1.
+
+| Query | Before (substring-anywhere, current SQLite LIKE) | After (tokenized + stemmed, Bleve) |
+|---|---|---|
+| `title:vampire` | matches "vampirically-inclined", "revampire" | matches "vampire", "vampires", "vampiric" (stemmer expands) |
+| `title:vamp` | matches "The Vampire Diaries" | does NOT match (needs `vamp*`) |
+| `author:mart` | matches "Martin", "Smart" | does NOT match (needs `mart*`) |
+
+Tokenized + stemmed is better for audiobook discovery: noise matches ("vampirically") disappear, morphology ("vampires", "vampiric") is captured. Trade-off: partial-word queries need an explicit `*`.
+
+**Typeahead workaround:** the library search bar UI auto-appends `*` to the last typed token in the free-text portion. `vamp` → `vamp*` behind the scenes, so users typing `vamp` still see "The Vampire Diaries" in live suggestions. Explicit queries (smart playlist definitions) receive no auto-append — if a user writes `title:vamp` in a saved query, they meant the whole word.
+
+## New operators added to our DSL
+
+Added in v1.1 to match Bleve's core capabilities. Consistent placement: always `field:<op><value>` or `field:<value><op>` — the colon sits between field and the value-expression, operators live inside the value-expression.
+
+| Operator | Syntax | Meaning | Example |
+|---|---|---|---|
+| Prefix / suffix / substring wildcard | `*` | Star matches zero-or-more chars | `title:vamp*`, `title:*vamp`, `title:*vamp*` |
+| Fuzzy | `~` | Edit-distance match (default distance 2) | `author:smith~` matches Smyth, Smiht |
+| Boost | `^N` | Multiply relevance score by N for this clause | `title:vampire^3` |
+| Numeric comparators | `:>`, `:<`, `:>=`, `:<=` | Inline with `field:` prefix (consistent style) | `year:>2022`, `duration:<3600` |
+| Numeric range | `:[A TO B]` | Inclusive range (reserved; MVP unfolds to `&&`) | `year:[2000 TO 2010]` |
+| Exact (reserved) | `:=` | Exact match, no tokenization | `title:="Twilight"` (future; MVP approximates) |
+
+**Consistency rule:** every value-side operator goes inside the `field:` expression. No more `year>2022` — it's `year:>2022`. Same everywhere.
+
+## Perf targets (at 24K-book scale)
+
+Ballpark numbers on a modest machine; validate in phase 2 of the migration plan.
+
+| Operation | Bleve | Current (FTS5 + LIKE + Go re-rank) | PebbleDB point lookup |
+|---|---|---|---|
+| Exact term match (`author:sanderson`) | 1-3 ms | 20-50 ms | — |
+| Prefix (`title:vamp*`) | 2-10 ms | 100-500 ms (full scan via LIKE) | — |
+| Fuzzy (`author:smith~`) | 10-50 ms | — (not supported) | — |
+| Multi-field boolean (`a && b`) | 2-10 ms | 30-100 ms | — |
+| Phrase (`"lord of the rings"`) | 1-5 ms | — (not supported as configured) | — |
+| Direct get-book-by-ID | — (not the right tool) | — | 50-200 μs |
+| Iterate all 24K books, no filter | — (not the right tool) | 200-500 ms | 100-300 ms (prefix scan) |
+
+**Typeahead budget** (target <100 ms keystroke → suggestions rendered):
+
+- Bleve prefix query: 2-10 ms
+- HTTP round-trip: 10-30 ms (localhost) / 30-80 ms (LAN)
+- React render: 20-40 ms
+- **Total: 30-80 ms at 24K books. Comfortably inside the <100 ms target.**
+
+**Caveats (honest):**
+
+- **First-time index build** after upgrade: 10-30 seconds for 24K books. Runs in background, UI shows "indexing…" on first hit.
+- **Per-document update**: sub-millisecond.
+- **Disk**: ~20-30% of raw indexed text, so 50-100 MB for our library.
+- **Memory**: Scorch backend, ~50-100 MB working set at current scale.
+- **Cold start**: first query after process boot takes 100-500 ms to load index segments; warm after.
+
+## Per-user indexing — deferred
+
+MVP indexes shared library state only. Per-user fields (`read_status`, `progress_pct`, `last_played`) are **Go-side post-filters** applied to Bleve's candidate result set using the calling user's state from PebbleDB (`user_book_state`, `user_position`).
+
+Why deferred:
+
+- Current scale (dozens of users max per install) doesn't justify per-user indexes
+- Post-filter on top of a scored candidate set is cheap — Bleve narrows from 24K to, say, 200; Go filters 200 → 50 in under a millisecond
+- Per-user indexes would multiply disk + memory cost by N users and complicate index maintenance on every status change
+
+When to revisit:
+
+1. Hundreds of active users and post-filter becomes a hot path (visible in profiles)
+2. Users want per-user smart playlists with complex per-user-field-first queries ("books I finished last month that nobody else finished") where post-filter over a large candidate set is actually slow
+3. A different use case needs per-user full-text indexing (notes on books, per-user tags)
+
+Options when the time comes:
+
+- **Sharded index keyed on userID** — one Bleve index per user for per-user fields only; shared index remains for library state. Query fanout: union results.
+- **Separate per-user small index** for status/progress, composed with shared library index at query time.
+- **Materialize per-user views** — periodically snapshot (user × book) state into a join-friendly structure.
+
+No code changes needed now to keep this door open; Go post-filter is just a function call that can be swapped for an index lookup later.
 
 ## Problem statement
 

--- a/docs/superpowers/specs/2026-04-15-bulk-organize-undo-design.md
+++ b/docs/superpowers/specs/2026-04-15-bulk-organize-undo-design.md
@@ -1,0 +1,136 @@
+<!-- file: docs/superpowers/specs/2026-04-15-bulk-organize-undo-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4b9e2c8f-1a7d-4f50-a3c8-2e8d0f1b6a47 -->
+
+# Bulk Organize Undo — Design
+
+**Status:** Design complete (Apr 15, 2026). Ready for implementation plan.
+**Scope item:** TODO.md §3.2.
+**Depends on:** existing `operation_changes` table + per-book revert buttons (already in place).
+
+## Goal
+
+Let a user undo a completed organize operation — either the whole op in one click or a per-book subset — by reversing every file move and DB mutation it recorded. The reversal preserves any later edits (metadata apply, tag writes, ISBN enrichment) by scoping the restore to only the fields organize itself touched.
+
+## Locked decisions
+
+### 1. Both op-level and per-book undo
+
+- **Op-level** (primary new UX): "Undo this organize" reverses every `operation_changes` row for the operation.
+- **Per-book** (already in place per memory): "Revert this change" button on BookDetail ChangeLog filters to one book's changes.
+- Same reversal engine; op-level is `WHERE operation_id = ?`, per-book is `WHERE book_id = ? AND operation_id = ?`.
+
+### 2. `operation_changes` schema (verify against existing shape in implementation)
+
+```
+operation_id   FK → operations.id   (NOT NULL)
+book_id        FK → books.id        (NULLABLE for directory-only changes)
+change_type    TEXT                  -- file_move | db_update | dir_create | dir_delete
+before_json    TEXT                  -- JSON snapshot of reversible fields
+after_json     TEXT                  -- JSON snapshot of new values
+created_at     TIMESTAMP
+reverted_at    TIMESTAMP              -- NULL until undone
+```
+
+Payload shapes per `change_type`:
+
+| Type | `before_json` | `after_json` |
+|---|---|---|
+| `file_move` | `{file_path: "/old/..."}` | `{file_path: "/new/..."}` |
+| `db_update` | `{file_path, library_state, last_organized_at, ...}` (only fields organize touched) | matching `after` values |
+| `dir_create` | `{path: "/dir/..."}` | `{}` |
+| `dir_delete` | `{}` | `{path: "/dir/..."}` |
+
+### 3. Undo as a tracked operation
+
+`type: "undo_operation"`, params `{target_operation_id, scope: "all" | "book:{bookID}"}`. Behaves like any other tracked op — progress, cancel, resume on restart via PR #270's framework.
+
+Execution:
+
+1. Load non-reverted `operation_changes` rows for the target op (filtered by scope), order by `created_at DESC` so reversal happens in reverse
+2. For each row: reverse the change per the table in §5
+3. On success, set `reverted_at = now()`
+4. Aggregate result: `{reverted, skipped_conflict, failed}`
+5. Activity log entry summarizing
+
+### 4. Field-scoped restore — the key property
+
+For `db_update` rows: `before_json` lists only the fields the operation touched (`file_path`, `library_state`, `last_organized_at`, and matching `book_files.*.file_path`). Undo sets only those fields back to their `before` values. Any field not in `before_json` is left alone.
+
+This is what preserves later edits: if the user applied metadata after organize, the title/author/cover on the book stay as-is; only the organize-specific fields roll back.
+
+### 5. Per-change reversal semantics
+
+| Change type | Reversal step | Conflict case |
+|---|---|---|
+| `file_move` | `os.Rename(after_path, before_path)`; `MkdirAll` parent if absent | `after_path` missing → skip "file no longer at expected location"; `before_path` occupied → skip "target now occupied" |
+| `db_update` (books) | Field-scoped restore from `before_json` | None; last-write-wins is acceptable — user launched the undo |
+| `db_update` (book_files) | Same field-scoped restore per row | None |
+| `dir_create` | `os.Remove` only if empty | Dir not empty → skip "directory now populated" |
+| `dir_delete` | `MkdirAll` | None |
+
+### 6. Conflict pre-flight
+
+Before executing, scan `operation_changes` and gather:
+
+- Files modified since the op (`mtime > created_at`) → "content may have changed, undo will move a possibly-different file"
+- Books soft-deleted since → will be skipped
+- Books re-organized in a later operation → conflict, will be skipped
+- Torrent removal in deluge → still notify deluge on path restore
+
+Surface a pre-flight dialog with counts per category. User can **Proceed** (run over conflicts per §5 rules), **Cancel**, or **Select subset** (proceed only on non-conflict books).
+
+### 7. Torrent `move_storage` on undo
+
+For any affected book with `book_versions.torrent_hash != NULL`, call deluge `move_storage` after the filesystem rename reversal. Same retry-3-with-backoff as the forward path in the 3.1 centralization design.
+
+### 8. Redo — not in MVP
+
+If user wants the organize back, re-run organize. Schema doesn't preclude future redo (undo itself would produce `operation_changes` rows if we ever want it), but it's a rabbit hole of nested state and out of scope.
+
+### 9. Which op types are undoable
+
+**MVP:** `organize` (including batch and per-book organize).
+
+**Future:** `bulk_write_back` (tag writes; `.bak-*` backups exist but semantics need separate thought), other targeted mutation ops.
+
+**Not planned:** `scan` (no reversible forward state), `metadata_apply` (already has per-book revert via `recordChangeHistory`), maintenance/cleanup ops.
+
+Mechanism is permissive: any op that records `operation_changes` rows is undoable. No allowlist needed in the engine; the producing op opts in by writing the rows.
+
+## UI
+
+- **Operation detail page** (reachable from Operations drawer / Activity log): existing completed-op card gains an **Undo** button when:
+  - Op type is in the allowlist above
+  - At least one `operation_changes` row for the op has `reverted_at IS NULL`
+- **Pre-flight dialog**: shows conflict counts, offers Proceed / Cancel / Select subset
+- **Progress**: shared progress-bar component with other tracked ops
+- **Post-undo**: result summary + link to the undo op's own detail page (which is itself viewable)
+- **BookDetail ChangeLog**: existing per-book revert buttons stay; no change
+
+## Storage cost
+
+`operation_changes` rows per book per organize: ~1 file_move + ~1 db_update + occasional dir changes. For 10K books × 10 organize ops historical = ~200K rows. Small JSON payloads. PebbleDB handles trivially. No retention trimming in MVP; revisit when rows exceed a few million.
+
+## Concurrency
+
+Undo is a tracked op queued through `operations.GlobalQueue`, so two undos of the same op can't run concurrently — queue serializes. If the user re-runs organize on the same books *while* an undo is in flight, the organize op waits in the queue (or the user sees a "busy" state). No new locking primitive required.
+
+## Risks
+
+- **Stale `operation_changes` data.** If the existing machinery records changes in a shape that doesn't match §2, the implementation PR will need a light schema migration. Verify in the code before coding the engine — treat §2 as target-shape, not ground-truth of current schema.
+- **Partial-success reporting.** Users need clear messaging when some books were reverted and some skipped. The summary format has to distinguish "reverted" from "skipped due to conflict" from "failed with error."
+- **Torrent tracking drift.** If deluge was unaware of the original forward move (somehow), the reverse call fails. Treat deluge errors as non-fatal warnings — filesystem reversal is the main event.
+
+## Non-goals
+
+- Redo (future if/when we need it)
+- Undo of arbitrary op types beyond the allowlist in §9
+- Rolling back metadata edits made after the organize (explicitly the property of field-scoped restore: those edits are preserved)
+- Distributed transactions / rollback across multiple machines
+
+## Open implementation questions
+
+- Exact shape of existing `operation_changes` rows — one of the first read tasks during implementation
+- Whether the existing per-book revert UI already uses the same engine, or has a parallel code path to unify
+- UX for "skipped: %d conflicts" — inline in the undo op detail page, or a separate downloadable report?

--- a/docs/superpowers/specs/2026-04-15-library-centralization-design.md
+++ b/docs/superpowers/specs/2026-04-15-library-centralization-design.md
@@ -1,0 +1,193 @@
+<!-- file: docs/superpowers/specs/2026-04-15-library-centralization-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f1a8c6d-2b4e-4f80-a9c1-5d2e7b8f0c34 -->
+
+# Library Centralization + Versioning — Design
+
+**Status:** Design complete (Apr 15, 2026). Ready for implementation plan.
+**Source:** Brainstorm session Apr 15, 2026 + locked decisions from memory `project_centralization_backlog.md` (Apr 10, 2026).
+**Scope item:** TODO.md §3.1 (pairs with §6.1 Deluge integration, partial overlap with §7.9 iTunes regen, §7.10 archive sweep).
+
+## Goal
+
+Centralize all non-iTunes book files into the managed library tree with a structured multi-version model, so every format / quality / source of the same book lives under one book and the user can swap primary, trash, and restore at will. iTunes-sourced files stay where they are (read-only references).
+
+Additionally: when a user purges a version, remember its content fingerprint forever so a re-download (via deluge) can be paused and surfaced for approval, preventing silent re-acquisition of deleted content.
+
+## Locked decisions
+
+### 1. Filesystem layout
+
+```
+Author/
+  Book Title/
+    Book Title.m4b              ← primary file — whichever version is "active"
+    .versions/
+      {version-ulid-A}/          ← alt version 1
+        Book Title.m4b
+      {version-ulid-B}/          ← alt version 2 (different format)
+        Book 01.mp3
+        Book 02.mp3
+        …
+```
+
+- Primary at the natural path (browsing the library filesystem directly looks normal)
+- Alts under `.versions/{ulid}/` (dot prefix hides from default directory listings)
+- No per-folder JSON manifest; all version metadata lives in the DB
+
+### 2. Version ID
+
+ULID. Sortable by creation time, stable across content changes (tag/cover rewrites don't rename the dir), 26 chars, already used repo-wide.
+
+### 3. Schema
+
+```sql
+CREATE TABLE book_versions (
+    id TEXT PRIMARY KEY,            -- ULID, matches .versions/{id}/
+    book_id TEXT NOT NULL,
+    status TEXT NOT NULL,           -- pending | active | alt | swapping_in | swapping_out
+                                    -- trash | inactive_purged | blocked_for_redownload
+    format TEXT NOT NULL,           -- m4b | mp3 | flac | …
+    source TEXT NOT NULL,           -- deluge | manual | transcoded | imported
+    source_original_path TEXT,      -- path at ingest (deluge's original)
+    torrent_hash TEXT,              -- infohash, fast-path fingerprint match
+    ingest_date TIMESTAMP NOT NULL,
+    purged_date TIMESTAMP,
+    metadata_json TEXT,             -- catch-all for source-specific extras
+    FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX idx_book_versions_single_active
+    ON book_versions(book_id) WHERE status = 'active';
+CREATE INDEX idx_book_versions_book_id      ON book_versions(book_id);
+CREATE INDEX idx_book_versions_torrent_hash ON book_versions(torrent_hash);
+CREATE INDEX idx_book_versions_status       ON book_versions(status);
+```
+
+`book_files` gets a new column (existing per-file table stays authoritative for file-level data):
+
+```sql
+ALTER TABLE book_files
+    ADD COLUMN version_id TEXT NULL REFERENCES book_versions(id) ON DELETE CASCADE;
+CREATE INDEX idx_book_files_version_id ON book_files(version_id);
+CREATE INDEX idx_book_files_file_hash  ON book_files(file_hash);
+```
+
+### 4. Primary swap mechanics
+
+Tracked operation `version_swap`, fields `{book_id, from_version_id, to_version_id}`:
+
+1. DB: `from.status = 'swapping_out'`, `to.status = 'swapping_in'`
+2. FS: rename every file at natural path into `.versions/{from_id}/` (O(1) on ZFS)
+3. FS: rename every file from `.versions/{to_id}/` up to natural path
+4. DB: `from = 'alt'`, `to = 'active'`, update affected `book_files.file_path`, update `books.file_path`
+5. Deluge: `move_storage` RPC for any version with a non-null `torrent_hash`
+6. Close operation (`ClearState`)
+
+Recovery on crash: standard `resumeInterruptedOperations` case. Each FS step checks destination before acting (idempotent). No "stuck in the middle" state.
+
+### 5. Fingerprint identity
+
+Two hashes, both stored:
+
+- `book_versions.torrent_hash` — deluge infohash, free from deluge RPC
+- `book_files.file_hash` — our SHA-256 of file contents, computed once at ingest
+
+Piece hashes and BTv2 Merkle roots are explicitly **not** stored — they don't add match power beyond SHA-256 and would force format-specific code paths.
+
+Fingerprint match on re-download:
+
+1. Fast path: infohash against `book_versions` where `status IN ('inactive_purged', 'blocked_for_redownload')`
+2. Fallback: hash-set match against `book_files.file_hash` scoped to the same status set
+
+Either match → **pause deluge + surface approval dialog** ("This torrent was previously purged as version X of book Y — add anyway?").
+
+### 6. Delete / restore / purge
+
+Three-state deletion:
+
+- `trash` — user clicked delete. Files stay, hidden from normal UI. 14-day TTL (configurable).
+- `inactive_purged` — TTL expired. Background job deleted files. `book_files` rows **kept forever** with `missing=true`, `file_path=null`, `file_hash` preserved — this is the fingerprint record.
+- Hard delete — only from the dedicated **Purged view**. Removes `book_versions` + `book_files` rows entirely. The only way to forget a fingerprint.
+
+Deleting the primary auto-promotes the most-recent `alt` (by `ingest_date`) to `active`. If no alt exists, book ends with zero active versions and UI shows "no playable files."
+
+Deleting a whole book: all versions → `trash`, book itself flips `MarkedForDeletion=true` after TTL. Uses the existing soft-delete field on `books`.
+
+### 7. Ingest flow
+
+**A. Deluge completes a torrent**
+
+1. Hook on torrent-complete (RPC event or poll)
+2. Fingerprint check (infohash first, then hash-set) against purged/blocked versions
+3. If match → pause deluge, surface approval dialog, short-circuit the rest
+4. If no match → identify the book (metadata match against existing library)
+5. If book exists → new version lands in `.versions/{new-id}/` as `alt` (never auto-promoted unless book has zero active versions)
+6. If new book → primary at natural path, `status='active'`, `source='deluge'`, `torrent_hash` set
+7. Deluge `move_storage` immediately so seeding continues from the centralized path
+
+**B. Manual file import**
+
+Same pipeline minus the infohash check. SHA-256 fingerprint check still runs.
+
+**C. iTunes import**
+
+Unchanged. Excluded from centralization. Existing `external_id_map` maintains the iTunes ↔ book link.
+
+### 8. UI surface
+
+**BookDetail "Versions" panel** replaces / extends the current Version Group panel:
+
+- One row per `book_versions` row (excluding trash/purged)
+- Columns: status dot · format · bitrate · duration · source · ingest_date
+- Actions per alt row: **Make primary** (triggers swap op), **Delete**
+- Multi-file books: row expands to show `book_files` segments + their `missing` state
+- `torrent_hash` present → small icon with deluge state tooltip
+
+**New dedicated pages:**
+
+- `/library/trash` — lists `trash` rows, actions: Restore, Purge Now, TTL countdown per row
+- `/library/purged` — lists `inactive_purged` + `blocked_for_redownload` rows, actions: Hard Delete (removes fingerprint permanently)
+
+### 9. Operational defaults
+
+- **Permissions on moves**: preserve `chown`/`chmod`, re-apply import path's group + `g+w` ACL (per `feedback_linux_acls.md`)
+- **Concurrent access during swap**: no in-flight protection. ZFS rename + kernel inode survival keeps streaming clients reading the old bytes
+- **Scanner skip window**: scanner ignores books where any `book_versions.status IN ('swapping_in', 'swapping_out')`
+- **Hash computation**: ingest only. Re-hash via explicit "verify integrity" user action
+- **Deluge `move_storage` failure**: retry 3x with backoff. Persistent failure → `metadata_json.deluge_move_failed=true`, UI warning, manual retry action
+
+### 10. Migration plan
+
+One-time `migrate-to-versions` operation, runs at startup after the feature ships:
+
+1. **Dry-run**: scan library, compute per-book plan, store as operation result
+2. **User confirms** from a UI prompt → operation executes
+3. **Per book**: one `book_versions` row, `status='active'`, `source='imported'`, `ingest_date = books.created_at or now()`. Compute SHA-256 for each file (parallel via `FileIOPool`). Backfill `book_files.version_id`.
+4. **iTunes-sourced books**: skipped — no `book_versions` row
+5. **Existing cross-book duplicates**: not merged by this migration; existing dedup handles them later
+6. **Resumable**: standard tracked operation, PR #270 framework covers crash recovery
+
+Expected runtime for the current 24K-book library (most <500 MB): a few hours of one-time hashing.
+
+## Implementation sequencing
+
+Rough order (each a separate PR):
+
+1. Schema migration — add `book_versions`, `book_files.version_id`, indexes
+2. Ingest refactor — route new files through version creation; keep old behavior when feature-flagged off
+3. Primary swap operation + recovery case
+4. Fingerprint check + deluge pause/approval dialog
+5. Delete / trash / purge states + background TTL job
+6. UI — Versions panel, Trash view, Purged view
+7. Deluge `move_storage` integration
+8. `migrate-to-versions` one-time operation + dry-run UI
+9. Flip feature flag to on
+10. Docs, retention-policy settings, cleanup
+
+## Open implementation questions (deferred, not blockers)
+
+- What does the "verify integrity" action check — rehash a version and compare? Per-file or roll-up?
+- UI behavior when a `book_versions` row exists but all `book_files` are marked `missing` (partial deluge failure, etc.)
+- Multi-user interaction (3.7): who owns a version? Per-user alts? Deferred until 3.7 design.
+- Admin-only override to hard-delete without going through Trash? (Probably yes — in the Purged view UI.)

--- a/docs/superpowers/specs/2026-04-15-multi-user-support-design.md
+++ b/docs/superpowers/specs/2026-04-15-multi-user-support-design.md
@@ -1,0 +1,286 @@
+<!-- file: docs/superpowers/specs/2026-04-15-multi-user-support-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8a2d5c1e-3b9f-4f60-a7d4-1c8e0f2b9a57 -->
+
+# Multi-User Support — Design
+
+**Status:** Design complete (Apr 15, 2026). Ready for implementation plan.
+**Scope item:** TODO.md §3.7.
+**Depends on:** 4.4 (DI for `Store`) — design complete, implementation in-flight.
+**Brainstorm:** Apr 15, 2026 session.
+
+## Goal
+
+Replace the single-implicit-user model with authenticated multi-user access. All books remain a **shared global library**; users have different permissions expressed via a role matrix. This is primarily about "let my friends view the library safely" — not per-user libraries, not multi-tenancy. Request-based sharing (users asking admin to add something) is reserved for a future spec.
+
+## Locked decisions
+
+### 1. Library scope — shared, not per-user
+
+- All `books`, `authors`, `series`, `book_versions`, operations, tags — global and shared across users
+- What differs between users is **permission to see/act on** that data, not *which* data
+- Non-admin users can see the entire library (read-only by default)
+- Future: `requests.create` / `requests.approve` permissions for user-requested additions (reserved now, implemented later)
+
+### 2. Auth — all three layered into one issuer
+
+| Mechanism | Entry | Result |
+|---|---|---|
+| Password (local) | Form login | Session cookie |
+| OAuth (GitHub, Google) | Provider callback | Session cookie |
+| JWT (personal API keys) | `Authorization: Bearer` | Per-request auth, no cookie |
+
+All three converge on the same `*User` in `c.Request.Context()`. Middleware is the single choke point. OAuth providers limited to GitHub + Google initially.
+
+### 3. Permissions model — atoms with role bundles
+
+Permissions are **Go string constants**, not DB rows — validated at route-registration time.
+
+```go
+const (
+    PermLibraryView         = "library.view"
+    PermLibraryEditMetadata = "library.edit_metadata"
+    PermLibraryDelete       = "library.delete"
+    PermLibraryOrganize     = "library.organize"
+    PermScanTrigger         = "scan.trigger"
+    PermIntegrationsManage  = "integrations.manage"   // deluge, iTunes, openai, etc.
+    PermUsersManage         = "users.manage"
+    PermSettingsManage      = "settings.manage"
+    PermRequestsCreate      = "requests.create"       // reserved, future
+    PermRequestsApprove     = "requests.approve"      // reserved, future
+)
+```
+
+Seed roles:
+
+| Role | Permissions |
+|---|---|
+| `admin` | all (including `users.manage`, `integrations.manage`, `settings.manage`) |
+| `editor` | everything except `users.manage`, `integrations.manage`, `settings.manage` |
+| `viewer` | `library.view` only |
+
+Users can have multiple roles; effective permission set is the union. Custom roles can be created by admins later.
+
+### 4. Enforcement — hybrid middleware + route-level
+
+```go
+protected.GET ("/audiobooks",      s.requirePerm(PermLibraryView),         s.listAudiobooks)
+protected.POST("/audiobooks/:id",  s.requirePerm(PermLibraryEditMetadata), s.updateAudiobook)
+```
+
+- `requirePerm` is a middleware factory: reads user from context, checks permissions, 403 otherwise
+- All mutating routes MUST call `requirePerm`; CI grep catches new routes that skip it
+- Login / OAuth-callback / health-check routes explicitly bypass via a short public list
+
+### 5. User lifecycle
+
+| Action | Who | Mechanism |
+|---|---|---|
+| First user created | Server | First-run setup wizard at `/setup` OR `audiobook-organizer user create` CLI |
+| Subsequent users | Admin | Users admin page → generates a single-use invite link |
+| Self-signup | — | **Disabled**. Invite-only |
+| Password reset | Admin | Admin regenerates invite; user re-sets password through it |
+| Email-based reset | — | Not in MVP. Infrastructure not worth it |
+| Self-edit | User | Can change own password, generate/revoke own API keys; cannot change own roles |
+| Lockout | Server | 10 failed logins in 15 min → 15-min lockout window, logged to activity |
+| 2FA | — | Not in MVP. Schema leaves room |
+
+### 6. First-run migration
+
+At startup, if no users exist:
+
+1. Server logs `"No users configured. Open http://<host>:<port>/setup or run 'audiobook-organizer user create'."`
+2. `/setup` route is enabled only while user count is zero. Accepts username + password + confirm. Creates the user as **admin** and disables `/setup`.
+3. All existing DB rows that need a `user_id` (see §10) get backfilled to this user on first login — retroactive provenance for single-user-era data.
+
+### 7. Audit trail — `user_id` on mutating records
+
+Added to:
+
+- `operations` (who launched this op; null → `_system`)
+- `operation_changes` (who made each change)
+- Activity log entries
+- `book_tags` (existing `source` field gains user-id precision when source is `user`)
+
+Scheduler / background jobs attribute to a reserved **`_system`** pseudo-user — a `users` row with `is_system=true`, no permissions, cannot log in, cannot be deleted.
+
+### 8. Integration scope
+
+All external integrations (iTunes, deluge, openlibrary, audible, openai) are **system-level**. Config and trigger gates on `integrations.manage` (admin by default). Viewers can *see* iTunes-sourced books and torrent status but can't configure or trigger anything.
+
+## PebbleDB key-space (matches existing conventions)
+
+### Users
+
+```
+user:{userID}                       → User JSON blob
+user_by_username:{lcase-username}   → userID
+user_by_oauth:{provider}:{subject}  → userID
+```
+
+### Roles (permissions inline)
+
+```
+role:{roleID}                       → Role JSON: {name, description, permissions: [...]}
+```
+
+No `permissions` or `role_permissions` tables — permissions are Go constants, role blobs carry their own permission lists.
+
+### Membership (existence-based, written in batch)
+
+```
+user_role:{userID}:{roleID}         → ""
+role_member:{roleID}:{userID}       → ""
+```
+
+Both written in one Pebble `Batch` to preserve the bidirectional invariant atomically.
+
+### Sessions
+
+```
+session:{sessionID}                 → Session JSON: {userID, permissions_snapshot, expires_at, ...}
+user_session:{userID}:{sessionID}   → ""
+```
+
+Session blob caches the user's permission set at login — no JOIN per request. Invalidated + rewritten on role change. Expired sessions cleaned in the existing maintenance window.
+
+### API keys
+
+```
+api_key:{keyID}                     → APIKey JSON: {userID, name, created_at, last_used_at, revoked_at}
+user_api_key:{userID}:{keyID}       → ""
+```
+
+JWT carries `keyID` as `jti`. Verification: decode → lookup `api_key:{keyID}` → check `revoked_at` is null → load user → auth complete.
+
+### Invites
+
+```
+invite:{token}                      → Invite JSON: {username, roleID, created_by, expires_at, used_at}
+invite_by_username:{username}       → token
+```
+
+Consumption (user first opens invite URL, sets password): delete both keys + create user + write role membership, all in one Pebble batch.
+
+## `Store` interface additions
+
+```go
+// Users
+GetUserByID(id string) (*User, error)
+GetUserByUsername(username string) (*User, error)
+GetUserByOAuth(provider, subject string) (*User, error)
+CreateUser(*User) (*User, error)
+UpdateUser(id string, *User) (*User, error)
+DeleteUser(id string) error
+ListUsers(limit, offset int) ([]User, int, error)
+CountUsers() (int, error)
+
+// Roles
+GetRoleByID(id string) (*Role, error)
+ListRoles() ([]Role, error)
+CreateRole(*Role) (*Role, error)
+UpdateRole(id string, *Role) (*Role, error)
+
+// Membership (atomic)
+GetUserRoleIDs(userID string) ([]string, error)
+SetUserRoles(userID string, roleIDs []string) error
+GetRoleMemberIDs(roleID string) ([]string, error)
+
+// Sessions
+CreateSession(*Session) error
+GetSession(id string) (*Session, error)
+DeleteSession(id string) error
+DeleteUserSessions(userID string) error       // logout-all
+CleanExpiredSessions(before time.Time) (int, error)
+
+// API keys
+CreateAPIKey(*APIKey) error
+GetAPIKey(id string) (*APIKey, error)
+RevokeAPIKey(id string) error
+ListUserAPIKeys(userID string) ([]APIKey, error)
+
+// Invites
+CreateInvite(*Invite) error
+GetInvite(token string) (*Invite, error)
+ConsumeInvite(token string, userID string) error   // atomic batch
+ListActiveInvites(createdBy string) ([]Invite, error)
+```
+
+Implemented on `PebbleStore`, `SQLiteStore`, `MockStore`.
+
+## Request-scoped plumbing (depends on 4.4)
+
+Typed context helpers (pair with 4.4's DI):
+
+```go
+type ctxKey int
+const (
+    userKey ctxKey = iota
+    permissionsKey
+)
+
+func WithUser(ctx context.Context, u *User) context.Context
+func UserFromContext(ctx context.Context) (*User, bool)
+func WithPermissions(ctx context.Context, perms []string) context.Context
+func PermissionsFromContext(ctx context.Context) []string
+func Can(ctx context.Context, perm string) bool
+```
+
+Middleware chain: authenticate → load user + permissions into ctx → `requirePerm` checks on routes → handler reads user via `UserFromContext`.
+
+## Why PebbleDB (not MySQL/Postgres) for multi-user
+
+Considered and rejected. Summary:
+
+| SQL feature | Needed for multi-user? |
+|---|---|
+| Cross-table transactions | Covered by Pebble `Batch` |
+| JOIN | No — all reads are point lookups or short prefix scans |
+| Foreign key enforcement | App-level via batch writes |
+| Row-level locking | No contention here |
+| Full-text search | Orthogonal (Bleve, not auth) |
+| Replication | Not in scope |
+
+No meaningful loss. The open TODO.md §4.1 Postgres research is about *library* data (books/authors/dedup/reporting), not auth — and if the library ever migrates to Postgres, the multi-user tables come along for free through the `Store` interface.
+
+## MVP scope (first shippable slice)
+
+1. Schema: all PebbleDB keys listed above
+2. Password auth + session cookies
+3. Login / logout pages, session middleware
+4. Roles + permissions + `requirePerm` middleware
+5. First-run setup wizard (`/setup`) + CLI alt (`user create`)
+6. Users admin page (list / create invite / reset password / deactivate)
+7. `user_id` columns + one-time migration to default admin
+8. CI grep to flag routes missing `requirePerm`
+
+## Deferred to follow-up PRs
+
+- **OAuth (GitHub + Google)** — separate PR, standard OAuth2 flow against existing middleware
+- **JWT personal API keys** — separate PR, adds bearer auth alongside cookies
+- **Request feature** (`requests.create`, `requests.approve`) — its own design + PR
+- **2FA** — later
+- **Email-based password reset** — later; admin-reset is enough for MVP
+- **Rate-limiting beyond login lockout** — later, if abuse shows up
+
+## Risks
+
+- **Session invalidation on role change** — permission snapshots in session blobs need to be rewritten. Mitigation: on role change, call `DeleteUserSessions(userID)` to force re-login. Simple but users get kicked out.
+- **First-run race** — if two admins hit `/setup` simultaneously. Mitigation: the `/setup` route checks `CountUsers() == 0` inside its handler and uses a mutex; once any user exists, route is disabled.
+- **Backfilling `user_id`** — existing rows without a user. Migration script attributes to the first admin. For large operation/activity log histories this is a non-trivial one-time write; runs as a tracked operation.
+- **Permission constants drift from role seeds** — if we add a new permission constant but forget to add it to seed roles, existing admins don't have it. Mitigation: seed roles are recomputed at startup (`upsert` behavior) — admin always gets the full set of known permissions.
+
+## Non-goals
+
+- Per-user libraries
+- Per-user settings (aside from self-edit of password + API keys)
+- Multi-tenancy (one org per server is all we need)
+- Delegation / impersonation
+- Audit of *reads* (only mutating actions recorded)
+
+## Open implementation questions (deferred)
+
+- OAuth provider whitelist enforced per-install? (probably a config flag, not a compile constant)
+- Session expiry default — 30 days? (match typical SaaS)
+- API key scopes — are personal API keys scoped to a subset of the user's permissions, or always full? (probably scoped)
+- Permission inheritance / negation — not supported, deliberately keep flat

--- a/docs/superpowers/specs/2026-04-15-read-unread-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-15-read-unread-tracking-design.md
@@ -1,0 +1,222 @@
+<!-- file: docs/superpowers/specs/2026-04-15-read-unread-tracking-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9a2c7e4f-5b3d-4f80-a6c1-8d0e2f1b9a65 -->
+
+# Read/Unread Tracking Beyond iTunes — Design
+
+**Status:** Design complete (Apr 15, 2026). Ready for implementation plan.
+**Scope item:** TODO.md §3.6.
+**Depends on:** 3.7 (multi-user — per-user attribution), existing iTunes ITL parser and bookmark field handling.
+
+## Goal
+
+First-class per-user read/progress tracking that works whether a book is in iTunes or not, and that supports multiple users each with their own progress against the shared library. iTunes sync is bidirectional for the attributed admin user using iTunes's `Bookmark` field (reliable for Audiobook-kind tracks).
+
+## Locked decisions
+
+### 1. Per-user state, shared library
+
+All books / authors / series are shared (per 3.7). **Read progress is per-user.** Alice having finished *Oathbringer* doesn't mark it finished for Bob.
+
+### 2. Two layers of state
+
+| Layer | Kind | Granularity |
+|---|---|---|
+| **Play position** | Continuous | Per `(user, book_file)` — second-precision offset into a segment |
+| **Read status** | Discrete | Per `(user, book)` — `unstarted` / `in_progress` / `finished` / `abandoned` |
+
+Read status is auto-computed from play position but user can manually override (e.g., "finished it in paperback elsewhere").
+
+### 3. iTunes interop — `Bookmark` is the real position
+
+iTunes stores per-track position in the `Bookmark` field (seconds, float) for Audiobook-kind tracks, reliably. Our model:
+
+- **On import/sync**: for each iTunes-sourced book_file with `Bookmark > 0`, seed the attributed admin user's position — one position row per book_file
+- **On admin position writes**: write back to iTunes `Bookmark` on next iTunes sync pass (so iPod / Apple player picks up the updated position)
+- **Other users' positions**: live in our DB only; iTunes has no multi-user model and we don't invent one on its side
+
+Attributed user: admin by default (MVP). Configurable later to "my user" for self-hosted single-user installs via a setting.
+
+### 4. Position tracking granularity
+
+Position keyed on `book_file` (segment), carrying:
+
+- `segment_id` — which chapter/file
+- `position_seconds` — offset into that file
+- `updated_at` — last event
+
+"Current position in the book" is `(last_updated_segment, position_seconds)`. Percent-through and time-remaining are computed on the fly from segment durations in `book_files.duration`.
+
+### 5. Event-based updates
+
+A player (our UI, future mobile, Plex-style client) sends a position event whenever:
+
+- User pauses
+- User seeks
+- User closes the book / navigates away
+- Periodically during playback (configurable heartbeat; default 30 s)
+
+Server upserts `(user, segment)` → position. No event queue, no write batching — rates are low (≤ 2/s per user). Writes also recompute and cache read status.
+
+### 6. Read-status auto-compute
+
+Rule: **`finished` when user has listened past 95% of total book duration.** Sum of (fully-played segments' duration) + (current segment position) ≥ 0.95 × total book duration.
+
+- `unstarted` — no position events ever
+- `in_progress` — some position events, < 95% consumed
+- `finished` — auto-flipped when 95% threshold crossed
+- `abandoned` — user-set only; no auto trigger
+
+### 7. Manual override
+
+UI offers "Mark as finished / unstarted / abandoned." Setting a manual value flips `status_manual = true` — the status no longer auto-updates even if position changes later. Clearing the manual override ("Use automatic status") resumes auto-computation from current position.
+
+## PebbleDB schema
+
+```
+user_position:{userID}:{bookID}:{segmentID}   → UserPosition JSON {
+                                                    position_seconds,
+                                                    updated_at
+                                                 }
+user_book_state:{userID}:{bookID}             → UserBookState JSON {
+                                                    status,
+                                                    status_manual,
+                                                    last_activity_at,
+                                                    last_segment_id,
+                                                    total_listened_seconds,  // cached for fast % calc
+                                                    progress_pct             // cached 0-100
+                                                 }
+book_user:{bookID}:{userID}                   → ""    (reverse lookup — "who has progress on this book")
+```
+
+No position history — latest wins. If future work wants "Continue Listening" history, that's a separate spec.
+
+## API
+
+```
+POST   /api/v1/books/:id/position
+  body: { segment_id, position_seconds }
+  → upserts user_position, recomputes user_book_state, schedules iTunes write-back if caller is the attributed admin user and book has an iTunes PID
+
+GET    /api/v1/books/:id/position
+  → latest position for the calling user (or 404 if none)
+
+GET    /api/v1/books/:id/state
+  → UserBookState for the calling user
+
+PATCH  /api/v1/books/:id/status
+  body: { status: "finished" | "unstarted" | "abandoned" }
+  → set status_manual=true, write status
+
+DELETE /api/v1/books/:id/status
+  → clear manual override, recompute from position
+
+GET    /api/v1/me/in-progress?limit=N
+GET    /api/v1/me/finished?limit=N
+  → lists sorted by last_activity_at DESC
+```
+
+Permissions:
+
+- Calling user reads/writes only their own state (implicit self-scope, no extra permission)
+- `library.view` required as baseline
+- Reading others' state: reserved for future `users.view_state` permission — not MVP
+
+## Search / filter / smart playlist integration
+
+Adds to `SEARCH_FIELDS` (evaluated against the calling user's state):
+
+- `read_status` — `unstarted` / `in_progress` / `finished` / `abandoned`
+- `last_played` — timestamp; supports `within_days:N`, `before:YYYY-MM-DD`, `after:YYYY-MM-DD`
+- `progress_pct` — integer 0-100; supports `:>`, `:<`, `:>=`, `:<=`, range
+
+Smart playlists like "Currently Reading" (`read_status:in_progress`) and "Abandoned" (`read_status:abandoned`) fall out naturally. See §3.4 design for playlist spec.
+
+## UI
+
+- **BookDetail**: prominent read-status chip, "X h Y m left" resume button (jumps to `last_segment_id` + `position_seconds`), "Mark as …" menu for override, "Use automatic" when manually overridden
+- **Library**: optional column for read status (hidden by default, toggleable via existing column config); optional column for progress bar
+- **Sidebar**: "Currently Reading" and "Finished" entries (quick filters, not saved smart playlists)
+
+## iTunes sync interaction
+
+Bidirectional for the attributed admin user only:
+
+- **Pull** (iTunes → app): during iTunes sync, for each iTunes-sourced track with `Bookmark > 0`, upsert admin user's position
+- **Push** (app → iTunes): during iTunes sync, for each admin position update since last sync (tracked via `updated_at > last_itunes_sync_at`), write back the `Bookmark` field for the corresponding iTunes track
+- Status isn't directly represented in iTunes (no "finished" flag per track). Play count + play date in iTunes map to our signal loosely:
+  - If `play_count > 0` in iTunes and we have no admin state → seed `finished` (assume listened)
+  - If we flip admin to `finished` → increment iTunes `play_count` by 1 and set `Played Date` to now
+  - Non-admin users' status never touches iTunes
+
+## Migration / backfill
+
+One-time at feature rollout:
+
+1. For each iTunes-sourced book with `play_count > 0` or `Bookmark > 0`:
+   - Create admin's `user_book_state` row
+   - Seed `status = finished` if `play_count > 0` else `in_progress` if `Bookmark > 0`
+   - `last_activity_at = max(last_played, bookmark_updated)` from ITL
+   - For each `book_file` with a Bookmark, create `user_position` row for admin
+2. No backfill for non-admin users — they start fresh
+
+## `Store` interface additions
+
+```go
+// Position
+SetUserPosition(userID, bookID, segmentID string, positionSeconds float64) error
+GetUserPosition(userID, bookID string) (*UserPosition, error)   // latest across segments
+ListUserPositionsForBook(userID, bookID string) ([]UserPosition, error)  // per-segment list
+ClearUserPosition(userID, bookID string) error
+
+// Status
+SetUserBookStatus(userID, bookID, status string, manual bool) error
+GetUserBookState(userID, bookID string) (*UserBookState, error)
+ClearUserManualStatus(userID, bookID string) error
+
+// Lists
+ListInProgressForUser(userID string, limit, offset int) ([]UserBookState, error)
+ListFinishedForUser(userID string, limit, offset int) ([]UserBookState, error)
+
+// Sync helpers
+ListAdminPositionsSince(t time.Time) ([]UserPosition, error)  // for iTunes write-back pass
+```
+
+## MVP scope
+
+1. PebbleDB keys + struct types
+2. `Store` method impls (Pebble + mock)
+3. Position + status HTTP endpoints
+4. BookDetail UI: status chip, resume button, override menu
+5. Library column (hidden by default)
+6. Search integration: `read_status`, `last_played`, `progress_pct`
+7. iTunes backfill for existing admin data (one-time)
+8. iTunes sync bidirectional for admin's `Bookmark`
+9. "Currently Reading" + "Finished" sidebar entries
+
+## Deferred
+
+- Position-event history (would enable "Resume your session" UX)
+- Cross-user analytics / admin dashboards (`users.view_state` permission)
+- Non-admin user iTunes attribution (would need per-user iTunes library, out of scope)
+- Listening-based recommendations (explicitly out of scope per TODO.md §8)
+- Per-segment re-listen flags / bookmarks beyond position
+
+## Risks
+
+- **Position write volume.** Heartbeat at 30 s = 120 writes/hour per active listener. Multiply by N users. PebbleDB handles this trivially, but the recomputation of `user_book_state` on every position write could become hot. Mitigation: recompute only on segment boundary crosses, not every heartbeat. Position upsert is always cheap; status recompute is periodic.
+- **iTunes Bookmark drift.** If user listens in our app, then in iTunes via iPod, Bookmark in iTunes advances independently. Next sync would see a forward-jumped Bookmark, write it to our position — correct. If both edit between syncs, last-sync-wins; acceptable for a "roughly keep in sync" model.
+- **Multi-file position sanity.** `last_segment_id` becomes the resume point; if user seeks to segment 5 then segment 2, the "current" segment is whichever has the most recent `updated_at`, not the highest segment number. Keep the simple "most recently updated" rule.
+
+## Non-goals
+
+- Shared/global "has this book been read by anyone" signal — explicitly per-user
+- Collaborative listening / watch-together
+- Auto-marking-finished across users (no global sync of status)
+- Writing status tags (beyond iTunes play count) back to the files themselves
+
+## Open implementation questions
+
+- Exact granularity of iTunes `Bookmark` — seconds float, ms, sample count? Confirm in ITL parser.
+- Does the existing player UI have hooks for position events, or do we need to add them? Probably add — no audio player was top-of-mind before this.
+- Browser audio player or rely on external players? In-app player would need streaming endpoint (ties into 3.8 Plex-style API).

--- a/docs/superpowers/specs/2026-04-15-replace-globalstore-with-di-design.md
+++ b/docs/superpowers/specs/2026-04-15-replace-globalstore-with-di-design.md
@@ -1,0 +1,161 @@
+<!-- file: docs/superpowers/specs/2026-04-15-replace-globalstore-with-di-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5c8d3a2f-9b1e-4f70-a4d8-2c7e0f1b9a58 -->
+
+# Replace `database.GlobalStore` with DI — Design
+
+**Status:** Design complete (Apr 15, 2026). Ready for implementation plan.
+**Scope item:** TODO.md §4.4.
+**Brainstorm:** Apr 15, 2026 session.
+
+## Goal
+
+Remove `database.GlobalStore` as a package-level variable and inject the `database.Store` dependency explicitly through the `Server` struct and service constructors. Unlocks clean per-test mocking, removes the "package global mutation in tests" pattern, and sets up a clean foundation for multi-user request-scoped state (3.7) and any future per-tenant store sharding.
+
+## Current state
+
+- `database.GlobalStore Store` — 455 references across 30 non-test files
+- `Server` struct already exists as the natural DI root; holds services (scanService, organizeService, metadataFetchService, ...) but currently they all reach out to `database.GlobalStore`
+- Tests universally use `database.GlobalStore = mock; defer database.GlobalStore = nil` — fragile under parallel tests
+- 5 other package-globals in the same shape: `GlobalQueue`, `GlobalScanner`, `GlobalMetadataExtractor`, `GlobalWriteBackBatcher`, `GlobalFileIOPool`
+
+## Scope
+
+**This design covers only `GlobalStore`.** The other five globals get the same treatment in follow-up PRs using this work as the template. Reasoning:
+
+- Migration of one global is already ~6 PRs; bundling all six would be 30+
+- The design choices (accessor shape, test-rewrite pattern, how non-handler packages accept a Store) are identical across all globals — nail them once for GlobalStore, then replay mechanically
+- Each global has its own test-setup idiom; touching them all at once means every test file gets touched multiple times
+
+## DI mechanism
+
+**Manual constructor injection. No framework.**
+
+- `Server` struct gains a `store database.Store` field
+- New `Server` constructor takes a `Store` as an argument
+- Handlers remain `func (s *Server) handlerX(c *gin.Context)` — replace `database.GlobalStore` with `s.store`
+- Non-handler packages (`scanner`, `organizer`, `backup`) take a `Store` as a constructor arg: `scanner.New(store, ...)`
+- Tests construct a `Server` directly with a mock store — no more package-var swap
+
+Explicitly **not** using:
+
+- **Wire** (google/wire): codegen + review overhead with no payoff at this scale
+- **Uber fx / do**: runtime-reflective DI, not idiomatic Go
+- **Context-based** (store in `ctx.Value`): stringly-typed, opaque, wrong for long-lived deps (fine for request-scoped state — see below)
+
+## Request-scoped state (multi-user foresight)
+
+Two kinds of dependency, handled differently:
+
+| Kind | Where it lives | Example |
+|---|---|---|
+| Long-lived | `Server` struct field | `store`, `queue`, `scanner` |
+| Request-scoped | `context.Context` via typed helper | current user, request ID, per-request logger |
+
+For request-scoped, standard Go pattern:
+
+```go
+type ctxKey int
+const userKey ctxKey = iota
+
+func WithUser(ctx context.Context, u *User) context.Context { return context.WithValue(ctx, userKey, u) }
+func UserFromContext(ctx context.Context) (*User, bool)     { u, ok := ctx.Value(userKey).(*User); return u, ok }
+```
+
+Middleware sets them on `c.Request.Context()`. Handlers read from there. This spec does **not** implement request-scoped state — but `Server` stays stateless per-request so 3.7 (multi-user) can plug in without a restructure.
+
+## Migration sequencing
+
+### Phase 1 — Bootstrap (1 PR)
+
+- Add `store database.Store` field to `Server` struct
+- Add `NewServer(store Store, ...)` constructor
+- In `cmd/root.go`'s startup code: initialize the store, then pass it into `NewServer`
+- **Dual-live**: `database.GlobalStore` is still assigned at startup so un-migrated code keeps working
+- Add `(s *Server) Store() Store` accessor — handlers will migrate to this
+
+**Acceptance**: build passes, all existing tests pass, `s.store` is reachable from handlers even though no handler uses it yet.
+
+### Phase 2 — Migrate handlers (~6 PRs)
+
+One PR per ~5 handler files. In each PR:
+
+- Replace `database.GlobalStore` with `s.Store()` (or `s.store` if the method-call overhead matters; prefer the method for future flexibility)
+- Convert the matching test file: replace `database.GlobalStore = mock; defer ...` with `srv := &Server{store: mock}; srv.setupRoutes()`
+- File groupings roughly by topic to keep diffs reviewable:
+  1. audiobooks_handlers + audiobook_service + versions_handlers
+  2. metadata_handlers + metadata_batch_candidates + metadata_fetch_service
+  3. organize_handlers + reconcile + maintenance_fixups
+  4. auth_handlers + user_tags + entities_handlers
+  5. ai_handlers + dedup_handlers + diagnostics_handlers
+  6. operations_handlers + system_handlers + file_ops_handlers + filesystem_handlers
+
+**Acceptance per PR**: target files have zero `database.GlobalStore` references, their tests pass without the package-var dance, no behavior change.
+
+### Phase 3 — Migrate non-handler packages (3 PRs)
+
+- `internal/scanner`: `scanner.Scanner` interface already exists; add a `store` field, update `ScanDirectory` / `ProcessBooks` signatures or move them to methods. Uses are in `cmd/root.go` and via `s.scanService`.
+- `internal/organizer`: similar.
+- `internal/backup`: smaller, straightforward.
+
+Each PR converts one package, updates callers, updates tests.
+
+### Phase 4 — Delete the global (1 PR)
+
+- Remove `var GlobalStore Store` from `internal/database/store.go`
+- Remove `InitializeStore` / `CloseStore` side-effects on GlobalStore (may need reshaping to return a `Store` instead of assigning to the package var)
+- Verify compile across the repo — any surviving reference is a compile error
+- Remove `database.GlobalStore = ...` boilerplate from test files (should be zero by this point)
+
+No special linter needed. If anyone later re-adds `var GlobalStore Store`, the declaration is an obvious code-review red flag. Compile-error > lint-warning.
+
+### Phase 5 (follow-up, out of scope here)
+
+Apply the same five-phase template to:
+
+1. `GlobalQueue` (`internal/operations`)
+2. `GlobalScanner` (`internal/scanner`) — may be subsumed by Phase 3 of this spec
+3. `GlobalMetadataExtractor` (`internal/metadata`)
+4. `GlobalWriteBackBatcher` (`internal/server`)
+5. `GlobalFileIOPool` (`internal/server`) + `globalServer` reference
+
+## Testing strategy
+
+Current pattern:
+
+```go
+database.GlobalStore = mockStore
+t.Cleanup(func() { database.GlobalStore = nil })
+srv := &Server{router: gin.New()}
+```
+
+New pattern:
+
+```go
+srv := &Server{store: mockStore, router: gin.New()}
+```
+
+- No more global mutation
+- Parallel-safe (`t.Parallel()` works)
+- Each test explicitly names its deps
+
+For handlers that also touch `GlobalQueue`, `GlobalMetadataExtractor`, etc., those globals stay in place until their Phase-5 migration — existing test setup for those unchanged.
+
+## Risks
+
+- **Merge conflicts with ongoing feature work.** Phase 2 PRs touch handler files that are hot in other branches. Mitigation: land phases quickly and in small chunks; don't hold a Phase 2 PR open for days.
+- **Test file churn.** Every test that mocks the store changes. Reviewers need to look at test conversions as a pattern, not line-by-line.
+- **Hidden shared state.** Some helpers may assume `database.GlobalStore` is set globally (e.g., a func outside `Server`). Phase 4 compile errors surface these — each becomes a small follow-up to refactor the helper.
+
+## Non-goals
+
+- Changing the `Store` interface
+- Changing `PebbleStore` / `SQLiteStore` implementations
+- Introducing a DI framework
+- Refactoring services into constructor chains (services still hang off `Server` as fields)
+- Multi-user support (3.7) — this spec only makes it possible cleanly, doesn't implement it
+
+## Open implementation questions (deferred, not blockers)
+
+- Should `Server.Store()` be an interface method accessor, or do we expose `s.store` directly? Probably method, to allow future decorator wrapping (audit log, per-tenant routing).
+- Does `cmd/root.go` need a meaningful refactor or just a few line changes? Likely the latter — existing `initializeStore` / `closeStore` vars already decouple the init call.

--- a/docs/superpowers/specs/2026-04-15-smart-and-static-playlists-design.md
+++ b/docs/superpowers/specs/2026-04-15-smart-and-static-playlists-design.md
@@ -1,0 +1,257 @@
+<!-- file: docs/superpowers/specs/2026-04-15-smart-and-static-playlists-design.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 7c4a8e2f-3d1b-4f90-a5d7-6b9e1c0f8a43 -->
+
+# Smart + Static Playlists with iTunes Sync — Design
+
+**Status:** Design complete (Apr 15, 2026, revised same session). Ready for implementation plan.
+**Scope item:** TODO.md §3.4.
+**Depends on:** existing library search parser (`web/src/utils/searchParser.ts`) + ITL parser (PR 2026-03-27).
+**Brainstorm:** Apr 15, 2026 session (v1.0 → v1.1 revision: simplified iTunes sync to push-only-static + one-time dynamic migration).
+
+## Goal
+
+Two playlist types — **static** (ordered book list, manually curated) and **smart** (live-evaluated filter expression) — with iTunes sync that is deliberately one-way-in-form: we always push as iTunes **static** playlists, never as iTunes dynamic (Smart Criteria). We own the evaluation; iTunes receives a materialized list.
+
+## Locked decisions
+
+### 1. Two types, unified storage
+
+| Type | Membership | Edit actions | iTunes form |
+|---|---|---|---|
+| `static` | Explicit ordered list of book IDs | Add / remove / reorder | Static iTunes playlist |
+| `smart` | Live-evaluated filter expression | Edit query, sort, limit; "Materialize as Static" | **Materialized** iTunes static playlist (refreshed each sync) |
+
+Single `playlist:{id}` JSON blob in PebbleDB with a `type` discriminator.
+
+### 2. Query DSL — extend existing library search
+
+Existing syntax unchanged. Additions (backward-compatible):
+
+```
+AND:  whitespace  |  &&  |  AND
+OR:               ||  |  OR
+NOT:  -   |  NOT
+Group: ( ... )
+Within-field alternation: field:(a|b|c)
+```
+
+- Single pipe `|` is reserved for within-field alternation
+- Double pipe `||` is top-level OR between clauses
+- Visually distinct on purpose
+
+Worked example (both parse identically):
+
+```
+(-title:twilight && -title:"New Dawn" && title:vampire) || title:(Fangtown|fangtown|"fang town")
+
+(NOT title:twilight AND NOT title:"New Dawn" AND title:vampire) OR title:(Fangtown|fangtown|"fang town")
+```
+
+- Substring match is default. `title:vampire` matches "Interview with the Vampire."
+- Quoted values stay substring; quotes only group whitespace.
+- Exact-match operator (`field:=value`) reserved for future, not MVP.
+- Field set: everything in existing `SEARCH_FIELDS`.
+
+### 3. iTunes sync — push-only-as-static
+
+**We never write iTunes Smart Criteria.** Every app-owned playlist pushes to iTunes as a **static** iTunes playlist.
+
+- `static` playlists: trivially, the book list pushes as-is
+- `smart` playlists: evaluate locally, **materialize** into a static book list, push that
+- Re-materialize smart playlists when:
+  - Query / sort / limit is edited
+  - Library changes could affect membership (new book, metadata edit, tag add/remove) — marked stale via a `dirty` flag, actual re-eval at next iTunes sync pass or on "Sync now"
+
+**Rationale for pushing static only:** iTunes's own Smart Criteria evaluator is weaker than ours, its field set is incomplete for our data (no `tag`, `language`, internal states), and we don't want to race iTunes's rule engine against ours. Our side computes; iTunes receives the result.
+
+### 4. One-time iTunes dynamic playlist migration
+
+New tracked operation `itunes_dynamic_playlist_migration`, idempotent. Runs once at feature rollout and on-demand from admin UI if needed.
+
+1. Enumerate all iTunes dynamic playlists (Smart Info + Smart Criteria present in ITL)
+2. For each:
+   1. Read + translate rules to our DSL (best-effort)
+   2. Store raw Smart Criteria blob alongside the translated query for audit
+   3. Create an `app`-owned **smart** playlist in our DB with the translated query
+   4. Evaluate locally, materialize the current matches
+   5. Write a **static** iTunes playlist with those matches; grab the new PID
+   6. Delete the original dynamic iTunes playlist
+   7. Log: "Migrated iTunes smart playlist 'X' → app-owned smart + iTunes static"
+3. Set `itunes_dynamic_migration_done = true`. Subsequent runs no-op unless new dynamic playlists appear (defensive catch, §5).
+
+Readers needed: ITL Smart Criteria parser (prereq — verify 2026-03-27 parser covers it; if not, add in this PR).
+
+Writers needed: none for Smart Criteria. Static playlist writer already exists.
+
+### 5. Defensive catch — new iTunes dynamic playlists post-migration
+
+If a user creates a new dynamic playlist directly in iTunes after migration, next iTunes sync pass detects it and surfaces a UI review dialog:
+
+> "Found a new iTunes smart playlist 'X'. Import and convert to app-owned smart + delete iTunes dynamic?"
+
+- **Yes** → runs the §4 migration path for that one playlist
+- **No** → leave it alone, stop re-prompting (mark the PID as `declined`, user can change mind later in settings)
+
+### 6. Ownership — simplified
+
+All playlists in our DB are **app-owned**. No `itunes` or `forked` states (earlier design had these). The only transient state is "being migrated" — a flag cleared once the new app-owned version is created and the old iTunes dynamic is deleted.
+
+### 7. Field mapping (iTunes → ours, one direction only)
+
+Needed for reading iTunes Smart Criteria during migration. Reverse mapping not needed since we never write Smart Criteria.
+
+| iTunes field | Our field | Notes |
+|---|---|---|
+| Name | `title` | |
+| Album Artist | `author` | Primary mapping for audiobooks |
+| Artist | `author` | Fallback if AA absent |
+| Composer | `narrator` | Per audiobook tag convention |
+| Grouping | `series` | |
+| Genre | `genre` | |
+| Year | `year` | |
+| Kind | `format` | String translation |
+| Time | `duration` | ms → seconds |
+| Bit Rate | `bitrate` | |
+| Has Artwork | `has_cover` | |
+| Plays, Rating, Last Played, etc. | (flagged as untranslatable, stored in raw blob for reference) | |
+
+Un-mappable iTunes fields get recorded as "approximation" markers in the translated query with a comment (`// approx: iTunes rule "Plays > 0" not directly representable`). User can refine after migration.
+
+### 8. Operator mapping (iTunes → ours)
+
+| iTunes operator | Our DSL |
+|---|---|
+| `contains` | `field:substring` |
+| `does not contain` | `-field:value` |
+| `is` | `field:=value` (future exact-match syntax — for MVP, approximate with substring) |
+| `is not` | `-field:value` |
+| `>`, `<` | `field:>N`, `field:<N` |
+| `in range` | `field:>=A && field:<=B` (unfold, or future `field:[A TO B]`) |
+| `All of the following` | AND (whitespace or `&&`) |
+| `Any of the following` | `||` |
+| Nested groups | `( ... )` |
+
+### 9. Manual playlist UX (static)
+
+- "Add to playlist" action on BookDetail, Library row, dedup view → dialog with existing static playlists + "+ New playlist"
+- Playlist page: drag-reorder, remove per row, "+ Add books" library picker, rename, delete
+- Bulk "Add to playlist" from Library toolbar depends on **5.3 Batch Select**; single-book works immediately
+
+### 10. Smart playlist UX (dynamic)
+
+- Single text box for query + live preview pane (first 20 matches, 300 ms debounced)
+- Syntax-error highlighting: "expected `)`", "unknown field `autor` — did you mean `author`?"
+- Field autocomplete dropdown from `SEARCH_FIELDS`
+- "Materialize as Static" button → creates new `static` playlist with current matches, named `"{smart name} (snapshot 2026-04-15)"`
+
+### 11. Permissions (ties to 3.7)
+
+- `library.view` → see any playlist
+- New `playlists.create` (default on `editor` + `admin`) → create / edit / delete own
+- Admin can edit / delete any
+- All users can duplicate-and-edit
+
+## PebbleDB schema
+
+```
+playlist:{playlistID} → Playlist JSON {
+    id, name, description,
+    type,                       // "static" | "smart"
+    book_ids,                   // static-only: ordered
+    query, sort_json, limit,    // smart-only
+    materialized_book_ids,      // smart-only: cached last materialization (for iTunes sync speed)
+    itunes_persistent_id,       // null until first sync
+    itunes_raw_criteria_b64,    // migration audit trail (only for playlists that came from iTunes migration)
+    created_at, updated_at,
+    created_by_user_id,
+    dirty                       // pending iTunes push
+}
+
+user_playlist:{userID}:{playlistID}  → ""      (listing "my playlists")
+playlist_name:{lcase-name}           → playlistID   (uniqueness + lookup)
+itunes_playlist_map:{persistentID}   → playlistID   (reverse lookup during sync)
+itunes_declined_pid:{persistentID}   → ""      (user said "don't migrate this one")
+```
+
+Settings keys:
+
+```
+setting:itunes_dynamic_migration_done → "true" | missing
+```
+
+## Query engine
+
+Same as v1.0 design: parse → AST → predicate compiler → index-aware evaluation → sort + limit. No materialization cache in MVP; the `materialized_book_ids` field is only for iTunes-sync round-trips, not for in-app viewing.
+
+## `Store` interface additions
+
+```go
+// CRUD
+CreatePlaylist(*Playlist) (*Playlist, error)
+GetPlaylist(id string) (*Playlist, error)
+GetPlaylistByName(name string) (*Playlist, error)
+GetPlaylistByITunesPID(pid string) (*Playlist, error)
+ListPlaylists(filter PlaylistFilter, limit, offset int) ([]Playlist, int, error)
+UpdatePlaylist(id string, *Playlist) (*Playlist, error)
+DeletePlaylist(id string) error
+
+// Static ops
+AddBookToPlaylist(playlistID, bookID string, position int) error
+RemoveBookFromPlaylist(playlistID, bookID string) error
+ReorderPlaylist(playlistID string, bookIDs []string) error
+
+// Dirty tracking for iTunes sync
+MarkPlaylistDirty(id string) error
+ListDirtyPlaylists() ([]Playlist, error)
+
+// iTunes migration
+DeclineITunesPlaylistMigration(pid string) error
+IsITunesPlaylistDeclined(pid string) (bool, error)
+IsITunesDynamicMigrationDone() (bool, error)
+SetITunesDynamicMigrationDone() error
+```
+
+## MVP scope
+
+1. Playlist schema + struct + CRUD
+2. Query-parser extension (new operators, value alternation)
+3. Predicate compiler + index-aware evaluator
+4. ITL Smart Criteria **reader** (verify existence first; add if needed)
+5. iTunes Smart Criteria → our DSL translator
+6. One-time `itunes_dynamic_playlist_migration` tracked op
+7. Defensive catch UI for post-migration iTunes dynamic playlists
+8. iTunes sync pass: push `app`-owned playlists as static (materialize smart first)
+9. Static editor UI: list page, drag-reorder, add/remove, "+ Add to Playlist" from BookDetail and Library row
+10. Smart editor UI: text query + live preview + field autocomplete
+11. Sidebar entry + playlist list page
+12. "Materialize as Static" on smart playlists
+
+## Deferred
+
+- Bulk "Add to playlist" from Library multi-select (needs 5.3)
+- Exact-match operator `field:=value`
+- Tracking iTunes fields we don't have (Plays, Rating, Last Played) for better migration translation
+- User-editable field mapping
+- Playlist folders / nesting
+- M3U / PLS export for user playlists
+- Result caching keyed on `(query, library_version)`
+
+## Risks
+
+- **ITL parser may not read Smart Criteria.** Verify first. Reader is required for migration; writer is explicitly not needed (that's the simplification).
+- **Lossy translation during migration.** Complex iTunes rules (Plays > N, Last Played in last N days) don't map. User sees the translated query, can refine. Raw blob stored for fidelity.
+- **Post-migration iTunes dynamic discovery** could annoy users if they intentionally create dynamic playlists in iTunes. The "decline" option lets them opt out per-playlist.
+
+## Non-goals
+
+- Writing iTunes Smart Criteria (explicitly dropped — major simplification)
+- Per-user playlist libraries (3.7 shared-library)
+- Plex/Emby/Jellyfin compatibility (3.8's territory)
+- Playlist import from M3U files
+
+## Open implementation questions
+
+- Does ITL parser already emit Smart Criteria? First read task.
+- How expensive is re-materialization on library changes? If it becomes a hot path, debounce or move behind a library-change counter.
+- Migration behavior if a user already has an app-owned playlist with the same name as an incoming iTunes dynamic → append suffix `(imported)` and surface in the review.


### PR DESCRIPTION
## Summary

Seven design specs produced during the Apr 15 brainstorm session, covering the highest-impact open items from the backlog:

**Tier 1 (architectural):**
- 3.1 Library centralization + \`.versions/\` layout
- 4.4 Replace \`GlobalStore\` with DI
- 3.7 Multi-user support (PebbleDB-native, shared library, role-matrix permissions)

**Tier 2 (features):**
- 3.2 Bulk organize undo via \`operation_changes\`
- 3.4 Smart + static playlists with bidirectional iTunes sync (push-only-as-static, one-time dynamic migration)
- 3.6 Read/unread tracking beyond iTunes (per-user, Bookmark bidirectional sync for admin)
- DES-1 Bleve library search v1.1 (DSL integration, syntax comparison, perf targets, per-user indexing deferred)

Also updates the existing 2026-04-11 Bleve spec to v1.1 with new sections for DSL translator design, usage map, operator comparison table, default-match-mode change (substring → tokenized+stemmed), three new DSL operators (\`*\`, \`~\`, \`^N\`), and consistent \`field:<op>value\` syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)