### PR TITLE
refactor(database): unexport GlobalStore — 4.4 DI migration complete

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -48,11 +48,11 @@ func stubCommandDeps(t *testing.T) {
 		// methods, add them here and the test will tell you which.
 		ms := mocks.NewMockStore(t)
 		ms.EXPECT().GetAllImportPaths().Return(nil, nil).Maybe()
-		database.GlobalStore = ms
+		database.SetGlobalStore(ms)
 		return nil
 	}
 	closeStore = func() error {
-		database.GlobalStore = nil
+		database.SetGlobalStore(nil)
 		return nil
 	}
 	scanDirectory = func(rootDir string, _ logger.Logger) ([]scanner.Book, error) {
@@ -97,7 +97,7 @@ func stubCommandDeps(t *testing.T) {
 		newServer = origNewServer
 		getDefaultServerConfig = origDefaultCfg
 		startServer = origStart
-		database.GlobalStore = nil
+		database.SetGlobalStore(nil)
 	})
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -242,7 +242,7 @@ var serveCmd = &cobra.Command{
 
 		// Attach database store to the operation queue (initialized early without store)
 		if operations.GlobalQueue != nil {
-			operations.GlobalQueue.SetStore(database.GlobalStore)
+			operations.GlobalQueue.SetStore(database.GetGlobalStore())
 			fmt.Println("Operation queue connected to database store")
 		}
 
@@ -254,7 +254,7 @@ var serveCmd = &cobra.Command{
 		fmt.Println("Settings encryption initialized")
 
 		// Load configuration from database (overrides defaults with persisted values)
-		if err := loadConfigFromDB(database.GlobalStore); err != nil {
+		if err := loadConfigFromDB(database.GetGlobalStore()); err != nil {
 			fmt.Printf("Warning: Could not load config from database: %v\n", err)
 		} else {
 			fmt.Println("Configuration loaded from database")
@@ -275,7 +275,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		// Log import path count
-		if folders, err := database.GlobalStore.GetAllImportPaths(); err == nil {
+		if folders, err := database.GetGlobalStore().GetAllImportPaths(); err == nil {
 			fmt.Printf("  - Import paths (scan paths): %d configured\n", len(folders))
 			for _, folder := range folders {
 				fmt.Printf("    * %s (%s)\n", folder.Name, folder.Path)
@@ -293,7 +293,7 @@ var serveCmd = &cobra.Command{
 		if w := cmd.Flag("workers").Value.String(); w != "" {
 			fmt.Sscanf(w, "%d", &workers)
 		}
-		initializeQueue(database.GlobalStore, workers)
+		initializeQueue(database.GetGlobalStore(), workers)
 		if config.AppConfig.OperationTimeoutMinutes > 0 {
 			operations.SetGlobalOperationTimeout(time.Duration(config.AppConfig.OperationTimeoutMinutes) * time.Minute)
 		}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1211,13 +1211,13 @@ func TestCreateBackupLowCompression(t *testing.T) {
 // TestBackupDatabaseNotInitialized tests BackupDatabase with nil GlobalStore
 func TestBackupDatabaseNotInitialized(t *testing.T) {
 	// Save original GlobalStore and defer restore
-	originalStore := database.GlobalStore
+	originalStore := database.GetGlobalStore()
 	defer func() {
-		database.GlobalStore = originalStore
+		database.SetGlobalStore(originalStore)
 	}()
 
 	// Set GlobalStore to nil
-	database.GlobalStore = nil
+	database.SetGlobalStore(nil)
 
 	config := BackupConfig{
 		BackupDir:        t.TempDir(),

--- a/internal/database/close_store_test.go
+++ b/internal/database/close_store_test.go
@@ -17,12 +17,12 @@ func TestCloseStoreWithDBOnly(t *testing.T) {
 		t.Fatalf("failed to open db: %v", err)
 	}
 
-	origStore := GlobalStore
+	origStore := globalStore
 	origDB := DB
-	GlobalStore = nil
+	globalStore = nil
 	DB = db
 	defer func() {
-		GlobalStore = origStore
+		globalStore = origStore
 		DB = origDB
 	}()
 

--- a/internal/database/coverage_test.go
+++ b/internal/database/coverage_test.go
@@ -13,10 +13,10 @@ import (
 
 func TestInitializeStoreAndClose(t *testing.T) {
 	tempDir := t.TempDir()
-	origStore := GlobalStore
+	origStore := globalStore
 	origDB := DB
 	defer func() {
-		GlobalStore = origStore
+		globalStore = origStore
 		DB = origDB
 	}()
 
@@ -27,13 +27,13 @@ func TestInitializeStoreAndClose(t *testing.T) {
 	if err := InitializeStore("sqlite", filepath.Join(tempDir, "db.sqlite"), true); err != nil {
 		t.Fatalf("unexpected sqlite init error: %v", err)
 	}
-	if GlobalStore == nil {
+	if globalStore == nil {
 		t.Fatal("expected global store to be set")
 	}
 	if err := CloseStore(); err != nil {
 		t.Fatalf("failed to close sqlite store: %v", err)
 	}
-	GlobalStore = nil
+	globalStore = nil
 	DB = nil
 
 	pebbleDir := filepath.Join(tempDir, "pebble")
@@ -43,7 +43,7 @@ func TestInitializeStoreAndClose(t *testing.T) {
 	if err := CloseStore(); err != nil {
 		t.Fatalf("failed to close pebble store: %v", err)
 	}
-	GlobalStore = nil
+	globalStore = nil
 
 	if err := InitializeStore("unknown", filepath.Join(tempDir, "bad"), false); err == nil {
 		t.Fatal("expected error for unsupported database type")
@@ -774,14 +774,14 @@ func TestGetOrCreateSeries(t *testing.T) {
 	}
 }
 
-// TestCloseStoreWithNilStore tests CloseStore when GlobalStore is nil
+// TestCloseStoreWithNilStore tests CloseStore when globalStore is nil
 func TestCloseStoreWithNilStore(t *testing.T) {
-	origStore := GlobalStore
+	origStore := globalStore
 	defer func() {
-		GlobalStore = origStore
+		globalStore = origStore
 	}()
 
-	GlobalStore = nil
+	globalStore = nil
 	if err := CloseStore(); err != nil {
 		t.Errorf("CloseStore() with nil store returned error: %v", err)
 	}

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -910,13 +910,13 @@ type DashboardStats struct {
 
 // Global store instance — use GetGlobalStore/SetGlobalStore for concurrent access.
 // Direct assignment is allowed in single-goroutine contexts (init, main).
-var GlobalStore Store
+var globalStore Store
 var globalStoreMu sync.RWMutex
 
 // GetGlobalStore returns the global store with read-lock protection.
 func GetGlobalStore() Store {
 	globalStoreMu.RLock()
-	s := GlobalStore
+	s := globalStore
 	globalStoreMu.RUnlock()
 	return s
 }
@@ -924,7 +924,7 @@ func GetGlobalStore() Store {
 // SetGlobalStore sets the global store with write-lock protection.
 func SetGlobalStore(s Store) {
 	globalStoreMu.Lock()
-	GlobalStore = s
+	globalStore = s
 	globalStoreMu.Unlock()
 }
 
@@ -937,13 +937,13 @@ func InitializeStore(dbType, path string, enableSQLite bool) error {
 		if !enableSQLite {
 			return fmt.Errorf("SQLite3 is not enabled. To use SQLite3, you must explicitly enable it with --enable-sqlite3-i-know-the-risks or set 'enable_sqlite3_i_know_the_risks: true' in your config file. PebbleDB is the recommended database for production use")
 		}
-		GlobalStore, err = NewSQLiteStore(path)
+		globalStore, err = NewSQLiteStore(path)
 		if err != nil {
 			return fmt.Errorf("failed to initialize SQLite store: %w", err)
 		}
 	case "pebble", "":
 		// PebbleDB is the default
-		GlobalStore, err = NewPebbleStore(path)
+		globalStore, err = NewPebbleStore(path)
 		if err != nil {
 			return fmt.Errorf("failed to initialize PebbleDB store: %w", err)
 		}
@@ -952,12 +952,12 @@ func InitializeStore(dbType, path string, enableSQLite bool) error {
 	}
 
 	// Maintain backwards compatibility with the global DB variable for SQLite
-	if sqliteStore, ok := GlobalStore.(*SQLiteStore); ok {
+	if sqliteStore, ok := globalStore.(*SQLiteStore); ok {
 		DB = sqliteStore.db
 	}
 
 	// Run migrations to ensure schema is up to date
-	if err := RunMigrations(GlobalStore); err != nil {
+	if err := RunMigrations(globalStore); err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 
@@ -968,8 +968,8 @@ func InitializeStore(dbType, path string, enableSQLite bool) error {
 func CloseStore() error {
 	// Grab and nil the global ref first so lingering goroutines
 	// see nil and fail gracefully instead of hitting a closed DB.
-	store := GlobalStore
-	GlobalStore = nil
+	store := globalStore
+	globalStore = nil
 
 	if store != nil {
 		// Brief pause to let in-flight goroutines notice the nil

--- a/internal/scanner/save_book_to_database_test.go
+++ b/internal/scanner/save_book_to_database_test.go
@@ -38,10 +38,10 @@ func TestSaveBookToDatabase_GlobalStoreCreateAndUpdate(t *testing.T) {
 	store, cleanup := setupSQLiteStore(t)
 	defer cleanup()
 
-	prevStore := database.GlobalStore
-	database.GlobalStore = store
+	prevStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
 	t.Cleanup(func() {
-		database.GlobalStore = prevStore
+		database.SetGlobalStore(prevStore)
 	})
 
 	prevConfig := config.AppConfig
@@ -101,10 +101,10 @@ func TestSaveBookToDatabase_GlobalStoreCreateAndUpdate(t *testing.T) {
 func TestSaveBookToDatabase_BlocklistSkips(t *testing.T) {
 	store, cleanup := setupSQLiteStore(t)
 	defer cleanup()
-	prevStore := database.GlobalStore
-	database.GlobalStore = store
+	prevStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
 	t.Cleanup(func() {
-		database.GlobalStore = prevStore
+		database.SetGlobalStore(prevStore)
 	})
 
 	prevConfig := config.AppConfig
@@ -158,9 +158,9 @@ func TestSaveBookToDatabase_DedupOnImportHook(t *testing.T) {
 	store, cleanup := setupSQLiteStore(t)
 	defer cleanup()
 
-	prevStore := database.GlobalStore
-	database.GlobalStore = store
-	t.Cleanup(func() { database.GlobalStore = prevStore })
+	prevStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() { database.SetGlobalStore(prevStore) })
 
 	prevConfig := config.AppConfig
 	t.Cleanup(func() { config.AppConfig = prevConfig })

--- a/internal/scanner/scanner_coverage_test.go
+++ b/internal/scanner/scanner_coverage_test.go
@@ -443,14 +443,14 @@ func TestSaveBookToDatabaseCodePaths(t *testing.T) {
 	// a full database setup, which can be complex and fragile in tests.
 
 	t.Run("no database available", func(t *testing.T) {
-		origStore := database.GlobalStore
+		origStore := database.GetGlobalStore()
 		origDB := database.DB
 		defer func() {
-			database.GlobalStore = origStore
+			database.SetGlobalStore(origStore)
 			database.DB = origDB
 		}()
 
-		database.GlobalStore = nil
+		database.SetGlobalStore(nil)
 		database.DB = nil
 
 		book := &Book{
@@ -481,8 +481,8 @@ func TestSaveBookToDatabaseCodePaths(t *testing.T) {
 		}
 		defer database.CloseStore()
 
-		origStore := database.GlobalStore
-		defer func() { database.GlobalStore = origStore }()
+		origStore := database.GetGlobalStore()
+		defer func() { database.SetGlobalStore(origStore) }()
 
 		config.AppConfig.RootDir = tmpDir
 
@@ -513,10 +513,10 @@ func TestSaveBookToDatabaseCodePaths(t *testing.T) {
 // TestSaveBookToDatabaseWithoutStore tests fallback when GlobalStore is nil
 func TestSaveBookToDatabaseWithoutStore(t *testing.T) {
 	// Save and clear GlobalStore
-	origStore := database.GlobalStore
-	database.GlobalStore = nil
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(nil)
 	t.Cleanup(func() {
-		database.GlobalStore = origStore
+		database.SetGlobalStore(origStore)
 	})
 
 	// Also need to set database.DB for the fallback path
@@ -548,15 +548,15 @@ func TestSaveBookToDatabaseWithoutStore(t *testing.T) {
 // TestSaveBookToDatabaseNoDatabase tests error when no database is available
 func TestSaveBookToDatabaseNoDatabase(t *testing.T) {
 	// Save originals
-	origStore := database.GlobalStore
+	origStore := database.GetGlobalStore()
 	origDB := database.DB
 
 	// Clear both
-	database.GlobalStore = nil
+	database.SetGlobalStore(nil)
 	database.DB = nil
 
 	t.Cleanup(func() {
-		database.GlobalStore = origStore
+		database.SetGlobalStore(origStore)
 		database.DB = origDB
 	})
 

--- a/internal/server/audiobook_service_history_test.go
+++ b/internal/server/audiobook_service_history_test.go
@@ -21,7 +21,7 @@ func TestUpdateAudiobook_FieldExtractorRecordsHistory(t *testing.T) {
 	_, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	bookID := ulid.Make().String()
 	book := &database.Book{
@@ -71,7 +71,7 @@ func TestUpdateAudiobook_NoHistoryWhenValueUnchanged(t *testing.T) {
 	_, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	bookID := ulid.Make().String()
 	book := &database.Book{

--- a/internal/server/audiobook_service_tags_test.go
+++ b/internal/server/audiobook_service_tags_test.go
@@ -50,9 +50,9 @@ func TestGetAudiobookTags_UsesSnapshotComparisonValues(t *testing.T) {
 		},
 	}
 
-	oldGlobal := database.GlobalStore
-	database.GlobalStore = store
-	defer func() { database.GlobalStore = oldGlobal }()
+	oldGlobal := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	defer func() { database.SetGlobalStore(oldGlobal) }()
 
 	svc := NewAudiobookService(store)
 	resp, err := svc.GetAudiobookTags(context.Background(), "book-1", "", timestamp.Format(time.RFC3339Nano))

--- a/internal/server/author_series_service_test.go
+++ b/internal/server/author_series_service_test.go
@@ -16,9 +16,9 @@ func TestAuthorSeriesService_ListAuthors_Empty(t *testing.T) {
 			return nil, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	as := NewAuthorSeriesService(mockDB)
 
@@ -38,9 +38,9 @@ func TestAuthorSeriesService_ListSeries_Empty(t *testing.T) {
 			return nil, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	as := NewAuthorSeriesService(mockDB)
 

--- a/internal/server/batch_service_test.go
+++ b/internal/server/batch_service_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestBatchUpdateAudiobooks_EmptyBatch(t *testing.T) {
 	mockDB := &database.MockStore{}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	bs := NewBatchService(mockDB)
 
@@ -48,9 +48,9 @@ func TestBatchUpdateAudiobooks_SingleBook(t *testing.T) {
 			return book, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	bs := NewBatchService(mockDB)
 

--- a/internal/server/changelog_service_test.go
+++ b/internal/server/changelog_service_test.go
@@ -38,7 +38,7 @@ func TestChangelogService_WithPathHistory(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	book, err := store.CreateBook(&database.Book{
 		Title:    "Changelog Test",
 		FilePath: "/tmp/changelog-test.m4b",
@@ -67,7 +67,7 @@ func TestChangelogEndpoint_Returns200(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	book, err := store.CreateBook(&database.Book{
 		Title:    "Changelog Endpoint Test",
 		FilePath: "/tmp/changelog-endpoint-test.m4b",
@@ -90,7 +90,7 @@ func TestChangelogEndpoint_WithEntries(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	book, err := store.CreateBook(&database.Book{
 		Title:    "Changelog With Entries",
 		FilePath: "/tmp/changelog-entries.m4b",

--- a/internal/server/handlers_integration_test.go
+++ b/internal/server/handlers_integration_test.go
@@ -40,10 +40,10 @@ func setupHandlerTestServer(t *testing.T) *Server {
 	}
 
 	// Temporarily set the global store for this test
-	oldStore := database.GlobalStore
-	database.GlobalStore = mockDB
+	oldStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
 	t.Cleanup(func() {
-		database.GlobalStore = oldStore
+		database.SetGlobalStore(oldStore)
 	})
 
 	return NewServer(nil)
@@ -91,7 +91,7 @@ func TestCreateWork_Success(t *testing.T) {
 	c.Request = req
 
 	// Mock the CreateWork function
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.CreateWorkFunc = func(w *database.Work) (*database.Work, error) {
 			w.ID = "new-123"
 			return w, nil
@@ -133,7 +133,7 @@ func TestGetWork_Success(t *testing.T) {
 	c.Params = append(c.Params, gin.Param{Key: "id", Value: "1"})
 
 	// Mock the GetWorkByID function
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.GetWorkByIDFunc = func(id string) (*database.Work, error) {
 			return &database.Work{ID: id, Title: "Work 1"}, nil
 		}
@@ -157,7 +157,7 @@ func TestGetWork_NotFound(t *testing.T) {
 	c.Params = append(c.Params, gin.Param{Key: "id", Value: "nonexistent"})
 
 	// Mock the GetWorkByID function to return nil
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.GetWorkByIDFunc = func(id string) (*database.Work, error) {
 			return nil, nil
 		}
@@ -279,7 +279,7 @@ func TestDeleteWork_Success(t *testing.T) {
 	c.Params = append(c.Params, gin.Param{Key: "id", Value: "1"})
 
 	// Mock the DeleteWork function
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.DeleteWorkFunc = func(id string) error {
 			return nil
 		}

--- a/internal/server/itunes_import_integration_test.go
+++ b/internal/server/itunes_import_integration_test.go
@@ -116,7 +116,7 @@ func TestITunesImport_BuildAndSaveBooks(t *testing.T) {
 		book, err := buildBookFromAlbumGroup(group, testLibraryPath(t), opts)
 		require.NoError(t, err, "build book for group %s", group.key)
 
-		created, err := database.GlobalStore.CreateBook(book)
+		created, err := database.GetGlobalStore().CreateBook(book)
 		require.NoError(t, err, "save book %s", book.Title)
 		savedBooks = append(savedBooks, created)
 	}
@@ -125,7 +125,7 @@ func TestITunesImport_BuildAndSaveBooks(t *testing.T) {
 
 	// Verify books exist in DB with correct titles
 	for _, book := range savedBooks {
-		fetched, err := database.GlobalStore.GetBookByID(book.ID)
+		fetched, err := database.GetGlobalStore().GetBookByID(book.ID)
 		require.NoError(t, err)
 		require.NotNil(t, fetched)
 		assert.Equal(t, book.Title, fetched.Title)
@@ -165,7 +165,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 	assignAuthorAndSeries(database.GetGlobalStore(), book1, track1)
 
 	require.NotNil(t, book1.AuthorID, "AuthorID should be set")
-	author, err := database.GlobalStore.GetAuthorByName("Frank Herbert")
+	author, err := database.GetGlobalStore().GetAuthorByName("Frank Herbert")
 	require.NoError(t, err)
 	require.NotNil(t, author)
 	assert.Equal(t, *book1.AuthorID, author.ID)
@@ -173,7 +173,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 	// "Dune Chronicles" has no separator with exactly 2 parts, so extractSeriesName
 	// returns the whole album name
 	require.NotNil(t, book1.SeriesID, "SeriesID should be set")
-	series, err := database.GlobalStore.GetSeriesByName("Dune Chronicles", book1.AuthorID)
+	series, err := database.GetGlobalStore().GetSeriesByName("Dune Chronicles", book1.AuthorID)
 	require.NoError(t, err)
 	require.NotNil(t, series)
 	assert.Equal(t, *book1.SeriesID, series.ID)
@@ -199,7 +199,7 @@ func TestITunesImport_AuthorAndSeriesCreation(t *testing.T) {
 
 	require.NotNil(t, book3.SeriesID)
 	// extractSeriesName("Middle-earth, Book 1") should return "Middle-earth"
-	seriesMiddle, err := database.GlobalStore.GetSeriesByName("Middle-earth", book3.AuthorID)
+	seriesMiddle, err := database.GetGlobalStore().GetSeriesByName("Middle-earth", book3.AuthorID)
 	require.NoError(t, err)
 	require.NotNil(t, seriesMiddle)
 	assert.Equal(t, *book3.SeriesID, seriesMiddle.ID)
@@ -224,7 +224,7 @@ func TestITunesImport_AuthorDedup(t *testing.T) {
 	assert.Equal(t, *bookA.AuthorID, *bookB.AuthorID, "both books should share the same author ID")
 
 	// Verify only one author named "Isaac Asimov" exists
-	authors, err := database.GlobalStore.GetAllAuthors()
+	authors, err := database.GetGlobalStore().GetAllAuthors()
 	require.NoError(t, err)
 	count := 0
 	for _, a := range authors {
@@ -266,7 +266,7 @@ func TestITunesImport_SeriesExtraction(t *testing.T) {
 	assignAuthorAndSeries(database.GetGlobalStore(), book, track)
 
 	require.NotNil(t, book.SeriesID)
-	series, err := database.GlobalStore.GetSeriesByID(*book.SeriesID)
+	series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID)
 	require.NoError(t, err)
 	require.NotNil(t, series)
 	assert.Equal(t, "Middle-earth", series.Name)
@@ -323,7 +323,7 @@ func TestITunesImport_MultiTrackBookSegments(t *testing.T) {
 	book, err := buildBookFromAlbumGroup(*mobyGroup, testLibraryPath(t), opts)
 	require.NoError(t, err)
 
-	created, err := database.GlobalStore.CreateBook(book)
+	created, err := database.GetGlobalStore().CreateBook(book)
 	require.NoError(t, err)
 
 	// Create book_files as executeITunesImport does (replaces legacy book_segments)
@@ -342,11 +342,11 @@ func TestITunesImport_MultiTrackBookSegments(t *testing.T) {
 			TrackNumber: track.TrackNumber,
 			TrackCount:  len(mobyGroup.tracks),
 		}
-		require.NoError(t, database.GlobalStore.CreateBookFile(bf))
+		require.NoError(t, database.GetGlobalStore().CreateBookFile(bf))
 	}
 
 	// Verify book_files
-	files, err := database.GlobalStore.GetBookFiles(created.ID)
+	files, err := database.GetGlobalStore().GetBookFiles(created.ID)
 	require.NoError(t, err)
 	require.Len(t, files, 3)
 

--- a/internal/server/itunes_test.go
+++ b/internal/server/itunes_test.go
@@ -672,7 +672,7 @@ func TestITunesSyncForceFlag_NoChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to stat library file: %v", err)
 	}
-	err = database.GlobalStore.SaveLibraryFingerprint(libPath, info.Size(), info.ModTime(), 0)
+	err = database.GetGlobalStore().SaveLibraryFingerprint(libPath, info.Size(), info.ModTime(), 0)
 	if err != nil {
 		t.Fatalf("failed to save fingerprint: %v", err)
 	}
@@ -725,7 +725,7 @@ func TestITunesSyncForceFlag_Bypass(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to stat library file: %v", err)
 	}
-	err = database.GlobalStore.SaveLibraryFingerprint(libPath, info.Size(), info.ModTime(), 0)
+	err = database.GetGlobalStore().SaveLibraryFingerprint(libPath, info.Size(), info.ModTime(), 0)
 	if err != nil {
 		t.Fatalf("failed to save fingerprint: %v", err)
 	}

--- a/internal/server/library_enhancement_test.go
+++ b/internal/server/library_enhancement_test.go
@@ -25,7 +25,7 @@ func createTestBook(t *testing.T, title string) *database.Book {
 	t.Helper()
 	tempFile := filepath.Join(t.TempDir(), title+".m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    title,
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -39,7 +39,7 @@ func createTestBookWithFields(t *testing.T, title string, genre, language *strin
 	t.Helper()
 	tempFile := filepath.Join(t.TempDir(), title+".m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    title,
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -238,7 +238,7 @@ func TestTagBatchOperations(t *testing.T) {
 
 		// Verify each book has both tags
 		for _, bookID := range []string{book1.ID, book2.ID, book3.ID} {
-			tags, err := database.GlobalStore.GetBookTags(bookID)
+			tags, err := database.GetGlobalStore().GetBookTags(bookID)
 			require.NoError(t, err)
 			assert.Contains(t, tags, "scifi")
 			assert.Contains(t, tags, "new")
@@ -260,12 +260,12 @@ func TestTagBatchOperations(t *testing.T) {
 
 		// book1 and book2 should only have "scifi"
 		for _, bookID := range []string{book1.ID, book2.ID} {
-			tags, err := database.GlobalStore.GetBookTags(bookID)
+			tags, err := database.GetGlobalStore().GetBookTags(bookID)
 			require.NoError(t, err)
 			assert.Equal(t, []string{"scifi"}, tags)
 		}
 		// book3 should still have both
-		tags3, err := database.GlobalStore.GetBookTags(book3.ID)
+		tags3, err := database.GetGlobalStore().GetBookTags(book3.ID)
 		require.NoError(t, err)
 		assert.Contains(t, tags3, "scifi")
 		assert.Contains(t, tags3, "new")
@@ -370,8 +370,8 @@ func TestListBooksWithTagFilter(t *testing.T) {
 	_ = createTestBook(t, "TagFilterBook3") // no tag
 
 	// Tag books 1 and 2 with "scifi"
-	require.NoError(t, database.GlobalStore.AddBookTag(book1.ID, "scifi"))
-	require.NoError(t, database.GlobalStore.AddBookTag(book2.ID, "scifi"))
+	require.NoError(t, database.GetGlobalStore().AddBookTag(book1.ID, "scifi"))
+	require.NoError(t, database.GetGlobalStore().AddBookTag(book2.ID, "scifi"))
 
 	t.Run("filter by tag returns only tagged books", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks?tag=scifi", nil)
@@ -399,7 +399,7 @@ func TestListBooksWithTagFilter(t *testing.T) {
 		// Set library_state on book1
 		organized := "organized"
 		book1.LibraryState = &organized
-		_, err := database.GlobalStore.UpdateBook(book1.ID, book1)
+		_, err := database.GetGlobalStore().UpdateBook(book1.ID, book1)
 		require.NoError(t, err)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks?tag=scifi&library_state=organized", nil)
@@ -442,7 +442,7 @@ func TestServerSideSorting(t *testing.T) {
 	// Without a post-filter, GetAudiobooks returns cached results before applySorting runs,
 	// which means different sort orders within the same test would all see the first sort.
 	for _, id := range []string{bookA.ID, bookB.ID, bookC.ID, bookD.ID} {
-		require.NoError(t, database.GlobalStore.AddBookTag(id, "sorttest"))
+		require.NoError(t, database.GetGlobalStore().AddBookTag(id, "sorttest"))
 	}
 
 	// Base URL includes tag filter to ensure cache bypass and sorting actually runs each time
@@ -712,17 +712,17 @@ func TestUserPreferencesColumnConfig(t *testing.T) {
 	// This validates the persistence layer that the frontend column config feature relies on.
 
 	t.Run("get non-existent preference returns nil", func(t *testing.T) {
-		pref, err := database.GlobalStore.GetUserPreference("library_column_config")
+		pref, err := database.GetGlobalStore().GetUserPreference("library_column_config")
 		assert.NoError(t, err)
 		assert.Nil(t, pref)
 	})
 
 	t.Run("save and retrieve column config", func(t *testing.T) {
 		configJSON := `{"visibleColumns":["title","author"]}`
-		err := database.GlobalStore.SetUserPreference("library_column_config", configJSON)
+		err := database.GetGlobalStore().SetUserPreference("library_column_config", configJSON)
 		require.NoError(t, err)
 
-		pref, err := database.GlobalStore.GetUserPreference("library_column_config")
+		pref, err := database.GetGlobalStore().GetUserPreference("library_column_config")
 		require.NoError(t, err)
 		require.NotNil(t, pref)
 		require.NotNil(t, pref.Value)
@@ -731,10 +731,10 @@ func TestUserPreferencesColumnConfig(t *testing.T) {
 
 	t.Run("update existing preference", func(t *testing.T) {
 		updatedJSON := `{"visibleColumns":["title","author","narrator","genre"]}`
-		err := database.GlobalStore.SetUserPreference("library_column_config", updatedJSON)
+		err := database.GetGlobalStore().SetUserPreference("library_column_config", updatedJSON)
 		require.NoError(t, err)
 
-		pref, err := database.GlobalStore.GetUserPreference("library_column_config")
+		pref, err := database.GetGlobalStore().GetUserPreference("library_column_config")
 		require.NoError(t, err)
 		require.NotNil(t, pref)
 		require.NotNil(t, pref.Value)

--- a/internal/server/merge_service_test.go
+++ b/internal/server/merge_service_test.go
@@ -19,7 +19,7 @@ func TestMergeService_MergeBooks(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Create two test books
 	book1 := &database.Book{
@@ -70,7 +70,7 @@ func TestMergeService_MergeBooks_ExplicitPrimary(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	book1 := &database.Book{
 		ID:       ulid.Make().String(),
@@ -115,7 +115,7 @@ func TestMergeService_MergeBooks_SoftDeletesLosers(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	book1 := &database.Book{
 		ID:       ulid.Make().String(),
@@ -175,7 +175,7 @@ func TestMergeService_MergeBooks_PrefersCuratedOverPristine(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Pristine M4B with high bitrate — would normally win by format+bitrate
 	pristineM4B := &database.Book{
@@ -277,7 +277,7 @@ func TestMergeService_MergeBooks_PrefersOrganizedOverITunesGhost(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// iTunes ghost — better format on paper (M4B, higher bitrate)
 	ghost := &database.Book{
@@ -343,7 +343,7 @@ func TestMergeService_MergeBooks_NotFound(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	ms := NewMergeService(database.GlobalStore)
+	ms := NewMergeService(database.GetGlobalStore())
 	_, err := ms.MergeBooks([]string{"nonexistent1", "nonexistent2"}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -38,7 +38,7 @@ func (m *mockMetadataSource) SearchByTitleAndAuthor(title, author string) ([]met
 	return nil, nil
 }
 
-// setupGlobalStoreForTest sets database.GlobalStore to a MockStore that handles
+// setupGlobalStoreForTest sets database.GetGlobalStore() to a MockStore that handles
 // metadata state calls (needed by persistFetchedMetadata -> loadMetadataState).
 func setupGlobalStoreForTest(t *testing.T) {
 	t.Helper()

--- a/internal/server/metadata_history_test.go
+++ b/internal/server/metadata_history_test.go
@@ -122,7 +122,7 @@ func TestUndoMetadataChange_Handler(t *testing.T) {
 		Title:    "Test Book",
 		FilePath: "/tmp/test.m4b",
 	}
-	createdBook, err := database.GlobalStore.CreateBook(book)
+	createdBook, err := database.GetGlobalStore().CreateBook(book)
 	require.NoError(t, err)
 
 	// Record a change to undo
@@ -137,7 +137,7 @@ func TestUndoMetadataChange_Handler(t *testing.T) {
 		Source:        "manual",
 		ChangedAt:     time.Now(),
 	}
-	err = database.GlobalStore.RecordMetadataChange(record)
+	err = database.GetGlobalStore().RecordMetadataChange(record)
 	require.NoError(t, err)
 
 	// POST undo
@@ -163,7 +163,7 @@ func TestUndoMetadataChange_NoHistory(t *testing.T) {
 		Title:    "Test Book",
 		FilePath: "/tmp/test2.m4b",
 	}
-	createdBook, err := database.GlobalStore.CreateBook(book)
+	createdBook, err := database.GetGlobalStore().CreateBook(book)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -186,7 +186,7 @@ func TestGetBookMetadataHistory_Handler(t *testing.T) {
 		Title:    "History Book",
 		FilePath: "/tmp/history.m4b",
 	}
-	createdBook, err := database.GlobalStore.CreateBook(book)
+	createdBook, err := database.GetGlobalStore().CreateBook(book)
 	require.NoError(t, err)
 
 	// Record a couple of changes
@@ -200,7 +200,7 @@ func TestGetBookMetadataHistory_Handler(t *testing.T) {
 			ChangeType: "fetched",
 			ChangedAt:  now.Add(time.Duration(i) * time.Second),
 		}
-		err := database.GlobalStore.RecordMetadataChange(record)
+		err := database.GetGlobalStore().RecordMetadataChange(record)
 		require.NoError(t, err)
 	}
 
@@ -228,7 +228,7 @@ func TestGetFieldMetadataHistory_Handler(t *testing.T) {
 		Title:    "Field History Book",
 		FilePath: "/tmp/field-history.m4b",
 	}
-	createdBook, err := database.GlobalStore.CreateBook(book)
+	createdBook, err := database.GetGlobalStore().CreateBook(book)
 	require.NoError(t, err)
 
 	// Record changes to two different fields
@@ -242,7 +242,7 @@ func TestGetFieldMetadataHistory_Handler(t *testing.T) {
 			ChangeType: "override",
 			ChangedAt:  now.Add(time.Duration(i) * time.Second),
 		}
-		err := database.GlobalStore.RecordMetadataChange(record)
+		err := database.GetGlobalStore().RecordMetadataChange(record)
 		require.NoError(t, err)
 	}
 

--- a/internal/server/metadata_search_test.go
+++ b/internal/server/metadata_search_test.go
@@ -21,7 +21,7 @@ func TestSearchMetadata_ReturnsResults(t *testing.T) {
 	srv, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	bookID := ulid.Make().String()
 	book := &database.Book{
 		ID:       bookID,
@@ -64,7 +64,7 @@ func TestMarkNoMatch_SetsStatus(t *testing.T) {
 	srv, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	bookID := ulid.Make().String()
 	book := &database.Book{
 		ID:       bookID,
@@ -91,7 +91,7 @@ func TestApplyMetadata_AppliesCandidate(t *testing.T) {
 	srv, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	bookID := ulid.Make().String()
 	book := &database.Book{
 		ID:       bookID,
@@ -127,7 +127,7 @@ func TestApplyMetadata_FieldFiltering(t *testing.T) {
 	srv, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	bookID := ulid.Make().String()
 	book := &database.Book{
 		ID:       bookID,

--- a/internal/server/reset_handler_test.go
+++ b/internal/server/reset_handler_test.go
@@ -22,7 +22,7 @@ func TestResetSystem_Success(t *testing.T) {
 	server := setupHandlerTestServer(t)
 
 	// Mock the Reset function
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.ResetFunc = func() error {
 			return nil
 		}
@@ -77,7 +77,7 @@ func TestResetSystem_Error(t *testing.T) {
 	server := setupHandlerTestServer(t)
 
 	// Mock the Reset function to return an error
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.ResetFunc = func() error {
 			return errors.New("test error")
 		}
@@ -101,7 +101,7 @@ func TestResetSystem_MultipleResets(t *testing.T) {
 	server := setupHandlerTestServer(t)
 
 	// Mock the Reset function
-	if store, ok := database.GlobalStore.(*database.MockStore); ok {
+	if store, ok := database.GetGlobalStore().(*database.MockStore); ok {
 		store.ResetFunc = func() error {
 			return nil
 		}

--- a/internal/server/server_ai_integration_test.go
+++ b/internal/server/server_ai_integration_test.go
@@ -89,7 +89,7 @@ func TestAIEndpoints_WithStubbedOpenAI(t *testing.T) {
 	// 3) POST /audiobooks/:id/parse-with-ai should update a book.
 	filePath := filepath.Join(t.TempDir(), "The Hobbit - J.R.R. Tolkien.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{Title: "Old", FilePath: filePath, Format: "m4b"})
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Old", FilePath: filePath, Format: "m4b"})
 	require.NoError(t, err)
 
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/audiobooks/"+book.ID+"/parse-with-ai", bytes.NewBufferString(`{}`))
@@ -98,7 +98,7 @@ func TestAIEndpoints_WithStubbedOpenAI(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	updated, err := database.GlobalStore.GetBookByID(book.ID)
+	updated, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 	assert.Equal(t, "The Hobbit", updated.Title)

--- a/internal/server/server_bulk_delete_test.go
+++ b/internal/server/server_bulk_delete_test.go
@@ -40,7 +40,7 @@ func TestBulkDeleteAuthors_AllEmpty(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Create authors with no books
 	a1, err := store.CreateAuthor("Author One")
@@ -75,7 +75,7 @@ func TestBulkDeleteAuthors_SkipsAuthorsWithBooks(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Create two authors
 	authorWithBooks, err := store.CreateAuthor("Has Books")
@@ -164,7 +164,7 @@ func TestBulkDeleteAuthors_MixedResults(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Create three authors
 	a1, err := store.CreateAuthor("Empty Author 1")
@@ -261,7 +261,7 @@ func TestBulkDeleteSeries_AllEmpty(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	s1, err := store.CreateSeries("Series One", nil)
 	require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestBulkDeleteSeries_SkipsSeriesWithBooks(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	seriesWithBooks, err := store.CreateSeries("Has Books", nil)
 	require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestBulkDeleteSeries_MixedResults(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	s1, err := store.CreateSeries("Empty 1", nil)
 	require.NoError(t, err)

--- a/internal/server/server_bulk_fetch_metadata_test.go
+++ b/internal/server/server_bulk_fetch_metadata_test.go
@@ -56,19 +56,19 @@ func TestBulkFetchMetadata_MixedResults(t *testing.T) {
 	// Book that should update (has missing publisher/language/year/isbn/author).
 	tempFile := filepath.Join(t.TempDir(), "bulk1.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book1, err := database.GlobalStore.CreateBook(&database.Book{Title: "Book One", FilePath: tempFile, Format: "m4b"})
+	book1, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Book One", FilePath: tempFile, Format: "m4b"})
 	require.NoError(t, err)
 
 	// Book with missing title.
 	tempFile2 := filepath.Join(t.TempDir(), "bulk2.m4b")
 	require.NoError(t, os.WriteFile(tempFile2, []byte("audio"), 0o644))
-	book2, err := database.GlobalStore.CreateBook(&database.Book{Title: "", FilePath: tempFile2, Format: "m4b"})
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "", FilePath: tempFile2, Format: "m4b"})
 	require.NoError(t, err)
 
 	// Book whose title returns no results.
 	tempFile3 := filepath.Join(t.TempDir(), "bulk3.m4b")
 	require.NoError(t, os.WriteFile(tempFile3, []byte("audio"), 0o644))
-	book3, err := database.GlobalStore.CreateBook(&database.Book{Title: "NoResults", FilePath: tempFile3, Format: "m4b"})
+	book3, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "NoResults", FilePath: tempFile3, Format: "m4b"})
 	require.NoError(t, err)
 
 	payload := map[string]interface{}{
@@ -144,7 +144,7 @@ func TestBulkFetchMetadata_OnlyMissingFalse_AllowsOverwrite(t *testing.T) {
 	tempFile := filepath.Join(t.TempDir(), "bulk-overwrite.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 	existingPublisher := "Existing Pub"
-	book, err := database.GlobalStore.CreateBook(&database.Book{Title: "Book One", FilePath: tempFile, Format: "m4b", Publisher: &existingPublisher})
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Book One", FilePath: tempFile, Format: "m4b", Publisher: &existingPublisher})
 	require.NoError(t, err)
 
 	payload := map[string]interface{}{
@@ -160,7 +160,7 @@ func TestBulkFetchMetadata_OnlyMissingFalse_AllowsOverwrite(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	updated, err := database.GlobalStore.GetBookByID(book.ID)
+	updated, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, updated)
 	require.NotNil(t, updated.Publisher)

--- a/internal/server/server_coverage_phase2_test.go
+++ b/internal/server/server_coverage_phase2_test.go
@@ -45,9 +45,9 @@ func TestGetAudiobookTagsErrors(t *testing.T) {
 			mockStore := mocks.NewMockStore(t)
 			tt.mockSetup(mockStore)
 
-			oldStore := database.GlobalStore
-			database.GlobalStore = mockStore
-			defer func() { database.GlobalStore = oldStore }()
+			oldStore := database.GetGlobalStore()
+			database.SetGlobalStore(mockStore)
+			defer func() { database.SetGlobalStore(oldStore) }()
 
 			srv := NewServer(nil)
 
@@ -100,9 +100,9 @@ func TestAddBlockedHashErrors(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			mockStore := mocks.NewMockStore(t)
 
-			oldStore := database.GlobalStore
-			database.GlobalStore = mockStore
-			defer func() { database.GlobalStore = oldStore }()
+			oldStore := database.GetGlobalStore()
+			database.SetGlobalStore(mockStore)
+			defer func() { database.SetGlobalStore(oldStore) }()
 
 			srv := NewServer(nil)
 
@@ -131,9 +131,9 @@ func TestAddBlockedHashDatabaseError(t *testing.T) {
 		Return(errors.New("database error: constraint violation")).
 		Once()
 
-	oldStore := database.GlobalStore
-	database.GlobalStore = mockStore
-	defer func() { database.GlobalStore = oldStore }()
+	oldStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockStore)
+	defer func() { database.SetGlobalStore(oldStore) }()
 
 	srv := NewServer(nil)
 
@@ -179,9 +179,9 @@ func TestDeleteWorkErrors(t *testing.T) {
 			mockStore := mocks.NewMockStore(t)
 			tt.mockSetup(mockStore)
 
-			oldStore := database.GlobalStore
-			database.GlobalStore = mockStore
-			defer func() { database.GlobalStore = oldStore }()
+			oldStore := database.GetGlobalStore()
+			database.SetGlobalStore(mockStore)
+			defer func() { database.SetGlobalStore(oldStore) }()
 
 			srv := NewServer(nil)
 

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -29,7 +29,7 @@ func createTestBookFmt(t *testing.T, title, format string) *database.Book {
 	filePath := filepath.Join(tempDir, title+"."+format)
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    title,
 		FilePath: filePath,
 		Format:   format,
@@ -384,10 +384,10 @@ func TestCoverageListAuthors(t *testing.T) {
 		filePath := filepath.Join(tempDir, "authored.m4b")
 		require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-		author, err := database.GlobalStore.CreateAuthor("Test Author")
+		author, err := database.GetGlobalStore().CreateAuthor("Test Author")
 		require.NoError(t, err)
 
-		_, err = database.GlobalStore.CreateBook(&database.Book{
+		_, err = database.GetGlobalStore().CreateBook(&database.Book{
 			Title:    "Authored Book",
 			FilePath: filePath,
 			Format:   "m4b",
@@ -431,10 +431,10 @@ func TestCoverageListSeries(t *testing.T) {
 		filePath := filepath.Join(tempDir, "series.m4b")
 		require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-		series, err := database.GlobalStore.CreateSeries("Test Series", nil)
+		series, err := database.GetGlobalStore().CreateSeries("Test Series", nil)
 		require.NoError(t, err)
 
-		_, err = database.GlobalStore.CreateBook(&database.Book{
+		_, err = database.GetGlobalStore().CreateBook(&database.Book{
 			Title:    "Series Book",
 			FilePath: filePath,
 			Format:   "m4b",
@@ -1086,13 +1086,13 @@ func TestCoverageAuthorBooks(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	author, err := database.GlobalStore.CreateAuthor("Book Author")
+	author, err := database.GetGlobalStore().CreateAuthor("Book Author")
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "authorbook.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Author Book",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -1123,13 +1123,13 @@ func TestCoverageSeriesBooks(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	series, err := database.GlobalStore.CreateSeries("Book Series", nil)
+	series, err := database.GetGlobalStore().CreateSeries("Book Series", nil)
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "seriesbook.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Series Book",
 		FilePath: filePath,
 		Format:   "m4b",

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -79,14 +79,14 @@ func TestDuplicateAndSoftDeleteEndpoints(t *testing.T) {
 	require.NoError(t, os.WriteFile(file2, []byte("audio"), 0o644))
 
 	hash := "dup-hash"
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:             "Dup One",
 		FilePath:          file1,
 		FileHash:          &hash,
 		OrganizedFileHash: &hash,
 	})
 	require.NoError(t, err)
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:             "Dup Two",
 		FilePath:          file2,
 		FileHash:          &hash,
@@ -103,7 +103,7 @@ func TestDuplicateAndSoftDeleteEndpoints(t *testing.T) {
 	require.NoError(t, os.WriteFile(softFile, []byte("audio"), 0o644))
 	marked := true
 	deletedAt := time.Now().Add(-24 * time.Hour)
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:               "Soft Delete",
 		FilePath:            softFile,
 		MarkedForDeletion:   &marked,
@@ -126,7 +126,7 @@ func TestDuplicateAndSoftDeleteEndpoints(t *testing.T) {
 
 	restoreFile := filepath.Join(tempDir, "restore.m4b")
 	require.NoError(t, os.WriteFile(restoreFile, []byte("audio"), 0o644))
-	restoreBook, err := database.GlobalStore.CreateBook(&database.Book{
+	restoreBook, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:               "Restore",
 		FilePath:            restoreFile,
 		MarkedForDeletion:   &marked,
@@ -178,7 +178,7 @@ func TestWorkEndpoints(t *testing.T) {
 
 	bookPath := filepath.Join(t.TempDir(), "work.m4b")
 	require.NoError(t, os.WriteFile(bookPath, []byte("audio"), 0o644))
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Work Book",
 		FilePath: bookPath,
 		WorkID:   &created.ID,
@@ -315,9 +315,9 @@ func TestSystemLogsEndpoints(t *testing.T) {
 	defer cleanup()
 
 	folder := "/tmp"
-	op, err := database.GlobalStore.CreateOperation("log-op", "scan", &folder)
+	op, err := database.GetGlobalStore().CreateOperation("log-op", "scan", &folder)
 	require.NoError(t, err)
-	require.NoError(t, database.GlobalStore.AddOperationLog(op.ID, "info", "hello", nil))
+	require.NoError(t, database.GetGlobalStore().AddOperationLog(op.ID, "info", "hello", nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/system/logs?level=info", nil)
 	w := httptest.NewRecorder()
@@ -367,7 +367,7 @@ func TestAIEndpoints(t *testing.T) {
 
 	bookPath := filepath.Join(t.TempDir(), "ai.m4b")
 	require.NoError(t, os.WriteFile(bookPath, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "AI Book",
 		FilePath: bookPath,
 	})
@@ -389,9 +389,9 @@ func TestVersionEndpoints(t *testing.T) {
 	require.NoError(t, os.WriteFile(book1Path, []byte("audio"), 0o644))
 	require.NoError(t, os.WriteFile(book2Path, []byte("audio"), 0o644))
 
-	book1, err := database.GlobalStore.CreateBook(&database.Book{Title: "Version One", FilePath: book1Path})
+	book1, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Version One", FilePath: book1Path})
 	require.NoError(t, err)
-	book2, err := database.GlobalStore.CreateBook(&database.Book{Title: "Version Two", FilePath: book2Path})
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Version Two", FilePath: book2Path})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/audiobooks/"+book1.ID+"/versions", nil)
@@ -422,7 +422,7 @@ func TestVersionEndpoints(t *testing.T) {
 
 	book3Path := filepath.Join(t.TempDir(), "v3.m4b")
 	require.NoError(t, os.WriteFile(book3Path, []byte("audio"), 0o644))
-	book3, err := database.GlobalStore.CreateBook(&database.Book{Title: "Version Three", FilePath: book3Path})
+	book3, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Version Three", FilePath: book3Path})
 	require.NoError(t, err)
 
 	req = httptest.NewRequest(http.MethodPut, "/api/v1/audiobooks/"+book3.ID+"/set-primary", nil)
@@ -435,7 +435,7 @@ func TestBlockedHashEndpoints(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	require.NoError(t, database.RunMigrations(database.GlobalStore))
+	require.NoError(t, database.RunMigrations(database.GetGlobalStore()))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/blocked-hashes", nil)
 	w := httptest.NewRecorder()
@@ -531,7 +531,7 @@ func TestDetectDuplicatesByFileHash(t *testing.T) {
 	require.NoError(t, os.WriteFile(file2, []byte("content"), 0o644))
 
 	// Create books with the same file hash
-	book1, err := database.GlobalStore.CreateBook(&database.Book{
+	book1, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book One",
 		FilePath: file1,
 		FileHash: &sharedHash,
@@ -539,7 +539,7 @@ func TestDetectDuplicatesByFileHash(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	book2, err := database.GlobalStore.CreateBook(&database.Book{
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book Two",
 		FilePath: file2,
 		FileHash: &sharedHash,
@@ -548,7 +548,7 @@ func TestDetectDuplicatesByFileHash(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve duplicates
-	duplicates, err := database.GlobalStore.GetDuplicateBooks()
+	duplicates, err := database.GetGlobalStore().GetDuplicateBooks()
 	require.NoError(t, err)
 
 	// Verify our books are in the duplicates list
@@ -578,7 +578,7 @@ func TestMarkDuplicateForDeletion(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte("content"), 0o644))
 
 	// Create a book
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book to Delete",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -594,11 +594,11 @@ func TestMarkDuplicateForDeletion(t *testing.T) {
 		Format:            book.Format,
 		MarkedForDeletion: &trueVal,
 	}
-	_, err = database.GlobalStore.UpdateBook(book.ID, updated)
+	_, err = database.GetGlobalStore().UpdateBook(book.ID, updated)
 	require.NoError(t, err)
 
 	// Retrieve and verify
-	retrieved, err := database.GlobalStore.GetBookByID(book.ID)
+	retrieved, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, retrieved.MarkedForDeletion)
 	require.True(t, *retrieved.MarkedForDeletion)
@@ -623,7 +623,7 @@ func TestListDuplicateBooks(t *testing.T) {
 	hash3 := "hash_3"
 
 	// Create books: 2 with hash1, 1 with hash3
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book A",
 		FilePath: file1,
 		FileHash: &hash1,
@@ -631,7 +631,7 @@ func TestListDuplicateBooks(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book B",
 		FilePath: file2,
 		FileHash: &hash1,
@@ -639,7 +639,7 @@ func TestListDuplicateBooks(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book C",
 		FilePath: file3,
 		FileHash: &hash3,
@@ -648,7 +648,7 @@ func TestListDuplicateBooks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get duplicates
-	duplicates, err := database.GlobalStore.GetDuplicateBooks()
+	duplicates, err := database.GetGlobalStore().GetDuplicateBooks()
 	require.NoError(t, err)
 
 	// Should have at least one group with 2+ books
@@ -684,7 +684,7 @@ func TestSoftDeleteExcludeFromList(t *testing.T) {
 	require.NoError(t, os.WriteFile(file2, []byte("content"), 0o644))
 
 	// Create active book
-	active, err := database.GlobalStore.CreateBook(&database.Book{
+	active, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Active Book",
 		FilePath: file1,
 		Format:   "m4b",
@@ -692,7 +692,7 @@ func TestSoftDeleteExcludeFromList(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and mark deleted book
-	deleted, err := database.GlobalStore.CreateBook(&database.Book{
+	deleted, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Deleted Book",
 		FilePath: file2,
 		Format:   "m4b",
@@ -707,11 +707,11 @@ func TestSoftDeleteExcludeFromList(t *testing.T) {
 		Format:            deleted.Format,
 		MarkedForDeletion: &trueVal,
 	}
-	_, err = database.GlobalStore.UpdateBook(deleted.ID, deletedUpdate)
+	_, err = database.GetGlobalStore().UpdateBook(deleted.ID, deletedUpdate)
 	require.NoError(t, err)
 
 	// List all books
-	all, err := database.GlobalStore.GetAllBooks(100, 0)
+	all, err := database.GetGlobalStore().GetAllBooks(100, 0)
 	require.NoError(t, err)
 
 	// Count them

--- a/internal/server/server_handlers_test.go
+++ b/internal/server/server_handlers_test.go
@@ -28,7 +28,7 @@ func TestAudiobookCountEndpoint(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
 	// Create a test book
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Count Test Book",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -51,7 +51,7 @@ func TestMetadataFetchAndUpdate(t *testing.T) {
 	filePath := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Fetch Test Book",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -83,7 +83,7 @@ func TestSearchAudiobooks(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
 	// Create a test book
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Searchable Book",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -115,7 +115,7 @@ func TestListAudiobooksWithPagination(t *testing.T) {
 		filePath := filepath.Join(tempDir, "book"+string(rune(i))+".m4b")
 		os.WriteFile(filePath, []byte("audio"), 0o644)
 
-		database.GlobalStore.CreateBook(&database.Book{
+		database.GetGlobalStore().CreateBook(&database.Book{
 			Title:    "Book " + string(rune(48+i)),
 			FilePath: filePath,
 			Format:   "m4b",
@@ -216,7 +216,7 @@ func TestSoftDeleteOperations(t *testing.T) {
 	filePath := filepath.Join(tempDir, "delete_test.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Book to Delete",
 		FilePath: filePath,
 		Format:   "m4b",
@@ -250,14 +250,14 @@ func TestDuplicateDetectionEndpoint(t *testing.T) {
 	os.WriteFile(file1, []byte("same"), 0o644)
 	os.WriteFile(file2, []byte("same"), 0o644)
 
-	database.GlobalStore.CreateBook(&database.Book{
+	database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Dup 1",
 		FilePath: file1,
 		FileHash: &sharedHash,
 		Format:   "m4b",
 	})
 
-	database.GlobalStore.CreateBook(&database.Book{
+	database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Dup 2",
 		FilePath: file2,
 		FileHash: &sharedHash,

--- a/internal/server/server_import_file_mocks_test.go
+++ b/internal/server/server_import_file_mocks_test.go
@@ -42,8 +42,8 @@ func TestImportFile_WithMockMetadata_CreateAuthorAndBook(t *testing.T) {
 
 	// Mocks
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
-	t.Cleanup(func() { database.GlobalStore = nil })
+	database.SetGlobalStore(mockStore)
+	t.Cleanup(func() { database.SetGlobalStore(nil) })
 
 	mockMeta := metamocks.NewMockMetadataExtractor(t)
 	metadata.GlobalMetadataExtractor = mockMeta
@@ -90,8 +90,8 @@ func TestImportFile_WithOrganize_QueuesOperation(t *testing.T) {
 	require.NoError(t, os.WriteFile(testFile, []byte("audio"), 0o644))
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
-	t.Cleanup(func() { database.GlobalStore = nil })
+	database.SetGlobalStore(mockStore)
+	t.Cleanup(func() { database.SetGlobalStore(nil) })
 	mockMeta := metamocks.NewMockMetadataExtractor(t)
 	metadata.GlobalMetadataExtractor = mockMeta
 	t.Cleanup(func() { metadata.GlobalMetadataExtractor = nil })
@@ -133,8 +133,8 @@ func TestImportFile_MetadataExtractError_Returns500(t *testing.T) {
 	require.NoError(t, os.WriteFile(testFile, []byte("audio"), 0o644))
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
-	t.Cleanup(func() { database.GlobalStore = nil })
+	database.SetGlobalStore(mockStore)
+	t.Cleanup(func() { database.SetGlobalStore(nil) })
 	mockMeta := metamocks.NewMockMetadataExtractor(t)
 	metadata.GlobalMetadataExtractor = mockMeta
 	t.Cleanup(func() { metadata.GlobalMetadataExtractor = nil })
@@ -164,8 +164,8 @@ func TestImportFile_CreateBookError_Returns500(t *testing.T) {
 	require.NoError(t, os.WriteFile(testFile, []byte("audio"), 0o644))
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
-	t.Cleanup(func() { database.GlobalStore = nil })
+	database.SetGlobalStore(mockStore)
+	t.Cleanup(func() { database.SetGlobalStore(nil) })
 	mockMeta := metamocks.NewMockMetadataExtractor(t)
 	metadata.GlobalMetadataExtractor = mockMeta
 	t.Cleanup(func() { metadata.GlobalMetadataExtractor = nil })

--- a/internal/server/server_import_paths_and_blocklist_test.go
+++ b/internal/server/server_import_paths_and_blocklist_test.go
@@ -81,9 +81,9 @@ func TestImportPaths_ListNilAndRemoveInvalidID(t *testing.T) {
 	store.EXPECT().GetAllImportPaths().Return(([]database.ImportPath)(nil), nil)
 	store.EXPECT().DeleteImportPath(mock.Anything).Return(nil).Maybe()
 
-	origStore := database.GlobalStore
-	database.GlobalStore = store
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	// listImportPaths should return [] not null.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/import-paths", nil)
@@ -113,7 +113,7 @@ func TestAddImportPath_EnqueuesAndExecutesOperationFunc(t *testing.T) {
 	config.AppConfig.RootDir = ""
 
 	store := dbmocks.NewMockStore(t)
-	origStore := database.GlobalStore
+	origStore := database.GetGlobalStore()
 	server, cleanup := setupTestServerWithStore(t, store)
 	defer cleanup()
 	queue := qmock.NewMockQueue(t)
@@ -124,7 +124,7 @@ func TestAddImportPath_EnqueuesAndExecutesOperationFunc(t *testing.T) {
 	operations.GlobalQueue = queue
 	scanner.GlobalScanner = scannerMock
 	t.Cleanup(func() {
-		database.GlobalStore = origStore
+		database.SetGlobalStore(origStore)
 		operations.GlobalQueue = origQueue
 		scanner.GlobalScanner = origScanner
 	})
@@ -166,9 +166,9 @@ func TestBlockedHashes_CRUD(t *testing.T) {
 	defer cleanup()
 
 	store := dbmocks.NewMockStore(t)
-	origStore := database.GlobalStore
-	database.GlobalStore = store
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	// addBlockedHash invalid hash length
 	bad := bytes.NewBufferString(`{"hash":"abc","reason":"nope"}`)

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -59,7 +59,7 @@ func waitForOperationStatus(t *testing.T, id string, timeout time.Duration) *dat
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		op, err := database.GlobalStore.GetOperationByID(id)
+		op, err := database.GetGlobalStore().GetOperationByID(id)
 		if err == nil && op != nil {
 			switch op.Status {
 			case "completed", "failed", "canceled":
@@ -192,7 +192,7 @@ func TestSearchAndFetchMetadata(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Test Book",
 		FilePath: "/tmp/test-book.m4b",
 	})
@@ -328,12 +328,12 @@ func TestServerStartGracefulShutdown(t *testing.T) {
 	config.AppConfig.PurgeSoftDeletedAfterDays = 1
 	config.AppConfig.PurgeSoftDeletedDeleteFiles = false
 
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Heartbeat Book",
 		FilePath: "/tmp/heartbeat.m4b",
 	})
 	require.NoError(t, err)
-	_, err = database.GlobalStore.CreateImportPath(t.TempDir(), "Heartbeat Import")
+	_, err = database.GetGlobalStore().CreateImportPath(t.TempDir(), "Heartbeat Import")
 	require.NoError(t, err)
 
 	done := make(chan error, 1)
@@ -393,10 +393,10 @@ func TestGetOperationLogsEndpoint(t *testing.T) {
 	defer cleanup()
 
 	opID := "op-logs"
-	_, err := database.GlobalStore.CreateOperation(opID, "scan", nil)
+	_, err := database.GetGlobalStore().CreateOperation(opID, "scan", nil)
 	require.NoError(t, err)
 	detail := "details"
-	require.NoError(t, database.GlobalStore.AddOperationLog(opID, "info", "message", &detail))
+	require.NoError(t, database.GetGlobalStore().AddOperationLog(opID, "info", "message", &detail))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/operations/"+opID+"/logs?tail=1", nil)
 	w := httptest.NewRecorder()
@@ -416,13 +416,13 @@ func TestGetAudiobookAndDashboard(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := copyFixtureToDir(t, "test_sample.m4b", tempDir)
 
-	author, err := database.GlobalStore.CreateAuthor("Author Name")
+	author, err := database.GetGlobalStore().CreateAuthor("Author Name")
 	require.NoError(t, err)
-	series, err := database.GlobalStore.CreateSeries("Series Name", &author.ID)
+	series, err := database.GetGlobalStore().CreateSeries("Series Name", &author.ID)
 	require.NoError(t, err)
 
 	size := int64(50 * 1024 * 1024)
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Dashboard Book",
 		FilePath: filePath,
 		FileSize: &size,
@@ -437,7 +437,7 @@ func TestGetAudiobookAndDashboard(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	size2 := int64(600 * 1024 * 1024)
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Dashboard Book 2",
 		FilePath: filepath.Join(tempDir, "book2.mp3"),
 		FileSize: &size2,
@@ -454,7 +454,7 @@ func TestExportMetadataEndpoint(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Exported Book",
 		FilePath: "/tmp/export.m4b",
 	})
@@ -477,7 +477,7 @@ func TestParseAudiobookWithAIEndpoint(t *testing.T) {
 	config.AppConfig.EnableAIParsing = false
 	config.AppConfig.OpenAIAPIKey = ""
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "AI Book",
 		FilePath: "/tmp/ai.m4b",
 	})
@@ -495,7 +495,7 @@ func TestParseAudiobookAIPayloadSplitsAuthors(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Multi Author Book",
 		FilePath: "/tmp/multi.m4b",
 	})
@@ -518,32 +518,32 @@ func TestParseAudiobookAIPayloadSplitsAuthors(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Verify book_authors junction table has 2 entries
-	bookAuthors, err := database.GlobalStore.GetBookAuthors(book.ID)
+	bookAuthors, err := database.GetGlobalStore().GetBookAuthors(book.ID)
 	require.NoError(t, err)
 	require.Len(t, bookAuthors, 2, "expected 2 book_authors after splitting on &")
 
 	// Verify first author
-	author1, err := database.GlobalStore.GetAuthorByID(bookAuthors[0].AuthorID)
+	author1, err := database.GetGlobalStore().GetAuthorByID(bookAuthors[0].AuthorID)
 	require.NoError(t, err)
 	require.Equal(t, "Author A", author1.Name)
 	require.Equal(t, "author", bookAuthors[0].Role)
 
 	// Verify second author
-	author2, err := database.GlobalStore.GetAuthorByID(bookAuthors[1].AuthorID)
+	author2, err := database.GetGlobalStore().GetAuthorByID(bookAuthors[1].AuthorID)
 	require.NoError(t, err)
 	require.Equal(t, "Author B", author2.Name)
 	require.Equal(t, "co-author", bookAuthors[1].Role)
 
 	// Verify book_narrators junction table has 2 entries
-	bookNarrators, err := database.GlobalStore.GetBookNarrators(book.ID)
+	bookNarrators, err := database.GetGlobalStore().GetBookNarrators(book.ID)
 	require.NoError(t, err)
 	require.Len(t, bookNarrators, 2, "expected 2 book_narrators after splitting on &")
 
-	narr1, err := database.GlobalStore.GetNarratorByID(bookNarrators[0].NarratorID)
+	narr1, err := database.GetGlobalStore().GetNarratorByID(bookNarrators[0].NarratorID)
 	require.NoError(t, err)
 	require.Equal(t, "Narrator X", narr1.Name)
 
-	narr2, err := database.GlobalStore.GetNarratorByID(bookNarrators[1].NarratorID)
+	narr2, err := database.GetGlobalStore().GetNarratorByID(bookNarrators[1].NarratorID)
 	require.NoError(t, err)
 	require.Equal(t, "Narrator Y", narr2.Name)
 }
@@ -556,7 +556,7 @@ func TestUpdateDeleteBatchAudiobook(t *testing.T) {
 	filePath := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 	hash := "hash-1"
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Old Title",
 		FilePath: filePath,
 		FileHash: &hash,
@@ -604,7 +604,7 @@ func TestUpdateDeleteBatchAudiobook(t *testing.T) {
 	filePath2 := filepath.Join(tempDir, "book2.m4b")
 	require.NoError(t, os.WriteFile(filePath2, []byte("audio"), 0o644))
 	hash2 := "hash-2"
-	book2, err := database.GlobalStore.CreateBook(&database.Book{
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Hard Delete",
 		FilePath: filePath2,
 		FileHash: &hash2,
@@ -636,7 +636,7 @@ func TestStartScanOperation(t *testing.T) {
 	copyFixtureToDir(t, "test_sample.m4b", rootDir)
 	copyFixtureToDir(t, "test_sample.m4b", importDir)
 
-	_, err := database.GlobalStore.CreateImportPath(importDir, "Import")
+	_, err := database.GetGlobalStore().CreateImportPath(importDir, "Import")
 	require.NoError(t, err)
 
 	payload := map[string]any{
@@ -674,7 +674,7 @@ func TestStartOrganizeOperation(t *testing.T) {
 	config.AppConfig.ConcurrentScans = 1
 
 	filePath := copyFixtureToDir(t, "test_sample.m4b", sourceDir)
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Organize Me",
 		FilePath: filePath,
 	})
@@ -698,7 +698,7 @@ func TestListActiveOperations(t *testing.T) {
 
 	block := make(chan struct{})
 	opID := "op-block"
-	_, err := database.GlobalStore.CreateOperation(opID, "scan", nil)
+	_, err := database.GetGlobalStore().CreateOperation(opID, "scan", nil)
 	require.NoError(t, err)
 
 	err = operations.GlobalQueue.Enqueue(opID, "scan", operations.PriorityNormal, func(ctx context.Context, progress operations.ProgressReporter) error {
@@ -734,7 +734,7 @@ func TestRunAutoPurgeSoftDeleted(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 	marked := true
 	deletedAt := time.Now().AddDate(0, 0, -2)
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:               "Old Book",
 		FilePath:            filePath,
 		MarkedForDeletion:   &marked,
@@ -744,7 +744,7 @@ func TestRunAutoPurgeSoftDeleted(t *testing.T) {
 
 	server.runAutoPurgeSoftDeleted()
 
-	if got, err := database.GlobalStore.GetBookByID(book.ID); err == nil && got != nil {
+	if got, err := database.GetGlobalStore().GetBookByID(book.ID); err == nil && got != nil {
 		t.Fatal("expected book to be purged")
 	}
 	if _, err := os.Stat(filePath); !os.IsNotExist(err) {

--- a/internal/server/server_narrators_fieldstates_test.go
+++ b/internal/server/server_narrators_fieldstates_test.go
@@ -32,7 +32,7 @@ func TestListNarrators(t *testing.T) {
 	assert.Empty(t, narrators)
 
 	// Add a narrator and re-check
-	store := database.GlobalStore.(*database.SQLiteStore)
+	store := database.GetGlobalStore().(*database.SQLiteStore)
 	_, err = store.CreateNarrator("Morgan Freeman")
 	require.NoError(t, err)
 	_, err = store.CreateNarrator("Stephen Fry")
@@ -64,7 +64,7 @@ func TestCountNarrators(t *testing.T) {
 	assert.Equal(t, float64(0), resp["count"])
 
 	// Add narrators
-	store := database.GlobalStore.(*database.SQLiteStore)
+	store := database.GetGlobalStore().(*database.SQLiteStore)
 	_, err = store.CreateNarrator("Narrator A")
 	require.NoError(t, err)
 	_, err = store.CreateNarrator("Narrator B")
@@ -85,7 +85,7 @@ func TestListAudiobookNarrators(t *testing.T) {
 	defer cleanup()
 
 	// Create a book
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Test Book",
 		FilePath: "/tmp/test.m4b",
 	})
@@ -103,11 +103,11 @@ func TestListAudiobookNarrators(t *testing.T) {
 	assert.Empty(t, narrators)
 
 	// Create narrator and assign to book
-	store := database.GlobalStore.(*database.SQLiteStore)
+	store := database.GetGlobalStore().(*database.SQLiteStore)
 	narrator, err := store.CreateNarrator("Test Narrator")
 	require.NoError(t, err)
 
-	err = database.GlobalStore.SetBookNarrators(book.ID, []database.BookNarrator{
+	err = database.GetGlobalStore().SetBookNarrators(book.ID, []database.BookNarrator{
 		{BookID: book.ID, NarratorID: narrator.ID, Role: "narrator", Position: 0},
 	})
 	require.NoError(t, err)
@@ -128,13 +128,13 @@ func TestSetAudiobookNarrators(t *testing.T) {
 	defer cleanup()
 
 	// Create a book and narrator
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Narrator Set Test",
 		FilePath: "/tmp/narrator-set.m4b",
 	})
 	require.NoError(t, err)
 
-	store := database.GlobalStore.(*database.SQLiteStore)
+	store := database.GetGlobalStore().(*database.SQLiteStore)
 	narrator, err := store.CreateNarrator("PUT Narrator")
 	require.NoError(t, err)
 
@@ -157,7 +157,7 @@ func TestSetAudiobookNarrators(t *testing.T) {
 	assert.Equal(t, "ok", resp["status"])
 
 	// Verify by reading back
-	narrators, err := database.GlobalStore.GetBookNarrators(book.ID)
+	narrators, err := database.GetGlobalStore().GetBookNarrators(book.ID)
 	require.NoError(t, err)
 	assert.Len(t, narrators, 1)
 	assert.Equal(t, narrator.ID, narrators[0].NarratorID)
@@ -175,7 +175,7 @@ func TestGetAudiobookFieldStates(t *testing.T) {
 	defer cleanup()
 
 	// Create a book
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Field States Test",
 		FilePath: "/tmp/field-states.m4b",
 	})

--- a/internal/server/server_operations_test.go
+++ b/internal/server/server_operations_test.go
@@ -29,7 +29,7 @@ func TestStartScan_WithMocks_Success(t *testing.T) {
 
 	// Arrange globals
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
+	database.SetGlobalStore(mockStore)
 
 	mockQueue := queuemocks.NewMockQueue(t)
 	operations.GlobalQueue = mockQueue
@@ -68,7 +68,7 @@ func TestStartScan_QueueNil_Returns500(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
+	database.SetGlobalStore(mockStore)
 	operations.GlobalQueue = nil
 
 	srv := &Server{router: gin.New()}
@@ -87,7 +87,7 @@ func TestStartScan_EnqueueError_Returns500(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
+	database.SetGlobalStore(mockStore)
 	mockQueue := queuemocks.NewMockQueue(t)
 	operations.GlobalQueue = mockQueue
 
@@ -111,7 +111,7 @@ func TestStartOrganize_WithMocks_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
+	database.SetGlobalStore(mockStore)
 	mockQueue := queuemocks.NewMockQueue(t)
 	operations.GlobalQueue = mockQueue
 
@@ -138,7 +138,7 @@ func TestStartOrganize_EnqueueError_Returns500(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockStore := dbmocks.NewMockStore(t)
-	database.GlobalStore = mockStore
+	database.SetGlobalStore(mockStore)
 	mockQueue := queuemocks.NewMockQueue(t)
 	operations.GlobalQueue = mockQueue
 

--- a/internal/server/server_queue_test.go
+++ b/internal/server/server_queue_test.go
@@ -76,7 +76,7 @@ func TestCancelOperationWithQueueMock(t *testing.T) {
 			// Create mock store
 			mockStore := dbmocks.NewMockStore(t)
 			tt.mockStoreSetup(mockStore)
-			database.GlobalStore = mockStore
+			database.SetGlobalStore(mockStore)
 
 			// Create and setup mock queue (or leave nil for nil test)
 			if tt.mockQueueSetup != nil {
@@ -182,7 +182,7 @@ func TestGetOperationsWithQueueMock(t *testing.T) {
 			// Create mock store
 			mockStore := dbmocks.NewMockStore(t)
 			tt.mockStoreSetup(mockStore)
-			database.GlobalStore = mockStore
+			database.SetGlobalStore(mockStore)
 
 			// Create and setup mock queue (or leave nil)
 			if tt.mockQueueSetup != nil {

--- a/internal/server/server_segment_tags_test.go
+++ b/internal/server/server_segment_tags_test.go
@@ -37,7 +37,7 @@ func TestGetSegmentTags_SegmentNotFound(t *testing.T) {
 	defer cleanup()
 
 	// Create a book first
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Segment Tags Test Book",
 		FilePath: "/tmp/test-segment-tags.m4b",
 	})
@@ -60,7 +60,7 @@ func TestGetSegmentTags_Success(t *testing.T) {
 	defer cleanup()
 
 	// Create a book
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Multi-File Book",
 		FilePath: "/tmp/multi-file-book/part1.m4b",
 	})
@@ -68,7 +68,7 @@ func TestGetSegmentTags_Success(t *testing.T) {
 
 	// Create a book file
 	fileID := ulid.Make().String()
-	err = database.GlobalStore.CreateBookFile(&database.BookFile{
+	err = database.GetGlobalStore().CreateBookFile(&database.BookFile{
 		ID:          fileID,
 		BookID:      book.ID,
 		FilePath:    "/tmp/multi-file-book/part1.m4b",

--- a/internal/server/server_soft_delete_purge_test.go
+++ b/internal/server/server_soft_delete_purge_test.go
@@ -25,7 +25,7 @@ func TestSoftDeleteAndPurge_WithFileDeletion(t *testing.T) {
 
 	filePath := filepath.Join(t.TempDir(), "purge.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{Title: "Purge Me", FilePath: filePath, Format: "m4b"})
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Purge Me", FilePath: filePath, Format: "m4b"})
 	require.NoError(t, err)
 
 	// Soft-delete via API.
@@ -56,7 +56,7 @@ func TestRunAutoPurgeSoftDeleted_DeletesOldEntries(t *testing.T) {
 
 	filePath := filepath.Join(t.TempDir(), "auto-purge.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{Title: "Auto Purge", FilePath: filePath, Format: "m4b"})
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Auto Purge", FilePath: filePath, Format: "m4b"})
 	require.NoError(t, err)
 
 	// Mark as soft-deleted older than cutoff.
@@ -65,13 +65,13 @@ func TestRunAutoPurgeSoftDeleted_DeletesOldEntries(t *testing.T) {
 	book.MarkedForDeletion = &marked
 	book.MarkedForDeletionAt = &deletedAt
 	book.LibraryState = stringPtr("deleted")
-	_, err = database.GlobalStore.UpdateBook(book.ID, book)
+	_, err = database.GetGlobalStore().UpdateBook(book.ID, book)
 	require.NoError(t, err)
 
 	server.runAutoPurgeSoftDeleted()
 
 	// Book removed.
-	fetched, err := database.GlobalStore.GetBookByID(book.ID)
+	fetched, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)
 	assert.Nil(t, fetched)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -235,7 +235,7 @@ func TestGetAudiobookTagsReportsEffectiveSourceSimple(t *testing.T) {
 	tempFile := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Stored Title",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -290,7 +290,7 @@ func TestGetAudiobookTagsRejectsInvalidSnapshotTimestamp(t *testing.T) {
 	tempFile := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Snapshot Test",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -313,7 +313,7 @@ func TestUpdateAudiobookOverridesPersist(t *testing.T) {
 	tempFile := filepath.Join(t.TempDir(), "book-override.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Original Title",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -333,7 +333,7 @@ func TestUpdateAudiobookOverridesPersist(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &updated))
 	assert.Equal(t, "New Title", updated.Title)
 
-	states, err := database.GlobalStore.GetMetadataFieldStates(created.ID)
+	states, err := database.GetGlobalStore().GetMetadataFieldStates(created.ID)
 	require.NoError(t, err)
 
 	stateByField := map[string]database.MetadataFieldState{}
@@ -657,7 +657,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	require.NoError(t, os.WriteFile(otherFile, []byte("audio"), 0o644))
 
 	// Arrange: book with a locked publisher override and missing language/author.
-	created, err := database.GlobalStore.CreateBook(&database.Book{
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "The Hobbit",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -673,7 +673,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	other, err := database.GlobalStore.CreateBook(&database.Book{
+	other, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Unknown Title",
 		FilePath: otherFile,
 		Format:   "m4b",
@@ -756,7 +756,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 
 	assert.Equal(t, "not_found", missingResult.Status)
 
-	updatedBook, err := database.GlobalStore.GetBookByID(created.ID)
+	updatedBook, err := database.GetGlobalStore().GetBookByID(created.ID)
 	require.NoError(t, err)
 	require.NotNil(t, updatedBook)
 	assert.Nil(t, updatedBook.Publisher)
@@ -1270,16 +1270,16 @@ func TestGetAudiobookTagsReportsEffectiveSource(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	author, err := database.GlobalStore.CreateAuthor("Test Author")
+	author, err := database.GetGlobalStore().CreateAuthor("Test Author")
 	require.NoError(t, err)
-	series, err := database.GlobalStore.CreateSeries("Test Series", &author.ID)
+	series, err := database.GetGlobalStore().CreateSeries("Test Series", &author.ID)
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("dummy audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Stored Title",
 		AuthorID: &author.ID,
 		SeriesID: &series.ID,
@@ -1342,7 +1342,7 @@ func TestUpdateAudiobookPersistsOverrides(t *testing.T) {
 	filePath := filepath.Join(tempDir, "book.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("dummy audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Original Title",
 		FilePath: filePath,
 	})
@@ -1488,7 +1488,7 @@ func TestSoftDeleteAudiobook(t *testing.T) {
 	filePath := filepath.Join(tempDir, "softdelete.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "To Soft Delete",
 		FilePath: filePath,
 	})
@@ -1536,7 +1536,7 @@ func TestListAudiobookVersions(t *testing.T) {
 	filePath := filepath.Join(tempDir, "version.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Version Test",
 		FilePath: filePath,
 	})
@@ -1619,7 +1619,7 @@ func TestRestoreAudiobook(t *testing.T) {
 	filePath := filepath.Join(tempDir, "restore.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "To Restore",
 		FilePath: filePath,
 	})
@@ -1664,9 +1664,9 @@ func TestLinkAudiobookVersion(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath1, []byte("v1"), 0o644))
 	require.NoError(t, os.WriteFile(filePath2, []byte("v2"), 0o644))
 
-	book1, err := database.GlobalStore.CreateBook(&database.Book{Title: "Book V1", FilePath: filePath1})
+	book1, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Book V1", FilePath: filePath1})
 	require.NoError(t, err)
-	book2, err := database.GlobalStore.CreateBook(&database.Book{Title: "Book V2", FilePath: filePath2})
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Book V2", FilePath: filePath2})
 	require.NoError(t, err)
 
 	payload := map[string]any{
@@ -1690,7 +1690,7 @@ func TestRemoveImportPath(t *testing.T) {
 	defer cleanup()
 
 	// Create an import path directly via DB
-	importPath, err := database.GlobalStore.CreateImportPath("/to/remove", "Remove Me")
+	importPath, err := database.GetGlobalStore().CreateImportPath("/to/remove", "Remove Me")
 	require.NoError(t, err)
 
 	// Delete via API - note route uses :id suffix on import-paths
@@ -1775,13 +1775,13 @@ func TestListAudiobooksWithFilters(t *testing.T) {
 	defer cleanup()
 
 	// Create an author and audiobook
-	author, err := database.GlobalStore.CreateAuthor("Filter Author")
+	author, err := database.GetGlobalStore().CreateAuthor("Filter Author")
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "filter.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Filter Book",
 		AuthorID: &author.ID,
 		FilePath: filePath,
@@ -1884,7 +1884,7 @@ func TestListBlockedHashes(t *testing.T) {
 	defer cleanup()
 
 	// Add a blocked hash
-	err := database.GlobalStore.AddBlockedHash("abc123", "test reason")
+	err := database.GetGlobalStore().AddBlockedHash("abc123", "test reason")
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/blocked-hashes", nil)
@@ -1931,7 +1931,7 @@ func TestRemoveBlockedHash(t *testing.T) {
 			name: "successfully remove blocked hash",
 			hash: "def456",
 			setup: func() {
-				err := database.GlobalStore.AddBlockedHash("def456", "test reason")
+				err := database.GetGlobalStore().AddBlockedHash("def456", "test reason")
 				require.NoError(t, err)
 			},
 			expectedStatus: http.StatusOK,
@@ -1989,7 +1989,7 @@ func TestExportMetadataHandler(t *testing.T) {
 	filePath := filepath.Join(tempDir, "test.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	_, err := database.GlobalStore.CreateBook(&database.Book{
+	_, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Export Test Book",
 		FilePath: filePath,
 	})
@@ -2052,14 +2052,14 @@ func TestGetDashboardWithData(t *testing.T) {
 	defer cleanup()
 
 	// Create some test data
-	author, err := database.GlobalStore.CreateAuthor("Test Author")
+	author, err := database.GetGlobalStore().CreateAuthor("Test Author")
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "test.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio data for testing"), 0o644))
 
-	_, err = database.GlobalStore.CreateBook(&database.Book{
+	_, err = database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Dashboard Test Book",
 		AuthorID: &author.ID,
 		FilePath: filePath,
@@ -2098,7 +2098,7 @@ func TestBatchUpdateAudiobooksWithData(t *testing.T) {
 	filePath := filepath.Join(tempDir, "batch.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Batch Test",
 		FilePath: filePath,
 	})
@@ -2152,7 +2152,7 @@ func TestDeleteAudiobookWithSoftDelete(t *testing.T) {
 	filePath := filepath.Join(tempDir, "softdel.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "To Be Soft Deleted",
 		FilePath: filePath,
 	})
@@ -2179,14 +2179,14 @@ func TestUpdateAudiobookWithMetadata(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	author, err := database.GlobalStore.CreateAuthor("Original Author")
+	author, err := database.GetGlobalStore().CreateAuthor("Original Author")
 	require.NoError(t, err)
 
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "meta.m4b")
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Original Title",
 		AuthorID: &author.ID,
 		FilePath: filePath,
@@ -2216,7 +2216,7 @@ func TestUpdateAudiobookWithMetadata(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Verify the metadata was updated
-	updated, err := database.GlobalStore.GetBookByID(book.ID)
+	updated, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "Updated Title", updated.Title)
 	require.NotNil(t, updated.Publisher)
@@ -2237,7 +2237,7 @@ func TestListAudiobooksWithSearchAndPagination(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		filePath := filepath.Join(tempDir, fmt.Sprintf("book%d.m4b", i))
 		require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-		_, err := database.GlobalStore.CreateBook(&database.Book{
+		_, err := database.GetGlobalStore().CreateBook(&database.Book{
 			Title:    fmt.Sprintf("Test Book %d", i),
 			FilePath: filePath,
 		})
@@ -2298,7 +2298,7 @@ func TestHandleITunesImportStatus(t *testing.T) {
 			setup: func() string {
 				libPath := "/fake/library.xml"
 				opID := ulid.Make().String()
-				op, err := database.GlobalStore.CreateOperation(opID, "itunes_import", &libPath)
+				op, err := database.GetGlobalStore().CreateOperation(opID, "itunes_import", &libPath)
 				require.NoError(t, err)
 				return op.ID
 			},
@@ -2363,7 +2363,7 @@ func TestListAudiobookVersions_ErrorCases(t *testing.T) {
 				tempDir := t.TempDir()
 				filePath := filepath.Join(tempDir, "single.m4b")
 				require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
-				book, err := database.GlobalStore.CreateBook(&database.Book{
+				book, err := database.GetGlobalStore().CreateBook(&database.Book{
 					Title:    "Single Version Book",
 					FilePath: filePath,
 				})
@@ -2390,13 +2390,13 @@ func TestListAudiobookVersions_ErrorCases(t *testing.T) {
 				require.NoError(t, os.WriteFile(filePath2, []byte("v2"), 0o644))
 
 				groupID := "vg-" + ulid.Make().String()
-				book1, err := database.GlobalStore.CreateBook(&database.Book{
+				book1, err := database.GetGlobalStore().CreateBook(&database.Book{
 					Title:          "Version 1",
 					FilePath:       filePath1,
 					VersionGroupID: &groupID,
 				})
 				require.NoError(t, err)
-				_, err = database.GlobalStore.CreateBook(&database.Book{
+				_, err = database.GetGlobalStore().CreateBook(&database.Book{
 					Title:          "Version 2",
 					FilePath:       filePath2,
 					VersionGroupID: &groupID,

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -30,7 +30,7 @@ func TestUndoLastApply_NoHistory(t *testing.T) {
 	// Create a book with no change history
 	tempFile := filepath.Join(t.TempDir(), "undo-no-history.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "No History Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -55,7 +55,7 @@ func TestUndoLastApply_OnlyUndoRecords(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-only-undos.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Only Undos Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -65,7 +65,7 @@ func TestUndoLastApply_OnlyUndoRecords(t *testing.T) {
 	// Insert only undo-type records
 	oldVal := `"Old Title"`
 	newVal := `"New Title"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "title",
 		PreviousValue: &oldVal,
@@ -93,7 +93,7 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-batch.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Batch Undo Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -107,7 +107,7 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 	oldAuthor := `"Original Author"`
 	newAuthor := `"Updated Author"`
 
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "title",
 		PreviousValue: &oldTitle,
@@ -116,7 +116,7 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 		Source:        "Open Library",
 		ChangedAt:     batchTime,
 	}))
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "author",
 		PreviousValue: &oldAuthor,
@@ -146,7 +146,7 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 	assert.Len(t, undoneFields, 2)
 
 	// Verify undo records were written to history
-	history, err := database.GlobalStore.GetBookChangeHistory(book.ID, 50)
+	history, err := database.GetGlobalStore().GetBookChangeHistory(book.ID, 50)
 	require.NoError(t, err)
 
 	undoCount := 0
@@ -166,7 +166,7 @@ func TestUndoLastApply_SkipsOldChanges(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-skip-old.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Skip Old Changes Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -177,7 +177,7 @@ func TestUndoLastApply_SkipsOldChanges(t *testing.T) {
 	oldTime := time.Now().Add(-10 * time.Second)
 	oldPublisher := `"Old Publisher"`
 	newPublisher := `"New Publisher"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "publisher",
 		PreviousValue: &oldPublisher,
@@ -191,7 +191,7 @@ func TestUndoLastApply_SkipsOldChanges(t *testing.T) {
 	recentTime := time.Now()
 	oldTitle := `"Title A"`
 	newTitle := `"Title B"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "title",
 		PreviousValue: &oldTitle,
@@ -229,7 +229,7 @@ func TestUndoLastApply_SkipsUndoRecordsInBatchDetection(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-skip-undo-type.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Skip Undo Type Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -241,7 +241,7 @@ func TestUndoLastApply_SkipsUndoRecordsInBatchDetection(t *testing.T) {
 	// Record a real change first
 	oldTitle := `"Before"`
 	newTitle := `"After"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "title",
 		PreviousValue: &oldTitle,
@@ -252,7 +252,7 @@ func TestUndoLastApply_SkipsUndoRecordsInBatchDetection(t *testing.T) {
 	}))
 
 	// Record a more recent undo record (should be skipped when finding batch time)
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "author",
 		PreviousValue: &newTitle,
@@ -285,7 +285,7 @@ func TestUndoLastApply_NilPreviousValueClearsOverride(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-nil-prev.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Nil Previous Value Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -294,7 +294,7 @@ func TestUndoLastApply_NilPreviousValueClearsOverride(t *testing.T) {
 
 	// Record a change where previous value is nil (field was empty before)
 	newISBN := `"1234567890"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "isbn",
 		PreviousValue: nil,
@@ -326,7 +326,7 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "undo-writeback.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "WriteBack Undo Book",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -336,7 +336,7 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	// Record a change to undo
 	oldVal := `"Old"`
 	newVal := `"New"`
-	require.NoError(t, database.GlobalStore.RecordMetadataChange(&database.MetadataChangeRecord{
+	require.NoError(t, database.GetGlobalStore().RecordMetadataChange(&database.MetadataChangeRecord{
 		BookID:        book.ID,
 		Field:         "title",
 		PreviousValue: &oldVal,
@@ -386,7 +386,7 @@ func TestApplyAudiobookMetadata_WriteBackTrue(t *testing.T) {
 	// Create a book to apply metadata to
 	tempFile := filepath.Join(t.TempDir(), "apply-wb-true.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Apply WriteBack True",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -449,7 +449,7 @@ func TestApplyAudiobookMetadata_WriteBackOmitted(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "apply-wb-omit.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Apply WriteBack Omit",
 		FilePath: tempFile,
 		Format:   "m4b",
@@ -511,7 +511,7 @@ func TestApplyAudiobookMetadata_WriteBackFalse(t *testing.T) {
 	// Create a book
 	tempFile := filepath.Join(t.TempDir(), "apply-wb-false.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
-	book, err := database.GlobalStore.CreateBook(&database.Book{
+	book, err := database.GetGlobalStore().CreateBook(&database.Book{
 		Title:    "Apply WriteBack False",
 		FilePath: tempFile,
 		Format:   "m4b",

--- a/internal/server/server_update_audiobook_more_test.go
+++ b/internal/server/server_update_audiobook_more_test.go
@@ -27,7 +27,7 @@ func TestUpdateAudiobook_EmptyBody_Returns400(t *testing.T) {
 	tempFile := filepath.Join(t.TempDir(), "book-empty-body.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{Title: "T", FilePath: tempFile, Format: "m4b"})
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "T", FilePath: tempFile, Format: "m4b"})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/audiobooks/%s", created.ID), nil)
@@ -45,7 +45,7 @@ func TestUpdateAudiobook_InvalidJSON_Returns400(t *testing.T) {
 	tempFile := filepath.Join(t.TempDir(), "book-bad-json.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{Title: "T", FilePath: tempFile, Format: "m4b"})
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "T", FilePath: tempFile, Format: "m4b"})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/audiobooks/%s", created.ID), bytes.NewBufferString("{"))
@@ -63,7 +63,7 @@ func TestUpdateAudiobook_CreatesAuthorSeries_AndUpdatesOverrideState(t *testing.
 	tempFile := filepath.Join(t.TempDir(), "book-update.m4b")
 	require.NoError(t, os.WriteFile(tempFile, []byte("audio"), 0o644))
 
-	created, err := database.GlobalStore.CreateBook(&database.Book{Title: "Original", FilePath: tempFile, Format: "m4b"})
+	created, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Original", FilePath: tempFile, Format: "m4b"})
 	require.NoError(t, err)
 
 	payload := map[string]interface{}{
@@ -100,7 +100,7 @@ func TestUpdateAudiobook_CreatesAuthorSeries_AndUpdatesOverrideState(t *testing.
 	require.NotNil(t, updated.SeriesID)
 	assert.Equal(t, "Override Title", updated.Title)
 
-	states, err := database.GlobalStore.GetMetadataFieldStates(created.ID)
+	states, err := database.GetGlobalStore().GetMetadataFieldStates(created.ID)
 	require.NoError(t, err)
 	stateByField := map[string]database.MetadataFieldState{}
 	for _, st := range states {

--- a/internal/server/server_versions_and_work_test.go
+++ b/internal/server/server_versions_and_work_test.go
@@ -22,9 +22,9 @@ func TestVersionEndpoints_HappyPaths(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	book1, err := database.GlobalStore.CreateBook(&database.Book{Title: "One", FilePath: "/tmp/one.m4b", Format: "m4b"})
+	book1, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "One", FilePath: "/tmp/one.m4b", Format: "m4b"})
 	require.NoError(t, err)
-	book2, err := database.GlobalStore.CreateBook(&database.Book{Title: "Two", FilePath: "/tmp/two.m4b", Format: "m4b"})
+	book2, err := database.GetGlobalStore().CreateBook(&database.Book{Title: "Two", FilePath: "/tmp/two.m4b", Format: "m4b"})
 	require.NoError(t, err)
 
 	// list versions when no group
@@ -58,9 +58,9 @@ func TestVersionEndpoints_HappyPaths(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	updated1, err := database.GlobalStore.GetBookByID(book1.ID)
+	updated1, err := database.GetGlobalStore().GetBookByID(book1.ID)
 	require.NoError(t, err)
-	updated2, err := database.GlobalStore.GetBookByID(book2.ID)
+	updated2, err := database.GetGlobalStore().GetBookByID(book2.ID)
 	require.NoError(t, err)
 	require.NotNil(t, updated1.VersionGroupID)
 	require.NotNil(t, updated2.VersionGroupID)
@@ -75,9 +75,9 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	defer cleanup()
 
 	store := dbmocks.NewMockStore(t)
-	origStore := database.GlobalStore
-	database.GlobalStore = store
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	author1 := 1
 	author2 := 2
@@ -92,7 +92,7 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	store2 := dbmocks.NewMockStore(t)
-	database.GlobalStore = store2
+	database.SetGlobalStore(store2)
 	store2.EXPECT().GetAllWorks().Return(works, nil)
 	store2.EXPECT().GetBooksByWorkID("w1").Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
 	store2.EXPECT().GetBooksByWorkID("w2").Return(nil, assert.AnError)

--- a/internal/server/settings_persistence_test.go
+++ b/internal/server/settings_persistence_test.go
@@ -26,7 +26,7 @@ func TestAPIKeyPersistenceRoundtrip(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 
 	// Step 1: Initialize encryption (required for secret storage)
 	tempDir := config.AppConfig.RootDir
@@ -155,7 +155,7 @@ func TestAPIKeyConfigFileFallback(t *testing.T) {
 	defer cleanup()
 	_ = server
 
-	store := database.GlobalStore
+	store := database.GetGlobalStore()
 	err := database.InitEncryption(config.AppConfig.RootDir)
 	require.NoError(t, err)
 

--- a/internal/server/work_service_test.go
+++ b/internal/server/work_service_test.go
@@ -16,9 +16,9 @@ func TestWorkService_ListWorks_Empty(t *testing.T) {
 			return nil, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	ws := NewWorkService(mockDB)
 
@@ -41,9 +41,9 @@ func TestWorkService_CreateWork_Success(t *testing.T) {
 			return w, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	ws := NewWorkService(mockDB)
 
@@ -60,9 +60,9 @@ func TestWorkService_CreateWork_Success(t *testing.T) {
 
 func TestWorkService_CreateWork_MissingTitle(t *testing.T) {
 	mockDB := &database.MockStore{}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	ws := NewWorkService(mockDB)
 
@@ -80,9 +80,9 @@ func TestWorkService_GetWork_NotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	origStore := database.GlobalStore
-	database.GlobalStore = mockDB
-	t.Cleanup(func() { database.GlobalStore = origStore })
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(mockDB)
+	t.Cleanup(func() { database.SetGlobalStore(origStore) })
 
 	ws := NewWorkService(mockDB)
 

--- a/internal/transcode/transcode_integration_test.go
+++ b/internal/transcode/transcode_integration_test.go
@@ -333,13 +333,13 @@ func TestTranscodeIntegration_ServerFlow(t *testing.T) {
 
 	// Build the operation function (mirrors server.go lines 5467-5551)
 	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		outputPath, err := transcode.Transcode(ctx, opts, database.GlobalStore, progress)
+		outputPath, err := transcode.Transcode(ctx, opts, database.GetGlobalStore(), progress)
 		if err != nil {
 			return err
 		}
 
 		// Get the original book to preserve its data
-		originalBook, err := database.GlobalStore.GetBookByID(bookID)
+		originalBook, err := database.GetGlobalStore().GetBookByID(bookID)
 		if err != nil {
 			return fmt.Errorf("failed to get original book: %w", err)
 		}
@@ -358,7 +358,7 @@ func TestTranscodeIntegration_ServerFlow(t *testing.T) {
 		originalBook.IsPrimaryVersion = &notPrimary
 		originalBook.VersionGroupID = &groupID
 		originalBook.VersionNotes = &origNotes
-		if _, err := database.GlobalStore.UpdateBook(bookID, originalBook); err != nil {
+		if _, err := database.GetGlobalStore().UpdateBook(bookID, originalBook); err != nil {
 			progress.Log("warn", fmt.Sprintf("Failed to update original book version info: %v", err), nil)
 		}
 
@@ -389,7 +389,7 @@ func TestTranscodeIntegration_ServerFlow(t *testing.T) {
 			VersionGroupID:   &groupID,
 			VersionNotes:     &m4bNotes,
 		}
-		if _, err := database.GlobalStore.CreateBook(newBook); err != nil {
+		if _, err := database.GetGlobalStore().CreateBook(newBook); err != nil {
 			return fmt.Errorf("failed to create M4B book record: %w", err)
 		}
 


### PR DESCRIPTION
Completes the 4.4 DI migration. `database.GlobalStore` is now unexported; all access must go through GetGlobalStore/SetGlobalStore helpers. 316 test refs migrated.