### PR TITLE
refactor(server): envelope migration — organize + rename handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.15.0 -->
+<!-- version: 2.16.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,11 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
+
+- **`internal/server/organize_handlers.go`**: migrated all 4 handlers (`previewRename`, `applyRename`, `previewOrganize`, `organizeBook`) and all success/error responses to `RespondWith*` helpers. "book not found" branches now use `RespondWithNotFound(c, "book", id)`.
+- **`web/src/services/api.ts`**: updated `previewRename`, `applyRename`, `previewOrganize`, `organizeBook` to unwrap `response.data`. Page callers (`BookDetail.tsx`) unchanged — envelope adapter stays in the API layer.
 
 #### April 23, 2026 — Envelope Migration: `quarantine_handlers.go`
 

--- a/internal/server/organize_handlers.go
+++ b/internal/server/organize_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 1522f0ec-663c-4527-a6d0-645658206a24
 //
 // Organize/rename HTTP handlers split out of server.go: preview/apply
@@ -10,7 +10,6 @@ package server
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -28,7 +27,7 @@ import (
 func (s *Server) previewRename(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		RespondWithBadRequest(c, "book id is required")
 		return
 	}
 
@@ -36,21 +35,21 @@ func (s *Server) previewRename(c *gin.Context) {
 	preview, err := svc.PreviewRename(id)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			RespondWithNotFound(c, "book", id)
 			return
 		}
 		internalError(c, "failed to preview rename", err)
 		return
 	}
 
-	c.JSON(http.StatusOK, preview)
+	RespondWithOK(c, preview)
 }
 
 // applyRename executes the rename + tag write + DB update for a book.
 func (s *Server) applyRename(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		RespondWithBadRequest(c, "book id is required")
 		return
 	}
 
@@ -59,7 +58,7 @@ func (s *Server) applyRename(c *gin.Context) {
 	op, err := s.Store().CreateOperation(opID, "rename", stringPtr(id))
 	if err != nil {
 		log.Printf("[ERROR] rename: failed to create operation: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create operation record"})
+		RespondWithInternalError(c, "failed to create operation record")
 		return
 	}
 
@@ -67,21 +66,21 @@ func (s *Server) applyRename(c *gin.Context) {
 	result, err := svc.ApplyRename(id, op.ID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			RespondWithNotFound(c, "book", id)
 			return
 		}
 		internalError(c, "failed to apply rename", err)
 		return
 	}
 
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 // previewOrganize returns a step-by-step preview of what organizing a single book would do.
 func (s *Server) previewOrganize(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		RespondWithBadRequest(c, "book id is required")
 		return
 	}
 
@@ -89,14 +88,14 @@ func (s *Server) previewOrganize(c *gin.Context) {
 	preview, err := svc.PreviewOrganize(id)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			RespondWithNotFound(c, "book", id)
 			return
 		}
 		internalError(c, "failed to preview organize", err)
 		return
 	}
 
-	c.JSON(http.StatusOK, preview)
+	RespondWithOK(c, preview)
 }
 
 // organizeBook executes the full organize pipeline for a single book.
@@ -107,7 +106,7 @@ func (s *Server) previewOrganize(c *gin.Context) {
 func (s *Server) organizeBook(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		RespondWithBadRequest(c, "book id is required")
 		return
 	}
 
@@ -116,14 +115,14 @@ func (s *Server) organizeBook(c *gin.Context) {
 	op, err := s.Store().CreateOperation(opID, "organize", stringPtr(id))
 	if err != nil {
 		log.Printf("[ERROR] organize: failed to create operation: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create operation record"})
+		RespondWithInternalError(c, "failed to create operation record")
 		return
 	}
 
 	book, err := s.Store().GetBookByID(id)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			RespondWithNotFound(c, "book", id)
 			return
 		}
 		internalError(c, "failed to fetch book", err)
@@ -168,7 +167,7 @@ func (s *Server) organizeBook(c *gin.Context) {
 	}
 
 	if oldPath == newPath {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"message":      "already organized",
 			"book_id":      book.ID,
 			"old_path":     oldPath,
@@ -200,7 +199,7 @@ func (s *Server) organizeBook(c *gin.Context) {
 			"new_path":     newPath,
 			"operation_id": op.ID,
 		}))
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"message":      fmt.Sprintf("re-organized: %s → %s", oldPath, newPath),
 			"book_id":      book.ID,
 			"old_path":     oldPath,
@@ -231,7 +230,7 @@ func (s *Server) organizeBook(c *gin.Context) {
 		"operation_id":     op.ID,
 	}))
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message":          fmt.Sprintf("organized: %s → %s", oldPath, newPath),
 		"book_id":          createdBook.ID,
 		"original_book_id": book.ID,

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -3278,7 +3278,8 @@ export async function previewRename(bookId: string): Promise<RenamePreview> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to preview rename');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function applyRename(bookId: string): Promise<RenameApplyResult> {
@@ -3289,7 +3290,8 @@ export async function applyRename(bookId: string): Promise<RenameApplyResult> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to apply rename');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // ---- Organize Preview & Execute ----
@@ -3332,7 +3334,8 @@ export async function previewOrganize(bookId: string): Promise<OrganizePreviewRe
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to preview organize');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function organizeBook(bookId: string): Promise<OrganizeResult> {
@@ -3343,7 +3346,8 @@ export async function organizeBook(bookId: string): Promise<OrganizeResult> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to organize book');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // ---- Reconciliation ----


### PR DESCRIPTION
## Summary

Continues [TODO 4.15](../blob/main/TODO.md).

- `internal/server/organize_handlers.go`: migrate all 4 handlers (`previewRename`, `applyRename`, `previewOrganize`, `organizeBook`) to `RespondWith*` helpers. Not-found branches use `RespondWithNotFound(c, "book", id)`.
- `web/src/services/api.ts`: 4 matching callers unwrap `.data`. `BookDetail.tsx` callsites unchanged — envelope adapter stays in the API layer.

## Test plan

- [x] `go build ./...` clean
- [x] `cd web && tsc --noEmit` clean
- [ ] CI green
- [ ] Manual smoke: preview-organize and organize on a book from BookDetail

🤖 Generated with [Claude Code](https://claude.com/claude-code)