### PR TITLE
feat(maintenance): RELINK-5 bulk-deluge-import async operation

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 
 package database
@@ -113,6 +113,9 @@ type BookFileStore interface {
 	UpdateBookFile(id string, file *BookFile) error
 	GetBookFiles(bookID string) ([]BookFile, error)
 	GetAllBookFiles() ([]BookFile, error)
+	// GetBookFilesNeedingDelugeImport returns book_files that have a deluge_hash
+	// but have not yet been copied into the library (imported_from_deluge_at IS NULL).
+	GetBookFilesNeedingDelugeImport() ([]BookFile, error)
 	GetBookFileByID(bookID, fileID string) (*BookFile, error)
 	GetBookFileByPID(itunesPID string) (*BookFile, error)
 	GetBookFileByPath(filePath string) (*BookFile, error)

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.40.0
+// version: 1.41.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package database
@@ -2160,6 +2160,7 @@ func (m *MockStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	return nil, nil
 }
 func (m *MockStore) GetAllBookFiles() ([]BookFile, error) { return nil, nil }
+func (m *MockStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) { return nil, nil }
 func (m *MockStore) GetBookFileByID(bookID, fileID string) (*BookFile, error) {
 	if m.GetBookFileByIDFunc != nil {
 		return m.GetBookFileByIDFunc(bookID, fileID)

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -30225,6 +30225,52 @@ func (_mock *MockStore) GetAllBookFiles() ([]database.BookFile, error) {
 	return r0, r1
 }
 
+// MockStore_GetBookFilesNeedingDelugeImport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImport'
+type MockStore_GetBookFilesNeedingDelugeImport_Call struct {
+	*mock.Call
+}
+
+// GetBookFilesNeedingDelugeImport is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetBookFilesNeedingDelugeImport() *MockStore_GetBookFilesNeedingDelugeImport_Call {
+	return &MockStore_GetBookFilesNeedingDelugeImport_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImport")}
+}
+
+func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) Run(run func()) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+	_c.Call.Run(func(args mock.Arguments) { run() })
+	return _c
+}
+
+func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) Return(bookFiles []database.BookFile, err error) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+	_c.Call.Return(bookFiles, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookFilesNeedingDelugeImport provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFilesNeedingDelugeImport() ([]database.BookFile, error) {
+	ret := _mock.Called()
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookFilesNeedingDelugeImport")
+	}
+	var r0 []database.BookFile
+	if rf, ok := ret.Get(0).(func() []database.BookFile); ok {
+		r0 = rf()
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]database.BookFile)
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // GetBookNarrators provides a mock function for the type MockStore
 func (_mock *MockStore) GetBookNarrators(bookID string) ([]database.BookNarrator, error) {
 	ret := _mock.Called(bookID)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.55.0
+// version: 1.56.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -7362,6 +7362,24 @@ func (s *PebbleStore) GetAllBookFiles() ([]BookFile, error) {
 		files = append(files, f)
 	}
 	return files, nil
+}
+
+// GetBookFilesNeedingDelugeImport returns book_files that have a non-empty
+// deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
+// PebbleStore is not the primary backend for deluge operations, so this returns
+// results by filtering GetAllBookFiles in memory.
+func (s *PebbleStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+	all, err := s.GetAllBookFiles()
+	if err != nil {
+		return nil, err
+	}
+	var out []BookFile
+	for _, f := range all {
+		if f.DelugeHash != "" && f.ImportedFromDelugeAt == nil {
+			out = append(out, f)
+		}
+	}
+	return out, nil
 }
 
 // GetBookFileByPID looks up a BookFile by iTunes persistent ID using the

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.66.0
+// version: 1.67.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -5729,6 +5729,31 @@ func (s *SQLiteStore) GetAllBookFiles() ([]BookFile, error) {
 		f, err := bookFileScan(rows)
 		if err != nil {
 			return nil, fmt.Errorf("GetAllBookFiles scan: %w", err)
+		}
+		files = append(files, f)
+	}
+	return files, rows.Err()
+}
+
+// GetBookFilesNeedingDelugeImport returns book_files that have a non-empty
+// deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
+func (s *SQLiteStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+	rows, err := s.db.Query(
+		`SELECT ` + bookFileCols + `
+		 FROM book_files
+		 WHERE deluge_hash IS NOT NULL AND deluge_hash != ''
+		   AND imported_from_deluge_at IS NULL
+		 ORDER BY book_id ASC, file_path ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GetBookFilesNeedingDelugeImport: %w", err)
+	}
+	defer rows.Close()
+	var files []BookFile
+	for rows.Next() {
+		f, err := bookFileScan(rows)
+		if err != nil {
+			return nil, fmt.Errorf("GetBookFilesNeedingDelugeImport scan: %w", err)
 		}
 		files = append(files, f)
 	}

--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -1,5 +1,5 @@
 // file: internal/operations/state.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package operations
@@ -83,6 +83,14 @@ type BulkMetadataFetchParams struct {
 type MissingFileRepairParams struct {
 	DryRun      bool     `json:"dry_run"`
 	SearchRoots []string `json:"search_roots,omitempty"`
+}
+
+// BulkImportDelugeParams stores the immutable parameters for a bulk-import-deluge operation.
+// DryRun=true reports what would be imported without making any changes.
+// MaxBooks limits the number of books imported in one run (0 = unlimited).
+type BulkImportDelugeParams struct {
+	DryRun   bool `json:"dry_run"`
+	MaxBooks int  `json:"max_books,omitempty"`
 }
 
 // SaveCheckpoint persists an operation's progress checkpoint.

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.24.0
+// version: 1.25.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -26,12 +26,16 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/oklog/ulid/v2"
 )
+
+// Ensure deluge import is only done via the package-level accessor
+// getDelugeClient() defined in deluge_integration.go — no direct import needed.
 
 // maintenanceStore is the narrow slice of database.Store that
 // maintenance-fixup helpers share. Every free function in this file
@@ -5758,4 +5762,136 @@ func (s *Server) handleRelinkReport(c *gin.Context) {
 		"offset":            offset,
 		"limit":             limit,
 	})
+}
+
+// handleBulkDelugeImport queues a resumable async operation that calls
+// importToLibrary for every book_file that has a deluge_hash but has not
+// yet been imported (imported_from_deluge_at IS NULL).
+//
+// Query params:
+//   - dry_run=true (default) — report what would be imported without writing
+//   - dry_run=false           — actually copy files
+//   - max_books=N             — cap the number of files imported per run (0 = unlimited)
+//
+// POST /api/v1/maintenance/bulk-deluge-import
+func (s *Server) handleBulkDelugeImport(c *gin.Context) {
+	dryRun := c.DefaultQuery("dry_run", "true") != "false"
+	maxBooks := 0
+	if v := c.Query("max_books"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxBooks = n
+		}
+	}
+
+	store := s.Store()
+	if store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		return
+	}
+
+	client := getDelugeClient()
+
+	opID := ulid.Make().String()
+	if _, err := store.CreateOperation(opID, "bulk-deluge-import", nil); err != nil {
+		internalError(c, "failed to create operation", err)
+		return
+	}
+
+	params := operations.BulkImportDelugeParams{DryRun: dryRun, MaxBooks: maxBooks}
+	if err := operations.SaveParams(store, opID, params); err != nil {
+		log.Printf("[WARN] bulk-deluge-import: failed to save params for %s: %v", opID, err)
+	}
+
+	capturedOpID := opID
+	capturedParams := params
+	capturedClient := client
+	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		return s.runBulkDelugeImport(ctx, capturedOpID, capturedParams, capturedClient, store, progress)
+	}
+	if err := s.queue.Enqueue(opID, "bulk-deluge-import", operations.PriorityNormal, opFunc); err != nil {
+		internalError(c, "failed to enqueue operation", err)
+		return
+	}
+
+	log.Printf("[INFO] bulk-deluge-import: queued %s dry_run=%v max_books=%d", opID, dryRun, maxBooks)
+	c.JSON(http.StatusAccepted, gin.H{
+		"operation_id": opID,
+		"message":      "bulk deluge import started — poll GET /api/v1/operations/" + opID,
+		"dry_run":      dryRun,
+		"max_books":    maxBooks,
+	})
+}
+
+// runBulkDelugeImport is the resumable core. Files already imported in a
+// prior run (imported_from_deluge_at IS NOT NULL) are filtered out by the
+// DB query so the operation is inherently idempotent.
+func (s *Server) runBulkDelugeImport(
+	ctx context.Context,
+	opID string,
+	params operations.BulkImportDelugeParams,
+	client *deluge.Client,
+	store database.Store,
+	progress operations.ProgressReporter,
+) error {
+	_ = progress.UpdateProgress(0, 0, "loading pending files")
+
+	pending, err := store.GetBookFilesNeedingDelugeImport()
+	if err != nil {
+		return fmt.Errorf("GetBookFilesNeedingDelugeImport: %w", err)
+	}
+	if params.MaxBooks > 0 && len(pending) > params.MaxBooks {
+		pending = pending[:params.MaxBooks]
+	}
+
+	total := len(pending)
+	log.Printf("[INFO] bulk-deluge-import %s: %d files pending (dry_run=%v)", opID, total, params.DryRun)
+	_ = progress.UpdateProgress(0, total, fmt.Sprintf("found %d files to import", total))
+
+	imported, failed := 0, 0
+	for i := range pending {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		f := &pending[i]
+		if params.DryRun {
+			resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "action": "dry_run"})
+			_ = store.CreateOperationResult(&database.OperationResult{
+				OperationID: opID,
+				BookID:      f.ID,
+				ResultJSON:  string(resultJSON),
+				Status:      "dry_run",
+			})
+			imported++
+		} else {
+			newPath, importErr := importToLibrary(&config.AppConfig, client, store, f)
+			if importErr != nil {
+				log.Printf("[WARN] bulk-deluge-import %s: %s: %v", opID, f.FilePath, importErr)
+				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "error": importErr.Error()})
+				_ = store.CreateOperationResult(&database.OperationResult{
+					OperationID: opID,
+					BookID:      f.ID,
+					ResultJSON:  string(resultJSON),
+					Status:      "error",
+				})
+				failed++
+			} else {
+				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "new_path": newPath})
+				_ = store.CreateOperationResult(&database.OperationResult{
+					OperationID: opID,
+					BookID:      f.ID,
+					ResultJSON:  string(resultJSON),
+					Status:      "imported",
+				})
+				imported++
+			}
+		}
+		if (i+1)%100 == 0 || i+1 == total {
+			_ = progress.UpdateProgress(i+1, total,
+				fmt.Sprintf("imported %d/%d (failed: %d)", imported, total, failed))
+		}
+	}
+	log.Printf("[INFO] bulk-deluge-import %s: done. imported=%d failed=%d", opID, imported, failed)
+	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.202.0
+// version: 1.203.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2539,6 +2539,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/revert-metadata-fetch", s.perm(auth.PermSettingsManage), s.handleRevertMetadataFetch)
 			protected.GET("/maintenance/scan-duration-mismatch", s.perm(auth.PermSettingsManage), s.handleScanDurationMismatch)
 			protected.GET("/maintenance/relink-report", s.perm(auth.PermSettingsManage), s.handleRelinkReport)
+			protected.POST("/maintenance/bulk-deluge-import", s.perm(auth.PermSettingsManage), s.handleBulkDelugeImport)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")


### PR DESCRIPTION
## Changes
- `GetBookFilesNeedingDelugeImport` DB query: book_files with deluge_hash but not yet imported (added to BookFileStore interface, SQLiteStore, PebbleStore, both mocks)
- `BulkImportDelugeParams` struct in operations/state.go
- `POST /api/v1/maintenance/bulk-deluge-import`: queues async op with dry-run + max_books params
- `runBulkDelugeImport`: resumable, idempotent (skips already-imported via DB filter), batches with progress

## Usage
```
POST /api/v1/maintenance/bulk-deluge-import?dry_run=true&max_books=100
```

## Related
RELINK-5, DELUGE-3 (importToLibrary)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>