### PR TITLE
fix(database): prefix iteration bug + feat(undo): undo engine (3.2 task 3)

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.47.0
+// version: 1.48.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -21,6 +21,17 @@ import (
 	"github.com/cockroachdb/pebble/v2"
 	ulid "github.com/oklog/ulid/v2"
 )
+
+// prefixEnd returns an upper-bound key for Pebble range iteration
+// over all keys sharing `prefix`. It creates a separate byte slice
+// so the increment doesn't mutate the original prefix.
+func prefixEnd(prefix []byte) []byte {
+	upper := make([]byte, len(prefix))
+	copy(upper, prefix)
+	upper[len(upper)-1]++
+	return upper
+}
+
 
 // PebbleStore implements the Store interface using PebbleDB (LSM key-value store)
 //
@@ -5782,7 +5793,7 @@ func (p *PebbleStore) GetOperationChanges(operationID string) ([]*OperationChang
 	prefix := []byte(fmt.Sprintf("opchange:%s:", operationID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6178,7 +6189,7 @@ func (p *PebbleStore) GetBookPathHistory(bookID string) ([]BookPathChange, error
 	prefix := []byte(fmt.Sprintf("path_history:%s:", bookID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6300,7 +6311,7 @@ func (p *PebbleStore) GetBookTags(bookID string) ([]string, error) {
 	prefix := []byte(fmt.Sprintf("book_tag:%s:", bookID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6327,7 +6338,7 @@ func (p *PebbleStore) GetBookTagsDetailed(bookID string) ([]BookTag, error) {
 	prefix := []byte(fmt.Sprintf("book_tag:%s:", bookID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6406,7 +6417,7 @@ func (p *PebbleStore) ListAllTags() ([]TagWithCount, error) {
 	prefix := []byte("tag_idx:")
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6443,7 +6454,7 @@ func (p *PebbleStore) GetBooksByTag(tag string) ([]string, error) {
 	prefix := []byte(fmt.Sprintf("tag_idx:%s:", tag))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6549,7 +6560,7 @@ func (p *PebbleStore) pebbleGetTags(ks pebbleTagKeyspace, entityID string) ([]st
 	prefix := []byte(fmt.Sprintf("%s%s:", ks.tagPrefix, entityID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6572,7 +6583,7 @@ func (p *PebbleStore) pebbleGetTagsDetailed(ks pebbleTagKeyspace, entityID strin
 	prefix := []byte(fmt.Sprintf("%s%s:", ks.tagPrefix, entityID))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6661,7 +6672,7 @@ func (p *PebbleStore) pebbleListAllTags(ks pebbleTagKeyspace) ([]TagWithCount, e
 	prefix := []byte(ks.indexPrefix)
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err
@@ -6697,7 +6708,7 @@ func (p *PebbleStore) pebbleEntitiesByTag(ks pebbleTagKeyspace, tag string) ([]s
 	prefix := []byte(fmt.Sprintf("%s%s:", ks.indexPrefix, tag))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
-		UpperBound: append(prefix[:len(prefix)-1], prefix[len(prefix)-1]+1),
+		UpperBound: prefixEnd(prefix),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/server/undo_engine.go
+++ b/internal/server/undo_engine.go
@@ -1,0 +1,220 @@
+// file: internal/server/undo_engine.go
+// version: 1.0.0
+// guid: 0b8c9d6e-1f7a-4a70-b8c5-3d7e0f1b9a99
+//
+// Undo engine (spec 3.2 task 3). Reverses the destructive changes
+// recorded by a prior operation by walking its operation_changes
+// rows in reverse order and applying the inverse transform.
+//
+// Supported change_type reversals:
+//   - file_move / organize_rename: os.Rename(new_value → old_value)
+//   - metadata_update / db_update: restore field from old_value
+//   - dir_create: remove directory if empty
+//   - tag_write: no-op (tags are idempotently re-derived)
+//
+// Each change row is marked reverted_at on success; already-reverted
+// rows are skipped (idempotent for resume after crash).
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// UndoResult summarizes the outcome of an undo operation.
+type UndoResult struct {
+	Reverted        int      `json:"reverted"`
+	SkippedConflict int      `json:"skipped_conflict"`
+	SkippedReverted int      `json:"skipped_reverted"`
+	Failed          int      `json:"failed"`
+	Errors          []string `json:"errors,omitempty"`
+}
+
+// RunUndoOperation loads the changes for targetOpID, walks them in
+// reverse order, and applies the inverse of each change. Progress
+// is reported via the callback (step description + percentage).
+func RunUndoOperation(
+	store database.Store,
+	targetOpID string,
+	progress func(step string, pct int),
+) (*UndoResult, error) {
+	if progress == nil {
+		progress = func(string, int) {}
+	}
+
+	changes, err := store.GetOperationChanges(targetOpID)
+	if err != nil {
+		return nil, fmt.Errorf("load operation changes: %w", err)
+	}
+	if len(changes) == 0 {
+		return &UndoResult{}, nil
+	}
+
+	// Reverse order: last change undone first.
+	reversed := make([]*database.OperationChange, len(changes))
+	for i, c := range changes {
+		reversed[len(changes)-1-i] = c
+	}
+
+	result := &UndoResult{}
+	total := len(reversed)
+
+	for i, change := range reversed {
+		pct := int(float64(i+1) / float64(total) * 100)
+		progress(fmt.Sprintf("undo %s on %s", change.ChangeType, change.BookID), pct)
+
+		if change.RevertedAt != nil {
+			result.SkippedReverted++
+			continue
+		}
+
+		err := revertChange(store, change)
+		if err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s/%s: %v", change.BookID, change.ChangeType, err))
+			continue
+		}
+
+		now := time.Now()
+		change.RevertedAt = &now
+		if updateErr := store.CreateOperationChange(change); updateErr != nil {
+			// Best effort — the FS/DB change already succeeded.
+			result.Errors = append(result.Errors, fmt.Sprintf("mark reverted %s: %v", change.ID, updateErr))
+		}
+		result.Reverted++
+	}
+
+	return result, nil
+}
+
+// revertChange applies the inverse of a single operation change.
+func revertChange(store database.Store, change *database.OperationChange) error {
+	switch change.ChangeType {
+	case "file_move", "organize_rename":
+		return revertFileMove(change)
+	case "metadata_update", "db_update":
+		return revertMetadataUpdate(store, change)
+	case "dir_create":
+		return revertDirCreate(change)
+	case "tag_write":
+		return nil // tags are re-derived on next metadata apply
+	default:
+		return fmt.Errorf("unknown change_type: %s", change.ChangeType)
+	}
+}
+
+// revertFileMove renames new_value back to old_value. If old_value
+// already exists (conflict), returns an error rather than clobbering.
+func revertFileMove(change *database.OperationChange) error {
+	if change.OldValue == "" || change.NewValue == "" {
+		return fmt.Errorf("missing path in change %s", change.ID)
+	}
+
+	// Check that new_value (the current location) exists.
+	if _, err := os.Stat(change.NewValue); os.IsNotExist(err) {
+		// Already moved back or deleted — idempotent no-op.
+		return nil
+	}
+
+	// Check that old_value (restore target) doesn't already exist.
+	if _, err := os.Stat(change.OldValue); err == nil {
+		return fmt.Errorf("conflict: restore target already exists: %s", change.OldValue)
+	}
+
+	// Ensure parent directory of old_value exists.
+	if err := os.MkdirAll(parentDir(change.OldValue), 0o775); err != nil {
+		return fmt.Errorf("mkdir for restore: %w", err)
+	}
+
+	return os.Rename(change.NewValue, change.OldValue)
+}
+
+// revertMetadataUpdate restores a book field from the change's
+// OldValue. OldValue is either a plain string (for single-field
+// changes) or a JSON object (for multi-field snapshots).
+func revertMetadataUpdate(store database.Store, change *database.OperationChange) error {
+	if change.BookID == "" {
+		return fmt.Errorf("no book_id on metadata change %s", change.ID)
+	}
+
+	book, err := store.GetBookByID(change.BookID)
+	if err != nil || book == nil {
+		return fmt.Errorf("book %s not found", change.BookID)
+	}
+
+	if change.FieldName != "" && change.OldValue != "" {
+		applyFieldRestore(book, change.FieldName, change.OldValue)
+	} else if change.OldValue != "" {
+		// Multi-field JSON snapshot.
+		var snapshot map[string]interface{}
+		if err := json.Unmarshal([]byte(change.OldValue), &snapshot); err == nil {
+			for field, val := range snapshot {
+				if s, ok := val.(string); ok {
+					applyFieldRestore(book, field, s)
+				}
+			}
+		}
+	}
+
+	_, err = store.UpdateBook(book.ID, book)
+	return err
+}
+
+// applyFieldRestore sets a single field on a Book from a string value.
+func applyFieldRestore(book *database.Book, field, value string) {
+	switch field {
+	case "title":
+		book.Title = value
+	case "file_path":
+		book.FilePath = value
+	case "format":
+		book.Format = value
+	case "narrator":
+		book.Narrator = &value
+	case "edition":
+		book.Edition = &value
+	case "description":
+		book.Description = &value
+	case "language":
+		book.Language = &value
+	case "publisher":
+		book.Publisher = &value
+	case "genre":
+		book.Genre = &value
+	case "library_state":
+		book.LibraryState = &value
+	}
+}
+
+// revertDirCreate removes a directory if it's empty. Non-empty
+// directories are left alone (the files inside may still be needed).
+func revertDirCreate(change *database.OperationChange) error {
+	if change.NewValue == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(change.NewValue)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // already gone
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil // not empty, leave it
+	}
+	return os.Remove(change.NewValue)
+}
+
+func parentDir(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[:i]
+		}
+	}
+	return "."
+}

--- a/internal/server/undo_engine_test.go
+++ b/internal/server/undo_engine_test.go
@@ -1,0 +1,195 @@
+// file: internal/server/undo_engine_test.go
+// version: 1.0.0
+// guid: 1c9d0e7f-2a8b-4a70-b8c5-3d7e0f1b9a99
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestUndo_FileMove(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, newPath, "audio-content")
+
+	if cerr := store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+	}); cerr != nil {
+		t.Fatalf("create change: %v", cerr)
+	}
+
+	result, err := RunUndoOperation(store, "op1", nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Reverted != 1 {
+		t.Errorf("reverted = %d, want 1", result.Reverted)
+	}
+
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("old path should exist after undo: %v", err)
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf("new path should not exist after undo")
+	}
+	if got := readTestFile(t, oldPath); got != "audio-content" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestUndo_ConflictDetected(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, oldPath, "something-new-at-old-location")
+	writeTestFile(t, newPath, "audio-content")
+
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+	})
+
+	result, err := RunUndoOperation(store, "op1", nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("failed = %d, want 1 (conflict)", result.Failed)
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected error message about conflict")
+	}
+}
+
+func TestUndo_SkipsAlreadyReverted(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+	writeTestFile(t, newPath, "content")
+
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+	})
+
+	// First undo reverts the change.
+	result, _ := RunUndoOperation(store, "op1", nil)
+	if result.Reverted != 1 {
+		t.Fatalf("first undo: reverted = %d", result.Reverted)
+	}
+
+	// Second undo should skip because RevertedAt is set.
+	result, _ = RunUndoOperation(store, "op1", nil)
+	if result.SkippedReverted != 1 {
+		t.Errorf("second undo: skipped_reverted = %d, want 1", result.SkippedReverted)
+	}
+}
+
+func TestUndo_EmptyChanges(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	result, err := RunUndoOperation(store, "nonexistent-op", nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Reverted != 0 {
+		t.Errorf("reverted = %d, want 0", result.Reverted)
+	}
+}
+
+func TestUndo_MetadataUpdate(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "New Title", FilePath: "/tmp/book", Format: "m4b",
+	})
+
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: book.ID,
+		ChangeType: "metadata_update",
+		FieldName:  "title",
+		OldValue:   "Original Title",
+		NewValue:   "New Title",
+	})
+
+	result, err := RunUndoOperation(store, "op1", nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Reverted != 1 {
+		t.Errorf("reverted = %d, want 1", result.Reverted)
+	}
+
+	restored, _ := store.GetBookByID(book.ID)
+	if restored.Title != "Original Title" {
+		t.Errorf("title = %q, want Original Title", restored.Title)
+	}
+}
+
+func TestUndo_DirCreateRemovesEmpty(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := filepath.Join(t.TempDir(), "new-dir")
+	if err := os.MkdirAll(dir, 0o775); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "dir_create",
+		NewValue:   dir,
+	})
+
+	result, _ := RunUndoOperation(store, "op1", nil)
+	if result.Reverted != 1 {
+		t.Errorf("reverted = %d, want 1", result.Reverted)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("empty dir should be removed")
+	}
+}


### PR DESCRIPTION
## Summary

**Bug fix:** Fixed a slice aliasing bug in Pebble's prefix range iteration (10 instances). \`append(prefix[:N-1], ...)\` was mutating the original prefix, making LowerBound == UpperBound → empty results. Replaced with \`prefixEnd()\` helper.

**Undo engine:** Reverses operation_changes in reverse order — file moves, metadata restores, dir cleanup. Idempotent (RevertedAt skip), conflict-safe (won't clobber existing files).

## Test plan

- [x] 6 undo tests: file move, conflict, skip-reverted, empty, metadata, dir cleanup
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)