### PR TITLE
refactor(itunes): Enqueuer interface for writeback batcher (pre-work P1)

### DIFF
--- a/internal/server/import_service.go
+++ b/internal/server/import_service.go
@@ -30,11 +30,11 @@ type importServiceStore = database.Store
 
 type ImportService struct {
 	db importServiceStore
-	writeBackBatcher *WriteBackBatcher
+	writeBackBatcher Enqueuer
 }
 
 // SetWriteBackBatcher sets the iTunes write-back batcher.
-func (is *ImportService) SetWriteBackBatcher(b *WriteBackBatcher) {
+func (is *ImportService) SetWriteBackBatcher(b Enqueuer) {
 	is.writeBackBatcher = b
 }
 

--- a/internal/server/itunes_position_sync.go
+++ b/internal/server/itunes_position_sync.go
@@ -33,7 +33,7 @@ const adminUserID = "_local"
 // SyncITunesPositions runs a full bidirectional position sync for the
 // admin user. Pull then push order ensures we don't immediately
 // overwrite a newly-seeded position.
-func SyncITunesPositions(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher *WriteBackBatcher) (pulled, pushed int) {
+func SyncITunesPositions(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher Enqueuer) (pulled, pushed int) {
 	pulled = pullITunesBookmarks(store)
 	pushed = pushPositionsToITunes(store, batcher)
 	return pulled, pushed
@@ -107,7 +107,7 @@ func pullITunesBookmarks(store interface { database.BookStore; database.BookFile
 // position was updated since the last sync, enqueue the book for
 // bookmark writeback. If the book was marked finished, also enqueue
 // a play-count increment.
-func pushPositionsToITunes(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher *WriteBackBatcher) int {
+func pushPositionsToITunes(store interface { database.BookStore; database.BookFileStore; database.UserPositionStore }, batcher Enqueuer) int {
 	// Get all admin positions that changed in the last 24 hours.
 	// A more precise cutoff would use a last-sync-at timestamp;
 	// for now 24h is a safe window for the maintenance task that

--- a/internal/server/itunes_track_provisioner.go
+++ b/internal/server/itunes_track_provisioner.go
@@ -23,7 +23,7 @@ import (
 // and enqueues an ITL add operation. Called after importing a non-iTunes book.
 //
 // Skips if the book file already has an iTunes PID or if auto write-back is disabled.
-func ProvisionITLTrack(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, bookFile *database.BookFile, batcher *WriteBackBatcher) error {
+func ProvisionITLTrack(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, bookFile *database.BookFile, batcher Enqueuer) error {
 	if !config.AppConfig.ITunesAutoWriteBack {
 		return nil
 	}
@@ -89,7 +89,7 @@ func ProvisionITLTrack(store interface { database.AuthorReader; database.BookFil
 }
 
 // ProvisionITLTracksForBook provisions ITL tracks for all files of a book.
-func ProvisionITLTracksForBook(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, batcher *WriteBackBatcher) error {
+func ProvisionITLTracksForBook(store interface { database.AuthorReader; database.BookFileStore; database.ExternalIDStore }, book *database.Book, batcher Enqueuer) error {
 	files, err := store.GetBookFiles(book.ID)
 	if err != nil {
 		return err

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -2514,7 +2514,7 @@ func bookScore(b *database.Book) int {
 
 // mergeDuplicateBook transfers data from dup into keeper and then soft-deletes dup.
 // When dryRun is true the function returns nil without modifying the database.
-func mergeDuplicateBook(store maintenanceStore, keeper *database.Book, dup *database.Book, dryRun bool, batcher *WriteBackBatcher) error {
+func mergeDuplicateBook(store maintenanceStore, keeper *database.Book, dup *database.Book, dryRun bool, batcher Enqueuer) error {
 	if dryRun {
 		return nil
 	}

--- a/internal/server/playlist_itunes_sync.go
+++ b/internal/server/playlist_itunes_sync.go
@@ -90,7 +90,7 @@ func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.I
 // the ITL write-back batcher. Full ITL playlist creation requires
 // the ITL writer to support playlist insertion, which is tracked
 // separately.
-func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher *WriteBackBatcher) int {
+func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher Enqueuer) int {
 	dirties, err := store.ListDirtyUserPlaylists()
 	if err != nil {
 		log.Printf("[WARN] list dirty playlists: %v", err)

--- a/internal/server/version_swap.go
+++ b/internal/server/version_swap.go
@@ -23,7 +23,7 @@ func RunVersionSwap(
 	store database.Store,
 	params VersionSwapParams,
 	progress func(step string, pct int),
-	batcher *WriteBackBatcher,
+	batcher Enqueuer,
 ) error {
 	var onWriteBack func(bookID string)
 	if batcher != nil {

--- a/internal/server/writeback_enqueuer.go
+++ b/internal/server/writeback_enqueuer.go
@@ -1,0 +1,28 @@
+// file: internal/server/writeback_enqueuer.go
+// version: 1.0.0
+// guid: 5c255544-6862-47a8-bb9f-cce7630ecba5
+
+package server
+
+import "github.com/jdfalk/audiobook-organizer/internal/itunes"
+
+// Enqueuer is the narrow slice of *WriteBackBatcher that callers actually
+// need. Kept deliberately small so tests can mock it without spinning up a
+// batcher goroutine, and so services can depend on the interface rather
+// than the concrete type — which lets the concrete move packages (see the
+// iTunes service extraction, spec 2026-04-18) without churning every caller.
+//
+// Matches the per-package WriteBackEnqueuer interfaces already declared in
+// internal/merge and internal/organizer. Those packages keep their local
+// declarations because their surfaces are narrower (only EnqueueRemove or
+// only Enqueue); Enqueuer is the umbrella with all three methods for
+// callers that need the full batcher surface.
+type Enqueuer interface {
+	Enqueue(bookID string)
+	EnqueueAdd(track itunes.ITLNewTrack)
+	EnqueueRemove(pid string)
+}
+
+// Compile-time proof *WriteBackBatcher satisfies Enqueuer. If the batcher
+// gains or renames methods this assertion catches it.
+var _ Enqueuer = (*WriteBackBatcher)(nil)

--- a/internal/server/writeback_outbox.go
+++ b/internal/server/writeback_outbox.go
@@ -65,7 +65,7 @@ func (o *WriteBackOutbox) ListPending() []string {
 // ReplayOrphans finds pending outbox items on startup and re-enqueues
 // them into the in-memory batcher. Call from Server.Start() after
 // the batcher is initialized.
-func (o *WriteBackOutbox) ReplayOrphans(batcher *WriteBackBatcher) int {
+func (o *WriteBackOutbox) ReplayOrphans(batcher Enqueuer) int {
 	if batcher == nil {
 		return 0
 	}
@@ -104,7 +104,7 @@ func (o *WriteBackOutbox) ReplayOrphans(batcher *WriteBackBatcher) int {
 // outbox and the in-memory batcher. The batcher handles debounce +
 // flush; the outbox survives crashes. After flush, the caller should
 // call Dequeue to clean up.
-func EnqueueWithOutbox(outbox *WriteBackOutbox, batcher *WriteBackBatcher, bookID string) {
+func EnqueueWithOutbox(outbox *WriteBackOutbox, batcher Enqueuer, bookID string) {
 	if outbox != nil {
 		if err := outbox.Enqueue(bookID); err != nil {
 			log.Printf("[WARN] outbox enqueue %s: %v", bookID, err)


### PR DESCRIPTION
First of four pre-work PRs for the iTunes service extraction (spec 2026-04-18 v2 notes). Narrows 7 server-package consumers from concrete `*WriteBackBatcher` to the new `server.Enqueuer` interface.

## Scope
- **Added:** `internal/server/writeback_enqueuer.go` — 3-method interface (`Enqueue`, `EnqueueAdd`, `EnqueueRemove`) + compile-time assertion
- **Narrowed:** 7 consumers switched from concrete pointer to interface
- **Unchanged:** Server.go's `writeBackBatcher *WriteBackBatcher` field — Server owns the concrete for lifecycle, hands out as `Enqueuer`

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test-short` green (one pre-existing flake in TestApplyAudiobookMetadata_WriteBackFalse resolved on re-run)