### PR TITLE
fix(maintenance): derive author from path components in relink endpoint

### DIFF
--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -4207,9 +4207,21 @@ func (s *Server) handleRelinkMissingToiTunes(c *gin.Context) {
 		}
 
 		// Book path is under organizer root and doesn't exist — candidate.
-		authorName := ""
-		if book.Author != nil {
-			authorName = book.Author.Name
+		// Derive author name from the organizer path (first component after root)
+		// so we don't need a DB join. Fall back to DB author lookup if path is
+		// ambiguous (e.g. file directly in root).
+		rel := strings.TrimPrefix(fp, organizerRoot)
+		rel = strings.TrimPrefix(rel, string(os.PathSeparator))
+		authorName := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+		if authorName == "" || authorName == filepath.Base(fp) {
+			// path is too flat — try DB author
+			if book.Author != nil {
+				authorName = book.Author.Name
+			} else if book.AuthorID != nil {
+				if a, err := store.GetAuthorByID(*book.AuthorID); err == nil && a != nil {
+					authorName = a.Name
+				}
+			}
 		}
 		if authorName == "" {
 			results = append(results, relinkMissingResult{
@@ -4217,7 +4229,7 @@ func (s *Server) handleRelinkMissingToiTunes(c *gin.Context) {
 				Title:   book.Title,
 				OldPath: fp,
 				Action:  "unresolved",
-				Error:   "no author name in DB",
+				Error:   "no author name",
 			})
 			unresolved++
 			continue


### PR DESCRIPTION
## Summary
- `GetAllBooks` does not join authors, so `book.Author` is always nil
- Fix: extract author name from first path component after organizer root (already embedded in the file path by the organizer), with DB fallback for edge cases

## Test Plan
- [ ] `POST /api/v1/maintenance/relink-missing-to-itunes?dry_run=true&itunes_root=...` — should now show `relinked` for the 26 broken books instead of `unresolved` with "no author name"