### PR TITLE
feat(activity): show info-tier entries by default in tier filter (ACT-2)

### DIFF
--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -118,7 +118,7 @@ export default function ActivityLog() {
 
   // Filters
   const [search, setSearch] = useState('');
-  const [tiers, setTiers] = useState<Set<string>>(new Set(['audit', 'change', 'digest']));
+  const [tiers, setTiers] = useState<Set<string>>(new Set(['audit', 'change', 'digest', 'info']));
   const [typeFilter, setTypeFilter] = useState('');
   const [levelFilter, setLevelFilter] = useState('');
   const [operationId, setOperationId] = useState('');


### PR DESCRIPTION
## Summary
- Adds 'info' to the default-on tier set in ActivityLog so EmitInfo summaries (operation completion lines like \"4 ops completed: temp-cleanup (12), isbn-enrich (340) ...\") are visible on first page load.

## Test plan
- [x] Frontend build passes (`npm run build`)
- [ ] Manual: open Activity Log, confirm 'info' chip is on by default and EmitInfo entries are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)