### PR TITLE
fix(ci): bump govulncheck Go version to 1.26

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/vulnerability-scan.yml
-# version: 1.4.0
+# version: 1.5.0
 # guid: vuln-scan-001
 
 name: Nightly Vulnerability Scan
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Summary
- Nightly vuln scan fails because `go.mod` requires `go 1.26.0` but the workflow pins `go-version: '1.25'`
- Bumps to `'1.26'` to match

## Test plan
- [x] One-line change, next nightly run will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)