### PR TITLE
fix(tests): resolve pre-existing + envelope-migration test fallout

### DIFF
--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -372,6 +372,8 @@ func (s *SQLiteStore) createTables() error {
 		last_organize_operation_id TEXT,
 		last_organized_at DATETIME,
 		itunes_sync_status TEXT,
+		quarantine_reason TEXT,
+		quarantined_at TIMESTAMP,
 		FOREIGN KEY (author_id) REFERENCES authors(id),
 		FOREIGN KEY (series_id) REFERENCES series(id)
 	);

--- a/internal/database/store_coverage_test.go
+++ b/internal/database/store_coverage_test.go
@@ -906,9 +906,17 @@ func TestCoverage_PathHistory(t *testing.T) {
 
 	history, err := store.GetBookPathHistory(bookID)
 	require.NoError(t, err)
-	assert.Len(t, history, 1)
-	assert.Equal(t, "/tmp/old.m4b", history[0].OldPath)
-	assert.Equal(t, "/library/new.m4b", history[0].NewPath)
+	// CreateBook records an implicit import entry; find the "organize" one.
+	var organizeEntry *BookPathChange
+	for i, h := range history {
+		if h.ChangeType == "organize" {
+			organizeEntry = &history[i]
+			break
+		}
+	}
+	require.NotNil(t, organizeEntry, "expected an organize entry in %v", history)
+	assert.Equal(t, "/tmp/old.m4b", organizeEntry.OldPath)
+	assert.Equal(t, "/library/new.m4b", organizeEntry.NewPath)
 }
 
 // --- Library Fingerprints ---

--- a/internal/server/changelog_service_test.go
+++ b/internal/server/changelog_service_test.go
@@ -58,10 +58,18 @@ func TestChangelogService_WithPathHistory(t *testing.T) {
 
 	entries, err := server.changelogService.GetBookChangelog(book.ID)
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	assert.Equal(t, "rename", entries[0].Type)
-	assert.Contains(t, entries[0].Summary, "/old/path.m4b")
-	assert.Contains(t, entries[0].Summary, "/new/path.m4b")
+	// CreateBook records an implicit import entry, so the manual rename
+	// is one of several entries. Find the specific one we recorded.
+	var renameEntry *activity.ChangeLogEntry
+	for i, e := range entries {
+		if e.Type == "rename" && e.Details != nil && e.Details["change_type"] == "rename" {
+			renameEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, renameEntry, "expected a user-recorded rename entry among %v", entries)
+	assert.Contains(t, renameEntry.Summary, "/old/path.m4b")
+	assert.Contains(t, renameEntry.Summary, "/new/path.m4b")
 }
 
 func TestChangelogEndpoint_Returns200(t *testing.T) {

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -177,9 +177,11 @@ func TestCoverageGetAudiobook(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.Equal(t, "Get Me", resp["title"])
+		var wrapper struct {
+			Data map[string]any `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+		assert.Equal(t, "Get Me", wrapper.Data["title"])
 	})
 
 	t.Run("non-existent book", func(t *testing.T) {
@@ -210,9 +212,11 @@ func TestCoverageUpdateAudiobook(t *testing.T) {
 		server.router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.Equal(t, "Updated Title", resp["title"])
+		var wrapper struct {
+			Data map[string]any `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+		assert.Equal(t, "Updated Title", wrapper.Data["title"])
 	})
 
 	t.Run("update narrator", func(t *testing.T) {
@@ -380,7 +384,7 @@ func TestCoverageListAuthors(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["items"])
+		assert.NotNil(t, resp["data"].(map[string]any)["items"])
 	})
 
 	t.Run("authors after creating books with authors", func(t *testing.T) {
@@ -428,7 +432,7 @@ func TestCoverageListSeries(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["items"])
+		assert.NotNil(t, resp["data"].(map[string]any)["items"])
 	})
 
 	t.Run("series after creating books with series", func(t *testing.T) {
@@ -649,7 +653,7 @@ func TestCoverageBatchOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		results := resp["results"].([]any)
+		results := resp["data"].(map[string]any)["results"].([]any)
 		assert.Equal(t, 2, len(results))
 	})
 
@@ -715,7 +719,7 @@ func TestCoverageBatchOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		results := resp["results"].([]any)
+		results := resp["data"].(map[string]any)["results"].([]any)
 		first := results[0].(map[string]any)
 		// On error, success is omitted (omitempty) and error is set
 		assert.NotEmpty(t, first["error"])
@@ -740,7 +744,7 @@ func TestCoverageCountEndpoints(t *testing.T) {
 
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		count := resp["count"].(float64)
+		count := resp["data"].(map[string]any)["count"].(float64)
 		assert.GreaterOrEqual(t, count, float64(1))
 	})
 
@@ -928,6 +932,7 @@ func TestCoverageBookSubresources(t *testing.T) {
 
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		resp = resp["data"].(map[string]any)
 		assert.NotNil(t, resp["entries"])
 	})
 
@@ -939,6 +944,7 @@ func TestCoverageBookSubresources(t *testing.T) {
 
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		resp = resp["data"].(map[string]any)
 		// history key exists in response (may be null for no history)
 		_, hasHistory := resp["history"]
 		assert.True(t, hasHistory, "response should contain 'history' key")
@@ -952,6 +958,7 @@ func TestCoverageBookSubresources(t *testing.T) {
 
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		resp = resp["data"].(map[string]any)
 		// external_ids key exists (may be empty array or null)
 		_, hasKey := resp["external_ids"]
 		assert.True(t, hasKey, "response should contain 'external_ids' key")

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -154,8 +154,11 @@ func TestWorkEndpoints(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusCreated, w.Code)
 
-	var created database.Work
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	var createdWrap struct {
+		Data database.Work `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &createdWrap))
+	created := createdWrap.Data
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/works", nil)
 	w = httptest.NewRecorder()

--- a/internal/server/server_import_paths_and_blocklist_test.go
+++ b/internal/server/server_import_paths_and_blocklist_test.go
@@ -56,6 +56,7 @@ func TestListAuthorsAndSeries_ReturnsEmptyArrayWhenNil(t *testing.T) {
 
 	var authorsResp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &authorsResp))
+	authorsResp = authorsResp["data"].(map[string]interface{})
 	items, ok := authorsResp["items"].([]interface{})
 	require.True(t, ok)
 	assert.Len(t, items, 0)
@@ -68,6 +69,7 @@ func TestListAuthorsAndSeries_ReturnsEmptyArrayWhenNil(t *testing.T) {
 
 	var seriesResp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &seriesResp))
+	seriesResp = seriesResp["data"].(map[string]interface{})
 	items, ok = seriesResp["items"].([]interface{})
 	require.True(t, ok)
 	assert.Len(t, items, 0)

--- a/internal/server/server_narrators_fieldstates_test.go
+++ b/internal/server/server_narrators_fieldstates_test.go
@@ -26,10 +26,12 @@ func TestListNarrators(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var narrators []database.Narrator
-	err := json.Unmarshal(w.Body.Bytes(), &narrators)
+	var wrapper struct {
+		Data []database.Narrator `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
-	assert.Empty(t, narrators)
+	assert.Empty(t, wrapper.Data)
 
 	// Add a narrator and re-check
 	store := database.GetGlobalStore().(*database.SQLiteStore)
@@ -43,9 +45,9 @@ func TestListNarrators(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	err = json.Unmarshal(w.Body.Bytes(), &narrators)
+	err = json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
-	assert.Len(t, narrators, 2)
+	assert.Len(t, wrapper.Data, 2)
 }
 
 func TestCountNarrators(t *testing.T) {
@@ -61,6 +63,7 @@ func TestCountNarrators(t *testing.T) {
 	var resp map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
+	resp = resp["data"].(map[string]any)
 	assert.Equal(t, float64(0), resp["count"])
 
 	// Add narrators
@@ -77,6 +80,7 @@ func TestCountNarrators(t *testing.T) {
 
 	err = json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
+	resp = resp["data"].(map[string]any)
 	assert.Equal(t, float64(2), resp["count"])
 }
 
@@ -97,10 +101,12 @@ func TestListAudiobookNarrators(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var narrators []database.BookNarrator
-	err = json.Unmarshal(w.Body.Bytes(), &narrators)
+	var wrapper struct {
+		Data []database.BookNarrator `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
-	assert.Empty(t, narrators)
+	assert.Empty(t, wrapper.Data)
 
 	// Create narrator and assign to book
 	store := database.GetGlobalStore().(*database.SQLiteStore)
@@ -117,10 +123,10 @@ func TestListAudiobookNarrators(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	err = json.Unmarshal(w.Body.Bytes(), &narrators)
+	err = json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
-	assert.Len(t, narrators, 1)
-	assert.Equal(t, narrator.ID, narrators[0].NarratorID)
+	assert.Len(t, wrapper.Data, 1)
+	assert.Equal(t, narrator.ID, wrapper.Data[0].NarratorID)
 }
 
 func TestSetAudiobookNarrators(t *testing.T) {
@@ -154,6 +160,7 @@ func TestSetAudiobookNarrators(t *testing.T) {
 	var resp map[string]any
 	err = json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
+	resp = resp["data"].(map[string]any)
 	assert.Equal(t, "ok", resp["status"])
 
 	// Verify by reading back
@@ -190,6 +197,7 @@ func TestGetAudiobookFieldStates(t *testing.T) {
 	var resp map[string]any
 	err = json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
+	resp = resp["data"].(map[string]any)
 	assert.Contains(t, resp, "field_states")
 
 	// field_states should be a map (possibly empty)

--- a/internal/server/server_segment_tags_test.go
+++ b/internal/server/server_segment_tags_test.go
@@ -89,6 +89,7 @@ func TestGetSegmentTags_Success(t *testing.T) {
 
 	var resp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	resp = resp["data"].(map[string]interface{})
 
 	// File doesn't exist on disk, so we expect a tags_read_error
 	assert.NotEmpty(t, resp["tags_read_error"], "expected tags_read_error since file doesn't exist")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -148,6 +148,7 @@ func TestListAudiobooks(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.NotNil(t, response["items"])
 			},
 		},
@@ -159,6 +160,7 @@ func TestListAudiobooks(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.NotNil(t, response["items"])
 			},
 		},
@@ -170,6 +172,7 @@ func TestListAudiobooks(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.NotNil(t, response["items"])
 			},
 		},
@@ -259,17 +262,20 @@ func TestGetAudiobookTagsReportsEffectiveSourceSimple(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response struct {
-		Tags map[string]struct {
-			EffectiveValue  any    `json:"effective_value"`
-			EffectiveSource string `json:"effective_source"`
-			StoredValue     any    `json:"stored_value"`
-			OverrideValue   any    `json:"override_value"`
-			FetchedValue    any    `json:"fetched_value"`
-			OverrideLocked  bool   `json:"override_locked"`
-		} `json:"tags"`
+	var wrapper struct {
+		Data struct {
+			Tags map[string]struct {
+				EffectiveValue  any    `json:"effective_value"`
+				EffectiveSource string `json:"effective_source"`
+				StoredValue     any    `json:"stored_value"`
+				OverrideValue   any    `json:"override_value"`
+				FetchedValue    any    `json:"fetched_value"`
+				OverrideLocked  bool   `json:"override_locked"`
+			} `json:"tags"`
+		} `json:"data"`
 	}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	response := wrapper.Data
 
 	entry, ok := response.Tags["title"]
 	require.True(t, ok, "title tag should exist")
@@ -328,8 +334,11 @@ func TestUpdateAudiobookOverridesPersist(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var updated database.Book
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &updated))
+	var updatedWrap struct {
+		Data database.Book `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &updatedWrap))
+	updated := updatedWrap.Data
 	assert.Equal(t, "New Title", updated.Title)
 
 	states, err := database.GetGlobalStore().GetMetadataFieldStates(created.ID)
@@ -396,6 +405,7 @@ func TestListAuthors(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 	assert.NotNil(t, response["items"])
 }
 
@@ -414,6 +424,7 @@ func TestListSeries(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 	assert.NotNil(t, response["items"])
 }
 
@@ -513,6 +524,7 @@ func TestGetConfig(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 	assert.NotNil(t, response["config"])
 }
 
@@ -627,9 +639,11 @@ func TestValidateMetadata(t *testing.T) {
 			var response map[string]any
 			err = json.Unmarshal(w.Body.Bytes(), &response)
 			require.NoError(t, err)
-
-			if valid, ok := response["valid"].(bool); ok {
-				assert.Equal(t, tt.expectValid, valid)
+			if tt.expectedStatus == http.StatusOK {
+				response = response["data"].(map[string]any)
+				if valid, ok := response["valid"].(bool); ok {
+					assert.Equal(t, tt.expectValid, valid)
+				}
 			}
 		})
 	}
@@ -986,6 +1000,7 @@ func TestSizeCalculationAccuracy(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 
 	// Verify totalSize is a number
 	totalSize, ok := response["totalSize"].(float64)
@@ -1036,6 +1051,7 @@ func TestSizeBucketDistribution(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 
 	// totalBooks and totalSize should be present
 	_, ok := response["totalBooks"]
@@ -1201,6 +1217,7 @@ func TestGetWork(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 
 	// Verify work queue structure
 	workItems, ok := response["items"].([]any)
@@ -1261,6 +1278,7 @@ func TestWorkQueuePriority(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 
 	workItems, ok := response["items"].([]any)
 	assert.True(t, ok)
@@ -1321,17 +1339,20 @@ func TestGetAudiobookTagsReportsEffectiveSource(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp struct {
-		Tags map[string]struct {
-			FileValue      any  `json:"file_value"`
-			FetchedValue   any  `json:"fetched_value"`
-			StoredValue    any  `json:"stored_value"`
-			OverrideValue  any  `json:"override_value"`
-			OverrideLocked bool `json:"override_locked"`
-		} `json:"tags"`
+	var wrapper struct {
+		Data struct {
+			Tags map[string]struct {
+				FileValue      any  `json:"file_value"`
+				FetchedValue   any  `json:"fetched_value"`
+				StoredValue    any  `json:"stored_value"`
+				OverrideValue  any  `json:"override_value"`
+				OverrideLocked bool `json:"override_locked"`
+			} `json:"tags"`
+		} `json:"data"`
 	}
 
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 
 	require.Contains(t, resp.Tags, "title")
 	assert.Equal(t, "Stored Title", resp.Tags["title"].StoredValue)
@@ -1471,6 +1492,7 @@ func TestUpdateConfig(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	resp = resp["data"].(map[string]any)
 	assert.Equal(t, "/new/root", resp["root_dir"])
 	assert.Equal(t, true, resp["auto_organize"])
 }
@@ -1908,9 +1930,12 @@ func TestListBlockedHashes(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response map[string]any
-	err = json.Unmarshal(w.Body.Bytes(), &response)
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &wrapper)
 	require.NoError(t, err)
+	response := wrapper.Data
 
 	assert.NotNil(t, response["items"])
 	assert.NotNil(t, response["total"])
@@ -1953,6 +1978,7 @@ func TestRemoveBlockedHash(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.Equal(t, "hash unblocked successfully", response["message"])
 				assert.Equal(t, "def456", response["hash"])
 			},
@@ -1968,6 +1994,7 @@ func TestRemoveBlockedHash(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.Equal(t, "hash unblocked successfully", response["message"])
 			},
 		},
@@ -2021,6 +2048,7 @@ func TestExportMetadataHandler(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				assert.NotNil(t, response)
 			},
 		},
@@ -2157,6 +2185,7 @@ func TestGetWorkStats(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 	assert.NotNil(t, response)
 }
 
@@ -2272,6 +2301,7 @@ func TestListAudiobooksWithSearchAndPagination(t *testing.T) {
 	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	require.NoError(t, err)
+	response = response["data"].(map[string]any)
 
 	items, ok := response["items"].([]any)
 	require.True(t, ok)
@@ -2394,6 +2424,7 @@ func TestListAudiobookVersions_ErrorCases(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				versions, ok := response["versions"].([]any)
 				assert.True(t, ok)
 				assert.Equal(t, 1, len(versions))
@@ -2428,6 +2459,7 @@ func TestListAudiobookVersions_ErrorCases(t *testing.T) {
 				var response map[string]any
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
+				response = response["data"].(map[string]any)
 				versions, ok := response["versions"].([]any)
 				assert.True(t, ok)
 				assert.Equal(t, 2, len(versions))

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -46,7 +46,8 @@ func TestUndoLastApply_NoHistory(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Contains(t, resp["error"], "no change history found")
+	errMsg, _ := resp["error"].(string)
+	assert.Contains(t, errMsg, "not found")
 }
 
 func TestUndoLastApply_OnlyUndoRecords(t *testing.T) {
@@ -84,7 +85,8 @@ func TestUndoLastApply_OnlyUndoRecords(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Contains(t, resp["error"], "no changes to undo")
+	errMsg, _ := resp["error"].(string)
+	assert.Contains(t, errMsg, "not found")
 }
 
 func TestUndoLastApply_RevertsBatch(t *testing.T) {
@@ -138,8 +140,11 @@ func TestUndoLastApply_RevertsBatch(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 	assert.Contains(t, resp["message"], "2 field(s)")
 
 	undoneFields, ok := resp["undone_fields"].([]any)
@@ -212,8 +217,11 @@ func TestUndoLastApply_SkipsOldChanges(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 	// Only the recent change should be undone, not the old publisher change
 	assert.Contains(t, resp["message"], "1 field(s)")
 
@@ -273,8 +281,11 @@ func TestUndoLastApply_SkipsUndoRecordsInBatchDetection(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 	// Should undo the fetched title change, skipping the undo record
 	assert.Contains(t, resp["message"], "1 field(s)")
 }
@@ -315,8 +326,11 @@ func TestUndoLastApply_NilPreviousValueClearsOverride(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	var wrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	resp := wrapper.Data
 	assert.Contains(t, resp["message"], "1 field(s)")
 }
 

--- a/internal/server/server_update_audiobook_more_test.go
+++ b/internal/server/server_update_audiobook_more_test.go
@@ -94,8 +94,11 @@ func TestUpdateAudiobook_CreatesAuthorSeries_AndUpdatesOverrideState(t *testing.
 
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var updated database.Book
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &updated))
+	var wrapper struct {
+		Data database.Book `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	updated := wrapper.Data
 	require.NotNil(t, updated.AuthorID)
 	require.NotNil(t, updated.SeriesID)
 	assert.Equal(t, "Override Title", updated.Title)

--- a/internal/server/server_versions_and_work_test.go
+++ b/internal/server/server_versions_and_work_test.go
@@ -101,8 +101,11 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	server2.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var statsResp map[string]interface{}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &statsResp))
+	var statsWrapper struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &statsWrapper))
+	statsResp := statsWrapper.Data
 	assert.Equal(t, float64(2), statsResp["total_books"])
 	assert.Equal(t, float64(2), statsResp["total_works"])
 	assert.Equal(t, float64(1), statsResp["works_with_multiple_editions"])

--- a/internal/server/settings_persistence_test.go
+++ b/internal/server/settings_persistence_test.go
@@ -133,9 +133,12 @@ func TestAPIKeyPersistenceRoundtrip(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var getResp map[string]any
-	err = json.Unmarshal(w.Body.Bytes(), &getResp)
+	var getWrapper struct {
+		Data map[string]any `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &getWrapper)
 	require.NoError(t, err)
+	getResp := getWrapper.Data
 
 	configData, ok := getResp["config"].(map[string]any)
 	require.True(t, ok, "Response should have config object")


### PR DESCRIPTION
Gets the full test suite green.

Two categories of fixes:

**Pre-existing breakage on main** (unrelated to envelope migration):
- SQLite `books` schema missing `quarantine_reason`/`quarantined_at` (migration 51 added them to PebbleDB but the SQLite CREATE TABLE never got updated).
- `TestChangelogService_WithPathHistory` and `TestCoverage_PathHistory` expected exactly 1 path-history entry, but `CreateBook` now records an implicit `import` entry. Tests updated to scan for the specific entry they care about.

**Envelope migration fallout** (from PRs #425–#438):
- Many test fixtures decoded raw-JSON response bodies. After envelope migration those bodies are `{"data": ...}` — decoders updated across ~10 test files.
- Error-response assertions left unenveloped (error shape is not enveloped).
- Undo handler tests updated to match new `RespondWithNotFound` error text.

## Test plan
- [x] `go test ./...` — PASS
- [x] All packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)