### PR TITLE
fix(metadata-review): scan 5000 ops so older fetch sessions stay visible

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-04-28
 
@@ -425,7 +425,11 @@ func (s *Server) handleGetLatestMetadataFetch(c *gin.Context) {
 	store := s.Store()
 	// Scan more than maxOps from recent history because the filter
 	// (type + completed + non-empty results) can reject many rows.
-	ops, err := store.GetRecentOperations(200)
+	// Use a large limit: GetRecentOperations loads all ops into memory anyway
+	// (PebbleDB scans all keys, sorts, then slices), so increasing the cap is
+	// free. Without a high limit, background maintenance/organize/scan ops
+	// quickly push older metadata-fetch operations out of the top 200.
+	ops, err := store.GetRecentOperations(5000)
 	if err != nil {
 		internalError(c, "failed to list recent operations", err)
 		return


### PR DESCRIPTION
## Problem

The Resume Review picker was only ever showing the latest fetch session. `handleGetLatestMetadataFetch` called `GetRecentOperations(200)`, which returns the 200 most recent operations across all types. With background maintenance, organize, reconcile, and scan tasks constantly creating new operation records, older `metadata_candidate_fetch` operations were pushed out of the top 200 and disappeared from the picker.

## Fix

Raise the scan limit from 200 to 5000. The PebbleDB implementation of `GetRecentOperations` already loads **all** operation records into memory, sorts them by created_at, and then slices — so a higher limit has zero additional cost at the DB layer. The N+1 `GetOperationResults` call only fires for matched `metadata_candidate_fetch` ops, not for all 5000.

## Test plan

- [ ] Run several metadata fetches over multiple sessions
- [ ] Trigger some maintenance/organize/scan tasks between fetches to create noise ops
- [ ] Click "Resume Review" — all past fetch sessions should appear in the picker, not just the latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)