### PR TITLE
fix(settings): unwrap data envelope in getConfig/updateConfig — Save button always disabled

### DIFF
--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1649,7 +1649,7 @@ export async function getConfig(): Promise<Config> {
     throw await buildApiError(response, 'Failed to fetch config');
   }
   const data = await response.json();
-  return data.config;
+  return data.data?.config ?? data.config;
 }
 
 export async function updateConfig(updates: Partial<Config>): Promise<Config> {
@@ -1662,7 +1662,7 @@ export async function updateConfig(updates: Partial<Config>): Promise<Config> {
     throw await buildApiError(response, 'Failed to update config');
   }
   const data = await response.json();
-  return data.config;
+  return data.data?.config ?? data.config;
 }
 
 // Auth


### PR DESCRIPTION
## Problem

The Settings page Save button was permanently disabled. `getConfig()` and `updateConfig()` in `api.ts` were returning `data.config`, but `RespondWithOK` wraps the response in `{data: ...}`, making the correct path `data.data.config`.

The TypeError from accessing `.openai_api_key` on `undefined` was caught silently in `loadConfig()`'s catch block, so `setConfigLoaded(true)` was never called, and `disabled={!configLoaded}` kept the Save button greyed out forever.

## Fix

`data.config` → `data.data?.config ?? data.config` (with fallback for any callers that send a flat response).

## Test plan
- [ ] Open Settings page — config fields populate correctly
- [ ] Edit any field and click Save — succeeds
- [ ] Save response correctly returns updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)