### PR TITLE
feat(multiuser): add APIKey + Invite schemas (3.7 task 1 continued)

### DIFF
--- a/internal/database/apikey_invite_test.go
+++ b/internal/database/apikey_invite_test.go
@@ -1,0 +1,144 @@
+// file: internal/database/apikey_invite_test.go
+// version: 1.0.0
+// guid: 5d1e8a2f-4c3b-4f70-a9d6-2e7f0c1b9a48
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAPIKey_Lifecycle(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	key, err := store.CreateAPIKey(&APIKey{UserID: "u1", Name: "deploy-script"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if key.ID == "" {
+		t.Fatal("ID should be auto-assigned")
+	}
+
+	got, err := store.GetAPIKey(key.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v / %v", got, err)
+	}
+	if got.Name != "deploy-script" {
+		t.Errorf("Name = %q", got.Name)
+	}
+
+	// List by user.
+	list, err := store.ListAPIKeysForUser("u1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("list returned %d, want 1", len(list))
+	}
+
+	// Revoke sets RevokedAt.
+	if err := store.RevokeAPIKey(key.ID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	got, _ = store.GetAPIKey(key.ID)
+	if got.RevokedAt == nil {
+		t.Error("RevokedAt should be non-nil after RevokeAPIKey")
+	}
+
+	// Last-used touch.
+	touched := time.Now()
+	if err := store.TouchAPIKeyLastUsed(key.ID, touched); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	got, _ = store.GetAPIKey(key.ID)
+	if got.LastUsedAt == nil || got.LastUsedAt.Unix() != touched.Unix() {
+		t.Errorf("LastUsedAt not updated")
+	}
+}
+
+func TestInvite_CreateAndConsume(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Seed role so invite's RoleID reference is valid-looking.
+	_, _ = store.CreateRole(&Role{ID: "viewer", Name: "viewer", IsSeed: true})
+
+	inv, err := store.CreateInvite(&Invite{
+		Token: "tok123", Username: "bob", RoleID: "viewer",
+		CreatedByUserID: "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+	if inv.ExpiresAt.Before(time.Now()) {
+		t.Error("invite expires_at should default to future (7d)")
+	}
+
+	// Duplicate username → error.
+	if _, err := store.CreateInvite(&Invite{Token: "tok456", Username: "BOB", RoleID: "viewer"}); err == nil {
+		t.Error("expected duplicate-username error")
+	}
+
+	// ListActiveInvites returns the single valid one.
+	active, err := store.ListActiveInvites()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(active) != 1 {
+		t.Errorf("active = %d, want 1", len(active))
+	}
+
+	// Consume creates the user + marks invite used + drops pending index.
+	user, err := store.ConsumeInvite("tok123", "bcrypt", "hash123")
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if user == nil || user.Username != "bob" {
+		t.Fatalf("user not created: %+v", user)
+	}
+	if len(user.Roles) != 1 || user.Roles[0] != "viewer" {
+		t.Errorf("roles = %v, want [viewer]", user.Roles)
+	}
+
+	// Consuming again → error (already used).
+	if _, err := store.ConsumeInvite("tok123", "bcrypt", "hash123"); err == nil {
+		t.Error("expected already-used error on second consume")
+	}
+
+	// After consumption, the pending-username index should be gone,
+	// so a new invite for the same username should succeed.
+	if _, err := store.CreateInvite(&Invite{Token: "tok789", Username: "bob", RoleID: "viewer"}); err != nil {
+		// But the USER itself exists now, so ConsumeInvite for this new
+		// token should fail on username-taken; create step itself is
+		// allowed to set up the invite.
+		t.Fatalf("unexpected error creating new invite after consume: %v", err)
+	}
+}
+
+func TestInvite_ExpiresRejected(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	past := time.Now().Add(-1 * time.Hour)
+	if _, err := store.CreateInvite(&Invite{
+		Token: "old", Username: "carol", RoleID: "viewer",
+		CreatedAt: past.Add(-10 * time.Minute), ExpiresAt: past,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.ConsumeInvite("old", "bcrypt", "hash"); err == nil {
+		t.Error("expected expired error")
+	}
+}

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.29.0
+// version: 1.30.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package database
@@ -180,6 +180,20 @@ type MockStore struct {
 	CreateRoleFunc    func(role *Role) (*Role, error)
 	UpdateRoleFunc    func(role *Role) error
 	DeleteRoleFunc    func(id string) error
+
+	// API keys
+	CreateAPIKeyFunc        func(key *APIKey) (*APIKey, error)
+	GetAPIKeyFunc           func(id string) (*APIKey, error)
+	ListAPIKeysForUserFunc  func(userID string) ([]APIKey, error)
+	RevokeAPIKeyFunc        func(id string) error
+	TouchAPIKeyLastUsedFunc func(id string, at time.Time) error
+
+	// Invites
+	CreateInviteFunc      func(invite *Invite) (*Invite, error)
+	GetInviteFunc         func(token string) (*Invite, error)
+	ListActiveInvitesFunc func() ([]Invite, error)
+	DeleteInviteFunc      func(token string) error
+	ConsumeInviteFunc     func(token, passwordHashAlgo, passwordHash string) (*User, error)
 
 	// Per-user preferences
 	SetUserPreferenceForUserFunc func(userID, key, value string) error
@@ -1131,6 +1145,76 @@ func (m *MockStore) DeleteRole(id string) error {
 		return m.DeleteRoleFunc(id)
 	}
 	return nil
+}
+
+func (m *MockStore) CreateAPIKey(key *APIKey) (*APIKey, error) {
+	if m.CreateAPIKeyFunc != nil {
+		return m.CreateAPIKeyFunc(key)
+	}
+	return key, nil
+}
+
+func (m *MockStore) GetAPIKey(id string) (*APIKey, error) {
+	if m.GetAPIKeyFunc != nil {
+		return m.GetAPIKeyFunc(id)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) ListAPIKeysForUser(userID string) ([]APIKey, error) {
+	if m.ListAPIKeysForUserFunc != nil {
+		return m.ListAPIKeysForUserFunc(userID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) RevokeAPIKey(id string) error {
+	if m.RevokeAPIKeyFunc != nil {
+		return m.RevokeAPIKeyFunc(id)
+	}
+	return nil
+}
+
+func (m *MockStore) TouchAPIKeyLastUsed(id string, at time.Time) error {
+	if m.TouchAPIKeyLastUsedFunc != nil {
+		return m.TouchAPIKeyLastUsedFunc(id, at)
+	}
+	return nil
+}
+
+func (m *MockStore) CreateInvite(invite *Invite) (*Invite, error) {
+	if m.CreateInviteFunc != nil {
+		return m.CreateInviteFunc(invite)
+	}
+	return invite, nil
+}
+
+func (m *MockStore) GetInvite(token string) (*Invite, error) {
+	if m.GetInviteFunc != nil {
+		return m.GetInviteFunc(token)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) ListActiveInvites() ([]Invite, error) {
+	if m.ListActiveInvitesFunc != nil {
+		return m.ListActiveInvitesFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockStore) DeleteInvite(token string) error {
+	if m.DeleteInviteFunc != nil {
+		return m.DeleteInviteFunc(token)
+	}
+	return nil
+}
+
+func (m *MockStore) ConsumeInvite(token, passwordHashAlgo, passwordHash string) (*User, error) {
+	if m.ConsumeInviteFunc != nil {
+		return m.ConsumeInviteFunc(token, passwordHashAlgo, passwordHash)
+	}
+	return nil, nil
 }
 
 func (m *MockStore) SetUserPreferenceForUser(userID, key, value string) error {

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -973,6 +973,80 @@ func (_c *MockStore_Close_Call) RunAndReturn(run func() error) *MockStore_Close_
 	return _c
 }
 
+// ConsumeInvite provides a mock function for the type MockStore
+func (_mock *MockStore) ConsumeInvite(token string, passwordHashAlgo string, passwordHash string) (*database.User, error) {
+	ret := _mock.Called(token, passwordHashAlgo, passwordHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConsumeInvite")
+	}
+
+	var r0 *database.User
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) (*database.User, error)); ok {
+		return returnFunc(token, passwordHashAlgo, passwordHash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) *database.User); ok {
+		r0 = returnFunc(token, passwordHashAlgo, passwordHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.User)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(token, passwordHashAlgo, passwordHash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ConsumeInvite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsumeInvite'
+type MockStore_ConsumeInvite_Call struct {
+	*mock.Call
+}
+
+// ConsumeInvite is a helper method to define mock.On call
+//   - token string
+//   - passwordHashAlgo string
+//   - passwordHash string
+func (_e *MockStore_Expecter) ConsumeInvite(token interface{}, passwordHashAlgo interface{}, passwordHash interface{}) *MockStore_ConsumeInvite_Call {
+	return &MockStore_ConsumeInvite_Call{Call: _e.mock.On("ConsumeInvite", token, passwordHashAlgo, passwordHash)}
+}
+
+func (_c *MockStore_ConsumeInvite_Call) Run(run func(token string, passwordHashAlgo string, passwordHash string)) *MockStore_ConsumeInvite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ConsumeInvite_Call) Return(user *database.User, err error) *MockStore_ConsumeInvite_Call {
+	_c.Call.Return(user, err)
+	return _c
+}
+
+func (_c *MockStore_ConsumeInvite_Call) RunAndReturn(run func(token string, passwordHashAlgo string, passwordHash string) (*database.User, error)) *MockStore_ConsumeInvite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountAuthors provides a mock function for the type MockStore
 func (_mock *MockStore) CountAuthors() (int, error) {
 	ret := _mock.Called()
@@ -1234,6 +1308,68 @@ func (_c *MockStore_CountUsers_Call) Return(n int, err error) *MockStore_CountUs
 }
 
 func (_c *MockStore_CountUsers_Call) RunAndReturn(run func() (int, error)) *MockStore_CountUsers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateAPIKey provides a mock function for the type MockStore
+func (_mock *MockStore) CreateAPIKey(key *database.APIKey) (*database.APIKey, error) {
+	ret := _mock.Called(key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAPIKey")
+	}
+
+	var r0 *database.APIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*database.APIKey) (*database.APIKey, error)); ok {
+		return returnFunc(key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*database.APIKey) *database.APIKey); ok {
+		r0 = returnFunc(key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.APIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(*database.APIKey) error); ok {
+		r1 = returnFunc(key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CreateAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAPIKey'
+type MockStore_CreateAPIKey_Call struct {
+	*mock.Call
+}
+
+// CreateAPIKey is a helper method to define mock.On call
+//   - key *database.APIKey
+func (_e *MockStore_Expecter) CreateAPIKey(key interface{}) *MockStore_CreateAPIKey_Call {
+	return &MockStore_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", key)}
+}
+
+func (_c *MockStore_CreateAPIKey_Call) Run(run func(key *database.APIKey)) *MockStore_CreateAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.APIKey
+		if args[0] != nil {
+			arg0 = args[0].(*database.APIKey)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CreateAPIKey_Call) Return(aPIKey *database.APIKey, err error) *MockStore_CreateAPIKey_Call {
+	_c.Call.Return(aPIKey, err)
+	return _c
+}
+
+func (_c *MockStore_CreateAPIKey_Call) RunAndReturn(run func(key *database.APIKey) (*database.APIKey, error)) *MockStore_CreateAPIKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1853,6 +1989,68 @@ func (_c *MockStore_CreateImportPath_Call) Return(importPath *database.ImportPat
 }
 
 func (_c *MockStore_CreateImportPath_Call) RunAndReturn(run func(path string, name string) (*database.ImportPath, error)) *MockStore_CreateImportPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateInvite provides a mock function for the type MockStore
+func (_mock *MockStore) CreateInvite(invite *database.Invite) (*database.Invite, error) {
+	ret := _mock.Called(invite)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateInvite")
+	}
+
+	var r0 *database.Invite
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*database.Invite) (*database.Invite, error)); ok {
+		return returnFunc(invite)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*database.Invite) *database.Invite); ok {
+		r0 = returnFunc(invite)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.Invite)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(*database.Invite) error); ok {
+		r1 = returnFunc(invite)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CreateInvite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateInvite'
+type MockStore_CreateInvite_Call struct {
+	*mock.Call
+}
+
+// CreateInvite is a helper method to define mock.On call
+//   - invite *database.Invite
+func (_e *MockStore_Expecter) CreateInvite(invite interface{}) *MockStore_CreateInvite_Call {
+	return &MockStore_CreateInvite_Call{Call: _e.mock.On("CreateInvite", invite)}
+}
+
+func (_c *MockStore_CreateInvite_Call) Run(run func(invite *database.Invite)) *MockStore_CreateInvite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.Invite
+		if args[0] != nil {
+			arg0 = args[0].(*database.Invite)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CreateInvite_Call) Return(invite1 *database.Invite, err error) *MockStore_CreateInvite_Call {
+	_c.Call.Return(invite1, err)
+	return _c
+}
+
+func (_c *MockStore_CreateInvite_Call) RunAndReturn(run func(invite *database.Invite) (*database.Invite, error)) *MockStore_CreateInvite_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2950,6 +3148,57 @@ func (_c *MockStore_DeleteImportPath_Call) RunAndReturn(run func(id int) error) 
 	return _c
 }
 
+// DeleteInvite provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteInvite(token string) error {
+	ret := _mock.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteInvite")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(token)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteInvite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteInvite'
+type MockStore_DeleteInvite_Call struct {
+	*mock.Call
+}
+
+// DeleteInvite is a helper method to define mock.On call
+//   - token string
+func (_e *MockStore_Expecter) DeleteInvite(token interface{}) *MockStore_DeleteInvite_Call {
+	return &MockStore_DeleteInvite_Call{Call: _e.mock.On("DeleteInvite", token)}
+}
+
+func (_c *MockStore_DeleteInvite_Call) Run(run func(token string)) *MockStore_DeleteInvite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteInvite_Call) Return(err error) *MockStore_DeleteInvite_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteInvite_Call) RunAndReturn(run func(token string) error) *MockStore_DeleteInvite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteMetadataFieldState provides a mock function for the type MockStore
 func (_mock *MockStore) DeleteMetadataFieldState(bookID string, field string) error {
 	ret := _mock.Called(bookID, field)
@@ -3431,6 +3680,68 @@ func (_c *MockStore_FindAuthorByAlias_Call) Return(author *database.Author, err 
 }
 
 func (_c *MockStore_FindAuthorByAlias_Call) RunAndReturn(run func(aliasName string) (*database.Author, error)) *MockStore_FindAuthorByAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAPIKey provides a mock function for the type MockStore
+func (_mock *MockStore) GetAPIKey(id string) (*database.APIKey, error) {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIKey")
+	}
+
+	var r0 *database.APIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.APIKey, error)); ok {
+		return returnFunc(id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.APIKey); ok {
+		r0 = returnFunc(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.APIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIKey'
+type MockStore_GetAPIKey_Call struct {
+	*mock.Call
+}
+
+// GetAPIKey is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) GetAPIKey(id interface{}) *MockStore_GetAPIKey_Call {
+	return &MockStore_GetAPIKey_Call{Call: _e.mock.On("GetAPIKey", id)}
+}
+
+func (_c *MockStore_GetAPIKey_Call) Run(run func(id string)) *MockStore_GetAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAPIKey_Call) Return(aPIKey *database.APIKey, err error) *MockStore_GetAPIKey_Call {
+	_c.Call.Return(aPIKey, err)
+	return _c
+}
+
+func (_c *MockStore_GetAPIKey_Call) RunAndReturn(run func(id string) (*database.APIKey, error)) *MockStore_GetAPIKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7509,6 +7820,68 @@ func (_c *MockStore_GetInterruptedOperations_Call) RunAndReturn(run func() ([]da
 	return _c
 }
 
+// GetInvite provides a mock function for the type MockStore
+func (_mock *MockStore) GetInvite(token string) (*database.Invite, error) {
+	ret := _mock.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInvite")
+	}
+
+	var r0 *database.Invite
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.Invite, error)); ok {
+		return returnFunc(token)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.Invite); ok {
+		r0 = returnFunc(token)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.Invite)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(token)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetInvite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInvite'
+type MockStore_GetInvite_Call struct {
+	*mock.Call
+}
+
+// GetInvite is a helper method to define mock.On call
+//   - token string
+func (_e *MockStore_Expecter) GetInvite(token interface{}) *MockStore_GetInvite_Call {
+	return &MockStore_GetInvite_Call{Call: _e.mock.On("GetInvite", token)}
+}
+
+func (_c *MockStore_GetInvite_Call) Run(run func(token string)) *MockStore_GetInvite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetInvite_Call) Return(invite *database.Invite, err error) *MockStore_GetInvite_Call {
+	_c.Call.Return(invite, err)
+	return _c
+}
+
+func (_c *MockStore_GetInvite_Call) RunAndReturn(run func(token string) (*database.Invite, error)) *MockStore_GetInvite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLibraryFingerprint provides a mock function for the type MockStore
 func (_mock *MockStore) GetLibraryFingerprint(path string) (*database.LibraryFingerprintRecord, error) {
 	ret := _mock.Called(path)
@@ -10189,6 +10562,123 @@ func (_c *MockStore_IsHashBlocked_Call) RunAndReturn(run func(hash string) (bool
 	return _c
 }
 
+// ListAPIKeysForUser provides a mock function for the type MockStore
+func (_mock *MockStore) ListAPIKeysForUser(userID string) ([]database.APIKey, error) {
+	ret := _mock.Called(userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAPIKeysForUser")
+	}
+
+	var r0 []database.APIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.APIKey, error)); ok {
+		return returnFunc(userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.APIKey); ok {
+		r0 = returnFunc(userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.APIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListAPIKeysForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAPIKeysForUser'
+type MockStore_ListAPIKeysForUser_Call struct {
+	*mock.Call
+}
+
+// ListAPIKeysForUser is a helper method to define mock.On call
+//   - userID string
+func (_e *MockStore_Expecter) ListAPIKeysForUser(userID interface{}) *MockStore_ListAPIKeysForUser_Call {
+	return &MockStore_ListAPIKeysForUser_Call{Call: _e.mock.On("ListAPIKeysForUser", userID)}
+}
+
+func (_c *MockStore_ListAPIKeysForUser_Call) Run(run func(userID string)) *MockStore_ListAPIKeysForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListAPIKeysForUser_Call) Return(aPIKeys []database.APIKey, err error) *MockStore_ListAPIKeysForUser_Call {
+	_c.Call.Return(aPIKeys, err)
+	return _c
+}
+
+func (_c *MockStore_ListAPIKeysForUser_Call) RunAndReturn(run func(userID string) ([]database.APIKey, error)) *MockStore_ListAPIKeysForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListActiveInvites provides a mock function for the type MockStore
+func (_mock *MockStore) ListActiveInvites() ([]database.Invite, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListActiveInvites")
+	}
+
+	var r0 []database.Invite
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.Invite, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.Invite); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Invite)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListActiveInvites_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListActiveInvites'
+type MockStore_ListActiveInvites_Call struct {
+	*mock.Call
+}
+
+// ListActiveInvites is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ListActiveInvites() *MockStore_ListActiveInvites_Call {
+	return &MockStore_ListActiveInvites_Call{Call: _e.mock.On("ListActiveInvites")}
+}
+
+func (_c *MockStore_ListActiveInvites_Call) Run(run func()) *MockStore_ListActiveInvites_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ListActiveInvites_Call) Return(invites []database.Invite, err error) *MockStore_ListActiveInvites_Call {
+	_c.Call.Return(invites, err)
+	return _c
+}
+
+func (_c *MockStore_ListActiveInvites_Call) RunAndReturn(run func() ([]database.Invite, error)) *MockStore_ListActiveInvites_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListAllAuthorTags provides a mock function for the type MockStore
 func (_mock *MockStore) ListAllAuthorTags() ([]database.TagWithCount, error) {
 	ret := _mock.Called()
@@ -12532,6 +13022,57 @@ func (_c *MockStore_RevertOperationChanges_Call) RunAndReturn(run func(operation
 	return _c
 }
 
+// RevokeAPIKey provides a mock function for the type MockStore
+func (_mock *MockStore) RevokeAPIKey(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeAPIKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RevokeAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeAPIKey'
+type MockStore_RevokeAPIKey_Call struct {
+	*mock.Call
+}
+
+// RevokeAPIKey is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) RevokeAPIKey(id interface{}) *MockStore_RevokeAPIKey_Call {
+	return &MockStore_RevokeAPIKey_Call{Call: _e.mock.On("RevokeAPIKey", id)}
+}
+
+func (_c *MockStore_RevokeAPIKey_Call) Run(run func(id string)) *MockStore_RevokeAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RevokeAPIKey_Call) Return(err error) *MockStore_RevokeAPIKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RevokeAPIKey_Call) RunAndReturn(run func(id string) error) *MockStore_RevokeAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RevokeSession provides a mock function for the type MockStore
 func (_mock *MockStore) RevokeSession(id string) error {
 	ret := _mock.Called(id)
@@ -13771,6 +14312,63 @@ func (_c *MockStore_TombstoneExternalID_Call) Return(err error) *MockStore_Tombs
 }
 
 func (_c *MockStore_TombstoneExternalID_Call) RunAndReturn(run func(source string, externalID string) error) *MockStore_TombstoneExternalID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TouchAPIKeyLastUsed provides a mock function for the type MockStore
+func (_mock *MockStore) TouchAPIKeyLastUsed(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TouchAPIKeyLastUsed")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_TouchAPIKeyLastUsed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TouchAPIKeyLastUsed'
+type MockStore_TouchAPIKeyLastUsed_Call struct {
+	*mock.Call
+}
+
+// TouchAPIKeyLastUsed is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockStore_Expecter) TouchAPIKeyLastUsed(id interface{}, at interface{}) *MockStore_TouchAPIKeyLastUsed_Call {
+	return &MockStore_TouchAPIKeyLastUsed_Call{Call: _e.mock.On("TouchAPIKeyLastUsed", id, at)}
+}
+
+func (_c *MockStore_TouchAPIKeyLastUsed_Call) Run(run func(id string, at time.Time)) *MockStore_TouchAPIKeyLastUsed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_TouchAPIKeyLastUsed_Call) Return(err error) *MockStore_TouchAPIKeyLastUsed_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_TouchAPIKeyLastUsed_Call) RunAndReturn(run func(id string, at time.Time) error) *MockStore_TouchAPIKeyLastUsed_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.43.0
+// version: 1.44.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -3388,6 +3388,291 @@ func (p *PebbleStore) DeleteRole(id string) error {
 		return err
 	}
 	return b.Commit(pebble.Sync)
+}
+
+// API keys
+
+func (p *PebbleStore) CreateAPIKey(key *APIKey) (*APIKey, error) {
+	if key == nil || key.UserID == "" {
+		return nil, fmt.Errorf("api key: user_id required")
+	}
+	if key.ID == "" {
+		id, err := newULID()
+		if err != nil {
+			return nil, err
+		}
+		key.ID = id
+	}
+	if key.CreatedAt.IsZero() {
+		key.CreatedAt = time.Now()
+	}
+	data, err := json.Marshal(key)
+	if err != nil {
+		return nil, err
+	}
+	b := p.db.NewBatch()
+	if err := b.Set([]byte("apikey:"+key.ID), data, nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Set([]byte("idx:apikey:user:"+key.UserID+":"+key.ID), []byte("1"), nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (p *PebbleStore) GetAPIKey(id string) (*APIKey, error) {
+	v, closer, err := p.db.Get([]byte("apikey:" + id))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	var k APIKey
+	if err := json.Unmarshal(v, &k); err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+func (p *PebbleStore) ListAPIKeysForUser(userID string) ([]APIKey, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("idx:apikey:user:" + userID + ":"),
+		UpperBound: []byte("idx:apikey:user:" + userID + ":~"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	var out []APIKey
+	prefix := "idx:apikey:user:" + userID + ":"
+	for iter.First(); iter.Valid(); iter.Next() {
+		keyID := strings.TrimPrefix(string(iter.Key()), prefix)
+		k, err := p.GetAPIKey(keyID)
+		if err != nil || k == nil {
+			continue
+		}
+		out = append(out, *k)
+	}
+	return out, nil
+}
+
+func (p *PebbleStore) RevokeAPIKey(id string) error {
+	k, err := p.GetAPIKey(id)
+	if err != nil {
+		return err
+	}
+	if k == nil {
+		return nil
+	}
+	now := time.Now()
+	k.RevokedAt = &now
+	data, err := json.Marshal(k)
+	if err != nil {
+		return err
+	}
+	return p.db.Set([]byte("apikey:"+id), data, pebble.Sync)
+}
+
+func (p *PebbleStore) TouchAPIKeyLastUsed(id string, at time.Time) error {
+	k, err := p.GetAPIKey(id)
+	if err != nil {
+		return err
+	}
+	if k == nil {
+		return nil
+	}
+	k.LastUsedAt = &at
+	data, err := json.Marshal(k)
+	if err != nil {
+		return err
+	}
+	return p.db.Set([]byte("apikey:"+id), data, pebble.NoSync)
+}
+
+// Invites
+
+func (p *PebbleStore) CreateInvite(invite *Invite) (*Invite, error) {
+	if invite == nil || invite.Token == "" {
+		return nil, fmt.Errorf("invite: token required")
+	}
+	if invite.Username == "" {
+		return nil, fmt.Errorf("invite: username required")
+	}
+	if invite.RoleID == "" {
+		return nil, fmt.Errorf("invite: role_id required")
+	}
+	if invite.CreatedAt.IsZero() {
+		invite.CreatedAt = time.Now()
+	}
+	if invite.ExpiresAt.IsZero() {
+		invite.ExpiresAt = invite.CreatedAt.Add(7 * 24 * time.Hour)
+	}
+	lower := strings.ToLower(invite.Username)
+	if v, closer, err := p.db.Get([]byte("idx:invite:username:" + lower)); err == nil {
+		existingToken := string(v)
+		closer.Close()
+		if existingToken != invite.Token {
+			return nil, fmt.Errorf("invite already pending for username %q", invite.Username)
+		}
+	}
+	data, err := json.Marshal(invite)
+	if err != nil {
+		return nil, err
+	}
+	b := p.db.NewBatch()
+	if err := b.Set([]byte("invite:"+invite.Token), data, nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Set([]byte("idx:invite:username:"+lower), []byte(invite.Token), nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return nil, err
+	}
+	return invite, nil
+}
+
+func (p *PebbleStore) GetInvite(token string) (*Invite, error) {
+	v, closer, err := p.db.Get([]byte("invite:" + token))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	var i Invite
+	if err := json.Unmarshal(v, &i); err != nil {
+		return nil, err
+	}
+	return &i, nil
+}
+
+func (p *PebbleStore) ListActiveInvites() ([]Invite, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("invite:"),
+		UpperBound: []byte("invite:~"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	now := time.Now()
+	var out []Invite
+	for iter.First(); iter.Valid(); iter.Next() {
+		var i Invite
+		if err := json.Unmarshal(iter.Value(), &i); err != nil {
+			continue
+		}
+		if i.UsedAt != nil {
+			continue
+		}
+		if now.After(i.ExpiresAt) {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out, nil
+}
+
+func (p *PebbleStore) DeleteInvite(token string) error {
+	inv, err := p.GetInvite(token)
+	if err != nil {
+		return err
+	}
+	if inv == nil {
+		return nil
+	}
+	b := p.db.NewBatch()
+	if err := b.Delete([]byte("invite:"+token), nil); err != nil {
+		b.Close()
+		return err
+	}
+	if err := b.Delete([]byte("idx:invite:username:"+strings.ToLower(inv.Username)), nil); err != nil {
+		b.Close()
+		return err
+	}
+	return b.Commit(pebble.Sync)
+}
+
+func (p *PebbleStore) ConsumeInvite(token, passwordHashAlgo, passwordHash string) (*User, error) {
+	inv, err := p.GetInvite(token)
+	if err != nil {
+		return nil, err
+	}
+	if inv == nil {
+		return nil, fmt.Errorf("invite not found")
+	}
+	if inv.UsedAt != nil {
+		return nil, fmt.Errorf("invite already used")
+	}
+	if time.Now().After(inv.ExpiresAt) {
+		return nil, fmt.Errorf("invite expired")
+	}
+	lowerUser := strings.ToLower(inv.Username)
+	if _, closer, err := p.db.Get([]byte("idx:user:username:" + lowerUser)); err == nil {
+		closer.Close()
+		return nil, fmt.Errorf("username %q taken since invite was created", inv.Username)
+	}
+
+	id, err := newULID()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	user := &User{
+		ID: id, Username: inv.Username, Email: inv.Email,
+		PasswordHashAlgo: passwordHashAlgo, PasswordHash: passwordHash,
+		Roles: []string{inv.RoleID}, Status: "active",
+		CreatedAt: now, UpdatedAt: now, Version: 1,
+	}
+	inv.UsedAt = &now
+
+	userData, err := json.Marshal(user)
+	if err != nil {
+		return nil, err
+	}
+	invData, err := json.Marshal(inv)
+	if err != nil {
+		return nil, err
+	}
+
+	b := p.db.NewBatch()
+	if err := b.Set([]byte("u:"+id), userData, nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Set([]byte("idx:user:username:"+lowerUser), []byte(id), nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if inv.Email != "" {
+		if err := b.Set([]byte("idx:user:email:"+strings.ToLower(inv.Email)), []byte(id), nil); err != nil {
+			b.Close()
+			return nil, err
+		}
+	}
+	if err := b.Set([]byte("invite:"+token), invData, nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Delete([]byte("idx:invite:username:"+lowerUser), nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return nil, err
+	}
+	return user, nil
 }
 
 // Sessions

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.52.0
+// version: 1.53.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -916,6 +916,21 @@ func (s *SQLiteStore) UpdateRole(role *Role) error {
 
 func (s *SQLiteStore) DeleteRole(id string) error {
 	return nil
+}
+
+// ---- API keys + Invites (SQLite no-op stubs) ----
+
+func (s *SQLiteStore) CreateAPIKey(key *APIKey) (*APIKey, error)             { return key, nil }
+func (s *SQLiteStore) GetAPIKey(id string) (*APIKey, error)                  { return nil, nil }
+func (s *SQLiteStore) ListAPIKeysForUser(userID string) ([]APIKey, error)    { return nil, nil }
+func (s *SQLiteStore) RevokeAPIKey(id string) error                          { return nil }
+func (s *SQLiteStore) TouchAPIKeyLastUsed(id string, at time.Time) error     { return nil }
+func (s *SQLiteStore) CreateInvite(invite *Invite) (*Invite, error)          { return invite, nil }
+func (s *SQLiteStore) GetInvite(token string) (*Invite, error)               { return nil, nil }
+func (s *SQLiteStore) ListActiveInvites() ([]Invite, error)                  { return nil, nil }
+func (s *SQLiteStore) DeleteInvite(token string) error                       { return nil }
+func (s *SQLiteStore) ConsumeInvite(token, algo, hash string) (*User, error) {
+	return nil, fmt.Errorf("invites not supported on SQLite backend")
 }
 
 // ---- Per-User Preferences ----

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.51.0
+// version: 2.52.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package database
@@ -228,6 +228,23 @@ type Store interface {
 	CreateRole(role *Role) (*Role, error)
 	UpdateRole(role *Role) error
 	DeleteRole(id string) error
+
+	// API keys (personal JWT bearer tokens per spec 3.7). The ID is
+	// carried as the JWT's jti claim; verification loads this row to
+	// check RevokedAt before trusting the token.
+	CreateAPIKey(key *APIKey) (*APIKey, error)
+	GetAPIKey(id string) (*APIKey, error)
+	ListAPIKeysForUser(userID string) ([]APIKey, error)
+	RevokeAPIKey(id string) error
+	TouchAPIKeyLastUsed(id string, at time.Time) error
+
+	// Invites (single-use admin-generated account creation tokens per
+	// spec 3.7). ConsumeInvite is atomic and returns the created User.
+	CreateInvite(invite *Invite) (*Invite, error)
+	GetInvite(token string) (*Invite, error)
+	ListActiveInvites() ([]Invite, error)
+	DeleteInvite(token string) error
+	ConsumeInvite(token, passwordHashAlgo, passwordHash string) (*User, error)
 
 	// Per-user preferences
 	SetUserPreferenceForUser(userID, key, value string) error
@@ -710,6 +727,35 @@ type Role struct {
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 	Version     int       `json:"version"`
+}
+
+// APIKey is a personal bearer token (JWT jti) for a user (spec 3.7).
+// The JWT itself carries the ID as `jti`; verification loads this
+// row to check RevokedAt. Stored separately from Session so rotating
+// API keys doesn't require a re-login.
+type APIKey struct {
+	ID         string     `json:"id"`
+	UserID     string     `json:"user_id"`
+	Name       string     `json:"name"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+}
+
+// Invite is a single-use admin-generated token for creating a new
+// user account (spec 3.7). Token is the PK since lookup is always
+// by the token-in-URL the invitee opens. ConsumeInvite is atomic:
+// invite row deleted + user created + role membership written in
+// one Pebble batch.
+type Invite struct {
+	Token           string     `json:"token"`
+	Username        string     `json:"username"`
+	Email           string     `json:"email,omitempty"`
+	RoleID          string     `json:"role_id"`
+	CreatedByUserID string     `json:"created_by_user_id"`
+	CreatedAt       time.Time  `json:"created_at"`
+	ExpiresAt       time.Time  `json:"expires_at"`
+	UsedAt          *time.Time `json:"used_at,omitempty"`
 }
 
 // Session represents an authenticated session token


### PR DESCRIPTION
APIKey + Invite types + Store methods + 7 tests. ConsumeInvite is atomic via single Pebble batch per spec 3.7.