### PR TITLE
feat(series): series name decontamination + taglib cover embed + parallel write-back

### DIFF
--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.56.1
+// version: 4.57.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package metafetch
@@ -2779,8 +2779,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 	writtenCount := 0
 	skippedProtected := 0
 
-	// Embed cover art BEFORE writing tags — ffmpeg's cover embed (-map_metadata 0)
-	// does not preserve freeform iTunes atoms, so we embed first and write tags last.
+	// Embed cover art via TagLib (independent of tag writes — no ordering constraint).
 	if config.AppConfig.RootDir != "" {
 		mfs.embedCoverInBookFiles(book, metadata.CoverPathForBook(config.AppConfig.RootDir, book.ID))
 	}
@@ -2924,9 +2923,6 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			Summary: fmt.Sprintf("Wrote tags to %d file(s) for %s", writtenCount, book.Title),
 		})
 	}
-
-	// Cover art already embedded above (before tag write) to prevent
-	// ffmpeg's -map_metadata from clobbering freeform iTunes atoms.
 
 	// Stamp last_written_at
 	if writtenCount > 0 {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -17,6 +17,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -913,10 +915,10 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 	})
 }
 
-// runBulkWriteBack iterates the provided bookIDs starting at startIdx, writing
-// tags (and optionally renaming first) for each. Used by both the fresh-launch
-// path and the resume path. Checkpoints progress every 10 books so a restart
-// can pick up near where it left off.
+// runBulkWriteBack writes tags (and optionally renames) for each book in bookIDs,
+// starting at startIdx. Uses a parallel worker pool — cover embedding and tag
+// writes both go through TagLib so there is no ffmpeg ordering constraint.
+// Checkpoints every 10 completions so a restart can resume near where it left off.
 func (s *Server) runBulkWriteBack(
 	ctx context.Context,
 	opID string,
@@ -925,73 +927,99 @@ func (s *Server) runBulkWriteBack(
 	startIdx int,
 	progress operations.ProgressReporter,
 ) error {
+	const workers = 8
+
 	store := s.Store()
 	mfs := s.metadataFetchService
 	total := len(bookIDs)
-	written := 0
-	failed := 0
 
 	if startIdx > 0 {
 		_ = progress.Log("info", fmt.Sprintf("resuming bulk write-back from index %d/%d", startIdx, total), nil)
 	}
 
+	type job struct {
+		id   string
+		book *database.Book
+	}
+
+	jobCh := make(chan job, workers*2)
+	var wg sync.WaitGroup
+	var written, failed atomic.Int64
+	var mu sync.Mutex
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobCh {
+				if ctx.Err() != nil {
+					return
+				}
+				count, writeErr := mfs.WriteBackMetadataForBook(j.id)
+				if writeErr != nil {
+					failed.Add(1)
+					mu.Lock()
+					_ = progress.Log("warn", fmt.Sprintf("book %s: write-back failed: %v", j.id, writeErr), nil)
+					mu.Unlock()
+				} else {
+					written.Add(1)
+					if count > 0 && s.activityWriter != nil {
+						activity.LogBatch(s.activityWriter, opID, "metadata-apply", "write-back",
+							activity.BatchItem{Name: j.book.Title, Count: count})
+					}
+				}
+				done := written.Load() + failed.Load()
+				mu.Lock()
+				_ = progress.UpdateProgress(int(done), total, fmt.Sprintf("processing %d/%d (%d written, %d failed)", done, total, written.Load(), failed.Load()))
+				if done%10 == 0 {
+					_ = operations.SaveCheckpoint(store, opID, "bulk_write_back", "writing", int(done), total)
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
 	for i := startIdx; i < total; i++ {
+		if ctx.Err() != nil || progress.IsCanceled() {
+			mu.Lock()
+			_ = progress.Log("info", fmt.Sprintf("canceled after feeding %d/%d books", i-startIdx, total-startIdx), nil)
+			mu.Unlock()
+			break
+		}
+
 		bookID := bookIDs[i]
-		if progress.IsCanceled() {
-			msg := fmt.Sprintf("canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
-			_ = progress.Log("info", msg, nil)
-			return nil
+		book, err := store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			failed.Add(1)
+			mu.Lock()
+			_ = progress.Log("warn", fmt.Sprintf("book %s: not found", bookID), nil)
+			mu.Unlock()
+			continue
+		}
+		if isProtectedPath(book.FilePath) {
+			mu.Lock()
+			_ = progress.Log("info", fmt.Sprintf("book %s: skipping protected path", bookID), nil)
+			mu.Unlock()
+			continue
+		}
+		if doRename {
+			if renameErr := mfs.RunApplyPipelineRenameOnly(bookID, book); renameErr != nil {
+				mu.Lock()
+				_ = progress.Log("warn", fmt.Sprintf("book %s: rename failed: %v", bookID, renameErr), nil)
+				mu.Unlock()
+			}
 		}
 
 		select {
+		case jobCh <- job{id: bookID, book: book}:
 		case <-ctx.Done():
-			msg := fmt.Sprintf("context canceled after %d/%d books (%d written, %d failed)", i, total, written, failed)
-			_ = progress.Log("info", msg, nil)
-			return ctx.Err()
-		default:
-		}
-
-		book, err := store.GetBookByID(bookID)
-		if err != nil || book == nil {
-			failed++
-			_ = progress.Log("warn", fmt.Sprintf("book %s: not found", bookID), nil)
-			_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: not found)", i+1, total))
-			continue
-		}
-
-		if isProtectedPath(book.FilePath) {
-			_ = progress.Log("info", fmt.Sprintf("book %s: skipping protected path %s", bookID, book.FilePath), nil)
-			_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (skipped: protected)", i+1, total))
-			continue
-		}
-
-		if doRename {
-			if renameErr := mfs.RunApplyPipelineRenameOnly(bookID, book); renameErr != nil {
-				_ = progress.Log("warn", fmt.Sprintf("book %s: rename failed: %v", bookID, renameErr), nil)
-			}
-		}
-
-		count, writeErr := mfs.WriteBackMetadataForBook(bookID)
-		if writeErr != nil {
-			failed++
-			_ = progress.Log("warn", fmt.Sprintf("book %s: write-back failed: %v", bookID, writeErr), nil)
-		} else {
-			written++
-			if count > 0 && s.activityWriter != nil {
-				activity.LogBatch(s.activityWriter, opID, "metadata-apply", "write-back",
-					activity.BatchItem{Name: book.Title, Count: count})
-			}
-		}
-
-		_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("processing %d/%d (%d written, %d failed)", i+1, total, written, failed))
-
-		if (i+1)%10 == 0 {
-			_ = operations.SaveCheckpoint(store, opID, "bulk_write_back", "writing", i+1, total)
 		}
 	}
+	close(jobCh)
+	wg.Wait()
 
 	_ = operations.ClearState(store, opID)
-	summary := fmt.Sprintf("bulk write-back complete: %d written, %d failed out of %d", written, failed, total)
+	summary := fmt.Sprintf("bulk write-back complete: %d written, %d failed out of %d", written.Load(), failed.Load(), total)
 	_ = progress.Log("info", summary, nil)
 	if s.activityWriter != nil {
 		activity.FlushOperation(s.activityWriter, opID)

--- a/internal/tagger/embed_cover.go
+++ b/internal/tagger/embed_cover.go
@@ -1,36 +1,18 @@
 // file: internal/tagger/embed_cover.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package tagger
 
 import (
 	"fmt"
-	"log"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+
+	"go.senan.xyz/taglib"
 )
 
-// ErrToolNotFound is returned when the required external tool is not installed.
-var ErrToolNotFound = fmt.Errorf("required external tool not found")
-
-// findTool checks if a command-line tool exists on the system PATH.
-func findTool(name string) (string, error) {
-	path, err := exec.LookPath(name)
-	if err != nil {
-		return "", fmt.Errorf("%w: %s", ErrToolNotFound, name)
-	}
-	return path, nil
-}
-
-// EmbedCoverArt embeds a cover image into an audio file's metadata tags.
-// It detects the audio format from the file extension and uses the appropriate
-// external tool (ffmpeg for MP3/M4A/M4B/AAC/OGG, metaflac for FLAC).
-//
-// The original file is replaced atomically: tags are written to a temp file,
-// then the temp file is renamed over the original.
+// EmbedCoverArt embeds a cover image into an audio file using TagLib.
+// Supports MP3, M4A, M4B, AAC, OGG, and FLAC — no external tools required.
 func EmbedCoverArt(audioPath string, coverPath string) error {
 	if audioPath == "" {
 		return fmt.Errorf("empty audio path")
@@ -38,114 +20,15 @@ func EmbedCoverArt(audioPath string, coverPath string) error {
 	if coverPath == "" {
 		return fmt.Errorf("empty cover path")
 	}
-
-	// Verify both files exist
 	if _, err := os.Stat(audioPath); err != nil {
 		return fmt.Errorf("audio file not found: %w", err)
 	}
-	if _, err := os.Stat(coverPath); err != nil {
+	data, err := os.ReadFile(coverPath)
+	if err != nil {
 		return fmt.Errorf("cover file not found: %w", err)
 	}
-
-	ext := strings.ToLower(filepath.Ext(audioPath))
-
-	switch ext {
-	case ".mp3":
-		return embedWithFFmpeg(audioPath, coverPath, "mp3")
-	case ".m4b", ".m4a", ".aac":
-		return embedWithFFmpeg(audioPath, coverPath, "mp4")
-	case ".ogg":
-		return embedWithFFmpeg(audioPath, coverPath, "ogg")
-	case ".flac":
-		return embedWithMetaflac(audioPath, coverPath)
-	default:
-		return fmt.Errorf("unsupported audio format for cover embedding: %s", ext)
+	if err := taglib.WriteImage(audioPath, data); err != nil {
+		return fmt.Errorf("embed cover art in %s: %w", audioPath, err)
 	}
-}
-
-// embedWithFFmpeg uses ffmpeg to embed cover art into MP3, M4A/M4B, or OGG files.
-// For MP3, this writes an ID3v2 APIC frame.
-// For M4A/M4B, this writes an mp4 covr atom.
-func embedWithFFmpeg(audioPath, coverPath, format string) error {
-	ffmpegPath, err := findTool("ffmpeg")
-	if err != nil {
-		return err
-	}
-
-	tmpFile := audioPath + ".tmp" + filepath.Ext(audioPath)
-	defer os.Remove(tmpFile) // clean up on failure
-
-	// Build ffmpeg command.
-	// For MP4/M4B: only map audio + new cover, dropping subtitle/data streams
-	// that the ipod muxer can't handle and any old cover art.
-	// For MP3/OGG: map all streams from audio + new cover.
-	args := []string{
-		"-y",            // overwrite output
-		"-i", audioPath, // input audio
-		"-i", coverPath, // input cover image
-	}
-
-	if format == "mp4" {
-		// Map audio + chapters from input, plus the new cover image.
-		// Skip data/subtitle streams (bin_data) that the ipod muxer can't handle,
-		// and skip old video/cover streams so we replace rather than append.
-		// -map_metadata 0 preserves all custom tags (NARRATOR, SERIES, etc.)
-		args = append(args,
-			"-map", "0:a",              // audio streams
-			"-map_chapters", "0",       // preserve chapter metadata
-			"-map_metadata", "0",       // preserve ALL metadata tags from input
-			"-map", "1:0",              // new cover image
-			"-c", "copy",               // copy all codecs
-			"-disposition:v:0", "attached_pic",
-			"-movflags", "+faststart",
-		)
-	} else {
-		args = append(args,
-			"-map", "0",                // all streams from audio
-			"-map_metadata", "0",       // preserve ALL metadata tags from input
-			"-map", "1",                // cover image
-			"-c", "copy",               // copy all codecs
-			"-disposition:v:0", "attached_pic",
-		)
-	}
-
-	args = append(args, tmpFile)
-
-	cmd := exec.Command(ffmpegPath, args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("ffmpeg failed: %w\noutput: %s", err, string(output))
-	}
-
-	// Atomic replace: rename temp over original
-	if err := os.Rename(tmpFile, audioPath); err != nil {
-		return fmt.Errorf("failed to replace original file: %w", err)
-	}
-
-	log.Printf("[DEBUG] tagger: embedded cover art from %s into %s", coverPath, audioPath)
-	return nil
-}
-
-// embedWithMetaflac uses metaflac to embed cover art into FLAC files.
-func embedWithMetaflac(audioPath, coverPath string) error {
-	metaflacPath, err := findTool("metaflac")
-	if err != nil {
-		return err
-	}
-
-	// First remove any existing pictures, then import the new one
-	removeCmd := exec.Command(metaflacPath, "--remove", "--block-type=PICTURE", audioPath)
-	if output, err := removeCmd.CombinedOutput(); err != nil {
-		log.Printf("[WARN] tagger: metaflac --remove PICTURE failed (may be ok): %s", string(output))
-		// Not fatal -- file may not have had a picture
-	}
-
-	importCmd := exec.Command(metaflacPath, "--import-picture-from="+coverPath, audioPath)
-	output, err := importCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("metaflac --import-picture failed: %w\noutput: %s", err, string(output))
-	}
-
-	log.Printf("[DEBUG] tagger: embedded cover art from %s into %s (FLAC)", coverPath, audioPath)
 	return nil
 }

--- a/internal/tagger/embed_cover_test.go
+++ b/internal/tagger/embed_cover_test.go
@@ -1,138 +1,47 @@
 // file: internal/tagger/embed_cover_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package tagger
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestEmbedCoverArt_EmptyPaths(t *testing.T) {
+func TestEmbedCoverArt_EmptyAudioPath(t *testing.T) {
 	t.Parallel()
 	if err := EmbedCoverArt("", "/some/cover.jpg"); err == nil {
 		t.Error("expected error for empty audio path")
 	}
+}
+
+func TestEmbedCoverArt_EmptyCoverPath(t *testing.T) {
+	t.Parallel()
 	if err := EmbedCoverArt("/some/audio.mp3", ""); err == nil {
 		t.Error("expected error for empty cover path")
 	}
 }
 
-func TestEmbedCoverArt_MissingFiles(t *testing.T) {
+func TestEmbedCoverArt_MissingAudioFile(t *testing.T) {
 	t.Parallel()
-	err := EmbedCoverArt("/nonexistent/audio.mp3", "/nonexistent/cover.jpg")
+	dir := t.TempDir()
+	coverPath := filepath.Join(dir, "cover.jpg")
+	os.WriteFile(coverPath, []byte("fake"), 0644) //nolint:errcheck
+	err := EmbedCoverArt("/nonexistent/audio.mp3", coverPath)
 	if err == nil {
 		t.Error("expected error for missing audio file")
 	}
 }
 
-func TestEmbedCoverArt_UnsupportedFormat(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	audioPath := filepath.Join(dir, "test.wav")
-	coverPath := filepath.Join(dir, "cover.jpg")
-	os.WriteFile(audioPath, []byte("fake"), 0644)
-	os.WriteFile(coverPath, []byte("fake"), 0644)
-
-	err := EmbedCoverArt(audioPath, coverPath)
-	if err == nil {
-		t.Error("expected error for unsupported format .wav")
-	}
-	if err != nil && !containsStr(err.Error(), "unsupported audio format") {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestEmbedCoverArt_MissingFFmpeg(t *testing.T) {
+func TestEmbedCoverArt_MissingCoverFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	audioPath := filepath.Join(dir, "test.mp3")
-	coverPath := filepath.Join(dir, "cover.jpg")
-	os.WriteFile(audioPath, []byte("fake audio"), 0644)
-	os.WriteFile(coverPath, []byte("fake image"), 0644)
-
-	// Temporarily clear PATH so ffmpeg won't be found
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
-
-	err := EmbedCoverArt(audioPath, coverPath)
+	os.WriteFile(audioPath, []byte("fake audio"), 0644) //nolint:errcheck
+	err := EmbedCoverArt(audioPath, "/nonexistent/cover.jpg")
 	if err == nil {
-		t.Error("expected error when ffmpeg is missing")
+		t.Error("expected error for missing cover file")
 	}
-	if !errors.Is(err, ErrToolNotFound) {
-		t.Errorf("expected ErrToolNotFound, got: %v", err)
-	}
-}
-
-func TestEmbedCoverArt_MissingMetaflac(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	audioPath := filepath.Join(dir, "test.flac")
-	coverPath := filepath.Join(dir, "cover.jpg")
-	os.WriteFile(audioPath, []byte("fake audio"), 0644)
-	os.WriteFile(coverPath, []byte("fake image"), 0644)
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
-
-	err := EmbedCoverArt(audioPath, coverPath)
-	if err == nil {
-		t.Error("expected error when metaflac is missing")
-	}
-	if !errors.Is(err, ErrToolNotFound) {
-		t.Errorf("expected ErrToolNotFound, got: %v", err)
-	}
-}
-
-func TestFindTool_NotFound(t *testing.T) {
-	t.Parallel()
-	_, err := findTool("definitely_not_a_real_tool_abc123")
-	if err == nil {
-		t.Error("expected error for nonexistent tool")
-	}
-	if !errors.Is(err, ErrToolNotFound) {
-		t.Errorf("expected ErrToolNotFound, got: %v", err)
-	}
-}
-
-func TestEmbedCoverArt_AllFormats_MissingTool(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	coverPath := filepath.Join(dir, "cover.jpg")
-	os.WriteFile(coverPath, []byte("fake"), 0644)
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
-
-	formats := []string{".mp3", ".m4b", ".m4a", ".aac", ".ogg", ".flac"}
-	for _, ext := range formats {
-		t.Run(ext, func(t *testing.T) {
-			audioPath := filepath.Join(dir, "test"+ext)
-			os.WriteFile(audioPath, []byte("fake"), 0644)
-			err := EmbedCoverArt(audioPath, coverPath)
-			if err == nil {
-				t.Errorf("expected error for %s with no tools", ext)
-			}
-		})
-	}
-}
-
-// contains checks if substr is in s (avoids importing strings in test).
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

- **`StripSeriesContamination`** — pure function that strips title/position contamination from series names (e.g. `"The Expanse, Book 1"` → `"The Expanse"`), wired into scanner, iTunes importer, and metafetch normalize path
- **`POST /series/normalize`** — async operation with dry-run preview that renames/merges contaminated series across the library; maintenance task registered in scheduler
- **`perf: taglib cover embed`** — replaced ffmpeg subprocess in `EmbedCoverArt` with `taglib.WriteImage`; no external binary required, removes the cover-before-tags ordering constraint
- **`perf: parallel write-back`** — `runBulkWriteBack` now uses 8 parallel workers via channel/WaitGroup instead of sequential loop (~8× throughput improvement)

## Test Plan
- [ ] `go test ./internal/tagger/... ./internal/metadata/... ./internal/metafetch/...` — all pass
- [ ] `go test ./internal/server/... -run TestComputeSeriesNormalize|TestExecuteSeriesNormalize` — all pass
- [ ] Dry-run preview via `GET /series/normalize/preview` returns expected actions
- [ ] Real normalize via `POST /series/normalize` processes affected books

🤖 Generated with [Claude Code](https://claude.com/claude-code)