### PR TITLE
feat(parallel-sweep): plan + step 1 (skeleton + state schema)

### DIFF
--- a/.claude/skills/parallel-sweep-impl/SKILL.md
+++ b/.claude/skills/parallel-sweep-impl/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: parallel-sweep-impl
+description: Procedural body for the /parallel-sweep slash command. Implements the coordinator that parses a task list, creates one git worktree per task, dispatches child sub-agents in parallel, watches their TaskUpdate events, opens PRs, polls CI, admin-merges on green, runs the sibling-rebase loop (with Sonnet/Opus conflict-resolver subagents), and persists per-run state to .claude/state/ for resume across usage-limit interruptions. Invoked by /parallel-sweep — not by direct user phrasing. Read this skill when /parallel-sweep is invoked, when troubleshooting an in-flight sweep, or when extending the sweep workflow.
+---
+
+# parallel-sweep-impl
+
+Procedural body of the `/parallel-sweep` slash command. The slash command itself is a thin trigger; everything load-bearing lives here so it can be edited and reviewed independently.
+
+The full design is in `docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md`. Read that before changing this skill — it captures the why behind every decision (failure modes from prior sweeps, locked Q&A from 2026-04-24, future-work plan for universal extraction).
+
+## What this skill does
+
+Given a YAML/markdown task list, run a coordinated multi-agent refactor sweep:
+
+1. Create one git worktree per task under `../worktrees/<slug>`.
+2. Drop a per-worktree `.claude/settings.local.json` containing a PreToolUse hook that blocks Edit/Write outside that worktree.
+3. Dispatch one child Task-tool agent per worktree, in parallel via a single tool call with multiple invocations.
+4. Watch each child's TaskUpdate stream. Persist progress to `.claude/state/parallel-sweep-<runID>.json` after every event.
+5. When a child finishes: run `make ci` *in the worktree* (catches test gaps GitHub Actions misses). Open PR. Poll GitHub CI. Admin-merge only when both gates are green.
+6. After each merge: rebase every still-unmerged sibling onto new `main`. Trivial conflicts (≤30 markers, ≤3 files) → Sonnet conflict-resolver subagent. Non-trivial → Opus file-copy cherry-pick fallback. Unresolvable → mark `rebase_blocked` and continue with other siblings.
+7. On usage-limit / SIGTERM: write a final state-file checkpoint with `status: paused` and exit. Resumable via `/parallel-sweep --resume <runID>` — the in-flight task gets `git reset --hard <base>` and re-dispatches from `pending`.
+
+## Why this exists
+
+`parallel-refactor-sweep` (the predecessor skill) ran the envelope-migration sweep (TODO 4.15, PRs #425-#438) successfully but exposed three failure modes:
+
+- Agents bled edits into the main checkout (worktree isolation bypassed via absolute paths).
+- Test fixture gaps caused green-CI PRs to break the suite post-merge.
+- Coordinator overhead grew linearly with PR count when work was split into many small PRs.
+
+This skill hardens against all three:
+
+- **Worktree isolation:** PreToolUse hook + post-hoc `git -C <worktree> status` cross-check (belt-and-suspenders — the post-hoc check is the authoritative barrier).
+- **Test gaps:** local `make ci` runs in each worktree before PR open; a green PR alone does not authorize merge.
+- **Coordinator overhead:** state file design lets the coordinator hand off mid-flight without losing context. Conflict resolution is delegated to subagents so the coordinator stays decisive.
+
+## State file
+
+The single source of truth for everything: which tasks are pending, dispatched, in-flight, merged; which PRs are open; what the sibling rebase queue looks like; an audit log of every conflict-resolver invocation. Schema and lifecycle in `references/state-schema.md`. CRUD via `scripts/state.py`.
+
+Atomicity matters because the coordinator can be SIGKILLed at any point — every mutation goes through `State.checkpoint()` which writes to a tmp file, fsyncs, and `os.replace`s atomically into place.
+
+## Implementation status (built incrementally per the plan)
+
+| Step | Status | Adds |
+|---|---|---|
+| 1. Skeleton + state schema | **in progress** | `state.py`, `state-schema.md`, this SKILL.md stub, unit tests for state.py |
+| 2. Coordinator + child prompts | not started | `references/coordinator-prompt.md`, `references/child-prompt.md`, slash command wired to a 1-task synthetic input |
+| 3. PreToolUse hook spike | not started | Verify hook actually blocks out-of-tree edits when sub-agent runs there |
+| 4. PR + merge loop | not started | Coordinator opens PR, polls CI, admin-merges on green-AND-local-`make ci` |
+| 5. Sibling rebase (clean) | not started | 2-task end-to-end with clean rebase |
+| 6. Conflict-resolver subagent (Sonnet) | not started | `references/conflict-resolver-prompt.md`, trivial-conflict path |
+| 7. File-copy cherry-pick fallback (Opus) | not started | Non-trivial conflict path |
+| 8. Resume from last completed task | not started | `--resume <runID>` flag, worktree reset on re-dispatch |
+| 9. Polish | not started | Spec doc, CLAUDE.md pointer, TODO 4.16 marked, gitignore |
+
+## Files
+
+```
+parallel-sweep-impl/
+├── SKILL.md                                 ← this file (procedural overview + roadmap)
+├── references/
+│   ├── state-schema.md                      ← state file schema + lifecycle (step 1)
+│   ├── coordinator-prompt.md                ← (step 2)
+│   ├── child-prompt.md                      ← (step 2)
+│   └── conflict-resolver-prompt.md          ← (step 6)
+└── scripts/
+    ├── state.py                             ← state CRUD (step 1)
+    └── test_state.py                        ← unit tests (step 1)
+```

--- a/.claude/skills/parallel-sweep-impl/references/state-schema.md
+++ b/.claude/skills/parallel-sweep-impl/references/state-schema.md
@@ -1,0 +1,87 @@
+<!-- file: .claude/skills/parallel-sweep-impl/references/state-schema.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f4e5d6c-7b8a-9c0d-1e2f-3a4b5c6d7e8f -->
+<!-- last-edited: 2026-04-24 -->
+
+# parallel-sweep state file schema
+
+Every `/parallel-sweep` run owns exactly one state file at:
+
+```
+.claude/state/parallel-sweep-<runID>.json
+```
+
+The file is the single source of truth for resume, post-merge sanity, and the rebase loop. It is written atomically (`tmp + os.replace`) on every checkpoint so a SIGKILL leaves either the previous version or the new version — never a partial.
+
+## Top-level shape
+
+| Field | Type | Notes |
+|---|---|---|
+| `runID` | string | `YYYY-MM-DD-HHMM-<slug>`. Generated at create. |
+| `createdAt` | ISO-8601 UTC | Set once. |
+| `lastCheckpointAt` | ISO-8601 UTC | Updated on every checkpoint. |
+| `status` | enum | `running` / `paused` / `complete` / `failed` |
+| `userPrompt` | string | Original `/parallel-sweep` input verbatim — used for resume + audit. |
+| `tasks` | array | One entry per task; ordered by user-supplied order. |
+| `siblingRebaseQueue` | array of slugs | Tasks waiting to be rebased after the most recent merge. |
+| `conflictResolverInvocations` | array | Audit log of every Sonnet/Opus resolver dispatch. |
+
+## Task entry
+
+| Field | Type | Notes |
+|---|---|---|
+| `slug` | string | Unique within run. Used as worktree dir name and branch suffix. |
+| `description` | string | One-line task body, fed to the child agent. |
+| `model` | enum | `haiku` / `sonnet` / `opus` — coordinator picks per task complexity. |
+| `worktreePath` | string | Absolute path; `null` until coordinator creates it. |
+| `branch` | string | `refactor/<slug>` by convention. |
+| `status` | enum | See lifecycle below. |
+| `agentID` | string \| null | Set when child Task agent dispatched; cleared on resume. |
+| `prNumber` | int \| null | Set when PR opened. |
+| `lastUpdate` | ISO-8601 UTC | Updated on any task field change. |
+| `errors` | array of strings | Append-only; each entry is a one-line error summary. |
+
+## Task lifecycle
+
+```
+pending
+  └─ dispatched          (child agent spawned; agentID set)
+       └─ in_progress    (first TaskUpdate received from child)
+            └─ committed (child's branch has commits; child reported done)
+                 └─ pr_opened       (PR created; prNumber set)
+                      ├─ merged              (CI green + local make ci passed; admin-merge done)
+                      ├─ rebase_blocked      (sibling rebase failed; needs user)
+                      └─ failed              (any unrecoverable error)
+```
+
+States are forward-only with one exception: `--resume` may move an `in_progress` or `dispatched` task back to `pending` after `git -C <worktree> reset --hard <base>`.
+
+## Conflict resolver invocation entry
+
+| Field | Type | Notes |
+|---|---|---|
+| `task` | string | Slug of the task being rebased. |
+| `triggeredBy` | string | Slug of the task that just merged (the rebase target). |
+| `outcome` | enum | `resolved` / `escalated_to_fallback` / `escalated_to_user` |
+| `subagentID` | string | The Task tool agent ID. |
+| `model` | enum | `sonnet` (trivial path) or `opus` (file-copy fallback). |
+| `markersBefore` | int | Total `<<<<<<<` count in conflicted files at dispatch. |
+| `filesAffected` | int | Number of files with conflict markers. |
+| `at` | ISO-8601 UTC | |
+
+## Atomicity guarantees
+
+- Every mutation goes through `state.checkpoint()`, which:
+  1. Serializes to `<path>.tmp`.
+  2. `os.fsync()` the tmp file.
+  3. `os.replace(tmp, path)` — atomic on POSIX.
+- The state file is therefore safe against SIGKILL at any point. After a kill, `State.load()` reads either the pre-checkpoint or post-checkpoint version, never a half-written file.
+- Concurrency model: exactly one coordinator process per `runID`. No file locking needed. If a second `/parallel-sweep --resume <runID>` is invoked while another is alive, the second will see the already-`running` status and refuse — coordinator must check this on resume.
+
+## Why JSON over SQLite
+
+Considered SQLite for ACID and richer queries. Rejected:
+
+- The data is small (≤100 tasks) and only one writer.
+- JSON is `cat`-able and `jq`-able from shell hooks during debugging.
+- Plain text diffs cleanly in `git status` if a stale state file leaks into a commit.

--- a/.claude/skills/parallel-sweep-impl/scripts/state.py
+++ b/.claude/skills/parallel-sweep-impl/scripts/state.py
@@ -210,7 +210,14 @@ class State:
 
     def _validate(self) -> None:
         d = self.data
-        for required in ("runID", "createdAt", "lastCheckpointAt", "status", "userPrompt", "tasks"):
+        for required in (
+            "runID",
+            "createdAt",
+            "lastCheckpointAt",
+            "status",
+            "userPrompt",
+            "tasks",
+        ):
             if required not in d:
                 raise ValueError(f"state missing required field {required!r}")
         if d["status"] not in TOP_STATUSES:

--- a/.claude/skills/parallel-sweep-impl/scripts/state.py
+++ b/.claude/skills/parallel-sweep-impl/scripts/state.py
@@ -1,0 +1,247 @@
+# file: .claude/skills/parallel-sweep-impl/scripts/state.py
+# version: 1.0.0
+# guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
+
+"""State file CRUD for /parallel-sweep.
+
+See ../references/state-schema.md for the schema. The only thing this module
+guarantees beyond plain JSON I/O is atomic writes: every mutation goes through
+checkpoint() which writes to a tmp file, fsyncs, and os.replace's into place.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+TOP_STATUSES = {"running", "paused", "complete", "failed"}
+TASK_STATUSES = {
+    "pending",
+    "dispatched",
+    "in_progress",
+    "committed",
+    "pr_opened",
+    "merged",
+    "rebase_blocked",
+    "failed",
+}
+MODELS = {"haiku", "sonnet", "opus"}
+RESOLVER_OUTCOMES = {"resolved", "escalated_to_fallback", "escalated_to_user"}
+
+_RUN_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{4}-[a-z0-9-]+$")
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _state_path(state_dir: Path, run_id: str) -> Path:
+    return state_dir / f"parallel-sweep-{run_id}.json"
+
+
+def make_run_id(slug: str, now: datetime | None = None) -> str:
+    """Generate a runID like 2026-04-24-1530-batch-api-migration."""
+    when = now or datetime.now(timezone.utc)
+    safe = re.sub(r"[^a-z0-9-]+", "-", slug.lower()).strip("-")
+    if not safe:
+        raise ValueError("slug must contain at least one alphanumeric character")
+    return f"{when:%Y-%m-%d-%H%M}-{safe}"
+
+
+class State:
+    """Mutable in-memory mirror of the on-disk state file.
+
+    Every public mutation calls self.checkpoint() implicitly. Reads are direct
+    attribute access on self.data. Validation runs on every checkpoint so an
+    invalid mutation is caught before it hits disk.
+    """
+
+    def __init__(self, state_dir: Path, data: dict[str, Any]):
+        self.state_dir = state_dir
+        self.data = data
+        self.path = _state_path(state_dir, data["runID"])
+
+    # ----- factories -----
+
+    @classmethod
+    def create(
+        cls,
+        state_dir: Path,
+        run_id: str,
+        user_prompt: str,
+        tasks: list[dict[str, Any]],
+    ) -> "State":
+        if not _RUN_ID_RE.match(run_id):
+            raise ValueError(f"runID {run_id!r} does not match expected format")
+        state_dir.mkdir(parents=True, exist_ok=True)
+        now = _utcnow()
+        data = {
+            "runID": run_id,
+            "createdAt": now,
+            "lastCheckpointAt": now,
+            "status": "running",
+            "userPrompt": user_prompt,
+            "tasks": [_normalize_task(t) for t in tasks],
+            "siblingRebaseQueue": [],
+            "conflictResolverInvocations": [],
+        }
+        s = cls(state_dir, data)
+        s.checkpoint()
+        return s
+
+    @classmethod
+    def load(cls, state_dir: Path, run_id: str) -> "State":
+        path = _state_path(state_dir, run_id)
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        s = cls(state_dir, data)
+        s._validate()
+        return s
+
+    # ----- mutations -----
+
+    def set_status(self, status: str) -> None:
+        if status not in TOP_STATUSES:
+            raise ValueError(f"invalid top-level status {status!r}")
+        self.data["status"] = status
+        self.checkpoint()
+
+    def update_task(self, slug: str, **fields: Any) -> dict[str, Any]:
+        task = self._task(slug)
+        if "status" in fields and fields["status"] not in TASK_STATUSES:
+            raise ValueError(f"invalid task status {fields['status']!r}")
+        if "model" in fields and fields["model"] not in MODELS:
+            raise ValueError(f"invalid model {fields['model']!r}")
+        for k, v in fields.items():
+            task[k] = v
+        task["lastUpdate"] = _utcnow()
+        self.checkpoint()
+        return task
+
+    def append_task_error(self, slug: str, message: str) -> None:
+        task = self._task(slug)
+        task.setdefault("errors", []).append(message)
+        task["lastUpdate"] = _utcnow()
+        self.checkpoint()
+
+    def set_sibling_queue(self, slugs: Iterable[str]) -> None:
+        known = {t["slug"] for t in self.data["tasks"]}
+        bad = [s for s in slugs if s not in known]
+        if bad:
+            raise ValueError(f"unknown slugs in sibling queue: {bad}")
+        self.data["siblingRebaseQueue"] = list(slugs)
+        self.checkpoint()
+
+    def record_resolver_invocation(
+        self,
+        *,
+        task: str,
+        triggered_by: str,
+        outcome: str,
+        subagent_id: str,
+        model: str,
+        markers_before: int,
+        files_affected: int,
+    ) -> None:
+        if outcome not in RESOLVER_OUTCOMES:
+            raise ValueError(f"invalid resolver outcome {outcome!r}")
+        if model not in MODELS:
+            raise ValueError(f"invalid model {model!r}")
+        self.data["conflictResolverInvocations"].append(
+            {
+                "task": task,
+                "triggeredBy": triggered_by,
+                "outcome": outcome,
+                "subagentID": subagent_id,
+                "model": model,
+                "markersBefore": markers_before,
+                "filesAffected": files_affected,
+                "at": _utcnow(),
+            }
+        )
+        self.checkpoint()
+
+    # ----- queries -----
+
+    def task(self, slug: str) -> dict[str, Any]:
+        return dict(self._task(slug))
+
+    def tasks_by_status(self, status: str) -> list[dict[str, Any]]:
+        if status not in TASK_STATUSES:
+            raise ValueError(f"invalid task status {status!r}")
+        return [dict(t) for t in self.data["tasks"] if t["status"] == status]
+
+    def is_complete(self) -> bool:
+        return all(t["status"] in {"merged", "failed"} for t in self.data["tasks"])
+
+    # ----- internals -----
+
+    def _task(self, slug: str) -> dict[str, Any]:
+        for t in self.data["tasks"]:
+            if t["slug"] == slug:
+                return t
+        raise KeyError(f"unknown task slug {slug!r}")
+
+    def checkpoint(self) -> None:
+        self.data["lastCheckpointAt"] = _utcnow()
+        self._validate()
+        # Atomic write: tmp + fsync + os.replace
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self.state_dir, prefix=f".{self.path.name}.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(self.data, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Best-effort cleanup of orphaned tmp file.
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def _validate(self) -> None:
+        d = self.data
+        for required in ("runID", "createdAt", "lastCheckpointAt", "status", "userPrompt", "tasks"):
+            if required not in d:
+                raise ValueError(f"state missing required field {required!r}")
+        if d["status"] not in TOP_STATUSES:
+            raise ValueError(f"invalid top-level status {d['status']!r}")
+        slugs: set[str] = set()
+        for t in d["tasks"]:
+            if t["slug"] in slugs:
+                raise ValueError(f"duplicate task slug {t['slug']!r}")
+            slugs.add(t["slug"])
+            if t["status"] not in TASK_STATUSES:
+                raise ValueError(f"invalid task status {t['status']!r} on {t['slug']}")
+            if t["model"] not in MODELS:
+                raise ValueError(f"invalid model {t['model']!r} on {t['slug']}")
+
+
+def _normalize_task(raw: dict[str, Any]) -> dict[str, Any]:
+    """Apply defaults to a user-supplied task dict."""
+    if "slug" not in raw or "description" not in raw:
+        raise ValueError("each task needs at least slug and description")
+    model = raw.get("model", "haiku")
+    if model not in MODELS:
+        raise ValueError(f"invalid model {model!r} on task {raw['slug']!r}")
+    return {
+        "slug": raw["slug"],
+        "description": raw["description"],
+        "model": model,
+        "worktreePath": raw.get("worktreePath"),
+        "branch": raw.get("branch", f"refactor/{raw['slug']}"),
+        "status": raw.get("status", "pending"),
+        "agentID": raw.get("agentID"),
+        "prNumber": raw.get("prNumber"),
+        "lastUpdate": _utcnow(),
+        "errors": list(raw.get("errors", [])),
+    }

--- a/.claude/skills/parallel-sweep-impl/scripts/test_state.py
+++ b/.claude/skills/parallel-sweep-impl/scripts/test_state.py
@@ -1,0 +1,197 @@
+# file: .claude/skills/parallel-sweep-impl/scripts/test_state.py
+# version: 1.0.0
+# guid: 5b6c7d8e-9f0a-1b2c-3d4e-5f6a7b8c9d0e
+
+"""Unit tests for state.py.
+
+Run from this directory:
+    python3 -m unittest test_state.py -v
+
+Or via the full path:
+    python3 -m unittest .claude/skills/parallel-sweep-impl/scripts/test_state.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import state
+
+
+SAMPLE_TASKS = [
+    {"slug": "task-a", "description": "Refactor handler A", "model": "haiku"},
+    {"slug": "task-b", "description": "Refactor handler B", "model": "sonnet"},
+]
+
+
+class StateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.state_dir = Path(self.tmp.name)
+        self.run_id = "2026-04-24-1530-test-run"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    # ----- create / load -----
+
+    def test_create_writes_file_with_defaults(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "test prompt", SAMPLE_TASKS)
+        self.assertTrue(s.path.exists())
+        loaded = json.loads(s.path.read_text())
+        self.assertEqual(loaded["runID"], self.run_id)
+        self.assertEqual(loaded["status"], "running")
+        self.assertEqual(len(loaded["tasks"]), 2)
+        self.assertEqual(loaded["tasks"][0]["status"], "pending")
+        self.assertEqual(loaded["tasks"][0]["branch"], "refactor/task-a")
+        self.assertIsNone(loaded["tasks"][0]["worktreePath"])
+        self.assertEqual(loaded["siblingRebaseQueue"], [])
+
+    def test_create_rejects_bad_run_id(self) -> None:
+        with self.assertRaises(ValueError):
+            state.State.create(self.state_dir, "not-a-run-id", "x", SAMPLE_TASKS)
+
+    def test_create_rejects_invalid_model(self) -> None:
+        with self.assertRaises(ValueError):
+            state.State.create(
+                self.state_dir, self.run_id, "x", [{"slug": "t", "description": "d", "model": "gpt-4"}]
+            )
+
+    def test_load_round_trips(self) -> None:
+        s1 = state.State.create(self.state_dir, self.run_id, "test", SAMPLE_TASKS)
+        s1.update_task("task-a", status="dispatched", agentID="agt-123")
+        s2 = state.State.load(self.state_dir, self.run_id)
+        self.assertEqual(s2.task("task-a")["status"], "dispatched")
+        self.assertEqual(s2.task("task-a")["agentID"], "agt-123")
+
+    # ----- mutations -----
+
+    def test_update_task_validates_status(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        with self.assertRaises(ValueError):
+            s.update_task("task-a", status="bogus")
+
+    def test_update_task_unknown_slug_raises(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        with self.assertRaises(KeyError):
+            s.update_task("no-such-task", status="dispatched")
+
+    def test_set_status_validates(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        s.set_status("paused")
+        self.assertEqual(state.State.load(self.state_dir, self.run_id).data["status"], "paused")
+        with self.assertRaises(ValueError):
+            s.set_status("bogus")
+
+    def test_append_task_error_persists(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        s.append_task_error("task-a", "rebase blocked: 5 files conflicted")
+        s.append_task_error("task-a", "second error")
+        loaded = state.State.load(self.state_dir, self.run_id)
+        self.assertEqual(len(loaded.task("task-a")["errors"]), 2)
+
+    def test_set_sibling_queue_rejects_unknown_slugs(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        with self.assertRaises(ValueError):
+            s.set_sibling_queue(["task-a", "ghost"])
+
+    def test_record_resolver_invocation_appends(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        s.record_resolver_invocation(
+            task="task-b",
+            triggered_by="task-a",
+            outcome="resolved",
+            subagent_id="agt-resolver-1",
+            model="sonnet",
+            markers_before=4,
+            files_affected=2,
+        )
+        loaded = state.State.load(self.state_dir, self.run_id)
+        self.assertEqual(len(loaded.data["conflictResolverInvocations"]), 1)
+        entry = loaded.data["conflictResolverInvocations"][0]
+        self.assertEqual(entry["outcome"], "resolved")
+        self.assertEqual(entry["model"], "sonnet")
+
+    def test_record_resolver_rejects_bad_outcome(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        with self.assertRaises(ValueError):
+            s.record_resolver_invocation(
+                task="task-a",
+                triggered_by="task-b",
+                outcome="not-an-outcome",
+                subagent_id="x",
+                model="sonnet",
+                markers_before=0,
+                files_affected=0,
+            )
+
+    # ----- queries -----
+
+    def test_tasks_by_status(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        s.update_task("task-a", status="merged")
+        merged = s.tasks_by_status("merged")
+        pending = s.tasks_by_status("pending")
+        self.assertEqual([t["slug"] for t in merged], ["task-a"])
+        self.assertEqual([t["slug"] for t in pending], ["task-b"])
+
+    def test_is_complete_true_when_all_terminal(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        self.assertFalse(s.is_complete())
+        s.update_task("task-a", status="merged")
+        s.update_task("task-b", status="failed")
+        self.assertTrue(s.is_complete())
+
+    # ----- atomicity -----
+
+    def test_checkpoint_no_orphan_tmp_files(self) -> None:
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        for i in range(20):
+            s.update_task("task-a", status="dispatched" if i % 2 else "pending")
+        leftover = [p for p in self.state_dir.iterdir() if p.name.endswith(".tmp")]
+        self.assertEqual(leftover, [], f"orphan tmp files: {leftover}")
+
+    def test_checkpoint_atomic_against_partial_read(self) -> None:
+        """Simulate: SIGKILL between fsync and rename leaves the original file intact."""
+        s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
+        original = s.path.read_bytes()
+        # If checkpoint never finished os.replace, the live file would still be the original.
+        # We can't kill mid-call from a unittest, but we can verify the contract: tmp files
+        # are written with a prefix that excludes them from a cold load, and replace happens last.
+        # Cold-load after a successful checkpoint must yield the new contents, never partial.
+        s.update_task("task-a", status="committed")
+        loaded = state.State.load(self.state_dir, self.run_id)
+        self.assertEqual(loaded.task("task-a")["status"], "committed")
+        # And the original bytes are no longer on disk under the canonical path.
+        self.assertNotEqual(s.path.read_bytes(), original)
+
+    # ----- run id helpers -----
+
+    def test_make_run_id_format(self) -> None:
+        rid = state.make_run_id("Some Slug With Spaces")
+        self.assertRegex(rid, r"^\d{4}-\d{2}-\d{2}-\d{4}-some-slug-with-spaces$")
+
+    def test_make_run_id_rejects_empty_slug(self) -> None:
+        with self.assertRaises(ValueError):
+            state.make_run_id("!!!")
+
+    # ----- normalize -----
+
+    def test_normalize_requires_slug_and_description(self) -> None:
+        with self.assertRaises(ValueError):
+            state.State.create(self.state_dir, self.run_id, "x", [{"slug": "only-slug"}])
+
+    def test_normalize_default_branch(self) -> None:
+        s = state.State.create(
+            self.state_dir, self.run_id, "x", [{"slug": "my-task", "description": "d"}]
+        )
+        self.assertEqual(s.task("my-task")["branch"], "refactor/my-task")
+        self.assertEqual(s.task("my-task")["model"], "haiku")  # default
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/parallel-sweep-impl/scripts/test_state.py
+++ b/.claude/skills/parallel-sweep-impl/scripts/test_state.py
@@ -14,7 +14,6 @@ Or via the full path:
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -58,7 +57,10 @@ class StateTests(unittest.TestCase):
     def test_create_rejects_invalid_model(self) -> None:
         with self.assertRaises(ValueError):
             state.State.create(
-                self.state_dir, self.run_id, "x", [{"slug": "t", "description": "d", "model": "gpt-4"}]
+                self.state_dir,
+                self.run_id,
+                "x",
+                [{"slug": "t", "description": "d", "model": "gpt-4"}],
             )
 
     def test_load_round_trips(self) -> None:
@@ -83,7 +85,9 @@ class StateTests(unittest.TestCase):
     def test_set_status_validates(self) -> None:
         s = state.State.create(self.state_dir, self.run_id, "x", SAMPLE_TASKS)
         s.set_status("paused")
-        self.assertEqual(state.State.load(self.state_dir, self.run_id).data["status"], "paused")
+        self.assertEqual(
+            state.State.load(self.state_dir, self.run_id).data["status"], "paused"
+        )
         with self.assertRaises(ValueError):
             s.set_status("bogus")
 
@@ -183,7 +187,9 @@ class StateTests(unittest.TestCase):
 
     def test_normalize_requires_slug_and_description(self) -> None:
         with self.assertRaises(ValueError):
-            state.State.create(self.state_dir, self.run_id, "x", [{"slug": "only-slug"}])
+            state.State.create(
+                self.state_dir, self.run_id, "x", [{"slug": "only-slug"}]
+            )
 
     def test_normalize_default_branch(self) -> None:
         s = state.State.create(

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,8 @@ local.env
 # Claude Code local settings (user-specific permissions)
 .claude/settings.local.json
 .claude/worktrees/
+.claude/state/
+.remember/
 .superpowers/
 
 # Build output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,31 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.21.0 -->
+<!-- version: 2.22.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-04-23 -->
+<!-- last-edited: 2026-04-24 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 24, 2026 — `/parallel-sweep` slash command — step 1 (skeleton + state schema)
+
+First step of TODO 4.16. Lays the plumbing for the new `/parallel-sweep` slash command (successor to the `parallel-refactor-sweep` user-global skill). No coordinator or dispatch yet — pure state-file infrastructure.
+
+- **Plan doc**: [`docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md`](docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md) v1.1.0 — open questions resolved, decisions locked. Hardens against three failure modes from the envelope sweep (worktree isolation bypass, missed test fixtures, post-merge schema gaps).
+- **`.claude/skills/parallel-sweep-impl/SKILL.md`**: skill stub + 9-step roadmap.
+- **`.claude/skills/parallel-sweep-impl/references/state-schema.md`**: state file schema, task lifecycle diagram, atomicity contract.
+- **`.claude/skills/parallel-sweep-impl/scripts/state.py`**: state CRUD with atomic checkpoint (tmp + fsync + os.replace). Schema validation on every mutation.
+- **`.claude/skills/parallel-sweep-impl/scripts/test_state.py`**: 19 unit tests (stdlib unittest, no third-party deps). All green.
+- **`.gitignore`**: ignore `.claude/state/` (per-run state files) and `.remember/` (plugin scratch).
+
+Decisions locked 2026-04-24 (full rationale in plan §13):
+- Hook scoping: belt-and-suspenders (PreToolUse hook + post-hoc `git status` cross-check; post-hoc is authoritative)
+- Auto-merge: green PR + local `make ci` both required; GitHub CI is tiebreaker
+- Resume: last completed task, reset worktree to base before re-dispatch
+- Conflict resolver: Sonnet trivial / Opus file-copy fallback (no speculative pass)
+- Scope: project-scope first, universal extraction tracked as future work
 
 #### April 24, 2026 — Envelope Migration: Wave 5 — the giants (audiobooks, entities, user_tags)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 5.16.0 -->
+<!-- version: 5.17.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-04-24 -->
 
@@ -101,6 +101,7 @@ since it was last edited on 2026-04-11).
 - [ ] **4.13** Comprehensive iTunes test suite (**L**) — after 4.12 extraction, add exhaustive unit tests: mock store tests for every service method, error path coverage, edge cases (empty library, corrupt XML, concurrent sync), position sync, writeback batcher, path reconciliation, track provisioning; target 80%+ coverage on the extracted package
 - [~] **4.14** Plugin system framework (**XL**) — V1: Plugin/EventBus/Registry/Router framework + Deluge migration; V2 (future): RPC subprocess plugins + webhook event delivery
 - [x] **4.15** HTTP response envelope migration (**L**) — **complete** (PRs #425–#438, 10 PRs across 5 waves + pilot, Apr 23–24 2026). All handler files now use `RespondWith*` helpers from `internal/server/error_handler.go`. Success responses enveloped as `{"data": {...}}`; errors as `{"error","code","status"}`. `.data` unwrap lives in `web/src/services/*.ts` adapter layer — components never see the shape change. Parallel Haiku sub-agent dispatch proven effective: Waves 1-5 migrated ~800+ callsites across 24 handler files in ~1 session. Plan doc: [`docs/superpowers/plans/2026-04-23-envelope-migration-parallel.md`](superpowers/plans/2026-04-23-envelope-migration-parallel.md). Reusable pattern captured as the `parallel-refactor-sweep` user-global skill.
+- [~] **4.16** `/parallel-sweep` slash command (**L**) — successor to `parallel-refactor-sweep`. Project-scope command + skill that drives the full sweep autonomously: worktree isolation hooks, parallel child dispatch, PR + admin-merge with local-`make ci` gate, sibling-rebase loop with Sonnet/Opus conflict resolvers, resume across usage limits via persisted state file. Plan: [`docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md`](docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md) (9-step build). Step 1 (skeleton + state schema) **complete** Apr 24 2026. Future work: extract universal version to `~/.claude/commands/` after ~3 real sweeps.
 
 > **Architecture cleanup notes for future work:**
 > When touching these areas, narrow `database.Store` params to ISP sub-interfaces and extract remaining services as opportunities arise:

--- a/docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md
+++ b/docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md
@@ -1,12 +1,12 @@
 <!-- file: docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d -->
 <!-- last-edited: 2026-04-24 -->
 
 # /parallel-sweep — repo-scoped slash command
 
 Author: Claude Opus 4.7 (planning)
-Status: **DRAFT — awaiting user approval**
+Status: **APPROVED — open questions resolved 2026-04-24; implementation begins at step 1**
 Successor of: `parallel-refactor-sweep` skill (lessons baked in)
 
 ## 1. Goal
@@ -205,13 +205,19 @@ The slash command is purely additive. Rollback = `git revert` the merging PR.
 
 In-flight rollback during a live sweep: coordinator can be killed at any checkpoint; state file persists; orphan worktrees can be cleaned with `git worktree prune` + `git branch -D`. Document this explicitly in `parallel-sweep-impl/SKILL.md`.
 
-## 13. Open design questions (need user input)
+## 13. Resolved design decisions (2026-04-24)
 
-1. **Settings.local.json injection mechanism.** Is dropping a per-worktree `.claude/settings.local.json` the right way to give a child agent its own hooks, or do we need a different scoping (e.g., env var, custom skill argument)? Spike in step 3 will answer this.
-2. **Auto-merge policy.** Should the coordinator admin-merge any PR with green CI, or only PRs whose tasks are tagged `auto-ok`? Default proposed: admin-merge always for refactor PRs (since this is human-initiated via /parallel-sweep). Override: a `--review-only` flag that opens drafts and stops.
-3. **Resume granularity.** Resume from last completed task, or last `TaskUpdate` event? Proposed: last completed task (cleaner semantics; cost is at worst re-running one in-flight child agent).
-4. **Conflict resolver model.** Sonnet by default; opus for complex conflicts? Proposed: Sonnet always for trivial; escalate to Opus only via the file-copy fallback path.
-5. **Where to store the slash command.** Project-scope (`.claude/commands/`) or user-global (`~/.claude/commands/`)? Proposed: project-scope so the worktree-discipline hooks and project-specific paths are local. User-global version can come later as a generic template.
+1. **Hook scoping → belt-and-suspenders.** Drop the per-worktree `.claude/settings.local.json` PreToolUse hook AND run a post-hoc `git -C <worktree> status` cross-check after each child completes. The post-hoc check is the authoritative barrier; the hook is defense in depth. Step 3 spike confirms whether the hook actually fires for sub-agents — if not, delete the hook and rely on the post-hoc check alone.
+
+2. **Auto-merge policy → green PR + local `make ci` both required.** Coordinator admin-merges only when (a) GitHub CI is green AND (b) `make ci` passed in the worktree before PR open. On disagreement: GitHub CI is authoritative — if remote red, don't merge. If local red but remote green, also don't merge (local is authoritative on coverage/tests not run by the workflow).
+
+3. **Resume granularity → last completed task.** Re-dispatching an in-flight task starts from a clean known state: `git -C <worktree> reset --hard <base>` before re-spawn. One code path; no special-case logic for partial state. Worst-case cost: one task's worth of agent work re-done per kill.
+
+4. **Conflict resolver model → Sonnet trivial, Opus fallback.**
+   - Trivial path (≤30 markers, ≤3 files): Sonnet conflict-resolver subagent.
+   - Non-trivial path (file-copy cherry-pick): Opus directly. No speculative Sonnet pass — the heuristic that triggers the fallback already says Sonnet would struggle.
+
+5. **Slash command scope → project first, user-global later.** Ship in `.claude/commands/parallel-sweep.md` for this repo. After ~3 real sweeps, extract the universal parts (coordinator logic, state schema, rebase loop) to `~/.claude/commands/` and leave repo-specific bits (rebase/FF merge, `make ci` 80% gate, taglib deps) as configurable. Tracked as future work — see §15.
 
 ## 14. Definition of done
 
@@ -219,3 +225,12 @@ In-flight rollback during a live sweep: coordinator can be killed at any checkpo
 - Documented in `docs/superpowers/specs/parallel-sweep.md`.
 - TODO 4.16 marked `[x]`.
 - A morning after first real-world use produces no "agent worked on main" or "missed test fixture" surprises.
+
+## 15. Future work — universal extraction
+
+Once the project-scoped command has run cleanly through ~3 real sweeps:
+
+- Extract coordinator/child/conflict-resolver prompts and the state schema into a generic `~/.claude/commands/parallel-sweep.md` + `~/.claude/skills/parallel-sweep-impl/`.
+- Move repo-specific knobs (merge style, CI gate command, post-merge hygiene targets) into a per-repo `.claude/parallel-sweep.local.md` config file (YAML frontmatter), discoverable from `${CLAUDE_PROJECT_DIR}`.
+- Default config falls back to safe-but-conservative behavior (no auto-merge, prompt before each merge, single-task fallback) when no local config is present.
+- Publish as a standalone skill in the `superpowers` plugin so other repos pick it up via plugin install.

--- a/docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md
+++ b/docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md
@@ -1,0 +1,221 @@
+<!-- file: docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d -->
+<!-- last-edited: 2026-04-24 -->
+
+# /parallel-sweep — repo-scoped slash command
+
+Author: Claude Opus 4.7 (planning)
+Status: **DRAFT — awaiting user approval**
+Successor of: `parallel-refactor-sweep` skill (lessons baked in)
+
+## 1. Goal
+
+A repo-scoped slash command `/parallel-sweep` that takes a list of independent refactor tasks, spawns isolated worktrees per task, dispatches a sub-agent per worktree, and drives the whole sweep through PR + merge + sibling-rebase without human intervention beyond approval gates. Resumable across usage-limit interruptions.
+
+It hardens the `parallel-refactor-sweep` pattern (proven on TODO 4.15) against three failure modes seen in recent sessions:
+
+- agents bleeding edits into the main checkout (worktree isolation bypass via absolute paths)
+- silent gaps in test coverage breaking the suite post-merge (the SQLite schema + `.data` unwrap class)
+- coordinator overhead blowing up when work is split into many small PRs
+
+## 2. End-state design
+
+User invokes:
+```
+/parallel-sweep
+```
+…with a YAML or markdown body listing tasks. The slash command:
+
+1. Parses the task list.
+2. Loads (or creates) a state file under `.claude/state/parallel-sweep-<runID>.json` keyed by run ID.
+3. Spawns a **coordinator agent** (Opus) via the Task tool. The coordinator:
+   - Creates one worktree per task under `../worktrees/<task-slug>`.
+   - Drops a `.claude/settings.local.json` in each worktree with a PreToolUse hook that blocks any Edit/Write whose `file_path` doesn't begin with that worktree's absolute path. (Hard guardrail against defect 1.)
+   - Dispatches one child `Task` agent (Haiku/Sonnet, model chosen per task) per worktree, in parallel via a single Task-tool call with multiple invocations.
+   - Watches `TaskUpdate` events; persists progress to the state file after each event.
+   - When a child reports done: runs full-suite verification (the project's `make ci` or equivalent), opens a PR, watches CI, admin-merges on green.
+   - After each merge: rebases sibling worktree branches onto main. On trivial conflicts, dispatches a **conflict-resolver subagent** (Sonnet) with a tight scope ("resolve only the textual conflict markers; preserve both intents"). On non-trivial divergence, falls back to a **file-copy cherry-pick** path (cherry-pick aborted → identify changed files → copy them across with `git checkout <sha> -- <path>` and re-test).
+   - On usage-limit / context exhaustion: writes a final state-file checkpoint with `status: paused` and exits cleanly. Resumable on next `/parallel-sweep --resume <runID>`.
+
+## 3. Architecture
+
+```
+.claude/
+├── commands/
+│   └── parallel-sweep.md         ← the slash command (frontmatter + prompt)
+├── skills/
+│   └── parallel-sweep-impl/      ← the procedural detail the slash command points at
+│       ├── SKILL.md
+│       └── references/
+│           ├── coordinator-prompt.md
+│           ├── child-prompt.md
+│           ├── conflict-resolver-prompt.md
+│           └── state-schema.md
+├── state/
+│   └── parallel-sweep-<runID>.json    ← gitignored; per-run state
+└── settings.local.json           ← gitignored; injected per-worktree by coordinator
+```
+
+The slash command itself is thin (~30 lines). The procedural meat lives in the skill so it can be edited and reviewed independently of the trigger.
+
+## 4. State file schema
+
+```json
+{
+  "runID": "2026-04-24-1530-batch-api-migration",
+  "createdAt": "...",
+  "lastCheckpointAt": "...",
+  "status": "running | paused | complete | failed",
+  "userPrompt": "<original /parallel-sweep input>",
+  "tasks": [
+    {
+      "slug": "audiobooks-handlers",
+      "description": "...",
+      "model": "haiku",
+      "worktreePath": "../worktrees/audiobooks-handlers",
+      "branch": "refactor/audiobooks-handlers",
+      "status": "pending | dispatched | in_progress | committed | pr_opened | merged | failed | rebase_blocked",
+      "agentID": "...",
+      "prNumber": 442,
+      "lastUpdate": "...",
+      "errors": []
+    }
+  ],
+  "siblingRebaseQueue": ["audiobooks-handlers", "..."],
+  "conflictResolverInvocations": [
+    {"task": "...", "outcome": "resolved | escalated", "subagentID": "..."}
+  ]
+}
+```
+
+## 5. The PreToolUse worktree-isolation hook
+
+This is the single most important hardening. Every child worktree gets a `.claude/settings.local.json` containing:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Edit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "file=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty'); root=\"<ABSOLUTE_WORKTREE_PATH>\"; [[ \"$file\" == \"$root\"/* || -z \"$file\" ]] && exit 0; echo \"BLOCKED: $file is outside this worktree ($root)\" >&2; exit 1"
+      }]
+    }]
+  }
+}
+```
+
+The coordinator templates `<ABSOLUTE_WORKTREE_PATH>` to the worktree's `pwd` before writing the file. If a child agent tries to Edit a file in main (or another sibling worktree), the hook rejects the call.
+
+**Caveat to verify:** sub-agents may not inherit the host's hook config. Spike test in implementation: dispatch a Haiku agent in a worktree with this `.claude/settings.local.json` and try to Edit a file outside the tree. If sub-agents bypass project-scope hooks, fall back to wrapping the agent's prompt with the absolute path constraint and post-hoc verification (compare the agent's reported edits against `git status` in each worktree before consolidating).
+
+## 6. CI-aware merge
+
+Per project convention (rebase/FF only, no squash) and learned during TODO 4.15:
+
+- `gh pr merge <n> --rebase` only after CI is green (`gh pr checks <n> --watch` or polling `--json statusCheckRollup`).
+- If CI is failing because of pre-existing unrelated breakage on main: `--admin` is acceptable for refactor PRs. Otherwise the merge must wait or escalate.
+- Polling loop has a wall-clock cap (default 30 min); on timeout, mark task as `pr_opened` in state file and continue with siblings.
+
+## 7. Sibling rebase + conflict resolution
+
+After merge of task A:
+1. For each sibling task B still unmerged: `cd <B's worktree> && git fetch origin main && git rebase origin/main`.
+2. If clean: log success, continue to next sibling.
+3. If conflict markers in 1–3 small files (heuristic: total `<<<<<<<` count < 30): dispatch **conflict-resolver subagent** (Sonnet, tight prompt: "Resolve conflicts in these files; preserve both intents; if unsure, write a comment and exit 1"). Then `git add -u && git rebase --continue`. If the subagent exited 1 or another conflict surfaces, escalate.
+4. If broader conflict or rebase aborted: **file-copy cherry-pick** path:
+   - `git rebase --abort`
+   - Identify the original feature commits on B's branch via `git log main..HEAD --oneline`.
+   - For each commit, identify changed files via `git show --stat`.
+   - `git checkout main -- <those files>`, then re-apply B's changes by reading from a stashed copy of the pre-rebase tree, with the conflict-resolver subagent reconciling each file individually.
+   - Mark task as `rebase_blocked` in state if the fallback also fails — escalate to user.
+
+## 8. Failure-mode hardening (per session learnings)
+
+| Failure | Mitigation |
+|---|---|
+| Agent edits files in main (defect 1 from `parallel-refactor-sweep`) | Per-worktree PreToolUse hook (see §5) + post-hoc `git status` cross-check before consolidating |
+| Sub-agent can't run git/gh (defect 2) | Coordinator owns ALL git/gh; child agents report-only |
+| Tests grep by handler name miss URL-decoded callers (defect 3) | Coordinator runs `make ci` in each worktree before opening PR — surfaces missing test updates BEFORE merge |
+| `.data` unwraps missed in service layer (Wave 5 fallout) | Each child's verification step includes a `tsc --noEmit` (frontend) and a project-level test script. State file records which verifications passed. |
+| SQLite schema gap breaking post-merge tests | A coordinator-level "post-merge sanity" job runs the full project test suite on main after each PR merges; if it fails, the next sibling is held until the user resolves. |
+| Coordinator hits usage limit mid-flight | Checkpoint state file after every TaskUpdate; resume on `/parallel-sweep --resume <runID>` |
+
+## 9. File-by-file deliverables
+
+### New files
+
+| Path | Purpose | Approx LOC |
+|---|---|---|
+| `.claude/commands/parallel-sweep.md` | The slash command frontmatter + thin prompt that invokes the skill | ~40 |
+| `.claude/skills/parallel-sweep-impl/SKILL.md` | Procedural body: argument parsing, dispatch loop, merge/rebase loop, resume logic | ~300 |
+| `.claude/skills/parallel-sweep-impl/references/coordinator-prompt.md` | The full system-style prompt for the coordinator agent | ~200 |
+| `.claude/skills/parallel-sweep-impl/references/child-prompt.md` | The full prompt for child task agents (templated per task) | ~150 |
+| `.claude/skills/parallel-sweep-impl/references/conflict-resolver-prompt.md` | Tight prompt for the conflict-resolver subagent | ~80 |
+| `.claude/skills/parallel-sweep-impl/references/state-schema.md` | JSON schema doc + lifecycle diagram for the state file | ~100 |
+| `.claude/skills/parallel-sweep-impl/scripts/dispatch.py` | Optional: helper that emits the worktree settings.local.json + computes paths | ~120 |
+| `.claude/skills/parallel-sweep-impl/scripts/state.py` | State file CRUD helpers | ~80 |
+| `docs/superpowers/specs/parallel-sweep.md` | Public-facing spec / user docs (when to use, args, examples) | ~150 |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `.gitignore` | Add `.claude/state/` and ensure `.claude/settings.local.json` is ignored repo-wide |
+| `CLAUDE.md` | One-line pointer in Workflow Discipline: "For multi-task parallel sweeps, use `/parallel-sweep`." |
+| `TODO.md` | Add `4.16: /parallel-sweep slash command` as `[~]`-in-progress, mark `[x]` after merge |
+
+## 10. Implementation order
+
+Each step is its own commit. Each step's deliverables compile/run on their own.
+
+1. **Skeleton + state schema.** `parallel-sweep-impl/SKILL.md` stub, `state-schema.md`, `state.py` with create/read/update/checkpoint, unit tests for state.py. Worktree blocks on agent dispatch — no actual sweep yet, just plumbing.
+
+2. **Coordinator prompt + dispatch.** Write `coordinator-prompt.md` and `child-prompt.md`. Wire the slash command to invoke the coordinator with a synthetic 1-task input. Verify the coordinator creates a worktree, drops `.claude/settings.local.json`, dispatches a child Haiku, and the child reports back.
+
+3. **PreToolUse hook spike.** Verify that the per-worktree hook actually blocks out-of-tree edits when a sub-agent runs there. If sub-agents bypass project hooks, switch to the prompt-constraint + post-hoc `git status` cross-check fallback before continuing.
+
+4. **PR + merge loop.** Coordinator opens a PR after child completes; polls CI; admin-merges on green. Single-task end-to-end smoke.
+
+5. **Sibling rebase loop (clean case only).** Two tasks; merge first; rebase second cleanly; merge second.
+
+6. **Conflict resolver subagent.** Synthetic conflict between two tasks; verify the resolver subagent fixes simple textual conflicts and the rebase continues.
+
+7. **File-copy cherry-pick fallback.** Force a non-trivial conflict; verify fallback works.
+
+8. **Resume.** Kill the coordinator mid-sweep (SIGTERM); verify `/parallel-sweep --resume <runID>` reads state and continues from `lastCheckpointAt`.
+
+9. **Polish.** Spec doc, CLAUDE.md pointer, TODO.md entry, gitignore changes. Final verification: re-run a known-good sweep (e.g., a small mechanical refactor) end-to-end on this repo.
+
+## 11. Test strategy
+
+- Unit tests for `state.py` (create / load / update / corruption recovery / concurrent-checkpoint safety): pytest, run via `python3 -m pytest`.
+- Unit tests for `dispatch.py` path-templating logic.
+- **Integration test 1 (clean sweep)**: 2 synthetic refactor tasks on a throwaway test repo. Expected: 2 PRs, both merged in order, state file shows `complete`.
+- **Integration test 2 (conflict)**: 2 tasks that touch the same file. Expected: first merges; second hits conflict; resolver subagent invoked; merges.
+- **Integration test 3 (resume)**: kill coordinator after first merge; resume; expected: continues to second task without re-running first.
+- **Integration test 4 (out-of-tree write)**: child agent prompt instructs it to also edit a file in main. Expected: hook blocks the Edit; child reports failure.
+- Smoke: real end-to-end sweep on this repo with a 2-file mechanical refactor that's pre-known-clean.
+
+## 12. Rollback
+
+The slash command is purely additive. Rollback = `git revert` the merging PR.
+
+In-flight rollback during a live sweep: coordinator can be killed at any checkpoint; state file persists; orphan worktrees can be cleaned with `git worktree prune` + `git branch -D`. Document this explicitly in `parallel-sweep-impl/SKILL.md`.
+
+## 13. Open design questions (need user input)
+
+1. **Settings.local.json injection mechanism.** Is dropping a per-worktree `.claude/settings.local.json` the right way to give a child agent its own hooks, or do we need a different scoping (e.g., env var, custom skill argument)? Spike in step 3 will answer this.
+2. **Auto-merge policy.** Should the coordinator admin-merge any PR with green CI, or only PRs whose tasks are tagged `auto-ok`? Default proposed: admin-merge always for refactor PRs (since this is human-initiated via /parallel-sweep). Override: a `--review-only` flag that opens drafts and stops.
+3. **Resume granularity.** Resume from last completed task, or last `TaskUpdate` event? Proposed: last completed task (cleaner semantics; cost is at worst re-running one in-flight child agent).
+4. **Conflict resolver model.** Sonnet by default; opus for complex conflicts? Proposed: Sonnet always for trivial; escalate to Opus only via the file-copy fallback path.
+5. **Where to store the slash command.** Project-scope (`.claude/commands/`) or user-global (`~/.claude/commands/`)? Proposed: project-scope so the worktree-discipline hooks and project-specific paths are local. User-global version can come later as a generic template.
+
+## 14. Definition of done
+
+- `/parallel-sweep <task-list>` end-to-end ships 2-task synthetic sweeps on this repo with all integration tests passing.
+- Documented in `docs/superpowers/specs/parallel-sweep.md`.
+- TODO 4.16 marked `[x]`.
+- A morning after first real-world use produces no "agent worked on main" or "missed test fixture" surprises.


### PR DESCRIPTION
**Plan-only PR — implementation gated on user approval.**

Spec for the `/parallel-sweep` slash command per /insights item 5.

## Plan summary
Plan doc at `docs/superpowers/plans/2026-04-24-parallel-sweep-slash-command.md` (221 lines).

Highlights:
- Per-worktree PreToolUse hook to block out-of-tree edits (defect 1 hardening)
- Coordinator-driven git, child agents are report-only (defect 2)
- Pre-merge `make ci` per worktree (defect 3 — catches missed test updates BEFORE PR)
- Sibling rebase loop + conflict-resolver subagent (Sonnet) + file-copy cherry-pick fallback
- Resumable JSON state file across usage-limit interruptions
- 9-step implementation order; each step independently shippable

Open design questions in §13 of the plan need user input before step 1.