### PR TITLE
fix(metadata-review): hide-skipped toggle, pagination visible count, metadata_source field

### DIFF
--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -1,5 +1,5 @@
 // file: internal/activity/writer.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
 
 package activity
@@ -18,29 +18,44 @@ import (
 // Writer is an io.Writer that tees log output to stdout AND sends
 // parsed entries through a buffered channel to an ActivityStore.
 type Writer struct {
-	stdout   io.Writer
-	ch       chan database.ActivityEntry
-	store    *database.ActivityStore
-	batcher  *ActivityBatcher
-	done     chan struct{}
-	stopOnce sync.Once
-	wg       sync.WaitGroup
-	mu       sync.Mutex
-	partial  string // incomplete line buffer
-	closed   atomic.Bool
+	stdout      io.Writer
+	ch          chan database.ActivityEntry
+	store       *database.ActivityStore
+	batcher     *ActivityBatcher
+	done        chan struct{}
+	stopOnce    sync.Once
+	wg          sync.WaitGroup
+	mu          sync.Mutex
+	partial     string // incomplete line buffer
+	closed      atomic.Bool
+	skipSources map[string]struct{}
 }
 
 // NewWriter creates a new Writer backed by store.
 // chanSize controls the depth of the internal entry buffer.
+// By default the "gin" source is skipped — HTTP request logs are not
+// useful as persistent activity entries and would flood the database.
 func NewWriter(store *database.ActivityStore, chanSize int) *Writer {
 	w := &Writer{
-		stdout: os.Stdout,
-		ch:     make(chan database.ActivityEntry, chanSize),
-		store:  store,
-		done:   make(chan struct{}),
+		stdout:      os.Stdout,
+		ch:          make(chan database.ActivityEntry, chanSize),
+		store:       store,
+		done:        make(chan struct{}),
+		skipSources: map[string]struct{}{"gin": {}},
 	}
 	w.batcher = NewActivityBatcher(w.ch)
 	return w
+}
+
+// SetSkipSources replaces the set of log sources that are dropped before
+// being written to the activity store. Entries are still printed to stdout.
+// Call before Start(). Pass no arguments to disable all skipping.
+func (w *Writer) SetSkipSources(sources ...string) {
+	m := make(map[string]struct{}, len(sources))
+	for _, s := range sources {
+		m[s] = struct{}{}
+	}
+	w.skipSources = m
 }
 
 // Start launches the background drain goroutine. Call once before writing.
@@ -98,6 +113,9 @@ func (w *Writer) sendEntry(line string) {
 		return
 	}
 	level, source, message := ParseLogLine(line)
+	if _, skip := w.skipSources[source]; skip {
+		return
+	}
 	entry := database.ActivityEntry{
 		Tier:    "debug",
 		Type:    "system",

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.59.0
+// version: 2.60.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package database
@@ -186,6 +186,10 @@ type Book struct {
 	LastOrganizedAt *time.Time `json:"last_organized_at,omitempty"`
 	// MetadataReviewStatus tracks manual metadata matching: null, "no_match", "matched".
 	MetadataReviewStatus *string `json:"metadata_review_status,omitempty"`
+	// MetadataSource records which provider supplied the last applied metadata
+	// (e.g. "audible", "google_books", "openlibrary"). Used to selectively
+	// re-fetch from a specific source in the future.
+	MetadataSource *string `json:"metadata_source,omitempty"`
 	// ITunesSyncStatus tracks whether this book's metadata is in sync with the iTunes library.
 	// Values: "synced" (up-to-date in ITL), "dirty" (changed since last write-back),
 	// "unlinked" (no iTunes presence), "pending" (new, needs adding to iTunes),

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.55.0
+// version: 4.56.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package metafetch
@@ -2460,9 +2460,11 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 
 	mfs.ApplyMetadataToBook(book, meta)
 
-	// Set review status to matched
+	// Set review status and record which provider supplied the metadata
 	matched := "matched"
 	book.MetadataReviewStatus = &matched
+	src := candidate.Source
+	book.MetadataSource = &src
 
 	updatedBook, updateErr := mfs.db.UpdateBook(id, book)
 	if updateErr != nil {

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -167,6 +167,7 @@ export function MetadataReviewDialog({
   const [hideApplied, setHideApplied] = useState(true);
   const [hideRejected, setHideRejected] = useState(true);
   const [hideNoMatch, setHideNoMatch] = useState(true);
+  const [hideSkipped, setHideSkipped] = useState(false);
   const [matchLanguage, setMatchLanguage] = useState<boolean>(loadLanguageFilter);
   // Calls onComplete (to refresh the library) only when changes were made,
   // then closes the dialog. Avoids mid-review library refreshes that reset
@@ -284,6 +285,7 @@ export function MetadataReviewDialog({
     )
     .filter((r) => !hideApplied || rowStates.get(r.book.id) !== 'applied')
     .filter((r) => !hideRejected || rowStates.get(r.book.id) !== 'rejected')
+    .filter((r) => !hideSkipped || rowStates.get(r.book.id) !== 'skipped')
     .filter((r) => !hideNoMatch || (r.status !== 'no_match' && r.status !== 'error'))
     .filter((r) => {
       // Language filter: hide candidates whose language
@@ -303,7 +305,7 @@ export function MetadataReviewDialog({
   // Reset page when filters change
   useEffect(() => {
     setReviewPage(1);
-  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideNoMatch, matchLanguage]);
+  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideSkipped, hideNoMatch, matchLanguage]);
 
   // Coalesce rapid Apply clicks into one batched API call
   const applyQueueRef = useRef<string[]>([]);
@@ -1043,6 +1045,16 @@ export function MetadataReviewDialog({
                   control={
                     <Switch
                       size="small"
+                      checked={hideSkipped}
+                      onChange={(e) => setHideSkipped(e.target.checked)}
+                    />
+                  }
+                  label={<Typography variant="body2">Hide Skipped</Typography>}
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      size="small"
                       checked={hideNoMatch}
                       onChange={(e) => setHideNoMatch(e.target.checked)}
                     />
@@ -1122,10 +1134,11 @@ export function MetadataReviewDialog({
                   sx={{ mb: 1 }}
                 >
                   <Typography variant="caption" color="text.secondary">
-                    Showing{' '}
-                    {totalCount > 0
-                      ? `${(reviewPage - 1) * reviewPageSize + 1}–${Math.min(reviewPage * reviewPageSize, totalCount)} of ${totalCount}`
-                      : '0'}
+                    {filteredResults.length < results.length
+                      ? `${filteredResults.length} visible of ${results.length} loaded · ${totalCount} total`
+                      : totalCount > 0
+                        ? `Showing ${(reviewPage - 1) * reviewPageSize + 1}–${Math.min(reviewPage * reviewPageSize, totalCount)} of ${totalCount}`
+                        : '0'}
                   </Typography>
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Pagination


### PR DESCRIPTION
## Summary
- Add **Hide Skipped** toggle to MetadataReviewDialog (alongside Hide Applied/Rejected/No Match)
- Fix pagination "Showing" text to display filtered visible count vs loaded count when client-side filters reduce results below page size
- Add `metadata_source` field to `Book` struct (PebbleDB JSON, no migration); set to provider name (`audible`, `google_books`, `openlibrary`, etc.) on every `ApplyMetadataCandidate` call for future source-targeted re-fetch

Also includes: feat(activity): skip configured sources before DB write; default skip gin

## Test plan
- [ ] Open metadata review dialog, skip a few entries, verify Hide Skipped toggle hides/shows them
- [ ] Apply filters that reduce visible count below page size, verify "Showing" text reflects filtered count
- [ ] Apply a candidate, verify the book's `metadata_source` field is set in the API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)