### PR TITLE
fix(ci): add GOEXPERIMENT=jsonv2 to vuln scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/vulnerability-scan.yml
-# version: 1.5.0
+# version: 1.6.0
 # guid: vuln-scan-001
 
 name: Nightly Vulnerability Scan
@@ -29,6 +29,8 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+        env:
+          GOEXPERIMENT: jsonv2
 
 
   scan-npm:


### PR DESCRIPTION
## Summary
- govulncheck needs `GOEXPERIMENT=jsonv2` to load packages that use `encoding/json/v2`
- Every other workflow already sets this; the vuln scan was the only one missing it

## Test plan
- [x] Next nightly run (or manual dispatch) will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)