### PR TITLE
feat(metadata): parse Audible category_ladders into book tags (CAT-1)

### DIFF
--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -74,8 +74,9 @@ type audibleProduct struct {
 	ProductImages        map[string]string `json:"product_images"`
 	Series               []audibleSeries   `json:"series"`
 	ContentDeliveryType  string            `json:"content_delivery_type"`
-	RuntimeLengthMin     *int              `json:"runtime_length_min"` // nullable in API
-	Rating               *audibleRating    `json:"rating"`
+	RuntimeLengthMin     *int                    `json:"runtime_length_min"` // nullable in API
+	Rating               *audibleRating          `json:"rating"`
+	CategoryLadders      []audibleCategoryLadder `json:"category_ladders"`
 }
 
 type audibleRating struct {
@@ -101,7 +102,17 @@ type audibleSeries struct {
 	Sequence string `json:"sequence"`
 }
 
-const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series,rating"
+type audibleCategoryNode struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type audibleCategoryLadder struct {
+	Ladder []audibleCategoryNode `json:"ladder"`
+	Root   string                `json:"root"`
+}
+
+const audibleResponseGroups = "product_desc,contributors,media,product_attrs,series,rating,category_ladders"
 
 // SearchByTitle searches Audible's catalog by title.
 func (c *AudibleClient) SearchByTitle(title string) ([]BookMetadata, error) {
@@ -263,6 +274,29 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 		meta.AudibleRatingStory = p.Rating.StoryDistribution.DisplayAverageRating
 		meta.AudibleRatingCount = p.Rating.OverallDistribution.NumRatings
 		meta.AudibleNumReviews = p.Rating.NumReviews
+	}
+
+	// Category ladders: collect all node names from all ladders, deduplicate.
+	// Each ladder is a path from broad to specific (e.g. "Science Fiction" →
+	// "Space Opera"). The Root field is a navigation bucket, not a genre — skip it.
+	if len(p.CategoryLadders) > 0 {
+		seen := map[string]struct{}{}
+		tags := make([]string, 0)
+		for _, ladder := range p.CategoryLadders {
+			for _, node := range ladder.Ladder {
+				name := strings.TrimSpace(node.Name)
+				if name == "" {
+					continue
+				}
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					tags = append(tags, name)
+				}
+			}
+		}
+		if len(tags) > 0 {
+			meta.CategoryTags = tags
+		}
 	}
 
 	return meta

--- a/internal/metadata/audible_test.go
+++ b/internal/metadata/audible_test.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c7d6e5-f4a3-2b1c-0d9e-8f7a6b5c4d3e
 
 package metadata
@@ -155,3 +155,57 @@ func TestAudibleClient_HTMLStripping(t *testing.T) {
 }
 
 var _ MetadataSource = (*AudibleClient)(nil)
+
+func TestProductToMetadata_CategoryLadders(t *testing.T) {
+	client := NewAudibleClientWithBaseURL("http://unused")
+
+	p := &audibleProduct{
+		ASIN:  "B08G9PRS1K",
+		Title: "Test Book",
+		CategoryLadders: []audibleCategoryLadder{
+			{
+				Root: "Audible Books & Originals",
+				Ladder: []audibleCategoryNode{
+					{ID: "18685580011", Name: "Science Fiction & Fantasy"},
+					{ID: "18685589011", Name: "Science Fiction"},
+					{ID: "18685594011", Name: "Space Opera"},
+				},
+			},
+			{
+				Root: "Audible Books & Originals",
+				Ladder: []audibleCategoryNode{
+					{ID: "18685580011", Name: "Science Fiction & Fantasy"},
+					{ID: "18685589011", Name: "Science Fiction"},
+				},
+			},
+		},
+	}
+
+	meta := client.productToMetadata(p)
+
+	// Expect 3 unique tags (deduplication across overlapping ladders)
+	want := []string{"Science Fiction & Fantasy", "Science Fiction", "Space Opera"}
+	if len(meta.CategoryTags) != len(want) {
+		t.Fatalf("CategoryTags: got %d tags, want %d: %v", len(meta.CategoryTags), len(want), meta.CategoryTags)
+	}
+	for i, w := range want {
+		if meta.CategoryTags[i] != w {
+			t.Errorf("CategoryTags[%d]: got %q, want %q", i, meta.CategoryTags[i], w)
+		}
+	}
+}
+
+func TestProductToMetadata_NoCategoryLadders(t *testing.T) {
+	client := NewAudibleClientWithBaseURL("http://unused")
+
+	p := &audibleProduct{
+		ASIN:  "B000001",
+		Title: "No Genres",
+	}
+
+	meta := client.productToMetadata(p)
+
+	if meta.CategoryTags != nil {
+		t.Errorf("expected nil CategoryTags when no ladders, got: %v", meta.CategoryTags)
+	}
+}

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package metadata
@@ -129,6 +129,11 @@ type BookMetadata struct {
 	// Google Books rating (1–5 scale).
 	GoogleRatingAverage float64
 	GoogleRatingCount   int
+
+	// CategoryTags contains genre/subject tags from Audible's category_ladders
+	// response group. Each element is a ladder node name (e.g. "Science Fiction",
+	// "Space Opera"). Applied as book_tags with source="audible_category".
+	CategoryTags []string
 }
 
 // SearchByTitle searches for books by title. Checks local dump store first if available.

--- a/internal/metafetch/category_tags_test.go
+++ b/internal/metafetch/category_tags_test.go
@@ -1,0 +1,114 @@
+// file: internal/metafetch/category_tags_test.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+
+package metafetch
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// TestApplyMetadataCandidate_CategoryTags verifies that category tags from
+// a MetadataCandidate are written to book_tags with source="audible_category".
+func TestApplyMetadataCandidate_CategoryTags(t *testing.T) {
+	bookID := "test-book-id-001"
+	title := "Test Book"
+
+	var tagCalls []struct{ tag, source string }
+
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{ID: id, Title: title}, nil
+		},
+		UpdateBookFunc: func(id string, book *database.Book) (*database.Book, error) {
+			return book, nil
+		},
+		AddBookTagWithSourceFunc: func(bID, tag, source string) error {
+			if bID == bookID {
+				tagCalls = append(tagCalls, struct{ tag, source string }{tag, source})
+			}
+			return nil
+		},
+	}
+
+	svc := NewService(mock)
+
+	candidate := MetadataCandidate{
+		Title:        title,
+		Author:       "Some Author",
+		Source:       "Audible",
+		Score:        1.0,
+		CategoryTags: []string{"Mystery", "Thriller"},
+	}
+
+	_, err := svc.ApplyMetadataCandidate(bookID, candidate, nil)
+	if err != nil {
+		t.Fatalf("ApplyMetadataCandidate returned error: %v", err)
+	}
+
+	// Filter to only audible_category source calls
+	var catCalls []string
+	for _, c := range tagCalls {
+		if c.source == "audible_category" {
+			catCalls = append(catCalls, c.tag)
+		}
+	}
+
+	if len(catCalls) != 2 {
+		t.Fatalf("expected 2 audible_category tag calls, got %d: %v", len(catCalls), catCalls)
+	}
+
+	want := map[string]bool{"Mystery": true, "Thriller": true}
+	for _, tag := range catCalls {
+		if !want[tag] {
+			t.Errorf("unexpected tag %q in audible_category calls", tag)
+		}
+		delete(want, tag)
+	}
+	for tag := range want {
+		t.Errorf("expected tag %q was not applied", tag)
+	}
+}
+
+// TestApplyMetadataCandidate_NoCategoryTags verifies that when CategoryTags
+// is empty, AddBookTagWithSource is not called with source="audible_category".
+func TestApplyMetadataCandidate_NoCategoryTags(t *testing.T) {
+	bookID := "test-book-id-002"
+
+	var catTagCalls int
+
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{ID: id, Title: "No Genres"}, nil
+		},
+		UpdateBookFunc: func(id string, book *database.Book) (*database.Book, error) {
+			return book, nil
+		},
+		AddBookTagWithSourceFunc: func(bID, tag, source string) error {
+			if source == "audible_category" {
+				catTagCalls++
+			}
+			return nil
+		},
+	}
+
+	svc := NewService(mock)
+
+	candidate := MetadataCandidate{
+		Title:  "No Genres",
+		Source: "Audible",
+		Score:  1.0,
+		// CategoryTags intentionally nil
+	}
+
+	_, err := svc.ApplyMetadataCandidate(bookID, candidate, nil)
+	if err != nil {
+		t.Fatalf("ApplyMetadataCandidate returned error: %v", err)
+	}
+
+	if catTagCalls != 0 {
+		t.Errorf("expected 0 audible_category tag calls, got %d", catTagCalls)
+	}
+}

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.58.0
+// version: 4.59.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package metafetch
@@ -156,6 +156,9 @@ type MetadataCandidate struct {
 	// Zero means either side had no duration, or they matched exactly.
 	// Non-zero lets the review UI flag candidates whose runtime diverges significantly.
 	DurationDeltaSec int `json:"duration_delta_sec,omitempty"`
+	// CategoryTags holds Audible category ladder node names (e.g. "Science Fiction").
+	// Only populated for Audible-sourced candidates. Applied as book_tags on apply.
+	CategoryTags []string `json:"category_tags,omitempty"`
 }
 
 // SearchMetadataResponse is returned by SearchMetadataForBook.
@@ -2347,6 +2350,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				Score:            score,
 				DurationSec:      r.DurationSec,
 				DurationDeltaSec: durationDelta,
+				CategoryTags:     r.CategoryTags,
 			})
 		}
 	}
@@ -2399,6 +2403,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					Score:            score,
 					DurationSec:      result.DurationSec,
 					DurationDeltaSec: asinDurationDelta,
+					CategoryTags:     result.CategoryTags,
 				})
 			}
 		} else {
@@ -2614,6 +2619,15 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// a true no-op at the tag layer (no wasted writes). Done after
 	// UpdateBook so a failed update never leaves stale tags behind.
 	mfs.ApplyMetadataSystemTags(id, candidate.Source, meta.Language)
+
+	// Apply Audible category ladder tags. These are additive enrichment — they
+	// are not controlled by the fields allowlist and do not fail the apply if
+	// a tag write errors.
+	for _, tag := range candidate.CategoryTags {
+		if err := mfs.db.AddBookTagWithSource(id, tag, "audible_category"); err != nil {
+			log.Printf("[WARN] failed to apply category tag %q to book %s: %v", tag, id, err)
+		}
+	}
 
 	// Intentionally keep the metadata fetch cache after apply. The cached
 	// API results are still valid — the TTL (MetadataFetchCacheTTLDays)


### PR DESCRIPTION
## Summary
- Adds category_ladders to Audible response groups, parses layered ladder entries into a deduped flat \`CategoryTags []string\`
- Wires CategoryTags through MetadataCandidate, then writes each tag via AddBookTagWithSource(\"audible_category\") in ApplyMetadataCandidate
- Matches AddBookUserTag's idempotent contract — duplicates are skipped automatically

## Test plan
- [x] make build-api clean
- [x] internal/metadata tests pass (incl. new TestProductToMetadata_CategoryLadders + dedup across overlapping ladders)
- [x] internal/metafetch tests pass (new category_tags_test.go asserting AddBookTagWithSource calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)