### PR TITLE
feat(frontend): API services + pages for all major features

### DIFF
--- a/web/src/components/audiobooks/ReadStatusChip.tsx
+++ b/web/src/components/audiobooks/ReadStatusChip.tsx
@@ -1,0 +1,123 @@
+// file: web/src/components/audiobooks/ReadStatusChip.tsx
+// version: 1.0.0
+// guid: 7c5d6e1f-8a9b-4a70-b8c5-3d7e0f1b9a99
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Chip, Menu, MenuItem, LinearProgress, Box, Typography } from '@mui/material';
+import {
+  MenuBook as ReadingIcon,
+  CheckCircle as FinishedIcon,
+  Cancel as AbandonedIcon,
+  RadioButtonUnchecked as UnstartedIcon,
+} from '@mui/icons-material';
+import {
+  type ReadStatus,
+  type UserBookState,
+  READ_STATUS_LABELS,
+  READ_STATUS_COLORS,
+  getBookState,
+  setBookStatus,
+  clearBookStatus,
+} from '../../services/readingApi';
+
+interface ReadStatusChipProps {
+  bookId: string;
+  compact?: boolean;
+}
+
+const STATUS_ICONS: Record<ReadStatus, React.ReactNode> = {
+  unstarted: <UnstartedIcon fontSize="small" />,
+  in_progress: <ReadingIcon fontSize="small" />,
+  finished: <FinishedIcon fontSize="small" />,
+  abandoned: <AbandonedIcon fontSize="small" />,
+};
+
+export default function ReadStatusChip({ bookId, compact }: ReadStatusChipProps) {
+  const [state, setState] = useState<UserBookState | null>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  useEffect(() => {
+    getBookState(bookId).then(setState).catch(() => {});
+  }, [bookId]);
+
+  const status: ReadStatus = (state?.status as ReadStatus) || 'unstarted';
+  const progressPct = state?.progress_pct ?? 0;
+
+  const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(e.currentTarget);
+  }, []);
+
+  const handleClose = useCallback(() => setAnchorEl(null), []);
+
+  const handleSelect = useCallback(
+    async (newStatus: ReadStatus | 'auto') => {
+      setAnchorEl(null);
+      try {
+        if (newStatus === 'auto') {
+          const updated = await clearBookStatus(bookId);
+          setState(updated);
+        } else {
+          const updated = await setBookStatus(bookId, newStatus);
+          setState(updated);
+        }
+      } catch {
+        // silently fail — chip will show stale state
+      }
+    },
+    [bookId]
+  );
+
+  return (
+    <>
+      <Chip
+        icon={STATUS_ICONS[status] as React.ReactElement}
+        label={
+          compact
+            ? undefined
+            : status === 'in_progress'
+              ? `${progressPct}%`
+              : READ_STATUS_LABELS[status]
+        }
+        size="small"
+        onClick={handleClick}
+        sx={{
+          bgcolor: READ_STATUS_COLORS[status] + '22',
+          color: READ_STATUS_COLORS[status],
+          borderColor: READ_STATUS_COLORS[status],
+          cursor: 'pointer',
+        }}
+        variant="outlined"
+      />
+      {status === 'in_progress' && !compact && (
+        <Box sx={{ width: 60, ml: 0.5, display: 'inline-flex', alignItems: 'center' }}>
+          <LinearProgress
+            variant="determinate"
+            value={progressPct}
+            sx={{ width: '100%', height: 4, borderRadius: 2 }}
+          />
+        </Box>
+      )}
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+        {(['unstarted', 'in_progress', 'finished', 'abandoned'] as ReadStatus[]).map((s) => (
+          <MenuItem
+            key={s}
+            selected={s === status}
+            onClick={() => handleSelect(s)}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {STATUS_ICONS[s]}
+              <Typography variant="body2">{READ_STATUS_LABELS[s]}</Typography>
+            </Box>
+          </MenuItem>
+        ))}
+        {state?.status_manual && (
+          <MenuItem onClick={() => handleSelect('auto')}>
+            <Typography variant="body2" color="text.secondary">
+              Reset to auto-detected
+            </Typography>
+          </MenuItem>
+        )}
+      </Menu>
+    </>
+  );
+}

--- a/web/src/pages/Playlists.tsx
+++ b/web/src/pages/Playlists.tsx
@@ -1,0 +1,224 @@
+// file: web/src/pages/Playlists.tsx
+// version: 1.0.0
+// guid: 2b0c1d6e-3f4a-4a70-b8c5-3d7e0f1b9a99
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Tab,
+  Tabs,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  PlaylistPlay as SmartIcon,
+  QueueMusic as StaticIcon,
+} from '@mui/icons-material';
+import {
+  type UserPlaylist,
+  listPlaylists,
+  createPlaylist,
+  deletePlaylist,
+} from '../services/playlistApi';
+
+export default function Playlists() {
+  const [playlists, setPlaylists] = useState<UserPlaylist[]>([]);
+  const [tab, setTab] = useState<'all' | 'static' | 'smart'>('all');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const typeFilter = tab === 'all' ? undefined : tab;
+      const resp = await listPlaylists(typeFilter as 'static' | 'smart' | undefined);
+      setPlaylists(resp.playlists || []);
+    } catch {
+      setPlaylists([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await deletePlaylist(id);
+    load();
+  }, [load]);
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+        <Typography variant="h4">Playlists</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setCreateOpen(true)}>
+          New Playlist
+        </Button>
+      </Box>
+
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="All" value="all" />
+        <Tab label="Static" value="static" />
+        <Tab label="Smart" value="smart" />
+      </Tabs>
+
+      {loading ? (
+        <Typography color="text.secondary">Loading...</Typography>
+      ) : playlists.length === 0 ? (
+        <Typography color="text.secondary">No playlists yet. Create one to get started.</Typography>
+      ) : (
+        <List>
+          {playlists.map((pl) => (
+            <ListItem
+              key={pl.id}
+              disablePadding
+              secondaryAction={
+                <IconButton edge="end" onClick={() => handleDelete(pl.id)}>
+                  <DeleteIcon />
+                </IconButton>
+              }
+            >
+              <ListItemButton>
+                <ListItemText
+                  primary={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      {pl.type === 'smart' ? <SmartIcon fontSize="small" /> : <StaticIcon fontSize="small" />}
+                      {pl.name}
+                      <Chip
+                        label={pl.type}
+                        size="small"
+                        color={pl.type === 'smart' ? 'primary' : 'default'}
+                      />
+                      {pl.book_ids && (
+                        <Typography variant="caption" color="text.secondary">
+                          {pl.book_ids.length} books
+                        </Typography>
+                      )}
+                    </Box>
+                  }
+                  secondary={pl.description || (pl.query ? `Query: ${pl.query}` : undefined)}
+                />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      )}
+
+      <CreatePlaylistDialog open={createOpen} onClose={() => setCreateOpen(false)} onCreated={load} />
+    </Box>
+  );
+}
+
+function CreatePlaylistDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState<'static' | 'smart'>('static');
+  const [query, setQuery] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+
+  const handleCreate = async () => {
+    setError('');
+    try {
+      await createPlaylist({
+        name,
+        type,
+        description: description || undefined,
+        query: type === 'smart' ? query : undefined,
+      });
+      setName('');
+      setQuery('');
+      setDescription('');
+      onClose();
+      onCreated();
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(msg || 'Failed to create playlist');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Create Playlist</DialogTitle>
+      <DialogContent>
+        <ToggleButtonGroup
+          value={type}
+          exclusive
+          onChange={(_, v) => v && setType(v)}
+          sx={{ mb: 2, mt: 1 }}
+          size="small"
+        >
+          <ToggleButton value="static">
+            <StaticIcon sx={{ mr: 0.5 }} /> Static
+          </ToggleButton>
+          <ToggleButton value="smart">
+            <SmartIcon sx={{ mr: 0.5 }} /> Smart
+          </ToggleButton>
+        </ToggleButtonGroup>
+
+        <TextField
+          fullWidth
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          margin="normal"
+          required
+        />
+        <TextField
+          fullWidth
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          margin="normal"
+          multiline
+          rows={2}
+        />
+        {type === 'smart' && (
+          <TextField
+            fullWidth
+            label="Query (DSL)"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            margin="normal"
+            required
+            placeholder='e.g. author:sanderson year:>2015'
+            helperText="Uses the search DSL: field:value, &&, ||, NOT, ranges, wildcards"
+          />
+        )}
+        {error && (
+          <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleCreate} variant="contained" disabled={!name || (type === 'smart' && !query)}>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -1,0 +1,130 @@
+// file: web/src/pages/Setup.tsx
+// version: 1.0.0
+// guid: 0f8a9b4c-1d2e-4a70-b8c5-3d7e0f1b9a99
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Container,
+  TextField,
+  Typography,
+  Alert,
+} from '@mui/material';
+const API_BASE = '/api/v1';
+
+export default function Setup() {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('admin');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const resp = await fetch(`${API_BASE}/auth/setup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password, email }),
+      });
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        throw Object.assign(new Error(body.error || 'Setup failed'), { response: { data: body } });
+      }
+      navigate('/');
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(msg || 'Setup failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Card>
+        <CardContent>
+          <Typography variant="h4" gutterBottom>
+            Welcome to Audiobook Organizer
+          </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+            Create your admin account to get started.
+          </Typography>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit}>
+            <TextField
+              fullWidth
+              label="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              margin="normal"
+              required
+              autoFocus
+            />
+            <TextField
+              fullWidth
+              label="Email (optional)"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              margin="normal"
+              type="email"
+            />
+            <TextField
+              fullWidth
+              label="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              margin="normal"
+              type="password"
+              required
+              helperText="Minimum 8 characters"
+            />
+            <TextField
+              fullWidth
+              label="Confirm Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              margin="normal"
+              type="password"
+              required
+            />
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              size="large"
+              disabled={loading}
+              sx={{ mt: 2 }}
+            >
+              {loading ? 'Creating...' : 'Create Admin Account'}
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/web/src/services/playlistApi.ts
+++ b/web/src/services/playlistApi.ts
@@ -1,0 +1,106 @@
+// file: web/src/services/playlistApi.ts
+// version: 1.1.0
+// guid: 8d6e7f2a-9b0c-4a70-b8c5-3d7e0f1b9a99
+
+const API_BASE = '/api/v1';
+
+export interface UserPlaylist {
+  id: string;
+  name: string;
+  description?: string;
+  type: 'static' | 'smart';
+  book_ids?: string[];
+  query?: string;
+  sort_json?: string;
+  limit?: number;
+  materialized_book_ids?: string[];
+  itunes_persistent_id?: string;
+  created_at: string;
+  updated_at: string;
+  created_by_user_id?: string;
+  dirty: boolean;
+  version: number;
+}
+
+async function jsonFetch(url: string, opts?: RequestInit) {
+  const resp = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...opts?.headers },
+    ...opts,
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw Object.assign(new Error(body.error || resp.statusText), { response: { data: body, status: resp.status } });
+  }
+  return resp.json();
+}
+
+export async function listPlaylists(
+  type?: 'static' | 'smart',
+  limit = 50,
+  offset = 0
+): Promise<{ playlists: UserPlaylist[]; count: number }> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (type) params.set('type', type);
+  return jsonFetch(`${API_BASE}/playlists?${params}`);
+}
+
+export async function getPlaylist(id: string): Promise<{ playlist: UserPlaylist; book_ids: string[] }> {
+  return jsonFetch(`${API_BASE}/playlists/${id}`);
+}
+
+export async function createPlaylist(data: {
+  name: string;
+  type: 'static' | 'smart';
+  description?: string;
+  book_ids?: string[];
+  query?: string;
+  sort_json?: string;
+  limit?: number;
+}): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return resp.playlist;
+}
+
+export async function updatePlaylist(
+  id: string,
+  data: Partial<Pick<UserPlaylist, 'name' | 'description' | 'book_ids' | 'query' | 'sort_json' | 'limit'>>
+): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+  return resp.playlist;
+}
+
+export async function deletePlaylist(id: string): Promise<void> {
+  await jsonFetch(`${API_BASE}/playlists/${id}`, { method: 'DELETE' });
+}
+
+export async function addBooksToPlaylist(id: string, bookIds: string[]): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists/${id}/books`, {
+    method: 'POST',
+    body: JSON.stringify({ book_ids: bookIds }),
+  });
+  return resp.playlist;
+}
+
+export async function removeBookFromPlaylist(id: string, bookId: string): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists/${id}/books/${bookId}`, { method: 'DELETE' });
+  return resp.playlist;
+}
+
+export async function reorderPlaylist(id: string, bookIds: string[]): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists/${id}/reorder`, {
+    method: 'POST',
+    body: JSON.stringify({ book_ids: bookIds }),
+  });
+  return resp.playlist;
+}
+
+export async function materializePlaylist(id: string): Promise<UserPlaylist> {
+  const resp = await jsonFetch(`${API_BASE}/playlists/${id}/materialize`, { method: 'POST' });
+  return resp.playlist;
+}

--- a/web/src/services/readingApi.ts
+++ b/web/src/services/readingApi.ts
@@ -1,0 +1,98 @@
+// file: web/src/services/readingApi.ts
+// version: 1.1.0
+// guid: 6b4c5d0e-7f8a-4a70-b8c5-3d7e0f1b9a99
+
+const API_BASE = '/api/v1';
+
+export interface UserPosition {
+  user_id: string;
+  book_id: string;
+  segment_id: string;
+  position_seconds: number;
+  updated_at: string;
+}
+
+export interface UserBookState {
+  user_id: string;
+  book_id: string;
+  status: string;
+  status_manual: boolean;
+  last_activity_at: string;
+  last_segment_id?: string;
+  total_listened_seconds?: number;
+  progress_pct: number;
+  updated_at: string;
+}
+
+export type ReadStatus = 'unstarted' | 'in_progress' | 'finished' | 'abandoned';
+
+export const READ_STATUS_LABELS: Record<ReadStatus, string> = {
+  unstarted: 'Unstarted',
+  in_progress: 'In Progress',
+  finished: 'Finished',
+  abandoned: 'Abandoned',
+};
+
+export const READ_STATUS_COLORS: Record<ReadStatus, string> = {
+  unstarted: '#9e9e9e',
+  in_progress: '#2196f3',
+  finished: '#4caf50',
+  abandoned: '#ff9800',
+};
+
+export async function getBookState(bookId: string): Promise<UserBookState | null> {
+  const resp = await fetch(`${API_BASE}/books/${bookId}/state`);
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data?.state ?? null;
+}
+
+export async function getBookPosition(bookId: string): Promise<UserPosition | null> {
+  const resp = await fetch(`${API_BASE}/books/${bookId}/position`);
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data?.position ?? null;
+}
+
+export async function setBookPosition(
+  bookId: string,
+  segmentId: string,
+  positionSeconds: number
+): Promise<UserBookState> {
+  const resp = await fetch(`${API_BASE}/books/${bookId}/position`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ segment_id: segmentId, position_seconds: positionSeconds }),
+  });
+  const data = await resp.json();
+  return data.state;
+}
+
+export async function setBookStatus(
+  bookId: string,
+  status: ReadStatus
+): Promise<UserBookState> {
+  const resp = await fetch(`${API_BASE}/books/${bookId}/status`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+  const data = await resp.json();
+  return data.state;
+}
+
+export async function clearBookStatus(bookId: string): Promise<UserBookState | null> {
+  const resp = await fetch(`${API_BASE}/books/${bookId}/status`, { method: 'DELETE' });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data?.state ?? null;
+}
+
+export async function listByStatus(
+  status: ReadStatus,
+  limit = 50,
+  offset = 0
+): Promise<{ states: UserBookState[]; count: number }> {
+  const resp = await fetch(`${API_BASE}/me/${status}?limit=${limit}&offset=${offset}`);
+  return resp.json();
+}

--- a/web/src/services/versionApi.ts
+++ b/web/src/services/versionApi.ts
@@ -1,0 +1,68 @@
+// file: web/src/services/versionApi.ts
+// version: 1.1.0
+// guid: 9e7f8a3b-0c1d-4a70-b8c5-3d7e0f1b9a99
+
+const API_BASE = '/api/v1';
+
+export interface BookVersion {
+  id: string;
+  book_id: string;
+  status: string;
+  format: string;
+  source: string;
+  source_original_path?: string;
+  torrent_hash?: string;
+  ingest_date: string;
+  purged_date?: string;
+  created_at: string;
+  updated_at: string;
+  version: number;
+}
+
+export interface UndoConflictReport {
+  total_changes: number;
+  already_reverted: number;
+  content_changed: Array<{ change_id: string; book_id: string; reason: string }>;
+  book_deleted: Array<{ change_id: string; book_id: string; reason: string }>;
+  re_organized: Array<{ change_id: string; book_id: string; reason: string }>;
+  safe: number;
+}
+
+async function jsonFetch(url: string, opts?: RequestInit) {
+  const resp = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...opts?.headers },
+    ...opts,
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw Object.assign(new Error(body.error || resp.statusText), { response: { data: body, status: resp.status } });
+  }
+  return resp.json();
+}
+
+export async function trashVersion(bookId: string, versionId: string): Promise<BookVersion> {
+  const resp = await jsonFetch(`${API_BASE}/books/${bookId}/versions/${versionId}`, { method: 'DELETE' });
+  return resp.version;
+}
+
+export async function restoreVersion(bookId: string, versionId: string): Promise<BookVersion> {
+  const resp = await jsonFetch(`${API_BASE}/books/${bookId}/versions/${versionId}/restore`, { method: 'POST' });
+  return resp.version;
+}
+
+export async function purgeVersion(bookId: string, versionId: string): Promise<BookVersion> {
+  const resp = await jsonFetch(`${API_BASE}/books/${bookId}/versions/${versionId}/purge-now`, { method: 'POST' });
+  return resp.version;
+}
+
+export async function hardDeleteVersion(versionId: string): Promise<void> {
+  await jsonFetch(`${API_BASE}/purged-versions/${versionId}`, { method: 'DELETE' });
+}
+
+export async function getUndoPreflight(operationId: string): Promise<UndoConflictReport> {
+  return jsonFetch(`${API_BASE}/operations/${operationId}/undo/preflight`);
+}
+
+export async function revertOperation(operationId: string): Promise<void> {
+  await jsonFetch(`${API_BASE}/operations/${operationId}/revert`, { method: 'POST' });
+}


### PR DESCRIPTION
## Summary

Frontend foundation for all 6 feature specs:

| File | Feature |
|---|---|
| \`readingApi.ts\` | 3.6 read/unread: position, state, status endpoints |
| \`ReadStatusChip.tsx\` | 3.6: clickable status chip + progress bar + override menu |
| \`playlistApi.ts\` | 3.4: full CRUD + reorder + materialize |
| \`Playlists.tsx\` | 3.4: tabbed list page + create dialog |
| \`versionApi.ts\` | 3.1 + 3.2: trash/restore/purge + undo preflight |
| \`Setup.tsx\` | 3.7: first-run admin account wizard |

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Manual browser testing needed for UI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)