### PR TITLE
feat(api): numeric search filters for user_rating_* (RATE-4)

### DIFF
--- a/internal/server/audiobook_service.go
+++ b/internal/server/audiobook_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package server
@@ -429,9 +429,22 @@ func matchesFieldFilters(book database.Book, filters []FieldFilter) bool {
 	return true
 }
 
-// fieldMatchesValue checks whether a book's field value contains the search value
-// (case-insensitive). Unknown fields return false.
+// fieldMatchesValue checks whether a book's field value matches the search
+// value. For user_rating_* fields the value may be a numeric comparison
+// expression such as ">4", "<=3.5", ">=4", "<3", "==5", "!=2"; any other
+// value is treated as an equality check.  All other fields use
+// case-insensitive substring matching.  Unknown fields return false.
 func fieldMatchesValue(book database.Book, field, value string) bool {
+	// Numeric rating fields — delegate to numericCompare.
+	switch field {
+	case "user_rating_overall":
+		return numericCompare(book.UserRatingOverall, value)
+	case "user_rating_story":
+		return numericCompare(book.UserRatingStory, value)
+	case "user_rating_performance":
+		return numericCompare(book.UserRatingPerformance, value)
+	}
+
 	var bookValue string
 	switch field {
 	case "title":
@@ -508,6 +521,57 @@ func fieldMatchesValue(book database.Book, field, value string) bool {
 		return false // unknown field
 	}
 	return strings.Contains(strings.ToLower(bookValue), strings.ToLower(value))
+}
+
+// numericCompare evaluates a filter value expression against a nullable
+// float64 book field.  The expression may start with one of the operators
+// >=, <=, !=, ==, >, <.  A bare number (no operator prefix) is treated as
+// == equality.  If the book field is nil (unset) the function always returns
+// false.
+func numericCompare(fieldVal *float64, expr string) bool {
+	if fieldVal == nil {
+		return false
+	}
+	bookNum := *fieldVal
+
+	var op string
+	var numStr string
+	switch {
+	case strings.HasPrefix(expr, ">="):
+		op, numStr = ">=", expr[2:]
+	case strings.HasPrefix(expr, "<="):
+		op, numStr = "<=", expr[2:]
+	case strings.HasPrefix(expr, "!="):
+		op, numStr = "!=", expr[2:]
+	case strings.HasPrefix(expr, "=="):
+		op, numStr = "==", expr[2:]
+	case strings.HasPrefix(expr, ">"):
+		op, numStr = ">", expr[1:]
+	case strings.HasPrefix(expr, "<"):
+		op, numStr = "<", expr[1:]
+	default:
+		op, numStr = "==", expr
+	}
+
+	threshold, err := strconv.ParseFloat(strings.TrimSpace(numStr), 64)
+	if err != nil {
+		return false // unparseable — treat as no match
+	}
+
+	switch op {
+	case ">":
+		return bookNum > threshold
+	case "<":
+		return bookNum < threshold
+	case ">=":
+		return bookNum >= threshold
+	case "<=":
+		return bookNum <= threshold
+	case "!=":
+		return bookNum != threshold
+	default: // "=="
+		return bookNum == threshold
+	}
 }
 
 // GetAudiobooks retrieves audiobooks with optional filtering.

--- a/internal/server/audiobook_service_unit_test.go
+++ b/internal/server/audiobook_service_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_service_unit_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -602,4 +602,151 @@ func TestAudiobookService_GetAudiobooks_PerUserNoUserID(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, got, 2, "no user → per-user filter skipped, all books returned")
+}
+
+// --- numericCompare / user_rating_* field filters ---
+
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestNumericCompare_Operators verifies every comparison operator against a
+// known book field value of 4.0.
+func TestNumericCompare_Operators(t *testing.T) {
+	val := float64Ptr(4.0)
+	tests := []struct {
+		expr string
+		want bool
+	}{
+		{">3", true},
+		{">4", false},
+		{">5", false},
+		{"<5", true},
+		{"<4", false},
+		{"<3", false},
+		{">=4", true},
+		{">=4.0", true},
+		{">=5", false},
+		{"<=4", true},
+		{"<=3", false},
+		{"==4", true},
+		{"==4.0", true},
+		{"==3", false},
+		{"!=4", false},
+		{"!=3", true},
+		// bare number → equality
+		{"4", true},
+		{"3", false},
+		// decimal threshold
+		{">3.5", true},
+		{"<=3.5", false},
+		{">=3.5", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			got := numericCompare(val, tc.expr)
+			assert.Equal(t, tc.want, got, "numericCompare(%v, %q)", *val, tc.expr)
+		})
+	}
+}
+
+// TestNumericCompare_NilField ensures a nil rating always returns false.
+func TestNumericCompare_NilField(t *testing.T) {
+	assert.False(t, numericCompare(nil, ">0"))
+	assert.False(t, numericCompare(nil, "==0"))
+}
+
+// TestNumericCompare_InvalidExpr ensures an unparseable expression returns false.
+func TestNumericCompare_InvalidExpr(t *testing.T) {
+	val := float64Ptr(3.0)
+	assert.False(t, numericCompare(val, ">abc"))
+	assert.False(t, numericCompare(val, ">="))
+}
+
+// TestFieldMatchesValue_UserRatingFields checks that fieldMatchesValue routes
+// user_rating_* fields through numeric comparison correctly.
+func TestFieldMatchesValue_UserRatingFields(t *testing.T) {
+	overall := float64Ptr(4.5)
+	story := float64Ptr(3.0)
+	perf := float64Ptr(5.0)
+
+	book := database.Book{
+		UserRatingOverall:     overall,
+		UserRatingStory:       story,
+		UserRatingPerformance: perf,
+	}
+
+	// overall
+	assert.True(t, fieldMatchesValue(book, "user_rating_overall", ">4"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_overall", ">4.5"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_overall", ">=4.5"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_overall", "<=5"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_overall", "<4"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_overall", "==4.5"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_overall", "==4"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_overall", "!=4"))
+
+	// story
+	assert.True(t, fieldMatchesValue(book, "user_rating_story", "<4"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_story", "==3"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_story", ">3"))
+
+	// performance
+	assert.True(t, fieldMatchesValue(book, "user_rating_performance", "==5"))
+	assert.True(t, fieldMatchesValue(book, "user_rating_performance", ">=5"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_performance", ">5"))
+}
+
+// TestFieldMatchesValue_UserRatingNilBook ensures nil rating fields return false.
+func TestFieldMatchesValue_UserRatingNilBook(t *testing.T) {
+	book := database.Book{} // all rating fields nil
+	assert.False(t, fieldMatchesValue(book, "user_rating_overall", ">0"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_story", ">=0"))
+	assert.False(t, fieldMatchesValue(book, "user_rating_performance", "==0"))
+}
+
+// TestGetAudiobooks_UserRatingFilter is an integration-style test through
+// GetAudiobooks that ensures user_rating_overall FieldFilter works end-to-end.
+func TestGetAudiobooks_UserRatingFilter(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+
+	hi := float64Ptr(4.5)
+	lo := float64Ptr(2.0)
+	books := []database.Book{
+		{ID: "high", Title: "High Rated", UserRatingOverall: hi},
+		{ID: "low", Title: "Low Rated", UserRatingOverall: lo},
+		{ID: "none", Title: "Not Rated"}, // nil
+	}
+	mockStore.EXPECT().GetAllBooks(0, 0).Return(books, nil)
+
+	got, err := svc.GetAudiobooks(context.Background(), 0, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{
+			{Field: "user_rating_overall", Value: ">4"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "high", got[0].ID)
+}
+
+// TestGetAudiobooks_UserRatingFilter_LessThan verifies the < operator returns
+// only books whose rating is strictly below the threshold.
+func TestGetAudiobooks_UserRatingFilter_LessThan(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+
+	books := []database.Book{
+		{ID: "b1", UserRatingOverall: float64Ptr(1.0)},
+		{ID: "b2", UserRatingOverall: float64Ptr(3.0)},
+		{ID: "b3", UserRatingOverall: float64Ptr(5.0)},
+	}
+	mockStore.EXPECT().GetAllBooks(0, 0).Return(books, nil)
+
+	got, err := svc.GetAudiobooks(context.Background(), 0, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{
+			{Field: "user_rating_overall", Value: "<3"},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "b1", got[0].ID)
 }

--- a/internal/server/metadata_normalize_test.go
+++ b/internal/server/metadata_normalize_test.go
@@ -1,10 +1,11 @@
 // file: internal/server/metadata_normalize_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 4f7c2b8d-3a91-4e5f-b6c0-1d8e7a9f3c45
 
 package server
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
@@ -93,7 +94,7 @@ func TestNormalizeMetaSeries_Idempotent(t *testing.T) {
 	metafetch.NormalizeMetaSeries(&meta)
 	first := meta
 	metafetch.NormalizeMetaSeries(&meta)
-	if meta != first {
+	if !reflect.DeepEqual(meta, first) {
 		t.Errorf("second call mutated meta; before=%+v after=%+v", first, meta)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds numericCompare helper supporting >, <, >=, <=, ==, !=, and bare-number equality
- Routes user_rating_overall, user_rating_story, user_rating_performance through it inside fieldMatchesValue
- Drive-by fix for a pre-existing compile error in metadata_normalize_test.go (struct with []string field compared with != — switched to reflect.DeepEqual)

## Test plan
- [x] 29 new unit tests pass (operators, nil-field guards, invalid-expression handling, fieldMatchesValue routing, end-to-end GetAudiobooks)
- [x] make build-api clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)