### PR TITLE
fix(itunes): complete M1 step 1 — apply missing modifications

### DIFF
--- a/internal/itunes/service/config.go
+++ b/internal/itunes/service/config.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/config.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6d05155e-42e3-4319-a2a7-2e80d10be2aa
 
 package itunesservice
@@ -10,15 +10,17 @@ import "time"
 // value at construction so the service has no transitive dependency on
 // the global config singleton.
 type Config struct {
-	Enabled           bool
-	LibraryReadPath   string
-	LibraryWritePath  string
-	DefaultMappings   []PathMapping
-	SyncInterval      time.Duration
-	WriteBackInterval time.Duration
-	WriteBackMaxBatch int
-	BackupKeep        int
-	ImportConcurrency int
+	Enabled             bool
+	LibraryReadPath     string
+	LibraryWritePath    string
+	DefaultMappings     []PathMapping
+	SyncInterval        time.Duration
+	WriteBackInterval   time.Duration
+	WriteBackMaxBatch   int
+	BackupKeep          int
+	ImportConcurrency   int
+	AutoWriteBack       bool // mirror of config.AppConfig.ITunesAutoWriteBack
+	ITLWriteBackEnabled bool // mirror of config.AppConfig.ITLWriteBackEnabled
 }
 
 // PathMapping is a single ITunesPath → OrganizedPath transform applied

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
 
 package itunesservice
@@ -25,24 +25,27 @@ type Deps struct {
 	Logger     logger.Logger
 }
 
-// Sub-component placeholder types. Real definitions land in PR 2 when
-// each sub-component is moved out of internal/server/. Kept as empty
+// Sub-component placeholder types. Real definitions land in Phase 2 M1
+// as each sub-component is moved out of internal/server/. Kept as empty
 // structs here so Service can declare typed fields without a forward
-// reference cycle or a disabled-only struct shape.
+// reference cycle. Each placeholder is deleted and replaced by a real
+// definition in its own file when the corresponding sub-component moves.
+//
+// Status after Phase 2 M1 step 1 (this PR):
+//   - TrackProvisioner: real (track_provisioner.go)
+//   - All others: placeholder
 type (
-	// Importer runs the iTunes import pipeline. Real type in PR 2.
+	// Importer runs the iTunes import pipeline. Placeholder until moved.
 	Importer struct{}
-	// WriteBackBatcher batches ITL write-backs. Real type in PR 2.
+	// WriteBackBatcher batches ITL write-backs. Placeholder until moved.
 	WriteBackBatcher struct{}
-	// PositionSync syncs playback positions with iTunes. Real type in PR 2.
+	// PositionSync syncs playback positions with iTunes. Placeholder until moved.
 	PositionSync struct{}
-	// PathReconciler reconciles iTunes-vs-library paths. Real type in PR 2.
+	// PathReconciler reconciles iTunes-vs-library paths. Placeholder until moved.
 	PathReconciler struct{}
-	// PlaylistSync syncs iTunes playlists. Real type in PR 2.
+	// PlaylistSync syncs iTunes playlists. Placeholder until moved.
 	PlaylistSync struct{}
-	// TrackProvisioner provisions iTunes tracks. Real type in PR 2.
-	TrackProvisioner struct{}
-	// TransferService transfers ITL files. Real type in PR 2.
+	// TransferService transfers ITL files. Placeholder until moved.
 	TransferService struct{}
 )
 
@@ -72,11 +75,16 @@ func New(deps Deps) (*Service, error) {
 	if deps.Logger == nil {
 		deps.Logger = logger.New("itunes")
 	}
-	return &Service{
+	svc := &Service{
 		deps: deps,
-		// Sub-components populated in PR 2. Until then they stay nil;
-		// method calls on a nil sub-component return ErrNotImplemented.
-	}, nil
+	}
+
+	// Wire real sub-components as they land. M1 step 1: Provisioner.
+	// The enqueuer (batcher) lives on Server until M1 step 2 — server
+	// calls Provisioner.SetEnqueuer after New() to complete wiring.
+	svc.Provisioner = newTrackProvisioner(deps.Store, nil /*enqueuer TBD*/, deps.Config)
+
+	return svc, nil
 }
 
 // NewDisabled constructs a Service whose methods all return

--- a/internal/server/import_service.go
+++ b/internal/server/import_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/import_service.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
 
 package server
@@ -14,6 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
 
@@ -29,13 +30,14 @@ type importServiceStore = database.Store
 
 
 type ImportService struct {
-	db importServiceStore
-	writeBackBatcher Enqueuer
+	db          importServiceStore
+	provisioner *itunesservice.TrackProvisioner
 }
 
-// SetWriteBackBatcher sets the iTunes write-back batcher.
-func (is *ImportService) SetWriteBackBatcher(b Enqueuer) {
-	is.writeBackBatcher = b
+// SetTrackProvisioner wires the iTunes track provisioner for newly-imported
+// books. Pass nil to disable ITL track provisioning (e.g. in tests).
+func (is *ImportService) SetTrackProvisioner(p *itunesservice.TrackProvisioner) {
+	is.provisioner = p
 }
 
 func NewImportService(db importServiceStore) *ImportService {
@@ -182,10 +184,14 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 		log.Printf("[WARN] create ingest version for %s: %v", created.ID, verErr)
 	}
 
-	// Provision ITL track (generates PID, stores in external_id_map, enqueues add)
-	if err := ProvisionITLTracksForBook(is.db, created, is.writeBackBatcher); err != nil {
-		// Non-fatal: book was created, ITL provisioning can be retried
-		log.Printf("[WARN] ITL track provisioning failed for %s: %v", created.ID, err)
+	// Provision ITL track via the injected iTunes service (moved from this
+	// package into internal/itunes/service/ during Phase 2 M1 step 1).
+	// Nil provisioner → iTunes disabled or not wired; book is still created
+	// and ITL provisioning can happen later when iTunes comes online.
+	if is.provisioner != nil {
+		if err := is.provisioner.ProvisionAll(created); err != nil {
+			log.Printf("[WARN] ITL track provisioning failed for %s: %v", created.ID, err)
+		}
 	}
 
 	return &ImportFileResponse{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -834,11 +834,27 @@ func NewServer(store database.Store) *Server {
 		changelogService:       activity.NewChangelogService(resolvedStore),
 	}
 
-	// Construct the iTunes service. PR 1 always uses NewDisabled — PR 2
-	// flips to conditional New based on config once sub-components are
-	// moved. Server still has the old *WriteBackBatcher, *LibraryWatcher,
-	// etc. fields populated via the existing code paths during PR 1+2.
-	server.itunesSvc = itunesservice.NewDisabled()
+	// Construct the iTunes service. Phase 2 M1 step 1 enables it via New()
+	// so the real TrackProvisioner gets wired into the import pipeline;
+	// remaining sub-components stay as empty-struct placeholders until
+	// they move in later M1 steps. Disabled fallback is preserved for
+	// construction failures or (future) test paths that explicitly opt out.
+	itunesCfg := itunesservice.Config{
+		Enabled:             true,
+		LibraryReadPath:     config.AppConfig.ITunesLibraryReadPath,
+		LibraryWritePath:    config.AppConfig.ITunesLibraryWritePath,
+		AutoWriteBack:       config.AppConfig.ITunesAutoWriteBack,
+		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
+	}
+	itunesSvc, err := itunesservice.New(itunesservice.Deps{
+		Store:  resolvedStore,
+		Config: itunesCfg,
+	})
+	if err != nil {
+		log.Printf("[WARN] iTunes service construction failed, falling back to disabled: %v", err)
+		itunesSvc = itunesservice.NewDisabled()
+	}
+	server.itunesSvc = itunesSvc
 
 	// Initialize update scheduler
 	server.updateScheduler = updater.NewScheduler(server.updater, func() updater.SchedulerConfig {
@@ -1024,7 +1040,17 @@ func NewServer(store database.Store) *Server {
 	server.organizeService.SetWriteBackBatcher(server.writeBackBatcher)
 	server.organizeService.SetQueue(server.queue)
 	server.mergeService.SetWriteBackBatcher(server.writeBackBatcher)
-	server.importService.SetWriteBackBatcher(server.writeBackBatcher)
+
+	// ImportService uses the iTunes service's TrackProvisioner (moved
+	// during Phase 2 M1 step 1). Nil provisioner → ITL track provisioning
+	// is skipped (service is disabled or construction failed above).
+	server.importService.SetTrackProvisioner(server.itunesSvc.Provisioner)
+	// The provisioner needs the batcher for EnqueueAdd. SetEnqueuer
+	// completes wiring here because the batcher still lives on Server
+	// until Phase 2 M1 step 2 moves it under Service.
+	if server.itunesSvc.Provisioner != nil {
+		server.itunesSvc.Provisioner.SetEnqueuer(server.writeBackBatcher)
+	}
 
 	// Register file-op recovery handler (uses server closure instead of globalServer)
 	RegisterFileOpRecovery("apply_metadata", func(bookID string) {

--- a/internal/server/writeback_enqueuer.go
+++ b/internal/server/writeback_enqueuer.go
@@ -1,27 +1,18 @@
 // file: internal/server/writeback_enqueuer.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 5c255544-6862-47a8-bb9f-cce7630ecba5
 
 package server
 
-import "github.com/jdfalk/audiobook-organizer/internal/itunes"
+import itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 
-// Enqueuer is the narrow slice of *WriteBackBatcher that callers actually
-// need. Kept deliberately small so tests can mock it without spinning up a
-// batcher goroutine, and so services can depend on the interface rather
-// than the concrete type — which lets the concrete move packages (see the
-// iTunes service extraction, spec 2026-04-18) without churning every caller.
-//
-// Matches the per-package WriteBackEnqueuer interfaces already declared in
-// internal/merge and internal/organizer. Those packages keep their local
-// declarations because their surfaces are narrower (only EnqueueRemove or
-// only Enqueue); Enqueuer is the umbrella with all three methods for
-// callers that need the full batcher surface.
-type Enqueuer interface {
-	Enqueue(bookID string)
-	EnqueueAdd(track itunes.ITLNewTrack)
-	EnqueueRemove(pid string)
-}
+// Enqueuer is a type alias for itunesservice.Enqueuer. The canonical
+// interface moved to internal/itunes/service/enqueuer.go during Phase 2
+// M1 step 1 so sub-components inside that package can depend on it
+// without importing server (which already imports itunesservice — would
+// be a cycle). Server-package callers continue to use `server.Enqueuer`
+// because Go type aliases make the names interchangeable.
+type Enqueuer = itunesservice.Enqueuer
 
 // Compile-time proof *WriteBackBatcher satisfies Enqueuer. If the batcher
 // gains or renames methods this assertion catches it.


### PR DESCRIPTION
🚨 **Origin/main is currently broken** — PR #411 merged only the new files and the deletion but none of the 5 file modifications (lost to a silent `git add` pathspec error). Result: `TrackProvisioner` is declared twice (real type + placeholder) and `ProvisionITLTracksForBook` is called but doesn't exist.

This fix lands the 5 missing modifications:

- `internal/itunes/service/service.go` — remove TrackProvisioner placeholder, wire `svc.Provisioner` in `New()`
- `internal/itunes/service/config.go` — add `AutoWriteBack` + `ITLWriteBackEnabled` fields
- `internal/server/writeback_enqueuer.go` — `type Enqueuer = itunesservice.Enqueuer` (canonical moved)
- `internal/server/import_service.go` — drop batcher field, add provisioner field + SetTrackProvisioner method
- `internal/server/server.go` — flip `NewDisabled()` to `New(deps)` + wire provisioner via SetTrackProvisioner / SetEnqueuer

## Test plan
- [x] `go build ./...` clean (before the fix: redeclaration error)
- [x] `go vet ./...` clean (full-tree)
- [x] `go test ./internal/server/ -run Import -short` green (6s)

Staging used `git add -A` this time to avoid the original silent-skip bug.