### PR TITLE
fix(activity): emit summary entries so maintenance ops show content in activity log

### DIFF
--- a/internal/activity/api.go
+++ b/internal/activity/api.go
@@ -1,5 +1,5 @@
 // file: internal/activity/api.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9a4f2e1b-3c7d-4b8e-a6f0-5d2c8e1b7a3f
 
 package activity
@@ -49,6 +49,27 @@ func LogBatch(w *Writer, operationID, batchType, source string, item BatchItem) 
 		Source:      source,
 		OperationID: operationID,
 	}, item)
+}
+
+// EmitInfo writes a single info-tier ActivityEntry directly to the activity log
+// for the given operation. Use this for operation summary messages that should
+// appear in the main activity feed regardless of whether any items were batched.
+// Safe to call from multiple goroutines. w may be nil — call is a no-op.
+func EmitInfo(w *Writer, operationID, entryType, source, summary string) {
+	if w == nil {
+		return
+	}
+	select {
+	case w.ch <- database.ActivityEntry{
+		Tier:        "info",
+		Type:        entryType,
+		Level:       "info",
+		Source:      source,
+		OperationID: operationID,
+		Summary:     summary,
+	}:
+	default:
+	}
 }
 
 // FlushOperation immediately flushes all pending batches whose OperationID

--- a/internal/activity/batcher.go
+++ b/internal/activity/batcher.go
@@ -1,5 +1,5 @@
 // file: internal/activity/batcher.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f3c1a2e-8b4d-4e9f-a5c6-2d0e3b7f9a1c
 
 package activity
@@ -210,6 +210,12 @@ func batchNoun(batchType string) string {
 		return "path repairs"
 	case "isbn-enrich":
 		return "ISBN enrichments"
+	case "temp-file-cleanup":
+		return "orphaned temp files removed"
+	case "missing-file-repair":
+		return "missing files repaired"
+	case "purge-deleted":
+		return "purge errors"
 	default:
 		return batchType + " operations"
 	}

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -191,13 +191,13 @@ func (s *Server) runAutoPurgeSoftDeleted(opID string) {
 		return
 	}
 
-	if result.Attempted > 0 {
-		log.Printf("[INFO] Auto-purge soft-deleted books: attempted=%d purged=%d files_deleted=%d errors=%d",
-			result.Attempted, result.Purged, result.FilesDeleted, len(result.Errors))
-		for _, e := range result.Errors {
-			activity.LogBatch(s.activityWriter, opID, "purge-deleted", "purge-deleted",
-				activity.BatchItem{Name: e, Detail: "error"})
-		}
+	msg := fmt.Sprintf("Purged %d/%d soft-deleted books (%d files deleted, %d errors)",
+		result.Purged, result.Attempted, result.FilesDeleted, len(result.Errors))
+	log.Printf("[INFO] Auto-purge: %s", msg)
+	activity.EmitInfo(s.activityWriter, opID, "purge-deleted", "purge-deleted", msg)
+	for _, e := range result.Errors {
+		activity.LogBatch(s.activityWriter, opID, "purge-deleted", "purge-deleted",
+			activity.BatchItem{Name: e, Detail: "error"})
 	}
 }
 

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -4767,8 +4767,10 @@ func (s *Server) runMissingFileRepair(
 
 	finalCount := atomic.LoadInt64(&completed)
 	activity.FlushOperation(s.activityWriter, opID)
-	_ = progress.UpdateProgress(int(finalCount), totalFiles, "repair complete")
+	msg := fmt.Sprintf("Repaired %d of %d missing files", finalCount, totalFiles)
+	_ = progress.UpdateProgress(int(finalCount), totalFiles, msg)
 	log.Printf("[INFO] repair-missing-files %s: finished %d/%d files", opID, finalCount, totalFiles)
+	activity.EmitInfo(s.activityWriter, opID, "missing-file-repair", "repair-missing-files", msg)
 	return nil
 }
 

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1348,9 +1348,10 @@ func (s *Server) runIsbnEnrichment(ctx context.Context, progress operations.Prog
 		return err
 	}
 	activity.FlushOperation(s.activityWriter, opID)
-	msg := fmt.Sprintf("ISBN enrichment complete: checked %d candidate book(s), updated %d", checked, updated)
+	msg := fmt.Sprintf("ISBN enrichment complete: checked %d, updated %d", checked, updated)
 	_ = progress.Log("info", msg, nil)
 	_ = progress.UpdateProgress(100, 100, msg)
+	activity.EmitInfo(s.activityWriter, opID, "isbn-enrich", "isbn-enrichment", msg)
 	return nil
 }
 

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -347,7 +347,9 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return ts.triggerOperationWithID("temp-file-cleanup", func(_ context.Context, progress operations.ProgressReporter, opID string) error {
 				removed := cleanupOrphanedTempFiles(config.AppConfig.RootDir, ts.server.activityWriter, opID)
 				activity.FlushOperation(ts.server.activityWriter, opID)
-				_ = progress.Log("info", fmt.Sprintf("Temp file cleanup: removed %d orphaned temp files", removed), nil)
+				msg := fmt.Sprintf("Removed %d orphaned temp files", removed)
+				_ = progress.Log("info", msg, nil)
+				activity.EmitInfo(ts.server.activityWriter, opID, "temp-file-cleanup", "temp-file-cleanup", msg)
 				return nil
 			})
 		},


### PR DESCRIPTION
## Summary

- `progress.Log()` only writes to the per-operation detail log — the main activity feed never sees it
- Operations that process 0 items never call `LogBatch`, so the activity log showed nothing between "started" and "completed"
- Adds `activity.EmitInfo()` — sends a single `info`-tier `ActivityEntry` directly to the writer channel, bypassing the batcher

## Changes

**`activity/api.go`** — new `EmitInfo(w, opID, type, source, summary)` function

**`activity/batcher.go`** — add `batchNoun` entries for the three new batch types so batched rows read naturally (e.g. "3 orphaned temp files removed")

**Four operations now emit a summary line to the activity feed:**

| Operation | Summary message |
|---|---|
| temp-file-cleanup | `Removed N orphaned temp files` |
| purge-deleted | `Purged N/M soft-deleted books (K files deleted, E errors)` |
| isbn-enrichment | `ISBN enrichment complete: checked N, updated M` |
| missing-file-repair | `Repaired N of M missing files` |

When items were also processed, the batched row appears *before* the summary (via `FlushOperation` then `EmitInfo`).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Deploy and verify activity log shows summary lines for each operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)