### PR TITLE
feat(system): add app and system uptime to system info page

### DIFF
--- a/docs/superpowers/plans/2026-04-27-suspicious-file-detection.md
+++ b/docs/superpowers/plans/2026-04-27-suspicious-file-detection.md
@@ -1,0 +1,529 @@
+# Suspicious File Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect single-file "books" below a configurable size threshold, save them with `library_state='suspicious'`, and skip all expensive processing (hashing, tag extraction, AI).
+
+**Architecture:** A fast `os.Stat` guard in `ProcessBooksParallel` fires right after the incremental-skip check. The scanner `Book` struct gains a `LibraryState` field so `saveBookToDatabase` can honour it instead of hardcoding `'imported'`. No new DB columns or migrations needed.
+
+**Tech Stack:** Go 1.24, SQLite (via existing store), React/TypeScript (MUI FilterSidebar)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Add `MinBookSizeBytes int64` field, viper wiring, default, validation |
+| `internal/scanner/scanner.go` | Add `LibraryState string` to `Book` struct; thread through `saveBookToDatabase`; add guard in `ProcessBooksParallel` |
+| `internal/config/config_unit_test.go` | Add `TestMinBookSizeBytesDefault` |
+| `internal/scanner/scanner_test.go` | Add `TestSuspiciousFileSkipped` |
+| `web/src/components/audiobooks/FilterSidebar.tsx` | Add `<MenuItem value="suspicious">` |
+| `web/src/components/audiobooks/SearchBar.tsx` | Add `library_state:suspicious` example |
+
+---
+
+## Task 1: Config — MinBookSizeBytes field
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_unit_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `internal/config/config_unit_test.go`. Add at the bottom, before the final `}`:
+
+```go
+func TestMinBookSizeBytesDefault(t *testing.T) {
+	c := &Config{MinBookSizeBytes: 0}
+	_ = c.Validate()
+	assert.Equal(t, int64(10*1024*1024), c.MinBookSizeBytes,
+		"zero value should be coerced to 10 MB default")
+}
+
+func TestMinBookSizeBytesDisable(t *testing.T) {
+	c := &Config{MinBookSizeBytes: -1}
+	_ = c.Validate()
+	assert.Equal(t, int64(-1), c.MinBookSizeBytes,
+		"-1 sentinel should not be coerced")
+}
+
+func TestMinBookSizeBytesCustom(t *testing.T) {
+	c := &Config{MinBookSizeBytes: 5 * 1024 * 1024}
+	_ = c.Validate()
+	assert.Equal(t, int64(5*1024*1024), c.MinBookSizeBytes,
+		"explicit value should be preserved")
+}
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+```bash
+cd /path/to/repo && go test ./internal/config/... -run TestMinBookSizeBytes -v
+```
+Expected: `FAIL — undefined: Config.MinBookSizeBytes`
+
+- [ ] **Step 3: Add the struct field**
+
+In `internal/config/config.go`, find the Performance section (around line 134):
+```go
+	// Performance
+	ConcurrentScans int `json:"concurrent_scans"`
+	// Background operation timeout in minutes (0 disables timeout)
+	OperationTimeoutMinutes int `json:"operation_timeout_minutes"`
+```
+Insert after `OperationTimeoutMinutes`:
+```go
+	// MinBookSizeBytes: single-file books below this size are flagged as suspicious and
+	// skipped for heavy processing. Set to -1 to disable. Defaults to 10485760 (10 MB).
+	MinBookSizeBytes int64 `json:"min_book_size_bytes"`
+```
+
+- [ ] **Step 4: Wire viper**
+
+In the same file, find the Performance viper block (around line 533):
+```go
+		ConcurrentScans:         viper.GetInt("concurrent_scans"),
+		OperationTimeoutMinutes: viper.GetInt("operation_timeout_minutes"),
+```
+Add after `OperationTimeoutMinutes` line:
+```go
+		MinBookSizeBytes:        viper.GetInt64("min_book_size_bytes"),
+```
+
+- [ ] **Step 5: Add default**
+
+Find `DefaultConfig()` (returns `&Config{...}`). Locate the Performance defaults section (around line 914):
+```go
+		// Performance
+		ConcurrentScans:         max(runtime.NumCPU(), 4),
+		OperationTimeoutMinutes: 30,
+```
+Add after `OperationTimeoutMinutes`:
+```go
+		MinBookSizeBytes:        10 * 1024 * 1024,
+```
+
+- [ ] **Step 6: Add validation / default coercion**
+
+Find the `Validate()` method, at the `if c.ConcurrentScans < 0` block (around line 812). Add after it:
+```go
+	if c.MinBookSizeBytes == 0 {
+		c.MinBookSizeBytes = 10 * 1024 * 1024
+	}
+```
+
+- [ ] **Step 7: Bump file version header**
+
+The file starts with `// version: X.Y.Z`. Increment the patch version (e.g. `1.0.0` → `1.0.1`).
+
+- [ ] **Step 8: Run tests to confirm pass**
+
+```bash
+go test ./internal/config/... -run TestMinBookSizeBytes -v
+```
+Expected: all three tests PASS.
+
+- [ ] **Step 9: Run full config suite to check for regressions**
+
+```bash
+go test ./internal/config/... -v 2>&1 | tail -20
+```
+Expected: PASS (no failures).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_unit_test.go
+git commit -m "feat(config): add MinBookSizeBytes threshold for suspicious file detection"
+```
+
+---
+
+## Task 2: Scanner Book.LibraryState + saveBookToDatabase passthrough
+
+**Files:**
+- Modify: `internal/scanner/scanner.go`
+- Test: `internal/scanner/scanner_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `internal/scanner/scanner_test.go`. Add after `TestProcessBooks`:
+
+```go
+func TestBookLibraryStateField(t *testing.T) {
+	// Verifies the LibraryState field exists on Book and is threaded to saveBook.
+	var capturedState string
+	oldSaver := saveBook
+	t.Cleanup(func() { saveBook = oldSaver })
+	saveBook = func(b *Book) error {
+		capturedState = b.LibraryState
+		return nil
+	}
+
+	books := withTempBooks(t, []string{"test.mp3"})
+	books[0].LibraryState = "suspicious"
+
+	oldExts := config.AppConfig.SupportedExtensions
+	t.Cleanup(func() { config.AppConfig.SupportedExtensions = oldExts })
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+
+	// Drive through saveBook directly (unit-level: just check the var is called).
+	err := saveBook(&books[0])
+	if err != nil {
+		t.Fatalf("saveBook returned error: %v", err)
+	}
+	if capturedState != "suspicious" {
+		t.Errorf("expected LibraryState=suspicious, got %q", capturedState)
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+```bash
+go test ./internal/scanner/... -run TestBookLibraryStateField -v
+```
+Expected: `FAIL — b.LibraryState undefined`
+
+- [ ] **Step 3: Add LibraryState to the Book struct**
+
+In `internal/scanner/scanner.go`, find the `Book` struct (line 108):
+```go
+type Book struct {
+	FilePath        string
+	Title           string
+	Author          string
+	Series          string
+	Position        int
+	Format          string
+	Duration        int
+	Narrator        string
+	Language        string
+	Publisher       string
+	BookOrganizerID string // Embedded AUDIOBOOK_ORGANIZER_ID for re-linking
+	ASIN            string
+	OpenLibraryID   string
+	HardcoverID     string
+	SegmentFiles    []string // For multi-file books grouped by album in mixed directories
+	GoogleBooksID   string
+	FileHash        string // Pre-computed hash from ProcessFile (avoids double-read)
+}
+```
+Replace with:
+```go
+type Book struct {
+	FilePath        string
+	Title           string
+	Author          string
+	Series          string
+	Position        int
+	Format          string
+	Duration        int
+	Narrator        string
+	Language        string
+	Publisher       string
+	BookOrganizerID string // Embedded AUDIOBOOK_ORGANIZER_ID for re-linking
+	ASIN            string
+	OpenLibraryID   string
+	HardcoverID     string
+	SegmentFiles    []string // For multi-file books grouped by album in mixed directories
+	GoogleBooksID   string
+	FileHash        string // Pre-computed hash from ProcessFile (avoids double-read)
+	LibraryState    string // If set, overrides the default "imported" state in saveBookToDatabase
+}
+```
+
+- [ ] **Step 4: Thread LibraryState through saveBookToDatabase**
+
+In `saveBookToDatabase` (line ~1424), find:
+```go
+		dbBook := &database.Book{
+			Title:             book.Title,
+```
+Replace with:
+```go
+		ls := "imported"
+		if book.LibraryState != "" {
+			ls = book.LibraryState
+		}
+		dbBook := &database.Book{
+			Title:             book.Title,
+```
+
+Then find:
+```go
+			LibraryState:      stringPtr("imported"),
+```
+Replace with:
+```go
+			LibraryState:      stringPtr(ls),
+```
+
+- [ ] **Step 5: Bump file version header**
+
+Increment the patch version in the `// version:` header at the top of `scanner.go`.
+
+- [ ] **Step 6: Run test to confirm pass**
+
+```bash
+go test ./internal/scanner/... -run TestBookLibraryStateField -v
+```
+Expected: PASS.
+
+- [ ] **Step 7: Run full scanner suite**
+
+```bash
+go test ./internal/scanner/... -v 2>&1 | tail -20
+```
+Expected: no new failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/scanner/scanner.go internal/scanner/scanner_test.go
+git commit -m "feat(scanner): add Book.LibraryState and thread through saveBookToDatabase"
+```
+
+---
+
+## Task 3: Suspicious-file guard in ProcessBooksParallel
+
+**Files:**
+- Modify: `internal/scanner/scanner.go`
+- Test: `internal/scanner/scanner_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `internal/scanner/scanner_test.go`. Add after `TestBookLibraryStateField`:
+
+```go
+func TestSuspiciousFileSkipped(t *testing.T) {
+	oldThreshold := config.AppConfig.MinBookSizeBytes
+	oldExts := config.AppConfig.SupportedExtensions
+	t.Cleanup(func() {
+		config.AppConfig.MinBookSizeBytes = oldThreshold
+		config.AppConfig.SupportedExtensions = oldExts
+	})
+	config.AppConfig.MinBookSizeBytes = 1024 * 1024 // 1 MB threshold
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+
+	dir := t.TempDir()
+	smallFile := filepath.Join(dir, "tiny.mp3")
+	// Write 100 bytes — well under the 1 MB threshold.
+	if err := os.WriteFile(smallFile, make([]byte, 100), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	books := []Book{{FilePath: smallFile, Format: ".mp3"}}
+
+	var savedBook *Book
+	oldSaver := saveBook
+	t.Cleanup(func() { saveBook = oldSaver })
+	saveBook = func(b *Book) error {
+		saved := *b
+		savedBook = &saved
+		return nil
+	}
+
+	err := ProcessBooksParallel(context.Background(), books, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ProcessBooksParallel: %v", err)
+	}
+	if savedBook == nil {
+		t.Fatal("expected saveBook to be called for suspicious file")
+	}
+	if savedBook.LibraryState != "suspicious" {
+		t.Errorf("expected LibraryState=suspicious, got %q", savedBook.LibraryState)
+	}
+}
+
+func TestSuspiciousFileSkipDisabledWhenNegativeOne(t *testing.T) {
+	oldThreshold := config.AppConfig.MinBookSizeBytes
+	oldExts := config.AppConfig.SupportedExtensions
+	t.Cleanup(func() {
+		config.AppConfig.MinBookSizeBytes = oldThreshold
+		config.AppConfig.SupportedExtensions = oldExts
+	})
+	config.AppConfig.MinBookSizeBytes = -1 // disabled
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+
+	dir := t.TempDir()
+	smallFile := filepath.Join(dir, "tiny.mp3")
+	if err := os.WriteFile(smallFile, make([]byte, 100), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	books := []Book{{FilePath: smallFile, Format: ".mp3"}}
+
+	var savedState string
+	oldSaver := saveBook
+	t.Cleanup(func() { saveBook = oldSaver })
+	saveBook = func(b *Book) error {
+		savedState = b.LibraryState
+		return nil
+	}
+
+	err := ProcessBooksParallel(context.Background(), books, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("ProcessBooksParallel: %v", err)
+	}
+	if savedState == "suspicious" {
+		t.Error("threshold=-1 should disable suspicious detection, but book was flagged")
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+```bash
+go test ./internal/scanner/... -run "TestSuspiciousFile" -v
+```
+Expected: both tests FAIL (guard does not exist yet, so `LibraryState` stays empty).
+
+- [ ] **Step 3: Add the guard to ProcessBooksParallel**
+
+In `scanner.go`, find this exact block (around line 369):
+```go
+			fallbackUsed := false
+			filePath := books[idx].FilePath
+
+			// Handle directory-based books (multi-file books grouped by album tag)
+			if info, statErr := os.Stat(filePath); statErr == nil && info.IsDir() {
+```
+Replace with:
+```go
+			fallbackUsed := false
+			filePath := books[idx].FilePath
+
+			// Suspicious-file guard: single files below MinBookSizeBytes skip heavy processing.
+			if threshold := config.AppConfig.MinBookSizeBytes; threshold > 0 {
+				if fi, statErr := os.Stat(filePath); statErr == nil && !fi.IsDir() && fi.Size() < threshold {
+					extractInfoFromPath(&books[idx])
+					books[idx].LibraryState = "suspicious"
+					if saveErr := saveBook(&books[idx]); saveErr != nil {
+						scanLog.Warn("failed to save suspicious book %s: %v", filePath, saveErr)
+					}
+					scanLog.Warn("suspicious file (%d bytes, threshold %d): %s", fi.Size(), threshold, filePath)
+					func() {
+						defer func() { recover() }()
+						if store := database.GetGlobalStore(); store != nil {
+							if dbBook, dbErr := store.GetBookByFilePath(filePath); dbErr == nil && dbBook != nil {
+								_ = store.UpdateScanCache(dbBook.ID, fi.ModTime().Unix(), fi.Size())
+							}
+						}
+					}()
+					return
+				}
+			}
+
+			// Handle directory-based books (multi-file books grouped by album tag)
+			if info, statErr := os.Stat(filePath); statErr == nil && info.IsDir() {
+```
+
+- [ ] **Step 4: Bump version header**
+
+Increment patch version in `// version:` at top of `scanner.go`.
+
+- [ ] **Step 5: Run tests to confirm pass**
+
+```bash
+go test ./internal/scanner/... -run "TestSuspiciousFile" -v
+```
+Expected: both PASS.
+
+- [ ] **Step 6: Run full scanner suite**
+
+```bash
+go test ./internal/scanner/... -v 2>&1 | tail -30
+```
+Expected: no new failures.
+
+- [ ] **Step 7: Run full backend test suite**
+
+```bash
+make test 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/scanner/scanner.go internal/scanner/scanner_test.go
+git commit -m "feat(scanner): flag single-file books below MinBookSizeBytes as suspicious"
+```
+
+---
+
+## Task 4: Frontend — add 'suspicious' to FilterSidebar and SearchBar
+
+**Files:**
+- Modify: `web/src/components/audiobooks/FilterSidebar.tsx`
+- Modify: `web/src/components/audiobooks/SearchBar.tsx`
+
+No automated test for this task — verify visually after running the dev server.
+
+- [ ] **Step 1: Add MenuItem to FilterSidebar**
+
+Open `web/src/components/audiobooks/FilterSidebar.tsx`. Find:
+```tsx
+              <MenuItem value="deleted">Deleted</MenuItem>
+            </Select>
+```
+Replace with:
+```tsx
+              <MenuItem value="deleted">Deleted</MenuItem>
+              <MenuItem value="suspicious">Suspicious</MenuItem>
+            </Select>
+```
+
+- [ ] **Step 2: Add search example to SearchBar**
+
+Open `web/src/components/audiobooks/SearchBar.tsx`. Find:
+```tsx
+  { example: 'library_state:imported', desc: 'Imported but not organized' },
+```
+Add after it:
+```tsx
+  { example: 'library_state:suspicious', desc: 'Suspicious / incomplete files' },
+```
+
+- [ ] **Step 3: Bump version headers**
+
+Increment patch version in the `// version:` header of both modified `.tsx` files.
+
+- [ ] **Step 4: Build frontend to confirm no type errors**
+
+```bash
+make build-api   # backend only — fast check
+cd web && npm run build 2>&1 | tail -20
+```
+Expected: no TypeScript errors, build succeeds.
+
+- [ ] **Step 5: Smoke test in browser**
+
+```bash
+make run-api
+```
+Open the app, open the filter sidebar, confirm "Suspicious" appears in the Library State dropdown.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/audiobooks/FilterSidebar.tsx \
+        web/src/components/audiobooks/SearchBar.tsx
+git commit -m "feat(ui): add suspicious library state to filter sidebar and search examples"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] Config: zero-value coercion (→ 10 MB) and -1 disable path both tested
+- [x] Guard calls `saveBook` (the mockable var), not `saveBookToDatabase` directly — testable
+- [x] Guard fires only for single files (`!fi.IsDir()`) — multi-file directory books unaffected
+- [x] `LibraryState` threads from `Book` struct into `saveBookToDatabase` dbBook
+- [x] Scan cache updated after suspicious save so incremental-skip catches it on next run
+- [x] recover() guard around scan cache update (matches existing pattern at line 594)
+- [x] Frontend: existing `library_state` filter infrastructure handles `suspicious` with no new endpoints
+- [x] No migrations needed — `library_state` is already free-form TEXT

--- a/docs/superpowers/specs/2026-04-27-series-name-normalization-design.md
+++ b/docs/superpowers/specs/2026-04-27-series-name-normalization-design.md
@@ -1,0 +1,181 @@
+# Series Name Normalization
+
+**Date:** 2026-04-27
+**Status:** Approved
+
+## Problem
+
+Series names in PebbleDB are contaminated from multiple sources (file tags, folder
+structure, Audible, Google Books, Open Library). Two distinct failure modes:
+
+1. **Embedded title/position** — the series field contains the full
+   `"Series - N - Title"` string, e.g. series=`"My Long Series - 1 - Foo"` and
+   title=`"My Long Series - 1 - Foo"`. The path formatter then builds
+   `Author/My Long Series - 1 - Foo - My Long Series - 1 - Foo/file.m4b`,
+   which exceeds the Windows MAX_PATH limit and breaks iTunes.
+
+2. **Ordinal variants** — the same series appears under multiple names because the
+   position was baked into the series name in different formats:
+   `"The Long Earth One"`, `"The Long Earth Two"`, `"The Long Earth 1"`,
+   `"The Long Earth 2"`. These create separate series rows in PebbleDB and
+   fragment the library.
+
+`NormalizeMetaSeries` / `ParseSeriesFromTitle` already handle the
+`"(Long Earth 05) The Long Cosmos"` parenthesized-prefix format. The new patterns
+fall through unhandled, and `CreateSeries` in the store does no normalization before
+writing, so bad names enter PebbleDB regardless of source.
+
+## Goals
+
+- Block contaminated series names from entering PebbleDB from any code path.
+- Remediate existing bad rows: rename, merge duplicates, then fix file tags and
+  folder paths via the existing write-back + organize pipeline.
+- Expose a dry-run preview before any writes, triggerable from the UI.
+
+## Architecture
+
+Three layers:
+
+### 1. `normalizeSeriesName()` — pure function
+
+**File:** `internal/metafetch/series_normalize.go`
+
+Signature:
+```go
+func normalizeSeriesName(name, title string) (series, position string, flagForReview bool)
+```
+
+Rules applied in order, stopping at first match:
+
+| Rule | Input | Output |
+|------|-------|--------|
+| Dash-embedded position+title | `"Long Earth - 1 - The Long Cosmos"` | series=`"Long Earth"`, pos=`"1"` |
+| Trailing digit | `"The Long Earth 2"` | series=`"The Long Earth"`, pos=`"2"` |
+| Trailing ordinal word (1–20) | `"The Long Earth One"` | series=`"The Long Earth"`, pos=`"1"` |
+| Series equals title | normalized series == book title | flagForReview=true, no auto-change |
+
+**Conservative bounds on rule 3:** Only ordinal words One through Twenty are matched
+as standalone trailing tokens (space-separated). Words like `"Someone"` or
+`"Everyone"` do not match because they are not preceded by a space boundary that
+isolates them from the preceding word. Series with legitimate number-words in their
+names (e.g. `"Fahrenheit 451"`) are not affected because the number is not a
+recognized ordinal word.
+
+The function is a pure, side-effect-free transformer — all callers are responsible
+for deciding what to do with the result.
+
+### 2. Normalization gate in the store
+
+**Files:** `internal/database/pebble_store.go` — `CreateSeries`, `UpdateSeriesName`
+
+Both functions call `normalizeSeriesName(name, "")` before writing. The `title`
+argument is empty here because the store layer does not have book-title context; the
+"series equals title" flag is therefore never set at this layer (it's only meaningful
+at the metafetch/remediation layer where both values are available).
+
+This ensures bad names cannot enter PebbleDB from any code path after this change.
+
+### 3. `NormalizeMetaSeries` extension
+
+**File:** `internal/metafetch/service.go`
+
+The existing `NormalizeMetaSeries` function is extended to call
+`normalizeSeriesName(meta.Series, meta.Title)` before the existing
+`ParseSeriesFromTitle` logic. If `flagForReview` is set, the series field is left
+unchanged and a warning is logged; it is not written to the DB.
+
+### 4. Remediation endpoint
+
+**Route:** `POST /api/v1/series/normalize?dry_run=true|false`
+
+**Handler:** `seriesNormalizeHandler` in `internal/server/series_handlers.go` (or
+equivalent server file following existing patterns)
+
+**Pipeline (non-dry-run):**
+
+1. **Scan** — load all series rows, apply `normalizeSeriesName(name, "")` to each.
+2. **Rename** — for rows where name changes, call `UpdateSeriesName`. Log old→new.
+3. **Merge** — after renaming, any two series rows with identical normalized name and
+   same `author_id` are duplicates. Merge via existing `mergeSeriesGroup` logic,
+   keeping the row with the most books as canonical.
+4. **Collect** — gather all book IDs whose `series_id` was renamed or merged.
+5. **Write-back** — call `WriteBackBatcher.Enqueue(bookID)` for each affected book.
+   The batcher coalesces concurrent enqueues within its existing timer window.
+6. **Organize** — enqueue an organize job for each affected book so files move to
+   their corrected (shorter) paths on disk.
+
+**Dry-run response:**
+```json
+{
+  "actions": [
+    {
+      "series_id": 42,
+      "old_name": "The Long Earth One",
+      "new_name": "The Long Earth",
+      "new_position": "1",
+      "action": "rename",
+      "book_count": 1
+    },
+    {
+      "series_id": 43,
+      "old_name": "The Long Earth Two",
+      "new_name": "The Long Earth",
+      "new_position": "2",
+      "action": "merge_into",
+      "merge_target_id": 42,
+      "book_count": 1
+    },
+    {
+      "series_id": 99,
+      "old_name": "My Long Series - 1 - Foo",
+      "new_name": "My Long Series",
+      "new_position": "1",
+      "action": "rename",
+      "book_count": 3
+    }
+  ],
+  "total_series_affected": 3,
+  "total_books_affected": 5,
+  "flagged_for_review": []
+}
+```
+
+Modeled directly on the existing `series-prune-preview` + `series-prune` pattern.
+
+### 5. Maintenance task integration
+
+A new `series-normalize` task type is added to the maintenance scheduler, wiring the
+remediation endpoint so it can be triggered on-demand from the Maintenance tab. No
+automatic schedule — this runs manually after bulk imports or when the admin notices
+fragmented series.
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `internal/metafetch/series_normalize.go` | New — `normalizeSeriesName()` + unit tests |
+| `internal/metafetch/service.go` | Extend `NormalizeMetaSeries` to call normalizer |
+| `internal/database/pebble_store.go` | Add normalization gate in `CreateSeries` + `UpdateSeriesName` |
+| `internal/server/duplicates_handlers.go` | Add `seriesNormalizeHandler` alongside `seriesPrune` |
+| `internal/server/server.go` | Register new route |
+| `internal/server/system_service.go` (or maintenance task registry) | Register `series-normalize` task type |
+
+## Testing
+
+- **Unit tests for `normalizeSeriesName()`**: cover all four rules, edge cases
+  (ordinal at start, ordinal in middle, `"Someone"` false-positive guard, ordinals
+  21+, series==title flag).
+- **Integration test for the endpoint**: mock store returns a set of known-bad series
+  names; assert dry-run response matches expected actions; assert non-dry-run
+  triggers correct `UpdateSeriesName` + `mergeSeriesGroup` calls.
+- **Gate test**: call `CreateSeries` with a known-bad name, assert the stored name is
+  normalized.
+
+## Rollback
+
+- The normalization gate in `CreateSeries` / `UpdateSeriesName` can be reverted by
+  removing the `normalizeSeriesName` call — the function is a single callsite in each.
+- The remediation endpoint is idempotent — running it twice produces no additional
+  changes after the first pass.
+- Write-back and organize are the same pipeline used everywhere else; their existing
+  rollback mechanisms (`.bak-*` copy-on-write, path history) apply.

--- a/internal/server/system_service.go
+++ b/internal/server/system_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_service.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
 
 package server
@@ -24,11 +24,12 @@ type systemServiceStore interface {
 
 
 type SystemService struct {
-	db systemServiceStore
+	db        systemServiceStore
+	startTime time.Time
 }
 
 func NewSystemService(db systemServiceStore) *SystemService {
-	return &SystemService{db: db}
+	return &SystemService{db: db, startTime: time.Now()}
 }
 
 type SystemStatus struct {
@@ -50,6 +51,8 @@ type SystemStatus struct {
 	Runtime          SystemRuntimeStatus  `json:"runtime"`
 	Operations       SystemOperationsInfo `json:"operations"`
 	PluginHealth     map[string]string    `json:"plugin_health,omitempty"`
+	AppUptimeSeconds    float64              `json:"app_uptime_seconds"`
+	SystemUptimeSeconds float64              `json:"system_uptime_seconds"`
 }
 
 type SystemLibraryStatus struct {
@@ -178,6 +181,8 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 		Operations: SystemOperationsInfo{
 			Recent: recentOps,
 		},
+		AppUptimeSeconds:    time.Since(ss.startTime).Seconds(),
+		SystemUptimeSeconds: sysinfo.GetSystemUptimeSeconds(),
 	}
 
 	return status, nil

--- a/internal/sysinfo/uptime.go
+++ b/internal/sysinfo/uptime.go
@@ -1,0 +1,14 @@
+// file: internal/sysinfo/uptime.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
+
+package sysinfo
+
+// systemUptimeProvider allows tests to override platform uptime queries.
+var systemUptimeProvider = getSystemUptimePlatform
+
+// GetSystemUptimeSeconds returns the number of seconds the OS has been running.
+// Returns 0 if unable to determine.
+func GetSystemUptimeSeconds() float64 {
+	return systemUptimeProvider()
+}

--- a/internal/sysinfo/uptime_darwin.go
+++ b/internal/sysinfo/uptime_darwin.go
@@ -1,0 +1,38 @@
+// file: internal/sysinfo/uptime_darwin.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
+
+//go:build darwin
+
+package sysinfo
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// kern.boottime is a struct timeval: {sec int64, usec int32}
+type timeval struct {
+	Sec  int64
+	Usec int32
+}
+
+func getSystemUptimePlatform() float64 {
+	mib := []int32{1 /* CTL_KERN */, 21 /* KERN_BOOTTIME */}
+	var tv timeval
+	n := unsafe.Sizeof(tv)
+	_, _, err := syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(len(mib)),
+		uintptr(unsafe.Pointer(&tv)),
+		uintptr(unsafe.Pointer(&n)),
+		0, 0,
+	)
+	if err != 0 {
+		return 0
+	}
+	boot := time.Unix(tv.Sec, int64(tv.Usec)*1000)
+	return time.Since(boot).Seconds()
+}

--- a/internal/sysinfo/uptime_linux.go
+++ b/internal/sysinfo/uptime_linux.go
@@ -1,0 +1,29 @@
+// file: internal/sysinfo/uptime_linux.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8b9c-0d1e-f2a3b4c5d6e7
+
+//go:build linux
+
+package sysinfo
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func getSystemUptimePlatform() float64 {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0
+	}
+	secs, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0
+	}
+	return secs
+}

--- a/internal/sysinfo/uptime_windows.go
+++ b/internal/sysinfo/uptime_windows.go
@@ -1,0 +1,11 @@
+// file: internal/sysinfo/uptime_windows.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0d1e-2f3a-b4c5d6e7f8a9
+
+//go:build windows
+
+package sysinfo
+
+func getSystemUptimePlatform() float64 {
+	return 0
+}

--- a/web/src/components/system/SystemInfoTab.tsx
+++ b/web/src/components/system/SystemInfoTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/system/SystemInfoTab.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 import { useState, useEffect } from 'react';
@@ -21,6 +21,7 @@ import {
   Storage as StorageIcon,
   Code as CodeIcon,
   Refresh as RefreshIcon,
+  Timer as TimerIcon,
 } from '@mui/icons-material';
 import * as api from '../../services/api';
 
@@ -49,6 +50,10 @@ interface SystemInfo {
     size: number;
     books: number;
     folderCount: number;
+  };
+  uptime: {
+    appSeconds: number;
+    systemSeconds: number;
   };
 }
 
@@ -99,6 +104,10 @@ export function SystemInfoTab() {
           books: libraryBooks,
           folderCount,
         },
+        uptime: {
+          appSeconds: status.app_uptime_seconds ?? 0,
+          systemSeconds: status.system_uptime_seconds ?? 0,
+        },
       });
     } catch (err) {
       console.error('Failed to fetch system info:', err);
@@ -115,6 +124,20 @@ export function SystemInfoTab() {
     if (bytes === 0) return '0 Bytes';
     const i = Math.floor(Math.log(bytes) / Math.log(1024));
     return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
+  };
+
+  const formatUptime = (totalSeconds: number): string => {
+    if (totalSeconds <= 0) return 'unknown';
+    const d = Math.floor(totalSeconds / 86400);
+    const h = Math.floor((totalSeconds % 86400) / 3600);
+    const m = Math.floor((totalSeconds % 3600) / 60);
+    const s = Math.floor(totalSeconds % 60);
+    const parts: string[] = [];
+    if (d > 0) parts.push(`${d}d`);
+    if (h > 0) parts.push(`${h}h`);
+    if (m > 0) parts.push(`${m}m`);
+    parts.push(`${s}s`);
+    return parts.join(' ');
   };
 
   const getOSIcon = () => {
@@ -277,6 +300,37 @@ export function SystemInfoTab() {
                     Available Cores
                   </Typography>
                   <Typography variant="body1">{info.cpu.cores}</Typography>
+                </Box>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Uptime */}
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" spacing={2} alignItems="center" mb={2}>
+                <TimerIcon color="primary" />
+                <Typography variant="h6">Uptime</Typography>
+              </Stack>
+              <Stack spacing={1.5}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Application
+                  </Typography>
+                  <Typography variant="body1">
+                    {formatUptime(info.uptime.appSeconds)}
+                  </Typography>
+                </Box>
+                <Divider />
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    System
+                  </Typography>
+                  <Typography variant="body1">
+                    {formatUptime(info.uptime.systemSeconds)}
+                  </Typography>
                 </Box>
               </Stack>
             </CardContent>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -437,6 +437,8 @@ export interface SystemStatus {
   operations: {
     recent: Operation[];
   };
+  app_uptime_seconds?: number;
+  system_uptime_seconds?: number;
 }
 
 export interface SystemStorage {


### PR DESCRIPTION
## Summary
- Adds `AppUptimeSeconds` and `SystemUptimeSeconds` to `SystemStatus` response
- New `sysinfo.GetSystemUptimeSeconds()` with platform-specific implementations (Linux `/proc/uptime`, Darwin `kern.boottime` sysctl, Windows stub)
- New Uptime card on the System Info tab showing both application and OS uptime formatted as `Xd Xh Xm Xs`

## Test plan
- [ ] Navigate to Settings → System Info tab and verify the Uptime card appears
- [ ] Application uptime increases on refresh
- [ ] System uptime reflects OS boot time (should be longer than app uptime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)