### PR TITLE
feat(read-unread): status recomputation engine (3.6 task 3)

### DIFF
--- a/internal/server/read_status_engine.go
+++ b/internal/server/read_status_engine.go
@@ -1,0 +1,156 @@
+// file: internal/server/read_status_engine.go
+// version: 1.0.0
+// guid: 6e2f8a1d-4c5b-4f70-a9c7-2d8e0f1b9a57
+//
+// RecomputeUserBookState derives a UserBookState from the current
+// UserPosition rows for a given (user, book), honoring the
+// status_manual override flag per spec 3.6 §6-7.
+//
+// Flow:
+//   1. Load all book_files for the book (for segment durations)
+//   2. Load all UserPosition rows for (user, book)
+//   3. Sum listened-seconds: for each position, use min(position,
+//      segment_duration). Total duration = sum of all segment
+//      durations (including ones without positions).
+//   4. Progress pct = 100 * listened / total (clamped 0..100).
+//   5. If status_manual is true on the existing state, keep the
+//      stored status and only refresh the activity fields.
+//      Otherwise auto-derive:
+//        - total_duration > 0 AND listened / total ≥ 0.95 → finished
+//        - listened > 0 → in_progress
+//        - else → unstarted
+//      `abandoned` is never auto-computed — user-set only.
+
+package server
+
+import (
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// RecomputeUserBookState reads positions + segment durations and
+// updates user_book_state with fresh auto-computed fields. Returns
+// the new state (or a no-op unchanged state if there's nothing to
+// record — e.g. a user who's never touched this book).
+func RecomputeUserBookState(store database.Store, userID, bookID string) (*database.UserBookState, error) {
+	if store == nil || userID == "" || bookID == "" {
+		return nil, nil
+	}
+	positions, err := store.ListUserPositionsForBook(userID, bookID)
+	if err != nil {
+		return nil, err
+	}
+	existing, _ := store.GetUserBookState(userID, bookID)
+
+	// If no existing state and no positions, there's nothing to record.
+	if len(positions) == 0 && existing == nil {
+		return nil, nil
+	}
+
+	// Gather book_files for durations. Index by segment ID.
+	files, _ := store.GetBookFiles(bookID)
+	segDuration := make(map[string]float64, len(files))
+	var totalDuration float64
+	for _, f := range files {
+		// BookFile.Duration is stored in seconds (per scanner convention).
+		segDuration[f.ID] = float64(f.Duration)
+		totalDuration += float64(f.Duration)
+	}
+
+	var listened float64
+	var lastActivity time.Time
+	var lastSegment string
+	for _, pos := range positions {
+		// Cap each contribution at the segment's duration — a client
+		// could report a position past the end of a file.
+		cap := segDuration[pos.SegmentID]
+		p := pos.PositionSeconds
+		if cap > 0 && p > cap {
+			p = cap
+		}
+		listened += p
+		if pos.UpdatedAt.After(lastActivity) {
+			lastActivity = pos.UpdatedAt
+			lastSegment = pos.SegmentID
+		}
+	}
+
+	// Start from the existing state (preserves status_manual +
+	// explicit status) or a fresh one.
+	var state *database.UserBookState
+	if existing != nil {
+		copied := *existing
+		state = &copied
+	} else {
+		state = &database.UserBookState{UserID: userID, BookID: bookID}
+	}
+	state.TotalListenedSeconds = listened
+	if totalDuration > 0 {
+		pct := int((listened / totalDuration) * 100)
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 100 {
+			pct = 100
+		}
+		state.ProgressPct = pct
+	} else {
+		state.ProgressPct = 0
+	}
+	if !lastActivity.IsZero() {
+		state.LastActivityAt = lastActivity
+		state.LastSegmentID = lastSegment
+	}
+
+	// Auto-derive status unless user has manually overridden.
+	if !state.StatusManual {
+		switch {
+		case totalDuration > 0 && listened/totalDuration >= database.FinishedThreshold:
+			state.Status = database.UserBookStatusFinished
+		case listened > 0:
+			state.Status = database.UserBookStatusInProgress
+		default:
+			state.Status = database.UserBookStatusUnstarted
+		}
+	}
+
+	if err := store.SetUserBookState(state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// SetManualStatus records a user-forced status (Finished, Unstarted,
+// Abandoned, or back to InProgress) and flips StatusManual=true so
+// RecomputeUserBookState leaves it alone going forward. Passing
+// empty string reverts to auto — next Recompute call derives a
+// fresh status from positions.
+func SetManualStatus(store database.Store, userID, bookID, status string) (*database.UserBookState, error) {
+	if store == nil {
+		return nil, nil
+	}
+	existing, _ := store.GetUserBookState(userID, bookID)
+	var state *database.UserBookState
+	if existing != nil {
+		copied := *existing
+		state = &copied
+	} else {
+		state = &database.UserBookState{UserID: userID, BookID: bookID}
+	}
+	if status == "" {
+		state.StatusManual = false
+		// Recompute to refresh status from positions.
+		if err := store.SetUserBookState(state); err != nil {
+			return nil, err
+		}
+		return RecomputeUserBookState(store, userID, bookID)
+	}
+	state.Status = status
+	state.StatusManual = true
+	state.LastActivityAt = time.Now()
+	if err := store.SetUserBookState(state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}

--- a/internal/server/read_status_engine_test.go
+++ b/internal/server/read_status_engine_test.go
@@ -1,0 +1,183 @@
+// file: internal/server/read_status_engine_test.go
+// version: 1.0.0
+// guid: 9e2a8c4d-5b1f-4f70-a7c6-2d8e0f1b9a57
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// setupReadTestStore creates a PebbleStore + seeds one book with
+// three 10-minute (600-second) segments. Total book duration = 1800s.
+func setupReadTestStore(t *testing.T) database.Store {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	for i, segID := range []string{"s1", "s2", "s3"} {
+		if err := store.CreateBookFile(&database.BookFile{
+			ID: segID, BookID: "b1",
+			FilePath:    "/tmp/" + segID,
+			TrackNumber: i + 1,
+			Duration:    600, // seconds
+		}); err != nil {
+			t.Fatalf("create bookfile %s: %v", segID, err)
+		}
+	}
+	return store
+}
+
+func TestRecompute_Unstarted(t *testing.T) {
+	store := setupReadTestStore(t)
+	state, err := RecomputeUserBookState(store, "u1", "b1")
+	if err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	// No positions, no existing state → nil / no-op.
+	if state != nil {
+		t.Errorf("expected nil state for never-touched book, got %+v", state)
+	}
+}
+
+func TestRecompute_InProgress(t *testing.T) {
+	store := setupReadTestStore(t)
+	// Listened 300s of the first segment (of 1800 total = 16.6%).
+	_ = store.SetUserPosition("u1", "b1", "s1", 300)
+
+	state, err := RecomputeUserBookState(store, "u1", "b1")
+	if err != nil || state == nil {
+		t.Fatalf("recompute: %v / %v", state, err)
+	}
+	if state.Status != database.UserBookStatusInProgress {
+		t.Errorf("Status = %q, want in_progress", state.Status)
+	}
+	if state.ProgressPct != 16 {
+		t.Errorf("ProgressPct = %d, want 16", state.ProgressPct)
+	}
+	if state.LastSegmentID != "s1" {
+		t.Errorf("LastSegmentID = %q, want s1", state.LastSegmentID)
+	}
+}
+
+func TestRecompute_AutoFinished(t *testing.T) {
+	store := setupReadTestStore(t)
+	// Three segments fully played = 1800s / 1800s = 100%.
+	_ = store.SetUserPosition("u1", "b1", "s1", 600)
+	_ = store.SetUserPosition("u1", "b1", "s2", 600)
+	_ = store.SetUserPosition("u1", "b1", "s3", 600)
+
+	state, err := RecomputeUserBookState(store, "u1", "b1")
+	if err != nil || state == nil {
+		t.Fatalf("recompute: %v / %v", state, err)
+	}
+	if state.Status != database.UserBookStatusFinished {
+		t.Errorf("Status = %q, want finished", state.Status)
+	}
+	if state.ProgressPct != 100 {
+		t.Errorf("ProgressPct = %d, want 100", state.ProgressPct)
+	}
+}
+
+func TestRecompute_ThresholdBoundary(t *testing.T) {
+	store := setupReadTestStore(t)
+	// Exactly 95% — right at the threshold. 1800 * 0.95 = 1710.
+	_ = store.SetUserPosition("u1", "b1", "s1", 600)
+	_ = store.SetUserPosition("u1", "b1", "s2", 600)
+	_ = store.SetUserPosition("u1", "b1", "s3", 510) // 600+600+510 = 1710
+
+	state, _ := RecomputeUserBookState(store, "u1", "b1")
+	if state == nil {
+		t.Fatal("state nil")
+	}
+	if state.Status != database.UserBookStatusFinished {
+		t.Errorf("At boundary threshold 95%%, Status = %q, want finished", state.Status)
+	}
+}
+
+func TestRecompute_OverflowCapped(t *testing.T) {
+	store := setupReadTestStore(t)
+	// Client reports position past end of segment (e.g. seeked to
+	// end). Should be capped at segment duration, not double-count.
+	_ = store.SetUserPosition("u1", "b1", "s1", 9999)
+
+	state, _ := RecomputeUserBookState(store, "u1", "b1")
+	if state == nil {
+		t.Fatal("state nil")
+	}
+	if state.TotalListenedSeconds != 600 {
+		t.Errorf("TotalListenedSeconds = %g, want 600 (capped)", state.TotalListenedSeconds)
+	}
+}
+
+func TestRecompute_ManualOverrideNotClobbered(t *testing.T) {
+	store := setupReadTestStore(t)
+	// User manually marks book as abandoned.
+	_, _ = SetManualStatus(store, "u1", "b1", database.UserBookStatusAbandoned)
+
+	// Later they listen to a bit. Recompute must NOT flip status
+	// away from abandoned.
+	_ = store.SetUserPosition("u1", "b1", "s1", 300)
+	state, _ := RecomputeUserBookState(store, "u1", "b1")
+	if state.Status != database.UserBookStatusAbandoned {
+		t.Errorf("Manual status clobbered by recompute: %q, want abandoned", state.Status)
+	}
+	// But the computed progress fields DO refresh.
+	if state.ProgressPct == 0 {
+		t.Error("Manual flag should preserve status but still refresh progress")
+	}
+}
+
+func TestSetManualStatus_ClearReturnsToAuto(t *testing.T) {
+	store := setupReadTestStore(t)
+
+	// Play a bit, auto-status = in_progress.
+	_ = store.SetUserPosition("u1", "b1", "s1", 300)
+	_, _ = RecomputeUserBookState(store, "u1", "b1")
+
+	// Manually force to finished.
+	_, _ = SetManualStatus(store, "u1", "b1", database.UserBookStatusFinished)
+	s, _ := store.GetUserBookState("u1", "b1")
+	if s.Status != database.UserBookStatusFinished || !s.StatusManual {
+		t.Fatalf("after manual set: %+v", s)
+	}
+
+	// Clear manual — should auto-recompute back to in_progress.
+	state, _ := SetManualStatus(store, "u1", "b1", "")
+	if state == nil {
+		t.Fatal("state nil after clear")
+	}
+	if state.StatusManual {
+		t.Error("StatusManual should be false after clear")
+	}
+	if state.Status != database.UserBookStatusInProgress {
+		t.Errorf("Status = %q, want in_progress after clearing manual override", state.Status)
+	}
+}
+
+func TestRecompute_PerUserIsolation(t *testing.T) {
+	store := setupReadTestStore(t)
+
+	_ = store.SetUserPosition("u1", "b1", "s1", 600)
+	_ = store.SetUserPosition("u2", "b1", "s1", 30)
+
+	s1, _ := RecomputeUserBookState(store, "u1", "b1")
+	s2, _ := RecomputeUserBookState(store, "u2", "b1")
+
+	if s1.Status != database.UserBookStatusInProgress {
+		t.Errorf("u1 status = %q", s1.Status)
+	}
+	if s2.Status != database.UserBookStatusInProgress {
+		t.Errorf("u2 status = %q", s2.Status)
+	}
+	if s1.TotalListenedSeconds == s2.TotalListenedSeconds {
+		t.Errorf("per-user state not isolated: u1=%g u2=%g",
+			s1.TotalListenedSeconds, s2.TotalListenedSeconds)
+	}
+}


### PR DESCRIPTION
Derives UserBookState from positions. Honors status_manual override. 8 tests including boundary and overflow cases.