### PR TITLE
perf(stats): persist LibraryStats to PebbleDB key with 10-min TTL

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 
 package database
@@ -228,6 +228,12 @@ type StatsStore interface {
 	GetBookCountsByLocation(rootDir string) (library, import_ int, err error)
 	GetBookSizesByLocation(rootDir string) (librarySize, importSize int64, err error)
 	GetDashboardStats() (*DashboardStats, error)
+	// SetRootDir tells the store which directory is the organized library root,
+	// used to split OrganizedBooks vs UnorganizedBooks in LibraryStats.
+	SetRootDir(rootDir string)
+	// InvalidateLibraryStats drops the cached LibraryStats so the next call
+	// to GetDashboardStats triggers a fresh recompute.
+	InvalidateLibraryStats()
 }
 
 // MaintenanceStore covers database maintenance and scan-cache.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.38.0
+// version: 1.39.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package database
@@ -57,6 +57,8 @@ type MockStore struct {
 	CountSeriesFunc                 func() (int, error)
 	GetBookCountsByLocationFunc     func(rootDir string) (int, int, error)
 	GetDashboardStatsFunc           func() (*DashboardStats, error)
+	SetRootDirFunc                  func(string)
+	InvalidateLibraryStatsFunc      func()
 	ListSoftDeletedBooksFunc        func(limit, offset int, olderThan *time.Time) ([]Book, error)
 
 	// Work methods
@@ -784,7 +786,21 @@ func (m *MockStore) GetDashboardStats() (*DashboardStats, error) {
 	return &DashboardStats{
 		StateDistribution:  map[string]int{},
 		FormatDistribution: map[string]int{},
+		BooksByImportPath:  map[int]int{},
+		SizeByImportPath:   map[int]int64{},
 	}, nil
+}
+
+func (m *MockStore) SetRootDir(rootDir string) {
+	if m.SetRootDirFunc != nil {
+		m.SetRootDirFunc(rootDir)
+	}
+}
+
+func (m *MockStore) InvalidateLibraryStats() {
+	if m.InvalidateLibraryStatsFunc != nil {
+		m.InvalidateLibraryStatsFunc()
+	}
 }
 
 func (m *MockStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Time) ([]Book, error) {

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -17077,6 +17077,52 @@ func (_c *MockStatsStore_GetDashboardStats_Call) RunAndReturn(run func() (*datab
 	return _c
 }
 
+// SetRootDir provides a mock function for the type MockStatsStore
+func (_mock *MockStatsStore) SetRootDir(rootDir string) {
+	_mock.Called(rootDir)
+}
+
+type MockStatsStore_SetRootDir_Call struct{ *mock.Call }
+
+func (_e *MockStatsStore_Expecter) SetRootDir(rootDir interface{}) *MockStatsStore_SetRootDir_Call {
+	return &MockStatsStore_SetRootDir_Call{Call: _e.mock.On("SetRootDir", rootDir)}
+}
+func (_c *MockStatsStore_SetRootDir_Call) Run(run func(rootDir string)) *MockStatsStore_SetRootDir_Call {
+	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
+	return _c
+}
+func (_c *MockStatsStore_SetRootDir_Call) Return() *MockStatsStore_SetRootDir_Call {
+	_c.Call.Return()
+	return _c
+}
+func (_c *MockStatsStore_SetRootDir_Call) RunAndReturn(run func(string)) *MockStatsStore_SetRootDir_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InvalidateLibraryStats provides a mock function for the type MockStatsStore
+func (_mock *MockStatsStore) InvalidateLibraryStats() {
+	_mock.Called()
+}
+
+type MockStatsStore_InvalidateLibraryStats_Call struct{ *mock.Call }
+
+func (_e *MockStatsStore_Expecter) InvalidateLibraryStats() *MockStatsStore_InvalidateLibraryStats_Call {
+	return &MockStatsStore_InvalidateLibraryStats_Call{Call: _e.mock.On("InvalidateLibraryStats")}
+}
+func (_c *MockStatsStore_InvalidateLibraryStats_Call) Run(run func()) *MockStatsStore_InvalidateLibraryStats_Call {
+	_c.Call.Run(func(args mock.Arguments) { run() })
+	return _c
+}
+func (_c *MockStatsStore_InvalidateLibraryStats_Call) Return() *MockStatsStore_InvalidateLibraryStats_Call {
+	_c.Call.Return()
+	return _c
+}
+func (_c *MockStatsStore_InvalidateLibraryStats_Call) RunAndReturn(run func()) *MockStatsStore_InvalidateLibraryStats_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockMaintenanceStore creates a new instance of MockMaintenanceStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockMaintenanceStore(t interface {
@@ -41106,6 +41152,52 @@ func (_c *MockStore_UpsertMetadataFieldState_Call) Return(err error) *MockStore_
 }
 
 func (_c *MockStore_UpsertMetadataFieldState_Call) RunAndReturn(run func(state *database.MetadataFieldState) error) *MockStore_UpsertMetadataFieldState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetRootDir provides a mock function for the type MockStore
+func (_mock *MockStore) SetRootDir(rootDir string) {
+	_mock.Called(rootDir)
+}
+
+type MockStore_SetRootDir_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) SetRootDir(rootDir interface{}) *MockStore_SetRootDir_Call {
+	return &MockStore_SetRootDir_Call{Call: _e.mock.On("SetRootDir", rootDir)}
+}
+func (_c *MockStore_SetRootDir_Call) Run(run func(rootDir string)) *MockStore_SetRootDir_Call {
+	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string)) })
+	return _c
+}
+func (_c *MockStore_SetRootDir_Call) Return() *MockStore_SetRootDir_Call {
+	_c.Call.Return()
+	return _c
+}
+func (_c *MockStore_SetRootDir_Call) RunAndReturn(run func(string)) *MockStore_SetRootDir_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InvalidateLibraryStats provides a mock function for the type MockStore
+func (_mock *MockStore) InvalidateLibraryStats() {
+	_mock.Called()
+}
+
+type MockStore_InvalidateLibraryStats_Call struct{ *mock.Call }
+
+func (_e *MockStore_Expecter) InvalidateLibraryStats() *MockStore_InvalidateLibraryStats_Call {
+	return &MockStore_InvalidateLibraryStats_Call{Call: _e.mock.On("InvalidateLibraryStats")}
+}
+func (_c *MockStore_InvalidateLibraryStats_Call) Run(run func()) *MockStore_InvalidateLibraryStats_Call {
+	_c.Call.Run(func(args mock.Arguments) { run() })
+	return _c
+}
+func (_c *MockStore_InvalidateLibraryStats_Call) Return() *MockStore_InvalidateLibraryStats_Call {
+	_c.Call.Return()
+	return _c
+}
+func (_c *MockStore_InvalidateLibraryStats_Call) RunAndReturn(run func()) *MockStore_InvalidateLibraryStats_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.53.0
+// version: 1.54.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -68,8 +68,51 @@ func prefixEnd(prefix []byte) []byte {
 // - author_tombstone:<old_id>        -> canonical_id (merged author redirect)
 
 type PebbleStore struct {
-	db      *pebble.DB
+	db        *pebble.DB
 	counterMu sync.Mutex // protects nextID read-modify-write
+	rootDir   string     // organized library root; set via SetRootDir after config load
+}
+
+const statsLibraryKey = "stats:library"
+const statsLibraryTTL = 10 * time.Minute
+
+// SetRootDir updates the organized-library root used when computing LibraryStats
+// and invalidates the cache so the next GetDashboardStats recomputes with the new path.
+func (p *PebbleStore) SetRootDir(rootDir string) {
+	if p.rootDir != rootDir {
+		p.rootDir = rootDir
+		p.InvalidateLibraryStats()
+	}
+}
+
+// InvalidateLibraryStats drops the cached stats:library key so the next
+// GetDashboardStats call triggers a fresh full recompute.
+func (p *PebbleStore) InvalidateLibraryStats() {
+	_ = p.db.Delete([]byte(statsLibraryKey), pebble.Sync)
+}
+
+func (p *PebbleStore) readCachedLibraryStats() *LibraryStats {
+	val, closer, err := p.db.Get([]byte(statsLibraryKey))
+	if err != nil {
+		return nil
+	}
+	defer closer.Close()
+	var s LibraryStats
+	if err := json.Unmarshal(val, &s); err != nil {
+		return nil
+	}
+	if time.Since(s.ComputedAt) > statsLibraryTTL {
+		return nil
+	}
+	return &s
+}
+
+func (p *PebbleStore) writeCachedLibraryStats(s *LibraryStats) {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return
+	}
+	_ = p.db.Set([]byte(statsLibraryKey), data, pebble.Sync)
 }
 
 // NewPebbleStore creates a new PebbleDB store
@@ -2068,27 +2111,25 @@ func (p *PebbleStore) GetDistinctLanguages() ([]string, error) {
 
 // CountFiles returns the total number of audio files across all books.
 // Books with active segments count their segments; books without segments count as 1 file each.
+// Uses two range scans instead of per-book GetBookFiles calls to avoid N+1 queries.
 func (p *PebbleStore) CountFiles() (int, error) {
-	// Collect IDs of all primary, non-deleted books
-	var bookIDs []string
-
-	iter, err := p.db.NewIter(&pebble.IterOptions{
+	// Pass 1: collect IDs of all primary, non-deleted books (key scan + JSON decode)
+	primaryBookIDs := make(map[string]struct{})
+	bookIter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
 		UpperBound: []byte("book:;"),
 	})
 	if err != nil {
 		return 0, err
 	}
-	defer iter.Close()
-
-	for iter.First(); iter.Valid(); iter.Next() {
-		key := string(iter.Key())
+	for bookIter.First(); bookIter.Valid(); bookIter.Next() {
+		key := string(bookIter.Key())
 		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
 			strings.Contains(key, ":author:") {
 			continue
 		}
 		var book Book
-		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+		if err := json.Unmarshal(bookIter.Value(), &book); err != nil {
 			return 0, err
 		}
 		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
@@ -2097,30 +2138,51 @@ func (p *PebbleStore) CountFiles() (int, error) {
 		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
 			continue
 		}
-		bookIDs = append(bookIDs, book.ID)
+		primaryBookIDs[book.ID] = struct{}{}
 	}
+	bookIter.Close()
 
-	totalFiles := 0
-	for _, id := range bookIDs {
-		files, err := p.GetBookFiles(id)
-		if err != nil || len(files) == 0 {
-			totalFiles++ // No files means single file
+	// Pass 2: single range scan over book_file: space — count active files per book
+	fileIter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book_file:"),
+		UpperBound: []byte("book_file;"),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer fileIter.Close()
+
+	bookActiveFiles := make(map[string]int, len(primaryBookIDs))
+	for fileIter.First(); fileIter.Valid(); fileIter.Next() {
+		// Primary keys are book_file:<bookID>:<fileID> (3 colon-delimited segments).
+		// The upper bound book_file; already excludes secondary indexes (book_file_pid:, etc.)
+		// but SplitN guards against any edge cases.
+		parts := strings.SplitN(string(fileIter.Key()), ":", 4)
+		if len(parts) != 3 {
 			continue
 		}
-		activeCount := 0
-		for _, f := range files {
-			if !f.Missing {
-				activeCount++
-			}
+		bookID := parts[1]
+		if _, ok := primaryBookIDs[bookID]; !ok {
+			continue
 		}
-		if activeCount > 0 {
-			totalFiles += activeCount
-		} else {
-			totalFiles++ // No active files, treat as single file
+		var f BookFile
+		if err := json.Unmarshal(fileIter.Value(), &f); err != nil {
+			continue
+		}
+		if !f.Missing {
+			bookActiveFiles[bookID]++
 		}
 	}
 
-	return totalFiles, nil
+	total := 0
+	for id := range primaryBookIDs {
+		if n := bookActiveFiles[id]; n > 0 {
+			total += n
+		} else {
+			total++ // no file records or all missing → count as 1
+		}
+	}
+	return total, nil
 }
 
 func (p *PebbleStore) CountAuthors() (int, error) {
@@ -2162,107 +2224,81 @@ func (p *PebbleStore) CountSeries() (int, error) {
 }
 
 func (p *PebbleStore) GetBookCountsByLocation(rootDir string) (library, import_ int, err error) {
-	iter, err := p.db.NewIter(&pebble.IterOptions{
-		LowerBound: []byte("book:0"),
-		UpperBound: []byte("book:;"),
-	})
+	stats, err := p.GetDashboardStats()
 	if err != nil {
 		return 0, 0, err
 	}
-	defer iter.Close()
-	for iter.First(); iter.Valid(); iter.Next() {
-		key := string(iter.Key())
-		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
-			strings.Contains(key, ":author:") {
-			continue
-		}
-		var book Book
-		if err := json.Unmarshal(iter.Value(), &book); err != nil {
-			continue
-		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
-			continue
-		}
-		// Skip non-primary versions so organized originals don't inflate import count
-		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
-			continue
-		}
-		if rootDir != "" && strings.HasPrefix(book.FilePath, rootDir) {
-			library++
-		} else {
-			import_++
-		}
-	}
-	return
+	return stats.OrganizedBooks, stats.UnorganizedBooks, nil
 }
 
 func (p *PebbleStore) GetBookSizesByLocation(rootDir string) (librarySize, importSize int64, err error) {
-	iter, err := p.db.NewIter(&pebble.IterOptions{
+	stats, err := p.GetDashboardStats()
+	if err != nil {
+		return 0, 0, err
+	}
+	return stats.OrganizedSize, stats.UnorganizedSize, nil
+}
+
+// GetDashboardStats returns LibraryStats, serving from the PebbleDB cache when fresh.
+// Cache miss (first call, TTL expiry, or explicit InvalidateLibraryStats) triggers
+// computeLibraryStats which does two range scans and writes the result back.
+func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
+	if cached := p.readCachedLibraryStats(); cached != nil {
+		return cached, nil
+	}
+	stats, err := p.computeLibraryStats()
+	if err != nil {
+		return nil, err
+	}
+	p.writeCachedLibraryStats(stats)
+	return stats, nil
+}
+
+// computeLibraryStats builds a fresh LibraryStats in two sequential range scans.
+// Pass 1 (book:): counts/sums all fields, splits organized vs unorganized, per-import-path counts.
+// Pass 2 (book_file:): counts active files without any per-book point lookups.
+func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
+	stats := &LibraryStats{
+		StateDistribution:  make(map[string]int),
+		FormatDistribution: make(map[string]int),
+		BooksByImportPath:  make(map[int]int),
+		SizeByImportPath:   make(map[int]int64),
+		ComputedAt:         time.Now(),
+	}
+
+	// Load import paths upfront (typically just a handful, not worth a separate scan).
+	importPaths, _ := p.GetAllImportPaths()
+
+	// Pass 1: book: range
+	primaryBookIDs := make(map[string]struct{}, 12000)
+	bookIter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
 		UpperBound: []byte("book:;"),
 	})
 	if err != nil {
-		return 0, 0, err
+		return nil, err
 	}
-	defer iter.Close()
-	for iter.First(); iter.Valid(); iter.Next() {
-		key := string(iter.Key())
+	for bookIter.First(); bookIter.Valid(); bookIter.Next() {
+		key := string(bookIter.Key())
 		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
 			strings.Contains(key, ":author:") {
 			continue
 		}
-		var book Book
-		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+		var b Book
+		if err := json.Unmarshal(bookIter.Value(), &b); err != nil {
 			continue
 		}
-		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
 			continue
 		}
-		// Skip non-primary versions (consistent with count logic)
-		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
-			continue
-		}
-		size := int64(0)
-		if book.FileSize != nil {
-			size = *book.FileSize
-		}
-		if rootDir != "" && strings.HasPrefix(book.FilePath, rootDir) {
-			librarySize += size
-		} else {
-			importSize += size
-		}
-	}
-	return
-}
-
-// GetDashboardStats iterates all books and computes aggregate stats.
-// PebbleDB has no SQL, so this scans the full key range.
-func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
-	stats := &DashboardStats{
-		StateDistribution:  make(map[string]int),
-		FormatDistribution: make(map[string]int),
-	}
-	if fc, err := p.CountFiles(); err == nil {
-		stats.TotalFiles = fc
-	}
-	if ac, err := p.CountAuthors(); err == nil {
-		stats.TotalAuthors = ac
-	}
-	if sc, err := p.CountSeries(); err == nil {
-		stats.TotalSeries = sc
-	}
-
-	books, err := p.GetAllBooks(1_000_000, 0)
-	if err != nil {
-		return nil, err
-	}
-	for _, b := range books {
 		stats.TotalBooks++
 		if b.Duration != nil {
 			stats.TotalDuration += int64(*b.Duration)
 		}
+		size := int64(0)
 		if b.FileSize != nil {
-			stats.TotalSize += *b.FileSize
+			size = *b.FileSize
+			stats.TotalSize += size
 		}
 		state := "imported"
 		if b.LibraryState != nil {
@@ -2274,7 +2310,70 @@ func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
 			codec = *b.Codec
 		}
 		stats.FormatDistribution[codec]++
+
+		// Organized vs unorganized + per-import-path (primary versions only)
+		if b.IsPrimaryVersion == nil || *b.IsPrimaryVersion {
+			primaryBookIDs[b.ID] = struct{}{}
+			if p.rootDir != "" && strings.HasPrefix(b.FilePath, p.rootDir) {
+				stats.OrganizedBooks++
+				stats.OrganizedSize += size
+			} else {
+				stats.UnorganizedBooks++
+				stats.UnorganizedSize += size
+				for _, ip := range importPaths {
+					if strings.HasPrefix(b.FilePath, ip.Path) {
+						stats.BooksByImportPath[ip.ID]++
+						stats.SizeByImportPath[ip.ID] += size
+						break
+					}
+				}
+			}
+		}
 	}
+	bookIter.Close()
+
+	// Pass 2: book_file: range — active file count per primary book
+	fileIter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book_file:"),
+		UpperBound: []byte("book_file;"),
+	})
+	if err == nil {
+		bookActiveFiles := make(map[string]int, len(primaryBookIDs))
+		for fileIter.First(); fileIter.Valid(); fileIter.Next() {
+			parts := strings.SplitN(string(fileIter.Key()), ":", 4)
+			if len(parts) != 3 {
+				continue
+			}
+			bookID := parts[1]
+			if _, ok := primaryBookIDs[bookID]; !ok {
+				continue
+			}
+			var f BookFile
+			if err := json.Unmarshal(fileIter.Value(), &f); err != nil {
+				continue
+			}
+			if !f.Missing {
+				bookActiveFiles[bookID]++
+			}
+		}
+		fileIter.Close()
+		for id := range primaryBookIDs {
+			if n := bookActiveFiles[id]; n > 0 {
+				stats.TotalFiles += n
+			} else {
+				stats.TotalFiles++ // no file records or all missing → count as 1
+			}
+		}
+	}
+
+	// Key-only scans — no JSON deserialization
+	if ac, err := p.CountAuthors(); err == nil {
+		stats.TotalAuthors = ac
+	}
+	if sc, err := p.CountSeries(); err == nil {
+		stats.TotalSeries = sc
+	}
+
 	return stats, nil
 }
 

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.64.0
+// version: 1.65.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -251,8 +251,12 @@ func nullableFloat(nf sql.NullFloat64) *float64 {
 
 // SQLiteStore implements the Store interface using SQLite3
 type SQLiteStore struct {
-	db *sql.DB
+	db      *sql.DB
+	rootDir string
 }
+
+func (s *SQLiteStore) SetRootDir(rootDir string) { s.rootDir = rootDir }
+func (s *SQLiteStore) InvalidateLibraryStats()   {} // SQLite uses SQL aggregation; no persistent cache to clear
 
 // NewSQLiteStore creates a new SQLite store
 func NewSQLiteStore(path string) (*SQLiteStore, error) {
@@ -3088,30 +3092,44 @@ func (s *SQLiteStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Ti
 // GetDashboardStats returns aggregated dashboard statistics using SQL aggregation
 // instead of loading all books into memory.
 func (s *SQLiteStore) GetDashboardStats() (*DashboardStats, error) {
+	const primaryFilter = " AND COALESCE(is_primary_version, 1) = 1"
 	stats := &DashboardStats{
 		StateDistribution:  make(map[string]int),
 		FormatDistribution: make(map[string]int),
+		BooksByImportPath:  make(map[int]int),
+		SizeByImportPath:   make(map[int]int64),
+		ComputedAt:         time.Now(),
 	}
 
 	// Aggregate counts and totals
-	err := s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(duration), 0), COALESCE(SUM(file_size), 0)
+	if err := s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(duration), 0), COALESCE(SUM(file_size), 0)
 		FROM books WHERE COALESCE(marked_for_deletion, 0) = 0`).Scan(
-		&stats.TotalBooks, &stats.TotalDuration, &stats.TotalSize)
-	if err != nil {
+		&stats.TotalBooks, &stats.TotalDuration, &stats.TotalSize); err != nil {
 		return nil, fmt.Errorf("failed to get book aggregates: %w", err)
 	}
 
-	// File count
 	if fc, err := s.CountFiles(); err == nil {
 		stats.TotalFiles = fc
 	}
-
-	// Author and series counts
 	if ac, err := s.CountAuthors(); err == nil {
 		stats.TotalAuthors = ac
 	}
 	if sc, err := s.CountSeries(); err == nil {
 		stats.TotalSeries = sc
+	}
+
+	// Organized vs unorganized (primary, non-deleted)
+	if s.rootDir != "" {
+		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
+			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND file_path LIKE ?`,
+			s.rootDir+"%").Scan(&stats.OrganizedBooks, &stats.OrganizedSize)
+		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
+			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND file_path NOT LIKE ?`,
+			s.rootDir+"%").Scan(&stats.UnorganizedBooks, &stats.UnorganizedSize)
+	} else {
+		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
+			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter).Scan(
+			&stats.UnorganizedBooks, &stats.UnorganizedSize)
 	}
 
 	// State distribution

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.60.0
+// version: 2.61.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package database
@@ -794,17 +794,29 @@ type ScanCacheEntry struct {
 	NeedsRescan bool
 }
 
-// DashboardStats holds aggregated statistics computed via SQL rather than loading all books.
-type DashboardStats struct {
+// LibraryStats holds all aggregated library statistics. On PebbleDB it is persisted
+// under the key "stats:library" and recomputed on TTL expiry or explicit invalidation.
+// Computed in two range scans (book: then book_file:) — no per-book point lookups.
+type LibraryStats struct {
 	TotalBooks         int            `json:"total_books"`
 	TotalFiles         int            `json:"total_files"`
 	TotalAuthors       int            `json:"total_authors"`
 	TotalSeries        int            `json:"total_series"`
 	TotalDuration      int64          `json:"total_duration"`
 	TotalSize          int64          `json:"total_size"`
+	OrganizedBooks     int            `json:"organized_books"`
+	UnorganizedBooks   int            `json:"unorganized_books"`
+	OrganizedSize      int64          `json:"organized_size"`
+	UnorganizedSize    int64          `json:"unorganized_size"`
+	BooksByImportPath  map[int]int    `json:"books_by_import_path"`
+	SizeByImportPath   map[int]int64  `json:"size_by_import_path"`
 	StateDistribution  map[string]int `json:"state_distribution"`
 	FormatDistribution map[string]int `json:"format_distribution"`
+	ComputedAt         time.Time      `json:"computed_at"`
 }
+
+// DashboardStats is an alias kept for callers that haven't migrated to LibraryStats yet.
+type DashboardStats = LibraryStats
 
 // Global store instance — use GetGlobalStore/SetGlobalStore for concurrent access.
 // Direct assignment is allowed in single-goroutine contexts (init, main).

--- a/internal/server/dashboard_service.go
+++ b/internal/server/dashboard_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/dashboard_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
 
 package server
@@ -14,13 +14,9 @@ import (
 
 // dashboardStore is the narrow slice of database.Store this service uses.
 type dashboardStore interface {
-	database.AuthorReader
-	database.BookReader
 	database.PlaylistStore
-	database.SeriesReader
 	database.StatsStore
 }
-
 
 // DashboardService handles dashboard statistics and metrics collection
 type DashboardService struct {
@@ -52,41 +48,26 @@ type HealthCheckResponse struct {
 	PartialError string           `json:"partial_error,omitempty"`
 }
 
-// CollectDashboardMetrics gathers all dashboard metrics
+// CollectDashboardMetrics gathers all dashboard metrics from the cached LibraryStats.
 func (ds *DashboardService) CollectDashboardMetrics() (*DashboardMetrics, error) {
-	metrics := &DashboardMetrics{
-		Timestamp: time.Now().Unix(),
-	}
+	metrics := &DashboardMetrics{Timestamp: time.Now().Unix()}
 
 	if ds.db == nil {
 		return metrics, fmt.Errorf("database not initialized")
 	}
 
-	// Collect book count
-	if bc, err := ds.db.CountBooks(); err == nil {
-		metrics.Books = bc
+	stats, err := ds.db.GetDashboardStats()
+	if err != nil {
+		return metrics, err
 	}
+	metrics.Books = stats.TotalBooks
+	metrics.Files = stats.TotalFiles
+	metrics.Authors = stats.TotalAuthors
+	metrics.Series = stats.TotalSeries
 
-	// Collect file count
-	if fc, err := ds.db.CountFiles(); err == nil {
-		metrics.Files = fc
-	}
-
-	// Collect author count
-	if authors, err := ds.db.GetAllAuthors(); err == nil {
-		metrics.Authors = len(authors)
-	}
-
-	// Collect series count
-	if series, err := ds.db.GetAllSeries(); err == nil {
-		metrics.Series = len(series)
-	}
-
-	// Collect playlist count (legacy, placeholder for now)
 	if playlists, err := ds.db.GetPlaylistBySeriesID(0); err == nil && playlists != nil {
 		metrics.Playlists = 1
 	}
-
 	return metrics, nil
 }
 
@@ -94,9 +75,7 @@ func (ds *DashboardService) CollectDashboardMetrics() (*DashboardMetrics, error)
 func (ds *DashboardService) GetHealthCheckResponse(version string) *HealthCheckResponse {
 	metrics, dbErr := ds.CollectDashboardMetrics()
 	if metrics == nil {
-		metrics = &DashboardMetrics{
-			Timestamp: time.Now().Unix(),
-		}
+		metrics = &DashboardMetrics{Timestamp: time.Now().Unix()}
 	}
 
 	response := &HealthCheckResponse{
@@ -115,62 +94,15 @@ func (ds *DashboardService) GetHealthCheckResponse(version string) *HealthCheckR
 	return response
 }
 
-// GetLibraryStats returns library statistics for the dashboard
-type LibraryStats struct {
-	TotalBooks       int `json:"total_books"`
-	TotalFiles       int `json:"total_files"`
-	TotalAuthors     int `json:"total_authors"`
-	TotalSeries      int `json:"total_series"`
-	OrganizedBooks   int `json:"organized_books"`
-	UnorganizedBooks int `json:"unorganized_books"`
-}
-
-// CollectLibraryStats gathers detailed library statistics
-func (ds *DashboardService) CollectLibraryStats() (*LibraryStats, error) {
+// CollectLibraryStats returns the full cached LibraryStats.
+func (ds *DashboardService) CollectLibraryStats() (*database.LibraryStats, error) {
 	if ds.db == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
-
-	stats := &LibraryStats{}
-
-	// Count total books
-	if bc, err := ds.db.CountBooks(); err == nil {
-		stats.TotalBooks = bc
-	}
-
-	// Count total files
-	if fc, err := ds.db.CountFiles(); err == nil {
-		stats.TotalFiles = fc
-	}
-
-	// Count authors
-	if authors, err := ds.db.GetAllAuthors(); err == nil {
-		stats.TotalAuthors = len(authors)
-	}
-
-	// Count series
-	if series, err := ds.db.GetAllSeries(); err == nil {
-		stats.TotalSeries = len(series)
-	}
-
-	// Count organized vs unorganized books (fetch in batches)
-	limit := 1000
-	offset := 0
-	if books, err := ds.db.GetAllBooks(limit, offset); err == nil {
-		for _, book := range books {
-			// Assuming a book is organized if it has a library_state = "organized"
-			if book.LibraryState != nil && *book.LibraryState == "organized" {
-				stats.OrganizedBooks++
-			} else {
-				stats.UnorganizedBooks++
-			}
-		}
-	}
-
-	return stats, nil
+	return ds.db.GetDashboardStats()
 }
 
-// GetQuickMetrics returns a quick set of metrics for display
+// QuickMetrics returns a quick set of metrics for display
 type QuickMetrics struct {
 	BookCount   int `json:"book_count"`
 	FileCount   int `json:"file_count"`
@@ -178,29 +110,19 @@ type QuickMetrics struct {
 	SeriesCount int `json:"series_count"`
 }
 
-// CollectQuickMetrics gathers metrics for quick display
+// CollectQuickMetrics gathers metrics for quick display from the cached LibraryStats.
 func (ds *DashboardService) CollectQuickMetrics() *QuickMetrics {
 	metrics := &QuickMetrics{}
-
 	if ds.db == nil {
 		return metrics
 	}
-
-	if bc, err := ds.db.CountBooks(); err == nil {
-		metrics.BookCount = bc
+	stats, err := ds.db.GetDashboardStats()
+	if err != nil {
+		return metrics
 	}
-
-	if fc, err := ds.db.CountFiles(); err == nil {
-		metrics.FileCount = fc
-	}
-
-	if authors, err := ds.db.GetAllAuthors(); err == nil {
-		metrics.AuthorCount = len(authors)
-	}
-
-	if series, err := ds.db.GetAllSeries(); err == nil {
-		metrics.SeriesCount = len(series)
-	}
-
+	metrics.BookCount = stats.TotalBooks
+	metrics.FileCount = stats.TotalFiles
+	metrics.AuthorCount = stats.TotalAuthors
+	metrics.SeriesCount = stats.TotalSeries
 	return metrics
 }

--- a/internal/server/dashboard_service_test.go
+++ b/internal/server/dashboard_service_test.go
@@ -1,32 +1,36 @@
 // file: internal/server/dashboard_service_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d
 
 package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
+func statsFor(books, files, authors, series, organized, unorganized int) *database.LibraryStats {
+	return &database.LibraryStats{
+		TotalBooks:       books,
+		TotalFiles:       files,
+		TotalAuthors:     authors,
+		TotalSeries:      series,
+		OrganizedBooks:   organized,
+		UnorganizedBooks: unorganized,
+		StateDistribution:  map[string]int{},
+		FormatDistribution: map[string]int{},
+		BooksByImportPath:  map[int]int{},
+		SizeByImportPath:   map[int]int64{},
+		ComputedAt:         time.Now(),
+	}
+}
+
 func TestDashboardService_CollectDashboardMetrics_Success(t *testing.T) {
 	mockDB := &database.MockStore{
-		CountBooksFunc: func() (int, error) {
-			return 42, nil
-		},
-		GetAllAuthorsFunc: func() ([]database.Author, error) {
-			return []database.Author{
-				{ID: 1, Name: "Author 1"},
-				{ID: 2, Name: "Author 2"},
-			}, nil
-		},
-		GetAllSeriesFunc: func() ([]database.Series, error) {
-			return []database.Series{
-				{ID: 1, Name: "Series 1"},
-				{ID: 2, Name: "Series 2"},
-				{ID: 3, Name: "Series 3"},
-			}, nil
+		GetDashboardStatsFunc: func() (*database.DashboardStats, error) {
+			return statsFor(42, 10, 2, 3, 0, 0), nil
 		},
 	}
 
@@ -49,14 +53,8 @@ func TestDashboardService_CollectDashboardMetrics_Success(t *testing.T) {
 
 func TestDashboardService_CollectDashboardMetrics_ZeroValues(t *testing.T) {
 	mockDB := &database.MockStore{
-		CountBooksFunc: func() (int, error) {
-			return 0, nil
-		},
-		GetAllAuthorsFunc: func() ([]database.Author, error) {
-			return []database.Author{}, nil
-		},
-		GetAllSeriesFunc: func() ([]database.Series, error) {
-			return []database.Series{}, nil
+		GetDashboardStatsFunc: func() (*database.DashboardStats, error) {
+			return statsFor(0, 0, 0, 0, 0, 0), nil
 		},
 	}
 
@@ -76,14 +74,8 @@ func TestDashboardService_CollectDashboardMetrics_ZeroValues(t *testing.T) {
 
 func TestDashboardService_GetHealthCheckResponse_Success(t *testing.T) {
 	mockDB := &database.MockStore{
-		CountBooksFunc: func() (int, error) {
-			return 10, nil
-		},
-		GetAllAuthorsFunc: func() ([]database.Author, error) {
-			return []database.Author{}, nil
-		},
-		GetAllSeriesFunc: func() ([]database.Series, error) {
-			return []database.Series{}, nil
+		GetDashboardStatsFunc: func() (*database.DashboardStats, error) {
+			return statsFor(10, 5, 0, 0, 0, 0), nil
 		},
 	}
 
@@ -105,24 +97,9 @@ func TestDashboardService_GetHealthCheckResponse_Success(t *testing.T) {
 }
 
 func TestDashboardService_CollectLibraryStats_Success(t *testing.T) {
-	organized := "organized"
-	imported := "imported"
-
 	mockDB := &database.MockStore{
-		CountBooksFunc: func() (int, error) {
-			return 100, nil
-		},
-		GetAllAuthorsFunc: func() ([]database.Author, error) {
-			return []database.Author{{ID: 1, Name: "Author"}}, nil
-		},
-		GetAllSeriesFunc: func() ([]database.Series, error) {
-			return []database.Series{{ID: 1, Name: "Series"}}, nil
-		},
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{
-				{ID: "1", LibraryState: &organized},
-				{ID: "2", LibraryState: &imported},
-			}, nil
+		GetDashboardStatsFunc: func() (*database.DashboardStats, error) {
+			return statsFor(100, 0, 1, 1, 1, 1), nil
 		},
 	}
 
@@ -145,18 +122,8 @@ func TestDashboardService_CollectLibraryStats_Success(t *testing.T) {
 
 func TestDashboardService_CollectQuickMetrics_Success(t *testing.T) {
 	mockDB := &database.MockStore{
-		CountBooksFunc: func() (int, error) {
-			return 50, nil
-		},
-		GetAllAuthorsFunc: func() ([]database.Author, error) {
-			return []database.Author{
-				{ID: 1, Name: "A"},
-				{ID: 2, Name: "B"},
-				{ID: 3, Name: "C"},
-			}, nil
-		},
-		GetAllSeriesFunc: func() ([]database.Series, error) {
-			return []database.Series{}, nil
+		GetDashboardStatsFunc: func() (*database.DashboardStats, error) {
+			return statsFor(50, 0, 3, 0, 0, 0), nil
 		},
 	}
 

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
@@ -35,10 +35,9 @@ func setupHandlerTest(t *testing.T) (*Server, *mocks.MockStore, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	mockStore := mocks.NewMockStore(t)
 	srv := &Server{
-		store:          mockStore,
-		dashboardCache: cache.New[gin.H]("dashboard", 30*time.Second),
-		dedupCache:     cache.New[gin.H]("dedup", 5*time.Minute),
-		listCache:      cache.New[gin.H]("list", 30*time.Second),
+		store:      mockStore,
+		dedupCache: cache.New[gin.H]("dedup", 5*time.Minute),
+		listCache:  cache.New[gin.H]("list", 30*time.Second),
 	}
 	router := gin.New()
 	return srv, mockStore, router
@@ -705,6 +704,7 @@ func TestHandler_ResetSystem_Success(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
 	mockStore.EXPECT().Reset().Return(nil)
+	mockStore.EXPECT().InvalidateLibraryStats().Return()
 
 	router.POST("/system/reset", srv.resetSystem)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.197.0
+// version: 1.198.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -701,7 +701,6 @@ type Server struct {
 	systemService          *SystemService
 	metadataStateService   *MetadataStateService
 	dashboardService       *DashboardService
-	dashboardCache         *cache.Cache[gin.H]
 	olService              *metafetch.OpenLibraryService
 	dedupCache             *cache.Cache[gin.H]
 	listCache              *cache.Cache[gin.H]
@@ -837,7 +836,6 @@ func NewServer(store database.Store) *Server {
 		systemService:          NewSystemService(resolvedStore),
 		metadataStateService:   NewMetadataStateService(resolvedStore),
 		dashboardService:       NewDashboardService(resolvedStore),
-		dashboardCache:         cache.New[gin.H]("dashboard", 5*time.Minute),
 		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),
 		listCache:              cache.New[gin.H]("list", 24*time.Hour),
 		facetsCache:            cache.New[gin.H]("facets", 24*time.Hour),
@@ -847,6 +845,9 @@ func NewServer(store database.Store) *Server {
 		diagnosticsService:     diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),
 		changelogService:       activity.NewChangelogService(resolvedStore),
 	}
+
+	// Propagate rootDir into the store so LibraryStats can split organized vs unorganized.
+	resolvedStore.SetRootDir(config.AppConfig.RootDir)
 
 	// Initialize plugin event bus and registry
 	server.eventBus = plugin.NewEventBus()

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_coverage_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package server
@@ -508,8 +508,8 @@ func TestCoverageDashboardStats(t *testing.T) {
 		createTestBook(t, "Dashboard Book 1")
 		createTestBookFmt(t, "Dashboard Book 2", "mp3")
 
-		// Invalidate the dashboard cache so new books are counted
-		server.dashboardCache.InvalidateAll()
+		// Invalidate the library stats cache so new books are counted
+		server.Store().InvalidateLibraryStats()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
 		w := httptest.NewRecorder()

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_handlers.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
 // System-level HTTP handlers split out of server.go: health, status,
@@ -227,7 +227,7 @@ func (s *Server) resetSystem(c *gin.Context) {
 
 	// Reset caches
 	resetLibrarySizeCache()
-	s.dashboardCache.InvalidateAll()
+	s.Store().InvalidateLibraryStats()
 
 	RespondWithOK(c, gin.H{"message": "System reset successfully"})
 }
@@ -295,7 +295,7 @@ func (s *Server) factoryReset(c *gin.Context) {
 
 	// Reset caches
 	resetLibrarySizeCache()
-	s.dashboardCache.InvalidateAll()
+	s.Store().InvalidateLibraryStats()
 
 	log.Printf("[INFO] Factory reset complete")
 	RespondWithOK(c, gin.H{"message": "factory reset complete"})
@@ -467,45 +467,35 @@ func (s *Server) deleteBackup(c *gin.Context) {
 	RespondWithOK(c, gin.H{"message": "backup deleted successfully"})
 }
 
-// getDashboard returns dashboard statistics with size and format distributions
+// getDashboard returns dashboard statistics. The store handles caching internally
+// (PebbleDB: stats:library key with 10-min TTL; SQLite: SQL aggregation directly).
 func (s *Server) getDashboard(c *gin.Context) {
 	if s.Store() == nil {
 		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
-	// Check cache first
-	if cached, ok := s.dashboardCache.Get("dashboard"); ok {
-		LogServiceCacheHit("Dashboard", "dashboard")
-		RespondWithOK(c, cached)
-		return
-	}
-	LogServiceCacheMiss("Dashboard", "dashboard")
-
-	// Use SQL aggregation instead of loading all books
 	stats, err := s.Store().GetDashboardStats()
 	if err != nil {
 		RespondWithInternalError(c, "failed to retrieve dashboard stats")
 		return
 	}
 
-	// Get recent operations
 	recentOps, err := s.Store().GetRecentOperations(5)
 	if err != nil {
 		recentOps = []database.Operation{}
 	}
 
-	result := gin.H{
+	RespondWithOK(c, gin.H{
 		"formatDistribution": stats.FormatDistribution,
 		"stateDistribution":  stats.StateDistribution,
 		"recentOperations":   recentOps,
 		"totalSize":          stats.TotalSize,
 		"totalBooks":         stats.TotalBooks,
 		"totalDuration":      stats.TotalDuration,
-	}
-
-	s.dashboardCache.Set("dashboard", result)
-	RespondWithOK(c, result)
+		"organizedBooks":     stats.OrganizedBooks,
+		"unorganizedBooks":   stats.UnorganizedBooks,
+	})
 }
 
 // listBlockedHashes returns all blocked hashes

--- a/internal/server/system_service.go
+++ b/internal/server/system_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_service.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
 
 package server
@@ -110,15 +110,12 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 	}
 
 	rootDir := config.AppConfig.RootDir
-	libraryBookCount, importBookCount, err := ss.db.GetBookCountsByLocation(rootDir)
-	if err != nil {
-		libraryBookCount = 0
-		importBookCount = 0
-	}
 
-	fileCount, _ := ss.db.CountFiles()
-	authorCount, _ := ss.db.CountAuthors()
-	seriesCount, _ := ss.db.CountSeries()
+	// One cached call covers books, files, authors, series, and size splits.
+	dbStats, _ := ss.db.GetDashboardStats()
+	if dbStats == nil {
+		dbStats = &database.LibraryStats{}
+	}
 
 	recentOps, err := ss.db.GetRecentOperations(5)
 	if err != nil {
@@ -131,34 +128,32 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 	librarySize, importSize := calculateLibrarySizes(rootDir, importFolders)
 	// Fall back to DB file sizes when filesystem walk returns 0 (e.g. paths don't exist on this host)
 	if librarySize+importSize == 0 {
-		if dbLib, dbImp, err := ss.db.GetBookSizesByLocation(rootDir); err == nil {
-			librarySize = dbLib
-			importSize = dbImp
-		}
+		librarySize = dbStats.OrganizedSize
+		importSize = dbStats.UnorganizedSize
 	}
 	totalSize := librarySize + importSize
 
 	status := &SystemStatus{
 		Status:           "running",
 		Version:          appVersion,
-		LibraryBookCount: libraryBookCount,
-		ImportBookCount:  importBookCount,
-		TotalBookCount:   libraryBookCount + importBookCount,
-		TotalFileCount:   fileCount,
-		AuthorCount:      authorCount,
-		SeriesCount:      seriesCount,
+		LibraryBookCount: dbStats.OrganizedBooks,
+		ImportBookCount:  dbStats.UnorganizedBooks,
+		TotalBookCount:   dbStats.TotalBooks,
+		TotalFileCount:   dbStats.TotalFiles,
+		AuthorCount:      dbStats.TotalAuthors,
+		SeriesCount:      dbStats.TotalSeries,
 		LibrarySizeBytes: librarySize,
 		ImportSizeBytes:  importSize,
 		TotalSizeBytes:   totalSize,
 		RootDirectory:    rootDir,
 		Library: SystemLibraryStatus{
-			BookCount:   libraryBookCount,
+			BookCount:   dbStats.OrganizedBooks,
 			FolderCount: 1,
 			TotalSize:   librarySize,
 			Path:        rootDir,
 		},
 		ImportPaths: SystemImportStatus{
-			BookCount:   importBookCount,
+			BookCount:   dbStats.UnorganizedBooks,
 			FolderCount: len(importFolders),
 			TotalSize:   importSize,
 		},


### PR DESCRIPTION
## Summary
- Replace per-request full-scan stats with a single `stats:library` PebbleDB key (O(1) hit, 2-scan miss)
- `LibraryStats` now covers organized/unorganized splits, per-import-path counts/sizes, all existing dashboard fields
- All server-layer stats callers (`CollectSystemStatus`, `CollectDashboardMetrics`, `CollectLibraryStats`, `CollectQuickMetrics`) collapse to one `GetDashboardStats()` call
- Drop in-memory `dashboardCache` from `Server` — store handles persistence across restarts
- `InvalidateLibraryStats()` wired to system reset and factory reset; `SetRootDir` invalidates on root change

## Test plan
- [ ] `go test ./internal/database/... ./internal/server/...` passes (pre-existing `TestActivity_Integration_TeeWriterCapture` failure is unrelated)
- [ ] Dashboard loads instantly on repeated requests (cache hit)
- [ ] Stats remain correct after server restart (persistent key)
- [ ] Stats refresh after a library scan (invalidation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)