### PR TITLE
perf(itunes): parallelize tier B tag scan + periodic progress

### DIFF
--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -92,16 +93,18 @@ func extractBookOrganizerID(audioFilePath string) (string, error) {
 // logs and the operation result. Field names mirror the dry-run JSON
 // payload that callers consume.
 type iTunesPathRepairResult struct {
-	XMLTracks        int                `json:"xml_tracks"`
-	Missing          int                `json:"missing"`
-	AutoResolved     int                `json:"auto_resolved"`
-	NeedsReview      int                `json:"needs_review"`
-	Unresolved       int                `json:"unresolved"`
-	Enqueued         int                `json:"enqueued"`
-	DryRun           bool               `json:"dry_run"`
-	ReportPath       string             `json:"report_path,omitempty"`
-	NeedsReviewItems []needsReviewItem  `json:"needs_review_items,omitempty"`
-	Errors           []string           `json:"errors,omitempty"`
+	XMLTracks        int               `json:"xml_tracks"`
+	Missing          int               `json:"missing"`
+	AutoResolved     int               `json:"auto_resolved"`
+	NeedsReview      int               `json:"needs_review"`
+	Unresolved       int               `json:"unresolved"`
+	Enqueued         int               `json:"enqueued"`
+	DryRun           bool              `json:"dry_run"`
+	ReportPath       string            `json:"report_path,omitempty"`
+	Resolutions      []resolvedTrack   `json:"resolutions,omitempty"`
+	NeedsReviewItems []needsReviewItem `json:"needs_review_items,omitempty"`
+	UnresolvedPIDs   []string          `json:"unresolved_pids,omitempty"`
+	Errors           []string          `json:"errors,omitempty"`
 }
 
 // needsReviewItem is one fuzzy-resolved missing track requiring human
@@ -207,23 +210,38 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 	_ = progress.UpdateProgress(0, len(lib.Tracks), "scanning iTunes locations")
 
 	// Tier B is built lazily — only constructed if tier A leaves
-	// residue. Walking the audiobook root is the expensive step and
-	// we don't want to pay it on libraries where every iTunes path
-	// resolves cleanly via the DB.
+	// residue. Walking the audiobook root is the expensive step; we
+	// don't want to pay it on libraries where every iTunes path
+	// resolves cleanly via the DB. When we DO build it, fan out the
+	// tag extraction across runtime.NumCPU()*4 workers and report
+	// progress every 250 files so the operator sees the long step
+	// is actually moving.
 	var tierB tagScanner
+	tierBBuiltLogged := false
 	getTierB := func() tagScanner {
 		if tierB == nil {
 			if r.cfg.AudiobookRoot == "" || r.bookIDExtractor == nil {
 				tierB = noopTagScanner{}
 			} else {
 				_ = progress.Log("info",
-					fmt.Sprintf("tier B: scanning audiobook root for embedded book IDs root=%s", r.cfg.AudiobookRoot), nil)
-				tierB = newFSTagScanner(r.cfg.AudiobookRoot, r.bookIDExtractor)
+					fmt.Sprintf("tier B: scanning audiobook root in parallel root=%s workers=%d",
+						r.cfg.AudiobookRoot, runtime.NumCPU()*4), nil)
+				scanner := newFSTagScanner(r.cfg.AudiobookRoot, r.bookIDExtractor).
+					withProgress(func(done, total int) {
+						_ = progress.Log("info",
+							fmt.Sprintf("tier B: tag scan progress %d/%d", done, total), nil)
+					}, 500)
+				tierB = scanner
 			}
+		}
+		if !tierBBuiltLogged {
+			tierBBuiltLogged = true
 		}
 		return tierB
 	}
 
+	const progressEvery = 500     // emit UpdateProgress every N tracks
+	const detailLogEvery = 1000   // emit a sample resolution log every N
 	scanned := 0
 	for _, track := range lib.Tracks {
 		select {
@@ -232,6 +250,11 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		default:
 		}
 		scanned++
+		if scanned%progressEvery == 0 {
+			_ = progress.UpdateProgress(scanned, len(lib.Tracks),
+				fmt.Sprintf("scanning iTunes locations: %d/%d missing=%d auto=%d review=%d unresolved=%d",
+					scanned, len(lib.Tracks), result.Missing, result.AutoResolved, result.NeedsReview, result.Unresolved))
+		}
 		if !itunes.IsAudiobook(track) {
 			continue
 		}
@@ -250,28 +273,38 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		// Tier A: bookID → DB-known on-disk path
 		if newPath, ok := resolveTierA(r.store, track.PersistentID, bookID, pathExists); ok {
 			result.AutoResolved++
+			result.Resolutions = append(result.Resolutions, resolvedTrack{
+				PID: track.PersistentID, OldPath: decoded, NewPath: newPath, Tier: "A", BookID: bookID,
+			})
 			if !dryRun {
 				if err := r.applyResolution(track.PersistentID, bookID, decoded, newPath, &result); err != nil {
 					result.Errors = append(result.Errors, fmt.Sprintf("apply tier=A pid=%s: %v", track.PersistentID, err))
 				}
 			}
-			_ = progress.Log("info",
-				fmt.Sprintf("repair pid=%s old=%s new=%s tier=A action=%s",
-					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			if result.AutoResolved%detailLogEvery == 1 {
+				_ = progress.Log("info",
+					fmt.Sprintf("sample tier=A pid=%s old=%s new=%s action=%s",
+						track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			}
 			continue
 		}
 
 		// Tier B: embedded AUDIOBOOK_ORGANIZER_ID tag scan
 		if newPath, ok := resolveTierB(getTierB(), bookID, pathExists); ok {
 			result.AutoResolved++
+			result.Resolutions = append(result.Resolutions, resolvedTrack{
+				PID: track.PersistentID, OldPath: decoded, NewPath: newPath, Tier: "B", BookID: bookID,
+			})
 			if !dryRun {
 				if err := r.applyResolution(track.PersistentID, bookID, decoded, newPath, &result); err != nil {
 					result.Errors = append(result.Errors, fmt.Sprintf("apply tier=B pid=%s: %v", track.PersistentID, err))
 				}
 			}
-			_ = progress.Log("info",
-				fmt.Sprintf("repair pid=%s old=%s new=%s tier=B action=%s",
-					track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			if result.AutoResolved%detailLogEvery == 1 {
+				_ = progress.Log("info",
+					fmt.Sprintf("sample tier=B pid=%s old=%s new=%s action=%s",
+						track.PersistentID, decoded, newPath, applyAction(dryRun)), nil)
+			}
 			continue
 		}
 
@@ -286,15 +319,11 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 				Title:      track.Name,
 				Candidates: candidates,
 			})
-			_ = progress.Log("info",
-				fmt.Sprintf("repair pid=%s old=%s tier=C candidates=%d action=review",
-					track.PersistentID, decoded, len(candidates)), nil)
 			continue
 		}
 
 		result.Unresolved++
-		_ = progress.Log("debug",
-			fmt.Sprintf("missing pid=%s old=%s tier=ABC unresolved", track.PersistentID, decoded), nil)
+		result.UnresolvedPIDs = append(result.UnresolvedPIDs, track.PersistentID)
 	}
 
 	if r.cfg.ReportDir != "" {

--- a/internal/itunes/service/path_repair_resolver.go
+++ b/internal/itunes/service/path_repair_resolver.go
@@ -11,9 +11,11 @@ package itunesservice
 import (
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/matcher"
@@ -39,19 +41,48 @@ type noopTagScanner struct{}
 func (noopTagScanner) bookIDToPaths(string) []string { return nil }
 func (noopTagScanner) allPaths() []string            { return nil }
 
+// scanProgressFn is invoked periodically while the audiobook tree is
+// being scanned. (done, total) where total is the count of audio files
+// discovered in phase 1; done counts how many have been tag-extracted
+// in phase 2. Implementations should be cheap — the scanner calls this
+// off the hot path but still in the same process.
+type scanProgressFn func(done, total int)
+
 // fsTagScanner walks the audiobook root once, lazily, the first time
-// bookIDToPaths or allPaths is called. Subsequent calls hit the
-// in-memory state.
+// bookIDToPaths or allPaths is called. The walk runs in two phases:
+// phase 1 enumerates audio files (cheap, single goroutine, just
+// directory I/O), phase 2 extracts the AUDIOBOOK_ORGANIZER_ID tag
+// from each file in parallel via a worker pool. Subsequent calls hit
+// the in-memory state.
 type fsTagScanner struct {
-	root    string
-	extract bookIDExtractor
-	once    sync.Once
-	index   map[string][]string
-	all     []string
+	root       string
+	extract    bookIDExtractor
+	workers    int            // 0 → runtime.NumCPU() * 4 (tag reads are I/O-bound)
+	progress   scanProgressFn // optional; nil means silent
+	progressEv int            // emit progress every N files; 0 → 250
+
+	once  sync.Once
+	index map[string][]string
+	all   []string
 }
 
 func newFSTagScanner(root string, extract bookIDExtractor) *fsTagScanner {
 	return &fsTagScanner{root: root, extract: extract}
+}
+
+// withWorkers overrides the default worker count. Useful for tests
+// that want a deterministic single-threaded scan.
+func (s *fsTagScanner) withWorkers(n int) *fsTagScanner {
+	s.workers = n
+	return s
+}
+
+// withProgress installs a callback fired every N processed files
+// during phase 2. Pass everyN=0 for the default cadence.
+func (s *fsTagScanner) withProgress(fn scanProgressFn, everyN int) *fsTagScanner {
+	s.progress = fn
+	s.progressEv = everyN
+	return s
 }
 
 func (s *fsTagScanner) bookIDToPaths(bookID string) []string {
@@ -69,6 +100,10 @@ func (s *fsTagScanner) scan() {
 	if s.root == "" {
 		return
 	}
+
+	// Phase 1: enumerate every audio file. Cheap (no tag I/O); must
+	// be sequential because filepath.WalkDir doesn't parallelize.
+	var paths []string
 	_ = filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() {
 			return nil
@@ -77,14 +112,73 @@ func (s *fsTagScanner) scan() {
 		if _, ok := audioExt[ext]; !ok {
 			return nil
 		}
-		s.all = append(s.all, path)
-		if s.extract != nil {
-			if bookID, err := s.extract(path); err == nil && bookID != "" {
-				s.index[bookID] = append(s.index[bookID], path)
-			}
-		}
+		paths = append(paths, path)
 		return nil
 	})
+	s.all = paths
+
+	if s.extract == nil || len(paths) == 0 {
+		return
+	}
+
+	// Phase 2: parallel tag extraction. Tag reads are dominated by
+	// taglib + disk seek; oversubscribing relative to NumCPU keeps
+	// spinning disks busy.
+	workers := s.workers
+	if workers <= 0 {
+		workers = runtime.NumCPU() * 4
+	}
+	if workers > len(paths) {
+		workers = len(paths)
+	}
+	everyN := s.progressEv
+	if everyN <= 0 {
+		everyN = 250
+	}
+
+	type result struct {
+		path   string
+		bookID string
+	}
+	jobs := make(chan string, workers*2)
+	results := make(chan result, workers*2)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for p := range jobs {
+				bookID, err := s.extract(p)
+				if err != nil || bookID == "" {
+					results <- result{path: p}
+					continue
+				}
+				results <- result{path: p, bookID: bookID}
+			}
+		}()
+	}
+	go func() {
+		for _, p := range paths {
+			jobs <- p
+		}
+		close(jobs)
+	}()
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var done int64
+	total := len(paths)
+	for r := range results {
+		if r.bookID != "" {
+			s.index[r.bookID] = append(s.index[r.bookID], r.path)
+		}
+		n := atomic.AddInt64(&done, 1)
+		if s.progress != nil && (n%int64(everyN) == 0 || n == int64(total)) {
+			s.progress(int(n), total)
+		}
+	}
 }
 
 // tierAStore is the slice tier A needs after the bookID has been

--- a/internal/itunes/service/path_repair_resolver_test.go
+++ b/internal/itunes/service/path_repair_resolver_test.go
@@ -5,8 +5,10 @@
 package itunesservice
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -163,6 +165,37 @@ func mustWrite(t *testing.T, p, content string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
 	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+}
+
+// ---------------------------------------------------------------------------
+// fsTagScanner — parallel extraction matches sequential, progress fires
+// ---------------------------------------------------------------------------
+
+func TestFSTagScanner_ParallelMatchesSequential(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 50; i++ {
+		mustWrite(t, filepath.Join(root, fmt.Sprintf("a%02d.m4b", i)), "x")
+	}
+	extractor := func(p string) (string, error) {
+		base := filepath.Base(p)
+		// Group into 5 books so the index has multi-path entries too.
+		return "book-" + string(base[1]), nil
+	}
+
+	seq := newFSTagScanner(root, extractor).withWorkers(1)
+	seqAll := append([]string(nil), seq.allPaths()...)
+	seqOne := append([]string(nil), seq.bookIDToPaths("book-0")...)
+
+	var progressCalls atomic.Int32
+	par := newFSTagScanner(root, extractor).
+		withWorkers(8).
+		withProgress(func(done, total int) { progressCalls.Add(1) }, 10)
+	parAll := append([]string(nil), par.allPaths()...)
+	parOne := append([]string(nil), par.bookIDToPaths("book-0")...)
+
+	assert.ElementsMatch(t, seqAll, parAll, "every audio file is found regardless of worker count")
+	assert.ElementsMatch(t, seqOne, parOne, "bookID index is identical")
+	assert.Greater(t, int(progressCalls.Load()), 0, "progress callback fires during scan")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The first dogfood run of `/operations/itunes-path-repair` on production stalled in tier B: a single goroutine doing `filepath.WalkDir + metadata.ExtractMetadata` on every audio file in the 10K+ library. 53 tier-A repairs in 16s, then frozen for 17 minutes.

This PR:

- Parallelizes the tier B scan into two phases — single-threaded enumeration, then a worker pool of `runtime.NumCPU()*4` for tag reads (I/O-bound; oversubscribing keeps spinning disks busy).
- Adds `withProgress(fn, everyN)` so the operation surfaces "tier B: tag scan progress N/M" every 500 files.
- Emits `UpdateProgress` every 500 iTunes tracks with a rolling missing/auto/review/unresolved tally.
- Drops per-resolution `Log` spam — at 88K tracks the operations log table itself was the bottleneck. Now we emit a sample every Nth instead.
- Promotes `Resolutions` and `UnresolvedPIDs` slices into the result struct so the JSON report carries the full per-track decision set.

## Test plan

- [x] `TestFSTagScanner_ParallelMatchesSequential` — 8 workers vs 1 yield identical index, progress callback fires
- [x] All existing path_repair tests stay green
- [ ] After deploy: re-run dry-run against prod, expect completion in minutes with progress updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)