### PR TITLE
feat(settings): ProtectedPaths field + bulk Deluge import trigger

### DIFF
--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_discovery.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: e6f7a8b9-c0d1-2e3f-4a5b-6c7d8e9f0a1b
 //
 // Deluge label-based audiobook discovery.
@@ -38,6 +38,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 )
@@ -419,5 +420,83 @@ func (s *Server) handleDelugeDiscoverImport(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{
 		"book":         resp,
 		"torrent_hash": req.TorrentHash,
+	})
+}
+
+// handleDiscoveryImport triggers importToLibrary for all book_files that
+// have a deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
+// This is the bulk-import trigger called from the Settings UI.
+// POST /api/v1/discovery/import
+// Optional body: { "dry_run": true, "max_books": 100 }
+func (s *Server) handleDiscoveryImport(c *gin.Context) {
+	var req struct {
+		DryRun   bool `json:"dry_run"`
+		MaxBooks int  `json:"max_books"`
+	}
+	_ = c.ShouldBindJSON(&req) // optional body
+
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+	client := getDelugeClient()
+	if client == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "deluge not configured"})
+		return
+	}
+
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		internalError(c, "failed to load book files", err)
+		return
+	}
+
+	var pending []database.BookFile
+	for i := range files {
+		f := &files[i]
+		if f.DelugeHash != "" && f.ImportedFromDelugeAt == nil {
+			pending = append(pending, *f)
+		}
+	}
+
+	if req.MaxBooks > 0 && len(pending) > req.MaxBooks {
+		pending = pending[:req.MaxBooks]
+	}
+
+	type result struct {
+		FileID  string `json:"file_id"`
+		Path    string `json:"path"`
+		NewPath string `json:"new_path,omitempty"`
+		Error   string `json:"error,omitempty"`
+	}
+
+	var results []result
+	imported, skipped, failed := 0, 0, 0
+
+	for i := range pending {
+		f := &pending[i]
+		if req.DryRun {
+			results = append(results, result{FileID: f.ID, Path: f.FilePath})
+			skipped++
+			continue
+		}
+		newPath, importErr := importToLibrary(&config.AppConfig, client, store, f)
+		if importErr != nil {
+			results = append(results, result{FileID: f.ID, Path: f.FilePath, Error: importErr.Error()})
+			failed++
+		} else {
+			results = append(results, result{FileID: f.ID, Path: f.FilePath, NewPath: newPath})
+			imported++
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"total":    len(pending),
+		"imported": imported,
+		"skipped":  skipped,
+		"failed":   failed,
+		"dry_run":  req.DryRun,
+		"results":  results,
 	})
 }

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_integration.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
 //
 // Deluge integration for library centralization (backlog 6.1).
@@ -183,6 +183,9 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 		dg.GET("/discover", s.perm("integrations.manage"), s.handleDelugeDiscover)
 		dg.POST("/discover/import", s.perm("integrations.manage"), s.handleDelugeDiscoverImport)
 	}
+
+	// Bulk-import pending Deluge files (settings.manage permission).
+	protected.POST("/discovery/import", s.perm("settings.manage"), s.handleDiscoveryImport)
 }
 
 // NotifyDelugeAfterUndo checks whether the reverted operation moved

--- a/web/src/components/settings/DelugeSettingsTab.tsx
+++ b/web/src/components/settings/DelugeSettingsTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/settings/DelugeSettingsTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f2a3b1c-5d6e-4a70-b8c5-3d7e0f1b9a99
 
 import { useCallback, useEffect, useState } from 'react';
@@ -42,6 +42,8 @@ export default function DelugeSettingsTab() {
   const [testing, setTesting] = useState(false);
   const [torrents, setTorrents] = useState<Record<string, TorrentInfo>>({});
   const [showTorrents, setShowTorrents] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [importResult, setImportResult] = useState<{ total: number; imported: number; failed: number } | null>(null);
 
   useEffect(() => {
     fetch(`${API_BASE}/deluge/status`)
@@ -72,6 +74,24 @@ export default function DelugeSettingsTab() {
       setShowTorrents(true);
     } catch {
       setTorrents({});
+    }
+  }, []);
+
+  const handleBulkImport = useCallback(async () => {
+    setImporting(true);
+    setImportResult(null);
+    try {
+      const resp = await fetch(`${API_BASE}/discovery/import`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dry_run: false }),
+      });
+      const data = await resp.json();
+      setImportResult({ total: data.total, imported: data.imported, failed: data.failed });
+    } catch {
+      setImportResult(null);
+    } finally {
+      setImporting(false);
     }
   }, []);
 
@@ -179,6 +199,29 @@ export default function DelugeSettingsTab() {
           </TableContainer>
         </Box>
       )}
+
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+          Bulk Import
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Import all pending Deluge files (those with a torrent hash but not yet copied to the
+          library).
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={handleBulkImport}
+          disabled={importing}
+        >
+          {importing ? 'Importing…' : 'Import Unimported'}
+        </Button>
+        {importResult && (
+          <Alert severity={importResult.failed > 0 ? 'warning' : 'success'} sx={{ mt: 2 }}>
+            Total: {importResult.total} — Imported: {importResult.imported} — Failed:{' '}
+            {importResult.failed}
+          </Alert>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.39.0
+// version: 1.41.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 import { useState, useEffect, useMemo, useRef, ChangeEvent } from 'react';
@@ -859,6 +859,9 @@ interface SettingsState {
   autoRenameOnApply: boolean;
   autoWriteTagsOnApply: boolean;
   verifyAfterWrite: boolean;
+
+  // Deluge integration
+  protectedPaths: string;
 }
 
 export function Settings() {
@@ -1032,6 +1035,9 @@ export function Settings() {
     autoRenameOnApply: true,
     autoWriteTagsOnApply: true,
     verifyAfterWrite: true,
+
+    // Deluge integration
+    protectedPaths: '',
   };
 
   const [settings, setSettings] = useState<SettingsState>(initialSettings);
@@ -1229,6 +1235,9 @@ export function Settings() {
         autoRenameOnApply: config.auto_rename_on_apply ?? true,
         autoWriteTagsOnApply: config.auto_write_tags_on_apply ?? true,
         verifyAfterWrite: config.verify_after_write ?? true,
+
+        // Deluge integration
+        protectedPaths: (config.protected_paths || []).join('\n'),
       };
       setSettings(nextSettings);
       setSavedSnapshot(JSON.stringify(nextSettings));
@@ -1831,6 +1840,10 @@ export function Settings() {
         auto_rename_on_apply: settings.autoRenameOnApply,
         auto_write_tags_on_apply: settings.autoWriteTagsOnApply,
         verify_after_write: settings.verifyAfterWrite,
+        protected_paths: settings.protectedPaths
+          .split('\n')
+          .map((p) => p.trim())
+          .filter(Boolean),
       };
 
       console.log(
@@ -3609,6 +3622,27 @@ export function Settings() {
         </TabPanel>
 
         <TabPanel value={tabValue} index={7}>
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+              Protected Paths
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Paths that the organizer will never move or delete files from. One path per line.
+              These are typically your Deluge download directories.
+            </Typography>
+            <TextField
+              multiline
+              minRows={3}
+              maxRows={10}
+              fullWidth
+              placeholder={'/mnt/downloads/audiobooks\n/mnt/media/deluge'}
+              value={settings.protectedPaths}
+              onChange={(e) => setSettings((prev) => ({ ...prev, protectedPaths: e.target.value }))}
+              size="small"
+              label="Protected Paths"
+              helperText="Changes are saved with the main Save button."
+            />
+          </Paper>
           <DelugeSettingsTab />
         </TabPanel>
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.6.0
+// version: 2.7.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -561,6 +561,9 @@ export interface Config {
   itl_write_back_enabled?: boolean;
   itunes_auto_write_back?: boolean;
   itunes_sync_enabled?: boolean;
+
+  // Deluge integration
+  protected_paths?: string[];
 
   // Legacy fields (Goodreads deprecated Dec 2020, removed)
   api_keys: Record<string, never>;


### PR DESCRIPTION
## Changes
- Deluge settings tab: multiline ProtectedPaths TextField, saved as string array via main Save button
- Backend: POST /api/v1/discovery/import bulk-imports all book_files with deluge_hash that haven't been copied to library yet
- DelugeSettingsTab: Bulk Import button with live imported/failed summary

## Related
DELUGE-2 (protected paths), DELUGE-3 (importToLibrary)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>