### PR TITLE
refactor(server): envelope migration — file_ops handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.16.0 -->
+<!-- version: 2.16.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,12 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 23, 2026 — Envelope Migration: `file_ops_handlers.go`
+
+- **`internal/server/file_ops_handlers.go`**: migrated 2 c.JSON callsites to `RespondWithOK` in `handleListPendingFileOps`.
+- **`web/src/services/fileOpsApi.ts`**: updated `fetchPendingFileOps` to unwrap `response.data`.
+- **Tests updated**: `file_ops_handlers_test.go` all 3 tests now unwrap the data envelope.
 
 #### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
 

--- a/internal/server/file_ops_handlers.go
+++ b/internal/server/file_ops_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/file_ops_handlers.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: 5a2e0c6b-1d4f-4a9e-9c3b-6f1a2d7e8b01
 //
 // HTTP handlers for in-flight file I/O operations. Exposes the
@@ -9,7 +9,6 @@
 package server
 
 import (
-	"net/http"
 	"sort"
 	"time"
 
@@ -28,7 +27,7 @@ type pendingFileOp struct {
 func (s *Server) handleListPendingFileOps(c *gin.Context) {
 	pool := s.fileIOPool
 	if pool == nil {
-		c.JSON(http.StatusOK, gin.H{"operations": []pendingFileOp{}, "count": 0})
+		RespondWithOK(c, gin.H{"operations": []pendingFileOp{}, "count": 0})
 		return
 	}
 
@@ -53,5 +52,5 @@ func (s *Server) handleListPendingFileOps(c *gin.Context) {
 		return out[i].StartedAt.Before(out[j].StartedAt)
 	})
 
-	c.JSON(http.StatusOK, gin.H{"operations": out, "count": len(out)})
+	RespondWithOK(c, gin.H{"operations": out, "count": len(out)})
 }

--- a/internal/server/file_ops_handlers_test.go
+++ b/internal/server/file_ops_handlers_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/file_ops_handlers_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c1f8b4d-9e3a-4f50-a7d6-8b1c5e0f9a23
 
 package server
@@ -28,14 +28,16 @@ func TestHandleListPendingFileOps_NoPool(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	var resp struct {
-		Count      int             `json:"count"`
-		Operations []pendingFileOp `json:"operations"`
+		Data struct {
+			Count      int             `json:"count"`
+			Operations []pendingFileOp `json:"operations"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Count != 0 || len(resp.Operations) != 0 {
-		t.Errorf("expected empty result, got count=%d ops=%v", resp.Count, resp.Operations)
+	if resp.Data.Count != 0 || len(resp.Data.Operations) != 0 {
+		t.Errorf("expected empty result, got count=%d ops=%v", resp.Data.Count, resp.Data.Operations)
 	}
 }
 
@@ -62,18 +64,20 @@ func TestHandleListPendingFileOps_PopulatedPool(t *testing.T) {
 		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
 	}
 	var resp struct {
-		Count      int             `json:"count"`
-		Operations []pendingFileOp `json:"operations"`
+		Data struct {
+			Count      int             `json:"count"`
+			Operations []pendingFileOp `json:"operations"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Count != 2 {
-		t.Fatalf("count = %d, want 2 (response: %s)", resp.Count, w.Body.String())
+	if resp.Data.Count != 2 {
+		t.Fatalf("count = %d, want 2 (response: %s)", resp.Data.Count, w.Body.String())
 	}
 
 	seen := map[string]string{}
-	for _, op := range resp.Operations {
+	for _, op := range resp.Data.Operations {
 		seen[op.BookID] = op.OpType
 	}
 	if seen["book-A"] != "apply_metadata" {
@@ -109,19 +113,21 @@ func TestHandleListPendingFileOps_SortedByStartedAt(t *testing.T) {
 	}
 
 	var resp struct {
-		Count      int             `json:"count"`
-		Operations []pendingFileOp `json:"operations"`
+		Data struct {
+			Count      int             `json:"count"`
+			Operations []pendingFileOp `json:"operations"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(resp.Operations) != 3 {
-		t.Fatalf("got %d ops, want 3", len(resp.Operations))
+	if len(resp.Data.Operations) != 3 {
+		t.Fatalf("got %d ops, want 3", len(resp.Data.Operations))
 	}
-	for i := 1; i < len(resp.Operations); i++ {
-		if resp.Operations[i].StartedAt.Before(resp.Operations[i-1].StartedAt) {
+	for i := 1; i < len(resp.Data.Operations); i++ {
+		if resp.Data.Operations[i].StartedAt.Before(resp.Data.Operations[i-1].StartedAt) {
 			t.Errorf("operations not sorted by started_at: %v before %v",
-				resp.Operations[i].StartedAt, resp.Operations[i-1].StartedAt)
+				resp.Data.Operations[i].StartedAt, resp.Data.Operations[i-1].StartedAt)
 		}
 	}
 }

--- a/web/src/services/fileOpsApi.ts
+++ b/web/src/services/fileOpsApi.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/fileOpsApi.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7b3d5a1e-9c2f-4e80-b1a4-3d8c6e0f4a12
 
 const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
@@ -21,5 +21,6 @@ export async function fetchPendingFileOps(): Promise<PendingFileOpsResponse> {
   if (!res.ok) {
     throw new Error(`fetchPendingFileOps failed: ${res.status}`);
   }
-  return res.json() as Promise<PendingFileOpsResponse>;
+  const body = await res.json();
+  return body.data;
 }


### PR DESCRIPTION
Continues TODO 4.15.

## Changes
- **Backend**: `internal/server/file_ops_handlers.go` — migrated 2 `c.JSON(http.StatusOK, ...)` callsites in `handleListPendingFileOps` to `RespondWithOK(c, ...)`.
- **Frontend**: `web/src/services/fileOpsApi.ts` — updated `fetchPendingFileOps` to unwrap `response.data` from the envelope.
- **Tests**: Updated all 3 tests in `file_ops_handlers_test.go` to unwrap the `data` envelope.

## Verification
- ✅ `go build ./...`
- ✅ `go fmt` passes
- ✅ TypeScript syntax valid
- ✅ Tests updated with envelope unwrap pattern
