### PR TITLE
refactor(server): envelope migration — Wave 2 (apikey, filesystem, plugins, diagnostics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.17.0 -->
+<!-- version: 2.18.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,16 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 24, 2026 — Envelope Migration: Wave 2 (apikey, filesystem, plugins, diagnostics)
+
+Shipped as one PR — parallel Haiku sub-agents migrated 4 handler files concurrently; coordinator (Opus) consolidated and reviewed.
+
+- **`internal/server/apikey_handlers.go`** (B1): 23 callsites across 5 handlers → `RespondWith*`. `web/src/services/api.ts`: 4 apikey callers unwrap `.data`.
+- **`internal/server/filesystem_handlers.go`** (B2): 22 callsites → `RespondWith*`. `api.ts`: 7 callers unwrap `.data`. 4 test files updated (`server_test.go`, `server_extra_test.go`, `server_import_paths_and_blocklist_test.go`, `server_more_test.go`).
+- **`internal/server/plugins_handlers.go`** (B3): 19 callsites → `RespondWith*`. No `api.ts` entry — `PluginsTab.tsx` has inline fetch and unwraps `.data` directly (acceptable exception).
+- **`internal/server/diagnostics_handlers.go`** (B4): 5 handlers migrated. `api.ts`: 4 callers unwrap `.data`; `downloadDiagnosticsExport` unchanged (blob response). `web/tests/e2e/diagnostics.spec.ts` mock responses wrapped in envelope.
+- **Plan update** (`docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md`): added Section 5b documenting three Wave-1 defects and their fixes (worktree isolation bypass via absolute paths; bash-restricted sub-agents; endpoint-path vs. function-name test grep).
 
 #### April 23, 2026 — Envelope Migration: `file_ops_handlers.go`
 

--- a/docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md
+++ b/docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md
@@ -1,7 +1,7 @@
 <!-- file: docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 3c9d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f -->
-<!-- last-edited: 2026-04-23 -->
+<!-- last-edited: 2026-04-24 -->
 
 # Parallel Envelope Migration Plan (TODO 4.15)
 
@@ -170,6 +170,27 @@ groupings) and run each sub-slice as its own PR with a real review.
 | `entities_handlers.go` | Authors CRUD / Series CRUD / Tag ops / Search |
 | `audiobooks_handlers.go` | List+search / Single-book / Batch ops / Sync+covers |
 
+## 5b. Wave 1 post-mortem (2026-04-24) — REQUIRED READING before dispatch
+
+Wave 1 completed (PRs #430–#434) but the original dispatch had three defects.
+Waves 2+ MUST incorporate these corrections:
+
+1. **Worktree isolation is NOT enough.** Even with `isolation: "worktree"`,
+   if prompts give Haiku absolute paths (`/Users/.../internal/server/...`)
+   the Edit tool writes to those absolute paths and bypasses the worktree.
+   Haiku's edits bled into the coordinator's main working tree.
+   **Fix:** use coordinator-driven git. Agents are forbidden from
+   running any git/gh command. They only edit files. Coordinator handles
+   every branch, commit, push, rebase, and PR.
+2. **Sub-agents cannot run git/gh reliably.** 4 of 5 Wave-1 agents
+   completed the refactor but were blocked on bash for commit/push/PR.
+   **Fix:** bake coordinator-driven git into the template (see Section 6).
+3. **Endpoint-path grep, not function-name grep.** A4 missed a test file
+   (`server_extra_test.go`) because it only searched for version handler
+   names. The test decoded responses by URL, not by function name.
+   **Fix:** agents must grep every endpoint URL path across the entire
+   `internal/server/*_test.go` tree, not just the obvious test file.
+
 ## 6. Agent task template
 
 Every Haiku agent gets **exactly** this prompt template, with the
@@ -231,25 +252,21 @@ STEP 4 — VERIFY
 
 All four MUST be clean. If anything fails, fix it — do NOT weaken tests.
 
-STEP 5 — COMMIT + PR
-Branch: refactor/envelope-<SHORT_NAME>
-Commit message:
-    refactor(server): envelope migration — <SHORT_NAME> handlers
+STEP 5 — REPORT (NO GIT)
+Do NOT run `git`, `gh`, or any branch/commit/push/PR command. Do NOT
+touch `CHANGELOG.md`. The coordinator owns all git + CHANGELOG edits.
 
-    Continues TODO 4.15.
+Your final message MUST list, in this exact format:
+  Handler file modified: <path>
+  API service file modified: <path>
+  Test files modified: <path>, <path>, ...
+  Backend callsites migrated: N
+  Frontend callers unwrapped: M
+  Endpoint paths touched: /api/v1/foo, /api/v1/bar, ...
+  Verification: go build=PASS, go vet=PASS, tsc=PASS, go test -run X=PASS
 
-    - <HANDLER_FILE>.go: migrate N c.JSON callsites to RespondWith*.
-    - <API_FILE>: M callers unwrap `.data`.
-
-    Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
-
-Push with -u, open a PR titled
-    refactor(server): envelope migration — <SHORT_NAME> handlers
-and reference TODO 4.15 in the body.
-
-Do NOT self-merge. Do NOT use `--squash` or `--merge` if the coordinator
-asks you to merge — this repo is **rebase / fast-forward only**. The
-coordinator does the merge with `gh pr merge <n> --rebase`.
+If any verification failed, list the error and stop — do NOT claim
+success.
 
 STEP 6 — CHANGELOG
 Add a bullet under the existing "HTTP Response Envelope Migration"

--- a/internal/server/apikey_handlers.go
+++ b/internal/server/apikey_handlers.go
@@ -1,12 +1,11 @@
 // file: internal/server/apikey_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
 
 package server
 
 import (
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -33,23 +32,23 @@ type createAPIKeyResponse struct {
 }
 
 type apiKeyResponse struct {
-	ID              string     `json:"id"`
-	UserID          string     `json:"user_id"`
-	Name            string     `json:"name"`
-	Description     string     `json:"description"`
-	Scopes          []string   `json:"scopes"`
-	Status          string     `json:"status"`
-	CreatedAt       time.Time  `json:"created_at"`
-	LastUsedAt      *time.Time `json:"last_used_at,omitempty"`
-	LastUsedIP      string     `json:"last_used_ip,omitempty"`
-	UseCount        int64      `json:"use_count"`
-	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
-	DeactivatedAt   *time.Time `json:"deactivated_at,omitempty"`
-	RevokedAt       *time.Time `json:"revoked_at,omitempty"`
-	Identifier      string     `json:"identifier"`
-	DaysSinceLastUse *int      `json:"days_since_last_use"`
-	NeverUsed       bool       `json:"never_used"`
-	Username        string     `json:"username,omitempty"`
+	ID               string     `json:"id"`
+	UserID           string     `json:"user_id"`
+	Name             string     `json:"name"`
+	Description      string     `json:"description"`
+	Scopes           []string   `json:"scopes"`
+	Status           string     `json:"status"`
+	CreatedAt        time.Time  `json:"created_at"`
+	LastUsedAt       *time.Time `json:"last_used_at,omitempty"`
+	LastUsedIP       string     `json:"last_used_ip,omitempty"`
+	UseCount         int64      `json:"use_count"`
+	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
+	DeactivatedAt    *time.Time `json:"deactivated_at,omitempty"`
+	RevokedAt        *time.Time `json:"revoked_at,omitempty"`
+	Identifier       string     `json:"identifier"`
+	DaysSinceLastUse *int       `json:"days_since_last_use"`
+	NeverUsed        bool       `json:"never_used"`
+	Username         string     `json:"username,omitempty"`
 }
 
 func buildAPIKeyResponse(key database.APIKey, username string) apiKeyResponse {
@@ -93,20 +92,20 @@ func isAdminUser(c *gin.Context) bool {
 func (s *Server) createAPIKey(c *gin.Context) {
 	caller, ok := servermiddleware.CurrentUser(c)
 	if !ok || caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		RespondWithUnauthorized(c, "authentication required")
 		return
 	}
 
 	var req createAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	targetUserID := caller.ID
 	if req.UserID != "" && req.UserID != caller.ID {
 		if !isAdminUser(c) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "only admins can create keys for other users"})
+			RespondWithForbidden(c, "only admins can create keys for other users")
 			return
 		}
 		targetUserID = req.UserID
@@ -118,12 +117,12 @@ func (s *Server) createAPIKey(c *gin.Context) {
 
 	for _, scope := range req.Scopes {
 		if !auth.IsKnown(scope) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown scope: " + scope})
+			RespondWithBadRequest(c, "unknown scope: "+scope)
 			return
 		}
 		if callerPermSet != nil {
 			if _, has := callerPermSet[auth.Permission(scope)]; !has {
-				c.JSON(http.StatusForbidden, gin.H{"error": "cannot grant scope you don't have: " + scope})
+				RespondWithForbidden(c, "cannot grant scope you don't have: "+scope)
 				return
 			}
 		}
@@ -169,14 +168,14 @@ func (s *Server) createAPIKey(c *gin.Context) {
 		ExpiresAt: created.ExpiresAt,
 		CreatedAt: created.CreatedAt,
 	}
-	c.JSON(http.StatusCreated, resp)
+	RespondWithCreated(c, resp)
 }
 
 // GET /api/v1/auth/api-keys
 func (s *Server) listAPIKeys(c *gin.Context) {
 	caller, ok := servermiddleware.CurrentUser(c)
 	if !ok || caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		RespondWithUnauthorized(c, "authentication required")
 		return
 	}
 
@@ -215,14 +214,14 @@ func (s *Server) listAPIKeys(c *gin.Context) {
 		results = append(results, buildAPIKeyResponse(k, username))
 	}
 
-	c.JSON(http.StatusOK, gin.H{"api_keys": results, "count": len(results)})
+	RespondWithOK(c, gin.H{"api_keys": results, "count": len(results)})
 }
 
 // GET /api/v1/auth/api-keys/:id
 func (s *Server) getAPIKey(c *gin.Context) {
 	caller, ok := servermiddleware.CurrentUser(c)
 	if !ok || caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		RespondWithUnauthorized(c, "authentication required")
 		return
 	}
 
@@ -233,11 +232,11 @@ func (s *Server) getAPIKey(c *gin.Context) {
 		return
 	}
 	if key == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+		RespondWithNotFound(c, "api key", id)
 		return
 	}
 	if key.UserID != caller.ID && !isAdminUser(c) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		RespondWithForbidden(c, "access denied")
 		return
 	}
 
@@ -248,14 +247,14 @@ func (s *Server) getAPIKey(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, buildAPIKeyResponse(*key, username))
+	RespondWithOK(c, buildAPIKeyResponse(*key, username))
 }
 
 // PATCH /api/v1/auth/api-keys/:id
 func (s *Server) updateAPIKeyStatus(c *gin.Context) {
 	caller, ok := servermiddleware.CurrentUser(c)
 	if !ok || caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		RespondWithUnauthorized(c, "authentication required")
 		return
 	}
 
@@ -266,11 +265,11 @@ func (s *Server) updateAPIKeyStatus(c *gin.Context) {
 		return
 	}
 	if key == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+		RespondWithNotFound(c, "api key", id)
 		return
 	}
 	if key.UserID != caller.ID && !isAdminUser(c) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		RespondWithForbidden(c, "access denied")
 		return
 	}
 
@@ -278,15 +277,15 @@ func (s *Server) updateAPIKeyStatus(c *gin.Context) {
 		Status string `json:"status" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if req.Status == "revoked" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "use DELETE to revoke a key"})
+		RespondWithBadRequest(c, "use DELETE to revoke a key")
 		return
 	}
 	if req.Status != "active" && req.Status != "inactive" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "status must be 'active' or 'inactive'"})
+		RespondWithBadRequest(c, "status must be 'active' or 'inactive'")
 		return
 	}
 
@@ -299,17 +298,17 @@ func (s *Server) updateAPIKeyStatus(c *gin.Context) {
 
 	updated, err := s.Store().GetAPIKey(id)
 	if err != nil || updated == nil {
-		c.JSON(http.StatusOK, gin.H{"status": req.Status})
+		RespondWithOK(c, gin.H{"status": req.Status})
 		return
 	}
-	c.JSON(http.StatusOK, buildAPIKeyResponse(*updated, ""))
+	RespondWithOK(c, buildAPIKeyResponse(*updated, ""))
 }
 
 // DELETE /api/v1/auth/api-keys/:id
 func (s *Server) revokeAPIKey(c *gin.Context) {
 	caller, ok := servermiddleware.CurrentUser(c)
 	if !ok || caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		RespondWithUnauthorized(c, "authentication required")
 		return
 	}
 
@@ -320,11 +319,11 @@ func (s *Server) revokeAPIKey(c *gin.Context) {
 		return
 	}
 	if key == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
+		RespondWithNotFound(c, "api key", id)
 		return
 	}
 	if key.UserID != caller.ID && !isAdminUser(c) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		RespondWithForbidden(c, "access denied")
 		return
 	}
 
@@ -334,6 +333,5 @@ func (s *Server) revokeAPIKey(c *gin.Context) {
 	}
 
 	log.Printf("[APIKEY] revoked: id=%s user=%s name=%s", id, caller.ID, key.Name)
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }
-

--- a/internal/server/diagnostics_handlers.go
+++ b/internal/server/diagnostics_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/diagnostics_handlers.go
-// version: 1.5.0
+// version: 2.0.0
 // guid: a2b3c4d5-e6f7-4890-ab12-cd34ef56gh78
 
 package server
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -39,7 +38,7 @@ func (s *Server) startDiagnosticsExport(c *gin.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -54,13 +53,13 @@ func (s *Server) startDiagnosticsExport(c *gin.Context) {
 		"general":          true,
 	}
 	if !validCategories[req.Category] {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid category; must be one of: deduplication, error_analysis, metadata_quality, general"})
+		RespondWithBadRequest(c, "invalid category; must be one of: deduplication, error_analysis, metadata_quality, general")
 		return
 	}
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -105,7 +104,7 @@ func (s *Server) startDiagnosticsExport(c *gin.Context) {
 		}()
 	}
 
-	c.JSON(http.StatusAccepted, gin.H{
+	RespondWithSuccess(c, 202, gin.H{
 		"operation_id": opID,
 		"status":       "generating",
 	})
@@ -117,18 +116,18 @@ func (s *Server) downloadDiagnosticsExport(c *gin.Context) {
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	op, err := store.GetOperationByID(opID)
 	if err != nil || op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", opID)
 		return
 	}
 
 	if op.Status != "completed" {
-		c.JSON(http.StatusAccepted, gin.H{
+		RespondWithSuccess(c, 202, gin.H{
 			"operation_id": opID,
 			"status":       op.Status,
 			"message":      op.Message,
@@ -137,24 +136,24 @@ func (s *Server) downloadDiagnosticsExport(c *gin.Context) {
 	}
 
 	if op.ResultData == nil || *op.ResultData == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "no result data available"})
+		RespondWithInternalError(c, "no result data available")
 		return
 	}
 
 	var result map[string]string
 	if err := json.Unmarshal([]byte(*op.ResultData), &result); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse result data"})
+		RespondWithInternalError(c, "failed to parse result data")
 		return
 	}
 
 	zipPath := result["zip_path"]
 	if zipPath == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "zip path not found in result"})
+		RespondWithInternalError(c, "zip path not found in result")
 		return
 	}
 
 	if _, err := os.Stat(zipPath); os.IsNotExist(err) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "export file no longer available"})
+		RespondWithNotFound(c, "export file", "no longer available")
 		return
 	}
 
@@ -165,7 +164,7 @@ func (s *Server) downloadDiagnosticsExport(c *gin.Context) {
 // submitDiagnosticsAI generates a diagnostics export and submits it to OpenAI batch API.
 func (s *Server) submitDiagnosticsAI(c *gin.Context) {
 	if config.AppConfig.OpenAIAPIKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "OpenAI API key not configured"})
+		RespondWithBadRequest(c, "OpenAI API key not configured")
 		return
 	}
 
@@ -174,7 +173,7 @@ func (s *Server) submitDiagnosticsAI(c *gin.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -184,7 +183,7 @@ func (s *Server) submitDiagnosticsAI(c *gin.Context) {
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -282,7 +281,7 @@ func (s *Server) submitDiagnosticsAI(c *gin.Context) {
 		}
 	}()
 
-	c.JSON(http.StatusAccepted, gin.H{
+	RespondWithSuccess(c, 202, gin.H{
 		"operation_id": opID,
 		"status":       "submitted",
 	})
@@ -294,18 +293,18 @@ func (s *Server) getDiagnosticsAIResults(c *gin.Context) {
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	op, err := store.GetOperationByID(opID)
 	if err != nil || op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", opID)
 		return
 	}
 
 	if op.Status != "completed" {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"operation_id": opID,
 			"status":       op.Status,
 			"message":      op.Message,
@@ -314,7 +313,7 @@ func (s *Server) getDiagnosticsAIResults(c *gin.Context) {
 	}
 
 	if op.ResultData == nil || *op.ResultData == "" {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"status":      "completed",
 			"suggestions": []interface{}{},
 		})
@@ -323,7 +322,7 @@ func (s *Server) getDiagnosticsAIResults(c *gin.Context) {
 
 	var resultData map[string]interface{}
 	if err := json.Unmarshal([]byte(*op.ResultData), &resultData); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse result data"})
+		RespondWithInternalError(c, "failed to parse result data")
 		return
 	}
 
@@ -336,7 +335,7 @@ func (s *Server) getDiagnosticsAIResults(c *gin.Context) {
 		rawResponses = []interface{}{}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"status":        op.Status,
 		"suggestions":   suggestions,
 		"raw_responses": rawResponses,
@@ -350,43 +349,43 @@ func (s *Server) applyDiagnosticsSuggestions(c *gin.Context) {
 		ApprovedSuggestionIDs []string `json:"approved_suggestion_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	op, err := store.GetOperationByID(req.OperationID)
 	if err != nil || op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", req.OperationID)
 		return
 	}
 
 	if op.ResultData == nil || *op.ResultData == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no suggestions available"})
+		RespondWithBadRequest(c, "no suggestions available")
 		return
 	}
 
 	var resultData map[string]interface{}
 	if err := json.Unmarshal([]byte(*op.ResultData), &resultData); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse result data"})
+		RespondWithInternalError(c, "failed to parse result data")
 		return
 	}
 
 	suggestionsRaw, ok := resultData["suggestions"]
 	if !ok {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no suggestions in result data"})
+		RespondWithBadRequest(c, "no suggestions in result data")
 		return
 	}
 
 	suggestionsJSON, _ := json.Marshal(suggestionsRaw)
 	var suggestions []diagnosticsSuggestion
 	if err := json.Unmarshal(suggestionsJSON, &suggestions); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse suggestions"})
+		RespondWithInternalError(c, "failed to parse suggestions")
 		return
 	}
 
@@ -493,7 +492,7 @@ func (s *Server) applyDiagnosticsSuggestions(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"applied": applied,
 		"failed":  failed,
 		"errors":  errors,

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/filesystem_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 565db679-19ba-4518-b63e-6892663be41b
 //
 // Filesystem HTTP handlers split out of server.go: home directory,
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -32,21 +31,21 @@ import (
 func (s *Server) getHomeDirectory(c *gin.Context) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(homeDir) == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to determine home directory"})
+		RespondWithInternalError(c, "failed to determine home directory")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"path": homeDir})
+	RespondWithOK(c, gin.H{"path": homeDir})
 }
 
 func (s *Server) browseFilesystem(c *gin.Context) {
 	path := c.Query("path")
 	result, err := s.filesystemService.BrowseDirectory(path)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 func (s *Server) createExclusion(c *gin.Context) {
@@ -54,14 +53,14 @@ func (s *Server) createExclusion(c *gin.Context) {
 		Path string `json:"path" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if err := s.filesystemService.CreateExclusion(req.Path); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"message": "exclusion created"})
+	RespondWithCreated(c, gin.H{"message": "exclusion created"})
 }
 
 func (s *Server) removeExclusion(c *gin.Context) {
@@ -69,19 +68,19 @@ func (s *Server) removeExclusion(c *gin.Context) {
 		Path string `json:"path" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if err := s.filesystemService.RemoveExclusion(req.Path); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }
 
 func (s *Server) listImportPaths(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	folders, err := s.Store().GetAllImportPaths()
@@ -95,12 +94,12 @@ func (s *Server) listImportPaths(c *gin.Context) {
 		folders = []database.ImportPath{}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"importPaths": folders, "count": len(folders)})
+	RespondWithOK(c, gin.H{"importPaths": folders, "count": len(folders)})
 }
 
 func (s *Server) addImportPath(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	var req struct {
@@ -109,12 +108,12 @@ func (s *Server) addImportPath(c *gin.Context) {
 		Enabled *bool  `json:"enabled"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	createdPath, err := s.importPathService.CreateImportPath(req.Path, req.Name)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	folder := createdPath
@@ -122,7 +121,7 @@ func (s *Server) addImportPath(c *gin.Context) {
 		folder.Enabled = false
 		if err := s.Store().UpdateImportPath(folder.ID, folder); err != nil {
 			// Non-fatal; return created folder anyway with note
-			c.JSON(http.StatusCreated, gin.H{"importPath": folder, "warning": "created but could not update enabled flag"})
+			RespondWithCreated(c, gin.H{"importPath": folder, "warning": "created but could not update enabled flag"})
 			return
 		}
 	}
@@ -222,7 +221,7 @@ func (s *Server) addImportPath(c *gin.Context) {
 			// Enqueue the scan operation with normal priority
 			_ = s.queue.Enqueue(op.ID, "scan", operations.PriorityNormal, operationFunc)
 
-			c.JSON(http.StatusCreated, gin.H{"importPath": folder, "scan_operation_id": op.ID})
+			RespondWithCreated(c, gin.H{"importPath": folder, "scan_operation_id": op.ID})
 			return
 		}
 	}
@@ -265,37 +264,37 @@ func (s *Server) addImportPath(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusCreated, gin.H{"importPath": folder})
+	RespondWithCreated(c, gin.H{"importPath": folder})
 }
 
 func (s *Server) removeImportPath(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid import path id"})
+		RespondWithBadRequest(c, "invalid import path id")
 		return
 	}
 	if err := s.Store().DeleteImportPath(id); err != nil {
 		internalError(c, "failed to remove import path", err)
 		return
 	}
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }
 
 func (s *Server) importFile(c *gin.Context) {
 	var req ImportFileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	result, err := s.importService.ImportFile(&req)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -304,5 +303,5 @@ func (s *Server) importFile(c *gin.Context) {
 		"source":    "import",
 	}))
 
-	c.JSON(http.StatusCreated, result)
+	RespondWithCreated(c, result)
 }

--- a/internal/server/plugins_handlers.go
+++ b/internal/server/plugins_handlers.go
@@ -1,12 +1,10 @@
 // file: internal/server/plugins_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: b3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e
 
 package server
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
@@ -47,7 +45,7 @@ func pluginToInfo(p plugin.Plugin, reg *plugin.Registry) pluginInfo {
 // listPlugins handles GET /api/v1/plugins
 func (s *Server) listPlugins(c *gin.Context) {
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusOK, gin.H{"plugins": []pluginInfo{}})
+		RespondWithOK(c, gin.H{"plugins": []pluginInfo{}})
 		return
 	}
 	all := s.pluginRegistry.All()
@@ -55,32 +53,33 @@ func (s *Server) listPlugins(c *gin.Context) {
 	for _, p := range all {
 		result = append(result, pluginToInfo(p, s.pluginRegistry))
 	}
-	c.JSON(http.StatusOK, gin.H{"plugins": result})
+	RespondWithOK(c, gin.H{"plugins": result})
 }
 
 // getPlugin handles GET /api/v1/plugins/:id
 func (s *Server) getPlugin(c *gin.Context) {
+	id := c.Param("id")
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin system not initialized"})
+		RespondWithNotFound(c, "plugin system", "not initialized")
 		return
 	}
-	p, ok := s.pluginRegistry.Get(c.Param("id"))
+	p, ok := s.pluginRegistry.Get(id)
 	if !ok {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin not found"})
+		RespondWithNotFound(c, "plugin", id)
 		return
 	}
-	c.JSON(http.StatusOK, pluginToInfo(p, s.pluginRegistry))
+	RespondWithOK(c, pluginToInfo(p, s.pluginRegistry))
 }
 
 // enablePlugin handles POST /api/v1/plugins/:id/enable
 func (s *Server) enablePlugin(c *gin.Context) {
 	id := c.Param("id")
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin system not initialized"})
+		RespondWithInternalError(c, "plugin system not initialized")
 		return
 	}
 	if _, ok := s.pluginRegistry.Get(id); !ok {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin not found"})
+		RespondWithNotFound(c, "plugin", id)
 		return
 	}
 	s.pluginRegistry.Enable(id)
@@ -93,18 +92,18 @@ func (s *Server) enablePlugin(c *gin.Context) {
 	}
 	config.AppConfig.Plugins[id] = cfg
 
-	c.JSON(http.StatusOK, gin.H{"id": id, "enabled": true})
+	RespondWithOK(c, gin.H{"id": id, "enabled": true})
 }
 
 // disablePlugin handles POST /api/v1/plugins/:id/disable
 func (s *Server) disablePlugin(c *gin.Context) {
 	id := c.Param("id")
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin system not initialized"})
+		RespondWithInternalError(c, "plugin system not initialized")
 		return
 	}
 	if _, ok := s.pluginRegistry.Get(id); !ok {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin not found"})
+		RespondWithNotFound(c, "plugin", id)
 		return
 	}
 	s.pluginRegistry.Disable(id)
@@ -116,43 +115,43 @@ func (s *Server) disablePlugin(c *gin.Context) {
 	}
 	config.AppConfig.Plugins[id] = cfg
 
-	c.JSON(http.StatusOK, gin.H{"id": id, "enabled": false})
+	RespondWithOK(c, gin.H{"id": id, "enabled": false})
 }
 
 // pluginHealth handles GET /api/v1/plugins/:id/health
 func (s *Server) pluginHealth(c *gin.Context) {
 	id := c.Param("id")
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"id": id, "health": "plugin system not initialized"})
+		RespondWithSuccess(c, 503, gin.H{"id": id, "health": "plugin system not initialized"})
 		return
 	}
 	p, ok := s.pluginRegistry.Get(id)
 	if !ok {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin not found"})
+		RespondWithNotFound(c, "plugin", id)
 		return
 	}
 	if err := p.HealthCheck(); err != nil {
-		c.JSON(http.StatusOK, gin.H{"id": id, "health": err.Error(), "ok": false})
+		RespondWithOK(c, gin.H{"id": id, "health": err.Error(), "ok": false})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"id": id, "health": "ok", "ok": true})
+	RespondWithOK(c, gin.H{"id": id, "health": "ok", "ok": true})
 }
 
 // updatePluginSettings handles PUT /api/v1/plugins/:id/settings
 func (s *Server) updatePluginSettings(c *gin.Context) {
 	id := c.Param("id")
 	if s.pluginRegistry == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin system not initialized"})
+		RespondWithInternalError(c, "plugin system not initialized")
 		return
 	}
 	if _, ok := s.pluginRegistry.Get(id); !ok {
-		c.JSON(http.StatusNotFound, gin.H{"error": "plugin not found"})
+		RespondWithNotFound(c, "plugin", id)
 		return
 	}
 
 	var settings map[string]string
 	if err := c.ShouldBindJSON(&settings); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid settings: " + err.Error()})
+		RespondWithBadRequest(c, "invalid settings: "+err.Error())
 		return
 	}
 
@@ -163,5 +162,5 @@ func (s *Server) updatePluginSettings(c *gin.Context) {
 	cfg.Settings = settings
 	config.AppConfig.Plugins[id] = cfg
 
-	c.JSON(http.StatusOK, gin.H{"id": id, "settings": settings})
+	RespondWithOK(c, gin.H{"id": id, "settings": settings})
 }

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -235,9 +235,11 @@ func TestImportPathEndpoints(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	var response map[string]interface{}
+	var response struct {
+		Data map[string]interface{} `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	importPath := response["importPath"].(map[string]interface{})
+	importPath := response.Data["importPath"].(map[string]interface{})
 	importID := int(importPath["id"].(float64))
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/import-paths", nil)

--- a/internal/server/server_import_paths_and_blocklist_test.go
+++ b/internal/server/server_import_paths_and_blocklist_test.go
@@ -91,9 +91,11 @@ func TestImportPaths_ListNilAndRemoveInvalidID(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var listResp map[string]interface{}
+	var listResp struct {
+		Data map[string]interface{} `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResp))
-	paths, ok := listResp["importPaths"].([]interface{})
+	paths, ok := listResp.Data["importPaths"].([]interface{})
 	require.True(t, ok)
 	assert.Len(t, paths, 0)
 

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -264,9 +264,11 @@ func TestAddImportPathAutoScan(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	var resp map[string]any
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	if opID, ok := resp["scan_operation_id"].(string); ok && opID != "" {
+	if opID, ok := resp.Data["scan_operation_id"].(string); ok && opID != "" {
 		waitForOperationStatus(t, opID, 10*time.Second)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -461,10 +461,12 @@ func TestListImportPaths(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
+	var response struct {
+		Data map[string]any `json:"data"`
+	}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
-	assert.NotNil(t, response["importPaths"])
+	assert.NotNil(t, response.Data["importPaths"])
 }
 
 // TestGetOperationStatus tests getting operation status

--- a/web/src/components/settings/PluginsTab.tsx
+++ b/web/src/components/settings/PluginsTab.tsx
@@ -48,8 +48,8 @@ interface PluginSettings {
 async function fetchPlugins(): Promise<PluginInfo[]> {
   const resp = await fetch('/api/v1/plugins');
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-  const data = await resp.json();
-  return data.plugins ?? [];
+  const body = await resp.json();
+  return body.data.plugins ?? [];
 }
 
 async function togglePlugin(id: string, enable: boolean): Promise<void> {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1223,7 +1223,8 @@ export async function getImportPaths(): Promise<ImportPath[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch import paths');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return data.importPaths || [];
 }
 
@@ -1239,9 +1240,9 @@ export async function addImportPath(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to add import path');
   }
-  const data = await response.json();
-  // Server returns { importPath, scan_operation_id?: string }
-  // Gracefully handle both shapes
+  const body = await response.json();
+  // Server returns { data: { importPath, scan_operation_id?: string } }
+  const data = body.data;
   return (data.importPath ? data.importPath : data) as ImportPath;
 }
 
@@ -1263,7 +1264,8 @@ export async function addImportPathDetailed(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to add import path');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   if (data.importPath) {
     return {
       importPath: data.importPath,
@@ -1759,7 +1761,7 @@ export async function moveSegments(bookId: string, segmentIds: string[], targetB
 export async function importFile(
   filePath: string,
   organize = false
-): Promise<{ message: string; book: Book; operation_id?: string }> {
+): Promise<Book> {
   const response = await fetch(`${API_BASE}/import/file`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1768,7 +1770,8 @@ export async function importFile(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to import file');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function validateITunesLibrary(
@@ -2479,7 +2482,8 @@ export async function browseFilesystem(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to browse filesystem');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 /** Fetches the server user's home directory path. */
@@ -2488,8 +2492,8 @@ export async function getHomeDirectory(): Promise<string> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch home directory');
   }
-  const data = await response.json();
-  return data.path as string;
+  const body = await response.json();
+  return body.data.path as string;
 }
 
 export async function excludeFilesystemPath(
@@ -2504,7 +2508,8 @@ export async function excludeFilesystemPath(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to exclude path');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function includeFilesystemPath(path: string): Promise<void> {
@@ -3451,7 +3456,8 @@ export async function startDiagnosticsExport(
     body: JSON.stringify({ category, description }),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to start export');
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function downloadDiagnosticsExport(operationId: string): Promise<Blob> {
@@ -3470,13 +3476,15 @@ export async function submitDiagnosticsAI(
     body: JSON.stringify({ category, description }),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to submit AI analysis');
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getDiagnosticsAIResults(operationId: string): Promise<DiagnosticsAIResults> {
   const response = await fetch(`${API_BASE}/diagnostics/ai-results/${operationId}`);
   if (!response.ok) throw await buildApiError(response, 'Failed to get AI results');
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function applyDiagnosticsSuggestions(
@@ -3489,7 +3497,8 @@ export async function applyDiagnosticsSuggestions(
     body: JSON.stringify({ operation_id: operationId, approved_suggestion_ids: approvedIds }),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to apply suggestions');
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // External ID mappings
@@ -3980,7 +3989,8 @@ export async function createAPIKey(body: CreateAPIKeyRequest): Promise<CreateAPI
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to create API key');
   }
-  return response.json();
+  const body_data = await response.json();
+  return body_data.data;
 }
 
 export async function listAPIKeys(all?: boolean): Promise<APIKey[]> {
@@ -3989,8 +3999,8 @@ export async function listAPIKeys(all?: boolean): Promise<APIKey[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to list API keys');
   }
-  const data = await response.json();
-  return data.api_keys ?? [];
+  const body_data = await response.json();
+  return body_data.data?.api_keys ?? [];
 }
 
 export async function getAPIKey(id: string): Promise<APIKey> {
@@ -3998,7 +4008,8 @@ export async function getAPIKey(id: string): Promise<APIKey> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to get API key');
   }
-  return response.json();
+  const body_data = await response.json();
+  return body_data.data;
 }
 
 export async function updateAPIKeyStatus(id: string, status: 'active' | 'inactive'): Promise<APIKey> {
@@ -4010,7 +4021,8 @@ export async function updateAPIKeyStatus(id: string, status: 'active' | 'inactiv
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to update API key status');
   }
-  return response.json();
+  const body_data = await response.json();
+  return body_data.data;
 }
 
 export async function revokeAPIKey(id: string): Promise<void> {

--- a/web/tests/e2e/diagnostics.spec.ts
+++ b/web/tests/e2e/diagnostics.spec.ts
@@ -61,13 +61,15 @@ async function setupAiResultsMocks(page: Page) {
   await page.route('**/api/v1/diagnostics/submit-ai', async (route) => {
     if (route.request().method() === 'POST') {
       return route.fulfill({
-        status: 200,
+        status: 202,
         contentType: 'application/json',
         body: JSON.stringify({
-          operation_id: 'op-2',
-          batch_id: 'batch-1',
-          status: 'submitted',
-          request_count: 5,
+          data: {
+            operation_id: 'op-2',
+            batch_id: 'batch-1',
+            status: 'submitted',
+            request_count: 5,
+          },
         }),
       });
     }
@@ -97,7 +99,7 @@ async function setupAiResultsMocks(page: Page) {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(aiResultsPayload),
+      body: JSON.stringify({ data: aiResultsPayload }),
     });
   });
 }
@@ -156,11 +158,13 @@ test.describe('Diagnostics', () => {
     await page.route('**/api/v1/diagnostics/export', async (route) => {
       if (route.request().method() === 'POST') {
         return route.fulfill({
-          status: 200,
+          status: 202,
           contentType: 'application/json',
           body: JSON.stringify({
-            operation_id: 'op-1',
-            status: 'generating',
+            data: {
+              operation_id: 'op-1',
+              status: 'generating',
+            },
           }),
         });
       }
@@ -263,9 +267,11 @@ test.describe('Diagnostics', () => {
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify({
-            applied: 2,
-            failed: 0,
-            errors: [],
+            data: {
+              applied: 2,
+              failed: 0,
+              errors: [],
+            },
           }),
         });
       }


### PR DESCRIPTION
## Summary

Continues [TODO 4.15](../blob/main/TODO.md). Wave 2 of parallel Haiku dispatch (4 agents ran concurrently; coordinator consolidated).

### Handlers migrated
- **apikey_handlers.go** — 23 callsites across 5 handlers; 4 api.ts unwraps
- **filesystem_handlers.go** — 22 callsites; 7 api.ts unwraps; 4 test files
- **plugins_handlers.go** — 19 callsites; `PluginsTab.tsx` unwraps inline (no api.ts indirection)
- **diagnostics_handlers.go** — 5 handlers; 4 api.ts unwraps; e2e mocks wrapped

### Plan doc update
Added Section 5b to `docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md` documenting three Wave-1 defects + fixes: worktree isolation bypass via absolute paths, sub-agent bash restrictions, endpoint-path vs function-name test grep.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/server/...` clean
- [x] `cd web && tsc --noEmit` clean
- [x] `go test ./internal/server/ -run 'Filesystem|Exclu|Browse|Home|ImportPath|Plugin|APIKey|Diagnostic'` — PASS
- [ ] CI (known pre-existing SQLite failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)