### PR TITLE
refactor: extract read_status_engine to internal/readstatus (pre-work P5)

### DIFF
--- a/internal/readstatus/readstatus.go
+++ b/internal/readstatus/readstatus.go
@@ -1,5 +1,5 @@
-// file: internal/server/read_status_engine.go
-// version: 1.1.0
+// file: internal/readstatus/readstatus.go
+// version: 2.0.0
 // guid: 6e2f8a1d-4c5b-4f70-a9c7-2d8e0f1b9a57
 //
 // RecomputeUserBookState derives a UserBookState from the current
@@ -21,7 +21,12 @@
 //        - else → unstarted
 //      `abandoned` is never auto-computed — user-set only.
 
-package server
+// Extracted from internal/server/ to internal/readstatus/ (pre-work P5)
+// so internal/itunes/service/ can call Recompute / SetManual without
+// creating a cyclic dep (server imports itunes/service; iTunes
+// position-sync calls into here).
+
+package readstatus
 
 import (
 	"time"

--- a/internal/readstatus/readstatus_test.go
+++ b/internal/readstatus/readstatus_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/read_status_engine_test.go
+// file: internal/readstatus/readstatus_test.go
 // version: 1.0.0
 // guid: 9e2a8c4d-5b1f-4f70-a7c6-2d8e0f1b9a57
 
-package server
+package readstatus
 
 import (
 	"path/filepath"

--- a/internal/server/itunes_position_sync.go
+++ b/internal/server/itunes_position_sync.go
@@ -22,6 +22,7 @@
 package server
 
 import (
+	"github.com/jdfalk/audiobook-organizer/internal/readstatus"
 	"log"
 	"time"
 
@@ -77,7 +78,7 @@ func pullITunesBookmarks(store interface { database.BookStore; database.BookFile
 		}
 
 		// Recompute the derived book state from the seeded position.
-		if _, err := RecomputeUserBookState(store, adminUserID, book.ID); err != nil {
+		if _, err := readstatus.RecomputeUserBookState(store, adminUserID, book.ID); err != nil {
 			log.Printf("[WARN] recompute state for %s after bookmark seed: %v", book.ID, err)
 		}
 		seeded++
@@ -92,7 +93,7 @@ func pullITunesBookmarks(store interface { database.BookStore; database.BookFile
 		if state != nil {
 			continue
 		}
-		if _, err := SetManualStatus(store, adminUserID, book.ID, database.UserBookStatusFinished); err != nil {
+		if _, err := readstatus.SetManualStatus(store, adminUserID, book.ID, database.UserBookStatusFinished); err != nil {
 			log.Printf("[WARN] seed finished for %s: %v", book.ID, err)
 			continue
 		}

--- a/internal/server/reading_handlers.go
+++ b/internal/server/reading_handlers.go
@@ -12,6 +12,7 @@
 package server
 
 import (
+	"github.com/jdfalk/audiobook-organizer/internal/readstatus"
 	"net/http"
 	"strconv"
 	"time"
@@ -59,7 +60,7 @@ func (s *Server) handleSetPosition(c *gin.Context) {
 		internalError(c, "failed to record position", err)
 		return
 	}
-	state, err := RecomputeUserBookState(s.Store(), userID, bookID)
+	state, err := readstatus.RecomputeUserBookState(s.Store(), userID, bookID)
 	if err != nil {
 		internalError(c, "failed to recompute book state", err)
 		return
@@ -132,7 +133,7 @@ func (s *Server) handleSetBookStatus(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status: " + req.Status})
 		return
 	}
-	state, err := SetManualStatus(s.Store(), callingUserID(c), bookID, req.Status)
+	state, err := readstatus.SetManualStatus(s.Store(), callingUserID(c), bookID, req.Status)
 	if err != nil {
 		internalError(c, "failed to set status", err)
 		return
@@ -149,7 +150,7 @@ func (s *Server) handleClearBookStatus(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
 		return
 	}
-	state, err := SetManualStatus(s.Store(), callingUserID(c), bookID, "")
+	state, err := readstatus.SetManualStatus(s.Store(), callingUserID(c), bookID, "")
 	if err != nil {
 		internalError(c, "failed to clear status", err)
 		return


### PR DESCRIPTION
First of four additional pre-work PRs (P5-P8) that the Phase 2 M1 BLOCKED attempt surfaced. See `docs/superpowers/specs/2026-04-18-itunes-service-extraction-v2-notes.md` §5.1.

## Scope
- `internal/server/read_status_engine.go` → `internal/readstatus/readstatus.go` (rename drops the now-redundant `_engine` suffix; the package name carries that meaning)
- Same treatment for the test file
- 5 call sites across 2 server-package files now call `readstatus.RecomputeUserBookState` / `readstatus.SetManualStatus`

## Why
`internal/server/itunes_position_sync.go` calls these helpers. When iTunes position-sync moves into `internal/itunes/service/` during Phase 2 M1, it can't import `internal/server` (server already imports itunes/service — cyclic). Extracting to a neutral package breaks that knot.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (full-tree)
- [x] `go test ./internal/readstatus/` green (both tests pass)