### PR TITLE
feat(undo): support organize_rename in RevertService (3.2 partial)

### DIFF
--- a/internal/server/revert_service.go
+++ b/internal/server/revert_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/revert_service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-d0e1-f2a3-b4c5d6e7f8a9
 
 package server
@@ -66,12 +66,19 @@ func (rs *RevertService) RevertOperation(operationID string) error {
 
 func (rs *RevertService) revertChange(c *database.OperationChange) error {
 	switch c.ChangeType {
-	case "file_move":
+	case "file_move", "organize_rename":
+		// organize_rename writes the same (OldValue, NewValue) shape as
+		// file_move — old path → new path, Book.file_path updated. The
+		// reversal is identical: move the file back and restore
+		// Book.file_path.
 		return rs.revertFileMove(c)
 	case "metadata_update":
 		return rs.revertMetadataUpdate(c)
 	case "tag_write":
 		return rs.revertTagWrite(c)
+	case "organize_failed", "organize_skipped", "organize_summary":
+		// No filesystem or DB mutation recorded; nothing to reverse.
+		return nil
 	default:
 		return fmt.Errorf("unknown change type: %s", c.ChangeType)
 	}

--- a/internal/server/revert_service_organize_test.go
+++ b/internal/server/revert_service_organize_test.go
@@ -1,0 +1,94 @@
+// file: internal/server/revert_service_organize_test.go
+// version: 1.0.0
+// guid: 4f8c2a1d-5e9b-4f70-a3c6-8d1e0f2b9a47
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// TestRevertChange_OrganizeRename verifies that organize_rename change
+// types are reversible by the RevertService — the same file_move
+// reversal path, just with the change_type the organize service writes.
+func TestRevertChange_OrganizeRename(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldPath := filepath.Join(tmpDir, "old", "Book.m4b")
+	newPath := filepath.Join(tmpDir, "new", "Author - Book.m4b")
+
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+		t.Fatalf("mkdir old: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		t.Fatalf("mkdir new: %v", err)
+	}
+	if err := os.WriteFile(newPath, []byte("audio"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	mockStore := &stubStoreForRevert{
+		book: &database.Book{ID: "b1", FilePath: newPath},
+	}
+	rs := NewRevertService(mockStore)
+
+	change := &database.OperationChange{
+		ID:         "c1",
+		BookID:     "b1",
+		ChangeType: "organize_rename",
+		FieldName:  "file_path",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+	}
+
+	if err := rs.revertChange(change); err != nil {
+		t.Fatalf("revertChange failed: %v", err)
+	}
+
+	// File moved back
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("expected file at %s after revert, got %v", oldPath, err)
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf("expected file gone from %s after revert, got %v", newPath, err)
+	}
+
+	// Book updated
+	if mockStore.book.FilePath != oldPath {
+		t.Errorf("Book.FilePath = %q, want %q", mockStore.book.FilePath, oldPath)
+	}
+}
+
+// TestRevertChange_OrganizeNonMutating verifies that organize_failed,
+// organize_skipped, and organize_summary types are treated as no-ops
+// by the revert engine.
+func TestRevertChange_OrganizeNonMutating(t *testing.T) {
+	rs := NewRevertService(nil)
+	for _, ct := range []string{"organize_failed", "organize_skipped", "organize_summary"} {
+		change := &database.OperationChange{ChangeType: ct}
+		if err := rs.revertChange(change); err != nil {
+			t.Errorf("revertChange(%s) returned error %v, want nil", ct, err)
+		}
+	}
+}
+
+// stubStoreForRevert satisfies database.Store for the two methods the
+// file_move revert path calls. Returning a non-nil error from the
+// method we care about is enough for the happy-path test; the rest
+// panic if called, which would surface a regression.
+type stubStoreForRevert struct {
+	database.Store
+	book *database.Book
+}
+
+func (s *stubStoreForRevert) GetBookByID(id string) (*database.Book, error) {
+	return s.book, nil
+}
+
+func (s *stubStoreForRevert) UpdateBook(id string, b *database.Book) (*database.Book, error) {
+	s.book = b
+	return b, nil
+}


### PR DESCRIPTION
Unblocks POST /operations/:id/revert for organize operations. Tests added.