### PR TITLE
feat(playlists): UserPlaylist schema + Pebble store (3.4 task 1)

### DIFF
--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.32.0
+// version: 1.33.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package database
@@ -201,6 +201,16 @@ type MockStore struct {
 	GetBookVersionByTorrentHashFunc func(hash string) (*BookVersion, error)
 	ListTrashedBookVersionsFunc     func() ([]BookVersion, error)
 	ListPurgedBookVersionsFunc      func() ([]BookVersion, error)
+
+	// User playlists (spec 3.4)
+	CreateUserPlaylistFunc          func(pl *UserPlaylist) (*UserPlaylist, error)
+	GetUserPlaylistFunc             func(id string) (*UserPlaylist, error)
+	GetUserPlaylistByNameFunc       func(name string) (*UserPlaylist, error)
+	GetUserPlaylistByITunesPIDFunc  func(pid string) (*UserPlaylist, error)
+	ListUserPlaylistsFunc           func(playlistType string, limit, offset int) ([]UserPlaylist, int, error)
+	UpdateUserPlaylistFunc          func(pl *UserPlaylist) error
+	DeleteUserPlaylistFunc          func(id string) error
+	ListDirtyUserPlaylistsFunc      func() ([]UserPlaylist, error)
 
 	// API keys
 	CreateAPIKeyFunc        func(key *APIKey) (*APIKey, error)
@@ -1283,6 +1293,64 @@ func (m *MockStore) ListTrashedBookVersions() ([]BookVersion, error) {
 func (m *MockStore) ListPurgedBookVersions() ([]BookVersion, error) {
 	if m.ListPurgedBookVersionsFunc != nil {
 		return m.ListPurgedBookVersionsFunc()
+	}
+	return nil, nil
+}
+
+// ---- User playlists (spec 3.4) ----
+
+func (m *MockStore) CreateUserPlaylist(pl *UserPlaylist) (*UserPlaylist, error) {
+	if m.CreateUserPlaylistFunc != nil {
+		return m.CreateUserPlaylistFunc(pl)
+	}
+	return pl, nil
+}
+
+func (m *MockStore) GetUserPlaylist(id string) (*UserPlaylist, error) {
+	if m.GetUserPlaylistFunc != nil {
+		return m.GetUserPlaylistFunc(id)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetUserPlaylistByName(name string) (*UserPlaylist, error) {
+	if m.GetUserPlaylistByNameFunc != nil {
+		return m.GetUserPlaylistByNameFunc(name)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error) {
+	if m.GetUserPlaylistByITunesPIDFunc != nil {
+		return m.GetUserPlaylistByITunesPIDFunc(pid)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	if m.ListUserPlaylistsFunc != nil {
+		return m.ListUserPlaylistsFunc(playlistType, limit, offset)
+	}
+	return nil, 0, nil
+}
+
+func (m *MockStore) UpdateUserPlaylist(pl *UserPlaylist) error {
+	if m.UpdateUserPlaylistFunc != nil {
+		return m.UpdateUserPlaylistFunc(pl)
+	}
+	return nil
+}
+
+func (m *MockStore) DeleteUserPlaylist(id string) error {
+	if m.DeleteUserPlaylistFunc != nil {
+		return m.DeleteUserPlaylistFunc(id)
+	}
+	return nil
+}
+
+func (m *MockStore) ListDirtyUserPlaylists() ([]UserPlaylist, error) {
+	if m.ListDirtyUserPlaylistsFunc != nil {
+		return m.ListDirtyUserPlaylistsFunc()
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -2788,6 +2788,68 @@ func (_c *MockStore_CreateUser_Call) RunAndReturn(run func(username string, emai
 	return _c
 }
 
+// CreateUserPlaylist provides a mock function for the type MockStore
+func (_mock *MockStore) CreateUserPlaylist(pl *database.UserPlaylist) (*database.UserPlaylist, error) {
+	ret := _mock.Called(pl)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUserPlaylist")
+	}
+
+	var r0 *database.UserPlaylist
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*database.UserPlaylist) (*database.UserPlaylist, error)); ok {
+		return returnFunc(pl)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*database.UserPlaylist) *database.UserPlaylist); ok {
+		r0 = returnFunc(pl)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(*database.UserPlaylist) error); ok {
+		r1 = returnFunc(pl)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CreateUserPlaylist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateUserPlaylist'
+type MockStore_CreateUserPlaylist_Call struct {
+	*mock.Call
+}
+
+// CreateUserPlaylist is a helper method to define mock.On call
+//   - pl *database.UserPlaylist
+func (_e *MockStore_Expecter) CreateUserPlaylist(pl interface{}) *MockStore_CreateUserPlaylist_Call {
+	return &MockStore_CreateUserPlaylist_Call{Call: _e.mock.On("CreateUserPlaylist", pl)}
+}
+
+func (_c *MockStore_CreateUserPlaylist_Call) Run(run func(pl *database.UserPlaylist)) *MockStore_CreateUserPlaylist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.UserPlaylist
+		if args[0] != nil {
+			arg0 = args[0].(*database.UserPlaylist)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CreateUserPlaylist_Call) Return(userPlaylist *database.UserPlaylist, err error) *MockStore_CreateUserPlaylist_Call {
+	_c.Call.Return(userPlaylist, err)
+	return _c
+}
+
+func (_c *MockStore_CreateUserPlaylist_Call) RunAndReturn(run func(pl *database.UserPlaylist) (*database.UserPlaylist, error)) *MockStore_CreateUserPlaylist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateWork provides a mock function for the type MockStore
 func (_mock *MockStore) CreateWork(work *database.Work) (*database.Work, error) {
 	ret := _mock.Called(work)
@@ -3737,6 +3799,57 @@ func (_c *MockStore_DeleteSetting_Call) Return(err error) *MockStore_DeleteSetti
 }
 
 func (_c *MockStore_DeleteSetting_Call) RunAndReturn(run func(key string) error) *MockStore_DeleteSetting_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteUserPlaylist provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteUserPlaylist(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserPlaylist")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteUserPlaylist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteUserPlaylist'
+type MockStore_DeleteUserPlaylist_Call struct {
+	*mock.Call
+}
+
+// DeleteUserPlaylist is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) DeleteUserPlaylist(id interface{}) *MockStore_DeleteUserPlaylist_Call {
+	return &MockStore_DeleteUserPlaylist_Call{Call: _e.mock.On("DeleteUserPlaylist", id)}
+}
+
+func (_c *MockStore_DeleteUserPlaylist_Call) Run(run func(id string)) *MockStore_DeleteUserPlaylist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteUserPlaylist_Call) Return(err error) *MockStore_DeleteUserPlaylist_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteUserPlaylist_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteUserPlaylist_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -10554,6 +10667,192 @@ func (_c *MockStore_GetUserByUsername_Call) RunAndReturn(run func(username strin
 	return _c
 }
 
+// GetUserPlaylist provides a mock function for the type MockStore
+func (_mock *MockStore) GetUserPlaylist(id string) (*database.UserPlaylist, error) {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserPlaylist")
+	}
+
+	var r0 *database.UserPlaylist
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.UserPlaylist, error)); ok {
+		return returnFunc(id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.UserPlaylist); ok {
+		r0 = returnFunc(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetUserPlaylist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserPlaylist'
+type MockStore_GetUserPlaylist_Call struct {
+	*mock.Call
+}
+
+// GetUserPlaylist is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) GetUserPlaylist(id interface{}) *MockStore_GetUserPlaylist_Call {
+	return &MockStore_GetUserPlaylist_Call{Call: _e.mock.On("GetUserPlaylist", id)}
+}
+
+func (_c *MockStore_GetUserPlaylist_Call) Run(run func(id string)) *MockStore_GetUserPlaylist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylist_Call) Return(userPlaylist *database.UserPlaylist, err error) *MockStore_GetUserPlaylist_Call {
+	_c.Call.Return(userPlaylist, err)
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylist_Call) RunAndReturn(run func(id string) (*database.UserPlaylist, error)) *MockStore_GetUserPlaylist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserPlaylistByITunesPID provides a mock function for the type MockStore
+func (_mock *MockStore) GetUserPlaylistByITunesPID(pid string) (*database.UserPlaylist, error) {
+	ret := _mock.Called(pid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserPlaylistByITunesPID")
+	}
+
+	var r0 *database.UserPlaylist
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.UserPlaylist, error)); ok {
+		return returnFunc(pid)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.UserPlaylist); ok {
+		r0 = returnFunc(pid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(pid)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetUserPlaylistByITunesPID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserPlaylistByITunesPID'
+type MockStore_GetUserPlaylistByITunesPID_Call struct {
+	*mock.Call
+}
+
+// GetUserPlaylistByITunesPID is a helper method to define mock.On call
+//   - pid string
+func (_e *MockStore_Expecter) GetUserPlaylistByITunesPID(pid interface{}) *MockStore_GetUserPlaylistByITunesPID_Call {
+	return &MockStore_GetUserPlaylistByITunesPID_Call{Call: _e.mock.On("GetUserPlaylistByITunesPID", pid)}
+}
+
+func (_c *MockStore_GetUserPlaylistByITunesPID_Call) Run(run func(pid string)) *MockStore_GetUserPlaylistByITunesPID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylistByITunesPID_Call) Return(userPlaylist *database.UserPlaylist, err error) *MockStore_GetUserPlaylistByITunesPID_Call {
+	_c.Call.Return(userPlaylist, err)
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylistByITunesPID_Call) RunAndReturn(run func(pid string) (*database.UserPlaylist, error)) *MockStore_GetUserPlaylistByITunesPID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserPlaylistByName provides a mock function for the type MockStore
+func (_mock *MockStore) GetUserPlaylistByName(name string) (*database.UserPlaylist, error) {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserPlaylistByName")
+	}
+
+	var r0 *database.UserPlaylist
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.UserPlaylist, error)); ok {
+		return returnFunc(name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.UserPlaylist); ok {
+		r0 = returnFunc(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetUserPlaylistByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserPlaylistByName'
+type MockStore_GetUserPlaylistByName_Call struct {
+	*mock.Call
+}
+
+// GetUserPlaylistByName is a helper method to define mock.On call
+//   - name string
+func (_e *MockStore_Expecter) GetUserPlaylistByName(name interface{}) *MockStore_GetUserPlaylistByName_Call {
+	return &MockStore_GetUserPlaylistByName_Call{Call: _e.mock.On("GetUserPlaylistByName", name)}
+}
+
+func (_c *MockStore_GetUserPlaylistByName_Call) Run(run func(name string)) *MockStore_GetUserPlaylistByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylistByName_Call) Return(userPlaylist *database.UserPlaylist, err error) *MockStore_GetUserPlaylistByName_Call {
+	_c.Call.Return(userPlaylist, err)
+	return _c
+}
+
+func (_c *MockStore_GetUserPlaylistByName_Call) RunAndReturn(run func(name string) (*database.UserPlaylist, error)) *MockStore_GetUserPlaylistByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserPosition provides a mock function for the type MockStore
 func (_mock *MockStore) GetUserPosition(userID string, bookID string) (*database.UserPosition, error) {
 	ret := _mock.Called(userID, bookID)
@@ -11522,6 +11821,61 @@ func (_c *MockStore_ListBookTombstones_Call) RunAndReturn(run func(limit int) ([
 	return _c
 }
 
+// ListDirtyUserPlaylists provides a mock function for the type MockStore
+func (_mock *MockStore) ListDirtyUserPlaylists() ([]database.UserPlaylist, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListDirtyUserPlaylists")
+	}
+
+	var r0 []database.UserPlaylist
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.UserPlaylist, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.UserPlaylist); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListDirtyUserPlaylists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListDirtyUserPlaylists'
+type MockStore_ListDirtyUserPlaylists_Call struct {
+	*mock.Call
+}
+
+// ListDirtyUserPlaylists is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ListDirtyUserPlaylists() *MockStore_ListDirtyUserPlaylists_Call {
+	return &MockStore_ListDirtyUserPlaylists_Call{Call: _e.mock.On("ListDirtyUserPlaylists")}
+}
+
+func (_c *MockStore_ListDirtyUserPlaylists_Call) Run(run func()) *MockStore_ListDirtyUserPlaylists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ListDirtyUserPlaylists_Call) Return(userPlaylists []database.UserPlaylist, err error) *MockStore_ListDirtyUserPlaylists_Call {
+	_c.Call.Return(userPlaylists, err)
+	return _c
+}
+
+func (_c *MockStore_ListDirtyUserPlaylists_Call) RunAndReturn(run func() ([]database.UserPlaylist, error)) *MockStore_ListDirtyUserPlaylists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListNarrators provides a mock function for the type MockStore
 func (_mock *MockStore) ListNarrators() ([]database.Narrator, error) {
 	ret := _mock.Called()
@@ -12108,6 +12462,86 @@ func (_c *MockStore_ListUserBookStatesByStatus_Call) Return(userBookStates []dat
 }
 
 func (_c *MockStore_ListUserBookStatesByStatus_Call) RunAndReturn(run func(userID string, status string, limit int, offset int) ([]database.UserBookState, error)) *MockStore_ListUserBookStatesByStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListUserPlaylists provides a mock function for the type MockStore
+func (_mock *MockStore) ListUserPlaylists(playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error) {
+	ret := _mock.Called(playlistType, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListUserPlaylists")
+	}
+
+	var r0 []database.UserPlaylist
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) ([]database.UserPlaylist, int, error)); ok {
+		return returnFunc(playlistType, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int, int) []database.UserPlaylist); ok {
+		r0 = returnFunc(playlistType, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int, int) int); ok {
+		r1 = returnFunc(playlistType, limit, offset)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(string, int, int) error); ok {
+		r2 = returnFunc(playlistType, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockStore_ListUserPlaylists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserPlaylists'
+type MockStore_ListUserPlaylists_Call struct {
+	*mock.Call
+}
+
+// ListUserPlaylists is a helper method to define mock.On call
+//   - playlistType string
+//   - limit int
+//   - offset int
+func (_e *MockStore_Expecter) ListUserPlaylists(playlistType interface{}, limit interface{}, offset interface{}) *MockStore_ListUserPlaylists_Call {
+	return &MockStore_ListUserPlaylists_Call{Call: _e.mock.On("ListUserPlaylists", playlistType, limit, offset)}
+}
+
+func (_c *MockStore_ListUserPlaylists_Call) Run(run func(playlistType string, limit int, offset int)) *MockStore_ListUserPlaylists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListUserPlaylists_Call) Return(userPlaylists []database.UserPlaylist, n int, err error) *MockStore_ListUserPlaylists_Call {
+	_c.Call.Return(userPlaylists, n, err)
+	return _c
+}
+
+func (_c *MockStore_ListUserPlaylists_Call) RunAndReturn(run func(playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error)) *MockStore_ListUserPlaylists_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -16172,6 +16606,57 @@ func (_c *MockStore_UpdateUser_Call) Return(err error) *MockStore_UpdateUser_Cal
 }
 
 func (_c *MockStore_UpdateUser_Call) RunAndReturn(run func(user *database.User) error) *MockStore_UpdateUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateUserPlaylist provides a mock function for the type MockStore
+func (_mock *MockStore) UpdateUserPlaylist(pl *database.UserPlaylist) error {
+	ret := _mock.Called(pl)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserPlaylist")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*database.UserPlaylist) error); ok {
+		r0 = returnFunc(pl)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_UpdateUserPlaylist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserPlaylist'
+type MockStore_UpdateUserPlaylist_Call struct {
+	*mock.Call
+}
+
+// UpdateUserPlaylist is a helper method to define mock.On call
+//   - pl *database.UserPlaylist
+func (_e *MockStore_Expecter) UpdateUserPlaylist(pl interface{}) *MockStore_UpdateUserPlaylist_Call {
+	return &MockStore_UpdateUserPlaylist_Call{Call: _e.mock.On("UpdateUserPlaylist", pl)}
+}
+
+func (_c *MockStore_UpdateUserPlaylist_Call) Run(run func(pl *database.UserPlaylist)) *MockStore_UpdateUserPlaylist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.UserPlaylist
+		if args[0] != nil {
+			arg0 = args[0].(*database.UserPlaylist)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_UpdateUserPlaylist_Call) Return(err error) *MockStore_UpdateUserPlaylist_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_UpdateUserPlaylist_Call) RunAndReturn(run func(pl *database.UserPlaylist) error) *MockStore_UpdateUserPlaylist_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.46.0
+// version: 1.47.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -3388,6 +3388,265 @@ func (p *PebbleStore) DeleteRole(id string) error {
 		return err
 	}
 	return b.Commit(pebble.Sync)
+}
+
+// User playlists (spec 3.4)
+//
+// Key schema:
+//   upl:{id}                    → UserPlaylist JSON
+//   idx:upl:name:{lcase-name}   → playlist ID
+//   idx:upl:itunes:{pid}        → playlist ID
+//   idx:upl:dirty:{id}          → "1" (pending-push set)
+
+func (p *PebbleStore) CreateUserPlaylist(pl *UserPlaylist) (*UserPlaylist, error) {
+	if pl == nil || pl.Name == "" {
+		return nil, fmt.Errorf("playlist: name required")
+	}
+	if pl.Type != UserPlaylistTypeStatic && pl.Type != UserPlaylistTypeSmart {
+		return nil, fmt.Errorf("playlist: type must be static or smart")
+	}
+	if pl.ID == "" {
+		id, err := newULID()
+		if err != nil {
+			return nil, err
+		}
+		pl.ID = id
+	}
+	lower := strings.ToLower(pl.Name)
+	if v, closer, err := p.db.Get([]byte("idx:upl:name:" + lower)); err == nil {
+		existing := string(v)
+		closer.Close()
+		if existing != pl.ID {
+			return nil, fmt.Errorf("playlist name %q already in use", pl.Name)
+		}
+	}
+	now := time.Now()
+	if pl.CreatedAt.IsZero() {
+		pl.CreatedAt = now
+	}
+	pl.UpdatedAt = now
+	if pl.Version == 0 {
+		pl.Version = 1
+	}
+	data, err := json.Marshal(pl)
+	if err != nil {
+		return nil, err
+	}
+	b := p.db.NewBatch()
+	if err := b.Set([]byte("upl:"+pl.ID), data, nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if err := b.Set([]byte("idx:upl:name:"+lower), []byte(pl.ID), nil); err != nil {
+		b.Close()
+		return nil, err
+	}
+	if pl.ITunesPersistentID != "" {
+		if err := b.Set([]byte("idx:upl:itunes:"+pl.ITunesPersistentID), []byte(pl.ID), nil); err != nil {
+			b.Close()
+			return nil, err
+		}
+	}
+	if pl.Dirty {
+		if err := b.Set([]byte("idx:upl:dirty:"+pl.ID), []byte("1"), nil); err != nil {
+			b.Close()
+			return nil, err
+		}
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return nil, err
+	}
+	return pl, nil
+}
+
+func (p *PebbleStore) GetUserPlaylist(id string) (*UserPlaylist, error) {
+	data, closer, err := p.db.Get([]byte("upl:" + id))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	var pl UserPlaylist
+	if err := json.Unmarshal(data, &pl); err != nil {
+		return nil, err
+	}
+	return &pl, nil
+}
+
+func (p *PebbleStore) GetUserPlaylistByName(name string) (*UserPlaylist, error) {
+	v, closer, err := p.db.Get([]byte("idx:upl:name:" + strings.ToLower(name)))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	id := string(v)
+	closer.Close()
+	return p.GetUserPlaylist(id)
+}
+
+func (p *PebbleStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error) {
+	if pid == "" {
+		return nil, nil
+	}
+	v, closer, err := p.db.Get([]byte("idx:upl:itunes:" + pid))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	id := string(v)
+	closer.Close()
+	return p.GetUserPlaylist(id)
+}
+
+func (p *PebbleStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("upl:"),
+		UpperBound: []byte("upl:~"),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer iter.Close()
+	var all []UserPlaylist
+	for iter.First(); iter.Valid(); iter.Next() {
+		var pl UserPlaylist
+		if err := json.Unmarshal(iter.Value(), &pl); err != nil {
+			continue
+		}
+		if playlistType != "" && pl.Type != playlistType {
+			continue
+		}
+		all = append(all, pl)
+	}
+	total := len(all)
+	if offset >= total {
+		return []UserPlaylist{}, total, nil
+	}
+	end := offset + limit
+	if limit <= 0 || end > total {
+		end = total
+	}
+	return all[offset:end], total, nil
+}
+
+func (p *PebbleStore) UpdateUserPlaylist(pl *UserPlaylist) error {
+	if pl == nil || pl.ID == "" {
+		return fmt.Errorf("playlist id required")
+	}
+	prev, err := p.GetUserPlaylist(pl.ID)
+	if err != nil {
+		return err
+	}
+	if prev == nil {
+		return fmt.Errorf("playlist %s not found", pl.ID)
+	}
+	pl.UpdatedAt = time.Now()
+	pl.Version = prev.Version + 1
+	data, err := json.Marshal(pl)
+	if err != nil {
+		return err
+	}
+	b := p.db.NewBatch()
+	if err := b.Set([]byte("upl:"+pl.ID), data, nil); err != nil {
+		b.Close()
+		return err
+	}
+	if strings.ToLower(prev.Name) != strings.ToLower(pl.Name) {
+		if err := b.Delete([]byte("idx:upl:name:"+strings.ToLower(prev.Name)), nil); err != nil {
+			b.Close()
+			return err
+		}
+		if err := b.Set([]byte("idx:upl:name:"+strings.ToLower(pl.Name)), []byte(pl.ID), nil); err != nil {
+			b.Close()
+			return err
+		}
+	}
+	if prev.ITunesPersistentID != pl.ITunesPersistentID {
+		if prev.ITunesPersistentID != "" {
+			if err := b.Delete([]byte("idx:upl:itunes:"+prev.ITunesPersistentID), nil); err != nil {
+				b.Close()
+				return err
+			}
+		}
+		if pl.ITunesPersistentID != "" {
+			if err := b.Set([]byte("idx:upl:itunes:"+pl.ITunesPersistentID), []byte(pl.ID), nil); err != nil {
+				b.Close()
+				return err
+			}
+		}
+	}
+	if pl.Dirty {
+		if err := b.Set([]byte("idx:upl:dirty:"+pl.ID), []byte("1"), nil); err != nil {
+			b.Close()
+			return err
+		}
+	} else if prev.Dirty {
+		if err := b.Delete([]byte("idx:upl:dirty:"+pl.ID), nil); err != nil {
+			b.Close()
+			return err
+		}
+	}
+	return b.Commit(pebble.Sync)
+}
+
+func (p *PebbleStore) DeleteUserPlaylist(id string) error {
+	pl, err := p.GetUserPlaylist(id)
+	if err != nil {
+		return err
+	}
+	if pl == nil {
+		return nil
+	}
+	b := p.db.NewBatch()
+	if err := b.Delete([]byte("upl:"+id), nil); err != nil {
+		b.Close()
+		return err
+	}
+	if err := b.Delete([]byte("idx:upl:name:"+strings.ToLower(pl.Name)), nil); err != nil {
+		b.Close()
+		return err
+	}
+	if pl.ITunesPersistentID != "" {
+		if err := b.Delete([]byte("idx:upl:itunes:"+pl.ITunesPersistentID), nil); err != nil {
+			b.Close()
+			return err
+		}
+	}
+	if pl.Dirty {
+		if err := b.Delete([]byte("idx:upl:dirty:"+id), nil); err != nil {
+			b.Close()
+			return err
+		}
+	}
+	return b.Commit(pebble.Sync)
+}
+
+func (p *PebbleStore) ListDirtyUserPlaylists() ([]UserPlaylist, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("idx:upl:dirty:"),
+		UpperBound: []byte("idx:upl:dirty:~"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+	var out []UserPlaylist
+	prefix := []byte("idx:upl:dirty:")
+	for iter.First(); iter.Valid(); iter.Next() {
+		id := string(iter.Key()[len(prefix):])
+		pl, err := p.GetUserPlaylist(id)
+		if err != nil || pl == nil {
+			continue
+		}
+		out = append(out, *pl)
+	}
+	return out, nil
 }
 
 // User positions + book state (spec 3.6)

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.55.0
+// version: 1.56.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -958,6 +958,21 @@ func (s *SQLiteStore) GetBookVersionByTorrentHash(hash string) (*BookVersion, er
 }
 func (s *SQLiteStore) ListTrashedBookVersions() ([]BookVersion, error) { return nil, nil }
 func (s *SQLiteStore) ListPurgedBookVersions() ([]BookVersion, error)  { return nil, nil }
+
+// ---- User playlists (SQLite no-op stubs, spec 3.4) ----
+
+func (s *SQLiteStore) CreateUserPlaylist(pl *UserPlaylist) (*UserPlaylist, error) { return pl, nil }
+func (s *SQLiteStore) GetUserPlaylist(id string) (*UserPlaylist, error)           { return nil, nil }
+func (s *SQLiteStore) GetUserPlaylistByName(name string) (*UserPlaylist, error)   { return nil, nil }
+func (s *SQLiteStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error) {
+	return nil, nil
+}
+func (s *SQLiteStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	return nil, 0, nil
+}
+func (s *SQLiteStore) UpdateUserPlaylist(pl *UserPlaylist) error        { return nil }
+func (s *SQLiteStore) DeleteUserPlaylist(id string) error               { return nil }
+func (s *SQLiteStore) ListDirtyUserPlaylists() ([]UserPlaylist, error)  { return nil, nil }
 
 // ---- API keys + Invites (SQLite no-op stubs) ----
 

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.54.0
+// version: 2.55.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package database
@@ -228,6 +228,17 @@ type Store interface {
 	CreateRole(role *Role) (*Role, error)
 	UpdateRole(role *Role) error
 	DeleteRole(id string) error
+
+	// User playlists (spec 3.4 — static + smart). Distinct from the
+	// auto-generated series-playlists above (Playlist / PlaylistItem).
+	CreateUserPlaylist(pl *UserPlaylist) (*UserPlaylist, error)
+	GetUserPlaylist(id string) (*UserPlaylist, error)
+	GetUserPlaylistByName(name string) (*UserPlaylist, error)
+	GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error)
+	ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error)
+	UpdateUserPlaylist(pl *UserPlaylist) error
+	DeleteUserPlaylist(id string) error
+	ListDirtyUserPlaylists() ([]UserPlaylist, error)
 
 	// User positions + book state (spec 3.6 read/unread tracking).
 	// Per-user, per-book-segment position tracking. UserBookState is
@@ -609,13 +620,58 @@ type Work struct {
 	AltTitles []string `json:"alt_titles,omitempty"` // Optional alternate titles
 }
 
-// Playlist represents a playlist
+// Playlist represents an auto-generated series playlist (the old
+// M3U-style playlist generator). For the 3.4 user-facing playlist
+// feature, see UserPlaylist below.
 type Playlist struct {
 	ID       int    `json:"id"`
 	Name     string `json:"name"`
 	SeriesID *int   `json:"series_id,omitempty"`
 	FilePath string `json:"file_path"`
 }
+
+// UserPlaylist represents a user-created playlist (spec 3.4) —
+// either a static ordered book list or a smart (live-evaluated)
+// filter expression. Distinct from the auto-generated Playlist
+// type above which is part of the older series-playlist generator.
+type UserPlaylist struct {
+	ID          string `json:"id"` // ULID
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Type discriminator: "static" or "smart"
+	Type string `json:"type"`
+	// Static playlists: ordered book ID list.
+	BookIDs []string `json:"book_ids,omitempty"`
+	// Smart playlists: DSL query string, sort + limit directives.
+	Query string `json:"query,omitempty"`
+	// SortJSON is a JSON-encoded []{field, direction} for stable
+	// ordering in smart playlists.
+	SortJSON string `json:"sort_json,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+	// MaterializedBookIDs caches the last evaluation of a smart
+	// playlist for fast iTunes-sync pushes without re-running the
+	// query. Refreshed on every sync pass.
+	MaterializedBookIDs []string `json:"materialized_book_ids,omitempty"`
+	// ITunesPersistentID links the playlist to its iTunes row
+	// once it's been pushed. Null until first sync.
+	ITunesPersistentID string `json:"itunes_persistent_id,omitempty"`
+	// ITunesRawCriteriaB64 stores the original iTunes Smart
+	// Criteria blob for playlists imported from iTunes (migration
+	// audit trail). Empty for app-native playlists.
+	ITunesRawCriteriaB64 string `json:"itunes_raw_criteria_b64,omitempty"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+	CreatedByUserID      string    `json:"created_by_user_id,omitempty"`
+	// Dirty marks the playlist as pending iTunes push.
+	Dirty   bool `json:"dirty"`
+	Version int  `json:"version"`
+}
+
+// UserPlaylist type constants.
+const (
+	UserPlaylistTypeStatic = "static"
+	UserPlaylistTypeSmart  = "smart"
+)
 
 // PlaylistItem represents an item in a playlist
 type PlaylistItem struct {

--- a/internal/database/user_playlist_test.go
+++ b/internal/database/user_playlist_test.go
@@ -1,0 +1,265 @@
+// file: internal/database/user_playlist_test.go
+// version: 1.0.0
+// guid: 8b1e2c4d-6f5a-4a70-b8c5-3d7e0f1b9a59
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newPlaylistTestStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestUserPlaylist_CreateAndGet(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	pl, err := store.CreateUserPlaylist(&UserPlaylist{
+		Name:    "Morning Commute",
+		Type:    UserPlaylistTypeStatic,
+		BookIDs: []string{"b1", "b2", "b3"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if pl.ID == "" {
+		t.Fatal("ID should be auto-assigned")
+	}
+	if pl.Version != 1 {
+		t.Errorf("Version = %d, want 1", pl.Version)
+	}
+	if pl.CreatedAt.IsZero() || pl.UpdatedAt.IsZero() {
+		t.Error("timestamps should be populated")
+	}
+
+	got, err := store.GetUserPlaylist(pl.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v / %v", got, err)
+	}
+	if got.Name != "Morning Commute" {
+		t.Errorf("Name = %q", got.Name)
+	}
+	if len(got.BookIDs) != 3 || got.BookIDs[1] != "b2" {
+		t.Errorf("BookIDs = %v", got.BookIDs)
+	}
+}
+
+func TestUserPlaylist_NameIndexUnique(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	_, err := store.CreateUserPlaylist(&UserPlaylist{Name: "dupe", Type: UserPlaylistTypeStatic})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := store.CreateUserPlaylist(&UserPlaylist{Name: "dupe", Type: UserPlaylistTypeStatic}); err == nil {
+		t.Error("expected duplicate-name rejection")
+	}
+	// Case-insensitive check.
+	if _, err := store.CreateUserPlaylist(&UserPlaylist{Name: "DUPE", Type: UserPlaylistTypeStatic}); err == nil {
+		t.Error("expected case-insensitive duplicate-name rejection")
+	}
+}
+
+func TestUserPlaylist_GetByName(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	pl, _ := store.CreateUserPlaylist(&UserPlaylist{Name: "My Faves", Type: UserPlaylistTypeSmart, Query: "tag:sci-fi"})
+
+	// Case-insensitive lookup.
+	got, err := store.GetUserPlaylistByName("my faves")
+	if err != nil || got == nil {
+		t.Fatalf("GetUserPlaylistByName: %v / %v", got, err)
+	}
+	if got.ID != pl.ID {
+		t.Errorf("ID = %q, want %q", got.ID, pl.ID)
+	}
+
+	miss, err := store.GetUserPlaylistByName("does not exist")
+	if err != nil {
+		t.Errorf("miss should not error: %v", err)
+	}
+	if miss != nil {
+		t.Errorf("miss should be nil")
+	}
+}
+
+func TestUserPlaylist_GetByITunesPID(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	pl, _ := store.CreateUserPlaylist(&UserPlaylist{
+		Name: "Imported", Type: UserPlaylistTypeStatic, ITunesPersistentID: "ABCDEF0123456789",
+	})
+
+	got, err := store.GetUserPlaylistByITunesPID("ABCDEF0123456789")
+	if err != nil || got == nil {
+		t.Fatalf("GetUserPlaylistByITunesPID: %v / %v", got, err)
+	}
+	if got.ID != pl.ID {
+		t.Errorf("ID = %q, want %q", got.ID, pl.ID)
+	}
+
+	miss, _ := store.GetUserPlaylistByITunesPID("NOTINLIBRARY")
+	if miss != nil {
+		t.Errorf("miss should be nil, got %v", miss)
+	}
+}
+
+func TestUserPlaylist_ListFilterByType(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	for _, name := range []string{"s1", "s2", "s3"} {
+		_, _ = store.CreateUserPlaylist(&UserPlaylist{Name: name, Type: UserPlaylistTypeStatic})
+	}
+	for _, name := range []string{"smart-1", "smart-2"} {
+		_, _ = store.CreateUserPlaylist(&UserPlaylist{Name: name, Type: UserPlaylistTypeSmart, Query: "*"})
+	}
+
+	all, total, err := store.ListUserPlaylists("", 100, 0)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if total != 5 || len(all) != 5 {
+		t.Errorf("list all: got %d/%d, want 5/5", len(all), total)
+	}
+
+	static, sTotal, _ := store.ListUserPlaylists(UserPlaylistTypeStatic, 100, 0)
+	if sTotal != 3 || len(static) != 3 {
+		t.Errorf("list static: got %d/%d, want 3/3", len(static), sTotal)
+	}
+
+	smart, smTotal, _ := store.ListUserPlaylists(UserPlaylistTypeSmart, 100, 0)
+	if smTotal != 2 || len(smart) != 2 {
+		t.Errorf("list smart: got %d/%d, want 2/2", len(smart), smTotal)
+	}
+}
+
+func TestUserPlaylist_ListPagination(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	for i := 0; i < 5; i++ {
+		_, _ = store.CreateUserPlaylist(&UserPlaylist{
+			Name: string(rune('a'+i)) + "-list", Type: UserPlaylistTypeStatic,
+		})
+	}
+
+	page1, total, _ := store.ListUserPlaylists("", 2, 0)
+	if total != 5 {
+		t.Errorf("total = %d, want 5", total)
+	}
+	if len(page1) != 2 {
+		t.Errorf("page1 len = %d, want 2", len(page1))
+	}
+
+	page2, _, _ := store.ListUserPlaylists("", 2, 2)
+	if len(page2) != 2 {
+		t.Errorf("page2 len = %d, want 2", len(page2))
+	}
+	if page1[0].ID == page2[0].ID {
+		t.Error("pages should not overlap")
+	}
+}
+
+func TestUserPlaylist_UpdateBumpsVersionAndReindexes(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	pl, _ := store.CreateUserPlaylist(&UserPlaylist{Name: "original", Type: UserPlaylistTypeStatic})
+
+	pl.Name = "renamed"
+	pl.BookIDs = []string{"b1", "b2"}
+	if err := store.UpdateUserPlaylist(pl); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, _ := store.GetUserPlaylist(pl.ID)
+	if got.Version != 2 {
+		t.Errorf("Version = %d, want 2", got.Version)
+	}
+	if got.Name != "renamed" {
+		t.Errorf("Name = %q", got.Name)
+	}
+
+	// Old name no longer indexed.
+	miss, _ := store.GetUserPlaylistByName("original")
+	if miss != nil {
+		t.Errorf("old name still indexed: %v", miss)
+	}
+
+	// New name indexed.
+	byNew, _ := store.GetUserPlaylistByName("renamed")
+	if byNew == nil || byNew.ID != pl.ID {
+		t.Errorf("new name lookup failed")
+	}
+}
+
+func TestUserPlaylist_Delete(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	pl, _ := store.CreateUserPlaylist(&UserPlaylist{
+		Name: "to-delete", Type: UserPlaylistTypeStatic, ITunesPersistentID: "PID123",
+	})
+	if err := store.DeleteUserPlaylist(pl.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	got, _ := store.GetUserPlaylist(pl.ID)
+	if got != nil {
+		t.Errorf("playlist still present after delete: %v", got)
+	}
+	byName, _ := store.GetUserPlaylistByName("to-delete")
+	if byName != nil {
+		t.Error("name index not cleared")
+	}
+	byPID, _ := store.GetUserPlaylistByITunesPID("PID123")
+	if byPID != nil {
+		t.Error("itunes PID index not cleared")
+	}
+
+	// Idempotent.
+	if err := store.DeleteUserPlaylist(pl.ID); err != nil {
+		t.Errorf("second delete should be no-op: %v", err)
+	}
+}
+
+func TestUserPlaylist_DirtyTracking(t *testing.T) {
+	store := newPlaylistTestStore(t)
+
+	clean, _ := store.CreateUserPlaylist(&UserPlaylist{Name: "clean", Type: UserPlaylistTypeStatic})
+	dirty1, _ := store.CreateUserPlaylist(&UserPlaylist{Name: "dirty1", Type: UserPlaylistTypeStatic, Dirty: true})
+	dirty2, _ := store.CreateUserPlaylist(&UserPlaylist{Name: "dirty2", Type: UserPlaylistTypeSmart, Query: "*", Dirty: true})
+
+	dirties, err := store.ListDirtyUserPlaylists()
+	if err != nil {
+		t.Fatalf("list dirty: %v", err)
+	}
+	if len(dirties) != 2 {
+		t.Errorf("dirty count = %d, want 2", len(dirties))
+	}
+	seen := map[string]bool{}
+	for _, d := range dirties {
+		seen[d.ID] = true
+	}
+	if !seen[dirty1.ID] || !seen[dirty2.ID] {
+		t.Errorf("expected %q and %q in dirty list", dirty1.ID, dirty2.ID)
+	}
+	if seen[clean.ID] {
+		t.Error("clean playlist should not be in dirty list")
+	}
+
+	// Clearing dirty via update removes from dirty index.
+	dirty1.Dirty = false
+	if err := store.UpdateUserPlaylist(dirty1); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	after, _ := store.ListDirtyUserPlaylists()
+	if len(after) != 1 {
+		t.Errorf("dirty count after clear = %d, want 1", len(after))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `UserPlaylist` type + Store methods for spec 3.4 (smart/static playlists + iTunes sync)
- PebbleStore implementation with `upl:{id}` primary, plus secondary indexes on name (case-insensitive), iTunes persistent ID, and a dirty-set index for sync workers
- SQLiteStore no-op stubs (legacy backend) + MockStore Func hooks; mocks regenerated

## Test plan

- [x] `go test ./internal/database/... -run TestUserPlaylist` — 8 new cases pass
- [x] Full `internal/database` package tests pass
- [x] `go build ./...` clean
- [x] `go vet ./internal/database/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)