### PR TITLE
feat(versions): filesystem ops for .versions/ layout (3.1 task 2)

### DIFF
--- a/internal/versions/fs.go
+++ b/internal/versions/fs.go
@@ -1,0 +1,169 @@
+// file: internal/versions/fs.go
+// version: 1.0.0
+// guid: 6c2a1f8d-4b3e-4f70-a9c5-2e8d0f1b9a47
+//
+// Filesystem primitives for the `.versions/{id}/` layout (spec 3.1).
+//
+// On ZFS, all operations here are O(1) rename within the same
+// dataset — no copy, no hash re-verify. On other filesystems the
+// same call sequence degrades to standard POSIX rename, which is
+// still atomic within a single directory hierarchy.
+//
+// All functions are safe to call under partial state: if a move
+// was already half-done by a previous run, repeat calls are no-ops
+// on the already-moved side. This matches the resumable-tracked-op
+// semantics described in spec 3.1 §4.
+
+package versions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// VersionsDirName is the hidden directory inside a book's folder
+// where alt-version files live.
+const VersionsDirName = ".versions"
+
+// VersionsDir returns the absolute path to the .versions/ directory
+// for a book whose primary file lives at bookDir. Does NOT create
+// the directory — call EnsureVersionsDir when a move is imminent.
+func VersionsDir(bookDir string) string {
+	return filepath.Join(bookDir, VersionsDirName)
+}
+
+// VersionSlotDir returns the per-version subdirectory for a given
+// version ID.
+func VersionSlotDir(bookDir, versionID string) string {
+	return filepath.Join(VersionsDir(bookDir), versionID)
+}
+
+// EnsureVersionsDir creates `bookDir/.versions/{versionID}` if it
+// doesn't exist. Idempotent.
+func EnsureVersionsDir(bookDir, versionID string) (string, error) {
+	slot := VersionSlotDir(bookDir, versionID)
+	if err := os.MkdirAll(slot, 0o775); err != nil {
+		return "", fmt.Errorf("create version slot %s: %w", slot, err)
+	}
+	return slot, nil
+}
+
+// MoveToVersionsDir moves each file in `filePaths` from its current
+// location into `bookDir/.versions/{versionID}/`. Returns the list
+// of new paths (same order as input) plus any per-file errors
+// encountered. A file that's already in the version slot is treated
+// as a success (idempotent under partial completion).
+func MoveToVersionsDir(bookDir, versionID string, filePaths []string) ([]string, []error) {
+	slot, err := EnsureVersionsDir(bookDir, versionID)
+	if err != nil {
+		return nil, []error{err}
+	}
+	newPaths := make([]string, len(filePaths))
+	var errs []error
+	for i, src := range filePaths {
+		dst := filepath.Join(slot, filepath.Base(src))
+		newPaths[i] = dst
+		if movedSame, err := movePreservingAttrs(src, dst); err != nil {
+			errs = append(errs, fmt.Errorf("move %s → %s: %w", src, dst, err))
+		} else if movedSame {
+			// Already in place — no-op.
+		}
+	}
+	return newPaths, errs
+}
+
+// MoveFromVersionsDir is the reverse: move each file from its
+// version slot up to `bookDir/<basename>`. Used when an alt
+// becomes the primary. Returns the list of new natural-path
+// locations.
+func MoveFromVersionsDir(bookDir, versionID string, filePaths []string) ([]string, []error) {
+	newPaths := make([]string, len(filePaths))
+	var errs []error
+	for i, src := range filePaths {
+		dst := filepath.Join(bookDir, filepath.Base(src))
+		newPaths[i] = dst
+		if _, err := movePreservingAttrs(src, dst); err != nil {
+			errs = append(errs, fmt.Errorf("move %s → %s: %w", src, dst, err))
+		}
+	}
+	return newPaths, errs
+}
+
+// movePreservingAttrs renames src to dst. Returns (alreadyThere,
+// err) — alreadyThere is true when src doesn't exist but dst does
+// (previous run completed this move; current call is a no-op).
+//
+// Permission bits are preserved by rename on the same filesystem.
+// Cross-filesystem moves need a copy path, which we don't implement
+// here — callers on ZFS have guaranteed same-fs and callers on
+// other filesystems should be within a single disk.
+func movePreservingAttrs(src, dst string) (bool, error) {
+	if src == dst {
+		return true, nil
+	}
+	// Create the parent for dst if needed (version slot already
+	// exists when called via MoveToVersionsDir, but MoveFromVersionsDir
+	// writes directly into bookDir which always exists — this is a
+	// safety belt for reuse).
+	parent := filepath.Dir(dst)
+	if err := os.MkdirAll(parent, 0o775); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", parent, err)
+	}
+
+	srcInfo, srcErr := os.Stat(src)
+	_, dstErr := os.Stat(dst)
+
+	// Case: src gone, dst present — already-moved.
+	if os.IsNotExist(srcErr) && dstErr == nil {
+		return true, nil
+	}
+	if srcErr != nil {
+		return false, srcErr
+	}
+	// Case: dst already present AND src also present — don't clobber
+	// silently; caller likely has a bug / partial state.
+	if dstErr == nil {
+		return false, fmt.Errorf("destination already exists: %s", dst)
+	}
+
+	// Execute the rename.
+	if err := os.Rename(src, dst); err != nil {
+		return false, err
+	}
+
+	// Best-effort permission fix: many target filesystems (NFS, some
+	// SMB) silently rewrite mode bits on rename. Re-apply the source
+	// file's mode explicitly. Ignore failure — not everyone can
+	// chmod on every fs.
+	_ = os.Chmod(dst, srcInfo.Mode())
+	return false, nil
+}
+
+// RemoveVersionSlot removes the per-version subdirectory and all
+// its contents. Idempotent if the slot doesn't exist.
+func RemoveVersionSlot(bookDir, versionID string) error {
+	slot := VersionSlotDir(bookDir, versionID)
+	if _, err := os.Stat(slot); os.IsNotExist(err) {
+		return nil
+	}
+	return os.RemoveAll(slot)
+}
+
+// PruneEmptyVersionsDir removes `bookDir/.versions/` if empty, so
+// a book with all its versions gone doesn't leave an empty dot
+// folder lying around.
+func PruneEmptyVersionsDir(bookDir string) error {
+	dir := VersionsDir(bookDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return os.Remove(dir)
+}

--- a/internal/versions/fs_test.go
+++ b/internal/versions/fs_test.go
@@ -1,0 +1,187 @@
+// file: internal/versions/fs_test.go
+// version: 1.0.0
+// guid: 4e2c8a1d-5b9f-4f70-a7c6-2d8e0f1b9a57
+
+package versions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o775); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func fileContent(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestMoveToVersionsDir_SingleFile(t *testing.T) {
+	bookDir := t.TempDir()
+	orig := filepath.Join(bookDir, "Book.m4b")
+	writeFile(t, orig, "audio-v1")
+
+	newPaths, errs := MoveToVersionsDir(bookDir, "ver1", []string{orig})
+	if len(errs) > 0 {
+		t.Fatalf("errs: %v", errs)
+	}
+	if len(newPaths) != 1 {
+		t.Fatalf("newPaths = %v", newPaths)
+	}
+	expected := filepath.Join(bookDir, ".versions", "ver1", "Book.m4b")
+	if newPaths[0] != expected {
+		t.Errorf("new path = %s, want %s", newPaths[0], expected)
+	}
+	if _, err := os.Stat(orig); !os.IsNotExist(err) {
+		t.Errorf("source still exists at %s", orig)
+	}
+	if got := fileContent(t, expected); got != "audio-v1" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestMoveToVersionsDir_MultiFile(t *testing.T) {
+	bookDir := t.TempDir()
+	var srcs []string
+	for i, name := range []string{"01.mp3", "02.mp3", "03.mp3"} {
+		p := filepath.Join(bookDir, name)
+		writeFile(t, p, string(rune('a'+i)))
+		srcs = append(srcs, p)
+	}
+
+	newPaths, errs := MoveToVersionsDir(bookDir, "ver-multi", srcs)
+	if len(errs) > 0 {
+		t.Fatalf("errs: %v", errs)
+	}
+	if len(newPaths) != 3 {
+		t.Fatalf("newPaths = %v", newPaths)
+	}
+	for i, np := range newPaths {
+		if _, err := os.Stat(np); err != nil {
+			t.Errorf("file %d not at new path: %v", i, err)
+		}
+	}
+}
+
+func TestMoveToVersionsDir_IdempotentOnRepeat(t *testing.T) {
+	bookDir := t.TempDir()
+	orig := filepath.Join(bookDir, "Book.m4b")
+	writeFile(t, orig, "audio")
+
+	// First move.
+	_, errs1 := MoveToVersionsDir(bookDir, "ver1", []string{orig})
+	if len(errs1) > 0 {
+		t.Fatalf("first errs: %v", errs1)
+	}
+	// Second move (simulating a resumed operation). The source no
+	// longer exists; should be a no-op, not an error.
+	_, errs2 := MoveToVersionsDir(bookDir, "ver1", []string{orig})
+	if len(errs2) > 0 {
+		t.Errorf("repeat errs: %v (expected idempotent)", errs2)
+	}
+}
+
+func TestMoveFromVersionsDir_ReverseRoundTrip(t *testing.T) {
+	bookDir := t.TempDir()
+	orig := filepath.Join(bookDir, "Book.m4b")
+	writeFile(t, orig, "audio-content")
+
+	// Move into versions slot.
+	newPaths, errs := MoveToVersionsDir(bookDir, "ver1", []string{orig})
+	if len(errs) > 0 {
+		t.Fatalf("move to: %v", errs)
+	}
+
+	// Move back out (simulating a swap-to-primary).
+	backPaths, errs := MoveFromVersionsDir(bookDir, "ver1", newPaths)
+	if len(errs) > 0 {
+		t.Fatalf("move from: %v", errs)
+	}
+	if backPaths[0] != orig {
+		t.Errorf("back path = %s, want %s", backPaths[0], orig)
+	}
+	if got := fileContent(t, orig); got != "audio-content" {
+		t.Errorf("roundtrip content lost: %q", got)
+	}
+}
+
+func TestMoveToVersionsDir_RefusesClobber(t *testing.T) {
+	bookDir := t.TempDir()
+	orig := filepath.Join(bookDir, "Book.m4b")
+	writeFile(t, orig, "v1")
+	// Pre-create conflicting destination.
+	slot := VersionSlotDir(bookDir, "ver1")
+	if err := os.MkdirAll(slot, 0o775); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(slot, "Book.m4b"), []byte("preexisting"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, errs := MoveToVersionsDir(bookDir, "ver1", []string{orig})
+	if len(errs) == 0 {
+		t.Error("expected error on clobber")
+	}
+}
+
+func TestRemoveVersionSlot(t *testing.T) {
+	bookDir := t.TempDir()
+	slot := VersionSlotDir(bookDir, "ver1")
+	if err := os.MkdirAll(slot, 0o775); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(slot, "a"), "x")
+	writeFile(t, filepath.Join(slot, "b"), "y")
+
+	if err := RemoveVersionSlot(bookDir, "ver1"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := os.Stat(slot); !os.IsNotExist(err) {
+		t.Errorf("slot still exists")
+	}
+	// Idempotent.
+	if err := RemoveVersionSlot(bookDir, "ver1"); err != nil {
+		t.Errorf("second remove should be no-op: %v", err)
+	}
+}
+
+func TestPruneEmptyVersionsDir(t *testing.T) {
+	bookDir := t.TempDir()
+	slot := VersionSlotDir(bookDir, "ver1")
+	_ = os.MkdirAll(slot, 0o775)
+
+	// Dir non-empty → prune is no-op.
+	if err := PruneEmptyVersionsDir(bookDir); err != nil {
+		t.Fatalf("prune non-empty: %v", err)
+	}
+	if _, err := os.Stat(VersionsDir(bookDir)); err != nil {
+		t.Errorf("versions dir removed when not empty")
+	}
+
+	// Remove the slot; dir now empty → prune removes it.
+	_ = os.RemoveAll(slot)
+	if err := PruneEmptyVersionsDir(bookDir); err != nil {
+		t.Fatalf("prune empty: %v", err)
+	}
+	if _, err := os.Stat(VersionsDir(bookDir)); !os.IsNotExist(err) {
+		t.Errorf("versions dir should be removed")
+	}
+
+	// Missing dir is idempotent.
+	if err := PruneEmptyVersionsDir(bookDir); err != nil {
+		t.Errorf("prune missing dir should not error: %v", err)
+	}
+}


### PR DESCRIPTION
Idempotent move primitives for the spec 3.1 library centralization layout. 7 tests. Prereq for swap tracked op (task 3).