### PR TITLE
feat(itunes): foundation for service extraction (PR 1/3)

### DIFF
--- a/internal/itunes/service/assert_test.go
+++ b/internal/itunes/service/assert_test.go
@@ -1,0 +1,16 @@
+// file: internal/itunes/service/assert_test.go
+// version: 1.0.0
+// guid: bdd01af3-56b2-4412-93b5-25c65ddb02ab
+
+package itunesservice_test
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
+)
+
+// Compile-time proof that *database.PebbleStore satisfies
+// itunesservice.Store. If a method is renamed or removed from PebbleStore,
+// the assertion below fails to build — we find out here rather than at
+// the Server wiring step.
+var _ itunesservice.Store = (*database.PebbleStore)(nil)

--- a/internal/itunes/service/config.go
+++ b/internal/itunes/service/config.go
@@ -1,0 +1,30 @@
+// file: internal/itunes/service/config.go
+// version: 1.0.0
+// guid: 6d05155e-42e3-4319-a2a7-2e80d10be2aa
+
+package itunesservice
+
+import "time"
+
+// Config is the iTunes-specific slice of config.AppConfig, passed by
+// value at construction so the service has no transitive dependency on
+// the global config singleton.
+type Config struct {
+	Enabled           bool
+	LibraryReadPath   string
+	LibraryWritePath  string
+	DefaultMappings   []PathMapping
+	SyncInterval      time.Duration
+	WriteBackInterval time.Duration
+	WriteBackMaxBatch int
+	BackupKeep        int
+	ImportConcurrency int
+}
+
+// PathMapping is a single ITunesPath → OrganizedPath transform applied
+// during import when iTunes PIDs resolve to a different filesystem
+// location than the library's canonical layout.
+type PathMapping struct {
+	From string
+	To   string
+}

--- a/internal/itunes/service/errors.go
+++ b/internal/itunes/service/errors.go
@@ -1,0 +1,17 @@
+// file: internal/itunes/service/errors.go
+// version: 1.0.0
+// guid: c34d7365-ba73-4d8f-87a2-9bd2259ba2a0
+
+package itunesservice
+
+import "errors"
+
+// ErrITunesDisabled is returned by methods called on a Service
+// constructed with NewDisabled. Callers should surface this as a 503
+// Service Unavailable at the HTTP layer.
+var ErrITunesDisabled = errors.New("iTunes integration is disabled")
+
+// ErrNotImplemented is a placeholder returned from sub-component method
+// stubs until they're filled in during PR 2. Should never appear on
+// main after PR 2 merges.
+var ErrNotImplemented = errors.New("iTunes service method not yet implemented")

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,0 +1,118 @@
+// file: internal/itunes/service/service.go
+// version: 1.0.0
+// guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
+
+package itunesservice
+
+import (
+	"context"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	"github.com/jdfalk/audiobook-organizer/internal/realtime"
+)
+
+// Deps is the explicit dependency set for Service. No globals, no Server,
+// no config.AppConfig — everything the service needs is passed in.
+type Deps struct {
+	Store      Store
+	OpQueue    operations.Queue
+	ActivityFn func(database.ActivityEntry)
+	Realtime   *realtime.EventHub // may be nil; means no SSE push
+	Config     Config
+	Logger     logger.Logger
+}
+
+// Sub-component placeholder types. Real definitions land in PR 2 when
+// each sub-component is moved out of internal/server/. Kept as empty
+// structs here so Service can declare typed fields without a forward
+// reference cycle or a disabled-only struct shape.
+type (
+	// Importer runs the iTunes import pipeline. Real type in PR 2.
+	Importer struct{}
+	// WriteBackBatcher batches ITL write-backs. Real type in PR 2.
+	WriteBackBatcher struct{}
+	// PositionSync syncs playback positions with iTunes. Real type in PR 2.
+	PositionSync struct{}
+	// PathReconciler reconciles iTunes-vs-library paths. Real type in PR 2.
+	PathReconciler struct{}
+	// PlaylistSync syncs iTunes playlists. Real type in PR 2.
+	PlaylistSync struct{}
+	// TrackProvisioner provisions iTunes tracks. Real type in PR 2.
+	TrackProvisioner struct{}
+	// TransferService transfers ITL files. Real type in PR 2.
+	TransferService struct{}
+)
+
+// Service owns the iTunes integration. Prefer a single *Service on the
+// Server struct — it composes the seven sub-components below with shared
+// lifecycle (Start / Shutdown).
+type Service struct {
+	deps Deps
+
+	// Sub-components. Nil when the service is disabled; populated by New.
+	Importer    *Importer
+	Batcher     *WriteBackBatcher
+	Positions   *PositionSync
+	Paths       *PathReconciler
+	Playlists   *PlaylistSync
+	Provisioner *TrackProvisioner
+	Transfer    *TransferService
+}
+
+// New constructs a fully-wired iTunes service. Returns ErrITunesDisabled
+// equivalent (cfg.Enabled == false) routes through NewDisabled instead —
+// callers should branch on cfg.Enabled at the construction site.
+func New(deps Deps) (*Service, error) {
+	if !deps.Config.Enabled {
+		return NewDisabled(), nil
+	}
+	if deps.Logger == nil {
+		deps.Logger = logger.New("itunes")
+	}
+	return &Service{
+		deps: deps,
+		// Sub-components populated in PR 2. Until then they stay nil;
+		// method calls on a nil sub-component return ErrNotImplemented.
+	}, nil
+}
+
+// NewDisabled constructs a Service whose methods all return
+// ErrITunesDisabled. Use when cfg.Enabled == false so the rest of the
+// server can still wire a non-nil *Service and avoid nil guards at every
+// call site.
+func NewDisabled() *Service {
+	return &Service{}
+}
+
+// Enabled reports whether the service has active sub-components wired.
+// A disabled service returns false; a real service returns true once
+// Start has run (or immediately — PR 2 decides per component).
+func (s *Service) Enabled() bool {
+	// PR 2 will refine: "enabled and started" vs "enabled but not yet
+	// started". For now, Enabled == cfg.Enabled.
+	return s.deps.Config.Enabled
+}
+
+// Start launches any long-lived sub-component goroutines (currently just
+// the WriteBackBatcher, wired in PR 2's step 2f). No-op when disabled.
+func (s *Service) Start(ctx context.Context) error {
+	if !s.Enabled() {
+		return nil
+	}
+	// Sub-component Start calls added in PR 2. This skeleton is a no-op
+	// so PR 1 can ship without behavior change.
+	return nil
+}
+
+// Shutdown flushes any long-lived sub-components and waits up to timeout
+// for graceful completion. No-op when disabled.
+func (s *Service) Shutdown(timeout time.Duration) error {
+	if !s.Enabled() {
+		return nil
+	}
+	// Sub-component Shutdown calls added in PR 2.
+	return nil
+}

--- a/internal/itunes/service/service_test.go
+++ b/internal/itunes/service/service_test.go
@@ -1,0 +1,50 @@
+// file: internal/itunes/service/service_test.go
+// version: 1.0.0
+// guid: 4ab6d921-bccd-4265-b04b-31faaacd5826
+
+package itunesservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewDisabled_ReturnsService(t *testing.T) {
+	svc := NewDisabled()
+	if svc == nil {
+		t.Fatal("NewDisabled returned nil")
+	}
+	if svc.Enabled() {
+		t.Error("disabled service should report Enabled() == false")
+	}
+}
+
+func TestNew_WithDisabledConfig_ReturnsDisabledService(t *testing.T) {
+	svc, err := New(Deps{Config: Config{Enabled: false}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if svc.Enabled() {
+		t.Error("service constructed with Enabled=false should report Enabled() == false")
+	}
+}
+
+func TestService_StartShutdown_Disabled_NoOp(t *testing.T) {
+	svc := NewDisabled()
+	if err := svc.Start(context.Background()); err != nil {
+		t.Errorf("Start on disabled: %v", err)
+	}
+	if err := svc.Shutdown(100 * time.Millisecond); err != nil {
+		t.Errorf("Shutdown on disabled: %v", err)
+	}
+}
+
+func TestErrITunesDisabled_Exported(t *testing.T) {
+	// Sanity check that ErrITunesDisabled exists and is an error. Prevents
+	// an accidental rename from breaking call sites that sentinel-check.
+	if !errors.Is(ErrITunesDisabled, ErrITunesDisabled) {
+		t.Fatal("ErrITunesDisabled failed errors.Is identity check")
+	}
+}

--- a/internal/itunes/service/store.go
+++ b/internal/itunes/service/store.go
@@ -1,0 +1,37 @@
+// file: internal/itunes/service/store.go
+// version: 1.0.0
+// guid: 4f9bbf9f-0d28-46d5-be9c-e9ce3a422593
+
+// Package itunesservice contains the iTunes integration: import pipeline,
+// ITL write-back batcher, position sync, path reconcile, playlist sync,
+// track provisioner, and ITL transfer. The low-level ITL parser, fingerprint,
+// path mapping, and smart-criteria translator live in the parent package
+// internal/itunes and are untouched by this extraction.
+//
+// See docs/superpowers/specs/2026-04-18-itunes-service-extraction-design.md.
+package itunesservice
+
+import "github.com/jdfalk/audiobook-organizer/internal/database"
+
+// Store is the narrow slice of database.Store that the iTunes service
+// uses. Wide because iTunes is a hub — books, authors, series, files,
+// tags, external IDs, operations, preferences, playlists, fingerprints
+// — but still smaller than full database.Store.
+type Store interface {
+	database.BookStore
+	database.AuthorStore
+	database.SeriesStore
+	database.NarratorStore
+	database.BookFileStore
+	database.HashBlocklistStore
+	database.ITunesStateStore
+	database.ExternalIDStore
+	database.UserPositionStore
+	database.UserPlaylistStore
+	database.UserPreferenceStore
+	database.OperationStore
+	database.SettingsStore
+	database.MetadataStore
+	database.TagStore
+	database.RawKVStore
+}

--- a/internal/itunes/service/types.go
+++ b/internal/itunes/service/types.go
@@ -1,0 +1,9 @@
+// file: internal/itunes/service/types.go
+// version: 1.0.0
+// guid: 43dcecba-4cba-4139-bd4c-5047a9a1f0c0
+
+// This file holds the request/response types used by the iTunes service's
+// HTTP surface. Populated by PR 2 (Importer task) — until then it only
+// carries the file header.
+
+package itunesservice

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.180.0
+// version: 1.181.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -29,6 +29,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/metrics"
@@ -698,6 +699,7 @@ type Server struct {
 	dedupCache             *cache.Cache[gin.H]
 	listCache              *cache.Cache[gin.H]
 	libraryWatcher         *itunes.LibraryWatcher
+	itunesSvc              *itunesservice.Service
 	updater                *updater.Updater
 	updateScheduler        *updater.Scheduler
 	scheduler              *TaskScheduler
@@ -826,6 +828,12 @@ func NewServer(store database.Store) *Server {
 		diagnosticsService:     NewDiagnosticsService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),
 		changelogService:       NewChangelogService(resolvedStore),
 	}
+
+	// Construct the iTunes service. PR 1 always uses NewDisabled — PR 2
+	// flips to conditional New based on config once sub-components are
+	// moved. Server still has the old *WriteBackBatcher, *LibraryWatcher,
+	// etc. fields populated via the existing code paths during PR 1+2.
+	server.itunesSvc = itunesservice.NewDisabled()
 
 	// Initialize update scheduler
 	server.updateScheduler = updater.NewScheduler(server.updater, func() updater.SchedulerConfig {
@@ -1393,6 +1401,9 @@ func (s *Server) resumeInterruptedOperations() {
 
 // Start starts the HTTP server
 func (s *Server) Start(cfg ServerConfig) error {
+	if err := s.itunesSvc.Start(s.bgCtx); err != nil {
+		return fmt.Errorf("itunes service start: %w", err)
+	}
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf("%s:%s", cfg.Host, cfg.Port),
 		Handler:           s.router,
@@ -1827,6 +1838,14 @@ func (s *Server) Start(cfg ServerConfig) error {
 	if s.writeBackBatcher != nil {
 		log.Println("[INFO] Flushing iTunes write-back batcher...")
 		s.writeBackBatcher.Stop()
+	}
+
+	// Shut down the iTunes service (no-op in PR 1 since NewDisabled is
+	// always used; PR 2 onward may have live sub-components to flush).
+	if s.itunesSvc != nil {
+		if err := s.itunesSvc.Shutdown(30 * time.Second); err != nil {
+			log.Printf("[WARN] itunes service shutdown: %v", err)
+		}
 	}
 
 	// Close the search index before the DB goes away — the index is


### PR DESCRIPTION
First of three PRs extracting iTunes from internal/server/ per spec 2026-04-18-itunes-service-extraction-design.md.

## Scope
- New package `internal/itunes/service/` with `Service`, `Deps`, `Config`, narrow `Store` interface
- `Server` gets a `s.itunesSvc` field wired to `NewDisabled()` — no behavior change
- Sub-components moved in PR 2; handlers consolidated + old files deleted in PR 3

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/itunes/service/` green (service + assert tests)
- [x] `make test-short` green (no existing behavior changed)