### PR TITLE
perf(metafetch): add persistent cache to fetch path (bulk + single)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,8 @@ since it was last edited on 2026-04-11).
 > **Architecture cleanup notes for future work:**
 > When touching these areas, narrow `database.Store` params to ISP sub-interfaces and extract remaining services as opportunities arise:
 > - Extracted packages (`dedup`, `metafetch`, `organizer`, `merge`, `versions`, `activity`, `diagnostics`) still accept full `database.Store` — narrow to sub-interfaces (e.g., `BookReader`) when modifying constructors
+> - **Refactor `bulkFetchMetadata` (server/metadata_handlers.go) to delegate to `metafetch.Service.FetchMetadataForBook` per book** — the handler duplicates the source-loop logic from the service and diverged (no cache, no ContextualSearch, simpler scoring, no retry variants). Centralizing removes two divergent copies of "try sources, score results, apply best". Medium effort.
+
 > - `TaskScheduler` still takes `*Server` — extract to `internal/schedule` once it accepts an interface instead
 > - `maintenance_fixups.go` (3,654 LOC) — all methods on `*Server`, extract when feasible
 > - `reconcile.go` (1,317 LOC) — cross-domain orchestration, extract when dependencies are clearer

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.53.0
+// version: 4.54.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package metafetch
@@ -309,57 +309,82 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		var results []metadata.BookMetadata
 		var searchErr error
 
-		// Try the ContextualSearch path first if the source implements
-		// it. This hands richer context (ASIN, ISBN, narrator) to
-		// sources that can use it — Audnexus uses the ASIN for a direct
-		// lookup that works when title search can't, Hardcover uses
-		// the ISBN for a more precise match than the fuzzy GraphQL
-		// search. Sources that don't implement the interface just
-		// fall through to the title/author path below.
-		if ctxSearch, ok := src.(metadata.ContextualSearch); ok {
-			ctx := buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
-			results, searchErr = ctxSearch.SearchByContext(ctx)
-			if searchErr != nil {
-				log.Printf("[WARN] %s context search failed for %q: %v", src.Name(), book.Title, searchErr)
-				// Context search failure is non-fatal — fall through
-				// to the regular title/author path in case that works.
+		// Check the persistent fetch cache before hitting the external API.
+		// The cache is shared with the search-dialog path — a bulk library
+		// fetch or a prior search dialog populates it, so a subsequent single-
+		// book fetch can return immediately without another network round-trip.
+		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
+			var cachedResults []metadata.BookMetadata
+			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+				results = cachedResults
+				log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
+					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 
-		// Try title+author search first for better match quality
-		if len(results) == 0 && currentAuthor != "" {
-			results, searchErr = src.SearchByTitleAndAuthor(searchTitle, currentAuthor)
-			if searchErr != nil {
-				log.Printf("[WARN] %s title+author search failed for %q by %q: %v", src.Name(), searchTitle, currentAuthor, searchErr)
-			}
-		}
-
-		// Fall back to title-only search
 		if len(results) == 0 {
-			results, searchErr = src.SearchByTitle(searchTitle)
-			if searchErr != nil {
-				log.Printf("[WARN] %s failed for %q: %v", src.Name(), searchTitle, searchErr)
-				lastErr = searchErr
+			// Try the ContextualSearch path first if the source implements
+			// it. This hands richer context (ASIN, ISBN, narrator) to
+			// sources that can use it — Audnexus uses the ASIN for a direct
+			// lookup that works when title search can't, Hardcover uses
+			// the ISBN for a more precise match than the fuzzy GraphQL
+			// search. Sources that don't implement the interface just
+			// fall through to the title/author path below.
+			if ctxSearch, ok := src.(metadata.ContextualSearch); ok {
+				ctx := buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
+				results, searchErr = ctxSearch.SearchByContext(ctx)
+				if searchErr != nil {
+					log.Printf("[WARN] %s context search failed for %q: %v", src.Name(), book.Title, searchErr)
+					// Context search failure is non-fatal — fall through
+					// to the regular title/author path in case that works.
+				}
 			}
-		}
 
-		// Try original title if cleaned title returned nothing
-		if len(results) == 0 && searchTitle != book.Title {
-			results, searchErr = src.SearchByTitle(book.Title)
-			if searchErr != nil {
-				lastErr = searchErr
-				continue
+			// Try title+author search first for better match quality
+			if len(results) == 0 && currentAuthor != "" {
+				results, searchErr = src.SearchByTitleAndAuthor(searchTitle, currentAuthor)
+				if searchErr != nil {
+					log.Printf("[WARN] %s title+author search failed for %q by %q: %v", src.Name(), searchTitle, currentAuthor, searchErr)
+				}
 			}
-		}
 
-		// Try with subtitle stripped (e.g. "Title: Subtitle" → "Title")
-		if len(results) == 0 {
-			strippedTitle := stripSubtitle(searchTitle)
-			if strippedTitle != searchTitle && strippedTitle != book.Title {
-				results, searchErr = src.SearchByTitle(strippedTitle)
+			// Fall back to title-only search
+			if len(results) == 0 {
+				results, searchErr = src.SearchByTitle(searchTitle)
+				if searchErr != nil {
+					log.Printf("[WARN] %s failed for %q: %v", src.Name(), searchTitle, searchErr)
+					lastErr = searchErr
+				}
+			}
+
+			// Try original title if cleaned title returned nothing
+			if len(results) == 0 && searchTitle != book.Title {
+				results, searchErr = src.SearchByTitle(book.Title)
 				if searchErr != nil {
 					lastErr = searchErr
 					continue
+				}
+			}
+
+			// Try with subtitle stripped (e.g. "Title: Subtitle" → "Title")
+			if len(results) == 0 {
+				strippedTitle := stripSubtitle(searchTitle)
+				if strippedTitle != searchTitle && strippedTitle != book.Title {
+					results, searchErr = src.SearchByTitle(strippedTitle)
+					if searchErr != nil {
+						lastErr = searchErr
+						continue
+					}
+				}
+			}
+
+			// Write non-empty results to cache so future fetch/search calls
+			// for this book+source can skip the external API entirely.
+			if len(results) > 0 {
+				if blob, merr := json.Marshal(results); merr == nil {
+					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
+						log.Printf("[WARN] metadata-fetch: cache put failed for (%s, %s): %v", id, src.Name(), perr)
+					}
 				}
 			}
 		}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -11,6 +11,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -545,6 +546,20 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 		var metaResults []metadata.BookMetadata
 		var sourceName string
 		for _, src := range sourceChain {
+			// Check the persistent fetch cache before hitting the external API.
+			// Populated by FetchMetadataForBook and SearchMetadata — so a prior
+			// full-library fetch or search-dialog open makes this instant.
+			if cached, cerr := database.GetCachedMetadataFetch(s.Store(), bookID, src.Name()); cerr == nil && cached != nil {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+					metaResults = cachedResults
+					sourceName = src.Name()
+					log.Printf("[DEBUG] bulkFetchMetadata: cache HIT for (%s, %s) — %d results, age=%s",
+						bookID, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+					break
+				}
+			}
+
 			// If we have an author, try title+author search first for more precise results
 			if currentAuthor != "" {
 				metaResults, err = src.SearchByTitleAndAuthor(searchTitle, currentAuthor)
@@ -575,6 +590,15 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 				}
 			}
 			log.Printf("[DEBUG] bulkFetchMetadata: source %s returned no results for %q, trying next", src.Name(), searchTitle)
+
+			// Write results to cache for future calls (fetch or search dialog).
+			if len(metaResults) > 0 {
+				if blob, merr := json.Marshal(metaResults); merr == nil {
+					if perr := database.PutCachedMetadataFetch(s.Store(), bookID, src.Name(), blob, 0); perr != nil {
+						log.Printf("[WARN] bulkFetchMetadata: cache put failed for (%s, %s): %v", bookID, src.Name(), perr)
+					}
+				}
+			}
 		}
 		if len(metaResults) == 0 {
 			result.Status = "not_found"


### PR DESCRIPTION
FetchMetadataForBook and bulkFetchMetadata were bypassing the
metadata_fetch_cache KV store that SearchMetadataForBookWithOptions
already uses. A full library fetch would call every external API once
per book, but a subsequent individual-book fetch would call them again
rather than using the already-cached results.

Fix: wrap each source iteration in both code paths with a cache check
before the external API call and a cache write on success. The cache is
keyed by (bookID, sourceName) and shared across all three paths, so
whichever runs first populates it for the others.

Also document the refactor opportunity: bulkFetchMetadata duplicates
the source-loop logic from Service.FetchMetadataForBook and should
eventually delegate to it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>