### PR TITLE
refactor(itunes): remove GlobalWriteBackBatcher singleton (pre-work P2)

### DIFF
--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -220,8 +220,8 @@ func InitFileIOPool() {
 		if _, err := srv.metadataFetchService.WriteBackMetadataForBook(bookID); err != nil {
 			log.Printf("[WARN] recovery write-back for %s: %v", bookID, err)
 		}
-		if GlobalWriteBackBatcher != nil {
-			GlobalWriteBackBatcher.Enqueue(bookID)
+		if srv.writeBackBatcher != nil {
+			srv.writeBackBatcher.Enqueue(bookID)
 		}
 	})
 }

--- a/internal/server/itunes_writeback_batcher.go
+++ b/internal/server/itunes_writeback_batcher.go
@@ -42,8 +42,6 @@ type WriteBackBatcher struct {
 	stopped        bool
 }
 
-// GlobalWriteBackBatcher is the singleton batcher instance.
-var GlobalWriteBackBatcher *WriteBackBatcher
 
 // NewWriteBackBatcher creates a batcher with the given debounce delay.
 func NewWriteBackBatcher(delay time.Duration) *WriteBackBatcher {
@@ -448,9 +446,4 @@ func (b *WriteBackBatcher) Stop() {
 	}
 	b.mu.Unlock()
 	b.flush()
-}
-
-// InitWriteBackBatcher initializes the global write-back batcher.
-func InitWriteBackBatcher() {
-	GlobalWriteBackBatcher = NewWriteBackBatcher(5 * time.Second)
 }

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -126,7 +126,7 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 		ChangedAt:     batchTime.Add(500 * time.Millisecond),
 	}))
 
-	// Ensure GlobalWriteBackBatcher is nil so we don't trigger actual write-back
+	// Ensure server.writeBackBatcher is nil so we don't trigger actual write-back
 	origBatcher := server.writeBackBatcher
 	server.writeBackBatcher = nil
 	defer func() { server.writeBackBatcher = origBatcher }()


### PR DESCRIPTION
Second of four pre-work PRs. Deletes the `GlobalWriteBackBatcher` package var + `InitWriteBackBatcher()` function. The global was never initialized (no caller of `InitWriteBackBatcher` exists), so the one usage site in `file_io_pool.go` was a dead nil-guarded no-op.

Incidental latent bug fix: the apply_metadata recovery handler now actually enqueues write-backs via `srv.writeBackBatcher` (already captured from the closure's `globalServer`).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean