### PR TITLE
feat(search): route /audiobooks search through Bleve (DES-1 task 5)

### DIFF
--- a/internal/server/audiobook_service.go
+++ b/internal/server/audiobook_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package server
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/mediainfo"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/search"
 )
 
 // AudiobookService handles all audiobook business logic
@@ -28,11 +29,22 @@ type AudiobookService struct {
 	bookCache       *cache.Cache[*database.Book]
 	listCache       *cache.Cache[[]database.Book]
 	activityService *ActivityService
+	// searchIndex is the Bleve index for full-text search. When nil
+	// the service falls back to the legacy Store.SearchBooks path.
+	// Wired in by the Server after Bleve opens in Start(), which is
+	// after NewAudiobookService runs in NewServer.
+	searchIndex *search.BleveIndex
 }
 
 // SetActivityService wires the activity service for snapshot fallback in GetAudiobookTags.
 func (svc *AudiobookService) SetActivityService(as *ActivityService) {
 	svc.activityService = as
+}
+
+// SetSearchIndex wires the Bleve index for Bleve-backed search.
+// Calling with nil reverts to the Store.SearchBooks fallback.
+func (svc *AudiobookService) SetSearchIndex(idx *search.BleveIndex) {
+	svc.searchIndex = idx
 }
 
 // NewAudiobookService creates a new AudiobookService instance
@@ -430,7 +442,11 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 
 	// Apply filters in order of precedence
 	if search != "" {
-		books, err = svc.store.SearchBooks(search, limit, offset)
+		if svc.searchIndex != nil {
+			books, err = svc.searchWithBleve(search, limit, offset)
+		} else {
+			books, err = svc.store.SearchBooks(search, limit, offset)
+		}
 	} else if authorID != nil {
 		books, err = svc.store.GetBooksByAuthorID(*authorID)
 	} else if seriesID != nil {
@@ -1609,4 +1625,39 @@ func (svc *AudiobookService) BatchUpdateUserTags(bookIDs []string, addTags []str
 		svc.InvalidateBookCaches()
 	}
 	return updated, nil
+}
+
+// searchWithBleve parses the query via the DSL, translates to a
+// Bleve native query, and returns the matching books. Per-user
+// filters produced by the translator (read_status / progress_pct /
+// last_played) are currently dropped here — the library-list route
+// doesn't carry user state. Spec 3.6 will wire them back in at the
+// handler layer once the user context is plumbed.
+//
+// Falls back to an empty slice (not nil) on zero matches so callers
+// get consistent JSON shape.
+func (svc *AudiobookService) searchWithBleve(query string, limit, offset int) ([]database.Book, error) {
+	ast, err := search.ParseQuery(query)
+	if err != nil {
+		// Parser failure: fall back to the substring search path so
+		// users still see results for simple queries the DSL parser
+		// rejects (e.g. punctuation-heavy book titles).
+		return svc.store.SearchBooks(query, limit, offset)
+	}
+	bleveQ, _, err := search.Translate(ast)
+	if err != nil {
+		return svc.store.SearchBooks(query, limit, offset)
+	}
+	hits, _, err := svc.searchIndex.SearchNative(bleveQ, offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("bleve search: %w", err)
+	}
+	books := make([]database.Book, 0, len(hits))
+	for _, h := range hits {
+		b, _ := svc.store.GetBookByID(h.BookID)
+		if b != nil {
+			books = append(books, *b)
+		}
+	}
+	return books, nil
 }

--- a/internal/server/audiobook_service_bleve_test.go
+++ b/internal/server/audiobook_service_bleve_test.go
@@ -1,0 +1,119 @@
+// file: internal/server/audiobook_service_bleve_test.go
+// version: 1.0.0
+// guid: 7f3d5a4b-9c5a-4a70-b8c5-3d7e0f1b9a99
+
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/search"
+)
+
+// setupBleveBackedService builds an AudiobookService with a real
+// PebbleStore, a real Bleve index, and a small fixture of books
+// and indexed docs so search paths can be verified end-to-end.
+func setupBleveBackedService(t *testing.T) (*AudiobookService, *database.PebbleStore, *search.BleveIndex) {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	idx, err := search.Open(filepath.Join(t.TempDir(), "bleve"))
+	if err != nil {
+		t.Fatalf("bleve: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	svc := NewAudiobookService(store)
+	svc.SetSearchIndex(idx)
+
+	seedRows := []struct {
+		id, title, author, format string
+		year                      int
+	}{
+		{"b1", "The Way of Kings", "Brandon Sanderson", "m4b", 2010},
+		{"b2", "Words of Radiance", "Brandon Sanderson", "m4b", 2014},
+		{"b3", "The Fifth Season", "N. K. Jemisin", "mp3", 2015},
+	}
+	for _, r := range seedRows {
+		year := r.year
+		if _, err := store.CreateBook(&database.Book{
+			ID: r.id, Title: r.title, FilePath: "/tmp/" + r.id, Format: r.format, PrintYear: &year,
+		}); err != nil {
+			t.Fatalf("seed book: %v", err)
+		}
+		if err := idx.IndexBook(search.BookDocument{
+			BookID: r.id, Title: r.title, Author: r.author, Format: r.format, Year: r.year,
+		}); err != nil {
+			t.Fatalf("index: %v", err)
+		}
+	}
+	return svc, store, idx
+}
+
+func TestService_SearchRoutedThroughBleve(t *testing.T) {
+	svc, _, _ := setupBleveBackedService(t)
+
+	books, err := svc.GetAudiobooks(context.Background(), 10, 0, "author:sanderson", nil, nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(books) != 2 {
+		t.Errorf("got %d books, want 2", len(books))
+	}
+}
+
+func TestService_SearchRangeQuery(t *testing.T) {
+	svc, _, _ := setupBleveBackedService(t)
+
+	books, err := svc.GetAudiobooks(context.Background(), 10, 0, "year:[2013 TO 2020]", nil, nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	// b2 (2014) + b3 (2015) in range.
+	if len(books) != 2 {
+		t.Errorf("got %d books for year range, want 2", len(books))
+	}
+}
+
+func TestService_SearchFallsBackOnParserFailure(t *testing.T) {
+	svc, _, _ := setupBleveBackedService(t)
+
+	// Malformed DSL — unterminated quote. Service should fall back
+	// to substring SearchBooks which (on PebbleStore) usually does
+	// a LIKE-style scan and may return zero but MUST NOT error.
+	books, err := svc.GetAudiobooks(context.Background(), 10, 0, `title:"unterminated`, nil, nil)
+	if err != nil {
+		t.Errorf("parser failure should fall back silently, got err: %v", err)
+	}
+	_ = books // shape is fine; contents depend on fallback behavior
+}
+
+func TestService_NoIndexUsesLegacy(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	_, _ = store.CreateBook(&database.Book{
+		ID: "b1", Title: "Only Book", FilePath: "/tmp/b1", Format: "m4b",
+	})
+
+	svc := NewAudiobookService(store)
+	// No SetSearchIndex — should use Store.SearchBooks path.
+	books, err := svc.GetAudiobooks(context.Background(), 10, 0, "Only", nil, nil)
+	if err != nil {
+		t.Fatalf("legacy search: %v", err)
+	}
+	// PebbleStore.SearchBooks may return 0 or 1 depending on
+	// implementation; the important contract is: no panic, no error,
+	// and the call path was legacy (not Bleve).
+	_ = books
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.175.0
+// version: 1.176.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -1498,6 +1498,10 @@ func (s *Server) Start(cfg ServerConfig) error {
 			defer s.bgWG.Done()
 			s.runIndexWorker()
 		}()
+		// Route the /audiobooks?search= path through Bleve.
+		if s.audiobookService != nil {
+			s.audiobookService.SetSearchIndex(s.searchIndex)
+		}
 	}
 
 	// Build the search index on first startup (or if it got wiped).


### PR DESCRIPTION
## Summary

- Routes the `/api/v1/audiobooks?search=` path through the Bleve index when available — full DSL support including field-scoped queries, ranges, fuzzy matching, and boolean operators
- Falls back to legacy `Store.SearchBooks` when the index isn't open or the DSL parser rejects the query (preserves backward compatibility for simple substring searches)
- Wired via `AudiobookService.SetSearchIndex(idx)` after the index opens in `Server.Start()`
- Per-user filters from the translator are dropped at this layer — they need user context plumbing before the library-list endpoint can honor them (smart playlist eval already handles this correctly)

## Test plan

- [x] 4 new tests: author query, year range, parser fallback, no-index legacy path
- [x] Full `internal/server` suite green
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)