### PR TITLE
feat(auth): permission constants + context helpers (3.7 task 2)

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,86 @@
+// file: internal/auth/auth_test.go
+// version: 1.0.0
+// guid: 4e8c1a2d-5b9f-4a70-b6d3-8c2e1f0a9b57
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestIsKnown(t *testing.T) {
+	if !IsKnown(PermLibraryView) {
+		t.Errorf("PermLibraryView should be known")
+	}
+	if IsKnown("not.a.permission") {
+		t.Errorf("unknown permission reported as known")
+	}
+}
+
+func TestAll_HasNoDuplicates(t *testing.T) {
+	seen := make(map[Permission]struct{})
+	for _, p := range All() {
+		if _, ok := seen[p]; ok {
+			t.Errorf("duplicate permission in All(): %q", p)
+		}
+		seen[p] = struct{}{}
+		if !IsKnown(p) {
+			t.Errorf("All() returned %q which IsKnown says is unknown — keep the two lists in sync", p)
+		}
+	}
+}
+
+func TestWithUser_Roundtrip(t *testing.T) {
+	u := &database.User{ID: "01HX", Username: "alice"}
+	ctx := WithUser(context.Background(), u)
+	got, ok := UserFromContext(ctx)
+	if !ok {
+		t.Fatal("UserFromContext !ok")
+	}
+	if got.ID != "01HX" {
+		t.Errorf("ID = %q, want 01HX", got.ID)
+	}
+}
+
+func TestUserFromContext_Unset(t *testing.T) {
+	if _, ok := UserFromContext(context.Background()); ok {
+		t.Error("UserFromContext should be !ok on empty context")
+	}
+	if _, ok := UserFromContext(nil); ok {
+		t.Error("UserFromContext should be !ok on nil context")
+	}
+}
+
+func TestCan(t *testing.T) {
+	ctx := WithPermissions(context.Background(), []Permission{PermLibraryView, PermScanTrigger})
+
+	if !Can(ctx, PermLibraryView) {
+		t.Error("should allow PermLibraryView")
+	}
+	if !Can(ctx, PermScanTrigger) {
+		t.Error("should allow PermScanTrigger")
+	}
+	if Can(ctx, PermUsersManage) {
+		t.Error("should NOT allow PermUsersManage")
+	}
+}
+
+func TestCan_Unauthenticated(t *testing.T) {
+	// No permissions attached → every Can call returns false.
+	if Can(context.Background(), PermLibraryView) {
+		t.Error("unauthenticated Can should always be false")
+	}
+	if Can(nil, PermLibraryView) {
+		t.Error("nil context Can should always be false")
+	}
+}
+
+func TestWithPermissions_EmptyIsNoop(t *testing.T) {
+	ctx := WithPermissions(context.Background(), nil)
+	if PermissionsFromContext(ctx) != nil {
+		t.Error("empty/nil perms should result in no permission set on context")
+	}
+}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,85 @@
+// file: internal/auth/context.go
+// version: 1.0.0
+// guid: 8c4a2f1d-9b3e-4f60-a8d5-2c7e0f1b9a47
+//
+// Request-scoped auth state plumbing (spec 3.7). Long-lived deps
+// (database.Store, services) live on the Server struct; per-request
+// state (who is calling, what they can do) flows through
+// context.Context using typed helpers so handlers can't accidentally
+// read them as strings.
+
+package auth
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+type ctxKey int
+
+const (
+	userKey ctxKey = iota
+	permissionsKey
+)
+
+// WithUser attaches the calling user to ctx. Typically set by the
+// authenticate middleware after session/JWT verification.
+func WithUser(ctx context.Context, u *database.User) context.Context {
+	if u == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, userKey, u)
+}
+
+// UserFromContext returns the user attached to ctx by WithUser, or
+// (nil, false) if no user is set (unauthenticated request or a
+// handler that bypassed auth middleware).
+func UserFromContext(ctx context.Context) (*database.User, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	u, ok := ctx.Value(userKey).(*database.User)
+	return u, ok && u != nil
+}
+
+// WithPermissions attaches the calling user's flattened permission
+// set to ctx. Computed at session creation by unioning the role
+// permissions and cached on the session blob; middleware copies it
+// into request context so Can() is a cheap map lookup.
+func WithPermissions(ctx context.Context, perms []Permission) context.Context {
+	if len(perms) == 0 {
+		return ctx
+	}
+	set := make(map[Permission]struct{}, len(perms))
+	for _, p := range perms {
+		set[p] = struct{}{}
+	}
+	return context.WithValue(ctx, permissionsKey, set)
+}
+
+// PermissionsFromContext returns the permission set attached to ctx,
+// or nil if no permissions have been loaded (which effectively means
+// the caller has none).
+func PermissionsFromContext(ctx context.Context) map[Permission]struct{} {
+	if ctx == nil {
+		return nil
+	}
+	set, _ := ctx.Value(permissionsKey).(map[Permission]struct{})
+	return set
+}
+
+// Can reports whether the caller in ctx has permission p.
+//
+// Returns false for an unauthenticated caller (no permissions set)
+// and for an authenticated caller whose roles do not include p.
+// Never panics — unset context or nil permission set both yield
+// false, which is the safe default.
+func Can(ctx context.Context, p Permission) bool {
+	set := PermissionsFromContext(ctx)
+	if set == nil {
+		return false
+	}
+	_, ok := set[p]
+	return ok
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -1,0 +1,106 @@
+// file: internal/auth/permissions.go
+// version: 1.0.0
+// guid: 2d8a1f4e-5c3b-4f90-a7d6-1e8c0f2b9a45
+//
+// Permission atoms for the multi-user model (spec 3.7). Permissions
+// are Go string constants — not DB rows. Roles carry inline lists of
+// these constants in `database.Role.Permissions`.
+//
+// Adding a new permission is a source change: add a const here, then
+// reference it from a requirePerm(...) middleware call at the route
+// where the check should run. The compile step catches typos.
+
+package auth
+
+// Permission is a named capability a user may be granted via role
+// membership.
+type Permission = string
+
+const (
+	// PermLibraryView gates read access to books, authors, series,
+	// playlists, and activity. Baseline permission — every role in the
+	// seed set includes it.
+	PermLibraryView Permission = "library.view"
+
+	// PermLibraryEditMetadata gates title / author / series / tag edits,
+	// metadata fetch + apply, and batch metadata operations. Does NOT
+	// grant file-mutation rights.
+	PermLibraryEditMetadata Permission = "library.edit_metadata"
+
+	// PermLibraryDelete gates deletion of books (soft or hard) and
+	// related cascades (version rows, book_files).
+	PermLibraryDelete Permission = "library.delete"
+
+	// PermLibraryOrganize gates file-level organize operations: rename,
+	// move, re-layout under the managed library tree.
+	PermLibraryOrganize Permission = "library.organize"
+
+	// PermScanTrigger gates starting library scans and imports.
+	PermScanTrigger Permission = "scan.trigger"
+
+	// PermIntegrationsManage gates configuring and triggering external
+	// integrations: iTunes (library path, sync, writeback), deluge,
+	// openai, openlibrary, hardcover, audible.
+	PermIntegrationsManage Permission = "integrations.manage"
+
+	// PermUsersManage gates creating/deleting users, generating invites,
+	// assigning roles, regenerating passwords, managing API keys for
+	// other users.
+	PermUsersManage Permission = "users.manage"
+
+	// PermSettingsManage gates editing global/system configuration.
+	PermSettingsManage Permission = "settings.manage"
+
+	// PermPlaylistsCreate gates creating and editing user-owned
+	// playlists (3.4). Read access is covered by PermLibraryView.
+	PermPlaylistsCreate Permission = "playlists.create"
+
+	// PermRequestsCreate — reserved for the future "request a book"
+	// feature. A viewer without full library.edit_metadata can still
+	// file a request for an admin to fulfill.
+	PermRequestsCreate Permission = "requests.create"
+
+	// PermRequestsApprove — reserved for the future request-approval
+	// flow (admin-equivalent for the requests subsystem).
+	PermRequestsApprove Permission = "requests.approve"
+)
+
+// All returns every permission constant defined in this package.
+// Useful for seeding the admin role and for validating role JSON at
+// registration time.
+func All() []Permission {
+	return []Permission{
+		PermLibraryView,
+		PermLibraryEditMetadata,
+		PermLibraryDelete,
+		PermLibraryOrganize,
+		PermScanTrigger,
+		PermIntegrationsManage,
+		PermUsersManage,
+		PermSettingsManage,
+		PermPlaylistsCreate,
+		PermRequestsCreate,
+		PermRequestsApprove,
+	}
+}
+
+// IsKnown reports whether p is a permission constant defined here.
+// Used during role-JSON validation to reject typo'd or dropped
+// permission strings before they reach the database.
+func IsKnown(p Permission) bool {
+	switch p {
+	case PermLibraryView,
+		PermLibraryEditMetadata,
+		PermLibraryDelete,
+		PermLibraryOrganize,
+		PermScanTrigger,
+		PermIntegrationsManage,
+		PermUsersManage,
+		PermSettingsManage,
+		PermPlaylistsCreate,
+		PermRequestsCreate,
+		PermRequestsApprove:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Second slice of 3.7 — auth package with 11 permission constants, Can(ctx, perm), and WithUser/UserFromContext typed context helpers. 7 tests pass.