### PR TITLE
chore(claude): add gofmt + Stop-reminder hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,26 @@
         "hooks": [
           {
             "type": "command",
+            "command": "file=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty') && [[ \"$file\" == *.go ]] && gofmt -w \"$file\" 2>/dev/null || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
             "command": "file=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty') && [[ \"$file\" == *.go ]] && dir=$(git -C \"$(dirname \"$file\")\" rev-parse --show-toplevel 2>/dev/null) && cd \"$dir\" && go vet ./$(dirname \"${file#$dir/}\")/... 2>&1 | head -5 || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "st=$(git -C \"$CLAUDE_PROJECT_DIR\" status --short 2>/dev/null); [[ -n \"$st\" ]] && jq -n --arg s \"$st\" '{\"systemMessage\": (\"Uncommitted changes:\\n\" + $s + \"\\n\\nRemember: CHANGELOG + TODO + commit\")}' || true"
           }
         ]
       }


### PR DESCRIPTION
Two hooks added to project .claude/settings.json (merged with existing):

- PostToolUse Edit|Write → `gofmt -w` on .go files
- Stop → systemMessage with `git status` + CHANGELOG/TODO/commit reminder when dirty

Both pipe-tested before writing. Existing hooks (.env block, prettier, go vet) untouched.

Per /insights recommendations.