### PR TITLE
refactor: narrow remaining server-package Store deps (ISP sweep 6/N)

### DIFF
--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_handlers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5d3a6a95-4ac8-42c2-a7fe-5ff4857dd31a
 //
 // AI-related HTTP handlers split out of server.go: filename parsing,
@@ -535,7 +535,7 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 }
 
 // aiReviewGroupsMode is the existing Groups mode — local heuristics build groups, AI validates.
-func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.ProgressReporter, parser aiParser, store database.Store, opID string, dedupGroups []AuthorDedupGroup) error {
+func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.ProgressReporter, parser aiParser, store interface { database.AuthorStore; database.OperationStore }, opID string, dedupGroups []AuthorDedupGroup) error {
 	_ = progress.Log("info", fmt.Sprintf("Starting AI review (groups mode) of %d duplicate author groups", len(dedupGroups)), nil)
 	_ = progress.UpdateProgress(0, len(dedupGroups), "Building AI review input...")
 
@@ -598,7 +598,7 @@ func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.Pro
 }
 
 // aiReviewFullMode sends all authors to AI for duplicate discovery.
-func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.ProgressReporter, parser aiParser, store database.Store, opID string) error {
+func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.ProgressReporter, parser aiParser, store interface { database.AuthorStore; database.OperationStore }, opID string) error {
 	_ = progress.Log("info", "Starting AI review (full mode) — discovering duplicates from all authors", nil)
 	_ = progress.UpdateProgress(0, 100, "Loading all authors...")
 

--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -1,5 +1,5 @@
 // file: internal/server/batch_poller.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f8a1b2c3-d4e5-6789-abcd-0123456789ab
 
 package server
@@ -22,7 +22,7 @@ type BatchCompletionHandler func(ctx context.Context, batchID string, outputFile
 // BatchPoller is a unified poller that discovers completed OpenAI batches
 // tagged with project metadata and routes them to the appropriate handler.
 type BatchPoller struct {
-	db       database.Store
+	db       database.OperationStore
 	parser   *ai.OpenAIParser
 	handlers map[string]BatchCompletionHandler
 
@@ -33,7 +33,7 @@ type BatchPoller struct {
 }
 
 // NewBatchPoller creates a new BatchPoller.
-func NewBatchPoller(db database.Store, parser *ai.OpenAIParser) *BatchPoller {
+func NewBatchPoller(db database.OperationStore, parser *ai.OpenAIParser) *BatchPoller {
 	return &BatchPoller{
 		db:               db,
 		parser:           parser,

--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_handlers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 47a3e3fb-f5cf-4970-a2fc-d2ef481368c9
 //
 // SQL-backed duplicate detection handlers split out of server.go:
@@ -900,7 +900,7 @@ func (s *Server) seriesPrune(c *gin.Context) {
 }
 
 // executeSeriesPrune performs the actual series prune logic (used by both HTTP handler and scheduler).
-func (s *Server) executeSeriesPrune(ctx context.Context, store database.Store, progress operations.ProgressReporter, operationID string) error {
+func (s *Server) executeSeriesPrune(ctx context.Context, store interface { database.BookStore; database.AuthorStore; database.SeriesStore; database.OperationStore }, progress operations.ProgressReporter, operationID string) error {
 	_ = progress.Log("info", "Starting series auto-prune...", nil)
 
 	allSeries, err := store.GetAllSeries()

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/external_id_backfill.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d
 
 package server
@@ -119,7 +119,7 @@ func (s *Server) backfillExternalIDs() {
 // backfillITunesTrackPIDs reads the iTunes XML and registers ALL track PIDs
 // for existing books. This catches the multi-track albums where only the first
 // track's PID was stored on the book record.
-func (s *Server) backfillITunesTrackPIDs(store database.Store, eidStore ExternalIDStore) int {
+func (s *Server) backfillITunesTrackPIDs(store interface { database.BookReader; database.BookFileStore; database.SettingsStore }, eidStore ExternalIDStore) int {
 	xmlPath := config.AppConfig.ITunesLibraryReadPath
 	if xmlPath == "" {
 		log.Printf("[INFO] backfillITunesTrackPIDs: no iTunes XML path configured, skipping")

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-04-05
 
@@ -213,7 +213,7 @@ func (s *Server) handleBatchFetchCandidates(c *gin.Context) {
 func (s *Server) fetchCandidateForBook(
 	ctx context.Context,
 	mfs *MetadataFetchService,
-	store database.Store,
+	store interface { database.BookReader; database.OperationStore; database.RawKVStore },
 	limiter *rate.Limiter,
 	opID, bookID string,
 ) CandidateResult {
@@ -543,7 +543,7 @@ func (s *Server) handleBatchApplyCandidates(c *gin.Context) {
 // loadRejectedCandidateKeys finds previously rejected candidates for a book.
 // Uses a dedicated rejection key prefix for fast lookup instead of scanning
 // all operation results.
-func loadRejectedCandidateKeys(store database.Store, bookID string) map[string]bool {
+func loadRejectedCandidateKeys(store database.RawKVStore, bookID string) map[string]bool {
 	keys := make(map[string]bool)
 	// Scan only rejection keys for this specific book
 	pairs, err := store.ScanPrefix(fmt.Sprintf("rejected_candidate:%s:", bookID))

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -1,5 +1,5 @@
 // file: internal/server/middleware/auth.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 83c42ecb-1df2-4baf-9890-3f91ab4db6fe
 
 package middleware
@@ -66,7 +66,7 @@ func CurrentSession(c *gin.Context) (*database.Session, bool) {
 }
 
 // RequireAuth enforces session-based auth when at least one user exists.
-func RequireAuth(store database.Store) gin.HandlerFunc {
+func RequireAuth(store interface { database.UserReader; database.RoleStore; database.SessionStore }) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if store == nil {
 			c.Next()
@@ -139,7 +139,7 @@ func RequireAuth(store database.Store) gin.HandlerFunc {
 // Permissions slice for the given user. Unknown roles are skipped.
 // Returns nil if the user has no roles (which makes every Can()
 // check return false — safe default).
-func effectivePermissionsFor(store database.Store, user *database.User) []auth.Permission {
+func effectivePermissionsFor(store database.RoleStore, user *database.User) []auth.Permission {
 	if user == nil || len(user.Roles) == 0 || store == nil {
 		return nil
 	}
@@ -170,7 +170,7 @@ func effectivePermissionsFor(store database.Store, user *database.User) []auth.P
 //
 // Exception: if no users exist yet (first-run bootstrap), the check
 // is bypassed so the /setup wizard can run unauthenticated.
-func RequirePermission(store database.Store, p auth.Permission) gin.HandlerFunc {
+func RequirePermission(store interface { database.UserReader; database.RoleStore; database.SessionStore }, p auth.Permission) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// First-run bypass — RequireAuth uses the same pattern.
 		if store != nil {


### PR DESCRIPTION
Sixth sweep batch — 6 remaining active server files.

## Test plan
- [x] `go build ./...` clean

Plan: `docs/superpowers/plans/2026-04-17-store-iface-sweep.md`