### PR TITLE
feat(playlists): smart playlist query evaluator (3.4 task 2)

### DIFF
--- a/internal/server/playlist_evaluator.go
+++ b/internal/server/playlist_evaluator.go
@@ -1,0 +1,352 @@
+// file: internal/server/playlist_evaluator.go
+// version: 1.0.0
+// guid: 9c2d5f1e-6b4a-4a70-b8c5-3d7e0f1b9a68
+//
+// Smart playlist query evaluator (spec 3.4 task 2).
+//
+// A smart playlist carries a DSL query string plus an optional
+// SortJSON and Limit directive. Evaluating the playlist produces
+// the ordered list of book IDs that currently match. The result is
+// also cached onto the playlist row (MaterializedBookIDs) so the
+// iTunes push worker doesn't need the index online to flush pending
+// playlists.
+//
+// The evaluator prefers the Bleve index when available: it yields
+// full text/relevance support and handles ranges natively. Per-user
+// fields (read_status, progress_pct, last_played) are split off by
+// the translator into a PerUserFilter slice and applied here with
+// Store lookups since Bleve only holds library-global state.
+//
+// When the Bleve index is nil (e.g. during early startup) the
+// evaluator returns an error — iTunes sync and the HTTP GET path
+// both retry after the index opens.
+
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/search"
+)
+
+// PlaylistSort is one ordering directive inside a smart playlist's
+// SortJSON. The parsed form of the playlist's SortJSON field.
+type PlaylistSort struct {
+	Field     string `json:"field"`
+	Direction string `json:"direction"` // "asc" | "desc"
+}
+
+// defaultEvalPageSize is the Bleve result window when a smart
+// playlist has no Limit set. Large enough to cover the library
+// while still keeping memory bounded.
+const defaultEvalPageSize = 10000
+
+// ErrSearchIndexUnavailable indicates the Bleve index is not open.
+// Callers can retry once the server has finished its startup phase.
+var ErrSearchIndexUnavailable = errors.New("search index not yet available")
+
+// EvaluateSmartPlaylist parses the playlist query, runs it against
+// the Bleve index, applies any per-user post-filters, sorts, caps
+// to Limit, and returns the ordered list of matching book IDs.
+//
+// store is required for per-user filter lookups + sort enrichment.
+// idx is the Bleve index; nil yields ErrSearchIndexUnavailable.
+// userID is the user the playlist evaluates for — per-user filters
+// read that user's state rows.
+func EvaluateSmartPlaylist(
+	store database.Store,
+	idx *search.BleveIndex,
+	query string,
+	sortJSON string,
+	limit int,
+	userID string,
+) ([]string, error) {
+	if idx == nil {
+		return nil, ErrSearchIndexUnavailable
+	}
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("empty query")
+	}
+
+	ast, err := search.ParseQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("parse query: %w", err)
+	}
+	bleveQ, perUserFilters, err := search.Translate(ast)
+	if err != nil {
+		return nil, fmt.Errorf("translate query: %w", err)
+	}
+
+	// Pull a wide window so we can sort+limit in-memory. If a Limit
+	// is set we still fetch defaultEvalPageSize worth to give the
+	// post-filter + sort pass freedom to reshuffle.
+	hits, _, err := idx.SearchNative(bleveQ, 0, defaultEvalPageSize)
+	if err != nil {
+		return nil, fmt.Errorf("bleve search: %w", err)
+	}
+	ids := make([]string, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, h.BookID)
+	}
+
+	ids = applyPerUserFilters(store, ids, perUserFilters, userID)
+
+	ids, err = sortBookIDs(store, ids, sortJSON)
+	if err != nil {
+		return nil, fmt.Errorf("sort: %w", err)
+	}
+
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}
+
+// applyPerUserFilters walks the candidate book IDs and drops any
+// whose per-user state doesn't satisfy every filter. Filters for
+// fields the user never wrote are treated as "no match" (the user
+// hasn't engaged with the book, so e.g. `read_status:finished`
+// doesn't match an unstarted book).
+func applyPerUserFilters(
+	store database.Store,
+	ids []string,
+	filters []search.PerUserFilter,
+	userID string,
+) []string {
+	if len(filters) == 0 {
+		return ids
+	}
+	kept := make([]string, 0, len(ids))
+	for _, id := range ids {
+		state, _ := store.GetUserBookState(userID, id)
+		match := true
+		for _, f := range filters {
+			ok := perUserFilterMatches(state, f.Node)
+			if f.Negated {
+				ok = !ok
+			}
+			if !ok {
+				match = false
+				break
+			}
+		}
+		if match {
+			kept = append(kept, id)
+		}
+	}
+	return kept
+}
+
+// perUserFilterMatches evaluates a single FieldNode against a
+// UserBookState. A nil state means the user has no record — only
+// negated filters can succeed against nil.
+func perUserFilterMatches(state *database.UserBookState, node *search.FieldNode) bool {
+	if state == nil {
+		// Treat absence as a zero-value state: status="" + progress=0.
+		// That way `read_status:unstarted` (if the caller maps
+		// "unstarted"→"") matches and `read_status:finished` rejects.
+		state = &database.UserBookState{}
+	}
+	switch node.Field {
+	case "read_status":
+		return strings.EqualFold(state.Status, node.Value)
+	case "progress_pct":
+		return numericFieldMatches(float64(state.ProgressPct), node)
+	case "last_played":
+		if state.LastActivityAt.IsZero() {
+			return false
+		}
+		return timeFieldMatches(state.LastActivityAt, node)
+	default:
+		return false
+	}
+}
+
+func numericFieldMatches(got float64, node *search.FieldNode) bool {
+	switch node.Op {
+	case "range":
+		lo, err1 := strconv.ParseFloat(node.RangeMin, 64)
+		hi, err2 := strconv.ParseFloat(node.RangeMax, 64)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		return got >= lo && got <= hi
+	case ">", "<", ">=", "<=", "=", "":
+		want, err := strconv.ParseFloat(node.Value, 64)
+		if err != nil {
+			return false
+		}
+		switch node.Op {
+		case ">":
+			return got > want
+		case "<":
+			return got < want
+		case ">=":
+			return got >= want
+		case "<=":
+			return got <= want
+		default:
+			return got == want
+		}
+	}
+	return false
+}
+
+func timeFieldMatches(got time.Time, node *search.FieldNode) bool {
+	parse := func(s string) (time.Time, bool) {
+		// Accept RFC3339 + plain YYYY-MM-DD.
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
+	}
+	switch node.Op {
+	case "range":
+		lo, ok1 := parse(node.RangeMin)
+		hi, ok2 := parse(node.RangeMax)
+		if !ok1 || !ok2 {
+			return false
+		}
+		return !got.Before(lo) && !got.After(hi)
+	default:
+		want, ok := parse(node.Value)
+		if !ok {
+			return false
+		}
+		switch node.Op {
+		case ">":
+			return got.After(want)
+		case "<":
+			return got.Before(want)
+		case ">=":
+			return got.After(want) || got.Equal(want)
+		case "<=":
+			return got.Before(want) || got.Equal(want)
+		default:
+			return got.Equal(want)
+		}
+	}
+}
+
+// sortBookIDs reorders ids per the playlist's SortJSON directives.
+// Empty or invalid SortJSON leaves ids in the order Bleve returned
+// them (relevance order). Unknown fields are skipped with no error
+// so a partly-broken sort spec still produces a stable result.
+func sortBookIDs(store database.Store, ids []string, sortJSON string) ([]string, error) {
+	if strings.TrimSpace(sortJSON) == "" || len(ids) < 2 {
+		return ids, nil
+	}
+	var directives []PlaylistSort
+	if err := json.Unmarshal([]byte(sortJSON), &directives); err != nil {
+		return ids, fmt.Errorf("parse sort_json: %w", err)
+	}
+	if len(directives) == 0 {
+		return ids, nil
+	}
+
+	type loaded struct {
+		id   string
+		book *database.Book
+	}
+	rows := make([]loaded, 0, len(ids))
+	for _, id := range ids {
+		b, _ := store.GetBookByID(id)
+		rows = append(rows, loaded{id: id, book: b})
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, d := range directives {
+			c := compareBookField(rows[i].book, rows[j].book, d.Field)
+			if c == 0 {
+				continue
+			}
+			if strings.EqualFold(d.Direction, "desc") {
+				return c > 0
+			}
+			return c < 0
+		}
+		return false
+	})
+
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.id
+	}
+	return out, nil
+}
+
+// compareBookField returns -1/0/+1 for a/b on the named Book field.
+// Missing books are treated as "less than" present books so they
+// cluster at one end rather than breaking the sort mid-list.
+func compareBookField(a, b *database.Book, field string) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	switch strings.ToLower(field) {
+	case "title":
+		return strings.Compare(strings.ToLower(a.Title), strings.ToLower(b.Title))
+	case "year":
+		return intCmp(derefInt(a.PrintYear), derefInt(b.PrintYear))
+	case "audiobook_year":
+		return intCmp(derefInt(a.AudiobookReleaseYear), derefInt(b.AudiobookReleaseYear))
+	case "rating":
+		return intCmp(derefInt(a.ITunesRating), derefInt(b.ITunesRating))
+	case "duration":
+		return intCmp(derefInt(a.Duration), derefInt(b.Duration))
+	case "date_added", "added":
+		return timeCmp(derefTime(a.CreatedAt), derefTime(b.CreatedAt))
+	case "date_modified", "modified":
+		return timeCmp(derefTime(a.UpdatedAt), derefTime(b.UpdatedAt))
+	case "itunes_last_played":
+		return timeCmp(derefTime(a.ITunesLastPlayed), derefTime(b.ITunesLastPlayed))
+	case "itunes_play_count":
+		return intCmp(derefInt(a.ITunesPlayCount), derefInt(b.ITunesPlayCount))
+	default:
+		return 0
+	}
+}
+
+func derefTime(p *time.Time) time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return *p
+}
+
+func intCmp(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func timeCmp(a, b time.Time) int {
+	switch {
+	case a.Before(b):
+		return -1
+	case a.After(b):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/server/playlist_evaluator_test.go
+++ b/internal/server/playlist_evaluator_test.go
@@ -1,0 +1,229 @@
+// file: internal/server/playlist_evaluator_test.go
+// version: 1.0.0
+// guid: 9d3e5f2a-7b4a-4a70-b8c5-3d7e0f1b9a69
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/search"
+)
+
+// buildEvalFixture seeds a PebbleStore with three books and a
+// Bleve index with matching docs. Returns the store, index, and
+// book IDs in insertion order.
+func buildEvalFixture(t *testing.T) (*database.PebbleStore, *search.BleveIndex, []string) {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	idx, err := search.Open(filepath.Join(t.TempDir(), "bleve"))
+	if err != nil {
+		t.Fatalf("bleve open: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	type seed struct {
+		id     string
+		title  string
+		author string
+		series string
+		year   int
+		format string
+	}
+	rows := []seed{
+		{"b1", "The Way of Kings", "Brandon Sanderson", "Stormlight Archive", 2010, "m4b"},
+		{"b2", "Words of Radiance", "Brandon Sanderson", "Stormlight Archive", 2014, "m4b"},
+		{"b3", "The Fifth Season", "N. K. Jemisin", "Broken Earth", 2015, "mp3"},
+	}
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		year := r.year
+		_, err := store.CreateBook(&database.Book{
+			ID: r.id, Title: r.title, FilePath: "/tmp/" + r.id, Format: r.format, PrintYear: &year,
+		})
+		if err != nil {
+			t.Fatalf("create book %s: %v", r.id, err)
+		}
+		if err := idx.IndexBook(search.BookDocument{
+			BookID: r.id, Title: r.title, Author: r.author,
+			Series: r.series, Year: r.year, Format: r.format,
+		}); err != nil {
+			t.Fatalf("index %s: %v", r.id, err)
+		}
+		ids = append(ids, r.id)
+	}
+	return store, idx, ids
+}
+
+func TestEvaluate_BasicAuthorQuery(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	got, err := EvaluateSmartPlaylist(store, idx, "author:sanderson", "", 0, "_local")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %d, want 2 (both Sanderson)", len(got))
+	}
+}
+
+func TestEvaluate_NilIndexErrors(t *testing.T) {
+	store, _, _ := buildEvalFixture(t)
+
+	_, err := EvaluateSmartPlaylist(store, nil, "author:sanderson", "", 0, "_local")
+	if err != ErrSearchIndexUnavailable {
+		t.Errorf("want ErrSearchIndexUnavailable, got: %v", err)
+	}
+}
+
+func TestEvaluate_EmptyQueryErrors(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	if _, err := EvaluateSmartPlaylist(store, idx, "   ", "", 0, "_local"); err == nil {
+		t.Error("empty query should error")
+	}
+}
+
+func TestEvaluate_LimitTruncates(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	got, err := EvaluateSmartPlaylist(store, idx, "format:m4b", "", 1, "_local")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("limit=1 returned %d ids", len(got))
+	}
+}
+
+func TestEvaluate_SortByYearDesc(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	sortJSON := `[{"field":"year","direction":"desc"}]`
+	got, err := EvaluateSmartPlaylist(store, idx, "author:sanderson", sortJSON, 0, "_local")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	// Sanderson books: b2 (2014) should come before b1 (2010) on desc.
+	if len(got) != 2 || got[0] != "b2" || got[1] != "b1" {
+		t.Errorf("sorted = %v, want [b2 b1]", got)
+	}
+}
+
+func TestEvaluate_SortByTitleAsc(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	sortJSON := `[{"field":"title","direction":"asc"}]`
+	got, err := EvaluateSmartPlaylist(store, idx, "*", sortJSON, 0, "_local")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	// Titles sorted asc: "The Fifth Season" < "The Way of Kings" < "Words of Radiance"
+	if len(got) != 3 || got[0] != "b3" || got[1] != "b1" || got[2] != "b2" {
+		t.Errorf("sorted = %v, want [b3 b1 b2]", got)
+	}
+}
+
+func TestEvaluate_PerUserFilterReadStatus(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	// Mark b1 finished for user "alice".
+	_ = store.SetUserBookState(&database.UserBookState{
+		UserID: "alice", BookID: "b1", Status: database.UserBookStatusFinished,
+		StatusManual: true, LastActivityAt: time.Now(),
+	})
+
+	// Query targets all Sanderson, but filter to finished only.
+	got, err := EvaluateSmartPlaylist(store, idx, "author:sanderson read_status:finished", "", 0, "alice")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(got) != 1 || got[0] != "b1" {
+		t.Errorf("want [b1], got %v", got)
+	}
+
+	// Different user — no state, so no match.
+	got, err = EvaluateSmartPlaylist(store, idx, "author:sanderson read_status:finished", "", 0, "bob")
+	if err != nil {
+		t.Fatalf("evaluate (bob): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("bob should see no finished books, got %v", got)
+	}
+}
+
+func TestEvaluate_PerUserFilterNegated(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	_ = store.SetUserBookState(&database.UserBookState{
+		UserID: "alice", BookID: "b1", Status: database.UserBookStatusFinished,
+		StatusManual: true, LastActivityAt: time.Now(),
+	})
+
+	// NOT read_status:finished should exclude b1 but include b2 (unstarted).
+	got, err := EvaluateSmartPlaylist(store, idx, "author:sanderson -read_status:finished", "", 0, "alice")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(got) != 1 || got[0] != "b2" {
+		t.Errorf("want [b2], got %v", got)
+	}
+}
+
+func TestEvaluate_PerUserFilterProgressRange(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	_ = store.SetUserBookState(&database.UserBookState{
+		UserID: "alice", BookID: "b1", Status: database.UserBookStatusInProgress,
+		ProgressPct: 50, LastActivityAt: time.Now(),
+	})
+	_ = store.SetUserBookState(&database.UserBookState{
+		UserID: "alice", BookID: "b2", Status: database.UserBookStatusInProgress,
+		ProgressPct: 10, LastActivityAt: time.Now(),
+	})
+
+	got, err := EvaluateSmartPlaylist(store, idx, "author:sanderson progress_pct:>25", "", 0, "alice")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(got) != 1 || got[0] != "b1" {
+		t.Errorf("want [b1] with >25%% progress, got %v", got)
+	}
+}
+
+func TestEvaluate_YearRangeQuery(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	got, err := EvaluateSmartPlaylist(store, idx, "year:[2013 TO 2020]", "", 0, "_local")
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	// b2 (2014) + b3 (2015) in range, b1 (2010) out.
+	if len(got) != 2 {
+		t.Errorf("year range got %d, want 2", len(got))
+	}
+	seen := map[string]bool{}
+	for _, id := range got {
+		seen[id] = true
+	}
+	if !seen["b2"] || !seen["b3"] || seen["b1"] {
+		t.Errorf("year range picked wrong books: %v", got)
+	}
+}
+
+func TestEvaluate_MalformedQueryErrors(t *testing.T) {
+	store, idx, _ := buildEvalFixture(t)
+
+	// Unterminated quote — parser should reject.
+	if _, err := EvaluateSmartPlaylist(store, idx, `title:"unterminated`, "", 0, "_local"); err == nil {
+		t.Error("expected parse error on unterminated quote")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `EvaluateSmartPlaylist(store, idx, query, sortJSON, limit, userID)` — parses the DSL query, translates to Bleve, applies per-user post-filters, sorts, and caps to Limit
- Per-user fields (`read_status`, `progress_pct`, `last_played`) are split off by the translator and applied via `Store.GetUserBookState` since Bleve only holds library-global state
- Sort accepts `SortJSON` directives on `title`, `year`, `rating`, `duration`, `date_added/modified`, and `itunes_last_played/play_count`
- Returns `ErrSearchIndexUnavailable` when Bleve is not yet open (callers retry after startup)

## Test plan

- [x] `go test ./internal/server/ -run TestEvaluate` — 10 cases pass
- [x] Full `internal/server` suite passes (no regressions)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)