### PR TITLE
feat(server): add Server.store field + Store() accessor (4.4 DI task 1)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 // file: cmd/root.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
 
 package cmd
@@ -305,8 +305,10 @@ var serveCmd = &cobra.Command{
 		}()
 		fmt.Printf("Operation queue initialized with %d workers\n", workers)
 
-		// Create and start server
-		srv := newServer()
+		// Create and start server. Store is passed explicitly per the 4.4 DI
+		// migration; database.GlobalStore remains assigned for call sites that
+		// haven't yet been migrated to use s.Store().
+		srv := newServer(database.GetGlobalStore())
 		cfg := getDefaultServerConfig()
 
 		// Apply command line flags (use defaults or user-provided values)

--- a/internal/server/e2e_workflow_test.go
+++ b/internal/server/e2e_workflow_test.go
@@ -43,7 +43,7 @@ func TestE2E_ITunesImportOrganizeWriteBack(t *testing.T) {
 			FilePath: dunePath, TotalTime: 72000000},
 	}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 
 	// Step 3: Import (non-organize mode)
 	importBody := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)

--- a/internal/server/handlers_integration_test.go
+++ b/internal/server/handlers_integration_test.go
@@ -46,7 +46,7 @@ func setupHandlerTestServer(t *testing.T) *Server {
 		database.GlobalStore = oldStore
 	})
 
-	return NewServer()
+	return NewServer(nil)
 }
 
 // TestListWorks_Success tests the listWorks handler with successful response

--- a/internal/server/itunes_error_test.go
+++ b/internal/server/itunes_error_test.go
@@ -28,7 +28,7 @@ func TestITunesImport_CorruptXML(t *testing.T) {
 	xmlPath := filepath.Join(env.TempDir, "corrupt.xml")
 	require.NoError(t, os.WriteFile(xmlPath, []byte("this is not valid XML at all <broken"), 0644))
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -51,7 +51,7 @@ func TestITunesImport_NonexistentFile(t *testing.T) {
 	_, cleanup := testutil.SetupIntegration(t)
 	defer cleanup()
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := `{"library_path":"/nonexistent/path/library.xml","import_mode":"import","skip_duplicates":false}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -68,7 +68,7 @@ func TestITunesImport_EmptyXML(t *testing.T) {
 	xmlPath := filepath.Join(env.TempDir, "empty.xml")
 	testutil.GenerateITunesXML(t, []testutil.ITunesTestTrack{}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -106,7 +106,7 @@ func TestITunesImport_MissingFilesPartial(t *testing.T) {
 			FilePath: "/nonexistent/missing2.m4b", TotalTime: 30000},
 	}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -129,7 +129,7 @@ func TestITunesImport_InvalidMode(t *testing.T) {
 	_, cleanup := testutil.SetupIntegration(t)
 	defer cleanup()
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := `{"library_path":"/tmp/fake.xml","import_mode":"invalid_mode","skip_duplicates":false}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -142,7 +142,7 @@ func TestITunesImport_MissingRequiredFields(t *testing.T) {
 	_, cleanup := testutil.SetupIntegration(t)
 	defer cleanup()
 
-	server := NewServer()
+	server := NewServer(nil)
 
 	tests := []struct {
 		name string
@@ -168,7 +168,7 @@ func TestITunesValidate_NonexistentFile(t *testing.T) {
 	_, cleanup := testutil.SetupIntegration(t)
 	defer cleanup()
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := `{"library_path":"/nonexistent/library.xml"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/validate", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -184,7 +184,7 @@ func TestITunesValidate_CorruptXML(t *testing.T) {
 	xmlPath := filepath.Join(env.TempDir, "corrupt.xml")
 	require.NoError(t, os.WriteFile(xmlPath, []byte("not xml"), 0644))
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s"}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/validate", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -200,7 +200,7 @@ func TestITunesWriteBack_NonexistentBook(t *testing.T) {
 	xmlPath := filepath.Join(env.TempDir, "Library.xml")
 	testutil.GenerateITunesXML(t, []testutil.ITunesTestTrack{}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","audiobook_ids":["nonexistent-id"],"create_backup":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/write-back", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -226,7 +226,7 @@ func TestITunesWriteBack_NoITunesPersistentID(t *testing.T) {
 	xmlPath := filepath.Join(env.TempDir, "Library.xml")
 	testutil.GenerateITunesXML(t, []testutil.ITunesTestTrack{}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","audiobook_ids":["%s"],"create_backup":false}`, xmlPath, created.ID)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/write-back", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -250,7 +250,7 @@ func TestITunesImport_RealTestLibrary(t *testing.T) {
 	// The paths are: file://localhost/Users/testuser/Music/iTunes/...
 	// These won't exist, so books with missing files will be skipped during import
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/itunes_integration_test.go
+++ b/internal/server/itunes_integration_test.go
@@ -50,7 +50,7 @@ func TestITunesImport_FullWorkflow(t *testing.T) {
 	}, xmlPath)
 
 	// Import via HTTP handler
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":true}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -111,7 +111,7 @@ func TestITunesImport_OrganizeMode(t *testing.T) {
 			FilePath: bookPath, TotalTime: 100000},
 	}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"organize","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -152,7 +152,7 @@ func TestITunesImport_SkipDuplicates(t *testing.T) {
 			FilePath: bookPath, TotalTime: 50000},
 	}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	importOnce := func() int {
 		body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":true}`, xmlPath)
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
@@ -195,7 +195,7 @@ func TestITunesWriteBack(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute write-back via HTTP — ITL is not configured in test, so should return 400
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"audiobook_ids":["%s"]}`, created.ID)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/write-back", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -223,7 +223,7 @@ func TestITunesValidate_Endpoint(t *testing.T) {
 			FilePath: "/nonexistent/missing.m4b", TotalTime: 20000},
 	}, xmlPath)
 
-	server := NewServer()
+	server := NewServer(nil)
 	body := fmt.Sprintf(`{"library_path":"%s"}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/validate", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/organize_integration_test.go
+++ b/internal/server/organize_integration_test.go
@@ -45,7 +45,7 @@ func TestOrganizeService_ViaHTTP(t *testing.T) {
 	}))
 
 	// Trigger organize via HTTP
-	server := NewServer()
+	server := NewServer(nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/organize", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.167.0
+// version: 1.168.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -665,6 +665,7 @@ func calculateLibrarySizes(rootDir string, importFolders []database.ImportPath) 
 
 // Server represents the HTTP server
 type Server struct {
+	store                  database.Store
 	httpServer             *http.Server
 	router                 *gin.Engine
 	audiobookService       *AudiobookService
@@ -729,7 +730,23 @@ type ServerConfig struct {
 }
 
 // NewServer creates a new server instance
-func NewServer() *Server {
+// Store returns the database.Store dependency the server was constructed
+// with. Handlers should prefer s.Store() over database.GlobalStore; the
+// global is being phased out per the 4.4 DI migration.
+func (s *Server) Store() database.Store {
+	if s.store != nil {
+		return s.store
+	}
+	// Fallback during migration: if s.store wasn't set (older construction
+	// paths, tests that build Server literals), fall back to the package
+	// global so behavior is unchanged.
+	return database.GetGlobalStore()
+}
+
+// NewServer constructs a Server with an explicit Store dependency.
+// database.GlobalStore is still assigned at startup for code that hasn't
+// been migrated to use s.Store() yet (see DI migration plan 4.4).
+func NewServer(store database.Store) *Server {
 	router := gin.New() // don't use gin.Default() — we add our own middleware
 
 	// Custom logger that skips noisy polling endpoints
@@ -743,9 +760,12 @@ func NewServer() *Server {
 	// Register metrics (idempotent)
 	metrics.Register()
 
-	store := database.GetGlobalStore()
+	if store == nil {
+		store = database.GetGlobalStore()
+	}
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	server := &Server{
+		store:                  store,
 		bgCtx:                  bgCtx,
 		bgCancel:               bgCancel,
 		router:                 router,

--- a/internal/server/server_coverage_phase2_test.go
+++ b/internal/server/server_coverage_phase2_test.go
@@ -49,7 +49,7 @@ func TestGetAudiobookTagsErrors(t *testing.T) {
 			database.GlobalStore = mockStore
 			defer func() { database.GlobalStore = oldStore }()
 
-			srv := NewServer()
+			srv := NewServer(nil)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks/"+tt.bookID+"/tags", nil)
 			w := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestAddBlockedHashErrors(t *testing.T) {
 			database.GlobalStore = mockStore
 			defer func() { database.GlobalStore = oldStore }()
 
-			srv := NewServer()
+			srv := NewServer(nil)
 
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/blocked-hashes", bytes.NewBufferString(tt.body))
 			req.Header.Set("Content-Type", "application/json")
@@ -135,7 +135,7 @@ func TestAddBlockedHashDatabaseError(t *testing.T) {
 	database.GlobalStore = mockStore
 	defer func() { database.GlobalStore = oldStore }()
 
-	srv := NewServer()
+	srv := NewServer(nil)
 
 	body := `{"hash": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "reason": "duplicate file"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/blocked-hashes", bytes.NewBufferString(body))
@@ -183,7 +183,7 @@ func TestDeleteWorkErrors(t *testing.T) {
 			database.GlobalStore = mockStore
 			defer func() { database.GlobalStore = oldStore }()
 
-			srv := NewServer()
+			srv := NewServer(nil)
 
 			req := httptest.NewRequest(http.MethodDelete, "/api/v1/works/"+tt.workID, nil)
 			w := httptest.NewRecorder()

--- a/internal/server/server_mockery_example_test.go.example
+++ b/internal/server/server_mockery_example_test.go.example
@@ -42,7 +42,7 @@ func TestListAudiobooksWithMockery(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks", nil)
 	// w := httptest.NewRecorder()
@@ -75,7 +75,7 @@ func TestListAudiobooksDatabaseError(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks", nil)
 	// w := httptest.NewRecorder()
@@ -116,7 +116,7 @@ func TestUpdateAudiobookWithVerification(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// updateData := map[string]interface{}{
 	// 	"title": "Updated Title",
@@ -147,7 +147,7 @@ func TestCountAudiobooksWithSearch(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks/count?search=test", nil)
 	// w := httptest.NewRecorder()
@@ -177,7 +177,7 @@ func TestAddBlockedHashWithMockery(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// hashData := map[string]interface{}{
 	// 	"hash":   testHash,
@@ -221,7 +221,7 @@ func TestWorkEndpointSequentialCalls(t *testing.T) {
 	// database.GlobalStore = mockStore
 	// defer func() { database.GlobalStore = nil }()
 	//
-	// server := NewServer()
+	// server := NewServer(nil)
 	//
 	// // Create work
 	// workData := map[string]interface{}{"title": "New Work"}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -62,7 +62,7 @@ func setupTestServer(t *testing.T) (*Server, func()) {
 	realtime.SetGlobalHub(hub)
 
 	// Create server
-	server := NewServer()
+	server := NewServer(nil)
 
 	// Cleanup function
 	cleanup := func() {
@@ -92,7 +92,7 @@ func setupTestServerWithStore(t *testing.T, store database.Store) (*Server, func
 	database.SetGlobalStore(store)
 
 	// Create server with the provided store (services will use it)
-	server := NewServer()
+	server := NewServer(nil)
 
 	// Cleanup function
 	cleanup := func() {


### PR DESCRIPTION
Task 1 of plan `docs/superpowers/plans/2026-04-15-replace-globalstore-with-di.md`. Additive only — dual-live with GlobalStore. Tests all pass.