### PR TITLE
refactor(server): adopt response envelope in tag + user handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.12.0 -->
+<!-- version: 2.13.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-04-22 -->
+<!-- last-edited: 2026-04-23 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 23, 2026 — HTTP Response Envelope Migration (pilot)
+
+- **Kickoff of TODO 4.15**: adopt `RespondWith*` helpers from `internal/server/error_handler.go` project-wide so all successful responses share the `{"data": {...}}` envelope and errors share the `{"error", "code", "status"}` shape.
+- **`internal/server/entity_tag_handlers.go`**: deduplicated 4 near-identical author/series tag handlers into 2 generic handlers parameterized by an `entityTagOps` descriptor (`name`, `getDetailed`, `add`, `addWithSource`). Added `parseEntityID` helper for int path-param parsing. Fixed latent bug: `handleAddSeriesTag` previously ignored `req.Source`; series now respects source identically to author. All 4 handlers migrated to `RespondWithOK`.
+- **`internal/server/user_handlers.go`**: migrated all 13 `c.JSON` callsites to `RespondWithOK` / `RespondWithCreated` / `RespondWithBadRequest` / `RespondWithNotFound` helpers. Removed a dead `if users == nil` branch (unreachable — `make([]..., 0, ...)` is never nil).
+- **Tests updated**: `entity_tag_handlers_test.go` and `user_handlers_test.go` now decode the `data` envelope.
+- **No frontend changes** this pass — both files are backend-only (admin user management and entity-tag endpoints aren't wired to the UI yet).
+- **Migration strategy documented**: future slices must bundle backend + frontend + tests per feature area to avoid response-shape skew across a merge boundary. Remaining ~37 handler files tracked in TODO 4.15.
 
 #### April 22, 2026 — Failed Book Quarantine (`.failed/`)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 5.10.0 -->
+<!-- version: 5.11.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-18 -->
+<!-- last-edited: 2026-04-23 -->
 
 # Project TODO
 
@@ -100,6 +100,7 @@ since it was last edited on 2026-04-11).
 - [x] **4.12** Extract iTunes integration into `internal/itunes` (**L**) — complete (3 PRs, Apr 18-20 2026). `internal/itunes/service/` ≈ 5K LOC; server iTunes surface ≈ 800 LOC pure handlers with disabled-mode guard.
 - [ ] **4.13** Comprehensive iTunes test suite (**L**) — after 4.12 extraction, add exhaustive unit tests: mock store tests for every service method, error path coverage, edge cases (empty library, corrupt XML, concurrent sync), position sync, writeback batcher, path reconciliation, track provisioning; target 80%+ coverage on the extracted package
 - [~] **4.14** Plugin system framework (**XL**) — V1: Plugin/EventBus/Registry/Router framework + Deluge migration; V2 (future): RPC subprocess plugins + webhook event delivery
+- [~] **4.15** HTTP response envelope migration (**L**) — adopt `RespondWith*` helpers from `internal/server/error_handler.go` across all handlers. Success responses gain `{"data": {...}}` envelope; error responses gain `{"error", "code", "status"}` shape. Current state: 299 helper uses vs. 1,035 raw `c.JSON(...)` calls across 39 handler files. Must migrate backend + frontend consumers together per feature area to avoid response-shape skew. Pilots completed: `entity_tag_handlers.go`, `user_handlers.go` (both backend-only, no UI consumers). Remaining high-traffic targets (each requires matching frontend update): `audiobooks_handlers.go`, `entities_handlers.go`, `auth_handlers.go`, `metadata_handlers.go`, `activity_handlers.go`, `apikey_handlers.go`, `dedup_handlers.go`, `duplicates_handlers.go`, `diagnostics_handlers.go`, `ai_handlers.go`, ~30 more. Also migrates callers to existing-but-unused helpers: `RespondWithList`, `EnsureNotNil`, `ParseQueryInt`.
 
 > **Architecture cleanup notes for future work:**
 > When touching these areas, narrow `database.Store` params to ISP sub-interfaces and extract remaining services as opportunities arise:

--- a/internal/server/entity_tag_handlers.go
+++ b/internal/server/entity_tag_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/entity_tag_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7e5f6a4b-8c9d-4a70-b8c5-3d7e0f1b9a99
 //
 // HTTP endpoints for author and series tags (backlog 7.7).
@@ -8,35 +8,74 @@
 package server
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-// handleGetAuthorTags returns tags for an author.
-// GET /api/v1/authors/:id/tags
-func (s *Server) handleGetAuthorTags(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid author id"})
-		return
-	}
-	tags, err := s.Store().GetAuthorTagsDetailed(id)
-	if err != nil {
-		internalError(c, "get author tags", err)
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"tags": tags})
+// entityTagOps bundles the store operations for one tagged-entity type
+// (author or series). It lets a single generic handler serve both without
+// plumbing the entity name and each function pointer through separately.
+type entityTagOps struct {
+	name          string // "author" or "series" — used in error messages
+	getDetailed   func(id int) ([]database.BookTag, error)
+	add           func(id int, tag string) error
+	addWithSource func(id int, tag, source string) error
 }
 
-// handleAddAuthorTag adds a tag to an author.
-// POST /api/v1/authors/:id/tags
-func (s *Server) handleAddAuthorTag(c *gin.Context) {
+func (s *Server) authorTagOps() entityTagOps {
+	return entityTagOps{
+		name:          "author",
+		getDetailed:   s.Store().GetAuthorTagsDetailed,
+		add:           s.Store().AddAuthorTag,
+		addWithSource: s.Store().AddAuthorTagWithSource,
+	}
+}
+
+func (s *Server) seriesTagOps() entityTagOps {
+	return entityTagOps{
+		name:          "series",
+		getDetailed:   s.Store().GetSeriesTagsDetailed,
+		add:           s.Store().AddSeriesTag,
+		addWithSource: s.Store().AddSeriesTagWithSource,
+	}
+}
+
+// parseEntityID parses the :id path param as an int, responding with a 400 on
+// failure. Returns (id, ok) so callers can bail early.
+func parseEntityID(c *gin.Context, entityName string) (int, bool) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid author id"})
+		RespondWithValidationError(c, entityName+" id", "must be an integer")
+		return 0, false
+	}
+	return id, true
+}
+
+// handleGetEntityTags returns tags for an author or series.
+func (s *Server) handleGetEntityTags(c *gin.Context, ops entityTagOps) {
+	id, ok := parseEntityID(c, ops.name)
+	if !ok {
+		return
+	}
+	tags, err := ops.getDetailed(id)
+	if err != nil {
+		internalError(c, "get "+ops.name+" tags", err)
+		return
+	}
+	if tags == nil {
+		tags = []database.BookTag{}
+	}
+	RespondWithOK(c, gin.H{"tags": tags})
+}
+
+// handleAddEntityTag adds a tag to an author or series, optionally with a
+// source. See TODO below — this is where your input shapes the behavior.
+func (s *Server) handleAddEntityTag(c *gin.Context, ops entityTagOps) {
+	id, ok := parseEntityID(c, ops.name)
+	if !ok {
 		return
 	}
 	var req struct {
@@ -44,64 +83,31 @@ func (s *Server) handleAddAuthorTag(c *gin.Context) {
 		Source string `json:"source,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
+
+	var err error
 	if req.Source != "" {
-		err = s.Store().AddAuthorTagWithSource(id, req.Tag, req.Source)
+		err = ops.addWithSource(id, req.Tag, req.Source)
 	} else {
-		err = s.Store().AddAuthorTag(id, req.Tag)
+		err = ops.add(id, req.Tag)
 	}
 	if err != nil {
-		internalError(c, "add author tag", err)
+		internalError(c, "add "+ops.name+" tag", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"added": req.Tag})
-}
-
-// handleGetSeriesTags returns tags for a series.
-// GET /api/v1/series/:id/tags
-func (s *Server) handleGetSeriesTags(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid series id"})
-		return
-	}
-	tags, err := s.Store().GetSeriesTagsDetailed(id)
-	if err != nil {
-		internalError(c, "get series tags", err)
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"tags": tags})
-}
-
-// handleAddSeriesTag adds a tag to a series.
-// POST /api/v1/series/:id/tags
-func (s *Server) handleAddSeriesTag(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid series id"})
-		return
-	}
-	var req struct {
-		Tag    string `json:"tag" binding:"required"`
-		Source string `json:"source,omitempty"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	if err := s.Store().AddSeriesTag(id, req.Tag); err != nil {
-		internalError(c, "add series tag", err)
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"added": req.Tag})
+	RespondWithOK(c, gin.H{"added": req.Tag})
 }
 
 // registerEntityTagRoutes wires the author/series tag endpoints.
 func (s *Server) registerEntityTagRoutes(protected *gin.RouterGroup) {
-	protected.GET("/authors/:id/tags", s.perm(auth.PermLibraryView), s.handleGetAuthorTags)
-	protected.POST("/authors/:id/tags", s.perm(auth.PermLibraryEditMetadata), s.handleAddAuthorTag)
-	protected.GET("/series/:id/tags", s.perm(auth.PermLibraryView), s.handleGetSeriesTags)
-	protected.POST("/series/:id/tags", s.perm(auth.PermLibraryEditMetadata), s.handleAddSeriesTag)
+	protected.GET("/authors/:id/tags", s.perm(auth.PermLibraryView),
+		func(c *gin.Context) { s.handleGetEntityTags(c, s.authorTagOps()) })
+	protected.POST("/authors/:id/tags", s.perm(auth.PermLibraryEditMetadata),
+		func(c *gin.Context) { s.handleAddEntityTag(c, s.authorTagOps()) })
+	protected.GET("/series/:id/tags", s.perm(auth.PermLibraryView),
+		func(c *gin.Context) { s.handleGetEntityTags(c, s.seriesTagOps()) })
+	protected.POST("/series/:id/tags", s.perm(auth.PermLibraryEditMetadata),
+		func(c *gin.Context) { s.handleAddEntityTag(c, s.seriesTagOps()) })
 }

--- a/internal/server/entity_tag_handlers_test.go
+++ b/internal/server/entity_tag_handlers_test.go
@@ -50,11 +50,13 @@ func TestHandleGetAuthorTags_Empty(t *testing.T) {
 	}
 
 	var resp struct {
-		Tags []database.BookTag `json:"tags"`
+		Data struct {
+			Tags []database.BookTag `json:"tags"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if len(resp.Tags) != 0 {
-		t.Errorf("expected 0 tags, got %d", len(resp.Tags))
+	if len(resp.Data.Tags) != 0 {
+		t.Errorf("expected 0 tags, got %d", len(resp.Data.Tags))
 	}
 }
 
@@ -75,11 +77,13 @@ func TestHandleAddAuthorTag(t *testing.T) {
 	}
 
 	var resp struct {
-		Added string `json:"added"`
+		Data struct {
+			Added string `json:"added"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Added != "sci-fi" {
-		t.Errorf("expected added=sci-fi, got %s", resp.Added)
+	if resp.Data.Added != "sci-fi" {
+		t.Errorf("expected added=sci-fi, got %s", resp.Data.Added)
 	}
 
 	// Verify via GET.

--- a/internal/server/user_handlers.go
+++ b/internal/server/user_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/user_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 2d0e1f8a-3b9c-4a70-b8c5-3d7e0f1b9a99
 //
 // User management admin endpoints (spec 3.7 task 7). All routes
@@ -10,7 +10,6 @@ package server
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"net/http"
 	"strings"
 	"time"
 
@@ -27,9 +26,6 @@ func (s *Server) handleListUsers(c *gin.Context) {
 		internalError(c, "failed to list users", err)
 		return
 	}
-	if users == nil {
-		users = []database.User{}
-	}
 	safe := make([]gin.H, 0, len(users))
 	for _, u := range users {
 		safe = append(safe, gin.H{
@@ -38,7 +34,7 @@ func (s *Server) handleListUsers(c *gin.Context) {
 			"created_at": u.CreatedAt, "updated_at": u.UpdatedAt,
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"users": safe, "count": len(safe)})
+	RespondWithOK(c, gin.H{"users": safe, "count": len(safe)})
 }
 
 // handleCreateInvite generates an invite token.
@@ -50,7 +46,7 @@ func (s *Server) handleCreateInvite(c *gin.Context) {
 		ExpiresIn int    `json:"expires_in"` // hours, default 72
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -71,7 +67,7 @@ func (s *Server) handleCreateInvite(c *gin.Context) {
 		internalError(c, "failed to create invite", err)
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"invite": created, "token": token})
+	RespondWithCreated(c, gin.H{"invite": created, "token": token})
 }
 
 // handleListInvites returns all active (non-expired, non-used) invites.
@@ -85,7 +81,7 @@ func (s *Server) handleListInvites(c *gin.Context) {
 	if invites == nil {
 		invites = []database.Invite{}
 	}
-	c.JSON(http.StatusOK, gin.H{"invites": invites, "count": len(invites)})
+	RespondWithOK(c, gin.H{"invites": invites, "count": len(invites)})
 }
 
 // handleDeleteInvite revokes an invite by token.
@@ -96,7 +92,7 @@ func (s *Server) handleDeleteInvite(c *gin.Context) {
 		internalError(c, "failed to delete invite", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"deleted": token})
+	RespondWithOK(c, gin.H{"deleted": token})
 }
 
 // handleAcceptInvite consumes an invite token and creates a user.
@@ -107,11 +103,11 @@ func (s *Server) handleAcceptInvite(c *gin.Context) {
 		Password string `json:"password" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.Password) < 8 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "password must be at least 8 characters"})
+		RespondWithBadRequest(c, "password must be at least 8 characters")
 		return
 	}
 
@@ -123,7 +119,7 @@ func (s *Server) handleAcceptInvite(c *gin.Context) {
 
 	user, err := s.Store().ConsumeInvite(req.Token, "bcrypt", string(hash))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -134,7 +130,7 @@ func (s *Server) handleAcceptInvite(c *gin.Context) {
 	}
 
 	setSessionCookie(c, sess.ID, sess.ExpiresAt)
-	c.JSON(http.StatusCreated, gin.H{"user": user, "session": sess})
+	RespondWithCreated(c, gin.H{"user": user, "session": sess})
 }
 
 // handleDeactivateUser soft-deactivates a user (sets status=locked).
@@ -147,7 +143,7 @@ func (s *Server) handleDeactivateUser(c *gin.Context) {
 		return
 	}
 	if user == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		RespondWithNotFound(c, "user", id)
 		return
 	}
 
@@ -156,7 +152,7 @@ func (s *Server) handleDeactivateUser(c *gin.Context) {
 		internalError(c, "deactivate user", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": user})
+	RespondWithOK(c, gin.H{"user": user})
 }
 
 // handleReactivateUser reactivates a locked user.
@@ -169,7 +165,7 @@ func (s *Server) handleReactivateUser(c *gin.Context) {
 		return
 	}
 	if user == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		RespondWithNotFound(c, "user", id)
 		return
 	}
 
@@ -178,7 +174,7 @@ func (s *Server) handleReactivateUser(c *gin.Context) {
 		internalError(c, "reactivate user", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": user})
+	RespondWithOK(c, gin.H{"user": user})
 }
 
 // handleResetPassword generates a new invite for an existing user
@@ -188,7 +184,7 @@ func (s *Server) handleResetPassword(c *gin.Context) {
 	id := c.Param("id")
 	user, err := s.Store().GetUserByID(id)
 	if err != nil || user == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		RespondWithNotFound(c, "user", id)
 		return
 	}
 
@@ -203,7 +199,7 @@ func (s *Server) handleResetPassword(c *gin.Context) {
 		internalError(c, "create reset invite", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"token": token, "expires_at": invite.ExpiresAt})
+	RespondWithOK(c, gin.H{"token": token, "expires_at": invite.ExpiresAt})
 }
 
 // registerUserAdminRoutes wires user management endpoints.

--- a/internal/server/user_handlers_test.go
+++ b/internal/server/user_handlers_test.go
@@ -47,12 +47,14 @@ func TestHandleListUsers_Empty(t *testing.T) {
 	}
 
 	var resp struct {
-		Users []map[string]interface{} `json:"users"`
-		Count int                      `json:"count"`
+		Data struct {
+			Users []map[string]interface{} `json:"users"`
+			Count int                      `json:"count"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Count != 0 {
-		t.Errorf("expected 0 users, got %d", resp.Count)
+	if resp.Data.Count != 0 {
+		t.Errorf("expected 0 users, got %d", resp.Data.Count)
 	}
 }
 
@@ -71,16 +73,18 @@ func TestHandleListUsers_WithUsers(t *testing.T) {
 	}
 
 	var resp struct {
-		Users []map[string]interface{} `json:"users"`
-		Count int                      `json:"count"`
+		Data struct {
+			Users []map[string]interface{} `json:"users"`
+			Count int                      `json:"count"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Count != 2 {
-		t.Errorf("expected 2 users, got %d", resp.Count)
+	if resp.Data.Count != 2 {
+		t.Errorf("expected 2 users, got %d", resp.Data.Count)
 	}
 
 	// Verify password hash is NOT exposed.
-	for _, u := range resp.Users {
+	for _, u := range resp.Data.Users {
 		if _, ok := u["password_hash"]; ok {
 			t.Error("password_hash should not be exposed in list response")
 		}
@@ -109,18 +113,20 @@ func TestHandleCreateInvite(t *testing.T) {
 	}
 
 	var resp struct {
-		Token  string           `json:"token"`
-		Invite *database.Invite `json:"invite"`
+		Data struct {
+			Token  string           `json:"token"`
+			Invite *database.Invite `json:"invite"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Token == "" {
+	if resp.Data.Token == "" {
 		t.Error("expected non-empty token")
 	}
-	if resp.Invite == nil {
+	if resp.Data.Invite == nil {
 		t.Fatal("expected invite in response")
 	}
-	if resp.Invite.Username != "newuser" {
-		t.Errorf("expected username=newuser, got %s", resp.Invite.Username)
+	if resp.Data.Invite.Username != "newuser" {
+		t.Errorf("expected username=newuser, got %s", resp.Data.Invite.Username)
 	}
 }
 
@@ -153,12 +159,14 @@ func TestHandleListInvites(t *testing.T) {
 	}
 
 	var resp struct {
-		Invites []database.Invite `json:"invites"`
-		Count   int               `json:"count"`
+		Data struct {
+			Invites []database.Invite `json:"invites"`
+			Count   int               `json:"count"`
+		} `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Count != 0 {
-		t.Errorf("expected 0 invites, got %d", resp.Count)
+	if resp.Data.Count != 0 {
+		t.Errorf("expected 0 invites, got %d", resp.Data.Count)
 	}
 }
 


### PR DESCRIPTION
## Summary

Kicks off [TODO 4.15](../blob/main/TODO.md): migrate all handlers to `RespondWith*` helpers from `internal/server/error_handler.go`. Success responses gain the `{"data": ...}` envelope; errors gain the `{"error", "code", "status"}` shape.

- **`entity_tag_handlers.go`**: dedupes 4 near-identical author/series tag handlers into 2 generics parameterized by an `entityTagOps` descriptor. Adds `parseEntityID` helper. **Fixes latent bug**: `handleAddSeriesTag` previously ignored `req.Source`; series now respects `source` identically to author.
- **`user_handlers.go`**: migrates all 13 `c.JSON` callsites to `RespondWith*`. Removes dead `if users == nil` branch.
- Tests updated to decode the `data` envelope.
- **No frontend impact** this pass — both endpoints are backend-only (admin user management and entity-tag endpoints are not wired to the UI).
- Migration strategy and remaining ~37 handler files tracked in TODO 4.15. Future slices must bundle backend + frontend + tests per feature area to avoid response-shape skew across a merge boundary.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/server/...` clean
- [x] `go test ./internal/server/ -run 'User|Invite|Tag|Author|Series|GenerateToken'` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)