### PR TITLE
feat(scheduler): maintenance window status/config API + is_running field

### DIFF
--- a/internal/server/maintenance_window_handlers_test.go
+++ b/internal/server/maintenance_window_handlers_test.go
@@ -1,0 +1,175 @@
+// file: internal/server/maintenance_window_handlers_test.go
+// version: 1.0.0
+// guid: d5e6f7a8-b9c0-1234-efab-456789012345
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMaintenanceTestServer creates a minimal Server with a real PebbleStore
+// and a wired TaskScheduler, then returns it ready for HTTP testing.
+func setupMaintenanceTestServer(t *testing.T) *Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	pebblePath := filepath.Join(t.TempDir(), "pebble")
+	store, err := database.NewPebbleStore(pebblePath)
+	require.NoError(t, err, "open pebble store")
+
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() {
+		database.SetGlobalStore(origStore)
+		store.Close()
+	})
+
+	srv := NewServer(nil)
+	srv.scheduler = NewTaskScheduler(srv)
+	return srv
+}
+
+func TestListTasksHasIsRunning(t *testing.T) {
+	srv := setupMaintenanceTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "expected 200 OK")
+
+	var resp struct {
+		Data []struct {
+			Name      string `json:"name"`
+			IsRunning bool   `json:"is_running"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data, "expected at least one task")
+
+	for _, task := range resp.Data {
+		// is_running should be present (false for all tasks in a fresh test server)
+		assert.False(t, task.IsRunning, "task %q should not be running", task.Name)
+	}
+}
+
+func TestGetMaintenanceWindowStatus(t *testing.T) {
+	// Set up known config values.
+	orig := config.AppConfig
+	defer func() { config.AppConfig = orig }()
+
+	config.AppConfig.MaintenanceWindowEnabled = true
+	config.AppConfig.MaintenanceWindowStart = 2
+	config.AppConfig.MaintenanceWindowEnd = 5
+
+	srv := setupMaintenanceTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/maintenance-window/status", nil)
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "expected 200 OK")
+
+	var resp struct {
+		Data struct {
+			Enabled          bool   `json:"enabled"`
+			WindowStart      int    `json:"window_start"`
+			WindowEnd        int    `json:"window_end"`
+			LastRunDate      string `json:"last_run_date"`
+			NextRunEstimate  string `json:"next_run_estimate"`
+			CurrentlyRunning bool   `json:"currently_running"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.True(t, resp.Data.Enabled, "enabled should be true")
+	assert.Equal(t, 2, resp.Data.WindowStart)
+	assert.Equal(t, 5, resp.Data.WindowEnd)
+	assert.NotEmpty(t, resp.Data.NextRunEstimate, "next_run_estimate should be non-empty")
+	assert.False(t, resp.Data.CurrentlyRunning, "no maintenance should be running")
+}
+
+func TestUpdateMaintenanceWindowConfig_Valid(t *testing.T) {
+	orig := config.AppConfig
+	defer func() { config.AppConfig = orig }()
+
+	srv := setupMaintenanceTestServer(t)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"enabled":      true,
+		"window_start": 3,
+		"window_end":   5,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/maintenance-window/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "expected 200 OK: %s", w.Body.String())
+
+	// Verify config was updated.
+	assert.True(t, config.AppConfig.MaintenanceWindowEnabled)
+	assert.Equal(t, 3, config.AppConfig.MaintenanceWindowStart)
+	assert.Equal(t, 5, config.AppConfig.MaintenanceWindowEnd)
+
+	// GET status and confirm round-trip.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/maintenance-window/status", nil)
+	w2 := httptest.NewRecorder()
+	srv.router.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp struct {
+		Data struct {
+			Enabled     bool `json:"enabled"`
+			WindowStart int  `json:"window_start"`
+			WindowEnd   int  `json:"window_end"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.True(t, resp.Data.Enabled)
+	assert.Equal(t, 3, resp.Data.WindowStart)
+	assert.Equal(t, 5, resp.Data.WindowEnd)
+}
+
+func TestUpdateMaintenanceWindowConfig_InvalidHour(t *testing.T) {
+	srv := setupMaintenanceTestServer(t)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"enabled":      true,
+		"window_start": 24,
+		"window_end":   5,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/maintenance-window/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "hour 24 should return 400")
+}
+
+func TestCalculateNextWindowRun(t *testing.T) {
+	// The result must be a valid RFC3339 time in the future.
+	result := calculateNextWindowRun(3)
+	parsed, err := time.Parse(time.RFC3339, result)
+	require.NoError(t, err, "should return valid RFC3339 time")
+	assert.True(t, parsed.After(time.Now().Add(-time.Minute)), "next run must be after now (with 1-min slack)")
+	assert.Equal(t, 3, parsed.Hour(), "result hour should match start hour")
+}

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -859,4 +859,60 @@ func (s *Server) runMaintenanceWindowNow(c *gin.Context) {
 		return
 	}
 	RespondWithSuccess(c, 202, gin.H{"message": "maintenance window triggered"})
+}
+
+// getMaintenanceWindowStatus returns current schedule config and live running status.
+func (s *Server) getMaintenanceWindowStatus(c *gin.Context) {
+	if s.scheduler == nil {
+		RespondWithInternalError(c, "scheduler not initialized")
+		return
+	}
+	cfg := config.AppConfig
+	RespondWithOK(c, gin.H{
+		"enabled":           cfg.MaintenanceWindowEnabled,
+		"window_start":      cfg.MaintenanceWindowStart,
+		"window_end":        cfg.MaintenanceWindowEnd,
+		"last_run_date":     s.scheduler.GetLastMaintenanceRunDate(),
+		"next_run_estimate": calculateNextWindowRun(cfg.MaintenanceWindowStart),
+		"currently_running": s.scheduler.IsMaintenanceRunning(),
+	})
+}
+
+// calculateNextWindowRun returns the next RFC3339 timestamp when startHour occurs locally.
+func calculateNextWindowRun(startHour int) string {
+	now := time.Now()
+	next := time.Date(now.Year(), now.Month(), now.Day(), startHour, 0, 0, 0, now.Location())
+	if !next.After(now) {
+		next = next.Add(24 * time.Hour)
+	}
+	return next.Format(time.RFC3339)
+}
+
+type maintenanceWindowConfigReq struct {
+	Enabled     bool `json:"enabled"`
+	WindowStart int  `json:"window_start"`
+	WindowEnd   int  `json:"window_end"`
+}
+
+// updateMaintenanceWindowConfig persists maintenance window schedule settings.
+func (s *Server) updateMaintenanceWindowConfig(c *gin.Context) {
+	var req maintenanceWindowConfigReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if req.WindowStart < 0 || req.WindowStart > 23 || req.WindowEnd < 0 || req.WindowEnd > 23 {
+		RespondWithBadRequest(c, "window_start and window_end must be 0-23")
+		return
+	}
+	config.AppConfig.MaintenanceWindowEnabled = req.Enabled
+	config.AppConfig.MaintenanceWindowStart = req.WindowStart
+	config.AppConfig.MaintenanceWindowEnd = req.WindowEnd
+	if s.Store() != nil {
+		if err := config.SaveConfigToDatabase(s.Store()); err != nil {
+			internalError(c, "failed to save maintenance window config", err)
+			return
+		}
+	}
+	RespondWithOK(c, gin.H{"ok": true})
 }

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -48,6 +48,7 @@ type TaskInfo struct {
 	RunOnStartup           bool    `json:"run_on_startup"`
 	RunInMaintenanceWindow bool    `json:"run_in_maintenance_window"`
 	LastRun                *string `json:"last_run,omitempty"`
+	IsRunning              bool    `json:"is_running"`
 }
 
 // TaskScheduler manages all registered tasks, their schedules, and manual triggers.
@@ -1276,6 +1277,7 @@ func (ts *TaskScheduler) ListTasks() []TaskInfo {
 			s := t.Format(time.RFC3339)
 			info.LastRun = &s
 		}
+		info.IsRunning = ts.isTaskRunning(info.Name)
 		result = append(result, info)
 	}
 	return result
@@ -1343,6 +1345,32 @@ func (ts *TaskScheduler) saveLastMaintenanceRun() {
 	today := time.Now().Format("2006-01-02")
 	_ = store.SetSetting("maintenance_window_last_run", today, "string", false)
 	ts.lastMaintenanceRun = time.Now()
+}
+
+// GetLastMaintenanceRunDate returns the last-run date as "2006-01-02", or "" if never run.
+func (ts *TaskScheduler) GetLastMaintenanceRunDate() string {
+	if ts.lastMaintenanceRun.IsZero() {
+		return ""
+	}
+	return ts.lastMaintenanceRun.Format("2006-01-02")
+}
+
+// IsMaintenanceRunning returns true if a maintenance-window operation is active.
+func (ts *TaskScheduler) IsMaintenanceRunning() bool {
+	store := ts.server.Store()
+	if store == nil {
+		return false
+	}
+	ops, _, err := store.ListOperations(20, 0)
+	if err != nil {
+		return false
+	}
+	for _, op := range ops {
+		if op.Type == "maintenance-window" && (op.Status == "running" || op.Status == "pending") {
+			return true
+		}
+	}
+	return false
 }
 
 // hasRunToday checks if the maintenance window has already run today.

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f3a7c2d1-8b4e-4f09-a5c6-1d2e3f4a5b6c
 
 package server
@@ -53,4 +53,20 @@ func TestHasRunToday(t *testing.T) {
 
 	ts.lastMaintenanceRun = time.Now().AddDate(0, 0, -1)
 	assert.False(t, ts.hasRunToday(), "yesterday should not count as today")
+}
+
+func TestGetLastMaintenanceRunDate_Zero(t *testing.T) {
+	ts := &TaskScheduler{lastMaintenanceRun: time.Time{}}
+	assert.Equal(t, "", ts.GetLastMaintenanceRunDate(), "zero time should return empty string")
+}
+
+func TestGetLastMaintenanceRunDate_Set(t *testing.T) {
+	fixed := time.Date(2026, 4, 27, 3, 0, 0, 0, time.UTC)
+	ts := &TaskScheduler{lastMaintenanceRun: fixed}
+	assert.Equal(t, "2026-04-27", ts.GetLastMaintenanceRunDate())
+}
+
+func TestIsMaintenanceRunning_NilStore(t *testing.T) {
+	ts := &TaskScheduler{server: &Server{}}
+	assert.False(t, ts.IsMaintenanceRunning(), "nil store should return false")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.192.0
+// version: 1.193.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2420,6 +2420,8 @@ func (s *Server) setupRoutes() {
 			protected.POST("/tasks/:name/run", s.perm(auth.PermSettingsManage), s.runTask)
 			protected.PUT("/tasks/:name", s.perm(auth.PermSettingsManage), s.updateTaskConfig)
 			protected.POST("/maintenance-window/run", s.perm(auth.PermSettingsManage), s.runMaintenanceWindowNow)
+			protected.GET("/maintenance-window/status", s.perm(auth.PermSettingsManage), s.getMaintenanceWindowStatus)
+			protected.PUT("/maintenance-window/config", s.perm(auth.PermSettingsManage), s.updateMaintenanceWindowConfig)
 			protected.POST("/maintenance/fix-read-by-narrator", s.perm(auth.PermSettingsManage), s.handleFixReadByNarrator)
 			protected.POST("/maintenance/cleanup-series", s.perm(auth.PermSettingsManage), s.handleCleanupSeries)
 			protected.POST("/maintenance/backfill-book-files", s.perm(auth.PermSettingsManage), s.handleBackfillBookFiles)


### PR DESCRIPTION
## Summary
- Adds `is_running: bool` to `TaskInfo` (populated via `isTaskRunning` in `ListTasks`)
- Adds `GetLastMaintenanceRunDate()` and `IsMaintenanceRunning()` public scheduler methods
- New `GET /maintenance-window/status` endpoint (enabled, window hours, last/next run, running flag)
- New `PUT /maintenance-window/config` endpoint (persists enabled + window hours to AppConfig + DB)
- 8 new backend tests (all passing)

## Test plan
- [ ] `make test` — all new tests pass; 2 pre-existing failures unrelated to this PR (`TestProp_DeterministicEvaluation`, `TestApplyAudiobookMetadata_WriteBackFalse`)
- [ ] `make build-api` passes
- [ ] `GET /api/v1/tasks` response includes `is_running: false` per task
- [ ] `GET /api/v1/maintenance-window/status` returns all expected fields
- [ ] `PUT /api/v1/maintenance-window/config` with hour > 23 returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)