### PR TITLE
feat(maintenance): repair truncated book_file paths + iTunes path-trim setting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.37.2
+// version: 1.38.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 
 package config
@@ -235,6 +235,8 @@ type Config struct {
 	ITunesLibraryReadPath  string          `json:"itunes_library_read_path"`  // path used for sync (XML or ITL)
 	ITunesPathMappings     []ITunesPathMap `json:"itunes_path_mappings"`      // Stored path mappings for write-back
 	ITunesAutoWriteBack    bool            `json:"itunes_auto_write_back"`    // Auto write-back on every edit (batched)
+	ITunesPathTrimEnabled  bool            `json:"itunes_path_trim_enabled"`   // Trim filenames to fit Windows MAX_PATH for iTunes compatibility
+	ITunesWindowsRootPath  string          `json:"itunes_windows_root_path"`   // Windows equivalent of RootDir, e.g. "W:\audiobook-organizer" (no trailing slash)
 
 	// Deluge integration
 	DelugeWebURL              string `json:"deluge_web_url"`               // e.g. "http://172.16.2.30:8112"
@@ -425,6 +427,8 @@ func InitConfig() {
 	viper.SetDefault("itunes_library_write_path", "")
 	viper.SetDefault("itunes_library_read_path", "")
 	viper.SetDefault("itunes_auto_write_back", false)
+	viper.SetDefault("itunes_path_trim_enabled", false)
+	viper.SetDefault("itunes_windows_root_path", "")
 
 	// Auto-update defaults
 	viper.SetDefault("auto_update_enabled", false)
@@ -591,6 +595,8 @@ func InitConfig() {
 		ITunesLibraryWritePath: viper.GetString("itunes_library_write_path"),
 		ITunesLibraryReadPath:  viper.GetString("itunes_library_read_path"),
 		ITunesAutoWriteBack:    viper.GetBool("itunes_auto_write_back"),
+		ITunesPathTrimEnabled:  viper.GetBool("itunes_path_trim_enabled"),
+		ITunesWindowsRootPath:  viper.GetString("itunes_windows_root_path"),
 
 		// Download client integration
 		DownloadClient: DownloadClientConfig{

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 
 package config
@@ -529,6 +529,12 @@ func applySetting(key, value, typ string) error {
 		if b, err := strconv.ParseBool(value); err == nil {
 			AppConfig.ITunesAutoWriteBack = b
 		}
+	case "itunes_path_trim_enabled":
+		if b, err := strconv.ParseBool(value); err == nil {
+			AppConfig.ITunesPathTrimEnabled = b
+		}
+	case "itunes_windows_root_path":
+		AppConfig.ITunesWindowsRootPath = value
 	case "itunes_path_mappings":
 		var mappings []ITunesPathMap
 		if err := json.Unmarshal([]byte(value), &mappings); err == nil {
@@ -874,6 +880,8 @@ func legacySaveConfigToDatabase_REMOVED(store database.SettingsStore) error { //
 		"itunes_library_write_path": {AppConfig.ITunesLibraryWritePath, "string", false},
 		"itunes_library_read_path":  {AppConfig.ITunesLibraryReadPath, "string", false},
 		"itunes_auto_write_back":    {strconv.FormatBool(AppConfig.ITunesAutoWriteBack), "bool", false},
+		"itunes_path_trim_enabled":  {strconv.FormatBool(AppConfig.ITunesPathTrimEnabled), "bool", false},
+		"itunes_windows_root_path":  {AppConfig.ITunesWindowsRootPath, "string", false},
 		"itunes_path_mappings":      {string(pathMappingsJSON), "json", false},
 
 		"basic_auth_enabled":  {strconv.FormatBool(AppConfig.BasicAuthEnabled), "bool", false},

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package organizer
@@ -230,6 +230,26 @@ func (o *Organizer) generateTargetPath(book *database.Book) (string, error) {
 		return "", fmt.Errorf("file pattern: %w", err)
 	}
 	fileName = sanitizeFilename(fileName) + ext
+
+	// When iTunes path trimming is enabled, shorten the filename stem so the
+	// Windows-equivalent path stays under MAX_PATH (260 chars). This uses
+	// config.ITunesWindowsRootPath as the Windows equivalent of RootDir.
+	if config.AppConfig.ITunesPathTrimEnabled && config.AppConfig.ITunesWindowsRootPath != "" {
+		windowsRoot := strings.TrimRight(config.AppConfig.ITunesWindowsRootPath, `\/`)
+		relDir := strings.ReplaceAll(folderPath, "/", `\`)
+		// Windows path = windowsRoot + \ + relDir + \ + filename
+		prefixLen := len(windowsRoot) + 1 + len(relDir) + 1
+		fileExt := filepath.Ext(fileName)
+		stem := strings.TrimSuffix(fileName, fileExt)
+		maxStem := 260 - prefixLen - len(fileExt)
+		if maxStem < 1 {
+			maxStem = 1
+		}
+		if len(stem) > maxStem {
+			stem = stem[:maxStem]
+			fileName = stem + fileExt
+		}
+	}
 
 	// Combine with root directory
 	fullPath := filepath.Join(o.config.RootDir, folderPath, fileName)

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -1894,12 +1894,16 @@ type fixBookFilePathsResult struct {
 
 // handleFixBookFilePaths iterates every book_files row and:
 //
-//  1. If file_path is a directory, globs for audio files inside it:
+//  1. If file_path doesn't exist but a file with the same stem prefix exists in
+//     the same directory, updates the row to the real filename (repairs truncated
+//     filenames left by old path-length limiting logic).
+//
+//  2. If file_path is a directory, globs for audio files inside it:
 //     - 1 file found  → update the row's file_path to that file
 //     - N>1 files     → create new book_file rows (one per file), delete the directory row
 //     - 0 files found → mark the row missing=true
 //
-//  2. If file_path is a real file and file_size < 100 bytes (likely measured
+//  3. If file_path is a real file and file_size < 100 bytes (likely measured
 //     from a directory inode), re-reads the size with os.Stat.
 //
 // For new/updated rows the handler also populates file_size, format, and
@@ -1942,7 +1946,65 @@ func (s *Server) handleFixBookFilePaths(c *gin.Context) {
 
 			info, statErr := os.Stat(f.FilePath)
 			if statErr != nil {
-				// File doesn't exist — leave to other fixup routines.
+				// File doesn't exist on disk. Try to find the real file by
+				// prefix-matching the truncated stem against siblings in the
+				// same directory (handles filenames truncated by old organizer
+				// runs that used the wrong path-length calculation).
+				dir := filepath.Dir(f.FilePath)
+				base := filepath.Base(f.FilePath)
+				ext := filepath.Ext(base)
+				stem := strings.TrimSuffix(base, ext)
+
+				dirEntries, readErr := os.ReadDir(dir)
+				var match string
+				if readErr == nil {
+					for _, de := range dirEntries {
+						if de.IsDir() {
+							continue
+						}
+						name := de.Name()
+						nameExt := filepath.Ext(name)
+						nameStem := strings.TrimSuffix(name, nameExt)
+						// Match: same extension and full name starts with truncated stem
+						if strings.EqualFold(nameExt, ext) && strings.HasPrefix(nameStem, stem) && name != base {
+							match = filepath.Join(dir, name)
+							break
+						}
+					}
+				}
+				if match == "" {
+					continue
+				}
+
+				fi, statErr2 := os.Stat(match)
+				res := fixBookFilePathsResult{
+					FileID:      f.ID,
+					BookID:      f.BookID,
+					OldPath:     f.FilePath,
+					NewPath:     match,
+					Action:      "truncated_name_repaired",
+					FileSizeOld: f.FileSize,
+				}
+				if statErr2 == nil {
+					res.FileSizeNew = fi.Size()
+				}
+				totalChanged++
+				if !dryRun {
+					f.FilePath = match
+					f.OriginalFilename = filepath.Base(match)
+					if statErr2 == nil {
+						f.FileSize = fi.Size()
+					}
+					f.Missing = false
+					if upErr := store.UpdateBookFile(f.ID, f); upErr != nil {
+						res.Error = upErr.Error()
+						totalErrors++
+					} else {
+						res.Applied = true
+						totalApplied++
+					}
+				}
+				results = append(results, res)
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- `handleFixBookFilePaths` now detects files missing from disk and does a prefix-match against siblings in the same directory, repairing filenames truncated by old path-length logic (e.g. `01 (63_85) Tarkin_ Star Wars (Unabri.mp3` → real file)
- New `itunes_path_trim_enabled` config (default **false**) — when enabled, the organizer trims filename stems to keep the Windows MAX_PATH (260 chars) limit
- New `itunes_windows_root_path` config (e.g. `W:\audiobook-organizer`) — used for the correct length calculation; trim only applies when both settings are set

## Test Plan
- [ ] `POST /api/v1/maintenance/fix-book-file-paths?dry_run=true` — confirm Tarkin-style truncated paths appear in results with `action: truncated_name_repaired`
- [ ] Re-run with `dry_run=false` — verify DB records updated to full filename
- [ ] Verify write-back cover embed no longer fails for repaired books
- [ ] Confirm `itunes_path_trim_enabled=false` (default) produces no filename truncation during organize