### PR TITLE
test: -short skips slow property tests; add make test-short

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # file: Makefile
-# version: 2.8.0
+# version: 2.9.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
 
 BINARY := audiobook-organizer
@@ -40,7 +40,8 @@ help:
 	@echo "  make web-lint       - Lint frontend code"
 	@echo ""
 	@echo "Testing:"
-	@echo "  make test           - Run Go backend tests"
+	@echo "  make test           - Run Go backend tests (full — includes slow prop tests, ~15 min)"
+	@echo "  make test-short     - Run Go backend tests in -short mode (slow prop tests skipped, ~1 min)"
 	@echo "  make test-all       - Run all tests (backend + frontend)"
 	@echo "  make test-frontend  - Run frontend tests only"
 	@echo "  make test-e2e       - Run Playwright E2E tests"
@@ -138,11 +139,20 @@ web-lint:
 
 # --- Testing targets ---
 
-## test: Run Go backend tests
+## test: Run Go backend tests (full — includes slow property tests)
 test: vet
-	@echo "🧪 Running backend tests..."
+	@echo "🧪 Running backend tests (full suite)..."
 	@go test ./... -v -race
 	@echo "✅ Backend tests passed"
+
+## test-short: Run Go backend tests in short mode — skips slow property
+## tests (undo/playlist/dedup/etc.) that create per-iteration PebbleStores.
+## Use for fast dev iteration and for sweep-style refactors where the
+## primary gate is `go build ./...`. CI still runs the full suite.
+test-short: vet
+	@echo "🧪 Running backend tests (-short — slow prop tests skipped)..."
+	@go test ./... -short -race
+	@echo "✅ Short backend tests passed"
 
 ## vet: Run go vet across every package. Catches hand-written mock
 ## drift (the stubStore / PR #234 incident) before tests even compile.

--- a/docs/superpowers/plans/2026-04-17-store-iface-sweep.md
+++ b/docs/superpowers/plans/2026-04-17-store-iface-sweep.md
@@ -78,10 +78,12 @@ For each row of the migration table:
 4. Enumerate method calls — e.g., `grep -oE "store\.[A-Z][a-zA-Z]+" <file> | sort -u` (adjust variable name as needed). Sanity-check against the table row's target interfaces.
 5. Pick pattern A, B, or C based on the file's shape.
 6. Make the edit. Bump the file's `// version:` header one minor.
-7. **Fast verification — do NOT run the full `go test ./...` suite.** The property-based tests in `internal/server` take 15+ minutes. Instead:
+7. **Fast verification — use `-short` mode.** The 33 slow property tests (undo, playlist, dedup, version lifecycle, pebble CRUD, audiobook sort/filter) call `testing.Short()` and skip under `-short`. Full suite under `-short` is ~1 min (vs. 15+ min without). Use:
     - `go build ./...` — primary gate. If the type refactor is correct, this passes. If a transitively-dependent helper still wants `database.Store`, the build fails with a clear error (see "Transitive dependencies" below).
     - `go vet ./<package>/` — always run, it's fast.
-    - Run only the targeted tests for the file touched — e.g., `go test ./internal/server/ -run "<TestNamePrefix>" -count=1 -timeout 60s -short`.
+    - `make test-short` (or `go test ./... -short`) — full suite in `-short` mode, ~1 min.
+    - Or targeted: `go test ./internal/server/ -run "<TestNamePrefix>" -count=1 -timeout 60s -short` when even that's overkill.
+    CI still runs `make test` (full suite) on every PR, so the slow prop tests never stop catching regressions — they just don't block every local iteration.
 8. Commit with `refactor: narrow <file> Store deps (ISP sweep)` and a body listing which sub-interfaces replaced `database.Store`.
 9. Push, PR, merge with `--rebase --admin`.
 
@@ -227,7 +229,7 @@ git checkout main && git pull
 go build ./... && go vet ./...
 ```
 
-Both must be clean. **Do NOT run the full `go test ./...` — it takes ~15 min because of property-based tests in `internal/server`.** The type refactor is caught by `go build` + targeted tests. If `go build` succeeds, `go test` was already green at each PR commit time.
+Both must be clean. For a broader test sanity check without paying the full 15-min price, run `make test-short` (or `go test ./... -short`) — that skips the slow property tests in `internal/server` but still exercises everything else. The full suite runs in CI on every PR, so you don't need to run it locally unless you're debugging a specific prop-test failure.
 
 If a regression appears, the last PR's narrowing was incorrect — revert via `gh pr revert <n>` and re-classify.
 

--- a/internal/database/pebble_store_prop_test.go
+++ b/internal/database/pebble_store_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 15afe4d2-3a00-4326-be15-1e3f0b11a10e
 
 // Black-box test package: internal/testutil/rapidgen imports the database
@@ -55,6 +55,9 @@ func newPropStore(t *rapid.T) *database.PebbleStore {
 // the same user-supplied scalar fields. We check the fields that are
 // not rewritten by the store (ID is assigned, timestamps are set).
 func TestProp_Book_RoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		b := rapidgen.Book(t)
@@ -89,6 +92,9 @@ func TestProp_Book_RoundTrip(t *testing.T) {
 // TestProp_Book_UpdatePreservesID: after UpdateBook, the ID is unchanged
 // and modified scalar fields are reflected on subsequent reads.
 func TestProp_Book_UpdatePreservesID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		created, err := store.CreateBook(rapidgen.Book(t))
@@ -126,6 +132,9 @@ func TestProp_Book_UpdatePreservesID(t *testing.T) {
 // TestProp_Book_DeleteThenGetReturnsNil: after DeleteBook, GetBookByID
 // returns (nil, nil).
 func TestProp_Book_DeleteThenGetReturnsNil(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		created, err := store.CreateBook(rapidgen.Book(t))
@@ -153,6 +162,9 @@ func TestProp_Book_DeleteThenGetReturnsNil(t *testing.T) {
 // by creating a random mix of statuses and then verifying the
 // active-pointer index matches the stored rows.
 func TestProp_BookVersion_SingleActiveInvariant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		bookID := "b-" + rapid.StringMatching(`[a-z0-9]{8}`).Draw(t, "book_id")
@@ -205,6 +217,9 @@ func TestProp_BookVersion_SingleActiveInvariant(t *testing.T) {
 // TestProp_UserPlaylist_NameUniqueness: creating two distinct playlists
 // with the same (case-insensitive) name — the second create fails.
 func TestProp_UserPlaylist_NameUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		pl1 := rapidgen.UserPlaylist(t)
@@ -225,6 +240,9 @@ func TestProp_UserPlaylist_NameUniqueness(t *testing.T) {
 // TestProp_User_UsernameUniqueness: creating two users with the same
 // (case-insensitive) username — the second create fails.
 func TestProp_User_UsernameUniqueness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		username, email1, hash1 := rapidgen.User(t)
@@ -246,6 +264,9 @@ func TestProp_User_UsernameUniqueness(t *testing.T) {
 // TestProp_Tag_AddRemoveRoundtrip: AddBookTag then GetBookTags contains
 // the tag; RemoveBookTag then GetBookTags no longer contains it.
 func TestProp_Tag_AddRemoveRoundtrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		created, err := store.CreateBook(rapidgen.Book(t))
@@ -281,6 +302,9 @@ func TestProp_Tag_AddRemoveRoundtrip(t *testing.T) {
 // TestProp_Session_CreateRevoke: CreateSession returns a session we can
 // GetSession back, and RevokeSession flips Revoked to true.
 func TestProp_Session_CreateRevoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		username, email, hash := rapidgen.User(t)
@@ -328,6 +352,9 @@ func TestProp_Session_CreateRevoke(t *testing.T) {
 // TestProp_OperationChange_Persistence: after CreateOperationChange,
 // GetOperationChanges for the same operation contains the new change.
 func TestProp_OperationChange_Persistence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		opID := "op-" + rapid.StringMatching(`[a-z0-9]{10}`).Draw(t, "op_id")
@@ -374,6 +401,9 @@ func TestProp_OperationChange_Persistence(t *testing.T) {
 // TestProp_ListUsers_ContainsCreatedUser: after CreateUser, ListUsers
 // returns a slice that includes the new user's ID.
 func TestProp_ListUsers_ContainsCreatedUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropStore(t)
 		username, email, hash := rapidgen.User(t)

--- a/internal/server/audiobook_service_prop_test.go
+++ b/internal/server/audiobook_service_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 864889b2-5529-4d23-9220-2f17e11fab35
 
 // Property-based tests for the library-list sort, filter, and pagination
@@ -110,6 +110,9 @@ func genBookSlice(t *rapid.T, label string, minLen, maxLen int) []database.Book 
 // an ID tiebreaker, so the second call must be a no-op at the order
 // level.
 func TestProp_SortStability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		books := genBookSlice(t, "books", 0, 40)
 		field := rapid.SampledFrom(sortableFields).Draw(t, "sort_field")
@@ -142,6 +145,9 @@ func TestProp_SortStability(t *testing.T) {
 // removes elements: the multiset of book IDs before and after sorting
 // must be identical.
 func TestProp_SortIsPermutation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		books := genBookSlice(t, "books", 0, 40)
 		field := rapid.SampledFrom(sortableFields).Draw(t, "sort_field")
@@ -168,6 +174,9 @@ func TestProp_SortIsPermutation(t *testing.T) {
 // the books matching P and the books NOT matching P together form
 // exactly the original input, with no overlap.
 func TestProp_FilterPartitioning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		books := genBookSlice(t, "books", 0, 40)
 		field := rapid.SampledFrom(filterableFields).Draw(t, "filter_field")
@@ -228,6 +237,9 @@ func TestProp_FilterPartitioning(t *testing.T) {
 // duplicates across the two halves. This exercises PebbleStore.GetAllBooks
 // offset/limit arithmetic through random book counts and page sizes.
 func TestProp_PaginationConsistency(outer *testing.T) {
+	if testing.Short() {
+		outer.Skip("slow property test; run without -short")
+	}
 	// Root temp dir for the whole test; each rapid iteration gets a
 	// fresh subdirectory so PebbleDB file locks never collide.
 	root := outer.TempDir()

--- a/internal/server/dedup_engine_prop_test.go
+++ b/internal/server/dedup_engine_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_engine_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e6425d8b-3ab4-4e0c-86fd-71ece563085e
 
 package server
@@ -60,6 +60,9 @@ func genNonZeroVector(t *rapid.T, dim int, label string) []float32 {
 // product and norms are symmetric), so any asymmetry would indicate
 // a numerical or refactor bug.
 func TestProp_CosineSimilaritySymmetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		a := genVector(t, propVectorDim, "a")
 		b := genVector(t, propVectorDim, "b")
@@ -79,6 +82,9 @@ func TestProp_CosineSimilaritySymmetry(t *testing.T) {
 // few ULPs, so we allow a 1e-5 tolerance rather than requiring
 // exact equality.
 func TestProp_CosineSelfSimilarity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		v := genNonZeroVector(t, propVectorDim, "v")
 		sim := database.CosineSimilarity(v, v)
@@ -95,6 +101,9 @@ func TestProp_CosineSelfSimilarity(t *testing.T) {
 // 1.0000001 under pathological floats). Anything outside
 // [-1-eps, 1+eps] is a real violation.
 func TestProp_CosineRange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		a := genVector(t, propVectorDim, "a")
 		b := genVector(t, propVectorDim, "b")
@@ -110,6 +119,9 @@ func TestProp_CosineRange(t *testing.T) {
 // against anything returns exactly 0 — CosineSimilarity short-
 // circuits when either norm is zero to avoid a NaN divide.
 func TestProp_CosineZeroVector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		v := genVector(t, propVectorDim, "v")
 		zero := make([]float32, propVectorDim)
@@ -156,6 +168,9 @@ func tPropTempDir(t *rapid.T) string {
 // holds regardless of input distribution because FindSimilar
 // sort.Slice'es by Similarity before applying the maxResults cap.
 func TestProp_FindSimilarOrdering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		es := newPropEmbedStore(t)
 		n := rapid.IntRange(2, 12).Draw(t, "n")
@@ -193,6 +208,9 @@ func TestProp_FindSimilarOrdering(t *testing.T) {
 // The filter happens inside the scan loop (sim >= minSimilarity)
 // before sort+cap so any leak past it would be a real bug.
 func TestProp_FindSimilarThreshold(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		es := newPropEmbedStore(t)
 		n := rapid.IntRange(2, 12).Draw(t, "n")
@@ -227,6 +245,9 @@ func TestProp_FindSimilarThreshold(t *testing.T) {
 // permits maxResults == 0 meaning "no cap", which we don't test
 // because the invariant is vacuous.
 func TestProp_FindSimilarMaxResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		es := newPropEmbedStore(t)
 		n := rapid.IntRange(5, 20).Draw(t, "n")
@@ -272,6 +293,9 @@ func TestProp_FindSimilarMaxResults(t *testing.T) {
 // stop the test from going flaky the day chromem tightens its
 // indexing heuristics.
 func TestProp_ChromemMatchesSqlite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		ctx := context.Background()
 		es := newPropEmbedStore(t)

--- a/internal/server/playlist_evaluator_prop_test.go
+++ b/internal/server/playlist_evaluator_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/playlist_evaluator_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: bcc094f5-1645-44d3-be21-3087888fdaea
 
 // Property-based tests for the smart-playlist evaluator in
@@ -86,6 +86,9 @@ func buildPropEvalFixture(t *testing.T, rt *rapid.T, n int) (*database.PebbleSto
 // EvaluateSmartPlaylist(limit=N) returns at most N IDs for any query
 // that produces a non-trivial candidate set.
 func TestProp_LimitIsRespected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		n := rapid.IntRange(1, 12).Draw(rt, "n_books")
 		limit := rapid.IntRange(1, 20).Draw(rt, "limit")
@@ -105,6 +108,9 @@ func TestProp_LimitIsRespected(t *testing.T) {
 // TestProp_EmptyQueryErrors verifies that empty / whitespace-only
 // queries always return a non-nil error and a nil result slice.
 func TestProp_EmptyQueryErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		// Draw a random whitespace-only string (possibly empty).
 		ws := rapid.StringMatching(`[ \t\n\r]{0,16}`).Draw(rt, "whitespace")
@@ -125,6 +131,9 @@ func TestProp_EmptyQueryErrors(t *testing.T) {
 // query against the same seeded store+index twice yields the same
 // result IDs in the same order.
 func TestProp_DeterministicEvaluation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		n := rapid.IntRange(1, 10).Draw(rt, "n_books")
 		limit := rapid.IntRange(0, 20).Draw(rt, "limit")
@@ -156,6 +165,9 @@ func TestProp_DeterministicEvaluation(t *testing.T) {
 // sort.SliceStable with a deterministic comparator, so the second
 // call must reproduce the first call exactly.
 func TestProp_SortIsStable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		n := rapid.IntRange(2, 10).Draw(rt, "n_books")
 		field := rapid.SampledFrom([]string{"title", "year", "date_added"}).Draw(rt, "sort_field")
@@ -188,6 +200,9 @@ func TestProp_SortIsStable(t *testing.T) {
 // B on `read_status:finished` must return zero books when only A has
 // any finished rows.
 func TestProp_PerUserFilterIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		n := rapid.IntRange(1, 8).Draw(rt, "n_books")
 		store, idx, bookIDs := buildPropEvalFixture(t, rt, n)

--- a/internal/server/undo_engine_prop_test.go
+++ b/internal/server/undo_engine_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/undo_engine_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1ff3d071-4c60-4bb0-92ed-d197fe8ad9d0
 //
 // Property-based tests for the undo engine (plan 4.5 task 8).
@@ -56,6 +56,9 @@ func newPropStore(t *testing.T) database.Store {
 // (because the random BookID doesn't resolve) — both outcomes preserve the
 // idempotency invariant.
 func TestProp_UndoIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		store := newPropStore(t)
 
@@ -107,6 +110,9 @@ func TestProp_UndoIdempotent(t *testing.T) {
 // reversibility story: the undo engine must cleanly release its hold on the
 // new path so the caller can re-execute the original operation.
 func TestProp_UndoRedoRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		store := newPropStore(t)
 
@@ -190,6 +196,9 @@ func TestProp_UndoRedoRoundTrip(t *testing.T) {
 // content-change conflict. The undo engine must refuse to silently clobber
 // user edits made between the original operation and the undo.
 func TestProp_UndoConflictConservative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(rt *rapid.T) {
 		store := newPropStore(t)
 

--- a/internal/server/version_lifecycle_prop_test.go
+++ b/internal/server/version_lifecycle_prop_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/version_lifecycle_prop_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4c4cd2b-c578-4a11-8229-83a516271b1b
 
 // Property-based tests for BookVersion lifecycle transitions (spec 4.5 task 6).
@@ -89,6 +89,9 @@ func restoreVersion(store database.Store, ver *database.BookVersion) error {
 // ----------------------------------------------------------------------------
 
 func TestProp_TrashIsReversible(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropLifecycleStore(t)
 
@@ -130,6 +133,9 @@ func TestProp_TrashIsReversible(t *testing.T) {
 // ----------------------------------------------------------------------------
 
 func TestProp_PurgeIsIrreversible(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropLifecycleStore(t)
 
@@ -174,6 +180,9 @@ func TestProp_PurgeIsIrreversible(t *testing.T) {
 // ----------------------------------------------------------------------------
 
 func TestProp_AutoPromotePicksMostRecent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropLifecycleStore(t)
 
@@ -260,6 +269,9 @@ const (
 )
 
 func TestProp_SingleActiveInvariantMaintained(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow property test; run without -short")
+	}
 	rapid.Check(t, func(t *rapid.T) {
 		store := newPropLifecycleStore(t)
 

--- a/scripts/add_short_skip.py
+++ b/scripts/add_short_skip.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Add `if testing.Short() { t.Skip(...) }` to the top of every TestProp_*
+function in the listed slow property-test files. Idempotent — re-runs leave
+already-annotated tests alone.
+
+Slow = creates a PebbleStore per rapid.Check iteration, or does filesystem I/O.
+Fast prop tests (pure compute — permissions, query parser, rapidgen) are not
+touched: they take seconds and carry no value from -short gating.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+SLOW_FILES = [
+    "internal/database/pebble_store_prop_test.go",
+    "internal/server/audiobook_service_prop_test.go",
+    "internal/server/dedup_engine_prop_test.go",
+    "internal/server/playlist_evaluator_prop_test.go",
+    "internal/server/undo_engine_prop_test.go",
+    "internal/server/version_lifecycle_prop_test.go",
+]
+
+FUNC_PATTERN = re.compile(
+    r"^func (TestProp_[A-Za-z_0-9]+)\(([a-zA-Z_][a-zA-Z0-9_]*) \*testing\.T\) \{\n",
+    re.MULTILINE,
+)
+
+
+def skip_block(receiver: str) -> str:
+    return (
+        f'\tif testing.Short() {{\n'
+        f'\t\t{receiver}.Skip("slow property test; run without -short")\n'
+        f'\t}}\n'
+    )
+
+
+def already_annotated(body: str, start: int) -> bool:
+    """Return True if the first non-blank line after `start` already calls
+    testing.Short(). Avoids double-inserting on re-run."""
+    # Look at the next 120 chars — enough for the skip block.
+    window = body[start : start + 200]
+    return "testing.Short()" in window
+
+
+def process(path: pathlib.Path) -> tuple[int, int]:
+    text = path.read_text()
+    funcs = list(FUNC_PATTERN.finditer(text))
+    if not funcs:
+        return 0, 0
+    inserted = 0
+    # Walk in reverse so earlier offsets stay valid.
+    new_text = text
+    for match in reversed(funcs):
+        opening_end = match.end()
+        receiver = match.group(2)
+        if already_annotated(new_text, opening_end):
+            continue
+        new_text = new_text[:opening_end] + skip_block(receiver) + new_text[opening_end:]
+        inserted += 1
+    if new_text != text:
+        path.write_text(new_text)
+    return len(funcs), inserted
+
+
+def main() -> int:
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    total_funcs = 0
+    total_inserted = 0
+    for rel in SLOW_FILES:
+        path = repo / rel
+        if not path.exists():
+            print(f"missing: {rel}", file=sys.stderr)
+            return 1
+        funcs, inserted = process(path)
+        total_funcs += funcs
+        total_inserted += inserted
+        print(f"{rel}: {inserted}/{funcs} annotated")
+    print(f"total: {total_inserted}/{total_funcs} annotated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Answers the slow-test problem we hit during the ISP sweep plan. The 33 slow property tests (those that create a fresh PebbleStore per `rapid.Check` iteration, or do real filesystem I/O) now call `testing.Short()` and skip under `-short`.

## Effect

| Invocation | Before | After |
|---|---|---|
| `go test ./internal/server/ -short` | 760s | 63s |
| `make test-short` (new) | n/a | ~1 min (full suite minus slow props) |
| `make test` | 15+ min | 15+ min (unchanged — full suite) |
| CI | 15+ min | 15+ min (unchanged — runs `make test`) |

Fast prop tests (auth permissions, query parser, rapidgen smoke) are untouched — they run in seconds regardless.

## What ships

- **33 skips** added to `TestProp_*` functions across `pebble_store_prop_test.go` + `internal/server/*_prop_test.go`. Each one: `if testing.Short() { t.Skip("slow property test; run without -short") }` as the first statement.
- **`make test-short`** — new target, passes `-short -race` to `go test ./...`.
- **`scripts/add_short_skip.py`** — idempotent annotator used to generate the 33 skips. Kept so future "I added a new slow prop test and forgot to annotate" mistakes are trivially fixable.
- **Sweep plan updated** to reference `make test-short` explicitly.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/server/ -short -run TestProp_ -v` — all 24 TestProp_* tests SKIP, none PASS, none FAIL
- [x] `go test ./internal/server/ -short` — completes in 63s (was 760s)
- [x] Fast prop tests (auth, search) still run and pass under `-short`