### PR TITLE
feat: add scan-composer-tags maintenance endpoint for Apple/iPhone sync fix

### DIFF
--- a/internal/metadata/taglib_cgo.go
+++ b/internal/metadata/taglib_cgo.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_cgo.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 //
 // Native CGO bindings to TagLib C API for high-performance tag writing.
@@ -73,6 +73,42 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, _
 		return fmt.Errorf("taglib: save failed for %s", abs)
 	}
 
+	return nil
+}
+
+// writeSingleTagWithTaglib writes one tag property without touching others.
+// Pass value="" to clear the property.
+func writeSingleTagWithTaglib(filePath, tagName, value string) error {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("taglib abs: %w", err)
+	}
+	cPath := C.CString(abs)
+	defer C.free(unsafe.Pointer(cPath))
+
+	file := C.taglib_file_new(cPath)
+	if file == nil {
+		return fmt.Errorf("taglib: failed to open %s", abs)
+	}
+	defer C.taglib_file_free(file)
+
+	if C.taglib_file_is_valid(file) == 0 {
+		return fmt.Errorf("taglib: file not valid: %s", abs)
+	}
+
+	cKey := C.CString(tagName)
+	defer C.free(unsafe.Pointer(cKey))
+	if value == "" {
+		C.taglib_property_set(file, cKey, nil)
+	} else {
+		cVal := C.CString(value)
+		C.taglib_property_set(file, cKey, cVal)
+		C.free(unsafe.Pointer(cVal))
+	}
+
+	if C.taglib_file_save(file) == 0 {
+		return fmt.Errorf("taglib: save failed for %s", abs)
+	}
 	return nil
 }
 

--- a/internal/metadata/taglib_exported.go
+++ b/internal/metadata/taglib_exported.go
@@ -1,0 +1,24 @@
+// file: internal/metadata/taglib_exported.go
+// version: 1.0.0
+// guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+//
+// Exported wrappers around the internal taglib read/write functions.
+// Both the WASM (taglib_support.go) and CGO (taglib_cgo.go) build
+// variants define the same internal signatures; this file calls them
+// without needing to duplicate the build-tag logic.
+
+package metadata
+
+// ReadRawTags returns the raw tag key→values map for a file via TagLib.
+// Keys are uppercase (e.g. "COMPOSER", "ALBUMARTIST"). Useful for
+// maintenance tools that need the actual on-disk value rather than the
+// parsed Metadata struct produced by ExtractMetadata.
+func ReadRawTags(filePath string) (map[string][]string, error) {
+	return readTagsWithTaglib(filePath)
+}
+
+// WriteSingleTag writes one tag property to a file without disturbing
+// any other tags. Pass value="" to clear the property.
+func WriteSingleTag(filePath, tagName, value string) error {
+	return writeSingleTagWithTaglib(filePath, tagName, value)
+}

--- a/internal/metadata/taglib_support.go
+++ b/internal/metadata/taglib_support.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/taglib_support.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 //
 // TagLib WASM writer (default, no CGO required).
@@ -40,6 +40,16 @@ func writeMetadataWithTaglib(filePath string, metadata map[string]interface{}, _
 	}
 
 	return nil
+}
+
+// writeSingleTagWithTaglib writes one tag property without touching others.
+// Pass value="" to clear the property from the file.
+func writeSingleTagWithTaglib(filePath, tagName, value string) error {
+	abs, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("taglib abs: %w", err)
+	}
+	return taglib.WriteTags(abs, map[string][]string{tagName: {value}}, 0)
 }
 
 // readTagsWithTaglib reads tags from a file via the TagLib WASM runtime.

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -3653,6 +3653,193 @@ func (s *Server) handleCleanupBackups(c *gin.Context) {
 		"bytes_freed":   result.BytesFreed,
 		"human_freed":   humanizeBytes(result.BytesFreed),
 		"errors":        result.Errors,
+	})
+}
+
+// composerTagResult describes the COMPOSER field state for one audio file.
+type composerTagResult struct {
+	BookID    string `json:"book_id"`
+	BookTitle string `json:"book_title"`
+	FilePath  string `json:"file_path"`
+	// Category is one of: "ok", "composer_equals_author", "composer_equals_narrator",
+	// "composer_mismatch", "missing_narrator", "read_error".
+	Category  string `json:"category"`
+	Composer  string `json:"composer_on_disk"`
+	Author    string `json:"author,omitempty"`
+	Narrator  string `json:"narrator,omitempty"`
+	WillWrite string `json:"will_write,omitempty"`
+	Applied   bool   `json:"applied,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// categorizeComposer returns the problem category and the value that should
+// be written in the given fix_mode ("set_narrator" or "clear").
+func categorizeComposer(composer, author, narrator, fixMode string) (category, willWrite string) {
+	composerLower := strings.ToLower(strings.TrimSpace(composer))
+	authorLower := strings.ToLower(strings.TrimSpace(author))
+	narratorLower := strings.ToLower(strings.TrimSpace(narrator))
+
+	if fixMode == "set_narrator" {
+		willWrite = strings.TrimSpace(narrator)
+	} else {
+		willWrite = ""
+	}
+
+	if strings.TrimSpace(composer) == "" {
+		if fixMode == "set_narrator" && strings.TrimSpace(narrator) != "" {
+			return "missing_narrator", strings.TrimSpace(narrator)
+		}
+		return "ok", ""
+	}
+
+	if author != "" && composerLower == authorLower {
+		// Old wrong mapping: author ended up in COMPOSER.
+		return "composer_equals_author", willWrite
+	}
+	if narrator != "" && composerLower == narratorLower {
+		if fixMode == "set_narrator" {
+			return "ok", strings.TrimSpace(narrator) // already correct
+		}
+		return "composer_equals_narrator", ""
+	}
+	// Non-empty COMPOSER that matches neither author nor narrator.
+	return "composer_mismatch", willWrite
+}
+
+// handleScanComposerTags reads the COMPOSER tag off every audio file on disk
+// and reports (or fixes) cases that cause Apple/iPhone sync problems.
+//
+// Common bad states:
+//   - composer = author name (old wrong mapping before narrator→composer convention)
+//   - composer has stale/contaminated text (series names, "read by", etc.)
+//   - composer is empty when a narrator exists and fix_mode=set_narrator
+//
+// Query params:
+//   - dry_run=true (default) — report without writing
+//   - dry_run=false — apply the fix
+//   - fix_mode=set_narrator (default) — write COMPOSER=narrator; use "clear" to always empty it
+func (s *Server) handleScanComposerTags(c *gin.Context) {
+	dryRun := c.DefaultQuery("dry_run", "true") != "false"
+	fixMode := c.DefaultQuery("fix_mode", "set_narrator")
+	if fixMode != "set_narrator" && fixMode != "clear" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "fix_mode must be 'set_narrator' or 'clear'"})
+		return
+	}
+
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+
+	log.Printf("[INFO] scan-composer-tags: start dry_run=%v fix_mode=%s", dryRun, fixMode)
+
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		internalError(c, "failed to list books", err)
+		return
+	}
+
+	counts := map[string]int{}
+	var problems []composerTagResult
+	totalFiles := 0
+	applied := 0
+	errors := 0
+
+	for i := range allBooks {
+		book := &allBooks[i]
+
+		authorName := ""
+		if book.AuthorID != nil {
+			if author, aErr := store.GetAuthorByID(*book.AuthorID); aErr == nil && author != nil {
+				authorName = author.Name
+			}
+		}
+		narratorName := ""
+		if book.Narrator != nil {
+			narratorName = *book.Narrator
+		}
+
+		files, fErr := store.GetBookFiles(book.ID)
+		if fErr != nil {
+			log.Printf("[WARN] scan-composer-tags: GetBookFiles book %s: %v", book.ID, fErr)
+			continue
+		}
+
+		for j := range files {
+			f := &files[j]
+			if f.FilePath == "" || f.Missing {
+				continue
+			}
+			ext := strings.ToLower(filepath.Ext(f.FilePath))
+			if ext != ".m4b" && ext != ".m4a" && ext != ".mp3" && ext != ".flac" && ext != ".ogg" {
+				continue
+			}
+			if _, statErr := os.Stat(f.FilePath); statErr != nil {
+				continue
+			}
+
+			totalFiles++
+
+			tags, readErr := metadata.ReadRawTags(f.FilePath)
+			if readErr != nil {
+				r := composerTagResult{
+					BookID: book.ID, BookTitle: book.Title, FilePath: f.FilePath,
+					Category: "read_error", Error: readErr.Error(),
+				}
+				problems = append(problems, r)
+				counts["read_error"]++
+				errors++
+				continue
+			}
+
+			composer := ""
+			if vs, ok := tags["COMPOSER"]; ok && len(vs) > 0 {
+				composer = strings.TrimSpace(vs[0])
+			}
+
+			category, willWrite := categorizeComposer(composer, authorName, narratorName, fixMode)
+			counts[category]++
+
+			if category == "ok" {
+				continue
+			}
+
+			r := composerTagResult{
+				BookID: book.ID, BookTitle: book.Title, FilePath: f.FilePath,
+				Category: category, Composer: composer,
+				Author: authorName, Narrator: narratorName, WillWrite: willWrite,
+			}
+
+			if !dryRun && willWrite != composer {
+				if writeErr := metadata.WriteSingleTag(f.FilePath, "COMPOSER", willWrite); writeErr != nil {
+					r.Error = writeErr.Error()
+					log.Printf("[WARN] scan-composer-tags: write failed %s: %v", f.FilePath, writeErr)
+					errors++
+				} else {
+					r.Applied = true
+					applied++
+					log.Printf("[INFO] scan-composer-tags: COMPOSER %q→%q book=%s file=%s",
+						composer, willWrite, book.ID, f.FilePath)
+				}
+			}
+
+			problems = append(problems, r)
+		}
+	}
+
+	log.Printf("[INFO] scan-composer-tags: done dry_run=%v fix_mode=%s total_files=%d problems=%d applied=%d errors=%d counts=%v",
+		dryRun, fixMode, totalFiles, len(problems), applied, errors, counts)
+
+	c.JSON(http.StatusOK, gin.H{
+		"dry_run":     dryRun,
+		"fix_mode":    fixMode,
+		"total_files": totalFiles,
+		"problems":    len(problems),
+		"applied":     applied,
+		"errors":      errors,
+		"by_category": counts,
+		"details":     problems,
 	})
 }
 

--- a/internal/server/maintenance_fixups_test.go
+++ b/internal/server/maintenance_fixups_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e
 
 package server
@@ -294,5 +294,66 @@ func TestCountErrors(t *testing.T) {
 	}
 	if got := countErrors(results); got != 2 {
 		t.Errorf("countErrors = %d, want 2", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// categorizeComposer tests
+// ---------------------------------------------------------------------------
+
+func TestCategorizeComposer_SetNarratorMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		composer  string
+		author    string
+		narrator  string
+		wantCat   string
+		wantWrite string
+	}{
+		{"ok_empty_no_narrator", "", "", "", "ok", ""},
+		{"ok_narrator_matches", "Nick Podehl", "", "Nick Podehl", "ok", "Nick Podehl"},
+		{"missing_narrator", "", "Brandon Sanderson", "Nick Podehl", "missing_narrator", "Nick Podehl"},
+		{"composer_equals_author", "Brandon Sanderson", "Brandon Sanderson", "Nick Podehl", "composer_equals_author", "Nick Podehl"},
+		{"composer_mismatch", "Some Random String", "Brandon Sanderson", "Nick Podehl", "composer_mismatch", "Nick Podehl"},
+		{"case_insensitive_author", "brandon sanderson", "Brandon Sanderson", "", "composer_equals_author", ""},
+		{"case_insensitive_narrator", "nick podehl", "", "Nick Podehl", "ok", "Nick Podehl"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, write := categorizeComposer(tc.composer, tc.author, tc.narrator, "set_narrator")
+			if cat != tc.wantCat {
+				t.Errorf("category = %q, want %q", cat, tc.wantCat)
+			}
+			if write != tc.wantWrite {
+				t.Errorf("willWrite = %q, want %q", write, tc.wantWrite)
+			}
+		})
+	}
+}
+
+func TestCategorizeComposer_ClearMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		composer  string
+		author    string
+		narrator  string
+		wantCat   string
+		wantWrite string
+	}{
+		{"empty_ok", "", "Author", "Narrator", "ok", ""},
+		{"narrator_in_composer_flagged", "Nick Podehl", "", "Nick Podehl", "composer_equals_narrator", ""},
+		{"author_in_composer_flagged", "Brandon Sanderson", "Brandon Sanderson", "", "composer_equals_author", ""},
+		{"mismatch_flagged", "Garbage Text", "Author", "Narrator", "composer_mismatch", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, write := categorizeComposer(tc.composer, tc.author, tc.narrator, "clear")
+			if cat != tc.wantCat {
+				t.Errorf("category = %q, want %q", cat, tc.wantCat)
+			}
+			if write != tc.wantWrite {
+				t.Errorf("willWrite = %q, want %q", write, tc.wantWrite)
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.193.2
+// version: 1.194.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2443,6 +2443,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/refetch-missing-authors", s.perm(auth.PermSettingsManage), s.handleRefetchMissingAuthors)
 			protected.POST("/maintenance/recompute-itunes-paths", s.perm(auth.PermSettingsManage), s.handleRecomputeITunesPaths)
 			protected.POST("/maintenance/generate-itl-tests", s.perm(auth.PermSettingsManage), s.handleGenerateITLTests)
+			protected.POST("/maintenance/scan-composer-tags", s.perm(auth.PermSettingsManage), s.handleScanComposerTags)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")


### PR DESCRIPTION
## Summary

- Adds `POST /maintenance/scan-composer-tags` — a new one-off maintenance endpoint that reads the actual `COMPOSER` tag off every audio file on disk and reports (or fixes) cases causing Apple Music sync problems on Windows/iPhone
- Exports `ReadRawTags` and `WriteSingleTag` from the `metadata` package so maintenance handlers can inspect/patch individual tags without going through the full write-back pipeline
- 11 unit tests covering all categorization branches in both `set_narrator` and `clear` fix modes

## Root Cause

Three code paths set `COMPOSER` inconsistently:
1. `rename.go` puts narrator in `meta["composer"]` — but `buildWriteTagMap` ignores that key entirely
2. `buildWriteTagMap` (taglib path) **clears** `COMPOSER` whenever `artist` is set
3. `enhanced.go` (AtomicParsley path) also clears `COMPOSER`

Files written by path 1 vs paths 2/3 end up with different `COMPOSER` values depending on which ran last. Apple Music on Windows reads `COMPOSER` as the narrator/secondary-artist field, so stale or wrong values break categorization and sync.

## How to use

```bash
# Dry run — see all problem files grouped by category
curl -X POST 'http://server/api/v1/maintenance/scan-composer-tags?dry_run=true'

# Dry run with clear mode (see what would be emptied)
curl -X POST 'http://server/api/v1/maintenance/scan-composer-tags?dry_run=true&fix_mode=clear'

# Apply fix — set COMPOSER=narrator on all problem files (Apple-friendly)
curl -X POST 'http://server/api/v1/maintenance/scan-composer-tags?dry_run=false&fix_mode=set_narrator'
```

## Response categories

| Category | Meaning |
|---|---|
| `ok` | File is already correct for the chosen mode |
| `composer_equals_author` | Old wrong mapping — author name in COMPOSER |
| `composer_equals_narrator` | Narrator in COMPOSER (ok for `set_narrator`, flagged for `clear`) |
| `composer_mismatch` | Non-empty COMPOSER matches neither author nor narrator |
| `missing_narrator` | Empty COMPOSER but narrator exists (`set_narrator` mode only) |
| `read_error` | TagLib couldn't read the file |

## Test plan

- [x] `go build ./...` — clean
- [x] `TestCategorizeComposer_SetNarratorMode` — 7 cases pass
- [x] `TestCategorizeComposer_ClearMode` — 4 cases pass
- [ ] Deploy to prod, run dry-run against full 10K library, review `by_category` counts before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)