### PR TITLE
docs: v2 notes — P5–P8 pre-work findings from M1 BLOCKED attempt

### DIFF
--- a/docs/superpowers/specs/2026-04-18-itunes-service-extraction-v2-notes.md
+++ b/docs/superpowers/specs/2026-04-18-itunes-service-extraction-v2-notes.md
@@ -1,5 +1,5 @@
 <!-- file: docs/superpowers/specs/2026-04-18-itunes-service-extraction-v2-notes.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7c4f1e2a-8d5b-4e9c-a3f6-2b1d0e4c5f78 -->
 
 # iTunes Extraction — v2 notes
@@ -79,22 +79,83 @@ v1 spec success criteria (`server.go` iTunes refs ≤ 15, `internal/server/itune
 
 ## Next-session execution plan
 
-Phase 1 (pre-work PRs) — one session session of focused work:
+Phase 1 (pre-work PRs) — **partially shipped 2026-04-18:**
 
-1. **P1** — `Enqueuer` interface. ~25 call-site changes. Maybe 30 min.
-2. **P2** — Remove `GlobalWriteBackBatcher`. ~3 file changes. Maybe 20 min.
-3. **P3** — Inject `WriteBackBatcherConfig` into batcher. ~5 inline reads converted + 1 caller. Maybe 30 min.
-4. **P4** — Plan handler-name corrections. 5 min.
+1. ✅ **P1** — `Enqueuer` interface (#403 merged). 7 server-package consumers narrowed from `*WriteBackBatcher` to `server.Enqueuer`.
+2. ✅ **P2** — Removed `GlobalWriteBackBatcher` singleton (#404 merged). Bonus: fixed latent bug where the `apply_metadata` recovery handler never actually enqueued write-backs (the nil-guarded path was always nil).
+3. ✅ **P3** — Injected `WriteBackBatcherConfig` into the batcher (#405 merged). Five inline `config.AppConfig` reads replaced with struct fields behind a dedicated `cfgMu` RWMutex (separate from `mu` so hot-reload doesn't contend with the pending-ops critical section). `UpdateConfig` method ready for hot-reload wiring.
+4. ⏭ **P4** — Plan handler-name corrections. Skipped — the v1 plan is being replaced by v2 entirely.
 
-Phase 2 (main extraction) — separate session(s):
+**A fresh Phase 2 M1 attempt after P1–P3 landed escalated BLOCKED with different cascades** than the v1 Task 2 attempt. Four additional pre-work PRs are needed before M1 can run mechanically. These were not anticipated by the original v1 spec or the v2 shift to self-registering routes.
 
-5. **M1** — Move 7 sub-components (one commit each). 2-3 hours.
-6. **M2** — Self-registering routes; handlers move into service; delete the 7 server-side files. 1-2 hours.
-7. **M3** — Docs closure (CHANGELOG, TODO 4.9, TODO 4.10, disabled-mode smoke test). 30 min.
+## 5. Additional pre-work required (discovered during v2 M1 attempt)
+
+### 5.1 Pre-PR P5 — Extract `read_status_engine.go` from `internal/server/`
+
+**Blocker:** `internal/server/itunes_position_sync.go` calls `RecomputeUserBookState` and `SetManualStatus` which live in `internal/server/read_status_engine.go`. Moving `itunes_position_sync.go` into `internal/itunes/service/` would force the service to import `internal/server`, but `internal/server` already imports `internal/itunes/service` — that's a circular dep.
+
+**Fix:** extract `read_status_engine.go` (+ its test) to a new `internal/readstatus/` package. Both `internal/server/` (for its existing handlers) and `internal/itunes/service/` (post-move) import it. Size: ~156 LOC plus tests. Narrow deps — probably just `database.BookFileStore + database.UserPositionStore` (already narrowed during the ISP sweep 4.8).
+
+### 5.2 Pre-PR P6 — Inject store into `WriteBackBatcher`
+
+**Blocker:** `internal/server/itunes_writeback_batcher.go` lines 147, 203 call `database.GetGlobalStore()` — a second hidden global that P2 didn't touch. Moving the batcher into `internal/itunes/service/` would leave a transitive dependency on the database-package global.
+
+**Fix:** mirror P3's pattern. Add a `store` field on `WriteBackBatcher` populated at construction. The line 147 case is a best-effort goroutine inside `EnqueueRemove`; the line 203 case is the flush-time store fetch. Both become field reads. Constructor signature grows one more arg.
+
+### 5.3 Pre-PR P7 — Organizer dependency shape
+
+**Blocker:** `internal/server/itunes.go:1742` calls `organizer.NewOrganizer(&config.AppConfig)` — the organizer takes a full `*config.Config`, not a narrow subset. The v2 `itunesservice.Config` (9 fields) doesn't expose a path for this. Can't just pass through `config.AppConfig` without reintroducing the global dependency the whole extraction is trying to remove.
+
+**Fix options** (each has trade-offs):
+- **(a) Inject the organizer as a `Deps.Organizer` field.** Cleanest — iTunes doesn't know about organizer config, just calls into a pre-built instance. Server owns organizer lifecycle. Needs the organizer to expose the exact surface iTunes uses (just `Organize(book)`? — check before deciding).
+- **(b) Widen `itunesservice.Config` to hold a `*config.Config` pointer.** Escape hatch. Explicitly violates the "no `config.AppConfig` transitive dep" invariant we just bought in P3. Marks the extraction as incomplete.
+- **(c) Narrow the organizer's signature first.** `organizer.NewOrganizer` taking a full config is itself a smell. Pre-PR would change it to take only the fields it needs. Then iTunes can pass those explicitly.
+
+Recommended: (a) for Phase 2; consider (c) as a later cleanup if the organizer surface is small enough.
+
+### 5.4 Pre-PR P8 — `executeITunesSync` scheduler integration
+
+**Blocker:** `internal/server/itunes.go:2065` defines `executeITunesSync` as a plain function. Two callers:
+- `internal/server/server.go:~2540` — invoked directly from the `triggerITunesSync` scheduler callback
+- The interrupted-operation resume path around `server.go:1413`
+
+When `executeITunesSync` moves to `internal/itunes/service/` as a `*Service` method (via `*Importer` or similar), both call sites need rewiring. The scheduler callback currently closes over package-level scope; after the move it needs to close over `s.itunesSvc`.
+
+**Fix:** expose `executeITunesSync` as a public method (probably `(s *Service) RunSync(...)` or on `*Importer.Sync`). Server's scheduler callback becomes a closure over `s` that calls `s.itunesSvc.Importer.Sync(...)`. Same pattern for the resume dispatch switch.
+
+Small change but spans two call sites + scheduler shape.
+
+### 5.5 Impact on M1
+
+With P5–P8 landed, M1's sub-component moves become truly mechanical:
+
+- **Transfer / TrackProvisioner / PlaylistSync / PathReconciler / Importer** — no additional surprises expected
+- **PositionSync** — unblocked by P5 (no longer reaches into server package)
+- **WriteBackBatcher** — unblocked by P6 (no more `GetGlobalStore` calls)
+- **Server wiring** — unblocked by P7 (organizer via Deps) + P8 (scheduler callback through service)
+
+Revised M1 estimate: still 2–3 hours after P5–P8 land, but with high confidence of success.
+
+## 6. Revised next-session execution order
+
+**Phase 1a** (this session's state): ✅ P1 #403, ✅ P2 #404, ✅ P3 #405, ⏭ P4 skipped.
+
+**Phase 1b** (next session — pre-work continued):
+5. **P5** — Extract `read_status_engine.go` to `internal/readstatus/`. ~30 min.
+6. **P6** — Inject store into `WriteBackBatcher`. ~20 min.
+7. **P7** — Inject organizer into `Deps` (option (a)). ~30 min unless organizer surface is wider than expected.
+8. **P8** — Expose `executeITunesSync` as a method + rewire scheduler callback. ~20 min.
+
+**Phase 2** (subsequent session — unchanged shape):
+9. **M1** — Move 7 sub-components. 2–3 hours.
+10. **M2** — Self-registering routes. 1–2 hours.
+11. **M3** — Docs closure. 30 min.
 
 ## References
 
-- v1 spec: `docs/superpowers/specs/2026-04-18-itunes-service-extraction-design.md` (§1–§8 still authoritative)
+- v1 spec: `docs/superpowers/specs/2026-04-18-itunes-service-extraction-design.md` (§1–§8 still authoritative for the Service shape)
 - v1 plan: `docs/superpowers/plans/2026-04-18-itunes-service-extraction.md` (replace with v2 before Phase 2 starts)
 - v1 foundation PR: #401 (merged)
-- v1 Task 2 BLOCKED escalation: session notes from 2026-04-18
+- v2 pre-work PRs: #403 (P1 Enqueuer), #404 (P2 no-global), #405 (P3 config-injected)
+- v1 Task 2 BLOCKED escalation: 2026-04-18 session notes (captured inline above under §10 in the main spec)
+- v2 M1 BLOCKED escalation: 2026-04-19 session — identified P5–P8 cascades above


### PR DESCRIPTION
Extends the v2 notes with the four additional pre-work PRs discovered when the Phase 2 M1 extraction was attempted (and correctly escalated BLOCKED).

## What's new
- Marks P1 #403, P2 #404, P3 #405 as shipped; P4 skipped (v1 plan being replaced).
- Adds §5 with concrete descriptions of P5 (extract read_status_engine), P6 (inject batcher store), P7 (organizer deps), P8 (scheduler callback rewire).
- Adds §6 with revised execution order for the next session.

## Why this matters
Phase 2 M1 cannot run mechanically until P5–P8 land. The v1 spec missed these couplings; the v2 spec caught the writeback-batcher cascades but not the read_status_engine cross-package call or the full-config organizer dep. This note documents the gap so next session doesn't start another attempt blind.

## Test plan
- [x] Docs only, no code