### PR TITLE
fix(storage,system): fix 0-book storage count + remove duplicate System logs

### DIFF
--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,6 @@
 // file: internal/database/sqlite_store.go
-// version: 1.67.0
+// version: 1.68.0
+// last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -3143,11 +3144,14 @@ func (s *SQLiteStore) GetBookCountsByLocation(rootDir string) (library, import_ 
 		err = s.db.QueryRow("SELECT COUNT(*) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0" + primaryFilter).Scan(&import_)
 		return 0, import_, err
 	}
-	err = s.db.QueryRow("SELECT COUNT(*) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path LIKE ?" + primaryFilter, rootDir+"%").Scan(&library)
+	// Normalise: strip trailing slash so LIKE '/path/%' works regardless of
+	// how the caller stored the root dir.
+	dir := strings.TrimRight(rootDir, "/")
+	err = s.db.QueryRow("SELECT COUNT(*) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND (file_path LIKE ? OR file_path = ?)"+primaryFilter, dir+"/%", dir).Scan(&library)
 	if err != nil {
 		return
 	}
-	err = s.db.QueryRow("SELECT COUNT(*) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path NOT LIKE ?" + primaryFilter, rootDir+"%").Scan(&import_)
+	err = s.db.QueryRow("SELECT COUNT(*) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path NOT LIKE ? AND file_path != ?"+primaryFilter, dir+"/%", dir).Scan(&import_)
 	return
 }
 
@@ -3156,11 +3160,12 @@ func (s *SQLiteStore) GetBookSizesByLocation(rootDir string) (librarySize, impor
 		err = s.db.QueryRow("SELECT COALESCE(SUM(file_size), 0) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0").Scan(&importSize)
 		return 0, importSize, err
 	}
-	err = s.db.QueryRow("SELECT COALESCE(SUM(file_size), 0) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path LIKE ?", rootDir+"%").Scan(&librarySize)
+	dir := strings.TrimRight(rootDir, "/")
+	err = s.db.QueryRow("SELECT COALESCE(SUM(file_size), 0) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND (file_path LIKE ? OR file_path = ?)", dir+"/%", dir).Scan(&librarySize)
 	if err != nil {
 		return
 	}
-	err = s.db.QueryRow("SELECT COALESCE(SUM(file_size), 0) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path NOT LIKE ?", rootDir+"%").Scan(&importSize)
+	err = s.db.QueryRow("SELECT COALESCE(SUM(file_size), 0) FROM books WHERE COALESCE(marked_for_deletion, 0) = 0 AND file_path NOT LIKE ? AND file_path != ?", dir+"/%", dir).Scan(&importSize)
 	return
 }
 
@@ -3228,12 +3233,13 @@ func (s *SQLiteStore) GetDashboardStats() (*DashboardStats, error) {
 
 	// Organized vs unorganized (primary, non-deleted)
 	if s.rootDir != "" {
+		dir := strings.TrimRight(s.rootDir, "/")
 		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
-			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND file_path LIKE ?`,
-			s.rootDir+"%").Scan(&stats.OrganizedBooks, &stats.OrganizedSize)
+			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND (file_path LIKE ? OR file_path = ?)`,
+			dir+"/%", dir).Scan(&stats.OrganizedBooks, &stats.OrganizedSize)
 		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
-			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND file_path NOT LIKE ?`,
-			s.rootDir+"%").Scan(&stats.UnorganizedBooks, &stats.UnorganizedSize)
+			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter+` AND file_path NOT LIKE ? AND file_path != ?`,
+			dir+"/%", dir).Scan(&stats.UnorganizedBooks, &stats.UnorganizedSize)
 	} else {
 		s.db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(file_size),0) FROM books
 			WHERE COALESCE(marked_for_deletion,0)=0`+primaryFilter).Scan(
@@ -3357,8 +3363,21 @@ func (s *SQLiteStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 // Import path operations
 
 func (s *SQLiteStore) GetAllImportPaths() ([]ImportPath, error) {
-	query := `SELECT id, path, name, enabled, created_at, last_scan, book_count
-			  FROM import_paths ORDER BY name`
+	// Use a live subquery for book_count so the value is always accurate,
+	// even when a scan has never been run for a newly-added import path.
+	// The prefix pattern uses RTRIM to normalise any trailing slash on the
+	// stored path before appending '/%', preventing false matches against
+	// sibling folders that share the same prefix (e.g. /books vs /books2).
+	query := `SELECT ip.id, ip.path, ip.name, ip.enabled, ip.created_at, ip.last_scan,
+			  COALESCE((
+			    SELECT COUNT(*)
+			    FROM books b
+			    WHERE (b.file_path LIKE RTRIM(ip.path, '/') || '/%'
+			           OR b.file_path = RTRIM(ip.path, '/'))
+			      AND COALESCE(b.marked_for_deletion, 0) = 0
+			      AND COALESCE(b.is_primary_version, 1) = 1
+			  ), 0) AS book_count
+			  FROM import_paths ip ORDER BY ip.name`
 	rows, err := s.db.Query(query)
 	if err != nil {
 		return nil, err

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -1,10 +1,12 @@
 // file: web/src/pages/System.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
+// last-edited: 2026-04-30
 
 import { useState } from 'react';
-import { Box, Typography, Paper, Tabs, Tab } from '@mui/material';
-import { LogsTab } from '../components/system/LogsTab';
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, Paper, Tabs, Tab, Button } from '@mui/material';
+import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
 import { StorageTab } from '../components/system/StorageTab';
 import { SystemInfoTab } from '../components/system/SystemInfoTab';
 import { QuotaTab } from '../components/system/QuotaTab';
@@ -34,6 +36,7 @@ function TabPanel(props: TabPanelProps) {
 
 export function System() {
   const [tabValue, setTabValue] = useState(0);
+  const navigate = useNavigate();
 
   return (
     <Box>
@@ -51,11 +54,19 @@ export function System() {
           <Tab label="Storage" />
           <Tab label="Quota" />
           <Tab label="Maintenance" />
-          <Tab label="Logs" />
         </Tabs>
 
         <TabPanel value={tabValue} index={0}>
           <SystemInfoTab />
+          <Box sx={{ mt: 2, px: 3, pb: 2 }}>
+            <Button
+              variant="outlined"
+              startIcon={<OpenInNewIcon />}
+              onClick={() => navigate('/activity')}
+            >
+              View Activity Log
+            </Button>
+          </Box>
         </TabPanel>
 
         <TabPanel value={tabValue} index={1}>
@@ -68,10 +79,6 @@ export function System() {
 
         <TabPanel value={tabValue} index={3}>
           <MaintenanceTab />
-        </TabPanel>
-
-        <TabPanel value={tabValue} index={4}>
-          <LogsTab />
         </TabPanel>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary

Fixes the Storage page showing **0 books** for configured import paths (e.g. `/mnt/bigdata/books/newbooks` with 7.4 TB of data).

## Root Cause

The `book_count` column on the `import_paths` table is a **cached** value only updated when a scan is explicitly triggered. If an import path is added without running a scan (or books are already in the DB from another mechanism), the count stays at 0 forever.

Additionally, path-prefix queries used `LIKE '/path/%''` but constructed the pattern by concatenating the raw stored path with `%`, meaning:
- A path stored **with** a trailing slash produced `LIKE '/path//%'` — never matching.
- Paths like `/books` would false-match `/books2`.

## Changes

### `internal/database/sqlite_store.go`
- **`GetAllImportPaths`**: replaced the static `book_count` column read with a live correlated subquery (`SELECT COUNT(*) FROM books WHERE file_path LIKE path || '/%'`), so the count is always accurate regardless of scan history.
- **`GetBookCountsByLocation`**, **`GetBookSizesByLocation`**, **`GetDashboardStats`**: normalize the root dir with `strings.TrimRight(dir, "/")` before building the LIKE pattern, and use `LIKE dir || '/%' OR file_path = dir` for correct prefix matching.

### `web/src/pages/System.tsx`
- Remove the duplicate **Logs** tab (logs are already on the Activity page).
- Add a **"View Activity Log"** button in the System Info tab that navigates to `/activity`.

## Testing

- Go database tests: ✅ all pass (`go test ./internal/database/...`)
- Frontend build: pre-existing `BookDetail.tsx` TS errors unrelated to this PR (confirmed same errors on `main`).