### PR TITLE
feat(system): merge Maintenance page into System tab + fix task list bug

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 // file: web/src/App.tsx
-// version: 1.17.0
+// version: 1.18.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 // Trigger CI E2E test run
 
@@ -40,10 +40,6 @@ const Settings = lazy(() =>
 );
 const FileBrowser = lazy(() =>
   import('./pages/FileBrowser').then((m) => ({ default: m.FileBrowser }))
-);
-// Operations page removed — redirects to /activity
-const Maintenance = lazy(() =>
-  import('./pages/Maintenance').then((m) => ({ default: m.Maintenance }))
 );
 const BookDedup = lazy(() =>
   import('./pages/BookDedup').then((m) => ({ default: m.BookDedup }))
@@ -207,7 +203,7 @@ function App() {
               <Route path="/login" element={<Navigate to="/dashboard" replace />} />
               <Route path="/files" element={<FileBrowser />} />
               <Route path="/operations" element={<Navigate to="/activity" replace />} />
-              <Route path="/maintenance" element={<Maintenance />} />
+              <Route path="/maintenance" element={<Navigate to="/system" replace />} />
               <Route path="/authors/dedup" element={<Navigate to="/dedup" replace />} />
               <Route path="/books/dedup" element={<Navigate to="/dedup" replace />} />
               <Route path="/dedup" element={<BookDedup />} />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/Sidebar.tsx
-// version: 1.11.0
+// version: 1.12.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
 
 import { useState } from 'react';
@@ -28,7 +28,6 @@ import MonitorIcon from '@mui/icons-material/Monitor.js';
 import SettingsIcon from '@mui/icons-material/Settings.js';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen.js';
 import MergeTypeIcon from '@mui/icons-material/MergeType.js';
-import BuildIcon from '@mui/icons-material/Build.js';
 import BugReportIcon from '@mui/icons-material/BugReport.js';
 import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark.js';
 import PeopleIcon from '@mui/icons-material/People.js';
@@ -58,7 +57,6 @@ const menuItems = [
   { text: 'Works', icon: <MenuBookIcon />, path: '/works' },
   { text: 'Playlists', icon: <MenuBookIcon />, path: '/playlists' },
   { text: 'Activity', icon: <TimelineIcon />, path: '/activity' },
-  { text: 'Maintenance', icon: <BuildIcon />, path: '/maintenance' },
   { text: 'Dedup', icon: <MergeTypeIcon />, path: '/dedup' },
   { text: 'Diagnostics', icon: <BugReportIcon />, path: '/diagnostics' },
   { text: 'System', icon: <MonitorIcon />, path: '/system' },

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,15 +1,17 @@
-// file: web/src/pages/Maintenance.tsx
-// version: 1.2.1
-// guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
+// file: web/src/components/system/MaintenanceTab.tsx
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-345678901234
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
   Alert,
   Box,
   Button,
   Card,
   CardContent,
+  CardHeader,
   Chip,
+  CircularProgress,
   FormControlLabel,
   Stack,
   Switch,
@@ -19,17 +21,142 @@ import {
   useTheme,
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow.js';
-import * as api from '../services/api';
+import * as api from '../../services/api';
+
+// ─── MaintenanceWindowCard ───────────────────────────────────────────────────
+
+function MaintenanceWindowCard() {
+  const [status, setStatus] = useState<api.MaintenanceWindowStatus | null>(null);
+  const [config, setConfig] = useState<api.MaintenanceWindowConfig>({
+    enabled: false,
+    window_start: 1,
+    window_end: 4,
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const s = await api.getMaintenanceWindowStatus();
+      setStatus(s);
+      setConfig({ enabled: s.enabled, window_start: s.window_start, window_end: s.window_end });
+    } catch {
+      // degrade silently if backend endpoint not yet deployed
+    }
+  }, []);
+
+  useEffect(() => { loadStatus(); }, [loadStatus]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccessMsg(null);
+    try {
+      await api.updateMaintenanceWindowConfig(config);
+      setSuccessMsg('Maintenance window settings saved');
+      await loadStatus();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRunNow = async () => {
+    setError(null);
+    setSuccessMsg(null);
+    try {
+      await api.runMaintenanceWindow();
+      setSuccessMsg('Maintenance window triggered');
+      setTimeout(loadStatus, 1000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to trigger');
+    }
+  };
+
+  const nextRunLabel = status?.next_run_estimate
+    ? new Date(status.next_run_estimate).toLocaleString()
+    : '—';
+  const lastRunLabel = status?.last_run_date || 'Never';
+
+  return (
+    <Card sx={{ mb: 3 }}>
+      <CardHeader
+        title="Maintenance Window"
+        subheader={`Last run: ${lastRunLabel} · Next run: ${nextRunLabel}`}
+        action={status?.currently_running ? <CircularProgress size={20} sx={{ mt: 1, mr: 1 }} /> : null}
+      />
+      <CardContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {successMsg && (
+          <Alert severity="success" sx={{ mb: 1.5 }} onClose={() => setSuccessMsg(null)}>
+            {successMsg}
+          </Alert>
+        )}
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 2 }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={config.enabled}
+                onChange={(e) => setConfig((c) => ({ ...c, enabled: e.target.checked }))}
+              />
+            }
+            label="Enabled"
+          />
+          <TextField
+            label="Start hour (0-23)"
+            type="number"
+            size="small"
+            inputProps={{ min: 0, max: 23 }}
+            value={config.window_start}
+            onChange={(e) =>
+              setConfig((c) => ({ ...c, window_start: Math.min(23, Math.max(0, parseInt(e.target.value) || 0)) }))
+            }
+            sx={{ width: 155 }}
+          />
+          <TextField
+            label="End hour (0-23)"
+            type="number"
+            size="small"
+            inputProps={{ min: 0, max: 23 }}
+            value={config.window_end}
+            onChange={(e) =>
+              setConfig((c) => ({ ...c, window_end: Math.min(23, Math.max(0, parseInt(e.target.value) || 0)) }))
+            }
+            sx={{ width: 155 }}
+          />
+          <Button variant="outlined" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<PlayArrowIcon />}
+            onClick={handleRunNow}
+            disabled={status?.currently_running ?? false}
+          >
+            Run Maintenance Now
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── MaintenanceTab ──────────────────────────────────────────────────────────
 
 const categoryLabels: Record<string, string> = {
   library: 'Library',
   sync: 'Sync',
   maintenance: 'Maintenance',
 };
-
 const categoryOrder = ['library', 'sync', 'maintenance'];
 
-export function Maintenance() {
+export function MaintenanceTab() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [tasks, setTasks] = useState<api.TaskInfo[]>([]);
@@ -38,23 +165,23 @@ export function Maintenance() {
   const [runningTask, setRunningTask] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
-  const fetchTasks = async () => {
+  const fetchTasks = useCallback(async () => {
     try {
       const data = await api.getRegisteredTasks();
-      setTasks(Array.isArray(data) ? data : []);
+      setTasks(data);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tasks');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchTasks();
     const interval = setInterval(fetchTasks, 10000);
     return () => clearInterval(interval);
-  }, []);
+  }, [fetchTasks]);
 
   const handleRun = async (name: string) => {
     setRunningTask(name);
@@ -106,41 +233,22 @@ export function Maintenance() {
     }
   };
 
-  const handleRunMaintenanceWindow = async () => {
-    setSuccessMsg(null);
-    try {
-      await api.runMaintenanceWindow();
-      setSuccessMsg('Maintenance window triggered');
-      setTimeout(fetchTasks, 1000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to run maintenance window');
-    }
-  };
-
-  const grouped = categoryOrder.map((cat) => ({
-    category: cat,
-    label: categoryLabels[cat] || cat,
-    tasks: tasks.filter((t) => t.category === cat),
-  })).filter((g) => g.tasks.length > 0);
+  const grouped = categoryOrder
+    .map((cat) => ({
+      category: cat,
+      label: categoryLabels[cat] || cat,
+      tasks: tasks.filter((t) => t.category === cat),
+    }))
+    .filter((g) => g.tasks.length > 0);
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography variant="h4" gutterBottom>
-        Maintenance & Scheduled Tasks
-      </Typography>
+    <Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Configure and manually trigger background tasks. Scheduled tasks run automatically at the configured interval.
+        Configure and manually trigger background tasks. Tasks marked "Maint. Window" run
+        automatically during the scheduled maintenance window.
       </Typography>
 
-      <Box sx={{ mb: 3 }}>
-        <Button
-          variant="outlined"
-          startIcon={<PlayArrowIcon />}
-          onClick={handleRunMaintenanceWindow}
-        >
-          Run Maintenance Now
-        </Button>
-      </Box>
+      <MaintenanceWindowCard />
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
@@ -154,7 +262,7 @@ export function Maintenance() {
       )}
 
       {loading ? (
-        <Typography>Loading tasks...</Typography>
+        <Typography>Loading tasks…</Typography>
       ) : (
         <Stack spacing={4}>
           {grouped.map((group) => (
@@ -166,16 +274,17 @@ export function Maintenance() {
                 {group.tasks.map((task) => (
                   <Card key={task.name} variant="outlined">
                     <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-                      {/* Task info row */}
-                      <Box sx={{ mb: isMobile ? 1 : 0 }}>
-                        <Typography variant="subtitle2">{task.description}</Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {task.name}
-                          {task.last_run && ` · Last run: ${new Date(task.last_run).toLocaleString()}`}
+                      <Box sx={{ mb: 0.5, display: 'flex', alignItems: 'center', gap: 1 }}>
+                        {task.is_running && <CircularProgress size={14} />}
+                        <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
+                          {task.description}
                         </Typography>
                       </Box>
+                      <Typography variant="caption" color="text.secondary">
+                        {task.name}
+                        {task.last_run && ` · Last run: ${new Date(task.last_run).toLocaleString()}`}
+                      </Typography>
 
-                      {/* Controls row — wraps on mobile */}
                       <Box
                         sx={{
                           display: 'flex',
@@ -229,7 +338,9 @@ export function Maintenance() {
                             <Switch
                               size="small"
                               checked={task.run_in_maintenance_window}
-                              onChange={(e) => handleMaintenanceWindowToggle(task.name, e.target.checked)}
+                              onChange={(e) =>
+                                handleMaintenanceWindowToggle(task.name, e.target.checked)
+                              }
                             />
                           }
                           label="Maint. Window"
@@ -247,11 +358,15 @@ export function Maintenance() {
                           variant="contained"
                           size="small"
                           fullWidth={isMobile}
-                          startIcon={<PlayArrowIcon />}
-                          disabled={runningTask === task.name}
+                          startIcon={
+                            task.is_running
+                              ? <CircularProgress size={14} color="inherit" />
+                              : <PlayArrowIcon />
+                          }
+                          disabled={runningTask === task.name || task.is_running}
                           onClick={() => handleRun(task.name)}
                         >
-                          {runningTask === task.name ? 'Starting...' : 'Run Now'}
+                          {runningTask === task.name ? 'Starting…' : 'Run Now'}
                         </Button>
                       </Box>
                     </CardContent>

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/System.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
 
 import { useState } from 'react';
@@ -8,6 +8,7 @@ import { LogsTab } from '../components/system/LogsTab';
 import { StorageTab } from '../components/system/StorageTab';
 import { SystemInfoTab } from '../components/system/SystemInfoTab';
 import { QuotaTab } from '../components/system/QuotaTab';
+import { MaintenanceTab } from '../components/system/MaintenanceTab';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -49,6 +50,7 @@ export function System() {
           <Tab label="System Info" />
           <Tab label="Storage" />
           <Tab label="Quota" />
+          <Tab label="Maintenance" />
           <Tab label="Logs" />
         </Tabs>
 
@@ -65,6 +67,10 @@ export function System() {
         </TabPanel>
 
         <TabPanel value={tabValue} index={3}>
+          <MaintenanceTab />
+        </TabPanel>
+
+        <TabPanel value={tabValue} index={4}>
           <LogsTab />
         </TabPanel>
       </Paper>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.4.0
+// version: 2.5.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -3222,6 +3222,7 @@ export interface TaskInfo {
   run_on_startup: boolean;
   run_in_maintenance_window: boolean;
   last_run?: string;
+  is_running: boolean;
 }
 
 export async function getRegisteredTasks(): Promise<TaskInfo[]> {
@@ -3229,7 +3230,8 @@ export async function getRegisteredTasks(): Promise<TaskInfo[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch tasks');
   }
-  return response.json();
+  const body = await response.json();
+  return Array.isArray(body) ? body : (body?.data ?? []);
 }
 
 export async function runTask(name: string): Promise<Operation | { message: string }> {
@@ -3259,6 +3261,36 @@ export async function updateTaskConfig(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to update task config');
   }
+}
+
+export interface MaintenanceWindowStatus {
+  enabled: boolean;
+  window_start: number;
+  window_end: number;
+  last_run_date: string;
+  next_run_estimate: string;
+  currently_running: boolean;
+}
+
+export interface MaintenanceWindowConfig {
+  enabled: boolean;
+  window_start: number;
+  window_end: number;
+}
+
+export async function getMaintenanceWindowStatus(): Promise<MaintenanceWindowStatus> {
+  const response = await fetch(`${API_BASE}/maintenance-window/status`);
+  if (!response.ok) throw await buildApiError(response, 'Failed to fetch maintenance window status');
+  return response.json();
+}
+
+export async function updateMaintenanceWindowConfig(cfg: MaintenanceWindowConfig): Promise<void> {
+  const response = await fetch(`${API_BASE}/maintenance-window/config`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(cfg),
+  });
+  if (!response.ok) throw await buildApiError(response, 'Failed to update maintenance window config');
 }
 
 // AI Author Review


### PR DESCRIPTION
## Summary
- Fixes the empty task list bug: `getRegisteredTasks()` now unwraps `{data:[...]}` envelope
- New **Maintenance** tab on `/system` page (index 3, between Quota and Logs)
- `MaintenanceWindowCard` at top: enable toggle, start/end hour config, last/next run display, Run Now button
- Per-task `is_running` spinner (live status from backend `is_running` field)
- Removed standalone `/maintenance` route (redirects to `/system`) and sidebar entry
- Deleted `web/src/pages/Maintenance.tsx`

## Test plan
- [ ] `make build` passes with zero TypeScript errors
- [ ] Navigate to `/system` → Maintenance tab loads
- [ ] Task list renders (not empty)
- [ ] Window config card shows, Save and Run Now buttons work
- [ ] `/maintenance` no longer in sidebar (redirects to /system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)