### PR TITLE
fix(ci): revert yamlv2 — only jsonv2 needed

### DIFF
--- a/.github/workflows/binary-smoke.yml
+++ b/.github/workflows/binary-smoke.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build CLI Binary
         run: go build -o audiobook-organizer .
         env:
-          GOEXPERIMENT: jsonv2,yamlv2
+          GOEXPERIMENT: jsonv2
 
       - name: Verify CLI Help Output
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@9796749d08eccc90b20b23ab3a97af28a73a14a0 # latest
     with:
       go-version: '1.26'
-      go-experiment: 'jsonv2,yamlv2'
+      go-experiment: 'jsonv2'
       node-version: '22'
       python-version: '3.13'
       rust-version: '1.76'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@
 # guid: 4e7a1b2c-3d5f-6e8a-9b0c-1d2e3f4a5b6c
 #
 # Overrides GitHub's dynamic default CodeQL workflow so GOEXPERIMENT is set.
-# go.yaml.in/yaml/v2 requires GOEXPERIMENT=yamlv2; jsonv2 is also needed for
+# GOEXPERIMENT=jsonv2 is required by the project's JSON handling (go.yaml.in indirect deps
 # the project's JSON handling.
 
 name: CodeQL
@@ -49,7 +49,7 @@ jobs:
       - name: Build for CodeQL
         run: go build ./...
         env:
-          GOEXPERIMENT: jsonv2,yamlv2
+          GOEXPERIMENT: jsonv2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run govulncheck
         run: govulncheck ./...
         env:
-          GOEXPERIMENT: jsonv2,yamlv2
+          GOEXPERIMENT: jsonv2
 
 
   scan-npm:


### PR DESCRIPTION
## Why

`go.yaml.in/yaml/v2` is only an **indirect** dep pulled transitively by `prometheus/common/model`. Our code never imports it directly, and `binary-smoke` CI was already passing with `GOEXPERIMENT=jsonv2` alone. Adding `yamlv2` was unnecessary.

## What

- `ci.yml`, `binary-smoke.yml`, `vulnerability-scan.yml`, `codeql.yml`: `jsonv2,yamlv2` → `jsonv2`
- `codeql.yml` comment corrected

The `codeql.yml` file itself (overriding GitHub's dynamic default to set `GOEXPERIMENT=jsonv2`) is still correct and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)