### PR TITLE
feat(dedup): deduplicate books by metadata source hash (MATCH-1)

### DIFF
--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,6 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
+// last-edited: 2026-04-30
 
 package database
 
@@ -38,6 +39,7 @@ type BookReader interface {
 	GetBooksBySeriesID(seriesID int) ([]Book, error)
 	GetBooksByAuthorID(authorID int) ([]Book, error)
 	GetBooksByVersionGroup(groupID string) ([]Book, error)
+	GetBooksByMetadataSourceHash(hash string) ([]Book, error)
 	SearchBooks(query string, limit, offset int) ([]Book, error)
 	CountBooks() (int, error)
 	GetDistinctGenres() ([]string, error)

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1,5 +1,5 @@
 // file: internal/database/migrations.go
-// version: 1.33.0
+// version: 1.34.0
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
 // last-edited: 2026-04-30
 
@@ -363,6 +363,12 @@ var migrations = []Migration{
 		Version:     54,
 		Description: "Add metadata_rejections table for auditing rejected metadata candidates",
 		Up:          migration054Up,
+		Down:        nil,
+	},
+	{
+		Version:     55,
+		Description: "Add metadata_source_hash column to books for metadata-based deduplication (MATCH-1)",
+		Up:          migration055Up,
 		Down:        nil,
 	},
 }
@@ -2700,5 +2706,27 @@ func migration054Up(store Store) error {
 		}
 	}
 	log.Println("  - Created metadata_rejections table")
+	return nil
+}
+
+// migration055Up adds metadata_source_hash to books for metadata-based dedup (MATCH-1).
+// The value is sha256("{source}:{canonical_id}"), e.g. sha256("audible:B0XXXXXXXX").
+// Identical hashes mean two book records were applied from the exact same external record
+// and are almost certainly duplicates.
+func migration055Up(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil // PebbleDB: schema-free, field lives on struct
+	}
+	stmts := []string{
+		`ALTER TABLE books ADD COLUMN metadata_source_hash TEXT`,
+		`CREATE INDEX IF NOT EXISTS idx_books_metadata_source_hash ON books(metadata_source_hash) WHERE metadata_source_hash IS NOT NULL`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			log.Printf("  - [WARN] migration 055: %v (continuing)", err)
+		}
+	}
+	log.Println("  - Added metadata_source_hash to books, created index idx_books_metadata_source_hash")
 	return nil
 }

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -291,7 +291,8 @@ type MockStore struct {
 	ListBookTombstonesFunc  func(limit int) ([]Book, error)
 
 	// Version Management
-	GetBooksByVersionGroupFunc func(groupID string) ([]Book, error)
+	GetBooksByVersionGroupFunc          func(groupID string) ([]Book, error)
+	GetBooksByMetadataSourceHashFunc    func(hash string) ([]Book, error)
 
 	// iTunes Library Fingerprints
 	SaveLibraryFingerprintFunc func(path string, size int64, modTime time.Time, crc32 uint32) error
@@ -863,6 +864,13 @@ func (m *MockStore) ListBookTombstones(limit int) ([]Book, error) {
 func (m *MockStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 	if m.GetBooksByVersionGroupFunc != nil {
 		return m.GetBooksByVersionGroupFunc(groupID)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) {
+	if m.GetBooksByMetadataSourceHashFunc != nil {
+		return m.GetBooksByMetadataSourceHashFunc(hash)
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -42587,3 +42587,189 @@ func (_c *MockStore_UpsertMetadataFieldState_Call) RunAndReturn(run func(state *
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetBooksByMetadataSourceHash provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+ret := _mock.Called(hash)
+
+if len(ret) == 0 {
+panic("no return value specified for GetBooksByMetadataSourceHash")
+}
+
+var r0 []database.Book
+var r1 error
+if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+return returnFunc(hash)
+}
+if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+r0 = returnFunc(hash)
+} else {
+if ret.Get(0) != nil {
+r0 = ret.Get(0).([]database.Book)
+}
+}
+if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+r1 = returnFunc(hash)
+} else {
+r1 = ret.Error(1)
+}
+return r0, r1
+}
+
+// MockBookReader_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockBookReader_GetBooksByMetadataSourceHash_Call struct {
+*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBookReader_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+return &MockBookReader_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+_c.Call.Run(func(args mock.Arguments) {
+var arg0 string
+if args[0] != nil {
+arg0 = args[0].(string)
+}
+run(
+arg0,
+)
+})
+return _c
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(books, err)
+return _c
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(run)
+return _c
+}
+
+// GetBooksByMetadataSourceHash provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+ret := _mock.Called(hash)
+
+if len(ret) == 0 {
+panic("no return value specified for GetBooksByMetadataSourceHash")
+}
+
+var r0 []database.Book
+var r1 error
+if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+return returnFunc(hash)
+}
+if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+r0 = returnFunc(hash)
+} else {
+if ret.Get(0) != nil {
+r0 = ret.Get(0).([]database.Book)
+}
+}
+if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+r1 = returnFunc(hash)
+} else {
+r1 = ret.Error(1)
+}
+return r0, r1
+}
+
+// MockBookStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockBookStore_GetBooksByMetadataSourceHash_Call struct {
+*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBookStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+return &MockBookStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Run(func(args mock.Arguments) {
+var arg0 string
+if args[0] != nil {
+arg0 = args[0].(string)
+}
+run(
+arg0,
+)
+})
+return _c
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(books, err)
+return _c
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(run)
+return _c
+}
+
+// GetBooksByMetadataSourceHash provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+ret := _mock.Called(hash)
+
+if len(ret) == 0 {
+panic("no return value specified for GetBooksByMetadataSourceHash")
+}
+
+var r0 []database.Book
+var r1 error
+if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+return returnFunc(hash)
+}
+if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+r0 = returnFunc(hash)
+} else {
+if ret.Get(0) != nil {
+r0 = ret.Get(0).([]database.Book)
+}
+}
+if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+r1 = returnFunc(hash)
+} else {
+r1 = ret.Error(1)
+}
+return r0, r1
+}
+
+// MockStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockStore_GetBooksByMetadataSourceHash_Call struct {
+*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockStore_GetBooksByMetadataSourceHash_Call {
+return &MockStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Run(func(args mock.Arguments) {
+var arg0 string
+if args[0] != nil {
+arg0 = args[0].(string)
+}
+run(
+arg0,
+)
+})
+return _c
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(books, err)
+return _c
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockStore_GetBooksByMetadataSourceHash_Call {
+_c.Call.Return(run)
+return _c
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.59.0
+// version: 1.60.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-04-30
 
@@ -2507,6 +2507,42 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 		}
 		return books[i].Title < books[j].Title
 	})
+
+	return books, nil
+}
+
+// GetBooksByMetadataSourceHash returns all books with the given metadata source hash.
+func (p *PebbleStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) {
+	var books []Book
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") {
+			continue
+		}
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			continue
+		}
+
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+
+		if book.MetadataSourceHash != nil && *book.MetadataSourceHash == hash {
+			books = append(books, book)
+		}
+	}
 
 	return books, nil
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.71.0
+// version: 1.72.0
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -41,7 +41,8 @@ const bookSelectColumns = `
 	audible_rating_overall, audible_rating_performance, audible_rating_story,
 	audible_rating_count, audible_num_reviews,
 	google_rating_average, google_rating_count,
-	user_rating_overall, user_rating_story, user_rating_performance, user_rating_notes
+	user_rating_overall, user_rating_story, user_rating_performance, user_rating_notes,
+	metadata_source_hash
 `
 
 // bookSelectColumnsQualified prefixes all columns with "books." for use in JOINs.
@@ -63,7 +64,8 @@ const bookSelectColumnsQualified = `
 	books.audible_rating_overall, books.audible_rating_performance, books.audible_rating_story,
 	books.audible_rating_count, books.audible_num_reviews,
 	books.google_rating_average, books.google_rating_count,
-	books.user_rating_overall, books.user_rating_story, books.user_rating_performance, books.user_rating_notes
+	books.user_rating_overall, books.user_rating_story, books.user_rating_performance, books.user_rating_notes,
+	books.metadata_source_hash
 `
 
 func scanBook(scanner rowScanner, book *Book) error {
@@ -98,6 +100,7 @@ func scanBook(scanner rowScanner, book *Book) error {
 		googleRatingCount                                                    sql.NullInt64
 		userRatingOverall, userRatingStory, userRatingPerformance            sql.NullFloat64
 		userRatingNotes                                                      sql.NullString
+		metadataSourceHash                                                   sql.NullString
 	)
 
 	if err := scanner.Scan(
@@ -119,6 +122,7 @@ func scanBook(scanner rowScanner, book *Book) error {
 		&audibleRatingCount, &audibleNumReviews,
 		&googleRatingAverage, &googleRatingCount,
 		&userRatingOverall, &userRatingStory, &userRatingPerformance, &userRatingNotes,
+		&metadataSourceHash,
 	); err != nil {
 		return err
 	}
@@ -224,6 +228,7 @@ func scanBook(scanner rowScanner, book *Book) error {
 	book.UserRatingStory = nullableFloat(userRatingStory)
 	book.UserRatingPerformance = nullableFloat(userRatingPerformance)
 	book.UserRatingNotes = nullableString(userRatingNotes)
+	book.MetadataSourceHash = nullableString(metadataSourceHash)
 	return nil
 }
 
@@ -752,6 +757,7 @@ func (s *SQLiteStore) ensureExtendedBookColumns() error {
 		"user_rating_story":            "REAL",
 		"user_rating_performance":      "REAL",
 		"user_rating_notes":            "TEXT",
+		"metadata_source_hash":         "TEXT",
 	}
 
 	// Fetch existing columns
@@ -1981,6 +1987,27 @@ func (s *SQLiteStore) GetBookByOrganizedHash(hash string) (*Book, error) {
 	return &book, nil
 }
 
+// GetBooksByMetadataSourceHash returns all books whose metadata_source_hash
+// matches the given value. Typically returns 0 or 1 books; 2+ means duplicates
+// were applied from the exact same external record.
+func (s *SQLiteStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) {
+	query := fmt.Sprintf(`SELECT %s FROM books WHERE metadata_source_hash = ? ORDER BY created_at`, bookSelectColumns)
+	rows, err := s.db.Query(query, hash)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var books []Book
+	for rows.Next() {
+		var b Book
+		if err := scanBook(rows, &b); err != nil {
+			return nil, err
+		}
+		books = append(books, b)
+	}
+	return books, rows.Err()
+}
+
 // GetDuplicateBooks returns groups of books with identical file hashes
 // Only returns groups with 2+ books (actual duplicates)
 func (s *SQLiteStore) GetDuplicateBooks() ([][]Book, error) {
@@ -2784,7 +2811,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		audible_rating_overall = ?, audible_rating_performance = ?, audible_rating_story = ?,
 		audible_rating_count = ?, audible_num_reviews = ?,
 		google_rating_average = ?, google_rating_count = ?,
-		user_rating_overall = ?, user_rating_story = ?, user_rating_performance = ?, user_rating_notes = ?
+		user_rating_overall = ?, user_rating_story = ?, user_rating_performance = ?, user_rating_notes = ?,
+		metadata_source_hash = ?
 	WHERE id = ?`
 	result, err := s.db.Exec(query,
 		book.Title, book.AuthorID, book.SeriesID, book.SeriesSequence,
@@ -2805,7 +2833,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		book.AudibleRatingOverall, book.AudibleRatingPerformance, book.AudibleRatingStory,
 		book.AudibleRatingCount, book.AudibleNumReviews,
 		book.GoogleRatingAverage, book.GoogleRatingCount,
-		book.UserRatingOverall, book.UserRatingStory, book.UserRatingPerformance, book.UserRatingNotes, id,
+		book.UserRatingOverall, book.UserRatingStory, book.UserRatingPerformance, book.UserRatingNotes,
+		book.MetadataSourceHash, id,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.65.0
+// version: 2.66.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 // last-edited: 2026-04-30
 
@@ -204,6 +204,11 @@ type Book struct {
 	// scan-duration-mismatch endpoint can compare it against the local file
 	// Duration without making live API calls.
 	AudibleRuntimeMin *int `json:"audible_runtime_min,omitempty"`
+	// MetadataSourceHash is sha256("{source}:{canonical_id}") set during
+	// metadata apply. Enables O(1) dedup detection: books sharing an ASIN
+	// or ISBN-13 will have the same hash and are almost certainly the same
+	// title. Format: sha256("audible:B0XXXXXXXX"), sha256("openlibrary:/works/OL123W"), etc.
+	MetadataSourceHash *string `json:"metadata_source_hash,omitempty"`
 	// Audible ratings (1–5 scale). Performance and Story are audiobook-specific
 	// dimensions absent from other providers.
 	AudibleRatingOverall     *float64 `json:"audible_rating_overall,omitempty"`

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
+// last-edited: 2026-04-30
 
 package dedup
 
@@ -145,6 +146,10 @@ func (de *Engine) CheckBook(ctx context.Context, bookID string) (bool, error) {
 
 	if err := de.checkExactISBN(book); err != nil {
 		log.Printf("dedup: ISBN check error for %s: %v", bookID, err)
+	}
+
+	if err := de.checkExactMetadataSourceHash(book); err != nil {
+		log.Printf("dedup: metadata-source-hash check error for %s: %v", bookID, err)
 	}
 
 	if err := de.checkExactTitle(book, authorName); err != nil {
@@ -298,6 +303,38 @@ func (de *Engine) checkExactISBN(book *database.Book) error {
 			break
 		}
 		offset += batchSize
+	}
+	return nil
+}
+
+// checkExactMetadataSourceHash is the MATCH-1 fast pre-pass: if two books
+// share the same metadata_source_hash (sha256 of source:canonical_id) they
+// were applied from the exact same external record and are almost certainly
+// duplicates. Creates a dedup candidate with similarity 0.99.
+func (de *Engine) checkExactMetadataSourceHash(book *database.Book) error {
+	if book.MetadataSourceHash == nil || *book.MetadataSourceHash == "" {
+		return nil
+	}
+	others, err := de.bookStore.GetBooksByMetadataSourceHash(*book.MetadataSourceHash)
+	if err != nil {
+		return fmt.Errorf("get books by metadata source hash: %w", err)
+	}
+	for i := range others {
+		other := &others[i]
+		if other.ID == book.ID {
+			continue
+		}
+		sim := 0.99
+		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+			EntityType: "book",
+			EntityAID:  book.ID,
+			EntityBID:  other.ID,
+			Layer:      "metadata_hash",
+			Similarity: &sim,
+			Status:     "pending",
+		}); err != nil {
+			log.Printf("dedup: upsert metadata-hash candidate error (book %s ↔ %s): %v", book.ID, other.ID, err)
+		}
 	}
 	return nil
 }

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -2689,9 +2689,23 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	src := candidate.Source
 	book.MetadataSource = &src
 
+	// Compute metadata_source_hash = sha256("{source}:{canonical_id}") so the
+	// dedup engine can later detect books sharing the exact same external record.
+	canonicalID := metadataCanonicalID(candidate)
+	if canonicalID != "" {
+		h := fmt.Sprintf("%x", sha256.Sum256([]byte(src+":"+canonicalID)))
+		book.MetadataSourceHash = &h
+	}
+
 	updatedBook, updateErr := mfs.db.UpdateBook(id, book)
 	if updateErr != nil {
 		return nil, fmt.Errorf("failed to update book: %w", updateErr)
+	}
+
+	// Check whether any other book already carries the same hash — if so,
+	// emit a dedup candidate so the user can review the potential duplicate.
+	if book.MetadataSourceHash != nil {
+		mfs.checkMetadataSourceHashDuplicates(id, *book.MetadataSourceHash)
 	}
 
 	// Persist fetched values for provenance tracking
@@ -2749,6 +2763,39 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		Book:    updatedBook,
 		Source:  candidate.Source,
 	}, nil
+}
+
+// metadataCanonicalID extracts the canonical external identifier from a
+// MetadataCandidate for use in the metadata_source_hash computation.
+// Priority: ASIN > ISBN-13 > ISBN-10 > ISBN. Returns "" if none present.
+func metadataCanonicalID(c MetadataCandidate) string {
+	if c.ASIN != "" {
+		return c.ASIN
+	}
+	if c.ISBN != "" && len(c.ISBN) == 13 {
+		return c.ISBN
+	}
+	if c.ISBN != "" {
+		return c.ISBN
+	}
+	return ""
+}
+
+// checkMetadataSourceHashDuplicates logs a warning if other books share the
+// same metadata_source_hash. Full dedup candidate creation is handled by
+// the dedup engine's checkExactMetadataSourceHash pass which runs after apply.
+func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
+	matches, err := mfs.db.GetBooksByMetadataSourceHash(hash)
+	if err != nil {
+		log.Printf("[WARN] metadata-source-hash dedup query failed for book %s: %v", bookID, err)
+		return
+	}
+	for _, other := range matches {
+		if other.ID == bookID {
+			continue
+		}
+		log.Printf("[INFO] MATCH-1: book %s and %s share metadata_source_hash %s — possible duplicate, dedup engine will create candidate", bookID, other.ID, hash)
+	}
 }
 
 // ApplyMetadataSystemTags writes the metadata:source:* and

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,11 +1,13 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.25.0
+// version: 1.26.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-04-30
 
 package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -5894,4 +5896,138 @@ func (s *Server) runBulkDelugeImport(
 	}
 	log.Printf("[INFO] bulk-deluge-import %s: done. imported=%d failed=%d", opID, imported, failed)
 	return nil
+}
+
+// ── MATCH-1: backfill metadata_source_hash ───────────────────────────────────
+
+// metadataHashBackfillResult is one entry in the backfill response.
+type metadataHashBackfillResult struct {
+BookID    string `json:"book_id"`
+BookTitle string `json:"book_title"`
+Hash      string `json:"hash,omitempty"`
+Source    string `json:"source,omitempty"`
+Skipped   bool   `json:"skipped,omitempty"`
+SkipReason string `json:"skip_reason,omitempty"`
+Applied   bool   `json:"applied,omitempty"`
+Error     string `json:"error,omitempty"`
+}
+
+// handleBackfillMetadataSourceHash handles
+// POST /api/v1/maintenance/backfill-metadata-source-hash
+//
+// Iterates all books that already have a known ASIN or ISBN-13 (or ISBN-10),
+// computes sha256("{source}:{id}"), and stores it in metadata_source_hash.
+// Books that already have a hash are skipped unless ?force=true is set.
+//
+// Query params:
+//   - dry_run=true  (default) — report what would change without modifying DB
+//   - dry_run=false — actually write the hash
+//   - force=true    — overwrite existing hashes
+func (s *Server) handleBackfillMetadataSourceHash(c *gin.Context) {
+dryRun := c.DefaultQuery("dry_run", "true") == "true"
+force := c.Query("force") == "true"
+
+store := s.Store()
+if store == nil {
+c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+return
+}
+
+allBooks, err := store.GetAllBooks(0, 0)
+if err != nil {
+internalError(c, "failed to list books", err)
+return
+}
+
+var results []metadataHashBackfillResult
+applied := 0
+skipped := 0
+errors := 0
+
+for i := range allBooks {
+book := &allBooks[i]
+
+// Skip if already has hash and force not requested.
+if book.MetadataSourceHash != nil && *book.MetadataSourceHash != "" && !force {
+results = append(results, metadataHashBackfillResult{
+BookID:     book.ID,
+BookTitle:  book.Title,
+Hash:       *book.MetadataSourceHash,
+Skipped:    true,
+SkipReason: "already has metadata_source_hash",
+})
+skipped++
+continue
+}
+
+// Derive source and canonical ID.
+source, canonicalID := bookMetadataSourceAndID(book)
+if canonicalID == "" {
+results = append(results, metadataHashBackfillResult{
+BookID:     book.ID,
+BookTitle:  book.Title,
+Skipped:    true,
+SkipReason: "no ASIN, ISBN-13, or ISBN-10 available",
+})
+skipped++
+continue
+}
+
+hash := fmt.Sprintf("%x", sha256.Sum256([]byte(source+":"+canonicalID)))
+result := metadataHashBackfillResult{
+BookID:    book.ID,
+BookTitle: book.Title,
+Hash:      hash,
+Source:    source,
+}
+
+if !dryRun {
+current, getErr := store.GetBookByID(book.ID)
+if getErr != nil || current == nil {
+result.Error = fmt.Sprintf("GetBookByID: %v", getErr)
+errors++
+results = append(results, result)
+continue
+}
+current.MetadataSourceHash = &hash
+if _, updateErr := store.UpdateBook(book.ID, current); updateErr != nil {
+result.Error = updateErr.Error()
+log.Printf("[WARN] backfill-metadata-source-hash: book %s (%q): %v", book.ID, book.Title, updateErr)
+errors++
+results = append(results, result)
+continue
+}
+result.Applied = true
+applied++
+} else {
+applied++ // dry-run: count as "would apply"
+}
+
+results = append(results, result)
+}
+
+c.JSON(http.StatusOK, gin.H{
+"dry_run":  dryRun,
+"total":    len(allBooks),
+"applied":  applied,
+"skipped":  skipped,
+"errors":   errors,
+"results":  results,
+})
+}
+
+// bookMetadataSourceAndID returns the best (source, canonical_id) pair for a
+// book, in priority order: ASIN → ISBN-13 → ISBN-10. Returns ("", "") if none
+// available.
+func bookMetadataSourceAndID(book *database.Book) (source, id string) {
+if book.ASIN != nil && *book.ASIN != "" {
+return "audible", *book.ASIN
+}
+if book.ISBN13 != nil && *book.ISBN13 != "" {
+return "openlibrary", *book.ISBN13
+}
+if book.ISBN10 != nil && *book.ISBN10 != "" {
+return "openlibrary", *book.ISBN10
+}
+return "", ""
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -307,11 +307,12 @@ func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 // enrichedBookResponse wraps a Book with resolved names for JSON responses.
 type enrichedBookResponse struct {
 	*database.Book
-	AuthorName *string         `json:"author_name,omitempty"`
-	SeriesName *string         `json:"series_name,omitempty"`
-	Authors    []authorEntry   `json:"authors,omitempty"`
-	Narrators  []narratorEntry `json:"narrators,omitempty"`
-	FileExists *bool           `json:"file_exists,omitempty"`
+	AuthorName                       *string         `json:"author_name,omitempty"`
+	SeriesName                       *string         `json:"series_name,omitempty"`
+	Authors                          []authorEntry   `json:"authors,omitempty"`
+	Narrators                        []narratorEntry `json:"narrators,omitempty"`
+	FileExists                       *bool           `json:"file_exists,omitempty"`
+	MetadataSourceHashDuplicateCount *int            `json:"metadata_source_hash_duplicate_count,omitempty"`
 }
 
 type authorEntry struct {
@@ -381,6 +382,23 @@ func enrichBookForResponse(book *database.Book) enrichedBookResponse {
 				}
 				combined := strings.Join(names, " & ")
 				book.Narrator = &combined
+			}
+		}
+	}
+
+	// Populate metadata_source_hash_duplicate_count if this book has a hash.
+	// This lets the BookDetail UI warn about possible duplicates without an
+	// extra round-trip.
+	if book.MetadataSourceHash != nil && *book.MetadataSourceHash != "" && database.GetGlobalStore() != nil {
+		if matches, err := database.GetGlobalStore().GetBooksByMetadataSourceHash(*book.MetadataSourceHash); err == nil {
+			count := 0
+			for _, m := range matches {
+				if m.ID != book.ID {
+					count++
+				}
+			}
+			if count > 0 {
+				resp.MetadataSourceHashDuplicateCount = &count
 			}
 		}
 	}
@@ -2519,6 +2537,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/fix-read-by-narrator", s.perm(auth.PermSettingsManage), s.handleFixReadByNarrator)
 			protected.POST("/maintenance/cleanup-series", s.perm(auth.PermSettingsManage), s.handleCleanupSeries)
 			protected.POST("/maintenance/backfill-book-files", s.perm(auth.PermSettingsManage), s.handleBackfillBookFiles)
+			protected.POST("/maintenance/backfill-metadata-source-hash", s.perm(auth.PermSettingsManage), s.handleBackfillMetadataSourceHash)
 			protected.POST("/maintenance/cleanup-empty-folders", s.perm(auth.PermSettingsManage), s.handleCleanupEmptyFolders)
 			protected.POST("/maintenance/cleanup-backups", s.perm(auth.PermSettingsManage), s.handleCleanupBackups)
 			protected.POST("/maintenance/cleanup-organize-mess", s.perm(auth.PermSettingsManage), s.handleCleanupOrganizeMess)

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -1275,6 +1275,17 @@ export const BookDetail = () => {
         </Alert>
       )}
 
+      {book.metadata_source_hash && (book.metadata_source_hash_duplicate_count ?? 0) > 0 && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          ⚠ This book shares its metadata source with{' '}
+          <strong>{book.metadata_source_hash_duplicate_count}</strong>{' '}
+          other book{(book.metadata_source_hash_duplicate_count ?? 0) === 1 ? '' : 's'} — possible duplicate.{' '}
+          <a href="/dedup/candidates" style={{ color: 'inherit', fontWeight: 'bold' }}>
+            View duplicates
+          </a>
+        </Alert>
+      )}
+
       <Paper sx={{ p: 2, mb: 3 }}>
         <Stack
           direction={{ xs: 'column', md: 'row' }}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,6 +1,7 @@
 // file: web/src/services/api.ts
 // version: 2.8.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
+// last-edited: 2026-04-30
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -128,6 +129,9 @@ export interface Book {
   // Audible runtime fields (DUR PR #549)
   audible_runtime_min?: number | null;
   duration_delta_sec?: number | null;
+  // MATCH-1: metadata-source deduplication
+  metadata_source_hash?: string | null;
+  metadata_source_hash_duplicate_count?: number | null;
 }
 
 export interface Author {


### PR DESCRIPTION
## Summary

Implements MATCH-1: metadata-source deduplication via a stable `sha256(source:canonical_id)` hash stored on every book record.

### What this adds

| Layer | Description |
|-------|-------------|
| DB column | `metadata_source_hash TEXT` on `books` table (migration 053) |
| Dedup pre-pass | `checkExactMetadataSourceHash` in `dedup.Engine.CheckBook` — emits `metadata_hash` layer candidates (similarity 0.99) |
| Apply-time hashing | `ApplyMetadataCandidate` computes and persists the hash; logs warnings on same-session duplicates |
| Backfill endpoint | `POST /maintenance/backfill-metadata-source-hash` with `?dry_run=true` (default) / `?force=true` |
| Frontend warning | BookDetail shows a dismissible Alert when `metadata_source_hash_duplicate_count > 0` |

### Files changed (13)

- `internal/database/store.go` — `MetadataSourceHash *string` on `Book`
- `internal/database/sqlite_store.go` — full persistence wiring + `GetBooksByMetadataSourceHash`
- `internal/database/pebble_store.go` — full-scan implementation of `GetBooksByMetadataSourceHash`
- `internal/database/iface_book.go` — new method on `BookReader`
- `internal/database/mock_store.go` + `mocks/mock_store.go` — mock implementations
- `internal/database/migrations.go` — migration053 (ALTER TABLE + CREATE INDEX)
- `internal/metafetch/service.go` — hash computation + duplicate-check logging
- `internal/dedup/engine.go` — `checkExactMetadataSourceHash` pre-pass
- `internal/server/maintenance_fixups.go` — backfill handler
- `internal/server/server.go` — route registration + `MetadataSourceHashDuplicateCount` in enriched response
- `web/src/services/api.ts` — `Book` interface additions
- `web/src/pages/BookDetail.tsx` — duplicate warning Alert

### Testing

- `go build ./...` passes clean
- `go test ./internal/database/mocks/... ./internal/dedup/... ./internal/metafetch/...` all pass
- Targeted server tests (`TestDedup|TestMeta|TestBackfill|TestGetAudiobook|TestEnrich`) pass

### Known gap

`metadata_source_hash_duplicate_count` is populated inline in `enrichBookForResponse` via `GetBooksByMetadataSourceHash`. Until a book has its hash backfilled (via the new endpoint) or metadata re-applied, the field will be null and the frontend Alert will not show.