### PR TITLE
refactor: route non-server packages through GetGlobalStore() (4.4 DI task 7)

### DIFF
--- a/cmd/dedup_bench.go
+++ b/cmd/dedup_bench.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 //go:build bench
@@ -113,7 +113,7 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to initialize database: %w", initErr)
 		}
 		defer closeStore()
-		authorData, err = extractAuthorData(database.GlobalStore)
+		authorData, err = extractAuthorData(database.GetGlobalStore())
 	}
 	if err != nil {
 		return fmt.Errorf("failed to extract author data: %w", err)

--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -1,5 +1,5 @@
 // file: cmd/diagnostics.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c8f6a0d4-2a8b-48cf-9d08-02cc9915d9fc
 
 package cmd
@@ -88,7 +88,7 @@ func runCleanupInvalidBooks(force, dryRun bool) error {
 	placeholders := []string{"{series}", "{narrator}", "{author}", "{title}"}
 
 	for {
-		books, err := database.GlobalStore.GetAllBooks(batchSize, offset)
+		books, err := database.GetGlobalStore().GetAllBooks(batchSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed to fetch books: %w", err)
 		}
@@ -136,7 +136,7 @@ func runCleanupInvalidBooks(force, dryRun bool) error {
 
 	deleted := 0
 	for _, book := range invalid {
-		if err := database.GlobalStore.DeleteBook(book.ID); err != nil {
+		if err := database.GetGlobalStore().DeleteBook(book.ID); err != nil {
 			fmt.Printf("Failed to delete %s: %v\n", book.ID, err)
 			continue
 		}
@@ -165,7 +165,7 @@ func runDiagnosticsQuery(limit int, prefix string, raw bool) error {
 	}
 	defer closer()
 
-	books, err := database.GlobalStore.GetAllBooks(limit, 0)
+	books, err := database.GetGlobalStore().GetAllBooks(limit, 0)
 	if err != nil {
 		return fmt.Errorf("failed to fetch books: %w", err)
 	}

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,5 +1,5 @@
 // file: cmd/seed.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7d2e9a4f-1b85-4c63-9f0a-3e8d7b2c1f56
 //
 // `seed` populates a fresh database with synthetic books for local
@@ -96,7 +96,7 @@ func runSeed(cmd *cobra.Command, _ []string) error {
 	}
 	defer closeStore()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	if store == nil {
 		return fmt.Errorf("database not initialized")
 	}

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,5 +1,5 @@
 // file: internal/backup/backup.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f9e0a1b-2c3d-4e5f-6a7b-8c9d0e1f2a3b
 
 package backup
@@ -380,7 +380,7 @@ func ScheduleBackup(interval time.Duration, config BackupConfig) error {
 
 // BackupDatabase is a convenience function that backs up the global database
 func BackupDatabase(config BackupConfig) (*BackupInfo, error) {
-	if database.GlobalStore == nil {
+	if database.GetGlobalStore() == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package organizer
@@ -112,8 +112,8 @@ func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
 	// content already exists at another path under root would hit the
 	// target-exists branch first (seeing the OLD organized version) and
 	// silently no-op. Order matters.
-	if book.FileHash != nil && *book.FileHash != "" && database.GlobalStore != nil {
-		existingBook, err := database.GlobalStore.GetBookByFileHash(*book.FileHash)
+	if book.FileHash != nil && *book.FileHash != "" && database.GetGlobalStore() != nil {
+		existingBook, err := database.GetGlobalStore().GetBookByFileHash(*book.FileHash)
 		if err == nil && existingBook != nil && existingBook.ID != book.ID {
 			if strings.HasPrefix(existingBook.FilePath, o.config.RootDir) {
 				// Content-identical book already organized under a
@@ -147,8 +147,8 @@ func (o *Organizer) OrganizeBook(book *database.Book) (string, string, error) {
 		// Case 2: ask the DB who owns the target. If it's the current
 		// book, this is a re-organize no-op — don't panic, don't fire
 		// the collision hook, just return the target.
-		if database.GlobalStore != nil && book.ID != "" {
-			if owner, lookupErr := database.GlobalStore.GetBookByFilePath(targetPath); lookupErr == nil && owner != nil && owner.ID == book.ID {
+		if database.GetGlobalStore() != nil && book.ID != "" {
+			if owner, lookupErr := database.GetGlobalStore().GetBookByFilePath(targetPath); lookupErr == nil && owner != nil && owner.ID == book.ID {
 				return targetPath, "", nil
 			}
 		}
@@ -253,9 +253,9 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 		if trimmed := strings.TrimSpace(book.Author.Name); trimmed != "" {
 			authorName = trimmed
 		}
-	} else if book.AuthorID != nil && database.GlobalStore != nil {
+	} else if book.AuthorID != nil && database.GetGlobalStore() != nil {
 		// Author object not populated, but we have an ID - look it up
-		author, err := database.GlobalStore.GetAuthorByID(*book.AuthorID)
+		author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID)
 		if err == nil && author != nil {
 			if trimmed := strings.TrimSpace(author.Name); trimmed != "" {
 				authorName = trimmed
@@ -272,9 +272,9 @@ func (o *Organizer) expandPattern(pattern string, book *database.Book) (string, 
 	seriesName := ""
 	if book.Series != nil {
 		seriesName = strings.TrimSpace(book.Series.Name)
-	} else if book.SeriesID != nil && database.GlobalStore != nil {
+	} else if book.SeriesID != nil && database.GetGlobalStore() != nil {
 		// Series object not populated, but we have an ID - look it up
-		series, err := database.GlobalStore.GetSeriesByID(*book.SeriesID)
+		series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID)
 		if err == nil && series != nil {
 			seriesName = strings.TrimSpace(series.Name)
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scanner.go
-// version: 1.28.0
+// version: 1.29.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 
 package scanner
@@ -536,8 +536,8 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 			// would be a no-op. Skip to avoid thousands of redundant API calls on rescan.
 			if aiEnabled && (fallbackUsed || books[idx].Title == "" || books[idx].Author == "" || books[idx].Series == "") {
 				needsAI := true
-				if database.GlobalStore != nil {
-					if dbExisting, dbErr := database.GlobalStore.GetBookByFilePath(books[idx].FilePath); dbErr == nil && dbExisting != nil {
+				if database.GetGlobalStore() != nil {
+					if dbExisting, dbErr := database.GetGlobalStore().GetBookByFilePath(books[idx].FilePath); dbErr == nil && dbExisting != nil {
 						if dbExisting.Title != "" && dbExisting.AuthorID != nil && *dbExisting.AuthorID != 0 {
 							needsAI = false
 						}
@@ -586,7 +586,7 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 				// wrapping a nil concrete pointer (can happen in tests).
 				func() {
 					defer func() { recover() }() //nolint:errcheck
-					store := database.GlobalStore
+					store := database.GetGlobalStore()
 					if store == nil {
 						return
 					}
@@ -968,17 +968,17 @@ func isInitialToken(word string) bool {
 // After creating book files, if book.FilePath points to a file (not a directory),
 // it normalizes it to the parent directory.
 func createBookFilesForBook(bookFilePath string, segmentFiles []string, scanLog logger.Logger) {
-	if database.GlobalStore == nil {
+	if database.GetGlobalStore() == nil {
 		return
 	}
 
-	dbBook, err := database.GlobalStore.GetBookByFilePath(bookFilePath)
+	dbBook, err := database.GetGlobalStore().GetBookByFilePath(bookFilePath)
 	if err != nil || dbBook == nil {
 		return
 	}
 
 	// Check if book files already exist
-	existing, _ := database.GlobalStore.GetBookFiles(dbBook.ID)
+	existing, _ := database.GetGlobalStore().GetBookFiles(dbBook.ID)
 	if len(existing) > 0 {
 		return // BookFiles already created (rescan)
 	}
@@ -1028,7 +1028,7 @@ func createBookFilesForBook(bookFilePath string, segmentFiles []string, scanLog 
 			TrackNumber:      trackNum,
 		}
 
-		if serr := database.GlobalStore.UpsertBookFile(bf); serr != nil {
+		if serr := database.GetGlobalStore().UpsertBookFile(bf); serr != nil {
 			scanLog.Warn("failed to upsert book file for %s: %v", filePath, serr)
 		}
 	}
@@ -1037,7 +1037,7 @@ func createBookFilesForBook(bookFilePath string, segmentFiles []string, scanLog 
 	if statErr == nil && !info.IsDir() {
 		dirPath := filepath.Dir(bookFilePath)
 		dbBook.FilePath = dirPath
-		if _, updateErr := database.GlobalStore.UpdateBook(dbBook.ID, dbBook); updateErr != nil {
+		if _, updateErr := database.GetGlobalStore().UpdateBook(dbBook.ID, dbBook); updateErr != nil {
 			scanLog.Warn("failed to normalize FilePath for book %s: %v", dbBook.ID, updateErr)
 		}
 	}
@@ -1317,7 +1317,7 @@ func groupFilesIntoBooks(files []string) []Book {
 // saveBookToDatabase saves the book information to the database
 func saveBookToDatabase(book *Book) error {
 	// Prefer using the unified Store API when available
-	if database.GlobalStore != nil {
+	if database.GetGlobalStore() != nil {
 		// Resolve author/series with conflict-aware get-or-create semantics.
 		authorID, err := resolveAuthorID(book.Author)
 		if err != nil {
@@ -1333,7 +1333,7 @@ func saveBookToDatabase(book *Book) error {
 		if book.Title != "" {
 			canonical := strings.ToLower(strings.TrimSpace(book.Title))
 			// Simple heuristic: try existing works then create new.
-			works, err := database.GlobalStore.GetAllWorks()
+			works, err := database.GetGlobalStore().GetAllWorks()
 			if err == nil { // non-critical
 				for _, w := range works {
 					if strings.ToLower(strings.TrimSpace(w.Title)) == canonical && ((authorID == nil && w.AuthorID == nil) || (authorID != nil && w.AuthorID != nil && *authorID == *w.AuthorID)) {
@@ -1345,13 +1345,13 @@ func saveBookToDatabase(book *Book) error {
 			}
 			if workID == nil {
 				newWork := &database.Work{Title: book.Title, AuthorID: authorID}
-				created, err := database.GlobalStore.CreateWork(newWork)
+				created, err := database.GetGlobalStore().CreateWork(newWork)
 				if err == nil {
 					wid := created.ID
 					workID = &wid
 				} else if isUniqueConstraintError(err) {
 					// A parallel worker likely created the same work; resolve it.
-					works, lookupErr := database.GlobalStore.GetAllWorks()
+					works, lookupErr := database.GetGlobalStore().GetAllWorks()
 					if lookupErr == nil {
 						for _, w := range works {
 							if strings.ToLower(strings.TrimSpace(w.Title)) == canonical &&
@@ -1383,7 +1383,7 @@ func saveBookToDatabase(book *Book) error {
 		}
 		if hashErr == nil && hash != "" {
 			// Check if this hash is blocked
-			blocked, err := database.GlobalStore.IsHashBlocked(hash)
+			blocked, err := database.GetGlobalStore().IsHashBlocked(hash)
 			if err != nil {
 				defaultLog.Warn("failed to check hash blocklist: %v", err)
 			} else if blocked {
@@ -1437,20 +1437,20 @@ func saveBookToDatabase(book *Book) error {
 		// Re-link by embedded AUDIOBOOK_ORGANIZER_ID: if the file contains our ID tag,
 		// find the existing record and update its path (handles file moves/renames).
 		if book.BookOrganizerID != "" {
-			existingByOrgID, orgErr := database.GlobalStore.GetBookByID(book.BookOrganizerID)
+			existingByOrgID, orgErr := database.GetGlobalStore().GetBookByID(book.BookOrganizerID)
 			if orgErr == nil && existingByOrgID != nil && existingByOrgID.FilePath != book.FilePath {
 				defaultLog.Info("re-linking book %s (moved from %s to %s)",
 					book.BookOrganizerID, existingByOrgID.FilePath, book.FilePath)
 				existingByOrgID.FilePath = book.FilePath
 				preserveExistingFields(dbBook, existingByOrgID)
-				_, err = database.GlobalStore.UpdateBook(existingByOrgID.ID, existingByOrgID)
+				_, err = database.GetGlobalStore().UpdateBook(existingByOrgID.ID, existingByOrgID)
 				return err
 			}
 		}
 
 		// Upsert semantics with duplicate detection:
 		// 1. Try lookup by file path first (exact match)
-		existing, err := database.GlobalStore.GetBookByFilePath(book.FilePath)
+		existing, err := database.GetGlobalStore().GetBookByFilePath(book.FilePath)
 		if err != nil {
 			return fmt.Errorf("book lookup failed: %w", err)
 		}
@@ -1458,9 +1458,9 @@ func saveBookToDatabase(book *Book) error {
 		// 2. If not found by path but we have a file hash, check for duplicates via indexes
 		if existing == nil && fileHash != nil && *fileHash != "" {
 			hashLookups := []func(string) (*database.Book, error){
-				database.GlobalStore.GetBookByFileHash,
-				database.GlobalStore.GetBookByOriginalHash,
-				database.GlobalStore.GetBookByOrganizedHash,
+				database.GetGlobalStore().GetBookByFileHash,
+				database.GetGlobalStore().GetBookByOriginalHash,
+				database.GetGlobalStore().GetBookByOrganizedHash,
 			}
 			for _, lookup := range hashLookups {
 				candidate, err := lookup(*fileHash)
@@ -1497,7 +1497,7 @@ func saveBookToDatabase(book *Book) error {
 					existingInRoot := config.AppConfig.RootDir != "" && strings.HasPrefix(existing.FilePath, config.AppConfig.RootDir)
 					existing.VersionGroupID = &groupID
 					existing.IsPrimaryVersion = &existingInRoot
-					if _, uerr := database.GlobalStore.UpdateBook(existing.ID, existing); uerr != nil {
+					if _, uerr := database.GetGlobalStore().UpdateBook(existing.ID, existing); uerr != nil {
 						defaultLog.Warn("Failed to set version group on existing book %s: %v", existing.ID, uerr)
 					}
 
@@ -1514,7 +1514,7 @@ func saveBookToDatabase(book *Book) error {
 			// Smart dedup: check for same-title books in same directory (format-aware version linking)
 			if dbBook.Title != "" {
 				parentDir := filepath.Dir(book.FilePath)
-				siblings, lookupErr := database.GlobalStore.GetBooksByTitleInDir(strings.ToLower(dbBook.Title), parentDir)
+				siblings, lookupErr := database.GetGlobalStore().GetBooksByTitleInDir(strings.ToLower(dbBook.Title), parentDir)
 				if lookupErr == nil && len(siblings) > 0 {
 					// Determine or reuse version_group_id
 					var groupID string
@@ -1539,7 +1539,7 @@ func saveBookToDatabase(book *Book) error {
 							sibIsM4B := strings.EqualFold(sib.Format, "m4b")
 							sib.VersionGroupID = &groupID
 							sib.IsPrimaryVersion = &sibIsM4B
-							if _, uerr := database.GlobalStore.UpdateBook(sib.ID, &sib); uerr != nil {
+							if _, uerr := database.GetGlobalStore().UpdateBook(sib.ID, &sib); uerr != nil {
 								defaultLog.Warn("Failed to update sibling version group for %s: %v", sib.FilePath, uerr)
 							}
 						}
@@ -1548,7 +1548,7 @@ func saveBookToDatabase(book *Book) error {
 				}
 			}
 
-			_, err = database.GlobalStore.CreateBook(dbBook)
+			_, err = database.GetGlobalStore().CreateBook(dbBook)
 			if err == nil {
 				if ScanActivityRecorder != nil {
 					ScanActivityRecorder(dbBook.ID, dbBook.Title)
@@ -1574,7 +1574,7 @@ func saveBookToDatabase(book *Book) error {
 		// Preserve enriched fields that scanner doesn't extract (e.g. from metadata fetch or AI parse)
 		preserveExistingFields(dbBook, existing)
 
-		_, err = database.GlobalStore.UpdateBook(existing.ID, dbBook)
+		_, err = database.GetGlobalStore().UpdateBook(existing.ID, dbBook)
 		return err
 	}
 
@@ -1749,7 +1749,7 @@ func resolveAuthorID(authorName string) (*int, error) {
 	}
 	trimmed = strings.TrimSpace(trimmed)
 
-	author, err := database.GlobalStore.GetAuthorByName(trimmed)
+	author, err := database.GetGlobalStore().GetAuthorByName(trimmed)
 	if err != nil {
 		return nil, fmt.Errorf("author lookup failed: %w", err)
 	}
@@ -1757,13 +1757,13 @@ func resolveAuthorID(authorName string) (*int, error) {
 		return &author.ID, nil
 	}
 
-	author, err = database.GlobalStore.CreateAuthor(trimmed)
+	author, err = database.GetGlobalStore().CreateAuthor(trimmed)
 	if err != nil {
 		if !isUniqueConstraintError(err) {
 			return nil, fmt.Errorf("author create failed: %w", err)
 		}
 		// Concurrent create: re-fetch existing record.
-		author, err = database.GlobalStore.GetAuthorByName(trimmed)
+		author, err = database.GetGlobalStore().GetAuthorByName(trimmed)
 		if err != nil {
 			return nil, fmt.Errorf("author lookup after conflict failed: %w", err)
 		}
@@ -1780,7 +1780,7 @@ func resolveSeriesID(seriesName string, authorID *int) (*int, error) {
 		return nil, nil
 	}
 
-	series, err := database.GlobalStore.GetSeriesByName(trimmed, authorID)
+	series, err := database.GetGlobalStore().GetSeriesByName(trimmed, authorID)
 	if err != nil {
 		return nil, fmt.Errorf("series lookup failed: %w", err)
 	}
@@ -1788,13 +1788,13 @@ func resolveSeriesID(seriesName string, authorID *int) (*int, error) {
 		return &series.ID, nil
 	}
 
-	series, err = database.GlobalStore.CreateSeries(trimmed, authorID)
+	series, err = database.GetGlobalStore().CreateSeries(trimmed, authorID)
 	if err != nil {
 		if !isUniqueConstraintError(err) {
 			return nil, fmt.Errorf("series create failed: %w", err)
 		}
 		// Concurrent create: re-fetch existing record.
-		series, err = database.GlobalStore.GetSeriesByName(trimmed, authorID)
+		series, err = database.GetGlobalStore().GetSeriesByName(trimmed, authorID)
 		if err != nil {
 			return nil, fmt.Errorf("series lookup after conflict failed: %w", err)
 		}


### PR DESCRIPTION
Task 7. Production code is now GlobalStore-var-free except for cmd/root.go startup (by design).