### PR TITLE
refactor: narrow AudiobookService Store deps (ISP proof-point 2/3)

### DIFF
--- a/internal/server/audiobook_service.go
+++ b/internal/server/audiobook_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package server
@@ -23,9 +23,29 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 )
 
+// audiobookStore is the narrow slice of database.Store that
+// AudiobookService actually needs — both for its own method calls
+// and for the helpers it forwards the store to (asExternalIDStore,
+// NewMetadataStateService). Declared as a named composite so the
+// service's dependency surface is inspectable in one place.
+type audiobookStore interface {
+	database.BookStore
+	database.AuthorStore
+	database.SeriesStore
+	database.NarratorStore
+	database.BookFileStore
+	database.HashBlocklistStore
+	database.TagStore
+	// Transitively required — audiobook_service forwards svc.store to
+	// NewMetadataStateService for change history tracking and to
+	// asExternalIDStore for tombstone cleanup.
+	database.MetadataStore
+	database.UserPreferenceStore
+}
+
 // AudiobookService handles all audiobook business logic
 type AudiobookService struct {
-	store           database.Store
+	store           audiobookStore
 	bookCache       *cache.Cache[*database.Book]
 	listCache       *cache.Cache[[]database.Book]
 	activityService *ActivityService
@@ -48,7 +68,7 @@ func (svc *AudiobookService) SetSearchIndex(idx *search.BleveIndex) {
 }
 
 // NewAudiobookService creates a new AudiobookService instance
-func NewAudiobookService(store database.Store) *AudiobookService {
+func NewAudiobookService(store audiobookStore) *AudiobookService {
 	return &AudiobookService{
 		store:     store,
 		bookCache: cache.New[*database.Book](30 * time.Second),

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -27,9 +27,12 @@ type ExternalIDStore interface {
 	BulkCreateExternalIDMappings(mappings []database.ExternalIDMapping) error
 }
 
-// asExternalIDStore returns the ExternalIDStore if the given Store implements
-// it, or nil otherwise. Callers should check for nil before using.
-func asExternalIDStore(s database.Store) ExternalIDStore {
+// asExternalIDStore returns the ExternalIDStore if the given store implements
+// it, or nil otherwise. Callers should check for nil before using. Accepts
+// `any` so callers holding a narrow sub-interface of database.Store (e.g.
+// audiobookStore) can still pass through — the type assertion checks the
+// underlying concrete type regardless of the static handle type.
+func asExternalIDStore(s any) ExternalIDStore {
 	if s == nil {
 		return nil
 	}

--- a/internal/server/metadata_state_service.go
+++ b/internal/server/metadata_state_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_state_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 package server
@@ -13,13 +13,21 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+// metadataStateStore is the narrow slice of database.Store that
+// MetadataStateService needs: metadata field state + change history
+// plus the user preference used as the cache key for state blobs.
+type metadataStateStore interface {
+	database.MetadataStore
+	database.UserPreferenceStore
+}
+
 // MetadataStateService handles metadata field state operations
 type MetadataStateService struct {
-	db database.Store
+	db metadataStateStore
 }
 
 // NewMetadataStateService creates a new metadata state service
-func NewMetadataStateService(db database.Store) *MetadataStateService {
+func NewMetadataStateService(db metadataStateStore) *MetadataStateService {
 	return &MetadataStateService{db: db}
 }
 


### PR DESCRIPTION
Second proof-point. Depends on #372.

## Summary
- AudiobookService.store: `database.Store` → `audiobookStore` composite (9 sub-interfaces: BookStore, AuthorStore, SeriesStore, NarratorStore, BookFileStore, HashBlocklistStore, TagStore, plus transitive MetadataStore + UserPreferenceStore)
- asExternalIDStore: `database.Store` → `any` (type-assertion based)
- NewMetadataStateService: `database.Store` → `metadataStateStore` composite (MetadataStore + UserPreferenceStore)

**Scope note:** narrowing the two helpers was a natural consequence — AudiobookService forwards svc.store to them. Both are small changes that would have happened in the follow-on sweep anyway.

## Test plan
- [x] go build ./... clean
- [x] go vet ./internal/server/ clean
- [x] go test ./internal/server/ -run 'Audiobook|MetadataState' -short green