### PR TITLE
feat(multiuser): seed roles at startup (3.7 task 1 complete)

### DIFF
--- a/internal/auth/seed.go
+++ b/internal/auth/seed.go
@@ -1,0 +1,126 @@
+// file: internal/auth/seed.go
+// version: 1.0.0
+// guid: 2e8f4a1d-7c3b-4f60-b9d5-1c6e0f2b9a57
+//
+// Seed roles — idempotent upsert of the three canonical roles
+// (admin, editor, viewer) with their permission sets. Called at
+// server startup per spec 3.7.
+//
+// Seed roles are defined in code, not config. Adding a new
+// permission here automatically grants it to admin on the next
+// startup — the seed logic recomputes permission sets every boot so
+// existing admins can't be out-of-date with the codebase.
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+const (
+	SeedRoleAdmin  = "admin"
+	SeedRoleEditor = "editor"
+	SeedRoleViewer = "viewer"
+)
+
+// adminPermissions returns every permission constant. Admin always
+// has all of them — computed fresh each call so that adding a new
+// permission to the source file is automatically picked up.
+func adminPermissions() []Permission {
+	return All()
+}
+
+// editorPermissions returns the editor role's permissions: everything
+// except the three admin-level management permissions.
+func editorPermissions() []Permission {
+	return []Permission{
+		PermLibraryView,
+		PermLibraryEditMetadata,
+		PermLibraryDelete,
+		PermLibraryOrganize,
+		PermScanTrigger,
+		PermPlaylistsCreate,
+		PermRequestsCreate,
+		PermRequestsApprove,
+	}
+}
+
+// viewerPermissions returns the viewer role's permissions: read-only
+// library access plus the ability to file requests.
+func viewerPermissions() []Permission {
+	return []Permission{
+		PermLibraryView,
+		PermRequestsCreate,
+	}
+}
+
+// SeedRoles ensures the three canonical roles (admin, editor, viewer)
+// exist in the store with their current permission sets. Safe to call
+// repeatedly — existing role permissions are updated on every call
+// so a deploy that adds a new permission constant automatically
+// reaches admin's effective set.
+//
+// Returns the number of roles created + updated.
+func SeedRoles(store database.Store) (created, updated int, err error) {
+	if store == nil {
+		return 0, 0, fmt.Errorf("seed roles: store is nil")
+	}
+	specs := []struct {
+		id, name, description string
+		perms                 []Permission
+	}{
+		{SeedRoleAdmin, "admin", "Full access — manage users, integrations, and library", adminPermissions()},
+		{SeedRoleEditor, "editor", "Library editor — can view, edit metadata, organize, scan", editorPermissions()},
+		{SeedRoleViewer, "viewer", "Read-only library access", viewerPermissions()},
+	}
+	for _, s := range specs {
+		existing, lookupErr := store.GetRoleByID(s.id)
+		if lookupErr != nil {
+			return created, updated, fmt.Errorf("lookup role %s: %w", s.id, lookupErr)
+		}
+		if existing == nil {
+			if _, cerr := store.CreateRole(&database.Role{
+				ID:          s.id,
+				Name:        s.name,
+				Description: s.description,
+				Permissions: s.perms,
+				IsSeed:      true,
+			}); cerr != nil {
+				return created, updated, fmt.Errorf("create role %s: %w", s.id, cerr)
+			}
+			created++
+			continue
+		}
+		if samePermSet(existing.Permissions, s.perms) && existing.Description == s.description && existing.IsSeed {
+			continue
+		}
+		existing.Permissions = s.perms
+		existing.Description = s.description
+		existing.IsSeed = true
+		if uerr := store.UpdateRole(existing); uerr != nil {
+			return created, updated, fmt.Errorf("update role %s: %w", s.id, uerr)
+		}
+		updated++
+	}
+	return created, updated, nil
+}
+
+// samePermSet reports whether two permission slices contain the same
+// set of values, independent of order.
+func samePermSet(a, b []Permission) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[Permission]struct{}, len(a))
+	for _, p := range a {
+		seen[p] = struct{}{}
+	}
+	for _, p := range b {
+		if _, ok := seen[p]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/auth/seed_test.go
+++ b/internal/auth/seed_test.go
@@ -1,0 +1,122 @@
+// file: internal/auth/seed_test.go
+// version: 1.0.0
+// guid: 8c4d1e2f-5b3a-4f60-b9c7-2d8e0f1b9a56
+
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestSeedRoles_FirstRun(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	created, updated, err := SeedRoles(store)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if created != 3 {
+		t.Errorf("created = %d, want 3", created)
+	}
+	if updated != 0 {
+		t.Errorf("updated = %d, want 0", updated)
+	}
+
+	// Verify each role's permission set.
+	admin, _ := store.GetRoleByID(SeedRoleAdmin)
+	if admin == nil {
+		t.Fatal("admin role not created")
+	}
+	if len(admin.Permissions) != len(All()) {
+		t.Errorf("admin has %d perms, want %d (All)", len(admin.Permissions), len(All()))
+	}
+	if !admin.IsSeed {
+		t.Error("admin should have IsSeed=true")
+	}
+
+	viewer, _ := store.GetRoleByID(SeedRoleViewer)
+	if viewer == nil {
+		t.Fatal("viewer role not created")
+	}
+	hasView := false
+	hasEdit := false
+	for _, p := range viewer.Permissions {
+		if p == PermLibraryView {
+			hasView = true
+		}
+		if p == PermLibraryEditMetadata {
+			hasEdit = true
+		}
+	}
+	if !hasView {
+		t.Error("viewer should include library.view")
+	}
+	if hasEdit {
+		t.Error("viewer should NOT include library.edit_metadata")
+	}
+}
+
+func TestSeedRoles_Idempotent(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	if _, _, err := SeedRoles(store); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	created, updated, err := SeedRoles(store)
+	if err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+	if created != 0 {
+		t.Errorf("second seed created = %d, want 0 (idempotent)", created)
+	}
+	if updated != 0 {
+		t.Errorf("second seed updated = %d, want 0 (permissions unchanged)", updated)
+	}
+}
+
+func TestSeedRoles_UpgradeAddsNewPermission(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Simulate an admin from a prior release: missing one permission.
+	_, err = store.CreateRole(&database.Role{
+		ID:          SeedRoleAdmin,
+		Name:        "admin",
+		Description: "(old)",
+		Permissions: []string{PermLibraryView}, // only one — stale
+		IsSeed:      true,
+	})
+	if err != nil {
+		t.Fatalf("create stale admin: %v", err)
+	}
+
+	created, updated, err := SeedRoles(store)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if created != 2 {
+		t.Errorf("created = %d, want 2 (editor + viewer)", created)
+	}
+	if updated != 1 {
+		t.Errorf("updated = %d, want 1 (stale admin refreshed)", updated)
+	}
+
+	admin, _ := store.GetRoleByID(SeedRoleAdmin)
+	if len(admin.Permissions) != len(All()) {
+		t.Errorf("admin still has %d perms after re-seed, want %d", len(admin.Permissions), len(All()))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.170.0
+// version: 1.171.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/cache"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -1328,6 +1329,15 @@ func (s *Server) Start(cfg ServerConfig) error {
 				log.Printf("Failed to start server: %v", err)
 			}
 		}()
+	}
+
+	// Seed / refresh the multi-user roles (spec 3.7). Idempotent: if
+	// the permission set in auth.SeedRoles has grown since last boot,
+	// existing roles pick up the new entries automatically.
+	if created, updated, err := auth.SeedRoles(s.Store()); err != nil {
+		log.Printf("[WARN] seed roles: %v", err)
+	} else if created > 0 || updated > 0 {
+		log.Printf("[INFO] seed roles: %d created, %d updated", created, updated)
 	}
 
 	// Resume any operations that were interrupted by a previous shutdown/crash


### PR DESCRIPTION
Seeds admin/editor/viewer roles on every boot. Idempotent: stale roles auto-refresh when new permission constants are added to auth package. 3 tests.