### PR TITLE
refactor(server): envelope migration — quarantine handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.14.0 -->
+<!-- version: 2.15.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 23, 2026 — Envelope Migration: `quarantine_handlers.go`
+
+- **`internal/server/quarantine_handlers.go`**: migrated all 3 handlers (`quarantineBook`, `unquarantineBook`, `listQuarantinedBooks`) to `RespondWithOK` / `RespondWithBadRequest` / `RespondWithInternalError`. No frontend changes needed: the two UI-facing handlers are called via `Promise<void>` wrappers in `api.ts` (caller never reads the response body), and `listQuarantinedBooks` has no frontend consumer.
 
 #### April 23, 2026 — Envelope Migration: `update_handlers.go` + Settings
 

--- a/internal/server/quarantine_handlers.go
+++ b/internal/server/quarantine_handlers.go
@@ -1,12 +1,10 @@
 // file: internal/server/quarantine_handlers.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 
 package server
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
@@ -15,7 +13,7 @@ import (
 func (s *Server) quarantineBook(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -23,7 +21,7 @@ func (s *Server) quarantineBook(c *gin.Context) {
 		Reason string `json:"reason"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if req.Reason == "" {
@@ -34,14 +32,14 @@ func (s *Server) quarantineBook(c *gin.Context) {
 		internalError(c, "quarantine failed", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "quarantined", "book_id": id})
+	RespondWithOK(c, gin.H{"status": "quarantined", "book_id": id})
 }
 
 // unquarantineBook handles DELETE /api/v1/audiobooks/:id/quarantine
 func (s *Server) unquarantineBook(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -49,13 +47,13 @@ func (s *Server) unquarantineBook(c *gin.Context) {
 		internalError(c, "unquarantine failed", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "unquarantined", "book_id": id})
+	RespondWithOK(c, gin.H{"status": "unquarantined", "book_id": id})
 }
 
 // listQuarantinedBooks handles GET /api/v1/audiobooks/quarantined
 func (s *Server) listQuarantinedBooks(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	params := ParsePaginationParams(c)
@@ -68,5 +66,5 @@ func (s *Server) listQuarantinedBooks(c *gin.Context) {
 		books = []database.Book{}
 	}
 	total, _ := s.Store().CountQuarantinedBooks()
-	c.JSON(http.StatusOK, gin.H{"books": books, "total": total})
+	RespondWithOK(c, gin.H{"books": books, "total": total})
 }


### PR DESCRIPTION
## Summary

Continues [TODO 4.15](../blob/main/TODO.md).

- `internal/server/quarantine_handlers.go`: migrate all 3 handlers (`quarantineBook`, `unquarantineBook`, `listQuarantinedBooks`) to `RespondWith*` helpers.
- **No frontend changes needed**:
  - `api.ts` `quarantineBook` / `unquarantineBook` are `Promise<void>` — they never read the response body.
  - `listQuarantinedBooks` has no frontend consumer.

## Test plan

- [x] `go build ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)