### PR TITLE
refactor(itunes): move WriteBackBatcher into itunesservice (M1 step 2)

### DIFF
--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -31,14 +31,13 @@ type Deps struct {
 // reference cycle. Each placeholder is deleted and replaced by a real
 // definition in its own file when the corresponding sub-component moves.
 //
-// Status after Phase 2 M1 step 1 (this PR):
+// Status after Phase 2 M1 step 2 (this PR):
 //   - TrackProvisioner: real (track_provisioner.go)
+//   - WriteBackBatcher: real (writeback_batcher.go)
 //   - All others: placeholder
 type (
 	// Importer runs the iTunes import pipeline. Placeholder until moved.
 	Importer struct{}
-	// WriteBackBatcher batches ITL write-backs. Placeholder until moved.
-	WriteBackBatcher struct{}
 	// PositionSync syncs playback positions with iTunes. Placeholder until moved.
 	PositionSync struct{}
 	// PathReconciler reconciles iTunes-vs-library paths. Placeholder until moved.
@@ -79,10 +78,19 @@ func New(deps Deps) (*Service, error) {
 		deps: deps,
 	}
 
-	// Wire real sub-components as they land. M1 step 1: Provisioner.
-	// The enqueuer (batcher) lives on Server until M1 step 2 — server
-	// calls Provisioner.SetEnqueuer after New() to complete wiring.
-	svc.Provisioner = newTrackProvisioner(deps.Store, nil /*enqueuer TBD*/, deps.Config)
+	// M1 step 2: Batcher lives here now. Built first so sub-components
+	// that need it (Provisioner today, Positions/Playlists/etc. in later
+	// M1 steps) can be wired with the real handle at construction time
+	// instead of via post-hoc setters.
+	svc.Batcher = NewWriteBackBatcher(5*time.Second, WriteBackBatcherConfig{
+		AutoWriteBack:       deps.Config.AutoWriteBack,
+		ITLWriteBackEnabled: deps.Config.ITLWriteBackEnabled,
+		LibraryWritePath:    deps.Config.LibraryWritePath,
+	}, deps.Store)
+
+	// M1 step 1: Provisioner. Gets the real batcher directly — no
+	// SetEnqueuer hop needed now that Batcher is wired above.
+	svc.Provisioner = newTrackProvisioner(deps.Store, svc.Batcher, deps.Config)
 
 	return svc, nil
 }

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,11 +1,11 @@
-// file: internal/server/itunes_writeback_batcher.go
-// version: 3.5.0
+// file: internal/itunes/service/writeback_batcher.go
+// version: 4.0.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
 // and track removals in a single ITL read-modify-write cycle.
 
-package server
+package itunesservice
 
 import (
 	"fmt"
@@ -192,6 +192,16 @@ func (b *WriteBackBatcher) resetTimer() {
 	b.timer = time.AfterFunc(delay, b.flush)
 }
 
+// HasPendingBook reports whether bookID is currently queued for a
+// location update. Intended for test assertions in other packages that
+// can no longer reach b.pendingBooks directly after the M1 step 2 move.
+// Safe to call concurrently with Enqueue.
+func (b *WriteBackBatcher) HasPendingBook(bookID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pendingBooks[bookID]
+}
+
 func (b *WriteBackBatcher) hasPending() bool {
 	return len(b.pendingBooks) > 0 || len(b.pendingAdds) > 0 || len(b.pendingRemoves) > 0
 }
@@ -318,7 +328,7 @@ func (b *WriteBackBatcher) flush() {
 		len(locationUpdates), len(metadataUpdates), len(adds), len(removes))
 
 	itlPath := writePath // from b.flushEnabled() above
-	if err := safeWriteITL(itlPath, ops); err != nil {
+	if err := SafeWriteITL(itlPath, ops); err != nil {
 		log.Printf("[WARN] iTunes write-back failed: %v", err)
 		return
 	}
@@ -347,7 +357,7 @@ var (
 	itlApplyOperationsFn    = itunes.ApplyITLOperations
 )
 
-// safeWriteITL performs a backup → write-temp → validate-temp →
+// SafeWriteITL performs a backup → write-temp → validate-temp →
 // rename → validate-final → cleanup cycle for ITL write-back. At
 // every failure point the original ITL is either untouched or
 // restored from the backup, so a corrupted write can never leave
@@ -366,7 +376,7 @@ var (
 //     produced corruption, or the write was partial), copy the
 //     backup back over itlPath.
 //  7. Log the result.
-func safeWriteITL(itlPath string, ops itunes.ITLOperationSet) error {
+func SafeWriteITL(itlPath string, ops itunes.ITLOperationSet) error {
 	// Step 1: sanity-check the source. If the ITL we're about to
 	// write over is ALREADY corrupted, the write has nothing to
 	// validate against and a rollback wouldn't help anyway.

--- a/internal/itunes/service/writeback_batcher_test.go
+++ b/internal/itunes/service/writeback_batcher_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/itunes_writeback_batcher_test.go
+// file: internal/itunes/service/writeback_batcher_test.go
 // version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-def4-56789abcdef0
 
-package server
+package itunesservice
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 )
 
 // withFakeITLHooks replaces the package-level itunes hooks with
-// test doubles and restores them on cleanup. Lets every safeWriteITL
+// test doubles and restores them on cleanup. Lets every SafeWriteITL
 // test drive the validate + apply paths without needing a real ITL
 // fixture on disk — the fixture is fragile and format changes have
 // broken it before.
@@ -71,11 +71,11 @@ func TestSafeWriteITL_HappyPath(t *testing.T) {
 		},
 	)
 
-	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+	err := SafeWriteITL(itlPath, itunes.ITLOperationSet{
 		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
 	})
 	if err != nil {
-		t.Fatalf("safeWriteITL happy path failed: %v", err)
+		t.Fatalf("SafeWriteITL happy path failed: %v", err)
 	}
 	if applyCalls != 1 {
 		t.Errorf("expected 1 apply call, got %d", applyCalls)
@@ -106,7 +106,7 @@ func TestSafeWriteITL_HappyPath(t *testing.T) {
 
 // TestSafeWriteITL_RefusesBrokenSource is the regression test for
 // rule #1: never write to an ITL that's already corrupted. The
-// validate call for the source path fails, and safeWriteITL must
+// validate call for the source path fails, and SafeWriteITL must
 // abort without creating a backup or touching the file.
 func TestSafeWriteITL_RefusesBrokenSource(t *testing.T) {
 	dir := t.TempDir()
@@ -122,7 +122,7 @@ func TestSafeWriteITL_RefusesBrokenSource(t *testing.T) {
 		},
 	)
 
-	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+	err := SafeWriteITL(itlPath, itunes.ITLOperationSet{
 		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
 	})
 	if err == nil {
@@ -168,7 +168,7 @@ func TestSafeWriteITL_TempValidationFailure(t *testing.T) {
 		},
 	)
 
-	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+	err := SafeWriteITL(itlPath, itunes.ITLOperationSet{
 		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
 	})
 	if err == nil {
@@ -216,7 +216,7 @@ func TestSafeWriteITL_PostRenameRestore(t *testing.T) {
 		},
 	)
 
-	err := safeWriteITL(itlPath, itunes.ITLOperationSet{
+	err := SafeWriteITL(itlPath, itunes.ITLOperationSet{
 		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
 	})
 	if err == nil {

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -6,13 +6,14 @@
 // against the current ITL file and computes the minimal set of
 // changes (adds, removes, metadata updates, location patches)
 // to synchronize them. Changes are applied in one atomic
-// ApplyITLOperations call through the existing safeWriteITL
+// ApplyITLOperations call through the existing itunesservice.SafeWriteITL
 // pipeline (backup → validate → apply → validate → rollback on
 // failure). Backlog 7.9 — "diff and batch" mode.
 
 package server
 
 import (
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"fmt"
 	"log"
 	"net/http"
@@ -226,7 +227,7 @@ func pidToHex(pid [8]byte) string {
 
 // rebuildITLHandler handles POST /api/v1/itunes/rebuild.
 // Query param: dry_run=true returns the diff preview without
-// applying. Otherwise applies the diff via safeWriteITL.
+// applying. Otherwise applies the diff via itunesservice.SafeWriteITL.
 func (s *Server) rebuildITLHandler(c *gin.Context) {
 	itlPath := config.AppConfig.ITunesLibraryWritePath
 	if itlPath == "" {
@@ -259,7 +260,7 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 		return
 	}
 
-	if err := safeWriteITL(itlPath, *ops); err != nil {
+	if err := itunesservice.SafeWriteITL(itlPath, *ops); err != nil {
 		c.JSON(http.StatusInternalServerError, ITLRebuildResult{
 			Preview: *preview,
 			Applied: false,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -733,7 +733,7 @@ type Server struct {
 
 	queue            operations.Queue
 	hub              *realtime.EventHub
-	writeBackBatcher *WriteBackBatcher
+	writeBackBatcher *itunesservice.WriteBackBatcher
 	fileIOPool       *FileIOPool
 
 	// Shutdown coordination. bgCtx is canceled when Shutdown() runs, and
@@ -1028,11 +1028,13 @@ func NewServer(store database.Store) *Server {
 	// Also set the global for backward compatibility during migration
 	operations.GlobalQueue = server.queue
 
-	server.writeBackBatcher = NewWriteBackBatcher(5*time.Second, WriteBackBatcherConfig{
-		AutoWriteBack:       config.AppConfig.ITunesAutoWriteBack,
-		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
-		LibraryWritePath:    config.AppConfig.ITunesLibraryWritePath,
-	}, resolvedStore)
+	// The batcher moved under itunesservice.Service in Phase 2 M1 step 2.
+	// Server still keeps a typed field for back-compat with the many call
+	// sites that were already using server.writeBackBatcher — but it now
+	// points at the service-owned instance. When the service is nil (test
+	// paths), the field stays nil and enqueues are silent no-ops via the
+	// `if batcher != nil` guards already in place.
+	server.writeBackBatcher = server.itunesSvc.Batcher
 	server.fileIOPool = NewFileIOPool(4)
 
 	// Wire writeBackBatcher into services that need it
@@ -1045,12 +1047,9 @@ func NewServer(store database.Store) *Server {
 	// during Phase 2 M1 step 1). Nil provisioner → ITL track provisioning
 	// is skipped (service is disabled or construction failed above).
 	server.importService.SetTrackProvisioner(server.itunesSvc.Provisioner)
-	// The provisioner needs the batcher for EnqueueAdd. SetEnqueuer
-	// completes wiring here because the batcher still lives on Server
-	// until Phase 2 M1 step 2 moves it under Service.
-	if server.itunesSvc.Provisioner != nil {
-		server.itunesSvc.Provisioner.SetEnqueuer(server.writeBackBatcher)
-	}
+	// After M1 step 2, the batcher is owned by itunesservice.Service and
+	// Provisioner was wired with the real Enqueuer at Service.New() time.
+	// No SetEnqueuer hop needed.
 
 	// Register file-op recovery handler (uses server closure instead of globalServer)
 	RegisterFileOpRecovery("apply_metadata", func(bookID string) {

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -351,7 +352,7 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil) // long delay so it won't flush
+	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil) // long delay so it won't flush
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -371,9 +372,7 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Verify the book ID was enqueued in the batcher
-	batcher.mu.Lock()
-	enqueued := batcher.pendingBooks[book.ID]
-	batcher.mu.Unlock()
+	enqueued := batcher.HasPendingBook(book.ID)
 	assert.True(t, enqueued, "expected book ID to be enqueued in WriteBackBatcher")
 }
 
@@ -398,7 +397,7 @@ func TestApplyAudiobookMetadata_WriteBackTrue(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
+	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -436,9 +435,7 @@ func TestApplyAudiobookMetadata_WriteBackTrue(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Verify enqueued
-	batcher.mu.Lock()
-	enqueued := batcher.pendingBooks[book.ID]
-	batcher.mu.Unlock()
+	enqueued := batcher.HasPendingBook(book.ID)
 	assert.True(t, enqueued, "expected book ID to be enqueued when write_back=true")
 }
 
@@ -461,7 +458,7 @@ func TestApplyAudiobookMetadata_WriteBackOmitted(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
+	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -498,9 +495,7 @@ func TestApplyAudiobookMetadata_WriteBackOmitted(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Verify enqueued (defaults to true)
-	batcher.mu.Lock()
-	enqueued := batcher.pendingBooks[book.ID]
-	batcher.mu.Unlock()
+	enqueued := batcher.HasPendingBook(book.ID)
 	assert.True(t, enqueued, "expected book ID to be enqueued when write_back is omitted (defaults to true)")
 }
 
@@ -523,7 +518,7 @@ func TestApplyAudiobookMetadata_WriteBackFalse(t *testing.T) {
 	origConfig := config.AppConfig
 	config.AppConfig.ITunesAutoWriteBack = true
 	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
-	batcher := NewWriteBackBatcher(1*time.Hour, WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
+	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
 		// Stop pool workers before restoring globals to avoid races
@@ -558,8 +553,6 @@ func TestApplyAudiobookMetadata_WriteBackFalse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Verify NOT enqueued
-	batcher.mu.Lock()
-	enqueued := batcher.pendingBooks[book.ID]
-	batcher.mu.Unlock()
+	enqueued := batcher.HasPendingBook(book.ID)
 	assert.False(t, enqueued, "expected book ID NOT to be enqueued when write_back=false")
 }

--- a/internal/server/writeback_enqueuer.go
+++ b/internal/server/writeback_enqueuer.go
@@ -14,6 +14,9 @@ import itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/serv
 // because Go type aliases make the names interchangeable.
 type Enqueuer = itunesservice.Enqueuer
 
-// Compile-time proof *WriteBackBatcher satisfies Enqueuer. If the batcher
-// gains or renames methods this assertion catches it.
-var _ Enqueuer = (*WriteBackBatcher)(nil)
+// Compile-time proof *itunesservice.WriteBackBatcher satisfies Enqueuer.
+// If the batcher gains or renames methods this assertion catches it.
+// (The batcher moved under internal/itunes/service/ during M1 step 2;
+// the assertion can eventually move alongside it once the server alias
+// disappears.)
+var _ Enqueuer = (*itunesservice.WriteBackBatcher)(nil)


### PR DESCRIPTION
Second sub-component move. Relocates the ~515-line WriteBackBatcher (batcher goroutine + config + store interface + safe-write helpers + backup rotation) from `internal/server/` into `internal/itunes/service/`.

## Scope
- `itunes_writeback_batcher.go` + its test → `internal/itunes/service/`
- `Service.New` constructs the batcher directly; Provisioner gets it at construction time (no more `SetEnqueuer` hop)
- `safeWriteITL` → `SafeWriteITL` (exported) so `itl_rebuild.go` can still call it from the server package
- New `*WriteBackBatcher.HasPendingBook(bookID) bool` public test helper (server_undo_test was using private field access)
- `server.writeBackBatcher` field re-typed to `*itunesservice.WriteBackBatcher`, now points at `server.itunesSvc.Batcher`

## Preserved invariants
- Zero behavior change — batcher code body unchanged
- All 10+ call sites using `server.Enqueuer` (via the M1-step-1 alias) continue to work
- `server.writeBackBatcher` usable across metadata_handlers / itunes_path_reconcile / file_io_pool / writeback_outbox

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (full-tree)
- [x] `go test ./internal/itunes/service/ -short` green (0.5s)
- [x] `go test ./internal/server/ -run 'WriteBack|Import' -short` green (9.1s)