### PR TITLE
refactor(server): envelope migration — versions handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
 - **`internal/server/reading_handlers.go`**: migrated 16 `c.JSON` callsites across 6 handlers to `RespondWith*` helpers.
 - **`web/src/services/readingApi.ts`**: 6 callers unwrap `response.data`.
 - Tests (`reading_handlers_test.go`) updated to decode the `data` envelope.
+#### April 23, 2026 — Envelope Migration: `versions_handlers.go` (Wave 1 A4)
+
+- **`internal/server/versions_handlers.go`**: migrated 8 handlers / ~31 `c.JSON` callsites to `RespondWith*` helpers.
+- **`web/src/services/api.ts`**: `getBookVersions`, `getVersionGroup`, `splitVersion`, `splitSegmentsToBooks` unwrap `response.data`. Void callers unchanged.
+- Tests (`server_versions_and_work_test.go`, `server_extra_test.go`) updated to decode the `data` envelope.
 
 #### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
 

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -404,9 +404,11 @@ func TestVersionEndpoints(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var linkResp map[string]string
+	var linkResp struct {
+		Data map[string]string `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &linkResp))
-	groupID := linkResp["version_group_id"]
+	groupID := linkResp.Data["version_group_id"]
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/version-groups/"+groupID, nil)
 	w = httptest.NewRecorder()

--- a/internal/server/server_versions_and_work_test.go
+++ b/internal/server/server_versions_and_work_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_versions_and_work_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a4b5c6d-7e8f-9012-a345-678901234567
-// last-edited: 2026-01-24
+// last-edited: 2026-04-23
 
 package server
 
@@ -41,9 +41,11 @@ func TestVersionEndpoints_HappyPaths(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var linkResp map[string]string
+	var linkResp struct {
+		Data map[string]string `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &linkResp))
-	groupID := linkResp["version_group_id"]
+	groupID := linkResp.Data["version_group_id"]
 	require.NotEmpty(t, groupID)
 
 	// getVersionGroup

--- a/internal/server/versions_handlers.go
+++ b/internal/server/versions_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/versions_handlers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2fde2ee-5301-4240-9def-503917e19a78
 //
 // Version-grouping HTTP handlers split out of server.go: list/link/
@@ -11,7 +11,6 @@ package server
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"path/filepath"
 
 	"github.com/gin-gonic/gin"
@@ -24,28 +23,28 @@ func (s *Server) listAudiobookVersions(c *gin.Context) {
 	id := c.Param("id")
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	book, err := s.Store().GetBookByID(id)
 	if err != nil || book == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
 	if book.VersionGroupID == nil {
-		c.JSON(http.StatusOK, gin.H{"versions": []any{book}})
+		RespondWithOK(c, gin.H{"versions": []any{book}})
 		return
 	}
 
 	books, err := s.Store().GetBooksByVersionGroup(*book.VersionGroupID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch versions"})
+		RespondWithInternalError(c, "failed to fetch versions")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"versions": books})
+	RespondWithOK(c, gin.H{"versions": books})
 }
 
 // linkAudiobookVersion links an audiobook as another version
@@ -57,24 +56,24 @@ func (s *Server) linkAudiobookVersion(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	book1, err := s.Store().GetBookByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
 	book2, err := s.Store().GetBookByID(req.OtherID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "other audiobook not found"})
+		RespondWithNotFound(c, "audiobook", req.OtherID)
 		return
 	}
 
@@ -91,16 +90,16 @@ func (s *Server) linkAudiobookVersion(c *gin.Context) {
 	book2.VersionGroupID = &versionGroupID
 
 	if _, err := s.Store().UpdateBook(id, book1); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update audiobook"})
+		RespondWithInternalError(c, "failed to update audiobook")
 		return
 	}
 
 	if _, err := s.Store().UpdateBook(req.OtherID, book2); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update other audiobook"})
+		RespondWithInternalError(c, "failed to update other audiobook")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"version_group_id": versionGroupID})
+	RespondWithOK(c, gin.H{"version_group_id": versionGroupID})
 }
 
 // setAudiobookPrimary sets an audiobook as the primary version
@@ -108,13 +107,13 @@ func (s *Server) setAudiobookPrimary(c *gin.Context) {
 	id := c.Param("id")
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	book, err := s.Store().GetBookByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
@@ -122,16 +121,16 @@ func (s *Server) setAudiobookPrimary(c *gin.Context) {
 		primaryFlag := true
 		book.IsPrimaryVersion = &primaryFlag
 		if _, err := s.Store().UpdateBook(id, book); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update audiobook"})
+			RespondWithInternalError(c, "failed to update audiobook")
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"message": "audiobook set as primary"})
+		RespondWithOK(c, gin.H{"message": "audiobook set as primary"})
 		return
 	}
 
 	books, err := s.Store().GetBooksByVersionGroup(*book.VersionGroupID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch versions"})
+		RespondWithInternalError(c, "failed to fetch versions")
 		return
 	}
 
@@ -139,12 +138,12 @@ func (s *Server) setAudiobookPrimary(c *gin.Context) {
 		primaryFlag := books[i].ID == id
 		books[i].IsPrimaryVersion = &primaryFlag
 		if _, err := s.Store().UpdateBook(books[i].ID, &books[i]); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update version"})
+			RespondWithInternalError(c, "failed to update version")
 			return
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "audiobook set as primary"})
+	RespondWithOK(c, gin.H{"message": "audiobook set as primary"})
 }
 
 // getVersionGroup gets all audiobooks in a version group
@@ -152,17 +151,17 @@ func (s *Server) getVersionGroup(c *gin.Context) {
 	groupID := c.Param("id")
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	books, err := s.Store().GetBooksByVersionGroup(groupID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch version group"})
+		RespondWithInternalError(c, "failed to fetch version group")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"audiobooks": books})
+	RespondWithOK(c, gin.H{"audiobooks": books})
 }
 
 // splitVersion moves selected segments from a book into a new version (a new book
@@ -174,23 +173,23 @@ func (s *Server) splitVersion(c *gin.Context) {
 		SegmentIDs []string `json:"segment_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.SegmentIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "segment_ids must not be empty"})
+		RespondWithBadRequest(c, "segment_ids must not be empty")
 		return
 	}
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	// 1. Get source book
 	sourceBook, err := s.Store().GetBookByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
@@ -202,7 +201,7 @@ func (s *Server) splitVersion(c *gin.Context) {
 		versionGroupID = ulid.Make().String()
 		sourceBook.VersionGroupID = &versionGroupID
 		if _, err := s.Store().UpdateBook(id, sourceBook); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update source book version group"})
+			RespondWithInternalError(c, "failed to update source book version group")
 			return
 		}
 	}
@@ -266,7 +265,7 @@ func (s *Server) splitVersion(c *gin.Context) {
 		s.Store().UpdateBook(sourceBook.ID, sourceBook)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"book":             createdBook,
 		"version_group_id": versionGroupID,
 		"segments_moved":   len(req.SegmentIDs),
@@ -283,29 +282,29 @@ func (s *Server) splitSegmentsToBooks(c *gin.Context) {
 		SegmentIDs []string `json:"segment_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.SegmentIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "segment_ids must not be empty"})
+		RespondWithBadRequest(c, "segment_ids must not be empty")
 		return
 	}
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	sourceBook, err := s.Store().GetBookByID(id)
 	if err != nil || sourceBook == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
 	// Build a lookup of file ID → BookFile
 	allFiles, err := s.Store().GetBookFiles(sourceBook.ID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list book files"})
+		RespondWithInternalError(c, "failed to list book files")
 		return
 	}
 	fileMap := make(map[string]database.BookFile, len(allFiles))
@@ -381,7 +380,7 @@ func (s *Server) splitSegmentsToBooks(c *gin.Context) {
 		s.Store().UpdateBook(sourceBook.ID, sourceBook)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"created_books": createdBooks,
 		"count":         len(createdBooks),
 	})
@@ -396,46 +395,46 @@ func (s *Server) moveSegments(c *gin.Context) {
 		TargetBookID string   `json:"target_book_id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.SegmentIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "segment_ids must not be empty"})
+		RespondWithBadRequest(c, "segment_ids must not be empty")
 		return
 	}
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	// 1. Get source and target books
 	sourceBook, err := s.Store().GetBookByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "source audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
 	targetBook, err := s.Store().GetBookByID(req.TargetBookID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "target audiobook not found"})
+		RespondWithNotFound(c, "audiobook", req.TargetBookID)
 		return
 	}
 
 	// 2. Verify both books are in the same version group
 	if sourceBook.VersionGroupID == nil || targetBook.VersionGroupID == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "both books must be in a version group"})
+		RespondWithBadRequest(c, "both books must be in a version group")
 		return
 	}
 	if *sourceBook.VersionGroupID != *targetBook.VersionGroupID {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "books must be in the same version group"})
+		RespondWithBadRequest(c, "books must be in the same version group")
 		return
 	}
 
 	// 3. Verify the files belong to the source book
 	sourceFiles, err := s.Store().GetBookFiles(id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list source book files"})
+		RespondWithInternalError(c, "failed to list source book files")
 		return
 	}
 	sourceFileMap := make(map[string]bool, len(sourceFiles))
@@ -444,7 +443,7 @@ func (s *Server) moveSegments(c *gin.Context) {
 	}
 	for _, segID := range req.SegmentIDs {
 		if !sourceFileMap[segID] {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("file %s does not belong to source book", segID)})
+			RespondWithBadRequest(c, fmt.Sprintf("file %s does not belong to source book", segID))
 			return
 		}
 	}
@@ -470,7 +469,7 @@ func (s *Server) moveSegments(c *gin.Context) {
 	// 6. Reassign external ID mappings (iTunes PIDs) for moved files
 	reassignExternalIDsForFiles(id, req.TargetBookID, movedFiles)
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"segments_moved": len(req.SegmentIDs),
 		"source_book_id": id,
 		"target_book_id": req.TargetBookID,

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1664,8 +1664,8 @@ export async function getBookVersions(bookId: string): Promise<Book[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch book versions');
   }
-  const data = await response.json();
-  return data.versions || [];
+  const body = await response.json();
+  return body.data?.versions || [];
 }
 
 export async function linkBookVersion(
@@ -1710,8 +1710,8 @@ export async function getVersionGroup(groupId: string): Promise<Book[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch version group');
   }
-  const data = await response.json();
-  return data.audiobooks || [];
+  const body = await response.json();
+  return body.data?.audiobooks || [];
 }
 
 // Split selected segments into a new version (new book in same version group)
@@ -1724,7 +1724,8 @@ export async function splitVersion(bookId: string, segmentIds: string[]): Promis
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to split version');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Split selected segments into independent new books (one per segment).
@@ -1738,7 +1739,8 @@ export async function splitSegmentsToBooks(bookId: string, segmentIds: string[])
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to split segments to books');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Move segments from one book to another (must be in same version group)


### PR DESCRIPTION
Continues TODO 4.15. Wave 1 A4 salvage.

- versions_handlers.go: ~31 c.JSON → RespondWith*
- api.ts: 4 versions callers unwrap `.data`
- Tests decode data envelope (including server_extra_test.go that A4 originally missed — fixed in salvage)

✓ go build ✓ go vet ✓ tsc ✓ go test -run 'TestVersion|TestWork'

🤖 Generated with [Claude Code](https://claude.com/claude-code)