### PR TITLE
docs: mark backlog 4.5 done

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 5.2.0 -->
+<!-- version: 5.3.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-16 -->
+<!-- last-edited: 2026-04-17 -->
 
 # Project TODO
 
@@ -91,7 +91,7 @@ since it was last edited on 2026-04-11).
 - [x] **4.2** Split the monolithic `server.go` (commit `c858ceb`)
 - [x] **4.3** Move write-back queue to a durable outbox (**M**) — #344
 - [x] **4.4** Replace `database.GlobalStore` package var with DI (**L**) — complete (#280-#291)
-- [ ] **4.5** Property-based tests for dedup engine (**M**)
+- [x] **4.5** Property-based tests for dedup engine (expanded to full codebase) (**M**) — complete (#357, #359, #361, #362, #363, #365, #366, #367, #368 — ~57 property tests across database / search / server / auth)
 - [ ] **4.6** Chaos tests for the embedding store under shutdown (**M**)
 - [ ] **4.7** Per-workload store evaluation: Pebble vs SQLite vs PostgreSQL vs Go-native NoSQL (**L** research)
 
@@ -102,7 +102,7 @@ since it was last edited on 2026-04-11).
 - [x] **5.3** Batch select in library view (**S**) — "Add to Playlist" batch action #345
 - [x] **5.4** Better error messages on organize failures (#273)
 - [x] **5.5** Dev mode "seed library" command (#274)
-- [ ] **5.6** Frontend test coverage baseline (**M**)
+- [x] **5.6** Frontend test coverage baseline (**M**) — Vitest + RTL tests for SearchBar, ReadStatusChip, Playlists, AddToPlaylistDialog; shared renderWithProviders + factories
 - [x] **5.7** API documentation (**M**) — OpenAPI 3.0.3 spec, 266 paths / 291 ops
 - [x] **5.8** Regenerate ITL test fixtures after format work (**S**) — #348
 - [x] **5.9** Enforce mockery-generated mocks via CI gate (commit `45492c3`)


### PR DESCRIPTION
## Summary

- Marks **4.5 Property-based tests** complete. Ships ~57 property tests via 9 merged PRs: #357, #359, #361, #362, #363, #365, #366, #367, #368.
- Also picks up a local update for **5.6 Frontend test coverage baseline** that was already in the working tree (per system note, intentional — keeping as-is).

## Test plan

- [x] No code changes; doc-only
- [x] Links to merged PRs verified