### PR TITLE
feat: chromem-go embedding vector store (DES-2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,7 +172,7 @@ Full details: [`memory/project_bulk_metadata_review.md`](../../.claude/projects/
 ### Design Spec Already Written (but not yet planned)
 
 - [x] **DES-1** Bleve library search — complete 6/7 (#298, #301-#302, #311-#312, #321)
-- [ ] **DES-2** chromem-go embedding store — spec at [`docs/superpowers/specs/2026-04-11-chromem-go-embedding-store.md`](docs/superpowers/specs/2026-04-11-chromem-go-embedding-store.md)
+- [x] **DES-2** chromem-go embedding store — #351 (store impl + tests; dedup engine wiring follows)
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/openai/openai-go v1.12.0
+	github.com/philippgille/chromem-go v0.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quic-go/quic-go v0.59.0
 	github.com/schollz/progressbar/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefw
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/philippgille/chromem-go v0.7.0 h1:4jfvfyKymjKNfGxBUhHUcj1kp7B17NL/I1P+vGh1RvY=
+github.com/philippgille/chromem-go v0.7.0/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/database/chromem_embedding_store.go
+++ b/internal/database/chromem_embedding_store.go
@@ -1,0 +1,194 @@
+// file: internal/database/chromem_embedding_store.go
+// version: 1.0.0
+// guid: 2d0e1f9a-3b4c-4a70-b8c5-3d7e0f1b9a99
+//
+// chromem-go backed embedding vector store (DES-2).
+//
+// Replaces the linear-scan FindSimilar from the SQLite embedding
+// store with HNSW-based approximate nearest neighbor search.
+// Supports metadata filtering at query time (primary-version,
+// series exclusion, etc.).
+//
+// The SQLite EmbeddingStore stays for DedupCandidate CRUD — this
+// only handles the vector operations.
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	chromem "github.com/philippgille/chromem-go"
+)
+
+// ChromemEmbeddingStore wraps chromem-go collections for ANN vector
+// search. One collection per entity type (books, authors).
+type ChromemEmbeddingStore struct {
+	db          *chromem.DB
+	collections map[string]*chromem.Collection
+	mu          sync.RWMutex
+	dims        int
+}
+
+// NewChromemEmbeddingStore opens or creates a persistent chromem-go
+// database at the given directory.
+func NewChromemEmbeddingStore(dir string, dims int) (*ChromemEmbeddingStore, error) {
+	dbPath := filepath.Join(dir, "chromem")
+	db, err := chromem.NewPersistentDB(dbPath, false)
+	if err != nil {
+		return nil, fmt.Errorf("open chromem at %s: %w", dbPath, err)
+	}
+	return &ChromemEmbeddingStore{
+		db:          db,
+		collections: make(map[string]*chromem.Collection),
+		dims:        dims,
+	}, nil
+}
+
+// NewInMemoryChromemStore creates an in-memory store for tests.
+func NewInMemoryChromemStore(dims int) *ChromemEmbeddingStore {
+	db := chromem.NewDB()
+	return &ChromemEmbeddingStore{
+		db:          db,
+		collections: make(map[string]*chromem.Collection),
+		dims:        dims,
+	}
+}
+
+func (s *ChromemEmbeddingStore) getOrCreateCollection(entityType string) (*chromem.Collection, error) {
+	s.mu.RLock()
+	col, ok := s.collections[entityType]
+	s.mu.RUnlock()
+	if ok {
+		return col, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Double-check.
+	if col, ok := s.collections[entityType]; ok {
+		return col, nil
+	}
+
+	col, err := s.db.GetOrCreateCollection(entityType, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	s.collections[entityType] = col
+	return col, nil
+}
+
+// Upsert stores or replaces an embedding with metadata.
+func (s *ChromemEmbeddingStore) Upsert(ctx context.Context, entityType, entityID string, vec []float32, meta map[string]string) error {
+	col, err := s.getOrCreateCollection(entityType)
+	if err != nil {
+		return err
+	}
+	doc := chromem.Document{
+		ID:        entityID,
+		Embedding: vec,
+		Metadata:  meta,
+	}
+	return col.AddDocument(ctx, doc)
+}
+
+// Get returns a single embedding's metadata by ID.
+func (s *ChromemEmbeddingStore) Get(ctx context.Context, entityType, entityID string) (map[string]string, error) {
+	col, err := s.getOrCreateCollection(entityType)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := col.GetByID(ctx, entityID)
+	if err != nil {
+		return nil, nil // not found
+	}
+	if doc.ID == "" {
+		return nil, nil
+	}
+	return doc.Metadata, nil
+}
+
+// Delete removes an embedding.
+func (s *ChromemEmbeddingStore) Delete(ctx context.Context, entityType, entityID string) error {
+	col, err := s.getOrCreateCollection(entityType)
+	if err != nil {
+		return err
+	}
+	return col.Delete(ctx, nil, nil, entityID)
+}
+
+// ChromemSimilarityResult is a scored match from FindSimilar.
+type ChromemSimilarityResult struct {
+	EntityID   string
+	Similarity float32
+	Metadata   map[string]string
+}
+
+// FindSimilar performs an ANN query with optional metadata filter.
+func (s *ChromemEmbeddingStore) FindSimilar(
+	ctx context.Context,
+	entityType string,
+	query []float32,
+	maxResults int,
+	filter map[string]string,
+) ([]ChromemSimilarityResult, error) {
+	col, err := s.getOrCreateCollection(entityType)
+	if err != nil {
+		return nil, err
+	}
+	if maxResults <= 0 {
+		maxResults = 20
+	}
+
+	count := col.Count()
+	if maxResults > count {
+		maxResults = count
+	}
+	if maxResults <= 0 {
+		return nil, nil
+	}
+	results, err := col.QueryEmbedding(ctx, query, maxResults, filter, nil)
+	if err != nil {
+		return nil, fmt.Errorf("chromem query: %w", err)
+	}
+
+	out := make([]ChromemSimilarityResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, ChromemSimilarityResult{
+			EntityID:   r.ID,
+			Similarity: r.Similarity,
+			Metadata:   r.Metadata,
+		})
+	}
+	return out, nil
+}
+
+// CountByType returns the document count in a collection.
+func (s *ChromemEmbeddingStore) CountByType(ctx context.Context, entityType string) (int, error) {
+	col, err := s.getOrCreateCollection(entityType)
+	if err != nil {
+		return 0, err
+	}
+	return col.Count(), nil
+}
+
+// Close is a no-op for chromem-go (persistence is automatic).
+func (s *ChromemEmbeddingStore) Close() error {
+	return nil
+}
+
+// Helper to convert metadata to typed values.
+
+// MetaBool reads a boolean metadata value.
+func MetaBool(meta map[string]string, key string) bool {
+	return meta[key] == "true"
+}
+
+// MetaInt reads an integer metadata value.
+func MetaInt(meta map[string]string, key string) int {
+	n, _ := strconv.Atoi(meta[key])
+	return n
+}

--- a/internal/database/chromem_embedding_store_test.go
+++ b/internal/database/chromem_embedding_store_test.go
@@ -1,0 +1,118 @@
+// file: internal/database/chromem_embedding_store_test.go
+// version: 1.0.0
+// guid: 3e1f2a0b-4c5d-4a70-b8c5-3d7e0f1b9a99
+
+package database
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestChromem_UpsertAndQuery(t *testing.T) {
+	store := NewInMemoryChromemStore(4)
+	ctx := context.Background()
+
+	vec1 := []float32{1, 0, 0, 0}
+	vec2 := []float32{0, 1, 0, 0}
+	vec3 := []float32{0.9, 0.1, 0, 0}
+
+	if err := store.Upsert(ctx, "book", "b1", vec1, map[string]string{"is_primary": "true"}); err != nil {
+		t.Fatalf("upsert b1: %v", err)
+	}
+	if err := store.Upsert(ctx, "book", "b2", vec2, map[string]string{"is_primary": "true"}); err != nil {
+		t.Fatalf("upsert b2: %v", err)
+	}
+	if err := store.Upsert(ctx, "book", "b3", vec3, map[string]string{"is_primary": "false"}); err != nil {
+		t.Fatalf("upsert b3: %v", err)
+	}
+
+	// Query for vectors similar to vec1 — should rank b3 (0.9 similarity) above b2 (0.0).
+	results, err := store.FindSimilar(ctx, "book", vec1, 10, nil)
+	if err != nil {
+		t.Fatalf("find similar: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+	// b1 is the query itself (similarity ~1.0), b3 should be next.
+	found := false
+	for _, r := range results {
+		if r.EntityID == "b3" {
+			found = true
+			if r.Similarity < 0.8 {
+				t.Errorf("b3 similarity = %f, want >= 0.8", r.Similarity)
+			}
+		}
+	}
+	if !found {
+		t.Error("b3 not in results")
+	}
+}
+
+func TestChromem_MetadataFilter(t *testing.T) {
+	store := NewInMemoryChromemStore(4)
+	ctx := context.Background()
+
+	vec := []float32{1, 0, 0, 0}
+	if err := store.Upsert(ctx, "book", "b1", vec, map[string]string{"is_primary": "true"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Upsert(ctx, "book", "b2", vec, map[string]string{"is_primary": "false"}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindSimilar(ctx, "book", vec, 10, map[string]string{"is_primary": "true"})
+	if err != nil {
+		t.Fatalf("query with filter: %v", err)
+	}
+	for _, r := range results {
+		if r.EntityID == "b2" {
+			t.Error("b2 (is_primary=false) should have been filtered out")
+		}
+	}
+}
+
+func TestChromem_Delete(t *testing.T) {
+	store := NewInMemoryChromemStore(4)
+	ctx := context.Background()
+
+	vec := []float32{1, 0, 0, 0}
+	_ = store.Upsert(ctx, "book", "b1", vec, nil)
+
+	if err := store.Delete(ctx, "book", "b1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	meta, err := store.Get(ctx, "book", "b1")
+	if err != nil {
+		t.Fatalf("get after delete: %v", err)
+	}
+	if meta != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestChromem_CountByType(t *testing.T) {
+	store := NewInMemoryChromemStore(4)
+	ctx := context.Background()
+
+	vec := []float32{1, 0, 0, 0}
+	_ = store.Upsert(ctx, "book", "b1", vec, nil)
+	_ = store.Upsert(ctx, "book", "b2", vec, nil)
+	_ = store.Upsert(ctx, "author", "a1", vec, nil)
+
+	bookCount, _ := store.CountByType(ctx, "book")
+	authorCount, _ := store.CountByType(ctx, "author")
+
+	if bookCount != 2 {
+		t.Errorf("book count = %d, want 2", bookCount)
+	}
+	if authorCount != 1 {
+		t.Errorf("author count = %d, want 1", authorCount)
+	}
+}
+
+// Silence unused import.
+var _ = math.Abs


### PR DESCRIPTION
## Summary

HNSW-based ANN vector store replacing the O(n) linear scan in FindSimilar:

- \`ChromemEmbeddingStore\` wraps chromem-go with Upsert/FindSimilar/Delete/Get/CountByType
- Metadata filter (is_primary, series exclusion) pushed into chromem query — no more Go-side post-filtering
- Persistent + in-memory modes
- 4 tests pass

Dedup engine wiring follows in a separate PR.

## Test plan

- [x] 4 chromem tests pass
- [x] \`go build ./...\` clean
- [x] \`go mod tidy\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)