### PR TITLE
feat(ratings): full Audible + Google Books rating dimensions

### DIFF
--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.62.0
+// version: 1.63.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -36,7 +36,10 @@ const bookSelectColumns = `
 	marked_for_deletion, marked_for_deletion_at, created_at, updated_at,
 	metadata_updated_at, last_written_at, metadata_review_status, cover_url, narrators_json,
 	last_organize_operation_id, last_organized_at, itunes_sync_status,
-	quarantine_reason, quarantined_at
+	quarantine_reason, quarantined_at,
+	audible_rating_overall, audible_rating_performance, audible_rating_story,
+	audible_rating_count, audible_num_reviews,
+	google_rating_average, google_rating_count
 `
 
 // bookSelectColumnsQualified prefixes all columns with "books." for use in JOINs.
@@ -54,7 +57,10 @@ const bookSelectColumnsQualified = `
 	books.marked_for_deletion, books.marked_for_deletion_at, books.created_at, books.updated_at,
 	books.metadata_updated_at, books.last_written_at, books.metadata_review_status, books.cover_url, books.narrators_json,
 	books.last_organize_operation_id, books.last_organized_at, books.itunes_sync_status,
-	books.quarantine_reason, books.quarantined_at
+	books.quarantine_reason, books.quarantined_at,
+	books.audible_rating_overall, books.audible_rating_performance, books.audible_rating_story,
+	books.audible_rating_count, books.audible_num_reviews,
+	books.google_rating_average, books.google_rating_count
 `
 
 func scanBook(scanner rowScanner, book *Book) error {
@@ -83,6 +89,10 @@ func scanBook(scanner rowScanner, book *Book) error {
 		itunesSyncStatus                                                     sql.NullString
 		quarantineReason                                                     sql.NullString
 		quarantinedAt                                                        sql.NullTime
+		audibleRatingOverall, audibleRatingPerformance, audibleRatingStory   sql.NullFloat64
+		audibleRatingCount, audibleNumReviews                                sql.NullInt64
+		googleRatingAverage                                                  sql.NullFloat64
+		googleRatingCount                                                    sql.NullInt64
 	)
 
 	if err := scanner.Scan(
@@ -100,6 +110,9 @@ func scanBook(scanner rowScanner, book *Book) error {
 		&metadataUpdatedAt, &lastWrittenAt, &metadataReviewStatus, &coverURL, &narratorsJSON,
 		&lastOrganizeOperationID, &lastOrganizedAt, &itunesSyncStatus,
 		&quarantineReason, &quarantinedAt,
+		&audibleRatingOverall, &audibleRatingPerformance, &audibleRatingStory,
+		&audibleRatingCount, &audibleNumReviews,
+		&googleRatingAverage, &googleRatingCount,
 	); err != nil {
 		return err
 	}
@@ -194,6 +207,13 @@ func scanBook(scanner rowScanner, book *Book) error {
 	if quarantinedAt.Valid {
 		book.QuarantinedAt = &quarantinedAt.Time
 	}
+	book.AudibleRatingOverall = nullableFloat(audibleRatingOverall)
+	book.AudibleRatingPerformance = nullableFloat(audibleRatingPerformance)
+	book.AudibleRatingStory = nullableFloat(audibleRatingStory)
+	book.AudibleRatingCount = nullableInt(audibleRatingCount)
+	book.AudibleNumReviews = nullableInt(audibleNumReviews)
+	book.GoogleRatingAverage = nullableFloat(googleRatingAverage)
+	book.GoogleRatingCount = nullableInt(googleRatingCount)
 	return nil
 }
 
@@ -211,6 +231,13 @@ func nullableInt(ni sql.NullInt64) *int {
 	}
 	val := int(ni.Int64)
 	return &val
+}
+
+func nullableFloat(nf sql.NullFloat64) *float64 {
+	if !nf.Valid {
+		return nil
+	}
+	return &nf.Float64
 }
 
 // SQLiteStore implements the Store interface using SQLite3
@@ -695,8 +722,15 @@ func (s *SQLiteStore) ensureExtendedBookColumns() error {
 		"marked_for_deletion_at": "DATETIME",
 		"created_at":             "DATETIME DEFAULT CURRENT_TIMESTAMP",
 		"updated_at":             "DATETIME",
-		"cover_url":              "TEXT",
-		"narrators_json":         "TEXT",
+		"cover_url":                    "TEXT",
+		"narrators_json":               "TEXT",
+		"audible_rating_overall":       "REAL",
+		"audible_rating_performance":   "REAL",
+		"audible_rating_story":         "REAL",
+		"audible_rating_count":         "INTEGER",
+		"audible_num_reviews":          "INTEGER",
+		"google_rating_average":        "REAL",
+		"google_rating_count":          "INTEGER",
 	}
 
 	// Fetch existing columns
@@ -2676,7 +2710,10 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		quarantine_reason = ?, quarantined_at = ?,
 		updated_at = ?, metadata_updated_at = ?, last_written_at = ?,
 		metadata_review_status = ?, cover_url = ?, narrators_json = ?,
-		last_organize_operation_id = ?, last_organized_at = ?, itunes_sync_status = ?
+		last_organize_operation_id = ?, last_organized_at = ?, itunes_sync_status = ?,
+		audible_rating_overall = ?, audible_rating_performance = ?, audible_rating_story = ?,
+		audible_rating_count = ?, audible_num_reviews = ?,
+		google_rating_average = ?, google_rating_count = ?
 	WHERE id = ?`
 	result, err := s.db.Exec(query,
 		book.Title, book.AuthorID, book.SeriesID, book.SeriesSequence,
@@ -2693,7 +2730,10 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		book.QuarantineReason, book.QuarantinedAt,
 		book.UpdatedAt, book.MetadataUpdatedAt, book.LastWrittenAt,
 		book.MetadataReviewStatus, book.CoverURL, book.NarratorsJSON,
-		book.LastOrganizeOperationID, book.LastOrganizedAt, book.ITunesSyncStatus, id,
+		book.LastOrganizeOperationID, book.LastOrganizedAt, book.ITunesSyncStatus,
+		book.AudibleRatingOverall, book.AudibleRatingPerformance, book.AudibleRatingStory,
+		book.AudibleRatingCount, book.AudibleNumReviews,
+		book.GoogleRatingAverage, book.GoogleRatingCount, id,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -195,6 +195,16 @@ type Book struct {
 	// "unlinked" (no iTunes presence), "pending" (new, needs adding to iTunes),
 	// "purge_pending" (quarantined, delete from iTunes on next sync).
 	ITunesSyncStatus *string `json:"itunes_sync_status,omitempty"`
+	// Audible ratings (1–5 scale). Performance and Story are audiobook-specific
+	// dimensions absent from other providers.
+	AudibleRatingOverall     *float64 `json:"audible_rating_overall,omitempty"`
+	AudibleRatingPerformance *float64 `json:"audible_rating_performance,omitempty"` // narrator/production
+	AudibleRatingStory       *float64 `json:"audible_rating_story,omitempty"`       // story/content
+	AudibleRatingCount       *int     `json:"audible_rating_count,omitempty"`
+	AudibleNumReviews        *int     `json:"audible_num_reviews,omitempty"`
+	// Google Books rating (1–5 scale).
+	GoogleRatingAverage *float64 `json:"google_rating_average,omitempty"`
+	GoogleRatingCount   *int     `json:"google_rating_count,omitempty"`
 	// Cover art
 	CoverURL *string `json:"cover_url,omitempty"`
 	// Narrators as JSON array

--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -75,6 +75,19 @@ type audibleProduct struct {
 	Series               []audibleSeries   `json:"series"`
 	ContentDeliveryType  string            `json:"content_delivery_type"`
 	RuntimeLengthMin     *int              `json:"runtime_length_min"` // nullable in API
+	Rating               *audibleRating    `json:"rating"`
+}
+
+type audibleRating struct {
+	NumReviews          int                      `json:"num_reviews"`
+	OverallDistribution audibleRatingDistribution `json:"overall_distribution"`
+	PerformanceDistribution audibleRatingDistribution `json:"performance_distribution"`
+	StoryDistribution   audibleRatingDistribution `json:"story_distribution"`
+}
+
+type audibleRatingDistribution struct {
+	DisplayAverageRating float64 `json:"display_average_rating"`
+	NumRatings           int     `json:"num_ratings"`
 }
 
 type audiblePerson struct {
@@ -88,7 +101,7 @@ type audibleSeries struct {
 	Sequence string `json:"sequence"`
 }
 
-const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series"
+const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series,rating"
 
 // SearchByTitle searches Audible's catalog by title.
 func (c *AudibleClient) SearchByTitle(title string) ([]BookMetadata, error) {
@@ -241,6 +254,15 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 	// Runtime: Audible returns minutes; BookMetadata stores seconds.
 	if p.RuntimeLengthMin != nil && *p.RuntimeLengthMin > 0 {
 		meta.DurationSec = *p.RuntimeLengthMin * 60
+	}
+
+	// Ratings: overall, narrator performance, story quality.
+	if p.Rating != nil {
+		meta.AudibleRatingOverall = p.Rating.OverallDistribution.DisplayAverageRating
+		meta.AudibleRatingPerformance = p.Rating.PerformanceDistribution.DisplayAverageRating
+		meta.AudibleRatingStory = p.Rating.StoryDistribution.DisplayAverageRating
+		meta.AudibleRatingCount = p.Rating.OverallDistribution.NumRatings
+		meta.AudibleNumReviews = p.Rating.NumReviews
 	}
 
 	return meta

--- a/internal/metadata/googlebooks.go
+++ b/internal/metadata/googlebooks.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/googlebooks.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-f2a3b4c5d6e7
 
 package metadata
@@ -7,6 +7,7 @@ package metadata
 import (
 	json "encoding/json/v2"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -58,14 +59,16 @@ type googleBooksVol struct {
 }
 
 type googleBooksVolumeInfo struct {
-	Title               string                       `json:"title"`
-	Authors             []string                     `json:"authors"`
-	Publisher           string                       `json:"publisher"`
-	PublishedDate       string                       `json:"publishedDate"`
-	Description         string                       `json:"description"`
-	IndustryIdentifiers []googleBooksIndustryID      `json:"industryIdentifiers"`
-	ImageLinks          *googleBooksImageLinks       `json:"imageLinks"`
-	Language            string                       `json:"language"`
+	Title               string                  `json:"title"`
+	Authors             []string                `json:"authors"`
+	Publisher           string                  `json:"publisher"`
+	PublishedDate       string                  `json:"publishedDate"`
+	Description         string                  `json:"description"`
+	IndustryIdentifiers []googleBooksIndustryID `json:"industryIdentifiers"`
+	ImageLinks          *googleBooksImageLinks  `json:"imageLinks"`
+	Language            string                  `json:"language"`
+	AverageRating       float64                 `json:"averageRating"`
+	RatingsCount        int                     `json:"ratingsCount"`
 }
 
 type googleBooksIndustryID struct {
@@ -106,8 +109,12 @@ func (c *GoogleBooksClient) search(escapedQuery string) ([]BookMetadata, error) 
 		return nil, fmt.Errorf("Google Books API returned status %d", resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Google Books response: %w", err)
+	}
 	var gbResp googleBooksResponse
-	if err := json.UnmarshalRead(resp.Body, &gbResp); err != nil {
+	if err := json.Unmarshal(body, &gbResp, json.DiscardUnknownMembers(true)); err != nil {
 		return nil, fmt.Errorf("failed to decode Google Books response: %w", err)
 	}
 
@@ -135,6 +142,10 @@ func (c *GoogleBooksClient) search(escapedQuery string) ([]BookMetadata, error) 
 		}
 		if vi.ImageLinks != nil && vi.ImageLinks.Thumbnail != "" {
 			meta.CoverURL = vi.ImageLinks.Thumbnail
+		}
+		if vi.AverageRating > 0 {
+			meta.GoogleRatingAverage = vi.AverageRating
+			meta.GoogleRatingCount = vi.RatingsCount
 		}
 		results = append(results, meta)
 	}

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package metadata
@@ -116,7 +116,19 @@ type BookMetadata struct {
 	Genre          string
 	Series         string
 	SeriesPosition string
-	DurationSec    int // audio runtime in seconds (Audible: runtime_length_min × 60)
+	DurationSec int // audio runtime in seconds (Audible: runtime_length_min × 60)
+
+	// Audible-specific ratings (1–5 scale). Performance and Story are
+	// audiobook-specific dimensions not available from other sources.
+	AudibleRatingOverall     float64
+	AudibleRatingPerformance float64 // narrator/production quality
+	AudibleRatingStory       float64 // story/content quality
+	AudibleRatingCount       int     // number of star ratings
+	AudibleNumReviews        int     // number of written reviews
+
+	// Google Books rating (1–5 scale).
+	GoogleRatingAverage float64
+	GoogleRatingCount   int
 }
 
 // SearchByTitle searches for books by title. Checks local dump store first if available.

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -665,6 +665,10 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 				return book.ISBN13 != nil && strings.TrimSpace(*book.ISBN13) != ""
 			case "duration":
 				return book.Duration != nil && *book.Duration > 0
+			case "audible_rating_overall":
+				return book.AudibleRatingOverall != nil && *book.AudibleRatingOverall > 0
+			case "google_rating_average":
+				return book.GoogleRatingAverage != nil && *book.GoogleRatingAverage > 0
 			default:
 				return false
 			}
@@ -758,6 +762,38 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 				dur := meta.DurationSec
 				book.Duration = &dur
 				appliedFields = append(appliedFields, "duration")
+				didUpdate = true
+			}
+		}
+
+		// Audible ratings — always overwrite (ratings update over time; newer > older).
+		if meta.AudibleRatingOverall > 0 {
+			addFetched("audible_rating_overall", meta.AudibleRatingOverall)
+			if shouldApply("audible_rating_overall", hasBookValue("audible_rating_overall")) {
+				v := meta.AudibleRatingOverall
+				book.AudibleRatingOverall = &v
+				v2 := meta.AudibleRatingPerformance
+				book.AudibleRatingPerformance = &v2
+				v3 := meta.AudibleRatingStory
+				book.AudibleRatingStory = &v3
+				c := meta.AudibleRatingCount
+				book.AudibleRatingCount = &c
+				r := meta.AudibleNumReviews
+				book.AudibleNumReviews = &r
+				appliedFields = append(appliedFields, "audible_ratings")
+				didUpdate = true
+			}
+		}
+
+		// Google Books rating.
+		if meta.GoogleRatingAverage > 0 {
+			addFetched("google_rating_average", meta.GoogleRatingAverage)
+			if shouldApply("google_rating_average", hasBookValue("google_rating_average")) {
+				v := meta.GoogleRatingAverage
+				book.GoogleRatingAverage = &v
+				c := meta.GoogleRatingCount
+				book.GoogleRatingCount = &c
+				appliedFields = append(appliedFields, "google_rating")
 				didUpdate = true
 			}
 		}


### PR DESCRIPTION
## Summary
- **7 new DB columns** on `books` (auto-added via `ensureExtendedBookColumns`, no migration file):
  - `audible_rating_overall`, `audible_rating_performance`, `audible_rating_story` — the three Audible-specific rating dimensions (1–5)
  - `audible_rating_count`, `audible_num_reviews`
  - `google_rating_average`, `google_rating_count`
- **Audible**: adds `rating` response group to all API calls; parses `overall_distribution`, `performance_distribution`, `story_distribution`
- **Google Books**: adds `averageRating`/`ratingsCount` to struct; fixes `UnmarshalRead` → `io.ReadAll + json.Unmarshal` (same streaming bug fixed earlier for Audible)
- **Apply pipeline**: ratings write through like other fields with `shouldApply`/`hasBookValue` guards
- **PebbleDB**: no changes needed — JSON blob picks up new struct fields automatically

## Why separate performance/story dimensions?
Audible rates narrator performance and story quality independently. This enables queries like:
- "performance > 4.5" — find books with great narrators
- "story < 3 AND performance > 4" — great narrator on a mediocre book (maybe get print edition)
- "audible_overall > 4 AND google_rating IS NULL" — highly rated but not indexed by Google

## Test plan
- [ ] Build: `make build-api` passes (verified locally)
- [ ] Trigger bulk metadata fetch with `prefer_audible=true`; verify books matched by Audible gain rating columns populated
- [ ] Verify Google Books results also populate google_rating columns
- [ ] Confirm existing books without ratings don't get zeroed (nil guard in apply pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)