### PR TITLE
refactor: narrow undo/outbox/archive Store deps (ISP sweep 4/N)

### DIFF
--- a/internal/server/archive_sweep.go
+++ b/internal/server/archive_sweep.go
@@ -1,5 +1,5 @@
 // file: internal/server/archive_sweep.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f0a1b9c-3d4e-4a70-b8c5-3d7e0f1b9a99
 //
 // Archive sweep for soft-deleted books (backlog 7.10).
@@ -23,7 +23,7 @@ const archiveRetentionDays = 30
 
 // SweepArchivedBooks removes soft-deleted books past the retention
 // window. Returns the count of books cleaned up.
-func SweepArchivedBooks(store database.Store) int {
+func SweepArchivedBooks(store interface { database.BookStore; database.BookFileStore }) int {
 	books, err := store.GetAllBooks(0, 0)
 	if err != nil {
 		log.Printf("[WARN] archive sweep: list books: %v", err)

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_integration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
 //
 // Deluge integration for library centralization (backlog 6.1).
@@ -172,7 +172,7 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 
 // NotifyDelugeAfterUndo checks whether the reverted operation moved
 // Deluge-sourced files and updates the torrent storage path.
-func NotifyDelugeAfterUndo(store database.Store, bookID, oldFilePath string) {
+func NotifyDelugeAfterUndo(store interface { database.BookReader; database.BookVersionStore }, bookID, oldFilePath string) {
 	book, _ := store.GetBookByID(bookID)
 	if book == nil {
 		return

--- a/internal/server/undo_engine.go
+++ b/internal/server/undo_engine.go
@@ -1,5 +1,5 @@
 // file: internal/server/undo_engine.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0b8c9d6e-1f7a-4a70-b8c5-3d7e0f1b9a99
 //
 // Undo engine (spec 3.2 task 3). Reverses the destructive changes
@@ -39,7 +39,7 @@ type UndoResult struct {
 // reverse order, and applies the inverse of each change. Progress
 // is reported via the callback (step description + percentage).
 func RunUndoOperation(
-	store database.Store,
+	store interface { database.BookStore; database.BookVersionStore; database.OperationStore },
 	targetOpID string,
 	progress func(step string, pct int),
 ) (*UndoResult, error) {
@@ -93,7 +93,7 @@ func RunUndoOperation(
 }
 
 // revertChange applies the inverse of a single operation change.
-func revertChange(store database.Store, change *database.OperationChange) error {
+func revertChange(store interface { database.BookStore; database.BookVersionStore; database.OperationStore }, change *database.OperationChange) error {
 	switch change.ChangeType {
 	case "file_move", "organize_rename":
 		if err := revertFileMove(change); err != nil {
@@ -141,7 +141,7 @@ func revertFileMove(change *database.OperationChange) error {
 // revertMetadataUpdate restores a book field from the change's
 // OldValue. OldValue is either a plain string (for single-field
 // changes) or a JSON object (for multi-field snapshots).
-func revertMetadataUpdate(store database.Store, change *database.OperationChange) error {
+func revertMetadataUpdate(store database.BookStore, change *database.OperationChange) error {
 	if change.BookID == "" {
 		return fmt.Errorf("no book_id on metadata change %s", change.ID)
 	}

--- a/internal/server/writeback_outbox.go
+++ b/internal/server/writeback_outbox.go
@@ -1,5 +1,5 @@
 // file: internal/server/writeback_outbox.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c3d4e2f-6a7b-4a70-b8c5-3d7e0f1b9a99
 //
 // Durable outbox for the ITL write-back queue (backlog 4.3).
@@ -27,11 +27,11 @@ const outboxPrefix = "outbox:writeback:"
 // WriteBackOutbox persists pending ITL write-back book IDs to the
 // store so they survive server restarts.
 type WriteBackOutbox struct {
-	store database.Store
+	store interface { database.BookReader; database.UserPreferenceStore }
 }
 
 // NewWriteBackOutbox creates an outbox backed by the given store.
-func NewWriteBackOutbox(store database.Store) *WriteBackOutbox {
+func NewWriteBackOutbox(store interface { database.BookReader; database.UserPreferenceStore }) *WriteBackOutbox {
 	return &WriteBackOutbox{store: store}
 }
 


### PR DESCRIPTION
Fourth sweep batch. 4 files.

| File | Replaced `database.Store` with |
|---|---|
| undo_engine.go (RunUndoOperation, revertChange) | BookStore + BookVersionStore + OperationStore |
| undo_engine.go (revertMetadataUpdate) | BookStore |
| writeback_outbox.go (WriteBackOutbox struct + NewWriteBackOutbox) | BookReader + UserPreferenceStore |
| archive_sweep.go (SweepArchivedBooks) | BookStore + BookFileStore |
| deluge_integration.go (NotifyDelugeAfterUndo) | BookReader + BookVersionStore (transitive from undo_engine) |

## Test plan
- [x] `go build ./...` clean