### PR TITLE
feat(maintenance): add revert-metadata-fetch endpoint

### DIFF
--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -30023,6 +30023,33 @@ func (_c *MockStore_GetBookFiles_Call) RunAndReturn(run func(bookID string) ([]d
 	return _c
 }
 
+// MockStore_GetAllBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFiles'
+type MockStore_GetAllBookFiles_Call struct {
+	*mock.Call
+}
+
+// GetAllBookFiles is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetAllBookFiles() *MockStore_GetAllBookFiles_Call {
+	return &MockStore_GetAllBookFiles_Call{Call: _e.mock.On("GetAllBookFiles")}
+}
+
+func (_c *MockStore_GetAllBookFiles_Call) Run(run func()) *MockStore_GetAllBookFiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAllBookFiles_Call) Return(bookFiles []database.BookFile, err error) *MockStore_GetAllBookFiles_Call {
+	_c.Call.Return(bookFiles, err)
+	return _c
+}
+
+func (_c *MockStore_GetAllBookFiles_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockStore_GetAllBookFiles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllBookFiles provides a mock function for the type MockStore
 func (_mock *MockStore) GetAllBookFiles() ([]database.BookFile, error) {
 	ret := _mock.Called()

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -5143,5 +5143,185 @@ func (s *Server) handleGetMissingFileRepairResults(c *gin.Context) {
 		"ambiguous":    ambiguous,
 		"skipped":      skipped,
 		"problems":     problems,
+	})
+}
+
+// handleRevertMetadataFetch rolls back all DB changes made by one or more
+// bulk_metadata_fetch operations. It reads the OperationResult rows to find
+// which books were updated, then restores PreviousValue for every
+// ChangeType=fetched MetadataChangeRecord recorded after the operation started.
+//
+// POST /api/v1/maintenance/revert-metadata-fetch
+// Body: {"operation_ids": ["01K...", "01K..."]}
+func (s *Server) handleRevertMetadataFetch(c *gin.Context) {
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+
+	var req struct {
+		OperationIDs []string `json:"operation_ids"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || len(req.OperationIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "operation_ids required"})
+		return
+	}
+
+	// Collect the earliest start time across all operations so we only revert
+	// changes that were made by this run (not older fetched records).
+	var revertAfter time.Time
+	bookIDSet := map[string]bool{}
+
+	for _, opID := range req.OperationIDs {
+		op, err := store.GetOperationByID(opID)
+		if err != nil || op == nil {
+			continue
+		}
+		if op.Type != "bulk_metadata_fetch" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "operation " + opID + " is not a bulk_metadata_fetch"})
+			return
+		}
+		ts := op.CreatedAt
+		if op.StartedAt != nil {
+			ts = *op.StartedAt
+		}
+		if revertAfter.IsZero() || ts.Before(revertAfter) {
+			revertAfter = ts
+		}
+
+		results, err := store.GetOperationResults(opID)
+		if err != nil {
+			internalError(c, "failed to load results for "+opID, err)
+			return
+		}
+		for _, r := range results {
+			if r.Status == "updated" {
+				bookIDSet[r.BookID] = true
+			}
+		}
+	}
+
+	log.Printf("[INFO] revert-metadata-fetch: reverting %d books, changes after %s",
+		len(bookIDSet), revertAfter.Format(time.RFC3339))
+
+	reverted := 0
+	skipped := 0
+	errors := 0
+
+	for bookID := range bookIDSet {
+		book, err := store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			errors++
+			continue
+		}
+
+		history, err := store.GetBookChangeHistory(bookID, 50)
+		if err != nil {
+			errors++
+			continue
+		}
+
+		// Gather the most recent fetched change per field after revertAfter.
+		// We want the PreviousValue (what the field was before the fetch ran).
+		type revertEntry struct {
+			field string
+			prev  string // empty string means "was empty before"
+		}
+		// Use a map so we only take the LAST change per field (most recent op).
+		byField := map[string]revertEntry{}
+		for _, h := range history {
+			if h.ChangeType != "fetched" {
+				continue
+			}
+			if h.ChangedAt.Before(revertAfter) {
+				continue
+			}
+			prev := ""
+			if h.PreviousValue != nil {
+				// PreviousValue is JSON-encoded string: "\"foo\"" → foo
+				if err := json.Unmarshal([]byte(*h.PreviousValue), &prev); err != nil {
+					prev = *h.PreviousValue
+				}
+			}
+			byField[h.Field] = revertEntry{field: h.Field, prev: prev}
+		}
+
+		if len(byField) == 0 {
+			skipped++
+			continue
+		}
+
+		didChange := false
+		for _, e := range byField {
+			switch e.field {
+			case "title":
+				book.Title = e.prev
+				didChange = true
+			case "author_name":
+				if e.prev == "" {
+					book.AuthorID = nil
+				} else {
+					if author, aerr := store.GetAuthorByName(e.prev); aerr == nil && author != nil {
+						book.AuthorID = &author.ID
+						didChange = true
+					}
+				}
+			case "publisher":
+				if e.prev == "" {
+					book.Publisher = nil
+				} else {
+					book.Publisher = &e.prev
+				}
+				didChange = true
+			case "language":
+				if e.prev == "" {
+					book.Language = nil
+				} else {
+					book.Language = &e.prev
+				}
+				didChange = true
+			case "audiobook_release_year":
+				if e.prev == "" {
+					book.AudiobookReleaseYear = nil
+				} else if yr, yerr := strconv.Atoi(e.prev); yerr == nil {
+					book.AudiobookReleaseYear = &yr
+				}
+				didChange = true
+			case "isbn10":
+				if e.prev == "" {
+					book.ISBN10 = nil
+				} else {
+					book.ISBN10 = &e.prev
+				}
+				didChange = true
+			case "isbn13":
+				if e.prev == "" {
+					book.ISBN13 = nil
+				} else {
+					book.ISBN13 = &e.prev
+				}
+				didChange = true
+			}
+		}
+
+		if didChange {
+			if _, uerr := store.UpdateBook(bookID, book); uerr != nil {
+				log.Printf("[WARN] revert-metadata-fetch: UpdateBook %s: %v", bookID, uerr)
+				errors++
+			} else {
+				reverted++
+			}
+		} else {
+			skipped++
+		}
+	}
+
+	log.Printf("[INFO] revert-metadata-fetch: done — reverted:%d skipped:%d errors:%d", reverted, skipped, errors)
+	c.JSON(http.StatusOK, gin.H{
+		"reverted": reverted,
+		"skipped":  skipped,
+		"errors":   errors,
+		"total":    len(bookIDSet),
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.196.0
+// version: 1.197.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2482,6 +2482,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/repair-missing-files", s.perm(auth.PermSettingsManage), s.handleRepairMissingFiles)
 			protected.GET("/maintenance/repair-missing-files/:id", s.perm(auth.PermSettingsManage), s.handleGetMissingFileRepairResults)
 			protected.POST("/maintenance/bulk-fetch-metadata", s.perm(auth.PermLibraryEditMetadata), s.handleBulkMetadataFetchAll)
+			protected.POST("/maintenance/revert-metadata-fetch", s.perm(auth.PermSettingsManage), s.handleRevertMetadataFetch)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/maintenance/revert-metadata-fetch` — rolls back all DB changes made by one or more `bulk_metadata_fetch` operations
- Reads `OperationResult` rows (status=updated) to find affected books
- Restores `PreviousValue` from `MetadataChangeRecord` (ChangeType=fetched) for title, author, publisher, language, release year, isbn10/13
- Only reverts changes recorded after the operation's start time (won't touch older fetches)

## Test plan

- [ ] POST with valid op IDs returns `{reverted, skipped, errors, total}`
- [ ] Books affected by the bulk fetch are restored to pre-fetch state
- [ ] Books with OverrideLocked fields are unaffected (those were never written by the fetch)
- [ ] POST with wrong op type returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)