### PR TITLE
fix: unwrap indexedStore for AIJobsStore assertion; cache stats Total column

### DIFF
--- a/internal/server/ai_jobs_handlers.go
+++ b/internal/server/ai_jobs_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_jobs_handlers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: cbb3180d-eb39-40d0-9f14-a2d57e738c0b
 
 package server
@@ -11,6 +11,23 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
+
+// unwrapAIJobsStore peels Store decorator layers (anything with Unwrap()) until
+// it finds one that satisfies AIJobsStore, mirroring the errors.As() pattern.
+func unwrapAIJobsStore(s database.Store) (database.AIJobsStore, bool) {
+	type unwrapper interface{ Unwrap() database.Store }
+	for s != nil {
+		if ai, ok := s.(database.AIJobsStore); ok {
+			return ai, true
+		}
+		u, ok := s.(unwrapper)
+		if !ok {
+			break
+		}
+		s = u.Unwrap()
+	}
+	return nil, false
+}
 
 // handleListAIJobs serves GET /api/v1/ai-jobs with optional type/status filters.
 // Query params: type, status, limit (default 100, max 500), offset (default 0).
@@ -26,7 +43,7 @@ func (s *Server) handleListAIJobs(c *gin.Context) {
 		offset = 0
 	}
 
-	store, ok := s.Store().(database.AIJobsStore)
+	store, ok := unwrapAIJobsStore(s.Store())
 	if !ok {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "store does not implement AIJobsStore"})
 		return

--- a/internal/server/indexed_store.go
+++ b/internal/server/indexed_store.go
@@ -1,5 +1,5 @@
 // file: internal/server/indexed_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5d2e4f3a-7b5a-4a70-b8c5-3d7e0f1b9a79
 //
 // indexedStore decorates a database.Store so that every successful
@@ -48,6 +48,12 @@ func (s *indexedStore) UpdateBook(id string, b *database.Book) (*database.Book, 
 		s.server.enqueueIndex(id, false)
 	}
 	return updated, err
+}
+
+// Unwrap returns the inner store so decorator-aware helpers (e.g.
+// unwrapAIJobsStore) can peel layers and reach concrete sub-interfaces.
+func (s *indexedStore) Unwrap() database.Store {
+	return s.Store
 }
 
 // DeleteBook removes the row and schedules a Bleve delete on success.

--- a/web/src/components/CacheStatsPanel.tsx
+++ b/web/src/components/CacheStatsPanel.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/CacheStatsPanel.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: b5c8d9ea-1f2g-3h4i-5j6k-7l8m9n0o1p2q
 
 import { useEffect, useState } from 'react';
@@ -52,6 +52,13 @@ const formatInvalidations = (inv: api.CacheInvalidations): string => {
     .filter(([, v]) => v > 0)
     .map(([k, v]) => `${k}: ${v}`);
   return parts.length > 0 ? parts.join(' / ') : '—';
+};
+
+const totalRequests = (cache: api.CacheStatsEntry): number => {
+  const misses = cache.misses
+    ? Object.values(cache.misses).reduce((a, b) => a + b, 0)
+    : 0;
+  return cache.hits + misses;
 };
 
 const formatEvictions = (evict: api.CacheEvictions): string => {
@@ -122,6 +129,7 @@ export function CacheStatsPanel() {
             <TableRow>
               <TableCell>Cache</TableCell>
               <TableCell align="right">Size</TableCell>
+              <TableCell align="right">Total</TableCell>
               <TableCell align="right">Hits</TableCell>
               <TableCell>Misses</TableCell>
               <TableCell align="center">Hit Rate</TableCell>
@@ -134,7 +142,7 @@ export function CacheStatsPanel() {
           <TableBody>
             {!stats || !stats.caches?.length ? (
               <TableRow>
-                <TableCell colSpan={9}>
+                <TableCell colSpan={10}>
                   <Typography variant="body2" color="text.secondary">
                     No cache stats available.
                   </Typography>
@@ -145,6 +153,7 @@ export function CacheStatsPanel() {
                 <TableRow key={cache.name}>
                   <TableCell>{cache.name}</TableCell>
                   <TableCell align="right">{cache.size}</TableCell>
+                  <TableCell align="right">{totalRequests(cache)}</TableCell>
                   <TableCell align="right">{cache.hits}</TableCell>
                   <TableCell>{formatMisses(cache.misses)}</TableCell>
                   <TableCell align="center">


### PR DESCRIPTION
## Summary
- Fixes `ApiError: store does not implement AIJobsStore` on the AI Jobs panel — `indexedStore` decorator was blocking the type assertion to `AIJobsStore`; added `Unwrap()` + `unwrapAIJobsStore()` helper (mirrors `errors.As()` pattern) to peel decorator layers and reach the underlying `*SQLiteStore`
- Adds a **Total** column (hits + sum of all misses) to the Cache Stats table so request volume is visible at a glance alongside the hit-rate percentage

## Test plan
- [ ] Navigate to Diagnostics → AI Jobs panel: should show job table (not the red ApiError)
- [ ] Navigate to Diagnostics → Cache Stats: verify Total column appears and equals Hits + sum(Misses)
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)