### PR TITLE
refactor(server): migrate backfill/poller/itl/OL internals (4.4 DI task 6a)

### DIFF
--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -1,5 +1,5 @@
 // file: internal/server/batch_poller.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f8a1b2c3-d4e5-6789-abcd-0123456789ab
 
 package server
@@ -185,7 +185,7 @@ func (s *Server) registerBatchPollerHandlers() {
 func (s *Server) storeBatchResultForOperation(batchID string, payload map[string]any) {
 	store := s.batchPoller.db
 	if store == nil {
-		store = database.GlobalStore
+		store = s.Store()
 	}
 	if store == nil {
 		log.Printf("[WARN] batch_poller: no store available to save batch %s results", batchID)

--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 
 package server
@@ -7,8 +7,6 @@ package server
 import (
 	"context"
 	"log"
-
-	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
 // backfillVersionMarker identifies the current generation of the dedup
@@ -34,7 +32,7 @@ const backfillVersionMarker = "embedding_backfill_v5_done"
 // runEmbeddingBackfill embeds all books and authors on first startup and
 // re-runs once after each backfill version bump.
 func (s *Server) runEmbeddingBackfill() {
-	store := database.GlobalStore
+	store := s.Store()
 	if store == nil || s.dedupEngine == nil {
 		return
 	}

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/external_id_backfill.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d
 
 package server
@@ -43,7 +43,7 @@ func asExternalIDStore(s database.Store) ExternalIDStore {
 // book that has an iTunes PersistentID set. This is idempotent — it checks the
 // setting "external_id_backfill_done" and only runs once.
 func (s *Server) backfillExternalIDs() {
-	store := database.GlobalStore
+	store := s.Store()
 	if store == nil {
 		return
 	}

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,5 +1,5 @@
 // file: internal/server/itl_rebuild.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
 //
 // iTunes library rebuild service: diffs the current DB state
@@ -234,7 +234,7 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 		return
 	}
 
-	store := database.GlobalStore
+	store := s.Store()
 	ops, preview, err := computeITLDiff(store, itlPath)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("diff failed: %v", err)})

--- a/internal/server/openlibrary_service.go
+++ b/internal/server/openlibrary_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/openlibrary_service.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package server
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
-	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/openlibrary"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/oklog/ulid/v2"
@@ -153,7 +152,7 @@ func (s *Server) startOLDownload(c *gin.Context) {
 	}
 
 	tracker := s.olService.tracker
-	store := database.GlobalStore
+	store := s.Store()
 	opID := ulid.Make().String()
 	folderPath := targetDir
 	if store != nil {
@@ -234,7 +233,7 @@ func (s *Server) startOLImport(c *gin.Context) {
 	}
 	svc.mu.Unlock()
 
-	store := database.GlobalStore
+	store := s.Store()
 	opID := ulid.Make().String()
 	folderPath := targetDir
 	if store != nil {


### PR DESCRIPTION
Task 6a of DI plan. scheduler.go + itunes.go + itunes_writeback_batcher.go deferred to 6b/6c.