### PR TITLE
fix: ignore SQLite WAL sidecars, bleve index, bootstrap token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,10 +199,24 @@ logs/
 
 # Database files (local development)
 *.db
+*.db-shm
+*.db-wal
+*.db-journal
 *.sqlite
+*.sqlite-shm
+*.sqlite-wal
 *.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
 *.pebble/
 audiobooks.pebble/
+
+# Bleve search index (local dev)
+*.bleve/
+library.bleve/
+
+# Bootstrap token (auth credential, do not commit)
+.bootstrap-token
 
 # Backup files
 *.bak


### PR DESCRIPTION
## Summary
- Adds `*.db-shm`, `*.db-wal`, `*.db-journal` (and sqlite/sqlite3 variants) so SQLite WAL mode doesn't dirty the tree on every dev restart
- Adds `*.bleve/` + `library.bleve/` for the local search index
- Adds `.bootstrap-token` (auth credential)

## Test plan
- [x] `git status` clean after applying
- [x] `git check-ignore -v` confirms each pattern hits the right line