### PR TITLE
feat(itunes): path repair operation — discover stale paths, push fixes through batcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,28 @@ Fixed "spins forever showing 0 books" when opening the metadata review dialog fo
 - **`MetadataReviewDialog`**: server-side pagination replaces client-side slice; per-book `getBook()` waterfall removed entirely; polling uses `limit=1` to cheaply check total count.
 - Regenerated mocks via `make mocks` (also fixes pre-existing `GetDistinctGenres` mock compile errors).
 
+#### April 26, 2026 — iTunes path repair operation (`POST /operations/itunes-path-repair`)
 
+Recovers cases where iTunes still references stale on-disk paths after organize/rename — common when many files have been moved out from under iTunes and the existing path reconciler can't help because `Book.FilePath` itself is also stale. Three-tier resolution per missing track:
+
+- **Tier A — PID → DB lookup.** Uses `external_id_map` to resolve the iTunes Persistent ID to a book ID, then prefers a matching `BookFile.FilePath` (multi-segment safe) before falling back to `Book.FilePath`. Only resolves when the DB-known path also exists on disk.
+- **Tier B — embedded `AUDIOBOOK_ORGANIZER_ID` tag scan.** Lazy: only fires after tier A leaves residue. Walks the audiobook root once, indexes book ID → on-disk paths, resolves missing tracks whose book ID has a unique disk match. Multi-segment ambiguity falls through to tier C.
+- **Tier C — fuzzy ranking.** Scores each walked audio file against the iTunes track title + original basename (existing `matcher.ScoreMatch`, threshold 85, equivalent to Jaro-Winkler 0.85). Top 3 candidates emit to `needs_review_items` for human confirmation. Never auto-applied.
+
+**Apply mode:** `?apply=true` flips dry-run off. Auto-resolved tracks update the matching `BookFile` (or `Book`) with the discovered `FilePath` and recomputed `ITunesPath` via `metafetch.ComputeITunesPath`, record a `book_path_history` row with `change_type="itunes_path_repair"`, and hand the book ID to `Enqueuer.Enqueue` so the existing `WriteBackBatcher` pushes the corrected location to the .itl on its normal cadence.
+
+**Reports:** every run drops a pretty-printed JSON at `<RootDir>/reports/itunes-repair-<opID>.json` and persists the same payload inline via `UpdateOperationResultData`.
+
+**Safety:** dry-run by default. Resume after interruption also defaults to dry-run; the operator must explicitly re-trigger with `?apply=true` once they confirm the report. iTunes-side writes go through `SafeWriteITL` (timestamped backups + atomic rename). DB-side updates are reversible via `book_path_history`.
+
+What ships:
+
+- `internal/itunes/service/path_repair.go` — `PathRepairer` operation (worker, apply-mode helper, report writer)
+- `internal/itunes/service/path_repair_resolver.go` — pure-function tier A/B/C resolvers + `fsTagScanner`
+- `POST /operations/itunes-path-repair` (PermScanTrigger gated)
+- `Deps.AudiobookRoot` + `Deps.ReportDir` plumbed at the service construction site
+- `pathRepairerStore` and `itunesservice.Store` now also embed `database.PathHistoryStore`
+- 18 new tests covering all three tiers, the fsTagScanner, lookupBookID, apply mode, end-to-end across all four track outcomes (OK / A / B / C), and scaffolding (`Start` / `parseDryRun`)
 
 #### April 25, 2026 — `/parallel-sweep` slash command — step 9 (polish, all 9 steps complete)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,62 +1,152 @@
-# Cache Metrics — Plan
+# iTunes Path Repair
 
-Branch: `feat/cache-metrics` · Worktree: `audiobook-organizer-cache-metrics`
+Branch: `feat/itunes-path-repair` · Worktree: `.worktrees/itunes-path-repair`
 
 ## Goal
-Add per-cache observability (hits, misses, sets, invalidations, evictions, size, latency) for every cache in the system. Expose via existing Prometheus `/metrics`, a JSON endpoint for the Diagnostics UI, a per-key debug endpoint, and a persistent history table for restart-surviving trends.
 
-OTel deferred to a separate future PR.
+After organize/rename, iTunes still references stale paths for hundreds of
+files that no longer exist on disk. Add an operation that **dumps the iTunes
+XML, finds every track whose `Location` doesn't exist, re-discovers the
+correct file via a three-tier strategy (PID → embedded tag → fuzzy match),
+and enqueues path corrections through the existing `WriteBackBatcher`** so
+they ship in normal batched .itl writes.
 
-## Files to change
+## Affected files
 
-### Wave 0 — foundation (coordinator, sequential)
-- `internal/metrics/metrics.go` — add cache counter/gauge/histogram primitives + helper funcs
-- `internal/cache/cache.go` — add `name` field, `New(name, ttl)`, instrument Get/Set/Invalidate(All)
-- `internal/cache/cache_test.go` — update tests for new signature, add metric-emission test
-- All 6 callsites of `cache.New[...]` (mechanical name addition):
-  - `internal/server/server.go:838-840` (dashboardCache, dedupCache, listCache)
-  - `internal/server/audiobook_service.go:80-81` (bookCache, listCache)
-  - `internal/ai/openai_parser.go:66` (responseCache)
+### New
+- `internal/itunes/service/path_repair.go` — `PathRepairer` operation;
+  mirrors `path_reconcile.go` (small store interface, `Start` HTTP handler
+  that registers a queued operation, `Repair(ctx, opID, progress)` worker).
+- `internal/itunes/service/path_repair_resolver.go` — pure-function
+  resolver implementing tiers A/B/C (no store deps, easy to unit-test).
+- `internal/itunes/service/path_repair_test.go` — operation-level integration
+  test using fixture XML + tmpdir tree.
+- `internal/itunes/service/path_repair_resolver_test.go` — per-tier unit
+  tests.
 
-### Wave 1 — parallel children
-- **T1 (Sonnet)**: `internal/database/metadata_fetch_cache.go` — wire counters at read/write boundaries
-- **T2 (Sonnet)**: `internal/database/embedding_store.go` — wire counters at cache lookup paths
-- **T3 (Haiku)**: `web/src/pages/Diagnostics.tsx` (or equivalent) — add Cache Stats panel
-- **T4 (Haiku)**: `internal/server/system_handlers.go` — add `GET /api/v1/cache/stats` JSON handler + `GET /api/v1/cache/stats/keys?cache=X` (admin-gated, key names only)
+### Modified
+- `internal/itunes/service/service.go` — wire `PathRepairer` into the
+  service struct + constructor (same pattern as `PathReconciler`).
+- `internal/server/server.go` — register
+  `POST /operations/itunes-path-repair` next to the existing reconcile
+  route (around line 2365).
+- `TODO.md` / `CHANGELOG.md` — entry for the new operation.
 
-### Wave 2 — persistence (coordinator, sequential)
-- New migration N+1: `cache_stats_history` table (cache_name, ts, hits, misses, sets, invalidations, evictions, size)
-- `internal/server/server.go` — background snapshotter goroutine (every 5 min)
-- `internal/server/system_handlers.go` — `GET /api/v1/cache/stats/history?cache=X&since=Y`
-- Tests + CHANGELOG.md + TODO.md
+### Reused (read-only dependencies)
+- `itunes.ParseLibrary` (parser.go) — XML dump
+- `metafetch.ComputeITunesPath` — recompute iTunes-format paths
+- `store.GetBookByExternalID("itunes", pid)` — tier A lookup
+- `store.GetBookPathHistory` / `store.RecordPathChange` — audit trail
+- `store.UpdateBook` — write corrected `FilePath` back to DB
+- `Enqueuer.Enqueue(bookID)` — hand off to `WriteBackBatcher`; existing
+  `SafeWriteITL` provides backups + atomic rename
+- audio-tag reader (whichever package `metafetch.ExtractMetadata` uses)
+  for tier B PID extraction
 
-### Wave 3 — LRU eviction (coordinator, sequential)
-- `internal/cache/cache.go` — add optional `maxEntries int` (0 = unbounded, current behavior). When set, maintain an access-ordered list (`container/list` doubly-linked list + map index) and evict the LRU entry on `Set` once `len(items) > maxEntries`. Each eviction calls `metrics.RecordCacheEviction(name)`.
-- New constructor: `NewWithLimit[T](name string, ttl time.Duration, maxEntries int) *Cache[T]` — keeps the existing `New` signature stable for callers that want unbounded.
-- Also evict expired entries lazily on `Get` (currently they linger): on a miss-due-to-expiry path, delete the stale entry and record an eviction with `reason="expired"`. This gives `cache_evictions_total{cache,reason}` real signal without forcing every cache to opt into LRU.
-- Pick sensible default limits per cache once we have a wave or two of production stats showing actual sizes — don't guess up front.
-- Tests: cover capacity-eviction ordering, expired-on-Get eviction, and that LRU access updates recency.
+## Design
 
-## Ordered steps
-1. **Wave 0a**: extend `internal/metrics/metrics.go` (new counter/gauge/histogram + helpers + register).
-2. **Wave 0b**: add `name` to `Cache[T]`, instrument operations, update 6 callsites in one commit. `make test` green.
-3. **Wave 1**: dispatch T1–T4 in parallel as subagents (worktree-isolated). Each opens its own PR or returns a patch the coordinator commits to this branch.
-4. **Wave 2**: write migration, snapshotter, history endpoint. Add tests.
-5. Run full `make ci`, update CHANGELOG/TODO, open PR.
+### Resolution tiers (applied in order)
+
+1. **(A) PID → DB lookup.** Each XML track has a `Persistent ID`. Call
+   `GetBookByExternalID("itunes", pid)`. If a book is found, take
+   `Book.FilePath` (or the matching `BookFile.FilePath` for multi-segment
+   books). If that path exists on disk, that's the correct location.
+   Cheap, exact, handles the common case.
+2. **(B) Embedded tag scan.** When (A) leaves residue, walk the audiobook
+   root once, extract `AUDIOBOOK_ORGANIZER_PERSISTENT_ID` from each audio
+   file's tags, build an in-memory `pid → on-disk-path` map. Re-resolve
+   unmatched tracks against this map. Recovers when `external_id_map` is
+   stale or never populated.
+3. **(C) Fuzzy match.** For still-unresolved tracks, score candidates by
+   filename + title similarity. **Never auto-apply.** Emit ranked
+   candidates to a `needs_review` list in the operation result for human
+   confirmation.
+
+### Source-of-truth ordering
+
+Filesystem > DB > iTunes XML. When (A) or (B) finds a real path that
+differs from `Book.FilePath`, the repairer:
+
+1. `RecordPathChange(book_id, old_path, new_path, "repair")`.
+2. `UpdateBook` with the new `FilePath`.
+3. Recompute `Book.ITunesPath` via `ComputeITunesPath(new_path)`.
+4. `Enqueuer.Enqueue(bookID)` — the batcher writes through
+   `UpdateITLLocations` on its normal schedule.
+
+This deliberately reuses the same path the reconciler already drives, so we
+inherit existing backup/atomic-rename safety.
+
+### Dry-run by default
+
+Operation defaults to dry-run: result lists `auto_resolved`, `needs_review`,
+`unresolved` with counts and book IDs but writes nothing. `?apply=true`
+flips it to write mode (matches the convention in `path_reconcile.go:69`).
+
+### Concurrency / scale
+
+Hundreds of books × thousands of files. Tiers A is cheap (DB lookup +
+`os.Stat`); parallelize with a worker pool sized to `runtime.NumCPU()`.
+Tier B runs only on the residue and is the expensive step (tag read per
+file) — same worker-pool pattern. Tier C is small and sequential.
+
+### Logging (per `feedback_logging.md`)
+
+- Start: `iTunes path repair started: tracks=N`
+- Per-tier rollup: `tier=A resolved=X unresolved=Y`
+- Per resolution: `repair pid=… old=… new=… tier=A|B|C action=enqueue|skip`
+- Skip: `tier=A skipped reason=path_exists`
+- Complete: `iTunes path repair complete: missing=N auto=X review=Y unresolved=Z duration=…`
+
+## Ordered steps (one commit each, conventional commits)
+
+1. **Scaffold** — `path_repair.go` + service wiring + route + dry-run
+   response shape with empty results. `make build-api` green.
+2. **Tier A** — XML parse, stat each `Location`, resolve missing via
+   `GetBookByExternalID`. Unit + small integration test with fixture XML.
+3. **Tier B** — pure resolver function backed by a tag reader; lazy
+   invocation; tests for PID match, multi-segment, no PID tag.
+4. **Tier C** — fuzzy filename + title scoring; emit to `needs_review`,
+   never auto-apply. Tests for ranking + threshold.
+5. **Apply mode** — `?apply=true` triggers `RecordPathChange` +
+   `UpdateBook` + `Enqueuer.Enqueue`. Test that the batcher receives the
+   right book IDs (mock enqueuer).
+6. **End-to-end** — fixture XML with one OK / one A-resolvable /
+   one B-resolvable track + tmpdir tree; assert dry-run report and
+   apply-mode side effects.
+7. **Docs** — TODO.md, CHANGELOG.md.
 
 ## Test strategy
-- Unit: `cache_test.go` asserts that Get hit/miss/expired paths emit the right counter.
-- Integration: hit `/api/v1/cache/stats` after seeding a cache, verify shape.
-- Metrics: scrape `/metrics`, assert `cache_hits_total{cache="dashboard"}` exists.
-- DB: history table populated after a forced snapshot tick.
+
+- `go test ./internal/itunes/service/... -run TestPathRepair -v`
+- `go test ./internal/itunes/... -run "TestPath|TestParseLibrary"` —
+  no regression in path mapping / parser
+- `make test` — full Go suite stays green
+- `make ci` before opening the PR
+- **Manual dry-run smoke against prod XML** (read-only) before any
+  `?apply=true` discussion: hit the endpoint with a dev DB pointed at the
+  prod XML and confirm `missing` count is plausible and most resolutions
+  land in tier A.
+
+Success: `make ci` green; dry-run smoke returns sane counts with the
+majority resolved by tier A.
 
 ## Rollback
-Single branch, single PR (or PR-per-wave). Revert merge commit. No schema destructive changes — the new table is additive; cache name parameter is required but defaults are easy to add if needed.
 
-## Cardinality safety
-Labels are bounded: `{cache}` ∈ {dashboard, dedup, list, book, ai_response, metadata_fetch, embedding, ...} — single digits. `{reason}` ∈ {not_found, expired}. No per-key labels — that's what the per-key debug endpoint is for, and it returns *names only*.
+- All iTunes writes go through existing `Enqueuer` → `WriteBackBatcher` →
+  `SafeWriteITL`, which keeps timestamped .itl backups. Restore from
+  backup if a bad apply lands.
+- DB-side: every `Book.FilePath` change is recorded in `book_path_history`
+  with `change_type=repair`; revert by replaying the most recent `repair`
+  row per book in reverse.
+- Code-side: revert the feature branch — operation is purely additive, no
+  schema changes, no behavior change to existing endpoints.
 
-## Out of scope
-- OTel migration (separate future PR)
-- Per-key value inspection (returns names only)
-- Tuning per-cache `maxEntries` defaults (Wave 3 ships the mechanism unbounded; tuning is a follow-up once we have history data)
+## Open questions / clarifications wanted
+
+- Is dry-run-default acceptable, or should the first run be apply-on?
+  (Default: dry-run.)
+- For tier C, what's the desired similarity threshold? Suggest start at
+  `0.85` Jaro-Winkler on basename and require title containment.
+- Should the operation persist its report (e.g. `docs/reports/itunes-repair-<ts>.json`)
+  or just return it in the HTTP response? Suggest both — return inline
+  for small results, write to disk if `>1000` items.

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,11 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
+## 🛠️ Slash commands
+
+- **`/parallel-sweep`** (project-scoped, [`.claude/commands/parallel-sweep.md`](.claude/commands/parallel-sweep.md)) — coordinated multi-task refactor sweep (≥3 mechanical tasks). Spec in [`docs/superpowers/specs/parallel-sweep.md`](docs/superpowers/specs/parallel-sweep.md).
+- **`/ship`** (global, `~/.claude/commands/ship.md`) — push current branch, open PR, admin-merge with rebase/FF, pull the default branch, run `make deploy` if present. Standard ship-it pipeline; works in any repo.
+
 ## 🔧 CI / Release Infrastructure — Complete
 
 - [x] Revert corrupted `release-go-action/action.yml`

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 5.26.0 -->
+<!-- version: 5.27.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-25 -->
+<!-- last-edited: 2026-04-26 -->
 
 # Project TODO
 
@@ -261,6 +261,13 @@ Every plan in chronological order. ✅ = implemented, ⏳ = design done, plan wr
 ---
 
 ## ✅ Recently Completed
+
+### Session 24 (2026-04-26) — iTunes path repair
+
+- New operation `POST /operations/itunes-path-repair` (PermScanTrigger gated). Three-tier resolution: tier A (PID → DB lookup), tier B (lazy embedded `AUDIOBOOK_ORGANIZER_ID` tag scan, single-pass `fsTagScanner`), tier C (fuzzy ranking via existing `matcher.ScoreMatch`, threshold 85, top-3 per missing track, never auto-applied).
+- Apply mode (`?apply=true`) updates `BookFile.FilePath`/`ITunesPath` (or `Book.*` fallback), records `book_path_history` rows with `change_type="itunes_path_repair"`, and enqueues through the existing `WriteBackBatcher` so corrected locations ship in normal batched .itl writes.
+- Each run drops a JSON report to `<RootDir>/reports/itunes-repair-<opID>.json` plus the same payload inline via `UpdateOperationResultData`.
+- 18 new tests; safe-by-default (dry-run on first invocation and on resume).
 
 ### Session 23 (2026-04-25) — cache observability
 

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -51,12 +52,33 @@ type PathRepairer struct {
 	enqueuer Enqueuer
 	queue    operations.Queue
 	cfg      PathRepairConfig
+	// bookIDExtractor pulls AUDIOBOOK_ORGANIZER_ID from one audio
+	// file. Production wires this to metadata.ExtractMetadata.
+	// Tests inject deterministic fakes.
+	bookIDExtractor bookIDExtractor
 }
 
 // newPathRepairer wires a PathRepairer. nil enqueuer skips the
 // write-back enqueue step (used by dry-run-only tests).
 func newPathRepairer(store pathRepairerStore, enqueuer Enqueuer, queue operations.Queue, cfg PathRepairConfig) *PathRepairer {
-	return &PathRepairer{store: store, enqueuer: enqueuer, queue: queue, cfg: cfg}
+	return &PathRepairer{
+		store:           store,
+		enqueuer:        enqueuer,
+		queue:           queue,
+		cfg:             cfg,
+		bookIDExtractor: extractBookOrganizerID,
+	}
+}
+
+// extractBookOrganizerID is the production extractor used by the
+// fsTagScanner. Reads embedded metadata and returns the
+// AUDIOBOOK_ORGANIZER_ID tag value (book-organizer book ID).
+func extractBookOrganizerID(audioFilePath string) (string, error) {
+	md, err := metadata.ExtractMetadata(audioFilePath, nil)
+	if err != nil {
+		return "", err
+	}
+	return md.BookOrganizerID, nil
 }
 
 // iTunesPathRepairResult is the per-run tally returned in progress
@@ -160,6 +182,24 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 	result := iTunesPathRepairResult{XMLTracks: len(lib.Tracks), DryRun: dryRun}
 	_ = progress.UpdateProgress(0, len(lib.Tracks), "scanning iTunes locations")
 
+	// Tier B is built lazily — only constructed if tier A leaves
+	// residue. Walking the audiobook root is the expensive step and
+	// we don't want to pay it on libraries where every iTunes path
+	// resolves cleanly via the DB.
+	var tierB tagScanner
+	getTierB := func() tagScanner {
+		if tierB == nil {
+			if r.cfg.AudiobookRoot == "" || r.bookIDExtractor == nil {
+				tierB = noopTagScanner{}
+			} else {
+				_ = progress.Log("info",
+					fmt.Sprintf("tier B: scanning audiobook root for embedded book IDs root=%s", r.cfg.AudiobookRoot), nil)
+				tierB = newFSTagScanner(r.cfg.AudiobookRoot, r.bookIDExtractor)
+			}
+		}
+		return tierB
+	}
+
 	scanned := 0
 	for _, track := range lib.Tracks {
 		select {
@@ -180,8 +220,11 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		}
 		result.Missing++
 
-		// Tier A: PID → DB → on-disk path
-		if newPath, ok := resolveTierA(r.store, track.PersistentID, pathExists); ok {
+		// Single PID → bookID lookup shared by tier A and tier B.
+		bookID := lookupBookID(r.store, track.PersistentID)
+
+		// Tier A: bookID → DB-known on-disk path
+		if newPath, ok := resolveTierA(r.store, track.PersistentID, bookID, pathExists); ok {
 			result.AutoResolved++
 			_ = progress.Log("info",
 				fmt.Sprintf("repair pid=%s old=%s new=%s tier=A action=%s",
@@ -189,10 +232,19 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 			continue
 		}
 
-		// Tier B/C land in subsequent commits.
+		// Tier B: embedded AUDIOBOOK_ORGANIZER_ID tag scan
+		if newPath, ok := resolveTierB(getTierB(), bookID, pathExists); ok {
+			result.AutoResolved++
+			_ = progress.Log("info",
+				fmt.Sprintf("repair pid=%s old=%s new=%s tier=B action=%s",
+					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			continue
+		}
+
+		// Tier C lands in the next commit.
 		result.Unresolved++
 		_ = progress.Log("debug",
-			fmt.Sprintf("missing pid=%s old=%s tier=A unresolved", track.PersistentID, decoded), nil)
+			fmt.Sprintf("missing pid=%s old=%s tier=AB unresolved", track.PersistentID, decoded), nil)
 	}
 
 	if err := persistRepairResult(r.store, opID, result); err != nil {

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -13,13 +13,16 @@ package itunesservice
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -118,17 +121,119 @@ func (r *PathRepairer) Start(c *gin.Context) {
 	c.JSON(http.StatusAccepted, op)
 }
 
-// Repair is the operation body. Step 1 scaffolds the worker shape;
-// tier A/B/C resolution lands in subsequent commits.
+// Repair is the operation body. Wraps repairWithResult so the
+// queue-side closure has the (ctx, id, progress) → error signature
+// the operations.Queue expects.
 func (r *PathRepairer) Repair(ctx context.Context, opID string, dryRun bool, progress operations.ProgressReporter) error {
+	_, err := r.repairWithResult(ctx, opID, dryRun, progress)
+	return err
+}
+
+// resolvedTrack records one resolution decision. Used inside the
+// operation worker for logging + report assembly.
+type resolvedTrack struct {
+	PID     string `json:"pid"`
+	OldPath string `json:"old_path"`
+	NewPath string `json:"new_path"`
+	Tier    string `json:"tier"`
+	BookID  string `json:"book_id,omitempty"`
+}
+
+// repairWithResult is the operation body. Returns the result struct so
+// tests can assert on counts; the JSON-encoded form is also persisted
+// to the operation row via UpdateOperationResultData.
+func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun bool, progress operations.ProgressReporter) (iTunesPathRepairResult, error) {
 	if r.store == nil {
-		return fmt.Errorf("database not initialized")
+		return iTunesPathRepairResult{}, fmt.Errorf("database not initialized")
 	}
-	_ = progress.Log("info", "iTunes path repair started", nil)
-	result := iTunesPathRepairResult{DryRun: dryRun}
+	if r.cfg.XMLPath == "" {
+		return iTunesPathRepairResult{}, fmt.Errorf("iTunes XMLPath not configured")
+	}
+
+	_ = progress.Log("info", fmt.Sprintf("iTunes path repair started: xml=%s dry_run=%t", r.cfg.XMLPath, dryRun), nil)
+
+	lib, err := itunes.ParseLibrary(r.cfg.XMLPath)
+	if err != nil {
+		return iTunesPathRepairResult{}, fmt.Errorf("parse iTunes library: %w", err)
+	}
+
+	result := iTunesPathRepairResult{XMLTracks: len(lib.Tracks), DryRun: dryRun}
+	_ = progress.UpdateProgress(0, len(lib.Tracks), "scanning iTunes locations")
+
+	scanned := 0
+	for _, track := range lib.Tracks {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+		scanned++
+		if !itunes.IsAudiobook(track) {
+			continue
+		}
+		decoded, derr := itunes.DecodeLocation(track.Location)
+		if derr != nil || decoded == "" {
+			continue
+		}
+		if pathExists(decoded) {
+			continue
+		}
+		result.Missing++
+
+		// Tier A: PID → DB → on-disk path
+		if newPath, ok := resolveTierA(r.store, track.PersistentID, pathExists); ok {
+			result.AutoResolved++
+			_ = progress.Log("info",
+				fmt.Sprintf("repair pid=%s old=%s new=%s tier=A action=%s",
+					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			continue
+		}
+
+		// Tier B/C land in subsequent commits.
+		result.Unresolved++
+		_ = progress.Log("debug",
+			fmt.Sprintf("missing pid=%s old=%s tier=A unresolved", track.PersistentID, decoded), nil)
+	}
+
+	if err := persistRepairResult(r.store, opID, result); err != nil {
+		log.Printf("[WARN] persist repair result: %v", err)
+	}
 	_ = operations.ClearState(r.store, opID)
-	_ = progress.Log("info", "iTunes path repair complete (scaffold; resolution tiers pending)", nil)
-	_ = progress.UpdateProgress(0, 0, "scaffold")
-	_ = result // populated in step 2+
-	return nil
+
+	summary := fmt.Sprintf(
+		"iTunes path repair complete: tracks=%d missing=%d auto=%d review=%d unresolved=%d enqueued=%d dry_run=%t",
+		result.XMLTracks, result.Missing, result.AutoResolved, result.NeedsReview, result.Unresolved, result.Enqueued, result.DryRun,
+	)
+	_ = progress.Log("info", summary, nil)
+	_ = progress.UpdateProgress(scanned, scanned, summary)
+	return result, nil
+}
+
+// pathExists is the production existsFn for the resolver. Test code
+// may inject a fake.
+func pathExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// applyAction returns the human-readable action label for a single
+// repair, distinguishing dry-run reports from real writes.
+func applyAction(dryRun bool) string {
+	if dryRun {
+		return "report"
+	}
+	return "enqueue"
+}
+
+// persistRepairResult JSON-encodes the result and stores it on the
+// operation row so the API can fetch the report after the run.
+func persistRepairResult(store database.OperationStore, opID string, result iTunesPathRepairResult) error {
+	b, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return store.UpdateOperationResultData(opID, string(b))
 }

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -85,16 +86,33 @@ func extractBookOrganizerID(audioFilePath string) (string, error) {
 // logs and the operation result. Field names mirror the dry-run JSON
 // payload that callers consume.
 type iTunesPathRepairResult struct {
-	XMLTracks    int      `json:"xml_tracks"`
-	Missing      int      `json:"missing"`
-	AutoResolved int      `json:"auto_resolved"`
-	NeedsReview  int      `json:"needs_review"`
-	Unresolved   int      `json:"unresolved"`
-	Enqueued     int      `json:"enqueued"`
-	DryRun       bool     `json:"dry_run"`
-	ReportPath   string   `json:"report_path,omitempty"`
-	Errors       []string `json:"errors,omitempty"`
+	XMLTracks        int                `json:"xml_tracks"`
+	Missing          int                `json:"missing"`
+	AutoResolved     int                `json:"auto_resolved"`
+	NeedsReview      int                `json:"needs_review"`
+	Unresolved       int                `json:"unresolved"`
+	Enqueued         int                `json:"enqueued"`
+	DryRun           bool               `json:"dry_run"`
+	ReportPath       string             `json:"report_path,omitempty"`
+	NeedsReviewItems []needsReviewItem  `json:"needs_review_items,omitempty"`
+	Errors           []string           `json:"errors,omitempty"`
 }
+
+// needsReviewItem is one fuzzy-resolved missing track requiring human
+// confirmation. Emitted by tier C; never auto-applied.
+type needsReviewItem struct {
+	PID        string           `json:"pid"`
+	OldPath    string           `json:"old_path"`
+	Title      string           `json:"title,omitempty"`
+	Candidates []tierCCandidate `json:"candidates"`
+}
+
+// Tier C tuning constants. Threshold matches the user-confirmed 0.85
+// Jaro-Winkler equivalent on the matcher 0–100 scale.
+const (
+	tierCThreshold = 85
+	tierCTopN      = 3
+)
 
 // parseDryRun reads the apply= query parameter and returns whether the
 // run should stay in dry-run mode. Any value not equal to "true" or
@@ -241,10 +259,26 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 			continue
 		}
 
-		// Tier C lands in the next commit.
+		// Tier C: fuzzy candidates for human review. Never auto-applied.
+		info := trackInfo{Title: track.Name, OldBasename: filepath.Base(decoded)}
+		candidates := resolveTierC(getTierB().allPaths(), info, tierCThreshold, tierCTopN)
+		if len(candidates) > 0 {
+			result.NeedsReview++
+			result.NeedsReviewItems = append(result.NeedsReviewItems, needsReviewItem{
+				PID:        track.PersistentID,
+				OldPath:    decoded,
+				Title:      track.Name,
+				Candidates: candidates,
+			})
+			_ = progress.Log("info",
+				fmt.Sprintf("repair pid=%s old=%s tier=C candidates=%d action=review",
+					track.PersistentID, decoded, len(candidates)), nil)
+			continue
+		}
+
 		result.Unresolved++
 		_ = progress.Log("debug",
-			fmt.Sprintf("missing pid=%s old=%s tier=AB unresolved", track.PersistentID, decoded), nil)
+			fmt.Sprintf("missing pid=%s old=%s tier=ABC unresolved", track.PersistentID, decoded), nil)
 	}
 
 	if err := persistRepairResult(r.store, opID, result); err != nil {

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -31,11 +31,15 @@ import (
 )
 
 // PathRepairConfig holds the immutable inputs the repairer needs:
-// where to read the iTunes XML, and where the audiobook tree lives
-// for tier-B/C disk scanning.
+// where to read the iTunes XML, where the audiobook tree lives for
+// tier-B/C disk scanning, and where to drop the JSON report file.
 type PathRepairConfig struct {
 	XMLPath       string
 	AudiobookRoot string
+	// ReportDir is the directory where each run drops its JSON
+	// report. Empty means no file is written; the result still flows
+	// inline via UpdateOperationResultData.
+	ReportDir string
 }
 
 // pathRepairerStore is the narrow slice of the service Store that
@@ -293,6 +297,13 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 			fmt.Sprintf("missing pid=%s old=%s tier=ABC unresolved", track.PersistentID, decoded), nil)
 	}
 
+	if r.cfg.ReportDir != "" {
+		if reportPath, err := writeReportFile(r.cfg.ReportDir, opID, result); err != nil {
+			log.Printf("[WARN] write repair report: %v", err)
+		} else {
+			result.ReportPath = reportPath
+		}
+	}
 	if err := persistRepairResult(r.store, opID, result); err != nil {
 		log.Printf("[WARN] persist repair result: %v", err)
 	}
@@ -409,4 +420,22 @@ func persistRepairResult(store database.OperationStore, opID string, result iTun
 		return err
 	}
 	return store.UpdateOperationResultData(opID, string(b))
+}
+
+// writeReportFile persists the result to <reportDir>/itunes-repair-<opID>.json.
+// Returns the absolute path of the written file.
+func writeReportFile(reportDir, opID string, result iTunesPathRepairResult) (string, error) {
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", reportDir, err)
+	}
+	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("itunes-repair-%s.json", opID)
+	out := filepath.Join(reportDir, name)
+	if err := os.WriteFile(out, b, 0o644); err != nil {
+		return "", err
+	}
+	return out, nil
 }

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -45,6 +46,7 @@ type pathRepairerStore interface {
 	database.BookFileStore
 	database.OperationStore
 	database.ExternalIDStore
+	database.PathHistoryStore
 }
 
 // PathRepairer is the operation worker.
@@ -244,6 +246,11 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		// Tier A: bookID → DB-known on-disk path
 		if newPath, ok := resolveTierA(r.store, track.PersistentID, bookID, pathExists); ok {
 			result.AutoResolved++
+			if !dryRun {
+				if err := r.applyResolution(track.PersistentID, bookID, decoded, newPath, &result); err != nil {
+					result.Errors = append(result.Errors, fmt.Sprintf("apply tier=A pid=%s: %v", track.PersistentID, err))
+				}
+			}
 			_ = progress.Log("info",
 				fmt.Sprintf("repair pid=%s old=%s new=%s tier=A action=%s",
 					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
@@ -253,6 +260,11 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		// Tier B: embedded AUDIOBOOK_ORGANIZER_ID tag scan
 		if newPath, ok := resolveTierB(getTierB(), bookID, pathExists); ok {
 			result.AutoResolved++
+			if !dryRun {
+				if err := r.applyResolution(track.PersistentID, bookID, decoded, newPath, &result); err != nil {
+					result.Errors = append(result.Errors, fmt.Sprintf("apply tier=B pid=%s: %v", track.PersistentID, err))
+				}
+			}
 			_ = progress.Log("info",
 				fmt.Sprintf("repair pid=%s old=%s new=%s tier=B action=%s",
 					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
@@ -293,6 +305,81 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 	_ = progress.Log("info", summary, nil)
 	_ = progress.UpdateProgress(scanned, scanned, summary)
 	return result, nil
+}
+
+// applyResolution writes the discovered new path back into the DB
+// (BookFile.FilePath/ITunesPath preferred; falls back to Book), records
+// a path-history entry, and enqueues the book through the
+// WriteBackBatcher so the existing flush loop pushes the corrected
+// location to the .itl on its normal cadence.
+func (r *PathRepairer) applyResolution(pid, bookID, oldPath, newPath string, result *iTunesPathRepairResult) error {
+	wantITunesPath := metafetch.ComputeITunesPath(newPath)
+
+	// Prefer the matching BookFile when one exists.
+	updated := false
+	if files, err := r.store.GetBookFiles(bookID); err == nil {
+		for _, bf := range files {
+			if bf.ITunesPersistentID != pid {
+				continue
+			}
+			if bf.FilePath == newPath && bf.ITunesPath == wantITunesPath {
+				updated = true
+				break
+			}
+			bf.FilePath = newPath
+			if wantITunesPath != "" {
+				bf.ITunesPath = wantITunesPath
+			}
+			if err := r.store.UpdateBookFile(bf.ID, &bf); err != nil {
+				return fmt.Errorf("update book_file %s: %w", bf.ID, err)
+			}
+			updated = true
+			break
+		}
+	}
+
+	// Fall back to book-level fields when no matching BookFile.
+	if !updated {
+		book, err := r.store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			return fmt.Errorf("get book %s: %w", bookID, err)
+		}
+		changed := false
+		if book.FilePath != newPath {
+			book.FilePath = newPath
+			changed = true
+		}
+		if wantITunesPath != "" {
+			cur := ""
+			if book.ITunesPath != nil {
+				cur = *book.ITunesPath
+			}
+			if cur != wantITunesPath {
+				book.ITunesPath = &wantITunesPath
+				changed = true
+			}
+		}
+		if changed {
+			if _, err := r.store.UpdateBook(bookID, book); err != nil {
+				return fmt.Errorf("update book %s: %w", bookID, err)
+			}
+		}
+	}
+
+	if err := r.store.RecordPathChange(&database.BookPathChange{
+		BookID:     bookID,
+		OldPath:    oldPath,
+		NewPath:    newPath,
+		ChangeType: "itunes_path_repair",
+	}); err != nil {
+		return fmt.Errorf("record path change: %w", err)
+	}
+
+	if r.enqueuer != nil {
+		r.enqueuer.Enqueue(bookID)
+		result.Enqueued++
+	}
+	return nil
 }
 
 // pathExists is the production existsFn for the resolver. Test code

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -1,0 +1,134 @@
+// file: internal/itunes/service/path_repair.go
+// version: 1.0.0
+// guid: 01ad6c79-5f3f-4ee1-a07a-1f4b3a8c0d12
+//
+// PathRepairer dumps the iTunes XML, finds tracks whose Location no
+// longer exists on disk, re-discovers the correct path via three tiers
+// (PID → DB lookup; embedded AUDIOBOOK_ORGANIZER_PERSISTENT_ID tag
+// scan; fuzzy filename + title match), and enqueues each fix through
+// the existing WriteBackBatcher so the ITL learns the new locations
+// during normal batched write-back.
+
+package itunesservice
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// PathRepairConfig holds the immutable inputs the repairer needs:
+// where to read the iTunes XML, and where the audiobook tree lives
+// for tier-B/C disk scanning.
+type PathRepairConfig struct {
+	XMLPath       string
+	AudiobookRoot string
+}
+
+// pathRepairerStore is the narrow slice of the service Store that
+// PathRepairer needs. Identical surface to pathReconcilerStore today,
+// declared separately so the two operations can evolve independently.
+type pathRepairerStore interface {
+	database.BookStore
+	database.BookFileStore
+	database.OperationStore
+	database.ExternalIDStore
+}
+
+// PathRepairer is the operation worker.
+type PathRepairer struct {
+	store    pathRepairerStore
+	enqueuer Enqueuer
+	queue    operations.Queue
+	cfg      PathRepairConfig
+}
+
+// newPathRepairer wires a PathRepairer. nil enqueuer skips the
+// write-back enqueue step (used by dry-run-only tests).
+func newPathRepairer(store pathRepairerStore, enqueuer Enqueuer, queue operations.Queue, cfg PathRepairConfig) *PathRepairer {
+	return &PathRepairer{store: store, enqueuer: enqueuer, queue: queue, cfg: cfg}
+}
+
+// iTunesPathRepairResult is the per-run tally returned in progress
+// logs and the operation result. Field names mirror the dry-run JSON
+// payload that callers consume.
+type iTunesPathRepairResult struct {
+	XMLTracks    int      `json:"xml_tracks"`
+	Missing      int      `json:"missing"`
+	AutoResolved int      `json:"auto_resolved"`
+	NeedsReview  int      `json:"needs_review"`
+	Unresolved   int      `json:"unresolved"`
+	Enqueued     int      `json:"enqueued"`
+	DryRun       bool     `json:"dry_run"`
+	ReportPath   string   `json:"report_path,omitempty"`
+	Errors       []string `json:"errors,omitempty"`
+}
+
+// parseDryRun reads the apply= query parameter and returns whether the
+// run should stay in dry-run mode. Any value not equal to "true" or
+// "1" leaves dry-run on (safer default).
+func parseDryRun(c *gin.Context) bool {
+	apply := strings.ToLower(c.Query("apply"))
+	if apply == "true" || apply == "1" {
+		return false
+	}
+	return true
+}
+
+// Start kicks off a tracked operation that walks the iTunes XML,
+// finds missing locations, and (in apply mode) enqueues path fixes
+// through the WriteBackBatcher. Defaults to dry-run.
+func (r *PathRepairer) Start(c *gin.Context) {
+	if r.store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+	if r.queue == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "operation queue not initialized"})
+		return
+	}
+
+	dryRun := parseDryRun(c)
+
+	id := ulid.Make().String()
+	op, err := r.store.CreateOperation(id, "itunes_path_repair", nil)
+	if err != nil {
+		log.Printf("[ERROR] failed to create operation: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create operation"})
+		return
+	}
+
+	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		return r.Repair(ctx, id, dryRun, progress)
+	}
+
+	if err := r.queue.Enqueue(op.ID, "itunes_path_repair", operations.PriorityNormal, operationFunc); err != nil {
+		log.Printf("[ERROR] failed to enqueue operation: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enqueue operation"})
+		return
+	}
+
+	c.JSON(http.StatusAccepted, op)
+}
+
+// Repair is the operation body. Step 1 scaffolds the worker shape;
+// tier A/B/C resolution lands in subsequent commits.
+func (r *PathRepairer) Repair(ctx context.Context, opID string, dryRun bool, progress operations.ProgressReporter) error {
+	if r.store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	_ = progress.Log("info", "iTunes path repair started", nil)
+	result := iTunesPathRepairResult{DryRun: dryRun}
+	_ = operations.ClearState(r.store, opID)
+	_ = progress.Log("info", "iTunes path repair complete (scaffold; resolution tiers pending)", nil)
+	_ = progress.UpdateProgress(0, 0, "scaffold")
+	_ = result // populated in step 2+
+	return nil
+}

--- a/internal/itunes/service/path_repair_resolver.go
+++ b/internal/itunes/service/path_repair_resolver.go
@@ -1,0 +1,45 @@
+// file: internal/itunes/service/path_repair_resolver.go
+// version: 1.0.0
+// guid: 7d4f25a1-8e29-4b8b-9a02-3c5e1f9d4b27
+//
+// Pure-function resolvers for the path-repair operation. Each tier
+// takes a narrow store interface and an existsFn so tests can drive
+// them without a real filesystem.
+
+package itunesservice
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// tierAStore is the slice tier A needs: PID → bookID via the
+// external_id_map, then the book + its files.
+type tierAStore interface {
+	GetBookByExternalID(source, externalID string) (string, error)
+	GetBookByID(id string) (*database.Book, error)
+	GetBookFiles(bookID string) ([]database.BookFile, error)
+}
+
+// resolveTierA looks up the iTunes PID via external_id_map and returns
+// the on-disk path the DB thinks the file is at — preferring the
+// matching BookFile over Book.FilePath. Returns ok=false when no
+// mapping exists or the DB-known path doesn't exist on disk.
+//
+// existsFn is injected so unit tests can fake the filesystem.
+func resolveTierA(s tierAStore, pid string, existsFn func(string) bool) (string, bool) {
+	bookID, err := s.GetBookByExternalID("itunes", pid)
+	if err != nil || bookID == "" {
+		return "", false
+	}
+	if files, err := s.GetBookFiles(bookID); err == nil {
+		for _, bf := range files {
+			if bf.ITunesPersistentID == pid && bf.FilePath != "" && existsFn(bf.FilePath) {
+				return bf.FilePath, true
+			}
+		}
+	}
+	if book, err := s.GetBookByID(bookID); err == nil && book != nil && book.FilePath != "" && existsFn(book.FilePath) {
+		return book.FilePath, true
+	}
+	return "", false
+}

--- a/internal/itunes/service/path_repair_resolver.go
+++ b/internal/itunes/service/path_repair_resolver.go
@@ -11,10 +11,12 @@ package itunesservice
 import (
 	"io/fs"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/matcher"
 )
 
 // audioExt is the set of file extensions tier B inspects. Anything
@@ -35,14 +37,17 @@ type bookIDExtractor func(audioFilePath string) (string, error)
 type noopTagScanner struct{}
 
 func (noopTagScanner) bookIDToPaths(string) []string { return nil }
+func (noopTagScanner) allPaths() []string            { return nil }
 
 // fsTagScanner walks the audiobook root once, lazily, the first time
-// bookIDToPaths is called. Subsequent calls hit the in-memory index.
+// bookIDToPaths or allPaths is called. Subsequent calls hit the
+// in-memory state.
 type fsTagScanner struct {
 	root    string
 	extract bookIDExtractor
 	once    sync.Once
 	index   map[string][]string
+	all     []string
 }
 
 func newFSTagScanner(root string, extract bookIDExtractor) *fsTagScanner {
@@ -54,9 +59,14 @@ func (s *fsTagScanner) bookIDToPaths(bookID string) []string {
 	return s.index[bookID]
 }
 
+func (s *fsTagScanner) allPaths() []string {
+	s.once.Do(s.scan)
+	return s.all
+}
+
 func (s *fsTagScanner) scan() {
 	s.index = make(map[string][]string)
-	if s.root == "" || s.extract == nil {
+	if s.root == "" {
 		return
 	}
 	_ = filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
@@ -67,11 +77,12 @@ func (s *fsTagScanner) scan() {
 		if _, ok := audioExt[ext]; !ok {
 			return nil
 		}
-		bookID, err := s.extract(path)
-		if err != nil || bookID == "" {
-			return nil
+		s.all = append(s.all, path)
+		if s.extract != nil {
+			if bookID, err := s.extract(path); err == nil && bookID != "" {
+				s.index[bookID] = append(s.index[bookID], path)
+			}
 		}
-		s.index[bookID] = append(s.index[bookID], path)
 		return nil
 	})
 }
@@ -103,11 +114,12 @@ func lookupBookID(s pidLookup, pid string) string {
 
 // tagScanner exposes a lazy, cached lookup from
 // AUDIOBOOK_ORGANIZER_ID tag value (the audiobook-organizer book ID)
-// to the on-disk paths whose audio files carry that tag. The
-// production implementation walks the audiobook root once and indexes
-// every file's BookOrganizerID; tests inject a fake.
+// to the on-disk paths whose audio files carry that tag, plus the
+// flat list of every audio file the walk found (for tier C scoring).
+// Tests inject a fake; production walks the audiobook root.
 type tagScanner interface {
 	bookIDToPaths(bookID string) []string
+	allPaths() []string
 }
 
 // resolveTierB resolves a missing PID via the embedded
@@ -127,6 +139,58 @@ func resolveTierB(scanner tagScanner, bookID string, existsFn func(string) bool)
 		return "", false
 	}
 	return paths[0], true
+}
+
+// trackInfo carries the iTunes-side hints tier C scores against.
+type trackInfo struct {
+	Title       string
+	OldBasename string
+}
+
+// tierCCandidate is one ranked match emitted to the needs_review list.
+type tierCCandidate struct {
+	Path  string `json:"path"`
+	Score int    `json:"score"`
+}
+
+// resolveTierC scores every candidate path against the iTunes track
+// title and the old basename, then returns the top-N candidates whose
+// score meets the threshold. Never auto-applies — caller emits to the
+// needs_review list for human confirmation.
+//
+// We score against both the title and the old basename and take the
+// max so e.g. a file renamed to use the title still scores well, and
+// a file whose basename was preserved across a directory move also
+// scores well.
+func resolveTierC(candidates []string, info trackInfo, threshold, topN int) []tierCCandidate {
+	if len(candidates) == 0 || (info.Title == "" && info.OldBasename == "") {
+		return nil
+	}
+	scored := make([]tierCCandidate, 0, len(candidates))
+	for _, p := range candidates {
+		base := strings.TrimSuffix(filepath.Base(p), filepath.Ext(p))
+		var s int
+		if info.Title != "" {
+			if v := matcher.ScoreMatch(info.Title, base); v > s {
+				s = v
+			}
+		}
+		if info.OldBasename != "" {
+			oldBase := strings.TrimSuffix(info.OldBasename, filepath.Ext(info.OldBasename))
+			if v := matcher.ScoreMatch(oldBase, base); v > s {
+				s = v
+			}
+		}
+		if s < threshold {
+			continue
+		}
+		scored = append(scored, tierCCandidate{Path: p, Score: s})
+	}
+	sort.SliceStable(scored, func(i, j int) bool { return scored[i].Score > scored[j].Score })
+	if topN > 0 && len(scored) > topN {
+		scored = scored[:topN]
+	}
+	return scored
 }
 
 // resolveTierA returns the on-disk path the DB thinks the file is at

--- a/internal/itunes/service/path_repair_resolver.go
+++ b/internal/itunes/service/path_repair_resolver.go
@@ -9,26 +9,135 @@
 package itunesservice
 
 import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-// tierAStore is the slice tier A needs: PID → bookID via the
-// external_id_map, then the book + its files.
+// audioExt is the set of file extensions tier B inspects. Anything
+// outside the set is skipped during the walk.
+var audioExt = map[string]struct{}{
+	".m4b": {}, ".m4a": {}, ".mp3": {}, ".ogg": {}, ".flac": {},
+	".opus": {}, ".aac": {}, ".wav": {},
+}
+
+// bookIDExtractor pulls the AUDIOBOOK_ORGANIZER_ID tag from one
+// audio file. Returns "" when the tag is absent. Production wires
+// this to metadata.ExtractMetadata; tests inject a deterministic fake.
+type bookIDExtractor func(audioFilePath string) (string, error)
+
+// noopTagScanner returns no matches. Used when tier B is misconfigured
+// (no audiobook root, no extractor) so the worker can stay on a single
+// code path without nil-checks.
+type noopTagScanner struct{}
+
+func (noopTagScanner) bookIDToPaths(string) []string { return nil }
+
+// fsTagScanner walks the audiobook root once, lazily, the first time
+// bookIDToPaths is called. Subsequent calls hit the in-memory index.
+type fsTagScanner struct {
+	root    string
+	extract bookIDExtractor
+	once    sync.Once
+	index   map[string][]string
+}
+
+func newFSTagScanner(root string, extract bookIDExtractor) *fsTagScanner {
+	return &fsTagScanner{root: root, extract: extract}
+}
+
+func (s *fsTagScanner) bookIDToPaths(bookID string) []string {
+	s.once.Do(s.scan)
+	return s.index[bookID]
+}
+
+func (s *fsTagScanner) scan() {
+	s.index = make(map[string][]string)
+	if s.root == "" || s.extract == nil {
+		return
+	}
+	_ = filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d == nil || d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if _, ok := audioExt[ext]; !ok {
+			return nil
+		}
+		bookID, err := s.extract(path)
+		if err != nil || bookID == "" {
+			return nil
+		}
+		s.index[bookID] = append(s.index[bookID], path)
+		return nil
+	})
+}
+
+// tierAStore is the slice tier A needs after the bookID has been
+// resolved at the worker level (see lookupBookID).
 type tierAStore interface {
-	GetBookByExternalID(source, externalID string) (string, error)
 	GetBookByID(id string) (*database.Book, error)
 	GetBookFiles(bookID string) ([]database.BookFile, error)
 }
 
-// resolveTierA looks up the iTunes PID via external_id_map and returns
-// the on-disk path the DB thinks the file is at — preferring the
-// matching BookFile over Book.FilePath. Returns ok=false when no
-// mapping exists or the DB-known path doesn't exist on disk.
-//
-// existsFn is injected so unit tests can fake the filesystem.
-func resolveTierA(s tierAStore, pid string, existsFn func(string) bool) (string, bool) {
+// pidLookup is the worker-level PID → bookID hop. Hoisted so tier A
+// and tier B share a single DB call per missing track.
+type pidLookup interface {
+	GetBookByExternalID(source, externalID string) (string, error)
+}
+
+// lookupBookID returns the bookID for an iTunes PID, or "" when the
+// mapping is absent or the store errors. Errors are intentionally
+// swallowed here — at the tier resolver level "no mapping" and
+// "lookup failed" lead to the same fall-through path.
+func lookupBookID(s pidLookup, pid string) string {
 	bookID, err := s.GetBookByExternalID("itunes", pid)
-	if err != nil || bookID == "" {
+	if err != nil {
+		return ""
+	}
+	return bookID
+}
+
+// tagScanner exposes a lazy, cached lookup from
+// AUDIOBOOK_ORGANIZER_ID tag value (the audiobook-organizer book ID)
+// to the on-disk paths whose audio files carry that tag. The
+// production implementation walks the audiobook root once and indexes
+// every file's BookOrganizerID; tests inject a fake.
+type tagScanner interface {
+	bookIDToPaths(bookID string) []string
+}
+
+// resolveTierB resolves a missing PID via the embedded
+// AUDIOBOOK_ORGANIZER_ID tag scan: bookID (already looked up at the
+// worker level) → unique on-disk path. Multi-segment books with
+// multiple disk matches are deliberately returned unresolved — those
+// go to tier C for human review.
+func resolveTierB(scanner tagScanner, bookID string, existsFn func(string) bool) (string, bool) {
+	if bookID == "" {
+		return "", false
+	}
+	paths := scanner.bookIDToPaths(bookID)
+	if len(paths) != 1 {
+		return "", false
+	}
+	if !existsFn(paths[0]) {
+		return "", false
+	}
+	return paths[0], true
+}
+
+// resolveTierA returns the on-disk path the DB thinks the file is at
+// for a given (pid, bookID) — preferring the matching BookFile over
+// Book.FilePath. Returns ok=false when the DB-known path doesn't
+// exist on disk.
+//
+// The caller is responsible for resolving PID → bookID via
+// lookupBookID first, so tier A and tier B share that DB call.
+func resolveTierA(s tierAStore, pid, bookID string, existsFn func(string) bool) (string, bool) {
+	if bookID == "" {
 		return "", false
 	}
 	if files, err := s.GetBookFiles(bookID); err == nil {

--- a/internal/itunes/service/path_repair_resolver_test.go
+++ b/internal/itunes/service/path_repair_resolver_test.go
@@ -1,0 +1,110 @@
+// file: internal/itunes/service/path_repair_resolver_test.go
+// version: 1.0.0
+// guid: 8aef0d23-1c84-4f3d-9b41-2d70eaf1c7c0
+
+package itunesservice
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	dbmocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// fileSet is a tiny fake filesystem for resolver tests — paths in the
+// set are considered to exist on disk.
+type fileSet map[string]bool
+
+func (fs fileSet) exists(p string) bool { return fs[p] }
+
+// ---------------------------------------------------------------------------
+// resolveTierA — happy path: PID → book → file-level path exists on disk
+// ---------------------------------------------------------------------------
+
+func TestResolveTierA_FileLevelPID(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_FOO").
+		Return("book-1", nil).Once()
+	m.EXPECT().GetBookFiles("book-1").
+		Return([]database.BookFile{
+			{ID: "f1", FilePath: "/disk/old.m4b", ITunesPersistentID: "PID_OTHER"},
+			{ID: "f2", FilePath: "/disk/new.m4b", ITunesPersistentID: "PID_FOO"},
+		}, nil).Once()
+
+	fs := fileSet{"/disk/new.m4b": true}
+	got, ok := resolveTierA(m, "PID_FOO", fs.exists)
+	assert.True(t, ok)
+	assert.Equal(t, "/disk/new.m4b", got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierA — falls back to book.FilePath when no file-level PID match
+// ---------------------------------------------------------------------------
+
+func TestResolveTierA_FallbackToBookFilePath(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_BAR").
+		Return("book-2", nil).Once()
+	m.EXPECT().GetBookFiles("book-2").
+		Return([]database.BookFile{
+			{ID: "f1", FilePath: "/disk/seg1.mp3", ITunesPersistentID: ""},
+		}, nil).Once()
+	m.EXPECT().GetBookByID("book-2").
+		Return(&database.Book{ID: "book-2", FilePath: "/disk/book2-folder/book.m4b"}, nil).Once()
+
+	fs := fileSet{"/disk/book2-folder/book.m4b": true}
+	got, ok := resolveTierA(m, "PID_BAR", fs.exists)
+	assert.True(t, ok)
+	assert.Equal(t, "/disk/book2-folder/book.m4b", got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierA — DB has the PID but the path doesn't exist on disk → unresolved
+// ---------------------------------------------------------------------------
+
+func TestResolveTierA_DBPathAlsoMissing(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_BAZ").
+		Return("book-3", nil).Once()
+	m.EXPECT().GetBookFiles("book-3").
+		Return([]database.BookFile{
+			{ID: "f1", FilePath: "/disk/also-gone.m4b", ITunesPersistentID: "PID_BAZ"},
+		}, nil).Once()
+	m.EXPECT().GetBookByID("book-3").
+		Return(&database.Book{ID: "book-3", FilePath: "/disk/also-gone-book.m4b"}, nil).Once()
+
+	fs := fileSet{} // nothing exists
+	got, ok := resolveTierA(m, "PID_BAZ", fs.exists)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierA — PID has no DB mapping → unresolved (cheap path)
+// ---------------------------------------------------------------------------
+
+func TestResolveTierA_NoMapping(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_UNKNOWN").
+		Return("", nil).Once()
+
+	got, ok := resolveTierA(m, "PID_UNKNOWN", func(string) bool { return true })
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierA — store error treated as unresolved (degrades gracefully)
+// ---------------------------------------------------------------------------
+
+func TestResolveTierA_StoreError(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", mock.Anything).
+		Return("", assert.AnError).Once()
+
+	got, ok := resolveTierA(m, "PID_X", func(string) bool { return true })
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}

--- a/internal/itunes/service/path_repair_resolver_test.go
+++ b/internal/itunes/service/path_repair_resolver_test.go
@@ -5,12 +5,15 @@
 package itunesservice
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	dbmocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // fileSet is a tiny fake filesystem for resolver tests — paths in the
@@ -25,8 +28,6 @@ func (fs fileSet) exists(p string) bool { return fs[p] }
 
 func TestResolveTierA_FileLevelPID(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetBookByExternalID("itunes", "PID_FOO").
-		Return("book-1", nil).Once()
 	m.EXPECT().GetBookFiles("book-1").
 		Return([]database.BookFile{
 			{ID: "f1", FilePath: "/disk/old.m4b", ITunesPersistentID: "PID_OTHER"},
@@ -34,7 +35,7 @@ func TestResolveTierA_FileLevelPID(t *testing.T) {
 		}, nil).Once()
 
 	fs := fileSet{"/disk/new.m4b": true}
-	got, ok := resolveTierA(m, "PID_FOO", fs.exists)
+	got, ok := resolveTierA(m, "PID_FOO", "book-1", fs.exists)
 	assert.True(t, ok)
 	assert.Equal(t, "/disk/new.m4b", got)
 }
@@ -45,8 +46,6 @@ func TestResolveTierA_FileLevelPID(t *testing.T) {
 
 func TestResolveTierA_FallbackToBookFilePath(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetBookByExternalID("itunes", "PID_BAR").
-		Return("book-2", nil).Once()
 	m.EXPECT().GetBookFiles("book-2").
 		Return([]database.BookFile{
 			{ID: "f1", FilePath: "/disk/seg1.mp3", ITunesPersistentID: ""},
@@ -55,7 +54,7 @@ func TestResolveTierA_FallbackToBookFilePath(t *testing.T) {
 		Return(&database.Book{ID: "book-2", FilePath: "/disk/book2-folder/book.m4b"}, nil).Once()
 
 	fs := fileSet{"/disk/book2-folder/book.m4b": true}
-	got, ok := resolveTierA(m, "PID_BAR", fs.exists)
+	got, ok := resolveTierA(m, "PID_BAR", "book-2", fs.exists)
 	assert.True(t, ok)
 	assert.Equal(t, "/disk/book2-folder/book.m4b", got)
 }
@@ -66,8 +65,6 @@ func TestResolveTierA_FallbackToBookFilePath(t *testing.T) {
 
 func TestResolveTierA_DBPathAlsoMissing(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetBookByExternalID("itunes", "PID_BAZ").
-		Return("book-3", nil).Once()
 	m.EXPECT().GetBookFiles("book-3").
 		Return([]database.BookFile{
 			{ID: "f1", FilePath: "/disk/also-gone.m4b", ITunesPersistentID: "PID_BAZ"},
@@ -76,7 +73,7 @@ func TestResolveTierA_DBPathAlsoMissing(t *testing.T) {
 		Return(&database.Book{ID: "book-3", FilePath: "/disk/also-gone-book.m4b"}, nil).Once()
 
 	fs := fileSet{} // nothing exists
-	got, ok := resolveTierA(m, "PID_BAZ", fs.exists)
+	got, ok := resolveTierA(m, "PID_BAZ", "book-3", fs.exists)
 	assert.False(t, ok)
 	assert.Empty(t, got)
 }
@@ -85,26 +82,133 @@ func TestResolveTierA_DBPathAlsoMissing(t *testing.T) {
 // resolveTierA — PID has no DB mapping → unresolved (cheap path)
 // ---------------------------------------------------------------------------
 
-func TestResolveTierA_NoMapping(t *testing.T) {
+func TestResolveTierA_EmptyBookID(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetBookByExternalID("itunes", "PID_UNKNOWN").
-		Return("", nil).Once()
-
-	got, ok := resolveTierA(m, "PID_UNKNOWN", func(string) bool { return true })
+	got, ok := resolveTierA(m, "PID_UNKNOWN", "", func(string) bool { return true })
 	assert.False(t, ok)
 	assert.Empty(t, got)
 }
 
 // ---------------------------------------------------------------------------
-// resolveTierA — store error treated as unresolved (degrades gracefully)
+// lookupBookID — store error treated as empty (graceful degradation)
 // ---------------------------------------------------------------------------
 
-func TestResolveTierA_StoreError(t *testing.T) {
+func TestLookupBookID_StoreErrorReturnsEmpty(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
 	m.EXPECT().GetBookByExternalID("itunes", mock.Anything).
 		Return("", assert.AnError).Once()
 
-	got, ok := resolveTierA(m, "PID_X", func(string) bool { return true })
+	got := lookupBookID(m, "PID_X")
+	assert.Empty(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// lookupBookID — successful mapping returns the book ID
+// ---------------------------------------------------------------------------
+
+func TestLookupBookID_HappyPath(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_HAPPY").
+		Return("book-happy", nil).Once()
+
+	got := lookupBookID(m, "PID_HAPPY")
+	assert.Equal(t, "book-happy", got)
+}
+
+// fakeTagScanner is a deterministic tag scanner for tier B tests.
+type fakeTagScanner struct {
+	index map[string][]string
+}
+
+func (f *fakeTagScanner) bookIDToPaths(bookID string) []string { return f.index[bookID] }
+
+// ---------------------------------------------------------------------------
+// fsTagScanner — production scanner walks a tmpdir and indexes via the
+// injected bookIDExtractor, then resolves on demand.
+// ---------------------------------------------------------------------------
+
+func TestFSTagScanner_IndexesAudioFiles(t *testing.T) {
+	root := t.TempDir()
+	// Create three audio files and one ignored .txt sidecar.
+	mustWrite(t, filepath.Join(root, "author/title-A.m4b"), "audio")
+	mustWrite(t, filepath.Join(root, "author/title-B.mp3"), "audio")
+	mustWrite(t, filepath.Join(root, "author/title-C.m4b"), "audio")
+	mustWrite(t, filepath.Join(root, "author/title-A.txt"), "ignored")
+
+	extractor := func(p string) (string, error) {
+		switch filepath.Base(p) {
+		case "title-A.m4b":
+			return "book-1", nil
+		case "title-B.mp3":
+			return "book-2", nil
+		case "title-C.m4b":
+			return "book-1", nil // shares bookID — multi-segment
+		}
+		return "", nil
+	}
+
+	scan := newFSTagScanner(root, extractor)
+	one := scan.bookIDToPaths("book-1")
+	assert.Len(t, one, 2)
+	two := scan.bookIDToPaths("book-2")
+	assert.Len(t, two, 1)
+	none := scan.bookIDToPaths("book-9999")
+	assert.Empty(t, none)
+}
+
+// mustWrite is a tiny helper for fixture trees.
+func mustWrite(t *testing.T, p, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierB — single on-disk file matches the bookID → resolved
+// ---------------------------------------------------------------------------
+
+func TestResolveTierB_UniqueMatch(t *testing.T) {
+	scan := &fakeTagScanner{index: map[string][]string{
+		"book-x": {"/disk/relocated.m4b"},
+	}}
+	fs := fileSet{"/disk/relocated.m4b": true}
+
+	got, ok := resolveTierB(scan, "book-x", fs.exists)
+	assert.True(t, ok)
+	assert.Equal(t, "/disk/relocated.m4b", got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierB — multi-segment book → ambiguous, defer to tier C
+// ---------------------------------------------------------------------------
+
+func TestResolveTierB_AmbiguousMultiSegment(t *testing.T) {
+	scan := &fakeTagScanner{index: map[string][]string{
+		"book-m": {"/disk/seg1.mp3", "/disk/seg2.mp3"},
+	}}
+	got, ok := resolveTierB(scan, "book-m", func(string) bool { return true })
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierB — bookID has no on-disk match → unresolved
+// ---------------------------------------------------------------------------
+
+func TestResolveTierB_NoOnDiskMatch(t *testing.T) {
+	scan := &fakeTagScanner{index: map[string][]string{}}
+	got, ok := resolveTierB(scan, "book-y", func(string) bool { return true })
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierB — empty bookID short-circuits (no scan)
+// ---------------------------------------------------------------------------
+
+func TestResolveTierB_EmptyBookID(t *testing.T) {
+	scan := &fakeTagScanner{index: map[string][]string{}}
+	got, ok := resolveTierB(scan, "", func(string) bool { return true })
 	assert.False(t, ok)
 	assert.Empty(t, got)
 }

--- a/internal/itunes/service/path_repair_resolver_test.go
+++ b/internal/itunes/service/path_repair_resolver_test.go
@@ -118,9 +118,11 @@ func TestLookupBookID_HappyPath(t *testing.T) {
 // fakeTagScanner is a deterministic tag scanner for tier B tests.
 type fakeTagScanner struct {
 	index map[string][]string
+	all   []string
 }
 
 func (f *fakeTagScanner) bookIDToPaths(bookID string) []string { return f.index[bookID] }
+func (f *fakeTagScanner) allPaths() []string                   { return f.all }
 
 // ---------------------------------------------------------------------------
 // fsTagScanner — production scanner walks a tmpdir and indexes via the
@@ -161,6 +163,62 @@ func mustWrite(t *testing.T, p, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
 	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierC — fuzzy candidates ranked by score, threshold-gated
+// ---------------------------------------------------------------------------
+
+func TestResolveTierC_RanksByScore(t *testing.T) {
+	candidates := []string{
+		"/disk/dune.m4b",
+		"/disk/dune-messiah.m4b",
+		"/disk/totally-different.m4b",
+	}
+	info := trackInfo{Title: "Dune", OldBasename: "dune.mp3"}
+
+	got := resolveTierC(candidates, info, 50, 3)
+	require.Len(t, got, 2, "totally-different should score below 50 and be excluded")
+	assert.Equal(t, "/disk/dune.m4b", got[0].Path, "exact basename match wins")
+	assert.GreaterOrEqual(t, got[0].Score, got[1].Score, "results sorted desc by score")
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierC — threshold filters out weak matches
+// ---------------------------------------------------------------------------
+
+func TestResolveTierC_ThresholdRespected(t *testing.T) {
+	candidates := []string{"/disk/zzzzz.m4b"}
+	info := trackInfo{Title: "The Hobbit", OldBasename: "hobbit.m4b"}
+
+	got := resolveTierC(candidates, info, 85, 5)
+	assert.Empty(t, got, "weak match filtered by high threshold")
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierC — topN cap respected
+// ---------------------------------------------------------------------------
+
+func TestResolveTierC_TopNCap(t *testing.T) {
+	candidates := []string{
+		"/disk/foo-1.m4b",
+		"/disk/foo-2.m4b",
+		"/disk/foo-3.m4b",
+		"/disk/foo-4.m4b",
+		"/disk/foo-5.m4b",
+	}
+	info := trackInfo{Title: "Foo", OldBasename: "foo.m4b"}
+	got := resolveTierC(candidates, info, 0, 2)
+	assert.Len(t, got, 2)
+}
+
+// ---------------------------------------------------------------------------
+// resolveTierC — empty inputs return empty
+// ---------------------------------------------------------------------------
+
+func TestResolveTierC_EmptyInputs(t *testing.T) {
+	assert.Empty(t, resolveTierC(nil, trackInfo{Title: "x"}, 50, 3))
+	assert.Empty(t, resolveTierC([]string{"/x.m4b"}, trackInfo{}, 50, 3))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -5,8 +5,11 @@
 package itunesservice
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -17,6 +20,51 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// noopProgressRepair mirrors the reconciler test helper.
+type noopProgressRepair struct{}
+
+func (noopProgressRepair) UpdateProgress(_, _ int, _ string) error { return nil }
+func (noopProgressRepair) Log(_, _ string, _ *string) error        { return nil }
+func (noopProgressRepair) IsCanceled() bool                        { return false }
+
+// writeFixtureXML writes a minimal iTunes XML with two audiobook
+// tracks at the given locations and returns the file path.
+func writeFixtureXML(t *testing.T, dir, locA, locB string) string {
+	t.Helper()
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Tracks</key>
+	<dict>
+		<key>1</key>
+		<dict>
+			<key>Track ID</key><integer>1</integer>
+			<key>Persistent ID</key><string>PID_A</string>
+			<key>Name</key><string>Track A</string>
+			<key>Kind</key><string>Audiobook</string>
+			<key>Location</key><string>file://localhost` + locA + `</string>
+		</dict>
+		<key>2</key>
+		<dict>
+			<key>Track ID</key><integer>2</integer>
+			<key>Persistent ID</key><string>PID_B</string>
+			<key>Name</key><string>Track B</string>
+			<key>Kind</key><string>Audiobook</string>
+			<key>Location</key><string>file://localhost` + locB + `</string>
+		</dict>
+	</dict>
+	<key>Playlists</key><array/>
+</dict>
+</plist>
+`
+	p := filepath.Join(dir, "iTunes Library.xml")
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o644))
+	return p
+}
 
 // ---------------------------------------------------------------------------
 // newPathRepairer constructor
@@ -120,6 +168,83 @@ func TestPathRepairerStart_HappyPath(t *testing.T) {
 
 	assert.Equal(t, http.StatusAccepted, w.Code)
 	assert.Contains(t, w.Body.String(), "test-op-id")
+}
+
+// ---------------------------------------------------------------------------
+// Repair — tier A: missing track resolved via DB → on-disk path
+// ---------------------------------------------------------------------------
+
+func TestRepair_TierA_AutoResolvesMissingTrack(t *testing.T) {
+	dir := t.TempDir()
+	// locA exists on disk; locB does not — but tier A finds the new
+	// path via DB and that new path also exists on disk.
+	locA := filepath.Join(dir, "alive.m4b")
+	require.NoError(t, os.WriteFile(locA, []byte("a"), 0o644))
+	locB := filepath.Join(dir, "vanished.m4b") // never created
+	newPath := filepath.Join(dir, "moved.m4b")
+	require.NoError(t, os.WriteFile(newPath, []byte("b"), 0o644))
+
+	xmlPath := writeFixtureXML(t, dir, locA, locB)
+
+	m := dbmocks.NewMockStore(t)
+	// Tier A is invoked only for missing tracks (PID_B).
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").
+		Return("book-b", nil).Once()
+	m.EXPECT().GetBookFiles("book-b").
+		Return([]database.BookFile{
+			{ID: "f1", FilePath: newPath, ITunesPersistentID: "PID_B"},
+		}, nil).Once()
+	m.EXPECT().DeleteOperationState("op-tierA").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-tierA", mock.Anything).Return(nil).Once()
+
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{XMLPath: xmlPath})
+	res, err := r.repairWithResult(context.Background(), "op-tierA", true, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, res.XMLTracks)
+	assert.Equal(t, 1, res.Missing)
+	assert.Equal(t, 1, res.AutoResolved)
+	assert.Equal(t, 0, res.NeedsReview)
+	assert.Equal(t, 0, res.Unresolved)
+	assert.True(t, res.DryRun)
+	assert.Equal(t, 0, res.Enqueued, "dry-run must not enqueue")
+}
+
+// ---------------------------------------------------------------------------
+// Repair — tier A: missing track with no DB mapping → unresolved
+// ---------------------------------------------------------------------------
+
+func TestRepair_TierA_NoMappingFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	locA := filepath.Join(dir, "alive.m4b")
+	require.NoError(t, os.WriteFile(locA, []byte("a"), 0o644))
+	locB := filepath.Join(dir, "vanished.m4b")
+	xmlPath := writeFixtureXML(t, dir, locA, locB)
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").
+		Return("", nil).Once()
+	m.EXPECT().DeleteOperationState("op-noMap").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-noMap", mock.Anything).Return(nil).Once()
+
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{XMLPath: xmlPath})
+	res, err := r.repairWithResult(context.Background(), "op-noMap", true, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.Missing)
+	assert.Equal(t, 0, res.AutoResolved)
+	assert.Equal(t, 1, res.Unresolved)
+}
+
+// ---------------------------------------------------------------------------
+// Repair — XML parse error returns the error
+// ---------------------------------------------------------------------------
+
+func TestRepair_XMLParseError(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{XMLPath: "/nonexistent/itunes.xml"})
+	_, err := r.repairWithResult(context.Background(), "op-bad", true, noopProgressRepair{})
+	require.Error(t, err)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -6,10 +6,13 @@ package itunesservice
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -39,6 +42,41 @@ type noopProgressRepair struct{}
 func (noopProgressRepair) UpdateProgress(_, _ int, _ string) error { return nil }
 func (noopProgressRepair) Log(_, _ string, _ *string) error        { return nil }
 func (noopProgressRepair) IsCanceled() bool                        { return false }
+
+// writeFixtureXMLN writes a minimal iTunes XML with N audiobook
+// tracks. Each entry is (pid, name, location).
+func writeFixtureXMLN(t *testing.T, dir string, tracks []struct{ PID, Name, Location string }) string {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Major Version</key><integer>1</integer>
+	<key>Minor Version</key><integer>1</integer>
+	<key>Tracks</key>
+	<dict>
+`)
+	for i, tr := range tracks {
+		fmt.Fprintf(&sb, `		<key>%d</key>
+		<dict>
+			<key>Track ID</key><integer>%d</integer>
+			<key>Persistent ID</key><string>%s</string>
+			<key>Name</key><string>%s</string>
+			<key>Kind</key><string>Audiobook</string>
+			<key>Location</key><string>file://localhost%s</string>
+		</dict>
+`, i+1, i+1, tr.PID, tr.Name, tr.Location)
+	}
+	sb.WriteString(`	</dict>
+	<key>Playlists</key><array/>
+</dict>
+</plist>
+`)
+	p := filepath.Join(dir, "iTunes Library.xml")
+	require.NoError(t, os.WriteFile(p, []byte(sb.String()), 0o644))
+	return p
+}
 
 // writeFixtureXML writes a minimal iTunes XML with two audiobook
 // tracks at the given locations and returns the file path.
@@ -374,6 +412,96 @@ func TestRepair_ApplyMode_TierA_UpdatesAndEnqueues(t *testing.T) {
 	assert.False(t, res.DryRun)
 	require.Len(t, enq.enqueues, 1)
 	assert.Equal(t, "book-b", enq.enqueues[0])
+}
+
+// ---------------------------------------------------------------------------
+// Repair — end-to-end: one OK / one tier A / one tier B / one tier C in
+// a single dry-run, plus the JSON report file lands on disk
+// ---------------------------------------------------------------------------
+
+func TestRepair_EndToEnd_AllTiers(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "library")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+
+	// Track-OK: location exists, no work needed.
+	okPath := filepath.Join(dir, "ok.m4b")
+	require.NoError(t, os.WriteFile(okPath, []byte("ok"), 0o644))
+
+	// Track-A: location missing; tier A finds the new path via DB.
+	missingA := filepath.Join(dir, "missing-A.m4b")
+	tierAPath := filepath.Join(root, "tier-a/file.m4b")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tierAPath), 0o755))
+	require.NoError(t, os.WriteFile(tierAPath, []byte("a"), 0o644))
+
+	// Track-B: location missing, DB also stale; tier B finds via tag scan.
+	missingB := filepath.Join(dir, "missing-B.m4b")
+	tierBPath := filepath.Join(root, "tier-b/file.m4b")
+	require.NoError(t, os.MkdirAll(filepath.Dir(tierBPath), 0o755))
+	require.NoError(t, os.WriteFile(tierBPath, []byte("b"), 0o644))
+
+	// Track-C: location missing, no DB mapping; tier C emits a fuzzy candidate.
+	missingC := filepath.Join(dir, "Unique-Title-C.m4b")
+	tierCCandidate := filepath.Join(root, "Unique-Title-C-relocated.m4b")
+	require.NoError(t, os.WriteFile(tierCCandidate, []byte("c"), 0o644))
+
+	xmlPath := writeFixtureXMLN(t, dir, []struct{ PID, Name, Location string }{
+		{"PID_OK", "Track OK", okPath},
+		{"PID_A", "Track A", missingA},
+		{"PID_B", "Track B", missingB},
+		{"PID_C", "Unique Title C", missingC},
+	})
+
+	m := dbmocks.NewMockStore(t)
+	// Tier A flow
+	m.EXPECT().GetBookByExternalID("itunes", "PID_A").Return("book-a", nil).Once()
+	m.EXPECT().GetBookFiles("book-a").Return([]database.BookFile{
+		{ID: "fa", FilePath: tierAPath, ITunesPersistentID: "PID_A"},
+	}, nil).Once()
+	// Tier B flow: PID lookup succeeds, tier A's BookFiles + book are stale.
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").Return("book-b", nil).Once()
+	m.EXPECT().GetBookFiles("book-b").Return([]database.BookFile{
+		{ID: "fb", FilePath: "/disk/STALE.m4b", ITunesPersistentID: "PID_B"},
+	}, nil).Once()
+	m.EXPECT().GetBookByID("book-b").Return(&database.Book{ID: "book-b", FilePath: "/disk/STALE.m4b"}, nil).Once()
+	// Tier C: no DB mapping
+	m.EXPECT().GetBookByExternalID("itunes", "PID_C").Return("", nil).Once()
+
+	reportDir := filepath.Join(dir, "reports")
+	m.EXPECT().DeleteOperationState("op-e2e").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-e2e", mock.Anything).Return(nil).Once()
+
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{
+		XMLPath:       xmlPath,
+		AudiobookRoot: root,
+		ReportDir:     reportDir,
+	})
+	r.bookIDExtractor = func(p string) (string, error) {
+		if p == tierBPath {
+			return "book-b", nil
+		}
+		return "", nil
+	}
+
+	res, err := r.repairWithResult(context.Background(), "op-e2e", true, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, res.XMLTracks)
+	assert.Equal(t, 3, res.Missing, "OK track skipped; the other 3 are missing")
+	assert.Equal(t, 2, res.AutoResolved, "tier A and tier B succeed")
+	assert.Equal(t, 1, res.NeedsReview, "tier C emits one")
+	assert.Equal(t, 0, res.Unresolved)
+	require.Len(t, res.NeedsReviewItems, 1)
+	assert.Equal(t, "PID_C", res.NeedsReviewItems[0].PID)
+
+	// Report file written and parses back to the same shape.
+	require.NotEmpty(t, res.ReportPath)
+	bytesOnDisk, err := os.ReadFile(res.ReportPath)
+	require.NoError(t, err)
+	var roundtrip iTunesPathRepairResult
+	require.NoError(t, json.Unmarshal(bytesOnDisk, &roundtrip))
+	assert.Equal(t, res.XMLTracks, roundtrip.XMLTracks)
+	assert.Equal(t, res.NeedsReview, roundtrip.NeedsReview)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -285,6 +285,44 @@ func TestRepair_TierB_RecoversFromStaleDBPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Repair — tier C: tiers A/B both fail, fuzzy match emits review items
+// ---------------------------------------------------------------------------
+
+func TestRepair_TierC_EmitsReviewCandidates(t *testing.T) {
+	dir := t.TempDir()
+	locA := filepath.Join(dir, "alive.m4b")
+	require.NoError(t, os.WriteFile(locA, []byte("a"), 0o644))
+	locB := filepath.Join(dir, "Track-B.mp3") // gone in iTunes XML
+	xmlPath := writeFixtureXML(t, dir, locA, locB)
+
+	root := filepath.Join(dir, "library")
+	// Disk has a candidate file with a similar basename, no embedded tag.
+	candidate := filepath.Join(root, "author/Track-B-relocated.mp3")
+	require.NoError(t, os.MkdirAll(filepath.Dir(candidate), 0o755))
+	require.NoError(t, os.WriteFile(candidate, []byte("b"), 0o644))
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").Return("", nil).Once()
+	m.EXPECT().DeleteOperationState("op-tierC").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-tierC", mock.Anything).Return(nil).Once()
+
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{XMLPath: xmlPath, AudiobookRoot: root})
+	r.bookIDExtractor = func(string) (string, error) { return "", nil }
+
+	res, err := r.repairWithResult(context.Background(), "op-tierC", true, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.Missing)
+	assert.Equal(t, 0, res.AutoResolved)
+	assert.Equal(t, 1, res.NeedsReview)
+	require.Len(t, res.NeedsReviewItems, 1)
+	assert.Equal(t, "PID_B", res.NeedsReviewItems[0].PID)
+	assert.Equal(t, "Track B", res.NeedsReviewItems[0].Title)
+	assert.NotEmpty(t, res.NeedsReviewItems[0].Candidates)
+	assert.Equal(t, candidate, res.NeedsReviewItems[0].Candidates[0].Path)
+}
+
+// ---------------------------------------------------------------------------
 // Repair — XML parse error returns the error
 // ---------------------------------------------------------------------------
 

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -1,0 +1,149 @@
+// file: internal/itunes/service/path_repair_test.go
+// version: 1.0.0
+// guid: 6b7e3d51-c0a3-4ab2-8d6c-7e9c1d4a8f01
+
+package itunesservice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	dbmocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	queuemocks "github.com/jdfalk/audiobook-organizer/internal/operations/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// newPathRepairer constructor
+// ---------------------------------------------------------------------------
+
+func TestNewPathRepairer(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	cfg := PathRepairConfig{XMLPath: "/tmp/iTunes Library.xml", AudiobookRoot: "/tmp/books"}
+	r := newPathRepairer(m, nil, nil, cfg)
+	require.NotNil(t, r)
+	assert.Equal(t, m, r.store)
+	assert.Nil(t, r.enqueuer)
+	assert.Nil(t, r.queue)
+	assert.Equal(t, cfg.XMLPath, r.cfg.XMLPath)
+	assert.Equal(t, cfg.AudiobookRoot, r.cfg.AudiobookRoot)
+}
+
+// ---------------------------------------------------------------------------
+// Start — nil store returns 500
+// ---------------------------------------------------------------------------
+
+func TestPathRepairerStart_NilStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := newPathRepairer(nil, nil, nil, PathRepairConfig{})
+
+	router := gin.New()
+	router.POST("/repair", r.Start)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repair", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "database not initialized")
+}
+
+// ---------------------------------------------------------------------------
+// Start — nil queue returns 500
+// ---------------------------------------------------------------------------
+
+func TestPathRepairerStart_NilQueue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := dbmocks.NewMockStore(t)
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{}) // queue is nil
+
+	router := gin.New()
+	router.POST("/repair", r.Start)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repair", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "operation queue not initialized")
+}
+
+// ---------------------------------------------------------------------------
+// Start — CreateOperation error returns 500
+// ---------------------------------------------------------------------------
+
+func TestPathRepairerStart_CreateOperationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := dbmocks.NewMockStore(t)
+	q := queuemocks.NewMockQueue(t)
+	m.EXPECT().CreateOperation(mock.Anything, "itunes_path_repair", mock.Anything).
+		Return(nil, assert.AnError).Once()
+
+	r := newPathRepairer(m, nil, q, PathRepairConfig{})
+	router := gin.New()
+	router.POST("/repair", r.Start)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repair", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Start — happy path returns 202
+// ---------------------------------------------------------------------------
+
+func TestPathRepairerStart_HappyPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	m := dbmocks.NewMockStore(t)
+	q := queuemocks.NewMockQueue(t)
+
+	op := &database.Operation{ID: "test-op-id", Type: "itunes_path_repair", Status: "queued"}
+	m.EXPECT().CreateOperation(mock.Anything, "itunes_path_repair", mock.Anything).
+		Return(op, nil).Once()
+	q.EXPECT().Enqueue(op.ID, "itunes_path_repair", mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	r := newPathRepairer(m, nil, q, PathRepairConfig{})
+	router := gin.New()
+	router.POST("/repair", r.Start)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repair", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.Contains(t, w.Body.String(), "test-op-id")
+}
+
+// ---------------------------------------------------------------------------
+// parseDryRun — query param parsing helper
+// ---------------------------------------------------------------------------
+
+func TestParseDryRun(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"", true},                  // default
+		{"apply=true", false},       // explicit apply
+		{"apply=1", false},          // truthy
+		{"apply=false", true},       // explicit dry
+		{"apply=0", true},           // falsy
+		{"apply=anything-else", true}, // unknown values stay safe
+	}
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/repair?"+tc.query, nil)
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = req
+			assert.Equal(t, tc.want, parseDryRun(c))
+		})
+	}
+}

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	dbmocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	queuemocks "github.com/jdfalk/audiobook-organizer/internal/operations/mocks"
@@ -20,6 +21,17 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// withITunesPathMapping installs a mapping covering dir → "Z:/" for
+// ComputeITunesPath, restoring the previous mappings on cleanup.
+func withITunesPathMapping(t *testing.T, dir string) {
+	t.Helper()
+	prev := config.AppConfig.ITunesPathMappings
+	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+		{From: "Z:/", To: dir + "/"},
+	}
+	t.Cleanup(func() { config.AppConfig.ITunesPathMappings = prev })
+}
 
 // noopProgressRepair mirrors the reconciler test helper.
 type noopProgressRepair struct{}
@@ -320,6 +332,48 @@ func TestRepair_TierC_EmitsReviewCandidates(t *testing.T) {
 	assert.Equal(t, "Track B", res.NeedsReviewItems[0].Title)
 	assert.NotEmpty(t, res.NeedsReviewItems[0].Candidates)
 	assert.Equal(t, candidate, res.NeedsReviewItems[0].Candidates[0].Path)
+}
+
+// ---------------------------------------------------------------------------
+// Repair — apply mode: tier A success → DB updated + Enqueuer called
+// ---------------------------------------------------------------------------
+
+func TestRepair_ApplyMode_TierA_UpdatesAndEnqueues(t *testing.T) {
+	dir := t.TempDir()
+	withITunesPathMapping(t, dir)
+	locA := filepath.Join(dir, "alive.m4b")
+	require.NoError(t, os.WriteFile(locA, []byte("a"), 0o644))
+	locB := filepath.Join(dir, "vanished.m4b") // gone
+	newPath := filepath.Join(dir, "moved.m4b")
+	require.NoError(t, os.WriteFile(newPath, []byte("b"), 0o644))
+	xmlPath := writeFixtureXML(t, dir, locA, locB)
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").Return("book-b", nil).Once()
+	bf := database.BookFile{ID: "f1", BookID: "book-b", FilePath: newPath, ITunesPersistentID: "PID_B"}
+	m.EXPECT().GetBookFiles("book-b").Return([]database.BookFile{bf}, nil).Once()
+	// Tier A returns the bf path; apply path then re-fetches files to do the update.
+	m.EXPECT().GetBookFiles("book-b").Return([]database.BookFile{bf}, nil).Once()
+	m.EXPECT().UpdateBookFile("f1", mock.MatchedBy(func(updated *database.BookFile) bool {
+		// FilePath stays the same (it was already correct); ITunesPath is recomputed.
+		return updated.FilePath == newPath && updated.ITunesPath != ""
+	})).Return(nil).Once()
+	m.EXPECT().RecordPathChange(mock.MatchedBy(func(c *database.BookPathChange) bool {
+		return c.BookID == "book-b" && c.NewPath == newPath && c.ChangeType == "itunes_path_repair"
+	})).Return(nil).Once()
+	m.EXPECT().DeleteOperationState("op-apply").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-apply", mock.Anything).Return(nil).Once()
+
+	enq := &mockEnqueuer{}
+	r := newPathRepairer(m, enq, nil, PathRepairConfig{XMLPath: xmlPath})
+	res, err := r.repairWithResult(context.Background(), "op-apply", false, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.AutoResolved)
+	assert.Equal(t, 1, res.Enqueued)
+	assert.False(t, res.DryRun)
+	require.Len(t, enq.enqueues, 1)
+	assert.Equal(t, "book-b", enq.enqueues[0])
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -187,7 +187,8 @@ func TestRepair_TierA_AutoResolvesMissingTrack(t *testing.T) {
 	xmlPath := writeFixtureXML(t, dir, locA, locB)
 
 	m := dbmocks.NewMockStore(t)
-	// Tier A is invoked only for missing tracks (PID_B).
+	// Single PID → bookID lookup at the worker level; tier A then
+	// reads the matching BookFile and finds the new path on disk.
 	m.EXPECT().GetBookByExternalID("itunes", "PID_B").
 		Return("book-b", nil).Once()
 	m.EXPECT().GetBookFiles("book-b").
@@ -234,6 +235,53 @@ func TestRepair_TierA_NoMappingFallsThrough(t *testing.T) {
 	assert.Equal(t, 1, res.Missing)
 	assert.Equal(t, 0, res.AutoResolved)
 	assert.Equal(t, 1, res.Unresolved)
+}
+
+// ---------------------------------------------------------------------------
+// Repair — tier B: tier A fails (no DB path), tier B finds via tag scan
+// ---------------------------------------------------------------------------
+
+func TestRepair_TierB_RecoversFromStaleDBPath(t *testing.T) {
+	dir := t.TempDir()
+	locA := filepath.Join(dir, "alive.m4b")
+	require.NoError(t, os.WriteFile(locA, []byte("a"), 0o644))
+	locB := filepath.Join(dir, "vanished.m4b") // gone in iTunes XML
+	xmlPath := writeFixtureXML(t, dir, locA, locB)
+
+	// The DB has stale paths for book-b — tier A returns false.
+	// Disk has a moved file under audiobook root that carries the
+	// AUDIOBOOK_ORGANIZER_ID tag for book-b.
+	root := filepath.Join(dir, "library")
+	movedFile := filepath.Join(root, "author/book-b/segment.m4b")
+	require.NoError(t, os.MkdirAll(filepath.Dir(movedFile), 0o755))
+	require.NoError(t, os.WriteFile(movedFile, []byte("b"), 0o644))
+
+	m := dbmocks.NewMockStore(t)
+	// Tier A path: external_id_map → bookID → BookFiles → none on disk;
+	// tier A's GetBookByID also lands on a missing file → tier A returns false.
+	m.EXPECT().GetBookByExternalID("itunes", "PID_B").Return("book-b", nil).Once()
+	m.EXPECT().GetBookFiles("book-b").
+		Return([]database.BookFile{{ID: "f1", FilePath: "/disk/STALE.m4b", ITunesPersistentID: "PID_B"}}, nil).Once()
+	m.EXPECT().GetBookByID("book-b").
+		Return(&database.Book{ID: "book-b", FilePath: "/disk/STALE.m4b"}, nil).Once()
+	m.EXPECT().DeleteOperationState("op-tierB").Return(nil).Once()
+	m.EXPECT().UpdateOperationResultData("op-tierB", mock.Anything).Return(nil).Once()
+
+	r := newPathRepairer(m, nil, nil, PathRepairConfig{XMLPath: xmlPath, AudiobookRoot: root})
+	// Inject deterministic extractor that maps movedFile → book-b.
+	r.bookIDExtractor = func(p string) (string, error) {
+		if p == movedFile {
+			return "book-b", nil
+		}
+		return "", nil
+	}
+
+	res, err := r.repairWithResult(context.Background(), "op-tierB", true, noopProgressRepair{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.Missing)
+	assert.Equal(t, 1, res.AutoResolved, "should be resolved by tier B")
+	assert.Equal(t, 0, res.Unresolved)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -24,6 +24,13 @@ type Deps struct {
 	Realtime         *realtime.EventHub // may be nil; means no SSE push
 	Config           Config
 	Logger           logger.Logger
+	// AudiobookRoot is the on-disk audiobook tree the path-repair
+	// operation walks for tier B (embedded tag scan) and tier C
+	// (fuzzy match). Empty disables those tiers.
+	AudiobookRoot string
+	// ReportDir is where the path-repair operation drops its JSON
+	// report file. Empty means inline-only (no file).
+	ReportDir string
 	// OnBookCreated fires after CreateBook so the dedup engine can check
 	// new iTunes imports against the organized library. May be nil.
 	OnBookCreated    func(bookID string)
@@ -100,8 +107,9 @@ func New(deps Deps) (*Service, error) {
 	// embedded tag scan, or fuzzy match. Apply mode enqueues fixes
 	// through the same Batcher.
 	svc.Repair = newPathRepairer(deps.Store, svc.Batcher, deps.OpQueue, PathRepairConfig{
-		XMLPath: deps.Config.LibraryReadPath,
-		// AudiobookRoot is plumbed via Deps in the tier-B/C steps.
+		XMLPath:       deps.Config.LibraryReadPath,
+		AudiobookRoot: deps.AudiobookRoot,
+		ReportDir:     deps.ReportDir,
 	})
 
 	// M1 step 6: TransferService. ITL download/upload/backup/restore

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -48,6 +48,7 @@ type Service struct {
 	Batcher     *WriteBackBatcher
 	Positions   *PositionSync
 	Paths       *PathReconciler
+	Repair      *PathRepairer
 	Playlists   *PlaylistSync
 	Provisioner *TrackProvisioner
 	Transfer    *TransferService
@@ -92,6 +93,16 @@ func New(deps Deps) (*Service, error) {
 	// M1 step 5: PathReconciler. Backfill operation that fixes up
 	// iTunes paths after library reorganizations.
 	svc.Paths = newPathReconciler(deps.Store, svc.Batcher, deps.OpQueue)
+
+	// PathRepairer. Recovers cases where iTunes still references a
+	// stale on-disk path after organize: dumps the iTunes XML, finds
+	// missing locations, and re-discovers them via PID lookup,
+	// embedded tag scan, or fuzzy match. Apply mode enqueues fixes
+	// through the same Batcher.
+	svc.Repair = newPathRepairer(deps.Store, svc.Batcher, deps.OpQueue, PathRepairConfig{
+		XMLPath: deps.Config.LibraryReadPath,
+		// AudiobookRoot is plumbed via Deps in the tier-B/C steps.
+	})
 
 	// M1 step 6: TransferService. ITL download/upload/backup/restore
 	// handlers. No deps — keyed off config.AppConfig.

--- a/internal/itunes/service/store.go
+++ b/internal/itunes/service/store.go
@@ -34,4 +34,5 @@ type Store interface {
 	database.MetadataStore
 	database.TagStore
 	database.RawKVStore
+	database.PathHistoryStore
 }

--- a/internal/server/audiobook_service_unit_test.go
+++ b/internal/server/audiobook_service_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	"github.com/stretchr/testify/assert"
@@ -492,6 +493,13 @@ func TestAudiobookService_EnrichAudiobooksWithNames_WithAuthorAndSeries(t *testi
 // --- InvalidateBookCaches ---
 
 func TestAudiobookService_InvalidateBookCaches_ClearsCache(t *testing.T) {
+	// Default behavior (commit 95b0f70d) keeps the list cache warm on
+	// book mutation. Opt the test back into full invalidation so it
+	// exercises the cleared-list path.
+	prev := config.AppConfig.CacheInvalidateOnBookUpdate
+	config.AppConfig.CacheInvalidateOnBookUpdate = true
+	t.Cleanup(func() { config.AppConfig.CacheInvalidateOnBookUpdate = prev })
+
 	mockStore := mocks.NewMockStore(t)
 	svc := NewAudiobookService(mockStore)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1475,6 +1475,13 @@ func (s *Server) resumeInterruptedOperations() {
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
 				return s.itunesSvc.Paths.Reconcile(ctx, reconcileOpID, progress)
 			}
+		case "itunes_path_repair":
+			repairOpID := opID
+			// Resume always defaults to dry-run for safety — operator
+			// can re-trigger with apply=true once they confirm the report.
+			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+				return s.itunesSvc.Repair.Repair(ctx, repairOpID, true, progress)
+			}
 		case "transcode", "diagnostics_export", "diagnostics_ai",
 			"cleanup_activity_log", "purge_old_logs",
 			"purge-deleted", "tombstone-cleanup",
@@ -2344,6 +2351,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/operations/reconcile/scan", s.perm(auth.PermScanTrigger), s.startReconcileScan)
 			protected.GET("/operations/reconcile/scan/latest", s.perm(auth.PermLibraryView), s.latestReconcileScan)
 			protected.POST("/operations/itunes-path-reconcile", s.perm(auth.PermScanTrigger), s.itunesSvcGuard(func(c *gin.Context) { s.itunesSvc.Paths.Start(c) }))
+			protected.POST("/operations/itunes-path-repair", s.perm(auth.PermScanTrigger), s.itunesSvcGuard(func(c *gin.Context) { s.itunesSvc.Repair.Start(c) }))
 			protected.POST("/operations/cleanup-version-groups", s.perm(auth.PermSettingsManage), s.cleanupDuplicateVersionGroupsHandler)
 			protected.POST("/operations/mark-broken-segments", s.perm(auth.PermSettingsManage), s.markBrokenSegmentBooksHandler)
 			protected.POST("/operations/merge-novg-duplicates", s.perm(auth.PermSettingsManage), s.mergeNoVGDuplicatesHandler)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -865,8 +865,10 @@ func NewServer(store database.Store) *Server {
 		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
 	}
 	itunesSvc, err := itunesservice.New(itunesservice.Deps{
-		Store:  resolvedStore,
-		Config: itunesCfg,
+		Store:         resolvedStore,
+		Config:        itunesCfg,
+		AudiobookRoot: config.AppConfig.RootDir,
+		ReportDir:     filepath.Join(config.AppConfig.RootDir, "reports"),
 		OnBookCreated: func(bookID string) {
 			// Resolved lazily via closure so server.fireDedupOnImport is available.
 			server.fireDedupOnImport(bookID)


### PR DESCRIPTION
## Summary

Recovers cases where iTunes still references stale on-disk paths after organize/rename — common when many files have been moved out from under iTunes and the existing `/operations/itunes-path-reconcile` can't help because `Book.FilePath` itself is also stale.

New endpoint `POST /operations/itunes-path-repair` (PermScanTrigger gated, dry-run by default) walks the iTunes XML, finds every audiobook track whose `Location` no longer exists, and re-discovers it via three tiers:

- **Tier A — PID → DB lookup.** `external_id_map` → bookID → matching `BookFile.FilePath` (multi-segment safe), fallback to `Book.FilePath`. Resolves only when the DB-known path also exists on disk.
- **Tier B — embedded `AUDIOBOOK_ORGANIZER_ID` tag scan.** Lazy: only fires after tier A leaves residue. Walks the audiobook root once, indexes book ID → on-disk paths. Multi-segment ambiguity falls through.
- **Tier C — fuzzy ranking.** `matcher.ScoreMatch` against title + original basename, threshold 85 (≈ Jaro-Winkler 0.85). Top 3 candidates land in `needs_review_items`. Never auto-applied — humans confirm.

Apply mode (`?apply=true`) updates `BookFile`/`Book` `FilePath` + `ITunesPath`, records `book_path_history` with `change_type="itunes_path_repair"`, and enqueues through the existing `WriteBackBatcher` so corrections ride normal batched .itl writes via `SafeWriteITL`. Reports drop to `<RootDir>/reports/itunes-repair-<opID>.json` and inline via `UpdateOperationResultData`.

Resume after interruption defaults back to dry-run; operator must explicitly re-trigger with `?apply=true`.

## Commits

- `chore(mocks)` regenerate `dbmocks.MockStore` for `GetDistinctGenres` (was stale on `main`, blocked compilation of every test in `internal/itunes/service`)
- `feat(itunes)` 6 incremental TDD steps: scaffold → tier A → tier B → tier C → apply mode → end-to-end + report file
- `docs(itunes)` CHANGELOG, TODO; fixes `TestAudiobookService_InvalidateBookCaches_ClearsCache` which predated commit `95b0f70d` and only worked under the old default
- `docs(todo)` index the new global `/ship` slash command

18 new unit + integration tests, all green. `make ci` is green for everything I touched. Three pre-existing flaky tests (`TestProp_DeterministicEvaluation`, `TestApplyAudiobookMetadata_WriteBackFalse`, `TestDeliver_*`) pass in isolation but flake under parallel CI execution — surfaced after my mock regen made them compile again, not regressions from this work.

## Test plan

- [x] `go test ./internal/itunes/service/...` — green
- [x] `go test ./internal/itunes/...` — green
- [x] `make ci` — green for everything path_repair touches
- [ ] Manual smoke: `POST /operations/itunes-path-repair` (no `apply`) on dev pointed at the prod XML; review JSON report; eyeball tier counts
- [ ] After dry-run looks right: `?apply=true` and verify the next iTunes write-back picks up corrected locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)