### PR TITLE
refactor(server): envelope migration — playlist handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,18 @@
 - **`internal/server/reading_handlers.go`**: migrated 16 `c.JSON` callsites across 6 handlers to `RespondWith*` helpers.
 - **`web/src/services/readingApi.ts`**: 6 callers unwrap `response.data`.
 - Tests (`reading_handlers_test.go`) updated to decode the `data` envelope.
+
 #### April 23, 2026 — Envelope Migration: `versions_handlers.go` (Wave 1 A4)
 
 - **`internal/server/versions_handlers.go`**: migrated 8 handlers / ~31 `c.JSON` callsites to `RespondWith*` helpers.
 - **`web/src/services/api.ts`**: `getBookVersions`, `getVersionGroup`, `splitVersion`, `splitSegmentsToBooks` unwrap `response.data`. Void callers unchanged.
 - Tests (`server_versions_and_work_test.go`, `server_extra_test.go`) updated to decode the `data` envelope.
+
+#### April 23, 2026 — Envelope Migration: `playlist_handlers.go` (Wave 1 A5)
+
+- **`internal/server/playlist_handlers.go`**: migrated 9 handlers / 34 `c.JSON` callsites to `RespondWith*` helpers. `handleListPlaylists` uses `RespondWithList` (paginated envelope).
+- **`web/src/services/playlistApi.ts`**: `jsonFetch` helper unwraps `response.data`; `listPlaylists` maps paginated `items` → `playlists`.
+- Tests (`playlist_handlers_test.go`) updated to decode the `data` envelope across 9 tests.
 
 #### April 23, 2026 — Envelope Migration: `organize_handlers.go` + rename/organize API
 

--- a/internal/server/playlist_handlers.go
+++ b/internal/server/playlist_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/playlist_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7a3d5f2e-8c4b-4a70-b8c5-3d7e0f1b9a79
 //
 // HTTP endpoints for user-created playlists (spec 3.4 task 3).
@@ -17,7 +17,6 @@ package server
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -61,11 +60,11 @@ type playlistReorderReq struct {
 func (s *Server) handleCreatePlaylist(c *gin.Context) {
 	var req playlistCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if err := validatePlaylistCreate(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -83,13 +82,13 @@ func (s *Server) handleCreatePlaylist(c *gin.Context) {
 	created, err := s.Store().CreateUserPlaylist(pl)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
-			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			RespondWithConflict(c, err.Error())
 			return
 		}
 		internalError(c, "failed to create playlist", err)
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"playlist": created})
+	RespondWithCreated(c, created)
 }
 
 // handleListPlaylists — GET /api/v1/playlists?type=static|smart&limit=N&offset=M
@@ -98,7 +97,7 @@ func (s *Server) handleListPlaylists(c *gin.Context) {
 	if plType != "" &&
 		plType != database.UserPlaylistTypeStatic &&
 		plType != database.UserPlaylistTypeSmart {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "type must be static, smart, or empty"})
+		RespondWithBadRequest(c, "type must be static, smart, or empty")
 		return
 	}
 	limit, offset := paginationFromQuery(c)
@@ -107,9 +106,7 @@ func (s *Server) handleListPlaylists(c *gin.Context) {
 		internalError(c, "failed to list playlists", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"playlists": lists, "count": total, "limit": limit, "offset": offset,
-	})
+	RespondWithList(c, lists, total, limit, offset)
 }
 
 // handleGetPlaylist — GET /api/v1/playlists/:id
@@ -125,7 +122,7 @@ func (s *Server) handleGetPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 
@@ -144,10 +141,10 @@ func (s *Server) handleGetPlaylist(c *gin.Context) {
 			// a transient condition during startup. Actual query
 			// errors are 400 (user's smart-playlist DSL is busted).
 			if evalErr == ErrSearchIndexUnavailable {
-				c.JSON(http.StatusServiceUnavailable, gin.H{"error": evalErr.Error()})
+				RespondWithError(c, 503, evalErr.Error(), "SERVICE_UNAVAILABLE")
 				return
 			}
-			c.JSON(http.StatusBadRequest, gin.H{"error": evalErr.Error()})
+			RespondWithBadRequest(c, evalErr.Error())
 			return
 		}
 		resp["book_ids"] = bookIDs
@@ -157,7 +154,7 @@ func (s *Server) handleGetPlaylist(c *gin.Context) {
 			_ = s.Store().UpdateUserPlaylist(pl)
 		}
 	}
-	c.JSON(http.StatusOK, resp)
+	RespondWithOK(c, resp)
 }
 
 // handleUpdatePlaylist — PUT /api/v1/playlists/:id
@@ -169,13 +166,13 @@ func (s *Server) handleUpdatePlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 
 	var req playlistUpdateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if req.Name != nil {
@@ -186,18 +183,18 @@ func (s *Server) handleUpdatePlaylist(c *gin.Context) {
 	}
 	if req.BookIDs != nil {
 		if pl.Type != database.UserPlaylistTypeStatic {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids only valid for static playlists"})
+			RespondWithBadRequest(c, "book_ids only valid for static playlists")
 			return
 		}
 		pl.BookIDs = *req.BookIDs
 	}
 	if req.Query != nil {
 		if pl.Type != database.UserPlaylistTypeSmart {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "query only valid for smart playlists"})
+			RespondWithBadRequest(c, "query only valid for smart playlists")
 			return
 		}
 		if _, err := search.ParseQuery(*req.Query); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid query: " + err.Error()})
+			RespondWithBadRequest(c, "invalid query: "+err.Error())
 			return
 		}
 		pl.Query = *req.Query
@@ -213,7 +210,7 @@ func (s *Server) handleUpdatePlaylist(c *gin.Context) {
 		internalError(c, "failed to update playlist", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"playlist": pl})
+	RespondWithOK(c, pl)
 }
 
 // handleDeletePlaylist — DELETE /api/v1/playlists/:id
@@ -223,7 +220,7 @@ func (s *Server) handleDeletePlaylist(c *gin.Context) {
 		internalError(c, "failed to delete playlist", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"deleted": id})
+	RespondWithOK(c, gin.H{"deleted": id})
 }
 
 // handleAddBooksToPlaylist — POST /api/v1/playlists/:id/books
@@ -233,7 +230,7 @@ func (s *Server) handleAddBooksToPlaylist(c *gin.Context) {
 	id := c.Param("id")
 	var req playlistBooksAddReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	pl, err := s.Store().GetUserPlaylist(id)
@@ -242,11 +239,11 @@ func (s *Server) handleAddBooksToPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 	if pl.Type != database.UserPlaylistTypeStatic {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot add books to smart playlist"})
+		RespondWithBadRequest(c, "cannot add books to smart playlist")
 		return
 	}
 	existing := make(map[string]bool, len(pl.BookIDs))
@@ -265,7 +262,7 @@ func (s *Server) handleAddBooksToPlaylist(c *gin.Context) {
 		internalError(c, "failed to add books", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"playlist": pl})
+	RespondWithOK(c, pl)
 }
 
 // handleRemoveBookFromPlaylist — DELETE /api/v1/playlists/:id/books/:bookID
@@ -278,11 +275,11 @@ func (s *Server) handleRemoveBookFromPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 	if pl.Type != database.UserPlaylistTypeStatic {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot remove books from smart playlist"})
+		RespondWithBadRequest(c, "cannot remove books from smart playlist")
 		return
 	}
 	filtered := pl.BookIDs[:0]
@@ -297,7 +294,7 @@ func (s *Server) handleRemoveBookFromPlaylist(c *gin.Context) {
 		internalError(c, "failed to remove book", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"playlist": pl})
+	RespondWithOK(c, pl)
 }
 
 // handleReorderPlaylist — POST /api/v1/playlists/:id/reorder
@@ -307,7 +304,7 @@ func (s *Server) handleReorderPlaylist(c *gin.Context) {
 	id := c.Param("id")
 	var req playlistReorderReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	pl, err := s.Store().GetUserPlaylist(id)
@@ -316,15 +313,15 @@ func (s *Server) handleReorderPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 	if pl.Type != database.UserPlaylistTypeStatic {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot reorder smart playlist"})
+		RespondWithBadRequest(c, "cannot reorder smart playlist")
 		return
 	}
 	if !sameBookSet(pl.BookIDs, req.BookIDs) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "reorder must keep the same book set"})
+		RespondWithBadRequest(c, "reorder must keep the same book set")
 		return
 	}
 	pl.BookIDs = req.BookIDs
@@ -333,7 +330,7 @@ func (s *Server) handleReorderPlaylist(c *gin.Context) {
 		internalError(c, "failed to reorder", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"playlist": pl})
+	RespondWithOK(c, pl)
 }
 
 // handleMaterializePlaylist — POST /api/v1/playlists/:id/materialize
@@ -347,11 +344,11 @@ func (s *Server) handleMaterializePlaylist(c *gin.Context) {
 		return
 	}
 	if src == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "playlist not found"})
+		RespondWithNotFound(c, "playlist", id)
 		return
 	}
 	if src.Type != database.UserPlaylistTypeSmart {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "only smart playlists can be materialized"})
+		RespondWithBadRequest(c, "only smart playlists can be materialized")
 		return
 	}
 	bookIDs, evalErr := EvaluateSmartPlaylist(
@@ -361,10 +358,10 @@ func (s *Server) handleMaterializePlaylist(c *gin.Context) {
 	)
 	if evalErr != nil {
 		if evalErr == ErrSearchIndexUnavailable {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": evalErr.Error()})
+			RespondWithError(c, 503, evalErr.Error(), "SERVICE_UNAVAILABLE")
 			return
 		}
-		c.JSON(http.StatusBadRequest, gin.H{"error": evalErr.Error()})
+		RespondWithBadRequest(c, evalErr.Error())
 		return
 	}
 
@@ -388,7 +385,7 @@ func (s *Server) handleMaterializePlaylist(c *gin.Context) {
 			return
 		}
 	}
-	c.JSON(http.StatusCreated, gin.H{"playlist": created})
+	RespondWithCreated(c, created)
 }
 
 // validatePlaylistCreate checks required fields and type-specific

--- a/internal/server/playlist_handlers_test.go
+++ b/internal/server/playlist_handlers_test.go
@@ -101,25 +101,27 @@ func TestPlaylist_CreateAndGetStatic(t *testing.T) {
 		t.Fatalf("create: %d %s", w.Code, w.Body.String())
 	}
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
-	if created.Playlist == nil || created.Playlist.ID == "" {
+	if created.Data == nil || created.Data.ID == "" {
 		t.Fatalf("missing playlist in response: %+v", created)
 	}
 
 	// GET returns both the playlist and the ordered book_ids.
-	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Playlist.ID, nil)
+	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Data.ID, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("get: %d %s", w.Code, w.Body.String())
 	}
 	var got struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
-		BookIDs  []string               `json:"book_ids"`
+		Data struct {
+			Playlist *database.UserPlaylist `json:"playlist"`
+			BookIDs  []string               `json:"book_ids"`
+		} `json:"data"`
 	}
 	decodeJSON(t, w.Body, &got)
-	if len(got.BookIDs) != 2 || got.BookIDs[0] != "b1" {
-		t.Errorf("book_ids = %v, want [b1 b2]", got.BookIDs)
+	if len(got.Data.BookIDs) != 2 || got.Data.BookIDs[0] != "b1" {
+		t.Errorf("book_ids = %v, want [b1 b2]", got.Data.BookIDs)
 	}
 }
 
@@ -167,24 +169,26 @@ func TestPlaylist_GetSmartEvaluates(t *testing.T) {
 		t.Fatalf("create: %d %s", w.Code, w.Body.String())
 	}
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
 
-	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Playlist.ID, nil)
+	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Data.ID, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("get: %d %s", w.Code, w.Body.String())
 	}
 	var got struct {
-		BookIDs []string `json:"book_ids"`
+		Data struct {
+			BookIDs []string `json:"book_ids"`
+		} `json:"data"`
 	}
 	decodeJSON(t, w.Body, &got)
-	if len(got.BookIDs) != 2 {
-		t.Errorf("smart playlist eval returned %d books, want 2", len(got.BookIDs))
+	if len(got.Data.BookIDs) != 2 {
+		t.Errorf("smart playlist eval returned %d books, want 2", len(got.Data.BookIDs))
 	}
 
 	// Materialized cache should have been persisted.
-	pl, _ := srv.Store().GetUserPlaylist(created.Playlist.ID)
+	pl, _ := srv.Store().GetUserPlaylist(created.Data.ID)
 	if len(pl.MaterializedBookIDs) != 2 {
 		t.Errorf("materialized cache = %v, want 2 entries", pl.MaterializedBookIDs)
 	}
@@ -198,12 +202,12 @@ func TestPlaylist_UpdateStatic(t *testing.T) {
 		"name": "rename-me", "type": "static", "book_ids": []string{"b1"},
 	})
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
 
 	newName := "renamed"
-	w = doJSONReq(srv, http.MethodPut, "/api/v1/playlists/"+created.Playlist.ID, gin.H{
+	w = doJSONReq(srv, http.MethodPut, "/api/v1/playlists/"+created.Data.ID, gin.H{
 		"name":     newName,
 		"book_ids": []string{"b1", "b2"},
 	})
@@ -212,7 +216,7 @@ func TestPlaylist_UpdateStatic(t *testing.T) {
 	}
 
 	// Changing query on a static playlist is a type-mismatch error.
-	w = doJSONReq(srv, http.MethodPut, "/api/v1/playlists/"+created.Playlist.ID, gin.H{
+	w = doJSONReq(srv, http.MethodPut, "/api/v1/playlists/"+created.Data.ID, gin.H{
 		"query": "author:sanderson",
 	})
 	if w.Code != http.StatusBadRequest {
@@ -228,35 +232,35 @@ func TestPlaylist_AddAndRemoveBooks(t *testing.T) {
 		"name": "book-ops", "type": "static", "book_ids": []string{"b1"},
 	})
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
 
 	// Add b2 + b3 (and a dupe of b1, should be deduped).
-	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Playlist.ID+"/books", gin.H{
+	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Data.ID+"/books", gin.H{
 		"book_ids": []string{"b2", "b3", "b1"},
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("add: %d %s", w.Code, w.Body.String())
 	}
 	var after struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &after)
-	if len(after.Playlist.BookIDs) != 3 {
-		t.Errorf("after add = %v, want 3 ids", after.Playlist.BookIDs)
+	if len(after.Data.BookIDs) != 3 {
+		t.Errorf("after add = %v, want 3 ids", after.Data.BookIDs)
 	}
 
 	// Remove b2.
-	w = doJSONReq(srv, http.MethodDelete, "/api/v1/playlists/"+created.Playlist.ID+"/books/b2", nil)
+	w = doJSONReq(srv, http.MethodDelete, "/api/v1/playlists/"+created.Data.ID+"/books/b2", nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("remove: %d %s", w.Code, w.Body.String())
 	}
 	decodeJSON(t, w.Body, &after)
-	if len(after.Playlist.BookIDs) != 2 {
-		t.Errorf("after remove = %v, want 2 ids", after.Playlist.BookIDs)
+	if len(after.Data.BookIDs) != 2 {
+		t.Errorf("after remove = %v, want 2 ids", after.Data.BookIDs)
 	}
-	for _, id := range after.Playlist.BookIDs {
+	for _, id := range after.Data.BookIDs {
 		if id == "b2" {
 			t.Errorf("b2 still present after remove")
 		}
@@ -271,27 +275,27 @@ func TestPlaylist_Reorder(t *testing.T) {
 		"name": "reorder-me", "type": "static", "book_ids": []string{"b1", "b2", "b3"},
 	})
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
 
 	// Valid reorder — same set.
-	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Playlist.ID+"/reorder", gin.H{
+	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Data.ID+"/reorder", gin.H{
 		"book_ids": []string{"b3", "b1", "b2"},
 	})
 	if w.Code != http.StatusOK {
 		t.Fatalf("reorder: %d %s", w.Code, w.Body.String())
 	}
 	var reordered struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &reordered)
-	if reordered.Playlist.BookIDs[0] != "b3" {
-		t.Errorf("reordered first = %q, want b3", reordered.Playlist.BookIDs[0])
+	if reordered.Data.BookIDs[0] != "b3" {
+		t.Errorf("reordered first = %q, want b3", reordered.Data.BookIDs[0])
 	}
 
 	// Invalid reorder — different set.
-	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Playlist.ID+"/reorder", gin.H{
+	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+created.Data.ID+"/reorder", gin.H{
 		"book_ids": []string{"b1", "b2"},
 	})
 	if w.Code != http.StatusBadRequest {
@@ -308,28 +312,28 @@ func TestPlaylist_Materialize(t *testing.T) {
 		"name": "Sanderson Live", "type": "smart", "query": "author:sanderson",
 	})
 	var smart struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &smart)
 
 	// Materialize.
-	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+smart.Playlist.ID+"/materialize", nil)
+	w = doJSONReq(srv, http.MethodPost, "/api/v1/playlists/"+smart.Data.ID+"/materialize", nil)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("materialize: %d %s", w.Code, w.Body.String())
 	}
 	var materialized struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &materialized)
-	if materialized.Playlist.Type != database.UserPlaylistTypeStatic {
-		t.Errorf("materialized type = %q, want static", materialized.Playlist.Type)
+	if materialized.Data.Type != database.UserPlaylistTypeStatic {
+		t.Errorf("materialized type = %q, want static", materialized.Data.Type)
 	}
-	if len(materialized.Playlist.BookIDs) != 2 {
-		t.Errorf("materialized book_ids = %v, want 2", materialized.Playlist.BookIDs)
+	if len(materialized.Data.BookIDs) != 2 {
+		t.Errorf("materialized book_ids = %v, want 2", materialized.Data.BookIDs)
 	}
 
 	// Original smart playlist is still there and still smart.
-	src, _ := srv.Store().GetUserPlaylist(smart.Playlist.ID)
+	src, _ := srv.Store().GetUserPlaylist(smart.Data.ID)
 	if src == nil || src.Type != database.UserPlaylistTypeSmart {
 		t.Errorf("source playlist changed or missing: %+v", src)
 	}
@@ -343,17 +347,17 @@ func TestPlaylist_Delete(t *testing.T) {
 		"name": "delete-me", "type": "static",
 	})
 	var created struct {
-		Playlist *database.UserPlaylist `json:"playlist"`
+		Data *database.UserPlaylist `json:"data"`
 	}
 	decodeJSON(t, w.Body, &created)
 
-	w = doJSONReq(srv, http.MethodDelete, "/api/v1/playlists/"+created.Playlist.ID, nil)
+	w = doJSONReq(srv, http.MethodDelete, "/api/v1/playlists/"+created.Data.ID, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("delete: %d %s", w.Code, w.Body.String())
 	}
 
 	// Subsequent GET should 404.
-	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Playlist.ID, nil)
+	w = doJSONReq(srv, http.MethodGet, "/api/v1/playlists/"+created.Data.ID, nil)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("after delete GET = %d, want 404", w.Code)
 	}
@@ -372,8 +376,10 @@ func TestPlaylist_ListFiltering(t *testing.T) {
 		t.Fatalf("list: %d %s", w.Code, w.Body.String())
 	}
 	var listResp struct {
-		Playlists []database.UserPlaylist `json:"playlists"`
-		Count     int                     `json:"count"`
+		Items  []database.UserPlaylist `json:"items"`
+		Count  int                     `json:"count"`
+		Limit  int                     `json:"limit"`
+		Offset int                     `json:"offset"`
 	}
 	decodeJSON(t, w.Body, &listResp)
 	if listResp.Count != 2 {

--- a/web/src/services/playlistApi.ts
+++ b/web/src/services/playlistApi.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/playlistApi.ts
-// version: 1.1.0
+// version: 2.0.0
 // guid: 8d6e7f2a-9b0c-4a70-b8c5-3d7e0f1b9a99
 
 const API_BASE = '/api/v1';
@@ -31,7 +31,8 @@ async function jsonFetch(url: string, opts?: RequestInit) {
     const body = await resp.json().catch(() => ({}));
     throw Object.assign(new Error(body.error || resp.statusText), { response: { data: body, status: resp.status } });
   }
-  return resp.json();
+  const body = await resp.json();
+  return body.data || body;
 }
 
 export async function listPlaylists(
@@ -41,7 +42,8 @@ export async function listPlaylists(
 ): Promise<{ playlists: UserPlaylist[]; count: number }> {
   const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
   if (type) params.set('type', type);
-  return jsonFetch(`${API_BASE}/playlists?${params}`);
+  const data = await jsonFetch(`${API_BASE}/playlists?${params}`);
+  return { playlists: data.items || [], count: data.count };
 }
 
 export async function getPlaylist(id: string): Promise<{ playlist: UserPlaylist; book_ids: string[] }> {


### PR DESCRIPTION
Continues TODO 4.15. Wave 1 A5 salvage.

- playlist_handlers.go: 34 c.JSON → RespondWith* (uses RespondWithList for paginated listing)
- playlistApi.ts: jsonFetch helper unwraps `.data`; listPlaylists handles pagination shape
- Tests decode data envelope (9 tests)

✓ go build ✓ go vet ✓ tsc ✓ go test -run Playlist (all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)