### PR TITLE
feat: ITL transfer endpoints (6.4 tasks 1-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.3.0 -->
+<!-- version: 2.4.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-17 -->
 
@@ -8,6 +8,15 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 17, 2026 — ITL Transfer Endpoints (6.4 tasks 1-3)
+
+- **Download**: `GET /api/v1/itunes/library/download` — serves current ITL as binary download with Content-Disposition
+- **Upload + validate**: `POST /api/v1/itunes/library/upload` — multipart upload (500 MB limit), validates via ParseITL, optional `?install=true` with automatic backup
+- **Backup list**: `GET /api/v1/itunes/library/backups` — lists `.bak-*` files sorted newest-first
+- **Restore**: `POST /api/v1/itunes/library/restore` — validates backup, backs up current, copies backup into place
+- All endpoints gated on `integrations.manage` permission
+- Atomic file operations: temp-write + rename for crash safety
 
 #### April 17, 2026 — Frontend Test Baseline (5.6)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 5.4.0 -->
+<!-- version: 5.5.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-04-17 -->
 
@@ -112,7 +112,7 @@ since it was last edited on 2026-04-11).
 - [x] **6.1** Deluge `move_storage` integration (**M**) — #349
 - [x] **6.2** Audnexus + Hardcover full integration (#7daef15)
 - [x] **6.3** Tag writeback to iTunes via ITL updates (shipped previously)
-- [ ] **6.4** ITL upload / download / partial export (**M**)
+- [ ] **6.4** ITL upload / download / partial export (**M**) — tasks 1-3 done (download, upload+validate, backup list+restore); task 4 (partial export) depends on 7.9; task 5 (frontend) pending
 
 ### 7. Tagging as Infrastructure — [section](docs/backlog-2026-04-10.md#7-tagging-as-infrastructure)
 

--- a/internal/server/itunes_transfer.go
+++ b/internal/server/itunes_transfer.go
@@ -1,0 +1,345 @@
+// file: internal/server/itunes_transfer.go
+// version: 1.0.0
+// guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+//
+// ITL file transfer handlers: download, upload+validate, backup
+// list, and restore. Part of backlog 6.4.
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+)
+
+// maxITLUploadSize is the maximum allowed ITL upload (500 MB).
+const maxITLUploadSize = 500 << 20
+
+// --- Download ---------------------------------------------------------------
+
+// handleITLDownload serves the current ITL file as a binary download.
+//
+// GET /api/v1/itunes/library/download
+func (s *Server) handleITLDownload(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "ITunesLibraryWritePath is not configured",
+		})
+		return
+	}
+
+	info, err := os.Stat(itlPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "ITL file not found at configured path",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("cannot stat ITL file: %v", err),
+		})
+		return
+	}
+
+	c.Header("Content-Disposition", `attachment; filename="iTunes Library.itl"`)
+	c.Header("Content-Length", fmt.Sprintf("%d", info.Size()))
+	c.Header("Last-Modified", info.ModTime().UTC().Format(http.TimeFormat))
+	c.File(itlPath)
+}
+
+// --- Upload + Validate ------------------------------------------------------
+
+// ITLUploadResponse is returned after uploading an ITL file.
+type ITLUploadResponse struct {
+	Valid     bool   `json:"valid"`
+	Installed bool   `json:"installed"`
+	Tracks    int    `json:"tracks"`
+	Playlists int    `json:"playlists"`
+	Version   string `json:"version"`
+	Error     string `json:"error,omitempty"`
+}
+
+// handleITLUpload accepts a multipart ITL upload, validates it, and
+// optionally installs it as the active library.
+//
+// POST /api/v1/itunes/library/upload?install=true|false
+func (s *Server) handleITLUpload(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "ITunesLibraryWritePath is not configured",
+		})
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxITLUploadSize)
+
+	file, _, err := c.Request.FormFile("library")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("missing or invalid 'library' form field: %v", err),
+		})
+		return
+	}
+	defer file.Close()
+
+	// Write to a temp file in the same directory as the target so
+	// os.Rename can be atomic on the same filesystem.
+	dir := filepath.Dir(itlPath)
+	tmp, err := os.CreateTemp(dir, "itl-upload-*.tmp")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("cannot create temp file: %v", err),
+		})
+		return
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // clean up on any error path
+
+	if _, err := io.Copy(tmp, file); err != nil {
+		tmp.Close()
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed writing upload to disk: %v", err),
+		})
+		return
+	}
+	tmp.Close()
+
+	// Validate: try to parse the uploaded file.
+	lib, parseErr := itunes.ParseITL(tmpPath)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, ITLUploadResponse{
+			Valid: false,
+			Error: fmt.Sprintf("invalid ITL file: %v", parseErr),
+		})
+		return
+	}
+
+	resp := ITLUploadResponse{
+		Valid:     true,
+		Tracks:    len(lib.Tracks),
+		Playlists: len(lib.Playlists),
+		Version:   lib.Version,
+	}
+
+	install := c.Query("install") == "true"
+	if !install {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	// Back up the current file before replacing.
+	if err := backupITLFile(itlPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to back up current ITL: %v", err),
+		})
+		return
+	}
+
+	// Atomic replace: rename temp → target (same filesystem).
+	if err := os.Rename(tmpPath, itlPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to install uploaded ITL: %v", err),
+		})
+		return
+	}
+
+	resp.Installed = true
+	c.JSON(http.StatusOK, resp)
+}
+
+// --- Backup List + Restore --------------------------------------------------
+
+// ITLBackupEntry describes a single .bak-* ITL backup file.
+type ITLBackupEntry struct {
+	Name      string    `json:"name"`
+	Size      int64     `json:"size"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// handleITLBackupList returns all .bak-* backups of the ITL file,
+// sorted newest-first.
+//
+// GET /api/v1/itunes/library/backups
+func (s *Server) handleITLBackupList(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "ITunesLibraryWritePath is not configured",
+		})
+		return
+	}
+
+	dir := filepath.Dir(itlPath)
+	base := filepath.Base(itlPath)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("cannot read directory: %v", err),
+		})
+		return
+	}
+
+	var backups []ITLBackupEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, base+".bak-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		backups = append(backups, ITLBackupEntry{
+			Name:      name,
+			Size:      info.Size(),
+			Timestamp: info.ModTime(),
+		})
+	}
+
+	// Newest first.
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Timestamp.After(backups[j].Timestamp)
+	})
+
+	c.JSON(http.StatusOK, gin.H{
+		"backups": backups,
+		"count":   len(backups),
+	})
+}
+
+// ITLRestoreRequest specifies which backup to restore.
+type ITLRestoreRequest struct {
+	BackupName string `json:"backup_name" binding:"required"`
+}
+
+// handleITLRestore restores a named backup as the active ITL file.
+//
+// POST /api/v1/itunes/library/restore
+func (s *Server) handleITLRestore(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "ITunesLibraryWritePath is not configured",
+		})
+		return
+	}
+
+	var req ITLRestoreRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("invalid request: %v", err),
+		})
+		return
+	}
+
+	// Sanitize: the backup must be in the same directory.
+	if filepath.Base(req.BackupName) != req.BackupName {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "backup_name must be a filename, not a path",
+		})
+		return
+	}
+
+	dir := filepath.Dir(itlPath)
+	base := filepath.Base(itlPath)
+	backupPath := filepath.Join(dir, req.BackupName)
+
+	// Must be a .bak-* file of the ITL base name.
+	if !strings.HasPrefix(req.BackupName, base+".bak-") {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "not a recognized ITL backup file",
+		})
+		return
+	}
+
+	// Validate the backup parses.
+	lib, err := itunes.ParseITL(backupPath)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("backup file is invalid: %v", err),
+		})
+		return
+	}
+
+	// Back up the current file before replacing.
+	if err := backupITLFile(itlPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to back up current ITL before restore: %v", err),
+		})
+		return
+	}
+
+	// Copy backup → itlPath (don't rename — keep the backup in place).
+	if err := copyFile(backupPath, itlPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to restore backup: %v", err),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"restored":  true,
+		"tracks":    len(lib.Tracks),
+		"playlists": len(lib.Playlists),
+		"version":   lib.Version,
+	})
+}
+
+// --- Helpers ----------------------------------------------------------------
+
+// backupITLFile creates a timestamped .bak-* copy of the given path.
+func backupITLFile(itlPath string) error {
+	if _, err := os.Stat(itlPath); os.IsNotExist(err) {
+		return nil // nothing to back up
+	}
+
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	backupPath := itlPath + ".bak-" + ts
+	return copyFile(itlPath, backupPath)
+}
+
+// copyFile copies src to dst using a temp-write + rename for atomicity.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	dir := filepath.Dir(dst)
+	tmp, err := os.CreateTemp(dir, ".itl-copy-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	tmp.Close()
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/internal/server/itunes_transfer_test.go
+++ b/internal/server/itunes_transfer_test.go
@@ -1,0 +1,117 @@
+// file: internal/server/itunes_transfer_test.go
+// version: 1.0.0
+// guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestBackupITLFile verifies that backupITLFile creates a .bak-* copy.
+func TestBackupITLFile(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := filepath.Join(dir, "iTunes Library.itl")
+
+	// Write a fake ITL file.
+	if err := os.WriteFile(itlPath, []byte("fake-itl-data"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := backupITLFile(itlPath); err != nil {
+		t.Fatalf("backupITLFile: %v", err)
+	}
+
+	// Should have created exactly one .bak-* file.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var bakFiles []string
+	for _, e := range entries {
+		if e.Name() != filepath.Base(itlPath) {
+			bakFiles = append(bakFiles, e.Name())
+		}
+	}
+	if len(bakFiles) != 1 {
+		t.Fatalf("expected 1 backup file, got %d: %v", len(bakFiles), bakFiles)
+	}
+
+	// Backup should contain the same data.
+	data, err := os.ReadFile(filepath.Join(dir, bakFiles[0]))
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(data) != "fake-itl-data" {
+		t.Errorf("backup content = %q, want %q", data, "fake-itl-data")
+	}
+}
+
+// TestBackupITLFile_NoExistingFile verifies noop when file doesn't exist.
+func TestBackupITLFile_NoExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := filepath.Join(dir, "nonexistent.itl")
+
+	if err := backupITLFile(itlPath); err != nil {
+		t.Fatalf("backupITLFile should be noop for missing file: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("expected empty dir, got %d entries", len(entries))
+	}
+}
+
+// TestCopyFile verifies atomic copy semantics.
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.itl")
+	dst := filepath.Join(dir, "dst.itl")
+
+	content := []byte("hello world")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("dst content = %q, want %q", got, content)
+	}
+
+	// Source should still exist.
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("source should still exist: %v", err)
+	}
+}
+
+// TestITLBackupEntry_Sort verifies newest-first sort order.
+func TestITLBackupEntry_Sort(t *testing.T) {
+	now := time.Now()
+	entries := []ITLBackupEntry{
+		{Name: "old.bak", Timestamp: now.Add(-time.Hour)},
+		{Name: "newest.bak", Timestamp: now},
+		{Name: "mid.bak", Timestamp: now.Add(-30 * time.Minute)},
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+
+	if entries[0].Name != "newest.bak" {
+		t.Errorf("first entry = %q, want %q", entries[0].Name, "newest.bak")
+	}
+	if entries[2].Name != "old.bak" {
+		t.Errorf("last entry = %q, want %q", entries[2].Name, "old.bak")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.177.0
+// version: 1.178.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2103,6 +2103,12 @@ func (s *Server) setupRoutes() {
 				// safeWriteITL call. Supports dry_run=true to
 				// preview without applying. Backlog 7.9.
 				itunesGroup.POST("/rebuild", s.perm(auth.PermLibraryEditMetadata), s.rebuildITLHandler)
+
+				// ITL file transfer (6.4)
+				itunesGroup.GET("/library/download", s.perm(auth.PermIntegrationsManage), s.handleITLDownload)
+				itunesGroup.POST("/library/upload", s.perm(auth.PermIntegrationsManage), s.handleITLUpload)
+				itunesGroup.GET("/library/backups", s.perm(auth.PermIntegrationsManage), s.handleITLBackupList)
+				itunesGroup.POST("/library/restore", s.perm(auth.PermIntegrationsManage), s.handleITLRestore)
 			}
 
 			// Cover art


### PR DESCRIPTION
## Summary
- **Download**: `GET /api/v1/itunes/library/download` — serves current ITL as binary with Content-Disposition
- **Upload + validate**: `POST /api/v1/itunes/library/upload` — multipart (500 MB limit), validates via ParseITL, optional `?install=true` with auto backup
- **Backup list**: `GET /api/v1/itunes/library/backups` — lists `.bak-*` files sorted newest-first
- **Restore**: `POST /api/v1/itunes/library/restore` — validates backup parses, backs up current, copies into place
- All gated on `integrations.manage` permission; atomic file ops (temp + rename)
- Task 4 (partial export) deferred — depends on 7.9 full ITL writer

## Test plan
- [x] `go test ./internal/server/ -run "TestBackup|TestCopy|TestITLBackup"` — 4 unit tests pass
- [x] `go vet ./internal/server/` — clean
- [x] Merge-safe: new file `itunes_transfer.go`, only 4 route lines added to `server.go` itunesGroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)