### PR TITLE
feat(metadata): show Audible/Google ratings on candidate cards (RATE-3)

### DIFF
--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -163,6 +163,16 @@ type MetadataCandidate struct {
 	// The review UI already renders a warning chip when duration_delta_sec > 600;
 	// this flag makes the threshold decision explicit in the API response.
 	DurationMismatch bool `json:"duration_mismatch,omitempty"`
+	// AudibleRatingOverall is the Audible overall star rating (1–5 scale).
+	// Zero means the source did not provide a rating.
+	AudibleRatingOverall float64 `json:"audible_rating_overall,omitempty"`
+	// AudibleRatingCount is the number of Audible star ratings.
+	AudibleRatingCount int `json:"audible_rating_count,omitempty"`
+	// GoogleRatingAverage is the Google Books average rating (1–5 scale).
+	// Zero means the source did not provide a rating.
+	GoogleRatingAverage float64 `json:"google_rating_average,omitempty"`
+	// GoogleRatingCount is the number of Google Books ratings.
+	GoogleRatingCount int `json:"google_rating_count,omitempty"`
 }
 
 // SearchMetadataResponse is returned by SearchMetadataForBook.
@@ -2345,24 +2355,28 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			}
 
 			candidates = append(candidates, MetadataCandidate{
-				Title:            r.Title,
-				Author:           r.Author,
-				Narrator:         r.Narrator,
-				Series:           r.Series,
-				SeriesPosition:   r.SeriesPosition,
-				Year:             r.PublishYear,
-				Publisher:        r.Publisher,
-				ISBN:             r.ISBN,
-				ASIN:             r.ASIN,
-				CoverURL:         r.CoverURL,
-				Description:      r.Description,
-				Language:         r.Language,
-				Source:           src.Name(),
-				Score:            score,
-				DurationSec:      r.DurationSec,
-				DurationDeltaSec: durationDelta,
-				CategoryTags:     r.CategoryTags,
-				DurationMismatch: durationDelta > 600,
+				Title:                r.Title,
+				Author:               r.Author,
+				Narrator:             r.Narrator,
+				Series:               r.Series,
+				SeriesPosition:       r.SeriesPosition,
+				Year:                 r.PublishYear,
+				Publisher:            r.Publisher,
+				ISBN:                 r.ISBN,
+				ASIN:                 r.ASIN,
+				CoverURL:             r.CoverURL,
+				Description:          r.Description,
+				Language:             r.Language,
+				Source:               src.Name(),
+				Score:                score,
+				DurationSec:          r.DurationSec,
+				DurationDeltaSec:     durationDelta,
+				CategoryTags:         r.CategoryTags,
+				DurationMismatch:     durationDelta > 600,
+				AudibleRatingOverall: r.AudibleRatingOverall,
+				AudibleRatingCount:   r.AudibleRatingCount,
+				GoogleRatingAverage:  r.GoogleRatingAverage,
+				GoogleRatingCount:    r.GoogleRatingCount,
 			})
 		}
 	}
@@ -2411,12 +2425,16 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					CoverURL:         result.CoverURL,
 					Description:      result.Description,
 					Language:         result.Language,
-					Source:           "Audnexus (Audible)",
-					Score:            score,
-					DurationSec:      result.DurationSec,
-					DurationDeltaSec: asinDurationDelta,
-					CategoryTags:     result.CategoryTags,
-					DurationMismatch: asinDurationDelta > 600,
+					Source:               "Audnexus (Audible)",
+					Score:                score,
+					DurationSec:          result.DurationSec,
+					DurationDeltaSec:     asinDurationDelta,
+					CategoryTags:         result.CategoryTags,
+					DurationMismatch:     asinDurationDelta > 600,
+					AudibleRatingOverall: result.AudibleRatingOverall,
+					AudibleRatingCount:   result.AudibleRatingCount,
+					GoogleRatingAverage:  result.GoogleRatingAverage,
+					GoogleRatingCount:    result.GoogleRatingCount,
 				})
 			}
 		} else {

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -783,6 +783,22 @@ export function MetadataReviewDialog({
                 color={SOURCE_COLORS[r.candidate.source] || 'default'}
                 variant="outlined"
               />
+              {(r.candidate.audible_rating_overall ?? 0) > 0 && (
+                <Chip
+                  label={`★ ${r.candidate.audible_rating_overall!.toFixed(1)}${(r.candidate.audible_rating_count ?? 0) > 0 ? ` (${r.candidate.audible_rating_count!.toLocaleString()})` : ''}`}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontWeight: 500 }}
+                />
+              )}
+              {(r.candidate.google_rating_average ?? 0) > 0 && (
+                <Chip
+                  label={`G★ ${r.candidate.google_rating_average!.toFixed(1)}${(r.candidate.google_rating_count ?? 0) > 0 ? ` (${r.candidate.google_rating_count!.toLocaleString()})` : ''}`}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontWeight: 500 }}
+                />
+              )}
               {Math.abs(r.candidate?.duration_delta_sec ?? 0) > 600 && (
                 <Chip
                   label={`⚠ runtime differs by ${formatDuration(Math.abs(r.candidate.duration_delta_sec!))}`}
@@ -967,8 +983,24 @@ export function MetadataReviewDialog({
                     size="small"
                     color={SOURCE_COLORS[r.candidate.source] || 'default'}
                     variant="outlined"
-                    sx={{ mt: 0.5 }}
+                    sx={{ mt: 0.5, mr: 0.5 }}
                   />
+                  {(r.candidate.audible_rating_overall ?? 0) > 0 && (
+                    <Chip
+                      label={`★ ${r.candidate.audible_rating_overall!.toFixed(1)}${(r.candidate.audible_rating_count ?? 0) > 0 ? ` (${r.candidate.audible_rating_count!.toLocaleString()})` : ''}`}
+                      size="small"
+                      variant="outlined"
+                      sx={{ mt: 0.5, mr: 0.5, fontWeight: 500 }}
+                    />
+                  )}
+                  {(r.candidate.google_rating_average ?? 0) > 0 && (
+                    <Chip
+                      label={`G★ ${r.candidate.google_rating_average!.toFixed(1)}${(r.candidate.google_rating_count ?? 0) > 0 ? ` (${r.candidate.google_rating_count!.toLocaleString()})` : ''}`}
+                      size="small"
+                      variant="outlined"
+                      sx={{ mt: 0.5, fontWeight: 500 }}
+                    />
+                  )}
                 </Box>
               </Stack>
             </Box>
@@ -1088,7 +1120,7 @@ export function MetadataReviewDialog({
                       Duration: {formatDuration(r.candidate.duration_sec!)}
                     </Typography>
                   )}
-                  <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+                  <Stack direction="row" spacing={0.5} flexWrap="wrap" sx={{ mt: 0.5 }}>
                     <Chip
                       label={`${Math.round(r.candidate.score * 100)}%`}
                       size="small"
@@ -1106,6 +1138,22 @@ export function MetadataReviewDialog({
                       color={SOURCE_COLORS[r.candidate.source] || 'default'}
                       variant="outlined"
                     />
+                    {(r.candidate.audible_rating_overall ?? 0) > 0 && (
+                      <Chip
+                        label={`★ ${r.candidate.audible_rating_overall!.toFixed(1)}${(r.candidate.audible_rating_count ?? 0) > 0 ? ` (${r.candidate.audible_rating_count!.toLocaleString()})` : ''}`}
+                        size="small"
+                        variant="outlined"
+                        sx={{ fontWeight: 500 }}
+                      />
+                    )}
+                    {(r.candidate.google_rating_average ?? 0) > 0 && (
+                      <Chip
+                        label={`G★ ${r.candidate.google_rating_average!.toFixed(1)}${(r.candidate.google_rating_count ?? 0) > 0 ? ` (${r.candidate.google_rating_count!.toLocaleString()})` : ''}`}
+                        size="small"
+                        variant="outlined"
+                        sx={{ fontWeight: 500 }}
+                      />
+                    )}
                   </Stack>
                   {isRowActionable(bookId) && (
                     <Stack direction="row" spacing={1} sx={{ mt: 1 }}>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2269,6 +2269,14 @@ export interface MetadataCandidate {
   language?: string;
   source: string;
   score: number;
+  /** Audible overall star rating (1–5 scale). Absent when not provided. */
+  audible_rating_overall?: number;
+  /** Number of Audible star ratings. */
+  audible_rating_count?: number;
+  /** Google Books average rating (1–5 scale). Absent when not provided. */
+  google_rating_average?: number;
+  /** Number of Google Books ratings. */
+  google_rating_count?: number;
 }
 
 export interface SearchMetadataResponse {


### PR DESCRIPTION
## Summary
- Surfaces audible_rating_overall/count and google_rating_average/count through the MetadataCandidate Go struct + TS interface
- MetadataReviewDialog candidate cards now display rating chips (\"★ 4.7 (1,234)\" / \"G★ 4.5 (892)\") in both compact and two-column views
- Skipped when rating is zero/absent

## Test plan
- [x] make build-api clean
- [x] npm run build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)