### PR TITLE
fix(metadata-review): persist 'applied' status to PebbleDB on apply

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-04-28
 
@@ -567,6 +567,18 @@ func (s *Server) handleBatchApplyCandidates(c *gin.Context) {
 		}
 
 		applied++
+
+		// Persist "applied" status so re-opens of the dialog don't show
+		// this book as still needing review. Mirrors the reject handler.
+		cr.Status = "applied"
+		if updatedJSON, err := json.Marshal(cr); err == nil {
+			_ = store.CreateOperationResult(&database.OperationResult{
+				OperationID: req.OperationID,
+				BookID:      bookID,
+				ResultJSON:  string(updatedJSON),
+				Status:      "applied",
+			})
+		}
 
 		// Queue file I/O through the worker pool (bounded concurrency).
 		if pool := s.fileIOPool; pool != nil {


### PR DESCRIPTION
## Problem

Clicking Apply (or Apply All / Apply Page / Apply High Confidence) applied the metadata to the book record in the DB but **never wrote the "applied" status back to the `OperationResult` in PebbleDB**. The dialog tracked applied state in `rowStates` (React in-memory), which evaporated on any page reload or server restart. Books appeared as still needing review every time the dialog was reopened.

## Root cause

`handleBatchApplyCandidates` called `mfs.ApplyMetadataCandidate()` and incremented the counter, then returned. The reject handler (`handleRejectCandidates`) correctly wrote a new `OperationResult` with `status: "rejected"` — apply simply never did the same thing.

## Fix

After each successful apply, write an `OperationResult` with `status: "applied"` using `store.CreateOperationResult` (same pattern as reject). This overwrites the existing "matched" result by key, so the next dialog load sees the correct state without any React state involved.

All apply entry points (Apply, Apply All, Apply Page, Apply High Confidence) route through the single `POST /metadata/batch-apply-candidates` handler, so one fix covers everything.

## Test plan

- [ ] Open Resume Review, apply a book
- [ ] Restart the server (or reload the page and reopen the same fetch session)
- [ ] Book should show as "Applied" — not as "matched/pending"
- [ ] Apply All / Apply Page should also persist correctly across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)