### PR TITLE
feat(scanner,metadata): duration chapter consolidation + duration scoring (MATCH-2, MATCH-3)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 // file: internal/config/config.go
-// version: 1.40.0
+// version: 1.41.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
+// last-edited: 2026-04-30
 
 package config
 
@@ -133,6 +134,12 @@ type Config struct {
 
 	// Performance
 	ConcurrentScans int `json:"concurrent_scans"`
+	// ChapterConsolidationThresholdMin is the per-file duration threshold (minutes)
+	// used during scanning to detect chapter-named files. If a group of ≥ 3 files
+	// sharing the same base title (e.g. "01 - My Book", "02 - My Book") each
+	// averages below this duration, they are consolidated into one book record.
+	// Default 10. Set to 0 to disable consolidation.
+	ChapterConsolidationThresholdMin int `json:"chapter_consolidation_threshold_min"`
 	// Background operation timeout in minutes (0 disables timeout)
 	OperationTimeoutMinutes int `json:"operation_timeout_minutes"`
 	// MinBookSizeBytes: single-file books below this size are flagged as suspicious and
@@ -378,6 +385,7 @@ func InitConfig() {
 		defaultWorkers = 4
 	}
 	viper.SetDefault("concurrent_scans", defaultWorkers)
+	viper.SetDefault("chapter_consolidation_threshold_min", 10)
 	viper.SetDefault("operation_timeout_minutes", 30)
 	viper.SetDefault("log_retention_days", 90)
 
@@ -543,8 +551,9 @@ func InitConfig() {
 		OpenAIAPIKey:    viper.GetString("openai_api_key"),
 
 		// Performance
-		ConcurrentScans:         viper.GetInt("concurrent_scans"),
-		OperationTimeoutMinutes: viper.GetInt("operation_timeout_minutes"),
+		ConcurrentScans:                  viper.GetInt("concurrent_scans"),
+		ChapterConsolidationThresholdMin: viper.GetInt("chapter_consolidation_threshold_min"),
+		OperationTimeoutMinutes:          viper.GetInt("operation_timeout_minutes"),
 		MinBookSizeBytes:        viper.GetInt64("min_book_size_bytes"),
 		APIRateLimitPerMinute:   viper.GetInt("api_rate_limit_per_minute"),
 		AuthRateLimitPerMinute:  viper.GetInt("auth_rate_limit_per_minute"),

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,6 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 4.60.0
+// version: 4.61.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
+// last-edited: 2026-04-30
 
 package metafetch
 
@@ -173,6 +174,14 @@ type MetadataCandidate struct {
 	// The review UI already renders a warning chip when duration_delta_sec > 600;
 	// this flag makes the threshold decision explicit in the API response.
 	DurationMismatch bool `json:"duration_mismatch,omitempty"`
+	// DurationScore is the additive score component from the duration signal.
+	// Positive when the candidate runtime closely matches the local file duration;
+	// negative when the runtimes diverge significantly (wrong edition / abridged).
+	// Zero when either side lacks duration data.
+	// Scoring bands (delta ratio = |candidate_dur - book_dur| / book_dur):
+	//   < 5%  → +20,  < 10% → +15,  < 20% → +10,
+	//   > 50% → -10,  > 100% → -20.
+	DurationScore float64 `json:"duration_score,omitempty"`
 	// AudibleRatingOverall is the Audible overall star rating (1–5 scale).
 	// Zero means the source did not provide a rating.
 	AudibleRatingOverall float64 `json:"audible_rating_overall,omitempty"`
@@ -1318,6 +1327,46 @@ func durationScoreMultiplier(bookDurationSec, candidateDurationSec int) float64 
 	}
 }
 
+// computeDurationScore returns an additive score component (in points) based on
+// how closely a candidate's runtime matches the book's known duration. Unlike
+// durationScoreMultiplier (which scales the overall score multiplicatively),
+// this function produces a human-readable breakdown value that surfaces in the
+// MetadataCandidate.DurationScore field.
+//
+// Both values are in seconds. If either is zero (unknown), the result is 0.
+// The delta ratio = |candidate_dur - book_dur| / book_dur:
+//
+//	ratio < 0.05  → +20  (within 5% — essentially the same edition)
+//	ratio < 0.10  → +15  (within 10%)
+//	ratio < 0.20  → +10  (within 20%)
+//	ratio > 1.00  → -20  (more than 2× off — almost certainly wrong book)
+//	ratio > 0.50  → -10  (more than 50% off — likely wrong edition)
+//	otherwise      →   0  (neutral)
+func computeDurationScore(bookDurationSec, candidateDurationSec int) float64 {
+	if bookDurationSec <= 0 || candidateDurationSec <= 0 {
+		return 0
+	}
+	delta := bookDurationSec - candidateDurationSec
+	if delta < 0 {
+		delta = -delta
+	}
+	ratio := float64(delta) / float64(bookDurationSec)
+	switch {
+	case ratio < 0.05:
+		return 20
+	case ratio < 0.10:
+		return 15
+	case ratio < 0.20:
+		return 10
+	case ratio > 1.00:
+		return -20
+	case ratio > 0.50:
+		return -10
+	default:
+		return 0
+	}
+}
+
 // pickBestMatchFromScored takes pre-computed base scores from any tier and
 // returns the single best-matching result above the tier-appropriate
 // threshold, applying the full stack of author/narrator/audiobook bonus
@@ -2383,6 +2432,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				Score:                score,
 				DurationSec:          r.DurationSec,
 				DurationDeltaSec:     durationDelta,
+				DurationScore:        computeDurationScore(bookDurationSec, r.DurationSec),
 				CategoryTags:         r.CategoryTags,
 				DurationMismatch:     durationDelta > 600,
 				AudibleRatingOverall: r.AudibleRatingOverall,
@@ -2441,6 +2491,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					Score:                score,
 					DurationSec:          result.DurationSec,
 					DurationDeltaSec:     asinDurationDelta,
+					DurationScore:        computeDurationScore(bookDurationSec, result.DurationSec),
 					CategoryTags:         result.CategoryTags,
 					DurationMismatch:     asinDurationDelta > 600,
 					AudibleRatingOverall: result.AudibleRatingOverall,

--- a/internal/scanner/chapter_consolidation.go
+++ b/internal/scanner/chapter_consolidation.go
@@ -1,0 +1,158 @@
+// file: internal/scanner/chapter_consolidation.go
+// version: 1.0.0
+// guid: f9a0b1c2-d3e4-5f60-a7b8-c9d0e1f2a3b4
+// last-edited: 2026-04-30
+
+package scanner
+
+import (
+	"log"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/mediainfo"
+)
+
+// chapterPrefixRe matches leading track/chapter numbers like "01 - ", "02. ",
+// "003 - ", "1 " etc. at the beginning of a filename stem.
+var chapterPrefixRe = regexp.MustCompile(`^[\d]+[\s\-\.]+`)
+
+// normalizeChapterTitle strips a leading chapter/track number from a filename
+// stem, lowercases the result, and collapses extra whitespace. This produces
+// the grouping key used to detect chapter-file sequences.
+func normalizeChapterTitle(stem string) string {
+	norm := chapterPrefixRe.ReplaceAllString(stem, "")
+	norm = strings.ToLower(strings.TrimSpace(norm))
+	norm = strings.Join(strings.Fields(norm), " ")
+	return norm
+}
+
+// consolidateChapterGroups inspects a list of audio files (typically files with
+// no album tag and no playlist claim) and detects chapter-naming patterns.
+// Files whose base name starts with a numeric prefix (e.g. "01 - My Book.mp3",
+// "02 - My Book.mp3") are grouped by their normalized base title.  When a group
+// has ≥ 3 files AND each file individually averages below
+// config.AppConfig.ChapterConsolidationThresholdMin minutes (default 10 min),
+// the whole group is emitted as a single multi-file Book with the total
+// duration; otherwise each file becomes its own Book.
+//
+// Files that show no numeric prefix are passed through unchanged.
+// Groups that contain at least one file exceeding the threshold are not
+// consolidated (mixed durations → likely separate books with similar names).
+func consolidateChapterGroups(files []string) []Book {
+	if len(files) == 0 {
+		return nil
+	}
+
+	thresholdMin := config.AppConfig.ChapterConsolidationThresholdMin
+	if thresholdMin <= 0 {
+		// Consolidation disabled.
+		return filesToBooks(files)
+	}
+	thresholdSec := thresholdMin * 60
+
+	type candidate struct {
+		path     string
+		duration int // seconds; 0 = unknown / unreadable
+	}
+
+	// Group by normalized title. Use a null-byte prefix as a per-file unique
+	// key for files that have no numeric prefix (cannot be chapters).
+	var groupOrder []string
+	groups := make(map[string][]candidate)
+
+	for _, f := range files {
+		stem := strings.TrimSuffix(filepath.Base(f), filepath.Ext(f))
+		norm := normalizeChapterTitle(stem)
+		stemLower := strings.ToLower(strings.TrimSpace(stem))
+
+		var key string
+		if norm != stemLower {
+			// Had a numeric prefix → potential chapter file.
+			key = norm
+		} else {
+			// No numeric prefix → treat as standalone file.
+			key = "\x00" + f
+		}
+
+		if _, seen := groups[key]; !seen {
+			groupOrder = append(groupOrder, key)
+		}
+		groups[key] = append(groups[key], candidate{path: f})
+	}
+
+	var books []Book
+	for _, key := range groupOrder {
+		group := groups[key]
+
+		// Non-chapter files or groups too small to be a chapter sequence.
+		if strings.HasPrefix(key, "\x00") || len(group) < 3 {
+			for _, c := range group {
+				books = append(books, Book{
+					FilePath: c.path,
+					Format:   strings.ToLower(filepath.Ext(c.path)),
+				})
+			}
+			continue
+		}
+
+		// Read duration for every file in the group (best-effort).
+		for i := range group {
+			if mi, err := mediainfo.Extract(group[i].path); err == nil && mi != nil && mi.Duration > 0 {
+				group[i].duration = mi.Duration
+			}
+		}
+
+		// Check for mixed durations (at least one file above the threshold).
+		totalSec := 0
+		hasLong := false
+		for _, c := range group {
+			totalSec += c.duration
+			if c.duration > thresholdSec {
+				hasLong = true
+			}
+		}
+		avgSec := totalSec / len(group)
+
+		if hasLong || avgSec >= thresholdSec {
+			// Files are individually long or mixed → don't consolidate.
+			for _, c := range group {
+				books = append(books, Book{
+					FilePath: c.path,
+					Format:   strings.ToLower(filepath.Ext(c.path)),
+				})
+			}
+			continue
+		}
+
+		// All files are short and share a base title → consolidate.
+		paths := make([]string, len(group))
+		for i, c := range group {
+			paths[i] = c.path
+		}
+		log.Printf("[INFO] scanner: chapter consolidation: merging %d files for %q (avg %ds/file, total %ds) into one book",
+			len(group), key, avgSec, totalSec)
+		books = append(books, Book{
+			FilePath:     paths[0],
+			Format:       strings.ToLower(filepath.Ext(paths[0])),
+			Duration:     totalSec,
+			SegmentFiles: paths,
+		})
+	}
+
+	return books
+}
+
+// filesToBooks converts a flat slice of file paths into individual Book records.
+func filesToBooks(files []string) []Book {
+	books := make([]Book, 0, len(files))
+	for _, f := range files {
+		books = append(books, Book{
+			FilePath: f,
+			Format:   strings.ToLower(filepath.Ext(f)),
+		})
+	}
+	return books
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,6 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.34.2
+// version: 1.35.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-04-30
 
 package scanner
 
@@ -1338,12 +1339,10 @@ func groupFilesIntoBooks(files []string) []Book {
 			})
 		}
 	}
-	for _, f := range noAlbum {
-		books = append(books, Book{
-			FilePath: f,
-			Format:   strings.ToLower(filepath.Ext(f)),
-		})
-	}
+	// Apply chapter consolidation to files with no album tag and no playlist
+	// claim. Groups of ≥ 3 files sharing a numbered base title that are
+	// individually short are merged into one multi-file book.
+	books = append(books, consolidateChapterGroups(noAlbum)...)
 	return books
 }
 


### PR DESCRIPTION
## MATCH-2: Chapter file consolidation

Files following chapter naming patterns (e.g. `01 - My Book.mp3`, `02 - My Book.mp3`) that are individually short (< `ChapterConsolidationThresholdMin`, default 10 min) are now pre-consolidated into a single book record during scanning, reducing false multi-book fragmentation.

### Algorithm
- After album-tag grouping and playlist fallback, remaining files with no album tag are passed through `consolidateChapterGroups()`
- Files are grouped by normalized base title (strip leading `[0-9]+[\s\-.]+` prefix, lowercase)
- Groups with ≥ 3 files where the average per-file duration is < threshold → merged into one multi-file Book with summed duration and SegmentFiles
- Groups with any file exceeding the threshold (mixed durations) → not consolidated

### Config
`ChapterConsolidationThresholdMin int` (default 10, set 0 to disable) added to `AppConfig`.

## MATCH-3: Duration metadata scoring

Metadata candidate scoring now includes a `DurationScore` breakdown component (additive points) surfaced in the `MetadataCandidate` struct.

### Algorithm (ratio-based: `delta / book_duration`)
| Delta ratio | Score |
|---|---|
| < 5% | +20 pts |
| < 10% | +15 pts |
| < 20% | +10 pts |
| > 50% | -10 pts |
| > 100% | -20 pts |
| No duration data | 0 (neutral) |

`DurationScore` is surfaced in both the main source loop and the ASIN lookup path. The existing `durationScoreMultiplier()` multiplier effect is unchanged — `DurationScore` is a human-readable breakdown field for UI display.