### PR TITLE
refactor: narrow Store deps in version + deluge cluster (ISP sweep 2/N)

### DIFF
--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_integration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
 //
 // Deluge integration for library centralization (backlog 6.1).
@@ -187,7 +187,7 @@ func NotifyDelugeAfterUndo(store database.Store, bookID, oldFilePath string) {
 
 // NotifyDelugeAfterVersionSwap checks whether the swapped versions
 // have torrent hashes and updates Deluge accordingly.
-func NotifyDelugeAfterVersionSwap(store database.Store, fromVer, toVer *database.BookVersion, bookFilePath string) {
+func NotifyDelugeAfterVersionSwap(store interface { database.BookReader; database.BookVersionStore }, fromVer, toVer *database.BookVersion, bookFilePath string) {
 	if toVer != nil && toVer.TorrentHash != "" {
 		NotifyDelugeMoveStorage(toVer.TorrentHash, bookFilePath)
 	}

--- a/internal/server/version_fingerprint.go
+++ b/internal/server/version_fingerprint.go
@@ -1,5 +1,5 @@
 // file: internal/server/version_fingerprint.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8d5e7f4c-9c5a-4a70-b8c5-3d7e0f1b9a99
 //
 // Fingerprint check for incoming files (spec 3.1 task 4).
@@ -36,7 +36,7 @@ type FingerprintMatch struct {
 // fallback for content without a torrent (manual imports). Both
 // can be empty — in which case no match is returned.
 func CheckFingerprint(
-	store database.Store,
+	store database.BookVersionStore,
 	torrentHash string,
 	fileHashes []string,
 ) *FingerprintMatch {
@@ -92,7 +92,7 @@ func isPurgedOrBlocked(status string) bool {
 // (torrent hash) fails, which is rare for automated ingestion.
 // A future optimization would add a file_hash→version_id index in
 // PebbleDB.
-func scanFileHashMatch(store database.Store, hash string) *FingerprintMatch {
+func scanFileHashMatch(store database.BookVersionStore, hash string) *FingerprintMatch {
 	// The current Store interface doesn't expose GetBookFileByHash.
 	// For now, this is a stub that returns nil. A follow-up PR will
 	// add the index + method.

--- a/internal/server/version_ingest.go
+++ b/internal/server/version_ingest.go
@@ -1,5 +1,5 @@
 // file: internal/server/version_ingest.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3e1f2a9b-4c5d-4a70-b8c5-3d7e0f1b9a99
 //
 // Version creation on ingest (spec 3.1 task 5).
@@ -41,7 +41,7 @@ type IngestVersionParams struct {
 //
 // Also computes and stores the file's SHA-256 hash on the BookFile row
 // (if one exists for the book + file path).
-func CreateIngestVersion(store database.Store, params IngestVersionParams) (*database.BookVersion, error) {
+func CreateIngestVersion(store interface { database.BookVersionStore; database.BookFileStore }, params IngestVersionParams) (*database.BookVersion, error) {
 	if params.BookID == "" || params.FilePath == "" {
 		return nil, fmt.Errorf("book_id and file_path required")
 	}

--- a/internal/server/version_lifecycle.go
+++ b/internal/server/version_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/version_lifecycle.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5a3b4c0d-6e7f-4a70-b8c5-3d7e0f1b9a99
 //
 // Version lifecycle operations (spec 3.1 task 6).
@@ -141,7 +141,7 @@ func (s *Server) handleHardDeleteVersion(c *gin.Context) {
 
 // autoPromoteAlt selects the most recent alt version and promotes it
 // to active. Called when the active version is trashed.
-func autoPromoteAlt(store database.Store, bookID string) error {
+func autoPromoteAlt(store interface { database.BookReader; database.BookVersionStore; database.BookFileStore }, bookID string) error {
 	allVers, err := store.GetBookVersionsByBookID(bookID)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func autoPromoteAlt(store database.Store, bookID string) error {
 
 // purgeVersion physically deletes the version's files and marks it
 // inactive_purged. Keeps the DB rows for fingerprint matching.
-func purgeVersion(store database.Store, ver *database.BookVersion) error {
+func purgeVersion(store interface { database.BookReader; database.BookVersionStore; database.BookFileStore }, ver *database.BookVersion) error {
 	book, err := store.GetBookByID(ver.BookID)
 	if err != nil || book == nil {
 		return fmt.Errorf("book %s not found", ver.BookID)
@@ -207,7 +207,7 @@ func purgeVersion(store database.Store, ver *database.BookVersion) error {
 
 // CleanupTrashedVersions is the maintenance task that purges versions
 // past their TTL. Called by the scheduler.
-func CleanupTrashedVersions(store database.Store) (purged int) {
+func CleanupTrashedVersions(store interface { database.BookReader; database.BookVersionStore; database.BookFileStore }) (purged int) {
 	trashed, err := store.ListTrashedBookVersions()
 	if err != nil {
 		log.Printf("[WARN] list trashed versions: %v", err)

--- a/internal/server/version_swap.go
+++ b/internal/server/version_swap.go
@@ -1,5 +1,5 @@
 // file: internal/server/version_swap.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6c3d5a2e-8b4c-4a70-b8c5-3d7e0f1b9a99
 //
 // Primary-version swap tracked operation (spec 3.1 task 3).
@@ -39,7 +39,7 @@ type VersionSwapParams struct {
 // primary files live (the parent of .versions/).
 func RunVersionSwap(
 	ctx context.Context,
-	store database.Store,
+	store interface { database.BookStore; database.BookVersionStore; database.BookFileStore },
 	params VersionSwapParams,
 	progress func(step string, pct int),
 	batcher *WriteBackBatcher,
@@ -161,7 +161,7 @@ func RunVersionSwap(
 // If the library hasn't been migrated yet (VersionID still empty),
 // returns all files for the book — the caller's move operations are
 // still correct because the active version owns all top-level files.
-func filesForVersion(store database.Store, bookID, versionID string) ([]database.BookFile, error) {
+func filesForVersion(store database.BookFileStore, bookID, versionID string) ([]database.BookFile, error) {
 	all, err := store.GetBookFiles(bookID)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func filePaths(files []database.BookFile) []string {
 // ResumeVersionSwaps checks for any BookVersions in swapping_in or
 // swapping_out status and resumes the swap operation. Called on
 // server startup to recover from interrupted swaps.
-func ResumeVersionSwaps(ctx context.Context, store database.Store) {
+func ResumeVersionSwaps(ctx context.Context, store interface { database.BookStore; database.BookVersionStore; database.BookFileStore }) {
 	// Find versions in transitional states by scanning all versions.
 	// In a large library this could be slow — a future optimization
 	// would add an index key for transitional statuses. For now,


### PR DESCRIPTION
Second sweep batch. Narrows 5 files including the transitive-dependency chain from `version_swap.go` into `deluge_integration.go`.

| File | Replaced `database.Store` with |
|---|---|
| version_fingerprint.go | BookVersionStore |
| version_ingest.go (CreateIngestVersion) | BookVersionStore + BookFileStore |
| version_lifecycle.go (autoPromoteAlt, CleanupTrashedVersions) | BookReader + BookVersionStore + BookFileStore |
| version_lifecycle.go (purgeVersion) | BookReader + BookVersionStore + BookFileStore |
| version_swap.go (SwapPrimary, ResumeVersionSwaps) | BookStore + BookVersionStore + BookFileStore |
| version_swap.go (filesForVersion) | BookFileStore |
| deluge_integration.go (NotifyDelugeAfterVersionSwap) | BookReader + BookVersionStore (transitive from version_swap) |

## Test plan
- [x] `go build ./...` clean (second attempt — first pass caught two missing interfaces, fixed, re-built clean)
- [x] All callers pass *PebbleStore

Plan: `docs/superpowers/plans/2026-04-17-store-iface-sweep.md`