### PR TITLE
feat(auth): add login lockout (3.7 task 4)

### DIFF
--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/auth_handlers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1457df2f-af76-46cb-a2f4-c9f6f275f93a
 
 package server
@@ -7,6 +7,7 @@ package server
 import (
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -15,6 +16,52 @@ import (
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
+
+const (
+	maxFailedLogins      = 10
+	lockoutWindowMinutes = 15
+)
+
+type failedAttempt struct {
+	count   int
+	firstAt time.Time
+}
+
+var (
+	loginLockoutMu sync.Mutex
+	loginLockout   = map[string]*failedAttempt{}
+)
+
+func isLockedOut(userID string) bool {
+	loginLockoutMu.Lock()
+	defer loginLockoutMu.Unlock()
+	a, ok := loginLockout[userID]
+	if !ok {
+		return false
+	}
+	if time.Since(a.firstAt) > lockoutWindowMinutes*time.Minute {
+		delete(loginLockout, userID)
+		return false
+	}
+	return a.count >= maxFailedLogins
+}
+
+func recordFailedLogin(userID string) {
+	loginLockoutMu.Lock()
+	defer loginLockoutMu.Unlock()
+	a, ok := loginLockout[userID]
+	if !ok || time.Since(a.firstAt) > lockoutWindowMinutes*time.Minute {
+		loginLockout[userID] = &failedAttempt{count: 1, firstAt: time.Now()}
+		return
+	}
+	a.count++
+}
+
+func clearFailedLogins(userID string) {
+	loginLockoutMu.Lock()
+	defer loginLockoutMu.Unlock()
+	delete(loginLockout, userID)
+}
 
 const defaultSessionTTL = 24 * time.Hour
 
@@ -175,10 +222,18 @@ func (s *Server) login(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return
 	}
+
+	if isLockedOut(user.ID) {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "account temporarily locked — try again later"})
+		return
+	}
+
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		recordFailedLogin(user.ID)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return
 	}
+	clearFailedLogins(user.ID)
 
 	session, err := s.Store().CreateSession(
 		user.ID,

--- a/internal/server/auth_lockout_test.go
+++ b/internal/server/auth_lockout_test.go
@@ -1,0 +1,43 @@
+// file: internal/server/auth_lockout_test.go
+// version: 1.0.0
+// guid: 8c4e5f3a-9b5a-4a70-b8c5-3d7e0f1b9a99
+
+package server
+
+import "testing"
+
+func TestLockout_TriggersAfterMaxFailures(t *testing.T) {
+	uid := "test-lockout-user"
+	clearFailedLogins(uid)
+	defer clearFailedLogins(uid)
+
+	for i := 0; i < maxFailedLogins; i++ {
+		if isLockedOut(uid) {
+			t.Fatalf("locked out after only %d attempts, want %d", i, maxFailedLogins)
+		}
+		recordFailedLogin(uid)
+	}
+	if !isLockedOut(uid) {
+		t.Errorf("should be locked out after %d failures", maxFailedLogins)
+	}
+}
+
+func TestLockout_ClearedOnSuccess(t *testing.T) {
+	uid := "test-clear-user"
+	clearFailedLogins(uid)
+	defer clearFailedLogins(uid)
+
+	for i := 0; i < maxFailedLogins-1; i++ {
+		recordFailedLogin(uid)
+	}
+	clearFailedLogins(uid)
+	if isLockedOut(uid) {
+		t.Error("should not be locked out after clear")
+	}
+}
+
+func TestLockout_NoLockoutForUnknownUser(t *testing.T) {
+	if isLockedOut("never-seen-user-123") {
+		t.Error("unknown user should not be locked out")
+	}
+}


### PR DESCRIPTION
## Summary

Adds failed-login tracking to the existing login handler. After 10 consecutive failures within 15 minutes, the account returns 429 and won't accept further attempts until the window expires or a successful login clears the counter.

In-memory map (single-instance deployment model). Multi-node would need Redis/DB.

## Test plan

- [x] 3 lockout tests (trigger, clear-on-success, unknown-user)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)