### PR TITLE
feat(maintenance): duration-mismatch backend — WARN log, flag, scan endpoint (DUR)

### DIFF
--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.61.1
+// version: 2.62.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 package database
@@ -195,6 +195,11 @@ type Book struct {
 	// "unlinked" (no iTunes presence), "pending" (new, needs adding to iTunes),
 	// "purge_pending" (quarantined, delete from iTunes on next sync).
 	ITunesSyncStatus *string `json:"itunes_sync_status,omitempty"`
+	// AudibleRuntimeMin is the runtime reported by Audible (in minutes) for
+	// the matched product. Stored during metadata apply so the maintenance
+	// scan-duration-mismatch endpoint can compare it against the local file
+	// Duration without making live API calls.
+	AudibleRuntimeMin *int `json:"audible_runtime_min,omitempty"`
 	// Audible ratings (1–5 scale). Performance and Story are audiobook-specific
 	// dimensions absent from other providers.
 	AudibleRatingOverall     *float64 `json:"audible_rating_overall,omitempty"`

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -159,6 +159,10 @@ type MetadataCandidate struct {
 	// CategoryTags holds Audible category ladder node names (e.g. "Science Fiction").
 	// Only populated for Audible-sourced candidates. Applied as book_tags on apply.
 	CategoryTags []string `json:"category_tags,omitempty"`
+	// DurationMismatch is true when DurationDeltaSec exceeds 600 s (10 min).
+	// The review UI already renders a warning chip when duration_delta_sec > 600;
+	// this flag makes the threshold decision explicit in the API response.
+	DurationMismatch bool `json:"duration_mismatch,omitempty"`
 }
 
 // SearchMetadataResponse is returned by SearchMetadataForBook.
@@ -663,6 +667,13 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 	}
 	if meta.Genre != "" {
 		book.Genre = stringPtr(meta.Genre)
+	}
+
+	// Persist Audible runtime so the scan-duration-mismatch endpoint can
+	// compare it offline without live API calls.
+	if meta.DurationSec > 0 {
+		runtimeMin := meta.DurationSec / 60
+		book.AudibleRuntimeMin = &runtimeMin
 	}
 
 	// Apply series info if available
@@ -2351,6 +2362,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				DurationSec:      r.DurationSec,
 				DurationDeltaSec: durationDelta,
 				CategoryTags:     r.CategoryTags,
+				DurationMismatch: durationDelta > 600,
 			})
 		}
 	}
@@ -2404,6 +2416,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					DurationSec:      result.DurationSec,
 					DurationDeltaSec: asinDurationDelta,
 					CategoryTags:     result.CategoryTags,
+					DurationMismatch: asinDurationDelta > 600,
 				})
 			}
 		} else {
@@ -2510,6 +2523,19 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		return nil, fmt.Errorf("audiobook not found")
 	}
 
+	// Warn when the candidate runtime diverges significantly from the local
+	// file duration — this suggests a wrong Audible match or an abridged copy.
+	const durationMismatchThresholdSec = 600
+	if candidate.DurationDeltaSec > durationMismatchThresholdSec {
+		bookDurSec := 0
+		if book.Duration != nil {
+			bookDurSec = *book.Duration
+		}
+		log.Printf("[WARN] duration-mismatch apply book=%s title=%q candidate=%q delta=%ds (book=%ds audible=%ds): wrong match or abridged version",
+			id, book.Title, candidate.Title,
+			candidate.DurationDeltaSec, bookDurSec, candidate.DurationSec)
+	}
+
 	meta := metadata.BookMetadata{
 		Title:          candidate.Title,
 		Author:         candidate.Author,
@@ -2522,6 +2548,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		CoverURL:       candidate.CoverURL,
 		Description:    candidate.Description,
 		Language:       candidate.Language,
+		DurationSec:    candidate.DurationSec,
 	}
 
 	// If fields list is non-empty, zero out fields NOT in the list

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.22.0
+// version: 1.23.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -5328,5 +5328,101 @@ func (s *Server) handleRevertMetadataFetch(c *gin.Context) {
 		"skipped":  skipped,
 		"errors":   errors,
 		"total":    len(bookIDSet),
+	})
+}
+
+// durationMismatchResult describes one book whose Audible runtime diverges
+// significantly from the local file duration.
+type durationMismatchResult struct {
+	BookID            string `json:"book_id"`
+	Title             string `json:"title"`
+	ASIN              string `json:"asin,omitempty"`
+	FileDurationSec   int    `json:"file_duration_sec"`
+	AudibleRuntimeMin int    `json:"audible_runtime_min"`
+	AudibleRuntimeSec int    `json:"audible_runtime_sec"`
+	DeltaSec          int    `json:"delta_sec"`
+}
+
+// handleScanDurationMismatch scans all books that have both a local file
+// duration and a stored Audible runtime, and returns those whose delta
+// exceeds the configured threshold.
+//
+// Query params:
+//   - max_delta_min=10  (integer, default 10) — threshold in minutes
+//
+// GET /api/v1/maintenance/scan-duration-mismatch
+func (s *Server) handleScanDurationMismatch(c *gin.Context) {
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+
+	// Parse threshold (minutes → seconds). Default = 10 min.
+	thresholdMin := 10
+	if raw := c.Query("max_delta_min"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			thresholdMin = v
+		}
+	}
+	thresholdSec := thresholdMin * 60
+
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		internalError(c, "failed to list books", err)
+		return
+	}
+
+	var mismatches []durationMismatchResult
+	scanned := 0
+
+	for i := range allBooks {
+		book := &allBooks[i]
+		if book.Duration == nil || *book.Duration <= 0 {
+			continue
+		}
+		if book.AudibleRuntimeMin == nil || *book.AudibleRuntimeMin <= 0 {
+			continue
+		}
+		scanned++
+
+		fileDurSec := *book.Duration
+		audibleSec := *book.AudibleRuntimeMin * 60
+		delta := fileDurSec - audibleSec
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta <= thresholdSec {
+			continue
+		}
+
+		asin := ""
+		if book.ASIN != nil {
+			asin = *book.ASIN
+		}
+		mismatches = append(mismatches, durationMismatchResult{
+			BookID:            book.ID,
+			Title:             book.Title,
+			ASIN:              asin,
+			FileDurationSec:   fileDurSec,
+			AudibleRuntimeMin: *book.AudibleRuntimeMin,
+			AudibleRuntimeSec: audibleSec,
+			DeltaSec:          delta,
+		})
+	}
+
+	// Sort by largest delta first so the worst mismatches appear at the top.
+	sort.Slice(mismatches, func(i, j int) bool {
+		return mismatches[i].DeltaSec > mismatches[j].DeltaSec
+	})
+
+	log.Printf("[INFO] scan-duration-mismatch: scanned=%d threshold=%dmin mismatches=%d",
+		scanned, thresholdMin, len(mismatches))
+
+	c.JSON(http.StatusOK, gin.H{
+		"threshold_min": thresholdMin,
+		"scanned":       scanned,
+		"mismatch_count": len(mismatches),
+		"mismatches":    mismatches,
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.199.0
+// version: 1.200.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2488,6 +2488,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/maintenance/repair-missing-files/:id", s.perm(auth.PermSettingsManage), s.handleGetMissingFileRepairResults)
 			protected.POST("/maintenance/bulk-fetch-metadata", s.perm(auth.PermLibraryEditMetadata), s.handleBulkMetadataFetchAll)
 			protected.POST("/maintenance/revert-metadata-fetch", s.perm(auth.PermSettingsManage), s.handleRevertMetadataFetch)
+			protected.GET("/maintenance/scan-duration-mismatch", s.perm(auth.PermSettingsManage), s.handleScanDurationMismatch)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")


### PR DESCRIPTION
## Summary
- Adds \`DurationMismatch bool\` to MetadataCandidate (set when |runtime_length_min*60 - book.Duration| > 600s)
- Logs a \`[WARN]\` line in ApplyMetadataCandidate when the threshold is exceeded
- Wires \`AudibleRuntimeMin\` field through Book struct so it persists alongside the duration delta
- New endpoint: \`GET /api/v1/maintenance/scan-duration-mismatch?max_delta_min=10\` — bulk scan with configurable threshold (default 600s)
- Endpoint guarded by \`PermSettingsManage\`

## Test plan
- [x] make build-api clean
- [x] internal/metafetch tests pass
- [x] internal/database tests pass
- [x] internal/metadata tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)