### PR TITLE
feat(frontend): ReadStatusChip in BookDetail + Library column (3.6 tasks 6-7)

### DIFF
--- a/web/src/config/columnDefinitions.ts
+++ b/web/src/config/columnDefinitions.ts
@@ -469,6 +469,18 @@ export const ALL_COLUMNS: ColumnDefinition[] = [
     defaultVisible: false,
   },
   {
+    id: 'read_status',
+    label: 'Read Status',
+    category: 'Lifecycle',
+    accessor: () => '',
+    sortKey: 'read_status',
+    searchKey: 'read_status',
+    defaultWidth: 120,
+    minWidth: 80,
+    sortable: false,
+    defaultVisible: false,
+  },
+  {
     id: 'created_at',
     label: 'Created',
     category: 'Lifecycle',

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -72,6 +72,7 @@ import { RelocateFileDialog } from '../components/audiobooks/RelocateFileDialog'
 import { TagComparison } from '../components/TagComparison';
 import { ChangeLog } from '../components/ChangeLog';
 import { useToast } from '../components/toast/ToastProvider';
+import ReadStatusChip from '../components/audiobooks/ReadStatusChip';
 import type { Audiobook } from '../types';
 
 const SEGMENT_PREVIEW_COUNT = 5;
@@ -1015,6 +1016,7 @@ export const BookDetail = () => {
               {book.is_primary_version && (
                 <Chip label="Primary Version" color="primary" />
               )}
+              <ReadStatusChip bookId={book.id} />
             </Box>
             <Typography variant="subtitle1" color="text.secondary">
               {book.authors && book.authors.length > 0


### PR DESCRIPTION
Wires the ReadStatusChip into BookDetail header and adds a read_status column to the Library grid.