### PR TITLE
fix(itunes): wire OperationQueue into iTunes service Deps

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -864,9 +864,18 @@ func NewServer(store database.Store) *Server {
 		AutoWriteBack:       config.AppConfig.ITunesAutoWriteBack,
 		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
 	}
+	// Build the operation queue before constructing the iTunes service
+	// so PathReconciler / PathRepairer get a real handle. The duplicate
+	// later in this function (kept for the GlobalQueue back-compat) is
+	// a no-op once this assignment lands.
+	if server.queue == nil {
+		server.queue = operations.NewOperationQueue(resolvedStore, 2, nil, server.hub)
+		operations.GlobalQueue = server.queue
+	}
 	itunesSvc, err := itunesservice.New(itunesservice.Deps{
 		Store:         resolvedStore,
 		Config:        itunesCfg,
+		OpQueue:       server.queue,
 		AudiobookRoot: config.AppConfig.RootDir,
 		ReportDir:     filepath.Join(config.AppConfig.RootDir, "reports"),
 		OnBookCreated: func(bookID string) {
@@ -1075,9 +1084,10 @@ func NewServer(store database.Store) *Server {
 	// Also set the global for backward compatibility during migration
 	realtime.SetGlobalHub(server.hub)
 
-	server.queue = operations.NewOperationQueue(resolvedStore, 2, nil, server.hub)
-	// Also set the global for backward compatibility during migration
-	operations.GlobalQueue = server.queue
+	if server.queue == nil {
+		server.queue = operations.NewOperationQueue(resolvedStore, 2, nil, server.hub)
+		operations.GlobalQueue = server.queue
+	}
 
 	// The batcher moved under itunesservice.Service in Phase 2 M1 step 2.
 	// Server still keeps a typed field for back-compat with the many call


### PR DESCRIPTION
## Summary

PathReconciler and PathRepairer both fail with "operation queue not initialized" because `Deps.OpQueue` was nil at iTunes service construction time — `server.queue` is built later in the same function. Move queue construction above iTunes service construction; gate the later assignment with a nil-check so we don't replace the queue mid-run.

Verified by hitting `POST /operations/itunes-path-repair` and `POST /operations/itunes-path-reconcile` against prod after deploy — both return 500 with that error today.

## Test plan

- [x] `go build ./...` clean
- [ ] After deploy: `POST /operations/itunes-path-repair` returns 202 instead of 500
- [ ] Same for `/operations/itunes-path-reconcile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)