### PR TITLE
refactor: inject store into WriteBackBatcher (pre-work P6)

### DIFF
--- a/internal/server/itunes_writeback_batcher.go
+++ b/internal/server/itunes_writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_writeback_batcher.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -32,6 +32,18 @@ type WriteBackBatcherConfig struct {
 	LibraryWritePath    string
 }
 
+// WriteBackStore is the narrow slice of database.Store the batcher needs.
+// Defined here (not in internal/database) so the batcher stays package-
+// portable: when the concrete type moves to internal/itunes/service/ in
+// Phase 2 M1 it drags its deps along without re-importing internal/database
+// via the service-level Store composite.
+type WriteBackStore interface {
+	database.BookStore        // GetBookByID, MarkITunesSynced
+	database.AuthorReader     // GetAuthorByID
+	database.BookFileStore    // GetBookFiles
+	database.ExternalIDStore  // MarkExternalIDRemoved
+}
+
 // WriteBackBatcher collects ITL operations and flushes them in a single batch
 // after a debounce delay. Supports location updates, track additions, and
 // track removals — all applied in one read-modify-write cycle.
@@ -58,11 +70,17 @@ type WriteBackBatcher struct {
 	autoWriteBack       bool
 	itlWriteBackEnabled bool
 	libraryWritePath    string
+
+	// store is the narrow database surface used by the flush goroutine
+	// and the EnqueueRemove best-effort tombstone marker. May be nil
+	// (pre-wiring path in older test fixtures); runtime call sites
+	// nil-guard.
+	store WriteBackStore
 }
 
 
 // NewWriteBackBatcher creates a batcher with the given debounce delay.
-func NewWriteBackBatcher(delay time.Duration, cfg WriteBackBatcherConfig) *WriteBackBatcher {
+func NewWriteBackBatcher(delay time.Duration, cfg WriteBackBatcherConfig, store WriteBackStore) *WriteBackBatcher {
 	return &WriteBackBatcher{
 		pendingBooks:        make(map[string]bool),
 		pendingRemoves:      make(map[string]bool),
@@ -72,6 +90,7 @@ func NewWriteBackBatcher(delay time.Duration, cfg WriteBackBatcherConfig) *Write
 		autoWriteBack:       cfg.AutoWriteBack,
 		itlWriteBackEnabled: cfg.ITLWriteBackEnabled,
 		libraryWritePath:    cfg.LibraryWritePath,
+		store:               store,
 	}
 }
 
@@ -144,8 +163,8 @@ func (b *WriteBackBatcher) EnqueueRemove(pid string) {
 
 	// Mark as removed in DB (best-effort, outside lock)
 	go func() {
-		if store := database.GetGlobalStore(); store != nil {
-			_ = store.MarkExternalIDRemoved("itunes", pid)
+		if b.store != nil {
+			_ = b.store.MarkExternalIDRemoved("itunes", pid)
 		}
 	}()
 }
@@ -200,7 +219,7 @@ func (b *WriteBackBatcher) flush() {
 	b.firstEnqueue = time.Time{} // reset for next batch
 	b.mu.Unlock()
 
-	store := database.GetGlobalStore()
+	store := b.store
 	if store == nil {
 		log.Printf("[WARN] iTunes write-back: no database store")
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1016,7 +1016,7 @@ func NewServer(store database.Store) *Server {
 		AutoWriteBack:       config.AppConfig.ITunesAutoWriteBack,
 		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
 		LibraryWritePath:    config.AppConfig.ITunesLibraryWritePath,
-	})
+	}, resolvedStore)
 	server.fileIOPool = NewFileIOPool(4)
 
 	// Wire writeBackBatcher into services that need it

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -351,7 +351,7 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}) // long delay so it won't flush
+	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil) // long delay so it won't flush
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -398,7 +398,7 @@ func TestApplyAudiobookMetadata_WriteBackTrue(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"})
+	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -461,7 +461,7 @@ func TestApplyAudiobookMetadata_WriteBackOmitted(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"})
+	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -523,7 +523,7 @@ func TestApplyAudiobookMetadata_WriteBackFalse(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"})
+	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races


### PR DESCRIPTION
Second of four P5-P8 pre-work PRs. See spec v2 §5.2 in `docs/superpowers/specs/2026-04-18-itunes-service-extraction-v2-notes.md`.

## Scope
- New `WriteBackStore` interface (4 sub-interfaces: BookStore, AuthorReader, BookFileStore, ExternalIDStore)
- `*WriteBackBatcher` gains a `store WriteBackStore` field
- `NewWriteBackBatcher` gains a 3rd arg `store WriteBackStore`
- Two `database.GetGlobalStore()` calls inside the batcher replaced with `b.store`
- Callers: server.go passes `resolvedStore`; 4 test call sites pass `nil` (tests use 1-hour debounce so flush never runs)

## Why
After P3 removed the batcher's `config.AppConfig` reads, this removes the remaining package-global dependency (`database.GetGlobalStore()`). Combined, the batcher is now fully package-portable — ready to move to `internal/itunes/service/` during Phase 2 M1 without dragging in `internal/config` or relying on `database` globals.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (full-tree)
- [x] `go test ./internal/server/ -run WriteBack -short` green (5.2s, covers the 4 updated test call sites)