### PR TITLE
fix(ci): replace govulncheck-action with direct CLI for SHA pinning

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/vulnerability-scan.yml
-# version: 1.3.0
+# version: 1.4.0
 # guid: vuln-scan-001
 
 name: Nightly Vulnerability Scan
@@ -24,10 +24,11 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       - name: Run govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          go-version-input: '1.25'
+        run: govulncheck ./...
 
 
   scan-npm:


### PR DESCRIPTION
## Summary
- `golang/govulncheck-action@v1.0.4` internally uses unpinned `actions/checkout@v4.1.1` and `actions/setup-go@v5.0.0`, which violates the repo's SHA-pinning policy
- Replaced composite action with direct `go install golang.org/x/vuln/cmd/govulncheck@latest` + `govulncheck ./...` invocation
- Since we already have `actions/checkout` and `actions/setup-go` steps, the composite action was redundant anyway

## Test plan
- [ ] Re-run the vulnerability scan workflow after merge
- [ ] Verify govulncheck runs successfully with direct CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)