### PR TITLE
docs(todo): session 23 shipped work + RELINK-1 bot-task spec

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 6.3.0 -->
+<!-- version: 6.4.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-28 -->
+<!-- last-edited: 2026-04-29 -->
 
 # Project TODO
 
@@ -18,12 +18,12 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — April 16, 2026
+## 🎯 Current Status — April 29, 2026
 
 **Library:** 10,891 books / 2,970 authors / 8,507 series (cleaned)
 **Production:** PebbleDB, Linux, HTTPS at `172.16.2.30:8484`, mTLS bridge active
-**Latest shipped release:** v0.210.0 (2026-04-16)
-**In flight:** Backend foundations for 6 major features (see below)
+**Latest shipped release:** v0.221.0 (2026-04-29) — PRs #507–#521
+**In flight:** User Ratings UI, ASYNC spec revision, iTunes relink unresolved cases (6,719 files)
 
 ---
 
@@ -43,13 +43,20 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## ⭐ User Ratings UI — DB columns reserved, API + UI pending
+## ⭐ User Ratings UI — DB + schema done, API + UI pending
 
-DB columns `user_rating_overall`, `user_rating_story`, `user_rating_performance`,
-`user_rating_notes` exist on `books` table. Still needed:
+PR #516 added full Audible rating dimensions (5 dims + count + reviews) and Google Books
+(rating + count) to DB and metadata pipeline. PR #517 reserved `user_rating_overall`,
+`user_rating_story`, `user_rating_performance`, `user_rating_notes` on `books` table.
+PR #520 wires Audible `runtime_length_min` into candidate scoring. Still needed:
 
+- [x] Audible ratings ingested (overall/story/performance/concept/delivery + count + reviews) — PR #516
+- [x] Google Books ratings ingested (rating + count) — PR #516
+- [x] User rating columns reserved on `books` table — PR #517
+- [x] Duration scoring for candidates from Audible runtime — PR #520
 - [ ] `PATCH /api/v1/audiobooks/:id/rating` — accepts `{overall, story, performance, notes}`
 - [ ] Book detail UI: star rating widget with three dimensions (overall / story / performance)
+- [ ] Show Audible/Google ratings in MetadataReviewDialog candidate cards
 - [ ] Library search/filter: "my overall > 4", "my performance < 3", etc.
 - [ ] Bulk rating view / quick-rate from list
 
@@ -86,6 +93,36 @@ Implementation steps (in order):
 - [ ] **Discovery → Import UI**: "Import" button on discovered torrent calls the import flow
 - [ ] **UI**: "Imported from Deluge" badge on book detail; original path shown in Files tab audit row
 - [ ] **Config**: add `protected_paths []string` field; expose in Settings UI
+
+---
+
+## 🔗 iTunes Relink — Unresolved Cases
+
+PR #507 shipped the iTunes relink endpoint (3-tier path resolver: same-dir M4B → flat iTunes
+search → disambiguation). It resolved **94.7%** of broken organizer-root books. Three groups
+of cases remain:
+
+**13 manually-identified unresolved books** — documented in [`docs/reports/unresolved-relinks-2026-04-28.md`](docs/reports/unresolved-relinks-2026-04-28.md). Root causes: co-author directory mismatch (organizer uses plain author, iTunes uses `Author, Co-Author`), title prefix collision after colon→underscore substitution, and zero-match disambiguation edge cases.
+
+**~6,719 missing-file-repair unresolved** — books whose organizer-root paths cannot be found
+anywhere (not in iTunes, not as flat M4B). Many are likely Deluge-only files not yet imported.
+
+- [ ] **RELINK-1** Apply 13 manual path fixes from the report — bot-task spec: [`docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md`](docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md)
+- [ ] **RELINK-2** Co-author dir matching: when first-word search returns no M4B, try all dirs where author's surname appears (not just first match) — fix in `internal/server/maintenance_fixups.go` `findInITunes`
+- [ ] **RELINK-3** Title prefix colon→underscore normalization: normalize both stored title and filename candidate before prefix comparison
+- [ ] **RELINK-4** `GET /api/v1/maintenance/relink-report` — endpoint that re-runs the dry-run and returns unresolved cases with their `why_unresolved` annotations (feeds a UI modal)
+- [ ] **RELINK-5** Bulk-import Deluge files into library for the ~6,719 that are Deluge-only — depends on Deluge Protected Paths (see below)
+
+---
+
+## 📡 Activity Feed — Follow-up Gaps
+
+PRs #509, #518, #521 wired batch logging + EmitInfo summaries + no-op tag filtering for
+the four scheduler-driven maintenance ops. A few gaps remain:
+
+- [ ] **ACT-1** Other scheduler ops (series-normalize, dedup-scan, bleve-index-rebuild) don't call `EmitInfo` — audit all `triggerOperation` call sites for missing summary lines
+- [ ] **ACT-2** `info`-tier entries not shown by default in the tier filter (currently only audit/change/digest are on by default) — confirm `info` tier entries from EmitInfo actually appear; add `info` to default-on tiers if not
+- [ ] **ACT-3** Batch noun for `isbn-enrich` in `batcher.go` is missing — `batchNoun` returns `"isbn-enrich entries"` (fallthrough); add a case `"isbn-enrich": return "books enriched with ISBN"` for nicer batch row labels
 
 ---
 
@@ -341,10 +378,36 @@ Every plan in chronological order. ✅ = implemented, ⏳ = design done, plan wr
 - [2026-04-11 chromem-go embedding store](docs/superpowers/specs/2026-04-11-chromem-go-embedding-store.md) — design only, no plan yet
 - [2026-04-28 Unified maintenance system](docs/superpowers/specs/2026-04-28-unified-maintenance-system.md) — MaintenanceJob interface + registry + dispatcher (ASYNC-CORE + W1-W3 + CLEAN-1; awaiting Opus review)
 - [2026-04-28 PR label dependency system](docs/superpowers/specs/2026-04-28-pr-label-dependencies.md) — GitHub label-based prerequisite tracking for multi-wave burndown bot work
+- [2026-04-29 iTunes relink manual fixes](docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md) — bot-task spec for applying 13 known manual path corrections (RELINK-1)
 
 ---
 
 ## ✅ Recently Completed
+
+### Session 23 (2026-04-29) — metadata pipeline + activity feed + ratings (#507–#521)
+
+**15 PRs merged** across one session:
+
+- **#507** `feat(relink)`: iTunes relink endpoint — 3-tier path resolver (same-dir M4B → flat iTunes search → disambiguation), dir-grouping, 94.7% success on ~8K broken paths. 13 unresolved cases documented in `docs/reports/unresolved-relinks-2026-04-28.md`.
+- **#508** `feat(metadata)`: async resumable bulk-fetch-metadata for full library
+- **#509** `fix(activity)`: wire `LogBatch` into purge-deleted, isbn-enrichment, temp-file-cleanup, missing-file-repair; rename `missing_file_repair` → `missing-file-repair` (dash consistency)
+- **#510** `fix(mocks)`: add missing `GetAllBookFiles` typed expecter to `MockStore` (unblocked `TestMockStore_Coverage`)
+- **#511** `fix(maintenance)`: `revert-metadata-fetch` endpoint
+- **#512** `fix(metadata)`: bulk-fetch-metadata no longer auto-applies
+- **#513** `feat(metadata)`: `prefer_audible` and `skip_cached` options for bulk-fetch
+- **#514** `fix(audible)`: json/v2 compat — `DiscardUnknownMembers` + nullable `RuntimeLengthMin`
+- **#515** `feat(audible)`: map `runtime_length_min` → `DurationSec` → `Book.Duration`
+- **#516** `feat(ratings)`: full Audible (5 dims + count + reviews) + Google Books (rating + count) rating dimensions ingested and stored
+- **#517** `feat(db)`: reserve user rating columns (`user_rating_overall/story/performance/notes`) on `books` table
+- **#518** `fix(activity)`: emit EmitInfo summary entries so maintenance ops show content in activity log (not just start/complete)
+- **#519** `fix(ui)`: MetadataReviewDialog refresh, regex filter, correct pagination + Deluge timeout fix
+- **#520** `feat(scoring)`: duration-based candidate ranking from Audible runtime
+- **#521** `feat(activity)`: no-op tag filtering — `EmitInfo` variadic tags, `NoOpTag`/`TagsIf` helpers, `ExcludeTags` SQL + HTTP param, frontend "hide no-op" chip (default on)
+
+Missing-file-repair scan results: **9,034 fixed**, 36 ambiguous, **6,719 unresolved** (see RELINK-5).
+CI: disabled Docker in prerelease workflow (was exhausting 14GB GitHub runner disk).
+
+---
 
 ### Sessions 21-22 (2026-04-16) — feature foundations + v0.209.0/v0.210.0
 

--- a/docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md
@@ -1,0 +1,262 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890 -->
+
+# BOT TASK: Apply Manual iTunes Relink Fixes
+
+**TODO ID:** RELINK-1
+**Audience:** burndown bot
+**Report that drives this task:** [`docs/reports/unresolved-relinks-2026-04-28.md`](../reports/unresolved-relinks-2026-04-28.md)
+
+---
+
+## What This Task Does
+
+The iTunes relink maintenance job (PR #507) auto-resolved ~94.7% of broken
+organizer-root book paths. A small number of books were left unresolved because
+of co-author directory mismatches, colon-vs-underscore title prefix mismatches,
+or series-prefix filenames. This task applies manual fixes for the ones where the
+correct iTunes file was identified by hand.
+
+**You must NOT invent or guess any file paths or book IDs.** Every value you use
+must come from reading the report file listed above in its entirety before doing
+anything else. If the report says a book has no iTunes file found, you must skip
+it and make no changes for that book.
+
+---
+
+## Prerequisites
+
+- PR #507 (`feat/broken-book-paths`) is merged. If it is not, stop and report that.
+- You have access to the production API. The base URL and admin API key are in the
+  repo `.env` file (`AUDIOBOOK_ORGANIZER_ADMIN_API_KEY` and `AUDIOBOOK_ORGANIZER_BASE_URL`).
+  Read `.env` with the Read tool before making any API calls.
+- You have `curl` available in the shell.
+
+---
+
+## Branch
+
+```
+fix/relink-1-manual-path-fixes
+```
+
+Create this branch from main. This task makes **no code changes** — it calls the
+existing admin API and documents results. The only file changes are to this task
+file (mark done) and CHANGELOG.md (add entry). Everything else happens via API
+calls.
+
+---
+
+## Step 1 — Read the report
+
+Read [`docs/reports/unresolved-relinks-2026-04-28.md`](../reports/unresolved-relinks-2026-04-28.md)
+in full. For each numbered entry, extract:
+
+- Book ID (the `01K...` ULID string after `**Book ID:**`)
+- Whether an iTunes file was found (look for `✅` in the summary table at the bottom)
+- The iTunes file path (the path after `**iTunes file:**`)
+
+Do this extraction before proceeding. Do not proceed if the file does not exist.
+
+---
+
+## Step 2 — Read .env
+
+Read the `.env` file at the repo root. Extract:
+
+- `AUDIOBOOK_ORGANIZER_BASE_URL` — call it `$BASE_URL` in curl commands below
+- `AUDIOBOOK_ORGANIZER_ADMIN_API_KEY` — call it `$API_KEY` in curl commands below
+
+Do not print these values to your response text. Use them only in shell commands.
+
+---
+
+## Step 3 — For each book with a confirmed iTunes path: call the patch endpoint
+
+For every entry in the report whose summary table row has `✅` (file found), do
+the following. Do them **one at a time** — call the API, wait for the response,
+check it, then proceed to the next. Do not batch them.
+
+The endpoint to call is:
+
+```
+PATCH $BASE_URL/api/v1/audiobooks/{BOOK_ID}/files/primary-path
+```
+
+The request body is:
+
+```json
+{
+  "new_path": "<exact iTunes file path from the report>"
+}
+```
+
+Do not alter the path in any way. Copy it exactly as written in the report.
+
+The curl command template is:
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"new_path": "<path from report>"}' \
+  "$BASE_URL/api/v1/audiobooks/<BOOK_ID>/files/primary-path"
+```
+
+**What to do with the response:**
+
+- HTTP 200: success. Record `BOOK_ID: OK` in your working notes.
+- HTTP 404: book not found in DB. Record `BOOK_ID: SKIP — book not found`.
+- HTTP 409: path conflict. Record `BOOK_ID: SKIP — path conflict, needs investigation`.
+- Any other error: record `BOOK_ID: ERROR — <status> <body>` and continue with
+  the remaining books. Do not abort the whole task for one error.
+
+**If the endpoint `primary-path` does not exist (returns 404 on the endpoint itself,
+not the resource):** the endpoint shape may have changed. In that case, fall back to
+the relink endpoint:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"book_ids": ["<BOOK_ID>"], "dry_run": false}' \
+  "$BASE_URL/api/v1/maintenance/relink-missing-to-itunes"
+```
+
+Only use this fallback if the primary-path endpoint consistently returns 404 on
+the endpoint URL for multiple books (not just the resource).
+
+---
+
+## Step 4 — For each book with no iTunes file found: run a shell search
+
+For every entry in the report whose summary table row has `❌` (not found), SSH
+into the production server and run the `find` command listed in that entry's
+**Manual fix** section. Copy the raw shell output exactly into your working notes.
+Do not modify any files or make any API calls for these books. Leave them for a
+human to resolve.
+
+The SSH address for the production server is in `memory/reference_server.md` —
+read that file before SSHing.
+
+---
+
+## Step 5 — Verify each successful fix
+
+For each BOOK_ID you recorded as `OK`, verify the update took effect:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $API_KEY" \
+  "$BASE_URL/api/v1/audiobooks/<BOOK_ID>"
+```
+
+Check that the `file_path` field in the response matches the iTunes path you sent.
+If it does not match, record `BOOK_ID: VERIFY FAILED — path did not update`.
+
+---
+
+## Step 6 — Write results to a follow-up report
+
+Create the file `docs/reports/relink-manual-fixes-result-2026-04-29.md` with
+this exact structure. For the not-found section, create one sub-section per `❌`
+entry using the book title from the report as the heading.
+
+```markdown
+# iTunes Relink Manual Fix Results — 2026-04-29
+
+## Applied Fixes
+
+| Book ID | Title | Result |
+|---------|-------|--------|
+| ... | ... | OK / SKIP / ERROR / VERIFY FAILED |
+
+## Not-Found Books — Search Output
+
+### <title from report, entry N>
+<paste raw find output here>
+
+(repeat for every ❌ entry in the report)
+
+## Summary
+
+- Fixed: N
+- Skipped: N
+- Errors: N
+- Not in iTunes (manual resolution needed): N
+```
+
+Fill in every cell. Do not leave any cell blank. The titles in the Not-Found
+section come from the report — copy them exactly as written.
+
+---
+
+## Step 7 — Update CHANGELOG.md
+
+Prepend to the top of `CHANGELOG.md` (above the existing first entry, below the
+header block if one exists):
+
+```markdown
+## [Unreleased]
+
+### Fixed
+- Applied manual iTunes path fixes for N books unresolved by the auto-relink
+  endpoint (co-author dir mismatch, colon/underscore title prefix mismatch,
+  series-prefix filenames). Results: `docs/reports/relink-manual-fixes-result-2026-04-29.md`
+```
+
+Replace `N` with the actual count of books successfully fixed.
+
+---
+
+## Step 8 — Commit and open PR
+
+Stage only these files:
+
+```bash
+git add docs/reports/relink-manual-fixes-result-2026-04-29.md CHANGELOG.md
+```
+
+Commit message:
+
+```
+fix(relink): apply 13 manual iTunes path fixes (RELINK-1)
+
+8 books had confirmed iTunes paths (colon/underscore mismatch, co-author
+dir). 4 books not found in iTunes — documented in follow-up report.
+1 book mapped via part-number scheme (Book 3 → Part 3).
+
+Results: docs/reports/relink-manual-fixes-result-2026-04-29.md
+```
+
+Open a PR:
+
+```bash
+gh pr create \
+  --title "fix(relink): apply manual iTunes path fixes (RELINK-1)" \
+  --body "Applies the 13 manual path fixes identified in the unresolved-relinks
+report. 8 books patched via admin API. 4 confirmed absent from iTunes —
+documented for human review.
+
+Results file: docs/reports/relink-manual-fixes-result-2026-04-29.md
+
+Closes RELINK-1."
+```
+
+---
+
+## What NOT to Do
+
+- Do NOT modify any Go source files.
+- Do NOT modify any migration files.
+- Do NOT modify `docs/reports/unresolved-relinks-2026-04-28.md` (that is the input report, not the output).
+- Do NOT guess any file path. Every path comes from the report.
+- Do NOT apply fixes for books where the report says `❌` (not found in iTunes).
+- Do NOT merge the PR yourself. Leave it for a human to review.
+
+---
+
+## Done
+
+Mark RELINK-1 as `[x]` in TODO.md once the PR is open and the results file is written.


### PR DESCRIPTION
## Summary

- Updates TODO.md for session 23 (PRs #507–#521): marks completed items, adds three new outstanding work sections
- Adds bot-task spec for RELINK-1 (13 manual iTunes path fixes)

## New TODO sections

- **User Ratings** — expanded with what shipped (#516 Audible/Google ratings, #517 user columns, #520 duration scoring) and what's still pending (UI, filter, PATCH endpoint)
- **RELINK-1..5** — iTunes relink unresolved cases: 13 manual fixes, co-author dir algorithm improvement, title colon/underscore normalisation, report endpoint, Deluge bulk import
- **ACT-1..3** — Activity feed gaps: audit other scheduler ops for EmitInfo, confirm `info` tier default visibility, add `isbn-enrich` noun to batchNoun()

## Bot-task spec

`docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md` — spec for RELINK-1. Contains zero personal library data; all book IDs and paths are read at runtime from the existing report file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)