### PR TITLE
feat(ops): toast notifications for operation lifecycle + async-ops design spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.34.0 -->
+<!-- version: 2.35.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-04-27 -->
+<!-- last-edited: 2026-04-28 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Added / Changed
+
+#### April 28, 2026 — Operation lifecycle toast notifications (feat/op-notifications)
+
+- **`useOperationsStore.startPolling`** now accepts a `resumed?: boolean` parameter. Shows a bottom-left toast (`info`) when an operation starts or resumes, and a `success`/`error`/`info` toast when it completes/fails/cancels.
+- **`OperationsIndicator.checkActiveOps`** passes `resumed=true` when picking up operations already running on the server (resumed from a restart). Those show "X resumed" rather than "X started."
+- **`formatOpLabel`** — shared label map moved into the store (previously only in `OperationsIndicator`), covering all known operation types.
+- **Design spec written** for backend async conversion (13+ maintenance handlers → operation queue with progress, cancel, resume on restart). Spec: `docs/superpowers/specs/2026-04-28-async-operations-design.md`. TODO items ASYNC-1..3 added (spec-pending, no bot-task yet).
 
 #### April 27, 2026 — Series name normalization (feat/series-name-normalization)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 5.7.0 -->
+<!-- version: 5.8.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-18 -->
+<!-- last-edited: 2026-04-28 -->
 
 # Project TODO
 
@@ -184,6 +184,17 @@ Full details: [`memory/project_bulk_metadata_review.md`](../../.claude/projects/
 
 - [x] **BMR-1** Audible "Series, Book N" baked into series field — `normalizeMetaSeries` now runs in `ApplyMetadataCandidate` too, not just the auto-fetch paths (#271)
 
+### Async Operations — Maintenance Handler Conversion
+
+> ⚠️ **SPEC PENDING — do not auto-execute.** Design spec lives at
+> [`docs/superpowers/specs/2026-04-28-async-operations-design.md`](docs/superpowers/specs/2026-04-28-async-operations-design.md).
+> No bot-task file exists yet. Needs human review before burndown bot pickup.
+
+- [ ] **ASYNC-1** Convert 13+ synchronous maintenance handlers to async (queue, progress, cancel) — see spec
+- [ ] **ASYNC-2** Add `IsCanceled()` checks to all long-running operation loops
+- [ ] **ASYNC-3** Make all converted maintenance ops resumable on restart (check-then-apply pattern)
+- [x] **ASYNC-0** Frontend: toast notifications for operation lifecycle (started / resumed / completed / failed / canceled) — PR this session
+
 ### Design Spec Already Written (but not yet planned)
 
 - [x] **DES-1** Bleve library search — complete 6/7 (#298, #301-#302, #311-#312, #321)
@@ -243,6 +254,7 @@ Every plan in chronological order. ✅ = implemented, ⏳ = design done, plan wr
 - [2026-04-10 Metadata candidate scoring](docs/superpowers/specs/2026-04-10-metadata-candidate-scoring-design.md)
 - [2026-04-11 Bleve library search](docs/superpowers/specs/2026-04-11-bleve-library-search.md) — design only, no plan yet
 - [2026-04-11 chromem-go embedding store](docs/superpowers/specs/2026-04-11-chromem-go-embedding-store.md) — design only, no plan yet
+- [2026-04-28 Async operations — maintenance handler conversion](docs/superpowers/specs/2026-04-28-async-operations-design.md) — spec only, no bot-task yet (ASYNC-1..3)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-28-async-operations-design.md
+++ b/docs/superpowers/specs/2026-04-28-async-operations-design.md
@@ -1,0 +1,201 @@
+<!-- file: docs/superpowers/specs/2026-04-28-async-operations-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7f3e2d1c-9a8b-4c5d-6e7f-8a9b0c1d2e3f -->
+
+# Design: Async Operations — Maintenance Handler Conversion
+
+**Status:** Spec written, not yet planned  
+**Audience:** Human review → burndown bot (after plan written)  
+**TODO IDs:** ASYNC-1, ASYNC-2, ASYNC-3  
+**Related:** `internal/operations/`, `internal/server/maintenance_fixups.go`
+
+---
+
+## Problem
+
+13+ maintenance endpoints in `maintenance_fixups.go` execute synchronously (inline handler, HTTP response blocked until done). They:
+
+- Show no progress in the UI spinner / notification badge
+- Cannot be cancelled by the user
+- Are not resumable on server restart
+- Risk HTTP client timeouts on large libraries
+- Mix validation, scanning, and mutation into one uninterruptible pass
+
+Already-async operations (`scan`, `organize`, `bulk_write_back`, `iTunes import`, etc.) handle all of the above correctly via `operations.OperationQueue`.
+
+---
+
+## Goal
+
+Every maintenance endpoint that touches > ~100 rows OR can take > ~1 second should:
+
+1. Validate inputs synchronously → return 4xx immediately on bad params
+2. Enqueue the work via `s.queue.Enqueue()` → return 202 immediately
+3. Report progress via `ProgressReporter.UpdateProgress()` and `Log()`
+4. Respect `ProgressReporter.IsCanceled()` at least once per batch loop
+5. Persist checkpoints via `operations.SaveCheckpoint()` so restart resumes from last committed position
+6. Follow check-then-apply: scan/count first, then mutate — so the dry-run preview is always consistent with the actual run
+
+Short ops (<1s, <100 rows) may stay synchronous — these are noted below.
+
+---
+
+## Handlers to Convert
+
+### Must Convert (async, progress, cancel, resumable)
+
+| Handler | Route | Why |
+|---------|-------|-----|
+| `fix-read-by-narrator` | `POST /api/v1/maintenance/fix-read-by-narrator` | Touches all books; already has dry-run mode |
+| `cleanup-series` | `POST /api/v1/maintenance/cleanup-series` | Merges series — can touch thousands of records |
+| `backfill-book-files` | `POST /api/v1/maintenance/backfill-book-files` | Scans disk; long on large libraries |
+| `cleanup-empty-folders` | `POST /api/v1/maintenance/cleanup-empty-folders` | File I/O, unbounded |
+| `cleanup-organize-mess` | `POST /api/v1/maintenance/cleanup-organize-mess` | Batch file moves |
+| `fix-author-narrator-swap` | `POST /api/v1/maintenance/fix-author-narrator-swap` | Touches all books |
+| `fix-version-groups` | `POST /api/v1/maintenance/fix-version-groups` | Touches all version groups |
+| `enrich-book-files` | `POST /api/v1/maintenance/enrich-book-files` | File I/O per book |
+| `dedup-books` | `POST /api/v1/maintenance/dedup-books` | Full library scan |
+| `fix-book-file-paths` | `POST /api/v1/maintenance/fix-book-file-paths` | Scans book_files table |
+| `refetch-missing-authors` | `POST /api/v1/maintenance/refetch-missing-authors` | External API calls |
+| `recompute-itunes-paths` | `POST /api/v1/maintenance/recompute-itunes-paths` | Touches all iTunes mappings |
+| `fix-library-states` | `POST /api/v1/maintenance/fix-library-states` | Full library pass |
+| `duplicates/scan` | `POST /api/v1/audiobooks/duplicates/scan` | Full library scan |
+
+### May Stay Synchronous (fast, bounded)
+
+| Handler | Route | Reason |
+|---------|-------|--------|
+| `cleanup-backups` | `POST /api/v1/maintenance/cleanup-backups` | Glob + delete, bounded by backup count |
+| `generate-itl-tests` | `POST /api/v1/maintenance/generate-itl-tests` | Dev-only, test data generation |
+
+---
+
+## Implementation Pattern
+
+Each converted handler follows this structure:
+
+```go
+// 1. Validate inputs — return 4xx immediately
+params, err := parseAndValidateRequest(c)
+if err != nil {
+    RespondWithBadRequest(c, err.Error())
+    return
+}
+
+// 2. Enqueue — return 202
+opID := ulid.Make().String()
+if err := s.queue.Enqueue(opID, "fix_read_by_narrator", operations.PriorityNormal, func(ctx context.Context, reporter operations.ProgressReporter) error {
+    return s.runFixReadByNarrator(ctx, reporter, params)
+}); err != nil {
+    RespondWithInternalError(c, "failed to enqueue operation")
+    return
+}
+c.JSON(http.StatusAccepted, gin.H{"operation_id": opID})
+
+// 3. The actual work function:
+func (s *Server) runFixReadByNarrator(ctx context.Context, reporter operations.ProgressReporter, params FixReadByNarratorParams) error {
+    // Phase 1: scan (check-then-apply)
+    books, err := s.Store().GetAllBooks()
+    if err != nil { return err }
+    
+    affected := filterAffected(books, params)
+    reporter.UpdateProgress(0, len(affected), "Scanning...")
+    
+    for i, book := range affected {
+        if reporter.IsCanceled() { return nil }  // graceful cancel
+        
+        // Checkpoint every N items for resumability
+        if i % 100 == 0 {
+            operations.SaveCheckpoint(s.Store(), reporter.OperationID(), &operations.OperationState{
+                PhaseIndex: i,
+                PhaseTotal: len(affected),
+            })
+        }
+        
+        if params.DryRun {
+            reporter.Log("info", fmt.Sprintf("Would fix: %s", book.Title), nil)
+            continue
+        }
+        
+        // Apply
+        if err := s.Store().UpdateBook(book); err != nil {
+            reporter.Log("error", fmt.Sprintf("Failed: %s: %v", book.Title, err), nil)
+            continue
+        }
+        reporter.UpdateProgress(i+1, len(affected), fmt.Sprintf("Fixed %d/%d", i+1, len(affected)))
+    }
+    return nil
+}
+```
+
+---
+
+## New OperationState Param Types
+
+Add to `internal/operations/state.go` for each resumable handler:
+
+```go
+type FixReadByNarratorParams struct {
+    DryRun bool `json:"dry_run"`
+}
+
+type CleanupSeriesParams struct {
+    DryRun bool `json:"dry_run"`
+}
+
+type EnrichBookFilesParams struct {
+    BookIDs []string `json:"book_ids,omitempty"` // nil = all
+    Force   bool     `json:"force"`
+}
+
+// ... etc for each converted handler
+```
+
+---
+
+## Resume on Restart
+
+Add each new operation type to `resumeInterruptedOperations()` in `server.go`:
+
+```go
+case "fix_read_by_narrator":
+    params, err := operations.LoadParams[operations.FixReadByNarratorParams](store, opID)
+    if err != nil { break }
+    resumeFn := func(ctx context.Context, reporter operations.ProgressReporter) error {
+        // Checkpoint.PhaseIndex tells us where to resume from
+        checkpoint := operations.LoadCheckpoint(store, opID)
+        return s.runFixReadByNarrator(ctx, reporter, params, checkpoint.PhaseIndex)
+    }
+    oq.EnqueueResume(opID, opType, operations.PriorityLow, resumeFn)
+```
+
+The work functions need to accept a `startFrom int` parameter for resume. This requires the check-then-apply scan to be deterministic (same order each run), which is satisfied by sorting by book ID.
+
+---
+
+## Frontend Impact
+
+No frontend changes needed beyond ASYNC-0 (already shipped). The toast notification system and OperationsIndicator badge pick up all operations via SSE and the 15-second active-operations poll.
+
+---
+
+## Test Strategy
+
+For each converted handler:
+1. Unit test the work function with a mock store and mock `ProgressReporter`
+2. Verify `IsCanceled()` is checked — inject a reporter that returns true after N calls
+3. Verify checkpoint is saved — assert `SaveCheckpoint` called with correct `PhaseIndex`
+4. Verify resume starts from checkpoint — call with `startFrom=50`, assert first 50 are skipped
+5. Integration test: call the endpoint, assert 202, poll operation status to completion
+
+---
+
+## Ordering Recommendation
+
+Execute as one batch via `/parallel-sweep` — each handler is independent, no shared state between them. Suggested wave:
+
+- **Wave 1 (4 handlers):** `fix-read-by-narrator`, `cleanup-series`, `fix-author-narrator-swap`, `fix-version-groups` — simplest patterns
+- **Wave 2 (4 handlers):** `backfill-book-files`, `cleanup-empty-folders`, `cleanup-organize-mess`, `fix-library-states` — file I/O variants
+- **Wave 3 (5 handlers):** `enrich-book-files`, `dedup-books`, `fix-book-file-paths`, `refetch-missing-authors`, `recompute-itunes-paths` — external API or complex DB joins
+
+Each wave: one PR per handler, admin-merge via `make ci` gate, rebase loop between siblings.

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.2.0
+// version: 3.3.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useEffect, useState } from 'react';
@@ -135,7 +135,7 @@ export function OperationsIndicator() {
             !alreadyTracked &&
             !['completed', 'failed', 'canceled'].includes(op.status)
           ) {
-            startPolling(op.id, op.type);
+            startPolling(op.id, op.type, true);
           }
         }
       } catch {

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,9 +1,10 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
 import * as api from '../services/api';
+import { useAppStore } from './useAppStore';
 
 export interface ActiveOperation {
   id: string;
@@ -13,30 +14,58 @@ export interface ActiveOperation {
   total: number;
   message: string;
   startedAt?: number; // timestamp ms
+  resumed?: boolean;
 }
 
 interface OperationsState {
   activeOperations: ActiveOperation[];
   polling: boolean;
 
-  startPolling: (operationId: string, type: string) => void;
+  startPolling: (operationId: string, type: string, resumed?: boolean) => void;
   removeOperation: (operationId: string) => void;
   updateOperation: (op: ActiveOperation) => void;
+}
+
+function formatOpLabel(type: string): string {
+  const labels: Record<string, string> = {
+    itunes_import: 'iTunes Import',
+    itunes_sync: 'iTunes Sync',
+    scan: 'Library Scan',
+    organize: 'Organize',
+    metadata_fetch: 'Metadata Fetch',
+    metadata_candidate_fetch: 'Metadata Fetch (Batch)',
+    bulk_write_back: 'Tag Write-back',
+    composer_tag_scan: 'Composer Tag Scan',
+    isbn_enrichment: 'ISBN Enrichment',
+    metadata_refresh: 'Metadata Refresh',
+    reconcile_scan: 'Reconcile Scan',
+    itunes_path_repair: 'iTunes Path Repair',
+    series_normalize: 'Series Normalize',
+    transcode: 'Transcode',
+    ol_dump_import: 'Open Library Import',
+  };
+  return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 export const useOperationsStore = create<OperationsState>()((set, get) => ({
   activeOperations: [],
   polling: false,
 
-  startPolling: (operationId: string, type: string) => {
+  startPolling: (operationId: string, type: string, resumed = false) => {
+    const label = formatOpLabel(type);
+    const notify = useAppStore.getState().addNotification;
+
+    notify(resumed ? `${label} resumed` : `${label} started`, 'info');
+
     const op: ActiveOperation = {
       id: operationId,
       type,
       status: 'queued',
       progress: 0,
       total: 0,
-      message: 'Starting...',
+      message: resumed ? 'Resuming...' : 'Starting...',
       startedAt: Date.now(),
+      resumed,
     };
 
     set((state) => ({
@@ -54,12 +83,20 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
           progress: status.progress,
           total: status.total,
           message: status.message,
+          resumed,
         };
 
         get().updateOperation(updated);
 
         if (['completed', 'failed', 'canceled'].includes(status.status)) {
-          // Keep completed ops visible for 10 seconds, then remove
+          const n = useAppStore.getState().addNotification;
+          if (status.status === 'completed') {
+            n(`${label} completed`, 'success');
+          } else if (status.status === 'failed') {
+            n(`${label} failed`, 'error');
+          } else {
+            n(`${label} canceled`, 'info');
+          }
           setTimeout(() => get().removeOperation(operationId), 10000);
           return;
         }


### PR DESCRIPTION
## Summary

- `useOperationsStore.startPolling` now accepts `resumed?: boolean` and shows a bottom-left toast (`info`) when an operation starts or resumes, plus a `success`/`error`/`info` toast when it completes, fails, or is canceled
- `OperationsIndicator.checkActiveOps` passes `resumed=true` when picking up operations already running on the server (e.g. after a restart), so they show "X resumed" instead of "X started"
- `formatOpLabel` helper moved into the store (was previously only in `OperationsIndicator`), covering all known operation types

Also includes:
- **Design spec** for backend async conversion of 13+ synchronous maintenance handlers → operation queue with progress reporting, cancellation, and resume on restart: `docs/superpowers/specs/2026-04-28-async-operations-design.md`
- **TODO items** ASYNC-1..3 added (spec-pending, no bot-task file yet — requires human review before burndown bot pickup)

## Test plan

- [ ] Start a scan/organize from the Library page — confirm "Library Scan started" toast appears bottom-left
- [ ] Let it complete — confirm "Library Scan completed" toast appears
- [ ] Cancel an in-progress operation — confirm "X canceled" toast appears
- [ ] Restart the server mid-operation, reload the browser — confirm "X resumed" toast appears within 15 seconds
- [ ] Verify pre-existing test failures in `api.test.ts` and `Library.bulkFetch.test.tsx` are unchanged (pre-existing, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)