### PR TITLE
feat(undo): track library_state in organize changes (3.2 task 2)

### DIFF
--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -526,6 +526,19 @@ func (orgSvc *OrganizeService) organizeBooks(ctx context.Context, booksToOrganiz
 							OldValue:    oldPath,
 							NewValue:    newPath,
 						})
+						oldState := ""
+						if book.LibraryState != nil {
+							oldState = *book.LibraryState
+						}
+						_ = orgSvc.db.CreateOperationChange(&database.OperationChange{
+							ID:          ulid.Make().String(),
+							OperationID: operationID,
+							BookID:      book.ID,
+							ChangeType:  "metadata_update",
+							FieldName:   "library_state",
+							OldValue:    oldState,
+							NewValue:    "organized",
+						})
 					}
 				} else {
 					// Version-aware organize: create a new book record for the organized copy


### PR DESCRIPTION
## Summary

The organize service now records a \`metadata_update\` change for \`library_state\` alongside the \`organize_rename\` change, so the undo engine can restore pre-organize state.

## Test plan

- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)