### PR TITLE
feat: Deluge Web JSON-RPC client + move_storage (backlog 6.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ since it was last edited on 2026-04-11).
 
 ### 6. Integration / Ecosystem — [section](docs/backlog-2026-04-10.md#6-integration--ecosystem)
 
-- [ ] **6.1** Deluge `move_storage` integration (**M**) — pairs with 3.1
+- [x] **6.1** Deluge `move_storage` integration (**M**) — #349
 - [x] **6.2** Audnexus + Hardcover full integration (#7daef15)
 - [x] **6.3** Tag writeback to iTunes via ITL updates (shipped previously)
 - [ ] **6.4** ITL upload / download / partial export (**M**)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,10 @@ type Config struct {
 	ITunesPathMappings     []ITunesPathMap `json:"itunes_path_mappings"`      // Stored path mappings for write-back
 	ITunesAutoWriteBack    bool            `json:"itunes_auto_write_back"`    // Auto write-back on every edit (batched)
 
+	// Deluge integration
+	DelugeWebURL      string `json:"deluge_web_url"`      // e.g. "http://172.16.2.30:8112"
+	DelugeWebPassword string `json:"deluge_web_password"` // Web UI password (default: "deluge")
+
 	// Auto-update
 	AutoUpdateEnabled      bool   `json:"auto_update_enabled"`
 	AutoUpdateChannel      string `json:"auto_update_channel"`       // "stable" or "develop"

--- a/internal/deluge/client.go
+++ b/internal/deluge/client.go
@@ -1,0 +1,191 @@
+// file: internal/deluge/client.go
+// version: 1.0.0
+// guid: 9a7b8c6d-0e1f-4a70-b8c5-3d7e0f1b9a99
+//
+// Deluge Web JSON-RPC client (backlog 6.1).
+//
+// Communicates with Deluge's Web UI at /json using JSON-RPC 2.0.
+// Session-based auth via cookie. Supports:
+//   - Authentication (auth.login)
+//   - Listing torrents (core.get_torrents_status)
+//   - Getting single torrent info (core.get_torrent_status)
+//   - Moving torrent storage (core.move_storage)
+//
+// Reference: https://deluge.readthedocs.io/en/latest/reference/webapi.html
+
+package deluge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"sync"
+	"sync/atomic"
+)
+
+// Client talks to a Deluge Web UI instance via JSON-RPC.
+type Client struct {
+	baseURL  string
+	password string
+	client   *http.Client
+	mu       sync.Mutex
+	authed   bool
+	reqID    atomic.Int64
+}
+
+// TorrentStatus holds the fields we care about from Deluge.
+type TorrentStatus struct {
+	Hash     string `json:"hash"`
+	Name     string `json:"name"`
+	SavePath string `json:"save_path"`
+	State    string `json:"state"`
+	Progress float64 `json:"progress"`
+}
+
+type rpcRequest struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+	ID     int64         `json:"id"`
+}
+
+type rpcResponse struct {
+	ID     int64           `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// New creates a Deluge Web JSON-RPC client.
+// baseURL is the Deluge Web UI URL (e.g. "http://172.16.2.30:8112").
+// password is the Web UI password (default: "deluge").
+func New(baseURL, password string) (*Client, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		baseURL:  baseURL,
+		password: password,
+		client:   &http.Client{Jar: jar},
+	}, nil
+}
+
+// call sends a JSON-RPC request and decodes the result.
+func (c *Client) call(method string, params ...interface{}) (json.RawMessage, error) {
+	if params == nil {
+		params = []interface{}{}
+	}
+	id := c.reqID.Add(1)
+	body, _ := json.Marshal(rpcRequest{
+		Method: method,
+		Params: params,
+		ID:     id,
+	})
+
+	resp, err := c.client.Post(c.baseURL+"/json", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("deluge rpc %s: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(raw, &rpcResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w (body: %s)", err, string(raw[:min(200, len(raw))]))
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("deluge error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}
+
+// Login authenticates with the Deluge Web UI. Must be called before
+// other methods. Idempotent — skips if already authenticated.
+func (c *Client) Login() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.authed {
+		return nil
+	}
+	result, err := c.call("auth.login", c.password)
+	if err != nil {
+		return fmt.Errorf("auth.login: %w", err)
+	}
+	var ok bool
+	if err := json.Unmarshal(result, &ok); err != nil || !ok {
+		return fmt.Errorf("auth.login failed (result: %s)", string(result))
+	}
+	c.authed = true
+	return nil
+}
+
+// ListTorrents returns all torrents with the requested fields.
+func (c *Client) ListTorrents() (map[string]TorrentStatus, error) {
+	if err := c.Login(); err != nil {
+		return nil, err
+	}
+	fields := []string{"hash", "name", "save_path", "state", "progress"}
+	result, err := c.call("core.get_torrents_status", map[string]interface{}{}, fields)
+	if err != nil {
+		return nil, err
+	}
+	var torrents map[string]TorrentStatus
+	if err := json.Unmarshal(result, &torrents); err != nil {
+		return nil, fmt.Errorf("decode torrents: %w", err)
+	}
+	return torrents, nil
+}
+
+// GetTorrent returns status for a single torrent by hash.
+func (c *Client) GetTorrent(torrentID string) (*TorrentStatus, error) {
+	if err := c.Login(); err != nil {
+		return nil, err
+	}
+	fields := []string{"hash", "name", "save_path", "state", "progress"}
+	result, err := c.call("core.get_torrent_status", torrentID, fields)
+	if err != nil {
+		return nil, err
+	}
+	var status TorrentStatus
+	if err := json.Unmarshal(result, &status); err != nil {
+		return nil, fmt.Errorf("decode torrent: %w", err)
+	}
+	return &status, nil
+}
+
+// MoveStorage moves a torrent's data to a new location on disk.
+// This is the key integration point for library centralization —
+// when a book version is swapped or reorganized, the torrent's
+// storage path needs to follow.
+func (c *Client) MoveStorage(torrentIDs []string, destPath string) error {
+	if err := c.Login(); err != nil {
+		return err
+	}
+	_, err := c.call("core.move_storage", torrentIDs, destPath)
+	return err
+}
+
+// Connected checks whether the Web UI is connected to a daemon.
+func (c *Client) Connected() (bool, error) {
+	if err := c.Login(); err != nil {
+		return false, err
+	}
+	result, err := c.call("web.connected")
+	if err != nil {
+		return false, err
+	}
+	var connected bool
+	_ = json.Unmarshal(result, &connected)
+	return connected, nil
+}

--- a/internal/deluge/client_test.go
+++ b/internal/deluge/client_test.go
@@ -1,0 +1,101 @@
+// file: internal/deluge/client_test.go
+// version: 1.0.0
+// guid: 0b8c9d7e-1f2a-4a70-b8c5-3d7e0f1b9a99
+
+package deluge
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogin_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "auth.login" {
+			json.NewEncoder(w).Encode(rpcResponse{ID: req.ID, Result: json.RawMessage(`true`)})
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL, "deluge")
+	if err := c.Login(); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if !c.authed {
+		t.Error("should be authed after login")
+	}
+	// Idempotent.
+	if err := c.Login(); err != nil {
+		t.Fatalf("second login: %v", err)
+	}
+}
+
+func TestLogin_BadPassword(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(rpcResponse{Result: json.RawMessage(`false`)})
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL, "wrong")
+	if err := c.Login(); err == nil {
+		t.Error("expected error on bad password")
+	}
+}
+
+func TestListTorrents(t *testing.T) {
+	reqCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		reqCount++
+		switch req.Method {
+		case "auth.login":
+			json.NewEncoder(w).Encode(rpcResponse{ID: req.ID, Result: json.RawMessage(`true`)})
+		case "core.get_torrents_status":
+			result := map[string]TorrentStatus{
+				"abc123": {Hash: "abc123", Name: "Test Book", SavePath: "/downloads/books", State: "Seeding", Progress: 100},
+			}
+			data, _ := json.Marshal(result)
+			json.NewEncoder(w).Encode(rpcResponse{ID: req.ID, Result: data})
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL, "deluge")
+	torrents, err := c.ListTorrents()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(torrents) != 1 {
+		t.Errorf("got %d torrents, want 1", len(torrents))
+	}
+	if torrents["abc123"].Name != "Test Book" {
+		t.Errorf("name = %q", torrents["abc123"].Name)
+	}
+}
+
+func TestMoveStorage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "auth.login":
+			json.NewEncoder(w).Encode(rpcResponse{ID: req.ID, Result: json.RawMessage(`true`)})
+		case "core.move_storage":
+			json.NewEncoder(w).Encode(rpcResponse{ID: req.ID, Result: json.RawMessage(`null`)})
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New(srv.URL, "deluge")
+	err := c.MoveStorage([]string{"abc123"}, "/new/path")
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+}

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,0 +1,91 @@
+// file: internal/server/deluge_integration.go
+// version: 1.0.0
+// guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
+//
+// Deluge integration for library centralization (backlog 6.1).
+//
+// When a book version that came from Deluge is swapped, trashed,
+// or its files are reorganized, we need to update the torrent's
+// save_path in Deluge so it keeps seeding from the new location.
+//
+// The Deluge client is optional — if not configured, the
+// integration is silently skipped.
+
+package server
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
+)
+
+// globalDelugeClient is lazily initialized on first use.
+var globalDelugeClient *deluge.Client
+
+// getDelugeClient returns the Deluge client, initializing it if
+// needed. Returns nil if Deluge is not configured.
+func getDelugeClient() *deluge.Client {
+	if globalDelugeClient != nil {
+		return globalDelugeClient
+	}
+	url := config.AppConfig.DelugeWebURL
+	pass := config.AppConfig.DelugeWebPassword
+	if url == "" {
+		return nil
+	}
+	if pass == "" {
+		pass = "deluge"
+	}
+	c, err := deluge.New(url, pass)
+	if err != nil {
+		log.Printf("[WARN] failed to create deluge client: %v", err)
+		return nil
+	}
+	globalDelugeClient = c
+	return c
+}
+
+// NotifyDelugeMoveStorage tells Deluge to move a torrent's storage
+// to a new path. Called after a version swap or organize moves files
+// that belong to a Deluge-sourced version.
+//
+// torrentHash is the infohash from BookVersion.TorrentHash.
+// newPath is the directory where the files now live.
+//
+// Silently no-ops if Deluge is not configured or the torrent hash
+// is empty.
+func NotifyDelugeMoveStorage(torrentHash, newPath string) {
+	if torrentHash == "" {
+		return
+	}
+	c := getDelugeClient()
+	if c == nil {
+		return
+	}
+	// Deluge expects the parent directory, not the file path.
+	dir := filepath.Dir(newPath)
+	if err := c.MoveStorage([]string{torrentHash}, dir); err != nil {
+		log.Printf("[WARN] deluge move_storage %s → %s: %v", torrentHash, dir, err)
+	} else {
+		log.Printf("[INFO] deluge move_storage %s → %s", torrentHash, dir)
+	}
+}
+
+// NotifyDelugeAfterVersionSwap checks whether the swapped versions
+// have torrent hashes and updates Deluge accordingly.
+func NotifyDelugeAfterVersionSwap(store database.Store, fromVer, toVer *database.BookVersion, bookFilePath string) {
+	if toVer != nil && toVer.TorrentHash != "" {
+		NotifyDelugeMoveStorage(toVer.TorrentHash, bookFilePath)
+	}
+	if fromVer != nil && fromVer.TorrentHash != "" {
+		// The "from" version moved into .versions/{id}/ — tell Deluge.
+		book, _ := store.GetBookByID(fromVer.BookID)
+		if book != nil {
+			slotDir := filepath.Join(filepath.Dir(book.FilePath), ".versions", fromVer.ID)
+			NotifyDelugeMoveStorage(fromVer.TorrentHash, slotDir)
+		}
+	}
+}

--- a/internal/server/version_swap.go
+++ b/internal/server/version_swap.go
@@ -146,7 +146,8 @@ func RunVersionSwap(
 	}
 	progress("db_finalized", 90)
 
-	// ── Step 5: Enqueue iTunes writeback ────────────────────────
+	// ── Step 5: Notify Deluge + enqueue iTunes writeback ────────
+	NotifyDelugeAfterVersionSwap(store, fromVer, toVer, book.FilePath)
 	if GlobalWriteBackBatcher != nil {
 		GlobalWriteBackBatcher.Enqueue(params.BookID)
 	}


### PR DESCRIPTION
## Summary

New \`internal/deluge\` package — JSON-RPC client for Deluge Web UI:
- auth.login, core.get_torrents_status, core.get_torrent_status, core.move_storage
- Session-based auth with cookie jar
- 4 tests with httptest mock

Integration layer:
- \`NotifyDelugeMoveStorage\` + \`NotifyDelugeAfterVersionSwap\` 
- Wired into version swap step 5
- Config: \`deluge_web_url\` + \`deluge_web_password\`

## Test plan

- [x] 4 Deluge client tests pass (login, bad password, list, move)
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)