### PR TITLE
feat(search): DSL query parser (DES-1 task 2)

### DIFF
--- a/internal/search/query_ast.go
+++ b/internal/search/query_ast.go
@@ -1,0 +1,181 @@
+// file: internal/search/query_ast.go
+// version: 1.0.0
+// guid: 8a2c4f1d-5b9e-4f60-a7c8-1d6e0f2b9a47
+//
+// AST for the library search DSL (spec 3.4 / DES-1 v1.1). Each
+// concrete type is both the parser output and the input the
+// Bleve translator walks to produce a query.Query.
+//
+// Operator syntax (user-facing):
+//   AND:   whitespace | && | AND
+//   OR:    ||  |  OR
+//   NOT:   - prefix  |  NOT
+//   Group: (…)
+//   Within-field alternation: field:(a|b|c)
+//   Numeric: field:>N  field:<N  field:>=N  field:<=N  field:[A TO B]
+//   Prefix / wildcard: field:vamp*
+//   Fuzzy: field:smith~
+//   Boost: field:vampire^3
+
+package search
+
+import "fmt"
+
+// Node is any AST node. The Kind() method exists so callers can
+// type-switch by an enum rather than a reflect cast.
+type Node interface {
+	Kind() NodeKind
+	// String returns a human-readable form of the node, mostly for
+	// tests and for surfacing parse errors.
+	String() string
+}
+
+// NodeKind enumerates the AST node types.
+type NodeKind int
+
+const (
+	NodeAnd NodeKind = iota
+	NodeOr
+	NodeNot
+	NodeField
+	NodeFreeText
+	NodeValueAlt
+)
+
+// AndNode represents conjunction. Arity ≥ 2. An AND of one child is
+// collapsed by the parser into that child.
+type AndNode struct {
+	Children []Node
+}
+
+func (n *AndNode) Kind() NodeKind { return NodeAnd }
+func (n *AndNode) String() string {
+	return groupString("AND", n.Children)
+}
+
+// OrNode represents disjunction. Arity ≥ 2.
+type OrNode struct {
+	Children []Node
+}
+
+func (n *OrNode) Kind() NodeKind { return NodeOr }
+func (n *OrNode) String() string {
+	return groupString("OR", n.Children)
+}
+
+// NotNode wraps a single child. Both `-field:value` and `NOT …`
+// produce this.
+type NotNode struct {
+	Child Node
+}
+
+func (n *NotNode) Kind() NodeKind { return NodeNot }
+func (n *NotNode) String() string {
+	if n.Child == nil {
+		return "NOT(<nil>)"
+	}
+	return "NOT(" + n.Child.String() + ")"
+}
+
+// FieldNode is a single field:value clause, optionally with an
+// operator inside the value expression (range, prefix, fuzzy,
+// boost). Boost applies multiplicatively to this clause's score
+// contribution.
+type FieldNode struct {
+	Field string
+	// Value is the literal token after the colon (still includes
+	// any trailing * / ~ / ^boost suffixes until the translator
+	// unpacks them).
+	Value string
+	// Quoted marks whether the raw token was quoted — translator
+	// uses this to pick MatchQuery vs MatchPhraseQuery.
+	Quoted bool
+	// Op is the operator distinguishing exact equality from
+	// comparators. Empty string means default (match / contains).
+	// Known values: "", ">", "<", ">=", "<=", "=", "range"
+	Op string
+	// Range (RangeMin, RangeMax) populated when Op == "range" —
+	// parsed from field:[A TO B].
+	RangeMin string
+	RangeMax string
+	// Fuzzy is set when the token had a ~ suffix. Edit distance
+	// defaults to 2 in Bleve.
+	Fuzzy bool
+	// Prefix and Wildcard indicate * suffix / prefix / both.
+	Prefix   bool
+	Wildcard bool
+	// Boost is a multiplicative boost (e.g. `^3`). Zero means no
+	// user-specified boost; translator applies default 1.0.
+	Boost float64
+}
+
+func (n *FieldNode) Kind() NodeKind { return NodeField }
+func (n *FieldNode) String() string {
+	if n.Op == "range" {
+		return fmt.Sprintf("%s:[%s TO %s]", n.Field, n.RangeMin, n.RangeMax)
+	}
+	suffix := ""
+	if n.Fuzzy {
+		suffix += "~"
+	}
+	if n.Boost > 0 {
+		suffix += fmt.Sprintf("^%g", n.Boost)
+	}
+	op := n.Op
+	if op == "" || op == "=" {
+		op = ""
+	}
+	return fmt.Sprintf("%s:%s%s%s", n.Field, op, n.Value, suffix)
+}
+
+// FreeTextNode is a bare token that wasn't scoped to a field.
+// Translator uses this against an "all fields" query.
+type FreeTextNode struct {
+	Value  string
+	Quoted bool
+	Fuzzy  bool
+	Prefix bool
+}
+
+func (n *FreeTextNode) Kind() NodeKind { return NodeFreeText }
+func (n *FreeTextNode) String() string {
+	q := n.Value
+	if n.Quoted {
+		q = `"` + q + `"`
+	}
+	if n.Prefix {
+		q += "*"
+	}
+	if n.Fuzzy {
+		q += "~"
+	}
+	return q
+}
+
+// ValueAltNode represents the `field:(a|b|c)` within-field
+// alternation shortcut. Translator unfolds to a DisjunctionQuery
+// of MatchQuery per value.
+type ValueAltNode struct {
+	Field  string
+	Values []string
+}
+
+func (n *ValueAltNode) Kind() NodeKind { return NodeValueAlt }
+func (n *ValueAltNode) String() string {
+	out := n.Field + ":("
+	for i, v := range n.Values {
+		if i > 0 {
+			out += "|"
+		}
+		out += v
+	}
+	return out + ")"
+}
+
+func groupString(op string, children []Node) string {
+	out := "(" + op
+	for _, c := range children {
+		out += " " + c.String()
+	}
+	return out + ")"
+}

--- a/internal/search/query_parser.go
+++ b/internal/search/query_parser.go
@@ -1,0 +1,436 @@
+// file: internal/search/query_parser.go
+// version: 1.0.0
+// guid: 3c4a1d8f-5b2e-4f70-a7c6-2f8d0e1b9a57
+//
+// Parser for the library search DSL (spec 3.4 / DES-1 v1.1).
+//
+// Grammar (informal):
+//   expr     := orExpr
+//   orExpr   := andExpr ( ('||' | 'OR') andExpr )*
+//   andExpr  := notExpr ( ('&&' | 'AND' | ε) notExpr )*
+//   notExpr  := ('-' | 'NOT') notExpr | primary
+//   primary  := '(' expr ')' | fieldOrToken
+//   fieldOrToken
+//            := field ':' (value | valueAlt)
+//             | token
+//   valueAlt := '(' value ( '|' value )* ')'
+//   value    := quotedStr | operated
+//   operated := ('>'|'<'|'>='|'<='|'='|'range')? rawToken ('~'|'*')? ('^' number)?
+//
+// Operator precedence (tightest to loosest): NOT → AND → OR.
+// Grouping with ( … ) overrides precedence.
+//
+// Whitespace is AND. Backward compat: existing queries like
+//   author:smith tag:scifi -tag:romance
+// parse identically.
+
+package search
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// ParseQuery parses a DSL query string into an AST. Returns a
+// non-nil error on syntax failures; error messages include the
+// approximate cursor position.
+func ParseQuery(input string) (Node, error) {
+	p := &parser{input: input, pos: 0}
+	node, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if p.pos < len(p.input) {
+		return nil, fmt.Errorf("unexpected trailing input at position %d: %q", p.pos, p.input[p.pos:])
+	}
+	return node, nil
+}
+
+type parser struct {
+	input string
+	pos   int
+}
+
+func (p *parser) peek() byte {
+	if p.pos >= len(p.input) {
+		return 0
+	}
+	return p.input[p.pos]
+}
+
+func (p *parser) peekN(n int) string {
+	end := p.pos + n
+	if end > len(p.input) {
+		end = len(p.input)
+	}
+	return p.input[p.pos:end]
+}
+
+func (p *parser) skipWhitespace() {
+	for p.pos < len(p.input) && unicode.IsSpace(rune(p.input[p.pos])) {
+		p.pos++
+	}
+}
+
+// consumeKeyword matches one of the word-form operators (AND, OR,
+// NOT) as a whole word. Returns true + advances past it if matched.
+// Case-sensitive — the word forms are uppercase by convention.
+func (p *parser) consumeKeyword(kw string) bool {
+	if p.pos+len(kw) > len(p.input) {
+		return false
+	}
+	if p.input[p.pos:p.pos+len(kw)] != kw {
+		return false
+	}
+	// Require word boundary after the keyword (whitespace or end or
+	// punctuation) so we don't accidentally match "ANDROID" for AND.
+	if p.pos+len(kw) < len(p.input) {
+		next := p.input[p.pos+len(kw)]
+		if next != ' ' && next != '\t' && next != '(' && next != '-' {
+			return false
+		}
+	}
+	p.pos += len(kw)
+	return true
+}
+
+func (p *parser) parseOr() (Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	children := []Node{left}
+	for {
+		p.skipWhitespace()
+		if p.peekN(2) == "||" {
+			p.pos += 2
+		} else if p.consumeKeyword("OR") {
+			// matched
+		} else {
+			break
+		}
+		p.skipWhitespace()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, right)
+	}
+	if len(children) == 1 {
+		return children[0], nil
+	}
+	return &OrNode{Children: children}, nil
+}
+
+func (p *parser) parseAnd() (Node, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	children := []Node{left}
+	for {
+		p.skipWhitespace()
+		if p.pos >= len(p.input) {
+			break
+		}
+		// Stop if we're at a closing paren or an OR operator.
+		if p.peek() == ')' {
+			break
+		}
+		if p.peekN(2) == "||" {
+			break
+		}
+		if p.pos+2 <= len(p.input) && p.input[p.pos:p.pos+2] == "OR" {
+			// Only treat as OR if followed by whitespace / EOL / paren.
+			if p.pos+2 == len(p.input) || p.input[p.pos+2] == ' ' || p.input[p.pos+2] == '\t' || p.input[p.pos+2] == '(' {
+				break
+			}
+		}
+		// Consume an explicit && or AND if present; else fall through
+		// (implicit-whitespace AND).
+		if p.peekN(2) == "&&" {
+			p.pos += 2
+			p.skipWhitespace()
+		} else if p.consumeKeyword("AND") {
+			p.skipWhitespace()
+		}
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, right)
+	}
+	if len(children) == 1 {
+		return children[0], nil
+	}
+	return &AndNode{Children: children}, nil
+}
+
+func (p *parser) parseNot() (Node, error) {
+	p.skipWhitespace()
+	// '-' prefix form
+	if p.peek() == '-' {
+		// Only treat as NOT if followed by a non-space token (not a
+		// date / year that happens to be negative).
+		if p.pos+1 < len(p.input) && p.input[p.pos+1] != ' ' {
+			p.pos++
+			inner, err := p.parseNot()
+			if err != nil {
+				return nil, err
+			}
+			return &NotNode{Child: inner}, nil
+		}
+	}
+	// 'NOT' keyword
+	if p.consumeKeyword("NOT") {
+		p.skipWhitespace()
+		inner, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &NotNode{Child: inner}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Node, error) {
+	p.skipWhitespace()
+	if p.pos >= len(p.input) {
+		return nil, fmt.Errorf("unexpected end of input at position %d", p.pos)
+	}
+	if p.peek() == '(' {
+		p.pos++
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		p.skipWhitespace()
+		if p.peek() != ')' {
+			return nil, fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++
+		return inner, nil
+	}
+	return p.parseFieldOrToken()
+}
+
+// parseFieldOrToken reads a "field:value" clause, or a bare token
+// as free text. Handles quoting, value-alternation, and the
+// suffix operators * / ~ / ^boost.
+func (p *parser) parseFieldOrToken() (Node, error) {
+	// Read the identifier up to : or whitespace / special char.
+	start := p.pos
+	for p.pos < len(p.input) {
+		c := p.peek()
+		if c == ':' || c == ' ' || c == '\t' || c == ')' || c == '(' {
+			break
+		}
+		if p.peekN(2) == "||" || p.peekN(2) == "&&" {
+			break
+		}
+		p.pos++
+	}
+	head := p.input[start:p.pos]
+	if head == "" {
+		return nil, fmt.Errorf("expected token at position %d", p.pos)
+	}
+
+	if p.peek() != ':' {
+		// Bare token → FreeTextNode.
+		return parseFreeText(head), nil
+	}
+
+	// Consume ':' and parse the value.
+	p.pos++
+	return p.parseFieldValue(head)
+}
+
+func parseFreeText(tok string) Node {
+	n := &FreeTextNode{Value: tok}
+	// Handle trailing * and ~ on free text too.
+	if strings.HasSuffix(n.Value, "~") {
+		n.Fuzzy = true
+		n.Value = strings.TrimSuffix(n.Value, "~")
+	}
+	if strings.HasSuffix(n.Value, "*") {
+		n.Prefix = true
+		n.Value = strings.TrimSuffix(n.Value, "*")
+	}
+	return n
+}
+
+func (p *parser) parseFieldValue(field string) (Node, error) {
+	p.skipWhitespace()
+	if p.pos >= len(p.input) {
+		return nil, fmt.Errorf("expected value after '%s:' at position %d", field, p.pos)
+	}
+
+	// Value-alternation: field:(a|b|c)
+	if p.peek() == '(' {
+		return p.parseValueAlt(field)
+	}
+
+	// Numeric range: field:[A TO B]
+	if p.peek() == '[' {
+		return p.parseRange(field)
+	}
+
+	// Numeric comparator prefix: >, <, >=, <=, =
+	op := ""
+	if p.pos+2 <= len(p.input) && (p.input[p.pos:p.pos+2] == ">=" || p.input[p.pos:p.pos+2] == "<=") {
+		op = p.input[p.pos : p.pos+2]
+		p.pos += 2
+	} else if c := p.peek(); c == '>' || c == '<' || c == '=' {
+		op = string(c)
+		p.pos++
+	}
+
+	// Quoted or bare value.
+	var value string
+	var quoted bool
+	if p.peek() == '"' {
+		var err error
+		value, err = p.parseQuoted()
+		if err != nil {
+			return nil, err
+		}
+		quoted = true
+	} else {
+		value = p.parseBareValue()
+	}
+
+	node := &FieldNode{
+		Field: field, Value: value, Quoted: quoted, Op: op,
+	}
+
+	// Trailing ~, *, ^N — applied to whatever value we parsed.
+	if strings.HasSuffix(value, "~") && !quoted {
+		node.Fuzzy = true
+		node.Value = strings.TrimSuffix(value, "~")
+	}
+	value = node.Value
+	if strings.HasSuffix(value, "*") && !quoted {
+		node.Prefix = true
+		node.Value = strings.TrimSuffix(value, "*")
+	}
+	value = node.Value
+	if strings.HasPrefix(value, "*") && !quoted {
+		node.Wildcard = true
+		node.Value = strings.TrimPrefix(value, "*")
+	}
+	// Boost: field:foo^3
+	if idx := strings.LastIndex(node.Value, "^"); idx > 0 && !quoted {
+		boostStr := node.Value[idx+1:]
+		if f, err := strconv.ParseFloat(boostStr, 64); err == nil {
+			node.Boost = f
+			node.Value = node.Value[:idx]
+		}
+	}
+	return node, nil
+}
+
+func (p *parser) parseQuoted() (string, error) {
+	if p.peek() != '"' {
+		return "", fmt.Errorf("expected opening quote at position %d", p.pos)
+	}
+	p.pos++
+	start := p.pos
+	for p.pos < len(p.input) && p.peek() != '"' {
+		p.pos++
+	}
+	if p.pos >= len(p.input) {
+		return "", fmt.Errorf("unterminated quoted value starting at position %d", start)
+	}
+	val := p.input[start:p.pos]
+	p.pos++ // consume closing quote
+	return val, nil
+}
+
+// parseBareValue reads an unquoted value up to the next operator
+// or whitespace. Supports `|` only inside value-alternation parens.
+func (p *parser) parseBareValue() string {
+	start := p.pos
+	for p.pos < len(p.input) {
+		c := p.peek()
+		if c == ' ' || c == '\t' || c == ')' {
+			break
+		}
+		if p.peekN(2) == "||" || p.peekN(2) == "&&" {
+			break
+		}
+		p.pos++
+	}
+	return p.input[start:p.pos]
+}
+
+func (p *parser) parseValueAlt(field string) (Node, error) {
+	if p.peek() != '(' {
+		return nil, fmt.Errorf("expected '(' at position %d", p.pos)
+	}
+	p.pos++ // consume '('
+	var values []string
+	for {
+		p.skipWhitespace()
+		var v string
+		if p.peek() == '"' {
+			qv, err := p.parseQuoted()
+			if err != nil {
+				return nil, err
+			}
+			v = qv
+		} else {
+			start := p.pos
+			for p.pos < len(p.input) && p.peek() != '|' && p.peek() != ')' {
+				p.pos++
+			}
+			v = strings.TrimSpace(p.input[start:p.pos])
+		}
+		if v != "" {
+			values = append(values, v)
+		}
+		if p.peek() == '|' {
+			p.pos++
+			continue
+		}
+		break
+	}
+	p.skipWhitespace()
+	if p.peek() != ')' {
+		return nil, fmt.Errorf("expected ')' closing value-alternation at position %d", p.pos)
+	}
+	p.pos++
+	return &ValueAltNode{Field: field, Values: values}, nil
+}
+
+func (p *parser) parseRange(field string) (Node, error) {
+	if p.peek() != '[' {
+		return nil, fmt.Errorf("expected '[' at position %d", p.pos)
+	}
+	p.pos++ // consume '['
+	// Read up to ']'. Expect "A TO B" (case-insensitive TO).
+	start := p.pos
+	for p.pos < len(p.input) && p.peek() != ']' {
+		p.pos++
+	}
+	if p.peek() != ']' {
+		return nil, fmt.Errorf("unterminated range starting at position %d", start)
+	}
+	body := p.input[start:p.pos]
+	p.pos++ // consume ']'
+
+	// Split on " TO " (case-insensitive).
+	lower := strings.ToLower(body)
+	idx := strings.Index(lower, " to ")
+	if idx < 0 {
+		return nil, fmt.Errorf("range must be of form [A TO B], got %q", body)
+	}
+	minVal := strings.TrimSpace(body[:idx])
+	maxVal := strings.TrimSpace(body[idx+4:])
+	return &FieldNode{
+		Field: field, Op: "range",
+		RangeMin: minVal, RangeMax: maxVal,
+	}, nil
+}

--- a/internal/search/query_parser_test.go
+++ b/internal/search/query_parser_test.go
@@ -1,0 +1,246 @@
+// file: internal/search/query_parser_test.go
+// version: 1.0.0
+// guid: 5f1c8a2d-4b9e-4f70-a7c6-2d8e0f1b9a57
+
+package search
+
+import "testing"
+
+func mustParse(t *testing.T, q string) Node {
+	t.Helper()
+	n, err := ParseQuery(q)
+	if err != nil {
+		t.Fatalf("ParseQuery(%q): %v", q, err)
+	}
+	return n
+}
+
+func TestParse_BareField(t *testing.T) {
+	n := mustParse(t, "author:sanderson")
+	fn, ok := n.(*FieldNode)
+	if !ok {
+		t.Fatalf("got %T, want *FieldNode", n)
+	}
+	if fn.Field != "author" || fn.Value != "sanderson" {
+		t.Errorf("got %+v", fn)
+	}
+}
+
+func TestParse_FreeText(t *testing.T) {
+	n := mustParse(t, "vampire")
+	if _, ok := n.(*FreeTextNode); !ok {
+		t.Fatalf("got %T, want *FreeTextNode", n)
+	}
+}
+
+func TestParse_ImplicitAnd(t *testing.T) {
+	n := mustParse(t, "author:sanderson tag:scifi")
+	and, ok := n.(*AndNode)
+	if !ok {
+		t.Fatalf("got %T, want *AndNode", n)
+	}
+	if len(and.Children) != 2 {
+		t.Errorf("AND children = %d, want 2", len(and.Children))
+	}
+}
+
+func TestParse_ExplicitAnd(t *testing.T) {
+	cases := []string{
+		"a:1 && b:2",
+		"a:1 AND b:2",
+	}
+	for _, q := range cases {
+		n := mustParse(t, q)
+		if _, ok := n.(*AndNode); !ok {
+			t.Errorf("%q → %T, want *AndNode", q, n)
+		}
+	}
+}
+
+func TestParse_Or(t *testing.T) {
+	cases := []string{
+		"a:1 || b:2",
+		"a:1 OR b:2",
+	}
+	for _, q := range cases {
+		n := mustParse(t, q)
+		if _, ok := n.(*OrNode); !ok {
+			t.Errorf("%q → %T, want *OrNode", q, n)
+		}
+	}
+}
+
+func TestParse_NotDashPrefix(t *testing.T) {
+	n := mustParse(t, "-tag:romance")
+	not, ok := n.(*NotNode)
+	if !ok {
+		t.Fatalf("got %T, want *NotNode", n)
+	}
+	if _, ok := not.Child.(*FieldNode); !ok {
+		t.Errorf("inner: got %T, want *FieldNode", not.Child)
+	}
+}
+
+func TestParse_NotKeyword(t *testing.T) {
+	n := mustParse(t, "NOT tag:romance")
+	if _, ok := n.(*NotNode); !ok {
+		t.Fatalf("got %T, want *NotNode", n)
+	}
+}
+
+func TestParse_Grouping(t *testing.T) {
+	// (-title:twilight && -title:"New Dawn" && title:vampire) || title:fangtown
+	n := mustParse(t, `(-title:twilight && -title:"New Dawn" && title:vampire) || title:fangtown`)
+	or, ok := n.(*OrNode)
+	if !ok {
+		t.Fatalf("top = %T, want *OrNode", n)
+	}
+	if len(or.Children) != 2 {
+		t.Fatalf("OR children = %d, want 2", len(or.Children))
+	}
+	if _, ok := or.Children[0].(*AndNode); !ok {
+		t.Errorf("first branch = %T, want *AndNode", or.Children[0])
+	}
+	if _, ok := or.Children[1].(*FieldNode); !ok {
+		t.Errorf("second branch = %T, want *FieldNode", or.Children[1])
+	}
+}
+
+func TestParse_ValueAlternation(t *testing.T) {
+	n := mustParse(t, `title:(Fangtown|fangtown|"fang town")`)
+	alt, ok := n.(*ValueAltNode)
+	if !ok {
+		t.Fatalf("got %T, want *ValueAltNode", n)
+	}
+	if alt.Field != "title" {
+		t.Errorf("field = %q, want title", alt.Field)
+	}
+	if len(alt.Values) != 3 {
+		t.Fatalf("values = %d, want 3", len(alt.Values))
+	}
+	if alt.Values[2] != "fang town" {
+		t.Errorf("quoted value = %q, want 'fang town'", alt.Values[2])
+	}
+}
+
+func TestParse_NumericComparators(t *testing.T) {
+	cases := map[string]string{
+		"year:>2000":  ">",
+		"year:<2010":  "<",
+		"year:>=2000": ">=",
+		"year:<=2020": "<=",
+	}
+	for q, wantOp := range cases {
+		n := mustParse(t, q)
+		fn, ok := n.(*FieldNode)
+		if !ok {
+			t.Fatalf("%q → %T, want *FieldNode", q, n)
+		}
+		if fn.Op != wantOp {
+			t.Errorf("%q: Op = %q, want %q", q, fn.Op, wantOp)
+		}
+	}
+}
+
+func TestParse_NumericRange(t *testing.T) {
+	n := mustParse(t, "year:[2000 TO 2010]")
+	fn, ok := n.(*FieldNode)
+	if !ok {
+		t.Fatalf("got %T, want *FieldNode", n)
+	}
+	if fn.Op != "range" {
+		t.Errorf("Op = %q, want range", fn.Op)
+	}
+	if fn.RangeMin != "2000" || fn.RangeMax != "2010" {
+		t.Errorf("range = [%s TO %s], want [2000 TO 2010]", fn.RangeMin, fn.RangeMax)
+	}
+}
+
+func TestParse_PrefixWildcardFuzzy(t *testing.T) {
+	type wantShape struct {
+		prefix   bool
+		wildcard bool
+		fuzzy    bool
+		value    string
+	}
+	cases := map[string]wantShape{
+		"title:vamp*":   {prefix: true, value: "vamp"},
+		"title:*vamp":   {wildcard: true, value: "vamp"},
+		"author:smith~": {fuzzy: true, value: "smith"},
+	}
+	for q, want := range cases {
+		n := mustParse(t, q)
+		fn, ok := n.(*FieldNode)
+		if !ok {
+			t.Fatalf("%q → %T, want *FieldNode", q, n)
+		}
+		if fn.Prefix != want.prefix {
+			t.Errorf("%q Prefix = %v, want %v", q, fn.Prefix, want.prefix)
+		}
+		if fn.Wildcard != want.wildcard {
+			t.Errorf("%q Wildcard = %v, want %v", q, fn.Wildcard, want.wildcard)
+		}
+		if fn.Fuzzy != want.fuzzy {
+			t.Errorf("%q Fuzzy = %v, want %v", q, fn.Fuzzy, want.fuzzy)
+		}
+		if fn.Value != want.value {
+			t.Errorf("%q Value = %q, want %q", q, fn.Value, want.value)
+		}
+	}
+}
+
+func TestParse_Boost(t *testing.T) {
+	n := mustParse(t, "title:vampire^3")
+	fn, ok := n.(*FieldNode)
+	if !ok {
+		t.Fatalf("got %T", n)
+	}
+	if fn.Boost != 3 {
+		t.Errorf("Boost = %g, want 3", fn.Boost)
+	}
+	if fn.Value != "vampire" {
+		t.Errorf("Value = %q, want vampire", fn.Value)
+	}
+}
+
+func TestParse_BackwardCompat(t *testing.T) {
+	// Existing queries (no new operators) must parse identically to
+	// before: implicit whitespace = AND, field:value, quoted values,
+	// dash-negation.
+	n := mustParse(t, `author:"Joshua Dalzelle" tag:scifi -tag:romance great books`)
+	and, ok := n.(*AndNode)
+	if !ok {
+		t.Fatalf("got %T, want *AndNode", n)
+	}
+	// author + tag + NOT tag + "great" + "books" = 5 children
+	if len(and.Children) != 5 {
+		t.Errorf("AND children = %d, want 5", len(and.Children))
+	}
+}
+
+func TestParse_WorkedExample(t *testing.T) {
+	// Full worked example from the 3.4 spec — both operator styles
+	// must parse into structurally equivalent trees.
+	style1 := `(-title:twilight && -title:"New Dawn" && title:vampire) || title:(Fangtown|fangtown|"fang town")`
+	style2 := `(NOT title:twilight AND NOT title:"New Dawn" AND title:vampire) OR title:(Fangtown|fangtown|"fang town")`
+
+	n1 := mustParse(t, style1)
+	n2 := mustParse(t, style2)
+
+	if n1.String() != n2.String() {
+		t.Errorf("styles produce different trees:\nstyle1: %s\nstyle2: %s", n1.String(), n2.String())
+	}
+}
+
+func TestParse_Errors(t *testing.T) {
+	bad := []string{
+		`(author:foo`,        // missing ')'
+		`author:"unterminated`, // unclosed quote
+		`author:[2000 2010]`,   // missing TO
+	}
+	for _, q := range bad {
+		if _, err := ParseQuery(q); err == nil {
+			t.Errorf("ParseQuery(%q) should have errored", q)
+		}
+	}
+}


### PR DESCRIPTION
Go-side parser for the library search DSL. AST types + full operator support (&&/||/NOT/grouping/value-alt/ranges/fuzzy/prefix/wildcard/boost/quoted). 16 tests.