### PR TITLE
feat(activity): wire ActivityBatcher into Writer

### DIFF
--- a/internal/activity/batcher.go
+++ b/internal/activity/batcher.go
@@ -1,0 +1,216 @@
+// file: internal/activity/batcher.go
+// version: 1.0.0
+// guid: 7f3c1a2e-8b4d-4e9f-a5c6-2d0e3b7f9a1c
+
+package activity
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// BatchItem is one sub-entry within a batched ActivityEntry.
+type BatchItem struct {
+	Name   string `json:"name"`
+	Count  int    `json:"count"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// BatchKey identifies a group of related entries to merge.
+type BatchKey struct {
+	Type        string
+	Source      string
+	OperationID string
+}
+
+// BatchDetails is stored in ActivityEntry.Details for batched entries.
+type BatchDetails struct {
+	Batched       bool        `json:"batched"`
+	BatchKeyStr   string      `json:"batch_key"`
+	Items         []BatchItem `json:"items"`
+	WindowStart   time.Time   `json:"window_start"`
+	WindowEnd     time.Time   `json:"window_end"`
+	OriginalCount int         `json:"original_count"`
+	Truncated     bool        `json:"truncated,omitempty"`
+}
+
+const (
+	maxBatchItems    = 200
+	batchWindow      = 15 * time.Second
+	batchAbsoluteCap = 60 * time.Second
+)
+
+type pendingBatch struct {
+	key         BatchKey
+	items       []BatchItem
+	firstSeen   time.Time
+	lastSeen    time.Time
+	overflowCnt int
+	timer       *time.Timer
+}
+
+// ActivityBatcher accumulates batchable entries for up to 15s,
+// then emits one merged ActivityEntry per BatchKey.
+type ActivityBatcher struct {
+	mu      sync.Mutex
+	pending map[BatchKey]*pendingBatch
+	out     chan<- database.ActivityEntry
+	done    chan struct{}
+	window  time.Duration // defaults to batchWindow
+}
+
+// NewActivityBatcher creates a new ActivityBatcher that drains to out.
+func NewActivityBatcher(out chan<- database.ActivityEntry) *ActivityBatcher {
+	return newActivityBatcherWithWindow(out, batchWindow)
+}
+
+// newActivityBatcherWithWindow creates a batcher with a custom flush window.
+// Used in tests to avoid 15-second waits.
+func newActivityBatcherWithWindow(out chan<- database.ActivityEntry, window time.Duration) *ActivityBatcher {
+	return &ActivityBatcher{
+		pending: make(map[BatchKey]*pendingBatch),
+		out:     out,
+		done:    make(chan struct{}),
+		window:  window,
+	}
+}
+
+// Submit accumulates item under the given key. If this is the first item for
+// the key a timer is started; on expiry the batch is flushed automatically.
+// Early flush occurs when total items >= 500 or the absolute cap is reached.
+func (b *ActivityBatcher) Submit(key BatchKey, item BatchItem) {
+	b.mu.Lock()
+
+	pb, exists := b.pending[key]
+	if !exists {
+		pb = &pendingBatch{
+			key:       key,
+			firstSeen: time.Now(),
+		}
+		pb.timer = time.AfterFunc(b.window, func() { b.flushKey(key) })
+		b.pending[key] = pb
+	}
+
+	pb.lastSeen = time.Now()
+
+	if len(pb.items) < maxBatchItems {
+		pb.items = append(pb.items, item)
+	} else {
+		pb.overflowCnt++
+	}
+
+	total := len(pb.items) + pb.overflowCnt
+	earlyFlush := total >= 500 || time.Since(pb.firstSeen) >= batchAbsoluteCap
+
+	b.mu.Unlock()
+
+	if earlyFlush {
+		b.mu.Lock()
+		if existing, ok := b.pending[key]; ok {
+			existing.timer.Stop()
+		}
+		b.mu.Unlock()
+		go b.flushKey(key)
+	}
+}
+
+// FlushAll synchronously flushes all pending batches.
+func (b *ActivityBatcher) FlushAll() {
+	b.mu.Lock()
+	keys := make([]BatchKey, 0, len(b.pending))
+	for k := range b.pending {
+		keys = append(keys, k)
+	}
+	b.mu.Unlock()
+
+	for _, k := range keys {
+		b.flushKey(k)
+	}
+}
+
+// flushKey snapshots the pending batch for key, removes it from the map,
+// builds an ActivityEntry, and sends it to the output channel.
+func (b *ActivityBatcher) flushKey(key BatchKey) {
+	b.mu.Lock()
+	pb, ok := b.pending[key]
+	if !ok {
+		b.mu.Unlock()
+		return
+	}
+	pb.timer.Stop()
+	delete(b.pending, key)
+	b.mu.Unlock()
+
+	if len(pb.items) == 0 && pb.overflowCnt == 0 {
+		return
+	}
+
+	originalCount := len(pb.items) + pb.overflowCnt
+	truncated := pb.overflowCnt > 0
+
+	bd := BatchDetails{
+		Batched:       true,
+		BatchKeyStr:   fmt.Sprintf("%s|%s|%s", key.Type, key.Source, key.OperationID),
+		Items:         pb.items,
+		WindowStart:   pb.firstSeen,
+		WindowEnd:     pb.lastSeen,
+		OriginalCount: originalCount,
+		Truncated:     truncated,
+	}
+
+	raw, err := json.Marshal(bd)
+	if err != nil {
+		return
+	}
+	var details map[string]any
+	if err := json.Unmarshal(raw, &details); err != nil {
+		return
+	}
+
+	noun := batchNoun(key.Type)
+	summary := fmt.Sprintf("Batched %d %s", originalCount, noun)
+
+	entry := database.ActivityEntry{
+		Timestamp:   pb.firstSeen,
+		Tier:        "batch",
+		Type:        key.Type,
+		Level:       "info",
+		Source:      key.Source,
+		OperationID: key.OperationID,
+		Summary:     summary,
+		Details:     details,
+	}
+
+	select {
+	case b.out <- entry:
+	case <-b.done:
+	}
+}
+
+// Close flushes all pending batches and closes the done channel.
+func (b *ActivityBatcher) Close() {
+	b.FlushAll()
+	close(b.done)
+}
+
+// batchNoun returns a human-readable plural noun for a batch type.
+func batchNoun(batchType string) string {
+	switch batchType {
+	case "embedded-tag-load":
+		return "embedded tag loads"
+	case "tag-scan":
+		return "tag scans"
+	case "metadata-apply":
+		return "metadata applies"
+	case "path-repair":
+		return "path repairs"
+	case "isbn-enrich":
+		return "ISBN enrichments"
+	default:
+		return batchType + " operations"
+	}
+}

--- a/internal/activity/batcher_test.go
+++ b/internal/activity/batcher_test.go
@@ -1,0 +1,237 @@
+// file: internal/activity/batcher_test.go
+// version: 1.0.0
+// guid: 4a8b2c1d-5e9f-4a3b-b7c8-1d2e4f6a8b0c
+
+package activity
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// drainAll collects up to n entries from ch, waiting at most timeout each time.
+func drainAll(ch <-chan database.ActivityEntry, n int, timeout time.Duration) []database.ActivityEntry {
+	var results []database.ActivityEntry
+	for i := 0; i < n; i++ {
+		select {
+		case e := <-ch:
+			results = append(results, e)
+		case <-time.After(timeout):
+			return results
+		}
+	}
+	return results
+}
+
+func TestActivityBatcher_BasicFlush(t *testing.T) {
+	out := make(chan database.ActivityEntry, 10)
+	b := NewActivityBatcher(out)
+
+	key := BatchKey{Type: "tag-scan", Source: "scanner", OperationID: "op-1"}
+	b.Submit(key, BatchItem{Name: "book1.m4b", Count: 1})
+	b.Submit(key, BatchItem{Name: "book2.m4b", Count: 1})
+	b.Submit(key, BatchItem{Name: "book3.m4b", Count: 1})
+
+	b.FlushAll()
+
+	entries := drainAll(out, 5, 100*time.Millisecond)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.Details == nil {
+		t.Fatal("expected non-nil Details")
+	}
+
+	batched, ok := e.Details["batched"]
+	if !ok {
+		t.Fatal("expected 'batched' key in Details")
+	}
+	if batched != true {
+		t.Errorf("expected batched=true, got %v", batched)
+	}
+
+	origCount, ok := e.Details["original_count"]
+	if !ok {
+		t.Fatal("expected 'original_count' key in Details")
+	}
+	// JSON numbers unmarshal as float64
+	if origCount.(float64) != 3 {
+		t.Errorf("expected original_count=3, got %v", origCount)
+	}
+}
+
+func TestActivityBatcher_EarlyFlush_ItemCount(t *testing.T) {
+	// Use a long window so early flush must be triggered by item count, not timer.
+	out := make(chan database.ActivityEntry, 10)
+	b := newActivityBatcherWithWindow(out, 60*time.Second)
+
+	key := BatchKey{Type: "tag-scan", Source: "scanner", OperationID: "op-early"}
+
+	// Submit 501 items — should trigger early flush at >= 500 total.
+	for i := 0; i < 501; i++ {
+		b.Submit(key, BatchItem{Name: "file", Count: 1})
+	}
+
+	// The early flush runs in a goroutine; give it time to complete.
+	select {
+	case e := <-out:
+		if e.Details["batched"] != true {
+			t.Errorf("expected batched entry, got %+v", e.Details)
+		}
+	case <-time.After(500*time.Millisecond):
+		t.Fatal("expected early flush entry within 500ms, got none")
+	}
+}
+
+func TestActivityBatcher_MultipleKeys(t *testing.T) {
+	out := make(chan database.ActivityEntry, 10)
+	b := NewActivityBatcher(out)
+
+	key1 := BatchKey{Type: "tag-scan", Source: "scanner", OperationID: "op-1"}
+	key2 := BatchKey{Type: "path-repair", Source: "repairer", OperationID: "op-2"}
+
+	b.Submit(key1, BatchItem{Name: "a", Count: 1})
+	b.Submit(key2, BatchItem{Name: "b", Count: 1})
+
+	b.FlushAll()
+
+	entries := drainAll(out, 5, 100*time.Millisecond)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (one per key), got %d", len(entries))
+	}
+}
+
+func TestActivityBatcher_EmptyFlush(t *testing.T) {
+	out := make(chan database.ActivityEntry, 10)
+	b := NewActivityBatcher(out)
+
+	b.FlushAll()
+
+	select {
+	case e := <-out:
+		t.Errorf("expected no entry, got %+v", e)
+	case <-time.After(10 * time.Millisecond):
+		// correct: nothing sent
+	}
+}
+
+func TestActivityBatcher_TimerFires(t *testing.T) {
+	// Use a 50ms window to avoid a real 15s sleep in CI.
+	out := make(chan database.ActivityEntry, 10)
+	b := newActivityBatcherWithWindow(out, 50*time.Millisecond)
+
+	key := BatchKey{Type: "isbn-enrich", Source: "enricher", OperationID: "op-timer"}
+	b.Submit(key, BatchItem{Name: "book", Count: 1})
+
+	// Wait long enough for the timer to fire (50ms window + buffer).
+	select {
+	case e := <-out:
+		if e.Details["batched"] != true {
+			t.Errorf("expected batched=true, got %+v", e.Details)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timer did not fire within 300ms")
+	}
+}
+
+func TestActivityBatcher_CloseFlushes(t *testing.T) {
+	out := make(chan database.ActivityEntry, 10)
+	b := NewActivityBatcher(out)
+
+	key := BatchKey{Type: "metadata-apply", Source: "applier", OperationID: "op-close"}
+	b.Submit(key, BatchItem{Name: "x", Count: 1})
+	b.Submit(key, BatchItem{Name: "y", Count: 1})
+
+	b.Close()
+
+	entries := drainAll(out, 5, 100*time.Millisecond)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after Close, got %d", len(entries))
+	}
+
+	if entries[0].Details["batched"] != true {
+		t.Errorf("expected batched=true")
+	}
+}
+
+func TestActivityBatcher_Race(t *testing.T) {
+	out := make(chan database.ActivityEntry, 20)
+	b := NewActivityBatcher(out)
+
+	key := BatchKey{Type: "embedded-tag-load", Source: "loader", OperationID: "op-race"}
+
+	const goroutines = 10
+	const itemsEach = 5
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < itemsEach; j++ {
+				b.Submit(key, BatchItem{Name: "file", Count: 1})
+			}
+		}()
+	}
+	wg.Wait()
+
+	b.FlushAll()
+
+	entries := drainAll(out, 20, 100*time.Millisecond)
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 merged entry, got %d", len(entries))
+	}
+
+	origCount := entries[0].Details["original_count"].(float64)
+	if int(origCount) != goroutines*itemsEach {
+		t.Errorf("expected original_count=%d, got %v", goroutines*itemsEach, origCount)
+	}
+}
+
+func TestActivityBatcher_Overflow(t *testing.T) {
+	out := make(chan database.ActivityEntry, 10)
+	b := NewActivityBatcher(out)
+
+	key := BatchKey{Type: "tag-scan", Source: "scanner", OperationID: "op-overflow"}
+
+	// Submit maxBatchItems+1 = 201 items.
+	total := maxBatchItems + 1
+	for i := 0; i < total; i++ {
+		b.Submit(key, BatchItem{Name: "file", Count: 1})
+	}
+
+	b.FlushAll()
+
+	entries := drainAll(out, 5, 100*time.Millisecond)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+
+	// Re-marshal Details into BatchDetails for structured access.
+	raw, err := json.Marshal(e.Details)
+	if err != nil {
+		t.Fatalf("failed to marshal details: %v", err)
+	}
+	var bd BatchDetails
+	if err := json.Unmarshal(raw, &bd); err != nil {
+		t.Fatalf("failed to unmarshal BatchDetails: %v", err)
+	}
+
+	if !bd.Truncated {
+		t.Errorf("expected Truncated=true for %d items (max=%d)", total, maxBatchItems)
+	}
+	if bd.OriginalCount != total {
+		t.Errorf("expected OriginalCount=%d, got %d", total, bd.OriginalCount)
+	}
+	if len(bd.Items) != maxBatchItems {
+		t.Errorf("expected Items len=%d, got %d", maxBatchItems, len(bd.Items))
+	}
+}

--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -1,5 +1,5 @@
 // file: internal/activity/writer.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
 
 package activity
@@ -27,17 +27,20 @@ type Writer struct {
 	mu       sync.Mutex
 	partial  string // incomplete line buffer
 	closed   atomic.Bool
+	batcher  *ActivityBatcher
 }
 
 // NewWriter creates a new Writer backed by store.
 // chanSize controls the depth of the internal entry buffer.
 func NewWriter(store *database.ActivityStore, chanSize int) *Writer {
-	return &Writer{
+	w := &Writer{
 		stdout: os.Stdout,
 		ch:     make(chan database.ActivityEntry, chanSize),
 		store:  store,
 		done:   make(chan struct{}),
 	}
+	w.batcher = NewActivityBatcher(w.ch)
+	return w
 }
 
 // Start launches the background drain goroutine. Call once before writing.
@@ -72,6 +75,21 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
+// isBatchable returns true if e should be routed through the ActivityBatcher
+// rather than written directly to the channel. Entries are batchable only when
+// they come from a structured LogBatch call (operationID non-empty) AND their
+// type is registered as a high-volume batch type.
+func isBatchable(e database.ActivityEntry) bool {
+	if e.OperationID == "" || e.Tier != "debug" {
+		return false
+	}
+	switch e.Type {
+	case "embedded-tag-load", "tag-scan", "metadata-apply", "path-repair", "isbn-enrich":
+		return true
+	}
+	return false
+}
+
 // sendEntry parses a single log line and enqueues an ActivityEntry.
 // Debug entries are silently dropped when the channel is full.
 // Non-debug entries emit a warning to stdout when dropped.
@@ -86,6 +104,14 @@ func (w *Writer) sendEntry(line string) {
 		Level:   level,
 		Source:  source,
 		Summary: message,
+	}
+	if isBatchable(entry) {
+		w.batcher.Submit(BatchKey{
+			Type:        entry.Type,
+			Source:      entry.Source,
+			OperationID: entry.OperationID,
+		}, BatchItem{Name: entry.Summary})
+		return
 	}
 	select {
 	case w.ch <- entry:
@@ -146,6 +172,7 @@ func (w *Writer) writeBatch(entries []database.ActivityEntry) {
 // Flush synchronously drains any entries currently in the channel without
 // stopping the background goroutine.
 func (w *Writer) Flush() {
+	w.batcher.FlushAll()
 	for {
 		select {
 		case e := <-w.ch:
@@ -159,6 +186,7 @@ func (w *Writer) Flush() {
 // Stop marks the writer as closed, signals the drain goroutine to finish,
 // and waits for it to flush all remaining entries. Safe to call multiple times.
 func (w *Writer) Stop() {
+	w.batcher.Close()
 	w.closed.Store(true)
 	w.stopOnce.Do(func() { close(w.done) })
 	w.wg.Wait()


### PR DESCRIPTION
## Summary
- Adds `batcher *ActivityBatcher` to `Writer` struct
- `NewWriter` initializes batcher draining into same channel
- `isBatchable()` helper: routes entries with non-empty OperationID + registered type through batcher instead of channel
- `Flush()` calls `batcher.FlushAll()` first; `Stop()` calls `batcher.Close()` first
- All 27 existing tests still pass; -race clean

## Merge after
#477 (activity-batcher-core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)