### PR TITLE
refactor(server): envelope migration — activity handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.16.1 -->
+<!-- version: 2.17.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -14,6 +14,12 @@
 - **`internal/server/file_ops_handlers.go`**: migrated 2 c.JSON callsites to `RespondWithOK` in `handleListPendingFileOps`.
 - **`web/src/services/fileOpsApi.ts`**: updated `fetchPendingFileOps` to unwrap `response.data`.
 - **Tests updated**: `file_ops_handlers_test.go` all 3 tests now unwrap the data envelope.
+
+#### April 23, 2026 — Envelope Migration: `activity_handlers.go` (Wave 1 A2)
+
+- **`internal/server/activity_handlers.go`**: migrated 11 `c.JSON` callsites to `RespondWith*` helpers.
+- **`web/src/services/activityApi.ts`**: `fetchActivity`, `fetchActivitySources`, `compactActivityLog` unwrap `response.data`.
+- Tests (`activity_handlers_test.go`, `activity_integration_test.go`) updated to decode the `data` envelope.
 
 #### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
 

--- a/internal/server/activity_handlers.go
+++ b/internal/server/activity_handlers.go
@@ -1,11 +1,10 @@
 // file: internal/server/activity_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 
 package server
 
 import (
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +32,7 @@ import (
 //	exclude_sources  – comma-separated list of sources to hide
 func (s *Server) listActivity(c *gin.Context) {
 	if s.activityService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "activity log not available"})
+		RespondWithInternalError(c, "activity log not available")
 		return
 	}
 
@@ -42,7 +41,7 @@ func (s *Server) listActivity(c *gin.Context) {
 	if v := c.Query("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit"})
+			RespondWithBadRequest(c, "invalid limit")
 			return
 		}
 		filter.Limit = n
@@ -51,7 +50,7 @@ func (s *Server) listActivity(c *gin.Context) {
 	if v := c.Query("offset"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid offset"})
+			RespondWithBadRequest(c, "invalid offset")
 			return
 		}
 		filter.Offset = n
@@ -66,7 +65,7 @@ func (s *Server) listActivity(c *gin.Context) {
 	if v := c.Query("since"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid since: must be RFC3339"})
+			RespondWithBadRequest(c, "invalid since: must be RFC3339")
 			return
 		}
 		filter.Since = &t
@@ -75,7 +74,7 @@ func (s *Server) listActivity(c *gin.Context) {
 	if v := c.Query("until"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid until: must be RFC3339"})
+			RespondWithBadRequest(c, "invalid until: must be RFC3339")
 			return
 		}
 		filter.Until = &t
@@ -120,7 +119,7 @@ func (s *Server) listActivity(c *gin.Context) {
 		entries = []database.ActivityEntry{}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"entries": entries,
 		"total":   total,
 	})
@@ -132,7 +131,7 @@ func (s *Server) listActivity(c *gin.Context) {
 // tier/level/since/until parameters as listActivity.
 func (s *Server) listActivitySources(c *gin.Context) {
 	if s.activityService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "activity log not available"})
+		RespondWithInternalError(c, "activity log not available")
 		return
 	}
 	filter := database.ActivityFilter{
@@ -157,13 +156,13 @@ func (s *Server) listActivitySources(c *gin.Context) {
 	if sources == nil {
 		sources = []database.SourceCount{}
 	}
-	c.JSON(http.StatusOK, gin.H{"sources": sources})
+	RespondWithOK(c, gin.H{"sources": sources})
 }
 
 // compactActivity handles POST /api/v1/activity/compact.
 func (s *Server) compactActivity(c *gin.Context) {
 	if s.activityService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "activity log not available"})
+		RespondWithInternalError(c, "activity log not available")
 		return
 	}
 
@@ -171,7 +170,7 @@ func (s *Server) compactActivity(c *gin.Context) {
 		OlderThanDays int `json:"older_than_days"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil || req.OlderThanDays < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "older_than_days must be zero or positive"})
+		RespondWithBadRequest(c, "older_than_days must be zero or positive")
 		return
 	}
 
@@ -183,5 +182,5 @@ func (s *Server) compactActivity(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }

--- a/internal/server/activity_handlers_test.go
+++ b/internal/server/activity_handlers_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/activity_handlers_test.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 
 package server
@@ -58,15 +58,17 @@ func TestListActivity_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		Entries []database.ActivityEntry `json:"entries"`
-		Total   int                      `json:"total"`
+		Data struct {
+			Entries []database.ActivityEntry `json:"entries"`
+			Total   int                      `json:"total"`
+		} `json:"data"`
 	}
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Equal(t, 0, resp.Total)
+	assert.Equal(t, 0, resp.Data.Total)
 	// entries must be an array, not null.
-	assert.NotNil(t, resp.Entries)
-	assert.Empty(t, resp.Entries)
+	assert.NotNil(t, resp.Data.Entries)
+	assert.Empty(t, resp.Data.Entries)
 }
 
 // TestListActivity_WithFilters inserts two entries (tiers: change, debug) and
@@ -115,15 +117,17 @@ func TestListActivity_WithFilters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		Entries []database.ActivityEntry `json:"entries"`
-		Total   int                      `json:"total"`
+		Data struct {
+			Entries []database.ActivityEntry `json:"entries"`
+			Total   int                      `json:"total"`
+		} `json:"data"`
 	}
 	err = json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	assert.Equal(t, 1, resp.Total)
-	require.Len(t, resp.Entries, 1)
-	assert.Equal(t, "change", resp.Entries[0].Tier)
-	assert.Equal(t, "metadata_apply", resp.Entries[0].Type)
+	assert.Equal(t, 1, resp.Data.Total)
+	require.Len(t, resp.Data.Entries, 1)
+	assert.Equal(t, "change", resp.Data.Entries[0].Tier)
+	assert.Equal(t, "metadata_apply", resp.Data.Entries[0].Type)
 }
 
 // TestListActivity_SearchParam verifies that the search query param filters
@@ -167,13 +171,15 @@ func TestListActivity_SearchParam(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		Entries []database.ActivityEntry `json:"entries"`
-		Total   int                      `json:"total"`
+		Data struct {
+			Entries []database.ActivityEntry `json:"entries"`
+			Total   int                      `json:"total"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 1, resp.Total)
-	require.Len(t, resp.Entries, 1)
-	assert.Contains(t, resp.Entries[0].Summary, "Hail Mary")
+	assert.Equal(t, 1, resp.Data.Total)
+	require.Len(t, resp.Data.Entries, 1)
+	assert.Contains(t, resp.Data.Entries[0].Summary, "Hail Mary")
 }
 
 // TestListActivitySources verifies that the sources endpoint returns distinct
@@ -220,13 +226,15 @@ func TestListActivitySources(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		Sources []database.SourceCount `json:"sources"`
+		Data struct {
+			Sources []database.SourceCount `json:"sources"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Len(t, resp.Sources, 2)
+	require.Len(t, resp.Data.Sources, 2)
 	// Ordered by count DESC: gin (2) first, scanner (1) second.
-	assert.Equal(t, "gin", resp.Sources[0].Source)
-	assert.Equal(t, 2, resp.Sources[0].Count)
-	assert.Equal(t, "scanner", resp.Sources[1].Source)
-	assert.Equal(t, 1, resp.Sources[1].Count)
+	assert.Equal(t, "gin", resp.Data.Sources[0].Source)
+	assert.Equal(t, 2, resp.Data.Sources[0].Count)
+	assert.Equal(t, "scanner", resp.Data.Sources[1].Source)
+	assert.Equal(t, 1, resp.Data.Sources[1].Count)
 }

--- a/internal/server/activity_integration_test.go
+++ b/internal/server/activity_integration_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/activity_integration_test.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: f8a3b2c1-d4e5-6f7a-8b9c-0d1e2f3a4b5c
 
 package server
@@ -62,8 +62,10 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	})
 
 	type activityResp struct {
-		Entries []database.ActivityEntry `json:"entries"`
-		Total   int                      `json:"total"`
+		Data struct {
+			Entries []database.ActivityEntry `json:"entries"`
+			Total   int                      `json:"total"`
+		} `json:"data"`
 	}
 
 	// Query all
@@ -75,8 +77,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if resp.Total != 3 {
-		t.Fatalf("expected 3, got %d", resp.Total)
+	if resp.Data.Total != 3 {
+		t.Fatalf("expected 3, got %d", resp.Data.Total)
 	}
 
 	// Query by operation
@@ -84,8 +86,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?operation_id=op-sync-1", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 2 {
-		t.Errorf("expected 2 entries for op-sync-1, got %d", resp.Total)
+	if resp.Data.Total != 2 {
+		t.Errorf("expected 2 entries for op-sync-1, got %d", resp.Data.Total)
 	}
 
 	// Query by book
@@ -93,8 +95,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?book_id=book-1&tier=change", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 1 {
-		t.Errorf("expected 1 entry for book-1, got %d", resp.Total)
+	if resp.Data.Total != 1 {
+		t.Errorf("expected 1 entry for book-1, got %d", resp.Data.Total)
 	}
 
 	// Query by tags
@@ -102,8 +104,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?tags=itunes", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 1 {
-		t.Errorf("expected 1 entry with tag=itunes, got %d", resp.Total)
+	if resp.Data.Total != 1 {
+		t.Errorf("expected 1 entry with tag=itunes, got %d", resp.Data.Total)
 	}
 
 	// Verify details round-trip
@@ -111,11 +113,11 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?type=itunes_sync", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 1 {
-		t.Fatalf("expected 1 itunes_sync, got %d", resp.Total)
+	if resp.Data.Total != 1 {
+		t.Fatalf("expected 1 itunes_sync, got %d", resp.Data.Total)
 	}
-	if v, ok := resp.Entries[0].Details["updated"]; !ok || v != float64(312) {
-		t.Errorf("details.updated mismatch: %v", resp.Entries[0].Details)
+	if v, ok := resp.Data.Entries[0].Details["updated"]; !ok || v != float64(312) {
+		t.Errorf("details.updated mismatch: %v", resp.Data.Entries[0].Details)
 	}
 
 	// Search filter
@@ -123,8 +125,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?search=312+updated", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 1 {
-		t.Errorf("search '312 updated': expected 1, got %d", resp.Total)
+	if resp.Data.Total != 1 {
+		t.Errorf("search '312 updated': expected 1, got %d", resp.Data.Total)
 	}
 
 	// Exclude sources
@@ -132,8 +134,8 @@ func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/api/v1/activity?exclude_sources=background", nil)
 	r.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp.Total != 2 {
-		t.Errorf("exclude background: expected 2, got %d", resp.Total)
+	if resp.Data.Total != 2 {
+		t.Errorf("exclude background: expected 2, got %d", resp.Data.Total)
 	}
 }
 

--- a/web/src/services/activityApi.ts
+++ b/web/src/services/activityApi.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/activityApi.ts
-// version: 1.2.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
@@ -73,7 +73,8 @@ export async function fetchActivity(filter?: ActivityFilter): Promise<ActivityRe
   if (!response.ok) {
     throw new Error(`Failed to fetch activity: ${response.status}`);
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function fetchActivitySources(filter: Partial<ActivityFilter> = {}): Promise<SourcesResponse> {
@@ -85,7 +86,8 @@ export async function fetchActivitySources(filter: Partial<ActivityFilter> = {})
   const url = `${API_BASE}/activity/sources?${params.toString()}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Sources API error: ${res.status}`);
-  return res.json();
+  const body = await res.json();
+  return body.data;
 }
 
 export interface CompactResult {
@@ -102,5 +104,6 @@ export async function compactActivityLog(olderThanDays: number): Promise<Compact
   if (!response.ok) {
     throw new Error(`Failed to compact activity log: ${response.status}`);
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }


### PR DESCRIPTION
Continues TODO 4.15. Wave 1 A2 salvage (Haiku agent completed refactor but couldn't commit due to bash permissions).

- activity_handlers.go: 11 c.JSON → RespondWith*
- activityApi.ts: 3 callers unwrap `.data`
- Tests decode data envelope

✓ go build ✓ go vet ✓ tsc ✓ go test -run Activity (all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)