### PR TITLE
feat(db): reserve user rating columns on books table

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 5.9.0 -->
+<!-- version: 6.0.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-04-28 -->
 
@@ -40,6 +40,18 @@ future agent) can scan the entire workspace in one page.
 - [x] `gha-release-go` — passes token through
 - [x] `ghcommon/reusable-release.yml` — `create-github-app-token` wired
 - [x] v0.207.0 through v0.213.0 all released successfully
+
+---
+
+## ⭐ User Ratings UI — DB columns reserved, API + UI pending
+
+DB columns `user_rating_overall`, `user_rating_story`, `user_rating_performance`,
+`user_rating_notes` exist on `books` table. Still needed:
+
+- [ ] `PATCH /api/v1/audiobooks/:id/rating` — accepts `{overall, story, performance, notes}`
+- [ ] Book detail UI: star rating widget with three dimensions (overall / story / performance)
+- [ ] Library search/filter: "my overall > 4", "my performance < 3", etc.
+- [ ] Bulk rating view / quick-rate from list
 
 ---
 

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.63.0
+// version: 1.64.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -39,7 +39,8 @@ const bookSelectColumns = `
 	quarantine_reason, quarantined_at,
 	audible_rating_overall, audible_rating_performance, audible_rating_story,
 	audible_rating_count, audible_num_reviews,
-	google_rating_average, google_rating_count
+	google_rating_average, google_rating_count,
+	user_rating_overall, user_rating_story, user_rating_performance, user_rating_notes
 `
 
 // bookSelectColumnsQualified prefixes all columns with "books." for use in JOINs.
@@ -60,7 +61,8 @@ const bookSelectColumnsQualified = `
 	books.quarantine_reason, books.quarantined_at,
 	books.audible_rating_overall, books.audible_rating_performance, books.audible_rating_story,
 	books.audible_rating_count, books.audible_num_reviews,
-	books.google_rating_average, books.google_rating_count
+	books.google_rating_average, books.google_rating_count,
+	books.user_rating_overall, books.user_rating_story, books.user_rating_performance, books.user_rating_notes
 `
 
 func scanBook(scanner rowScanner, book *Book) error {
@@ -93,6 +95,8 @@ func scanBook(scanner rowScanner, book *Book) error {
 		audibleRatingCount, audibleNumReviews                                sql.NullInt64
 		googleRatingAverage                                                  sql.NullFloat64
 		googleRatingCount                                                    sql.NullInt64
+		userRatingOverall, userRatingStory, userRatingPerformance            sql.NullFloat64
+		userRatingNotes                                                      sql.NullString
 	)
 
 	if err := scanner.Scan(
@@ -113,6 +117,7 @@ func scanBook(scanner rowScanner, book *Book) error {
 		&audibleRatingOverall, &audibleRatingPerformance, &audibleRatingStory,
 		&audibleRatingCount, &audibleNumReviews,
 		&googleRatingAverage, &googleRatingCount,
+		&userRatingOverall, &userRatingStory, &userRatingPerformance, &userRatingNotes,
 	); err != nil {
 		return err
 	}
@@ -214,6 +219,10 @@ func scanBook(scanner rowScanner, book *Book) error {
 	book.AudibleNumReviews = nullableInt(audibleNumReviews)
 	book.GoogleRatingAverage = nullableFloat(googleRatingAverage)
 	book.GoogleRatingCount = nullableInt(googleRatingCount)
+	book.UserRatingOverall = nullableFloat(userRatingOverall)
+	book.UserRatingStory = nullableFloat(userRatingStory)
+	book.UserRatingPerformance = nullableFloat(userRatingPerformance)
+	book.UserRatingNotes = nullableString(userRatingNotes)
 	return nil
 }
 
@@ -731,6 +740,10 @@ func (s *SQLiteStore) ensureExtendedBookColumns() error {
 		"audible_num_reviews":          "INTEGER",
 		"google_rating_average":        "REAL",
 		"google_rating_count":          "INTEGER",
+		"user_rating_overall":          "REAL",
+		"user_rating_story":            "REAL",
+		"user_rating_performance":      "REAL",
+		"user_rating_notes":            "TEXT",
 	}
 
 	// Fetch existing columns
@@ -2713,7 +2726,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		last_organize_operation_id = ?, last_organized_at = ?, itunes_sync_status = ?,
 		audible_rating_overall = ?, audible_rating_performance = ?, audible_rating_story = ?,
 		audible_rating_count = ?, audible_num_reviews = ?,
-		google_rating_average = ?, google_rating_count = ?
+		google_rating_average = ?, google_rating_count = ?,
+		user_rating_overall = ?, user_rating_story = ?, user_rating_performance = ?, user_rating_notes = ?
 	WHERE id = ?`
 	result, err := s.db.Exec(query,
 		book.Title, book.AuthorID, book.SeriesID, book.SeriesSequence,
@@ -2733,7 +2747,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		book.LastOrganizeOperationID, book.LastOrganizedAt, book.ITunesSyncStatus,
 		book.AudibleRatingOverall, book.AudibleRatingPerformance, book.AudibleRatingStory,
 		book.AudibleRatingCount, book.AudibleNumReviews,
-		book.GoogleRatingAverage, book.GoogleRatingCount, id,
+		book.GoogleRatingAverage, book.GoogleRatingCount,
+		book.UserRatingOverall, book.UserRatingStory, book.UserRatingPerformance, book.UserRatingNotes, id,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -205,6 +205,13 @@ type Book struct {
 	// Google Books rating (1–5 scale).
 	GoogleRatingAverage *float64 `json:"google_rating_average,omitempty"`
 	GoogleRatingCount   *int     `json:"google_rating_count,omitempty"`
+	// User personal ratings (1–5 scale, independent of community ratings).
+	// UI/API for setting these is TODO — columns are reserved so data can be
+	// populated once the rating UI is built.
+	UserRatingOverall     *float64 `json:"user_rating_overall,omitempty"`
+	UserRatingStory       *float64 `json:"user_rating_story,omitempty"`
+	UserRatingPerformance *float64 `json:"user_rating_performance,omitempty"`
+	UserRatingNotes       *string  `json:"user_rating_notes,omitempty"`
 	// Cover art
 	CoverURL *string `json:"cover_url,omitempty"`
 	// Narrators as JSON array


### PR DESCRIPTION
## Summary
- Adds `user_rating_overall`, `user_rating_story`, `user_rating_performance`, `user_rating_notes` to `books` via `ensureExtendedBookColumns` (auto-added on startup, no migration file)
- PebbleDB picks up the new struct fields automatically via JSON serialization
- `scanBook` and `UpdateBook` wired for SQLite round-trip
- TODO.md documents the remaining work: API endpoint, star-rating UI widget, search/filter support, bulk rating view

🤖 Generated with [Claude Code](https://claude.com/claude-code)