### PR TITLE
feat: keep metadata fetch cache after apply; configurable TTL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,6 +208,10 @@ type Config struct {
 	// invalidates the list/facets caches. Defaults to false so caches stay
 	// warm across metadata fetches and write-back operations.
 	CacheInvalidateOnBookUpdate bool `json:"cache_invalidate_on_book_update"`
+	// MetadataFetchCacheTTLDays is how long (in days) the DB-backed metadata
+	// fetch cache (Audible/Audnexus/etc. API results) is considered fresh.
+	// 0 means never expire. Default 7.
+	MetadataFetchCacheTTLDays int `json:"metadata_fetch_cache_ttl_days"`
 	MemoryLimitPercent int    `json:"memory_limit_percent"` // % of system memory
 	MemoryLimitMB      int    `json:"memory_limit_mb"`      // absolute MB
 
@@ -380,6 +384,7 @@ func InitConfig() {
 	// Set memory management defaults
 	viper.SetDefault("memory_limit_type", "items")
 	viper.SetDefault("cache_size", 1000)
+	viper.SetDefault("metadata_fetch_cache_ttl_days", 7)
 	viper.SetDefault("memory_limit_percent", 25)
 	viper.SetDefault("memory_limit_mb", 512)
 
@@ -537,10 +542,11 @@ func InitConfig() {
 		BasicAuthPassword:       viper.GetString("basic_auth_password"),
 
 		// Memory management
-		MemoryLimitType:    viper.GetString("memory_limit_type"),
-		CacheSize:          viper.GetInt("cache_size"),
-		MemoryLimitPercent: viper.GetInt("memory_limit_percent"),
-		MemoryLimitMB:      viper.GetInt("memory_limit_mb"),
+		MemoryLimitType:           viper.GetString("memory_limit_type"),
+		CacheSize:                 viper.GetInt("cache_size"),
+		MetadataFetchCacheTTLDays: viper.GetInt("metadata_fetch_cache_ttl_days"),
+		MemoryLimitPercent:        viper.GetInt("memory_limit_percent"),
+		MemoryLimitMB:             viper.GetInt("memory_limit_mb"),
 
 		// Lifecycle / retention
 		PurgeSoftDeletedAfterDays:   viper.GetInt("purge_soft_deleted_after_days"),

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -424,6 +424,10 @@ func applySetting(key, value, typ string) error {
 		}
 	case "cache_invalidate_on_book_update":
 		AppConfig.CacheInvalidateOnBookUpdate = value == "true"
+	case "metadata_fetch_cache_ttl_days":
+		if i, err := strconv.Atoi(value); err == nil {
+			AppConfig.MetadataFetchCacheTTLDays = i
+		}
 	case "memory_limit_percent":
 		if i, err := strconv.Atoi(value); err == nil {
 			AppConfig.MemoryLimitPercent = i
@@ -740,7 +744,8 @@ func SaveConfigToDatabase(store database.SettingsStore) error {
 		// Memory management
 		"memory_limit_type":              {AppConfig.MemoryLimitType, "string", false},
 		"cache_size":                     {strconv.Itoa(AppConfig.CacheSize), "int", false},
-		"cache_invalidate_on_book_update": {strconv.FormatBool(AppConfig.CacheInvalidateOnBookUpdate), "bool", false},
+		"cache_invalidate_on_book_update":  {strconv.FormatBool(AppConfig.CacheInvalidateOnBookUpdate), "bool", false},
+		"metadata_fetch_cache_ttl_days":    {strconv.Itoa(AppConfig.MetadataFetchCacheTTLDays), "int", false},
 		"memory_limit_percent": {strconv.Itoa(AppConfig.MemoryLimitPercent), "int", false},
 		"memory_limit_mb":      {strconv.Itoa(AppConfig.MemoryLimitMB), "int", false},
 

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.54.0
+// version: 4.55.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package metafetch
@@ -314,11 +314,18 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		// fetch or a prior search dialog populates it, so a subsequent single-
 		// book fetch can return immediately without another network round-trip.
 		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
-			var cachedResults []metadata.BookMetadata
-			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
-				results = cachedResults
-				log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
-					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+			ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+			expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
+			if expired {
+				log.Printf("[DEBUG] metadata-fetch: cache EXPIRED for (%s, %s) — age=%s",
+					id, src.Name(), time.Since(cached.CachedAt).Round(time.Hour))
+			} else {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+					results = cachedResults
+					log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
+						id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+				}
 			}
 		}
 
@@ -2080,12 +2087,16 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		// 8000 times even for books we'd already matched with
 		// high confidence.
 		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
-			var cachedResults []metadata.BookMetadata
-			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
-				allResults = cachedResults
-				cacheHit = true
-				log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
-					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+			ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+			expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
+			if !expired {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
+					allResults = cachedResults
+					cacheHit = true
+					log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
+						id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+				}
 			}
 		}
 
@@ -2494,14 +2505,10 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// UpdateBook so a failed update never leaves stale tags behind.
 	mfs.ApplyMetadataSystemTags(id, candidate.Source, meta.Language)
 
-	// Invalidate the metadata fetch cache for this book. After a
-	// successful apply the book's title/author may have changed,
-	// which means any cached candidates from the per-source cache
-	// were queried against stale search terms and should be
-	// re-fetched next time the user asks.
-	if cerr := database.InvalidateAllCachedMetadataFetchesForBook(mfs.db, id); cerr != nil {
-		log.Printf("[WARN] metadata apply: failed to invalidate fetch cache for %s: %v", id, cerr)
-	}
+	// Intentionally keep the metadata fetch cache after apply. The cached
+	// API results are still valid — the TTL (MetadataFetchCacheTTLDays)
+	// governs when re-fetches happen. Wiping here would force every
+	// subsequent scan to hit the external API again.
 
 	return &FetchMetadataResponse{
 		Message: "metadata candidate applied",

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -838,6 +838,7 @@ interface SettingsState {
   memoryLimitType: string;
   cacheSize: number;
   cacheInvalidateOnBookUpdate: boolean;
+  metadataFetchCacheTTLDays: number;
   memoryLimitPercent: number;
   memoryLimitMB: number;
   logLevel: string;
@@ -1000,6 +1001,7 @@ export function Settings() {
     memoryLimitType: 'items',
     cacheSize: 1000, // items
     cacheInvalidateOnBookUpdate: false,
+    metadataFetchCacheTTLDays: 7,
     memoryLimitPercent: 25, // % of system memory
     memoryLimitMB: 512, // MB
 
@@ -1195,6 +1197,7 @@ export function Settings() {
         memoryLimitType: config.memory_limit_type || 'items',
         cacheSize: config.cache_size || 1000,
         cacheInvalidateOnBookUpdate: config.cache_invalidate_on_book_update ?? false,
+        metadataFetchCacheTTLDays: config.metadata_fetch_cache_ttl_days ?? 7,
         memoryLimitPercent: config.memory_limit_percent || 25,
         memoryLimitMB: config.memory_limit_mb || 512,
 
@@ -1797,6 +1800,7 @@ export function Settings() {
         memory_limit_type: settings.memoryLimitType,
         cache_size: settings.cacheSize,
         cache_invalidate_on_book_update: settings.cacheInvalidateOnBookUpdate,
+        metadata_fetch_cache_ttl_days: settings.metadataFetchCacheTTLDays,
         memory_limit_percent: settings.memoryLimitPercent,
         memory_limit_mb: settings.memoryLimitMB,
 
@@ -3392,6 +3396,20 @@ export function Settings() {
                 />
               </Grid>
             )}
+
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                type="number"
+                label="Metadata fetch cache TTL (days)"
+                value={settings.metadataFetchCacheTTLDays}
+                onChange={(e) =>
+                  handleChange('metadataFetchCacheTTLDays', parseInt(e.target.value) || 0)
+                }
+                inputProps={{ min: 0, max: 365 }}
+                helperText="How long to keep Audible/Audnexus API results before re-fetching. 0 = never expire."
+              />
+            </Grid>
 
             <Grid item xs={12}>
               <FormControlLabel

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -516,6 +516,7 @@ export interface Config {
   memory_limit_type: string;
   cache_size: number;
   cache_invalidate_on_book_update: boolean;
+  metadata_fetch_cache_ttl_days: number;
   memory_limit_percent: number;
   memory_limit_mb: number;
 


### PR DESCRIPTION
## Summary
- **Remove wipe-on-apply**: `ApplyMetadataCandidate` no longer calls `InvalidateAllCachedMetadataFetchesForBook` — Audible/Audnexus results survive after confirming a match, so re-scans are instant
- **TTL-based expiry**: both fetch paths (`FetchMetadata` and `SearchMetadata`) check `CachedAt` against `MetadataFetchCacheTTLDays` (default 7); expired entries fall through to the external API
- **Settings toggle**: new "Metadata fetch cache TTL (days)" field in Settings → Memory Management; set to 0 to never expire

## Why
Wipe-on-apply was added to handle stale search terms after title/author changes, but it meant every scan after an apply had to re-hit all external APIs — defeating the cache entirely. With the TTL approach, good matches persist for days; wrong matches expire naturally.

## Test plan
- [ ] Apply metadata to a book, immediately re-fetch — should show "cache HIT" in logs with near-zero latency
- [ ] Set TTL to 0 in settings — entries never expire
- [ ] Set TTL to 1 day, wait 25h, re-fetch — should show "cache EXPIRED" and hit external API

🤖 Generated with [Claude Code](https://claude.com/claude-code)