### PR TITLE
feat(read-unread): position + status HTTP endpoints (3.6 task 2)

### DIFF
--- a/internal/server/reading_handlers.go
+++ b/internal/server/reading_handlers.go
@@ -1,0 +1,206 @@
+// file: internal/server/reading_handlers.go
+// version: 1.0.0
+// guid: 7f2c4a1d-5b8e-4f70-a9d6-2e8c0f1b9a57
+//
+// HTTP endpoints for the per-user read/unread tracking system
+// (spec 3.6). All endpoints scope to the calling user from
+// auth.UserFromContext — users can only read/write their own
+// state. Anonymous / first-run bootstrap requests use a synthetic
+// "_local" user id so the endpoints remain functional before
+// multi-user login ships.
+
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	svrmw "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
+)
+
+// callingUserID pulls the authenticated user's ID from context.
+// Falls back to "_local" for unauthenticated / bootstrap mode so
+// single-user installs can exercise the endpoints before running
+// the 3.7 setup wizard.
+func callingUserID(c *gin.Context) string {
+	if u, ok := auth.UserFromContext(c.Request.Context()); ok && u != nil {
+		return u.ID
+	}
+	if u, ok := svrmw.CurrentUser(c); ok && u != nil {
+		return u.ID
+	}
+	return "_local"
+}
+
+type setPositionRequest struct {
+	SegmentID       string  `json:"segment_id" binding:"required"`
+	PositionSeconds float64 `json:"position_seconds"`
+}
+
+// handleSetPosition records one position heartbeat and recomputes
+// derived UserBookState. POST /api/v1/books/:id/position
+func (s *Server) handleSetPosition(c *gin.Context) {
+	bookID := c.Param("id")
+	if bookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		return
+	}
+	var req setPositionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	userID := callingUserID(c)
+	if err := s.Store().SetUserPosition(userID, bookID, req.SegmentID, req.PositionSeconds); err != nil {
+		internalError(c, "failed to record position", err)
+		return
+	}
+	state, err := RecomputeUserBookState(s.Store(), userID, bookID)
+	if err != nil {
+		internalError(c, "failed to recompute book state", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"state": state})
+}
+
+// handleGetPosition returns the latest position for the calling user.
+// GET /api/v1/books/:id/position
+func (s *Server) handleGetPosition(c *gin.Context) {
+	bookID := c.Param("id")
+	if bookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		return
+	}
+	pos, err := s.Store().GetUserPosition(callingUserID(c), bookID)
+	if err != nil {
+		internalError(c, "failed to load position", err)
+		return
+	}
+	if pos == nil {
+		c.JSON(http.StatusOK, gin.H{"position": nil})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"position": pos})
+}
+
+// handleGetBookState returns the derived UserBookState — status +
+// progress percent + last activity — for the calling user.
+// GET /api/v1/books/:id/state
+func (s *Server) handleGetBookState(c *gin.Context) {
+	bookID := c.Param("id")
+	if bookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		return
+	}
+	state, err := s.Store().GetUserBookState(callingUserID(c), bookID)
+	if err != nil {
+		internalError(c, "failed to load state", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"state": state})
+}
+
+type patchStatusRequest struct {
+	Status string `json:"status" binding:"required"`
+}
+
+// handleSetBookStatus sets a manual status override. User-forced
+// status takes precedence over auto-derived in future recomputes.
+// PATCH /api/v1/books/:id/status
+func (s *Server) handleSetBookStatus(c *gin.Context) {
+	bookID := c.Param("id")
+	if bookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		return
+	}
+	var req patchStatusRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	switch req.Status {
+	case database.UserBookStatusFinished,
+		database.UserBookStatusInProgress,
+		database.UserBookStatusUnstarted,
+		database.UserBookStatusAbandoned:
+		// ok
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status: " + req.Status})
+		return
+	}
+	state, err := SetManualStatus(s.Store(), callingUserID(c), bookID, req.Status)
+	if err != nil {
+		internalError(c, "failed to set status", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"state": state})
+}
+
+// handleClearBookStatus clears the manual override — next recompute
+// derives a fresh status from positions.
+// DELETE /api/v1/books/:id/status
+func (s *Server) handleClearBookStatus(c *gin.Context) {
+	bookID := c.Param("id")
+	if bookID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		return
+	}
+	state, err := SetManualStatus(s.Store(), callingUserID(c), bookID, "")
+	if err != nil {
+		internalError(c, "failed to clear status", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"state": state})
+}
+
+// handleListByStatus returns the calling user's books filtered by
+// status, paginated. GET /api/v1/me/{in-progress|finished|abandoned|unstarted}
+func (s *Server) handleListByStatus(c *gin.Context) {
+	status := c.Param("status")
+	switch status {
+	case database.UserBookStatusInProgress,
+		database.UserBookStatusFinished,
+		database.UserBookStatusAbandoned,
+		database.UserBookStatusUnstarted:
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
+		return
+	}
+	limit := 50
+	offset := 0
+	if l := c.Query("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 500 {
+			limit = n
+		}
+	}
+	if o := c.Query("offset"); o != "" {
+		if n, err := strconv.Atoi(o); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	list, err := s.Store().ListUserBookStatesByStatus(callingUserID(c), status, limit, offset)
+	if err != nil {
+		internalError(c, "failed to list states", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"states": list, "count": len(list), "limit": limit, "offset": offset})
+}
+
+// registerReadingRoutes wires the read/unread endpoints onto the
+// given router group.
+func (s *Server) registerReadingRoutes(protected *gin.RouterGroup) {
+	protected.POST("/books/:id/position", s.handleSetPosition)
+	protected.GET("/books/:id/position", s.handleGetPosition)
+	protected.GET("/books/:id/state", s.handleGetBookState)
+	protected.PATCH("/books/:id/status", s.handleSetBookStatus)
+	protected.DELETE("/books/:id/status", s.handleClearBookStatus)
+	protected.GET("/me/:status", s.handleListByStatus)
+}
+
+// Silence unused-import if the reading code block ever gets compiled
+// without touching time — handler test paths reach here.
+var _ = time.Now

--- a/internal/server/reading_handlers_test.go
+++ b/internal/server/reading_handlers_test.go
@@ -1,0 +1,195 @@
+// file: internal/server/reading_handlers_test.go
+// version: 1.0.0
+// guid: 4f9a2c1d-5b8e-4f70-a7d6-2e8c0f1b9a57
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func setupReadingTestServer(t *testing.T) *Server {
+	t.Helper()
+	// Spec 3.6 features live on PebbleDB (SQLite has no-op stubs),
+	// so override the default SQLite test setup with a PebbleStore.
+	pebblePath := t.TempDir() + "/pebble"
+	store, err := database.NewPebbleStore(pebblePath)
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() {
+		database.SetGlobalStore(origStore)
+		store.Close()
+	})
+
+	srv := NewServer(nil)
+
+	_, err = store.CreateBook(&database.Book{
+		ID: "b1", Title: "Test Book", FilePath: "/tmp/b1", Format: "m4b",
+	})
+	if err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+	for i, segID := range []string{"s1", "s2", "s3"} {
+		_ = store.CreateBookFile(&database.BookFile{
+			ID: segID, BookID: "b1", FilePath: "/tmp/" + segID,
+			TrackNumber: i + 1, Duration: 600,
+		})
+	}
+	return srv
+}
+
+func TestReading_SetAndGetPosition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := setupReadingTestServer(t)
+
+	// POST position
+	body, _ := json.Marshal(map[string]interface{}{
+		"segment_id": "s1", "position_seconds": 300,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/books/b1/position", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST position: %d %s", w.Code, w.Body.String())
+	}
+
+	// GET position
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/books/b1/position", nil)
+	w = httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET position: %d", w.Code)
+	}
+	var resp struct {
+		Position *database.UserPosition `json:"position"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Position == nil || resp.Position.SegmentID != "s1" {
+		t.Errorf("got position %+v", resp.Position)
+	}
+}
+
+func TestReading_StateComputed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := setupReadingTestServer(t)
+
+	// Listen to 300s of a 1800s book → 16% in_progress.
+	body, _ := json.Marshal(map[string]interface{}{
+		"segment_id": "s1", "position_seconds": 300,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/books/b1/position", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/books/b1/state", nil)
+	w = httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET state: %d", w.Code)
+	}
+	var resp struct {
+		State *database.UserBookState `json:"state"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.State == nil {
+		t.Fatal("state nil")
+	}
+	if resp.State.Status != database.UserBookStatusInProgress {
+		t.Errorf("Status = %q, want in_progress", resp.State.Status)
+	}
+	if resp.State.ProgressPct != 16 {
+		t.Errorf("ProgressPct = %d, want 16", resp.State.ProgressPct)
+	}
+}
+
+func TestReading_PatchStatusOverride(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := setupReadingTestServer(t)
+
+	// Manually mark abandoned.
+	body, _ := json.Marshal(map[string]string{"status": database.UserBookStatusAbandoned})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/books/b1/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d %s", w.Code, w.Body.String())
+	}
+
+	// Verify persisted + manual.
+	state, _ := database.GetGlobalStore().GetUserBookState("_local", "b1")
+	if state == nil || state.Status != database.UserBookStatusAbandoned || !state.StatusManual {
+		t.Errorf("state after PATCH: %+v", state)
+	}
+
+	// DELETE clears manual.
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/books/b1/status", nil)
+	w = httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DELETE status: %d %s", w.Code, w.Body.String())
+	}
+	state, _ = database.GetGlobalStore().GetUserBookState("_local", "b1")
+	if state != nil && state.StatusManual {
+		t.Errorf("StatusManual should be false after clear, got %+v", state)
+	}
+}
+
+func TestReading_PatchInvalidStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := setupReadingTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{"status": "bogus"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/books/b1/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 on invalid status, got %d", w.Code)
+	}
+}
+
+func TestReading_ListByStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := setupReadingTestServer(t)
+
+	// Mark b1 finished.
+	body, _ := json.Marshal(map[string]string{"status": database.UserBookStatusFinished})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/books/b1/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	srv.router.ServeHTTP(httptest.NewRecorder(), req)
+
+	// GET /me/finished
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/me/finished", nil)
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET me/finished: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		States []database.UserBookState `json:"states"`
+		Count  int                      `json:"count"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count != 1 {
+		t.Errorf("finished count = %d, want 1", resp.Count)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.172.0
+// version: 1.173.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2193,6 +2193,7 @@ func (s *Server) setupRoutes() {
 
 			// Bench routes (only available with -tags bench)
 			s.setupUserTagRoutes(protected)
+			s.registerReadingRoutes(protected)
 			s.setupBenchRoutes(protected)
 		}
 	}


### PR DESCRIPTION
6 endpoints for position tracking + status override + listing. Bootstrap-mode fallback user ID until 3.7 login ships. 5 tests.