### PR TITLE
docs(burndown): add 12 bot-task/spec files + wire TODO.md bot-task links

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,11 +54,11 @@ PR #520 wires Audible `runtime_length_min` into candidate scoring. Still needed:
 - [x] Google Books ratings ingested (rating + count) — PR #516
 - [x] User rating columns reserved on `books` table — PR #517
 - [x] Duration scoring for candidates from Audible runtime — PR #520
-- [ ] `PATCH /api/v1/audiobooks/:id/rating` — accepts `{overall, story, performance, notes}`
-- [ ] Book detail UI: star rating widget with three dimensions (overall / story / performance)
-- [ ] Show Audible/Google ratings in MetadataReviewDialog candidate cards
-- [ ] Library search/filter: "my overall > 4", "my performance < 3", etc.
-- [ ] Bulk rating view / quick-rate from list
+- [ ] **RATE-1** `PATCH /api/v1/audiobooks/:id/rating` — accepts `{overall, story, performance, notes}` — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-user-ratings-api.md`](docs/superpowers/bot-tasks/2026-04-29-user-ratings-api.md)
+- [ ] **RATE-2** Book detail UI: star rating widget with three dimensions (overall / story / performance)
+- [ ] **RATE-3** Show Audible/Google ratings in MetadataReviewDialog candidate cards
+- [ ] **RATE-4** Library search/filter: "my overall > 4", "my performance < 3", etc.
+- [ ] **RATE-5** Bulk rating view / quick-rate from list
 
 ---
 
@@ -71,7 +71,7 @@ Audible product was matched or the file is an abridged version.
 
 - [ ] During metadata fetch/apply: compare `runtime_length_min * 60` vs stored `book.Duration`; if delta > 600 s, log a `[WARN]` and set a `duration_mismatch` flag on the candidate result
 - [ ] `GET /api/v1/maintenance/scan-duration-mismatch` — bulk scan, returns books where Audible runtime diverges from file duration by more than a configurable threshold (default 10 min)
-- [ ] Surface in `MetadataReviewDialog`: show a yellow warning chip on the candidate row when `audible_runtime_min` and book `duration` differ by > 10 min, e.g. "⚠ runtime differs by 45 min"
+- [ ] **DUR-1** Surface in `MetadataReviewDialog`: show a yellow warning chip on the candidate row when `audible_runtime_min` and book `duration` differ by > 10 min, e.g. "⚠ runtime differs by 45 min" — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-duration-mismatch-chip.md`](docs/superpowers/bot-tasks/2026-04-29-duration-mismatch-chip.md)
 - [ ] Book detail panel: show Audible runtime alongside local duration so mismatches are obvious
 - [ ] Threshold configurable via query param `?max_delta_min=10`
 
@@ -85,9 +85,9 @@ Core rule: never edit files outside `RootDir`. Deluge files are reflinked into t
 
 Implementation steps (in order):
 
-- [ ] **DB migration**: add `deluge_hash`, `deluge_original_path`, `imported_from_deluge_at` to `book_files`
-- [ ] **`protectedPathCache`**: fetch Deluge `save_path` values at startup + 5 min TTL; merge with `config.ProtectedPaths`
-- [ ] **`importToLibrary`**: reflink `src → library_path`, update DB, call `core.move_storage` if enabled (best-effort)
+- [ ] **DELUGE-1** DB migration: add `deluge_hash`, `deluge_original_path`, `imported_from_deluge_at` to `book_files` — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-1-db-migration.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-1-db-migration.md)
+- [ ] **DELUGE-2** `protectedPathCache`: fetch Deluge `save_path` values at startup + 5 min TTL; merge with `config.ProtectedPaths` — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-2-protected-path-cache.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-2-protected-path-cache.md)
+- [ ] **DELUGE-3** `importToLibrary`: reflink `src → library_path`, update DB, call `core.move_storage` if enabled (best-effort) — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md)
 - [ ] **`WriteTagsSafe`**: pre-flight guard wrapping all tag-write call sites; falls back to `os.Copy` on non-reflink FS
 - [ ] **Migrate all call sites** to `WriteTagsSafe` (bulk write-back, single-file write, cover embed)
 - [ ] **Discovery → Import UI**: "Import" button on discovered torrent calls the import flow
@@ -108,8 +108,8 @@ of cases remain:
 anywhere (not in iTunes, not as flat M4B). Many are likely Deluge-only files not yet imported.
 
 - [ ] **RELINK-1** Apply 13 manual path fixes from the report — bot-task spec: [`docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md`](docs/superpowers/bot-tasks/2026-04-29-relink-manual-fixes.md)
-- [ ] **RELINK-2** Co-author dir matching: when first-word search returns no M4B, try all dirs where author's surname appears (not just first match) — fix in `internal/server/maintenance_fixups.go` `findInITunes`
-- [ ] **RELINK-3** Title prefix colon→underscore normalization: normalize both stored title and filename candidate before prefix comparison
+- [ ] **RELINK-2** Co-author dir matching: when first-word search returns no M4B, try all dirs where author's surname appears (not just first match) — fix in `internal/server/maintenance_fixups.go` `findInITunes` — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-relink-2-coauthor-dir.md`](docs/superpowers/bot-tasks/2026-04-29-relink-2-coauthor-dir.md)
+- [ ] **RELINK-3** Title prefix colon→underscore normalization: normalize both stored title and filename candidate before prefix comparison — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-relink-3-title-normalization.md`](docs/superpowers/bot-tasks/2026-04-29-relink-3-title-normalization.md)
 - [ ] **RELINK-4** `GET /api/v1/maintenance/relink-report` — endpoint that re-runs the dry-run and returns unresolved cases with their `why_unresolved` annotations (feeds a UI modal)
 - [ ] **RELINK-5** Bulk-import Deluge files into library for the ~6,719 that are Deluge-only — depends on Deluge Protected Paths (see below)
 
@@ -120,9 +120,9 @@ anywhere (not in iTunes, not as flat M4B). Many are likely Deluge-only files not
 PRs #509, #518, #521 wired batch logging + EmitInfo summaries + no-op tag filtering for
 the four scheduler-driven maintenance ops. A few gaps remain:
 
-- [ ] **ACT-1** Other scheduler ops (series-normalize, dedup-scan, bleve-index-rebuild) don't call `EmitInfo` — audit all `triggerOperation` call sites for missing summary lines
+- [ ] **ACT-1** Other scheduler ops (series-normalize, dedup-scan) don't call `EmitInfo` — audit all `triggerOperation` call sites for missing summary lines — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-activity-act1-emit-info.md`](docs/superpowers/bot-tasks/2026-04-29-activity-act1-emit-info.md)
 - [ ] **ACT-2** `info`-tier entries not shown by default in the tier filter (currently only audit/change/digest are on by default) — confirm `info` tier entries from EmitInfo actually appear; add `info` to default-on tiers if not
-- [ ] **ACT-3** Batch noun for `isbn-enrich` in `batcher.go` is missing — `batchNoun` returns `"isbn-enrich entries"` (fallthrough); add a case `"isbn-enrich": return "books enriched with ISBN"` for nicer batch row labels
+- [ ] **ACT-3** Batch noun for `isbn-enrich` in `batcher.go` is missing — `batchNoun` returns `"isbn-enrich entries"` (fallthrough); add a case `"isbn-enrich": return "books enriched with ISBN"` for nicer batch row labels — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-activity-act3-isbn-batch-noun.md`](docs/superpowers/bot-tasks/2026-04-29-activity-act3-isbn-batch-noun.md)
 
 ---
 
@@ -132,7 +132,7 @@ Audible's `category_ladders` response group returns a full hierarchy per book,
 e.g. `Audible Books > Science Fiction > Space Opera`. Each layer should be
 applied as a user tag on the book so browsing by genre is hierarchical, not flat.
 
-- [ ] Add `category_ladders` to `audibleResponseGroups` in `internal/metadata/audible.go`
+- [ ] **CAT-1** Add `category_ladders` to `audibleResponseGroups`, parse into `CategoryTags`, apply via `AddBookUserTag` — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-audible-category-ladders.md`](docs/superpowers/bot-tasks/2026-04-29-audible-category-ladders.md)
 - [ ] Parse ladder entries into `BookMetadata.CategoryTags []string` (all layers, e.g. `["Science Fiction", "Space Opera"]`)
 - [ ] In the apply pipeline, write each tag via `AddBookUserTag` (idempotent) with source `"audible_category"`
 - [ ] UI: show Audible-sourced category tags separately from user tags in the book detail panel

--- a/docs/superpowers/bot-tasks/2026-04-29-activity-act1-emit-info.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-activity-act1-emit-info.md
@@ -1,0 +1,263 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-activity-act1-emit-info.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7e3a9f1c-4d2b-5087-b6e8-0c4f1a7d3e92 -->
+<!-- last-edited: 2026-04-29 -->
+
+# BOT TASK: ACT-1 — Add EmitInfo to series-normalize and dedup-refresh
+
+**TODO ID:** ACT-1
+**Audience:** burndown bot
+**Branch:** `fix/activity-act1-emit-info-scheduler-ops`
+**PR title:** `fix(activity): add EmitInfo summary lines to series-normalize and dedup-refresh`
+
+---
+
+## What This Task Does
+
+Adds `activity.EmitInfo` summary lines to two scheduler tasks that currently finish
+silently with no activity log entry visible in the UI:
+
+- `series-normalize` (registered as `series_normalize` task, op type `"series-normalize"`)
+- `dedup_refresh` (registered as `dedup_refresh` task, op type `"author-dedup-scan"`)
+
+Both tasks currently use `ts.triggerOperation(...)` — a variant that does NOT pass
+`opID` to the callback. To emit an activity entry you need the `opID`. You must
+change both tasks from `triggerOperation` to `triggerOperationWithID`.
+
+**There is no `bleve-index-rebuild` task in the scheduler.** The prompt mentioned it
+as a third op, but after running `grep -n "bleve" internal/server/scheduler.go` the
+result is empty — bleve is used elsewhere but there is no scheduled rebuild task.
+Do NOT invent one. Only fix the two tasks listed above.
+
+---
+
+## What NOT to Do
+
+- **Do NOT modify any file outside `internal/server/scheduler.go`** unless you
+  also need to update the version header in a file you touch.
+- **Do NOT add a bleve-index-rebuild task.** It does not exist.
+- **Do NOT change the op type strings** (`"series-normalize"`, `"author-dedup-scan"`)
+  — those are used by the frontend and must stay the same.
+- **Do NOT remove the existing `progress.Log` calls** — keep them alongside the new
+  `EmitInfo` calls.
+- **Do NOT import any new packages.** `activity` is already imported in scheduler.go.
+
+---
+
+## Background: EmitInfo Signature
+
+```go
+// From internal/activity/api.go:
+func EmitInfo(w *Writer, operationID, entryType, source, summary string, tags ...string)
+```
+
+- `w` = `ts.server.activityWriter`
+- `operationID` = the `opID` string passed into the new `triggerOperationWithID` callback
+- `entryType` = same as the op type string (e.g. `"series-normalize"`)
+- `source` = same as the op type string (e.g. `"series-normalize"`)
+- `summary` = human-readable message string (e.g. `"Series normalize complete: 3 series fixed"`)
+- `tags` = `activity.TagsIf(count == 0, activity.NoOpTag)...`
+
+Example of an existing correct EmitInfo call (from the `temp-file-cleanup` task in
+the same file, approximately line 352):
+
+```go
+activity.EmitInfo(ts.server.activityWriter, opID, "temp-file-cleanup", "temp-file-cleanup", msg,
+    activity.TagsIf(removed == 0, activity.NoOpTag)...)
+```
+
+---
+
+## Verification: Run These Grep Commands First
+
+Run both commands and read the output before making any changes. The output tells
+you the exact line numbers so you know what to edit.
+
+```bash
+grep -n "series.normalize\|series_normalize" \
+  /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/internal/server/scheduler.go
+```
+
+Expected output includes lines similar to:
+```
+288:		Name:        "series_normalize",
+292:			return ts.triggerOperation("series-normalize", func(ctx context.Context, progress operations.ProgressReporter) error {
+302:				_, err := executeSeriesNormalizeCore(ctx, store, enqueueWB)
+303:				return err
+```
+
+```bash
+grep -n "dedup.refresh\|dedup_refresh\|author-dedup-scan" \
+  /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/internal/server/scheduler.go
+```
+
+Expected output includes lines similar to:
+```
+191:	ts.registerTask(TaskDefinition{
+192:		Name:        "dedup_refresh",
+196:			return ts.triggerOperation("author-dedup-scan", func(ctx context.Context, progress operations.ProgressReporter) error {
+224:			resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors", len(groups), total)
+```
+
+---
+
+## Change 1 — series-normalize Task
+
+### Find this exact block (approximately lines 291-304):
+
+```go
+			return ts.triggerOperation("series-normalize", func(ctx context.Context, progress operations.ProgressReporter) error {
+				store := ts.server.Store()
+				if store == nil {
+					return fmt.Errorf("database not initialized")
+				}
+				enqueueWB := func(bookID string) {
+					if ts.server.writeBackBatcher != nil {
+						ts.server.writeBackBatcher.Enqueue(bookID)
+					}
+				}
+				_, err := executeSeriesNormalizeCore(ctx, store, enqueueWB)
+				return err
+			})
+```
+
+### Replace it with:
+
+```go
+			return ts.triggerOperationWithID("series-normalize", func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
+				store := ts.server.Store()
+				if store == nil {
+					return fmt.Errorf("database not initialized")
+				}
+				enqueueWB := func(bookID string) {
+					if ts.server.writeBackBatcher != nil {
+						ts.server.writeBackBatcher.Enqueue(bookID)
+					}
+				}
+				affected, err := executeSeriesNormalizeCore(ctx, store, enqueueWB)
+				msg := fmt.Sprintf("Series normalize complete: %d series affected, %d books enqueued for write-back",
+					len(affected), len(affected))
+				_ = progress.Log("info", msg, nil)
+				activity.EmitInfo(ts.server.activityWriter, opID, "series-normalize", "series-normalize", msg,
+					activity.TagsIf(len(affected) == 0, activity.NoOpTag)...)
+				return err
+			})
+```
+
+**What changed:**
+1. `triggerOperation` → `triggerOperationWithID`
+2. Callback now receives `opID string` as third parameter
+3. `_, err :=` changed to `affected, err :=` so we can use the returned slice length
+4. Added `msg` variable, `progress.Log`, and `activity.EmitInfo` after the call
+
+---
+
+## Change 2 — dedup_refresh Task
+
+### Find this exact block (approximately lines 224-228):
+
+```go
+				resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors", len(groups), total)
+				_ = progress.Log("info", resultMsg, nil)
+				_ = progress.UpdateProgress(100, 100, resultMsg)
+				return nil
+			})
+```
+
+This block is inside the `triggerOperation("author-dedup-scan", ...)` callback.
+
+### Step 2a — Change `triggerOperation` to `triggerOperationWithID`
+
+Find (approximately line 196):
+
+```go
+			return ts.triggerOperation("author-dedup-scan", func(ctx context.Context, progress operations.ProgressReporter) error {
+```
+
+Replace with:
+
+```go
+			return ts.triggerOperationWithID("author-dedup-scan", func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
+```
+
+### Step 2b — Add EmitInfo after the existing resultMsg block
+
+Find (approximately lines 224-227, now with `opID` available):
+
+```go
+				resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors", len(groups), total)
+				_ = progress.Log("info", resultMsg, nil)
+				_ = progress.UpdateProgress(100, 100, resultMsg)
+				return nil
+```
+
+Replace with:
+
+```go
+				resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors", len(groups), total)
+				_ = progress.Log("info", resultMsg, nil)
+				_ = progress.UpdateProgress(100, 100, resultMsg)
+				activity.EmitInfo(ts.server.activityWriter, opID, "author-dedup-scan", "author-dedup-scan", resultMsg,
+					activity.TagsIf(len(groups) == 0, activity.NoOpTag)...)
+				return nil
+```
+
+**What changed:**
+1. `triggerOperation` → `triggerOperationWithID` (step 2a above)
+2. Callback now receives `opID string` as third parameter (step 2a above)
+3. Added `activity.EmitInfo` call after `progress.UpdateProgress` (step 2b above)
+
+---
+
+## Step 3 — Bump the Version Header
+
+Open `internal/server/scheduler.go`. The first three lines look like:
+
+```
+// file: internal/server/scheduler.go
+// version: 1.17.2
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+Increment the patch version: change `1.17.2` → `1.17.3`.
+
+---
+
+## Step 4 — Verify Build and Tests
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./...
+go test ./internal/server/...
+```
+
+Both must pass with zero errors. The most likely failure is a type mismatch if
+you forgot to change the callback signature from two parameters to three. If that
+happens, re-read the diff above carefully.
+
+---
+
+## Step 5 — Commit and Open PR
+
+```bash
+git checkout -b fix/activity-act1-emit-info-scheduler-ops
+git add internal/server/scheduler.go
+git commit -m "fix(activity): add EmitInfo summary lines to series-normalize and dedup-refresh"
+git push -u origin fix/activity-act1-emit-info-scheduler-ops
+gh pr create \
+  --title "fix(activity): add EmitInfo summary lines to series-normalize and dedup-refresh" \
+  --body "Changes both tasks from triggerOperation to triggerOperationWithID so they get an opID, then emits an activity.EmitInfo summary line at completion. Adds no-op tag when zero items are affected."
+```
+
+---
+
+## Checklist
+
+- [ ] Grep commands run and output read before making any edits
+- [ ] `series_normalize` task: `triggerOperation` → `triggerOperationWithID`, opID added, EmitInfo added
+- [ ] `dedup_refresh` task: `triggerOperation` → `triggerOperationWithID`, opID added, EmitInfo added
+- [ ] No bleve task invented or added
+- [ ] Version header in `scheduler.go` bumped to `1.17.3`
+- [ ] `go build ./...` passes
+- [ ] `go test ./internal/server/...` passes
+- [ ] PR opened with correct branch and title

--- a/docs/superpowers/bot-tasks/2026-04-29-activity-act3-isbn-batch-noun.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-activity-act3-isbn-batch-noun.md
@@ -1,0 +1,162 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-activity-act3-isbn-batch-noun.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2f8b4c6e-1a3d-5079-e7f1-9d5b0c2a4e83 -->
+<!-- last-edited: 2026-04-29 -->
+
+# BOT TASK: ACT-3 — Fix isbn-enrich Batch Noun Label
+
+**TODO ID:** ACT-3
+**Audience:** burndown bot
+**Branch:** `fix/activity-act3-isbn-batch-noun`
+**PR title:** `fix(activity): add isbn-enrich batch noun label`
+
+---
+
+## What This Task Does
+
+This is a **one-line change**. The `batchNoun` function in
+`internal/activity/batcher.go` has a `case "isbn-enrich":` that currently returns
+`"ISBN enrichments"`. The correct return value should be `"books enriched with ISBN"`
+to match the UI label used by the ISBN enrichment operation.
+
+---
+
+## What NOT to Do
+
+- **Do NOT modify any other code** in `batcher.go` or anywhere else.
+- **Do NOT delete any existing case** in the switch statement.
+- **Do NOT add new cases** other than the one isbn-enrich fix.
+- **Do NOT modify the case key string** — it must remain exactly `"isbn-enrich"`
+  (with a hyphen, not an underscore).
+- This is a one-line change. If you find yourself editing more than one line, stop
+  and re-read this file.
+
+---
+
+## Step 1 — Run Grep to Find the Exact Location
+
+Run this command and read the output carefully:
+
+```bash
+grep -n "batchNoun\|isbn-enrich" \
+  /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/internal/activity/batcher.go
+```
+
+Expected output:
+```
+174:	noun := batchNoun(key.Type)
+200:// batchNoun returns a human-readable plural noun for a batch type.
+201:func batchNoun(batchType string) string {
+211:	case "isbn-enrich":
+212:		return "ISBN enrichments"
+```
+
+The line you need to change is line 212 (the `return` inside `case "isbn-enrich":`).
+The exact line number may differ slightly — use the grep output to find it.
+
+---
+
+## Step 2 — Make the Change
+
+Open `internal/activity/batcher.go`.
+
+Find this exact text (two lines):
+
+```go
+	case "isbn-enrich":
+		return "ISBN enrichments"
+```
+
+Replace it with:
+
+```go
+	case "isbn-enrich":
+		return "books enriched with ISBN"
+```
+
+That is the entire change. One line edited. Nothing else.
+
+---
+
+## Step 3 — Confirm the Full Switch Statement Looks Correct
+
+After your edit, the `batchNoun` function should look exactly like this:
+
+```go
+// batchNoun returns a human-readable plural noun for a batch type.
+func batchNoun(batchType string) string {
+	switch batchType {
+	case "embedded-tag-load":
+		return "embedded tag loads"
+	case "tag-scan":
+		return "tag scans"
+	case "metadata-apply":
+		return "metadata applies"
+	case "path-repair":
+		return "path repairs"
+	case "isbn-enrich":
+		return "books enriched with ISBN"
+	case "temp-file-cleanup":
+		return "orphaned temp files removed"
+	case "missing-file-repair":
+		return "missing files repaired"
+	case "purge-deleted":
+		return "purge errors"
+	default:
+		return batchType + " operations"
+	}
+}
+```
+
+If it does not look like this, you made an error. Undo and redo.
+
+---
+
+## Step 4 — Bump the Version Header
+
+Open `internal/activity/batcher.go`. The first three lines look like:
+
+```
+// file: internal/activity/batcher.go
+// version: 1.1.0
+// guid: 7f3c1a2e-8b4d-4e9f-a5c6-2d0e3b7f9a1c
+```
+
+Increment the patch version: change `1.1.0` → `1.1.1`.
+
+---
+
+## Step 5 — Verify Tests Pass
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go test ./...
+```
+
+All tests must pass. This change cannot break any test. If a test fails, it is
+unrelated to your change — read the failure carefully before touching anything else.
+
+---
+
+## Step 6 — Commit and Open PR
+
+```bash
+git checkout -b fix/activity-act3-isbn-batch-noun
+git add internal/activity/batcher.go
+git commit -m "fix(activity): add isbn-enrich batch noun label"
+git push -u origin fix/activity-act3-isbn-batch-noun
+gh pr create \
+  --title "fix(activity): add isbn-enrich batch noun label" \
+  --body "One-line fix: changes batchNoun(\"isbn-enrich\") to return \"books enriched with ISBN\" instead of \"ISBN enrichments\", matching the UI label for the ISBN enrichment operation."
+```
+
+---
+
+## Checklist
+
+- [ ] Grep command run and line number confirmed before editing
+- [ ] Exactly one line changed in `internal/activity/batcher.go`
+- [ ] `case "isbn-enrich": return "books enriched with ISBN"` is the only change
+- [ ] Version header in `batcher.go` bumped to `1.1.1`
+- [ ] `go test ./...` passes
+- [ ] PR opened with correct branch and title

--- a/docs/superpowers/bot-tasks/2026-04-29-audible-category-ladders.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-audible-category-ladders.md
@@ -1,0 +1,473 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-audible-category-ladders.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8c4b2d1f-7e3a-4f9c-b5d2-1a6e0c8f3b74 -->
+<!-- last-edited: 2026-04-29 -->
+
+# Bot Task: CAT-1 — Audible Category Ladders
+
+> **Read every word.** Do exactly what is written. Do not guess, do not
+> improvise, do not add extra changes. If something is unclear, STOP and ask.
+
+---
+
+## Goal
+
+Ingest Audible's `category_ladders` API data into the book tag system so that
+genre categories (e.g. "Science Fiction", "Space Opera") are stored as user tags
+with `source = "audible_category"` when a metadata candidate is applied.
+
+---
+
+## Files You Will Touch
+
+| File | What changes |
+|------|--------------|
+| `internal/metadata/audible.go` | Add response group, add structs, populate `CategoryTags` |
+| `internal/metadata/openlibrary.go` | Add `CategoryTags []string` to `BookMetadata` |
+| `internal/metafetch/service.go` | After apply, loop over `CategoryTags` and call `AddBookUserTag` |
+| `internal/metadata/audible_test.go` | New unit test for category ladder parsing |
+
+Do NOT touch any other file unless explicitly told to.
+
+---
+
+## Step 1 — `internal/metadata/audible.go`
+
+### 1a. Add `"category_ladders"` to the response groups constant
+
+Find this exact line (line 104):
+
+```go
+const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series,rating"
+```
+
+Replace it with:
+
+```go
+const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series,rating,category_ladders"
+```
+
+### 1b. Add the two new structs
+
+Find the closing brace of `audibleSeries` (which ends around line 102):
+
+```go
+type audibleSeries struct {
+	ASIN     string `json:"asin"`
+	Title    string `json:"title"`
+	Sequence string `json:"sequence"`
+}
+```
+
+IMMEDIATELY AFTER that closing brace (before the blank line before `const`),
+insert:
+
+```go
+type audibleCategoryNode struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type audibleCategoryLadder struct {
+	Ladder []audibleCategoryNode `json:"ladder"`
+	Root   string                `json:"root"`
+}
+```
+
+### 1c. Add `CategoryLadders` field to `audibleProduct`
+
+Find the `audibleProduct` struct. It currently ends with:
+
+```go
+	Rating               *audibleRating    `json:"rating"`
+}
+```
+
+Replace that closing section with:
+
+```go
+	Rating               *audibleRating         `json:"rating"`
+	CategoryLadders      []audibleCategoryLadder `json:"category_ladders"`
+}
+```
+
+### 1d. Populate `CategoryTags` in `productToMetadata`
+
+Find the end of `productToMetadata`. It currently ends with:
+
+```go
+	// Ratings: overall, narrator performance, story quality.
+	if p.Rating != nil {
+		meta.AudibleRatingOverall = p.Rating.OverallDistribution.DisplayAverageRating
+		meta.AudibleRatingPerformance = p.Rating.PerformanceDistribution.DisplayAverageRating
+		meta.AudibleRatingStory = p.Rating.StoryDistribution.DisplayAverageRating
+		meta.AudibleRatingCount = p.Rating.OverallDistribution.NumRatings
+		meta.AudibleNumReviews = p.Rating.NumReviews
+	}
+
+	return meta
+}
+```
+
+Replace that block with:
+
+```go
+	// Ratings: overall, narrator performance, story quality.
+	if p.Rating != nil {
+		meta.AudibleRatingOverall = p.Rating.OverallDistribution.DisplayAverageRating
+		meta.AudibleRatingPerformance = p.Rating.PerformanceDistribution.DisplayAverageRating
+		meta.AudibleRatingStory = p.Rating.StoryDistribution.DisplayAverageRating
+		meta.AudibleRatingCount = p.Rating.OverallDistribution.NumRatings
+		meta.AudibleNumReviews = p.Rating.NumReviews
+	}
+
+	// Category ladders: collect all node names from all ladders, deduplicate.
+	// Each ladder is a path from broad to specific (e.g. "Science Fiction" →
+	// "Space Opera"). The Root field is a navigation bucket, not a genre — skip it.
+	if len(p.CategoryLadders) > 0 {
+		seen := map[string]struct{}{}
+		tags := make([]string, 0)
+		for _, ladder := range p.CategoryLadders {
+			for _, node := range ladder.Ladder {
+				name := strings.TrimSpace(node.Name)
+				if name == "" {
+					continue
+				}
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					tags = append(tags, name)
+				}
+			}
+		}
+		if len(tags) > 0 {
+			meta.CategoryTags = tags
+		}
+	}
+
+	return meta
+}
+```
+
+---
+
+## Step 2 — `internal/metadata/openlibrary.go`
+
+This file contains the `BookMetadata` struct (around line 104). Find it:
+
+```go
+// BookMetadata represents enriched book metadata
+type BookMetadata struct {
+	Title          string
+	Author         string
+	Narrator       string
+	Description    string
+	Publisher      string
+	PublishYear    int
+	ISBN           string
+	ASIN           string
+	CoverURL       string
+	Language       string
+	Genre          string
+	Series         string
+	SeriesPosition string
+	DurationSec int // audio runtime in seconds (Audible: runtime_length_min × 60)
+```
+
+Find the closing brace of the struct (after the Google ratings fields). Add
+`CategoryTags` as the last field before the closing `}`:
+
+```go
+	// CategoryTags contains genre/subject tags from Audible's category_ladders
+	// response group. Each element is a ladder node name (e.g. "Science Fiction",
+	// "Space Opera"). Applied as book_tags with source="audible_category".
+	CategoryTags []string
+}
+```
+
+The full struct tail (what you are replacing) looks like:
+
+```go
+	// Google Books rating (1–5 scale).
+	GoogleRatingAverage float64
+	GoogleRatingCount   int
+}
+```
+
+Replace it with:
+
+```go
+	// Google Books rating (1–5 scale).
+	GoogleRatingAverage float64
+	GoogleRatingCount   int
+
+	// CategoryTags contains genre/subject tags from Audible's category_ladders
+	// response group. Each element is a ladder node name (e.g. "Science Fiction",
+	// "Space Opera"). Applied as book_tags with source="audible_category".
+	CategoryTags []string
+}
+```
+
+---
+
+## Step 3 — `internal/metafetch/service.go`
+
+### 3a. Find the right insertion point
+
+Open `internal/metafetch/service.go`. Find the function `ApplyMetadataCandidate`
+(around line 2502). Inside that function, find the call to
+`mfs.ApplyMetadataSystemTags`:
+
+```go
+	mfs.ApplyMetadataSystemTags(id, candidate.Source, meta.Language)
+```
+
+### 3b. Insert the category tag loop AFTER that call
+
+Replace:
+
+```go
+	mfs.ApplyMetadataSystemTags(id, candidate.Source, meta.Language)
+
+	// Intentionally keep the metadata fetch cache after apply.
+```
+
+With:
+
+```go
+	mfs.ApplyMetadataSystemTags(id, candidate.Source, meta.Language)
+
+	// Apply Audible category ladder tags. These are additive enrichment — they
+	// are not controlled by the fields allowlist and do not fail the apply if
+	// a tag write errors.
+	for _, tag := range meta.CategoryTags {
+		if err := mfs.db.AddBookUserTag(id, tag, "audible_category"); err != nil {
+			log.Printf("[WARN] failed to apply category tag %q to book %s: %v", tag, id, err)
+		}
+	}
+
+	// Intentionally keep the metadata fetch cache after apply.
+```
+
+### 3c. Verify the meta variable has CategoryTags
+
+In `ApplyMetadataCandidate`, the `meta` variable is built from `candidate` fields.
+The `CategoryTags` field is NOT in `MetadataCandidate` — it comes from
+`BookMetadata` returned by the Audible client. However, the apply path receives
+a `MetadataCandidate` (the stored search result), not the raw `BookMetadata`.
+
+This means `meta.CategoryTags` will always be nil in the apply path UNLESS we
+also add `CategoryTags` to `MetadataCandidate` and wire it through the search
+result serialization.
+
+**Do the following additional changes:**
+
+#### 3c-i. Add `CategoryTags` to `MetadataCandidate` struct
+
+Find `MetadataCandidate` struct (around line 137):
+
+```go
+type MetadataCandidate struct {
+	Title          string  `json:"title"`
+	Author         string  `json:"author"`
+	...
+	DurationDeltaSec int `json:"duration_delta_sec,omitempty"`
+}
+```
+
+Add this field at the end (before the closing `}`):
+
+```go
+	// CategoryTags holds Audible category ladder node names (e.g. "Science Fiction").
+	// Only populated for Audible-sourced candidates. Applied as book_tags on apply.
+	CategoryTags []string `json:"category_tags,omitempty"`
+```
+
+#### 3c-ii. Populate `CategoryTags` in the candidate builder
+
+Search for the function that converts `BookMetadata` to `MetadataCandidate`.
+Grep for: `MetadataCandidate{` to find where candidates are constructed from
+`BookMetadata`. It will look something like:
+
+```go
+candidate := MetadataCandidate{
+    Title:    meta.Title,
+    Author:   meta.Author,
+    ...
+    Source:   source,
+    Score:    score,
+}
+```
+
+Add `CategoryTags: meta.CategoryTags,` to every such construction site where
+`meta` is a `metadata.BookMetadata`. Do NOT add it to construction sites that
+build from DB records or other non-BookMetadata sources.
+
+#### 3c-iii. Use `candidate.CategoryTags` in `ApplyMetadataCandidate`
+
+In step 3b above, the loop uses `meta.CategoryTags`. Since `meta` is built from
+`candidate` fields in `ApplyMetadataCandidate`, change the loop to use
+`candidate.CategoryTags` directly (not `meta.CategoryTags`):
+
+```go
+	// Apply Audible category ladder tags. These are additive enrichment — they
+	// are not controlled by the fields allowlist and do not fail the apply if
+	// a tag write errors.
+	for _, tag := range candidate.CategoryTags {
+		if err := mfs.db.AddBookUserTag(id, tag, "audible_category"); err != nil {
+			log.Printf("[WARN] failed to apply category tag %q to book %s: %v", tag, id, err)
+		}
+	}
+```
+
+---
+
+## Step 4 — Tests
+
+### 4a. Unit test: category ladder parsing (audible_test.go)
+
+File: `internal/metadata/audible_test.go`
+
+Add this test function. If the file does not exist, create it with the
+appropriate package declaration `package metadata`:
+
+```go
+func TestProductToMetadata_CategoryLadders(t *testing.T) {
+	client := NewAudibleClientWithBaseURL("http://unused")
+
+	p := &audibleProduct{
+		ASIN:  "B08G9PRS1K",
+		Title: "Test Book",
+		CategoryLadders: []audibleCategoryLadder{
+			{
+				Root: "Audible Books & Originals",
+				Ladder: []audibleCategoryNode{
+					{ID: "18685580011", Name: "Science Fiction & Fantasy"},
+					{ID: "18685589011", Name: "Science Fiction"},
+					{ID: "18685594011", Name: "Space Opera"},
+				},
+			},
+			{
+				Root: "Audible Books & Originals",
+				Ladder: []audibleCategoryNode{
+					{ID: "18685580011", Name: "Science Fiction & Fantasy"},
+					{ID: "18685589011", Name: "Science Fiction"},
+				},
+			},
+		},
+	}
+
+	meta := client.productToMetadata(p)
+
+	// Expect 3 unique tags (deduplication across overlapping ladders)
+	want := []string{"Science Fiction & Fantasy", "Science Fiction", "Space Opera"}
+	if len(meta.CategoryTags) != len(want) {
+		t.Fatalf("CategoryTags: got %d tags, want %d: %v", len(meta.CategoryTags), len(want), meta.CategoryTags)
+	}
+	for i, w := range want {
+		if meta.CategoryTags[i] != w {
+			t.Errorf("CategoryTags[%d]: got %q, want %q", i, meta.CategoryTags[i], w)
+		}
+	}
+}
+
+func TestProductToMetadata_NoCategoryLadders(t *testing.T) {
+	client := NewAudibleClientWithBaseURL("http://unused")
+
+	p := &audibleProduct{
+		ASIN:  "B000001",
+		Title: "No Genres",
+	}
+
+	meta := client.productToMetadata(p)
+
+	if meta.CategoryTags != nil {
+		t.Errorf("expected nil CategoryTags when no ladders, got: %v", meta.CategoryTags)
+	}
+}
+```
+
+### 4b. Integration test: AddBookUserTag is called
+
+In `internal/metafetch/service_mock_test.go` (or a new file
+`internal/metafetch/category_tags_test.go`), add a test that:
+
+1. Builds a `MetadataCandidate` with `CategoryTags: []string{"Mystery", "Thriller"}`.
+2. Calls `svc.ApplyMetadataCandidate(bookID, candidate, nil)`.
+3. Asserts that the mock store's `AddBookUserTag` was called twice — once with
+   `("Mystery", "audible_category")` and once with `("Thriller", "audible_category")`.
+
+Use the existing mock store pattern already present in the test file.
+
+---
+
+## Step 5 — Verify
+
+Run:
+
+```bash
+go test ./internal/metadata/... ./internal/metafetch/... ./internal/server/...
+```
+
+All tests must pass with no new failures. If a test fails, fix it before moving on.
+
+---
+
+## What NOT to Do
+
+- Do NOT remove or rename any existing fields on `audibleProduct`,
+  `BookMetadata`, or `MetadataCandidate`.
+- Do NOT change the `audibleResponseGroups` line to anything other than exactly
+  what is shown in step 1a. Do not reorder the existing groups.
+- Do NOT add `CategoryTags` to the `fields` allowlist processing in
+  `ApplyMetadataCandidate`. Category tags bypass the allowlist by design.
+- Do NOT call `AddBookUserTag` with source `"user"` or `"system"`. The source
+  must be exactly `"audible_category"`.
+- Do NOT delete category tags during re-apply. The operation is additive only.
+- Do NOT change the `book_tags` table schema. The existing schema supports this
+  without modification.
+- Do NOT add CategoryTags to the tag write-back path (audio file tags). This
+  is book_tags enrichment only.
+
+---
+
+## PR Instructions
+
+Branch name: `feat/cat-1-audible-category-ladders`
+
+```bash
+git checkout -b feat/cat-1-audible-category-ladders
+# make your changes
+git add internal/metadata/audible.go \
+        internal/metadata/openlibrary.go \
+        internal/metafetch/service.go \
+        internal/metadata/audible_test.go
+git commit -m "feat(metadata): ingest Audible category_ladders as user tags
+
+Adds category_ladders response group to the Audible API request.
+Each ladder node name is stored as a book_tag with source=audible_category
+during ApplyMetadataCandidate. Idempotent via INSERT OR IGNORE."
+git push -u origin feat/cat-1-audible-category-ladders
+gh pr create \
+  --title "feat(metadata): ingest Audible category_ladders as user tags" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds \`category_ladders\` to \`audibleResponseGroups\` constant
+- Parses ladder nodes into \`BookMetadata.CategoryTags []string\`
+- Wires \`CategoryTags\` through \`MetadataCandidate\` so they survive serialization
+- Calls \`AddBookUserTag(id, tag, \"audible_category\")\` in \`ApplyMetadataCandidate\`
+- Unit tests verify deduplication across overlapping ladders
+
+## Test plan
+- [ ] \`go test ./internal/metadata/...\` passes (new unit tests)
+- [ ] \`go test ./internal/metafetch/...\` passes (integration test)
+- [ ] Apply an Audible candidate for a known SF book; verify tags appear in UI
+- [ ] Re-apply the same candidate; verify no duplicate tags created
+EOF
+)"
+```
+
+After CI is green, merge with rebase (no squash):
+
+```bash
+gh pr merge --rebase
+```

--- a/docs/superpowers/bot-tasks/2026-04-29-deluge-1-db-migration.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-deluge-1-db-migration.md
@@ -1,0 +1,332 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-deluge-1-db-migration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3a7f2c1d-b8e5-4091-a6f3-9c2d0e4b7a85 -->
+<!-- last-edited: 2026-04-29 -->
+
+# BOT TASK: DELUGE-1 — Add Deluge Columns to book_files
+
+**TODO ID:** DELUGE-1
+**Audience:** burndown bot
+**Branch:** `feat/deluge-1-db-columns`
+**PR title:** `feat(deluge): add deluge_hash/original_path/imported_at columns to book_files`
+
+---
+
+## What This Task Does
+
+Adds three new columns to the `book_files` SQLite table:
+
+- `deluge_hash TEXT` — the Deluge torrent info-hash for this file's torrent
+- `deluge_original_path TEXT` — the original file path before it was copied into
+  the library (i.e., where it lived in the Deluge save directory)
+- `imported_from_deluge_at TIMESTAMP` — when the copy-into-library happened
+
+These columns are added via the **`ensureExtendedBookFileColumns`** pattern — NOT
+via a `.sql` migration file. Read the "What NOT to do" section carefully.
+
+---
+
+## What NOT to Do
+
+- **Do NOT create any file in `internal/database/migrations/`** (or any `.sql`
+  file anywhere). This project uses the `ensureExtended*` pattern for optional
+  columns on existing tables.
+- **Do NOT touch PebbleDB** (`internal/database/pebble_store.go`). PebbleDB is
+  schema-free JSON. Column changes only apply to SQLite.
+- **Do NOT modify `ensureExtendedBookColumns`** (which is for the `books` table).
+  You are adding a **separate** function for `book_files`.
+- **Do NOT rename or remove any existing field** from `BookFile`. Only append new
+  fields.
+- **Do NOT guess import paths.** Use exactly the imports already in the file.
+
+---
+
+## Files to Change
+
+Only these two files:
+
+1. `internal/database/store.go`
+2. `internal/database/sqlite_store.go`
+
+Do not create any new files. Do not modify any other files.
+
+---
+
+## Step 1 — Edit `internal/database/store.go`
+
+### Find the `BookFile` struct
+
+Open `internal/database/store.go`. Search for the line:
+
+```
+type BookFile struct {
+```
+
+It is at approximately line 573. The struct ends with:
+
+```go
+	OrganizeMethod        string    `json:"organize_method,omitempty"` // "reflink", "hardlink", "copy", "symlink"
+	Missing            bool      `json:"missing"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+```
+
+### Add three fields BEFORE the closing brace `}`
+
+Add the following three lines immediately before `}` (the closing brace of `BookFile`):
+
+```go
+	// Deluge integration fields (spec: deluge-protected-paths-design).
+	// DelugeHash is the torrent info-hash (40-char hex string).
+	// DelugeOriginalPath is the file path before copy-into-library.
+	// ImportedFromDelugeAt is when the copy completed.
+	DelugeHash             string     `json:"deluge_hash,omitempty"`
+	DelugeOriginalPath     string     `json:"deluge_original_path,omitempty"`
+	ImportedFromDelugeAt   *time.Time `json:"imported_from_deluge_at,omitempty"`
+```
+
+**Column types explanation:**
+
+- `deluge_hash TEXT` — hex string like `"a1b2c3d4..."`, nullable (empty = not from Deluge)
+- `deluge_original_path TEXT` — absolute file path string, nullable
+- `imported_from_deluge_at TIMESTAMP` — SQLite stores timestamps as TEXT in ISO-8601.
+  In Go this is `*time.Time` (pointer) so it can be nil when the book was not imported
+  from Deluge. Use `sql.NullTime` when scanning.
+
+**The result should look like this (full end of struct):**
+
+```go
+	OrganizeMethod        string    `json:"organize_method,omitempty"` // "reflink", "hardlink", "copy", "symlink"
+	Missing            bool      `json:"missing"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	// Deluge integration fields (spec: deluge-protected-paths-design).
+	// DelugeHash is the torrent info-hash (40-char hex string).
+	// DelugeOriginalPath is the file path before copy-into-library.
+	// ImportedFromDelugeAt is when the copy completed.
+	DelugeHash             string     `json:"deluge_hash,omitempty"`
+	DelugeOriginalPath     string     `json:"deluge_original_path,omitempty"`
+	ImportedFromDelugeAt   *time.Time `json:"imported_from_deluge_at,omitempty"`
+}
+```
+
+---
+
+## Step 2 — Edit `internal/database/sqlite_store.go`
+
+You will make **three** changes to this file:
+
+### Change A — Add `ensureExtendedBookFileColumns` function
+
+Find the line:
+
+```go
+// Close closes the database connection
+func (s *SQLiteStore) Close() error {
+```
+
+It is at approximately line 797. Insert the following function **immediately before** that line (before the comment `// Close closes the database connection`):
+
+```go
+// ensureExtendedBookFileColumns adds newly introduced optional columns to the
+// book_files table for existing databases created before these columns existed.
+// SQLite lacks IF NOT EXISTS for ADD COLUMN, so we inspect PRAGMA table_info
+// and conditionally ALTER TABLE.
+func (s *SQLiteStore) ensureExtendedBookFileColumns() error {
+	columns := map[string]string{
+		"deluge_hash":           "TEXT",
+		"deluge_original_path":  "TEXT",
+		"imported_from_deluge_at": "TIMESTAMP",
+	}
+
+	rows, err := s.db.Query("PRAGMA table_info(book_files)")
+	if err != nil {
+		return fmt.Errorf("failed to inspect book_files schema: %w", err)
+	}
+	defer rows.Close()
+
+	existing := make(map[string]struct{})
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dfltValue interface{}
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return fmt.Errorf("failed to scan book_files table_info: %w", err)
+		}
+		existing[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating book_files table_info: %w", err)
+	}
+
+	for name, colType := range columns {
+		if _, ok := existing[name]; ok {
+			continue
+		}
+		alter := fmt.Sprintf("ALTER TABLE book_files ADD COLUMN %s %s", name, colType)
+		if _, err := s.db.Exec(alter); err != nil {
+			return fmt.Errorf("failed adding column %s to book_files: %w", name, err)
+		}
+	}
+	return nil
+}
+```
+
+### Change B — Call `ensureExtendedBookFileColumns` from the init/open function
+
+Find the line in the `open` or `initSchema` function that reads:
+
+```go
+	// Non-destructive migration for existing databases: add missing columns
+	return s.ensureExtendedBookColumns()
+```
+
+It is at approximately line 637-638. Change it to:
+
+```go
+	// Non-destructive migration for existing databases: add missing columns
+	if err := s.ensureExtendedBookColumns(); err != nil {
+		return err
+	}
+	return s.ensureExtendedBookFileColumns()
+```
+
+**IMPORTANT:** The existing call returns directly. You must split the return so
+both functions are called. The exact replacement is shown above.
+
+### Change C — Update `bookFileCols` constant and `bookFileScan` function
+
+#### C1 — Update `bookFileCols`
+
+Find the constant (approximately line 5320):
+
+```go
+const bookFileCols = `id, book_id, file_path, original_filename, itunes_path, itunes_persistent_id,
+	track_number, track_count, disc_number, disc_count, title, format, codec, duration,
+	file_size, bitrate_kbps, sample_rate_hz, channels, bit_depth, file_hash, original_file_hash,
+	acoustid_seg0, acoustid_seg1, acoustid_seg2, acoustid_seg3, acoustid_seg4, acoustid_seg5, acoustid_seg6,
+	missing, created_at, updated_at`
+```
+
+Replace it with:
+
+```go
+const bookFileCols = `id, book_id, file_path, original_filename, itunes_path, itunes_persistent_id,
+	track_number, track_count, disc_number, disc_count, title, format, codec, duration,
+	file_size, bitrate_kbps, sample_rate_hz, channels, bit_depth, file_hash, original_file_hash,
+	acoustid_seg0, acoustid_seg1, acoustid_seg2, acoustid_seg3, acoustid_seg4, acoustid_seg5, acoustid_seg6,
+	missing, created_at, updated_at,
+	deluge_hash, deluge_original_path, imported_from_deluge_at`
+```
+
+#### C2 — Update `bookFileScan` to scan the new columns
+
+Find the variable declarations at the top of `bookFileScan` (approximately line 5332):
+
+```go
+	var originalFilename, itunesPath, itunesPID sql.NullString
+```
+
+After the existing `var` declarations, add:
+
+```go
+	var delugeHash, delugeOriginalPath sql.NullString
+	var importedFromDelugeAt sql.NullTime
+```
+
+Find the `row.Scan(...)` call inside `bookFileScan`. It currently ends with:
+
+```go
+		&missing, &f.CreatedAt, &f.UpdatedAt,
+	)
+```
+
+Change that ending to:
+
+```go
+		&missing, &f.CreatedAt, &f.UpdatedAt,
+		&delugeHash, &delugeOriginalPath, &importedFromDelugeAt,
+	)
+```
+
+After the `if err != nil { return f, err }` block, and after the existing `if acoustidSeg6.Valid { ... }` and `f.Missing = missing != 0` assignments, add:
+
+```go
+	if delugeHash.Valid {
+		f.DelugeHash = delugeHash.String
+	}
+	if delugeOriginalPath.Valid {
+		f.DelugeOriginalPath = delugeOriginalPath.String
+	}
+	if importedFromDelugeAt.Valid {
+		t := importedFromDelugeAt.Time
+		f.ImportedFromDelugeAt = &t
+	}
+```
+
+Place these lines immediately before the `return f, nil` statement.
+
+---
+
+## Step 3 — Verify the Build
+
+Run these two commands in order. Both must pass with zero errors.
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./...
+```
+
+```bash
+go test ./internal/database/...
+```
+
+If `go build` fails with "undefined: sql.NullTime", the Go version is below 1.15.
+`sql.NullTime` was added in Go 1.15. Check `go.mod` — the module declares `go 1.24.0`
+so this is not expected to fail. If it does fail for another reason, read the error
+message carefully and fix only the line it points to.
+
+If `go test` fails, read the test output. The most likely failure is that
+`bookFileScan` now tries to scan 3 more columns than `CreateBookFile` inserts. If
+that happens, you also need to update `CreateBookFile` and `UpdateBookFile` to
+include the new columns — but check the test output first before touching those
+functions.
+
+---
+
+## Step 4 — Bump the Version Header
+
+The version header is at the top of each file you changed. Bump the patch version:
+
+- `internal/database/store.go` — increment the `// version:` line by 0.0.1
+- `internal/database/sqlite_store.go` — increment the `// version:` line by 0.0.1
+
+---
+
+## Step 5 — Commit and Open PR
+
+```bash
+git checkout -b feat/deluge-1-db-columns
+git add internal/database/store.go internal/database/sqlite_store.go
+git commit -m "feat(deluge): add deluge_hash/original_path/imported_at columns to book_files"
+git push -u origin feat/deluge-1-db-columns
+gh pr create \
+  --title "feat(deluge): add deluge_hash/original_path/imported_at columns to book_files" \
+  --body "Adds three nullable columns to book_files via ensureExtendedBookFileColumns (PRAGMA table_info + ALTER TABLE). No migration file needed. Part of the Deluge protected-paths integration (spec: 2026-04-29-deluge-protected-paths-design.md)."
+```
+
+---
+
+## Checklist
+
+- [ ] `BookFile` struct has three new fields in `store.go`
+- [ ] `ensureExtendedBookFileColumns` function added to `sqlite_store.go`
+- [ ] `ensureExtendedBookFileColumns` called from init/open (after `ensureExtendedBookColumns`)
+- [ ] `bookFileCols` constant updated to include the three new column names
+- [ ] `bookFileScan` scans the three new columns via `sql.NullString` / `sql.NullTime`
+- [ ] `go build ./...` passes
+- [ ] `go test ./internal/database/...` passes
+- [ ] Version headers bumped in both files
+- [ ] PR opened with correct branch name and title

--- a/docs/superpowers/bot-tasks/2026-04-29-deluge-2-protected-path-cache.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-deluge-2-protected-path-cache.md
@@ -1,0 +1,397 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-deluge-2-protected-path-cache.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c4e1f8a2-6b9d-4073-8e5c-1a7f3d2b0e96 -->
+<!-- last-edited: 2026-04-29 -->
+
+# BOT TASK: DELUGE-2 — protectedPathCache
+
+**TODO ID:** DELUGE-2
+**Audience:** burndown bot
+**Branch:** `feat/deluge-2-protected-path-cache`
+**PR title:** `feat(deluge): add ProtectedPathCache with TTL refresh and stale fallback`
+
+---
+
+## What This Task Does
+
+Creates `internal/deluge/protected_paths.go` — a thread-safe, TTL-based cache of
+filesystem path prefixes that the app must never move, rename, or delete because
+they are managed by Deluge. The cache is populated from:
+
+1. The `SavePath` of every active Deluge torrent (returned by `ListTorrents`)
+2. Any extra paths from `config.AppConfig.ProtectedPaths` (if that field exists;
+   if it does not exist yet, use `config.AppConfig.DelugeDiscoveryLabel` as a
+   placeholder — see Step 1)
+
+If Deluge is unreachable when the cache tries to refresh, it keeps the last-known
+data (stale cache). The TTL is 5 minutes.
+
+Also creates `internal/deluge/protected_paths_test.go` with exactly 3 tests.
+
+---
+
+## What NOT to Do
+
+- **Do NOT modify `internal/deluge/client.go`** in any way. Read it, do not write it.
+- **Do NOT call `ListTorrentsByLabel`** — call `ListTorrents()` (no label filter)
+  to collect ALL save paths regardless of label.
+- **Do NOT use a `sync.RWMutex` paired with a `Mutex` in the same struct** — pick
+  one. Use `sync.RWMutex` (allows concurrent reads).
+- **Do NOT import `internal/config`** inside `internal/deluge/` — that would create
+  a circular dependency. The caller passes extra paths as `[]string`. The cache
+  struct does NOT know about config directly.
+- **Do NOT use `time.Sleep` inside any method** — the TTL is checked lazily on
+  each call to `IsProtected`.
+
+---
+
+## Background: Existing `client.go` API
+
+You MUST read `internal/deluge/client.go` before writing any code. The relevant
+method signatures are:
+
+```go
+// ListTorrents returns all torrents with the standard field set.
+func (c *Client) ListTorrents() (map[string]TorrentStatus, error)
+
+// TorrentStatus holds the fields we care about from Deluge.
+type TorrentStatus struct {
+    Hash     string  `json:"hash"`
+    Name     string  `json:"name"`
+    SavePath string  `json:"save_path"`
+    State    string  `json:"state"`
+    Progress float64 `json:"progress"`
+    Label    string  `json:"label"`
+    TotalSize int64  `json:"total_size"`
+}
+```
+
+`ListTorrents` returns a `map[string]TorrentStatus` where the key is the torrent
+hash. You want `TorrentStatus.SavePath` for each entry.
+
+---
+
+## Step 1 — Create `internal/deluge/protected_paths.go`
+
+Write the file with the **exact** contents below. Do not change the logic; do not
+rename any exported identifiers.
+
+```go
+// file: internal/deluge/protected_paths.go
+// version: 1.0.0
+// guid: d5b8e2a1-3c9f-4076-b7d4-0e8a2c5f1b93
+
+// Package deluge provides integration with the Deluge BitTorrent client.
+package deluge
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+const protectedPathTTL = 5 * time.Minute
+
+// ProtectedPathCache maintains a set of filesystem path prefixes that must
+// not be moved, renamed, or deleted. Paths come from two sources:
+//
+//  1. The SavePath of every active Deluge torrent (refreshed every 5 min).
+//  2. Extra paths supplied at construction time (e.g. config.ProtectedPaths).
+//
+// Thread-safe. If Deluge is unreachable on refresh, the last-known set is kept.
+type ProtectedPathCache struct {
+	mu          sync.RWMutex
+	paths       []string
+	extraPaths  []string
+	client      *Client
+	lastRefresh time.Time
+}
+
+// NewProtectedPathCache creates a cache backed by the given Deluge client.
+// extraPaths is a static list of additional protected prefixes (e.g. from config).
+// The cache is empty until the first call to IsProtected triggers a refresh.
+func NewProtectedPathCache(client *Client, extraPaths []string) *ProtectedPathCache {
+	extra := make([]string, len(extraPaths))
+	copy(extra, extraPaths)
+	return &ProtectedPathCache{
+		client:     client,
+		extraPaths: extra,
+	}
+}
+
+// IsProtected returns true if filePath has any cached path as a prefix.
+// It lazily refreshes the cache when the TTL has expired.
+func (c *ProtectedPathCache) IsProtected(filePath string) bool {
+	c.maybeRefresh()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, prefix := range c.paths {
+		if prefix != "" && strings.HasPrefix(filePath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Invalidate forces the next IsProtected call to refresh from Deluge immediately.
+func (c *ProtectedPathCache) Invalidate() {
+	c.mu.Lock()
+	c.lastRefresh = time.Time{} // zero value — older than any TTL
+	c.mu.Unlock()
+}
+
+// maybeRefresh checks whether the TTL has expired and, if so, calls refresh.
+// Uses a double-checked pattern: read lock to check, write lock to update.
+func (c *ProtectedPathCache) maybeRefresh() {
+	c.mu.RLock()
+	expired := time.Since(c.lastRefresh) > protectedPathTTL
+	c.mu.RUnlock()
+	if !expired {
+		return
+	}
+	c.refresh()
+}
+
+// refresh fetches current torrent save paths from Deluge and rebuilds the
+// path list. If Deluge is unreachable, the existing list is kept unchanged.
+func (c *ProtectedPathCache) refresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Re-check under write lock in case another goroutine refreshed first.
+	if time.Since(c.lastRefresh) <= protectedPathTTL {
+		return
+	}
+
+	torrents, err := c.client.ListTorrents()
+	if err != nil {
+		// Deluge unreachable — keep stale data, do not update lastRefresh
+		// so the next call will try again.
+		log.Printf("[WARN] ProtectedPathCache: failed to refresh from Deluge: %v (using stale data)", err)
+		return
+	}
+
+	// Collect unique save paths from all torrents.
+	seen := make(map[string]struct{})
+	var fresh []string
+	for _, t := range torrents {
+		if t.SavePath == "" {
+			continue
+		}
+		if _, dup := seen[t.SavePath]; !dup {
+			seen[t.SavePath] = struct{}{}
+			fresh = append(fresh, t.SavePath)
+		}
+	}
+
+	// Merge in extra (static) paths.
+	for _, p := range c.extraPaths {
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; !dup {
+			seen[p] = struct{}{}
+			fresh = append(fresh, p)
+		}
+	}
+
+	c.paths = fresh
+	c.lastRefresh = time.Now()
+	log.Printf("[DEBUG] ProtectedPathCache: refreshed %d protected path prefixes", len(c.paths))
+}
+```
+
+---
+
+## Step 2 — Create `internal/deluge/protected_paths_test.go`
+
+Write the file with the **exact** contents below. Do not add or remove tests.
+
+```go
+// file: internal/deluge/protected_paths_test.go
+// version: 1.0.0
+// guid: e6c9f3b2-4d0a-5187-c8e5-2b9f4e1c0d74
+
+package deluge
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// mockClient is a fake *Client that returns controlled ListTorrents results.
+// It is unexported and only used in tests. We cannot embed *Client because
+// Client has unexported fields, so we use a wrapper approach via monkey-patching
+// the ProtectedPathCache's refresh function.
+//
+// Instead, we construct a real ProtectedPathCache but replace its internals
+// directly, because all fields are unexported. The cleanest approach is a
+// test-only constructor that accepts a function.
+
+// listFunc is the type of a function that imitates ListTorrents for tests.
+type listFunc func() (map[string]TorrentStatus, error)
+
+// newTestCache creates a ProtectedPathCache wired to a fake list function
+// instead of a real *Client. Used only in tests.
+func newTestCache(lf listFunc, extraPaths []string) *ProtectedPathCache {
+	// We create a dummy client (nil) and override the refresh behavior via
+	// a thin subtype. Since Client is a struct with unexported fields we
+	// cannot embed it. Instead we call refresh manually with a stub.
+	//
+	// Strategy: create the cache, then immediately call a helper that
+	// populates c.paths directly, simulating what refresh() would do.
+	c := &ProtectedPathCache{
+		client:     nil, // never called in tests — we populate manually
+		extraPaths: extraPaths,
+	}
+	populateCacheForTest(c, lf)
+	return c
+}
+
+// populateCacheForTest runs the same logic as refresh() but uses lf instead
+// of c.client.ListTorrents(). Sets lastRefresh to now so TTL doesn't expire.
+func populateCacheForTest(c *ProtectedPathCache, lf listFunc) {
+	torrents, err := lf()
+	if err != nil {
+		// Simulate stale-on-error: do not update paths or lastRefresh.
+		return
+	}
+	seen := make(map[string]struct{})
+	var fresh []string
+	for _, t := range torrents {
+		if t.SavePath == "" {
+			continue
+		}
+		if _, dup := seen[t.SavePath]; !dup {
+			seen[t.SavePath] = struct{}{}
+			fresh = append(fresh, t.SavePath)
+		}
+	}
+	for _, p := range c.extraPaths {
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; !dup {
+			seen[p] = struct{}{}
+			fresh = append(fresh, p)
+		}
+	}
+	c.paths = fresh
+	c.lastRefresh = time.Now()
+}
+
+// Test 1: IsProtected returns true when filePath has a cached prefix.
+func TestIsProtected_True(t *testing.T) {
+	lf := func() (map[string]TorrentStatus, error) {
+		return map[string]TorrentStatus{
+			"aabbcc": {SavePath: "/mnt/downloads/audiobooks"},
+		}, nil
+	}
+	cache := newTestCache(lf, nil)
+
+	filePath := "/mnt/downloads/audiobooks/TheName/file.m4b"
+	if !cache.IsProtected(filePath) {
+		t.Errorf("expected IsProtected(%q) = true, got false", filePath)
+	}
+}
+
+// Test 2: IsProtected returns false when filePath has no matching prefix.
+func TestIsProtected_False(t *testing.T) {
+	lf := func() (map[string]TorrentStatus, error) {
+		return map[string]TorrentStatus{
+			"aabbcc": {SavePath: "/mnt/downloads/audiobooks"},
+		}, nil
+	}
+	cache := newTestCache(lf, nil)
+
+	filePath := "/mnt/bigdata/books/audiobook-organizer/Author/Title/file.m4b"
+	if cache.IsProtected(filePath) {
+		t.Errorf("expected IsProtected(%q) = false, got true", filePath)
+	}
+}
+
+// Test 3: When refresh fails, stale data is kept and IsProtected still works.
+func TestIsProtected_StaleOnError(t *testing.T) {
+	// First, populate with good data.
+	goodLF := func() (map[string]TorrentStatus, error) {
+		return map[string]TorrentStatus{
+			"aabbcc": {SavePath: "/mnt/downloads/stale-path"},
+		}, nil
+	}
+	cache := newTestCache(goodLF, nil)
+
+	// Verify stale path is protected before simulating error.
+	if !cache.IsProtected("/mnt/downloads/stale-path/book.m4b") {
+		t.Fatal("precondition: stale path should be protected before error")
+	}
+
+	// Simulate Deluge going down: reset lastRefresh so refresh() will run,
+	// then use the error-returning lf.
+	cache.lastRefresh = time.Time{} // force TTL expiry
+	errorLF := func() (map[string]TorrentStatus, error) {
+		return nil, fmt.Errorf("connection refused")
+	}
+	// populateCacheForTest with error lf — should NOT clear existing paths.
+	populateCacheForTest(cache, errorLF)
+
+	// Stale paths must still be protected.
+	if !cache.IsProtected("/mnt/downloads/stale-path/book.m4b") {
+		t.Errorf("expected stale path to still be protected after refresh error")
+	}
+}
+```
+
+---
+
+## Step 3 — Run the Tests
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go test ./internal/deluge/...
+```
+
+All three tests must pass. If any test fails, read the error and fix it. Do not
+delete tests to make them pass.
+
+---
+
+## Step 4 — Verify Build
+
+```bash
+go build ./...
+```
+
+Must produce zero errors.
+
+---
+
+## Step 5 — Bump Version Header
+
+Both new files already have `// version: 1.0.0` in the header written above. Do
+not change them unless you made code changes that deviate from the spec.
+
+---
+
+## Step 6 — Commit and Open PR
+
+```bash
+git checkout -b feat/deluge-2-protected-path-cache
+git add internal/deluge/protected_paths.go internal/deluge/protected_paths_test.go
+git commit -m "feat(deluge): add ProtectedPathCache with TTL refresh and stale fallback"
+git push -u origin feat/deluge-2-protected-path-cache
+gh pr create \
+  --title "feat(deluge): add ProtectedPathCache with TTL refresh and stale fallback" \
+  --body "Adds internal/deluge/protected_paths.go: thread-safe, 5-min TTL cache of Deluge torrent save_paths + extra static prefixes. On Deluge unreachable, keeps stale data. Three unit tests. Part of protected-paths spec."
+```
+
+---
+
+## Checklist
+
+- [ ] `internal/deluge/protected_paths.go` created with exact code above
+- [ ] `internal/deluge/protected_paths_test.go` created with exact code above
+- [ ] `go test ./internal/deluge/...` passes all 3 tests
+- [ ] `go build ./...` passes
+- [ ] PR opened with correct branch name and title

--- a/docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md
@@ -1,0 +1,498 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2d9e7c3-5f1a-4082-9e6b-3c0a5d8f2e17 -->
+<!-- last-edited: 2026-04-29 -->
+
+# BOT TASK: DELUGE-3 — importToLibrary Function
+
+**TODO ID:** DELUGE-3
+**Audience:** burndown bot
+**Branch:** `feat/deluge-3-import-to-library`
+**PR title:** `feat(deluge): add importToLibrary to copy Deluge files into the library`
+
+**Prerequisite:** DELUGE-1 must be merged first (the three new `BookFile` fields
+`DelugeHash`, `DelugeOriginalPath`, `ImportedFromDelugeAt` must exist).
+
+---
+
+## What This Task Does
+
+Creates `internal/server/deluge_import.go` — the `importToLibrary` function. When
+a file currently living in a Deluge-managed directory needs to enter the organized
+library, this function:
+
+1. Copies the file into the library root (trying reflink first, falling back to
+   `io.Copy`).
+2. Updates the `BookFile` in the database (`DelugeOriginalPath`, `FilePath`,
+   `ImportedFromDelugeAt`).
+3. Optionally calls `delugeClient.MoveStorage` to move the torrent's storage to the
+   new directory (best-effort — log errors but do not return them).
+
+---
+
+## What NOT to Do
+
+- **Do NOT use `ffmpeg`** for the copy. Use either the OS reflink syscall or
+  `io.Copy`. The old ffmpeg approach is gone from this codebase.
+- **Do NOT call `os.Rename`** across filesystem boundaries. Reflink or copy only.
+- **Do NOT call `store.UpdateBook`** — this function only updates `BookFile` rows
+  via `store.UpdateBookFile`.
+- **Do NOT return an error from `MoveStorage` failure** — log it with `log.Printf`
+  and continue. The Deluge move is best-effort.
+- **Do NOT import `internal/deluge` inside `internal/server`** as a package import
+  without verifying the import path compiles. The Deluge client is passed in as a
+  `*deluge.Client` parameter.
+- **Do NOT skip creating the destination directory** — call `os.MkdirAll` before
+  writing the file.
+
+---
+
+## Background: Key Types
+
+Before writing any code, read these files:
+
+- `internal/database/store.go` lines ~573-612 — the `BookFile` struct. After
+  DELUGE-1 merges, it has `DelugeHash`, `DelugeOriginalPath`, `ImportedFromDelugeAt`.
+- `internal/deluge/client.go` — `MoveStorage(torrentIDs []string, destPath string) error`.
+  Note: `MoveStorage` takes a **slice** of torrent ID strings, not a single string.
+- `internal/config/config.go` lines ~89, ~242-247 — `RootDir string`,
+  `DelugeMoveEnabled bool`.
+
+The relevant `UpdateBookFile` signature (from `internal/database/sqlite_store.go`):
+
+```go
+func (s *SQLiteStore) UpdateBookFile(id string, file *BookFile) error
+```
+
+The `Store` interface in `internal/database/iface_ops.go` has `UpdateBookFile`.
+Use the interface type `database.Store` for the parameter.
+
+---
+
+## Step 1 — Create `internal/server/deluge_import.go`
+
+Write the file with the **exact** contents below.
+
+```go
+// file: internal/server/deluge_import.go
+// version: 1.0.0
+// guid: f3e7a9c1-2b4d-5086-d9f2-4e1c7b0a3e58
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
+)
+
+// importToLibrary copies a file from a Deluge-managed path into the library root,
+// updates the BookFile record in the database, and optionally tells Deluge to move
+// the torrent storage to the new directory.
+//
+// Parameters:
+//   - cfg: app config (used for RootDir and DelugeMoveEnabled)
+//   - delugeClient: Deluge JSON-RPC client (may be nil; if nil, MoveStorage is skipped)
+//   - store: database store (used to call UpdateBookFile)
+//   - bookFile: the BookFile to import; its FilePath must point to the source file.
+//     After a successful return, bookFile.FilePath is updated to the new path.
+//
+// Returns the new absolute file path and nil on success.
+// Returns an error if the source file cannot be read or the destination cannot be written.
+// A MoveStorage failure is NOT returned as an error — it is logged only.
+func importToLibrary(
+	cfg *config.Config,
+	delugeClient *deluge.Client,
+	store database.Store,
+	bookFile *database.BookFile,
+) (newPath string, err error) {
+	if bookFile == nil {
+		return "", fmt.Errorf("importToLibrary: bookFile is nil")
+	}
+	src := bookFile.FilePath
+	if src == "" {
+		return "", fmt.Errorf("importToLibrary: bookFile.FilePath is empty")
+	}
+
+	// Determine destination directory inside RootDir.
+	// If the source is already under RootDir, preserve relative structure.
+	// If it is outside, place it directly under RootDir using just the filename.
+	var destDir string
+	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
+	if relErr == nil && !filepath.IsAbs(rel) && !isParentTraversal(rel) {
+		// Source is under RootDir (or a sub-path of it) — preserve structure.
+		destDir = filepath.Join(cfg.RootDir, rel)
+	} else {
+		// Source is outside RootDir — place directly under RootDir.
+		destDir = cfg.RootDir
+	}
+
+	dest := filepath.Join(destDir, filepath.Base(src))
+
+	// Do not copy if source and destination are the same path.
+	if src == dest {
+		log.Printf("[INFO] importToLibrary: source and dest are the same (%s), skipping copy", src)
+		return src, nil
+	}
+
+	// Create destination directory if it does not exist.
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", fmt.Errorf("importToLibrary: create dest dir %s: %w", destDir, err)
+	}
+
+	// Attempt reflink copy (Linux: ioctl FICLONE; macOS: clonefile).
+	// Falls back to io.Copy on any error.
+	copyErr := reflinkCopy(src, dest)
+	if copyErr != nil {
+		log.Printf("[DEBUG] importToLibrary: reflink failed (%v), falling back to io.Copy", copyErr)
+		if err := ioCopy(src, dest); err != nil {
+			return "", fmt.Errorf("importToLibrary: copy %s -> %s: %w", src, dest, err)
+		}
+	}
+
+	// Update the BookFile record.
+	now := time.Now()
+	bookFile.DelugeOriginalPath = src
+	bookFile.FilePath = dest
+	bookFile.ImportedFromDelugeAt = &now
+
+	if err := store.UpdateBookFile(bookFile.ID, bookFile); err != nil {
+		// The file has been copied but the DB update failed. Log it — the
+		// caller is responsible for retry or rollback.
+		return dest, fmt.Errorf("importToLibrary: UpdateBookFile %s: %w", bookFile.ID, err)
+	}
+
+	log.Printf("[INFO] importToLibrary: copied %s -> %s", src, dest)
+
+	// Best-effort: tell Deluge to move the torrent storage.
+	if cfg.DelugeMoveEnabled && bookFile.DelugeHash != "" && delugeClient != nil {
+		moveErr := delugeClient.MoveStorage([]string{bookFile.DelugeHash}, filepath.Dir(dest))
+		if moveErr != nil {
+			log.Printf("[WARN] importToLibrary: MoveStorage for hash %s failed (non-fatal): %v",
+				bookFile.DelugeHash, moveErr)
+			// Do NOT return this error. MoveStorage is best-effort.
+		} else {
+			log.Printf("[INFO] importToLibrary: MoveStorage for hash %s -> %s succeeded",
+				bookFile.DelugeHash, filepath.Dir(dest))
+		}
+	}
+
+	return dest, nil
+}
+
+// isParentTraversal returns true if the rel path starts with ".." (escapes root).
+func isParentTraversal(rel string) bool {
+	return len(rel) >= 2 && rel[:2] == ".."
+}
+
+// reflinkCopy attempts a copy-on-write clone of src to dest using OS-specific
+// syscalls. Returns an error if the reflink is not supported or fails.
+func reflinkCopy(src, dest string) error {
+	return reflinkCopyOS(src, dest)
+}
+
+// ioCopy copies src to dest using standard io.Copy (read all bytes, write all bytes).
+func ioCopy(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+	return nil
+}
+```
+
+---
+
+## Step 2 — Create Platform-Specific Reflink Files
+
+The `reflinkCopyOS` function referenced above must exist in platform-specific files.
+Create both files below. Do NOT modify any other files.
+
+### `internal/server/deluge_import_linux.go`
+
+```go
+// file: internal/server/deluge_import_linux.go
+// version: 1.0.0
+// guid: a9c2e5f7-1d3b-4087-b8a6-5f2c0e9d1b74
+
+package server
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// reflinkCopyOS attempts a reflink copy using Linux's FICLONE ioctl.
+// Returns an error if the filesystem does not support reflinks (e.g. ext4)
+// or if the operation fails for any other reason.
+func reflinkCopyOS(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+	defer out.Close()
+
+	err = unix.IoctlFileClone(int(out.Fd()), int(in.Fd()))
+	if err != nil {
+		// Remove the empty dest file created above, so the caller's ioCopy
+		// will create a fresh one.
+		_ = os.Remove(dest)
+		return fmt.Errorf("FICLONE ioctl: %w", err)
+	}
+	return nil
+}
+```
+
+### `internal/server/deluge_import_darwin.go`
+
+```go
+// file: internal/server/deluge_import_darwin.go
+// version: 1.0.0
+// guid: c7f4b1e8-2a6d-4093-9c8f-3d0b5a7e2c19
+
+package server
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// reflinkCopyOS attempts a reflink copy using macOS's clonefile(2) syscall.
+// clonefile is available on macOS 10.12+ on APFS volumes.
+func reflinkCopyOS(src, dest string) error {
+	srcBytes, err := syscall.BytePtrFromString(src)
+	if err != nil {
+		return fmt.Errorf("src path: %w", err)
+	}
+	destBytes, err := syscall.BytePtrFromString(dest)
+	if err != nil {
+		return fmt.Errorf("dest path: %w", err)
+	}
+	// clonefile(2): syscall number 462 on arm64/amd64 macOS.
+	// Flags = 0 (no CLONE_NOFOLLOW, no CLONE_NOOWNERCOPY).
+	_, _, errno := syscall.Syscall(462,
+		uintptr(unsafe.Pointer(srcBytes)),
+		uintptr(unsafe.Pointer(destBytes)),
+		0,
+	)
+	if errno != 0 {
+		return fmt.Errorf("clonefile: %w", errno)
+	}
+	return nil
+}
+```
+
+**IMPORTANT:** The Linux file uses `golang.org/x/sys/unix`. Before writing that
+file, verify this dependency exists in `go.mod`:
+
+```bash
+grep "golang.org/x/sys" /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/go.mod
+```
+
+If it exists, proceed. If it does NOT exist, replace the Linux implementation with
+the following stub that always returns an error (which causes the fallback to
+`io.Copy`):
+
+```go
+// reflinkCopyOS always returns an error on this platform (no reflink support).
+func reflinkCopyOS(src, dest string) error {
+	return fmt.Errorf("reflink not supported on this build")
+}
+```
+
+And change the imports in `deluge_import_linux.go` to just `"fmt"`.
+
+---
+
+## Step 3 — Write 2 Tests
+
+Create `internal/server/deluge_import_test.go`:
+
+```go
+// file: internal/server/deluge_import_test.go
+// version: 1.0.0
+// guid: e1b5d8f2-3c7a-4091-a2e9-6f4d0c8b3a15
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// fakeStore is a minimal database.Store implementation for testing.
+// Only UpdateBookFile is implemented; all others panic or return nil.
+type fakeStore struct {
+	database.Store // embed the interface so we don't need to implement all methods
+	updated *database.BookFile
+}
+
+func (f *fakeStore) UpdateBookFile(id string, file *database.BookFile) error {
+	f.updated = file
+	return nil
+}
+
+// Test 1: When reflink fails, ioCopy succeeds and the database is updated.
+func TestImportToLibrary_FallbackToCopy(t *testing.T) {
+	// Create a temp source file.
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "book.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Destination is a different temp dir (the "library root").
+	rootDir := t.TempDir()
+
+	cfg := &config.Config{
+		RootDir:          rootDir,
+		DelugeMoveEnabled: false, // no Deluge move
+	}
+	store := &fakeStore{}
+	bf := &database.BookFile{
+		ID:       "test-id-001",
+		FilePath: srcFile,
+		// DelugeHash intentionally empty so MoveStorage is skipped.
+	}
+
+	newPath, err := importToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("importToLibrary returned error: %v", err)
+	}
+
+	// Verify destination file exists.
+	if _, statErr := os.Stat(newPath); statErr != nil {
+		t.Errorf("destination file does not exist: %v", statErr)
+	}
+
+	// Verify DB was updated.
+	if store.updated == nil {
+		t.Fatal("UpdateBookFile was not called")
+	}
+	if store.updated.FilePath != newPath {
+		t.Errorf("BookFile.FilePath = %q, want %q", store.updated.FilePath, newPath)
+	}
+	if store.updated.DelugeOriginalPath != srcFile {
+		t.Errorf("BookFile.DelugeOriginalPath = %q, want %q", store.updated.DelugeOriginalPath, srcFile)
+	}
+	if store.updated.ImportedFromDelugeAt == nil {
+		t.Error("BookFile.ImportedFromDelugeAt is nil, want non-nil")
+	}
+}
+
+// Test 2: When source and destination are the same path, no copy is done.
+func TestImportToLibrary_SameSourceAndDest(t *testing.T) {
+	rootDir := t.TempDir()
+
+	// Create a file inside the library root.
+	srcFile := filepath.Join(rootDir, "book.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		RootDir:          rootDir,
+		DelugeMoveEnabled: false,
+	}
+	store := &fakeStore{}
+	bf := &database.BookFile{
+		ID:       "test-id-002",
+		FilePath: srcFile,
+	}
+
+	newPath, err := importToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("importToLibrary returned error: %v", err)
+	}
+	if newPath != srcFile {
+		t.Errorf("expected newPath = %q (same as src), got %q", srcFile, newPath)
+	}
+	// When source == dest, UpdateBookFile should NOT be called.
+	if store.updated != nil {
+		t.Error("UpdateBookFile was called even though source == dest; expected no-op")
+	}
+	_ = time.Now() // keep time import used
+}
+```
+
+---
+
+## Step 4 — Verify Build
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./...
+go test ./internal/server/... -run TestImportToLibrary
+```
+
+Both must pass with no errors. If `go build` fails because `database.Store` does
+not have `UpdateBookFile` in the interface, open `internal/database/iface_ops.go`
+and check if it is listed. If it is not, do NOT add it — that is a sign that DELUGE-1
+was not merged yet. Stop and report this dependency.
+
+---
+
+## Step 5 — Commit and Open PR
+
+```bash
+git checkout -b feat/deluge-3-import-to-library
+git add \
+  internal/server/deluge_import.go \
+  internal/server/deluge_import_linux.go \
+  internal/server/deluge_import_darwin.go \
+  internal/server/deluge_import_test.go
+git commit -m "feat(deluge): add importToLibrary to copy Deluge files into the library"
+git push -u origin feat/deluge-3-import-to-library
+gh pr create \
+  --title "feat(deluge): add importToLibrary to copy Deluge files into the library" \
+  --body "Adds importToLibrary: tries OS reflink (FICLONE on Linux, clonefile on macOS), falls back to io.Copy. Updates BookFile.DelugeOriginalPath/FilePath/ImportedFromDelugeAt in DB. Best-effort MoveStorage call to Deluge. 2 unit tests. Requires DELUGE-1."
+```
+
+---
+
+## Checklist
+
+- [ ] `internal/server/deluge_import.go` created
+- [ ] `internal/server/deluge_import_linux.go` created
+- [ ] `internal/server/deluge_import_darwin.go` created
+- [ ] `internal/server/deluge_import_test.go` created with 2 tests
+- [ ] `go build ./...` passes
+- [ ] `go test ./internal/server/... -run TestImportToLibrary` passes both tests
+- [ ] PR opened with correct branch name and title

--- a/docs/superpowers/bot-tasks/2026-04-29-duration-mismatch-chip.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-duration-mismatch-chip.md
@@ -1,0 +1,207 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-duration-mismatch-chip.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c2a85e4f-17d3-4b8c-a9e3-6d4f93c70b25 -->
+<!-- last-edited: 2026-04-29 -->
+
+# Bot Task: RATE-5 / DUR-1 — Duration Mismatch Warning Chip in MetadataReviewDialog
+
+## Task ID
+RATE-5 / DUR-1
+
+## Summary
+Add a yellow warning chip to `MetadataReviewDialog` when a metadata candidate's runtime differs from the book's known runtime by more than 10 minutes. Also show the candidate's own duration in the two-column card view. This is a **frontend-only** change.
+
+## DO NOT DO THESE THINGS
+- **DO NOT** modify any Go/backend file.
+- **DO NOT** create any new files. Only edit the one file listed below.
+- **DO NOT** change the API or data fetching logic.
+- **DO NOT** remove any existing chips, rows, or UI elements.
+
+---
+
+## Background / Context
+
+PR #520 added `duration_sec` and `duration_delta_sec` to `MetadataCandidate`. These fields are already returned by `GET /api/v1/audiobooks/:id/metadata-candidates` and are available on the `CandidateResult` / `r.candidate` object inside `MetadataReviewDialog`.
+
+- `r.candidate.duration_sec`: the candidate source's total duration in seconds (0 if unknown)
+- `r.candidate.duration_delta_sec`: difference between candidate duration and the local book's duration, in seconds. Positive means candidate is longer, negative means shorter. Magnitude is what matters for the warning.
+
+---
+
+## The ONE File You Edit
+
+```
+web/src/components/audiobooks/MetadataReviewDialog.tsx
+```
+
+---
+
+## Step 1 — Bump the version header
+
+At the very top of the file there is a comment block like:
+
+```tsx
+// file: web/src/components/audiobooks/MetadataReviewDialog.tsx
+// version: X.Y.Z
+```
+
+Change the version to the next patch version (e.g. `1.4.2` → `1.4.3`). If the version comment is missing, add it as the first two lines of the file.
+
+---
+
+## Step 2 — Add the duration formatting helper
+
+Search the file for any existing time/duration formatting helpers (grep for `formatDuration\|formatSeconds\|toHoursMinutes`). If one exists that converts seconds to "Xh Ym" format, reuse it. If not, add this helper near the top of the component file, outside the component function, after the imports:
+
+```ts
+/** Converts a duration in seconds to a compact "Xh Ym" string. */
+function formatDurationSec(totalSec: number): string {
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+```
+
+---
+
+## Step 3 — Add the duration mismatch chip in `renderCompactRow`
+
+### Find the function
+
+Search the file for `renderCompactRow`. The function signature will look something like:
+
+```tsx
+const renderCompactRow = (r: CandidateRowData, ...) => {
+```
+
+or it may be an inner function. Find it.
+
+### Find where chips are rendered
+
+Inside `renderCompactRow`, look for a `<Box>` or `<Stack>` that contains `<Chip` elements. There will be chips for things like the source name, match score, ISBN, etc. You need to add the duration-mismatch chip **after** all existing chips in that group.
+
+### Add the chip
+
+After the existing chips block, add exactly this code:
+
+```tsx
+{Math.abs(r.candidate?.duration_delta_sec ?? 0) > 600 && (
+  <Chip
+    label={`⚠ runtime differs by ${formatDurationSec(Math.abs(r.candidate.duration_delta_sec))}`}
+    color="warning"
+    size="small"
+    sx={{ fontWeight: 500 }}
+  />
+)}
+```
+
+Explanation:
+- `600` seconds = 10 minutes threshold
+- `Math.abs` because the delta can be negative (candidate shorter) or positive (candidate longer)
+- `color="warning"` renders as yellow in MUI
+- `size="small"` keeps it compact
+
+If `r.candidate` might be undefined, use optional chaining throughout: `r.candidate?.duration_delta_sec`.
+
+---
+
+## Step 4 — Show candidate duration in `renderTwoColumnCard`
+
+### Find the function
+
+Search the file for `renderTwoColumnCard`. The function renders the expanded/two-column view of a candidate card.
+
+### Find where candidate metadata rows are shown
+
+Inside `renderTwoColumnCard`, there will be a section that renders field rows — e.g., author, narrator, publisher, runtime. Look for any existing row that shows `runtime` or `duration`. It may look like:
+
+```tsx
+{candidate.runtime && <DetailRow label="Runtime" value={candidate.runtime} />}
+```
+
+### Add or modify the duration row
+
+If there is already a runtime row, modify it to also show the computed duration. If there is no runtime row, add one after the last metadata field row:
+
+```tsx
+{(r.candidate?.duration_sec ?? 0) > 0 && (
+  <DetailRow
+    label="Duration"
+    value={formatDurationSec(r.candidate!.duration_sec)}
+  />
+)}
+```
+
+(`DetailRow` may have a different name in the file — grep for `label="Runtime"\|label="Duration"\|DetailRow\|MetaRow` and use whatever component is already used for metadata rows in this view.)
+
+If no row component exists and duration is shown inline, use the same pattern as the nearest existing field (e.g., a `<Typography>` or a `<Box>` with a label span and a value span).
+
+---
+
+## Step 5 — TypeScript types
+
+Confirm that the `CandidateResult` or equivalent type (grep for `interface CandidateResult\|type CandidateResult\|duration_sec`) already has `duration_sec` and `duration_delta_sec` as optional number fields. They should have been added in PR #520.
+
+If they are missing from the TypeScript type, add them:
+
+```ts
+duration_sec?: number;
+duration_delta_sec?: number;
+```
+
+Add them inside the relevant interface, in alphabetical order among the other `d` fields, or at the end of the interface block.
+
+---
+
+## Step 6 — Verify
+
+Run the TypeScript compiler:
+
+```bash
+cd web && npx tsc --noEmit
+```
+
+Must produce zero errors.
+
+Run the frontend tests:
+
+```bash
+cd web && npm test -- --watchAll=false
+```
+
+Must produce zero failures.
+
+Visually verify (if possible):
+
+1. Open the MetadataReviewDialog for a book.
+2. Find a candidate where the duration differs from the book by more than 10 minutes.
+3. Confirm a yellow "⚠ runtime differs by Xh Ym" chip appears in the compact row.
+4. Expand that candidate's two-column card.
+5. Confirm a "Duration: Xh Ym" row appears.
+
+---
+
+## Checklist
+
+- [ ] File version header bumped in `MetadataReviewDialog.tsx`
+- [ ] `formatDurationSec` helper added (or existing helper reused)
+- [ ] Duration-mismatch chip added in `renderCompactRow`
+- [ ] Chip only appears when `|duration_delta_sec| > 600`
+- [ ] Chip uses `color="warning"` and `size="small"`
+- [ ] Candidate duration row added in `renderTwoColumnCard`
+- [ ] Row only appears when `duration_sec > 0`
+- [ ] `duration_sec` and `duration_delta_sec` present in TypeScript type
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` passes
+
+---
+
+## PR Instructions
+
+1. Branch name: `feat/duration-mismatch-chip`
+2. Commit message: `feat(ui): show duration mismatch warning chip in MetadataReviewDialog (DUR-1)`
+3. PR title: `feat(ui): duration mismatch warning chip in candidate cards (DUR-1)`
+4. PR body: mention that this is frontend-only, no backend changes, links to PR #520 for context.
+5. Do NOT include any backend or Go file changes in this PR.

--- a/docs/superpowers/bot-tasks/2026-04-29-relink-2-coauthor-dir.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-relink-2-coauthor-dir.md
@@ -1,0 +1,316 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-relink-2-coauthor-dir.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1e9a4c7f-3d2b-4e8a-c6f0-5b1d7a3e9c2f -->
+<!-- last-edited: 2026-04-29 -->
+
+# Bot Task: RELINK-2 — Co-author Directory Matching
+
+> **Read every word.** Do exactly what is written. Do not guess, do not
+> improvise, do not add extra changes. If something is unclear, STOP and ask.
+
+---
+
+## Goal
+
+Fix a bug in `findInITunes` where a book whose DB author is `"Robert Jordan"`
+fails to match an iTunes directory named `"Robert Jordan, Brandon Sanderson"`.
+The current code only searches for directories containing the first significant
+word of the author name (e.g. `"Robert"`). This finds too many false positives
+and misses co-author combos. The fix adds a second-pass fallback that uses the
+author's surname to match directories that include the primary author alongside
+co-authors.
+
+---
+
+## File You Will Touch
+
+`internal/server/maintenance_fixups.go`
+
+Do NOT touch any other file until step 4 (tests).
+
+---
+
+## Step 0 — Find the function
+
+Before making any edits, run:
+
+```bash
+grep -n "findInITunes" internal/server/maintenance_fixups.go
+```
+
+Confirm the function is a closure assigned around line 4154. If the line numbers
+have shifted, find the correct location by searching for the comment:
+
+```
+// findInITunes searches iTunesRoot for iTunes album directories (or single
+```
+
+All edits below are relative to the function body, not absolute line numbers.
+
+---
+
+## Step 1 — Understand the current code
+
+The function `findInITunes` (a closure inside the relink handler) currently does
+the following:
+
+1. Computes `authorWordLower` = first space-delimited word of `authorName`
+   (e.g. `"robert"` from `"Robert Jordan"`).
+2. Scans top-level entries in `iTunesRoot`.
+3. Skips any entry whose name does not contain `authorWordLower`.
+4. For matching author dirs, searches album subdirectories by `titlePrefixLower`.
+
+The bug: `authorWordLower = "robert"` does NOT match a directory named
+`"Robert Jordan, Brandon Sanderson"` if that directory is structured differently,
+AND even when it does match by first name, the current code has no fallback when
+zero M4B/audio files are found via the primary search and the directory structure
+uses the co-author pattern.
+
+The fix adds a **surname fallback pass** after the primary pass. It is activated
+only when the primary pass returns zero matches.
+
+---
+
+## Step 2 — Add the surname fallback
+
+Find the exact block at the end of `findInITunes` that assembles and returns the
+result:
+
+```go
+		result := make([]string, 0, len(dirMatches))
+		for d := range dirMatches {
+			result = append(result, d)
+		}
+		sort.Strings(result)
+		return result
+	}
+```
+
+Replace it with:
+
+```go
+		// Primary pass produced matches — return them directly.
+		if len(dirMatches) > 0 {
+			result := make([]string, 0, len(dirMatches))
+			for d := range dirMatches {
+				result = append(result, d)
+			}
+			sort.Strings(result)
+			return result
+		}
+
+		// Surname fallback: when the primary (first-word) pass finds nothing,
+		// try matching iTunes directories by the author's surname — the last
+		// space-delimited word of the primary author name. This handles
+		// co-author directories like "Robert Jordan, Brandon Sanderson".
+		surname := authorName
+		if idx := strings.LastIndex(authorName, " "); idx > 0 {
+			surname = authorName[idx+1:]
+		}
+		surnameLower := strings.ToLower(surname)
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(entry.Name()), surnameLower) {
+				continue
+			}
+			authorDir := filepath.Join(iTunesRoot, entry.Name())
+
+			albumEntries, err := os.ReadDir(authorDir)
+			if err != nil {
+				continue
+			}
+			for _, album := range albumEntries {
+				albumPath := filepath.Join(authorDir, album.Name())
+				if album.IsDir() {
+					if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+						continue
+					}
+					_ = filepath.WalkDir(albumPath, func(path string, d os.DirEntry, err error) error {
+						if err != nil || d.IsDir() {
+							return nil
+						}
+						if !audioExts[strings.ToLower(filepath.Ext(path))] {
+							return nil
+						}
+						if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+							dirMatches[albumPath] = struct{}{}
+							return filepath.SkipDir
+						}
+						return nil
+					})
+				} else {
+					if !audioExts[strings.ToLower(filepath.Ext(albumPath))] {
+						continue
+					}
+					if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+					}
+				}
+			}
+		}
+
+		result := make([]string, 0, len(dirMatches))
+		for d := range dirMatches {
+			result = append(result, d)
+		}
+		sort.Strings(result)
+		return result
+	}
+```
+
+### Important notes about this replacement
+
+- The variable `entries` is already declared earlier in the function (the
+  `os.ReadDir(iTunesRoot)` call). The fallback reuses it — do NOT add a second
+  `os.ReadDir` call.
+- The `dirMatches` map is also already declared. The fallback writes into the
+  same map — this is intentional. If the primary pass found some matches, we
+  returned early. If we reach the fallback, the map is empty.
+- `audioExts` is declared in the outer handler function and is in scope for the
+  closure — do NOT redefine it.
+- Do NOT change anything ABOVE the result-assembly block you replaced.
+
+---
+
+## Step 3 — Verify no new imports are needed
+
+The fallback uses only `strings`, `os`, `filepath`, and `sort` — all of which
+are already imported in this file. Run:
+
+```bash
+grep -n '"strings"\|"os"\|"path/filepath"\|"sort"' internal/server/maintenance_fixups.go | head -10
+```
+
+Confirm all four are present. If any is missing, add it to the import block.
+
+---
+
+## Step 4 — Tests
+
+File: `internal/server/maintenance_fixups_test.go`
+
+If this file does not exist, create it with `package server`.
+
+Add the following test. It builds a fake iTunes directory tree on disk using
+`t.TempDir()` and calls the relink handler's internal logic through an
+exported helper or by testing the HTTP handler end-to-end with a test store.
+
+Because `findInITunes` is a closure inside the HTTP handler, you cannot call it
+directly. Instead, write a small black-box test that exercises the relink
+endpoint with a temporary iTunes root set via the config.
+
+If an existing test harness for the relink handler already exists, add the case
+there. Otherwise, add this unit-level reproduction:
+
+```go
+func TestFindInITunes_CoauthorDirectory(t *testing.T) {
+	// Build a fake iTunes root:
+	//   <root>/Robert Jordan, Brandon Sanderson/The Wheel of Time/book.m4b
+	iTunesRoot := t.TempDir()
+	coauthorDir := filepath.Join(iTunesRoot, "Robert Jordan, Brandon Sanderson")
+	albumDir := filepath.Join(coauthorDir, "The Wheel of Time")
+	if err := os.MkdirAll(albumDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(albumDir, "The Wheel of Time.m4b"), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invoke findInITunes via the exported helper (if one is added) or via
+	// a test-only shim. See comment below.
+	//
+	// If no exported helper exists, add this to maintenance_fixups.go for tests:
+	//
+	//   func findInITunesForTest(iTunesRoot, authorName, title string) []string { ... }
+	//
+	// Then call it here:
+	results := findInITunesForTest(iTunesRoot, "Robert Jordan", "The Wheel of Time")
+
+	if len(results) == 0 {
+		t.Fatal("expected at least one match for co-author directory, got none")
+	}
+	if !strings.Contains(results[0], "Robert Jordan, Brandon Sanderson") {
+		t.Errorf("expected match inside co-author dir, got: %v", results)
+	}
+}
+```
+
+**To make the test compile,** add this exported test helper at the bottom of
+`internal/server/maintenance_fixups.go` (guarded by a build tag so it does not
+ship in production):
+
+```go
+// findInITunesForTest is a test-only shim that exposes the findInITunes
+// closure logic as a callable function. Only compiled during tests.
+//
+//go:build ignore
+```
+
+Actually, the cleanest approach is to extract `findInITunes` into a
+package-level function (unexported is fine, tests in the same package can call
+it). Do this extraction ONLY if the test cannot otherwise be written. If the
+existing test setup already has an integration harness, use that instead and
+skip the extraction.
+
+---
+
+## Step 5 — Verify
+
+```bash
+go test ./internal/server/...
+```
+
+All existing tests must pass. The new co-author test must pass.
+
+---
+
+## What NOT to Do
+
+- Do NOT replace the primary (first-word) search. The fallback only runs when
+  the primary search returns zero results.
+- Do NOT add a third `os.ReadDir(iTunesRoot)` call. The fallback reuses the
+  `entries` slice already read at the top of the function.
+- Do NOT change the `disambiguate` function or anything after `findInITunes`.
+- Do NOT change the title-matching logic (the `titlePrefixLower` comparison).
+  Only the author directory matching gets the fallback.
+- Do NOT change the `sort.Strings(result)` behavior — results must remain
+  sorted for deterministic disambiguation.
+
+---
+
+## PR Instructions
+
+Branch: `fix/relink-2-coauthor-dir-matching`
+
+```bash
+git checkout -b fix/relink-2-coauthor-dir-matching
+# make your changes
+git add internal/server/maintenance_fixups.go \
+        internal/server/maintenance_fixups_test.go
+git commit -m "fix(relink): surname fallback for co-author iTunes directories
+
+When findInITunes finds no matches by first-word prefix, fall back to
+matching by the author's surname. This allows \"Robert Jordan\" to match
+the iTunes directory \"Robert Jordan, Brandon Sanderson\"."
+git push -u origin fix/relink-2-coauthor-dir-matching
+gh pr create \
+  --title "fix(relink): surname fallback for co-author iTunes directories" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds a surname-based fallback pass to \`findInITunes\`
+- Fallback only activates when the primary (first-word) search returns 0 matches
+- Reuses the already-read \`entries\` slice — no extra filesystem I/O
+- Covers the \"Robert Jordan\" → \"Robert Jordan, Brandon Sanderson\" case
+
+## Test plan
+- [ ] \`go test ./internal/server/...\` passes
+- [ ] Co-author directory test passes
+- [ ] Verified against production: relink a co-authored Wheel of Time book
+EOF
+)"
+gh pr merge --rebase
+```

--- a/docs/superpowers/bot-tasks/2026-04-29-relink-3-title-normalization.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-relink-3-title-normalization.md
@@ -1,0 +1,324 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-relink-3-title-normalization.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5d2f8b3a-9e1c-4a7d-b6f2-0c4e8a1d5f3b -->
+<!-- last-edited: 2026-04-29 -->
+
+# Bot Task: RELINK-3 — Title Colon-to-Underscore Normalization
+
+> **Read every word.** Do exactly what is written. Do not guess, do not
+> improvise, do not add extra changes. If something is unclear, STOP and ask.
+
+---
+
+## Goal
+
+Fix a bug in `findInITunes` where a book titled `"Mistborn: The Final Empire"`
+fails to match the iTunes filename `"Mistborn_ The Final Empire.m4b"`. macOS
+and iTunes replace `: ` with `_ ` in filenames because colons are illegal in
+HFS+ paths. The current code compares raw title strings without normalizing
+colons, so the prefix check fails. The fix normalizes both the search title and
+the filename candidate before comparison.
+
+---
+
+## File You Will Touch
+
+`internal/server/maintenance_fixups.go`
+
+Do NOT touch any other file until step 4 (tests).
+
+---
+
+## Step 0 — Find the function
+
+Before making any edits, run:
+
+```bash
+grep -n "findInITunes\|titlePrefixLower\|normalizeForFilename" internal/server/maintenance_fixups.go
+```
+
+Confirm:
+- `findInITunes` is a closure (around line 4154).
+- `titlePrefixLower` is used inside the closure (several times).
+- `normalizeForFilename` does NOT yet exist.
+
+---
+
+## Step 1 — Add the `normalizeForFilename` helper
+
+This helper must be a **package-level function** (not a closure), defined
+OUTSIDE the HTTP handler. Find the end of the file or a suitable place near
+other helper functions in `maintenance_fixups.go`.
+
+Add the following function. Place it BEFORE the handler that contains
+`findInITunes`, or at the bottom of the file — either location is acceptable:
+
+```go
+// normalizeForFilename normalizes a string for iTunes/macOS filename comparison.
+// macOS HFS+ and iTunes replace ": " and ":" with "_ " and "_" respectively
+// because colons are illegal in filenames. This function applies the same
+// transformation so that "Mistborn: The Final Empire" matches the file
+// "Mistborn_ The Final Empire.m4b".
+func normalizeForFilename(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, ": ", "_ ")
+	s = strings.ReplaceAll(s, ":", "_")
+	return strings.TrimSpace(s)
+}
+```
+
+**Do not** add this inside the `findInITunes` closure. It must be a top-level
+function so the test file can call it too.
+
+---
+
+## Step 2 — Update `findInITunes` to use `normalizeForFilename`
+
+### 2a. Find the title prefix computation
+
+Inside `findInITunes`, find these lines (exact text):
+
+```go
+		titlePrefix := title
+		if len(titlePrefix) > 25 {
+			titlePrefix = titlePrefix[:25]
+		}
+		titlePrefixLower := strings.ToLower(titlePrefix)
+```
+
+Replace them with:
+
+```go
+		titlePrefix := title
+		if len(titlePrefix) > 25 {
+			titlePrefix = titlePrefix[:25]
+		}
+		// Normalize for macOS/iTunes filename encoding: ":" → "_", ": " → "_ "
+		titlePrefixLower := normalizeForFilename(titlePrefix)
+```
+
+### 2b. Normalize filename candidates at the comparison sites
+
+There are FOUR places inside `findInITunes` where `titlePrefixLower` is compared
+against a filename or directory name. You must wrap each left-hand side with
+`normalizeForFilename(...)`.
+
+Find and replace each occurrence exactly as shown:
+
+**Occurrence 1** — album directory name (fast path):
+
+Find:
+```go
+					if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+						continue
+					}
+```
+
+Replace with:
+```go
+					if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+						continue
+					}
+```
+
+**Occurrence 2** — file inside album dir (WalkDir callback):
+
+Find:
+```go
+						if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+							dirMatches[albumPath] = struct{}{}
+							return filepath.SkipDir
+						}
+```
+
+Replace with:
+```go
+						if strings.Contains(normalizeForFilename(filepath.Base(path)), titlePrefixLower) {
+							dirMatches[albumPath] = struct{}{}
+							return filepath.SkipDir
+						}
+```
+
+**Occurrence 3** — single audio file directly under author dir:
+
+Find:
+```go
+					if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+					}
+```
+
+(This is in the `else` branch for non-directory album entries.)
+
+Replace with:
+```go
+					if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+					}
+```
+
+### Important — distinguish occurrence 3 from occurrence 1
+
+Occurrence 1 is in the `if album.IsDir()` branch and has `continue` after it.
+Occurrence 3 is in the `else` branch and has NO `continue`. Make sure you edit
+the right one.
+
+### 2c. Check for occurrence 4
+
+The `disambiguate` closure (defined AFTER `findInITunes`) also does its own
+filename normalization via:
+
+```go
+			stemNorm := strings.ReplaceAll(strings.ReplaceAll(stemLower, "_", " "), ":", " ")
+```
+
+Do NOT change `disambiguate`. It already handles underscores by normalizing both
+sides to spaces. Leave it exactly as is.
+
+---
+
+## Step 3 — Verify imports
+
+`normalizeForFilename` uses `strings` only. `strings` is already imported.
+No new imports are needed. Confirm with:
+
+```bash
+grep -n '"strings"' internal/server/maintenance_fixups.go
+```
+
+---
+
+## Step 4 — Tests
+
+### 4a. Test `normalizeForFilename` directly
+
+File: `internal/server/maintenance_fixups_test.go`
+
+Add these test cases. If the file does not exist, create it with
+`package server`:
+
+```go
+func TestNormalizeForFilename(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"Mistborn: The Final Empire", "mistborn_ the final empire"},
+		{"Mistborn:The Final Empire", "mistborn_the final empire"},
+		{"The Name of the Wind", "the name of the wind"},
+		{"SHOGUN", "shogun"},
+		{"  Leading Space  ", "leading space"},
+		{"A: B: C", "a_ b_ c"},
+	}
+	for _, tc := range cases {
+		got := normalizeForFilename(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeForFilename(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+```
+
+### 4b. Test that `findInITunes` matches colon-title to underscore-filename
+
+Add this test. It builds a fake iTunes directory tree with the macOS underscore
+encoding and asserts that the relink logic finds it:
+
+```go
+func TestFindInITunes_ColonTitleMatchesUnderscoreFilename(t *testing.T) {
+	// Build fake iTunes root:
+	//   <root>/Brandon Sanderson/Mistborn_ The Final Empire.m4b
+	iTunesRoot := t.TempDir()
+	authorDir := filepath.Join(iTunesRoot, "Brandon Sanderson")
+	if err := os.MkdirAll(authorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fname := "Mistborn_ The Final Empire.m4b"
+	if err := os.WriteFile(filepath.Join(authorDir, fname), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call findInITunes (via exported shim if needed — see RELINK-2 task for
+	// the extraction pattern). The book's title has a colon; the file has an
+	// underscore.
+	results := findInITunesForTest(iTunesRoot, "Brandon Sanderson", "Mistborn: The Final Empire")
+
+	if len(results) == 0 {
+		t.Fatalf("expected a match for colon-title vs underscore-filename, got none")
+	}
+	if !strings.Contains(results[0], "Mistborn_") && !strings.Contains(results[0], "Brandon Sanderson") {
+		t.Errorf("unexpected match path: %v", results)
+	}
+}
+```
+
+Note: if the RELINK-2 task already extracted `findInITunesForTest`, reuse it
+here. If RELINK-2 has not been done yet, extract the helper as described in that
+task first, then write this test.
+
+---
+
+## Step 5 — Verify
+
+```bash
+go test ./internal/server/...
+```
+
+All existing tests must pass. Both new tests must pass.
+
+---
+
+## What NOT to Do
+
+- Do NOT change `disambiguate`. It already normalizes underscores to spaces
+  internally.
+- Do NOT change the 25-character prefix truncation. The truncation happens
+  BEFORE normalization in the updated code (that order is correct — truncate
+  the raw title, then normalize). Do NOT swap the order.
+- Do NOT call `strings.ToLower` again after `normalizeForFilename` — the helper
+  already lowercases the input.
+- Do NOT normalize the `authorWordLower` or `surnameLower` variables with this
+  function. The author directory matching uses a different pattern (the `: `
+  problem is specific to titles, not author names).
+- Do NOT touch the iTunes XML parsing code. This fix is filesystem path
+  comparison only.
+- Do NOT use `strings.ReplaceAll(s, "_", " ")` on the title side. The
+  correct direction is title `": "` → `"_ "` to match the filename encoding,
+  not the reverse.
+
+---
+
+## PR Instructions
+
+Branch: `fix/relink-3-title-normalization`
+
+```bash
+git checkout -b fix/relink-3-title-normalization
+# make your changes
+git add internal/server/maintenance_fixups.go \
+        internal/server/maintenance_fixups_test.go
+git commit -m "fix(relink): normalize colon to underscore in title comparison
+
+macOS replaces ': ' with '_ ' in filenames (HFS+ restriction). Add
+normalizeForFilename() and apply it in findInITunes so that a book titled
+'Mistborn: The Final Empire' matches 'Mistborn_ The Final Empire.m4b'."
+git push -u origin fix/relink-3-title-normalization
+gh pr create \
+  --title "fix(relink): normalize colon to underscore in iTunes title comparison" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds \`normalizeForFilename(s string) string\` helper (lowercases, \`: \` → \`_ \`, \`:\` → \`_\`)
+- Applies normalization to both the search title prefix and every filename/dirname candidate in \`findInITunes\`
+- Leaves \`disambiguate\` unchanged (it already normalizes \`_\` → \` \` on both sides)
+
+## Test plan
+- [ ] \`go test ./internal/server/...\` passes
+- [ ] \`TestNormalizeForFilename\` all cases pass
+- [ ] \`TestFindInITunes_ColonTitleMatchesUnderscoreFilename\` passes
+- [ ] Verified on production: relink "Mistborn: The Final Empire" finds correct iTunes file
+EOF
+)"
+gh pr merge --rebase
+```

--- a/docs/superpowers/bot-tasks/2026-04-29-user-ratings-api.md
+++ b/docs/superpowers/bot-tasks/2026-04-29-user-ratings-api.md
@@ -1,0 +1,463 @@
+<!-- file: docs/superpowers/bot-tasks/2026-04-29-user-ratings-api.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b8d41f3c-96e2-4a7b-c5d2-3f0e82b64d17 -->
+<!-- last-edited: 2026-04-29 -->
+
+# Bot Task: RATE-1 — PATCH /api/v1/audiobooks/:id/rating
+
+## Task ID
+RATE-1
+
+## Summary
+Add a `PATCH /api/v1/audiobooks/:id/rating` endpoint that lets callers set or clear user ratings (overall, story, performance) and notes on a book. The four DB columns already exist. The `Book` struct already has the fields. You are only adding a store method, a handler, a route, and tests.
+
+## DO NOT DO THESE THINGS
+- **DO NOT** modify the `Book` struct in `internal/database/store.go`. The fields are already there.
+- **DO NOT** create any migration file. The columns already exist via `ensureExtendedBookColumns`.
+- **DO NOT** rename or remove any existing functions.
+- **DO NOT** touch any file not listed in this task.
+
+---
+
+## Step 1 — Add `UpdateBookRating` to the store interface
+
+**File:** `internal/database/store.go`
+
+Find the `Store` interface. It contains methods like `UpdateBook`, `GetBook`, `DeleteBook`, etc. Add the following method to the interface (in alphabetical order among the U methods, after `UpdateBook` and before any `Upsert` method):
+
+```go
+UpdateBookRating(ctx context.Context, id string, overall, story, performance *float64, notes *string) error
+```
+
+The full signature using the exact types:
+- `ctx context.Context` — standard context
+- `id string` — book UUID
+- `overall *float64` — pointer; nil means "don't change this column"; non-nil sets the value (including to 0.0)
+- `story *float64` — same semantics
+- `performance *float64` — same semantics
+- `notes *string` — pointer; nil means "don't change"; non-nil sets the value (empty string clears text but leaves column non-NULL; to set NULL pass a special sentinel — see handler section)
+
+**Wait** — notes NULL vs empty string requires a different approach. Use `**float64` is not idiomatic in Go. Instead, use a wrapper struct for the partial-update logic in the handler, and pass explicit `sql.NullFloat64` / `sql.NullString` to the store. Revised signature:
+
+```go
+UpdateBookRating(ctx context.Context, id string, req UpdateBookRatingRequest) error
+```
+
+Where `UpdateBookRatingRequest` is a new struct you add to `internal/database/store.go`:
+
+```go
+// UpdateBookRatingRequest carries partial-update fields for user ratings.
+// Each field uses a pointer so the caller can distinguish "omitted" (nil)
+// from "set to zero/empty" (non-nil pointing to zero value).
+// To clear a rating to NULL, set ClearOverall = true (etc.).
+type UpdateBookRatingRequest struct {
+    Overall        *float64
+    ClearOverall   bool
+    Story          *float64
+    ClearStory     bool
+    Performance    *float64
+    ClearPerf      bool
+    Notes          *string
+    ClearNotes     bool
+}
+```
+
+Add both the struct and the interface method to `internal/database/store.go`.
+
+---
+
+## Step 2 — Implement in SQLiteStore
+
+**File:** `internal/database/sqlite_store.go`
+
+Find the block where other `Update*` methods are implemented (search for `func (s *SQLiteStore) UpdateBook`). Add the following method immediately after it:
+
+```go
+func (s *SQLiteStore) UpdateBookRating(ctx context.Context, id string, req database.UpdateBookRatingRequest) error {
+    setClauses := []string{}
+    args := []interface{}{}
+
+    if req.ClearOverall {
+        setClauses = append(setClauses, "user_rating_overall = NULL")
+    } else if req.Overall != nil {
+        setClauses = append(setClauses, "user_rating_overall = ?")
+        args = append(args, *req.Overall)
+    }
+
+    if req.ClearStory {
+        setClauses = append(setClauses, "user_rating_story = NULL")
+    } else if req.Story != nil {
+        setClauses = append(setClauses, "user_rating_story = ?")
+        args = append(args, *req.Story)
+    }
+
+    if req.ClearPerf {
+        setClauses = append(setClauses, "user_rating_performance = NULL")
+    } else if req.Performance != nil {
+        setClauses = append(setClauses, "user_rating_performance = ?")
+        args = append(args, *req.Performance)
+    }
+
+    if req.ClearNotes {
+        setClauses = append(setClauses, "user_rating_notes = NULL")
+    } else if req.Notes != nil {
+        setClauses = append(setClauses, "user_rating_notes = ?")
+        args = append(args, *req.Notes)
+    }
+
+    if len(setClauses) == 0 {
+        return nil // nothing to do
+    }
+
+    query := "UPDATE books SET " + strings.Join(setClauses, ", ") + " WHERE id = ?"
+    args = append(args, id)
+
+    result, err := s.db.ExecContext(ctx, query, args...)
+    if err != nil {
+        return fmt.Errorf("UpdateBookRating: %w", err)
+    }
+    rows, err := result.RowsAffected()
+    if err != nil {
+        return fmt.Errorf("UpdateBookRating rows affected: %w", err)
+    }
+    if rows == 0 {
+        return ErrNotFound
+    }
+    return nil
+}
+```
+
+Make sure `strings` and `fmt` are already imported in `sqlite_store.go` (they will be). `ErrNotFound` is whatever sentinel the file already uses for not-found (search for `ErrNotFound` in the file and use that exact identifier).
+
+---
+
+## Step 3 — Implement in PebbleStore
+
+**File:** `internal/database/pebble_store.go`
+
+Find where other `Update*` methods are implemented (search for `func (s *PebbleStore) UpdateBook`). Add after it:
+
+```go
+func (s *PebbleStore) UpdateBookRating(ctx context.Context, id string, req database.UpdateBookRatingRequest) error {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+
+    book, err := s.getBook(id)
+    if err != nil {
+        return err
+    }
+
+    if req.ClearOverall {
+        book.UserRatingOverall = nil
+    } else if req.Overall != nil {
+        book.UserRatingOverall = req.Overall
+    }
+
+    if req.ClearStory {
+        book.UserRatingStory = nil
+    } else if req.Story != nil {
+        book.UserRatingStory = req.Story
+    }
+
+    if req.ClearPerf {
+        book.UserRatingPerformance = nil
+    } else if req.Performance != nil {
+        book.UserRatingPerformance = req.Performance
+    }
+
+    if req.ClearNotes {
+        book.UserRatingNotes = nil
+    } else if req.Notes != nil {
+        book.UserRatingNotes = req.Notes
+    }
+
+    return s.putBook(book)
+}
+```
+
+`getBook` and `putBook` are the internal helpers already used by other methods in `pebble_store.go`. If they have different names, search for them with `grep -n "func (s \*PebbleStore) get" internal/database/pebble_store.go` and use whatever names you find.
+
+---
+
+## Step 4 — Add to MockStore
+
+**File:** `internal/database/mock_store.go` (or wherever the mock/test store is defined — search with `grep -rn "MockStore\|mockStore\|FakeStore" internal/database/`)
+
+Add a method with the same signature. The mock implementation just records the call and returns nil:
+
+```go
+func (m *MockStore) UpdateBookRating(ctx context.Context, id string, req database.UpdateBookRatingRequest) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    // record the call if the mock tracks calls
+    return m.UpdateBookRatingError // field you add to the mock struct
+}
+```
+
+Also add `UpdateBookRatingError error` to the `MockStore` struct so tests can inject errors.
+
+If the project uses a generated mock (e.g., with `mockgen`), add `UpdateBookRating` to the interface and regenerate. The regenerate command is typically in a `//go:generate` comment at the top of `mock_store.go` or in `Makefile`. Run it.
+
+---
+
+## Step 5 — Write the HTTP Handler
+
+**File:** `internal/server/metadata_handlers.go`
+
+### 5a. Add the request body struct
+
+Near the top of the file (after the package declaration and imports), add:
+
+```go
+// ratingPatchRequest is the JSON body for PATCH /api/v1/audiobooks/:id/rating.
+// Each field is a json.RawMessage so the handler can distinguish null (clear)
+// from absent (don't touch) from a numeric value.
+type ratingPatchRequest struct {
+    Overall     json.RawMessage `json:"overall"`
+    Story       json.RawMessage `json:"story"`
+    Performance json.RawMessage `json:"performance"`
+    Notes       json.RawMessage `json:"notes"`
+}
+```
+
+### 5b. Add the validation helper
+
+```go
+// parseOptionalRating decodes a json.RawMessage into a *float64 and a clear flag.
+// Returns (nil, false, nil) if raw is empty (field omitted).
+// Returns (nil, true, nil) if raw is JSON null (clear).
+// Returns (&v, false, nil) if raw is a valid number in [0,5] step 0.5.
+// Returns (nil, false, err) on invalid value.
+func parseOptionalRating(raw json.RawMessage, fieldName string) (*float64, bool, error) {
+    if len(raw) == 0 {
+        return nil, false, nil
+    }
+    if string(raw) == "null" {
+        return nil, true, nil
+    }
+    var v float64
+    if err := json.Unmarshal(raw, &v); err != nil {
+        return nil, false, fmt.Errorf("%s: must be a number", fieldName)
+    }
+    if v < 0 || v > 5 {
+        return nil, false, fmt.Errorf("%s: must be between 0 and 5", fieldName)
+    }
+    // check 0.5 step: v*2 must be an integer
+    if math.Round(v*2) != v*2 {
+        return nil, false, fmt.Errorf("%s: must be a multiple of 0.5", fieldName)
+    }
+    return &v, false, nil
+}
+```
+
+Add `"math"` to the import block if it is not already there.
+
+### 5c. Add the handler function
+
+Search for `func (s *Server) handleUpdateBook` — add the new handler right after it:
+
+```go
+// handleUpdateBookRating handles PATCH /api/v1/audiobooks/:id/rating.
+func (s *Server) handleUpdateBookRating(c *gin.Context) {
+    id := c.Param("id")
+    if id == "" {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "missing book id"})
+        return
+    }
+
+    var body ratingPatchRequest
+    // Allow empty body (no changes)
+    if c.Request.ContentLength != 0 {
+        if err := c.ShouldBindJSON(&body); err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+            return
+        }
+    }
+
+    req := database.UpdateBookRatingRequest{}
+
+    if overall, clear, err := parseOptionalRating(body.Overall, "overall"); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    } else {
+        req.Overall = overall
+        req.ClearOverall = clear
+    }
+
+    if story, clear, err := parseOptionalRating(body.Story, "story"); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    } else {
+        req.Story = story
+        req.ClearStory = clear
+    }
+
+    if perf, clear, err := parseOptionalRating(body.Performance, "performance"); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    } else {
+        req.Performance = perf
+        req.ClearPerf = clear
+    }
+
+    // Notes: null clears, string sets, absent leaves alone
+    if len(body.Notes) > 0 {
+        if string(body.Notes) == "null" {
+            req.ClearNotes = true
+        } else {
+            var notes string
+            if err := json.Unmarshal(body.Notes, &notes); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "notes: must be a string or null"})
+                return
+            }
+            req.Notes = &notes
+        }
+    }
+
+    ctx := c.Request.Context()
+    if err := s.store.UpdateBookRating(ctx, id, req); err != nil {
+        if errors.Is(err, database.ErrNotFound) {
+            c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+            return
+        }
+        s.log.Errorf("UpdateBookRating %s: %v", id, err)
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+        return
+    }
+
+    // Return the updated book
+    book, err := s.store.GetBook(ctx, id)
+    if err != nil {
+        s.log.Errorf("GetBook after rating update %s: %v", id, err)
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+        return
+    }
+    c.JSON(http.StatusOK, book)
+}
+```
+
+Make sure `errors`, `encoding/json`, `net/http` are imported. They will already be in the file — just verify.
+
+---
+
+## Step 6 — Register the Route
+
+**File:** `internal/server/server.go`
+
+Search for where `handleUpdateBook` is registered. It will look like:
+
+```go
+audiobooks.PATCH("/:id", s.handleUpdateBook)
+```
+
+or similar (the exact router group name may vary — it's the group that handles `/api/v1/audiobooks`).
+
+Add the new route **immediately after** the existing PATCH route for the book:
+
+```go
+audiobooks.PATCH("/:id/rating", s.handleUpdateBookRating)
+```
+
+Make sure this line is inside the same router group as the other audiobook routes, before the group's closing brace.
+
+---
+
+## Step 7 — Write Tests
+
+**File:** `internal/server/metadata_handlers_test.go`
+
+Add two test functions at the end of the file:
+
+### Test 1: Happy path — set ratings
+
+```go
+func TestHandleUpdateBookRating_SetRatings(t *testing.T) {
+    s, mock := newTestServer(t)  // use whatever helper already exists in the file
+
+    bookID := "test-book-123"
+    // Ensure GetBook returns a book after the update
+    mock.Books[bookID] = &database.Book{ID: bookID, Title: "Test Book"}
+
+    body := `{"overall": 4.5, "story": 4.0, "performance": 5.0, "notes": "Great!"}`
+    req := httptest.NewRequest(http.MethodPatch, "/api/v1/audiobooks/"+bookID+"/rating", strings.NewReader(body))
+    req.Header.Set("Content-Type", "application/json")
+    w := httptest.NewRecorder()
+
+    s.ServeHTTP(w, req)
+
+    assert.Equal(t, http.StatusOK, w.Code)
+
+    var result database.Book
+    require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+    assert.Equal(t, bookID, result.ID)
+}
+```
+
+### Test 2: Validation error — out of range
+
+```go
+func TestHandleUpdateBookRating_InvalidValue(t *testing.T) {
+    s, _ := newTestServer(t)
+
+    body := `{"overall": 6.0}`
+    req := httptest.NewRequest(http.MethodPatch, "/api/v1/audiobooks/anything/rating", strings.NewReader(body))
+    req.Header.Set("Content-Type", "application/json")
+    w := httptest.NewRecorder()
+
+    s.ServeHTTP(w, req)
+
+    assert.Equal(t, http.StatusBadRequest, w.Code)
+    assert.Contains(t, w.Body.String(), "overall")
+}
+```
+
+Note: `newTestServer(t)` is whatever test helper already exists in the test file. Search for it with `grep -n "func newTestServer\|func setupTestServer" internal/server/`. Use the exact name you find.
+
+---
+
+## Step 8 — Verify
+
+Run:
+
+```bash
+go build ./...
+go test ./internal/database/... ./internal/server/...
+```
+
+Both must pass with zero failures.
+
+Also run the full test suite:
+
+```bash
+make test
+```
+
+Must pass.
+
+---
+
+## Step 9 — PR Instructions
+
+1. Branch name: `feat/user-ratings-api`
+2. Commit message: `feat(ratings): add PATCH /api/v1/audiobooks/:id/rating endpoint`
+3. PR title: `feat(ratings): user rating PATCH endpoint (RATE-1)`
+4. PR body must mention: "closes RATE-1", list the four files changed, note that no migration is needed.
+5. Do NOT include frontend changes in this PR.
+6. Do NOT squash commits.
+
+---
+
+## Checklist
+
+- [ ] `UpdateBookRatingRequest` struct added to `internal/database/store.go`
+- [ ] `UpdateBookRating` added to `Store` interface in `internal/database/store.go`
+- [ ] `SQLiteStore.UpdateBookRating` implemented in `internal/database/sqlite_store.go`
+- [ ] `PebbleStore.UpdateBookRating` implemented in `internal/database/pebble_store.go`
+- [ ] Mock updated in `internal/database/mock_store.go`
+- [ ] `ratingPatchRequest` struct added to `internal/server/metadata_handlers.go`
+- [ ] `parseOptionalRating` helper added to `internal/server/metadata_handlers.go`
+- [ ] `handleUpdateBookRating` handler added to `internal/server/metadata_handlers.go`
+- [ ] Route registered in `internal/server/server.go`
+- [ ] 2 tests added to `internal/server/metadata_handlers_test.go`
+- [ ] `go build ./...` passes
+- [ ] `make test` passes

--- a/docs/superpowers/specs/2026-04-29-audible-category-ladders-design.md
+++ b/docs/superpowers/specs/2026-04-29-audible-category-ladders-design.md
@@ -1,0 +1,193 @@
+<!-- file: docs/superpowers/specs/2026-04-29-audible-category-ladders-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f7a1c2e-5b9d-4e8f-a2c1-6d0e3f8b2a47 -->
+<!-- last-edited: 2026-04-29 -->
+
+# Design: Audible Category Ladders as User Tags
+
+## Overview
+
+Audible's catalog API supports a `category_ladders` response group that returns
+hierarchical genre/subject information. This document describes how to ingest
+those categories into the audiobook-organizer tag system so they appear on book
+detail pages, drive search, and remain idempotent on re-apply.
+
+---
+
+## Audible API Data Shape
+
+When `category_ladders` is added to the `response_groups` query parameter,
+each product's JSON includes a top-level array like:
+
+```json
+"category_ladders": [
+  {
+    "ladder": [
+      { "id": "18685580011", "name": "Science Fiction & Fantasy" },
+      { "id": "18685589011", "name": "Science Fiction" },
+      { "id": "18685594011", "name": "Space Opera" }
+    ],
+    "root": "Audible Books & Originals"
+  },
+  {
+    "ladder": [
+      { "id": "18685580011", "name": "Science Fiction & Fantasy" },
+      { "id": "18685589011", "name": "Science Fiction" }
+    ],
+    "root": "Audible Books & Originals"
+  }
+]
+```
+
+Key properties:
+
+- `root` is always a top-level Audible navigation bucket (e.g. "Audible Books &
+  Originals"). It is NOT a meaningful genre tag — skip it.
+- Each `ladder` entry is an ordered path from broad to specific. Every node in
+  the ladder (except the implicit root) is a candidate genre tag.
+- A book commonly appears in two or three ladders with overlapping nodes. The
+  tag layer must deduplicate.
+
+---
+
+## Tag Storage Strategy
+
+Tags are stored in the `book_tags` table with schema:
+
+```
+book_id   TEXT NOT NULL
+tag       TEXT NOT NULL
+source    TEXT NOT NULL
+created_at TIMESTAMP
+UNIQUE(book_id, tag, source)   -- enforced by AddBookUserTag
+```
+
+Category ladder nodes are stored with `source = "audible_category"`. This
+distinguishes them from human-applied tags (`source = "user"`) and system
+provenance tags (`source = "system"`).
+
+`AddBookUserTag` in `internal/database/sqlite_store.go` is already idempotent
+via `INSERT OR IGNORE`, so re-applying the same candidate does not duplicate
+tags.
+
+---
+
+## Ingestion Pipeline
+
+### Step 1 — Fetch
+
+`audibleResponseGroups` constant (in `internal/metadata/audible.go`) must
+include `"category_ladders"`. The API then populates
+`audibleProduct.CategoryLadders`.
+
+### Step 2 — Parse
+
+`productToMetadata()` iterates all ladders, collects all node `Name` fields
+(skipping the root bucket itself, which has no ladder entry — the root is a
+string field, not a node), deduplicates them in insertion order, and writes them
+to `BookMetadata.CategoryTags []string`.
+
+### Step 3 — Apply
+
+`ApplyMetadataCandidate` in `internal/metafetch/service.go` (and its batch
+equivalent) already calls `mfs.ApplyMetadataSystemTags(...)` after updating the
+book record. After that call, a new loop over `meta.CategoryTags` calls
+`mfs.db.AddBookUserTag(book.ID, tag, "audible_category")` for each tag.
+
+Category tags intentionally bypass the `fields` allowlist mechanism — they are
+additive enrichment, not a replacement of a specific book field.
+
+### Step 4 — Tag Lifecycle
+
+Tags accumulate; they are never automatically removed on re-apply. If a user
+wants to remove a mistaken category tag, they use the existing tag-delete UI.
+This matches the behavior of `metadata:source:*` and `metadata:language:*`
+system tags.
+
+---
+
+## UI Presentation
+
+### Tag chips
+
+The frontend (`TagList` component) already renders chips for each `book_tags`
+entry. The `source` field is available in the API response. Category tags should
+render with the MUI `color="info"` chip variant (cyan/teal) to distinguish them
+from:
+
+- `color="default"` — user-added tags
+- `color="secondary"` — system provenance tags (`metadata:source:*`, etc.)
+
+### Tag tooltip
+
+Hovering an `audible_category` chip should show "Genre from Audible" as the
+tooltip. This keeps the distinction clear without requiring a legend.
+
+### No new UI components needed
+
+The existing chip rendering path already supports per-source colors via a
+`sourceColorMap` lookup — add `"audible_category": "info"` to that map.
+
+---
+
+## Search
+
+The existing `has_tag:"Science Fiction"` query syntax in the search parser
+already drives a `book_tags` join. No parser changes are needed. Category tags
+are immediately searchable after the first apply.
+
+Example queries that will work once tags are populated:
+
+```
+has_tag:"Space Opera"
+has_tag:"Science Fiction & Fantasy"
+has_tag:"Mystery"
+```
+
+---
+
+## Deduplication Rules
+
+1. Within a single product, collect all node names across all ladders into a
+   `map[string]struct{}` (insertion-order slice backed by the map for
+   determinism).
+2. Across re-applies, `AddBookUserTag`'s `INSERT OR IGNORE` is the
+   deduplication boundary — no pre-check needed.
+3. Case sensitivity: store tags exactly as Audible returns them (title case).
+   The search layer already does case-insensitive LIKE matching.
+
+---
+
+## Error Handling
+
+- If `category_ladders` is absent from the API response (e.g. ASIN lookups
+  that don't include the group), `CategoryLadders` is nil — the loop is a
+  no-op.
+- `AddBookUserTag` errors are logged as `[WARN]` and do not fail the apply
+  transaction. Category tagging is best-effort enrichment.
+
+---
+
+## Not In Scope
+
+- Hierarchical / nested display of categories in the UI (flat chip list is
+  sufficient for v1).
+- Category-to-genre field mapping (the `genre` DB column is a free-text field
+  managed separately; category tags are additive).
+- Syncing category tags back into audio file ID3/MP4 tags (tag write-back
+  covers standard fields only).
+- Removing stale category tags when a book's Audible entry changes category.
+
+---
+
+## Acceptance Criteria
+
+1. After applying an Audible metadata candidate, `book_tags` contains one row
+   per ladder node with `source = "audible_category"`.
+2. Re-applying the same candidate does not create duplicate rows.
+3. Category tag chips render with `color="info"` in the book detail UI.
+4. `has_tag:"Science Fiction"` returns books with that category tag.
+5. Unit test: fake Audible JSON with two overlapping ladders → exactly the
+   expected deduplicated tag set.
+6. `go test ./internal/metadata/... ./internal/server/...` passes with no new
+   failures.

--- a/docs/superpowers/specs/2026-04-29-user-ratings-design.md
+++ b/docs/superpowers/specs/2026-04-29-user-ratings-design.md
@@ -1,0 +1,288 @@
+<!-- file: docs/superpowers/specs/2026-04-29-user-ratings-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a3f7c2e1-84b5-4d9a-b6f0-2c8e51d73a09 -->
+<!-- last-edited: 2026-04-29 -->
+
+# User Ratings — Design Spec
+
+## Overview
+
+Allow users to rate audiobooks across three dimensions: **Overall**, **Story**, and **Performance**. Ratings are stored as nullable floats (0–5, 0.5-step granularity) plus an optional free-text notes field. External ratings (Audible, Google) remain read-only display data and are shown alongside user ratings in the MetadataReviewDialog candidate cards.
+
+---
+
+## 1. Data Model
+
+### 1.1 Book Struct Fields (already added in PR #517)
+
+```go
+// internal/database/store.go  — Book struct
+UserRatingOverall     *float64 `json:"user_rating_overall"`
+UserRatingStory       *float64 `json:"user_rating_story"`
+UserRatingPerformance *float64 `json:"user_rating_performance"`
+UserRatingNotes       *string  `json:"user_rating_notes"`
+```
+
+All four fields are **nullable**:
+
+| Value | Meaning |
+|-------|---------|
+| `nil` / JSON `null` | User has not rated this dimension |
+| `0.0` | User explicitly rated 0 stars (lowest) |
+| `5.0` | User rated 5 stars (highest) |
+
+A rating of `0.0` is semantically different from "not rated". The UI must distinguish between the two states (e.g., a "not yet rated" placeholder vs. an explicit zero-star rating).
+
+### 1.2 Storage
+
+Columns exist via `ensureExtendedBookColumns` in `internal/database/sqlite_store.go`. No migration file is required. Pebble stores the JSON blob; the fields round-trip through standard JSON marshal/unmarshal.
+
+### 1.3 Valid Rating Values
+
+- Range: `0.0` to `5.0` inclusive
+- Step: `0.5`
+- Valid discrete values: `0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0`
+- The backend must reject values outside this set with `400 Bad Request`.
+
+---
+
+## 2. API
+
+### 2.1 Endpoint
+
+```
+PATCH /api/v1/audiobooks/:id/rating
+```
+
+- **Auth**: standard bearer token (same as all other mutating endpoints)
+- **Content-Type**: `application/json`
+
+### 2.2 Request Body
+
+All fields are optional. Sending a field sets it. Sending `null` for a field clears it (sets DB column to NULL). Omitting a field leaves the existing value unchanged.
+
+```json
+{
+  "overall":     4.5,
+  "story":       4.0,
+  "performance": 5.0,
+  "notes":       "Fantastic narration; dragged a bit in the middle."
+}
+```
+
+Clear a single dimension:
+
+```json
+{ "overall": null }
+```
+
+Clear everything:
+
+```json
+{ "overall": null, "story": null, "performance": null, "notes": null }
+```
+
+### 2.3 Response
+
+On success: `200 OK` with the full updated `Book` object (same shape as `GET /api/v1/audiobooks/:id`).
+
+On validation error: `400 Bad Request`
+
+```json
+{ "error": "overall must be between 0 and 5 in 0.5 increments" }
+```
+
+On not-found: `404 Not Found`.
+
+### 2.4 Nullability Rules (detailed)
+
+The request body uses a **pointer-of-pointer** sentinel pattern server-side (or explicit `json.RawMessage` parsing) so the handler can distinguish between three states:
+
+| JSON value | Meaning |
+|------------|---------|
+| Field omitted | Do not touch this column |
+| `null` | Set column to NULL (clear rating) |
+| `4.5` | Set column to 4.5 |
+
+Implementation guidance: decode into a struct where each rating field is `**float64`. The outer pointer being `nil` means "field was absent"; inner pointer being `nil` means "field was `null`"; non-nil inner pointer carries the value.
+
+---
+
+## 3. Frontend — Book Detail UI
+
+### 3.1 Star Widget Component
+
+A reusable `<StarRating>` component lives at `web/src/components/common/StarRating.tsx`.
+
+Props:
+
+```ts
+interface StarRatingProps {
+  label: string;           // "Overall", "Story", "Performance"
+  value: number | null;    // null = not rated
+  onChange: (v: number | null) => void;
+  readOnly?: boolean;
+}
+```
+
+Behavior:
+
+- Renders 5 stars; each star has two clickable half-regions (left = N-0.5, right = N).
+- MUI `Rating` component supports `precision={0.5}` — use it.
+- Clicking the currently-selected value toggles back to `null` ("not rated").
+- A small `✕ Clear` `IconButton` appears to the right when `value !== null`.
+- `readOnly` disables interaction and hides the clear button (used for displaying Audible/Google ratings).
+
+### 3.2 Book Detail Ratings Panel
+
+Located in `web/src/components/audiobooks/BookDetail.tsx`, rendered as a collapsible `<Accordion>` section titled **"My Ratings"**, positioned below the main metadata panel.
+
+Layout:
+
+```
+My Ratings                         [Save]
+─────────────────────────────────────────
+Overall      ★ ★ ★ ★ ☆   4.0    [✕]
+Story        ★ ★ ★ ★ ★   5.0    [✕]
+Performance  ★ ★ ★ ☆ ☆   3.0    [✕]
+
+Notes
+┌─────────────────────────────────────┐
+│ Great performance, slow middle act. │
+└─────────────────────────────────────┘
+                                [Save]
+```
+
+- Changes are local-state until **Save** is clicked.
+- **Save** calls `PATCH /api/v1/audiobooks/:id/rating` with only changed fields (delta patch).
+- Optimistic update: immediately update local state, rollback with a snackbar on error.
+- If all three star ratings are `null` and notes is empty, display a muted "Not yet rated" placeholder instead of the widget rows (expand accordion to add rating).
+
+### 3.3 External Ratings (read-only)
+
+When a book has Audible or Google metadata, show a separate read-only sub-section **"External Ratings"** with:
+
+- Audible: up to 5 dimensions displayed as read-only `StarRating` widgets (overall + 4 sub-scores if present).
+- Google: single rating, shown with its review count.
+- These are never editable.
+
+---
+
+## 4. MetadataReviewDialog — Candidate Cards
+
+`web/src/components/audiobooks/MetadataReviewDialog.tsx`
+
+In `renderCompactRow` (and/or `renderTwoColumnCard`), add info chips to each candidate card showing the source's rating data:
+
+### 4.1 Audible Ratings Chips
+
+If the candidate has an Audible overall rating (field: `audible_rating_overall`):
+
+```tsx
+<Chip
+  label={`★ ${candidate.audible_rating_overall?.toFixed(1)} Audible`}
+  size="small"
+  variant="outlined"
+  color="default"
+/>
+```
+
+If sub-scores are available (story, performance, value):
+
+```tsx
+<Chip label={`Story ${candidate.audible_rating_story?.toFixed(1)}`} size="small" />
+<Chip label={`Perf ${candidate.audible_rating_performance?.toFixed(1)}`} size="small" />
+```
+
+### 4.2 Google Ratings Chip
+
+```tsx
+<Chip
+  label={`★ ${candidate.google_rating?.toFixed(1)} Google (${candidate.google_ratings_count} ratings)`}
+  size="small"
+  variant="outlined"
+/>
+```
+
+Only render each chip if the field is non-null.
+
+---
+
+## 5. Library Search / Filter
+
+### 5.1 Search Syntax
+
+Extend the existing filter parser to support:
+
+| Expression | Meaning |
+|------------|---------|
+| `user_rating_overall > 4` | Overall rating strictly greater than 4 |
+| `user_rating_overall >= 4` | Overall rating ≥ 4 |
+| `user_rating_overall = 4.5` | Exact match |
+| `user_rating_story <= 3` | Story rating ≤ 3 |
+| `user_rating_performance > 0` | Performance has been rated (any positive value) |
+| `user_rating_overall = null` | Not yet rated |
+
+### 5.2 SQL Implementation
+
+The filter parser (`internal/database/filter_parser.go` or equivalent) maps `user_rating_overall` → `user_rating_overall` column. NULL-aware comparisons:
+
+```sql
+-- "user_rating_overall > 4"
+user_rating_overall > 4.0
+
+-- "user_rating_overall = null"
+user_rating_overall IS NULL
+```
+
+### 5.3 Frontend Filter UI
+
+In the advanced search panel, add a **"My Ratings"** filter group with three range sliders (min 0, max 5, step 0.5) for Overall, Story, Performance. A "Not yet rated" checkbox per dimension emits the `= null` filter.
+
+---
+
+## 6. Bulk Quick-Rate from List View
+
+### 6.1 UX Flow
+
+1. User selects one or more books in the library list using checkboxes.
+2. A bulk-action bar appears at the bottom of the screen (same bar used for batch-delete, etc.).
+3. The bar includes a **"Rate"** button.
+4. Clicking **Rate** opens a compact dialog:
+
+```
+Rate 12 books
+─────────────────────────────────────────
+Overall      [★ ★ ★ ★ ☆]   (leave blank = don't change)
+Story        [★ ★ ★ ★ ☆]   (leave blank = don't change)
+Performance  [★ ★ ★ ★ ☆]   (leave blank = don't change)
+Notes        [                          ]
+
+[Cancel]                          [Apply to 12 books]
+```
+
+5. Blank dimensions are not sent (existing values preserved).
+6. Submit fires `N` parallel `PATCH /api/v1/audiobooks/:id/rating` requests (one per book). Use `Promise.allSettled` so partial failures don't block the rest.
+7. Show a summary snackbar: "Rated 12 books (0 errors)" or "Rated 10 books (2 errors — see console)".
+
+### 6.2 API
+
+No new bulk endpoint is needed. The frontend fires individual PATCHes. If we later need a bulk endpoint for performance, add `POST /api/v1/audiobooks/batch-operations` action `"rate"`.
+
+---
+
+## 7. Non-Goals (Out of Scope for This Iteration)
+
+- Rating history / changelog entries for rating changes
+- Rating-based smart playlists
+- Syncing user ratings to Audible or any external service
+- Star ratings displayed in the library list columns (filter only, no column)
+- Rating analytics / dashboard
+
+---
+
+## 8. Open Questions
+
+1. Should clearing all three star ratings AND clearing notes via the dialog auto-collapse the accordion to "Not yet rated" state? (Suggested: yes, with a 300ms animation.)
+2. Should the bulk quick-rate dialog have a "Clear ratings" mode in addition to "Set ratings"? (Deferred to follow-up.)
+3. Audible sub-score field names in `MetadataCandidate` — confirm exact JSON keys with the Audible fetcher before implementing chips.


### PR DESCRIPTION
## Summary

- Added 2 human design specs: user ratings (3-dim) and Audible category ladders
- Added 10 machine bot-tasks (worst-LLM-ever format) for the burndown queue:
  - RATE-1: `PATCH /audiobooks/:id/rating` endpoint
  - DUR-1: duration-mismatch warning chip in MetadataReviewDialog
  - CAT-1: `category_ladders` ingestion + `AddBookUserTag` apply pipeline
  - RELINK-2: co-author dir fallback in `findInITunes`
  - RELINK-3: title prefix colon→underscore normalization helper
  - DELUGE-1/2/3: book_files migration, `protectedPathCache`, `importToLibrary` reflink workflow
  - ACT-1: `EmitInfo` for series-normalize + dedup-scan
  - ACT-3: isbn-enrich batch noun fix
- Updated TODO.md to add RATE/DUR/CAT/DELUGE/RELINK/ACT task IDs with direct links to bot-task files
- Also captured session 23 shipped work (PRs #509-521) and RELINK-1 spec in a prior commit

## Test plan

- [ ] Verify all 12 new files exist under `docs/superpowers/`
- [ ] Confirm TODO.md bot-task links resolve to the correct files
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)