### PR TITLE
fix(audible): fix json/v2 compat — DiscardUnknownMembers + nullable RuntimeLengthMin

### DIFF
--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -59,21 +59,21 @@ type audibleProductResponse struct {
 }
 
 type audibleProduct struct {
-	ASIN                string                    `json:"asin"`
-	Title               string                    `json:"title"`
-	Subtitle            string                    `json:"subtitle"`
-	Authors             []audiblePerson           `json:"authors"`
-	Narrators           []audiblePerson           `json:"narrators"`
-	PublisherName       string                    `json:"publisher_name"`
-	Language            string                    `json:"language"`
-	IssueDate           string                    `json:"issue_date"`
-	ReleaseDate         string                    `json:"release_date"`
-	FormatType          string                    `json:"format_type"`
-	MerchandisingSummary string                   `json:"merchandising_summary"`
-	ProductImages       map[string]string         `json:"product_images"`
-	Series              []audibleSeries           `json:"series"`
-	ContentDeliveryType string                    `json:"content_delivery_type"`
-	RuntimeLengthMin    int                       `json:"runtime_length_min"`
+	ASIN                 string            `json:"asin"`
+	Title                string            `json:"title"`
+	Subtitle             string            `json:"subtitle"`
+	Authors              []audiblePerson   `json:"authors"`
+	Narrators            []audiblePerson   `json:"narrators"`
+	PublisherName        string            `json:"publisher_name"`
+	Language             string            `json:"language"`
+	IssueDate            string            `json:"issue_date"`
+	ReleaseDate          string            `json:"release_date"`
+	FormatType           string            `json:"format_type"`
+	MerchandisingSummary string            `json:"merchandising_summary"`
+	ProductImages        map[string]string `json:"product_images"`
+	Series               []audibleSeries   `json:"series"`
+	ContentDeliveryType  string            `json:"content_delivery_type"`
+	RuntimeLengthMin     *int              `json:"runtime_length_min"` // nullable in API
 }
 
 type audiblePerson struct {
@@ -125,7 +125,7 @@ func (c *AudibleClient) LookupByASIN(asin string) (*BookMetadata, error) {
 	}
 
 	var result audibleProductResponse
-	if err := json.UnmarshalRead(resp.Body, &result); err != nil {
+	if err := json.UnmarshalRead(resp.Body, &result, json.DiscardUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("failed to decode Audible response: %w", err)
 	}
 
@@ -155,7 +155,7 @@ func (c *AudibleClient) searchCatalog(searchURL string) ([]BookMetadata, error) 
 	}
 
 	var catalog audibleCatalogResponse
-	if err := json.UnmarshalRead(resp.Body, &catalog); err != nil {
+	if err := json.UnmarshalRead(resp.Body, &catalog, json.DiscardUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("failed to decode Audible response: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

json/v2 silently drops array elements when any field in a struct fails to decode (unlike v1 which used zero values). Audible returns `runtime_length_min: null` for some products — with a non-pointer `int`, json/v2 treats this as a type mismatch and silently discards the entire product, yielding 0 results with no error.

Two fixes:
- `json.UnmarshalRead(..., json.DiscardUnknownMembers(true))` — handles Audible's many undocumented fields without error
- `RuntimeLengthMin *int` — null decodes correctly to `nil` instead of failing

## Test plan

- [ ] Bulk metadata fetch returns `cached:N` instead of `not_found:N` for known books
- [ ] Individual Audible search in UI returns results for well-known titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)