### PR TITLE
refactor(server): envelope migration — reading handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
 - **`web/src/services/activityApi.ts`**: `fetchActivity`, `fetchActivitySources`, `compactActivityLog` unwrap `response.data`.
 - Tests (`activity_handlers_test.go`, `activity_integration_test.go`) updated to decode the `data` envelope.
 
+#### April 23, 2026 — Envelope Migration: `reading_handlers.go` (Wave 1 A3)
+
+- **`internal/server/reading_handlers.go`**: migrated 16 `c.JSON` callsites across 6 handlers to `RespondWith*` helpers.
+- **`web/src/services/readingApi.ts`**: 6 callers unwrap `response.data`.
+- Tests (`reading_handlers_test.go`) updated to decode the `data` envelope.
+
 #### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
 
 - **`internal/server/organize_handlers.go`**: migrated all 4 handlers (`previewRename`, `applyRename`, `previewOrganize`, `organizeBook`) and all success/error responses to `RespondWith*` helpers. "book not found" branches now use `RespondWithNotFound(c, "book", id)`.

--- a/internal/server/reading_handlers.go
+++ b/internal/server/reading_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/reading_handlers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f2c4a1d-5b8e-4f70-a9d6-2e8c0f1b9a57
 //
 // HTTP endpoints for the per-user read/unread tracking system
@@ -13,7 +13,6 @@ package server
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/readstatus"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -47,12 +46,12 @@ type setPositionRequest struct {
 func (s *Server) handleSetPosition(c *gin.Context) {
 	bookID := c.Param("id")
 	if bookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		RespondWithBadRequest(c, "book id required")
 		return
 	}
 	var req setPositionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	userID := callingUserID(c)
@@ -65,7 +64,7 @@ func (s *Server) handleSetPosition(c *gin.Context) {
 		internalError(c, "failed to recompute book state", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"state": state})
+	RespondWithOK(c, state)
 }
 
 // handleGetPosition returns the latest position for the calling user.
@@ -73,7 +72,7 @@ func (s *Server) handleSetPosition(c *gin.Context) {
 func (s *Server) handleGetPosition(c *gin.Context) {
 	bookID := c.Param("id")
 	if bookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		RespondWithBadRequest(c, "book id required")
 		return
 	}
 	pos, err := s.Store().GetUserPosition(callingUserID(c), bookID)
@@ -81,11 +80,7 @@ func (s *Server) handleGetPosition(c *gin.Context) {
 		internalError(c, "failed to load position", err)
 		return
 	}
-	if pos == nil {
-		c.JSON(http.StatusOK, gin.H{"position": nil})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"position": pos})
+	RespondWithOK(c, pos)
 }
 
 // handleGetBookState returns the derived UserBookState — status +
@@ -94,7 +89,7 @@ func (s *Server) handleGetPosition(c *gin.Context) {
 func (s *Server) handleGetBookState(c *gin.Context) {
 	bookID := c.Param("id")
 	if bookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		RespondWithBadRequest(c, "book id required")
 		return
 	}
 	state, err := s.Store().GetUserBookState(callingUserID(c), bookID)
@@ -102,7 +97,7 @@ func (s *Server) handleGetBookState(c *gin.Context) {
 		internalError(c, "failed to load state", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"state": state})
+	RespondWithOK(c, state)
 }
 
 type patchStatusRequest struct {
@@ -115,12 +110,12 @@ type patchStatusRequest struct {
 func (s *Server) handleSetBookStatus(c *gin.Context) {
 	bookID := c.Param("id")
 	if bookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		RespondWithBadRequest(c, "book id required")
 		return
 	}
 	var req patchStatusRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	switch req.Status {
@@ -130,7 +125,7 @@ func (s *Server) handleSetBookStatus(c *gin.Context) {
 		database.UserBookStatusAbandoned:
 		// ok
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status: " + req.Status})
+		RespondWithBadRequest(c, "invalid status: "+req.Status)
 		return
 	}
 	state, err := readstatus.SetManualStatus(s.Store(), callingUserID(c), bookID, req.Status)
@@ -138,7 +133,7 @@ func (s *Server) handleSetBookStatus(c *gin.Context) {
 		internalError(c, "failed to set status", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"state": state})
+	RespondWithOK(c, state)
 }
 
 // handleClearBookStatus clears the manual override — next recompute
@@ -147,7 +142,7 @@ func (s *Server) handleSetBookStatus(c *gin.Context) {
 func (s *Server) handleClearBookStatus(c *gin.Context) {
 	bookID := c.Param("id")
 	if bookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id required"})
+		RespondWithBadRequest(c, "book id required")
 		return
 	}
 	state, err := readstatus.SetManualStatus(s.Store(), callingUserID(c), bookID, "")
@@ -155,7 +150,7 @@ func (s *Server) handleClearBookStatus(c *gin.Context) {
 		internalError(c, "failed to clear status", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"state": state})
+	RespondWithOK(c, state)
 }
 
 // handleListByStatus returns the calling user's books filtered by
@@ -168,7 +163,7 @@ func (s *Server) handleListByStatus(c *gin.Context) {
 		database.UserBookStatusAbandoned,
 		database.UserBookStatusUnstarted:
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
+		RespondWithBadRequest(c, "invalid status")
 		return
 	}
 	limit := 50
@@ -188,7 +183,7 @@ func (s *Server) handleListByStatus(c *gin.Context) {
 		internalError(c, "failed to list states", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"states": list, "count": len(list), "limit": limit, "offset": offset})
+	RespondWithOK(c, gin.H{"states": list, "count": len(list), "limit": limit, "offset": offset})
 }
 
 // registerReadingRoutes wires the read/unread endpoints onto the

--- a/internal/server/reading_handlers_test.go
+++ b/internal/server/reading_handlers_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/reading_handlers_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f9a2c1d-5b8e-4f70-a7d6-2e8c0f1b9a57
 
 package server
@@ -72,13 +72,13 @@ func TestReading_SetAndGetPosition(t *testing.T) {
 		t.Fatalf("GET position: %d", w.Code)
 	}
 	var resp struct {
-		Position *database.UserPosition `json:"position"`
+		Data *database.UserPosition `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Position == nil || resp.Position.SegmentID != "s1" {
-		t.Errorf("got position %+v", resp.Position)
+	if resp.Data == nil || resp.Data.SegmentID != "s1" {
+		t.Errorf("got position %+v", resp.Data)
 	}
 }
 
@@ -102,19 +102,19 @@ func TestReading_StateComputed(t *testing.T) {
 		t.Fatalf("GET state: %d", w.Code)
 	}
 	var resp struct {
-		State *database.UserBookState `json:"state"`
+		Data *database.UserBookState `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.State == nil {
+	if resp.Data == nil {
 		t.Fatal("state nil")
 	}
-	if resp.State.Status != database.UserBookStatusInProgress {
-		t.Errorf("Status = %q, want in_progress", resp.State.Status)
+	if resp.Data.Status != database.UserBookStatusInProgress {
+		t.Errorf("Status = %q, want in_progress", resp.Data.Status)
 	}
-	if resp.State.ProgressPct != 16 {
-		t.Errorf("ProgressPct = %d, want 16", resp.State.ProgressPct)
+	if resp.Data.ProgressPct != 16 {
+		t.Errorf("ProgressPct = %d, want 16", resp.Data.ProgressPct)
 	}
 }
 
@@ -183,13 +183,15 @@ func TestReading_ListByStatus(t *testing.T) {
 		t.Fatalf("GET me/finished: %d %s", w.Code, w.Body.String())
 	}
 	var resp struct {
-		States []database.UserBookState `json:"states"`
-		Count  int                      `json:"count"`
+		Data struct {
+			States []database.UserBookState `json:"states"`
+			Count  int                      `json:"count"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Count != 1 {
-		t.Errorf("finished count = %d, want 1", resp.Count)
+	if resp.Data.Count != 1 {
+		t.Errorf("finished count = %d, want 1", resp.Data.Count)
 	}
 }

--- a/web/src/services/readingApi.ts
+++ b/web/src/services/readingApi.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/readingApi.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6b4c5d0e-7f8a-4a70-b8c5-3d7e0f1b9a99
 
 const API_BASE = '/api/v1';
@@ -43,15 +43,15 @@ export const READ_STATUS_COLORS: Record<ReadStatus, string> = {
 export async function getBookState(bookId: string): Promise<UserBookState | null> {
   const resp = await fetch(`${API_BASE}/books/${bookId}/state`);
   if (!resp.ok) return null;
-  const data = await resp.json();
-  return data?.state ?? null;
+  const body = await resp.json();
+  return body?.data ?? null;
 }
 
 export async function getBookPosition(bookId: string): Promise<UserPosition | null> {
   const resp = await fetch(`${API_BASE}/books/${bookId}/position`);
   if (!resp.ok) return null;
-  const data = await resp.json();
-  return data?.position ?? null;
+  const body = await resp.json();
+  return body?.data ?? null;
 }
 
 export async function setBookPosition(
@@ -64,8 +64,8 @@ export async function setBookPosition(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ segment_id: segmentId, position_seconds: positionSeconds }),
   });
-  const data = await resp.json();
-  return data.state;
+  const body = await resp.json();
+  return body.data;
 }
 
 export async function setBookStatus(
@@ -77,15 +77,15 @@ export async function setBookStatus(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ status }),
   });
-  const data = await resp.json();
-  return data.state;
+  const body = await resp.json();
+  return body.data;
 }
 
 export async function clearBookStatus(bookId: string): Promise<UserBookState | null> {
   const resp = await fetch(`${API_BASE}/books/${bookId}/status`, { method: 'DELETE' });
   if (!resp.ok) return null;
-  const data = await resp.json();
-  return data?.state ?? null;
+  const body = await resp.json();
+  return body?.data ?? null;
 }
 
 export async function listByStatus(
@@ -94,5 +94,6 @@ export async function listByStatus(
   offset = 0
 ): Promise<{ states: UserBookState[]; count: number }> {
   const resp = await fetch(`${API_BASE}/me/${status}?limit=${limit}&offset=${offset}`);
-  return resp.json();
+  const body = await resp.json();
+  return body.data;
 }


### PR DESCRIPTION
Continues TODO 4.15. Wave 1 A3 salvage.

- reading_handlers.go: 16 c.JSON → RespondWith*
- readingApi.ts: 6 callers unwrap `.data`
- Tests decode data envelope

✓ go build ✓ go vet ✓ tsc ✓ go test -run Reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)