### PR TITLE
feat(activity): expandable batch entry rendering in ActivityLog

### DIFF
--- a/web/src/components/BatchActivityEntry.tsx
+++ b/web/src/components/BatchActivityEntry.tsx
@@ -1,0 +1,196 @@
+// file: web/src/components/BatchActivityEntry.tsx
+// version: 1.0.0
+// guid: 7e3a1f9c-4b82-4d5e-a6c8-2f0d8e7b3a91
+
+import React, { useState } from 'react';
+import {
+  Box,
+  Chip,
+  Collapse,
+  IconButton,
+  TableCell,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight.js';
+import type { ActivityEntry } from '../services/activityApi';
+
+// ---- Local types -------------------------------------------------------
+
+interface BatchItem {
+  name: string;
+  count: number;
+  detail?: string;
+}
+
+interface BatchDetails {
+  batched: true;
+  batch_key: string;
+  items: BatchItem[];
+  window_start: string;
+  window_end: string;
+  original_count: number;
+  truncated?: boolean;
+}
+
+// ---- Props -------------------------------------------------------------
+
+interface BatchActivityEntryProps {
+  /** The ActivityEntry row emitted by the backend with details.batched === true */
+  entry: ActivityEntry;
+  /** Hex color string for the tier indicator dot */
+  tierColor: string;
+}
+
+// ---- Helpers -----------------------------------------------------------
+
+function formatTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+}
+
+// ---- Component ---------------------------------------------------------
+
+export function BatchActivityEntry({ entry, tierColor }: BatchActivityEntryProps) {
+  const [expanded, setExpanded] = useState(false);
+  const details = entry.details as unknown as BatchDetails;
+
+  // Safely cap rendered items at 200
+  const visibleItems = details?.items?.slice(0, 200) ?? [];
+  const hiddenCount =
+    details?.original_count != null && details.original_count > visibleItems.length
+      ? details.original_count - visibleItems.length
+      : 0;
+
+  return (
+    <React.Fragment>
+      {/* ---- Header row ---- */}
+      <TableRow
+        hover
+        sx={{ cursor: 'pointer', bgcolor: 'rgba(25, 118, 210, 0.04)' }}
+        onClick={() => setExpanded((e) => !e)}
+      >
+        {/* 1. Expand/collapse icon */}
+        <TableCell sx={{ whiteSpace: 'nowrap', color: 'text.secondary', fontSize: '0.75rem' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <IconButton
+              size="small"
+              sx={{ p: 0 }}
+              aria-label={expanded ? 'Collapse batch' : 'Expand batch'}
+              onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+            >
+              {expanded ? (
+                <ExpandMoreIcon fontSize="small" />
+              ) : (
+                <ChevronRightIcon fontSize="small" />
+              )}
+            </IconButton>
+            {/* Tier colored dot */}
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                bgcolor: tierColor,
+                flexShrink: 0,
+              }}
+            />
+            {/* Timestamp with staleness tooltip */}
+            <Tooltip title="Batch entries may be up to 15 seconds old" placement="top">
+              <span>{formatTimestamp(entry.timestamp)}</span>
+            </Tooltip>
+          </Box>
+        </TableCell>
+
+        {/* 2. Level chip placeholder — batched entries show a "batch" chip */}
+        <TableCell>
+          <Chip
+            size="small"
+            label="batch"
+            sx={{ bgcolor: tierColor, color: 'white', opacity: 0.85 }}
+          />
+        </TableCell>
+
+        {/* 3. Source chip */}
+        <TableCell>
+          {entry.source ? (
+            <Chip size="small" label={entry.source} variant="outlined" />
+          ) : null}
+        </TableCell>
+
+        {/* 4. Summary (spans wider column) */}
+        <TableCell>
+          <Typography variant="body2" noWrap title={entry.summary}>
+            {entry.summary}
+          </Typography>
+        </TableCell>
+
+        {/* 5. Item count chip + type info (desktop source column) */}
+        <TableCell>
+          <Chip
+            size="small"
+            label={`${details?.original_count ?? visibleItems.length} items`}
+            variant="outlined"
+          />
+        </TableCell>
+
+        {/* 6. Tags column — empty for batch rows */}
+        <TableCell />
+
+        {/* 7. Action column — empty for batch rows */}
+        <TableCell />
+      </TableRow>
+
+      {/* ---- Expanded detail row ---- */}
+      <TableRow>
+        <TableCell
+          colSpan={7}
+          sx={{
+            py: 0,
+            borderBottom: expanded ? undefined : 'none',
+          }}
+        >
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <Box sx={{ py: 1, pl: 4 }}>
+              {visibleItems.map((item, idx) => (
+                <Typography
+                  key={idx}
+                  variant="body2"
+                  sx={{ py: 0.25 }}
+                >
+                  {idx + 1}.{' '}
+                  <strong>{item.name}</strong>
+                  {' — '}
+                  {item.count === 1 ? '1 item' : `${item.count} items`}
+                  {item.detail ? ` (${item.detail})` : ''}
+                </Typography>
+              ))}
+              {(details?.truncated || hiddenCount > 0) && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ pt: 0.5, display: 'block' }}
+                >
+                  … and {hiddenCount > 0 ? hiddenCount : (details?.original_count ?? 0) - visibleItems.length} more not shown
+                </Typography>
+              )}
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </React.Fragment>
+  );
+}

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.3.0
+// version: 2.4.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -41,6 +41,7 @@ import CancelIcon from '@mui/icons-material/Cancel.js';
 import FilterListIcon from '@mui/icons-material/FilterList.js';
 import { fetchActivity, fetchActivitySources, compactActivityLog } from '../services/activityApi';
 import type { ActivityEntry, SourceCount } from '../services/activityApi';
+import { BatchActivityEntry } from '../components/BatchActivityEntry';
 import * as api from '../services/api';
 import { PendingFileOpsBanner } from '../components/PendingFileOpsBanner';
 import { usePendingFileOps } from '../hooks/usePendingFileOps';
@@ -1015,6 +1016,16 @@ export default function ActivityLog() {
             </TableHead>
             <TableBody>
               {entries.map((entry) => {
+                // Batched entries: collapsed/expanded list view
+                if ((entry.details as any)?.batched === true) {
+                  return (
+                    <BatchActivityEntry
+                      key={entry.id}
+                      entry={entry}
+                      tierColor={TIER_COLORS[entry.tier] ?? '#757575'}
+                    />
+                  );
+                }
                 if (entry.tier === 'digest') {
                   const isExpanded = expandedDigests.has(Number(entry.id));
                   const details = entry.details as {


### PR DESCRIPTION
## Summary
- New `web/src/components/BatchActivityEntry.tsx`: renders entries with `details.batched === true` as a collapsible group
- Click to expand/collapse; shows numbered item list (up to 200 items, truncation notice if more)
- Staleness tooltip on timestamp: "Batch entries may be up to 15 seconds old"
- ActivityLog.tsx: short-circuits to BatchActivityEntry when `entry.details?.batched === true`

## Wire-up
Backend batch entries won't appear until activity-batcher-core + activity-wire-writer + activity-api land. This PR is safe to merge independently — non-batched entries render exactly as before.

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Non-batched entries render unchanged
- [ ] A manually crafted entry with `details.batched=true` renders as expandable group

🤖 Generated with [Claude Code](https://claude.com/claude-code)