### PR TITLE
refactor(server): envelope migration — Wave 3 (system, auth, duplicates, dedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.18.0 -->
+<!-- version: 2.19.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,17 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 24, 2026 — Envelope Migration: Wave 3 (system, auth, duplicates, dedup)
+
+Shipped as one PR — 4 parallel Haiku sub-agents; coordinator consolidated + resolved several test failures.
+
+- **`internal/server/system_handlers.go`** (C1): 21 handlers / ~45 callsites → `RespondWith*`. `api.ts`: 11 callers unwrap `.data`. Tests updated: `handlers_unit_test.go`, `server_coverage_test.go`.
+- **`internal/server/auth_handlers.go`** (C2): 8 handlers / 43 callsites → `RespondWith*`. **Cookie-setting order preserved** (`setSessionCookie` / `clearSessionCookie` still called before response body). `api.ts`: 3 callers unwrap `.data`.
+- **`internal/server/duplicates_handlers.go`** (C3): 27 callsites → `RespondWith*`. Also migrated 3 soft-delete handlers inside `audiobooks_handlers.go` since they share the "duplicates" semantic space. `api.ts`: 17 callers unwrap `.data`.
+- **`internal/server/dedup_handlers.go`** (C4): 52 callsites (largest in wave) → `RespondWith*`. Added new `RespondWithServiceUnavailable` helper in `error_handler.go` (v1.4.0). `api.ts`: 12 callers unwrap `.data`.
+- **Coordinator fixes**: updated `server_test.go`, `server_backup_restore_test.go`, `handlers_unit_test.go` for decoded dashboard/backup/position response shapes.
+- **Plan doc** (v3.0.0): added Section 5c documenting single-PR-per-wave as the new default (Wave 2 outcome).
 
 #### April 24, 2026 — Envelope Migration: Wave 2 (apikey, filesystem, plugins, diagnostics)
 

--- a/docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md
+++ b/docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md
@@ -1,5 +1,5 @@
 <!-- file: docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md -->
-<!-- version: 2.0.0 -->
+<!-- version: 3.0.0 -->
 <!-- guid: 3c9d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f -->
 <!-- last-edited: 2026-04-24 -->
 
@@ -169,6 +169,24 @@ groupings) and run each sub-slice as its own PR with a real review.
 |---|---|
 | `entities_handlers.go` | Authors CRUD / Series CRUD / Tag ops / Search |
 | `audiobooks_handlers.go` | List+search / Single-book / Batch ops / Sync+covers |
+
+## 5c. Wave 2 post-mortem (2026-04-24) — single-PR-per-wave is the default
+
+Wave 2 (PR #435) shipped 4 handler migrations in one consolidated PR
+instead of four separate PRs. Outcome: 1 merge vs. 5 rebases + 5 merges
+in Wave 1. Zero CHANGELOG conflicts. ~10x less coordinator overhead.
+
+**New default for Waves 3+:**
+- Dispatch all wave agents in parallel, each in a worktree.
+- Agents edit files only — no git, no CHANGELOG (same as Wave 2).
+- Coordinator consolidates all 4 agents' edits into ONE branch +
+  ONE commit + ONE PR per wave.
+- CHANGELOG entry covers the whole wave in a single block.
+
+Use per-agent PRs only if: (a) wave files have heavy test-file overlap
+that would make a consolidated diff hard to review, or (b) one agent's
+work needs to ship ahead of the others for feature reasons. Neither
+applies to Waves 3–4.
 
 ## 5b. Wave 1 post-mortem (2026-04-24) — REQUIRED READING before dispatch
 

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -123,7 +123,7 @@ func (s *Server) listSoftDeletedAudiobooks(c *gin.Context) {
 	allBooks, _ := s.audiobookService.GetSoftDeletedBooks(c.Request.Context(), 10000, 0, olderThanDays)
 	total := len(allBooks)
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"items":  books,
 		"count":  len(books),
 		"total":  total,
@@ -149,7 +149,7 @@ func (s *Server) purgeSoftDeletedAudiobooks(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 func (s *Server) runAutoPurgeSoftDeleted() {
@@ -183,11 +183,11 @@ func (s *Server) restoreAudiobook(c *gin.Context) {
 	id := c.Param("id")
 	updated, err := s.audiobookService.RestoreAudiobook(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message": "audiobook restored",
 		"book":    updated,
 	})

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/auth_handlers.go
-// version: 1.4.0
+// version: 2.0.0
 // guid: 1457df2f-af76-46cb-a2f4-c9f6f275f93a
 
 package server
@@ -125,17 +125,17 @@ func clearSessionCookie(c *gin.Context) {
 
 func (s *Server) getAuthStatus(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	count, err := s.Store().CountUsers()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read auth status"})
+		RespondWithInternalError(c, "failed to read auth status")
 		return
 	}
 	authEnabled := config.AppConfig.EnableAuth
 	requiresAuth := authEnabled && count > 0
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"has_users":       count > 0,
 		"auth_enabled":    authEnabled,
 		"requires_auth":   requiresAuth,
@@ -145,7 +145,7 @@ func (s *Server) getAuthStatus(c *gin.Context) {
 
 func (s *Server) setupInitialAdmin(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -155,14 +155,14 @@ func (s *Server) setupInitialAdmin(c *gin.Context) {
 		Email    string `json:"email"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	req.Username = strings.TrimSpace(req.Username)
 	req.Email = strings.TrimSpace(req.Email)
 	if req.Username == "" || len(req.Password) < 8 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username and password (min 8 chars) are required"})
+		RespondWithBadRequest(c, "username and password (min 8 chars) are required")
 		return
 	}
 	if req.Email == "" {
@@ -171,27 +171,27 @@ func (s *Server) setupInitialAdmin(c *gin.Context) {
 
 	count, err := s.Store().CountUsers()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check existing users"})
+		RespondWithInternalError(c, "failed to check existing users")
 		return
 	}
 	if count > 0 {
-		c.JSON(http.StatusConflict, gin.H{"error": "initial setup already completed"})
+		RespondWithConflict(c, "initial setup already completed")
 		return
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
+		RespondWithInternalError(c, "failed to hash password")
 		return
 	}
 
 	created, err := s.Store().CreateUser(req.Username, req.Email, "bcrypt", string(hash), []string{"admin"}, "active")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to create initial user"})
+		RespondWithBadRequest(c, "failed to create initial user")
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
+	RespondWithCreated(c, gin.H{
 		"message": "admin user created",
 		"user":    buildAuthUserResponse(created),
 	})
@@ -199,7 +199,7 @@ func (s *Server) setupInitialAdmin(c *gin.Context) {
 
 func (s *Server) login(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -208,29 +208,29 @@ func (s *Server) login(c *gin.Context) {
 		Password string `json:"password"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	req.Username = strings.TrimSpace(req.Username)
 	if req.Username == "" || req.Password == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username and password are required"})
+		RespondWithBadRequest(c, "username and password are required")
 		return
 	}
 
 	user, err := s.Store().GetUserByUsername(req.Username)
 	if err != nil || user == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		RespondWithUnauthorized(c, "invalid credentials")
 		return
 	}
 
 	if isLockedOut(user.ID) {
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": "account temporarily locked — try again later"})
+		RespondWithError(c, 429, "account temporarily locked — try again later", "LOCKOUT")
 		return
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
 		recordFailedLogin(user.ID)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		RespondWithUnauthorized(c, "invalid credentials")
 		return
 	}
 	clearFailedLogins(user.ID)
@@ -242,12 +242,12 @@ func (s *Server) login(c *gin.Context) {
 		defaultSessionTTL,
 	)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		RespondWithInternalError(c, "failed to create session")
 		return
 	}
 
 	setSessionCookie(c, session.ID, session.ExpiresAt)
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"user":    buildAuthUserResponse(user),
 		"session": session,
 	})
@@ -256,15 +256,15 @@ func (s *Server) login(c *gin.Context) {
 func (s *Server) me(c *gin.Context) {
 	user, ok := servermiddleware.CurrentUser(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+		RespondWithUnauthorized(c, "not authenticated")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": buildAuthUserResponse(user)})
+	RespondWithOK(c, gin.H{"user": buildAuthUserResponse(user)})
 }
 
 func (s *Server) logout(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	session, ok := servermiddleware.CurrentSession(c)
@@ -272,24 +272,24 @@ func (s *Server) logout(c *gin.Context) {
 		_ = s.Store().RevokeSession(session.ID)
 	}
 	clearSessionCookie(c)
-	c.JSON(http.StatusOK, gin.H{"message": "logged out"})
+	RespondWithOK(c, gin.H{"message": "logged out"})
 }
 
 func (s *Server) listMySessions(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	user, ok := servermiddleware.CurrentUser(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+		RespondWithUnauthorized(c, "not authenticated")
 		return
 	}
 	currentSession, _ := servermiddleware.CurrentSession(c)
 
 	sessions, err := s.Store().ListUserSessions(user.ID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list sessions"})
+		RespondWithInternalError(c, "failed to list sessions")
 		return
 	}
 
@@ -304,46 +304,46 @@ func (s *Server) listMySessions(c *gin.Context) {
 			Current: currentSession != nil && session.ID == currentSession.ID,
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"sessions": response})
+	RespondWithOK(c, gin.H{"sessions": response})
 }
 
 func (s *Server) revokeMySession(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	user, ok := servermiddleware.CurrentUser(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+		RespondWithUnauthorized(c, "not authenticated")
 		return
 	}
 	currentSession, _ := servermiddleware.CurrentSession(c)
 
 	sessionID := strings.TrimSpace(c.Param("id"))
 	if sessionID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "session id required"})
+		RespondWithBadRequest(c, "session id required")
 		return
 	}
 
 	targetSession, err := s.Store().GetSession(sessionID)
 	if err != nil || targetSession == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+		RespondWithNotFound(c, "session", sessionID)
 		return
 	}
 	if targetSession.UserID != user.ID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "cannot revoke another user's session"})
+		RespondWithForbidden(c, "cannot revoke another user's session")
 		return
 	}
 
 	if err := s.Store().RevokeSession(sessionID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to revoke session"})
+		RespondWithInternalError(c, "failed to revoke session")
 		return
 	}
 
 	if currentSession != nil && currentSession.ID == sessionID {
 		clearSessionCookie(c)
 	}
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }
 
 // changePassword handles PUT /api/v1/auth/me/password.
@@ -352,13 +352,13 @@ func (s *Server) revokeMySession(c *gin.Context) {
 // by also providing a user_id field.
 func (s *Server) changePassword(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	caller, _ := servermiddleware.CurrentUser(c)
 	if caller == nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authenticated"})
+		RespondWithUnauthorized(c, "not authenticated")
 		return
 	}
 
@@ -368,11 +368,11 @@ func (s *Server) changePassword(c *gin.Context) {
 		NewPassword     string `json:"new_password"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.NewPassword) < 8 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "new password must be at least 8 characters"})
+		RespondWithBadRequest(c, "new password must be at least 8 characters")
 		return
 	}
 
@@ -397,7 +397,7 @@ func (s *Server) changePassword(c *gin.Context) {
 			}
 		}
 		if !isAdmin {
-			c.JSON(http.StatusForbidden, gin.H{"error": "only admins can reset another user's password"})
+			RespondWithForbidden(c, "only admins can reset another user's password")
 			return
 		}
 		targetID = req.UserID
@@ -406,34 +406,34 @@ func (s *Server) changePassword(c *gin.Context) {
 
 	target, err := s.Store().GetUserByID(targetID)
 	if err != nil || target == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		RespondWithNotFound(c, "user", targetID)
 		return
 	}
 
 	// Non-admin users must verify their current password.
 	if !isAdminReset {
 		if req.CurrentPassword == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "current_password is required"})
+			RespondWithBadRequest(c, "current_password is required")
 			return
 		}
 		if err := bcrypt.CompareHashAndPassword([]byte(target.PasswordHash), []byte(req.CurrentPassword)); err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "current password is incorrect"})
+			RespondWithUnauthorized(c, "current password is incorrect")
 			return
 		}
 	}
 
 	newHash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
+		RespondWithInternalError(c, "failed to hash password")
 		return
 	}
 
 	target.PasswordHash = string(newHash)
 	target.PasswordHashAlgo = "bcrypt"
 	if err := s.Store().UpdateUser(target); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update password"})
+		RespondWithInternalError(c, "failed to update password")
 		return
 	}
 
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 1.12.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -27,7 +27,7 @@ import (
 // Query params: entity_type, status, layer, min_similarity (float), limit (int, default 50), offset (int).
 func (s *Server) listDedupCandidates(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
@@ -45,7 +45,7 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 	if v := c.Query("min_similarity"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_similarity"})
+			RespondWithBadRequest(c, "invalid min_similarity")
 			return
 		}
 		filter.MinSimilarity = &f
@@ -53,7 +53,7 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 	if v := c.Query("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit"})
+			RespondWithBadRequest(c, "invalid limit")
 			return
 		}
 		filter.Limit = n
@@ -61,7 +61,7 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 	if v := c.Query("offset"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid offset"})
+			RespondWithBadRequest(c, "invalid offset")
 			return
 		}
 		filter.Offset = n
@@ -73,7 +73,7 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"candidates": candidates,
 		"total":      total,
 	})
@@ -98,13 +98,13 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 // llm_verdict, llm_reason, created_at, updated_at.
 func (s *Server) exportDedupCandidates(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
 	format := c.DefaultQuery("format", "csv")
 	if format != "csv" && format != "json" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "format must be csv or json"})
+		RespondWithBadRequest(c, "format must be csv or json")
 		return
 	}
 
@@ -121,7 +121,7 @@ func (s *Server) exportDedupCandidates(c *gin.Context) {
 	if v := c.Query("min_similarity"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_similarity"})
+			RespondWithBadRequest(c, "invalid min_similarity")
 			return
 		}
 		filter.MinSimilarity = &f
@@ -288,7 +288,7 @@ type dedupSeriesSummary struct {
 // "series-aware bulk merge" workflow.
 func (s *Server) listDedupCandidateSeries(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
@@ -385,7 +385,7 @@ func (s *Server) listDedupCandidateSeries(c *gin.Context) {
 		return summary[i].SeriesName < summary[j].SeriesName
 	})
 
-	c.JSON(http.StatusOK, gin.H{"series": summary})
+	RespondWithOK(c, gin.H{"series": summary})
 }
 
 // mergeDedupCandidateSeries handles
@@ -404,11 +404,11 @@ func (s *Server) listDedupCandidateSeries(c *gin.Context) {
 // can use the regular Merge Filtered action.
 func (s *Server) mergeDedupCandidateSeries(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 	if s.mergeService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "merge service not available"})
+		RespondWithServiceUnavailable(c, "merge service not available")
 		return
 	}
 
@@ -416,7 +416,7 @@ func (s *Server) mergeDedupCandidateSeries(c *gin.Context) {
 		SeriesID int `json:"series_id"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.SeriesID <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "series_id must be a positive integer"})
+		RespondWithBadRequest(c, "series_id must be a positive integer")
 		return
 	}
 
@@ -520,7 +520,7 @@ func (s *Server) mergeDedupCandidateSeries(c *gin.Context) {
 	log.Printf("[dedup] series merge: series=%d clusters_merged=%d books_merged=%d candidates_updated=%d failures=%d",
 		body.SeriesID, mergedClusters, mergedBooks, candidatesUpdated, len(failures))
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"series_id":          body.SeriesID,
 		"clusters_merged":    mergedClusters,
 		"books_merged":       mergedBooks,
@@ -532,7 +532,7 @@ func (s *Server) mergeDedupCandidateSeries(c *gin.Context) {
 // getDedupStats handles GET /api/v1/dedup/stats.
 func (s *Server) getDedupStats(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
@@ -542,7 +542,7 @@ func (s *Server) getDedupStats(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"stats": stats})
+	RespondWithOK(c, gin.H{"stats": stats})
 }
 
 // bulkMergeDedupCandidates handles POST /api/v1/dedup/candidates/bulk-merge.
@@ -561,11 +561,11 @@ func (s *Server) getDedupStats(c *gin.Context) {
 // this is destructive and irreversible.
 func (s *Server) bulkMergeDedupCandidates(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 	if s.mergeService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "merge service not available"})
+		RespondWithServiceUnavailable(c, "merge service not available")
 		return
 	}
 
@@ -588,7 +588,7 @@ func (s *Server) bulkMergeDedupCandidates(c *gin.Context) {
 		body.EntityType = "book"
 	}
 	if body.EntityType != "book" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "bulk merge only supports entity_type=book"})
+		RespondWithBadRequest(c, "bulk merge only supports entity_type=book")
 		return
 	}
 
@@ -633,7 +633,7 @@ func (s *Server) bulkMergeDedupCandidates(c *gin.Context) {
 	log.Printf("[dedup] bulk merge complete: %d merged, %d failed out of %d matched",
 		merged, len(failures), total)
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"attempted": total,
 		"merged":    merged,
 		"failed":    len(failures),
@@ -654,11 +654,11 @@ func (s *Server) bulkMergeDedupCandidates(c *gin.Context) {
 // time (which would fight the version-group state mid-way).
 func (s *Server) mergeDedupCluster(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 	if s.mergeService == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "merge service not available"})
+		RespondWithServiceUnavailable(c, "merge service not available")
 		return
 	}
 
@@ -667,11 +667,11 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 		PrimaryBookID string   `json:"primary_book_id,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 	if len(body.BookIDs) < 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids must contain at least 2 entries"})
+		RespondWithBadRequest(c, "book_ids must contain at least 2 entries")
 		return
 	}
 	// If primary_book_id is set, it must be one of the books in the
@@ -685,7 +685,7 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 			}
 		}
 		if !found {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "primary_book_id must be one of book_ids"})
+			RespondWithBadRequest(c, "primary_book_id must be one of book_ids")
 			return
 		}
 	}
@@ -728,7 +728,7 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 	log.Printf("[dedup] cluster merge: merged %d books, marked %d candidate row(s) as merged",
 		len(body.BookIDs), updated)
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"status":              "merged",
 		"merged_books":        len(body.BookIDs),
 		"candidates_updated":  updated,
@@ -745,7 +745,7 @@ func (s *Server) mergeDedupCluster(c *gin.Context) {
 // from the pending queue.
 func (s *Server) dismissDedupCluster(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
@@ -753,11 +753,11 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 		BookIDs []string `json:"book_ids"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 	if len(body.BookIDs) < 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids must contain at least 2 entries"})
+		RespondWithBadRequest(c, "book_ids must contain at least 2 entries")
 		return
 	}
 
@@ -790,7 +790,7 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 	log.Printf("[dedup] cluster dismiss: dismissed %d candidate row(s) across %d books",
 		dismissed, len(body.BookIDs))
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"status":    "dismissed",
 		"dismissed": dismissed,
 	})
@@ -818,7 +818,7 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 // If both are provided, they're merged into a single set.
 func (s *Server) removeFromDedupCluster(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
@@ -828,7 +828,7 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 		RemoveBookIDs  []string `json:"remove_book_ids,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 
@@ -845,11 +845,11 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 		}
 	}
 	if len(removeSet) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "remove_book_id or remove_book_ids is required"})
+		RespondWithBadRequest(c, "remove_book_id or remove_book_ids is required")
 		return
 	}
 	if len(body.ClusterBookIDs) < 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster_book_ids must contain at least 2 entries"})
+		RespondWithBadRequest(c, "cluster_book_ids must contain at least 2 entries")
 		return
 	}
 
@@ -863,7 +863,7 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 		remaining[id] = struct{}{}
 	}
 	if len(remaining) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cluster must contain at least one book that is not in remove set"})
+		RespondWithBadRequest(c, "cluster must contain at least one book that is not in remove set")
 		return
 	}
 
@@ -912,7 +912,7 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 	log.Printf("[dedup] remove-from-cluster: dismissed %d edge(s), removed %d book(s) from cluster of %d",
 		dismissed, len(removeSet), len(body.ClusterBookIDs))
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"status":    "removed",
 		"dismissed": dismissed,
 		"removed":   len(removeSet),
@@ -922,14 +922,14 @@ func (s *Server) removeFromDedupCluster(c *gin.Context) {
 // mergeDedupCandidate handles POST /api/v1/dedup/candidates/:id/merge.
 func (s *Server) mergeDedupCandidate(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid candidate id"})
+		RespondWithBadRequest(c, "invalid candidate id")
 		return
 	}
 
@@ -939,7 +939,7 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 		return
 	}
 	if candidate == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "candidate not found"})
+		RespondWithNotFound(c, "candidate", idStr)
 		return
 	}
 
@@ -964,20 +964,20 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 		"candidate_id": id,
 	}))
 
-	c.JSON(http.StatusOK, gin.H{"status": "merged", "result": result})
+	RespondWithOK(c, gin.H{"status": "merged", "result": result})
 }
 
 // dismissDedupCandidate handles POST /api/v1/dedup/candidates/:id/dismiss.
 func (s *Server) dismissDedupCandidate(c *gin.Context) {
 	if s.embeddingStore == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "embedding store not available"})
+		RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
 
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid candidate id"})
+		RespondWithBadRequest(c, "invalid candidate id")
 		return
 	}
 
@@ -986,7 +986,7 @@ func (s *Server) dismissDedupCandidate(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "dismissed"})
+	RespondWithOK(c, gin.H{"status": "dismissed"})
 }
 
 // triggerDedupScan handles POST /api/v1/dedup/scan.
@@ -1000,11 +1000,11 @@ func (s *Server) dismissDedupCandidate(c *gin.Context) {
 // live progress updates and final-completion messages.
 func (s *Server) triggerDedupScan(c *gin.Context) {
 	if s.dedupEngine == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
+		RespondWithServiceUnavailable(c, "dedup engine not available")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -1062,7 +1062,7 @@ func (s *Server) triggerDedupScan(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, http.StatusAccepted, op)
 }
 
 // triggerDedupLLM handles POST /api/v1/dedup/scan-llm.
@@ -1070,11 +1070,11 @@ func (s *Server) triggerDedupScan(c *gin.Context) {
 // tracked Operation so the UI can display progress and completion.
 func (s *Server) triggerDedupLLM(c *gin.Context) {
 	if s.dedupEngine == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
+		RespondWithServiceUnavailable(c, "dedup engine not available")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -1099,7 +1099,7 @@ func (s *Server) triggerDedupLLM(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, http.StatusAccepted, op)
 }
 
 // triggerDedupRefresh handles POST /api/v1/dedup/refresh.
@@ -1115,11 +1115,11 @@ func (s *Server) triggerDedupRefresh(c *gin.Context) {
 // and emits DedupCandidate rows with layer="acoustid" for any matches.
 func (s *Server) triggerDedupAcoustID(c *gin.Context) {
 	if s.dedupEngine == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dedup engine not available"})
+		RespondWithServiceUnavailable(c, "dedup engine not available")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -1166,5 +1166,5 @@ func (s *Server) triggerDedupAcoustID(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, http.StatusAccepted, op)
 }

--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 47a3e3fb-f5cf-4970-a2fc-d2ef481368c9
 //
 // SQL-backed duplicate detection handlers split out of server.go:
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,7 +28,7 @@ import (
 
 func (s *Server) listDuplicateAudiobooks(c *gin.Context) {
 	if cached, ok := s.dedupCache.Get("book-duplicates"); ok {
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
 
@@ -45,22 +44,22 @@ func (s *Server) listDuplicateAudiobooks(c *gin.Context) {
 		"duplicate_count": result.DuplicateCount,
 	}
 	s.dedupCache.Set("book-duplicates", resp)
-	c.JSON(http.StatusOK, resp)
+	RespondWithOK(c, resp)
 }
 
 // listBookDuplicateScanResults returns cached results from the last async book-dedup scan.
 func (s *Server) listBookDuplicateScanResults(c *gin.Context) {
 	if cached, ok := s.dedupCache.Get("book-dedup-scan"); ok {
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"groups": []any{}, "group_count": 0, "duplicate_count": 0, "needs_refresh": true})
+	RespondWithOK(c, gin.H{"groups": []any{}, "group_count": 0, "duplicate_count": 0, "needs_refresh": true})
 }
 
 // scanBookDuplicates triggers an async scan for book duplicates using metadata matching.
 func (s *Server) scanBookDuplicates(c *gin.Context) {
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -171,7 +170,7 @@ func (s *Server) scanBookDuplicates(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // mergeBookDuplicatesAsVersions merges a group of duplicate books into a version group.
@@ -180,11 +179,11 @@ func (s *Server) mergeBookDuplicatesAsVersions(c *gin.Context) {
 		BookIDs []string `json:"book_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.BookIDs) < 2 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "need at least 2 book IDs"})
+		RespondWithBadRequest(c, "need at least 2 book IDs")
 		return
 	}
 
@@ -196,7 +195,7 @@ func (s *Server) mergeBookDuplicatesAsVersions(c *gin.Context) {
 	result, err := ms.MergeBooks(req.BookIDs, "")
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			RespondWithNotFound(c, "book", "")
 		} else {
 			internalError(c, "failed to merge duplicate books", err)
 		}
@@ -206,7 +205,7 @@ func (s *Server) mergeBookDuplicatesAsVersions(c *gin.Context) {
 	s.dedupCache.Invalidate("book-dedup-scan")
 	s.dedupCache.Invalidate("book-duplicates")
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message":          fmt.Sprintf("Merged %d books into version group", result.MergedCount),
 		"version_group_id": result.VersionGroupID,
 		"primary_id":       result.PrimaryID,
@@ -219,13 +218,13 @@ func (s *Server) dismissBookDuplicateGroup(c *gin.Context) {
 		GroupKey string `json:"group_key" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -236,7 +235,7 @@ func (s *Server) dismissBookDuplicateGroup(c *gin.Context) {
 
 	s.dedupCache.Invalidate("book-dedup-scan")
 
-	c.JSON(http.StatusOK, gin.H{"message": "Group dismissed"})
+	RespondWithOK(c, gin.H{"message": "Group dismissed"})
 }
 
 func (s *Server) mergeBooks(c *gin.Context) {
@@ -245,24 +244,24 @@ func (s *Server) mergeBooks(c *gin.Context) {
 		MergeIDs []string `json:"merge_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if len(req.MergeIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "merge_ids must not be empty"})
+		RespondWithBadRequest(c, "merge_ids must not be empty")
 		return
 	}
 
 	store := s.Store()
 	keepBook, err := store.GetBookByID(req.KeepID)
 	if err != nil || keepBook == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "keep book not found"})
+		RespondWithNotFound(c, "book", req.KeepID)
 		return
 	}
 
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -356,22 +355,22 @@ func (s *Server) mergeBooks(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 func (s *Server) listDuplicateAuthors(c *gin.Context) {
 	if cached, ok := s.dedupCache.Get("author-duplicates"); ok {
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
 
 	// No cache — return empty with needs_refresh flag so frontend triggers async scan
-	c.JSON(http.StatusOK, gin.H{"groups": []any{}, "count": 0, "needs_refresh": true})
+	RespondWithOK(c, gin.H{"groups": []any{}, "count": 0, "needs_refresh": true})
 }
 
 func (s *Server) refreshDuplicateAuthors(c *gin.Context) {
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -422,7 +421,7 @@ func (s *Server) refreshDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // filterReviewedAuthorGroups removes author dedup groups where all author IDs
@@ -479,17 +478,17 @@ func (s *Server) filterReviewedAuthorGroups(groups []dedup.AuthorDedupGroup) []d
 
 func (s *Server) listSeriesDuplicates(c *gin.Context) {
 	if cached, ok := s.dedupCache.Get("series-duplicates"); ok {
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
 
 	// No cache — return empty with needs_refresh flag so frontend triggers async scan
-	c.JSON(http.StatusOK, gin.H{"groups": []any{}, "count": 0, "total_series": 0, "needs_refresh": true})
+	RespondWithOK(c, gin.H{"groups": []any{}, "count": 0, "total_series": 0, "needs_refresh": true})
 }
 
 func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -675,7 +674,7 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // validateDedupEntry searches metadata sources (OpenLibrary, Audible, etc.) to validate
@@ -686,7 +685,7 @@ func (s *Server) validateDedupEntry(c *gin.Context) {
 		Type  string `json:"type"` // "series", "author", "book"
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "query is required"})
+		RespondWithBadRequest(c, "query is required")
 		return
 	}
 	if req.Type == "" {
@@ -695,7 +694,7 @@ func (s *Server) validateDedupEntry(c *gin.Context) {
 
 	chain := s.metadataFetchService.BuildSourceChain()
 	if len(chain) == 0 {
-		c.JSON(http.StatusOK, gin.H{"results": []interface{}{}, "message": "no metadata sources configured"})
+		RespondWithOK(c, gin.H{"results": []interface{}{}, "message": "no metadata sources configured"})
 		return
 	}
 
@@ -741,17 +740,17 @@ func (s *Server) validateDedupEntry(c *gin.Context) {
 	if results == nil {
 		results = []validationResult{}
 	}
-	c.JSON(http.StatusOK, gin.H{"results": results, "query": req.Query, "type": req.Type})
+	RespondWithOK(c, gin.H{"results": results, "query": req.Query, "type": req.Type})
 }
 
 func (s *Server) deduplicateSeriesHandler(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -851,13 +850,13 @@ func (s *Server) deduplicateSeriesHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 func (s *Server) seriesPrunePreview(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -867,17 +866,17 @@ func (s *Server) seriesPrunePreview(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, preview)
+	RespondWithOK(c, preview)
 }
 
 func (s *Server) seriesPrune(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -898,7 +897,7 @@ func (s *Server) seriesPrune(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // executeSeriesPrune performs the actual series prune logic (used by both HTTP handler and scheduler).
@@ -1077,24 +1076,24 @@ func (s *Server) mergeSeriesGroup(c *gin.Context) {
 		CustomName string `json:"custom_name"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if len(req.MergeIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "merge_ids must not be empty"})
+		RespondWithBadRequest(c, "merge_ids must not be empty")
 		return
 	}
 
 	store := s.Store()
 	keepSeries, err := store.GetSeriesByID(req.KeepID)
 	if err != nil || keepSeries == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "keep series not found"})
+		RespondWithNotFound(c, "series", "")
 		return
 	}
 
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -1259,5 +1258,5 @@ func (s *Server) mergeSeriesGroup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }

--- a/internal/server/error_handler.go
+++ b/internal/server/error_handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/error_handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5d6e7f8a-9b0c-1d2e-3f4a-5b6c7d8e9f0a
-// last-edited: 2026-02-04
+// last-edited: 2026-04-23
 
 package server
 
@@ -89,6 +89,11 @@ func RespondWithUnauthorized(c *gin.Context, message string) {
 // RespondWithForbidden sends a 403 Forbidden error response
 func RespondWithForbidden(c *gin.Context, message string) {
 	RespondWithError(c, http.StatusForbidden, message, "FORBIDDEN")
+}
+
+// RespondWithServiceUnavailable sends a 503 Service Unavailable error response
+func RespondWithServiceUnavailable(c *gin.Context, message string) {
+	RespondWithError(c, http.StatusServiceUnavailable, message, "SERVICE_UNAVAILABLE")
 }
 
 // RespondWithSuccess sends a successful response with data

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -61,11 +61,11 @@ func TestHandler_HealthCheck_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, "ok", resp["status"])
+	assert.Equal(t, "ok", resp.Data["status"])
 
-	metrics := resp["metrics"].(map[string]any)
+	metrics := resp.Data["metrics"].(map[string]any)
 	assert.Equal(t, float64(42), metrics["books"])
 	assert.Equal(t, float64(1), metrics["authors"])
 	assert.Equal(t, float64(1), metrics["series"])
@@ -85,9 +85,9 @@ func TestHandler_HealthCheck_DBError(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Contains(t, resp, "partial_error")
+	assert.Contains(t, resp.Data, "partial_error")
 }
 
 // =============== getOperationStatus ===============
@@ -290,9 +290,9 @@ func TestHandler_ListBlockedHashes_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(1), resp["total"])
+	assert.Equal(t, float64(1), resp.Data["total"])
 }
 
 // =============== addBlockedHash ===============
@@ -390,9 +390,9 @@ func TestHandler_GetUserPreference_Found(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, "theme", resp["key"])
+	assert.Equal(t, "theme", resp.Data["key"])
 }
 
 func TestHandler_GetUserPreference_NotFound(t *testing.T) {
@@ -425,10 +425,10 @@ func TestHandler_SetUserPreference_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, "theme", resp["key"])
-	assert.Equal(t, "light", resp["value"])
+	assert.Equal(t, "theme", resp.Data["key"])
+	assert.Equal(t, "light", resp.Data["value"])
 }
 
 func TestHandler_SetUserPreference_StoreError(t *testing.T) {
@@ -485,9 +485,9 @@ func TestHandler_GetDashboard_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(100), resp["totalBooks"])
+	assert.Equal(t, float64(100), resp.Data["totalBooks"])
 }
 
 func TestHandler_GetDashboard_StoreError(t *testing.T) {
@@ -672,9 +672,9 @@ func TestHandler_GetSystemActivityLog_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(1), resp["count"])
+	assert.Equal(t, float64(1), resp.Data["count"])
 }
 
 func TestHandler_GetSystemActivityLog_WithSourceAndLimit(t *testing.T) {
@@ -770,9 +770,13 @@ func TestHandler_GetPosition_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.NotNil(t, resp["position"])
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	// Data IS the UserPosition — check for expected fields.
+	assert.Equal(t, "b1", wrapper.Data["book_id"])
+	assert.Equal(t, "seg1", wrapper.Data["segment_id"])
 }
 
 func TestHandler_GetPosition_NoneRecorded(t *testing.T) {
@@ -1351,9 +1355,9 @@ func TestHandler_GetAuthStatus_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, true, resp["has_users"])
+	assert.Equal(t, true, resp.Data["has_users"])
 }
 
 func TestHandler_GetAuthStatus_NoUsers(t *testing.T) {
@@ -1368,9 +1372,9 @@ func TestHandler_GetAuthStatus_NoUsers(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]any
+	var resp struct{ Data map[string]any }
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, false, resp["has_users"])
+	assert.Equal(t, false, resp.Data["has_users"])
 }
 
 func TestHandler_GetAuthStatus_StoreError(t *testing.T) {

--- a/internal/server/server_backup_restore_test.go
+++ b/internal/server/server_backup_restore_test.go
@@ -35,8 +35,11 @@ func TestRestoreBackup_Success(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var info backup.BackupInfo
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &info))
+	var wrapper struct {
+		Data backup.BackupInfo `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	info := wrapper.Data
 	require.NotEmpty(t, info.Filename)
 
 	// Restore into a new target directory.
@@ -75,8 +78,11 @@ func TestDeleteBackup_Success(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var info backup.BackupInfo
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &info))
+	var wrapper struct {
+		Data backup.BackupInfo `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	info := wrapper.Data
 	require.NotEmpty(t, info.Filename)
 
 	// Backup dir is resolved relative to DatabasePath directory

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -345,9 +345,13 @@ func TestCoverageRestoreAudiobook(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
+		var resp struct {
+			Data struct {
+				Message string `json:"message"`
+			} `json:"data"`
+		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.Equal(t, "audiobook restored", resp["message"])
+		assert.Equal(t, "audiobook restored", resp.Data.Message)
 	})
 
 	t.Run("restore non-existent book", func(t *testing.T) {
@@ -487,12 +491,12 @@ func TestCoverageDashboardStats(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
+		var resp struct{ Data map[string]any }
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["formatDistribution"])
-		assert.NotNil(t, resp["stateDistribution"])
-		assert.NotNil(t, resp["totalBooks"])
-		assert.NotNil(t, resp["totalSize"])
+		assert.NotNil(t, resp.Data["formatDistribution"])
+		assert.NotNil(t, resp.Data["stateDistribution"])
+		assert.NotNil(t, resp.Data["totalBooks"])
+		assert.NotNil(t, resp.Data["totalSize"])
 	})
 
 	t.Run("with books", func(t *testing.T) {
@@ -507,9 +511,9 @@ func TestCoverageDashboardStats(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
+		var resp struct{ Data map[string]any }
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		totalBooks := resp["totalBooks"].(float64)
+		totalBooks := resp.Data["totalBooks"].(float64)
 		assert.GreaterOrEqual(t, totalBooks, float64(2))
 	})
 
@@ -773,10 +777,13 @@ func TestCoverageListSoftDeletedAudiobooks(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
+		var resp struct {
+			Data struct {
+				Items []any `json:"items"`
+			} `json:"data"`
+		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		items := resp["items"].([]any)
-		assert.Equal(t, 0, len(items))
+		assert.Equal(t, 0, len(resp.Data.Items))
 	})
 
 	t.Run("with soft-deleted books", func(t *testing.T) {
@@ -791,10 +798,13 @@ func TestCoverageListSoftDeletedAudiobooks(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
+		var resp struct {
+			Data struct {
+				Items []any `json:"items"`
+			} `json:"data"`
+		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		items := resp["items"].([]any)
-		assert.GreaterOrEqual(t, len(items), 1)
+		assert.GreaterOrEqual(t, len(resp.Data.Items), 1)
 	})
 
 	t.Run("with pagination params", func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -116,14 +116,16 @@ func TestHealthCheck(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var response map[string]any
-		err := json.Unmarshal(w.Body.Bytes(), &response)
+		var wrapper struct {
+			Data map[string]any `json:"data"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &wrapper)
 		require.NoError(t, err)
 
-		assert.Equal(t, "ok", response["status"])
-		assert.NotNil(t, response["timestamp"])
-		assert.NotNil(t, response["version"])
-		assert.NotNil(t, response["metrics"])
+		assert.Equal(t, "ok", wrapper.Data["status"])
+		assert.NotNil(t, wrapper.Data["timestamp"])
+		assert.NotNil(t, wrapper.Data["version"])
+		assert.NotNil(t, wrapper.Data["metrics"])
 	}
 }
 
@@ -526,10 +528,12 @@ func TestListBackups(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
-	err := json.Unmarshal(w.Body.Bytes(), &response)
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
-	assert.NotNil(t, response["backups"])
+	assert.NotNil(t, wrapper.Data["backups"])
 }
 
 // TestBatchUpdateMetadata tests batch metadata updates
@@ -936,9 +940,12 @@ func TestDashboardSizeFormat(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
-	err := json.Unmarshal(w.Body.Bytes(), &response)
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
+	response := wrapper.Data
 
 	// Verify formatDistribution exists
 	formatDistribution, ok := response["formatDistribution"].(map[string]any)
@@ -1047,9 +1054,12 @@ func TestEmptyDashboardSizeFormat(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
-	err := json.Unmarshal(w.Body.Bytes(), &response)
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
+	response := wrapper.Data
 
 	// Even with no audiobooks, distributions should exist
 	formatDistribution, ok := response["formatDistribution"].(map[string]any)
@@ -2073,9 +2083,12 @@ func TestGetDashboardWithData(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
-	err = json.Unmarshal(w.Body.Bytes(), &response)
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
+	response := wrapper.Data
 
 	// Verify dashboard response structure with data
 	assert.NotNil(t, response["totalBooks"])

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,11 +1,11 @@
 // file: internal/server/system_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
 // System-level HTTP handlers split out of server.go: health, status,
 // storage, logs, announcements, reset/factory-reset, config get/update,
 // SSE event stream, dashboard, backup CRUD, blocked-hash CRUD, and
-// user-preference CRUD.
+// user-preference CRUD. Migrated to use RespondWith* helpers.
 
 package server
 
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,7 +65,7 @@ func (s *Server) healthCheck(c *gin.Context) {
 	if dbErr != nil {
 		resp["partial_error"] = dbErr.Error()
 	}
-	c.JSON(http.StatusOK, resp)
+	RespondWithOK(c, resp)
 }
 
 func (s *Server) getSystemStatus(c *gin.Context) {
@@ -89,7 +88,7 @@ func (s *Server) getSystemStatus(c *gin.Context) {
 		status.PluginHealth = pluginHealth
 	}
 
-	c.JSON(http.StatusOK, status)
+	RespondWithOK(c, status)
 }
 
 func (s *Server) getSystemAnnouncements(c *gin.Context) {
@@ -144,19 +143,19 @@ func (s *Server) getSystemAnnouncements(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"announcements": announcements})
+	RespondWithOK(c, gin.H{"announcements": announcements})
 }
 
 func (s *Server) getSystemStorage(c *gin.Context) {
 	rootDir := strings.TrimSpace(config.AppConfig.RootDir)
 	if rootDir == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "root_dir is not configured"})
+		RespondWithBadRequest(c, "root_dir is not configured")
 		return
 	}
 
 	totalBytes, freeBytes, err := getDiskStats(rootDir)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read filesystem stats"})
+		RespondWithInternalError(c, "failed to read filesystem stats")
 		return
 	}
 
@@ -166,7 +165,7 @@ func (s *Server) getSystemStorage(c *gin.Context) {
 		percentUsed = (float64(usedBytes) / float64(totalBytes)) * 100.0
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"path":                rootDir,
 		"total_bytes":         totalBytes,
 		"used_bytes":          usedBytes,
@@ -194,7 +193,7 @@ func (s *Server) getSystemLogs(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"logs":   logs,
 		"limit":  params.Limit,
 		"offset": params.Offset,
@@ -213,7 +212,7 @@ func (s *Server) getSystemActivityLog(c *gin.Context) {
 		internalError(c, "failed to get activity log", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"items": logs, "count": len(logs)})
+	RespondWithOK(c, gin.H{"items": logs, "count": len(logs)})
 }
 
 func (s *Server) resetSystem(c *gin.Context) {
@@ -238,7 +237,7 @@ func (s *Server) factoryReset(c *gin.Context) {
 		Confirm string `json:"confirm"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil || req.Confirm != "RESET" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "request body must contain {\"confirm\": \"RESET\"}"})
+		RespondWithBadRequest(c, "request body must contain {\"confirm\": \"RESET\"}")
 		return
 	}
 
@@ -299,7 +298,7 @@ func (s *Server) factoryReset(c *gin.Context) {
 	s.dashboardCache.InvalidateAll()
 
 	log.Printf("[INFO] Factory reset complete")
-	c.JSON(http.StatusOK, gin.H{"message": "factory reset complete"})
+	RespondWithOK(c, gin.H{"message": "factory reset complete"})
 }
 
 func (s *Server) getConfig(c *gin.Context) {
@@ -308,13 +307,13 @@ func (s *Server) getConfig(c *gin.Context) {
 	if maskedConfig.OpenAIAPIKey != "" {
 		maskedConfig.OpenAIAPIKey = database.MaskSecret(maskedConfig.OpenAIAPIKey)
 	}
-	c.JSON(http.StatusOK, gin.H{"config": maskedConfig})
+	RespondWithOK(c, gin.H{"config": maskedConfig})
 }
 
 func (s *Server) updateConfig(c *gin.Context) {
 	var payload map[string]any
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -328,7 +327,7 @@ func (s *Server) updateConfig(c *gin.Context) {
 
 	if err := config.AppConfig.Validate(); err != nil {
 		config.AppConfig = previousConfig
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -342,13 +341,13 @@ func (s *Server) updateConfig(c *gin.Context) {
 			}
 		}
 	}
-	c.JSON(http.StatusOK, response)
+	RespondWithOK(c, response)
 }
 
 // handleEvents handles Server-Sent Events (SSE) for real-time updates
 func (s *Server) handleEvents(c *gin.Context) {
 	if s.hub == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "event hub not initialized"})
+		RespondWithError(c, 503, "event hub not initialized", "SERVICE_UNAVAILABLE")
 		return
 	}
 	s.hub.HandleSSE(c)
@@ -381,7 +380,7 @@ func (s *Server) createBackup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, info)
+	RespondWithOK(c, info)
 }
 
 // listBackups lists all available backups
@@ -402,7 +401,7 @@ func (s *Server) listBackups(c *gin.Context) {
 		backups = []backup.BackupInfo{}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"backups": backups,
 		"count":   len(backups),
 	})
@@ -417,7 +416,7 @@ func (s *Server) restoreBackup(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -438,7 +437,7 @@ func (s *Server) restoreBackup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message": "backup restored successfully",
 		"target":  targetPath,
 	})
@@ -448,7 +447,7 @@ func (s *Server) restoreBackup(c *gin.Context) {
 func (s *Server) deleteBackup(c *gin.Context) {
 	filename := c.Param("filename")
 	if filename == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "filename required"})
+		RespondWithBadRequest(c, "filename required")
 		return
 	}
 
@@ -465,20 +464,20 @@ func (s *Server) deleteBackup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "backup deleted successfully"})
+	RespondWithOK(c, gin.H{"message": "backup deleted successfully"})
 }
 
 // getDashboard returns dashboard statistics with size and format distributions
 func (s *Server) getDashboard(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	// Check cache first
 	if cached, ok := s.dashboardCache.Get("dashboard"); ok {
 		LogServiceCacheHit("Dashboard", "dashboard")
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
 	LogServiceCacheMiss("Dashboard", "dashboard")
@@ -486,7 +485,7 @@ func (s *Server) getDashboard(c *gin.Context) {
 	// Use SQL aggregation instead of loading all books
 	stats, err := s.Store().GetDashboardStats()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve dashboard stats"})
+		RespondWithInternalError(c, "failed to retrieve dashboard stats")
 		return
 	}
 
@@ -506,13 +505,13 @@ func (s *Server) getDashboard(c *gin.Context) {
 	}
 
 	s.dashboardCache.Set("dashboard", result)
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 // listBlockedHashes returns all blocked hashes
 func (s *Server) listBlockedHashes(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -522,7 +521,7 @@ func (s *Server) listBlockedHashes(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"items": hashes,
 		"total": len(hashes),
 	})
@@ -531,7 +530,7 @@ func (s *Server) listBlockedHashes(c *gin.Context) {
 // addBlockedHash adds a hash to the blocklist
 func (s *Server) addBlockedHash(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -541,13 +540,13 @@ func (s *Server) addBlockedHash(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	// Validate hash format (should be 64 character hex string for SHA256)
 	if len(req.Hash) != 64 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "hash must be 64 characters (SHA256)"})
+		RespondWithBadRequest(c, "hash must be 64 characters (SHA256)")
 		return
 	}
 
@@ -557,7 +556,7 @@ func (s *Server) addBlockedHash(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
+	RespondWithCreated(c, gin.H{
 		"message": "hash blocked successfully",
 		"hash":    req.Hash,
 		"reason":  req.Reason,
@@ -567,13 +566,13 @@ func (s *Server) addBlockedHash(c *gin.Context) {
 // removeBlockedHash removes a hash from the blocklist
 func (s *Server) removeBlockedHash(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	hash := c.Param("hash")
 	if hash == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "hash parameter required"})
+		RespondWithBadRequest(c, "hash parameter required")
 		return
 	}
 
@@ -583,7 +582,7 @@ func (s *Server) removeBlockedHash(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message": "hash unblocked successfully",
 		"hash":    hash,
 	})
@@ -593,53 +592,53 @@ func (s *Server) removeBlockedHash(c *gin.Context) {
 func (s *Server) getUserPreference(c *gin.Context) {
 	key := c.Param("key")
 	if key == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
+		RespondWithBadRequest(c, "key is required")
 		return
 	}
 	pref, err := s.Store().GetUserPreference(key)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get preference"})
+		RespondWithInternalError(c, "failed to get preference")
 		return
 	}
 	if pref == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "preference not found"})
+		RespondWithNotFound(c, "preference", key)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"key": pref.Key, "value": pref.Value})
+	RespondWithOK(c, gin.H{"key": pref.Key, "value": pref.Value})
 }
 
 // setUserPreference creates or updates a user preference.
 func (s *Server) setUserPreference(c *gin.Context) {
 	key := c.Param("key")
 	if key == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
+		RespondWithBadRequest(c, "key is required")
 		return
 	}
 	var body struct {
 		Value string `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 	if err := s.Store().SetUserPreference(key, body.Value); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save preference"})
+		RespondWithInternalError(c, "failed to save preference")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"key": key, "value": body.Value})
+	RespondWithOK(c, gin.H{"key": key, "value": body.Value})
 }
 
 // deleteUserPreference removes a user preference by setting it to empty.
 func (s *Server) deleteUserPreference(c *gin.Context) {
 	key := c.Param("key")
 	if key == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "key is required"})
+		RespondWithBadRequest(c, "key is required")
 		return
 	}
 	// Set to empty string to "delete" (store doesn't have a delete method)
 	if err := s.Store().SetUserPreference(key, ""); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete preference"})
+		RespondWithInternalError(c, "failed to delete preference")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "preference deleted"})
+	RespondWithOK(c, gin.H{"message": "preference deleted"})
 }

--- a/internal/server/user_handlers.go
+++ b/internal/server/user_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/user_handlers.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 2d0e1f8a-3b9c-4a70-b8c5-3d7e0f1b9a99
 //
 // User management admin endpoints (spec 3.7 task 7). All routes

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 1.77.0
+// version: 1.78.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -682,7 +682,8 @@ export async function getSoftDeletedBooks(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch soft-deleted books');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return {
     items: data.items || [],
     count: data.total ?? data.count ?? (data.items ? data.items.length : 0),
@@ -713,7 +714,8 @@ export async function purgeSoftDeletedBooks(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to purge soft-deleted books');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function quarantineBook(bookId: string, reason?: string): Promise<void> {
@@ -929,7 +931,8 @@ export async function getAuthorDuplicates(): Promise<{ groups: AuthorDedupGroup[
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch author duplicates');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return { groups: data.groups || [], needs_refresh: data.needs_refresh };
 }
 
@@ -938,7 +941,8 @@ export async function refreshAuthorDuplicates(): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start author dedup scan');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function mergeAuthors(keepId: number, mergeIds: number[]): Promise<Operation> {
@@ -1024,7 +1028,8 @@ export async function getBookDuplicates(): Promise<DuplicatesResponse> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch book duplicates');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function mergeBooks(keepId: string, mergeIds: string[]): Promise<Operation> {
@@ -1059,7 +1064,8 @@ export async function getBookDedupScanResults(): Promise<BookDedupScanResponse> 
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch book dedup scan results');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function scanBookDuplicates(): Promise<Operation> {
@@ -1069,7 +1075,8 @@ export async function scanBookDuplicates(): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start book dedup scan');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function mergeBookDuplicatesAsVersions(bookIds: string[]): Promise<{ message: string; version_group_id: string; primary_id: string }> {
@@ -1081,7 +1088,8 @@ export async function mergeBookDuplicatesAsVersions(bookIds: string[]): Promise<
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge book duplicates as versions');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function dismissBookDuplicateGroup(groupKey: string): Promise<{ message: string }> {
@@ -1093,7 +1101,8 @@ export async function dismissBookDuplicateGroup(groupKey: string): Promise<{ mes
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to dismiss duplicate group');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Series
@@ -1485,7 +1494,8 @@ export async function getSystemStatus(): Promise<SystemStatus> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch system status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getSystemStorage(): Promise<SystemStorage> {
@@ -1493,7 +1503,8 @@ export async function getSystemStorage(): Promise<SystemStorage> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch system storage');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function factoryReset(confirm: string): Promise<{ message: string }> {
@@ -1505,7 +1516,8 @@ export async function factoryReset(confirm: string): Promise<{ message: string }
   if (!response.ok) {
     throw await buildApiError(response, 'Factory reset failed');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Organize operation
@@ -1548,7 +1560,8 @@ export async function getSystemLogs(params?: {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch system logs');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Config
@@ -1582,7 +1595,8 @@ export async function getAuthStatus(): Promise<AuthStatus> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch auth status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function setupAdmin(payload: {
@@ -1599,7 +1613,8 @@ export async function setupAdmin(payload: {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to create admin account');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function login(payload: {
@@ -1615,7 +1630,8 @@ export async function login(payload: {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to login');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getMe(): Promise<AuthUser> {
@@ -1960,7 +1976,8 @@ export async function getSeriesDuplicates(): Promise<{ groups: SeriesDupGroup[];
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch series duplicates');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function refreshSeriesDuplicates(): Promise<Operation> {
@@ -1968,7 +1985,8 @@ export async function refreshSeriesDuplicates(): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start series dedup scan');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Dedup validation
@@ -1991,7 +2009,8 @@ export async function validateDedupEntry(query: string, type: 'series' | 'author
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to validate dedup entry');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export interface SeriesDedupResult {
@@ -2007,7 +2026,8 @@ export async function deduplicateSeries(): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to deduplicate series');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function mergeSeriesGroup(keepId: number, mergeIds: number[], customName?: string): Promise<Operation> {
@@ -2021,7 +2041,8 @@ export async function mergeSeriesGroup(keepId: number, mergeIds: number[], custo
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge series');
   }
-  return response.json();
+  const respBody = await response.json();
+  return respBody.data;
 }
 
 export interface SeriesPrunePreviewGroup {
@@ -2044,7 +2065,8 @@ export async function seriesPrunePreview(): Promise<SeriesPrunePreview> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to get series prune preview');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function seriesPrune(): Promise<Operation> {
@@ -2054,7 +2076,8 @@ export async function seriesPrune(): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to prune series');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function updateSeriesName(id: number, name: string): Promise<Series> {
@@ -2551,7 +2574,8 @@ export async function createBackup(maxBackups?: number): Promise<BackupInfo> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to create backup');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function listBackups(): Promise<BackupListResponse> {
@@ -2559,7 +2583,8 @@ export async function listBackups(): Promise<BackupListResponse> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to list backups');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function restoreBackup(
@@ -2574,7 +2599,8 @@ export async function restoreBackup(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to restore backup');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function deleteBackup(filename: string): Promise<void> {
@@ -2603,7 +2629,8 @@ export async function getBlockedHashes(): Promise<BlockedHashesResponse> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch blocked hashes');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function addBlockedHash(
@@ -2618,7 +2645,8 @@ export async function addBlockedHash(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to add blocked hash');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function removeBlockedHash(
@@ -2630,7 +2658,8 @@ export async function removeBlockedHash(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to remove blocked hash');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Metadata History
@@ -3744,7 +3773,8 @@ export async function getDedupCandidates(params?: {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch dedup candidates');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function getDedupStats(): Promise<{ stats: DedupStats[] }> {
@@ -3752,7 +3782,8 @@ export async function getDedupStats(): Promise<{ stats: DedupStats[] }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch dedup stats');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function mergeDedupCandidate(id: number): Promise<void> {
@@ -3795,7 +3826,8 @@ export async function bulkMergeDedupCandidates(filter: {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to bulk-merge dedup candidates');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export interface ClusterMergeResult {
@@ -3825,7 +3857,8 @@ export async function mergeDedupCluster(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge dedup cluster');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export interface DedupSeriesSummary {
@@ -3841,8 +3874,8 @@ export async function listDedupCandidateSeries(): Promise<DedupSeriesSummary[]> 
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to list dedup series summary');
   }
-  const data = await response.json();
-  return data.series || [];
+  const envelope = await response.json();
+  return envelope.data.series || [];
 }
 
 export interface SeriesMergeResult {
@@ -3862,7 +3895,8 @@ export async function mergeDedupCandidateSeries(seriesId: number): Promise<Serie
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge dedup series');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function dismissDedupCluster(bookIds: string[]): Promise<{ status: string; dismissed: number }> {
@@ -3874,7 +3908,8 @@ export async function dismissDedupCluster(bookIds: string[]): Promise<{ status: 
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to dismiss dedup cluster');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 // Remove one or more books from a cluster by dismissing only the
@@ -3902,7 +3937,8 @@ export async function removeFromDedupCluster(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to remove book from dedup cluster');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function triggerDedupScan(): Promise<{ status: string }> {
@@ -3910,7 +3946,8 @@ export async function triggerDedupScan(): Promise<{ status: string }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger dedup scan');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function triggerDedupLLM(): Promise<{ status: string }> {
@@ -3920,7 +3957,8 @@ export async function triggerDedupLLM(): Promise<{ status: string }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger dedup LLM scan');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function triggerDedupAcoustID(): Promise<{ status: string }> {
@@ -3928,7 +3966,8 @@ export async function triggerDedupAcoustID(): Promise<{ status: string }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger AcoustID scan');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 export async function triggerDedupRefresh(): Promise<{ status: string }> {
@@ -3938,7 +3977,8 @@ export async function triggerDedupRefresh(): Promise<{ status: string }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger dedup refresh');
   }
-  return response.json();
+  const responseData = await response.json();
+  return responseData.data;
 }
 
 // ── API Key management ────────────────────────────────────────────────────────


### PR DESCRIPTION
Continues [TODO 4.15](../blob/main/TODO.md). Wave 3 of parallel Haiku dispatch, first using single-PR-per-wave as default (plan §5c).

### Handlers migrated
- **system_handlers.go** — 21 handlers / ~45 callsites; 11 api.ts unwraps
- **auth_handlers.go** — 8 handlers / 43 callsites; cookie order preserved; 3 api.ts unwraps
- **duplicates_handlers.go** — 27 callsites; soft-delete handlers in audiobooks_handlers.go too; 17 api.ts unwraps
- **dedup_handlers.go** — 52 callsites (largest); 12 api.ts unwraps; added `RespondWithServiceUnavailable` helper

### Test updates
`handlers_unit_test.go`, `server_test.go`, `server_backup_restore_test.go`, `server_coverage_test.go` updated for data envelope.

### Plan doc
Bumped to v3.0.0 with §5c — single-PR-per-wave is now the default.

## Test plan
- [x] go build
- [x] go vet
- [x] tsc --noEmit
- [x] go test -run 'System|Status|Storage|Log|Announc|Health|Auth|Login|Logout|Session|Lockout|Duplicate|SoftDelete|Purge|Restore|Dedup|Cluster|Evidence|Dashboard|Handler_|Backup' — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)