### PR TITLE
docs: close out ISP sweep (4.8 → done)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 5.8.0 -->
+<!-- version: 5.9.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-04-18 -->
 
@@ -94,7 +94,7 @@ since it was last edited on 2026-04-11).
 - [x] **4.5** Property-based tests for dedup engine (expanded to full codebase) (**M**) — complete (#357, #359, #361, #362, #363, #365, #366, #367, #368 — ~57 property tests across database / search / server / auth)
 - [x] **4.6** Chaos tests for the embedding store under shutdown (**M**) — 7 tests: double-close, ops-after-close, concurrent write/read during close, mixed access, durability, WAL checkpoint
 - [ ] **4.7** Per-workload store evaluation: Pebble vs SQLite vs PostgreSQL vs Go-native NoSQL (**L** research)
-- [~] **4.8** Split the `database.Store` interface (ISP refactor) (**L**) — foundation + 3 proof-points + 8-PR sweep shipped (#372, #376, #379–#382, #387–#395 incl. #394 test-scaffolding fix). ~50 of 79 consumers now use narrow sub-interfaces. **Remaining by design (hubs/wide consumers):** `server.go`, `indexed_store.go`, `itunes.go`, `metadata_fetch_service.go`, `organize_service.go`, `dedup_engine.go`. **Remaining cleanup (optional):** `config_update_service.go` unused-field removal.
+- [x] **4.8** Split the `database.Store` interface (ISP refactor) (**L**) — complete. Foundation + 3 proof-points + 8-PR sweep + doc closure: #372, #376, #379–#382, #387–#395. ~50 of 79 consumers migrated to narrow sub-interfaces. Six files remain on full `Store` as intentional wide consumers (server bootstrap, decorator, 4 hubs) — see [sweep plan Completion note](docs/superpowers/plans/2026-04-17-store-iface-sweep.md) for the rationale.
 
 ### 5. UX / DX Polish — [section](docs/backlog-2026-04-10.md#5-ux--dx-polish)
 

--- a/docs/superpowers/plans/2026-04-17-store-iface-sweep.md
+++ b/docs/superpowers/plans/2026-04-17-store-iface-sweep.md
@@ -1,8 +1,38 @@
 <!-- file: docs/superpowers/plans/2026-04-17-store-iface-sweep.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: bc332f80-16ea-44bd-afa9-a0634820909f -->
 
 # Store Interface Sweep — Follow-on Migration Plan
+
+> **STATUS: COMPLETE (2026-04-18).** Eight sweep PRs shipped (#387–#395). The six files still on full `database.Store` are documented below as intentional wide consumers — further narrowing has diminishing returns. Leaving this plan in place for historical context and as a template for future ISP sweeps.
+
+## Completion note
+
+**What shipped:** ~50 of 79 consumers migrated to narrow sub-interfaces. Plus `IntegrationEnv.Store` deliberately left wide (PR #394) — test scaffolding is anti-ISP.
+
+**What intentionally stayed wide:**
+
+| File | Reason |
+|---|---|
+| `internal/server/server.go` | Bootstrap — genuinely needs every domain during startup |
+| `internal/server/indexed_store.go` | Decorator — must be a drop-in `Store` so every forwarded method works |
+| `internal/server/itunes.go` | Hub — forwards to 8+ helpers across metadata-fetch + organize pipelines; narrowing cascades 15+ more signatures |
+| `internal/server/metadata_fetch_service.go` | Hub — 79 method calls spanning ~8 sub-interfaces; narrow composite ≈ full `Store` |
+| `internal/server/organize_service.go` | Hub — 30 calls across book + author + series + ops + files |
+| `internal/server/dedup_engine.go` | Hub — 22 calls, similar shape |
+| `internal/testutil/integration.go` | Test fixture — integration tests hit every domain; narrowing moves pain into every test file |
+
+**Optional future cleanups** (low ROI):
+- `internal/server/config_update_service.go` — unused `db database.Store` field; removing it churns ~20 test call sites for zero behavioral change.
+- The hubs could be narrowed, but each would produce a composite embedding 6–10 sub-interfaces — not materially more discoverable than the full `Store`, and each needs its own transitive-dep untangle.
+
+**Process lessons captured elsewhere:**
+- `CHANGELOG.md` April 18 entries — PR #394 incident post-mortem (scoped `go vet` misses test-file breakage; ran scoped instead of full-tree and paid for it)
+- `scripts/check_store_noops.py`, `narrow_struct_services.py`, `apply_narrowing.py` — reusable tooling for the next ISP sweep or for finishing this one if scope changes
+
+---
+
+## Original plan (historical — kept for reference)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Foundation is already merged — this plan migrates the remaining 58 files one-by-one. The three proof-point migrations (#379, #380, #381) are the templates to follow.
 


### PR DESCRIPTION
Marks 4.8 complete. Documents the six intentional wide consumers (server, indexed_store, itunes, metadata_fetch_service, organize_service, dedup_engine) in the sweep plan's Completion note so future readers understand they're deliberate, not oversights.

## Test plan
- [x] Docs only