### PR TITLE
feat(ui): bulk rating dialog from library row selection (RATE-5)

### DIFF
--- a/web/src/components/audiobooks/BulkRatingDialog.tsx
+++ b/web/src/components/audiobooks/BulkRatingDialog.tsx
@@ -1,0 +1,185 @@
+// file: web/src/components/audiobooks/BulkRatingDialog.tsx
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Typography,
+  Stack,
+  Alert,
+  CircularProgress,
+  LinearProgress,
+  Box,
+} from '@mui/material';
+import Rating from '@mui/material/Rating';
+import StarIcon from '@mui/icons-material/Star';
+import * as api from '../../services/api';
+
+interface BulkRatingDialogProps {
+  open: boolean;
+  onClose: () => void;
+  bookIds: string[];
+  onComplete?: () => void;
+}
+
+export const BulkRatingDialog: React.FC<BulkRatingDialogProps> = ({
+  open,
+  onClose,
+  bookIds,
+  onComplete,
+}) => {
+  const [overall, setOverall] = useState<number | null>(null);
+  const [story, setStory] = useState<number | null>(null);
+  const [performance, setPerformance] = useState<number | null>(null);
+  const [notes, setNotes] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState<{ completed: number; total: number } | null>(null);
+  const [result, setResult] = useState<{ success: number; failed: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasAnyRating = overall !== null || story !== null || performance !== null || notes.trim() !== '';
+
+  const handleApply = async () => {
+    if (!hasAnyRating) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setProgress({ completed: 0, total: bookIds.length });
+
+    const body: api.RatingPatchBody = {};
+    if (overall !== null) body.overall = overall;
+    if (story !== null) body.story = story;
+    if (performance !== null) body.performance = performance;
+    if (notes.trim() !== '') body.notes = notes.trim();
+
+    let success = 0;
+    let failed = 0;
+
+    for (let i = 0; i < bookIds.length; i++) {
+      try {
+        await api.patchAudiobookRating(bookIds[i], body);
+        success++;
+      } catch (_err) {
+        failed++;
+      }
+      setProgress({ completed: i + 1, total: bookIds.length });
+    }
+
+    setResult({ success, failed });
+    setLoading(false);
+    if (failed === 0) {
+      onComplete?.();
+    }
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setOverall(null);
+    setStory(null);
+    setPerformance(null);
+    setNotes('');
+    setProgress(null);
+    setResult(null);
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Rate {bookIds.length} book{bookIds.length !== 1 ? 's' : ''}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Set ratings for all selected books. Leave a dimension blank to keep each book's existing value.
+          </Typography>
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>Overall</Typography>
+            <Rating
+              value={overall}
+              onChange={(_e, v) => setOverall(v)}
+              precision={0.5}
+              emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>Story</Typography>
+            <Rating
+              value={story}
+              onChange={(_e, v) => setStory(v)}
+              precision={0.5}
+              emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>Performance</Typography>
+            <Rating
+              value={performance}
+              onChange={(_e, v) => setPerformance(v)}
+              precision={0.5}
+              emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+            />
+          </Box>
+
+          <TextField
+            label="Notes"
+            multiline
+            minRows={2}
+            maxRows={5}
+            size="small"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Optional notes applied to all selected books..."
+            disabled={loading}
+          />
+
+          {loading && progress && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Rating {progress.completed} / {progress.total}...
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={(progress.completed / progress.total) * 100}
+                sx={{ mt: 0.5 }}
+              />
+            </Box>
+          )}
+
+          {error && <Alert severity="error">{error}</Alert>}
+
+          {result && (
+            <Alert severity={result.failed === 0 ? 'success' : 'warning'}>
+              {result.failed === 0
+                ? `Ratings applied to ${result.success} book${result.success !== 1 ? 's' : ''}.`
+                : `Applied to ${result.success} books; ${result.failed} failed.`}
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          {result ? 'Close' : 'Cancel'}
+        </Button>
+        {!result && (
+          <Button
+            variant="contained"
+            onClick={handleApply}
+            disabled={loading || !hasAnyRating}
+            startIcon={loading ? <CircularProgress size={16} /> : undefined}
+          >
+            {loading ? 'Applying...' : `Apply to all ${bookIds.length}`}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.50.0
+// version: 1.51.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -59,6 +59,7 @@ import { BatchEditDialog } from '../components/audiobooks/BatchEditDialog';
 import { VersionManagement } from '../components/audiobooks/VersionManagement';
 import { BulkMetadataSearchDialog } from '../components/audiobooks/BulkMetadataSearchDialog';
 import { BulkTagDialog } from '../components/audiobooks/BulkTagDialog';
+import { BulkRatingDialog } from '../components/audiobooks/BulkRatingDialog';
 import { MetadataReviewDialog } from '../components/audiobooks/MetadataReviewDialog';
 import { useToast } from '../components/toast/ToastProvider';
 import type { Audiobook, FilterOptions } from '../types';
@@ -232,6 +233,7 @@ export const Library = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [parsedSearch, setParsedSearch] = useState<ParsedSearch>(() => parseSearch(initialSearch));
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
+  const [bulkRatingDialogOpen, setBulkRatingDialogOpen] = useState(false);
 
   // Column config
   const {
@@ -1805,6 +1807,7 @@ export const Library = () => {
             <Box sx={{ borderLeft: 1, borderColor: 'divider', height: 24 }} />
             <Button size="small" variant="outlined" color="primary" onClick={() => { setMergePrimaryId(selectedAudiobooks[0]?.id || ''); setMergeDialogOpen(true); }} disabled={selectedAudiobooks.length < 2}>Merge as Versions</Button>
             <Button size="small" variant="outlined" onClick={() => setBulkTagDialogOpen(true)} disabled={!hasSelection}>Tag</Button>
+            <Button size="small" variant="outlined" onClick={() => setBulkRatingDialogOpen(true)} disabled={!hasSelection}>Rate</Button>
             <Box sx={{ flex: 1 }} />
             <Button size="small" variant="outlined" color="secondary" onClick={() => setBatchDeleteDialogOpen(true)} disabled={!selectedHasActive}>Delete Selected</Button>
             <Button size="small" variant="outlined" color="success" onClick={handleBatchRestore} disabled={!selectedHasDeleted || batchRestoreInProgress}>{batchRestoreInProgress ? 'Restoring...' : 'Restore Selected'}</Button>
@@ -2085,6 +2088,21 @@ export const Library = () => {
                         disabled={!hasSelection}
                       >
                         Tag
+                      </Button>
+                    </span>
+                  </Tooltip>
+                  <Tooltip
+                    title={!hasSelection ? 'Select books first' : ''}
+                    disableHoverListener={hasSelection}
+                  >
+                    <span>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setBulkRatingDialogOpen(true)}
+                        disabled={!hasSelection}
+                      >
+                        Rate
                       </Button>
                     </span>
                   </Tooltip>
@@ -2534,6 +2552,13 @@ export const Library = () => {
             refreshTags();
             loadAudiobooks();
           }}
+        />
+
+        <BulkRatingDialog
+          open={bulkRatingDialogOpen}
+          onClose={() => setBulkRatingDialogOpen(false)}
+          bookIds={selectedAudiobooks.map((b) => b.id)}
+          onComplete={() => loadAudiobooks()}
         />
 
         <Dialog open={mergeDialogOpen} onClose={() => setMergeDialogOpen(false)} maxWidth="sm" fullWidth>


### PR DESCRIPTION
## Summary
- New BulkRatingDialog mirrors the BulkTagDialog pattern with 3-dimension MUI Rating + Notes textarea
- Loops through selected book IDs calling patchAudiobookRating, shows linear progress + success/warning alert
- Wired into Library.tsx bulk actions toolbar (compact + grid/list views)

## Test plan
- [x] npm run build clean (tsc + vite)
- [x] make build-api clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)