### PR TITLE
refactor(server): migrate itunes.go helpers + server-internal refs (4.4 DI task 6)

### DIFF
--- a/internal/server/itunes.go
+++ b/internal/server/itunes.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes.go
-// version: 2.23.0
+// version: 2.24.0
 // guid: 719912e9-7b5f-48e1-afa6-1b0b7f57c2fa
 
 package server
@@ -347,7 +347,7 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 	itunesImportStatuses.Store(op.ID, status)
 
 	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return executeITunesImport(ctx, operations.LoggerFromReporter(progress), op.ID, req)
+		return executeITunesImport(ctx, s.Store(), operations.LoggerFromReporter(progress), op.ID, req)
 	}
 
 	if err := operations.GlobalQueue.Enqueue(op.ID, "itunes_import", operations.PriorityNormal, operationFunc); err != nil {
@@ -919,9 +919,7 @@ type albumGroup struct {
 	tracks []*itunes.Track
 }
 
-func executeITunesImport(ctx context.Context, log logger.Logger, opID string, req ITunesImportRequest) error {
-	store := database.GlobalStore
-
+func executeITunesImport(ctx context.Context, store database.Store, log logger.Logger, opID string, req ITunesImportRequest) error {
 	// Persist operation parameters for resume
 	pathMappings := make(map[string]string)
 	for _, pm := range req.PathMappings {
@@ -1005,7 +1003,7 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 		}
 
 		// Use first track for author/series assignment
-		assignAuthorAndSeries(book, group.tracks[0])
+		assignAuthorAndSeries(store, book, group.tracks[0])
 
 		// Resolve first track's actual file path (book.FilePath may be a directory for multi-track albums)
 		firstTrackPath := book.FilePath
@@ -1027,8 +1025,8 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 				}
 				// Check if we already have a mapping for this PID
 				if bookID, err := eidStore.GetBookByExternalID("itunes", firstPID); err == nil && bookID != "" {
-					if existing, err := database.GlobalStore.GetBookByID(bookID); err == nil && existing != nil {
-						linkITunesMetadata(existing, book, group.tracks[0], log)
+					if existing, err := store.GetBookByID(bookID); err == nil && existing != nil {
+						linkITunesMetadata(store, existing, book, group.tracks[0], log)
 						updateITunesLinked(status)
 						updateITunesProgress(log, status, processed, totalGroups, book.Title)
 						continue
@@ -1039,8 +1037,8 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 
 		if req.SkipDuplicates {
 			// Fast check: file path match (no disk I/O, just DB lookup)
-			if existing, err := database.GlobalStore.GetBookByFilePath(book.FilePath); err == nil && existing != nil {
-				linkITunesMetadata(existing, book, group.tracks[0], log)
+			if existing, err := store.GetBookByFilePath(book.FilePath); err == nil && existing != nil {
+				linkITunesMetadata(store, existing, book, group.tracks[0], log)
 				updateITunesLinked(status)
 				updateITunesProgress(log, status, processed, totalGroups, book.Title)
 				continue
@@ -1062,7 +1060,7 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 			book.CoverURL = stringPtr("/api/v1/covers/local/" + coverFilename)
 		}
 
-		created, err := database.GlobalStore.CreateBook(book)
+		created, err := store.CreateBook(book)
 		if err != nil {
 			recordITunesFailure(status, fmt.Sprintf("Failed to save '%s': %v", book.Title, err))
 			log.Error("Failed to save '%s': %v", book.Title, err)
@@ -1124,7 +1122,7 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 				if segHash, hashErr := scanner.ComputeSegmentFileHash(trackPath); hashErr == nil {
 					bf.FileHash = segHash
 				}
-				if createErr := database.GlobalStore.CreateBookFile(bf); createErr != nil {
+				if createErr := store.CreateBookFile(bf); createErr != nil {
 					log.Warn("Failed to create book file for track %d of '%s': %v", track.TrackNumber, book.Title, createErr)
 				}
 			}
@@ -1135,9 +1133,9 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 			for i := range book.Authors {
 				book.Authors[i].BookID = created.ID
 			}
-			_ = database.GlobalStore.SetBookAuthors(created.ID, book.Authors)
+			_ = store.SetBookAuthors(created.ID, book.Authors)
 		} else if created.AuthorID != nil {
-			_ = database.GlobalStore.SetBookAuthors(created.ID, []database.BookAuthor{
+			_ = store.SetBookAuthors(created.ID, []database.BookAuthor{
 				{BookID: created.ID, AuthorID: *created.AuthorID, Role: "author", Position: 0},
 			})
 		}
@@ -1176,7 +1174,7 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 				break
 			}
 
-			book, err := database.GlobalStore.GetBookByID(bookID)
+			book, err := store.GetBookByID(bookID)
 			if err != nil || book == nil {
 				continue
 			}
@@ -1198,19 +1196,19 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 			}
 
 			// Check for blocked hash
-			if blocked, err := database.GlobalStore.IsHashBlocked(hash); err == nil && blocked {
+			if blocked, err := store.IsHashBlocked(hash); err == nil && blocked {
 				log.Warn("Hash validation: blocked hash for %s, soft-deleting", book.Title)
 				marked := true
 				now := time.Now()
 				book.MarkedForDeletion = &marked
 				book.MarkedForDeletionAt = &now
-				database.GlobalStore.UpdateBook(book.ID, book)
+				store.UpdateBook(book.ID, book)
 				hashBlocked++
 				continue
 			}
 
 			// Check for existing book with same hash — merge into its VG
-			if existing, err := database.GlobalStore.GetBookByFileHash(hash); err == nil && existing != nil && existing.ID != book.ID {
+			if existing, err := store.GetBookByFileHash(hash); err == nil && existing != nil && existing.ID != book.ID {
 				// This new book is a duplicate — link it to the existing book's VG
 				if existing.VersionGroupID != nil && *existing.VersionGroupID != "" {
 					book.VersionGroupID = existing.VersionGroupID
@@ -1222,7 +1220,7 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 			}
 
 			// Save the hash (and any VG changes) to the book
-			if _, err := database.GlobalStore.UpdateBook(book.ID, book); err != nil {
+			if _, err := store.UpdateBook(book.ID, book); err != nil {
 				log.Warn("Hash validation: failed to update %s: %v", book.ID, err)
 			}
 
@@ -1240,14 +1238,14 @@ func executeITunesImport(ctx context.Context, log logger.Logger, opID string, re
 	if req.FetchMetadata {
 		_ = operations.SaveCheckpoint(store, opID, "itunes_import", "enriching", 0, 0)
 		log.Info("Starting metadata enrichment phase...")
-		enrichITunesImportedBooks(log, status)
+		enrichITunesImportedBooks(store, log, status)
 	}
 
 	// Phase 5: Organize (if requested) — runs after enrichment
 	if importMode == itunes.ImportModeOrganize && !req.PreserveLocation {
 		_ = operations.SaveCheckpoint(store, opID, "itunes_import", "organizing", 0, 0)
 		log.Info("Starting organize phase...")
-		organizeImportedBooks(log, status)
+		organizeImportedBooks(store, log, status)
 	}
 
 	// Clear checkpoint on successful completion
@@ -1310,11 +1308,11 @@ func groupTracksByAlbum(library *itunes.Library) []albumGroup {
 
 // enrichITunesImportedBooks fetches metadata for recently imported books
 // to normalize author names and get cover art before organizing.
-func enrichITunesImportedBooks(log logger.Logger, status *itunesImportStatus) {
-	mfs := NewMetadataFetchService(database.GlobalStore)
+func enrichITunesImportedBooks(store database.Store, log logger.Logger, status *itunesImportStatus) {
+	mfs := NewMetadataFetchService(store)
 
 	// Get all imported books (library_state = 'imported')
-	books, err := database.GlobalStore.GetAllBooks(10000, 0)
+	books, err := store.GetAllBooks(10000, 0)
 	if err != nil {
 		log.Error("Failed to list books for enrichment: %v", err)
 		return
@@ -1347,10 +1345,10 @@ func enrichITunesImportedBooks(log logger.Logger, status *itunesImportStatus) {
 		enriched++
 		// If metadata found a new author, add to book_authors without clobbering existing multi-author links
 		if resp.Book != nil && resp.Book.AuthorID != nil {
-			existing, _ := database.GlobalStore.GetBookAuthors(book.ID)
+			existing, _ := store.GetBookAuthors(book.ID)
 			if len(existing) <= 1 {
 				// Only one or zero authors — safe to replace with metadata result
-				_ = database.GlobalStore.SetBookAuthors(book.ID, []database.BookAuthor{
+				_ = store.SetBookAuthors(book.ID, []database.BookAuthor{
 					{BookID: book.ID, AuthorID: *resp.Book.AuthorID, Role: "author", Position: 0},
 				})
 			}
@@ -1369,8 +1367,8 @@ func enrichITunesImportedBooks(log logger.Logger, status *itunesImportStatus) {
 
 // organizeImportedBooks moves all imported books into the organized folder structure.
 // Runs as a separate phase after metadata enrichment so author/title are accurate.
-func organizeImportedBooks(log logger.Logger, status *itunesImportStatus) {
-	books, err := database.GlobalStore.GetAllBooks(100000, 0)
+func organizeImportedBooks(store database.Store, log logger.Logger, status *itunesImportStatus) {
+	books, err := store.GetAllBooks(100000, 0)
 	if err != nil {
 		log.Error("Failed to list books for organize: %v", err)
 		return
@@ -1392,7 +1390,7 @@ func organizeImportedBooks(log logger.Logger, status *itunesImportStatus) {
 			log.Warn("Failed to organize '%s': %v", book.Title, err)
 		} else {
 			book.LibraryState = stringPtr("organized")
-			if _, err := database.GlobalStore.UpdateBook(book.ID, book); err != nil {
+			if _, err := store.UpdateBook(book.ID, book); err != nil {
 				log.Error("Failed to update organized path for '%s': %v — rolling back", book.Title, err)
 				if book.FilePath != oldPath {
 					if rbErr := os.Rename(book.FilePath, oldPath); rbErr != nil {
@@ -1417,7 +1415,7 @@ func organizeImportedBooks(log logger.Logger, status *itunesImportStatus) {
 // linkITunesMetadata copies iTunes-specific fields (play count, rating, bookmark,
 // persistent ID, date added) from an import book onto an existing book that was
 // matched by file path. Also ensures the existing book has a version group.
-func linkITunesMetadata(existing *database.Book, importBook *database.Book, track *itunes.Track, log logger.Logger) {
+func linkITunesMetadata(store database.Store, existing *database.Book, importBook *database.Book, track *itunes.Track, log logger.Logger) {
 	changed := false
 	if existing.ITunesPersistentID == nil && importBook.ITunesPersistentID != nil {
 		existing.ITunesPersistentID = importBook.ITunesPersistentID
@@ -1455,7 +1453,7 @@ func linkITunesMetadata(existing *database.Book, importBook *database.Book, trac
 		changed = true
 	}
 	if changed {
-		if _, err := database.GlobalStore.UpdateBook(existing.ID, existing); err != nil {
+		if _, err := store.UpdateBook(existing.ID, existing); err != nil {
 			log.Warn("Failed to link iTunes metadata to %s: %v", existing.ID, err)
 		}
 	}
@@ -1463,14 +1461,14 @@ func linkITunesMetadata(existing *database.Book, importBook *database.Book, trac
 
 // linkAsVersion creates the import book as a non-primary version linked to the
 // existing book's version group. The existing book (organized copy) stays primary.
-func linkAsVersion(existing *database.Book, importBook *database.Book, track *itunes.Track, log logger.Logger) {
+func linkAsVersion(store database.Store, existing *database.Book, importBook *database.Book, track *itunes.Track, log logger.Logger) {
 	// Ensure the existing book has a version group
 	if existing.VersionGroupID == nil || *existing.VersionGroupID == "" {
 		vgID := fmt.Sprintf("vg-%s", ulid.Make().String())
 		existing.VersionGroupID = &vgID
 		isPrimary := true
 		existing.IsPrimaryVersion = &isPrimary
-		if _, err := database.GlobalStore.UpdateBook(existing.ID, existing); err != nil {
+		if _, err := store.UpdateBook(existing.ID, existing); err != nil {
 			log.Warn("Failed to set VG on existing book %s: %v", existing.ID, err)
 			return
 		}
@@ -1482,14 +1480,14 @@ func linkAsVersion(existing *database.Book, importBook *database.Book, track *it
 	importBook.IsPrimaryVersion = &isPrimary
 	importBook.LibraryState = stringPtr("imported")
 
-	created, err := database.GlobalStore.CreateBook(importBook)
+	created, err := store.CreateBook(importBook)
 	if err != nil {
 		log.Warn("Failed to create version link for %s: %v", importBook.Title, err)
 		return
 	}
 
 	// Copy iTunes metadata to the existing primary if it's missing
-	linkITunesMetadata(existing, importBook, track, log)
+	linkITunesMetadata(store, existing, importBook, track, log)
 
 	log.Info("Created version link: %s (iTunes) → %s (primary) in %s", created.ID, existing.ID, *existing.VersionGroupID)
 }
@@ -1625,13 +1623,13 @@ func commonParentDir(tracks []*itunes.Track, opts itunes.ImportOptions) string {
 // records (splitting composites like "A / B") and links them to the book.
 // The first author becomes the primary AuthorID; all are stored in book_authors.
 // This is called both during import and sync for new books.
-func assignAuthorAndSeries(book *database.Book, track *itunes.Track) {
+func assignAuthorAndSeries(store database.Store, book *database.Book, track *itunes.Track) {
 	if book == nil || track == nil {
 		return
 	}
 
 	if track.Artist != "" {
-		ids, err := ensureAuthorIDs(track.Artist)
+		ids, err := ensureAuthorIDs(store, track.Artist)
 		if err == nil && len(ids) > 0 {
 			book.AuthorID = &ids[0]
 			// Store multi-author links (needs book.ID set — caller must
@@ -1650,7 +1648,7 @@ func assignAuthorAndSeries(book *database.Book, track *itunes.Track) {
 
 	seriesName := extractSeriesName(track.Album)
 	if seriesName != "" {
-		seriesID, err := ensureSeriesID(seriesName, book.AuthorID)
+		seriesID, err := ensureSeriesID(store, seriesName, book.AuthorID)
 		if err == nil {
 			book.SeriesID = seriesID
 		}
@@ -1661,7 +1659,7 @@ func assignAuthorAndSeries(book *database.Book, track *itunes.Track) {
 // "Author1 / Author2") into individual author records. Returns all author IDs
 // with the first being the primary. If the name is not composite, returns a
 // single-element slice.
-func ensureAuthorIDs(name string) ([]int, error) {
+func ensureAuthorIDs(store database.Store, name string) ([]int, error) {
 	parts := SplitCompositeAuthorName(name)
 	if len(parts) == 0 {
 		// Not composite — treat as single author
@@ -1675,12 +1673,12 @@ func ensureAuthorIDs(name string) ([]int, error) {
 			continue
 		}
 		part = NormalizeAuthorName(part)
-		author, err := database.GlobalStore.GetAuthorByName(part)
+		author, err := store.GetAuthorByName(part)
 		if err != nil {
 			return nil, err
 		}
 		if author == nil {
-			author, err = database.GlobalStore.CreateAuthor(part)
+			author, err = store.CreateAuthor(part)
 			if err != nil {
 				return nil, err
 			}
@@ -1693,25 +1691,16 @@ func ensureAuthorIDs(name string) ([]int, error) {
 	return ids, nil
 }
 
-// ensureAuthorID resolves a (possibly composite) author name and returns the
-// primary author ID. For backwards compatibility with callers that only need one ID.
-func ensureAuthorID(name string) (*int, error) {
-	ids, err := ensureAuthorIDs(name)
-	if err != nil {
-		return nil, err
-	}
-	return &ids[0], nil
-}
 
-func ensureSeriesID(name string, authorID *int) (*int, error) {
-	series, err := database.GlobalStore.GetSeriesByName(name, authorID)
+func ensureSeriesID(store database.Store, name string, authorID *int) (*int, error) {
+	series, err := store.GetSeriesByName(name, authorID)
 	if err != nil {
 		return nil, err
 	}
 	if series != nil {
 		return &series.ID, nil
 	}
-	series, err = database.GlobalStore.CreateSeries(name, authorID)
+	series, err = store.CreateSeries(name, authorID)
 	if err != nil {
 		return nil, err
 	}
@@ -2003,7 +1992,7 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		libraryPath = config.AppConfig.ITunesLibraryReadPath
 	}
 	if libraryPath == "" {
-		libraryPath = discoverITunesLibraryPath()
+		libraryPath = discoverITunesLibraryPath(s.Store())
 	}
 	if libraryPath == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no iTunes library path configured or provided"})
@@ -2042,7 +2031,7 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		}
 	}
 	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return executeITunesSync(ctx, operations.LoggerFromReporter(progress), libraryPath, pathMappings)
+		return executeITunesSync(ctx, s.Store(), operations.LoggerFromReporter(progress), libraryPath, pathMappings)
 	}
 
 	if err := operations.GlobalQueue.Enqueue(op.ID, "itunes_sync", operations.PriorityNormal, operationFunc); err != nil {
@@ -2057,11 +2046,11 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 }
 
 // discoverITunesLibraryPath finds the library path from the most recent imported book.
-func discoverITunesLibraryPath() string {
-	if database.GlobalStore == nil {
+func discoverITunesLibraryPath(store database.Store) string {
+	if store == nil {
 		return ""
 	}
-	books, err := database.GlobalStore.GetAllBooks(100, 0)
+	books, err := store.GetAllBooks(100, 0)
 	if err != nil {
 		return ""
 	}
@@ -2075,9 +2064,7 @@ func discoverITunesLibraryPath() string {
 
 // executeITunesSync re-reads an iTunes Library.xml and updates changed fields
 // or imports new audiobooks.
-func executeITunesSync(ctx context.Context, log logger.Logger, libraryPath string, pathMappings []itunes.PathMapping) error {
-	store := database.GlobalStore
-
+func executeITunesSync(ctx context.Context, store database.Store, log logger.Logger, libraryPath string, pathMappings []itunes.PathMapping) error {
 	log.UpdateProgress(0, 0, "Parsing iTunes library XML...")
 	log.Info("Starting iTunes sync from %s", libraryPath)
 
@@ -2316,7 +2303,7 @@ func executeITunesSync(ctx context.Context, log logger.Logger, libraryPath strin
 				log.Warn("Failed to build book from group '%s': %v", group.key, err)
 				continue
 			}
-			assignAuthorAndSeries(book, firstTrack)
+			assignAuthorAndSeries(store, book, firstTrack)
 			book.LibraryState = stringPtr("imported")
 
 			created, err := store.CreateBook(book)

--- a/internal/server/itunes_import_integration_test.go
+++ b/internal/server/itunes_import_integration_test.go
@@ -162,7 +162,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 		Artist: "Frank Herbert",
 		Album:  "Dune Chronicles",
 	}
-	assignAuthorAndSeries(book1, track1)
+	assignAuthorAndSeries(database.GetGlobalStore(), book1, track1)
 
 	require.NotNil(t, book1.AuthorID, "AuthorID should be set")
 	author, err := database.GlobalStore.GetAuthorByName("Frank Herbert")
@@ -184,7 +184,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 		Artist: "Frank Herbert",
 		Album:  "Dune Messiah",
 	}
-	assignAuthorAndSeries(book2, track2)
+	assignAuthorAndSeries(database.GetGlobalStore(), book2, track2)
 
 	require.NotNil(t, book2.AuthorID)
 	assert.Equal(t, *book1.AuthorID, *book2.AuthorID, "same author should be reused")
@@ -195,7 +195,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 		Artist: "J.R.R. Tolkien",
 		Album:  "Middle-earth, Book 1",
 	}
-	assignAuthorAndSeries(book3, track3)
+	assignAuthorAndSeries(database.GetGlobalStore(), book3, track3)
 
 	require.NotNil(t, book3.SeriesID)
 	// extractSeriesName("Middle-earth, Book 1") should return "Middle-earth"
@@ -213,11 +213,11 @@ func TestITunesImport_AuthorDedup(t *testing.T) {
 
 	bookA := &database.Book{Title: "Book A"}
 	trackA := &itunes.Track{Artist: "Isaac Asimov", Album: "Foundation"}
-	assignAuthorAndSeries(bookA, trackA)
+	assignAuthorAndSeries(database.GetGlobalStore(), bookA, trackA)
 
 	bookB := &database.Book{Title: "Book B"}
 	trackB := &itunes.Track{Artist: "Isaac Asimov", Album: "I, Robot"}
-	assignAuthorAndSeries(bookB, trackB)
+	assignAuthorAndSeries(database.GetGlobalStore(), bookB, trackB)
 
 	require.NotNil(t, bookA.AuthorID)
 	require.NotNil(t, bookB.AuthorID)
@@ -263,7 +263,7 @@ func TestITunesImport_SeriesExtraction(t *testing.T) {
 		Artist: "Test Author",
 		Album:  "Middle-earth, Book 1",
 	}
-	assignAuthorAndSeries(book, track)
+	assignAuthorAndSeries(database.GetGlobalStore(), book, track)
 
 	require.NotNil(t, book.SeriesID)
 	series, err := database.GlobalStore.GetSeriesByID(*book.SeriesID)
@@ -277,7 +277,7 @@ func TestITunesImport_SeriesExtraction(t *testing.T) {
 		Artist: "Test Author",
 		Album:  "Middle-earth, Book 2",
 	}
-	assignAuthorAndSeries(book2, track2)
+	assignAuthorAndSeries(database.GetGlobalStore(), book2, track2)
 	require.NotNil(t, book2.SeriesID)
 	assert.Equal(t, *book.SeriesID, *book2.SeriesID, "same series name should yield same series ID")
 }

--- a/internal/server/itunes_writeback_batcher.go
+++ b/internal/server/itunes_writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_writeback_batcher.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -100,7 +100,7 @@ func (b *WriteBackBatcher) EnqueueRemove(pid string) {
 
 	// Mark as removed in DB (best-effort, outside lock)
 	go func() {
-		if store := database.GlobalStore; store != nil {
+		if store := database.GetGlobalStore(); store != nil {
 			_ = store.MarkExternalIDRemoved("itunes", pid)
 		}
 	}()
@@ -156,7 +156,7 @@ func (b *WriteBackBatcher) flush() {
 	b.firstEnqueue = time.Time{} // reset for next batch
 	b.mu.Unlock()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	if store == nil {
 		log.Printf("[WARN] iTunes write-back: no database store")
 		return

--- a/internal/server/metadata_fetch_service.go
+++ b/internal/server/metadata_fetch_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_fetch_service.go
-// version: 4.51.0
+// version: 4.52.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package server
@@ -171,8 +171,8 @@ func buildSearchContext(book *database.Book, searchTitle, author, narrator strin
 		}
 		// buildSearchContext is a top-level helper; use the package
 		// global here until the function is refactored into a method.
-		if book.SeriesID != nil && database.GlobalStore != nil {
-			if series, err := database.GlobalStore.GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+		if book.SeriesID != nil && database.GetGlobalStore() != nil {
+			if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
 				ctx.Series = series.Name
 			}
 		}

--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service.go
-// version: 1.25.0
+// version: 1.26.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package server
@@ -184,7 +184,7 @@ func (orgSvc *OrganizeService) autoBackup(log logger.Logger) {
 }
 
 func (orgSvc *OrganizeService) syncITunesBeforeOrganize(ctx context.Context, log logger.Logger) {
-	libraryPath := discoverITunesLibraryPath()
+	libraryPath := discoverITunesLibraryPath(orgSvc.db)
 	if libraryPath == "" {
 		log.Info("Skipping iTunes sync: no library found")
 		return
@@ -192,7 +192,7 @@ func (orgSvc *OrganizeService) syncITunesBeforeOrganize(ctx context.Context, log
 
 	log.Info("Running iTunes sync before organize: %s", libraryPath)
 
-	if err := executeITunesSync(ctx, log, libraryPath, nil); err != nil {
+	if err := executeITunesSync(ctx, orgSvc.db, log, libraryPath, nil); err != nil {
 		log.Warn("iTunes pre-sync failed (continuing with organize): %s", err.Error())
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.169.0
+// version: 1.170.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -126,7 +126,7 @@ func encodeMetadataValue(value any) (*string, error) {
 func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
 
-	pref, err := database.GlobalStore.GetUserPreference(metadataStateKey(bookID))
+	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
 	if err != nil {
 		return state, err
 	}
@@ -142,11 +142,11 @@ func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, erro
 
 func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
-	if database.GlobalStore == nil {
+	if database.GetGlobalStore() == nil {
 		return state, fmt.Errorf("database not initialized")
 	}
 
-	stored, err := database.GlobalStore.GetMetadataFieldStates(bookID)
+	stored, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -177,11 +177,11 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 }
 
 func saveMetadataState(bookID string, state map[string]metadataFieldState) error {
-	if database.GlobalStore == nil {
+	if database.GetGlobalStore() == nil {
 		return fmt.Errorf("database not initialized")
 	}
 
-	existing, err := database.GlobalStore.GetMetadataFieldStates(bookID)
+	existing, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
 	if err != nil {
 		return err
 	}
@@ -213,14 +213,14 @@ func saveMetadataState(bookID string, state map[string]metadataFieldState) error
 			UpdatedAt:      entry.UpdatedAt,
 		}
 
-		if err := database.GlobalStore.UpsertMetadataFieldState(&dbState); err != nil {
+		if err := database.GetGlobalStore().UpsertMetadataFieldState(&dbState); err != nil {
 			return fmt.Errorf("failed to persist metadata state for %s: %w", field, err)
 		}
 		delete(existingFields, field)
 	}
 
 	for field := range existingFields {
-		if err := database.GlobalStore.DeleteMetadataFieldState(bookID, field); err != nil {
+		if err := database.GetGlobalStore().DeleteMetadataFieldState(bookID, field); err != nil {
 			return fmt.Errorf("failed to clean up metadata state for %s: %w", field, err)
 		}
 	}
@@ -275,7 +275,7 @@ func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 	if book.Author != nil {
 		authorName = book.Author.Name
 	} else if book.AuthorID != nil {
-		if author, err := database.GlobalStore.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+		if author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID); err == nil && author != nil {
 			authorName = author.Name
 		}
 	}
@@ -284,7 +284,7 @@ func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 	if book.Series != nil {
 		seriesName = book.Series.Name
 	} else if book.SeriesID != nil {
-		if series, err := database.GlobalStore.GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+		if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
 			seriesName = series.Name
 		}
 	}
@@ -335,10 +335,10 @@ func enrichBookForResponse(book *database.Book) enrichedBookResponse {
 		resp.FileExists = &exists
 	}
 
-	if database.GlobalStore != nil {
-		if bookAuthors, err := database.GlobalStore.GetBookAuthors(book.ID); err == nil && len(bookAuthors) > 0 {
+	if database.GetGlobalStore() != nil {
+		if bookAuthors, err := database.GetGlobalStore().GetBookAuthors(book.ID); err == nil && len(bookAuthors) > 0 {
 			for _, ba := range bookAuthors {
-				if author, err := database.GlobalStore.GetAuthorByID(ba.AuthorID); err == nil && author != nil {
+				if author, err := database.GetGlobalStore().GetAuthorByID(ba.AuthorID); err == nil && author != nil {
 					resp.Authors = append(resp.Authors, authorEntry{
 						ID: author.ID, Name: author.Name, Role: ba.Role, Position: ba.Position,
 					})
@@ -354,9 +354,9 @@ func enrichBookForResponse(book *database.Book) enrichedBookResponse {
 			}
 		}
 
-		if bookNarrators, err := database.GlobalStore.GetBookNarrators(book.ID); err == nil && len(bookNarrators) > 0 {
+		if bookNarrators, err := database.GetGlobalStore().GetBookNarrators(book.ID); err == nil && len(bookNarrators) > 0 {
 			for _, bn := range bookNarrators {
-				if narrator, err := database.GlobalStore.GetNarratorByID(bn.NarratorID); err == nil && narrator != nil {
+				if narrator, err := database.GetGlobalStore().GetNarratorByID(bn.NarratorID); err == nil && narrator != nil {
 					resp.Narrators = append(resp.Narrators, narratorEntry{
 						ID: narrator.ID, Name: narrator.Name, Role: bn.Role, Position: bn.Position,
 					})
@@ -731,7 +731,7 @@ type ServerConfig struct {
 
 // NewServer creates a new server instance
 // Store returns the database.Store dependency the server was constructed
-// with. Handlers should prefer s.Store() over database.GlobalStore; the
+// with. Handlers should prefer s.Store() over database.GetGlobalStore(); the
 // global is being phased out per the 4.4 DI migration.
 func (s *Server) Store() database.Store {
 	if s.store != nil {
@@ -744,7 +744,7 @@ func (s *Server) Store() database.Store {
 }
 
 // NewServer constructs a Server with an explicit Store dependency.
-// database.GlobalStore is still assigned at startup for code that hasn't
+// s.Store() is still assigned at startup for code that hasn't
 // been migrated to use s.Store() yet (see DI migration plan 4.4).
 func NewServer(store database.Store) *Server {
 	router := gin.New() // don't use gin.Default() — we add our own middleware
@@ -765,7 +765,7 @@ func NewServer(store database.Store) *Server {
 	// passed-in store on s.store when the caller provided one — if
 	// the caller passed nil, s.Store() falls through to the package
 	// global dynamically, which matters for tests that swap
-	// database.GlobalStore mid-test.
+	// database.GetGlobalStore() mid-test.
 	resolvedStore := store
 	if resolvedStore == nil {
 		resolvedStore = database.GetGlobalStore()
@@ -822,7 +822,7 @@ func NewServer(store database.Store) *Server {
 	isbnSources := server.metadataFetchService.BuildSourceChain()
 	if len(isbnSources) > 0 {
 		server.metadataFetchService.SetISBNEnrichment(
-			NewISBNEnrichmentService(database.GlobalStore, isbnSources),
+			NewISBNEnrichmentService(database.GetGlobalStore(), isbnSources),
 		)
 	}
 
@@ -836,8 +836,8 @@ func NewServer(store database.Store) *Server {
 			server.aiScanStore = aiScanStore
 			aiParserInst := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 			if p, ok := aiParserInst.(*ai.OpenAIParser); ok {
-				server.pipelineManager = NewPipelineManager(aiScanStore, database.GlobalStore, p, server)
-				server.batchPoller = NewBatchPoller(database.GlobalStore, p)
+				server.pipelineManager = NewPipelineManager(aiScanStore, database.GetGlobalStore(), p, server)
+				server.batchPoller = NewBatchPoller(database.GetGlobalStore(), p)
 				server.registerBatchPollerHandlers()
 			}
 		}
@@ -878,7 +878,7 @@ func NewServer(store database.Store) *Server {
 				llmParser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 				server.dedupEngine = NewDedupEngine(
 					embeddingStore,
-					database.GlobalStore,
+					database.GetGlobalStore(),
 					embedClient,
 					llmParser,
 					server.mergeService,
@@ -916,13 +916,13 @@ func NewServer(store database.Store) *Server {
 				// Runs inside a bgWG-tracked goroutine so it doesn't block
 				// the organize caller and shutdown drains it cleanly.
 				organizer.OrganizeCollisionHook = func(currentBookID, occupantPath string) {
-					if server.embeddingStore == nil || database.GlobalStore == nil {
+					if server.embeddingStore == nil || database.GetGlobalStore() == nil {
 						return
 					}
 					server.bgWG.Add(1)
 					go func() {
 						defer server.bgWG.Done()
-						occupant, err := database.GlobalStore.GetBookByFilePath(occupantPath)
+						occupant, err := database.GetGlobalStore().GetBookByFilePath(occupantPath)
 						if err != nil {
 							log.Printf("[WARN] organize-collision hook: lookup %s failed: %v", occupantPath, err)
 							return
@@ -1085,7 +1085,7 @@ func (s *Server) fireDedupOnImport(bookID string) {
 // resumeInterruptedOperations checks for operations left in running/queued state
 // from a previous server lifecycle and re-enqueues them.
 func (s *Server) resumeInterruptedOperations() {
-	store := database.GlobalStore
+	store := s.Store()
 	if store == nil || operations.GlobalQueue == nil {
 		return
 	}
@@ -1130,7 +1130,7 @@ func (s *Server) resumeInterruptedOperations() {
 				for from, to := range params.PathMappings {
 					mappings = append(mappings, itunes.PathMapping{From: from, To: to})
 				}
-				return executeITunesImport(ctx, operations.LoggerFromReporter(progress), opID, ITunesImportRequest{
+				return executeITunesImport(ctx, s.Store(), operations.LoggerFromReporter(progress), opID, ITunesImportRequest{
 					LibraryPath:      params.LibraryXMLPath,
 					ImportMode:       params.ImportMode,
 					PathMappings:     mappings,
@@ -1349,8 +1349,8 @@ func (s *Server) Start(cfg ServerConfig) error {
 	}()
 
 	// Start periodic cleanup of stale transcode temp files
-	if database.GlobalStore != nil {
-		if paths, err := database.GlobalStore.GetAllImportPaths(); err == nil {
+	if s.Store() != nil {
+		if paths, err := s.Store().GetAllImportPaths(); err == nil {
 			for _, p := range paths {
 				stopCleanup := transcode.StartCleanupTicker(p.Path, 1*time.Hour, 2*time.Hour)
 				defer stopCleanup()
@@ -1382,11 +1382,11 @@ func (s *Server) Start(cfg ServerConfig) error {
 					runtime.ReadMemStats(&alloc)
 					bookCount := 0
 					folderCount := 0
-					if database.GlobalStore != nil {
-						if bc, err := database.GlobalStore.CountBooks(); err == nil {
+					if s.Store() != nil {
+						if bc, err := s.Store().CountBooks(); err == nil {
 							bookCount = bc
 						}
-						if folders, err := database.GlobalStore.GetAllImportPaths(); err == nil {
+						if folders, err := s.Store().GetAllImportPaths(); err == nil {
 							folderCount = len(folders)
 						}
 					}
@@ -1416,8 +1416,8 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// so users with multiple import locations had silent blind spots on
 	// every path after the first.
 	var fileWatchers []*watcher.Watcher
-	if config.AppConfig.AutoScanEnabled && database.GlobalStore != nil {
-		importPaths, err := database.GlobalStore.GetAllImportPaths()
+	if config.AppConfig.AutoScanEnabled && s.Store() != nil {
+		importPaths, err := s.Store().GetAllImportPaths()
 		if err == nil && len(importPaths) > 0 {
 			var watchPaths []string
 			for _, ip := range importPaths {
@@ -1430,7 +1430,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 				if config.AppConfig.AutoScanDebounceSeconds > 0 {
 					debounce = time.Duration(config.AppConfig.AutoScanDebounceSeconds) * time.Second
 				}
-				watchLog := logger.NewWithActivityLog("auto-scan", database.GlobalStore)
+				watchLog := logger.NewWithActivityLog("auto-scan", s.Store())
 				// The same callback is reused across watchers because
 				// each watcher invokes it with its own root path, so
 				// the scan target is correct per event.
@@ -1446,7 +1446,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 						go func() {
 							scanPath := path
 							id := ulid.Make().String()
-							op, opErr := database.GlobalStore.CreateOperation(id, "scan", &scanPath)
+							op, opErr := s.Store().CreateOperation(id, "scan", &scanPath)
 							if opErr != nil {
 								watchLog.Error("Auto-scan: failed to create operation: %v", opErr)
 								return
@@ -1475,8 +1475,8 @@ func (s *Server) Start(cfg ServerConfig) error {
 	}
 
 	// Periodic cleanup of expired/revoked auth sessions.
-	if database.GlobalStore != nil {
-		sessionLog := logger.NewWithActivityLog("session-cleanup", database.GlobalStore)
+	if s.Store() != nil {
+		sessionLog := logger.NewWithActivityLog("session-cleanup", s.Store())
 		sessionCleanupTicker := time.NewTicker(10 * time.Minute)
 		backgroundWG.Add(1)
 		go func() {
@@ -1485,7 +1485,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 			for {
 				select {
 				case <-sessionCleanupTicker.C:
-					if deleted, err := database.GlobalStore.DeleteExpiredSessions(time.Now()); err != nil {
+					if deleted, err := s.Store().DeleteExpiredSessions(time.Now()); err != nil {
 						sessionLog.Warn("failed to clean up expired sessions: %v", err)
 					} else if deleted > 0 {
 						sessionLog.Info("cleaned up %d expired/revoked sessions", deleted)
@@ -1498,7 +1498,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 	}
 
 	// Periodically mark stale operations as failed.
-	if database.GlobalStore != nil && config.AppConfig.OperationTimeoutMinutes > 0 {
+	if s.Store() != nil && config.AppConfig.OperationTimeoutMinutes > 0 {
 		staleTimeout := time.Duration(config.AppConfig.OperationTimeoutMinutes) * time.Minute
 		staleTicker := time.NewTicker(1 * time.Minute)
 		backgroundWG.Add(1)
@@ -1687,7 +1687,7 @@ func (s *Server) setupRoutes() {
 		c.Next()
 	})
 	if config.AppConfig.EnableAuth {
-		authMiddleware = servermiddleware.RequireAuth(database.GlobalStore)
+		authMiddleware = servermiddleware.RequireAuth(s.Store())
 	}
 
 	// API routes (auth + rate limits + request-size limits)
@@ -2119,8 +2119,8 @@ func isProtectedPath(filePath string) bool {
 	absPath, _ := filepath.Abs(filePath)
 
 	// Check import paths
-	if database.GlobalStore != nil {
-		importPaths, err := database.GlobalStore.GetAllImportPaths()
+	if database.GetGlobalStore() != nil {
+		importPaths, err := database.GetGlobalStore().GetAllImportPaths()
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)
@@ -2285,17 +2285,17 @@ func saveDismissedDedupGroups(store database.Store, dismissed map[string]bool) {
 
 // triggerITunesSync finds the library path from DB and enqueues a sync if the file changed.
 func (s *Server) triggerITunesSync() {
-	if database.GlobalStore == nil || operations.GlobalQueue == nil {
+	if s.Store() == nil || operations.GlobalQueue == nil {
 		return
 	}
 
-	libraryPath := discoverITunesLibraryPath()
+	libraryPath := discoverITunesLibraryPath(s.Store())
 	if libraryPath == "" {
 		return
 	}
 
 	// Check fingerprint — skip if unchanged (quick mtime+size check)
-	if rec, err := database.GlobalStore.GetLibraryFingerprint(libraryPath); err == nil && rec != nil {
+	if rec, err := s.Store().GetLibraryFingerprint(libraryPath); err == nil && rec != nil {
 		if info, statErr := os.Stat(libraryPath); statErr == nil {
 			if info.Size() == rec.Size && info.ModTime().Equal(rec.ModTime) {
 				return // No changes
@@ -2303,9 +2303,9 @@ func (s *Server) triggerITunesSync() {
 		}
 	}
 
-	itunesTriggerLog := logger.NewWithActivityLog("itunes-scheduler", database.GlobalStore)
+	itunesTriggerLog := logger.NewWithActivityLog("itunes-scheduler", s.Store())
 	opID := ulid.Make().String()
-	op, err := database.GlobalStore.CreateOperation(opID, "itunes_sync", &libraryPath)
+	op, err := s.Store().CreateOperation(opID, "itunes_sync", &libraryPath)
 	if err != nil {
 		itunesTriggerLog.Warn("iTunes sync scheduler: failed to create operation: %v", err)
 		return
@@ -2318,7 +2318,7 @@ func (s *Server) triggerITunesSync() {
 	}
 
 	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return executeITunesSync(ctx, operations.LoggerFromReporter(progress), libraryPath, scheduledMappings)
+		return executeITunesSync(ctx, s.Store(), operations.LoggerFromReporter(progress), libraryPath, scheduledMappings)
 	}
 
 	if err := operations.GlobalQueue.Enqueue(op.ID, "itunes_sync", operations.PriorityNormal, operationFunc); err != nil {
@@ -2349,11 +2349,11 @@ func (s *Server) collectStaleOperations(timeout time.Duration) ([]database.Opera
 	if timeout <= 0 {
 		return []database.Operation{}, nil
 	}
-	if database.GlobalStore == nil {
+	if s.Store() == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	ops, err := database.GlobalStore.GetRecentOperations(500)
+	ops, err := s.Store().GetRecentOperations(500)
 	if err != nil {
 		return nil, err
 	}
@@ -2373,7 +2373,7 @@ func (s *Server) collectStaleOperations(timeout time.Duration) ([]database.Opera
 }
 
 func (s *Server) failStaleOperations(timeout time.Duration) {
-	staleLog := logger.NewWithActivityLog("reaper", database.GlobalStore)
+	staleLog := logger.NewWithActivityLog("reaper", s.Store())
 	stale, err := s.collectStaleOperations(timeout)
 	if err != nil {
 		staleLog.Warn("stale operation check failed: %v", err)
@@ -2385,7 +2385,7 @@ func (s *Server) failStaleOperations(timeout time.Duration) {
 
 	for _, op := range stale {
 		msg := fmt.Sprintf("operation timed out after %s", timeout)
-		if err := database.GlobalStore.UpdateOperationError(op.ID, msg); err != nil {
+		if err := s.Store().UpdateOperationError(op.ID, msg); err != nil {
 			staleLog.Warn("failed to mark stale operation %s as failed: %v", op.ID, err)
 			continue
 		}
@@ -2671,7 +2671,7 @@ func extractTitleFromSegmentFilename(filename string) string {
 // sourceBookID to targetBookID for the given files. It matches by file_path or
 // ITunesPersistentID on the external_id_map entries.
 func reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []database.BookFile) {
-	eidStore := asExternalIDStore(database.GlobalStore)
+	eidStore := asExternalIDStore(database.GetGlobalStore())
 	if eidStore == nil {
 		return
 	}
@@ -2708,7 +2708,7 @@ func reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []data
 	// Reassign each mapping: delete old reverse key, update primary, add new reverse key
 	for _, m := range toMove {
 		oldReverseKey := fmt.Sprintf("ext_id:book:%s:%s:%s", sourceBookID, m.Source, m.ExternalID)
-		_ = database.GlobalStore.DeleteRaw(oldReverseKey)
+		_ = database.GetGlobalStore().DeleteRaw(oldReverseKey)
 
 		m.BookID = targetBookID
 		if createErr := eidStore.CreateExternalIDMapping(&m); createErr != nil {


### PR DESCRIPTION
Finishes DI task 6. All itunes.go refs migrated; remaining refs in batcher/metadata/server.go top-level helpers route through database.GetGlobalStore() to centralize access.