### PR TITLE
docs(todo,changelog): add new tasks + CHANGELOG for PRs #561-#563

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.37.0 -->
+<!-- version: 2.38.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-04-29 -->
+<!-- last-edited: 2026-04-30 -->
 
 # Changelog
 
@@ -18,6 +18,24 @@
   confirmed absent from iTunes — documented for human review.
 
 ### Added / Changed
+
+#### April 30, 2026 — Book detail polish, Deluge settings UI, RELINK-5 bulk import (#561–#563)
+
+- **PR #561** `feat(ui)`: BookDetail enhancements
+  - Audible category chips split by source: system-sourced tags (Audible category ladders) shown as outlined chips with `LabelIcon`; user-applied labels shown as plain chips
+  - Duration-delta warning chip: if `|duration_delta_sec| > 300s`, shows a `color="warning"` chip (`±Xh Ym off from Audible`) with tooltip
+  - Origin column in Files tab: "Deluge" outlined chip with tooltip showing original path for reflinked files; `—` otherwise
+
+- **PR #562** `feat(settings)`: ProtectedPaths field + bulk Deluge import
+  - `Settings.tsx`: Protected Paths multiline `TextField` added to Deluge settings tab (index 7); saved as `protected_paths` string array in config
+  - `POST /api/v1/discovery/import` (new endpoint): bulk-imports all `BookFile` records where `deluge_hash != ""` and `imported_from_deluge_at IS NULL`; registered with `settings.manage` permission
+  - `DelugeSettingsTab`: "Import Unimported" button with loading state and success/warning `Alert` showing total/imported/failed counts
+
+- **PR #563** `feat(maintenance)`: RELINK-5 bulk-deluge-import async operation
+  - `GetBookFilesNeedingDelugeImport()` added to `BookFileStore` interface + implemented in SQLiteStore (`deluge_hash != '' AND imported_from_deluge_at IS NULL`) and PebbleStore (in-memory filter)
+  - Both mock stores updated with stubs
+  - `handleBulkDelugeImport` + `runBulkDelugeImport` in `maintenance_fixups.go`: idempotent batch with `dry_run`/`max_books` params, per-book progress updates, `OperationResult` rows
+  - `POST /api/v1/maintenance/bulk-deluge-import` route registered
 
 #### April 28, 2026 — iTunes relink endpoint for broken organizer-root books (fix/broken-book-paths, PR #507)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 6.4.0 -->
+<!-- version: 6.5.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-04-29 -->
+<!-- last-edited: 2026-04-30 -->
 
 # Project TODO
 
@@ -18,11 +18,11 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — April 29, 2026
+## 🎯 Current Status — April 30, 2026
 
 **Library:** 10,891 books / 2,970 authors / 8,507 series (cleaned)
 **Production:** PebbleDB, Linux, HTTPS at `172.16.2.30:8484`, mTLS bridge active
-**Latest shipped release:** v0.221.0 (2026-04-29) — PRs #507–#521
+**Latest shipped release:** v0.221.0 (2026-04-29) — PRs #507–#521; PRs #561–#563 merged 2026-04-30
 **In flight:** User Ratings UI, ASYNC spec revision, iTunes relink unresolved cases (6,719 files)
 
 ---
@@ -72,7 +72,7 @@ Audible product was matched or the file is an abridged version.
 - [x] WARN log + `duration_mismatch` flag on candidate result when delta > 600s — PR #549
 - [x] `GET /api/v1/maintenance/scan-duration-mismatch` bulk scan endpoint — PR #549
 - [x] **DUR-1** Surface in `MetadataReviewDialog`: show a yellow warning chip on the candidate row when `audible_runtime_min` and book `duration` differ by > 10 min, e.g. "⚠ runtime differs by 45 min" — chip implemented at `MetadataReviewDialog.tsx:604`
-- [ ] Book detail panel: show Audible runtime alongside local duration so mismatches are obvious
+- [x] Book detail panel: show Audible runtime alongside local duration so mismatches are obvious — PR #561
 - [x] Threshold configurable via query param `?max_delta_min=10` — PR #549
 
 ---
@@ -90,9 +90,9 @@ Implementation steps (in order):
 - [ ] **DELUGE-3** `importToLibrary`: reflink `src → library_path`, update DB, call `core.move_storage` if enabled (best-effort) — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md)
 - [ ] **`WriteTagsSafe`**: pre-flight guard wrapping all tag-write call sites; falls back to `os.Copy` on non-reflink FS
 - [ ] **Migrate all call sites** to `WriteTagsSafe` (bulk write-back, single-file write, cover embed)
-- [ ] **Discovery → Import UI**: "Import" button on discovered torrent calls the import flow
-- [ ] **UI**: "Imported from Deluge" badge on book detail; original path shown in Files tab audit row
-- [ ] **Config**: add `protected_paths []string` field; expose in Settings UI
+- [x] **Discovery → Import UI**: "Import" button on discovered torrent calls the import flow — PR #562
+- [x] **UI**: "Imported from Deluge" badge on book detail; original path shown in Files tab audit row — PR #561
+- [x] **Config**: add `protected_paths []string` field; expose in Settings UI — PR #562
 
 ---
 
@@ -111,7 +111,7 @@ anywhere (not in iTunes, not as flat M4B). Many are likely Deluge-only files not
 - [x] **RELINK-2** Co-author dir matching: tries all dirs where author's surname appears — implemented at `maintenance_fixups.go:4154`
 - [x] **RELINK-3** Title prefix colon→underscore normalization — implemented at `maintenance_fixups.go:4257`
 - [x] **RELINK-4** `GET /api/v1/maintenance/relink-report` re-runs dry-run with why_unresolved annotations — PR #555
-- [ ] **RELINK-5** Bulk-import Deluge files into library for the ~6,719 that are Deluge-only — depends on Deluge Protected Paths (see below)
+- [x] **RELINK-5** Bulk-import Deluge files into library for the ~6,719 that are Deluge-only — depends on Deluge Protected Paths (see below) — PR #563
 
 ---
 
@@ -135,7 +135,7 @@ applied as a user tag on the book so browsing by genre is hierarchical, not flat
 - [x] **CAT-1** category_ladders parsed into CategoryTags + AddBookTagWithSource("audible_category") in apply pipeline — PR #548
 - [x] Parse ladder entries into `BookMetadata.CategoryTags []string` (all layers, e.g. `["Science Fiction", "Space Opera"]`) — PR #548
 - [x] In the apply pipeline, write each tag via `AddBookTagWithSource` (idempotent) with source `"audible_category"` — PR #548
-- [ ] UI: show Audible-sourced category tags separately from user tags in the book detail panel
+- [x] UI: show Audible-sourced category tags separately from user tags in the book detail panel — PR #561
 - [ ] Search/filter: "has tag Science Fiction" or browsable tag cloud on library page
 
 ---
@@ -156,6 +156,45 @@ next picks up. Full plan in
 - [ ] **AI-RESP-D** [hold] Migrate Batches API (`openai_batch.go`) once OpenAI supports `/v1/responses` URLs in batch lines — verify endpoint allowlist before pickup
 - [ ] **AI-RESP-E** [hold] Migrate `aijobs/aijobs.go` multi-turn flows — adds `last_response_id` to job state; biggest token win
 - [ ] **AI-RESP-F** [hold] Cleanup: delete remaining Chat Completions call sites in `internal/ai/`
+
+---
+
+---
+
+## 🩺 Diagnostics & Visibility
+
+- [ ] **DIAG-1** Fix `ApiError: store does not implement AIJobsStore` on Diagnostics page — `AIJobsStore` interface (`iface_misc.go:255-265`) has no methods implemented in `sqlite_store.go` or `pebble_store.go`; crash occurs when `batch_poller` asserts `s.Store().(database.AIJobsStore)`
+- [ ] **DIAG-2** Expand Diagnostics to surface DB health — SQLite table row counts, PebbleDB key counts, embeddings DB stats, `ai_scans.db` stats, recently-rejected metadata with reasons, `metadata_fetch` cache hit/miss/age
+- [ ] **DIAG-3** Surface `ai_scans.db` and `embeddings.db` stats in Diagnostics — both are opened in `server.go:934-1004` but never shown on the diagnostics or system-info pages
+- [ ] **DIAG-4** Increase `MetadataFetchCacheTTLDays` default — metadata_fetch cache TTL (configured via `config.AppConfig.MetadataFetchCacheTTLDays`) is expiring too fast; audit and increase default to 30+ days
+
+---
+
+## 🖥️ System Page Cleanup
+
+- [ ] **SYS-1** Remove duplicate log viewer from System page — System page uses `/system/logs` (a different endpoint and data model from Activity); replace with a navigation link to the Activity page
+- [ ] **SYS-2** Fix Storage page showing 0 books for `/mnt/bigdata/books/newbooks` — storage handler uses `file_path LIKE rootDir || '%'` prefix matching; investigate whether `newbooks` mount is configured as `RootDir` or import path
+
+---
+
+## 🔍 Data Quality & Matching Improvements
+
+- [ ] **MATCH-1** Deduplicate books by metadata URL/response hash — when importing or applying metadata, compute a hash of the source URL or response body; if two books share the same hash they should be merged into one book with multiple versions (`BookVersion`)
+- [ ] **MATCH-2** Consolidate multi-file chapter books by duration — files with sequential naming (`01 - Book`, `02 - Book`, etc.) that are individually very short (< 10 min each) should be pre-consolidated into a single book entry using cumulative duration rather than treated as separate books
+- [ ] **MATCH-3** Use duration as metadata scoring signal — boost metadata candidates whose Audible `runtime_length_min` roughly matches local file total duration; combine with existing title/author/series scoring for much higher confidence matches
+
+---
+
+## 🔐 File Identity & SHA Tracking
+
+- [ ] **FILE-SHA-1** Pre-metadata-write SHA capture — ensure `original_sha` / `OriginalFileHash` on `book_files` is recorded **before** any metadata tag write (scanner already computes it but confirm all write-back paths check); add `post_metadata_sha` field for after-write hash to detect transform drift
+- [ ] **FILE-SHA-2** Cross-folder duplicate detection via SHA — use `original_sha` to identify identical files across different library paths (e.g. same file in iTunes + Deluge + organized); surface as consolidation candidates in the dedup UI
+
+---
+
+## 🗃️ Rejected Metadata Store
+
+- [ ] **META-REJ-1** Rejected metadata tracking — add a store/table for metadata candidates that were explicitly skipped or rejected, recording: `book_file_id`, source (Audible/OpenLibrary), candidate title/author/ASIN, rejection reason, timestamp; surface on book detail page and diagnostics
 
 ---
 


### PR DESCRIPTION
Updates TODO.md with new feature/bug items (DIAG-1..4, SYS-1..2, MATCH-1..3, FILE-SHA-1..2, META-REJ-1) and marks completed items (RELINK-5, DELUGE sub-items). Prepends April 30 CHANGELOG entry for PRs #561-#563.