### PR TITLE
feat(composer-scan): async resumable COMPOSER-tag scan with bulk DB loading

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 
 package database
@@ -112,6 +112,7 @@ type BookFileStore interface {
 	CreateBookFile(file *BookFile) error
 	UpdateBookFile(id string, file *BookFile) error
 	GetBookFiles(bookID string) ([]BookFile, error)
+	GetAllBookFiles() ([]BookFile, error)
 	GetBookFileByID(bookID, fileID string) (*BookFile, error)
 	GetBookFileByPID(itunesPID string) (*BookFile, error)
 	GetBookFileByPath(filePath string) (*BookFile, error)

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -2138,6 +2138,7 @@ func (m *MockStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	}
 	return nil, nil
 }
+func (m *MockStore) GetAllBookFiles() ([]BookFile, error) { return nil, nil }
 func (m *MockStore) GetBookFileByID(bookID, fileID string) (*BookFile, error) {
 	if m.GetBookFileByIDFunc != nil {
 		return m.GetBookFileByIDFunc(bookID, fileID)

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -30023,6 +30023,27 @@ func (_c *MockStore_GetBookFiles_Call) RunAndReturn(run func(bookID string) ([]d
 	return _c
 }
 
+// GetAllBookFiles provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllBookFiles() ([]database.BookFile, error) {
+	ret := _mock.Called()
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBookFiles")
+	}
+	var r0 []database.BookFile
+	if rf, ok := ret.Get(0).(func() []database.BookFile); ok {
+		r0 = rf()
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]database.BookFile)
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // GetBookNarrators provides a mock function for the type MockStore
 func (_mock *MockStore) GetBookNarrators(bookID string) ([]database.BookNarrator, error) {
 	ret := _mock.Called(bookID)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -7190,6 +7190,42 @@ func (s *PebbleStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	return files, nil
 }
 
+// GetAllBookFiles returns every BookFile in the database by iterating the
+// book_file: prefix space. Used by bulk-scan operations that would otherwise
+// make one GetBookFiles call per book (N+1 problem).
+func (s *PebbleStore) GetAllBookFiles() ([]BookFile, error) {
+	prefix := []byte("book_file:")
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: []byte("book_file;"), // ';' is one past ':' in ASCII
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var files []BookFile
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		// Skip secondary index entries (book_file_pid:, book_file_path:, book_file_acoustid:).
+		if !strings.HasPrefix(key, "book_file:") {
+			continue
+		}
+		// Primary keys look like book_file:<bookID>:<fileID> — must have exactly 2 colons
+		// after the prefix, meaning the full key has 3 colon-separated segments.
+		parts := strings.SplitN(key, ":", 4)
+		if len(parts) != 3 {
+			continue
+		}
+		var f BookFile
+		if err := json.Unmarshal(iter.Value(), &f); err != nil {
+			return nil, err
+		}
+		files = append(files, f)
+	}
+	return files, nil
+}
+
 // GetBookFileByPID looks up a BookFile by iTunes persistent ID using the
 // book_file_pid:<pid> secondary index.
 func (s *PebbleStore) GetBookFileByPID(itunesPID string) (*BookFile, error) {

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -5503,6 +5503,29 @@ func (s *SQLiteStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	return files, rows.Err()
 }
 
+// GetAllBookFiles returns every book_file row in the database. Used by bulk
+// maintenance scans that would otherwise make one GetBookFiles call per book.
+func (s *SQLiteStore) GetAllBookFiles() ([]BookFile, error) {
+	rows, err := s.db.Query(
+		`SELECT ` + bookFileCols + `
+		 FROM book_files
+		 ORDER BY book_id ASC, disc_number ASC, track_number ASC, file_path ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllBookFiles: %w", err)
+	}
+	defer rows.Close()
+	var files []BookFile
+	for rows.Next() {
+		f, err := bookFileScan(rows)
+		if err != nil {
+			return nil, fmt.Errorf("GetAllBookFiles scan: %w", err)
+		}
+		files = append(files, f)
+	}
+	return files, rows.Err()
+}
+
 // GetBookFileByPID returns the book_file with the given iTunes persistent ID, or
 // nil if not found.
 func (s *SQLiteStore) GetBookFileByPID(itunesPID string) (*BookFile, error) {

--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -63,6 +63,12 @@ type MetadataRefreshParams struct {
 	Source  string   `json:"source,omitempty"`
 }
 
+// ComposerScanParams stores the immutable parameters for a composer-tag scan operation.
+type ComposerScanParams struct {
+	DryRun  bool   `json:"dry_run"`
+	FixMode string `json:"fix_mode"` // "set_narrator" or "clear"
+}
+
 // SaveCheckpoint persists an operation's progress checkpoint.
 func SaveCheckpoint(store database.OperationStore, opID, opType, phase string, index, total int) error {
 	state := OperationState{

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -5,6 +5,8 @@
 package server
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,6 +16,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -25,6 +29,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -3778,18 +3783,30 @@ func categorizeComposer(composer, author, narrator, fixMode string) (category, w
 	return "composer_mismatch", willWrite
 }
 
-// handleScanComposerTags reads the COMPOSER tag off every audio file on disk
-// and reports (or fixes) cases that cause Apple/iPhone sync problems.
+// composerScanWork is one unit of work dispatched to the parallel reader pool.
+type composerScanWork struct {
+	bookID    string
+	bookTitle string
+	filePath  string
+	author    string
+	narrator  string
+}
+
+// handleScanComposerTags starts an async, resumable COMPOSER-tag scan as a
+// queued operation and returns the operation ID immediately (HTTP 202).
 //
-// Common bad states:
-//   - composer = author name (old wrong mapping before narrator→composer convention)
-//   - composer has stale/contaminated text (series names, "read by", etc.)
-//   - composer is empty when a narrator exists and fix_mode=set_narrator
+// The operation bulk-loads all books/authors/files, fans out tag reads across
+// 8 goroutines, persists per-file results to the OperationResult table, and
+// survives server restarts — on startup resumeInterruptedOperations() picks up
+// any interrupted composer_tag_scan and re-enqueues from where it left off.
 //
 // Query params:
-//   - dry_run=true (default) — report without writing
-//   - dry_run=false — apply the fix
-//   - fix_mode=set_narrator (default) — write COMPOSER=narrator; use "clear" to always empty it
+//   - dry_run=true (default) — scan and report without writing
+//   - dry_run=false — apply the fix to problematic files
+//   - fix_mode=set_narrator (default) — write COMPOSER=narrator; "clear" to always empty it
+//
+// Poll progress via GET /api/v1/operations/{id}.
+// View results via GET /api/v1/maintenance/scan-composer-tags/{id}.
 func (s *Server) handleScanComposerTags(c *gin.Context) {
 	dryRun := c.DefaultQuery("dry_run", "true") != "false"
 	fixMode := c.DefaultQuery("fix_mode", "set_narrator")
@@ -3804,114 +3821,264 @@ func (s *Server) handleScanComposerTags(c *gin.Context) {
 		return
 	}
 
-	log.Printf("[INFO] scan-composer-tags: start dry_run=%v fix_mode=%s", dryRun, fixMode)
+	opID := ulid.Make().String()
+	if _, err := store.CreateOperation(opID, "composer_tag_scan", nil); err != nil {
+		internalError(c, "failed to create operation", err)
+		return
+	}
 
+	params := operations.ComposerScanParams{DryRun: dryRun, FixMode: fixMode}
+	if err := operations.SaveParams(store, opID, params); err != nil {
+		log.Printf("[WARN] scan-composer-tags: failed to save params for %s: %v", opID, err)
+	}
+
+	capturedOpID := opID
+	capturedParams := params
+	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		return s.runComposerTagScan(ctx, capturedOpID, capturedParams, store, progress)
+	}
+
+	if err := s.queue.Enqueue(opID, "composer_tag_scan", operations.PriorityNormal, opFunc); err != nil {
+		internalError(c, "failed to enqueue operation", err)
+		return
+	}
+
+	log.Printf("[INFO] scan-composer-tags: queued operation %s dry_run=%v fix_mode=%s", opID, dryRun, fixMode)
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"operation_id": opID,
+		"message":      "composer tag scan started — poll GET /api/v1/operations/" + opID + " for progress",
+		"dry_run":      dryRun,
+		"fix_mode":     fixMode,
+	})
+}
+
+// runComposerTagScan is the resumable core of the composer-tag scan. It is
+// called both on first run (from handleScanComposerTags) and on resume (from
+// resumeInterruptedOperations). Already-processed files are skipped by
+// checking existing OperationResult rows, making the function idempotent.
+func (s *Server) runComposerTagScan(
+	ctx context.Context,
+	opID string,
+	params operations.ComposerScanParams,
+	store database.Store,
+	progress operations.ProgressReporter,
+) error {
+	_ = progress.UpdateProgress(0, 0, "loading library data")
+
+	// --- Bulk load (eliminates N+1 DB queries) ---
 	allBooks, err := store.GetAllBooks(0, 0)
 	if err != nil {
-		internalError(c, "failed to list books", err)
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+	allAuthors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("GetAllAuthors: %w", err)
+	}
+	authorByID := make(map[int]string, len(allAuthors))
+	for _, a := range allAuthors {
+		authorByID[a.ID] = a.Name
+	}
+	allFiles, err := store.GetAllBookFiles()
+	if err != nil {
+		return fmt.Errorf("GetAllBookFiles: %w", err)
+	}
+	filesByBook := make(map[string][]database.BookFile, len(allFiles))
+	for i := range allFiles {
+		f := &allFiles[i]
+		filesByBook[f.BookID] = append(filesByBook[f.BookID], *f)
+	}
+
+	// Load already-processed file paths from a previous (interrupted) run.
+	existingResults, _ := store.GetOperationResults(opID)
+	done := make(map[string]bool, len(existingResults))
+	for _, r := range existingResults {
+		done[r.BookID] = true // BookID field stores the file path for this operation
+	}
+
+	// Build work queue, skipping already-processed files.
+	audioExts := map[string]bool{".m4b": true, ".m4a": true, ".mp3": true, ".flac": true, ".ogg": true}
+	var workItems []composerScanWork
+	for i := range allBooks {
+		b := &allBooks[i]
+		author := ""
+		if b.AuthorID != nil {
+			author = authorByID[*b.AuthorID]
+		}
+		narrator := ""
+		if b.Narrator != nil {
+			narrator = *b.Narrator
+		}
+		for _, f := range filesByBook[b.ID] {
+			if f.FilePath == "" || f.Missing {
+				continue
+			}
+			if !audioExts[strings.ToLower(filepath.Ext(f.FilePath))] {
+				continue
+			}
+			if done[f.FilePath] {
+				continue // already processed in a previous run
+			}
+			workItems = append(workItems, composerScanWork{
+				bookID:    b.ID,
+				bookTitle: b.Title,
+				filePath:  f.FilePath,
+				author:    author,
+				narrator:  narrator,
+			})
+		}
+	}
+
+	totalFiles := len(existingResults) + len(workItems)
+	alreadyDone := len(existingResults)
+	log.Printf("[INFO] scan-composer-tags %s: %d files total, %d already done, %d to process",
+		opID, totalFiles, alreadyDone, len(workItems))
+	_ = progress.UpdateProgress(alreadyDone, totalFiles,
+		fmt.Sprintf("resuming: %d/%d already processed", alreadyDone, totalFiles))
+
+	if len(workItems) == 0 {
+		_ = progress.UpdateProgress(totalFiles, totalFiles, "all files already processed")
+		return nil
+	}
+
+	// --- Parallel NAS reads ---
+	const workers = 8
+	workCh := make(chan composerScanWork, len(workItems))
+	for _, w := range workItems {
+		workCh <- w
+	}
+	close(workCh)
+
+	var completed int64 = int64(alreadyDone)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for w := range workCh {
+				if ctx.Err() != nil {
+					return
+				}
+				if _, statErr := os.Stat(w.filePath); statErr != nil {
+					// File missing on disk — record as skipped so it's not retried
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      w.filePath,
+						ResultJSON:  `{"category":"missing"}`,
+						Status:      "missing",
+					})
+					atomic.AddInt64(&completed, 1)
+					continue
+				}
+
+				tags, readErr := metadata.ReadRawTags(w.filePath)
+				var r composerTagResult
+				if readErr != nil {
+					r = composerTagResult{
+						BookID: w.bookID, BookTitle: w.bookTitle, FilePath: w.filePath,
+						Category: "read_error", Error: readErr.Error(),
+					}
+				} else {
+					composer := ""
+					if vs, ok := tags["COMPOSER"]; ok && len(vs) > 0 {
+						composer = strings.TrimSpace(vs[0])
+					}
+					category, willWrite := categorizeComposer(composer, w.author, w.narrator, params.FixMode)
+					r = composerTagResult{
+						BookID: w.bookID, BookTitle: w.bookTitle, FilePath: w.filePath,
+						Category: category, Composer: composer,
+						Author: w.author, Narrator: w.narrator, WillWrite: willWrite,
+					}
+					if !params.DryRun && category != "ok" && willWrite != composer {
+						if writeErr := metadata.WriteSingleTag(w.filePath, "COMPOSER", willWrite); writeErr != nil {
+							r.Error = writeErr.Error()
+							log.Printf("[WARN] scan-composer-tags %s: write failed %s: %v", opID, w.filePath, writeErr)
+						} else {
+							r.Applied = true
+							log.Printf("[INFO] scan-composer-tags %s: COMPOSER %q→%q %s", opID, composer, willWrite, w.filePath)
+						}
+					}
+				}
+
+				resultJSON, _ := json.Marshal(r)
+				_ = store.CreateOperationResult(&database.OperationResult{
+					OperationID: opID,
+					BookID:      w.filePath, // file path as unique key per file
+					ResultJSON:  string(resultJSON),
+					Status:      r.Category,
+				})
+
+				n := atomic.AddInt64(&completed, 1)
+				mu.Lock()
+				_ = progress.UpdateProgress(int(n), totalFiles,
+					fmt.Sprintf("scanned %d/%d files", n, totalFiles))
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	finalCount := atomic.LoadInt64(&completed)
+	_ = progress.UpdateProgress(int(finalCount), totalFiles, "scan complete")
+	log.Printf("[INFO] scan-composer-tags %s: finished %d/%d files", opID, finalCount, totalFiles)
+	return nil
+}
+
+// handleGetComposerScanResults returns the aggregated results for a completed
+// (or in-progress) composer_tag_scan operation.
+func (s *Server) handleGetComposerScanResults(c *gin.Context) {
+	opID := c.Param("id")
+	if opID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "operation id required"})
+		return
+	}
+
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+
+	op, err := store.GetOperationByID(opID)
+	if err != nil || op == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
+		return
+	}
+	if op.Type != "composer_tag_scan" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "not a composer_tag_scan operation"})
+		return
+	}
+
+	rawResults, err := store.GetOperationResults(opID)
+	if err != nil {
+		internalError(c, "failed to load results", err)
 		return
 	}
 
 	counts := map[string]int{}
 	var problems []composerTagResult
-	totalFiles := 0
-	applied := 0
-	errors := 0
-
-	for i := range allBooks {
-		book := &allBooks[i]
-
-		authorName := ""
-		if book.AuthorID != nil {
-			if author, aErr := store.GetAuthorByID(*book.AuthorID); aErr == nil && author != nil {
-				authorName = author.Name
-			}
-		}
-		narratorName := ""
-		if book.Narrator != nil {
-			narratorName = *book.Narrator
-		}
-
-		files, fErr := store.GetBookFiles(book.ID)
-		if fErr != nil {
-			log.Printf("[WARN] scan-composer-tags: GetBookFiles book %s: %v", book.ID, fErr)
+	for _, raw := range rawResults {
+		var r composerTagResult
+		if err := json.Unmarshal([]byte(raw.ResultJSON), &r); err != nil {
 			continue
 		}
-
-		for j := range files {
-			f := &files[j]
-			if f.FilePath == "" || f.Missing {
-				continue
-			}
-			ext := strings.ToLower(filepath.Ext(f.FilePath))
-			if ext != ".m4b" && ext != ".m4a" && ext != ".mp3" && ext != ".flac" && ext != ".ogg" {
-				continue
-			}
-			if _, statErr := os.Stat(f.FilePath); statErr != nil {
-				continue
-			}
-
-			totalFiles++
-
-			tags, readErr := metadata.ReadRawTags(f.FilePath)
-			if readErr != nil {
-				r := composerTagResult{
-					BookID: book.ID, BookTitle: book.Title, FilePath: f.FilePath,
-					Category: "read_error", Error: readErr.Error(),
-				}
-				problems = append(problems, r)
-				counts["read_error"]++
-				errors++
-				continue
-			}
-
-			composer := ""
-			if vs, ok := tags["COMPOSER"]; ok && len(vs) > 0 {
-				composer = strings.TrimSpace(vs[0])
-			}
-
-			category, willWrite := categorizeComposer(composer, authorName, narratorName, fixMode)
-			counts[category]++
-
-			if category == "ok" {
-				continue
-			}
-
-			r := composerTagResult{
-				BookID: book.ID, BookTitle: book.Title, FilePath: f.FilePath,
-				Category: category, Composer: composer,
-				Author: authorName, Narrator: narratorName, WillWrite: willWrite,
-			}
-
-			if !dryRun && willWrite != composer {
-				if writeErr := metadata.WriteSingleTag(f.FilePath, "COMPOSER", willWrite); writeErr != nil {
-					r.Error = writeErr.Error()
-					log.Printf("[WARN] scan-composer-tags: write failed %s: %v", f.FilePath, writeErr)
-					errors++
-				} else {
-					r.Applied = true
-					applied++
-					log.Printf("[INFO] scan-composer-tags: COMPOSER %q→%q book=%s file=%s",
-						composer, willWrite, book.ID, f.FilePath)
-				}
-			}
-
+		counts[r.Category]++
+		if r.Category != "ok" && r.Category != "missing" {
 			problems = append(problems, r)
 		}
 	}
 
-	log.Printf("[INFO] scan-composer-tags: done dry_run=%v fix_mode=%s total_files=%d problems=%d applied=%d errors=%d counts=%v",
-		dryRun, fixMode, totalFiles, len(problems), applied, errors, counts)
-
 	c.JSON(http.StatusOK, gin.H{
-		"dry_run":     dryRun,
-		"fix_mode":    fixMode,
-		"total_files": totalFiles,
-		"problems":    len(problems),
-		"applied":     applied,
-		"errors":      errors,
-		"by_category": counts,
-		"details":     problems,
+		"operation_id": opID,
+		"status":       op.Status,
+		"progress":     op.Progress,
+		"total":        op.Total,
+		"by_category":  counts,
+		"problems":     len(problems),
+		"details":      problems,
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1503,6 +1503,17 @@ func (s *Server) resumeInterruptedOperations() {
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
 				return s.itunesSvc.Repair.Repair(ctx, repairOpID, true, progress)
 			}
+		case "composer_tag_scan":
+			params, _ := operations.LoadParams[operations.ComposerScanParams](store, opID)
+			if params == nil {
+				log.Printf("[WARN] No params found for interrupted composer_tag_scan %s, marking failed", opID)
+				_ = store.UpdateOperationError(opID, "no saved params, cannot resume")
+				continue
+			}
+			capturedParams := *params
+			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+				return s.runComposerTagScan(ctx, opID, capturedParams, store, progress)
+			}
 		case "transcode", "diagnostics_export", "diagnostics_ai",
 			"cleanup_activity_log", "purge_old_logs",
 			"purge-deleted", "tombstone-cleanup",
@@ -2444,6 +2455,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/recompute-itunes-paths", s.perm(auth.PermSettingsManage), s.handleRecomputeITunesPaths)
 			protected.POST("/maintenance/generate-itl-tests", s.perm(auth.PermSettingsManage), s.handleGenerateITLTests)
 			protected.POST("/maintenance/scan-composer-tags", s.perm(auth.PermSettingsManage), s.handleScanComposerTags)
+			protected.GET("/maintenance/scan-composer-tags/:id", s.perm(auth.PermSettingsManage), s.handleGetComposerScanResults)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")


### PR DESCRIPTION
## Summary

- Converts `handleScanComposerTags` from a synchronous handler (was timing out on 10K+ books) to an async queued operation returning HTTP 202 with `operation_id`
- `runComposerTagScan` is now fully resumable: loads existing `OperationResult` rows on startup and skips already-processed files, so a server restart picks up exactly where it left off
- `GetAllBookFiles()` added to all store implementations (SQLite, Pebble, mock) — eliminates the N+1 query problem (20K+ individual `GetBookFiles` calls → 3 bulk queries)
- 8-worker goroutine pool for parallel NAS tag reads
- `ComposerScanParams` added to `operations` package for typed parameter persistence across restarts
- `resumeInterruptedOperations()` wires `composer_tag_scan` case for server restart recovery
- New GET `/api/v1/maintenance/scan-composer-tags/:id` endpoint returns aggregated results

## Test plan

- [ ] `POST /maintenance/scan-composer-tags?dry_run=true` returns 202 with `operation_id`
- [ ] `GET /operations/{id}` shows progress incrementing
- [ ] `GET /maintenance/scan-composer-tags/{id}` returns result breakdown by category
- [ ] Restart server mid-scan; confirm resume skips already-processed files
- [ ] `make test` passes (11 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)