### PR TITLE
test: rapid generators for core types (4.5 task 1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,4 +120,5 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	pgregory.net/rapid v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -340,3 +340,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
 howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/internal/testutil/rapidgen/rapidgen.go
+++ b/internal/testutil/rapidgen/rapidgen.go
@@ -1,0 +1,243 @@
+// file: internal/testutil/rapidgen/rapidgen.go
+// version: 1.0.0
+// guid: b093c713-a945-4937-8871-a7786dd843cb
+
+// Package rapidgen provides reusable `pgregory.net/rapid` generators for the
+// project's core domain types. All property-based tests across the codebase
+// should draw their fuzz inputs from here so invariants are exercised with the
+// same distribution of shapes — random titles, optional-pointer permutations,
+// valid-but-weird statuses — regardless of which package the test lives in.
+//
+// This is a regular (non-_test) package so it can be imported from tests in
+// any package (database, server, search, auth). Importing a `_test.go` file
+// across packages is not supported in Go; the small cost of pulling rapid
+// into the production binary is the trade-off.
+package rapidgen
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"pgregory.net/rapid"
+)
+
+// ----------------------------------------------------------------------------
+// Primitive helpers
+// ----------------------------------------------------------------------------
+
+// nonEmptyString draws a string guaranteed to contain at least one non-space
+// rune. rapid's default string generator includes the empty string and
+// whitespace-only strings, which trip over validation code that calls
+// strings.TrimSpace before comparing to "".
+func nonEmptyString(t *rapid.T, label string) string {
+	return rapid.StringMatching(`[A-Za-z0-9][A-Za-z0-9 \-_'.,:!?]{0,63}`).Draw(t, label)
+}
+
+// alnum draws lowercase alphanumeric strings of the given length range. Used
+// for usernames and other identifier-shaped fields.
+func alnum(t *rapid.T, label string, minLen, maxLen int) string {
+	return rapid.StringMatching(
+		fmt.Sprintf(`[a-z0-9]{%d,%d}`, minLen, maxLen),
+	).Draw(t, label)
+}
+
+// optString returns a *string that is nil ~30% of the time and a non-empty
+// string otherwise. Using a skewed distribution (not 50/50) is deliberate —
+// most real data has optional fields populated, but we still want to exercise
+// the nil path.
+func optString(t *rapid.T, label string) *string {
+	if rapid.Float64Range(0, 1).Draw(t, label+"_present") < 0.7 {
+		s := nonEmptyString(t, label)
+		return &s
+	}
+	return nil
+}
+
+// optInt returns a *int that is nil ~30% of the time.
+func optInt(t *rapid.T, label string, min, max int) *int {
+	if rapid.Float64Range(0, 1).Draw(t, label+"_present") < 0.7 {
+		v := rapid.IntRange(min, max).Draw(t, label)
+		return &v
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Core type generators
+// ----------------------------------------------------------------------------
+
+// Book generates a *database.Book with a random non-empty Title, optional
+// author/series metadata, and a plausible file path. The ID is left empty so
+// CreateBook assigns a fresh ULID — round-trip tests can pass the result of
+// CreateBook back to GetBookByID without collision.
+func Book(t *rapid.T) *database.Book {
+	format := rapid.SampledFrom([]string{"m4b", "mp3", "flac", "ogg", "m4a"}).Draw(t, "format")
+	return &database.Book{
+		Title:                nonEmptyString(t, "title"),
+		FilePath:             "/library/" + alnum(t, "pathseg", 4, 16) + "/" + alnum(t, "file", 4, 16) + "." + format,
+		Format:               format,
+		Duration:             optInt(t, "duration", 60, 360000), // 1min–100h
+		Narrator:             optString(t, "narrator"),
+		Description:          optString(t, "description"),
+		Language:             optString(t, "language"),
+		Publisher:            optString(t, "publisher"),
+		Genre:                optString(t, "genre"),
+		PrintYear:            optInt(t, "print_year", 1800, 2030),
+		AudiobookReleaseYear: optInt(t, "release_year", 1950, 2030),
+		ISBN10:               optString(t, "isbn10"),
+		ISBN13:               optString(t, "isbn13"),
+		ASIN:                 optString(t, "asin"),
+	}
+}
+
+// Author generates a random database.Author. ID is left 0 so CreateAuthor
+// assigns a fresh integer ID.
+func Author(t *rapid.T) database.Author {
+	return database.Author{
+		Name: nonEmptyString(t, "author_name"),
+	}
+}
+
+// Series generates a random database.Series. ID is left 0 so CreateSeries
+// assigns a fresh integer ID. AuthorID is always nil — callers that want to
+// tie the series to an author should set it after generation.
+func Series(t *rapid.T) database.Series {
+	return database.Series{
+		Name: nonEmptyString(t, "series_name"),
+	}
+}
+
+// BookFile generates a *database.BookFile scoped to the given bookID. ID is
+// left empty so CreateBookFile / UpsertBookFile assigns a fresh ULID.
+func BookFile(t *rapid.T, bookID string) database.BookFile {
+	format := rapid.SampledFrom([]string{"m4b", "mp3", "flac", "m4a", "ogg"}).Draw(t, "bf_format")
+	track := rapid.IntRange(1, 40).Draw(t, "bf_track")
+	return database.BookFile{
+		BookID:      bookID,
+		FilePath:    "/library/" + bookID + "/" + alnum(t, "bf_file", 4, 16) + "." + format,
+		Format:      format,
+		Codec:       rapid.SampledFrom([]string{"aac", "mp3", "flac", "opus"}).Draw(t, "bf_codec"),
+		Duration:    rapid.IntRange(60, 36000).Draw(t, "bf_duration"),
+		FileSize:    rapid.Int64Range(1024, 2<<30).Draw(t, "bf_size"),
+		TrackNumber: track,
+		TrackCount:  rapid.IntRange(track, track+20).Draw(t, "bf_trackcount"),
+	}
+}
+
+// bookVersionStatuses is the subset of version statuses that generators emit.
+// Transition-only statuses (swapping_in, swapping_out) are created by the
+// server layer during lifecycle operations, never by direct CreateBookVersion
+// calls, so we exclude them here.
+var bookVersionStatuses = []string{
+	database.BookVersionStatusPending,
+	database.BookVersionStatusActive,
+	database.BookVersionStatusAlt,
+	database.BookVersionStatusTrash,
+	database.BookVersionStatusInactivePurged,
+	database.BookVersionStatusBlockedForRedownload,
+}
+
+// BookVersion generates a *database.BookVersion scoped to the given bookID.
+// ID is left empty so CreateBookVersion assigns a fresh ULID. Status is drawn
+// from the set of statuses that are valid as direct-create inputs.
+func BookVersion(t *rapid.T, bookID string) *database.BookVersion {
+	return &database.BookVersion{
+		BookID:      bookID,
+		Status:      rapid.SampledFrom(bookVersionStatuses).Draw(t, "bv_status"),
+		Format:      rapid.SampledFrom([]string{"m4b", "mp3", "flac", "ogg"}).Draw(t, "bv_format"),
+		Source:      rapid.SampledFrom([]string{"deluge", "manual", "transcoded", "imported"}).Draw(t, "bv_source"),
+		TorrentHash: alnum(t, "bv_hash", 0, 40),
+		IngestDate:  time.Now().Add(-time.Duration(rapid.IntRange(0, 365*86400).Draw(t, "bv_age")) * time.Second),
+	}
+}
+
+// BookVersionActive generates a BookVersion with status forced to "active".
+// Useful for the single-active-invariant test where we explicitly want one
+// active row per book.
+func BookVersionActive(t *rapid.T, bookID string) *database.BookVersion {
+	v := BookVersion(t, bookID)
+	v.Status = database.BookVersionStatusActive
+	return v
+}
+
+// User generates the tuple (username, email, passwordHash) accepted by
+// Store.CreateUser. The caller supplies passwordHashAlgo, roles, and status.
+// Usernames are lowercase alphanumeric 3–24 chars; emails contain an @ with
+// non-empty parts on both sides.
+func User(t *rapid.T) (username, email, passwordHash string) {
+	username = alnum(t, "username", 3, 24)
+	emailLocal := alnum(t, "email_local", 3, 16)
+	emailDomain := alnum(t, "email_domain", 3, 12)
+	emailTLD := rapid.SampledFrom([]string{"com", "net", "org", "io", "dev"}).Draw(t, "email_tld")
+	email = fmt.Sprintf("%s@%s.%s", emailLocal, emailDomain, emailTLD)
+	// 32 hex chars — looks like a hash, no collisions with other draws.
+	passwordHash = rapid.StringMatching(`[a-f0-9]{32,64}`).Draw(t, "password_hash")
+	return
+}
+
+// UserPlaylist generates a *database.UserPlaylist of type "static" or "smart".
+// For static playlists BookIDs is populated (possibly empty slice); for smart
+// playlists Query is populated with a non-empty DSL-shaped string.
+func UserPlaylist(t *rapid.T) *database.UserPlaylist {
+	plType := rapid.SampledFrom([]string{
+		database.UserPlaylistTypeStatic,
+		database.UserPlaylistTypeSmart,
+	}).Draw(t, "upl_type")
+
+	pl := &database.UserPlaylist{
+		Name:        nonEmptyString(t, "upl_name"),
+		Description: rapid.StringMatching(`[A-Za-z0-9 ]{0,80}`).Draw(t, "upl_desc"),
+		Type:        plType,
+	}
+
+	if plType == database.UserPlaylistTypeStatic {
+		n := rapid.IntRange(0, 8).Draw(t, "upl_bookcount")
+		pl.BookIDs = make([]string, n)
+		for i := range pl.BookIDs {
+			pl.BookIDs[i] = alnum(t, fmt.Sprintf("upl_bookid_%d", i), 16, 26)
+		}
+	} else {
+		// Smart playlist: a simple DSL query like `author:"Foo"`.
+		pl.Query = fmt.Sprintf("%s:%s",
+			rapid.SampledFrom([]string{"author", "series", "format", "genre"}).Draw(t, "upl_field"),
+			alnum(t, "upl_value", 2, 12))
+		pl.Limit = rapid.IntRange(0, 500).Draw(t, "upl_limit")
+	}
+	return pl
+}
+
+// Tag generates a lowercase tag string 2–20 characters long. Matches the
+// canonical user-tag shape enforced by the UI (lowercased, alnum + hyphen).
+func Tag(t *rapid.T) string {
+	return rapid.StringMatching(`[a-z][a-z0-9-]{1,19}`).Draw(t, "tag")
+}
+
+// operationChangeTypes enumerates the change_type values tracked by the undo
+// engine. Keep this in sync with the comment on database.OperationChange.
+var operationChangeTypes = []string{"file_move", "metadata_update", "tag_write"}
+
+// OperationChange generates a *database.OperationChange for the given
+// operationID and bookID. CreatedAt is set to the current time; RevertedAt is
+// left nil (revert is an explicit transition the test applies after creation).
+func OperationChange(t *rapid.T, operationID, bookID string) *database.OperationChange {
+	changeType := rapid.SampledFrom(operationChangeTypes).Draw(t, "oc_type")
+	var fieldName string
+	switch changeType {
+	case "file_move":
+		fieldName = "file_path"
+	case "metadata_update":
+		fieldName = rapid.SampledFrom([]string{"title", "narrator", "genre", "isbn13"}).Draw(t, "oc_field")
+	case "tag_write":
+		fieldName = rapid.SampledFrom([]string{"TITLE", "ARTIST", "GENRE", "AUDIOBOOK_ORGANIZER_BOOK_ID"}).Draw(t, "oc_tag")
+	}
+	return &database.OperationChange{
+		OperationID: operationID,
+		BookID:      bookID,
+		ChangeType:  changeType,
+		FieldName:   fieldName,
+		OldValue:    nonEmptyString(t, "oc_old"),
+		NewValue:    nonEmptyString(t, "oc_new"),
+		CreatedAt:   time.Now(),
+	}
+}

--- a/internal/testutil/rapidgen/rapidgen_test.go
+++ b/internal/testutil/rapidgen/rapidgen_test.go
@@ -1,0 +1,217 @@
+// file: internal/testutil/rapidgen/rapidgen_test.go
+// version: 1.0.0
+// guid: 2931b48a-8535-4f2a-a455-cf322f99cea5
+
+package rapidgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"pgregory.net/rapid"
+)
+
+// Each TestGen_* verifies the generator produces values that satisfy the
+// invariant the plan calls out for it: non-empty titles, valid statuses, etc.
+// The generators will be used by every downstream property test, so we smoke
+// them here to fail fast if a shrink ever produces an invalid value.
+
+func TestGen_Book(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		b := Book(t)
+		if b == nil {
+			t.Fatal("Book returned nil")
+		}
+		if b.Title == "" {
+			t.Errorf("Title must be non-empty, got %q", b.Title)
+		}
+		if b.FilePath == "" {
+			t.Errorf("FilePath must be non-empty")
+		}
+		if b.Format == "" {
+			t.Errorf("Format must be non-empty")
+		}
+		if b.ID != "" {
+			t.Errorf("ID must be empty (CreateBook assigns ULID), got %q", b.ID)
+		}
+	})
+}
+
+func TestGen_Author(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		a := Author(t)
+		if a.Name == "" {
+			t.Errorf("Author.Name must be non-empty")
+		}
+		if a.ID != 0 {
+			t.Errorf("Author.ID must be 0 (CreateAuthor assigns), got %d", a.ID)
+		}
+	})
+}
+
+func TestGen_Series(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := Series(t)
+		if s.Name == "" {
+			t.Errorf("Series.Name must be non-empty")
+		}
+		if s.ID != 0 {
+			t.Errorf("Series.ID must be 0, got %d", s.ID)
+		}
+	})
+}
+
+func TestGen_BookFile(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		bookID := "01H" + strings.Repeat("A", 23) // fake ULID
+		f := BookFile(t, bookID)
+		if f.BookID != bookID {
+			t.Errorf("BookID must propagate, got %q", f.BookID)
+		}
+		if f.FilePath == "" {
+			t.Errorf("FilePath must be non-empty")
+		}
+		if f.Format == "" {
+			t.Errorf("Format must be non-empty")
+		}
+		if f.Duration <= 0 {
+			t.Errorf("Duration must be positive, got %d", f.Duration)
+		}
+		if f.TrackCount < f.TrackNumber {
+			t.Errorf("TrackCount (%d) must be >= TrackNumber (%d)", f.TrackCount, f.TrackNumber)
+		}
+	})
+}
+
+func TestGen_BookVersion(t *testing.T) {
+	validStatuses := make(map[string]struct{}, len(bookVersionStatuses))
+	for _, s := range bookVersionStatuses {
+		validStatuses[s] = struct{}{}
+	}
+	rapid.Check(t, func(t *rapid.T) {
+		bookID := "book-" + rapid.StringMatching(`[a-z0-9]{6}`).Draw(t, "bid")
+		v := BookVersion(t, bookID)
+		if v.BookID != bookID {
+			t.Errorf("BookID must propagate, got %q", v.BookID)
+		}
+		if _, ok := validStatuses[v.Status]; !ok {
+			t.Errorf("Status %q not in valid set", v.Status)
+		}
+		if v.Format == "" {
+			t.Errorf("Format must be non-empty")
+		}
+		if v.Source == "" {
+			t.Errorf("Source must be non-empty")
+		}
+		if v.ID != "" {
+			t.Errorf("ID must be empty (CreateBookVersion assigns), got %q", v.ID)
+		}
+		if v.IngestDate.IsZero() {
+			t.Errorf("IngestDate must be set")
+		}
+	})
+}
+
+func TestGen_BookVersionActive(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		v := BookVersionActive(t, "b1")
+		if v.Status != database.BookVersionStatusActive {
+			t.Errorf("Status must be active, got %q", v.Status)
+		}
+	})
+}
+
+func TestGen_User(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		u, e, ph := User(t)
+		if len(u) < 3 || len(u) > 24 {
+			t.Errorf("Username length out of range: %q (len=%d)", u, len(u))
+		}
+		for _, r := range u {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+				t.Errorf("Username %q has non-alnum-lowercase rune %q", u, r)
+			}
+		}
+		if !strings.Contains(e, "@") || strings.Count(e, "@") != 1 {
+			t.Errorf("Email %q must contain exactly one @", e)
+		}
+		parts := strings.Split(e, "@")
+		if parts[0] == "" || parts[1] == "" {
+			t.Errorf("Email %q must have non-empty local + domain", e)
+		}
+		if !strings.Contains(parts[1], ".") {
+			t.Errorf("Email domain %q must contain a dot", parts[1])
+		}
+		if len(ph) < 32 {
+			t.Errorf("PasswordHash too short: %d chars", len(ph))
+		}
+	})
+}
+
+func TestGen_UserPlaylist(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		pl := UserPlaylist(t)
+		if pl.Name == "" {
+			t.Errorf("Name must be non-empty")
+		}
+		switch pl.Type {
+		case database.UserPlaylistTypeStatic:
+			// BookIDs may legitimately be empty (user creates empty playlist first).
+			if pl.Query != "" {
+				t.Errorf("static playlist should not have Query, got %q", pl.Query)
+			}
+		case database.UserPlaylistTypeSmart:
+			if pl.Query == "" {
+				t.Errorf("smart playlist must have non-empty Query")
+			}
+			if len(pl.BookIDs) != 0 {
+				t.Errorf("smart playlist should not have BookIDs, got %d", len(pl.BookIDs))
+			}
+		default:
+			t.Errorf("unknown Type %q", pl.Type)
+		}
+	})
+}
+
+func TestGen_Tag(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		tag := Tag(t)
+		if len(tag) < 2 || len(tag) > 20 {
+			t.Errorf("Tag length out of range [2,20]: %q (len=%d)", tag, len(tag))
+		}
+		for i, r := range tag {
+			ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || (i > 0 && r == '-')
+			if !ok {
+				t.Errorf("Tag %q has invalid rune %q at %d", tag, r, i)
+			}
+		}
+	})
+}
+
+func TestGen_OperationChange(t *testing.T) {
+	validTypes := map[string]struct{}{
+		"file_move": {}, "metadata_update": {}, "tag_write": {},
+	}
+	rapid.Check(t, func(t *rapid.T) {
+		oc := OperationChange(t, "op1", "book1")
+		if oc.OperationID != "op1" {
+			t.Errorf("OperationID must propagate, got %q", oc.OperationID)
+		}
+		if oc.BookID != "book1" {
+			t.Errorf("BookID must propagate, got %q", oc.BookID)
+		}
+		if _, ok := validTypes[oc.ChangeType]; !ok {
+			t.Errorf("ChangeType %q not in valid set", oc.ChangeType)
+		}
+		if oc.FieldName == "" {
+			t.Errorf("FieldName must be non-empty")
+		}
+		if oc.CreatedAt.IsZero() {
+			t.Errorf("CreatedAt must be set")
+		}
+		if oc.RevertedAt != nil {
+			t.Errorf("RevertedAt must be nil on generation")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- First of 9 PRs implementing the property-based tests plan (backlog 4.5).
- Adds `pgregory.net/rapid v1.2.0` dependency.
- Introduces `internal/testutil/rapidgen` package with generators for Book, Author, Series, BookFile, BookVersion, User, UserPlaylist, Tag, OperationChange.
- Companion smoke tests (`*_test.go`) run each generator against 100 random inputs and assert domain invariants (non-empty title, valid status, alnum usernames, etc.).

## Design note

The plan asked for `internal/database/rapid_generators_test.go`, but subsequent tasks live in `internal/search`, `internal/server`, and `internal/auth` — Go does not allow importing `_test.go` files across packages. Generators are therefore placed in a regular (non-test) package that any test can import. This follows the existing `internal/testutil/` convention.

## Test plan

- [x] `go test ./internal/testutil/rapidgen/` — 10 tests, 100 runs each, all pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean

Plan: `docs/superpowers/plans/2026-04-17-property-based-tests-rapid.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)