### PR TITLE
refactor: narrow 18 struct-based server services (ISP sweep 8/N)

### DIFF
--- a/internal/server/ai_scan_pipeline.go
+++ b/internal/server/ai_scan_pipeline.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_scan_pipeline.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: b8c4d0e2-5f6a-7b8c-9d0e-1f2a3b4c5d6e
 
 package server
@@ -17,10 +17,17 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+// aiScanPipelineStore is the narrow slice of database.Store this service uses.
+type aiScanPipelineStore interface {
+	database.AuthorReader
+	database.OperationStore
+}
+
+
 // PipelineManager coordinates the multi-pass AI author dedup pipeline.
 type PipelineManager struct {
 	scanStore *database.AIScanStore
-	mainStore database.Store
+	mainStore aiScanPipelineStore
 	parser    *ai.OpenAIParser
 	server    *Server
 	mu        sync.Mutex
@@ -29,7 +36,7 @@ type PipelineManager struct {
 }
 
 // NewPipelineManager creates a new pipeline manager.
-func NewPipelineManager(scanStore *database.AIScanStore, mainStore database.Store, parser *ai.OpenAIParser, server *Server) *PipelineManager {
+func NewPipelineManager(scanStore *database.AIScanStore, mainStore aiScanPipelineStore, parser *ai.OpenAIParser, server *Server) *PipelineManager {
 	return &PipelineManager{
 		scanStore: scanStore,
 		mainStore: mainStore,

--- a/internal/server/audiobook_update_service.go
+++ b/internal/server/audiobook_update_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_update_service.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: b2c3d4e5-f6g7-h8i9-j0k1-l2m3n4o5p6q7
 
 package server
@@ -13,12 +13,26 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
+// audiobookUpdateStore is the narrow slice of database.Store this service uses.
+type audiobookUpdateStore interface {
+	database.BookStore
+	database.AuthorStore
+	database.SeriesStore
+	database.NarratorStore
+	database.BookFileStore
+	database.HashBlocklistStore
+	database.TagStore
+	database.MetadataStore
+	database.UserPreferenceStore
+}
+
+
 type AudiobookUpdateService struct {
-	db               database.Store
+	db audiobookUpdateStore
 	audiobookService *AudiobookService
 }
 
-func NewAudiobookUpdateService(db database.Store) *AudiobookUpdateService {
+func NewAudiobookUpdateService(db audiobookUpdateStore) *AudiobookUpdateService {
 	return &AudiobookUpdateService{
 		db:               db,
 		audiobookService: NewAudiobookService(db),

--- a/internal/server/author_series_service.go
+++ b/internal/server/author_series_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/author_series_service.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
 
 package server
@@ -8,11 +8,18 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-type AuthorSeriesService struct {
-	db database.Store
+// authorSeriesStore is the narrow slice of database.Store this service uses.
+type authorSeriesStore interface {
+	database.AuthorReader
+	database.SeriesReader
 }
 
-func NewAuthorSeriesService(db database.Store) *AuthorSeriesService {
+
+type AuthorSeriesService struct {
+	db authorSeriesStore
+}
+
+func NewAuthorSeriesService(db authorSeriesStore) *AuthorSeriesService {
 	return &AuthorSeriesService{db: db}
 }
 

--- a/internal/server/batch_service.go
+++ b/internal/server/batch_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/batch_service.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -11,12 +11,18 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-// BatchService handles bulk operations on audiobooks.
-type BatchService struct {
-	db database.Store
+// batchServiceStore is the narrow slice of database.Store this service uses.
+type batchServiceStore interface {
+	database.BookStore
 }
 
-func NewBatchService(db database.Store) *BatchService {
+
+// BatchService handles bulk operations on audiobooks.
+type BatchService struct {
+	db batchServiceStore
+}
+
+func NewBatchService(db batchServiceStore) *BatchService {
 	return &BatchService{db: db}
 }
 

--- a/internal/server/changelog_service.go
+++ b/internal/server/changelog_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/changelog_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 93167949-a587-41e9-8ef9-92d03f86aea6
 
 package server
@@ -12,6 +12,14 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+// changelogStore is the narrow slice of database.Store this service uses.
+type changelogStore interface {
+	database.MetadataStore
+	database.OperationStore
+	database.PathHistoryStore
+}
+
+
 // ChangeLogEntry represents a single entry in a book's changelog timeline.
 type ChangeLogEntry struct {
 	Timestamp time.Time      `json:"timestamp"`
@@ -22,11 +30,11 @@ type ChangeLogEntry struct {
 
 // ChangelogService merges history data from multiple sources into a unified changelog.
 type ChangelogService struct {
-	db database.Store
+	db changelogStore
 }
 
 // NewChangelogService creates a new ChangelogService instance.
-func NewChangelogService(db database.Store) *ChangelogService {
+func NewChangelogService(db changelogStore) *ChangelogService {
 	return &ChangelogService{db: db}
 }
 

--- a/internal/server/dashboard_service.go
+++ b/internal/server/dashboard_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/dashboard_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
 
 package server
@@ -12,13 +12,23 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+// dashboardStore is the narrow slice of database.Store this service uses.
+type dashboardStore interface {
+	database.AuthorReader
+	database.BookReader
+	database.PlaylistStore
+	database.SeriesReader
+	database.StatsStore
+}
+
+
 // DashboardService handles dashboard statistics and metrics collection
 type DashboardService struct {
-	db database.Store
+	db dashboardStore
 }
 
 // NewDashboardService creates a new dashboard service
-func NewDashboardService(db database.Store) *DashboardService {
+func NewDashboardService(db dashboardStore) *DashboardService {
 	return &DashboardService{db: db}
 }
 

--- a/internal/server/diagnostics_service.go
+++ b/internal/server/diagnostics_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/diagnostics_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d1a9n0st-1cs0-s3rv-1c3z-1pexp0rt001
 
 package server
@@ -15,15 +15,26 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 )
 
+// diagnosticsStore is the narrow slice of database.Store this service uses.
+type diagnosticsStore interface {
+	database.AuthorReader
+	database.BookReader
+	database.OperationStore
+	database.SeriesReader
+	database.StatsStore
+	database.SystemActivityStore
+}
+
+
 // DiagnosticsService generates diagnostic ZIP exports for troubleshooting and AI analysis.
 type DiagnosticsService struct {
-	db            database.Store
+	db diagnosticsStore
 	aiPipeline    interface{} // *ai.Pipeline or nil
 	itunesXMLPath string
 }
 
 // NewDiagnosticsService creates a new DiagnosticsService.
-func NewDiagnosticsService(db database.Store, aiPipeline interface{}, itunesXMLPath string) *DiagnosticsService {
+func NewDiagnosticsService(db diagnosticsStore, aiPipeline interface{}, itunesXMLPath string) *DiagnosticsService {
 	return &DiagnosticsService{
 		db:            db,
 		aiPipeline:    aiPipeline,

--- a/internal/server/import_path_service.go
+++ b/internal/server/import_path_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/import_path_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6g7-h8i9-j0k1-l2m3-n4o5p6q7r8s9
 
 package server
@@ -13,10 +13,10 @@ import (
 )
 
 type ImportPathService struct {
-	db database.Store
+	db database.ImportPathStore
 }
 
-func NewImportPathService(db database.Store) *ImportPathService {
+func NewImportPathService(db database.ImportPathStore) *ImportPathService {
 	return &ImportPathService{db: db}
 }
 

--- a/internal/server/import_service.go
+++ b/internal/server/import_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/import_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
 
 package server
@@ -16,8 +16,24 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
 
+// importServiceStore is the narrow slice of database.Store this service uses.
+// Includes the transitive surfaces required by forwarded helpers:
+// CreateIngestVersion needs BookVersionStore + BookFileStore; ProvisionITLTracksForBook
+// needs ExternalIDStore (plus the AuthorReader + BookFileStore already present).
+type importServiceStore interface {
+	database.AuthorReader
+	database.AuthorWriter
+	database.BookWriter
+	database.SeriesReader
+	database.SeriesWriter
+	database.BookVersionStore
+	database.BookFileStore
+	database.ExternalIDStore
+}
+
+
 type ImportService struct {
-	db               database.Store
+	db importServiceStore
 	writeBackBatcher *WriteBackBatcher
 }
 
@@ -26,7 +42,7 @@ func (is *ImportService) SetWriteBackBatcher(b *WriteBackBatcher) {
 	is.writeBackBatcher = b
 }
 
-func NewImportService(db database.Store) *ImportService {
+func NewImportService(db importServiceStore) *ImportService {
 	return &ImportService{db: db}
 }
 

--- a/internal/server/isbn_enrichment.go
+++ b/internal/server/isbn_enrichment.go
@@ -1,5 +1,5 @@
 // file: internal/server/isbn_enrichment.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
 
 package server
@@ -13,16 +13,24 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
 
+// isbnEnrichmentStore is the narrow slice of database.Store this service uses.
+type isbnEnrichmentStore interface {
+	database.AuthorReader
+	database.BookReader
+	database.BookWriter
+}
+
+
 // ISBNEnrichmentService searches external metadata sources for ISBN (and ASIN)
 // when a book is missing those identifiers after a metadata fetch/apply.
 type ISBNEnrichmentService struct {
-	db      database.Store
+	db isbnEnrichmentStore
 	sources []metadata.MetadataSource
 }
 
 // NewISBNEnrichmentService creates an enrichment service that will search the
 // given metadata sources for ISBN/ASIN data.
-func NewISBNEnrichmentService(db database.Store, sources []metadata.MetadataSource) *ISBNEnrichmentService {
+func NewISBNEnrichmentService(db isbnEnrichmentStore, sources []metadata.MetadataSource) *ISBNEnrichmentService {
 	return &ISBNEnrichmentService{db: db, sources: sources}
 }
 

--- a/internal/server/merge_service.go
+++ b/internal/server/merge_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/merge_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
 
 package server
@@ -12,9 +12,23 @@ import (
 	ulid "github.com/oklog/ulid/v2"
 )
 
+// mergeServiceStore is the narrow slice of database.Store this service uses.
+// Widened to satisfy the transitive `maintenanceStore` composite expected by
+// softDeleteBook in maintenance_fixups.go.
+type mergeServiceStore interface {
+	database.BookStore
+	database.AuthorStore
+	database.SeriesStore
+	database.BookFileStore
+	database.UserTagStore
+	database.ExternalIDStore
+	database.StatsStore
+}
+
+
 // MergeService handles merging duplicate books into version groups.
 type MergeService struct {
-	db               database.Store
+	db mergeServiceStore
 	writeBackBatcher *WriteBackBatcher
 }
 
@@ -31,7 +45,7 @@ type MergeResult struct {
 }
 
 // NewMergeService creates a new MergeService.
-func NewMergeService(db database.Store) *MergeService {
+func NewMergeService(db mergeServiceStore) *MergeService {
 	return &MergeService{db: db}
 }
 

--- a/internal/server/metadata_upgrade.go
+++ b/internal/server/metadata_upgrade.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_upgrade.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a3b2c1d-0e9f-8a7b-6c5d-4e3f2a1b0c9d
 //
 // Background job that upgrades metadata from lower-quality sources
@@ -28,17 +28,24 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+// metadataUpgradeStore is the narrow slice of database.Store this service uses.
+type metadataUpgradeStore interface {
+	database.BookReader
+	database.TagStore
+}
+
+
 // MetadataUpgradeService finds books with low-quality metadata
 // sources and attempts to upgrade them to richer sources.
 type MetadataUpgradeService struct {
-	db      database.Store
+	db metadataUpgradeStore
 	fetcher *MetadataFetchService
 }
 
 // NewMetadataUpgradeService creates an upgrade service. The fetcher
 // provides the search + apply pipeline; the db provides the tag
 // lookup for finding eligible books.
-func NewMetadataUpgradeService(db database.Store, fetcher *MetadataFetchService) *MetadataUpgradeService {
+func NewMetadataUpgradeService(db metadataUpgradeStore, fetcher *MetadataFetchService) *MetadataUpgradeService {
 	return &MetadataUpgradeService{db: db, fetcher: fetcher}
 }
 

--- a/internal/server/organize_preview_service.go
+++ b/internal/server/organize_preview_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_preview_service.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f1a2b3c4-d5e6-7890-abcd-ef1234567890
 
 package server
@@ -14,6 +14,16 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 )
+
+// organizePreviewStore is the narrow slice of database.Store this service uses.
+type organizePreviewStore interface {
+	database.BookWriter
+	database.NarratorStore
+	database.OperationStore
+	database.BookFileStore
+	database.BookReader
+}
+
 
 // OrganizePreviewStep describes a single step in the organize preview.
 type OrganizePreviewStep struct {
@@ -41,11 +51,11 @@ type OrganizePreviewResponse struct {
 
 // OrganizePreviewService builds a read-only preview of what a single-book organize would do.
 type OrganizePreviewService struct {
-	db database.Store
+	db organizePreviewStore
 }
 
 // NewOrganizePreviewService creates a new OrganizePreviewService.
-func NewOrganizePreviewService(db database.Store) *OrganizePreviewService {
+func NewOrganizePreviewService(db organizePreviewStore) *OrganizePreviewService {
 	return &OrganizePreviewService{db: db}
 }
 

--- a/internal/server/rename_service.go
+++ b/internal/server/rename_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/rename_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package server
@@ -19,13 +19,23 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 )
 
+// renameServiceStore is the narrow slice of database.Store this service uses.
+type renameServiceStore interface {
+	database.BookFileStore
+	database.BookReader
+	database.BookWriter
+	database.NarratorStore
+	database.OperationStore
+}
+
+
 // RenameService handles preview and execution of file rename + tag write operations.
 type RenameService struct {
-	db database.Store
+	db renameServiceStore
 }
 
 // NewRenameService creates a new RenameService.
-func NewRenameService(db database.Store) *RenameService {
+func NewRenameService(db renameServiceStore) *RenameService {
 	return &RenameService{db: db}
 }
 

--- a/internal/server/revert_service.go
+++ b/internal/server/revert_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/revert_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-d0e1-f2a3-b4c5d6e7f8a9
 
 package server
@@ -15,13 +15,21 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
 
+// revertServiceStore is the narrow slice of database.Store this service uses.
+type revertServiceStore interface {
+	database.BookReader
+	database.BookWriter
+	database.OperationStore
+}
+
+
 // RevertService handles reverting operations by undoing recorded changes.
 type RevertService struct {
-	db database.Store
+	db revertServiceStore
 }
 
 // NewRevertService creates a new RevertService.
-func NewRevertService(db database.Store) *RevertService {
+func NewRevertService(db revertServiceStore) *RevertService {
 	return &RevertService{db: db}
 }
 

--- a/internal/server/scan_service.go
+++ b/internal/server/scan_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/scan_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -20,11 +20,21 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 )
 
-type ScanService struct {
-	db database.Store
+// scanServiceStore is the narrow slice of database.Store this service uses.
+type scanServiceStore interface {
+	database.OperationStore
+	database.BookReader
+	database.BookWriter
+	database.ImportPathStore
+	database.MaintenanceStore
 }
 
-func NewScanService(db database.Store) *ScanService {
+
+type ScanService struct {
+	db scanServiceStore
+}
+
+func NewScanService(db scanServiceStore) *ScanService {
 	return &ScanService{db: db}
 }
 

--- a/internal/server/system_service.go
+++ b/internal/server/system_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_service.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
 
 package server
@@ -15,11 +15,19 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
 )
 
-type SystemService struct {
-	db database.Store
+// systemServiceStore is the narrow slice of database.Store this service uses.
+type systemServiceStore interface {
+	database.ImportPathStore
+	database.OperationStore
+	database.StatsStore
 }
 
-func NewSystemService(db database.Store) *SystemService {
+
+type SystemService struct {
+	db systemServiceStore
+}
+
+func NewSystemService(db systemServiceStore) *SystemService {
 	return &SystemService{db: db}
 }
 

--- a/internal/server/work_service.go
+++ b/internal/server/work_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/work_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
 
 package server
@@ -12,10 +12,10 @@ import (
 )
 
 type WorkService struct {
-	db database.Store
+	db database.WorkStore
 }
 
-func NewWorkService(db database.Store) *WorkService {
+func NewWorkService(db database.WorkStore) *WorkService {
 	return &WorkService{db: db}
 }
 

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -20,6 +20,10 @@ import (
 
 // IntegrationEnv holds all resources for an integration test.
 type IntegrationEnv struct {
+	// Store is intentionally the full database.Store surface. Integration
+	// tests poke at fixtures across any domain the scenario requires —
+	// narrowing here forces churn in every test file for no real benefit
+	// (see PR #394 for the regression this deliberate wide type prevents).
 	Store     database.Store
 	RootDir   string
 	ImportDir string

--- a/scripts/apply_narrowing.py
+++ b/scripts/apply_narrowing.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Replace `database.Store` with narrow composites in the 18 small struct-
+based services identified by narrow_struct_services.py. Each file gets a
+file-local named interface (e.g. `batchServiceStore`) because inline
+anonymous interfaces with 3+ embedded sub-interfaces read poorly and clutter
+both the struct declaration and the constructor signature.
+
+Idempotent — re-run is a no-op once applied."""
+from __future__ import annotations
+
+import pathlib
+import re
+
+SPEC = {
+    "internal/server/ai_scan_pipeline.go": {
+        "alias": "aiScanPipelineStore",
+        "ifaces": ["AuthorReader", "OperationStore"],
+        "field_re": r"^(\s+)mainStore\s+database\.Store\b",
+        "field_sub": r"\1mainStore aiScanPipelineStore",
+        "param_re": r"mainStore database\.Store",
+        "param_sub": "mainStore aiScanPipelineStore",
+    },
+    "internal/server/audiobook_update_service.go": {
+        "alias": "audiobookUpdateStore",
+        "ifaces": ["BookReader"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db audiobookUpdateStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db audiobookUpdateStore",
+    },
+    "internal/server/author_series_service.go": {
+        "alias": "authorSeriesStore",
+        "ifaces": ["AuthorReader", "SeriesReader"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db authorSeriesStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db authorSeriesStore",
+    },
+    "internal/server/batch_service.go": {
+        "alias": "batchServiceStore",
+        "ifaces": ["BookStore"],  # combined BookReader + BookWriter
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db batchServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db batchServiceStore",
+    },
+    "internal/server/changelog_service.go": {
+        "alias": "changelogStore",
+        "ifaces": ["MetadataStore", "OperationStore", "PathHistoryStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db changelogStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db changelogStore",
+    },
+    "internal/server/dashboard_service.go": {
+        "alias": "dashboardStore",
+        "ifaces": ["AuthorReader", "BookReader", "PlaylistStore", "SeriesReader", "StatsStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db dashboardStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db dashboardStore",
+    },
+    "internal/server/diagnostics_service.go": {
+        "alias": "diagnosticsStore",
+        "ifaces": ["AuthorReader", "BookReader", "OperationStore", "SeriesReader", "StatsStore", "SystemActivityStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db diagnosticsStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db diagnosticsStore",
+    },
+    "internal/server/import_path_service.go": {
+        "alias": "importPathStore",
+        "ifaces": ["ImportPathStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db database.ImportPathStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db database.ImportPathStore",
+        "skip_alias": True,  # single interface, use bare
+    },
+    "internal/server/import_service.go": {
+        "alias": "importServiceStore",
+        "ifaces": ["AuthorReader", "AuthorWriter", "BookWriter", "SeriesReader", "SeriesWriter"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db importServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db importServiceStore",
+    },
+    "internal/server/isbn_enrichment.go": {
+        "alias": "isbnEnrichmentStore",
+        "ifaces": ["AuthorReader", "BookReader", "BookWriter"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db isbnEnrichmentStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db isbnEnrichmentStore",
+    },
+    "internal/server/merge_service.go": {
+        "alias": "mergeServiceStore",
+        "ifaces": ["BookReader", "BookWriter", "ExternalIDStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db mergeServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db mergeServiceStore",
+    },
+    "internal/server/metadata_upgrade.go": {
+        "alias": "metadataUpgradeStore",
+        "ifaces": ["BookReader", "TagStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db metadataUpgradeStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db metadataUpgradeStore",
+    },
+    "internal/server/organize_preview_service.go": {
+        "alias": "organizePreviewStore",
+        "ifaces": ["BookFileStore", "BookReader"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db organizePreviewStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db organizePreviewStore",
+    },
+    "internal/server/rename_service.go": {
+        "alias": "renameServiceStore",
+        "ifaces": ["BookFileStore", "BookReader", "BookWriter", "NarratorStore", "OperationStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db renameServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db renameServiceStore",
+    },
+    "internal/server/revert_service.go": {
+        "alias": "revertServiceStore",
+        "ifaces": ["BookReader", "BookWriter", "OperationStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db revertServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db revertServiceStore",
+    },
+    "internal/server/scan_service.go": {
+        "alias": "scanServiceStore",
+        "ifaces": ["BookReader", "BookWriter", "ImportPathStore", "MaintenanceStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db scanServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db scanServiceStore",
+    },
+    "internal/server/system_service.go": {
+        "alias": "systemServiceStore",
+        "ifaces": ["ImportPathStore", "OperationStore", "StatsStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db systemServiceStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db systemServiceStore",
+    },
+    "internal/server/work_service.go": {
+        "alias": "workServiceStore",
+        "ifaces": ["WorkStore"],
+        "field_re": r"^(\s+)db\s+database\.Store\b",
+        "field_sub": r"\1db database.WorkStore",
+        "param_re": r"db database\.Store",
+        "param_sub": "db database.WorkStore",
+        "skip_alias": True,
+    },
+}
+
+
+def make_alias_block(alias: str, ifaces: list[str]) -> str:
+    lines = [f"// {alias} is the narrow slice of database.Store this service uses."]
+    lines.append(f"type {alias} interface {{")
+    for iface in ifaces:
+        lines.append(f"\tdatabase.{iface}")
+    lines.append("}")
+    return "\n".join(lines) + "\n\n"
+
+
+# Insert the alias after the last import block closing (`)`).
+IMPORT_BLOCK_END = re.compile(r"^\)$", re.MULTILINE)
+
+
+def insert_alias(text: str, alias: str, ifaces: list[str]) -> str:
+    if f"type {alias} interface" in text:
+        return text  # already inserted
+    m = IMPORT_BLOCK_END.search(text)
+    if not m:
+        raise RuntimeError("no import block found")
+    end = m.end()
+    # Find next blank line and insert after it.
+    rest = text[end:]
+    block = "\n\n" + make_alias_block(alias, ifaces).rstrip() + "\n"
+    return text[:end] + block + rest
+
+
+def process(path: pathlib.Path, spec: dict) -> None:
+    text = path.read_text()
+    orig = text
+
+    # Narrow field
+    text = re.sub(spec["field_re"], spec["field_sub"], text, flags=re.MULTILINE)
+    # Narrow constructor param (and any other occurrences)
+    text = re.sub(spec["param_re"], spec["param_sub"], text)
+
+    # Insert alias if needed
+    if not spec.get("skip_alias"):
+        text = insert_alias(text, spec["alias"], spec["ifaces"])
+
+    if text != orig:
+        path.write_text(text)
+        print(f"updated: {path.name}")
+    else:
+        print(f"unchanged: {path.name}")
+
+
+def main() -> None:
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    for rel, spec in SPEC.items():
+        path = repo / rel
+        if not path.exists():
+            print(f"MISSING: {rel}")
+            continue
+        try:
+            process(path, spec)
+        except Exception as exc:
+            print(f"ERROR {rel}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_store_noops.py
+++ b/scripts/check_store_noops.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""For each candidate noop file, identify the struct field(s) of type
+`database.Store` and check whether the file actually calls any methods on
+those fields. Files with zero method calls are safe to migrate by deleting
+the field entirely."""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+CANDIDATES = [
+    "internal/server/ai_scan_pipeline.go",
+    "internal/server/audiobook_update_service.go",
+    "internal/server/author_series_service.go",
+    "internal/server/batch_service.go",
+    "internal/server/changelog_service.go",
+    "internal/server/config_update_service.go",
+    "internal/server/dashboard_service.go",
+    "internal/server/dedup_engine.go",
+    "internal/server/diagnostics_service.go",
+    "internal/server/import_path_service.go",
+    "internal/server/import_service.go",
+    "internal/server/isbn_enrichment.go",
+    "internal/server/merge_service.go",
+    "internal/server/metadata_fetch_service.go",
+    "internal/server/metadata_upgrade.go",
+    "internal/server/organize_preview_service.go",
+    "internal/server/organize_service.go",
+    "internal/server/rename_service.go",
+    "internal/server/revert_service.go",
+    "internal/server/scan_service.go",
+    "internal/server/system_service.go",
+    "internal/server/work_service.go",
+]
+
+# Field declaration: "<name>    database.Store" with any whitespace,
+# capturing the name. Anchored to line start (after optional tab/spaces)
+# so it only matches struct fields, not random references.
+FIELD_RE = re.compile(r"^\s+([a-z][a-zA-Z0-9_]*)\s+database\.Store\b", re.MULTILINE)
+
+# Method call: <name>.<Capital>...
+CALL_TEMPLATE = re.compile(
+    r"(?:^|[^a-zA-Z_0-9])(?:[a-z]\.)?{name}\.[A-Z][a-zA-Z0-9]+\s*\("
+)
+
+
+def scan(path: pathlib.Path) -> dict:
+    text = path.read_text()
+    fields = FIELD_RE.findall(text)
+    fields = list(dict.fromkeys(fields))  # preserve order, dedup
+    report = {"path": str(path), "fields": fields, "calls": {}}
+    for name in fields:
+        pat = re.compile(rf"(?:^|[^a-zA-Z_0-9]){re.escape(name)}\.[A-Z][a-zA-Z0-9]+\s*\(", re.MULTILINE)
+        hits = pat.findall(text)
+        report["calls"][name] = len(hits)
+    return report
+
+
+def main() -> int:
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    noop = []
+    has_calls = []
+    for rel in CANDIDATES:
+        path = repo / rel
+        if not path.exists():
+            print(f"MISSING: {rel}")
+            continue
+        r = scan(path)
+        total_calls = sum(r["calls"].values())
+        if not r["fields"]:
+            print(f"{rel}: NO database.Store field found (already cleaned?)")
+            continue
+        fields_desc = ", ".join(f"{n}({r['calls'][n]})" for n in r["fields"])
+        if total_calls == 0:
+            noop.append((rel, r["fields"]))
+            print(f"NOOP: {rel}  fields: {fields_desc}")
+        else:
+            has_calls.append((rel, r["calls"]))
+            print(f"HAS CALLS: {rel}  {fields_desc}")
+
+    print(f"\nSummary: {len(noop)} noop, {len(has_calls)} with calls")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/narrow_struct_services.py
+++ b/scripts/narrow_struct_services.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""For each struct-based service in the target list, extract:
+  - The store-field name and the struct it lives in
+  - The set of methods called on that field
+  - The Store interface methods those resolve to, mapped to sub-interfaces
+
+Produces a per-file report the operator uses to write the narrowed interface.
+Does NOT edit files — we do the edits by hand per file after reviewing output,
+because transitive deps may force composite changes (see PR #380 / #388).
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+FILES = [
+    "internal/server/ai_scan_pipeline.go",
+    "internal/server/audiobook_update_service.go",
+    "internal/server/author_series_service.go",
+    "internal/server/batch_service.go",
+    "internal/server/changelog_service.go",
+    "internal/server/dashboard_service.go",
+    "internal/server/diagnostics_service.go",
+    "internal/server/import_path_service.go",
+    "internal/server/import_service.go",
+    "internal/server/isbn_enrichment.go",
+    "internal/server/merge_service.go",
+    "internal/server/metadata_upgrade.go",
+    "internal/server/organize_preview_service.go",
+    "internal/server/rename_service.go",
+    "internal/server/revert_service.go",
+    "internal/server/scan_service.go",
+    "internal/server/system_service.go",
+    "internal/server/work_service.go",
+]
+
+# Method → sub-interface map (matches iface_*.go on main)
+METHOD_TO_IFACE = {
+    # BookReader
+    "GetBookByID": "BookReader",
+    "GetAllBooks": "BookReader",
+    "GetBookByFilePath": "BookReader",
+    "GetBookByITunesPersistentID": "BookReader",
+    "GetBookByFileHash": "BookReader",
+    "GetBookByOriginalHash": "BookReader",
+    "GetBookByOrganizedHash": "BookReader",
+    "GetDuplicateBooks": "BookReader",
+    "GetFolderDuplicates": "BookReader",
+    "GetDuplicateBooksByMetadata": "BookReader",
+    "GetBooksByTitleInDir": "BookReader",
+    "GetBooksBySeriesID": "BookReader",
+    "GetBooksByAuthorID": "BookReader",
+    "GetBooksByVersionGroup": "BookReader",
+    "SearchBooks": "BookReader",
+    "CountBooks": "BookReader",
+    "ListSoftDeletedBooks": "BookReader",
+    "GetBookSnapshots": "BookReader",
+    "GetBookAtVersion": "BookReader",
+    "GetBookTombstone": "BookReader",
+    "ListBookTombstones": "BookReader",
+    "GetITunesDirtyBooks": "BookReader",
+    # BookWriter
+    "CreateBook": "BookWriter",
+    "UpdateBook": "BookWriter",
+    "DeleteBook": "BookWriter",
+    "SetLastWrittenAt": "BookWriter",
+    "MarkITunesSynced": "BookWriter",
+    "RevertBookToVersion": "BookWriter",
+    "PruneBookSnapshots": "BookWriter",
+    "CreateBookTombstone": "BookWriter",
+    "DeleteBookTombstone": "BookWriter",
+    # AuthorReader
+    "GetAllAuthors": "AuthorReader",
+    "GetAuthorByID": "AuthorReader",
+    "GetAuthorByName": "AuthorReader",
+    "GetAuthorAliases": "AuthorReader",
+    "GetAllAuthorAliases": "AuthorReader",
+    "FindAuthorByAlias": "AuthorReader",
+    "GetBookAuthors": "AuthorReader",
+    "GetBooksByAuthorIDWithRole": "AuthorReader",
+    "GetAllAuthorBookCounts": "AuthorReader",
+    "GetAllAuthorFileCounts": "AuthorReader",
+    "GetAuthorTombstone": "AuthorReader",
+    # AuthorWriter
+    "CreateAuthor": "AuthorWriter",
+    "DeleteAuthor": "AuthorWriter",
+    "UpdateAuthorName": "AuthorWriter",
+    "CreateAuthorAlias": "AuthorWriter",
+    "DeleteAuthorAlias": "AuthorWriter",
+    "SetBookAuthors": "AuthorWriter",
+    "CreateAuthorTombstone": "AuthorWriter",
+    "ResolveTombstoneChains": "AuthorWriter",
+    # SeriesReader
+    "GetAllSeries": "SeriesReader",
+    "GetSeriesByID": "SeriesReader",
+    "GetSeriesByName": "SeriesReader",
+    "GetAllSeriesBookCounts": "SeriesReader",
+    "GetAllSeriesFileCounts": "SeriesReader",
+    # SeriesWriter
+    "CreateSeries": "SeriesWriter",
+    "DeleteSeries": "SeriesWriter",
+    "UpdateSeriesName": "SeriesWriter",
+    # UserReader
+    "GetUserByID": "UserReader",
+    "GetUserByUsername": "UserReader",
+    "GetUserByEmail": "UserReader",
+    "ListUsers": "UserReader",
+    "CountUsers": "UserReader",
+    # UserWriter
+    "CreateUser": "UserWriter",
+    "UpdateUser": "UserWriter",
+    # OperationStore (hot — lots of methods)
+    "CreateOperation": "OperationStore",
+    "GetOperationByID": "OperationStore",
+    "GetRecentOperations": "OperationStore",
+    "ListOperations": "OperationStore",
+    "UpdateOperationStatus": "OperationStore",
+    "UpdateOperationError": "OperationStore",
+    "UpdateOperationResultData": "OperationStore",
+    "SaveOperationState": "OperationStore",
+    "GetOperationState": "OperationStore",
+    "SaveOperationParams": "OperationStore",
+    "GetOperationParams": "OperationStore",
+    "DeleteOperationState": "OperationStore",
+    "GetInterruptedOperations": "OperationStore",
+    "CreateOperationChange": "OperationStore",
+    "GetOperationChanges": "OperationStore",
+    "GetBookChanges": "OperationStore",
+    "RevertOperationChanges": "OperationStore",
+    "AddOperationLog": "OperationStore",
+    "GetOperationLogs": "OperationStore",
+    "SaveOperationSummaryLog": "OperationStore",
+    "GetOperationSummaryLog": "OperationStore",
+    "ListOperationSummaryLogs": "OperationStore",
+    "CreateOperationResult": "OperationStore",
+    "GetOperationResults": "OperationStore",
+    "GetRecentCompletedOperations": "OperationStore",
+    "PruneOperationLogs": "OperationStore",
+    "PruneOperationChanges": "OperationStore",
+    "DeleteOperationsByStatus": "OperationStore",
+    # Other single-interfaces
+    "Close": "LifecycleStore",
+    "Reset": "LifecycleStore",
+    "CreateNarrator": "NarratorStore",
+    "GetNarratorByID": "NarratorStore",
+    "GetNarratorByName": "NarratorStore",
+    "ListNarrators": "NarratorStore",
+    "GetBookNarrators": "NarratorStore",
+    "SetBookNarrators": "NarratorStore",
+    "GetAllWorks": "WorkStore",
+    "GetWorkByID": "WorkStore",
+    "CreateWork": "WorkStore",
+    "UpdateWork": "WorkStore",
+    "DeleteWork": "WorkStore",
+    "GetBooksByWorkID": "WorkStore",
+    "CreateSession": "SessionStore",
+    "GetSession": "SessionStore",
+    "RevokeSession": "SessionStore",
+    "ListUserSessions": "SessionStore",
+    "DeleteExpiredSessions": "SessionStore",
+    "GetRoleByID": "RoleStore",
+    "GetRoleByName": "RoleStore",
+    "ListRoles": "RoleStore",
+    "CreateRole": "RoleStore",
+    "UpdateRole": "RoleStore",
+    "DeleteRole": "RoleStore",
+    "CreateAPIKey": "APIKeyStore",
+    "GetAPIKey": "APIKeyStore",
+    "ListAPIKeysForUser": "APIKeyStore",
+    "RevokeAPIKey": "APIKeyStore",
+    "TouchAPIKeyLastUsed": "APIKeyStore",
+    "CreateInvite": "InviteStore",
+    "GetInvite": "InviteStore",
+    "ListActiveInvites": "InviteStore",
+    "DeleteInvite": "InviteStore",
+    "ConsumeInvite": "InviteStore",
+    "GetUserPreference": "UserPreferenceStore",
+    "SetUserPreference": "UserPreferenceStore",
+    "GetAllUserPreferences": "UserPreferenceStore",
+    "SetUserPreferenceForUser": "UserPreferenceStore",
+    "GetUserPreferenceForUser": "UserPreferenceStore",
+    "GetAllPreferencesForUser": "UserPreferenceStore",
+    "SetUserPosition": "UserPositionStore",
+    "GetUserPosition": "UserPositionStore",
+    "ListUserPositionsForBook": "UserPositionStore",
+    "ClearUserPositions": "UserPositionStore",
+    "SetUserBookState": "UserPositionStore",
+    "GetUserBookState": "UserPositionStore",
+    "ListUserBookStatesByStatus": "UserPositionStore",
+    "ListUserPositionsSince": "UserPositionStore",
+    "CreateBookVersion": "BookVersionStore",
+    "GetBookVersion": "BookVersionStore",
+    "GetBookVersionsByBookID": "BookVersionStore",
+    "GetActiveVersionForBook": "BookVersionStore",
+    "UpdateBookVersion": "BookVersionStore",
+    "DeleteBookVersion": "BookVersionStore",
+    "GetBookVersionByTorrentHash": "BookVersionStore",
+    "ListTrashedBookVersions": "BookVersionStore",
+    "ListPurgedBookVersions": "BookVersionStore",
+    "CreateBookFile": "BookFileStore",
+    "UpdateBookFile": "BookFileStore",
+    "GetBookFiles": "BookFileStore",
+    "GetBookFileByID": "BookFileStore",
+    "GetBookFileByPID": "BookFileStore",
+    "GetBookFileByPath": "BookFileStore",
+    "DeleteBookFile": "BookFileStore",
+    "DeleteBookFilesForBook": "BookFileStore",
+    "UpsertBookFile": "BookFileStore",
+    "BatchUpsertBookFiles": "BookFileStore",
+    "MoveBookFilesToBook": "BookFileStore",
+    "CreateBookSegment": "BookSegmentStore",
+    "UpdateBookSegment": "BookSegmentStore",
+    "ListBookSegments": "BookSegmentStore",
+    "MergeBookSegments": "BookSegmentStore",
+    "GetBookSegmentByID": "BookSegmentStore",
+    "MoveSegmentsToBook": "BookSegmentStore",
+    "CreatePlaylist": "PlaylistStore",
+    "GetPlaylistByID": "PlaylistStore",
+    "GetPlaylistBySeriesID": "PlaylistStore",
+    "AddPlaylistItem": "PlaylistStore",
+    "GetPlaylistItems": "PlaylistStore",
+    "CreateUserPlaylist": "UserPlaylistStore",
+    "GetUserPlaylist": "UserPlaylistStore",
+    "GetUserPlaylistByName": "UserPlaylistStore",
+    "GetUserPlaylistByITunesPID": "UserPlaylistStore",
+    "ListUserPlaylists": "UserPlaylistStore",
+    "UpdateUserPlaylist": "UserPlaylistStore",
+    "DeleteUserPlaylist": "UserPlaylistStore",
+    "ListDirtyUserPlaylists": "UserPlaylistStore",
+    "GetAllImportPaths": "ImportPathStore",
+    "GetImportPathByID": "ImportPathStore",
+    "GetImportPathByPath": "ImportPathStore",
+    "CreateImportPath": "ImportPathStore",
+    "UpdateImportPath": "ImportPathStore",
+    "DeleteImportPath": "ImportPathStore",
+    # Tags
+    "AddBookTag": "TagStore",
+    "AddBookTagWithSource": "TagStore",
+    "RemoveBookTag": "TagStore",
+    "RemoveBookTagsByPrefix": "TagStore",
+    "GetBookTags": "TagStore",
+    "GetBookTagsDetailed": "TagStore",
+    "SetBookTags": "TagStore",
+    "ListAllTags": "TagStore",
+    "GetBooksByTag": "TagStore",
+    "AddAuthorTag": "TagStore",
+    "AddAuthorTagWithSource": "TagStore",
+    "RemoveAuthorTag": "TagStore",
+    "RemoveAuthorTagsByPrefix": "TagStore",
+    "GetAuthorTags": "TagStore",
+    "GetAuthorTagsDetailed": "TagStore",
+    "SetAuthorTags": "TagStore",
+    "ListAllAuthorTags": "TagStore",
+    "GetAuthorsByTag": "TagStore",
+    "AddSeriesTag": "TagStore",
+    "AddSeriesTagWithSource": "TagStore",
+    "RemoveSeriesTag": "TagStore",
+    "RemoveSeriesTagsByPrefix": "TagStore",
+    "GetSeriesTags": "TagStore",
+    "GetSeriesTagsDetailed": "TagStore",
+    "SetSeriesTags": "TagStore",
+    "ListAllSeriesTags": "TagStore",
+    "GetSeriesByTag": "TagStore",
+    "GetBookUserTags": "UserTagStore",
+    "SetBookUserTags": "UserTagStore",
+    "AddBookUserTag": "UserTagStore",
+    "RemoveBookUserTag": "UserTagStore",
+    # Metadata
+    "GetMetadataFieldStates": "MetadataStore",
+    "UpsertMetadataFieldState": "MetadataStore",
+    "DeleteMetadataFieldState": "MetadataStore",
+    "RecordMetadataChange": "MetadataStore",
+    "GetMetadataChangeHistory": "MetadataStore",
+    "GetBookChangeHistory": "MetadataStore",
+    "GetBookAlternativeTitles": "MetadataStore",
+    "AddBookAlternativeTitle": "MetadataStore",
+    "RemoveBookAlternativeTitle": "MetadataStore",
+    "SetBookAlternativeTitles": "MetadataStore",
+    # Hash blocklist
+    "IsHashBlocked": "HashBlocklistStore",
+    "AddBlockedHash": "HashBlocklistStore",
+    "RemoveBlockedHash": "HashBlocklistStore",
+    "GetAllBlockedHashes": "HashBlocklistStore",
+    "GetBlockedHashByHash": "HashBlocklistStore",
+    # iTunes state
+    "SaveLibraryFingerprint": "ITunesStateStore",
+    "GetLibraryFingerprint": "ITunesStateStore",
+    "CreateDeferredITunesUpdate": "ITunesStateStore",
+    "GetPendingDeferredITunesUpdates": "ITunesStateStore",
+    "MarkDeferredITunesUpdateApplied": "ITunesStateStore",
+    "GetDeferredITunesUpdatesByBookID": "ITunesStateStore",
+    # Path history
+    "RecordPathChange": "PathHistoryStore",
+    "GetBookPathHistory": "PathHistoryStore",
+    # External IDs
+    "CreateExternalIDMapping": "ExternalIDStore",
+    "GetBookByExternalID": "ExternalIDStore",
+    "GetExternalIDsForBook": "ExternalIDStore",
+    "IsExternalIDTombstoned": "ExternalIDStore",
+    "TombstoneExternalID": "ExternalIDStore",
+    "ReassignExternalIDs": "ExternalIDStore",
+    "BulkCreateExternalIDMappings": "ExternalIDStore",
+    "MarkExternalIDRemoved": "ExternalIDStore",
+    "SetExternalIDProvenance": "ExternalIDStore",
+    "GetRemovedExternalIDs": "ExternalIDStore",
+    # Raw KV
+    "SetRaw": "RawKVStore",
+    "GetRaw": "RawKVStore",
+    "DeleteRaw": "RawKVStore",
+    "ScanPrefix": "RawKVStore",
+    # Playback
+    "AddPlaybackEvent": "PlaybackStore",
+    "ListPlaybackEvents": "PlaybackStore",
+    "UpdatePlaybackProgress": "PlaybackStore",
+    "GetPlaybackProgress": "PlaybackStore",
+    "IncrementBookPlayStats": "PlaybackStore",
+    "GetBookStats": "PlaybackStore",
+    "IncrementUserListenStats": "PlaybackStore",
+    "GetUserStats": "PlaybackStore",
+    # Settings
+    "GetSetting": "SettingsStore",
+    "SetSetting": "SettingsStore",
+    "GetAllSettings": "SettingsStore",
+    "DeleteSetting": "SettingsStore",
+    # Stats
+    "CountFiles": "StatsStore",
+    "CountAuthors": "StatsStore",
+    "CountSeries": "StatsStore",
+    "GetBookCountsByLocation": "StatsStore",
+    "GetBookSizesByLocation": "StatsStore",
+    "GetDashboardStats": "StatsStore",
+    # Maintenance
+    "Optimize": "MaintenanceStore",
+    "GetScanCacheMap": "MaintenanceStore",
+    "UpdateScanCache": "MaintenanceStore",
+    "MarkNeedsRescan": "MaintenanceStore",
+    "GetDirtyBookFolders": "MaintenanceStore",
+    # System activity
+    "AddSystemActivityLog": "SystemActivityStore",
+    "GetSystemActivityLogs": "SystemActivityStore",
+    "PruneSystemActivityLogs": "SystemActivityStore",
+}
+
+FIELD_RE = re.compile(r"^\s+([a-z][a-zA-Z0-9_]*)\s+database\.Store\b", re.MULTILINE)
+
+
+def analyze(path: pathlib.Path) -> None:
+    text = path.read_text()
+    fields = list(dict.fromkeys(FIELD_RE.findall(text)))
+    if not fields:
+        print(f"  (no database.Store field found)")
+        return
+    print(f"  field(s): {', '.join(fields)}")
+    for name in fields:
+        pat = re.compile(
+            rf"(?:^|[^a-zA-Z_0-9]){re.escape(name)}\.([A-Z][a-zA-Z0-9]+)\s*\(",
+            re.MULTILINE,
+        )
+        methods = sorted(set(pat.findall(text)))
+        if not methods:
+            print(f"    {name}: (zero calls)")
+            continue
+        ifaces = set()
+        unknown = []
+        for m in methods:
+            iface = METHOD_TO_IFACE.get(m)
+            if iface:
+                ifaces.add(iface)
+            else:
+                unknown.append(m)
+        print(f"    {name}: {len(methods)} method(s), {len(ifaces)} iface(s)")
+        print(f"      ifaces needed: {sorted(ifaces)}")
+        if unknown:
+            print(f"      UNKNOWN METHODS: {unknown}")
+
+
+def main() -> int:
+    repo = pathlib.Path(__file__).resolve().parent.parent
+    for rel in FILES:
+        print(f"=== {rel} ===")
+        p = repo / rel
+        if not p.exists():
+            print("  MISSING")
+            continue
+        analyze(p)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Final planned sweep PR. Important scope correction:

## The "noop cleanup" was mostly wrong

The sweep plan called for deleting unused `store` fields from 18 consumers. Turns out only **1** file (`config_update_service.go`) is a true noop — the other 21 classified as 'field-but-no-calls' actually use the `db` field name. The original Explore grep only looked for `store.<Method>`, missing them.

This PR narrows the 18 smallest real consumers (each <15 calls) to file-local composites. Left for later:
- `config_update_service.go` — 1 true noop, but removal needs ~20 test call-site updates; low ROI
- `metadata_fetch_service.go` (79 calls), `organize_service.go` (30), `dedup_engine.go` (22) — hub shape like `itunes.go`, narrowing cascades into many helpers

## Transitive deps hit again

Five files needed widening beyond the method-level analysis because they forward `db` to helpers that expect wider types:
- `audiobook_update_service` → `NewAudiobookService(audiobookStore)`
- `import_service` → `CreateIngestVersion`, `ProvisionITLTracksForBook`
- `merge_service` → `softDeleteBook(maintenanceStore)`
- `organize_preview_service` → `renameServiceStore` builder
- `scan_service` → `operations.SaveParams/ClearState`

## Also

- Rebased on main (picks up #394's `IntegrationEnv.Store` revert to full `database.Store` — test scaffolding is anti-ISP intentionally)
- Adds `scripts/`: `check_store_noops.py`, `narrow_struct_services.py`, `apply_narrowing.py`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (would have caught the test-file breakage in #394 — earlier PRs only ran vet on `./internal/server/`)