### PR TITLE
feat(diagnostics): DB health stats + metadata cache TTL (DIAG-2/3/4)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.41.0
+// version: 1.42.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-04-30
 
@@ -402,7 +402,7 @@ func InitConfig() {
 	// Set memory management defaults
 	viper.SetDefault("memory_limit_type", "items")
 	viper.SetDefault("cache_size", 1000)
-	viper.SetDefault("metadata_fetch_cache_ttl_days", 7)
+	viper.SetDefault("metadata_fetch_cache_ttl_days", 30)
 	viper.SetDefault("memory_limit_percent", 25)
 	viper.SetDefault("memory_limit_mb", 512)
 

--- a/internal/database/ai_scan_store.go
+++ b/internal/database/ai_scan_store.go
@@ -1,5 +1,6 @@
 // file: internal/database/ai_scan_store.go
-// version: 1.2.0
+// version: 1.3.0
+// last-edited: 2026-04-30
 // guid: a7b3c9d1-4e5f-6a7b-8c9d-0e1f2a3b4c5d
 
 package database
@@ -522,4 +523,31 @@ func (s *AIScanStore) GetAllAppliedResults() ([]ScanResult, error) {
 		}
 	}
 	return results, nil
+}
+
+// AIScanHealthStats contains diagnostic counts for the AI scan PebbleDB store.
+type AIScanHealthStats struct {
+JobCount    int   `json:"job_count"`
+PendingCount int  `json:"pending_count"`
+SizeBytes   uint64 `json:"size_bytes"`
+}
+
+// HealthStats returns diagnostic counts and disk usage for the AI scan store.
+func (s *AIScanStore) HealthStats() (AIScanHealthStats, error) {
+scans, err := s.ListScans()
+if err != nil {
+return AIScanHealthStats{}, err
+}
+var pending int
+for _, sc := range scans {
+if sc.Status == "pending" || sc.Status == "scanning" || sc.Status == "enriching" || sc.Status == "cross_validating" {
+pending++
+}
+}
+sizeBytes := s.db.Metrics().DiskSpaceUsage()
+return AIScanHealthStats{
+JobCount:    len(scans),
+PendingCount: pending,
+SizeBytes:   sizeBytes,
+}, nil
 }

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 1.6.0
+// version: 1.7.0
+// last-edited: 2026-04-30
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -745,4 +746,27 @@ FROM dedup_candidates WHERE id=?`, id)
 		return nil, fmt.Errorf("get candidate by id: %w", err)
 	}
 	return &c, nil
+}
+
+// EmbeddingHealthStats contains diagnostic counts for the embedding SQLite store.
+type EmbeddingHealthStats struct {
+VectorCount int64 `json:"vector_count"`
+SizeBytes   int64 `json:"size_bytes"`
+}
+
+// HealthStats returns embedding vector count and on-disk size (via SQLite PRAGMA).
+func (s *EmbeddingStore) HealthStats() (EmbeddingHealthStats, error) {
+var vectorCount int64
+if err := s.db.QueryRow(`SELECT COUNT(*) FROM embeddings`).Scan(&vectorCount); err != nil {
+vectorCount = 0
+}
+
+var pageCount, pageSize int64
+_ = s.db.QueryRow(`PRAGMA page_count`).Scan(&pageCount)
+_ = s.db.QueryRow(`PRAGMA page_size`).Scan(&pageSize)
+
+return EmbeddingHealthStats{
+VectorCount: vectorCount,
+SizeBytes:   pageCount * pageSize,
+}, nil
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,6 @@
 // file: internal/database/pebble_store.go
-// version: 1.57.0
+// version: 1.58.0
+// last-edited: 2026-04-30
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 
 package database
@@ -7866,4 +7867,19 @@ func (p *PebbleStore) MarkAIJobFailed(_, _ string) error {
 // ListAIJobs is not supported on PebbleStore.
 func (p *PebbleStore) ListAIJobs(_, _ string, _, _ int) ([]AIJob, error) {
 	return nil, fmt.Errorf("AIJobsStore.ListAIJobs: not supported by PebbleStore")
+}
+
+// KeyCount returns the total number of keys stored in the PebbleDB instance
+// and the estimated on-disk byte size. Used by the DB health diagnostics endpoint.
+func (p *PebbleStore) KeyCount() (count int64, sizeBytes uint64, err error) {
+iter, iterErr := p.db.NewIter(nil)
+if iterErr != nil {
+return 0, 0, fmt.Errorf("pebble key count iterator: %w", iterErr)
+}
+defer iter.Close()
+for iter.First(); iter.Valid(); iter.Next() {
+count++
+}
+sizeBytes = p.db.Metrics().DiskSpaceUsage()
+return count, sizeBytes, nil
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.68.0
+// version: 1.69.0
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -6145,4 +6145,38 @@ func (s *SQLiteStore) IncrScanFailCount(pathHash string) (int, error) {
 func (s *SQLiteStore) ResetScanFailCount(pathHash string) error {
 	key := "scan_fail:" + pathHash
 	return s.SetSetting(key, "0", "int", false)
+}
+
+// SQLiteTableStat holds a row count for a single table.
+type SQLiteTableStat struct {
+Name     string `json:"name"`
+RowCount int64  `json:"row_count"`
+}
+
+// TableRowCounts returns row counts for the primary tables in the SQLite store.
+// Used by the DB health diagnostics endpoint.
+func (s *SQLiteStore) TableRowCounts() ([]SQLiteTableStat, error) {
+tables := []string{
+"books", "book_files", "authors", "series",
+"operations", "operation_logs",
+}
+stats := make([]SQLiteTableStat, 0, len(tables))
+for _, tbl := range tables {
+var count int64
+row := s.db.QueryRow(`SELECT COUNT(*) FROM ` + tbl) //nolint:gosec
+if err := row.Scan(&count); err != nil {
+count = -1
+}
+stats = append(stats, SQLiteTableStat{Name: tbl, RowCount: count})
+}
+return stats, nil
+}
+
+// SQLitePageSizeBytes returns the on-disk size of the SQLite database
+// estimated via page_count * page_size.
+func (s *SQLiteStore) SQLitePageSizeBytes() int64 {
+var pageCount, pageSize int64
+_ = s.db.QueryRow(`PRAGMA page_count`).Scan(&pageCount)
+_ = s.db.QueryRow(`PRAGMA page_size`).Scan(&pageSize)
+return pageCount * pageSize
 }

--- a/internal/server/diagnostics_handlers.go
+++ b/internal/server/diagnostics_handlers.go
@@ -1,5 +1,6 @@
 // file: internal/server/diagnostics_handlers.go
-// version: 2.0.0
+// version: 3.0.0
+// last-edited: 2026-04-30
 // guid: a2b3c4d5-e6f7-4890-ab12-cd34ef56gh78
 
 package server
@@ -11,10 +12,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/diagnostics"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
@@ -497,4 +500,130 @@ func (s *Server) applyDiagnosticsSuggestions(c *gin.Context) {
 		"failed":  failed,
 		"errors":  errors,
 	})
+}
+
+// dbHealthResponse is the JSON shape returned by GET /api/v1/diagnostics/db-health.
+type dbHealthResponse struct {
+SQLite        *dbHealthSQLite        `json:"sqlite,omitempty"`
+Pebble        *dbHealthPebble        `json:"pebble,omitempty"`
+Embeddings    dbHealthEmbeddings     `json:"embeddings"`
+AiScans       dbHealthAiScans        `json:"ai_scans"`
+MetadataCache dbHealthMetadataCache  `json:"metadata_cache"`
+}
+
+type dbHealthSQLite struct {
+Tables    []database.SQLiteTableStat `json:"tables"`
+SizeBytes int64                      `json:"size_bytes"`
+}
+
+type dbHealthPebble struct {
+KeyCount  int64  `json:"key_count"`
+SizeBytes uint64 `json:"size_bytes"`
+}
+
+type dbHealthEmbeddings struct {
+VectorCount int64 `json:"vector_count"`
+SizeBytes   int64 `json:"size_bytes"`
+}
+
+type dbHealthAiScans struct {
+JobCount     int    `json:"job_count"`
+PendingCount int    `json:"pending_count"`
+SizeBytes    uint64 `json:"size_bytes"`
+}
+
+type dbHealthMetadataCache struct {
+TotalEntries   int64 `json:"total_entries"`
+TTLDays        int   `json:"ttl_days"`
+ExpiredEntries int64 `json:"expired_entries"`
+}
+
+// getDBHealth returns health stats for all backing stores.
+// GET /api/v1/diagnostics/db-health
+func (s *Server) getDBHealth(c *gin.Context) {
+store := s.Store()
+if store == nil {
+RespondWithInternalError(c, "database not initialized")
+return
+}
+
+resp := dbHealthResponse{}
+
+// Main store stats — branch on concrete type.
+switch st := store.(type) {
+case *database.SQLiteStore:
+tables, err := st.TableRowCounts()
+if err != nil {
+log.Printf("[WARN] db-health: sqlite table counts: %v", err)
+}
+resp.SQLite = &dbHealthSQLite{
+Tables:    tables,
+SizeBytes: st.SQLitePageSizeBytes(),
+}
+case *database.PebbleStore:
+keyCount, sizeBytes, err := st.KeyCount()
+if err != nil {
+log.Printf("[WARN] db-health: pebble key count: %v", err)
+}
+resp.Pebble = &dbHealthPebble{
+KeyCount:  keyCount,
+SizeBytes: sizeBytes,
+}
+}
+
+// Embeddings store (always SQLite, may be nil if DB path not set yet).
+if s.embeddingStore != nil {
+estats, err := s.embeddingStore.HealthStats()
+if err != nil {
+log.Printf("[WARN] db-health: embedding stats: %v", err)
+}
+resp.Embeddings = dbHealthEmbeddings{
+VectorCount: estats.VectorCount,
+SizeBytes:   estats.SizeBytes,
+}
+}
+
+// AI scan store (always PebbleDB, may be nil).
+if s.aiScanStore != nil {
+astats, err := s.aiScanStore.HealthStats()
+if err != nil {
+log.Printf("[WARN] db-health: ai scan stats: %v", err)
+}
+resp.AiScans = dbHealthAiScans{
+JobCount:     astats.JobCount,
+PendingCount: astats.PendingCount,
+SizeBytes:    astats.SizeBytes,
+}
+}
+
+// Metadata fetch cache — works against whatever backend is active.
+totalEntries, err := database.CountCachedMetadataFetches(store)
+if err != nil {
+log.Printf("[WARN] db-health: metadata cache count: %v", err)
+}
+ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+
+var expiredEntries int64
+if ttlDays > 0 {
+cutoff := time.Now().Add(-time.Duration(ttlDays) * 24 * time.Hour)
+pairs, scanErr := store.ScanPrefix("metadata_fetch_cache:")
+if scanErr == nil {
+for _, kv := range pairs {
+var entry database.CachedMetadataEntry
+if jsonErr := json.Unmarshal(kv.Value, &entry); jsonErr == nil {
+if entry.CachedAt.Before(cutoff) {
+expiredEntries++
+}
+}
+}
+}
+}
+
+resp.MetadataCache = dbHealthMetadataCache{
+TotalEntries:   totalEntries,
+TTLDays:        ttlDays,
+ExpiredEntries: expiredEntries,
+}
+
+RespondWithOK(c, resp)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.203.0
+// version: 1.204.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 
 package server
@@ -2659,6 +2659,7 @@ func (s *Server) setupRoutes() {
 			protected.DELETE("/blocked-hashes/:hash", s.perm(auth.PermLibraryDelete), s.removeBlockedHash)
 
 			// Diagnostics routes
+			protected.GET("/diagnostics/db-health", s.perm(auth.PermSettingsManage), s.getDBHealth)
 			protected.POST("/diagnostics/export", s.perm(auth.PermSettingsManage), s.startDiagnosticsExport)
 			protected.GET("/diagnostics/export/:operationId/download", s.perm(auth.PermSettingsManage), s.downloadDiagnosticsExport)
 			protected.POST("/diagnostics/submit-ai", s.perm(auth.PermSettingsManage), s.submitDiagnosticsAI)

--- a/web/src/pages/Diagnostics.tsx
+++ b/web/src/pages/Diagnostics.tsx
@@ -1,5 +1,6 @@
 // file: web/src/pages/Diagnostics.tsx
-// version: 1.2.0
+// version: 1.3.0
+// last-edited: 2026-04-30
 // guid: f2323fc4-b3e7-4298-9ec5-759447cbd643
 
 import { useState, useCallback, useRef, useEffect } from 'react';
@@ -17,6 +18,7 @@ import {
   CardContent,
   Checkbox,
   Chip,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -25,8 +27,14 @@ import {
   FormControlLabel,
   Grid,
   LinearProgress,
+  Paper,
   Stack,
   Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   TextField,
   Typography,
 } from '@mui/material';
@@ -99,6 +107,24 @@ export function Diagnostics() {
   const [showRaw, setShowRaw] = useState(false);
   const [applyDialogOpen, setApplyDialogOpen] = useState(false);
   const [applying, setApplying] = useState(false);
+
+  // DB health stats
+  const [dbHealth, setDbHealth] = useState<api.DBHealthStats | null>(null);
+  const [dbHealthLoading, setDbHealthLoading] = useState(false);
+  const [dbHealthError, setDbHealthError] = useState<string | null>(null);
+
+  const fetchDBHealth = useCallback(async () => {
+    setDbHealthLoading(true);
+    setDbHealthError(null);
+    try {
+      const stats = await api.getDBHealthStats();
+      setDbHealth(stats);
+    } catch (e) {
+      setDbHealthError(e instanceof Error ? e.message : 'Failed to load DB health');
+    } finally {
+      setDbHealthLoading(false);
+    }
+  }, []);
 
   // Cleanup polling on unmount
   useEffect(() => {
@@ -550,6 +576,106 @@ export function Diagnostics() {
 
       {/* AI Jobs Panel */}
       <AIJobsPanel />
+
+      {/* DB Health Section */}
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} onClick={() => { if (!dbHealth && !dbHealthLoading) fetchDBHealth(); }}>
+          <Typography variant="h6" fontWeight="bold">Database Health</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Stack spacing={2}>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button size="small" variant="outlined" onClick={fetchDBHealth} disabled={dbHealthLoading}>
+                {dbHealthLoading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null}
+                Refresh
+              </Button>
+            </Box>
+
+            {dbHealthError && <Alert severity="error">{dbHealthError}</Alert>}
+
+            {dbHealth && (
+              <Stack spacing={2}>
+                {/* SQLite main store tables */}
+                {dbHealth.sqlite && (
+                  <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+                      SQLite — Main Store ({(dbHealth.sqlite.size_bytes / 1024 / 1024).toFixed(1)} MB)
+                    </Typography>
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Table</TableCell>
+                          <TableCell align="right">Row Count</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {dbHealth.sqlite.tables.map((t) => (
+                          <TableRow key={t.name}>
+                            <TableCell>{t.name}</TableCell>
+                            <TableCell align="right">{t.row_count.toLocaleString()}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </Paper>
+                )}
+
+                {/* PebbleDB main store */}
+                {dbHealth.pebble && (
+                  <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+                      PebbleDB — Main Store
+                    </Typography>
+                    <Stack direction="row" spacing={4}>
+                      <Box>
+                        <Typography variant="caption" color="text.secondary">Keys</Typography>
+                        <Typography>{dbHealth.pebble.key_count.toLocaleString()}</Typography>
+                      </Box>
+                      <Box>
+                        <Typography variant="caption" color="text.secondary">Size</Typography>
+                        <Typography>{(dbHealth.pebble.size_bytes / 1024 / 1024).toFixed(1)} MB</Typography>
+                      </Box>
+                    </Stack>
+                  </Paper>
+                )}
+
+                {/* Embeddings + AI Scans + Metadata cache as grid */}
+                <Grid container spacing={2}>
+                  <Grid item xs={12} sm={4}>
+                    <Paper variant="outlined" sx={{ p: 2 }}>
+                      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>Embeddings DB</Typography>
+                      <Stack spacing={0.5}>
+                        <Box><Typography variant="caption" color="text.secondary">Vectors</Typography><Typography>{dbHealth.embeddings.vector_count.toLocaleString()}</Typography></Box>
+                        <Box><Typography variant="caption" color="text.secondary">Size</Typography><Typography>{(dbHealth.embeddings.size_bytes / 1024 / 1024).toFixed(1)} MB</Typography></Box>
+                      </Stack>
+                    </Paper>
+                  </Grid>
+                  <Grid item xs={12} sm={4}>
+                    <Paper variant="outlined" sx={{ p: 2 }}>
+                      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>AI Scans DB</Typography>
+                      <Stack spacing={0.5}>
+                        <Box><Typography variant="caption" color="text.secondary">Jobs</Typography><Typography>{dbHealth.ai_scans.job_count.toLocaleString()}</Typography></Box>
+                        <Box><Typography variant="caption" color="text.secondary">Pending</Typography><Typography>{dbHealth.ai_scans.pending_count.toLocaleString()}</Typography></Box>
+                        <Box><Typography variant="caption" color="text.secondary">Size</Typography><Typography>{(dbHealth.ai_scans.size_bytes / 1024 / 1024).toFixed(1)} MB</Typography></Box>
+                      </Stack>
+                    </Paper>
+                  </Grid>
+                  <Grid item xs={12} sm={4}>
+                    <Paper variant="outlined" sx={{ p: 2 }}>
+                      <Typography variant="subtitle2" fontWeight="bold" gutterBottom>Metadata Cache</Typography>
+                      <Stack spacing={0.5}>
+                        <Box><Typography variant="caption" color="text.secondary">Total entries</Typography><Typography>{dbHealth.metadata_cache.total_entries.toLocaleString()}</Typography></Box>
+                        <Box><Typography variant="caption" color="text.secondary">TTL</Typography><Typography>{dbHealth.metadata_cache.ttl_days} days</Typography></Box>
+                        <Box><Typography variant="caption" color="text.secondary">Expired</Typography><Typography>{dbHealth.metadata_cache.expired_entries.toLocaleString()}</Typography></Box>
+                      </Stack>
+                    </Paper>
+                  </Grid>
+                </Grid>
+              </Stack>
+            )}
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
 
       {/* Cache Stats Panel */}
       <CacheStatsPanel />

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.41.0
+// version: 1.42.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 import { useState, useEffect, useMemo, useRef, ChangeEvent } from 'react';
@@ -1004,7 +1004,7 @@ export function Settings() {
     memoryLimitType: 'items',
     cacheSize: 1000, // items
     cacheInvalidateOnBookUpdate: false,
-    metadataFetchCacheTTLDays: 7,
+    metadataFetchCacheTTLDays: 30,
     memoryLimitPercent: 25, // % of system memory
     memoryLimitMB: 512, // MB
 
@@ -1203,7 +1203,7 @@ export function Settings() {
         memoryLimitType: config.memory_limit_type || 'items',
         cacheSize: config.cache_size || 1000,
         cacheInvalidateOnBookUpdate: config.cache_invalidate_on_book_update ?? false,
-        metadataFetchCacheTTLDays: config.metadata_fetch_cache_ttl_days ?? 7,
+        metadataFetchCacheTTLDays: config.metadata_fetch_cache_ttl_days ?? 30,
         memoryLimitPercent: config.memory_limit_percent || 25,
         memoryLimitMB: config.memory_limit_mb || 512,
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.7.0
+// version: 2.8.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 
 // API service layer for audiobook-organizer backend
@@ -3766,6 +3766,43 @@ export async function applyDiagnosticsSuggestions(
     body: JSON.stringify({ operation_id: operationId, approved_suggestion_ids: approvedIds }),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to apply suggestions');
+  const body = await response.json();
+  return body.data;
+}
+
+export interface DBHealthTableStat {
+  name: string;
+  row_count: number;
+}
+
+export interface DBHealthStats {
+  sqlite?: {
+    tables: DBHealthTableStat[];
+    size_bytes: number;
+  };
+  pebble?: {
+    key_count: number;
+    size_bytes: number;
+  };
+  embeddings: {
+    vector_count: number;
+    size_bytes: number;
+  };
+  ai_scans: {
+    job_count: number;
+    pending_count: number;
+    size_bytes: number;
+  };
+  metadata_cache: {
+    total_entries: number;
+    ttl_days: number;
+    expired_entries: number;
+  };
+}
+
+export async function getDBHealthStats(): Promise<DBHealthStats> {
+  const response = await fetch(`${API_BASE}/diagnostics/db-health`);
+  if (!response.ok) throw await buildApiError(response, 'Failed to fetch DB health stats');
   const body = await response.json();
   return body.data;
 }


### PR DESCRIPTION
## DIAG-2/3: Database Health on Diagnostics page

New `GET /api/v1/diagnostics/db-health` endpoint returns:
- SQLite table row counts (books, authors, series, operations, etc.) + size
- PebbleDB key count + size
- Embeddings DB vector count + size
- AI Scans DB job/pending count + size
- Metadata fetch cache total/expired entry counts + TTL setting

Frontend Diagnostics page gets a new collapsible **Database Health** accordion with tables and stat cards for all stores.

## DIAG-4: Metadata cache TTL

Increases `MetadataFetchCacheTTLDays` default to **30 days** (was 7). Updates Settings page frontend defaults from 7 to 30.