### PR TITLE
fix(ci): add GOEXPERIMENT=yamlv2 to all workflows + override CodeQL

### DIFF
--- a/.github/workflows/binary-smoke.yml
+++ b/.github/workflows/binary-smoke.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build CLI Binary
         run: go build -o audiobook-organizer .
         env:
-          GOEXPERIMENT: jsonv2
+          GOEXPERIMENT: jsonv2,yamlv2
 
       - name: Verify CLI Help Output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@9796749d08eccc90b20b23ab3a97af28a73a14a0 # latest
     with:
       go-version: '1.26'
-      go-experiment: 'jsonv2'
+      go-experiment: 'jsonv2,yamlv2'
       node-version: '22'
       python-version: '3.13'
       rust-version: '1.76'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,100 @@
+# file: .github/workflows/codeql.yml
+# version: 1.0.0
+# guid: 4e7a1b2c-3d5f-6e8a-9b0c-1d2e3f4a5b6c
+#
+# Overrides GitHub's dynamic default CodeQL workflow so GOEXPERIMENT is set.
+# go.yaml.in/yaml/v2 requires GOEXPERIMENT=yamlv2; jsonv2 is also needed for
+# the project's JSON handling.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: '0 8 * * 1' # Weekly Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-go:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26'
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libtag1-dev
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          languages: go
+          queries: security-extended
+
+      - name: Build for CodeQL
+        run: go build ./...
+        env:
+          GOEXPERIMENT: jsonv2,yamlv2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          category: /language:go
+
+  analyze-js:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          category: /language:javascript-typescript
+
+  analyze-actions:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          category: /language:actions

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/vulnerability-scan.yml
-# version: 1.6.0
+# version: 1.7.0
 # guid: vuln-scan-001
 
 name: Nightly Vulnerability Scan
@@ -30,7 +30,7 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
         env:
-          GOEXPERIMENT: jsonv2
+          GOEXPERIMENT: jsonv2,yamlv2
 
 
   scan-npm:


### PR DESCRIPTION
## Problem

`go.yaml.in/yaml/v2` (indirect dep via several packages) requires `GOEXPERIMENT=yamlv2` to compile. All build-path workflows only set `jsonv2`, so:

- **CodeQL** used GitHub's dynamic autobuild with `GOEXPERIMENT=''` → incomplete Go analysis
- **Dependabot PRs** / scheduled CI → build failures when the yaml module is exercised
- **binary-smoke** and **vulnerability-scan** → same gap

## Changes

| File | Change |
|------|--------|
| `ci.yml` | `go-experiment: 'jsonv2'` → `'jsonv2,yamlv2'` (fixes Dependabot PRs) |
| `binary-smoke.yml` | `GOEXPERIMENT: jsonv2` → `jsonv2,yamlv2` |
| `vulnerability-scan.yml` | `GOEXPERIMENT: jsonv2` → `jsonv2,yamlv2` |
| `codeql.yml` | **New file** — overrides GitHub's dynamic default; sets `GOEXPERIMENT=jsonv2,yamlv2` on the Go build step; JS and Actions languages use autobuild as before |

## Test plan
- [ ] CI passes on this PR
- [ ] CodeQL "Analyze (go)" job completes without build failure
- [ ] Next Dependabot Go PR CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)