### PR TITLE
refactor(server): envelope migration — update handlers + Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.13.0 -->
+<!-- version: 2.14.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,12 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 23, 2026 — Envelope Migration: `update_handlers.go` + Settings
+
+- **`internal/server/update_handlers.go`**: migrated all 3 handlers (`getUpdateStatus`, `checkForUpdate`, `applyUpdate`) to `RespondWithOK` / `RespondWithBadRequest`.
+- **`web/src/services/api.ts`**: updated `getUpdateStatus` and `checkForUpdate` to unwrap `response.data` (matches new backend envelope). `applyUpdate` is unchanged (void return).
+- First coupled backend+frontend slice under TODO 4.15. Settings.tsx call sites unchanged — the adapter lives entirely in `api.ts`.
 
 #### April 23, 2026 — HTTP Response Envelope Migration (pilot)
 

--- a/internal/server/update_handlers.go
+++ b/internal/server/update_handlers.go
@@ -1,12 +1,10 @@
 // file: internal/server/update_handlers.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 )
@@ -15,7 +13,7 @@ import (
 func (s *Server) getUpdateStatus(c *gin.Context) {
 	info := s.updater.LastCheck()
 	if info == nil {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"current_version":  appVersion,
 			"latest_version":   "",
 			"channel":          config.AppConfig.AutoUpdateChannel,
@@ -24,7 +22,7 @@ func (s *Server) getUpdateStatus(c *gin.Context) {
 		})
 		return
 	}
-	c.JSON(http.StatusOK, info)
+	RespondWithOK(c, info)
 }
 
 // checkForUpdate triggers an immediate update check and returns the result.
@@ -35,14 +33,14 @@ func (s *Server) checkForUpdate(c *gin.Context) {
 		internalError(c, "failed to check for updates", err)
 		return
 	}
-	c.JSON(http.StatusOK, info)
+	RespondWithOK(c, info)
 }
 
 // applyUpdate downloads and applies an available update, then exits for restart.
 func (s *Server) applyUpdate(c *gin.Context) {
 	info := s.updater.LastCheck()
 	if info == nil || !info.UpdateAvailable {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no update available"})
+		RespondWithBadRequest(c, "no update available")
 		return
 	}
 
@@ -51,7 +49,7 @@ func (s *Server) applyUpdate(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "update applied, restarting..."})
+	RespondWithOK(c, gin.H{"message": "update applied, restarting..."})
 
 	// Exit after response is sent; systemd/launchd restarts the process
 	go s.updater.RestartSelf()

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2983,7 +2983,8 @@ export async function getUpdateStatus(): Promise<UpdateInfo> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to get update status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function checkForUpdate(): Promise<UpdateInfo> {
@@ -2991,7 +2992,8 @@ export async function checkForUpdate(): Promise<UpdateInfo> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to check for updates');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function applyUpdate(): Promise<void> {


### PR DESCRIPTION
## Summary

Continues [TODO 4.15](../blob/main/TODO.md) — first coupled backend+frontend slice.

- `internal/server/update_handlers.go`: migrate 3 handlers (`getUpdateStatus`, `checkForUpdate`, `applyUpdate`) to `RespondWithOK` / `RespondWithBadRequest`.
- `web/src/services/api.ts`: unwrap `.data` envelope in `getUpdateStatus` and `checkForUpdate`. `applyUpdate` is unchanged (void return).
- `Settings.tsx` callsites are unchanged — the envelope adapter lives entirely in `api.ts`, so page code never sees the shape change.

## Test plan

- [x] `go build ./...` clean
- [x] `cd web && tsc --noEmit` clean
- [ ] CI green
- [ ] Manual smoke: check for update on Settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)