### PR TITLE
refactor(server): envelope migration — Wave 4 (operations, ai, metadata, itunes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.19.0 -->
+<!-- version: 2.20.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-23 -->
 
@@ -8,6 +8,16 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 24, 2026 — Envelope Migration: Wave 4 (operations, ai, metadata, itunes)
+
+Shipped as one PR — 4 parallel Haiku sub-agents; coordinator consolidated + fixed several downstream test failures.
+
+- **`internal/server/operations_handlers.go`** (D1): 24 handlers / 56 callsites → `RespondWith*`. `api.ts`: 8 callers unwrap `.data`. Updated integration tests across `handlers_unit_test.go`, `server_coverage_test.go`, `server_more_test.go`, `organize_integration_test.go`, `itunes_integration_test.go`, `e2e_workflow_test.go`.
+- **`internal/server/ai_handlers.go`** (D2): 17 handlers / 53 callsites → `RespondWith*`. Covers AI scan lifecycle, metadata-source testing, LLM-assisted parsing, AI-driven author-duplicate review. `api.ts`: 12 callers unwrap `.data`. Tests: `server_ai_integration_test.go`.
+- **`internal/server/metadata_handlers.go`** (D3): 52 callsites → `RespondWith*`. Covers metadata search/fetch/apply/write-back across 24 endpoints. `api.ts`: 8 callers unwrap `.data`. Tests: `server_bulk_fetch_metadata_test.go`, `server_test.go`.
+- **`internal/server/itunes_handlers.go`** (D4): 12 handlers / 51 callsites → `RespondWith*`. Covers XML import, write-back, sync, library status, import progress polling. `api.ts`: 11 callers unwrap `.data`. Tests: `itunes_error_test.go`.
+- **Coordinator fixes**: `itunes_integration_test.go`, `itunes_test.go`, `server_test.go`, `server_write_back_test.go` — updated response-shape decoders for envelope + iTunes import-status tests.
 
 #### April 24, 2026 — Envelope Migration: Wave 3 (system, auth, duplicates, dedup)
 

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 5d3a6a95-4ac8-42c2-a7fe-5ff4857dd31a
 //
 // AI-related HTTP handlers split out of server.go: filename parsing,
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -37,14 +36,14 @@ func (s *Server) parseFilenameWithAI(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "filename is required"})
+		RespondWithBadRequest(c, "filename is required")
 		return
 	}
 
 	// Create AI parser
 	parser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 	if !parser.IsEnabled() {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "AI parsing is not enabled or API key not configured"})
+		RespondWithBadRequest(c, "AI parsing is not enabled or API key not configured")
 		return
 	}
 
@@ -55,7 +54,7 @@ func (s *Server) parseFilenameWithAI(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"metadata": metadata})
+	RespondWithOK(c, gin.H{"metadata": metadata})
 }
 
 // testAIConnection tests the OpenAI API connection
@@ -72,7 +71,7 @@ func (s *Server) testAIConnection(c *gin.Context) {
 	}
 
 	if apiKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "API key not provided", "success": false})
+		RespondWithBadRequest(c, "API key not provided")
 		return
 	}
 
@@ -80,11 +79,11 @@ func (s *Server) testAIConnection(c *gin.Context) {
 	parser := ai.NewOpenAIParser(apiKey, true)
 	if err := parser.TestConnection(c.Request.Context()); err != nil {
 		log.Printf("[ERROR] connection test failed: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "connection test failed", "success": false})
+		RespondWithInternalError(c, "connection test failed")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"success": true, "message": "OpenAI connection successful"})
+	RespondWithOK(c, gin.H{"success": true, "message": "OpenAI connection successful"})
 }
 
 // testMetadataSource tests a metadata source API key by performing a simple search.
@@ -94,11 +93,11 @@ func (s *Server) testMetadataSource(c *gin.Context) {
 		APIKey   string `json:"api_key"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil || req.SourceID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "source_id is required", "success": false})
+		RespondWithBadRequest(c, "source_id is required")
 		return
 	}
 	if req.APIKey == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "api_key is required", "success": false})
+		RespondWithBadRequest(c, "api_key is required")
 		return
 	}
 
@@ -109,22 +108,22 @@ func (s *Server) testMetadataSource(c *gin.Context) {
 		client := metadata.NewGoogleBooksClient(req.APIKey)
 		results, err := client.SearchByTitle(testQuery)
 		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"success": false, "error": fmt.Sprintf("Google Books API error: %v", err)})
+			RespondWithOK(c, gin.H{"success": false, "error": fmt.Sprintf("Google Books API error: %v", err)})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"success": true, "message": fmt.Sprintf("Google Books connection successful (%d results)", len(results))})
+		RespondWithOK(c, gin.H{"success": true, "message": fmt.Sprintf("Google Books connection successful (%d results)", len(results))})
 
 	case "hardcover":
 		client := metadata.NewHardcoverClient(req.APIKey)
 		results, err := client.SearchByTitle(testQuery)
 		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"success": false, "error": fmt.Sprintf("Hardcover API error: %v", err)})
+			RespondWithOK(c, gin.H{"success": false, "error": fmt.Sprintf("Hardcover API error: %v", err)})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"success": true, "message": fmt.Sprintf("Hardcover connection successful (%d results)", len(results))})
+		RespondWithOK(c, gin.H{"success": true, "message": fmt.Sprintf("Hardcover connection successful (%d results)", len(results))})
 
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unknown source: %s", req.SourceID), "success": false})
+		RespondWithBadRequest(c, fmt.Sprintf("unknown source: %s", req.SourceID))
 	}
 }
 
@@ -133,21 +132,21 @@ func (s *Server) parseAudiobookWithAI(c *gin.Context) {
 	id := c.Param("id")
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	// Get the book
 	book, err := s.Store().GetBookByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", id)
 		return
 	}
 
 	// Create AI parser
 	parser := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 	if !parser.IsEnabled() {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "AI parsing is not enabled or API key not configured"})
+		RespondWithBadRequest(c, "AI parsing is not enabled or API key not configured")
 		return
 	}
 
@@ -208,7 +207,7 @@ func (s *Server) parseAudiobookWithAI(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message":    "audiobook updated with AI-parsed metadata",
 		"book":       enrichBookForResponse(updatedBook),
 		"confidence": metadata.Confidence,
@@ -218,7 +217,7 @@ func (s *Server) parseAudiobookWithAI(c *gin.Context) {
 // startAIScan kicks off a new multi-pass AI author dedup scan.
 func (s *Server) startAIScan(c *gin.Context) {
 	if s.pipelineManager == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "AI scan pipeline not configured"})
+		RespondWithInternalError(c, "AI scan pipeline not configured")
 		return
 	}
 	var req struct {
@@ -235,13 +234,13 @@ func (s *Server) startAIScan(c *gin.Context) {
 		internalError(c, "failed to start AI scan", err)
 		return
 	}
-	c.JSON(http.StatusAccepted, scan)
+	RespondWithSuccess(c, 202, scan)
 }
 
 // listAIScans returns all AI scan pipeline runs.
 func (s *Server) listAIScans(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusOK, gin.H{"scans": []interface{}{}})
+		RespondWithOK(c, gin.H{"scans": []interface{}{}})
 		return
 	}
 	scans, err := s.aiScanStore.ListScans()
@@ -252,18 +251,18 @@ func (s *Server) listAIScans(c *gin.Context) {
 	if scans == nil {
 		scans = []database.Scan{}
 	}
-	c.JSON(http.StatusOK, gin.H{"scans": scans})
+	RespondWithOK(c, gin.H{"scans": scans})
 }
 
 // getAIScan returns a single scan with its phases.
 func (s *Server) getAIScan(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan store not configured"})
+		RespondWithNotFound(c, "scan store", "")
 		return
 	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+		RespondWithBadRequest(c, "invalid scan ID")
 		return
 	}
 	scan, err := s.aiScanStore.GetScan(id)
@@ -272,22 +271,22 @@ func (s *Server) getAIScan(c *gin.Context) {
 		return
 	}
 	if scan == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
+		RespondWithNotFound(c, "scan", "")
 		return
 	}
 	phases, _ := s.aiScanStore.GetPhases(id)
-	c.JSON(http.StatusOK, gin.H{"scan": scan, "phases": phases})
+	RespondWithOK(c, gin.H{"scan": scan, "phases": phases})
 }
 
 // getAIScanResults returns results for a scan, with optional agreement filter.
 func (s *Server) getAIScanResults(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan store not configured"})
+		RespondWithNotFound(c, "scan store", "")
 		return
 	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+		RespondWithBadRequest(c, "invalid scan ID")
 		return
 	}
 	results, err := s.aiScanStore.GetScanResults(id)
@@ -311,25 +310,25 @@ func (s *Server) getAIScanResults(c *gin.Context) {
 	if results == nil {
 		results = []database.ScanResult{}
 	}
-	c.JSON(http.StatusOK, gin.H{"results": results})
+	RespondWithOK(c, gin.H{"results": results})
 }
 
 // applyAIScanResults marks selected scan results as applied.
 func (s *Server) applyAIScanResults(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan store not configured"})
+		RespondWithNotFound(c, "scan store", "")
 		return
 	}
 	scanID, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+		RespondWithBadRequest(c, "invalid scan ID")
 		return
 	}
 	var req struct {
 		ResultIDs []int `json:"result_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 
@@ -343,59 +342,59 @@ func (s *Server) applyAIScanResults(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"applied": applied, "errors": errors})
+	RespondWithOK(c, gin.H{"applied": applied, "errors": errors})
 }
 
 // deleteAIScan removes a scan and all its associated data.
 func (s *Server) deleteAIScan(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan store not configured"})
+		RespondWithNotFound(c, "scan store", "")
 		return
 	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+		RespondWithBadRequest(c, "invalid scan ID")
 		return
 	}
 	if err := s.aiScanStore.DeleteScan(id); err != nil {
 		internalError(c, "failed to delete AI scan", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+	RespondWithOK(c, gin.H{"status": "deleted"})
 }
 
 // cancelAIScan cancels a running AI scan, including any in-flight batch jobs.
 func (s *Server) cancelAIScan(c *gin.Context) {
 	if s.pipelineManager == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "AI scan pipeline not configured"})
+		RespondWithInternalError(c, "AI scan pipeline not configured")
 		return
 	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+		RespondWithBadRequest(c, "invalid scan ID")
 		return
 	}
 	if err := s.pipelineManager.CancelScan(id); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		RespondWithNotFound(c, "scan", "")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"status": "canceled"})
+	RespondWithOK(c, gin.H{"status": "canceled"})
 }
 
 // compareAIScans compares results between two scans.
 func (s *Server) compareAIScans(c *gin.Context) {
 	if s.aiScanStore == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "scan store not configured"})
+		RespondWithNotFound(c, "scan store", "")
 		return
 	}
 	aID, err := strconv.Atoi(c.Query("a"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID 'a'"})
+		RespondWithBadRequest(c, "invalid scan ID 'a'")
 		return
 	}
 	bID, err := strconv.Atoi(c.Query("b"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID 'b'"})
+		RespondWithBadRequest(c, "invalid scan ID 'b'")
 		return
 	}
 
@@ -428,7 +427,7 @@ func (s *Server) compareAIScans(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"new_in_b":        newInB,
 		"resolved_from_a": resolvedFromA,
 		"unchanged":       unchanged,
@@ -438,12 +437,12 @@ func (s *Server) compareAIScans(c *gin.Context) {
 func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 	parser := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 	if !parser.IsEnabled() {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "AI parsing is not enabled"})
+		RespondWithBadRequest(c, "AI parsing is not enabled")
 		return
 	}
 
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -457,7 +456,7 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 		mode = "groups"
 	}
 	if mode != "full" && mode != "groups" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid mode %q; must be full or groups", mode)})
+		RespondWithBadRequest(c, fmt.Sprintf("invalid mode %q; must be full or groups", mode))
 		return
 	}
 
@@ -468,7 +467,7 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 	recentOps, _, _ := store.ListOperations(50, 0)
 	for _, existing := range recentOps {
 		if existing.Type == opType && (existing.Status == "pending" || existing.Status == "running") {
-			c.JSON(http.StatusAccepted, existing)
+			RespondWithSuccess(c, 202, existing)
 			return
 		}
 	}
@@ -505,7 +504,7 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 		}
 		if len(dedupGroups) == 0 {
-			c.JSON(http.StatusOK, gin.H{"message": "no duplicate groups to review"})
+			RespondWithOK(c, gin.H{"message": "no duplicate groups to review"})
 			return
 		}
 	}
@@ -532,7 +531,7 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // aiReviewGroupsMode is the existing Groups mode — local heuristics build groups, AI validates.
@@ -720,17 +719,17 @@ func (s *Server) applyAIAuthorReview(c *gin.Context) {
 		} `json:"suggestions"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if len(req.Suggestions) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no suggestions provided"})
+		RespondWithBadRequest(c, "no suggestions provided")
 		return
 	}
 
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -920,5 +919,5 @@ func (s *Server) applyAIAuthorReview(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }

--- a/internal/server/e2e_workflow_test.go
+++ b/internal/server/e2e_workflow_test.go
@@ -52,9 +52,11 @@ func TestE2E_ITunesImportOrganizeWriteBack(t *testing.T) {
 	server.router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import",
 		strings.NewReader(importBody)))
 	require.Equal(t, http.StatusAccepted, w.Code)
-	var importResp map[string]string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &importResp))
-	testutil.WaitForOp(t, env.Store, importResp["operation_id"], 15*time.Second)
+	var respEnv map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respEnv))
+	data := respEnv["data"].(map[string]any)
+	opID := data["operation_id"].(string)
+	testutil.WaitForOp(t, env.Store, opID, 15*time.Second)
 
 	// Step 4: Verify 2 books in DB
 	books, err := env.Store.GetAllBooks(100, 0)
@@ -78,10 +80,11 @@ func TestE2E_ITunesImportOrganizeWriteBack(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 	var orgResp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &orgResp))
-	opID := ""
-	if id, ok := orgResp["id"].(string); ok {
+	orgData := orgResp["data"].(map[string]any)
+	opID = ""
+	if id, ok := orgData["id"].(string); ok {
 		opID = id
-	} else if id, ok := orgResp["operation_id"].(string); ok {
+	} else if id, ok := orgData["operation_id"].(string); ok {
 		opID = id
 	}
 	require.NotEmpty(t, opID, "organize response should contain id")

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -107,7 +107,8 @@ func TestHandler_GetOperationStatus_Found(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, "op-123", resp["id"])
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, "op-123", data["id"])
 }
 
 func TestHandler_GetOperationStatus_NotFound(t *testing.T) {
@@ -144,9 +145,10 @@ func TestHandler_ListOperations_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	items := resp["items"].([]any)
+	data := resp["data"].(map[string]any)
+	items := data["items"].([]any)
 	assert.Len(t, items, 2)
-	assert.Equal(t, float64(2), resp["total"])
+	assert.Equal(t, float64(2), data["total"])
 }
 
 func TestHandler_ListOperations_StoreError(t *testing.T) {
@@ -183,7 +185,8 @@ func TestHandler_GetOperationLogs_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(2), resp["count"])
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(2), data["count"])
 }
 
 func TestHandler_GetOperationLogs_WithTail(t *testing.T) {
@@ -205,7 +208,8 @@ func TestHandler_GetOperationLogs_WithTail(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(1), resp["count"])
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, float64(1), data["count"])
 }
 
 // =============== getOperationResult ===============
@@ -226,7 +230,8 @@ func TestHandler_GetOperationResult_WithData(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.NotNil(t, resp["result_data"])
+	data := resp["data"].(map[string]any)
+	assert.NotNil(t, data["result_data"])
 }
 
 func TestHandler_GetOperationResult_NoData(t *testing.T) {

--- a/internal/server/itunes_error_test.go
+++ b/internal/server/itunes_error_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_error_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-2345-678901abcdef
 
 package server
@@ -37,8 +37,11 @@ func TestITunesImport_CorruptXML(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, w.Code) // async, so it accepts
 
 	// Wait for operation to complete (should fail)
-	var resp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var respBody struct {
+		Data ITunesImportResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respBody))
+	resp := respBody.Data
 	testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
 
 	// Verify operation failed
@@ -76,8 +79,11 @@ func TestITunesImport_EmptyXML(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusAccepted, w.Code)
 
-	var resp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var respBody struct {
+		Data ITunesImportResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respBody))
+	resp := respBody.Data
 	testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
 
 	// Should complete with 0 books
@@ -114,8 +120,11 @@ func TestITunesImport_MissingFilesPartial(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusAccepted, w.Code)
 
-	var resp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var respBody struct {
+		Data ITunesImportResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respBody))
+	resp := respBody.Data
 	testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
 
 	// Should have imported the existing book, failed on the missing ones
@@ -258,8 +267,11 @@ func TestITunesImport_RealTestLibrary(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusAccepted, w.Code)
 
-	var resp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var respBody struct {
+		Data ITunesImportResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respBody))
+	resp := respBody.Data
 	testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
 
 	// Operation should complete (files don't exist, so tracks will fail with "file does not exist")

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_handlers.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
 
 // iTunes HTTP handlers. All business logic lives in internal/itunes/service.
@@ -26,11 +26,11 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
-// itunesEnabledOrError writes a 503 and returns false when the iTunes service
+// itunesEnabledOrError returns false and sends a 503 error when the iTunes service
 // is nil or disabled. Callers should return immediately on false.
 func (s *Server) itunesEnabledOrError(c *gin.Context) bool {
 	if s.itunesSvc == nil || !s.itunesSvc.Enabled() {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": itunesservice.ErrITunesDisabled.Error()})
+		RespondWithServiceUnavailable(c, itunesservice.ErrITunesDisabled.Error())
 		return false
 	}
 	return true
@@ -165,7 +165,7 @@ type ITunesSyncResponse struct {
 func (s *Server) handleITunesValidate(c *gin.Context) {
 	var req ITunesValidateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -180,14 +180,14 @@ func (s *Server) handleITunesValidate(c *gin.Context) {
 	})
 	if err != nil {
 		if errors.Is(err, itunesservice.ErrLibraryNotFound) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			RespondWithBadRequest(c, err.Error())
 		} else {
 			internalError(c, "validation failed", err)
 		}
 		return
 	}
 
-	c.JSON(http.StatusOK, ITunesValidateResponse{
+	RespondWithOK(c, ITunesValidateResponse{
 		TotalTracks:     resp.TotalTracks,
 		AudiobookTracks: resp.AudiobookTracks,
 		AudiobookCount:  resp.AudiobookCount,
@@ -204,7 +204,7 @@ func (s *Server) handleITunesValidate(c *gin.Context) {
 func (s *Server) handleITunesTestMapping(c *gin.Context) {
 	var req ITunesTestMappingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -214,7 +214,7 @@ func (s *Server) handleITunesTestMapping(c *gin.Context) {
 		To:          req.To,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) handleITunesTestMapping(c *gin.Context) {
 	for i, e := range resp.Examples {
 		examples[i] = ITunesTestExample{Title: e.Title, Path: e.Path}
 	}
-	c.JSON(http.StatusOK, ITunesTestMappingResponse{
+	RespondWithOK(c, ITunesTestMappingResponse{
 		Tested:   resp.Tested,
 		Found:    resp.Found,
 		Examples: examples,
@@ -235,22 +235,22 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
 	var req ITunesImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if _, err := os.Stat(req.LibraryPath); os.IsNotExist(err) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "iTunes library file not found"})
+		RespondWithBadRequest(c, "iTunes library file not found")
 		return
 	}
 
@@ -284,7 +284,7 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, ITunesImportResponse{
+	RespondWithSuccess(c, http.StatusAccepted, ITunesImportResponse{
 		OperationID: op.ID,
 		Status:      "queued",
 		Message:     "iTunes import operation queued",
@@ -294,18 +294,18 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 // handleITunesWriteBack updates the iTunes ITL binary with new file paths.
 func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	var req ITunesWriteBackRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if !config.AppConfig.ITLWriteBackEnabled || config.AppConfig.ITunesLibraryWritePath == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ITL write-back is not enabled in config"})
+		RespondWithBadRequest(c, "ITL write-back is not enabled in config")
 		return
 	}
 
@@ -320,9 +320,7 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	for _, id := range req.AudiobookIDs {
 		book, err := s.Store().GetBookByID(id)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": fmt.Sprintf("failed to get audiobook %s: %v", id, err),
-			})
+			RespondWithInternalError(c, fmt.Sprintf("failed to get audiobook %s: %v", id, err))
 			return
 		}
 		if book == nil || book.ITunesPersistentID == nil || *book.ITunesPersistentID == "" {
@@ -337,7 +335,7 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	}
 
 	if len(itlUpdates) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no audiobooks with iTunes persistent IDs found"})
+		RespondWithBadRequest(c, "no audiobooks with iTunes persistent IDs found")
 		return
 	}
 
@@ -345,22 +343,18 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	itlResult, itlErr := itunes.UpdateITLLocations(itlPath, itlPath+".tmp", itlUpdates)
 	if itlErr != nil {
 		stdlog.Printf("[WARN] ITL write-back failed: %v", itlErr)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": fmt.Sprintf("ITL write-back failed: %v", itlErr),
-		})
+		RespondWithInternalError(c, fmt.Sprintf("ITL write-back failed: %v", itlErr))
 		return
 	}
 
 	if renameErr := itunes.RenameITLFile(itlPath+".tmp", itlPath); renameErr != nil {
 		stdlog.Printf("[WARN] ITL rename failed: %v", renameErr)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": fmt.Sprintf("ITL rename failed: %v", renameErr),
-		})
+		RespondWithInternalError(c, fmt.Sprintf("ITL rename failed: %v", renameErr))
 		return
 	}
 
 	stdlog.Printf("[INFO] ITL write-back: updated %d tracks", itlResult.UpdatedCount)
-	c.JSON(http.StatusOK, ITunesWriteBackResponse{
+	RespondWithOK(c, ITunesWriteBackResponse{
 		Success:      true,
 		UpdatedCount: itlResult.UpdatedCount,
 		Message:      fmt.Sprintf("Successfully updated %d audiobook locations in ITL", itlResult.UpdatedCount),
@@ -373,35 +367,35 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	if !config.AppConfig.ITLWriteBackEnabled {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ITL write-back is not enabled in config"})
+		RespondWithBadRequest(c, "ITL write-back is not enabled in config")
 		return
 	}
 
 	itlPath := config.AppConfig.ITunesLibraryWritePath
 	if itlPath == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no ITL library path configured"})
+		RespondWithBadRequest(c, "no ITL library path configured")
 		return
 	}
 
 	if _, err := os.Stat(itlPath); os.IsNotExist(err) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ITL file not found at configured path"})
+		RespondWithBadRequest(c, "ITL file not found at configured path")
 		return
 	}
 
 	if err := itunesservice.CheckITLConflict(itlPath); err != nil {
-		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+		RespondWithConflict(c, err.Error())
 		return
 	}
 
 	itlUpdates, writtenBookIDs := s.itunesSvc.Importer.CollectITLUpdatesWithBookIDs()
 
 	if len(itlUpdates) == 0 {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"success":       true,
 			"updated_count": 0,
 			"message":       "no books with iTunes persistent IDs found",
@@ -411,16 +405,12 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 
 	itlResult, itlErr := itunes.UpdateITLLocations(itlPath, itlPath+".tmp", itlUpdates)
 	if itlErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": fmt.Sprintf("ITL write-back failed: %v", itlErr),
-		})
+		RespondWithInternalError(c, fmt.Sprintf("ITL write-back failed: %v", itlErr))
 		return
 	}
 
 	if renameErr := itunes.RenameITLFile(itlPath+".tmp", itlPath); renameErr != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": fmt.Sprintf("ITL rename failed: %v", renameErr),
-		})
+		RespondWithInternalError(c, fmt.Sprintf("ITL rename failed: %v", renameErr))
 		return
 	}
 
@@ -431,7 +421,7 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 		stdlog.Printf("[INFO] Marked %d books as iTunes-synced after write-back", n)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"success":       true,
 		"updated_count": itlResult.UpdatedCount,
 		"total_books":   len(itlUpdates),
@@ -442,18 +432,18 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 // handleITunesWriteBackPreview returns a comparison of local paths vs iTunes paths.
 func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	var req ITunesWriteBackPreviewRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
 	if _, err := os.Stat(req.LibraryPath); os.IsNotExist(err) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "iTunes library file not found"})
+		RespondWithBadRequest(c, "iTunes library file not found")
 		return
 	}
 
@@ -526,7 +516,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, ITunesWriteBackPreviewResponse{
+	RespondWithOK(c, ITunesWriteBackPreviewResponse{
 		Items: items,
 		Total: len(items),
 	})
@@ -535,7 +525,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 // handleListITunesBooks returns paginated books that have iTunes persistent IDs.
 func (s *Server) handleListITunesBooks(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -601,7 +591,7 @@ func (s *Server) handleListITunesBooks(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"items": items,
 		"count": total,
 	})
@@ -613,21 +603,21 @@ func (s *Server) handleITunesImportStatus(c *gin.Context) {
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	opID := c.Param("id")
 	op, err := s.Store().GetOperationByID(opID)
 	if err != nil || op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", opID)
 		return
 	}
 
 	progress := calculatePercent(op.Progress, op.Total)
 	snapshot := s.itunesSvc.Importer.GetStatus(op.ID)
 
-	c.JSON(http.StatusOK, ITunesImportStatusResponse{
+	RespondWithOK(c, ITunesImportStatusResponse{
 		OperationID: op.ID,
 		Status:      op.Status,
 		Progress:    progress,
@@ -646,7 +636,7 @@ func (s *Server) handleITunesImportStatusBulk(c *gin.Context) {
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -654,7 +644,7 @@ func (s *Server) handleITunesImportStatusBulk(c *gin.Context) {
 		IDs []string `json:"ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -685,19 +675,19 @@ func (s *Server) handleITunesImportStatusBulk(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"statuses": results})
+	RespondWithOK(c, gin.H{"statuses": results})
 }
 
 // handleITunesLibraryStatus returns the current status of an iTunes library file.
 func (s *Server) handleITunesLibraryStatus(c *gin.Context) {
 	path := c.Query("path")
 	if path == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "path query parameter required"})
+		RespondWithBadRequest(c, "path query parameter required")
 		return
 	}
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -711,7 +701,7 @@ func (s *Server) handleITunesLibraryStatus(c *gin.Context) {
 	fileExists := statErr == nil
 
 	if rec == nil {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"path":        path,
 			"exists":      fileExists,
 			"last_synced": nil,
@@ -725,7 +715,7 @@ func (s *Server) handleITunesLibraryStatus(c *gin.Context) {
 		changed = stat.Size() != rec.Size || !stat.ModTime().Equal(rec.ModTime)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"path":        path,
 		"exists":      fileExists,
 		"last_synced": rec.ModTime,
@@ -740,11 +730,11 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -761,12 +751,12 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		libraryPath = s.itunesSvc.Importer.DiscoverLibraryPath()
 	}
 	if libraryPath == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no iTunes library path configured or provided"})
+		RespondWithBadRequest(c, "no iTunes library path configured or provided")
 		return
 	}
 
 	if _, err := os.Stat(libraryPath); os.IsNotExist(err) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "iTunes library file not found"})
+		RespondWithBadRequest(c, "iTunes library file not found")
 		return
 	}
 
@@ -774,7 +764,7 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		if rec, err := s.Store().GetLibraryFingerprint(libraryPath); err == nil && rec != nil {
 			if info, statErr := os.Stat(libraryPath); statErr == nil {
 				if info.Size() == rec.Size && info.ModTime().Equal(rec.ModTime) {
-					c.JSON(http.StatusOK, gin.H{"message": "no changes detected — use force:true to sync anyway", "operation_id": ""})
+					RespondWithOK(c, gin.H{"message": "no changes detected — use force:true to sync anyway", "operation_id": ""})
 					return
 				}
 			}
@@ -807,7 +797,7 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, ITunesSyncResponse{
+	RespondWithSuccess(c, http.StatusAccepted, ITunesSyncResponse{
 		OperationID: op.ID,
 		Message:     "iTunes sync operation queued",
 	})

--- a/internal/server/itunes_integration_test.go
+++ b/internal/server/itunes_integration_test.go
@@ -59,10 +59,12 @@ func TestITunesImport_FullWorkflow(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, w.Code)
 
 	// Wait for async import
-	var importResp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &importResp))
-	require.NotEmpty(t, importResp.OperationID)
-	testutil.WaitForOp(t, env.Store, importResp.OperationID, 15*time.Second)
+	var respEnv map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respEnv))
+	data := respEnv["data"].(map[string]any)
+	opID := data["operation_id"].(string)
+	require.NotEmpty(t, opID)
+	testutil.WaitForOp(t, env.Store, opID, 15*time.Second)
 
 	// Verify books in database
 	books, err := env.Store.GetAllBooks(100, 0)
@@ -119,9 +121,11 @@ func TestITunesImport_OrganizeMode(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusAccepted, w.Code)
 
-	var resp ITunesImportResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
+	var respEnv map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &respEnv))
+	data := respEnv["data"].(map[string]any)
+	opID := data["operation_id"].(string)
+	testutil.WaitForOp(t, env.Store, opID, 15*time.Second)
 
 	// Verify book was imported and organized
 	books, err := env.Store.GetAllBooks(100, 0)
@@ -159,9 +163,11 @@ func TestITunesImport_SkipDuplicates(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		server.router.ServeHTTP(w, req)
-		var resp ITunesImportResponse
-		json.Unmarshal(w.Body.Bytes(), &resp)
-		testutil.WaitForOp(t, env.Store, resp.OperationID, 15*time.Second)
+		var wrapper struct {
+			Data ITunesImportResponse `json:"data"`
+		}
+		json.Unmarshal(w.Body.Bytes(), &wrapper)
+		testutil.WaitForOp(t, env.Store, wrapper.Data.OperationID, 15*time.Second)
 		books, _ := env.Store.GetAllBooks(100, 0)
 		return len(books)
 	}
@@ -203,9 +209,10 @@ func TestITunesWriteBack(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	// Without ITL configured, endpoint returns 400
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	var resp map[string]string
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Contains(t, resp["error"], "ITL write-back is not enabled")
+	errMsg, _ := resp["error"].(string)
+	assert.Contains(t, errMsg, "ITL write-back is not enabled")
 }
 
 func TestITunesValidate_Endpoint(t *testing.T) {
@@ -231,8 +238,11 @@ func TestITunesValidate_Endpoint(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp ITunesValidateResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var wrapper struct {
+		Data ITunesValidateResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 	assert.Equal(t, 2, resp.AudiobookTracks)
 	assert.Equal(t, 1, resp.FilesFound)
 	assert.Equal(t, 1, resp.FilesMissing)

--- a/internal/server/itunes_test.go
+++ b/internal/server/itunes_test.go
@@ -119,10 +119,13 @@ func TestITunesSyncForceFlag_NoChanges(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+	var wrapper struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+	resp := wrapper.Data
 	msg, _ := resp["message"].(string)
 	if !strings.Contains(msg, "no changes detected") {
 		t.Errorf("expected 'no changes detected' in message, got %q", msg)
@@ -170,10 +173,13 @@ func TestITunesSyncForceFlag_Bypass(t *testing.T) {
 		t.Fatalf("expected 202 (Accepted), got %d: %s", w.Code, w.Body.String())
 	}
 
-	var resp map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+	var wrapper struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrapper); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
+	resp := wrapper.Data
 	opID, _ := resp["operation_id"].(string)
 	if opID == "" {
 		t.Errorf("expected non-empty operation_id when force=true")

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 1.3.0
+// version: 2.0.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -34,7 +33,7 @@ import (
 // batchUpdateMetadata handles batch metadata updates with validation
 func (s *Server) batchUpdateMetadata(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -44,7 +43,7 @@ func (s *Server) batchUpdateMetadata(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -61,9 +60,9 @@ func (s *Server) batchUpdateMetadata(c *gin.Context) {
 			errorMessages[i] = err.Error()
 		}
 		response["errors"] = errorMessages
-		c.JSON(http.StatusPartialContent, response)
+		RespondWithSuccess(c, 206, response)
 	} else {
-		c.JSON(http.StatusOK, response)
+		RespondWithOK(c, response)
 	}
 }
 
@@ -74,7 +73,7 @@ func (s *Server) validateMetadata(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -86,12 +85,9 @@ func (s *Server) validateMetadata(c *gin.Context) {
 		for i, err := range errors {
 			errorMessages[i] = err.Error()
 		}
-		c.JSON(http.StatusBadRequest, gin.H{
-			"valid":  false,
-			"errors": errorMessages,
-		})
+		RespondWithBadRequest(c, fmt.Sprintf("validation errors: %v", errorMessages))
 	} else {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"valid":   true,
 			"message": "metadata is valid",
 		})
@@ -101,7 +97,7 @@ func (s *Server) validateMetadata(c *gin.Context) {
 // exportMetadata exports all audiobook metadata
 func (s *Server) exportMetadata(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -119,13 +115,13 @@ func (s *Server) exportMetadata(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, exportData)
+	RespondWithOK(c, exportData)
 }
 
 // importMetadata imports audiobook metadata
 func (s *Server) importMetadata(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -135,7 +131,7 @@ func (s *Server) importMetadata(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -151,9 +147,9 @@ func (s *Server) importMetadata(c *gin.Context) {
 			errorMessages[i] = err.Error()
 		}
 		response["errors"] = errorMessages
-		c.JSON(http.StatusPartialContent, response)
+		RespondWithSuccess(c, 206, response)
 	} else {
-		c.JSON(http.StatusOK, response)
+		RespondWithOK(c, response)
 	}
 }
 
@@ -163,7 +159,7 @@ func (s *Server) searchMetadata(c *gin.Context) {
 	author := c.Query("author")
 
 	if title == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title parameter required"})
+		RespondWithBadRequest(c, "title parameter required")
 		return
 	}
 
@@ -184,7 +180,7 @@ func (s *Server) searchMetadata(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"results": results,
 		"source":  "Open Library",
 	})
@@ -195,13 +191,13 @@ func (s *Server) fetchAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	resp, err := s.metadataFetchService.FetchMetadataForBook(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		RespondWithError(c, 404, err.Error(), "NOT_FOUND")
 		return
 	}
 
@@ -215,7 +211,7 @@ func (s *Server) fetchAudiobookMetadata(c *gin.Context) {
 	if fresh, err := s.Store().GetBookByID(id); err == nil && fresh != nil {
 		enrichedBook = fresh
 	}
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message": resp.Message,
 		"book":    enrichBookForResponse(enrichedBook),
 		"source":  resp.Source,
@@ -226,7 +222,7 @@ func (s *Server) fetchAudiobookMetadata(c *gin.Context) {
 func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	var body struct {
@@ -244,7 +240,7 @@ func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 	cacheKey := fmt.Sprintf("meta_search:%s:%s:%s:%s:%s:%t",
 		id, body.Query, body.Author, body.Narrator, body.Series, body.UseRerank)
 	if cached, ok := s.listCache.Get(cacheKey); ok {
-		c.JSON(http.StatusOK, cached)
+		RespondWithOK(c, cached)
 		return
 	}
 
@@ -253,20 +249,20 @@ func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 		metafetch.SearchOptions{UseRerank: body.UseRerank},
 	)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		RespondWithError(c, 404, err.Error(), "NOT_FOUND")
 		return
 	}
 	// Cache as gin.H wrapper
 	respH := gin.H{"results": resp.Results, "query": resp.Query, "sources_tried": resp.SourcesTried, "sources_failed": resp.SourcesFailed}
 	s.listCache.Set(cacheKey, respH)
-	c.JSON(http.StatusOK, resp)
+	RespondWithOK(c, resp)
 }
 
 // applyAudiobookMetadata handles POST /api/v1/audiobooks/:id/apply-metadata.
 func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	var body struct {
@@ -275,7 +271,7 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 		WriteBack *bool             `json:"write_back"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 	resp, err := s.metadataFetchService.ApplyMetadataCandidate(id, body.Candidate, body.Fields)
@@ -313,7 +309,7 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 	if fresh, err := s.Store().GetBookByID(id); err == nil && fresh != nil {
 		enrichedBook = fresh
 	}
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message": resp.Message,
 		"book":    enrichBookForResponse(enrichedBook),
 		"source":  resp.Source,
@@ -324,14 +320,14 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 func (s *Server) markAudiobookNoMatch(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if err := s.metadataFetchService.MarkNoMatch(id); err != nil {
 		internalError(c, "failed to mark no match", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "Book marked as no match"})
+	RespondWithOK(c, gin.H{"message": "Book marked as no match"})
 }
 
 // revertAudiobookMetadata handles POST /api/v1/audiobooks/:id/revert-metadata.
@@ -339,19 +335,19 @@ func (s *Server) markAudiobookNoMatch(c *gin.Context) {
 func (s *Server) revertAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	var body struct {
 		Timestamp string `json:"timestamp"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.Timestamp == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "timestamp is required"})
+		RespondWithBadRequest(c, "timestamp is required")
 		return
 	}
 	ts, err := time.Parse(time.RFC3339Nano, body.Timestamp)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid timestamp format, use RFC3339Nano"})
+		RespondWithBadRequest(c, "invalid timestamp format, use RFC3339Nano")
 		return
 	}
 	book, err := s.Store().RevertBookToVersion(id, ts)
@@ -359,7 +355,7 @@ func (s *Server) revertAudiobookMetadata(c *gin.Context) {
 		internalError(c, "failed to revert metadata", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "Book reverted to version", "book": book})
+	RespondWithOK(c, gin.H{"message": "Book reverted to version", "book": book})
 }
 
 // listBookCOWVersions handles GET /api/v1/audiobooks/:id/cow-versions.
@@ -367,7 +363,7 @@ func (s *Server) revertAudiobookMetadata(c *gin.Context) {
 func (s *Server) listBookCOWVersions(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	limit := 50
@@ -381,7 +377,7 @@ func (s *Server) listBookCOWVersions(c *gin.Context) {
 		internalError(c, "failed to list versions", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"versions": versions})
+	RespondWithOK(c, gin.H{"versions": versions})
 }
 
 // pruneBookCOWVersions handles POST /api/v1/audiobooks/:id/cow-versions/prune.
@@ -389,14 +385,14 @@ func (s *Server) listBookCOWVersions(c *gin.Context) {
 func (s *Server) pruneBookCOWVersions(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	var body struct {
 		KeepCount int `json:"keep_count"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil || body.KeepCount <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "keep_count must be a positive integer"})
+		RespondWithBadRequest(c, "keep_count must be a positive integer")
 		return
 	}
 	pruned, err := s.Store().PruneBookSnapshots(id, body.KeepCount)
@@ -404,7 +400,7 @@ func (s *Server) pruneBookCOWVersions(c *gin.Context) {
 		internalError(c, "failed to prune versions", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"pruned": pruned})
+	RespondWithOK(c, gin.H{"pruned": pruned})
 }
 
 // writeBackAudiobookMetadata handles POST /api/v1/audiobooks/:id/write-back.
@@ -412,7 +408,7 @@ func (s *Server) pruneBookCOWVersions(c *gin.Context) {
 func (s *Server) writeBackAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book id is required"})
+		RespondWithBadRequest(c, "book id is required")
 		return
 	}
 
@@ -425,7 +421,7 @@ func (s *Server) writeBackAudiobookMetadata(c *gin.Context) {
 
 	book, err := s.Store().GetBookByID(id)
 	if err != nil || book == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "audiobook not found"})
+		RespondWithNotFound(c, "audiobook", "")
 		return
 	}
 
@@ -462,7 +458,7 @@ func (s *Server) writeBackAudiobookMetadata(c *gin.Context) {
 		msg += ", files renamed"
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"message":       msg,
 		"written_count": writtenCount,
 		"renamed":       renamed > 0,
@@ -473,17 +469,17 @@ func (s *Server) writeBackAudiobookMetadata(c *gin.Context) {
 // fields only when they are missing and not manually overridden or locked.
 func (s *Server) bulkFetchMetadata(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	var req bulkFetchMetadataRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.BookIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids is required"})
+		RespondWithBadRequest(c, "book_ids is required")
 		return
 	}
 
@@ -752,7 +748,7 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 		results = append(results, result)
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"updated_count": updatedCount,
 		"total_count":   len(req.BookIDs),
 		"results":       results,
@@ -764,11 +760,11 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 // for all books matching the provided filters (or all organized/imported books).
 func (s *Server) handleBulkWriteBack(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -838,7 +834,7 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 
 	// Dry run: just return the count
 	if req.DryRun {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"estimated_books": estimatedBooks,
 			"dry_run":         true,
 		})
@@ -846,7 +842,7 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 	}
 
 	if estimatedBooks == 0 {
-		c.JSON(http.StatusOK, gin.H{
+		RespondWithOK(c, gin.H{
 			"estimated_books": 0,
 			"message":         "no books match the given filters",
 		})
@@ -881,7 +877,7 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, gin.H{
+	RespondWithSuccess(c, 202, gin.H{
 		"operation_id":    op.ID,
 		"estimated_books": estimatedBooks,
 	})
@@ -1031,11 +1027,11 @@ func (s *Server) batchWriteBackAudiobooks(c *gin.Context) {
 		Force    bool     `json:"force"` // skip change detection, rewrite everything
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if len(req.BookIDs) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book_ids is required"})
+		RespondWithBadRequest(c, "book_ids is required")
 		return
 	}
 
@@ -1148,7 +1144,7 @@ func (s *Server) batchWriteBackAudiobooks(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"operation_id": opID,
 		"message":      fmt.Sprintf("Save to files queued for %d books", totalBooks),
 		"book_count":   totalBooks,
@@ -1227,7 +1223,7 @@ func (s *Server) getMetadataFields(c *gin.Context) {
 		},
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"fields": fields,
 	})
 }

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -30,11 +29,11 @@ import (
 
 func (s *Server) startScan(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -75,16 +74,16 @@ func (s *Server) startScan(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 func (s *Server) startOrganize(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -130,16 +129,16 @@ func (s *Server) startOrganize(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 func (s *Server) startTranscode(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		RespondWithInternalError(c, "operation queue not initialized")
 		return
 	}
 
@@ -150,13 +149,13 @@ func (s *Server) startTranscode(c *gin.Context) {
 		KeepOriginal *bool  `json:"keep_original"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil || req.BookID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "book_id is required"})
+		RespondWithBadRequest(c, "book_id is required")
 		return
 	}
 
 	// Verify the book exists
 	if _, err := s.Store().GetBookByID(req.BookID); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+		RespondWithNotFound(c, "book", req.BookID)
 		return
 	}
 
@@ -289,26 +288,26 @@ func (s *Server) startTranscode(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 func (s *Server) getOperationStatus(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	id := c.Param("id")
 	op, err := s.Store().GetOperationByID(id)
 	if err != nil || op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", id)
 		return
 	}
-	c.JSON(http.StatusOK, op)
+	RespondWithOK(c, op)
 }
 
 func (s *Server) cancelOperation(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -322,7 +321,7 @@ func (s *Server) cancelOperation(c *gin.Context) {
 				if err := s.pipelineManager.CancelScan(scan.ID); err != nil {
 					log.Printf("[cancelOperation] AI scan %d cancel warning: %v", scan.ID, err)
 				}
-				c.Status(http.StatusNoContent)
+				RespondWithNoContent(c)
 				return
 			}
 		}
@@ -331,7 +330,7 @@ func (s *Server) cancelOperation(c *gin.Context) {
 	// Try cancel via queue (for running queue operations)
 	if s.queue != nil {
 		if err := s.queue.Cancel(id); err == nil {
-			c.Status(http.StatusNoContent)
+			RespondWithNoContent(c)
 			return
 		}
 	}
@@ -341,13 +340,13 @@ func (s *Server) cancelOperation(c *gin.Context) {
 		internalError(c, "failed to cancel operation", dbErr)
 		return
 	}
-	c.Status(http.StatusNoContent)
+	RespondWithNoContent(c)
 }
 
 // clearStaleOperations force-marks all pending/running/queued operations as failed.
 func (s *Server) clearStaleOperations(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -365,20 +364,20 @@ func (s *Server) clearStaleOperations(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"cleared": cleared})
+	RespondWithOK(c, gin.H{"cleared": cleared})
 }
 
 // deleteOperationHistory deletes operations matching the given status(es).
 // Query param: ?status=completed or ?status=failed or ?status=completed,failed
 func (s *Server) deleteOperationHistory(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
 	statusParam := c.Query("status")
 	if statusParam == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "status parameter required"})
+		RespondWithBadRequest(c, "status parameter required")
 		return
 	}
 
@@ -387,7 +386,7 @@ func (s *Server) deleteOperationHistory(c *gin.Context) {
 	allowed := map[string]bool{"completed": true, "failed": true, "canceled": true}
 	for _, s := range statuses {
 		if !allowed[s] {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("cannot delete operations with status %q", s)})
+			RespondWithBadRequest(c, fmt.Sprintf("cannot delete operations with status %q", s))
 			return
 		}
 	}
@@ -398,13 +397,13 @@ func (s *Server) deleteOperationHistory(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"deleted": deleted})
+	RespondWithOK(c, gin.H{"deleted": deleted})
 }
 
 // optimizeDatabase splits &-delimited author/narrator strings and re-extracts empty media info.
 func (s *Server) optimizeDatabase(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -473,7 +472,7 @@ func (s *Server) optimizeDatabase(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"books_processed": len(books),
 		"authors_split":   authorsSplit,
 		"narrators_split": narratorsSplit,
@@ -482,7 +481,7 @@ func (s *Server) optimizeDatabase(c *gin.Context) {
 
 func (s *Server) sweepTombstones(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	result, err := SweepTombstones(s.Store())
@@ -490,7 +489,7 @@ func (s *Server) sweepTombstones(c *gin.Context) {
 		internalError(c, "failed to sweep tombstones", err)
 		return
 	}
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 // setInternalFlag sets an arbitrary internal settings flag in PebbleDB.
@@ -501,11 +500,11 @@ func (s *Server) setInternalFlag(c *gin.Context) {
 		Value string `json:"value"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if err := s.Store().SetSetting(req.Key, req.Value, "string", false); err != nil {
@@ -513,12 +512,12 @@ func (s *Server) setInternalFlag(c *gin.Context) {
 		return
 	}
 	log.Printf("[INFO] setInternalFlag: %s = %q", req.Key, req.Value)
-	c.JSON(http.StatusOK, gin.H{"key": req.Key, "value": req.Value})
+	RespondWithOK(c, gin.H{"key": req.Key, "value": req.Value})
 }
 
 func (s *Server) auditFileConsistency(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	result, err := AuditFileConsistency(s.Store())
@@ -526,7 +525,7 @@ func (s *Server) auditFileConsistency(c *gin.Context) {
 		internalError(c, "failed to audit file consistency", err)
 		return
 	}
-	c.JSON(http.StatusOK, result)
+	RespondWithOK(c, result)
 }
 
 // listActiveOperations returns a snapshot of currently queued/running operations with basic progress
@@ -534,7 +533,7 @@ func (s *Server) listOperations(c *gin.Context) {
 	params := ParsePaginationParams(c)
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusOK, gin.H{"items": []database.Operation{}, "total": 0, "limit": params.Limit, "offset": params.Offset})
+		RespondWithOK(c, gin.H{"items": []database.Operation{}, "total": 0, "limit": params.Limit, "offset": params.Offset})
 		return
 	}
 	ops, total, err := store.ListOperations(params.Limit, params.Offset)
@@ -545,12 +544,12 @@ func (s *Server) listOperations(c *gin.Context) {
 	if ops == nil {
 		ops = []database.Operation{}
 	}
-	c.JSON(http.StatusOK, gin.H{"items": ops, "total": total, "limit": params.Limit, "offset": params.Offset})
+	RespondWithOK(c, gin.H{"items": ops, "total": total, "limit": params.Limit, "offset": params.Offset})
 }
 
 func (s *Server) listActiveOperations(c *gin.Context) {
 	if s.queue == nil {
-		c.JSON(http.StatusOK, gin.H{"operations": []gin.H{}})
+		RespondWithOK(c, gin.H{"operations": []gin.H{}})
 		return
 	}
 	active := s.queue.ActiveOperations()
@@ -577,7 +576,7 @@ func (s *Server) listActiveOperations(c *gin.Context) {
 			"message":  message,
 		})
 	}
-	c.JSON(http.StatusOK, gin.H{"operations": results})
+	RespondWithOK(c, gin.H{"operations": results})
 }
 
 func (s *Server) listStaleOperations(c *gin.Context) {
@@ -593,10 +592,10 @@ func (s *Server) listStaleOperations(c *gin.Context) {
 
 	stale, err := s.collectStaleOperations(time.Duration(timeoutMinutes) * time.Minute)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list stale operations"})
+		RespondWithInternalError(c, "failed to list stale operations")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{
+	RespondWithOK(c, gin.H{
 		"timeout_minutes": timeoutMinutes,
 		"count":           len(stale),
 		"operations":      stale,
@@ -606,7 +605,7 @@ func (s *Server) listStaleOperations(c *gin.Context) {
 // getOperationLogs returns logs for a given operation
 func (s *Server) getOperationLogs(c *gin.Context) {
 	if s.Store() == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	id := c.Param("id")
@@ -621,7 +620,7 @@ func (s *Server) getOperationLogs(c *gin.Context) {
 			logs = logs[len(logs)-n:]
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"items": logs, "count": len(logs)})
+	RespondWithOK(c, gin.H{"items": logs, "count": len(logs)})
 }
 
 func (s *Server) getOperationResult(c *gin.Context) {
@@ -633,23 +632,23 @@ func (s *Server) getOperationResult(c *gin.Context) {
 		return
 	}
 	if op == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		RespondWithNotFound(c, "operation", id)
 		return
 	}
 
 	if op.ResultData == nil {
-		c.JSON(http.StatusOK, gin.H{"result_data": nil})
+		RespondWithOK(c, gin.H{"result_data": nil})
 		return
 	}
 
 	// Parse the JSON result data to return as structured JSON
 	var resultData json.RawMessage
 	if err := json.Unmarshal([]byte(*op.ResultData), &resultData); err != nil {
-		c.JSON(http.StatusOK, gin.H{"result_data": *op.ResultData})
+		RespondWithOK(c, gin.H{"result_data": *op.ResultData})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"result_data": resultData})
+	RespondWithOK(c, gin.H{"result_data": resultData})
 }
 
 // getOperationChanges returns change tracking records for an operation.
@@ -660,7 +659,7 @@ func (s *Server) getOperationChanges(c *gin.Context) {
 		internalError(c, "failed to get operation changes", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"changes": changes})
+	RespondWithOK(c, gin.H{"changes": changes})
 }
 
 // undoPreflightHandler checks for conflicts before executing an undo.
@@ -672,7 +671,7 @@ func (s *Server) undoPreflightHandler(c *gin.Context) {
 		internalError(c, "failed to check conflicts", err)
 		return
 	}
-	c.JSON(http.StatusOK, report)
+	RespondWithOK(c, report)
 }
 
 // revertOperation undoes all changes from a given operation.
@@ -683,35 +682,35 @@ func (s *Server) revertOperation(c *gin.Context) {
 		internalError(c, "failed to revert operation", err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "operation reverted successfully"})
+	RespondWithOK(c, gin.H{"message": "operation reverted successfully"})
 }
 
 // listTasks returns all registered tasks with their status and schedule.
 func (s *Server) listTasks(c *gin.Context) {
 	if s.scheduler == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "scheduler not initialized"})
+		RespondWithInternalError(c, "scheduler not initialized")
 		return
 	}
-	c.JSON(http.StatusOK, s.scheduler.ListTasks())
+	RespondWithOK(c, s.scheduler.ListTasks())
 }
 
 // runTask triggers a task by name.
 func (s *Server) runTask(c *gin.Context) {
 	if s.scheduler == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "scheduler not initialized"})
+		RespondWithInternalError(c, "scheduler not initialized")
 		return
 	}
 	name := c.Param("name")
 	op, err := s.scheduler.RunTask(name)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if op == nil {
-		c.JSON(http.StatusAccepted, gin.H{"message": "task triggered"})
+		RespondWithSuccess(c, 202, gin.H{"message": "task triggered"})
 		return
 	}
-	c.JSON(http.StatusAccepted, op)
+	RespondWithSuccess(c, 202, op)
 }
 
 // updateTaskConfig updates schedule config for a task.
@@ -725,7 +724,7 @@ func (s *Server) updateTaskConfig(c *gin.Context) {
 		RunInMaintenanceWindow *bool `json:"run_in_maintenance_window"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -834,7 +833,7 @@ func (s *Server) updateTaskConfig(c *gin.Context) {
 			config.AppConfig.MaintenanceWindowLibraryOrganize = *req.RunInMaintenanceWindow
 		}
 	default:
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("task %q config is not configurable", name)})
+		RespondWithBadRequest(c, fmt.Sprintf("task %q config is not configurable", name))
 		return
 	}
 
@@ -845,13 +844,13 @@ func (s *Server) updateTaskConfig(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "task config updated"})
+	RespondWithOK(c, gin.H{"message": "task config updated"})
 }
 
 // runMaintenanceWindowNow triggers the full maintenance window sequence immediately.
 func (s *Server) runMaintenanceWindowNow(c *gin.Context) {
 	if s.scheduler == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "scheduler not initialized"})
+		RespondWithInternalError(c, "scheduler not initialized")
 		return
 	}
 	ctx := context.WithValue(c.Request.Context(), ignoreWindowKey, true)
@@ -859,5 +858,5 @@ func (s *Server) runMaintenanceWindowNow(c *gin.Context) {
 		internalError(c, "failed to run maintenance", err)
 		return
 	}
-	c.JSON(http.StatusAccepted, gin.H{"message": "maintenance window triggered"})
+	RespondWithSuccess(c, 202, gin.H{"message": "maintenance window triggered"})
 }

--- a/internal/server/organize_integration_test.go
+++ b/internal/server/organize_integration_test.go
@@ -55,12 +55,13 @@ func TestOrganizeService_ViaHTTP(t *testing.T) {
 	// Wait for operation
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	opID, ok := resp["id"].(string)
+	data := resp["data"].(map[string]any)
+	opID, ok := data["id"].(string)
 	if !ok {
 		// Fallback: try operation_id key
-		opID, ok = resp["operation_id"].(string)
+		opID, ok = data["operation_id"].(string)
 	}
-	require.True(t, ok, "response should contain id or operation_id, got: %v", resp)
+	require.True(t, ok, "response should contain id or operation_id, got: %v", data)
 	testutil.WaitForOp(t, env.Store, opID, 15*time.Second)
 
 	// Verify book was organized — now creates a new version record

--- a/internal/server/server_ai_integration_test.go
+++ b/internal/server/server_ai_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_ai_integration_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 6d5c4b3a-2918-1706-f5e4-d3c2b1a09f8e
-// last-edited: 2026-01-24
+// last-edited: 2026-04-23
 
 package server
 
@@ -77,6 +77,13 @@ func TestAIEndpoints_WithStubbedOpenAI(t *testing.T) {
 	w := httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
+	// Response is wrapped in {"data": ...}
+	var parseResp struct {
+		Data struct {
+			Metadata map[string]interface{} `json:"metadata"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parseResp))
 
 	// 2) POST /ai/test-connection should succeed using provided api_key.
 	connBody := bytes.NewBufferString(`{"api_key":"test-key"}`)
@@ -85,6 +92,15 @@ func TestAIEndpoints_WithStubbedOpenAI(t *testing.T) {
 	w = httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
+	// Response is wrapped in {"data": ...}
+	var connResp struct {
+		Data struct {
+			Success bool   `json:"success"`
+			Message string `json:"message"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &connResp))
+	require.True(t, connResp.Data.Success)
 
 	// 3) POST /audiobooks/:id/parse-with-ai should update a book.
 	filePath := filepath.Join(t.TempDir(), "The Hobbit - J.R.R. Tolkien.m4b")
@@ -97,6 +113,15 @@ func TestAIEndpoints_WithStubbedOpenAI(t *testing.T) {
 	w = httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
+	// Response is wrapped in {"data": ...}
+	var parseABResp struct {
+		Data struct {
+			Message    string                 `json:"message"`
+			Book       map[string]interface{} `json:"book"`
+			Confidence string                 `json:"confidence"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parseABResp))
 
 	updated, err := database.GetGlobalStore().GetBookByID(book.ID)
 	require.NoError(t, err)

--- a/internal/server/server_bulk_fetch_metadata_test.go
+++ b/internal/server/server_bulk_fetch_metadata_test.go
@@ -84,23 +84,25 @@ func TestBulkFetchMetadata_MixedResults(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var resp struct {
-		UpdatedCount int `json:"updated_count"`
-		TotalCount   int `json:"total_count"`
-		Results      []struct {
-			BookID  string `json:"book_id"`
-			Status  string `json:"status"`
-			Message string `json:"message"`
-		} `json:"results"`
+		Data struct {
+			UpdatedCount int `json:"updated_count"`
+			TotalCount   int `json:"total_count"`
+			Results      []struct {
+				BookID  string `json:"book_id"`
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			} `json:"results"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 4, resp.TotalCount)
-	assert.GreaterOrEqual(t, resp.UpdatedCount, 1)
+	assert.Equal(t, 4, resp.Data.TotalCount)
+	assert.GreaterOrEqual(t, resp.Data.UpdatedCount, 1)
 
 	byID := map[string]struct {
 		Status  string
 		Message string
 	}{}
-	for _, r := range resp.Results {
+	for _, r := range resp.Data.Results {
 		byID[r.BookID] = struct {
 			Status  string
 			Message string

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -543,7 +543,8 @@ func TestCoverageStartOrganize(t *testing.T) {
 		assert.Equal(t, http.StatusAccepted, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotEmpty(t, resp["id"])
+		data := resp["data"].(map[string]any)
+		assert.NotEmpty(t, data["id"])
 	})
 
 	t.Run("organize with folder_path", func(t *testing.T) {
@@ -586,7 +587,8 @@ func TestCoverageListActiveOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		ops := resp["operations"].([]any)
+		data := resp["data"].(map[string]any)
+		ops := data["operations"].([]any)
 		assert.NotNil(t, ops)
 	})
 }
@@ -831,7 +833,8 @@ func TestCoverageListOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["items"])
+		data := resp["data"].(map[string]any)
+		assert.NotNil(t, data["items"])
 	})
 
 	t.Run("list operations with pagination", func(t *testing.T) {
@@ -858,7 +861,8 @@ func TestCoverageListStaleOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["operations"])
+		data := resp["data"].(map[string]any)
+		assert.NotNil(t, data["operations"])
 	})
 
 	t.Run("custom timeout", func(t *testing.T) {

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -652,9 +652,11 @@ func TestStartScanOperation(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusAccepted, w.Code)
 
-	var op database.Operation
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &op))
-	waitForOperationStatus(t, op.ID, 10*time.Second)
+	var resp struct {
+		Data database.Operation `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	waitForOperationStatus(t, resp.Data.ID, 10*time.Second)
 }
 
 func TestStartOrganizeOperation(t *testing.T) {
@@ -688,9 +690,11 @@ func TestStartOrganizeOperation(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusAccepted, w.Code)
 
-	var op database.Operation
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &op))
-	waitForOperationStatus(t, op.ID, 10*time.Second)
+	var resp struct {
+		Data database.Operation `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	waitForOperationStatus(t, resp.Data.ID, 10*time.Second)
 	waitForQueueIdle(t, server, 10*time.Second)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -721,18 +721,20 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response struct {
-		UpdatedCount int `json:"updated_count"`
-		TotalCount   int `json:"total_count"`
-		Results      []struct {
-			BookID        string   `json:"book_id"`
-			Status        string   `json:"status"`
-			AppliedFields []string `json:"applied_fields"`
-			FetchedFields []string `json:"fetched_fields"`
-		} `json:"results"`
+		Data struct {
+			UpdatedCount int `json:"updated_count"`
+			TotalCount   int `json:"total_count"`
+			Results      []struct {
+				BookID        string   `json:"book_id"`
+				Status        string   `json:"status"`
+				AppliedFields []string `json:"applied_fields"`
+				FetchedFields []string `json:"fetched_fields"`
+			} `json:"results"`
+		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.Equal(t, 2, response.TotalCount)
-	assert.Equal(t, 1, response.UpdatedCount)
+	assert.Equal(t, 2, response.Data.TotalCount)
+	assert.Equal(t, 1, response.Data.UpdatedCount)
 
 	var primaryResult, missingResult *struct {
 		BookID        string   `json:"book_id"`
@@ -740,12 +742,12 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 		AppliedFields []string `json:"applied_fields"`
 		FetchedFields []string `json:"fetched_fields"`
 	}
-	for i := range response.Results {
-		if response.Results[i].BookID == created.ID {
-			primaryResult = &response.Results[i]
+	for i := range response.Data.Results {
+		if response.Data.Results[i].BookID == created.ID {
+			primaryResult = &response.Data.Results[i]
 		}
-		if response.Results[i].BookID == other.ID {
-			missingResult = &response.Results[i]
+		if response.Data.Results[i].BookID == other.ID {
+			missingResult = &response.Data.Results[i]
 		}
 	}
 	require.NotNil(t, primaryResult)
@@ -1087,13 +1089,16 @@ func TestGetMetadataFields(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
+	var response struct {
+		Data struct {
+			Fields []any `json:"fields"`
+		} `json:"data"`
+	}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
 
 	// Verify fields structure
-	fields, ok := response["fields"].([]any)
-	assert.True(t, ok, "fields should be an array")
+	fields := response.Data.Fields
 	assert.NotNil(t, fields)
 
 	// Verify required fields are present
@@ -1110,7 +1115,7 @@ func TestGetMetadataFields(t *testing.T) {
 	}
 
 	for _, required := range requiredFields {
-		assert.True(t, fieldNames[required], "Required field %s should be present", required)
+		assert.True(t, fieldNames[required], fmt.Sprintf("Required field %s should be present", required))
 	}
 }
 
@@ -2316,11 +2321,13 @@ func TestHandleITunesImportStatus(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			validateFunc: func(t *testing.T, body []byte) {
-				var response map[string]any
-				err := json.Unmarshal(body, &response)
+				var wrapper struct {
+					Data map[string]any `json:"data"`
+				}
+				err := json.Unmarshal(body, &wrapper)
 				require.NoError(t, err)
-				assert.NotNil(t, response["operation_id"])
-				assert.NotNil(t, response["status"])
+				assert.NotNil(t, wrapper.Data["operation_id"])
+				assert.NotNil(t, wrapper.Data["status"])
 			},
 		},
 	}

--- a/internal/server/server_write_back_test.go
+++ b/internal/server/server_write_back_test.go
@@ -60,12 +60,15 @@ func TestBatchWriteBackEndpoint_ReturnsSummary(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// The endpoint is async — it returns an operation ID, not inline results
-	var resp struct {
-		OperationID string `json:"operation_id"`
-		Message     string `json:"message"`
-		BookCount   int    `json:"book_count"`
+	var wrapper struct {
+		Data struct {
+			OperationID string `json:"operation_id"`
+			Message     string `json:"message"`
+			BookCount   int    `json:"book_count"`
+		} `json:"data"`
 	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 
 	assert.NotEmpty(t, resp.OperationID)
 	assert.Equal(t, 2, resp.BookCount)

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1314,7 +1314,8 @@ export async function startScan(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start scan');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function startTranscode(
@@ -1334,7 +1335,8 @@ export async function startTranscode(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start transcode');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getOperationStatus(id: string): Promise<Operation> {
@@ -1342,7 +1344,8 @@ export async function getOperationStatus(id: string): Promise<Operation> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch operation status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Poll an operation until it completes or fails. Calls onProgress with each update.
@@ -1374,7 +1377,8 @@ export async function optimizeDatabase(): Promise<OptimizeDatabaseResult> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to optimize database');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getOperationLogs(id: string): Promise<OperationLog[]> {
@@ -1416,7 +1420,8 @@ export async function clearStaleOperations(): Promise<{ cleared: number }> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to clear stale operations');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function listOperations(limit = 50, offset = 0): Promise<{ items: Operation[]; total: number; limit: number; offset: number }> {
@@ -1424,7 +1429,8 @@ export async function listOperations(limit = 50, offset = 0): Promise<{ items: O
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch operations');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function deleteOperationHistory(
@@ -1437,7 +1443,8 @@ export async function deleteOperationHistory(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to delete operation history');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export interface OperationChange {
@@ -1541,7 +1548,8 @@ export async function startOrganize(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start organize');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getSystemLogs(params?: {
@@ -1801,7 +1809,8 @@ export async function validateITunesLibrary(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to validate iTunes library');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export interface ITunesTestMappingResponse {
@@ -1823,7 +1832,8 @@ export async function testITunesPathMapping(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to test path mapping');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function importITunesLibrary(
@@ -1837,7 +1847,8 @@ export async function importITunesLibrary(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to import iTunes library');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function writeBackITunesLibrary(
@@ -1855,7 +1866,8 @@ export async function writeBackITunesLibrary(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to write back iTunes library');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export interface ITunesBookMapping {
@@ -1881,7 +1893,8 @@ export async function getITunesBooks(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch iTunes books');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function previewITunesWriteBack(
@@ -1896,7 +1909,8 @@ export async function previewITunesWriteBack(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to preview write-back');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function startITunesSync(
@@ -1909,7 +1923,8 @@ export async function startITunesSync(
     body: JSON.stringify({ library_path: libraryPath, force: force ?? true }),
   });
   if (!response.ok) throw await buildApiError(response, 'Sync failed');
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getITunesLibraryStatus(
@@ -1921,7 +1936,8 @@ export async function getITunesLibraryStatus(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch library status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getITunesImportStatus(
@@ -1933,7 +1949,8 @@ export async function getITunesImportStatus(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch iTunes import status');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getITunesImportStatusBulk(
@@ -1948,7 +1965,7 @@ export async function getITunesImportStatusBulk(
     throw await buildApiError(response, 'Failed to fetch bulk import status');
   }
   const data = await response.json();
-  return data.statuses || {};
+  return data.data.statuses || {};
 }
 
 // Series dedup
@@ -2141,7 +2158,8 @@ export async function searchMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to search metadata');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function fetchBookMetadata(
@@ -2156,7 +2174,8 @@ export async function fetchBookMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch metadata');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function searchMetadataForBook(
@@ -2189,7 +2208,8 @@ export async function searchMetadataForBook(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to search metadata');
   }
-  return response.json();
+  const responseBody = await response.json();
+  return responseBody.data;
 }
 
 export async function applyMetadataCandidate(
@@ -2216,7 +2236,8 @@ export async function applyMetadataCandidate(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to apply metadata');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function markNoMatch(bookId: string): Promise<void> {
@@ -2266,7 +2287,8 @@ export async function writeBackMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to write metadata to files');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function batchWriteBackMetadata(
@@ -2282,7 +2304,8 @@ export async function batchWriteBackMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to write metadata to files');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Bulk write-back (async operation for all/filtered books)
@@ -2316,7 +2339,8 @@ export async function bulkWriteBackMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start bulk write-back');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Extract track info from filenames
@@ -2336,7 +2360,8 @@ export async function extractTrackInfo(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to extract track info');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // File Relocation
@@ -2366,7 +2391,8 @@ export async function relocateBookFiles(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to relocate files');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Bulk Metadata Fetching
@@ -2397,7 +2423,8 @@ export async function bulkFetchMetadata(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to bulk fetch metadata');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // AI Parsing
@@ -2423,7 +2450,8 @@ export async function parseFilenameWithAI(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to parse filename with AI');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function testMetadataSource(
@@ -2437,7 +2465,8 @@ export async function testMetadataSource(
     },
     body: JSON.stringify({ source_id: sourceId, api_key: apiKey }),
   });
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function testAIConnection(
@@ -2454,7 +2483,8 @@ export async function testAIConnection(
     const data = await response.json();
     throw new Error(data.error || 'Connection test failed');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function parseAudiobookWithAI(
@@ -2469,7 +2499,8 @@ export async function parseAudiobookWithAI(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to parse audiobook with AI');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // Filesystem Browsing
@@ -3133,7 +3164,8 @@ export async function requestAIAuthorReview(mode: AIReviewMode = 'groups'): Prom
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start AI author review');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function getOperationResult(id: string): Promise<{ result_data: unknown }> {
@@ -3155,7 +3187,8 @@ export async function applyAIAuthorReview(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to apply AI author review');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // --- AI Scan Pipeline Types ---
@@ -3218,7 +3251,8 @@ export async function startAIScan(mode: 'batch' | 'realtime'): Promise<AIScan> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to start AI scan');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function listAIScans(): Promise<AIScan[]> {
@@ -3226,7 +3260,8 @@ export async function listAIScans(): Promise<AIScan[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to list AI scans');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return data.scans || [];
 }
 
@@ -3235,7 +3270,8 @@ export async function getAIScan(id: number): Promise<AIScanDetail> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to get AI scan');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return { ...data.scan, phases: data.phases || [] };
 }
 
@@ -3245,7 +3281,8 @@ export async function getAIScanResults(id: number, agreement?: string): Promise<
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to get scan results');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data;
   return data.results || [];
 }
 
@@ -3258,7 +3295,8 @@ export async function applyAIScanResults(scanID: number, resultIDs: number[]): P
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to apply scan results');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 export async function cancelAIScan(id: number): Promise<void> {
@@ -3280,7 +3318,8 @@ export async function compareAIScans(a: number, b: number): Promise<AIScanCompar
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to compare scans');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // --- Rename Preview & Apply ---


### PR DESCRIPTION
Continues [TODO 4.15](../blob/main/TODO.md). Wave 4 of parallel Haiku dispatch (biggest wave: ~212 callsites).

### Handlers migrated
- **operations_handlers.go** — 24 handlers / 56 callsites; 8 api.ts unwraps
- **ai_handlers.go** — 17 handlers / 53 callsites (AI scan lifecycle, LLM, duplicates review); 12 api.ts unwraps
- **metadata_handlers.go** — 52 callsites across 24 metadata endpoints; 8 api.ts unwraps
- **itunes_handlers.go** — 12 handlers / 51 callsites (XML import, write-back, sync); 11 api.ts unwraps

### Coordinator fixes
iTunes integration tests, iTunes sync force-flag tests, batch write-back test, iTunes import-status test — all updated to decode envelope.

## Test plan
- [x] go build, go vet, tsc --noEmit all clean
- [x] `go test -run 'Operation|Scan|Organize|Transcode|AI|Ai|LLM|Llm|Batch|Metadata|Fetch|Provider|TagCompar|ITunes|Itunes|PID|Reconcile|Workflow|WriteBack'` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)