### PR TITLE
Docs/OpenAI responses migration spec

### DIFF
--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.bulkFetch.test.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5b7b0d6f-5c2b-4d57-9b6c-8dbb7a9e9e2c
 
 import { render, screen, waitFor, within } from '@testing-library/react';
@@ -9,54 +9,74 @@ import userEvent from '@testing-library/user-event';
 import { Library } from './Library';
 import * as api from '../services/api';
 
-vi.mock('../services/api', () => ({
-  getActiveOperations: vi.fn().mockResolvedValue([]),
-  getOperationLogsTail: vi.fn().mockResolvedValue([]),
-  getBooks: vi.fn().mockResolvedValue([
-    {
-      id: 'id-1',
-      title: 'Test Book',
-      file_path: '/tmp/book.m4b',
-      created_at: '2026-01-01T00:00:00Z',
-      updated_at: '2026-01-01T00:00:00Z',
-      author_name: 'Author',
-    },
-    {
-      id: 'id-2',
-      title: 'Second Book',
-      file_path: '/tmp/book2.m4b',
-      created_at: '2026-01-01T00:00:00Z',
-      updated_at: '2026-01-01T00:00:00Z',
-      author_name: 'Author',
-    },
-  ]),
-  searchBooks: vi.fn().mockResolvedValue([]),
-  getImportPaths: vi.fn().mockResolvedValue([]),
-  countBooks: vi.fn().mockResolvedValue(2),
-  getSystemStatus: vi.fn().mockResolvedValue({
-    status: 'ok',
-    library: { path: '/tmp', book_count: 2, total_size: 0 },
-    import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
-    memory: {},
-    runtime: {},
-    operations: { recent: [] },
-  }),
-  getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
-  getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
-  getUserColumnConfig: vi.fn().mockResolvedValue(null),
-  saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
-  listAllUserTags: vi.fn().mockResolvedValue([]),
-  batchFetchCandidates: vi.fn().mockResolvedValue({
-    operation_id: 'op-1',
-  }),
-  batchWriteBackMetadata: vi.fn().mockResolvedValue({
-    written: 1,
-    written_files: 1,
-    renamed: 1,
-    failed: 0,
-    errors: [],
-  }),
-}));
+vi.mock('../services/api', () => {
+  class ApiError extends Error {
+    status: number;
+    data?: unknown;
+    constructor(message: string, status: number, data?: unknown) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.data = data;
+    }
+  }
+  return {
+    ApiError,
+    getActiveOperations: vi.fn().mockResolvedValue([]),
+    getOperationLogsTail: vi.fn().mockResolvedValue([]),
+    getBooks: vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: 'id-1',
+          title: 'Test Book',
+          file_path: '/tmp/book.m4b',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          author_name: 'Author',
+        },
+        {
+          id: 'id-2',
+          title: 'Second Book',
+          file_path: '/tmp/book2.m4b',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          author_name: 'Author',
+        },
+      ],
+      count: 2,
+    }),
+    searchBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    searchBooksPage: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getImportPaths: vi.fn().mockResolvedValue([]),
+    countBooks: vi.fn().mockResolvedValue(2),
+    getBookFacets: vi.fn().mockResolvedValue({ genres: [], languages: [] }),
+    getAuthors: vi.fn().mockResolvedValue([]),
+    getSeries: vi.fn().mockResolvedValue([]),
+    getSystemStatus: vi.fn().mockResolvedValue({
+      status: 'ok',
+      library: { path: '/tmp', book_count: 2, total_size: 0 },
+      import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
+      memory: {},
+      runtime: {},
+      operations: { recent: [] },
+    }),
+    getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
+    getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getUserColumnConfig: vi.fn().mockResolvedValue(null),
+    saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
+    listAllUserTags: vi.fn().mockResolvedValue([]),
+    batchFetchCandidates: vi.fn().mockResolvedValue({
+      operation_id: 'op-1',
+    }),
+    batchWriteBackMetadata: vi.fn().mockResolvedValue({
+      written: 1,
+      written_files: 1,
+      renamed: 1,
+      failed: 0,
+      errors: [],
+    }),
+  };
+});
 
 describe('Library bulk metadata fetch', () => {
   it('triggers bulk fetch when confirmed', async () => {

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.0.1
+// version: 1.1.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -8,45 +8,65 @@ import { describe, it, expect, vi } from 'vitest';
 import { Library } from './Library';
 import * as api from '../services/api';
 
-vi.mock('../services/api', () => ({
-  getActiveOperations: vi.fn().mockResolvedValue([]),
-  getOperationLogsTail: vi.fn().mockResolvedValue([]),
-  getBooks: vi.fn().mockResolvedValue([
-    {
-      id: 'id-1',
-      title: 'Test Book',
-      file_path: '/tmp/book.m4b',
-      created_at: '2026-01-01T00:00:00Z',
-      updated_at: '2026-01-01T00:00:00Z',
-      author_name: 'Author',
-    },
-  ]),
-  searchBooks: vi.fn().mockResolvedValue([]),
-  getImportPaths: vi.fn().mockResolvedValue([]),
-  countBooks: vi.fn().mockResolvedValue(1),
-  getSystemStatus: vi.fn().mockResolvedValue({
-    status: 'ok',
-    library: { path: '/tmp', book_count: 1, total_size: 0 },
-    import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
-    memory: {},
-    runtime: {},
-    operations: { recent: [] },
-  }),
-  getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
-  getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
-  getUserColumnConfig: vi.fn().mockResolvedValue(null),
-  saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
-  listAllUserTags: vi.fn().mockResolvedValue([]),
-  browseFilesystem: vi.fn().mockResolvedValue({
-    path: '/',
-    items: [],
-    disk_info: { total: 0, free: 0, available: 0 },
-  }),
-  importFile: vi.fn().mockResolvedValue({
-    message: 'import started',
-    book: { id: 'id-1', title: 'Test Book', file_path: '/tmp/book.m4b' },
-  }),
-}));
+vi.mock('../services/api', () => {
+  class ApiError extends Error {
+    status: number;
+    data?: unknown;
+    constructor(message: string, status: number, data?: unknown) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.data = data;
+    }
+  }
+  return {
+    ApiError,
+    getActiveOperations: vi.fn().mockResolvedValue([]),
+    getOperationLogsTail: vi.fn().mockResolvedValue([]),
+    getBooks: vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: 'id-1',
+          title: 'Test Book',
+          file_path: '/tmp/book.m4b',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          author_name: 'Author',
+        },
+      ],
+      count: 1,
+    }),
+    searchBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    searchBooksPage: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getImportPaths: vi.fn().mockResolvedValue([]),
+    countBooks: vi.fn().mockResolvedValue(1),
+    getBookFacets: vi.fn().mockResolvedValue({ genres: [], languages: [] }),
+    getAuthors: vi.fn().mockResolvedValue([]),
+    getSeries: vi.fn().mockResolvedValue([]),
+    getSystemStatus: vi.fn().mockResolvedValue({
+      status: 'ok',
+      library: { path: '/tmp', book_count: 1, total_size: 0 },
+      import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
+      memory: {},
+      runtime: {},
+      operations: { recent: [] },
+    }),
+    getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
+    getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getUserColumnConfig: vi.fn().mockResolvedValue(null),
+    saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
+    listAllUserTags: vi.fn().mockResolvedValue([]),
+    browseFilesystem: vi.fn().mockResolvedValue({
+      path: '/',
+      items: [],
+      disk_info: { total: 0, free: 0, available: 0 },
+    }),
+    importFile: vi.fn().mockResolvedValue({
+      message: 'import started',
+      book: { id: 'id-1', title: 'Test Book', file_path: '/tmp/book.m4b' },
+    }),
+  };
+});
 
 describe('Library import dialog', () => {
   it('imports a selected file path', async () => {

--- a/web/src/services/api.test.ts
+++ b/web/src/services/api.test.ts
@@ -1,5 +1,5 @@
 // file: src/services/api.test.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -28,16 +28,18 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          importPaths: [
-            {
-              id: 1,
-              path: '/tmp',
-              name: 'Tmp',
-              enabled: true,
-              created_at: 'now',
-              book_count: 0,
-            },
-          ],
+          data: {
+            importPaths: [
+              {
+                id: 1,
+                path: '/tmp',
+                name: 'Tmp',
+                enabled: true,
+                created_at: 'now',
+                book_count: 0,
+              },
+            ],
+          },
         }),
         {
           status: 200,
@@ -64,13 +66,15 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          importPath: {
-            id: 2,
-            path: '/new',
-            name: 'New',
-            enabled: true,
-            created_at: 'now',
-            book_count: 0,
+          data: {
+            importPath: {
+              id: 2,
+              path: '/new',
+              name: 'New',
+              enabled: true,
+              created_at: 'now',
+              book_count: 0,
+            },
           },
         }),
         {
@@ -92,15 +96,17 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          importPath: {
-            id: 3,
-            path: '/detailed',
-            name: 'Detailed',
-            enabled: true,
-            created_at: 'now',
-            book_count: 0,
+          data: {
+            importPath: {
+              id: 3,
+              path: '/detailed',
+              name: 'Detailed',
+              enabled: true,
+              created_at: 'now',
+              book_count: 0,
+            },
+            scan_operation_id: 'op-1',
           },
-          scan_operation_id: 'op-1',
         }),
         {
           status: 200,
@@ -127,17 +133,19 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          updated_count: 1,
-          total_count: 2,
-          results: [
-            {
-              book_id: 'id-1',
-              status: 'updated',
-              applied_fields: ['publisher'],
-              fetched_fields: ['publisher'],
-            },
-          ],
-          source: 'Open Library',
+          data: {
+            updated_count: 1,
+            total_count: 2,
+            results: [
+              {
+                book_id: 'id-1',
+                status: 'updated',
+                applied_fields: ['publisher'],
+                fetched_fields: ['publisher'],
+              },
+            ],
+            source: 'Open Library',
+          },
         }),
         {
           status: 200,
@@ -160,11 +168,13 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          written: 2,
-          written_files: 3,
-          renamed: 1,
-          failed: 0,
-          errors: [],
+          data: {
+            written: 2,
+            written_files: 3,
+            renamed: 1,
+            failed: 0,
+            errors: [],
+          },
         }),
         {
           status: 200,


### PR DESCRIPTION
This pull request introduces several improvements and preparations across the codebase, focusing on two main areas: planning for a migration to the OpenAI Responses API and enhancing the frontend's metadata review and test infrastructure.

**Summary of changes:**
- A detailed migration plan for the OpenAI Responses API has been added, outlining a phased rollout and its rationale.
- The frontend's metadata review dialog now surfaces additional information about audiobook durations.
- Test mocks for API calls have been refactored and expanded for greater accuracy and coverage.
- API test fixtures have been updated to match the latest response formats.

The most important changes are:

### OpenAI Responses API Migration Planning

- Added a comprehensive migration plan and design spec for moving from OpenAI's Chat Completions API to the newer Responses API, including rationale, phased rollout, risk mitigation, and implementation details. This includes a new spec file: `docs/superpowers/specs/2026-04-29-responses-api-migration-design.md` and a new section in `TODO.md`. [[1]](diffhunk://#diff-34609b68c5208299ff6fd2a2fcc6982aba64347ee6edd6863f8056c8a7a2161eR1-R181) [[2]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986R143-R161)

### Frontend: Metadata Review Dialog Improvements

- The `MetadataReviewDialog` component now displays a warning chip if the candidate's runtime differs by more than 10 minutes from the existing data, and always shows the candidate's duration if available. This improves visibility into significant metadata discrepancies. [[1]](diffhunk://#diff-1bd13c0601ffb850a0714003018454ba2b71e18b5bd90cb5b84176f9b99f2b8aR604-R611) [[2]](diffhunk://#diff-1bd13c0601ffb850a0714003018454ba2b71e18b5bd90cb5b84176f9b99f2b8aR904-R908)

### Frontend: Test Mock and Fixture Refactoring

- Refactored API mocks in `Library.bulkFetch.test.tsx` and `Library.importFile.test.tsx` to use a more realistic structure, including a custom `ApiError` class and updated function return values to match the actual API (e.g., returning objects with `items` and `count` instead of arrays). This supports more robust and accurate frontend testing. [[1]](diffhunk://#diff-8a3c737fd39504f641ffb8797fe16eead6ca0f6fc9c27ab1f3bb8c947d63fd47L12-R28) [[2]](diffhunk://#diff-8a3c737fd39504f641ffb8797fe16eead6ca0f6fc9c27ab1f3bb8c947d63fd47L32-R54) [[3]](diffhunk://#diff-8a3c737fd39504f641ffb8797fe16eead6ca0f6fc9c27ab1f3bb8c947d63fd47L59-R79) [[4]](diffhunk://#diff-538e17e0d26ec91ca219969d6eee0146d6ab1bfef3255ab89cdc823ca7470fafL11-R27) [[5]](diffhunk://#diff-538e17e0d26ec91ca219969d6eee0146d6ab1bfef3255ab89cdc823ca7470fafL23-R45) [[6]](diffhunk://#diff-538e17e0d26ec91ca219969d6eee0146d6ab1bfef3255ab89cdc823ca7470fafL49-R69)

- Expanded the mocked API surface in tests to include additional endpoints such as `getBookFacets`, `getAuthors`, and `getSeries`, ensuring the test environment more closely matches production. [[1]](diffhunk://#diff-8a3c737fd39504f641ffb8797fe16eead6ca0f6fc9c27ab1f3bb8c947d63fd47L32-R54) [[2]](diffhunk://#diff-538e17e0d26ec91ca219969d6eee0146d6ab1bfef3255ab89cdc823ca7470fafL23-R45)

### API Test Fixture Updates

- Updated API test fixtures in `api.test.ts` to wrap response payloads in a `data` field, matching the latest backend API response structure. This ensures tests remain valid as the backend evolves. [[1]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R31) [[2]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R42) [[3]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R69) [[4]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R78) [[5]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R99) [[6]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R109) [[7]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R136) [[8]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R148) [[9]](diffhunk://#diff-195329e6687b865a751b904dc843b5a45528b773a520661751feb8dd03c257b1R171-R177)