### PR TITLE
fix: repair test build after ISP Store sweep

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -70,7 +70,7 @@ func stubCommandDeps(t *testing.T) {
 	initEncryption = func(dir string) error {
 		return nil
 	}
-	loadConfigFromDB = func(store database.Store) error {
+	loadConfigFromDB = func(store database.SettingsStore) error {
 		return nil
 	}
 	syncConfigFromEnv = func() {}

--- a/internal/server/server_versions_and_work_test.go
+++ b/internal/server/server_versions_and_work_test.go
@@ -71,14 +71,7 @@ func TestVersionEndpoints_HappyPaths(t *testing.T) {
 }
 
 func TestWorkEndpoints_WithMockStore(t *testing.T) {
-	server, cleanup := setupTestServer(t)
-	defer cleanup()
-
 	store := dbmocks.NewMockStore(t)
-	origStore := database.GetGlobalStore()
-	database.SetGlobalStore(store)
-	t.Cleanup(func() { database.SetGlobalStore(origStore) })
-
 	author1 := 1
 	author2 := 2
 	works := []database.Work{{ID: "w1", Title: "Work One", AuthorID: &author1}, {ID: "w2", Title: "Work Two", AuthorID: &author2}}
@@ -86,20 +79,24 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	store.EXPECT().GetBooksByWorkID("w1").Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
 	store.EXPECT().GetBooksByWorkID("w2").Return(nil, assert.AnError)
 
+	server, cleanup := setupTestServerWithStore(t, store)
+	defer cleanup()
+
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/work", nil)
 	w := httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	store2 := dbmocks.NewMockStore(t)
-	database.SetGlobalStore(store2)
 	store2.EXPECT().GetAllWorks().Return(works, nil)
 	store2.EXPECT().GetBooksByWorkID("w1").Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
 	store2.EXPECT().GetBooksByWorkID("w2").Return(nil, assert.AnError)
+	server2, cleanup2 := setupTestServerWithStore(t, store2)
+	defer cleanup2()
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/work/stats", nil)
 	w = httptest.NewRecorder()
-	server.router.ServeHTTP(w, req)
+	server2.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var statsResp map[string]interface{}

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,5 +1,5 @@
 // file: internal/testutil/integration.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package testutil
@@ -20,7 +20,7 @@ import (
 
 // IntegrationEnv holds all resources for an integration test.
 type IntegrationEnv struct {
-	Store     interface { database.LifecycleStore; database.OperationStore }
+	Store     database.Store
 	RootDir   string
 	ImportDir string
 	TempDir   string


### PR DESCRIPTION
## Summary
CI has been red since the ISP sweep commits (4/N–7/N) — not a test timeout, an actual build failure in the test packages.

- `cmd/commands_test.go`: `loadConfigFromDB` mock signature updated to `SettingsStore`
- `internal/testutil/integration.go`: Revert over-narrowing of `IntegrationEnv.Store`. Test scaffolding needs the full `database.Store` — narrowing it broke ~10 consuming tests that call `GetAllBooks`, `CreateBook`, `AddAuthorTag`, etc.
- `internal/server/server_versions_and_work_test.go`: switch to `setupTestServerWithStore` so mock expectations are actually hit by `s.Store()` (handlers stopped using `GetGlobalStore` in a prior refactor).

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -short ./...` — all packages pass
- [ ] CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)