### PR TITLE
chore(gomod): run go mod tidy for clean release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jdfalk/audiobook-organizer
 go 1.26.0
 
 require (
+	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/cockroachdb/pebble/v2 v2.1.4
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/fsnotify/fsnotify v1.9.0
@@ -33,7 +34,6 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.22.0 // indirect
-	github.com/blevesearch/bleve/v2 v2.5.7 // indirect
 	github.com/blevesearch/bleve_index_api v1.2.11 // indirect
 	github.com/blevesearch/geo v0.2.4 // indirect
 	github.com/blevesearch/go-faiss v1.0.26 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION
Fixes release failure where goreleaser aborted with "git is in a dirty state" because the CI pipeline runs \`go mod tidy\` before building and it wanted to promote \`github.com/blevesearch/bleve/v2\` from indirect to direct (the Bleve search package imports merged in PR #301).

Committing the tidy result so the next release starts clean.

Details: https://github.com/jdfalk/audiobook-organizer/actions/runs/24533881209/job/71724892471

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go mod tidy\` is a no-op after this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)