### PR TITLE
feat(audible): map runtime_length_min → DurationSec → Book.Duration

### DIFF
--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -7,6 +7,7 @@ package metadata
 import (
 	json "encoding/json/v2"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -154,12 +155,16 @@ func (c *AudibleClient) searchCatalog(searchURL string) ([]BookMetadata, error) 
 		return nil, fmt.Errorf("Audible API returned status %d", resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Audible response: %w", err)
+	}
 	var catalog audibleCatalogResponse
-	if err := json.UnmarshalRead(resp.Body, &catalog, json.DiscardUnknownMembers(true)); err != nil {
+	if err := json.Unmarshal(body, &catalog, json.DiscardUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("failed to decode Audible response: %w", err)
 	}
 
-	log.Printf("[DEBUG] Audible API returned %d products", len(catalog.Products))
+	log.Printf("[INFO] Audible API returned %d products", len(catalog.Products))
 
 	results := make([]BookMetadata, 0, len(catalog.Products))
 	for _, p := range catalog.Products {
@@ -231,6 +236,11 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 	if len(p.Series) > 0 {
 		meta.Series = p.Series[0].Title
 		meta.SeriesPosition = p.Series[0].Sequence
+	}
+
+	// Runtime: Audible returns minutes; BookMetadata stores seconds.
+	if p.RuntimeLengthMin != nil && *p.RuntimeLengthMin > 0 {
+		meta.DurationSec = *p.RuntimeLengthMin * 60
 	}
 
 	return meta

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package metadata
@@ -116,6 +116,7 @@ type BookMetadata struct {
 	Genre          string
 	Series         string
 	SeriesPosition string
+	DurationSec    int // audio runtime in seconds (Audible: runtime_length_min × 60)
 }
 
 // SearchByTitle searches for books by title. Checks local dump store first if available.

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -663,6 +663,8 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 				return book.ISBN10 != nil && strings.TrimSpace(*book.ISBN10) != ""
 			case "isbn13":
 				return book.ISBN13 != nil && strings.TrimSpace(*book.ISBN13) != ""
+			case "duration":
+				return book.Duration != nil && *book.Duration > 0
 			default:
 				return false
 			}
@@ -747,6 +749,16 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 					appliedFields = append(appliedFields, "isbn13")
 					didUpdate = true
 				}
+			}
+		}
+
+		if meta.DurationSec > 0 {
+			addFetched("duration", meta.DurationSec)
+			if shouldApply("duration", hasBookValue("duration")) {
+				dur := meta.DurationSec
+				book.Duration = &dur
+				appliedFields = append(appliedFields, "duration")
+				didUpdate = true
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Add `DurationSec int` to `BookMetadata` struct (stored as seconds; Audible API gives minutes)
- `productToMetadata` now maps `RuntimeLengthMin × 60` → `DurationSec`
- Apply pipeline gains `duration` field support with `hasBookValue`/`shouldApply` guards — only writes when book has no existing duration and field isn't override-locked
- Remove `[DEBUG] Audible raw response` log line from `searchCatalog`; keep the `io.ReadAll + json.Unmarshal` streaming fix

## Test plan
- [ ] Build: `make build-api` passes (verified locally)
- [ ] Trigger bulk metadata fetch with `prefer_audible=true`; check that books with Audible matches gain a `duration` value in the DB
- [ ] Verify books with existing duration are not overwritten (only-missing guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)