### PR TITLE
docs: CHANGELOG + TODO entries for make test-short (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.6.0 -->
+<!-- version: 2.7.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-04-17 -->
+<!-- last-edited: 2026-04-18 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 18, 2026 — Fast-iteration test mode (`make test-short`)
+
+Property-based tests added in 4.5 were making local test iteration painful — the `internal/server` package alone took 15+ minutes because 33 prop tests create a fresh PebbleStore per `rapid.Check` iteration. Added `testing.Short()` gates so those tests skip under `-short`, cutting local iteration ~12×.
+
+- **33 slow prop tests annotated** (#384): `pebble_store_prop_test.go`, `audiobook_service_prop_test.go`, `dedup_engine_prop_test.go`, `playlist_evaluator_prop_test.go`, `undo_engine_prop_test.go`, `version_lifecycle_prop_test.go` — each `TestProp_*` calls `testing.Short()` and skips with a clear message
+- **Fast prop tests unchanged** — auth permissions, query parser, rapidgen smoke tests take seconds either way; no skip needed
+- **`make test-short`** — new target runs `go test ./... -short -race` (~1 min vs 15+ min for `make test`)
+- **CI behavior unchanged** — still runs `make test` (full suite) on every PR, so slow prop tests keep catching regressions; they just don't block every local iteration
+- **`scripts/add_short_skip.py`** — idempotent helper retained so newly-added slow prop tests can be annotated in one command
+
+Timing: `go test ./internal/server/ -short` drops from 760s → 63s.
 
 #### April 17, 2026 — Store Interface Segregation (ISP refactor)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 5.6.0 -->
+<!-- version: 5.7.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-17 -->
+<!-- last-edited: 2026-04-18 -->
 
 # Project TODO
 
@@ -107,6 +107,7 @@ since it was last edited on 2026-04-11).
 - [x] **5.7** API documentation (**M**) — OpenAPI 3.0.3 spec, 266 paths / 291 ops
 - [x] **5.8** Regenerate ITL test fixtures after format work (**S**) — #348
 - [x] **5.9** Enforce mockery-generated mocks via CI gate (commit `45492c3`)
+- [x] **5.10** Fast-iteration backend test mode — `make test-short` + `testing.Short()` gates on 33 slow property tests (#384); `internal/server` drops from 760s → 63s
 
 ### 6. Integration / Ecosystem — [section](docs/backlog-2026-04-10.md#6-integration--ecosystem)
 


### PR DESCRIPTION
Backfills the docs for yesterday's #384. Adds:
- CHANGELOG: April 18 section on the `-short` property-test gating
- TODO: **5.10** — Fast-iteration backend test mode (marked done)

## Test plan
- [x] Docs only