### PR TITLE
refactor(itunes): move PlaylistSync into itunes service package (M1 step 4)

### DIFF
--- a/internal/itunes/service/playlist_sync.go
+++ b/internal/itunes/service/playlist_sync.go
@@ -1,5 +1,5 @@
-// file: internal/server/playlist_itunes_sync.go
-// version: 1.1.0
+// file: internal/itunes/service/playlist_sync.go
+// version: 2.0.0
 // guid: 1e9f0a8b-2c3d-4a70-b8c5-3d7e0f1b9a99
 //
 // iTunes playlist sync (spec 3.4 tasks 5-6).
@@ -17,7 +17,7 @@
 //   track list. Smart playlists are pushed as static (materialized)
 //   since iTunes will manage its own smart criteria.
 
-package server
+package itunesservice
 
 import (
 	"encoding/base64"
@@ -29,10 +29,30 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 )
 
-// MigrateITunesSmartPlaylists reads smart playlists from the ITL
-// library and creates UserPlaylist rows for each. Idempotent —
-// playlists already imported (by iTunes PID) are skipped.
-func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.ITLLibrary) (imported, skipped int) {
+// playlistSyncStore is the narrow slice of the service's Store that
+// PlaylistSync needs.
+type playlistSyncStore interface {
+	database.UserPlaylistStore
+}
+
+// PlaylistSync owns the two-way iTunes-playlist sync paths (import
+// smart playlists from the ITL, push dirty playlists back out).
+type PlaylistSync struct {
+	store    playlistSyncStore
+	enqueuer Enqueuer
+}
+
+// newPlaylistSync wires a PlaylistSync with the given store and
+// enqueuer. A nil enqueuer disables the push direction's ITL write-back
+// enqueue (the dirty flag is still cleared).
+func newPlaylistSync(store playlistSyncStore, enqueuer Enqueuer) *PlaylistSync {
+	return &PlaylistSync{store: store, enqueuer: enqueuer}
+}
+
+// MigrateSmartPlaylists reads smart playlists from the ITL library
+// and creates UserPlaylist rows for each. Idempotent — playlists
+// already imported (by iTunes PID) are skipped.
+func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, skipped int) {
 	if lib == nil {
 		return 0, 0
 	}
@@ -44,14 +64,12 @@ func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.I
 
 		pid := hex.EncodeToString(pl.PersistentID[:])
 
-		// Skip if already imported.
-		existing, _ := store.GetUserPlaylistByITunesPID(pid)
+		existing, _ := p.store.GetUserPlaylistByITunesPID(pid)
 		if existing != nil {
 			skipped++
 			continue
 		}
 
-		// Parse and translate criteria.
 		parsed, err := itunes.ParseSmartCriteria(pl.SmartCriteria)
 		if err != nil {
 			log.Printf("[WARN] parse smart criteria for %q (PID %s): %v", pl.Title, pid, err)
@@ -60,10 +78,9 @@ func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.I
 		}
 		dslQuery := itunes.TranslateSmartCriteria(parsed)
 
-		// Store the raw criteria for audit.
 		rawB64 := base64.StdEncoding.EncodeToString(pl.SmartCriteria)
 
-		_, err = store.CreateUserPlaylist(&database.UserPlaylist{
+		_, err = p.store.CreateUserPlaylist(&database.UserPlaylist{
 			Name:                 pl.Title,
 			Type:                 database.UserPlaylistTypeSmart,
 			Query:                dslQuery,
@@ -82,16 +99,15 @@ func MigrateITunesSmartPlaylists(store database.UserPlaylistStore, lib *itunes.I
 	return imported, skipped
 }
 
-// PushDirtyPlaylistsToITunes writes dirty playlists to the ITL.
-// Smart playlists are materialized first (the materialized_book_ids
-// field is used). Returns the number pushed.
+// PushDirty writes dirty playlists to the ITL. Smart playlists are
+// materialized first (the materialized_book_ids field is used).
+// Returns the number pushed.
 //
-// This is a placeholder that enqueues the playlist book IDs for
-// the ITL write-back batcher. Full ITL playlist creation requires
-// the ITL writer to support playlist insertion, which is tracked
-// separately.
-func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher Enqueuer) int {
-	dirties, err := store.ListDirtyUserPlaylists()
+// Placeholder that enqueues the playlist book IDs for the ITL
+// write-back batcher. Full ITL playlist creation requires the ITL
+// writer to support playlist insertion, which is tracked separately.
+func (p *PlaylistSync) PushDirty() int {
+	dirties, err := p.store.ListDirtyUserPlaylists()
 	if err != nil {
 		log.Printf("[WARN] list dirty playlists: %v", err)
 		return 0
@@ -101,7 +117,6 @@ func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher Enqueu
 	for i := range dirties {
 		pl := &dirties[i]
 
-		// For smart playlists, use materialized book IDs.
 		bookIDs := pl.BookIDs
 		if pl.Type == database.UserPlaylistTypeSmart {
 			bookIDs = pl.MaterializedBookIDs
@@ -111,16 +126,14 @@ func PushDirtyPlaylistsToITunes(store database.UserPlaylistStore, batcher Enqueu
 			continue
 		}
 
-		// Enqueue each book for ITL writeback so its track exists.
-		if batcher != nil {
+		if p.enqueuer != nil {
 			for _, bid := range bookIDs {
-				batcher.Enqueue(bid)
+				p.enqueuer.Enqueue(bid)
 			}
 		}
 
-		// Clear dirty flag.
 		pl.Dirty = false
-		if err := store.UpdateUserPlaylist(pl); err != nil {
+		if err := p.store.UpdateUserPlaylist(pl); err != nil {
 			log.Printf("[WARN] clear dirty for %s: %v", pl.ID, err)
 			continue
 		}

--- a/internal/itunes/service/playlist_sync_test.go
+++ b/internal/itunes/service/playlist_sync_test.go
@@ -1,7 +1,7 @@
-// file: internal/server/playlist_itunes_sync_test.go
-// version: 1.0.0
+// file: internal/itunes/service/playlist_sync_test.go
+// version: 2.0.0
 
-package server
+package itunesservice
 
 import (
 	"path/filepath"
@@ -12,16 +12,17 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 )
 
-func TestMigrateITunesSmartPlaylists_NilLibrary(t *testing.T) {
+func TestMigrateSmartPlaylists_NilLibrary(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	imported, skipped := MigrateITunesSmartPlaylists(nil, nil)
+	ps := newPlaylistSync(nil, nil)
+	imported, skipped := ps.MigrateSmartPlaylists(nil)
 	if imported != 0 || skipped != 0 {
 		t.Errorf("nil library: imported=%d skipped=%d, want 0/0", imported, skipped)
 	}
 }
 
-func TestMigrateITunesSmartPlaylists_SkipsNonSmart(t *testing.T) {
+func TestMigrateSmartPlaylists_SkipsNonSmart(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	pebblePath := filepath.Join(t.TempDir(), "pebble")
@@ -40,13 +41,14 @@ func TestMigrateITunesSmartPlaylists_SkipsNonSmart(t *testing.T) {
 		},
 	}
 
-	imported, skipped := MigrateITunesSmartPlaylists(store, lib)
+	ps := newPlaylistSync(store, nil)
+	imported, skipped := ps.MigrateSmartPlaylists(lib)
 	if imported != 0 || skipped != 0 {
 		t.Errorf("non-smart: imported=%d skipped=%d, want 0/0", imported, skipped)
 	}
 }
 
-func TestMigrateITunesSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
+func TestMigrateSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	pebblePath := filepath.Join(t.TempDir(), "pebble")
@@ -60,7 +62,6 @@ func TestMigrateITunesSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
 	pid[0] = 0xAA
 	pidHex := "aa00000000000000"
 
-	// Pre-create a playlist with this iTunes PID.
 	_, _ = store.CreateUserPlaylist(&database.UserPlaylist{
 		Name:               "Already Imported",
 		Type:               database.UserPlaylistTypeSmart,
@@ -73,12 +74,13 @@ func TestMigrateITunesSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
 				Title:         "Already Imported",
 				IsSmart:       true,
 				PersistentID:  pid,
-				SmartCriteria: []byte{0x01, 0x02, 0x03, 0x04}, // non-empty
+				SmartCriteria: []byte{0x01, 0x02, 0x03, 0x04},
 			},
 		},
 	}
 
-	imported, skipped := MigrateITunesSmartPlaylists(store, lib)
+	ps := newPlaylistSync(store, nil)
+	imported, skipped := ps.MigrateSmartPlaylists(lib)
 	if imported != 0 {
 		t.Errorf("expected 0 imported (already exists), got %d", imported)
 	}
@@ -87,7 +89,7 @@ func TestMigrateITunesSmartPlaylists_SkipsAlreadyImported(t *testing.T) {
 	}
 }
 
-func TestPushDirtyPlaylistsToITunes_NoDirty(t *testing.T) {
+func TestPushDirty_NoDirty(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	pebblePath := filepath.Join(t.TempDir(), "pebble")
@@ -102,7 +104,7 @@ func TestPushDirtyPlaylistsToITunes_NoDirty(t *testing.T) {
 		store.Close()
 	})
 
-	pushed := PushDirtyPlaylistsToITunes(store, nil)
+	pushed := newPlaylistSync(store, nil).PushDirty()
 	if pushed != 0 {
 		t.Errorf("expected 0 pushed with no dirty playlists, got %d", pushed)
 	}

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
 
 package itunesservice
@@ -41,8 +41,6 @@ type (
 	Importer struct{}
 	// PathReconciler reconciles iTunes-vs-library paths. Placeholder until moved.
 	PathReconciler struct{}
-	// PlaylistSync syncs iTunes playlists. Placeholder until moved.
-	PlaylistSync struct{}
 	// TransferService transfers ITL files. Placeholder until moved.
 	TransferService struct{}
 )
@@ -94,6 +92,10 @@ func New(deps Deps) (*Service, error) {
 	// M1 step 3: PositionSync. Reads/writes admin user positions and
 	// pushes bookmark updates via the batcher.
 	svc.Positions = newPositionSync(deps.Store, svc.Batcher)
+
+	// M1 step 4: PlaylistSync. Imports smart playlists from the ITL
+	// and pushes dirty playlists back out. Pushes use the batcher.
+	svc.Playlists = newPlaylistSync(deps.Store, svc.Batcher)
 
 	return svc, nil
 }


### PR DESCRIPTION
## Summary
- Moves playlist_itunes_sync.go + test from internal/server/ to internal/itunes/service/
- Converts the two free functions (MigrateITunesSmartPlaylists / PushDirtyPlaylistsToITunes) into methods on a new *PlaylistSync struct
- Narrow playlistSyncStore interface (UserPlaylistStore only) + Enqueuer dependency
- Wired via Service.New with svc.Playlists = newPlaylistSync(deps.Store, svc.Batcher)

Phase 2 M1 step 4 of the iTunes extraction plan. Neither function had external callers prior to this move, so no downstream call-site updates were required.

## Test plan
- [x] go build ./...
- [x] go vet ./... (full tree)
- [x] go test ./internal/itunes/service/ -short
- [x] go test ./internal/server/ -short