### PR TITLE
fix(maintenance): prevent crash when tasks API returns null

### DIFF
--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1258,7 +1258,7 @@ func (ts *TaskScheduler) ListTasks() []TaskInfo {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 
-	var result []TaskInfo
+	result := make([]TaskInfo, 0, len(ts.order))
 	for _, name := range ts.order {
 		task := ts.tasks[name]
 		info := TaskInfo{

--- a/web/src/pages/Maintenance.tsx
+++ b/web/src/pages/Maintenance.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Maintenance.tsx
-// version: 1.2.0
+// version: 1.2.1
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
 
 import { useEffect, useState } from 'react';
@@ -41,7 +41,7 @@ export function Maintenance() {
   const fetchTasks = async () => {
     try {
       const data = await api.getRegisteredTasks();
-      setTasks(data);
+      setTasks(Array.isArray(data) ? data : []);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tasks');


### PR DESCRIPTION
## Summary

Fixes a `TypeError: C.filter is not a function` crash on the Maintenance page.

## Root Cause

Go nil slices marshal to JSON `null`, not `[]`. `ListTasks()` used
`var result []TaskInfo` — a nil slice — so when the scheduler has no tasks
registered yet (or before first registration completes) the `/api/v1/tasks`
endpoint returned `null`. The frontend then stored `null` in the `tasks`
React state and subsequently called `tasks.filter(...)`, which threw:

```
TypeError: C.filter is not a function. (In 'C.filter(n=>n.category===e)', 'C.filter' is undefined)
```

## Changes

### `internal/server/scheduler.go`
- Initialize `result` with `make([]TaskInfo, 0, len(ts.order))` so the JSON
  response is always an array (`[]`) and never `null`.

### `web/src/pages/Maintenance.tsx`
- Guard `setTasks()` with `Array.isArray(data) ? data : []` as a defensive
  safety net against any unexpected non-array API shape.

## Testing

- `go build ./...` — clean
- TypeScript check — no new errors (pre-existing missing-module errors
  unrelated to this change)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)