### PR TITLE
fix(activity): wire LogBatch into purge-deleted, isbn-enrichment, temp-file-cleanup, missing-file-repair

### DIFF
--- a/internal/activity/api.go
+++ b/internal/activity/api.go
@@ -1,5 +1,5 @@
 // file: internal/activity/api.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9a4f2e1b-3c7d-4b8e-a6f0-5d2c8e1b7a3f
 
 package activity
@@ -14,6 +14,9 @@ var batchableTypes = map[string]bool{
 	"metadata-apply":    true,
 	"path-repair":       true,
 	"isbn-enrich":       true,
+	"temp-file-cleanup": true,
+	"missing-file-repair": true,
+	"purge-deleted":     true,
 }
 
 // LogBatch submits a single BatchItem to the batcher inside w for the given

--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/isbn.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
 
 package metafetch
@@ -9,6 +9,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
@@ -95,7 +96,9 @@ func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
 
 // EnrichMissingISBNs scans books missing ISBN data and enriches up to limit of them.
 // It returns the number of candidate books checked and the number updated.
-func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int) (int, int, error) {
+// w and opID are optional — if provided, each enriched book is submitted to the
+// activity batcher instead of emitting a per-book log line.
+func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *activity.Writer, opID string) (int, int, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -131,6 +134,8 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int) (int, i
 				log.Printf("[WARN] ISBN enrichment failed for %s during batch scan: %v", books[i].ID, err)
 			} else if found {
 				updated++
+				activity.LogBatch(w, opID, "isbn-enrich", "isbn-enrichment",
+					activity.BatchItem{Name: books[i].Title, Detail: books[i].ID})
 			}
 			if checked >= limit {
 				break

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
@@ -175,7 +175,7 @@ func (s *Server) purgeSoftDeletedAudiobooks(c *gin.Context) {
 	RespondWithOK(c, result)
 }
 
-func (s *Server) runAutoPurgeSoftDeleted() {
+func (s *Server) runAutoPurgeSoftDeleted(opID string) {
 	if config.AppConfig.PurgeSoftDeletedAfterDays <= 0 {
 		return
 	}
@@ -194,10 +194,9 @@ func (s *Server) runAutoPurgeSoftDeleted() {
 	if result.Attempted > 0 {
 		log.Printf("[INFO] Auto-purge soft-deleted books: attempted=%d purged=%d files_deleted=%d errors=%d",
 			result.Attempted, result.Purged, result.FilesDeleted, len(result.Errors))
-		if len(result.Errors) > 0 {
-			for _, e := range result.Errors {
-				log.Printf("[WARN] Auto-purge error: %s", e)
-			}
+		for _, e := range result.Errors {
+			activity.LogBatch(s.activityWriter, opID, "purge-deleted", "purge-deleted",
+				activity.BatchItem{Name: e, Detail: "error"})
 		}
 	}
 }

--- a/internal/server/isbn_enrichment_test.go
+++ b/internal/server/isbn_enrichment_test.go
@@ -236,7 +236,7 @@ func TestEnrichMissingISBNs_RespectsLimit(t *testing.T) {
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
 
-	checked, updated, err := svc.EnrichMissingISBNs(context.Background(), 2)
+	checked, updated, err := svc.EnrichMissingISBNs(context.Background(), 2, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -4571,7 +4571,7 @@ func (s *Server) handleRepairMissingFiles(c *gin.Context) {
 	}
 
 	opID := ulid.Make().String()
-	if _, err := store.CreateOperation(opID, "missing_file_repair", nil); err != nil {
+	if _, err := store.CreateOperation(opID, "missing-file-repair", nil); err != nil {
 		internalError(c, "failed to create operation", err)
 		return
 	}
@@ -4586,7 +4586,7 @@ func (s *Server) handleRepairMissingFiles(c *gin.Context) {
 	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
 		return s.runMissingFileRepair(ctx, capturedOpID, capturedParams, store, progress)
 	}
-	if err := s.queue.Enqueue(opID, "missing_file_repair", operations.PriorityNormal, opFunc); err != nil {
+	if err := s.queue.Enqueue(opID, "missing-file-repair", operations.PriorityNormal, opFunc); err != nil {
 		internalError(c, "failed to enqueue operation", err)
 		return
 	}
@@ -4766,6 +4766,7 @@ func (s *Server) runMissingFileRepair(
 	wg.Wait()
 
 	finalCount := atomic.LoadInt64(&completed)
+	activity.FlushOperation(s.activityWriter, opID)
 	_ = progress.UpdateProgress(int(finalCount), totalFiles, "repair complete")
 	log.Printf("[INFO] repair-missing-files %s: finished %d/%d files", opID, finalCount, totalFiles)
 	return nil
@@ -5076,7 +5077,8 @@ func (s *Server) repairOneMissingFile(
 		log.Printf("[WARN] repair-missing-files %s: UpdateBookFile %s: %v", opID, f.ID, upErr)
 	} else {
 		res.Applied = true
-		log.Printf("[INFO] repair-missing-files %s: repaired via %s: %q → %q", opID, method, res.OldPath, candidate)
+		activity.LogBatch(s.activityWriter, opID, "missing-file-repair", "repair-missing-files",
+			activity.BatchItem{Name: filepath.Base(res.OldPath), Detail: method + ": " + candidate})
 	}
 	return res
 }
@@ -5099,8 +5101,8 @@ func (s *Server) handleGetMissingFileRepairResults(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
 		return
 	}
-	if op.Type != "missing_file_repair" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "not a missing_file_repair operation"})
+	if op.Type != "missing-file-repair" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "not a missing-file-repair operation"})
 		return
 	}
 	rawResults, err := store.GetOperationResults(opID)

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -1392,16 +1392,17 @@ func (s *Server) runBulkWriteBack(
 // runIsbnEnrichment enriches missing ISBN identifiers from external sources.
 // Idempotent — books that already have an ISBN are skipped, so a restart
 // safely re-runs from scratch (no checkpoint needed).
-func (s *Server) runIsbnEnrichment(ctx context.Context, progress operations.ProgressReporter) error {
+func (s *Server) runIsbnEnrichment(ctx context.Context, progress operations.ProgressReporter, opID string) error {
 	if s.metadataFetchService == nil || s.metadataFetchService.ISBNEnrichment() == nil {
 		_ = progress.Log("info", "ISBN enrichment service is not configured, skipping", nil)
 		return nil
 	}
 	_ = progress.Log("info", "Scanning for books missing ISBN identifiers", nil)
-	checked, updated, err := s.metadataFetchService.ISBNEnrichment().EnrichMissingISBNs(ctx, 100)
+	checked, updated, err := s.metadataFetchService.ISBNEnrichment().EnrichMissingISBNs(ctx, 100, s.activityWriter, opID)
 	if err != nil {
 		return err
 	}
+	activity.FlushOperation(s.activityWriter, opID)
 	msg := fmt.Sprintf("ISBN enrichment complete: checked %d candidate book(s), updated %d", checked, updated)
 	_ = progress.Log("info", msg, nil)
 	_ = progress.UpdateProgress(100, 100, msg)

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler.go
-// version: 1.17.1
+// version: 1.17.2
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -313,7 +314,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Enrich missing ISBN identifiers from external metadata sources",
 		Category:    "maintenance",
 		TriggerFn: func() (*database.Operation, error) {
-			return ts.triggerOperation("isbn-enrichment", s.runIsbnEnrichment)
+			return ts.triggerOperationWithID("isbn-enrichment", s.runIsbnEnrichment)
 		},
 		IsEnabled:              func() bool { return s.metadataFetchService != nil && s.metadataFetchService.ISBNEnrichment() != nil },
 		GetInterval:            func() time.Duration { return 0 },
@@ -343,8 +344,9 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Remove orphaned *.tmp.m4b / *.tmp.m4a files left by crashed ffmpeg operations",
 		Category:    "maintenance",
 		TriggerFn: func() (*database.Operation, error) {
-			return ts.triggerOperation("temp-file-cleanup", func(_ context.Context, progress operations.ProgressReporter) error {
-				removed := cleanupOrphanedTempFiles(config.AppConfig.RootDir)
+			return ts.triggerOperationWithID("temp-file-cleanup", func(_ context.Context, progress operations.ProgressReporter, opID string) error {
+				removed := cleanupOrphanedTempFiles(config.AppConfig.RootDir, ts.server.activityWriter, opID)
+				activity.FlushOperation(ts.server.activityWriter, opID)
 				_ = progress.Log("info", fmt.Sprintf("Temp file cleanup: removed %d orphaned temp files", removed), nil)
 				return nil
 			})
@@ -695,10 +697,11 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Purge soft-deleted books past retention",
 		Category:    "maintenance",
 		TriggerFn: func() (*database.Operation, error) {
-			return ts.triggerOperation("purge-deleted", func(ctx context.Context, progress operations.ProgressReporter) error {
+			return ts.triggerOperationWithID("purge-deleted", func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
 				_ = progress.Log("info", "Starting purge of soft-deleted books", nil)
 				_ = progress.UpdateProgress(0, 100, "Purging soft-deleted books...")
-				s.runAutoPurgeSoftDeleted()
+				s.runAutoPurgeSoftDeleted(opID)
+				activity.FlushOperation(ts.server.activityWriter, opID)
 				_ = progress.Log("info", "Purge complete", nil)
 				_ = progress.UpdateProgress(100, 100, "Purge complete")
 				return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1483,7 +1483,10 @@ func (s *Server) resumeInterruptedOperations() {
 				return s.runBulkWriteBack(ctx, opID, bookIDs, doRename, startIdx, progress)
 			}
 		case "isbn-enrichment":
-			resumeFn = s.runIsbnEnrichment
+			isbnOpID := opID
+			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+				return s.runIsbnEnrichment(ctx, progress, isbnOpID)
+			}
 		case "metadata-refresh":
 			resumeFn = s.runMetadataRefreshScan
 		case "reconcile_scan":

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -748,7 +748,7 @@ func TestRunAutoPurgeSoftDeleted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	server.runAutoPurgeSoftDeleted()
+	server.runAutoPurgeSoftDeleted("")
 
 	if got, err := database.GetGlobalStore().GetBookByID(book.ID); err == nil && got != nil {
 		t.Fatal("expected book to be purged")

--- a/internal/server/server_soft_delete_purge_test.go
+++ b/internal/server/server_soft_delete_purge_test.go
@@ -68,7 +68,7 @@ func TestRunAutoPurgeSoftDeleted_DeletesOldEntries(t *testing.T) {
 	_, err = database.GetGlobalStore().UpdateBook(book.ID, book)
 	require.NoError(t, err)
 
-	server.runAutoPurgeSoftDeleted()
+	server.runAutoPurgeSoftDeleted("")
 
 	// Book removed.
 	fetched, err := database.GetGlobalStore().GetBookByID(book.ID)

--- a/internal/server/temp_file_cleanup.go
+++ b/internal/server/temp_file_cleanup.go
@@ -1,5 +1,5 @@
 // file: internal/server/temp_file_cleanup.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e4f5a6b7-c8d9-0e1f-2a3b-4c5d6e7f8a9b
 
 package server
@@ -10,12 +10,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 )
 
 // cleanupOrphanedTempFiles removes *.tmp.m4b, *.tmp.m4a, *.tmp.mp3, and
 // *.remux.tmp files left behind by ffmpeg operations that were interrupted
 // by a crash or server restart. Returns the number of files removed.
-func cleanupOrphanedTempFiles(root string) int {
+// w and opID are optional — if provided, each removal is submitted to the
+// activity batcher instead of emitting a per-file log line.
+func cleanupOrphanedTempFiles(root string, w *activity.Writer, opID string) int {
 	if root == "" {
 		return 0
 	}
@@ -30,8 +34,9 @@ func cleanupOrphanedTempFiles(root string) int {
 			if rmErr := os.Remove(path); rmErr != nil {
 				log.Printf("[WARN] temp file cleanup: could not remove %s: %v", path, rmErr)
 			} else {
-				log.Printf("[INFO] temp file cleanup: removed %s", path)
 				removed++
+				activity.LogBatch(w, opID, "temp-file-cleanup", "temp-file-cleanup",
+					activity.BatchItem{Name: name, Detail: path})
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary

- Wire `activity.LogBatch` + `FlushOperation` into four maintenance operations that were emitting per-item `log.Printf` lines, collapsing them into expandable batch rows in the UI activity log
- Register `"temp-file-cleanup"`, `"missing-file-repair"`, and `"purge-deleted"` in `batchableTypes` in `activity/api.go`
- Rename `missing_file_repair` operation type (DB + queue enqueue) from snake_case → kebab-case (`"missing-file-repair"`) to match every other op type (`isbn-enrichment`, `temp-file-cleanup`, `purge-deleted`, etc.)

## Per-operation changes

| Operation | Before | After |
|---|---|---|
| `temp-file-cleanup` | one `log.Printf` per removed file | `LogBatch` per removal; `FlushOperation` before summary |
| `purge-deleted` | one `log.Printf` per error | `LogBatch` per error; `FlushOperation` in scheduler closure |
| `isbn-enrichment` | plain `log.Printf` per enriched book | `LogBatch` per found book; switched to `triggerOperationWithID` |
| `missing-file-repair` | one `log.Printf` per repaired file | `LogBatch` per repair; `FlushOperation` before final progress |

## Test plan

- [ ] `go vet ./...` passes (verified locally)
- [ ] `go build ./...` passes (verified locally)
- [ ] Existing tests updated for new signatures (`EnrichMissingISBNs`, `runAutoPurgeSoftDeleted`)
- [ ] Trigger each operation via UI/API and confirm activity log shows batched entries instead of individual rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)