### PR TITLE
refactor: narrow Store deps in 6 leaf files (ISP sweep 1/N)

### DIFF
--- a/internal/server/file_move.go
+++ b/internal/server/file_move.go
@@ -1,5 +1,5 @@
 // file: internal/server/file_move.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -28,7 +28,7 @@ type MoveBookFileResult struct {
 //  4. If DB update fails, move the file back and return error
 //
 // This prevents orphaned files (file moved but DB not updated).
-func MoveBookFile(store database.Store, bookID, oldPath, newPath string, extraUpdates *database.Book) error {
+func MoveBookFile(store database.BookWriter, bookID, oldPath, newPath string, extraUpdates *database.Book) error {
 	if oldPath == newPath {
 		return nil // Nothing to do
 	}

--- a/internal/server/import_collision.go
+++ b/internal/server/import_collision.go
@@ -1,5 +1,5 @@
 // file: internal/server/import_collision.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4b2c3d1e-5f6a-4a70-b8c5-3d7e0f1b9a99
 //
 // Import-time collision preview (backlog 1.6). Before importing a
@@ -110,7 +110,7 @@ func (s *Server) handleImportCollisionPreview(c *gin.Context) {
 	})
 }
 
-func bookTitle(store database.Store, id string) string {
+func bookTitle(store database.BookReader, id string) string {
 	b, _ := store.GetBookByID(id)
 	if b != nil {
 		return b.Title

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,5 +1,5 @@
 // file: internal/server/itl_rebuild.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
 //
 // iTunes library rebuild service: diffs the current DB state
@@ -47,7 +47,7 @@ type ITLRebuildResult struct {
 // computeITLDiff reads the current ITL and the current DB state,
 // and returns the ITLOperationSet that would synchronize them
 // plus a preview of what that set contains.
-func computeITLDiff(store database.Store, itlPath string) (*itunes.ITLOperationSet, *ITLRebuildPreview, error) {
+func computeITLDiff(store database.BookReader, itlPath string) (*itunes.ITLOperationSet, *ITLRebuildPreview, error) {
 	// Parse the current ITL to get all existing tracks.
 	lib, err := itunes.ParseITL(itlPath)
 	if err != nil {
@@ -179,7 +179,7 @@ func computeITLDiff(store database.Store, itlPath string) (*itunes.ITLOperationS
 // buildNewTrackFromBook constructs an ITLNewTrack from a database
 // Book for insertion into the ITL. Fills as many fields as
 // possible from the book's metadata.
-func buildNewTrackFromBook(store database.Store, book *database.Book) itunes.ITLNewTrack {
+func buildNewTrackFromBook(store database.BookReader, book *database.Book) itunes.ITLNewTrack {
 	authorName, _ := resolveAuthorAndSeriesNames(book)
 	genre := "Audiobook"
 	if book.Genre != nil && *book.Genre != "" {

--- a/internal/server/pipeline_checkpoint.go
+++ b/internal/server/pipeline_checkpoint.go
@@ -1,5 +1,5 @@
 // file: internal/server/pipeline_checkpoint.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f8a9b0c-1d2e-4a70-b8c5-3d7e0f1b9a99
 //
 // Phase checkpoints for the metadata apply pipeline (GFO-4).
@@ -38,13 +38,13 @@ const (
 )
 
 // setCheckpoint marks a phase as complete for a book.
-func setCheckpoint(store database.Store, bookID, phase string) {
+func setCheckpoint(store database.UserPreferenceStore, bookID, phase string) {
 	key := checkpointPrefix + bookID + ":" + phase
 	_ = store.SetUserPreferenceForUser("_system", key, time.Now().Format(time.RFC3339))
 }
 
 // hasCheckpoint returns true if the phase was already completed.
-func hasCheckpoint(store database.Store, bookID, phase string) bool {
+func hasCheckpoint(store database.UserPreferenceStore, bookID, phase string) bool {
 	key := checkpointPrefix + bookID + ":" + phase
 	pref, _ := store.GetUserPreferenceForUser("_system", key)
 	return pref != nil && pref.Value != ""
@@ -52,7 +52,7 @@ func hasCheckpoint(store database.Store, bookID, phase string) bool {
 
 // clearCheckpoints removes all phase markers for a book.
 // Called after the full pipeline completes successfully.
-func clearCheckpoints(store database.Store, bookID string) {
+func clearCheckpoints(store database.UserPreferenceStore, bookID string) {
 	for _, phase := range []string{phaseRename, phaseTags, phaseITunes} {
 		key := checkpointPrefix + bookID + ":" + phase
 		_ = store.SetUserPreferenceForUser("_system", key, "")

--- a/internal/server/playlist_itunes_sync.go
+++ b/internal/server/playlist_itunes_sync.go
@@ -1,5 +1,5 @@
 // file: internal/server/playlist_itunes_sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1e9f0a8b-2c3d-4a70-b8c5-3d7e0f1b9a99
 //
 // iTunes playlist sync (spec 3.4 tasks 5-6).
@@ -32,7 +32,7 @@ import (
 // MigrateITunesSmartPlaylists reads smart playlists from the ITL
 // library and creates UserPlaylist rows for each. Idempotent —
 // playlists already imported (by iTunes PID) are skipped.
-func MigrateITunesSmartPlaylists(store database.Store, lib *itunes.ITLLibrary) (imported, skipped int) {
+func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.ITLLibrary) (imported, skipped int) {
 	if lib == nil {
 		return 0, 0
 	}
@@ -90,7 +90,7 @@ func MigrateITunesSmartPlaylists(store database.Store, lib *itunes.ITLLibrary) (
 // the ITL write-back batcher. Full ITL playlist creation requires
 // the ITL writer to support playlist insertion, which is tracked
 // separately.
-func PushDirtyPlaylistsToITunes(store database.Store, batcher *WriteBackBatcher) int {
+func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher *WriteBackBatcher) int {
 	dirties, err := store.ListDirtyUserPlaylists()
 	if err != nil {
 		log.Printf("[WARN] list dirty playlists: %v", err)

--- a/internal/server/sweeper.go
+++ b/internal/server/sweeper.go
@@ -1,5 +1,5 @@
 // file: internal/server/sweeper.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-abcd-ef2345678901
 
 package server
@@ -23,7 +23,7 @@ type SweeperResult struct {
 // SweepTombstones cleans up tombstone records where:
 // - The original book record is gone (deleted successfully)
 // - The file no longer exists on disk (deleted or moved)
-func SweepTombstones(store database.Store) (*SweeperResult, error) {
+func SweepTombstones(store database.BookStore) (*SweeperResult, error) {
 	result := &SweeperResult{
 		Errors: []string{},
 	}
@@ -75,7 +75,7 @@ func SweepTombstones(store database.Store) (*SweeperResult, error) {
 // AuditFileConsistency checks all books in the database and reports:
 // - Books pointing to files that don't exist
 // It does NOT fix anything — just reports.
-func AuditFileConsistency(store database.Store) (*SweeperResult, error) {
+func AuditFileConsistency(store database.BookStore) (*SweeperResult, error) {
 	result := &SweeperResult{
 		MissingFiles: []string{},
 		Errors:       []string{},


### PR DESCRIPTION
First batch of the Store ISP sweep. Six single-interface leaf files — each function takes the narrow sub-interface it actually calls.

| File | Replaced `database.Store` with |
|---|---|
| file_move.go (MoveBookFile) | BookWriter |
| import_collision.go (bookTitle) | BookReader |
| itl_rebuild.go (computeITLDiff, buildNewTrackFromBook) | BookReader |
| sweeper.go (SweepTombstones, AuditFileConsistency) | BookStore |
| pipeline_checkpoint.go (set/has/clearCheckpoint) | UserPreferenceStore |
| playlist_itunes_sync.go (Migrate, Push) | UserPlaylistStore |

## Test plan
- [x] `go build ./...` clean
- [x] All callers pass `*PebbleStore` which satisfies every sub-interface

Plan: `docs/superpowers/plans/2026-04-17-store-iface-sweep.md`