### PR TITLE
chore(database): rename BookVersion → BookSnapshot

### DIFF
--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -40,7 +40,7 @@ type MockStore struct {
 	GetBookByFileHashFunc           func(hash string) (*Book, error)
 	GetBookByOriginalHashFunc       func(hash string) (*Book, error)
 	GetBookByOrganizedHashFunc      func(hash string) (*Book, error)
-	GetBookVersionsFunc             func(id string, limit int) ([]BookVersion, error)
+	GetBookVersionsFunc             func(id string, limit int) ([]BookSnapshot, error)
 	GetBookAtVersionFunc            func(id string, ts time.Time) (*Book, error)
 	RevertBookToVersionFunc         func(id string, ts time.Time) (*Book, error)
 	PruneBookVersionsFunc           func(id string, keepCount int) (int, error)
@@ -1396,7 +1396,7 @@ func (m *MockStore) SetLastWrittenAt(id string, t time.Time) error {
 	return nil
 }
 
-func (m *MockStore) GetBookVersions(id string, limit int) ([]BookVersion, error) {
+func (m *MockStore) GetBookSnapshots(id string, limit int) ([]BookSnapshot, error) {
 	if m.GetBookVersionsFunc != nil {
 		return m.GetBookVersionsFunc(id, limit)
 	}
@@ -1417,7 +1417,7 @@ func (m *MockStore) RevertBookToVersion(id string, ts time.Time) (*Book, error) 
 	return nil, fmt.Errorf("not implemented in mock")
 }
 
-func (m *MockStore) PruneBookVersions(id string, keepCount int) (int, error) {
+func (m *MockStore) PruneBookSnapshots(id string, keepCount int) (int, error) {
 	if m.PruneBookVersionsFunc != nil {
 		return m.PruneBookVersionsFunc(id, keepCount)
 	}

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -6672,24 +6672,24 @@ func (_c *MockStore_GetBookUserTags_Call) RunAndReturn(run func(bookID string) (
 	return _c
 }
 
-// GetBookVersions provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookVersions(id string, limit int) ([]database.BookVersion, error) {
+// GetBookSnapshots provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookSnapshots(id string, limit int) ([]database.BookSnapshot, error) {
 	ret := _mock.Called(id, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBookVersions")
+		panic("no return value specified for GetBookSnapshots")
 	}
 
-	var r0 []database.BookVersion
+	var r0 []database.BookSnapshot
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.BookVersion, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.BookSnapshot, error)); ok {
 		return returnFunc(id, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int) []database.BookVersion); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.BookSnapshot); ok {
 		r0 = returnFunc(id, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookVersion)
+			r0 = ret.Get(0).([]database.BookSnapshot)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
@@ -6700,16 +6700,16 @@ func (_mock *MockStore) GetBookVersions(id string, limit int) ([]database.BookVe
 	return r0, r1
 }
 
-// MockStore_GetBookVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookVersions'
+// MockStore_GetBookVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookSnapshots'
 type MockStore_GetBookVersions_Call struct {
 	*mock.Call
 }
 
-// GetBookVersions is a helper method to define mock.On call
+// GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockStore_Expecter) GetBookVersions(id interface{}, limit interface{}) *MockStore_GetBookVersions_Call {
-	return &MockStore_GetBookVersions_Call{Call: _e.mock.On("GetBookVersions", id, limit)}
+func (_e *MockStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockStore_GetBookVersions_Call {
+	return &MockStore_GetBookVersions_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
 func (_c *MockStore_GetBookVersions_Call) Run(run func(id string, limit int)) *MockStore_GetBookVersions_Call {
@@ -6730,12 +6730,12 @@ func (_c *MockStore_GetBookVersions_Call) Run(run func(id string, limit int)) *M
 	return _c
 }
 
-func (_c *MockStore_GetBookVersions_Call) Return(bookVersions []database.BookVersion, err error) *MockStore_GetBookVersions_Call {
+func (_c *MockStore_GetBookVersions_Call) Return(bookVersions []database.BookSnapshot, err error) *MockStore_GetBookVersions_Call {
 	_c.Call.Return(bookVersions, err)
 	return _c
 }
 
-func (_c *MockStore_GetBookVersions_Call) RunAndReturn(run func(id string, limit int) ([]database.BookVersion, error)) *MockStore_GetBookVersions_Call {
+func (_c *MockStore_GetBookVersions_Call) RunAndReturn(run func(id string, limit int) ([]database.BookSnapshot, error)) *MockStore_GetBookVersions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -11876,12 +11876,12 @@ func (_c *MockStore_Optimize_Call) RunAndReturn(run func() error) *MockStore_Opt
 	return _c
 }
 
-// PruneBookVersions provides a mock function for the type MockStore
-func (_mock *MockStore) PruneBookVersions(id string, keepCount int) (int, error) {
+// PruneBookSnapshots provides a mock function for the type MockStore
+func (_mock *MockStore) PruneBookSnapshots(id string, keepCount int) (int, error) {
 	ret := _mock.Called(id, keepCount)
 
 	if len(ret) == 0 {
-		panic("no return value specified for PruneBookVersions")
+		panic("no return value specified for PruneBookSnapshots")
 	}
 
 	var r0 int
@@ -11902,16 +11902,16 @@ func (_mock *MockStore) PruneBookVersions(id string, keepCount int) (int, error)
 	return r0, r1
 }
 
-// MockStore_PruneBookVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneBookVersions'
+// MockStore_PruneBookVersions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PruneBookSnapshots'
 type MockStore_PruneBookVersions_Call struct {
 	*mock.Call
 }
 
-// PruneBookVersions is a helper method to define mock.On call
+// PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockStore_Expecter) PruneBookVersions(id interface{}, keepCount interface{}) *MockStore_PruneBookVersions_Call {
-	return &MockStore_PruneBookVersions_Call{Call: _e.mock.On("PruneBookVersions", id, keepCount)}
+func (_e *MockStore_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockStore_PruneBookVersions_Call {
+	return &MockStore_PruneBookVersions_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
 func (_c *MockStore_PruneBookVersions_Call) Run(run func(id string, keepCount int)) *MockStore_PruneBookVersions_Call {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1733,8 +1733,8 @@ func (p *PebbleStore) GetITunesDirtyBooks() ([]Book, error) {
 	return dirty, nil
 }
 
-// GetBookVersions returns CoW version snapshots for a book, newest-first.
-func (p *PebbleStore) GetBookVersions(id string, limit int) ([]BookVersion, error) {
+// GetBookSnapshots returns CoW version snapshots for a book, newest-first.
+func (p *PebbleStore) GetBookSnapshots(id string, limit int) ([]BookSnapshot, error) {
 	prefix := fmt.Sprintf("book_ver:%s:", id)
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte(prefix),
@@ -1745,7 +1745,7 @@ func (p *PebbleStore) GetBookVersions(id string, limit int) ([]BookVersion, erro
 	}
 	defer iter.Close()
 
-	var versions []BookVersion
+	var versions []BookSnapshot
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := string(iter.Key())
 		parts := strings.SplitN(key, ":", 3)
@@ -1758,7 +1758,7 @@ func (p *PebbleStore) GetBookVersions(id string, limit int) ([]BookVersion, erro
 		}
 		dataCopy := make([]byte, len(iter.Value()))
 		copy(dataCopy, iter.Value())
-		versions = append(versions, BookVersion{
+		versions = append(versions, BookSnapshot{
 			BookID:    id,
 			Timestamp: time.Unix(0, nsec),
 			Data:      dataCopy,
@@ -1803,12 +1803,12 @@ func (p *PebbleStore) RevertBookToVersion(id string, ts time.Time) (*Book, error
 	return p.UpdateBook(id, oldBook)
 }
 
-// PruneBookVersions keeps the newest keepCount versions and deletes the rest.
-func (p *PebbleStore) PruneBookVersions(id string, keepCount int) (int, error) {
+// PruneBookSnapshots keeps the newest keepCount versions and deletes the rest.
+func (p *PebbleStore) PruneBookSnapshots(id string, keepCount int) (int, error) {
 	if keepCount < 0 {
 		keepCount = 0
 	}
-	versions, err := p.GetBookVersions(id, 0)
+	versions, err := p.GetBookSnapshots(id, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -843,7 +843,7 @@ func TestPebbleUpdateBookCreatesVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Updated Title", updated.Title)
 
-	versions, err := store.GetBookVersions(created.ID, 10)
+	versions, err := store.GetBookSnapshots(created.ID, 10)
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 
@@ -867,7 +867,7 @@ func TestPebbleGetBookAtVersion(t *testing.T) {
 	created.Title = "V3"
 	store.UpdateBook(created.ID, created)
 
-	versions, err := store.GetBookVersions(created.ID, 10)
+	versions, err := store.GetBookSnapshots(created.ID, 10)
 	require.NoError(t, err)
 	require.Len(t, versions, 2)
 
@@ -888,7 +888,7 @@ func TestPebbleRevertBookToVersion(t *testing.T) {
 	created.Title = "Modified"
 	store.UpdateBook(created.ID, created)
 
-	versions, err := store.GetBookVersions(created.ID, 10)
+	versions, err := store.GetBookSnapshots(created.ID, 10)
 	require.NoError(t, err)
 	require.Len(t, versions, 1)
 
@@ -901,7 +901,7 @@ func TestPebbleRevertBookToVersion(t *testing.T) {
 	require.Equal(t, "Original", current.Title)
 
 	// Revert creates a new version (snapshot of "Modified")
-	versions2, err := store.GetBookVersions(created.ID, 10)
+	versions2, err := store.GetBookSnapshots(created.ID, 10)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(versions2), 2)
 }
@@ -920,14 +920,14 @@ func TestPebblePruneBookVersions(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	versions, _ := store.GetBookVersions(created.ID, 100)
+	versions, _ := store.GetBookSnapshots(created.ID, 100)
 	require.Len(t, versions, 5)
 
-	pruned, err := store.PruneBookVersions(created.ID, 2)
+	pruned, err := store.PruneBookSnapshots(created.ID, 2)
 	require.NoError(t, err)
 	require.Equal(t, 3, pruned)
 
-	remaining, _ := store.GetBookVersions(created.ID, 100)
+	remaining, _ := store.GetBookSnapshots(created.ID, 100)
 	require.Len(t, remaining, 2)
 }
 

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -4346,8 +4346,8 @@ func (s *SQLiteStore) CountTableRows(table string) (int64, error) {
 	return n, nil
 }
 
-// GetBookVersions is a stub — book versioning is not yet supported in SQLite store.
-func (s *SQLiteStore) GetBookVersions(id string, limit int) ([]BookVersion, error) {
+// GetBookSnapshots is a stub — book versioning is not yet supported in SQLite store.
+func (s *SQLiteStore) GetBookSnapshots(id string, limit int) ([]BookSnapshot, error) {
 	return nil, nil
 }
 
@@ -4361,8 +4361,8 @@ func (s *SQLiteStore) RevertBookToVersion(id string, ts time.Time) (*Book, error
 	return nil, fmt.Errorf("book versioning not supported in SQLite store")
 }
 
-// PruneBookVersions is a stub — book versioning is not yet supported in SQLite store.
-func (s *SQLiteStore) PruneBookVersions(id string, keepCount int) (int, error) {
+// PruneBookSnapshots is a stub — book versioning is not yet supported in SQLite store.
+func (s *SQLiteStore) PruneBookSnapshots(id string, keepCount int) (int, error) {
 	return 0, nil
 }
 

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -100,10 +100,10 @@ type Store interface {
 	UpdateBook(id string, book *Book) (*Book, error) // ID is ULID string
 
 	// Book Version History (copy-on-write)
-	GetBookVersions(id string, limit int) ([]BookVersion, error)
+	GetBookSnapshots(id string, limit int) ([]BookSnapshot, error)
 	GetBookAtVersion(id string, ts time.Time) (*Book, error)
 	RevertBookToVersion(id string, ts time.Time) (*Book, error)
-	PruneBookVersions(id string, keepCount int) (int, error)
+	PruneBookSnapshots(id string, keepCount int) (int, error)
 	SetLastWrittenAt(id string, t time.Time) error   // Stamps last_written_at for write-back
 	MarkITunesSynced(bookIDs []string) (int64, error) // Marks books as synced with iTunes
 	GetITunesDirtyBooks() ([]Book, error)             // Returns books that need iTunes write-back
@@ -890,8 +890,8 @@ type MetadataChangeRecord struct {
 	ChangedAt     time.Time `json:"changed_at"`
 }
 
-// BookVersion represents an immutable snapshot of a book at a point in time.
-type BookVersion struct {
+// BookSnapshot represents an immutable snapshot of a book at a point in time.
+type BookSnapshot struct {
 	BookID    string    `json:"book_id"`
 	Timestamp time.Time `json:"timestamp"`
 	Data      []byte    `json:"data"` // Full JSON-serialized Book

--- a/internal/database/store_coverage_test.go
+++ b/internal/database/store_coverage_test.go
@@ -696,7 +696,7 @@ func TestCoverage_AuthorTombstoneStubs(t *testing.T) {
 func TestCoverage_BookVersionStubs(t *testing.T) {
 	store := setupCoverageDB(t)
 
-	versions, err := store.GetBookVersions("some-id", 10)
+	versions, err := store.GetBookSnapshots("some-id", 10)
 	assert.NoError(t, err)
 	assert.Nil(t, versions)
 
@@ -706,7 +706,7 @@ func TestCoverage_BookVersionStubs(t *testing.T) {
 	_, err = store.RevertBookToVersion("some-id", time.Now())
 	assert.Error(t, err)
 
-	n, err := store.PruneBookVersions("some-id", 5)
+	n, err := store.PruneBookSnapshots("some-id", 5)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
 }

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -369,7 +369,7 @@ func (s *Server) listBookCOWVersions(c *gin.Context) {
 			limit = v
 		}
 	}
-	versions, err := s.Store().GetBookVersions(id, limit)
+	versions, err := s.Store().GetBookSnapshots(id, limit)
 	if err != nil {
 		internalError(c, "failed to list versions", err)
 		return
@@ -392,7 +392,7 @@ func (s *Server) pruneBookCOWVersions(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "keep_count must be a positive integer"})
 		return
 	}
-	pruned, err := s.Store().PruneBookVersions(id, body.KeepCount)
+	pruned, err := s.Store().PruneBookSnapshots(id, body.KeepCount)
 	if err != nil {
 		internalError(c, "failed to prune versions", err)
 		return


### PR DESCRIPTION
Rename the CoW snapshot type to its true name, freeing BookVersion for the spec 3.1 library centralization work. No behavior change.