### PR TITLE
feat(library): needs_writeback filter + Save-to-Files op visibility

### DIFF
--- a/internal/server/audiobook_service.go
+++ b/internal/server/audiobook_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service.go
-// version: 1.20.0
+// version: 1.21.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package server
@@ -474,6 +474,15 @@ func fieldMatchesValue(book database.Book, field, value string) bool {
 		}
 	case "has_written":
 		if book.LastWrittenAt != nil {
+			bookValue = "yes"
+		} else {
+			bookValue = "no"
+		}
+	case "needs_writeback":
+		// True when metadata was updated after the last file write (or never written).
+		needsWrite := book.MetadataUpdatedAt != nil &&
+			(book.LastWrittenAt == nil || book.LastWrittenAt.Before(*book.MetadataUpdatedAt))
+		if needsWrite {
 			bookValue = "yes"
 		} else {
 			bookValue = "no"

--- a/web/src/components/audiobooks/AudiobookCard.tsx
+++ b/web/src/components/audiobooks/AudiobookCard.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/AudiobookCard.tsx
-// version: 1.10.0
+// version: 1.11.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 
 import React from 'react';
@@ -238,6 +238,13 @@ export const AudiobookCard: React.FC<AudiobookCardProps> = ({
           {audiobook.quarantined_at && (
             <Tooltip title={audiobook.quarantine_reason || 'Quarantined'}>
               <Chip label="Failed" size="small" color="error" />
+            </Tooltip>
+          )}
+          {audiobook.metadata_updated_at &&
+            (!audiobook.last_written_at ||
+              new Date(audiobook.last_written_at) < new Date(audiobook.metadata_updated_at)) && (
+            <Tooltip title="Metadata saved to DB but not yet written to file tags">
+              <Chip label="Write pending" size="small" color="warning" variant="outlined" />
             </Tooltip>
           )}
           {audiobook.version_group_id && (

--- a/web/src/components/audiobooks/SearchBar.tsx
+++ b/web/src/components/audiobooks/SearchBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.tsx
-// version: 2.1.1
+// version: 2.2.0
 // guid: 1d2e3f4a-5b6c-7d8e-9f0a-1b2c3d4e5f6a
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -91,6 +91,7 @@ const SEARCH_HELP = [
   { example: 'has_cover:no', desc: 'Books missing cover art' },
   { example: 'has_written:yes', desc: 'Tags written to files' },
   { example: 'has_written:no', desc: 'Tags not yet written' },
+  { example: 'needs_writeback:yes', desc: 'DB metadata updated after last file write' },
   { example: 'has_organized:yes', desc: 'Files organized into library' },
   { example: 'has_organized:no', desc: 'Files not yet organized' },
   { example: 'review:matched', desc: 'Manually applied metadata' },

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -144,6 +144,8 @@ const convertApiBook = (book: api.Book): Audiobook => ({
   updated_at: book.updated_at,
   library_state: book.library_state,
   metadata_review_status: book.metadata_review_status,
+  metadata_updated_at: book.metadata_updated_at,
+  last_written_at: book.last_written_at,
   marked_for_deletion: book.marked_for_deletion,
   marked_for_deletion_at: book.marked_for_deletion_at,
   original_file_hash: book.original_file_hash,
@@ -1241,12 +1243,15 @@ export const Library = () => {
 
     setBulkWriteBackInProgress(true);
     try {
-      await api.batchWriteBackMetadata(
+      const result = await api.batchWriteBackMetadata(
         activeBooks.map((book) => book.id),
         bulkWriteBackRename,
         bulkWriteBackForce
       );
-      toast(`Saving ${activeBooks.length} books to files — check operations for progress.`, 'success');
+      if (result.operation_id) {
+        startOperationPolling(result.operation_id, 'batch_save_to_files');
+      }
+      toast(`Saving ${activeBooks.length} books to files…`, 'success');
       setBulkWriteBackDialogOpen(false);
       setSelectedAudiobooks([]);
     } catch (error) {
@@ -2681,20 +2686,20 @@ export const Library = () => {
             {bulkWriteBackResult && (
               <Box sx={{ mt: 2 }}>
                 <Alert
-                  severity={bulkWriteBackResult.failed > 0 ? 'warning' : 'success'}
+                  severity={(bulkWriteBackResult.failed ?? 0) > 0 ? 'warning' : 'success'}
                   sx={{ mb: 2 }}
                 >
-                  Wrote {bulkWriteBackResult.written} books to files, updated{' '}
-                  {bulkWriteBackResult.written_files} file
-                  {bulkWriteBackResult.written_files === 1 ? '' : 's'}
-                  {bulkWriteBackResult.renamed > 0
+                  Wrote {bulkWriteBackResult.written ?? 0} books to files, updated{' '}
+                  {bulkWriteBackResult.written_files ?? 0} file
+                  {(bulkWriteBackResult.written_files ?? 0) === 1 ? '' : 's'}
+                  {(bulkWriteBackResult.renamed ?? 0) > 0
                     ? `, renamed ${bulkWriteBackResult.renamed}`
                     : ''}
-                  {bulkWriteBackResult.failed > 0 ? `, ${bulkWriteBackResult.failed} failed` : ''}.
+                  {(bulkWriteBackResult.failed ?? 0) > 0 ? `, ${bulkWriteBackResult.failed} failed` : ''}.
                 </Alert>
-                {bulkWriteBackResult.errors.length > 0 && (
+                {(bulkWriteBackResult.errors ?? []).length > 0 && (
                   <List dense>
-                    {bulkWriteBackResult.errors.map((error) => (
+                    {(bulkWriteBackResult.errors ?? []).map((error) => (
                       <ListItem key={`${error.book_id}-${error.error}`}>
                         <ListItemText primary={error.book_id} secondary={error.error} />
                       </ListItem>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.5.0
+// version: 2.6.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -2365,12 +2365,15 @@ export interface BatchWriteBackError {
 }
 
 export interface BatchWriteBackResponse {
-  written: number;
-  written_files: number;
-  renamed: number;
-  organized: number;
-  failed: number;
-  errors: BatchWriteBackError[];
+  operation_id: string;
+  message?: string;
+  book_count?: number;
+  written?: number;
+  written_files?: number;
+  renamed?: number;
+  organized?: number;
+  failed?: number;
+  errors?: BatchWriteBackError[];
 }
 
 export async function writeBackMetadata(
@@ -2407,7 +2410,8 @@ export async function batchWriteBackMetadata(
     throw await buildApiError(response, 'Failed to write metadata to files');
   }
   const body = await response.json();
-  return body.data;
+  // Server returns operation_id at top level; data key carries legacy fields.
+  return { ...body.data, operation_id: body.data?.operation_id ?? body.operation_id };
 }
 
 // Bulk write-back (async operation for all/filtered books)

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,5 +1,5 @@
 // file: web/src/types/index.ts
-// version: 1.11.0
+// version: 1.12.0
 // guid: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a
 
 // Audiobook (Book) type
@@ -57,6 +57,8 @@ export interface Audiobook {
   quarantined_at?: string;
   organize_error?: string;
   metadata_review_status?: string; // null, "matched", "no_match"
+  metadata_updated_at?: string;
+  last_written_at?: string;
 
   created_at: string;
   updated_at: string;

--- a/web/src/utils/searchParser.ts
+++ b/web/src/utils/searchParser.ts
@@ -1,5 +1,5 @@
 // file: web/src/utils/searchParser.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: ADC8CF65-5107-463A-891C-CABE8C1D74CF
 
 /**
@@ -53,6 +53,7 @@ export const SEARCH_FIELDS: readonly string[] = [
   'review',
   'has_cover',
   'has_written',
+  'needs_writeback',
   'has_organized',
   'itunes_sync_status',
   'read_status',


### PR DESCRIPTION
## Summary

### `needs_writeback` filter & indicator
- New search field `needs_writeback:yes/no` in Go's `fieldMatchesValue` — matches books where `metadata_updated_at > last_written_at` (or file was never written). More accurate than `has_written:no` because it catches books that were written once but had metadata re-applied since.
- Added to search parser, SearchBar autocomplete examples, and Audiobook type.
- "Write pending" amber chip renders on AudiobookCard when the DB metadata timestamp is newer than the last file write.
- Useful quick filter to bulk-select books that need a Save-to-Files run after applying candidates.

### Save-to-Files shows in Active Operations
- `batchWriteBackMetadata` now captures the `operation_id` returned by the server and calls `startOperationPolling('batch_save_to_files')`, so the job appears in the Active Operations panel and bell while it's running.
- Previously the frontend ignored the operation_id entirely — the server was doing the right thing but the UI was blind to it.

## Test plan

- [ ] Search `needs_writeback:yes` — should return books with metadata applied but files not written
- [ ] AudiobookCard shows amber "Write pending" chip for those books
- [ ] After Save to Files completes, chip disappears on refresh
- [ ] Start Save to Files — operation appears in the Active Operations bell/panel immediately
- [ ] Operation disappears from Active Operations when complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)