### PR TITLE
fix(missing-file-repair): resolve multi-author iTunes dir ambiguity

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -186,8 +186,17 @@ Full details: [`memory/project_bulk_metadata_review.md`](../../.claude/projects/
 
 ### Async Operations — Unified Maintenance System
 
-> 🔍 **AWAITING OPUS REVIEW** — All bot-task files written; pending devil's advocate + code review
-> before burndown bot pickup. Design: [`docs/superpowers/specs/2026-04-28-unified-maintenance-system.md`](docs/superpowers/specs/2026-04-28-unified-maintenance-system.md)
+> 🛑 **BLOCKED ON SPEC REVISION — DO NOT BURNDOWN.** Opus review (2026-04-28) found
+> BLOCKERs in CORE-2 (unverified `s.Store()` / `s.queue.Enqueue` / `EnqueueResume`
+> signatures, body-bind into `json.RawMessage`, `default:` insertion assuming a
+> switch), placeholder business logic in W1-3 / W1-4 / W2-4 / W3-2 (will land
+> no-op PRs with green CI on destructive paths), `**` glob bug in W3-3, missing
+> `itunes_path_trim_enabled` handling in W3-5, and CLEAN-1 gating that only
+> checks PR labels (not registry presence). All bot-task entries below are
+> intentionally left unchecked but **must not be picked up by the burndown bot
+> until the spec is revised.** Tracked as ASYNC-REVISE.
+>
+> Design: [`docs/superpowers/specs/2026-04-28-unified-maintenance-system.md`](docs/superpowers/specs/2026-04-28-unified-maintenance-system.md)
 > Dependency system: [`docs/superpowers/specs/2026-04-28-pr-label-dependencies.md`](docs/superpowers/specs/2026-04-28-pr-label-dependencies.md)
 > Opus brief: [`docs/superpowers/specs/2026-04-28-opus-review-brief.md`](docs/superpowers/specs/2026-04-28-opus-review-brief.md)
 

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -4620,7 +4620,7 @@ func (s *Server) repairOneMissingFile(
 		case 0:
 			// no match
 		default:
-			// Multiple — narrow by parent dir name
+			// Multiple — narrow by parent dir name (album folder)
 			parentDir := filepath.Base(filepath.Dir(f.FilePath))
 			var narrowed []string
 			for _, p := range paths {
@@ -4628,12 +4628,31 @@ func (s *Server) repairOneMissingFile(
 					narrowed = append(narrowed, p)
 				}
 			}
-			if len(narrowed) == 1 {
+			// If still multiple, narrow by grandparent dir containing author's last name.
+			// iTunes multi-author dirs ("Amy DuBoff, Michael Anderle") contain the stored
+			// author ("Michael Anderle") as a substring; this resolves those cases.
+			if len(narrowed) > 1 && bm.author != "" {
+				lastName := strings.ToLower(bm.author)
+				if i := strings.LastIndex(lastName, " "); i > 0 {
+					lastName = lastName[i+1:]
+				}
+				var n2 []string
+				for _, p := range narrowed {
+					if strings.Contains(strings.ToLower(filepath.Base(filepath.Dir(filepath.Dir(p)))), lastName) {
+						n2 = append(n2, p)
+					}
+				}
+				if len(n2) >= 1 {
+					narrowed = n2
+				}
+			}
+			switch len(narrowed) {
+			case 1:
 				candidate, method = narrowed[0], "filename"
 				res.Matches = 1
-			} else {
+			default:
 				res.Method = "ambiguous"
-				res.Matches = len(paths)
+				res.Matches = len(narrowed)
 				return res
 			}
 		}
@@ -4665,16 +4684,21 @@ func (s *Server) repairOneMissingFile(
 		}
 	}
 
-	// Tier 4: author+title walk under search roots
+	// Tier 4: author last-name + title-prefixed album dir, then stored basename.
+	// Uses the author's last name so it matches both "Michael Anderle" and
+	// "Amy DuBoff, Michael Anderle" directories. Matches album dirs whose name
+	// starts with the title prefix, then looks for the stored filename within
+	// that album dir (avoids false ambiguity from multiple tracks per album).
 	if candidate == "" && bm.author != "" && bm.title != "" {
-		authorWord := bm.author
-		if idx := strings.Index(bm.author, " "); idx > 0 {
-			authorWord = bm.author[:idx]
+		lastName := bm.author
+		if i := strings.LastIndex(bm.author, " "); i > 0 {
+			lastName = bm.author[i+1:]
 		}
 		titlePrefix := bm.title
-		if len(titlePrefix) > 25 {
-			titlePrefix = titlePrefix[:25]
+		if len(titlePrefix) > 30 {
+			titlePrefix = titlePrefix[:30]
 		}
+		storedBase := filepath.Base(f.FilePath)
 		var matches []string
 		for _, root := range params.SearchRoots {
 			entries, rerr := os.ReadDir(root)
@@ -4685,19 +4709,39 @@ func (s *Server) repairOneMissingFile(
 				if !entry.IsDir() {
 					continue
 				}
-				if !strings.Contains(strings.ToLower(entry.Name()), strings.ToLower(authorWord)) {
+				if !strings.Contains(strings.ToLower(entry.Name()), strings.ToLower(lastName)) {
 					continue
 				}
-				_ = filepath.WalkDir(filepath.Join(root, entry.Name()), func(path string, d os.DirEntry, walkErr error) error {
-					if walkErr != nil || d.IsDir() {
-						return nil
+				authorDir := filepath.Join(root, entry.Name())
+				albumEntries, aErr := os.ReadDir(authorDir)
+				if aErr != nil {
+					continue
+				}
+				for _, album := range albumEntries {
+					if !album.IsDir() {
+						continue
 					}
-					if audioExts[strings.ToLower(filepath.Ext(path))] &&
-						strings.Contains(strings.ToLower(filepath.Base(path)), strings.ToLower(titlePrefix)) {
-						matches = append(matches, path)
+					if !strings.HasPrefix(strings.ToLower(album.Name()), strings.ToLower(titlePrefix)) {
+						continue
 					}
-					return nil
-				})
+					// Prefer the exact stored basename within this album dir.
+					exact := filepath.Join(authorDir, album.Name(), storedBase)
+					if _, statErr := os.Stat(exact); statErr == nil {
+						matches = append(matches, exact)
+						continue
+					}
+					// Fall back: any audio file in the album dir (single-track books).
+					albumFiles, _ := os.ReadDir(filepath.Join(authorDir, album.Name()))
+					var audioInAlbum []string
+					for _, af := range albumFiles {
+						if !af.IsDir() && audioExts[strings.ToLower(filepath.Ext(af.Name()))] {
+							audioInAlbum = append(audioInAlbum, filepath.Join(authorDir, album.Name(), af.Name()))
+						}
+					}
+					if len(audioInAlbum) == 1 {
+						matches = append(matches, audioInAlbum[0])
+					}
+				}
 			}
 		}
 		switch len(matches) {


### PR DESCRIPTION
## Summary
- Tier 2 narrowing: after matching on album dir name, add a third pass filtering by grandparent (author) dir containing the stored author's last name — resolves files under "Michael Anderle" that now live under "Amy DuBoff, Michael Anderle" co-author iTunes dirs
- Tier 4 matching: switch from checking book title in track filenames (unreliable) to matching album subdirectory names against the title prefix, then looking for the stored basename within that dir
- TODO: mark repair ambiguity items and maintenance spec tasks

## Test plan
- [ ] `make build-api` passes
- [ ] Dry-run repair op shows fewer ambiguous results for multi-author books
- [ ] Live repair op resolves previously-ambiguous files to a single candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)