### PR TITLE
fix(maintenance): prevent crash when tasks API returns null

### DIFF
--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1258,7 +1258,7 @@ func (ts *TaskScheduler) ListTasks() []TaskInfo {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 
-	var result []TaskInfo
+	result := make([]TaskInfo, 0, len(ts.order))
 	for _, name := range ts.order {
 		task := ts.tasks[name]
 		info := TaskInfo{

--- a/web/src/pages/Maintenance.tsx
+++ b/web/src/pages/Maintenance.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Maintenance.tsx
-// version: 1.2.0
+// version: 1.2.1
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
 
 import { useEffect, useState } from 'react';
@@ -41,7 +41,7 @@ export function Maintenance() {
   const fetchTasks = async () => {
     try {
       const data = await api.getRegisteredTasks();
-      setTasks(data);
+      setTasks(Array.isArray(data) ? data : []);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tasks');


### PR DESCRIPTION
## Summary

- Guards against a null/missing response from the maintenance tasks API that was causing a frontend crash
- Defensive check added before iterating the tasks list

## Test plan

- [ ] Navigate to maintenance page — no crash when tasks endpoint returns null or empty
- [ ] Normal task list renders correctly when data is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)