### PR TITLE
refactor: narrow cross-package Store deps (ISP sweep 5/N)

### DIFF
--- a/cmd/dedup_bench_types.go
+++ b/cmd/dedup_bench_types.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_types.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
 
 //go:build bench
@@ -57,7 +57,7 @@ type AuthorData struct {
 }
 
 // extractAuthorData loads all authors, book counts, and sample titles from the local DB.
-func extractAuthorData(store database.Store) (*AuthorData, error) {
+func extractAuthorData(store database.AuthorReader) (*AuthorData, error) {
 	authors, err := store.GetAllAuthors()
 	if err != nil {
 		return nil, fmt.Errorf("GetAllAuthors: %w", err)

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,5 +1,5 @@
 // file: cmd/seed.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7d2e9a4f-1b85-4c63-9f0a-3e8d7b2c1f56
 //
 // `seed` populates a fresh database with synthetic books for local
@@ -228,21 +228,21 @@ func pickTitle(rng *rand.Rand) string {
 	return fmt.Sprintf("The %s %s", adj, noun)
 }
 
-func upsertAuthor(store database.Store, name string) (*database.Author, error) {
+func upsertAuthor(store database.AuthorStore, name string) (*database.Author, error) {
 	if existing, err := store.GetAuthorByName(name); err == nil && existing != nil {
 		return existing, nil
 	}
 	return store.CreateAuthor(name)
 }
 
-func upsertSeries(store database.Store, name string, authorID *int) (*database.Series, error) {
+func upsertSeries(store database.SeriesStore, name string, authorID *int) (*database.Series, error) {
 	if existing, err := store.GetSeriesByName(name, authorID); err == nil && existing != nil {
 		return existing, nil
 	}
 	return store.CreateSeries(name, authorID)
 }
 
-func purgeSeedBooks(store database.Store) (int, error) {
+func purgeSeedBooks(store database.BookStore) (int, error) {
 	books, err := store.GetAllBooks(100000, 0)
 	if err != nil {
 		return 0, err

--- a/internal/auth/seed.go
+++ b/internal/auth/seed.go
@@ -1,5 +1,5 @@
 // file: internal/auth/seed.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2e8f4a1d-7c3b-4f60-b9d5-1c6e0f2b9a57
 //
 // Seed roles — idempotent upsert of the three canonical roles
@@ -63,7 +63,7 @@ func viewerPermissions() []Permission {
 // reaches admin's effective set.
 //
 // Returns the number of roles created + updated.
-func SeedRoles(store database.Store) (created, updated int, err error) {
+func SeedRoles(store database.RoleStore) (created, updated int, err error) {
 	if store == nil {
 		return 0, 0, fmt.Errorf("seed roles: store is nil")
 	}
@@ -115,7 +115,7 @@ const SystemUserID = "_system"
 // SeedSystemUser creates the _system pseudo-user if absent.
 // It has no password and cannot log in — it exists solely as an
 // audit attribution target.
-func SeedSystemUser(store database.Store) error {
+func SeedSystemUser(store interface { database.UserStore; database.RoleStore }) error {
 	if store == nil {
 		return nil
 	}

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 
 package config
@@ -141,7 +141,7 @@ func SaveConfigToFile() error {
 
 // LoadConfigFromDatabase loads settings from database and applies them to AppConfig
 // This is called after database initialization to override defaults with persisted values
-func LoadConfigFromDatabase(store database.Store) error {
+func LoadConfigFromDatabase(store database.SettingsStore) error {
 	if store == nil {
 		return fmt.Errorf("store is nil")
 	}
@@ -235,7 +235,7 @@ func LoadConfigFromDatabase(store database.Store) error {
 
 // MigrateMaintenanceWindow migrates auto-update window fields to maintenance window.
 // Idempotent — safe to call multiple times.
-func MigrateMaintenanceWindow(store database.Store) {
+func MigrateMaintenanceWindow(store database.SettingsStore) {
 	migrated, _ := store.GetSetting("maintenance_window_migrated")
 	if migrated != nil && migrated.Value == "true" {
 		return
@@ -643,7 +643,7 @@ func applySetting(key, value, typ string) error {
 
 // SaveConfigToDatabase persists current AppConfig to database AND config file.
 // This should be called whenever config is modified via API.
-func SaveConfigToDatabase(store database.Store) error {
+func SaveConfigToDatabase(store database.SettingsStore) error {
 	if store == nil {
 		return fmt.Errorf("store is nil")
 	}

--- a/internal/metadata/enhanced.go
+++ b/internal/metadata/enhanced.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/enhanced.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 7e8d9c0b-1a2f-3e4d-5c6b-7a8d9c0b1a2f
 
 package metadata
@@ -158,7 +158,7 @@ func ValidateMetadata(updates map[string]interface{}, rules map[string]Validatio
 }
 
 // BatchUpdateMetadata applies metadata updates to multiple books with validation
-func BatchUpdateMetadata(updates []MetadataUpdate, store database.Store, validate bool) ([]error, int) {
+func BatchUpdateMetadata(updates []MetadataUpdate, store database.BookStore, validate bool) ([]error, int) {
 	var errors []error
 	successCount := 0
 	rules := DefaultValidationRules()
@@ -596,7 +596,7 @@ func RecordMetadataChange(bookID string, field, oldValue, newValue, updatedBy st
 
 // GetMetadataHistory retrieves metadata change history for a book
 // This is a placeholder for future database implementation
-func GetMetadataHistory(bookID string, store database.Store) ([]MetadataHistory, error) {
+func GetMetadataHistory(bookID string, store database.BookStore) ([]MetadataHistory, error) {
 	// TODO: Implement metadata history storage and retrieval in database
 	return nil, fmt.Errorf("metadata history not yet implemented in database")
 }
@@ -627,7 +627,7 @@ func ExportMetadata(books []database.Book) (map[string]interface{}, error) {
 }
 
 // ImportMetadata imports book metadata from a structured format
-func ImportMetadata(data map[string]interface{}, store database.Store, validate bool) (int, []error) {
+func ImportMetadata(data map[string]interface{}, store database.BookStore, validate bool) (int, []error) {
 	var errors []error
 	importCount := 0
 

--- a/internal/operations/mocks/mock_queue.go
+++ b/internal/operations/mocks/mock_queue.go
@@ -206,7 +206,7 @@ func (_c *MockQueue_Enqueue_Call) RunAndReturn(run func(id string, opType string
 }
 
 // SetStore provides a mock function for the type MockQueue
-func (_mock *MockQueue) SetStore(store database.Store) {
+func (_mock *MockQueue) SetStore(store database.OperationStore) {
 	_mock.Called(store)
 	return
 }
@@ -217,16 +217,16 @@ type MockQueue_SetStore_Call struct {
 }
 
 // SetStore is a helper method to define mock.On call
-//   - store database.Store
+//   - store database.OperationStore
 func (_e *MockQueue_Expecter) SetStore(store interface{}) *MockQueue_SetStore_Call {
 	return &MockQueue_SetStore_Call{Call: _e.mock.On("SetStore", store)}
 }
 
-func (_c *MockQueue_SetStore_Call) Run(run func(store database.Store)) *MockQueue_SetStore_Call {
+func (_c *MockQueue_SetStore_Call) Run(run func(store database.OperationStore)) *MockQueue_SetStore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.Store
+		var arg0 database.OperationStore
 		if args[0] != nil {
-			arg0 = args[0].(database.Store)
+			arg0 = args[0].(database.OperationStore)
 		}
 		run(
 			arg0,
@@ -240,7 +240,7 @@ func (_c *MockQueue_SetStore_Call) Return() *MockQueue_SetStore_Call {
 	return _c
 }
 
-func (_c *MockQueue_SetStore_Call) RunAndReturn(run func(store database.Store)) *MockQueue_SetStore_Call {
+func (_c *MockQueue_SetStore_Call) RunAndReturn(run func(store database.OperationStore)) *MockQueue_SetStore_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/operations/queue.go
+++ b/internal/operations/queue.go
@@ -1,5 +1,5 @@
 // file: internal/operations/queue.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 7d6e5f4a-3c2b-1a09-8f7e-6d5c4b3a2190
 
 package operations
@@ -62,7 +62,7 @@ type Queue interface {
 	Cancel(id string) error
 	ActiveOperations() []ActiveOperation
 	Shutdown(timeout time.Duration) error
-	SetStore(store database.Store)
+	SetStore(store database.OperationStore)
 }
 
 // OperationQueue manages async operations with priority handling
@@ -71,7 +71,7 @@ type OperationQueue struct {
 	operations map[string]*QueuedOperation
 	pending    chan *QueuedOperation
 	workers    int
-	store      database.Store
+	store      database.OperationStore
 	timeout    time.Duration
 	wg         sync.WaitGroup
 	ctx        context.Context
@@ -92,7 +92,7 @@ type OperationProgress struct {
 }
 
 // NewOperationQueue creates a new operation queue
-func NewOperationQueue(store database.Store, workers int, activityLogger ActivityLogger, hub *realtime.EventHub) *OperationQueue {
+func NewOperationQueue(store database.OperationStore, workers int, activityLogger ActivityLogger, hub *realtime.EventHub) *OperationQueue {
 	if workers <= 0 {
 		workers = 2 // Default to 2 workers
 	}
@@ -487,7 +487,7 @@ func (q *OperationQueue) Shutdown(timeout time.Duration) error {
 // operationProgressReporter implements ProgressReporter
 type operationProgressReporter struct {
 	operationID string
-	store       database.Store
+	store       database.OperationStore
 	queue       *OperationQueue
 	hub         *realtime.EventHub
 	current     int
@@ -555,7 +555,7 @@ func (r *operationProgressReporter) IsCanceled() bool {
 
 // queueStoreAdapter bridges database.Store to logger.OperationStore.
 type queueStoreAdapter struct {
-	store          database.Store
+	store          database.OperationStore
 	activityLogger ActivityLogger
 }
 
@@ -619,7 +619,7 @@ func (a *queueStoreAdapter) UpdateOperationProgress(id string, current, total in
 // It is the authoritative reporter used by the queue worker.
 type loggerProgressReporter struct {
 	logger  *logger.OperationLogger
-	store   database.Store
+	store   database.OperationStore
 	queue   *OperationQueue
 	hub     *realtime.EventHub
 	current int
@@ -740,7 +740,7 @@ func (q *OperationQueue) SetActivityLogger(logger ActivityLogger) {
 // SetStore assigns a database store to an already-initialized queue if it doesn't have one yet.
 // This enables early queue initialization (before database setup) while still allowing
 // operation status persistence once the database becomes available.
-func (q *OperationQueue) SetStore(store database.Store) {
+func (q *OperationQueue) SetStore(store database.OperationStore) {
 	if q == nil || store == nil {
 		return
 	}

--- a/internal/search/index_builder.go
+++ b/internal/search/index_builder.go
@@ -1,5 +1,5 @@
 // file: internal/search/index_builder.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8a1c2f4d-5b3e-4f70-b7d6-2e8d0f1b9a57
 //
 // Helpers that project a database.Book (with its author, series,
@@ -17,7 +17,7 @@ import (
 // BookToDoc resolves a Book's related rows through the Store and
 // returns the flat BookDocument for indexing. Missing relations are
 // silently skipped — the document is built best-effort.
-func BookToDoc(store database.Store, book *database.Book) BookDocument {
+func BookToDoc(store interface { database.AuthorReader; database.BookReader; database.SeriesReader; database.TagStore }, book *database.Book) BookDocument {
 	doc := BookDocument{
 		BookID: book.ID,
 		Type:   BookDocType,
@@ -105,7 +105,7 @@ func BookToDoc(store database.Store, book *database.Book) BookDocument {
 // ReindexBookByID convenience: load the book + project + index.
 // Used by the update/create hook path; callers that already have a
 // Book struct should call BookToDoc + IndexBook directly.
-func ReindexBookByID(store database.Store, idx *BleveIndex, bookID string) error {
+func ReindexBookByID(store interface { database.AuthorReader; database.BookReader; database.SeriesReader; database.TagStore }, idx *BleveIndex, bookID string) error {
 	if store == nil || idx == nil {
 		return nil
 	}

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,5 +1,5 @@
 // file: internal/testutil/integration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package testutil
@@ -20,7 +20,7 @@ import (
 
 // IntegrationEnv holds all resources for an integration test.
 type IntegrationEnv struct {
-	Store     database.Store
+	Store     interface { database.LifecycleStore; database.OperationStore }
 	RootDir   string
 	ImportDir string
 	TempDir   string
@@ -124,7 +124,7 @@ func FindRepoRoot(t *testing.T) string {
 }
 
 // WaitForOp polls until an operation completes or times out.
-func WaitForOp(t *testing.T, store database.Store, opID string, timeout time.Duration) {
+func WaitForOp(t *testing.T, store database.OperationStore, opID string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		op, err := store.GetOperationByID(opID)

--- a/internal/transcode/transcode.go
+++ b/internal/transcode/transcode.go
@@ -1,5 +1,5 @@
 // file: internal/transcode/transcode.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f8a1b2c3-d4e5-6789-abcd-ef0123456789
 
 package transcode
@@ -188,7 +188,7 @@ func BuildChapterMetadataWithProber(inputFiles []string, prober func(string) (fl
 }
 
 // Transcode converts audio files for a book into a single M4B.
-func Transcode(ctx context.Context, opts TranscodeOpts, store database.Store, progress operations.ProgressReporter) (string, error) {
+func Transcode(ctx context.Context, opts TranscodeOpts, store interface { database.BookReader; database.BookFileStore }, progress operations.ProgressReporter) (string, error) {
 	ffmpegPath, err := FindFFmpeg()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fifth sweep batch — 9 files across cmd/ + non-server internal packages. Includes the `operations.Queue` interface change (SetStore narrowed to OperationStore) which triggers a mock regeneration.

## Test plan
- [x] `go build ./...` clean
- [x] `make mocks-check` passes after regen of `internal/operations/mocks/mock_queue.go`