### PR TITLE
fix(metadata-review): show global total counts alongside per-page counts

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-04-05
+// last-edited: 2026-04-28
 
 package server
 
@@ -348,14 +348,38 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 		return
 	}
 
-	rawResults, totalCount, err := store.GetOperationResultsPage(opID, limit, offset)
+	allRaw, err := store.GetOperationResults(opID)
 	if err != nil {
 		internalError(c, "failed to get operation results", err)
 		return
 	}
+	totalCount := len(allRaw)
 
-	candidateResults := make([]CandidateResult, 0, len(rawResults))
-	for _, r := range rawResults {
+	// Global counts by Status field — no JSON unmarshal needed.
+	var totalMatched, totalNoMatch, totalErrors int
+	for _, r := range allRaw {
+		switch r.Status {
+		case "matched":
+			totalMatched++
+		case "no_match":
+			totalNoMatch++
+		case "error":
+			totalErrors++
+		}
+	}
+
+	// Slice for the requested page.
+	end := totalCount
+	if limit > 0 && offset+limit < totalCount {
+		end = offset + limit
+	}
+	var pageRaw []database.OperationResult
+	if offset < totalCount {
+		pageRaw = allRaw[offset:end]
+	}
+
+	candidateResults := make([]CandidateResult, 0, len(pageRaw))
+	for _, r := range pageRaw {
 		var cr CandidateResult
 		if err := json.Unmarshal([]byte(r.ResultJSON), &cr); err != nil {
 			log.Printf("[WARN] failed to unmarshal result for book %s in op %s: %v", r.BookID, opID, err)
@@ -365,15 +389,18 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"operation":   op,
-		"results":     candidateResults,
-		"total":       totalCount,
-		"total_count": totalCount,
-		"matched":     countByStatus(candidateResults, "matched"),
-		"no_match":    countByStatus(candidateResults, "no_match"),
-		"errors":      countByStatus(candidateResults, "error"),
-		"limit":       limit,
-		"offset":      offset,
+		"operation":     op,
+		"results":       candidateResults,
+		"total":         totalCount,
+		"total_count":   totalCount,
+		"matched":       countByStatus(candidateResults, "matched"),
+		"no_match":      countByStatus(candidateResults, "no_match"),
+		"errors":        countByStatus(candidateResults, "error"),
+		"total_matched": totalMatched,
+		"total_no_match": totalNoMatch,
+		"total_errors":  totalErrors,
+		"limit":         limit,
+		"offset":        offset,
 	})
 }
 

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -161,6 +161,7 @@ export function MetadataReviewDialog({
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
   const [summary, setSummary] = useState({ matched: 0, no_match: 0, errors: 0, total: 0 });
+  const [totalSummary, setTotalSummary] = useState<{ matched: number; no_match: number; errors: number } | null>(null);
   const [previewCover, setPreviewCover] = useState<string | null>(null);
   const [reviewPage, setReviewPage] = useState(1);
   const [reviewPageSize, setReviewPageSize] = useState<number>(loadReviewPageSize);
@@ -223,6 +224,13 @@ export function MetadataReviewDialog({
           errors: data.errors ?? pageResults.filter((r) => r.status === 'error').length,
           total: tc,
         });
+        if (data.total_matched !== undefined) {
+          setTotalSummary({
+            matched: data.total_matched,
+            no_match: data.total_no_match ?? 0,
+            errors: data.total_errors ?? 0,
+          });
+        }
         setLoading(false);
       })
       .catch(() => {
@@ -970,10 +978,24 @@ export function MetadataReviewDialog({
           ) : (
             <>
               {/* Stats chips */}
-              <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-                <Chip label={`${summary.matched} matched`} color="success" size="small" />
-                <Chip label={`${summary.no_match} no match`} size="small" />
-                <Chip label={`${summary.errors} errors`} color="error" size="small" />
+              <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mb: 2, rowGap: 1 }}>
+                {totalSummary ? (
+                  <>
+                    <Chip label={`${totalSummary.matched} matched (total)`} color="success" size="small" />
+                    <Chip label={`${totalSummary.no_match} no match (total)`} size="small" />
+                    {totalSummary.errors > 0 && (
+                      <Chip label={`${totalSummary.errors} errors (total)`} color="error" size="small" />
+                    )}
+                    <Chip label={`${summary.matched} matched (page)`} color="success" variant="outlined" size="small" />
+                    <Chip label={`${summary.no_match} no match (page)`} variant="outlined" size="small" />
+                  </>
+                ) : (
+                  <>
+                    <Chip label={`${summary.matched} matched`} color="success" size="small" />
+                    <Chip label={`${summary.no_match} no match`} size="small" />
+                    <Chip label={`${summary.errors} errors`} color="error" size="small" />
+                  </>
+                )}
               </Stack>
 
               {/* Confidence slider */}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2866,6 +2866,9 @@ export interface BatchFetchResponse {
   total_count: number;
   limit: number;
   offset: number;
+  total_matched?: number;
+  total_no_match?: number;
+  total_errors?: number;
 }
 
 export async function batchFetchCandidates(bookIds: string[]): Promise<{ operation_id: string }> {


### PR DESCRIPTION
## Summary

- Backend (`handleGetOperationResults`) now computes `total_matched`/`total_no_match`/`total_errors` across **all** operation results, not just the current page
- Frontend shows filled chips for operation totals and outlined chips for the current page when total counts are available
- `BatchFetchResponse` TS interface extended with optional `total_matched`/`total_no_match`/`total_errors` fields

## Test plan

- [ ] Start a bulk metadata fetch for a large library (1000+ books)
- [ ] Open the review dialog while the fetch is running or after completion
- [ ] Verify filled chips show total counts across all pages (e.g. "3500 matched (total)")
- [ ] Verify outlined chips show current page counts (e.g. "227 matched (page)")
- [ ] Verify changing pages does not reset the total chips
- [ ] Verify the fallback (no total chips, just page chips) works on older responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)