### PR TITLE
feat(versions): fingerprint check for incoming files (3.1 task 4)

### DIFF
--- a/internal/server/version_fingerprint.go
+++ b/internal/server/version_fingerprint.go
@@ -1,0 +1,102 @@
+// file: internal/server/version_fingerprint.go
+// version: 1.0.0
+// guid: 8d5e7f4c-9c5a-4a70-b8c5-3d7e0f1b9a99
+//
+// Fingerprint check for incoming files (spec 3.1 task 4).
+//
+// When a new file arrives (via deluge, manual import, or scan), we
+// check whether it matches a previously-purged or blocked version.
+// If so, the caller can pause deluge / surface a dialog before
+// re-importing content that was explicitly removed.
+//
+// Fast path: torrent hash lookup (O(1) in PebbleDB via the
+// idx:bv:torrent:{hash} index). Slow path: per-file hash scan
+// against existing BookFile rows.
+
+package server
+
+import "github.com/jdfalk/audiobook-organizer/internal/database"
+
+// FingerprintMatch describes a match between an incoming file/torrent
+// and a previously-seen version in the library. The caller uses this
+// to decide whether to block, prompt, or allow the ingest.
+type FingerprintMatch struct {
+	Matched   bool   `json:"matched"`
+	BookID    string `json:"book_id,omitempty"`
+	VersionID string `json:"version_id,omitempty"`
+	MatchType string `json:"match_type,omitempty"` // "torrent_hash" | "file_hash"
+	Status    string `json:"status,omitempty"`
+}
+
+// CheckFingerprint looks up a torrent hash and/or file hashes
+// against the library's version database. Returns a match if the
+// content was previously purged or blocked.
+//
+// torrentHash is checked first (fast path). fileHashes is a
+// fallback for content without a torrent (manual imports). Both
+// can be empty — in which case no match is returned.
+func CheckFingerprint(
+	store database.Store,
+	torrentHash string,
+	fileHashes []string,
+) *FingerprintMatch {
+	// Fast path: torrent hash lookup.
+	if torrentHash != "" {
+		ver, err := store.GetBookVersionByTorrentHash(torrentHash)
+		if err == nil && ver != nil && isPurgedOrBlocked(ver.Status) {
+			return &FingerprintMatch{
+				Matched:   true,
+				BookID:    ver.BookID,
+				VersionID: ver.ID,
+				MatchType: "torrent_hash",
+				Status:    ver.Status,
+			}
+		}
+	}
+
+	// Slow path: per-file hash scan. For each incoming hash, check
+	// if any BookFile in the library has a matching file_hash whose
+	// parent version is purged/blocked.
+	for _, hash := range fileHashes {
+		if hash == "" {
+			continue
+		}
+		match := scanFileHashMatch(store, hash)
+		if match != nil {
+			return match
+		}
+	}
+
+	return &FingerprintMatch{Matched: false}
+}
+
+// isPurgedOrBlocked returns true for version statuses that indicate
+// the content was intentionally removed from the library. These are
+// the statuses the fingerprint check guards against re-importing.
+func isPurgedOrBlocked(status string) bool {
+	switch status {
+	case database.BookVersionStatusInactivePurged,
+		database.BookVersionStatusBlockedForRedownload,
+		database.BookVersionStatusTrash:
+		return true
+	default:
+		return false
+	}
+}
+
+// scanFileHashMatch searches BookFile rows for a matching file_hash
+// and checks whether the owning version is purged or blocked.
+//
+// This is a linear scan across all book files — expensive for large
+// libraries. In practice it's only invoked when the fast path
+// (torrent hash) fails, which is rare for automated ingestion.
+// A future optimization would add a file_hash→version_id index in
+// PebbleDB.
+func scanFileHashMatch(store database.Store, hash string) *FingerprintMatch {
+	// The current Store interface doesn't expose GetBookFileByHash.
+	// For now, this is a stub that returns nil. A follow-up PR will
+	// add the index + method.
+	_ = store
+	_ = hash
+	return nil
+}

--- a/internal/server/version_fingerprint_test.go
+++ b/internal/server/version_fingerprint_test.go
@@ -1,0 +1,106 @@
+// file: internal/server/version_fingerprint_test.go
+// version: 1.0.0
+// guid: 9e6f8a5d-0c5a-4a70-b8c5-3d7e0f1b9a99
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestCheckFingerprint_TorrentHashMatch(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Create a purged version with a torrent hash.
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: "b1", Status: database.BookVersionStatusInactivePurged,
+		Format: "m4b", Source: "deluge", TorrentHash: "abc123",
+	})
+
+	match := CheckFingerprint(store, "abc123", nil)
+	if !match.Matched {
+		t.Fatal("expected match on purged torrent hash")
+	}
+	if match.MatchType != "torrent_hash" {
+		t.Errorf("MatchType = %q, want torrent_hash", match.MatchType)
+	}
+	if match.BookID != "b1" {
+		t.Errorf("BookID = %q, want b1", match.BookID)
+	}
+	if match.Status != database.BookVersionStatusInactivePurged {
+		t.Errorf("Status = %q", match.Status)
+	}
+}
+
+func TestCheckFingerprint_TorrentHashActiveNotBlocked(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Active version should NOT trigger a fingerprint block.
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: "b1", Status: database.BookVersionStatusActive,
+		Format: "m4b", Source: "deluge", TorrentHash: "active-hash",
+	})
+
+	match := CheckFingerprint(store, "active-hash", nil)
+	if match.Matched {
+		t.Error("active version should not trigger fingerprint match")
+	}
+}
+
+func TestCheckFingerprint_BlockedForRedownload(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: "b1", Status: database.BookVersionStatusBlockedForRedownload,
+		Format: "m4b", Source: "deluge", TorrentHash: "blocked-hash",
+	})
+
+	match := CheckFingerprint(store, "blocked-hash", nil)
+	if !match.Matched {
+		t.Fatal("blocked_for_redownload should match")
+	}
+	if match.Status != database.BookVersionStatusBlockedForRedownload {
+		t.Errorf("Status = %q", match.Status)
+	}
+}
+
+func TestCheckFingerprint_NoMatch(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	match := CheckFingerprint(store, "unknown-hash", []string{"unknown-file-hash"})
+	if match.Matched {
+		t.Error("should not match unknown hashes")
+	}
+}
+
+func TestCheckFingerprint_EmptyInputs(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	match := CheckFingerprint(store, "", nil)
+	if match.Matched {
+		t.Error("empty inputs should not match")
+	}
+}


### PR DESCRIPTION
## Summary

Adds \`CheckFingerprint(store, torrentHash, fileHashes)\` — the guard that prevents re-importing content that was explicitly purged or blocked.

- Fast path: \`GetBookVersionByTorrentHash\` — O(1) PebbleDB index
- Returns match type, book/version IDs, and current status for the UI to surface
- Only matches purged/blocked/trash statuses — active/alt versions are ignored
- File hash slow path stubbed pending a \`file_hash→version_id\` index

## Test plan

- [x] 5 tests: torrent match, active-not-blocked, blocked_for_redownload, no-match, empty inputs
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)