### PR TITLE
feat(versions): lifecycle + ingest versioning (3.1 tasks 5-6)

### DIFF
--- a/internal/server/import_service.go
+++ b/internal/server/import_service.go
@@ -156,6 +156,14 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 		return nil, fmt.Errorf("failed to create book: %w", err)
 	}
 
+	// Create version row for the imported file (spec 3.1).
+	if _, verErr := CreateIngestVersion(is.db, IngestVersionParams{
+		BookID: created.ID, FilePath: created.FilePath,
+		Format: created.Format, Source: "imported",
+	}); verErr != nil {
+		log.Printf("[WARN] create ingest version for %s: %v", created.ID, verErr)
+	}
+
 	// Provision ITL track (generates PID, stores in external_id_map, enqueues add)
 	if err := ProvisionITLTracksForBook(is.db, created); err != nil {
 		// Non-fatal: book was created, ITL provisioning can be retried

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2245,6 +2245,7 @@ func (s *Server) setupRoutes() {
 			s.registerReadingRoutes(protected)
 			s.registerPlaylistRoutes(protected)
 			s.registerUserAdminRoutes(protected)
+			s.registerVersionLifecycleRoutes(protected)
 			s.setupBenchRoutes(protected)
 		}
 	}

--- a/internal/server/version_ingest.go
+++ b/internal/server/version_ingest.go
@@ -1,0 +1,109 @@
+// file: internal/server/version_ingest.go
+// version: 1.0.0
+// guid: 3e1f2a9b-4c5d-4a70-b8c5-3d7e0f1b9a99
+//
+// Version creation on ingest (spec 3.1 task 5).
+//
+// Every time a new book enters the library (import, scan, organize)
+// or a new file is added to an existing book, a BookVersion row is
+// created. The version tracks the file's provenance (source, hash,
+// torrent hash) and its lifecycle status.
+//
+// New books get an `active` version. Known books adding a second
+// copy get an `alt` version — the user must explicitly promote it
+// via the swap operation.
+
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// IngestVersionParams describes the provenance of a newly-ingested file.
+type IngestVersionParams struct {
+	BookID      string
+	FilePath    string
+	Format      string
+	Source      string // "imported", "scanned", "organized", "deluge"
+	TorrentHash string // empty for non-torrent sources
+}
+
+// CreateIngestVersion creates a BookVersion for a newly-ingested file.
+// If the book already has an active version, the new one gets status=alt.
+// If no active version exists, the new one becomes active.
+//
+// Also computes and stores the file's SHA-256 hash on the BookFile row
+// (if one exists for the book + file path).
+func CreateIngestVersion(store database.Store, params IngestVersionParams) (*database.BookVersion, error) {
+	if params.BookID == "" || params.FilePath == "" {
+		return nil, fmt.Errorf("book_id and file_path required")
+	}
+
+	// Check fingerprint first — refuse if this file was previously purged.
+	if params.TorrentHash != "" {
+		match := CheckFingerprint(store, params.TorrentHash, nil)
+		if match != nil && match.Matched {
+			return nil, fmt.Errorf("fingerprint match: this content was previously %s (book %s, version %s)",
+				match.Status, match.BookID, match.VersionID)
+		}
+	}
+
+	// Determine status: active if no existing active, alt otherwise.
+	status := database.BookVersionStatusActive
+	existing, err := store.GetActiveVersionForBook(params.BookID)
+	if err == nil && existing != nil {
+		status = database.BookVersionStatusAlt
+	}
+
+	ver, err := store.CreateBookVersion(&database.BookVersion{
+		BookID:      params.BookID,
+		Status:      status,
+		Format:      params.Format,
+		Source:      params.Source,
+		TorrentHash: params.TorrentHash,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create version: %w", err)
+	}
+
+	// Compute file hash and update the BookFile row.
+	hash, hashErr := hashFile(params.FilePath)
+	if hashErr != nil {
+		log.Printf("[WARN] hash %s: %v", params.FilePath, hashErr)
+	} else {
+		files, _ := store.GetBookFiles(params.BookID)
+		for _, f := range files {
+			if f.FilePath == params.FilePath {
+				f.FileHash = hash
+				f.VersionID = ver.ID
+				if updateErr := store.UpdateBookFile(f.ID, &f); updateErr != nil {
+					log.Printf("[WARN] update file hash %s: %v", f.ID, updateErr)
+				}
+				break
+			}
+		}
+	}
+
+	return ver, nil
+}
+
+// hashFile computes the SHA-256 hex digest of the file at path.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/server/version_ingest_test.go
+++ b/internal/server/version_ingest_test.go
@@ -1,0 +1,153 @@
+// file: internal/server/version_ingest_test.go
+// version: 1.0.0
+// guid: 4f2a3b0c-5d6e-4a70-b8c5-3d7e0f1b9a99
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestCreateIngestVersion_NewBook(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "Book.m4b")
+	writeTestFile(t, filePath, "audio-data-for-hash")
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "New Book", FilePath: filePath, Format: "m4b",
+	})
+
+	ver, err := CreateIngestVersion(store, IngestVersionParams{
+		BookID: book.ID, FilePath: filePath, Format: "m4b", Source: "imported",
+	})
+	if err != nil {
+		t.Fatalf("create version: %v", err)
+	}
+	if ver.Status != database.BookVersionStatusActive {
+		t.Errorf("first version status = %q, want active", ver.Status)
+	}
+	if ver.Source != "imported" {
+		t.Errorf("source = %q", ver.Source)
+	}
+}
+
+func TestCreateIngestVersion_SecondVersionIsAlt(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	book, _ := store.CreateBook(&database.Book{
+		Title: "Book", FilePath: filepath.Join(dir, "Book.m4b"), Format: "m4b",
+	})
+
+	// First version → active.
+	v1, _ := CreateIngestVersion(store, IngestVersionParams{
+		BookID: book.ID, FilePath: filepath.Join(dir, "Book.m4b"), Format: "m4b", Source: "imported",
+	})
+	if v1.Status != database.BookVersionStatusActive {
+		t.Fatalf("v1 status = %q, want active", v1.Status)
+	}
+
+	// Second version → alt.
+	v2, err := CreateIngestVersion(store, IngestVersionParams{
+		BookID: book.ID, FilePath: filepath.Join(dir, "Book.mp3"), Format: "mp3", Source: "deluge",
+	})
+	if err != nil {
+		t.Fatalf("v2: %v", err)
+	}
+	if v2.Status != database.BookVersionStatusAlt {
+		t.Errorf("v2 status = %q, want alt", v2.Status)
+	}
+}
+
+func TestCreateIngestVersion_FingerprintBlocksPurged(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Create a purged version with a known torrent hash.
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: "old-book", Status: database.BookVersionStatusInactivePurged,
+		Format: "m4b", Source: "deluge", TorrentHash: "blocked-hash",
+	})
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "New Import", FilePath: "/tmp/new", Format: "m4b",
+	})
+
+	_, err = CreateIngestVersion(store, IngestVersionParams{
+		BookID: book.ID, FilePath: "/tmp/new", Format: "m4b",
+		Source: "deluge", TorrentHash: "blocked-hash",
+	})
+	if err == nil {
+		t.Error("expected fingerprint rejection")
+	}
+}
+
+func TestHashFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	writeTestFile(t, path, "hello world")
+
+	hash, err := hashFile(path)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64 (SHA-256 hex)", len(hash))
+	}
+}
+
+func TestCreateIngestVersion_FileHashUpdated(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "Book.m4b")
+	writeTestFile(t, filePath, "audio-content-to-hash")
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "Hash Test", FilePath: filePath, Format: "m4b",
+	})
+	_ = store.CreateBookFile(&database.BookFile{
+		ID: "f1", BookID: book.ID, FilePath: filePath, Format: "m4b",
+	})
+
+	ver, _ := CreateIngestVersion(store, IngestVersionParams{
+		BookID: book.ID, FilePath: filePath, Format: "m4b", Source: "imported",
+	})
+
+	files, _ := store.GetBookFiles(book.ID)
+	found := false
+	for _, f := range files {
+		if f.ID == "f1" {
+			found = true
+			if f.FileHash == "" {
+				t.Errorf("file hash not populated")
+			}
+			if f.VersionID != ver.ID {
+				t.Errorf("version_id = %q, want %q", f.VersionID, ver.ID)
+			}
+		}
+	}
+	if !found {
+		t.Error("file f1 not found")
+	}
+}

--- a/internal/server/version_lifecycle.go
+++ b/internal/server/version_lifecycle.go
@@ -1,0 +1,238 @@
+// file: internal/server/version_lifecycle.go
+// version: 1.0.0
+// guid: 5a3b4c0d-6e7f-4a70-b8c5-3d7e0f1b9a99
+//
+// Version lifecycle operations (spec 3.1 task 6).
+//
+// Lifecycle states:
+//   active → alt → trash → inactive_purged → (hard delete)
+//
+// Delete puts a version in trash (14-day TTL). Auto-promote selects
+// the most recent alt if the active version was trashed. Restore
+// moves trash back to alt. Purge physically deletes files and
+// marks inactive_purged (keeps metadata for fingerprint). Hard
+// delete removes all traces.
+
+package server
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/versions"
+)
+
+const trashTTLDays = 14
+
+// handleTrashVersion moves a version to trash.
+// DELETE /api/v1/books/:id/versions/:vid
+func (s *Server) handleTrashVersion(c *gin.Context) {
+	bookID := c.Param("id")
+	versionID := c.Param("vid")
+
+	ver, err := s.Store().GetBookVersion(versionID)
+	if err != nil || ver == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "version not found"})
+		return
+	}
+	if ver.BookID != bookID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "version/book mismatch"})
+		return
+	}
+
+	wasActive := ver.Status == database.BookVersionStatusActive
+
+	ver.Status = database.BookVersionStatusTrash
+	if err := s.Store().UpdateBookVersion(ver); err != nil {
+		internalError(c, "trash version", err)
+		return
+	}
+
+	if wasActive {
+		if err := autoPromoteAlt(s.Store(), bookID); err != nil {
+			log.Printf("[WARN] auto-promote after trash: %v", err)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"version": ver})
+}
+
+// handleRestoreVersion restores a trashed version to alt.
+// POST /api/v1/books/:id/versions/:vid/restore
+func (s *Server) handleRestoreVersion(c *gin.Context) {
+	bookID := c.Param("id")
+	versionID := c.Param("vid")
+
+	ver, err := s.Store().GetBookVersion(versionID)
+	if err != nil || ver == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "version not found"})
+		return
+	}
+	if ver.BookID != bookID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "version/book mismatch"})
+		return
+	}
+	if ver.Status != database.BookVersionStatusTrash {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "version is not in trash"})
+		return
+	}
+
+	ver.Status = database.BookVersionStatusAlt
+	if err := s.Store().UpdateBookVersion(ver); err != nil {
+		internalError(c, "restore version", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"version": ver})
+}
+
+// handlePurgeVersion physically deletes files and marks purged.
+// POST /api/v1/books/:id/versions/:vid/purge-now
+func (s *Server) handlePurgeVersion(c *gin.Context) {
+	bookID := c.Param("id")
+	versionID := c.Param("vid")
+
+	ver, err := s.Store().GetBookVersion(versionID)
+	if err != nil || ver == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "version not found"})
+		return
+	}
+	if ver.BookID != bookID {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "version/book mismatch"})
+		return
+	}
+
+	if err := purgeVersion(s.Store(), ver); err != nil {
+		internalError(c, "purge version", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"version": ver})
+}
+
+// handleHardDeleteVersion removes all traces of a purged version.
+// DELETE /api/v1/purged-versions/:vid
+func (s *Server) handleHardDeleteVersion(c *gin.Context) {
+	versionID := c.Param("vid")
+
+	ver, err := s.Store().GetBookVersion(versionID)
+	if err != nil || ver == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "version not found"})
+		return
+	}
+	if ver.Status != database.BookVersionStatusInactivePurged {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "version is not purged"})
+		return
+	}
+
+	if err := s.Store().DeleteBookVersion(ver.ID); err != nil {
+		internalError(c, "hard delete version", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"deleted": ver.ID})
+}
+
+// autoPromoteAlt selects the most recent alt version and promotes it
+// to active. Called when the active version is trashed.
+func autoPromoteAlt(store database.Store, bookID string) error {
+	allVers, err := store.GetBookVersionsByBookID(bookID)
+	if err != nil {
+		return err
+	}
+	var bestAlt *database.BookVersion
+	for i := range allVers {
+		v := &allVers[i]
+		if v.Status != database.BookVersionStatusAlt {
+			continue
+		}
+		if bestAlt == nil || v.IngestDate.After(bestAlt.IngestDate) {
+			bestAlt = v
+		}
+	}
+	if bestAlt == nil {
+		return nil
+	}
+	bestAlt.Status = database.BookVersionStatusActive
+	return store.UpdateBookVersion(bestAlt)
+}
+
+// purgeVersion physically deletes the version's files and marks it
+// inactive_purged. Keeps the DB rows for fingerprint matching.
+func purgeVersion(store database.Store, ver *database.BookVersion) error {
+	book, err := store.GetBookByID(ver.BookID)
+	if err != nil || book == nil {
+		return fmt.Errorf("book %s not found", ver.BookID)
+	}
+
+	// Remove files from .versions/{vid}/ or book root.
+	bookDir := ""
+	if book.FilePath != "" {
+		bookDir = book.FilePath[:len(book.FilePath)-len(book.FilePath)+len(book.FilePath)]
+		// Use filepath.Dir in a robust way
+		for i := len(book.FilePath) - 1; i >= 0; i-- {
+			if book.FilePath[i] == '/' {
+				bookDir = book.FilePath[:i]
+				break
+			}
+		}
+	}
+
+	if bookDir != "" {
+		if err := versions.RemoveVersionSlot(bookDir, ver.ID); err != nil {
+			log.Printf("[WARN] remove version slot %s: %v", ver.ID, err)
+		}
+		_ = versions.PruneEmptyVersionsDir(bookDir)
+	}
+
+	// Also remove any files directly associated with this version.
+	files, _ := store.GetBookFiles(ver.BookID)
+	for _, f := range files {
+		if f.VersionID == ver.ID {
+			_ = os.Remove(f.FilePath)
+		}
+	}
+
+	now := time.Now()
+	ver.Status = database.BookVersionStatusInactivePurged
+	ver.PurgedDate = &now
+	return store.UpdateBookVersion(ver)
+}
+
+// CleanupTrashedVersions is the maintenance task that purges versions
+// past their TTL. Called by the scheduler.
+func CleanupTrashedVersions(store database.Store) (purged int) {
+	trashed, err := store.ListTrashedBookVersions()
+	if err != nil {
+		log.Printf("[WARN] list trashed versions: %v", err)
+		return 0
+	}
+
+	cutoff := time.Now().Add(-time.Duration(trashTTLDays) * 24 * time.Hour)
+	for i := range trashed {
+		v := &trashed[i]
+		if v.CreatedAt.After(cutoff) {
+			continue
+		}
+		if err := purgeVersion(store, v); err != nil {
+			log.Printf("[WARN] purge trashed %s: %v", v.ID, err)
+			continue
+		}
+		purged++
+	}
+	return purged
+}
+
+// registerVersionLifecycleRoutes wires the version lifecycle endpoints.
+func (s *Server) registerVersionLifecycleRoutes(protected *gin.RouterGroup) {
+	protected.DELETE("/books/:id/versions/:vid", s.perm(auth.PermLibraryDelete), s.handleTrashVersion)
+	protected.POST("/books/:id/versions/:vid/restore", s.perm(auth.PermLibraryOrganize), s.handleRestoreVersion)
+	protected.POST("/books/:id/versions/:vid/purge-now", s.perm(auth.PermLibraryDelete), s.handlePurgeVersion)
+	protected.DELETE("/purged-versions/:vid", s.perm(auth.PermLibraryDelete), s.handleHardDeleteVersion)
+}


### PR DESCRIPTION
## Summary

Two 3.1 tasks in one branch:

**Task 5 — Ingest versioning:**
- \`CreateIngestVersion\` creates BookVersion rows on file ingest (active for first, alt for subsequent)
- Fingerprint check blocks re-importing purged content
- SHA-256 file hash computed and stored on BookFile

**Task 6 — Lifecycle:**
- 4 HTTP endpoints: trash, restore, purge-now, hard-delete
- Auto-promotes most recent alt when active is trashed
- \`CleanupTrashedVersions\` maintenance function (14-day TTL)

## Test plan

- [x] 5 ingest tests pass
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)