### PR TITLE
refactor: narrow iTunes sync + read-status Store deps (ISP sweep 3/N)

### DIFF
--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -1,5 +1,5 @@
 // file: internal/operations/state.go
-// version: 1.1.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package operations
@@ -64,7 +64,7 @@ type MetadataRefreshParams struct {
 }
 
 // SaveCheckpoint persists an operation's progress checkpoint.
-func SaveCheckpoint(store database.Store, opID, opType, phase string, index, total int) error {
+func SaveCheckpoint(store database.OperationStore, opID, opType, phase string, index, total int) error {
 	state := OperationState{
 		OperationID: opID,
 		Type:        opType,
@@ -82,7 +82,7 @@ func SaveCheckpoint(store database.Store, opID, opType, phase string, index, tot
 }
 
 // LoadCheckpoint loads an operation's progress checkpoint. Returns nil if none exists.
-func LoadCheckpoint(store database.Store, opID string) (*OperationState, error) {
+func LoadCheckpoint(store database.OperationStore, opID string) (*OperationState, error) {
 	data, err := store.GetOperationState(opID)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func LoadCheckpoint(store database.Store, opID string) (*OperationState, error) 
 }
 
 // SaveParams persists an operation's immutable parameters.
-func SaveParams(store database.Store, opID string, params any) error {
+func SaveParams(store database.OperationStore, opID string, params any) error {
 	data, err := json.Marshal(params)
 	if err != nil {
 		return err
@@ -123,6 +123,6 @@ func LoadParams[T any](store database.Store, opID string) (*T, error) {
 }
 
 // ClearState removes all persisted state for an operation (called on completion/failure).
-func ClearState(store database.Store, opID string) error {
+func ClearState(store database.OperationStore, opID string) error {
 	return store.DeleteOperationState(opID)
 }

--- a/internal/server/itunes_position_sync.go
+++ b/internal/server/itunes_position_sync.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_position_sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9f7a8b5c-0d6e-4a70-b8c5-3d7e0f1b9a99
 //
 // Bidirectional sync between the app's per-user position/state
@@ -33,7 +33,7 @@ const adminUserID = "_local"
 // SyncITunesPositions runs a full bidirectional position sync for the
 // admin user. Pull then push order ensures we don't immediately
 // overwrite a newly-seeded position.
-func SyncITunesPositions(store database.Store, batcher *WriteBackBatcher) (pulled, pushed int) {
+func SyncITunesPositions(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher *WriteBackBatcher) (pulled, pushed int) {
 	pulled = pullITunesBookmarks(store)
 	pushed = pushPositionsToITunes(store, batcher)
 	return pulled, pushed
@@ -42,7 +42,7 @@ func SyncITunesPositions(store database.Store, batcher *WriteBackBatcher) (pulle
 // pullITunesBookmarks seeds admin positions from iTunes Bookmark data.
 // Iterates books with an iTunes Bookmark value and creates a position
 // row if none exists yet.
-func pullITunesBookmarks(store database.Store) int {
+func pullITunesBookmarks(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }) int {
 	books, err := store.GetAllBooks(0, 0)
 	if err != nil {
 		log.Printf("[WARN] itunes position sync: list books: %v", err)
@@ -107,7 +107,7 @@ func pullITunesBookmarks(store database.Store) int {
 // position was updated since the last sync, enqueue the book for
 // bookmark writeback. If the book was marked finished, also enqueue
 // a play-count increment.
-func pushPositionsToITunes(store database.Store, batcher *WriteBackBatcher) int {
+func pushPositionsToITunes(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher *WriteBackBatcher) int {
 	// Get all admin positions that changed in the last 24 hours.
 	// A more precise cutoff would use a last-sync-at timestamp;
 	// for now 24h is a safe window for the maintenance task that

--- a/internal/server/itunes_track_provisioner.go
+++ b/internal/server/itunes_track_provisioner.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_track_provisioner.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-0123456789ab
 //
 // Provisions ITL tracks for non-iTunes books. Generates a random persistent ID,
@@ -23,7 +23,7 @@ import (
 // and enqueues an ITL add operation. Called after importing a non-iTunes book.
 //
 // Skips if the book file already has an iTunes PID or if auto write-back is disabled.
-func ProvisionITLTrack(store database.Store, book *database.Book, bookFile *database.BookFile, batcher *WriteBackBatcher) error {
+func ProvisionITLTrack(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, bookFile *database.BookFile, batcher *WriteBackBatcher) error {
 	if !config.AppConfig.ITunesAutoWriteBack {
 		return nil
 	}
@@ -89,7 +89,7 @@ func ProvisionITLTrack(store database.Store, book *database.Book, bookFile *data
 }
 
 // ProvisionITLTracksForBook provisions ITL tracks for all files of a book.
-func ProvisionITLTracksForBook(store database.Store, book *database.Book, batcher *WriteBackBatcher) error {
+func ProvisionITLTracksForBook(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, batcher *WriteBackBatcher) error {
 	files, err := store.GetBookFiles(book.ID)
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func linuxToWindowsPath(p string) string {
 }
 
 // bookAuthor returns the author name for a book.
-func bookAuthor(store database.Store, book *database.Book) string {
+func bookAuthor(store database.AuthorReader, book *database.Book) string {
 	if book.AuthorID == nil {
 		return ""
 	}

--- a/internal/server/read_status_engine.go
+++ b/internal/server/read_status_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/read_status_engine.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e2f8a1d-4c5b-4f70-a9c7-2d8e0f1b9a57
 //
 // RecomputeUserBookState derives a UserBookState from the current
@@ -33,7 +33,7 @@ import (
 // updates user_book_state with fresh auto-computed fields. Returns
 // the new state (or a no-op unchanged state if there's nothing to
 // record — e.g. a user who's never touched this book).
-func RecomputeUserBookState(store database.Store, userID, bookID string) (*database.UserBookState, error) {
+func RecomputeUserBookState(store interface { database.BookFileStore; database.UserPositionStore }, userID, bookID string) (*database.UserBookState, error) {
 	if store == nil || userID == "" || bookID == "" {
 		return nil, nil
 	}
@@ -126,7 +126,7 @@ func RecomputeUserBookState(store database.Store, userID, bookID string) (*datab
 // RecomputeUserBookState leaves it alone going forward. Passing
 // empty string reverts to auto — next Recompute call derives a
 // fresh status from positions.
-func SetManualStatus(store database.Store, userID, bookID, status string) (*database.UserBookState, error) {
+func SetManualStatus(store interface { database.BookFileStore; database.UserPositionStore }, userID, bookID, status string) (*database.UserBookState, error) {
 	if store == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Third sweep batch. Four files narrowed; itunes.go itself stays wide (flagged as a hub consumer).

| File | Replaced `database.Store` with |
|---|---|
| itunes_position_sync.go | BookStore + BookFileStore + UserPositionStore |
| itunes_track_provisioner.go (ProvisionITLTrack*) | AuthorReader + BookFileStore + ExternalIDStore |
| itunes_track_provisioner.go (bookAuthor) | AuthorReader |
| read_status_engine.go (Recompute/SetManualStatus) | BookFileStore + UserPositionStore (transitive) |
| operations/state.go (Save/Load checkpoint + params + clear) | OperationStore |

**Scope note:** `internal/server/itunes.go` stays on full `database.Store`. It forwards its store to 8+ helpers across the metadata-fetch and organize pipelines; narrowing would cascade 15+ more signature changes. Treating it as a wide hub consumer (like server.go) is the pragmatic call.

## Test plan
- [x] `go build ./...` clean

Plan: `docs/superpowers/plans/2026-04-17-store-iface-sweep.md`