### PR TITLE
fix(library): apply per-user read_status / progress_pct filters on list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.22.0 -->
+<!-- version: 2.23.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-04-24 -->
 
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 24, 2026 — Sidebar `In Progress` / `Finished` filters now work end-to-end
+
+`GET /api/v1/audiobooks?filters=...` previously dropped per-user fields
+(`read_status`, `progress_pct`, `last_played`) on the floor — the comment
+at `audiobook_service.go:1652` flagged this as a spec-3.6 TODO. Result: the
+sidebar links built `?search=read_status:in_progress` URLs that returned
+zero books because every book failed the unknown-field filter.
+
+- **`internal/server/audiobook_service.go`**: `ListFilters` gains
+  `PerUserFilters []FieldFilter` + `UserID string`; `GetAudiobooks` runs
+  a per-user pass after the existing global field-filter pass, calling
+  `store.GetUserBookState(userID, bookID)`. Matching mirrors
+  `playlist_evaluator.perUserFilterMatches` so smart-playlists and the
+  library list agree on `finished` / `in_progress` semantics. `audiobookStore`
+  / `audiobookUpdateStore` interfaces extended with `database.UserPositionStore`.
+- **`internal/server/audiobooks_handlers.go`**: `listAudiobooks` partitions
+  the incoming `filters` JSON into book-global vs per-user buckets via
+  `IsPerUserField`, resolves the caller via `servermiddleware.CurrentUser`,
+  and skips the response cache when per-user filters are active (cache
+  key doesn't encode userID, so a hit could leak between users).
+- Anon callers and missing `UserID` cleanly skip the per-user pass instead
+  of dropping every book. Tests in `audiobook_service_unit_test.go` cover
+  positive, negated (NOT finished), and no-user-ID cases.
 
 #### April 24, 2026 — `/parallel-sweep` slash command — step 1 (skeleton + state schema)
 

--- a/internal/server/audiobook_service.go
+++ b/internal/server/audiobook_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package server
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ type audiobookStore interface {
 	// asExternalIDStore for tombstone cleanup.
 	database.MetadataStore
 	database.UserPreferenceStore
+	// Per-user filter pass on the listing endpoint reads UserBookState
+	// to evaluate read_status / progress_pct / last_played.
+	database.UserPositionStore
 }
 
 // AudiobookService handles all audiobook business logic
@@ -162,7 +166,25 @@ type ListFilters struct {
 	Tag              string
 	SortBy           string        // column sort key
 	SortOrder        string        // "asc" or "desc"
-	FieldFilters     []FieldFilter // advanced field-specific filters
+	FieldFilters     []FieldFilter // advanced field-specific filters (book-global)
+	PerUserFilters   []FieldFilter // per-user filters (read_status, progress_pct, last_played)
+	UserID           string        // caller's user ID; required for PerUserFilters
+}
+
+// PerUserFieldNames is the set of search fields whose values come from
+// per-user state (database.UserBookState) rather than book columns.
+// Handlers use this to split incoming FieldFilters between the global
+// pass (matchesFieldFilters) and the per-user pass.
+var PerUserFieldNames = map[string]struct{}{
+	"read_status":  {},
+	"progress_pct": {},
+	"last_played":  {},
+}
+
+// IsPerUserField reports whether f targets per-user state.
+func IsPerUserField(field string) bool {
+	_, ok := PerUserFieldNames[field]
+	return ok
 }
 
 // derefStr safely dereferences a *string, returning "" for nil.
@@ -340,6 +362,52 @@ func applySorting(books []database.Book, f ListFilters) {
 	})
 }
 
+// matchesPerUserFilter evaluates one per-user FieldFilter against a
+// UserBookState. A nil state is treated as zero-value (Status="",
+// ProgressPct=0, no last activity) so that e.g. `-read_status:finished`
+// correctly matches books the user has never opened. Mirrors the
+// semantics of playlist_evaluator.perUserFilterMatches so smart
+// playlists and the library list agree on what "finished" means.
+func matchesPerUserFilter(state *database.UserBookState, f FieldFilter) bool {
+	if state == nil {
+		state = &database.UserBookState{}
+	}
+	switch f.Field {
+	case "read_status":
+		return strings.EqualFold(state.Status, f.Value)
+	case "progress_pct":
+		// Listing-side FieldFilters carry no operator (parser strips
+		// them at this layer), so equality is the only sensible match.
+		want, err := strconv.Atoi(f.Value)
+		if err != nil {
+			return false
+		}
+		return state.ProgressPct == want
+	case "last_played":
+		// Without an operator we can only test presence — value is
+		// ignored. Useful as `-last_played:` (never played).
+		return !state.LastActivityAt.IsZero()
+	default:
+		return false
+	}
+}
+
+// matchesAllPerUserFilters returns true iff every per-user filter
+// matches (with negation applied), i.e. the book belongs in the
+// filtered set for this user.
+func matchesAllPerUserFilters(state *database.UserBookState, filters []FieldFilter) bool {
+	for _, f := range filters {
+		ok := matchesPerUserFilter(state, f)
+		if f.Negated {
+			ok = !ok
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // matchesFieldFilters returns true if a book matches all the given field filters.
 // All filters are ANDed: every filter must match for the book to be included.
 func matchesFieldFilters(book database.Book, filters []FieldFilter) bool {
@@ -447,7 +515,8 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 		f = filters[0]
 	}
 	hasSorting := f.SortBy != ""
-	hasPostFilters := f.IsPrimaryVersion != nil || f.LibraryState != "" || f.Tag != "" || len(f.FieldFilters) > 0 || hasSorting
+	hasPerUser := len(f.PerUserFilters) > 0 && f.UserID != ""
+	hasPostFilters := f.IsPrimaryVersion != nil || f.LibraryState != "" || f.Tag != "" || len(f.FieldFilters) > 0 || hasPerUser || hasSorting
 
 	// When post-filters are active, fetch all and filter in memory
 	// (PebbleStore doesn't support query-level boolean/string filtering)
@@ -544,6 +613,20 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 				}
 			}
 			filtered = fieldFiltered
+		}
+
+		// Apply per-user filters (read_status / progress_pct / last_played).
+		// Requires a caller user ID; without one we skip rather than
+		// silently dropping every book.
+		if hasPerUser {
+			perUserFiltered := make([]database.Book, 0, len(filtered))
+			for _, b := range filtered {
+				state, _ := svc.store.GetUserBookState(f.UserID, b.ID)
+				if matchesAllPerUserFilters(state, f.PerUserFilters) {
+					perUserFiltered = append(perUserFiltered, b)
+				}
+			}
+			filtered = perUserFiltered
 		}
 
 		// Apply pagination after filtering

--- a/internal/server/audiobook_service_unit_test.go
+++ b/internal/server/audiobook_service_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service_unit_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -515,4 +515,83 @@ func TestAudiobookService_InvalidateBookCaches_ClearsCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, books3, 1)
 	assert.Equal(t, "fresh", books3[0].ID)
+}
+
+// --- Per-user filters (read_status / progress_pct / last_played) ---
+
+// TestAudiobookService_GetAudiobooks_PerUserReadStatus verifies that
+// `read_status:in_progress` queries the per-user state for the caller
+// and only returns books matching that user's status — not other users'.
+func TestAudiobookService_GetAudiobooks_PerUserReadStatus(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+
+	books := []database.Book{
+		{ID: "b1", Title: "Reading"},
+		{ID: "b2", Title: "Finished"},
+		{ID: "b3", Title: "Untouched"},
+	}
+	mockStore.EXPECT().GetAllBooks(0, 0).Return(books, nil)
+
+	// Alice: b1 in-progress, b2 finished, b3 no state.
+	mockStore.EXPECT().GetUserBookState("alice", "b1").
+		Return(&database.UserBookState{UserID: "alice", BookID: "b1", Status: database.UserBookStatusInProgress}, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b2").
+		Return(&database.UserBookState{UserID: "alice", BookID: "b2", Status: database.UserBookStatusFinished}, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b3").Return(nil, nil)
+
+	got, err := svc.GetAudiobooks(context.Background(), 0, 0, "", nil, nil, ListFilters{
+		UserID: "alice",
+		PerUserFilters: []FieldFilter{
+			{Field: "read_status", Value: "in_progress"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "b1", got[0].ID)
+}
+
+// TestAudiobookService_GetAudiobooks_PerUserNegated verifies that the
+// negated form (e.g. `-read_status:finished`) excludes finished books
+// while keeping unstarted ones (nil state treated as zero-value).
+func TestAudiobookService_GetAudiobooks_PerUserNegated(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+
+	books := []database.Book{
+		{ID: "b1", Title: "Finished"},
+		{ID: "b2", Title: "Unstarted"},
+	}
+	mockStore.EXPECT().GetAllBooks(0, 0).Return(books, nil)
+
+	mockStore.EXPECT().GetUserBookState("alice", "b1").
+		Return(&database.UserBookState{Status: database.UserBookStatusFinished}, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b2").Return(nil, nil)
+
+	got, err := svc.GetAudiobooks(context.Background(), 0, 0, "", nil, nil, ListFilters{
+		UserID: "alice",
+		PerUserFilters: []FieldFilter{
+			{Field: "read_status", Value: "finished", Negated: true},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "b2", got[0].ID)
+}
+
+// TestAudiobookService_GetAudiobooks_PerUserNoUserID verifies that
+// without a UserID (anon caller) the per-user filter pass is skipped
+// rather than dropping every book.
+func TestAudiobookService_GetAudiobooks_PerUserNoUserID(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+
+	books := []database.Book{{ID: "b1"}, {ID: "b2"}}
+	mockStore.EXPECT().GetAllBooks(50, 0).Return(books, nil)
+
+	got, err := svc.GetAudiobooks(context.Background(), 0, 0, "", nil, nil, ListFilters{
+		PerUserFilters: []FieldFilter{{Field: "read_status", Value: "finished"}},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got, 2, "no user → per-user filter skipped, all books returned")
 }

--- a/internal/server/audiobook_update_service.go
+++ b/internal/server/audiobook_update_service.go
@@ -24,6 +24,7 @@ type audiobookUpdateStore interface {
 	database.TagStore
 	database.MetadataStore
 	database.UserPreferenceStore
+	database.UserPositionStore
 }
 
 

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
@@ -28,16 +28,10 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
+	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 )
 
 func (s *Server) listAudiobooks(c *gin.Context) {
-	// Build cache key from the full query string
-	cacheKey := "list:" + c.Request.URL.RawQuery
-	if cached, ok := s.listCache.Get(cacheKey); ok {
-		RespondWithOK(c, cached)
-		return
-	}
-
 	// Parse pagination parameters
 	params := ParsePaginationParams(c)
 	authorID := ParseQueryIntPtr(c, "author_id")
@@ -56,14 +50,42 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		SortOrder:        sortOrder,
 	}
 
-	// Parse field filters from JSON query param
+	// Parse field filters from JSON query param. Per-user filters
+	// (read_status / progress_pct / last_played) are split off so the
+	// service can apply them via UserBookState lookups; book-global
+	// filters stay on the original FieldFilters slice.
 	if filtersJSON := c.Query("filters"); filtersJSON != "" {
 		var fieldFilters []FieldFilter
 		if err := json.Unmarshal([]byte(filtersJSON), &fieldFilters); err != nil {
 			RespondWithBadRequest(c, "invalid filters parameter: "+err.Error())
 			return
 		}
-		filters.FieldFilters = fieldFilters
+		for _, ff := range fieldFilters {
+			if IsPerUserField(ff.Field) {
+				filters.PerUserFilters = append(filters.PerUserFilters, ff)
+			} else {
+				filters.FieldFilters = append(filters.FieldFilters, ff)
+			}
+		}
+	}
+
+	// Resolve caller for per-user filters; anon callers just don't
+	// get per-user filtering applied (filters.UserID stays "" and
+	// the service skips that pass).
+	if caller, ok := servermiddleware.CurrentUser(c); ok && caller != nil {
+		filters.UserID = caller.ID
+	}
+
+	// Cache key from the full query string. Skip the cache when
+	// per-user filters are active because the cache key doesn't
+	// encode userID — a hit could leak User A's filtered list
+	// to User B.
+	cacheKey := "list:" + c.Request.URL.RawQuery
+	if len(filters.PerUserFilters) == 0 {
+		if cached, ok := s.listCache.Get(cacheKey); ok {
+			RespondWithOK(c, cached)
+			return
+		}
 	}
 
 	// Call service
@@ -104,7 +126,9 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 	}
 
 	resp := gin.H{"items": enriched, "count": totalCount, "limit": params.Limit, "offset": params.Offset}
-	s.listCache.Set(cacheKey, resp)
+	if len(filters.PerUserFilters) == 0 {
+		s.listCache.Set(cacheKey, resp)
+	}
 	RespondWithOK(c, resp)
 }
 


### PR DESCRIPTION
## Summary
- Fixes the sidebar **In Progress** / **Finished** links returning zero books. They were building `?search=read_status:in_progress` URLs, but `GET /api/v1/audiobooks?filters=…` had no handling for per-user fields and silently dropped every book via the `default: return false` branch in `fieldMatchesValue` (the spec-3.6 TODO called out at `audiobook_service.go:1652`).
- Wires per-user filters (`read_status`, `progress_pct`, `last_played`) through the listing path. `ListFilters` gains `PerUserFilters` + `UserID`; `GetAudiobooks` runs a per-user pass via `store.GetUserBookState` after the global pass. Matching mirrors `playlist_evaluator.perUserFilterMatches` so smart playlists and the list endpoint agree on what "finished" / "in_progress" mean.
- `listAudiobooks` partitions incoming `FieldFilters` into book-global vs per-user buckets via `IsPerUserField`, resolves the caller via `servermiddleware.CurrentUser`, and skips the response cache when per-user filters are active (cache key doesn't encode userID — would otherwise leak between users).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/server/ -short -timeout 180s` — full server package green
- [x] New unit tests in `audiobook_service_unit_test.go` — positive (in_progress), negated (`-read_status:finished` keeps unstarted), no-UserID (anon caller → filter skipped, all books returned)
- [ ] Manual: `make build && make run`, click sidebar **All Books** / **In Progress** / **Finished**, confirm correct counts and switching between them works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)