### PR TITLE
feat(database,maintenance,web): SHA cross-folder dedup + Storage path prefix diagnostic (FILE-SHA-2, DIAG-5)

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 // last-edited: 2026-04-30
 
@@ -130,6 +130,10 @@ type BookFileStore interface {
 	// UpdateBookFileHashes is a surgical update that records pre-write and post-write
 	// SHA-256 hashes without touching any other BookFile fields.
 	UpdateBookFileHashes(id, originalHash, postMetadataHash string) error
+	// GetDuplicateFilesByHash returns groups of book_files that share the same
+	// original_file_hash (non-empty). Each group has ≥2 entries and represents
+	// the same physical audio file in multiple locations.
+	GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, error)
 }
 
 // BookSegmentStore covers the deprecated segment surface, kept until

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.44.0
+// version: 1.45.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-04-30
 
@@ -328,6 +328,7 @@ type MockStore struct {
 	UpsertBookFileFunc          func(file *BookFile) error
 	BatchUpsertBookFilesFunc    func(files []*BookFile) error
 	MoveBookFilesToBookFunc     func(fileIDs []string, sourceBookID, targetBookID string) error
+	GetDuplicateFilesByHashFunc func(limit int) ([]DuplicateFileGroup, error)
 
 	// Path history
 	RecordPathChangeFunc   func(change *BookPathChange) error
@@ -2248,6 +2249,13 @@ func (m *MockStore) MoveBookFilesToBook(fileIDs []string, sourceBookID, targetBo
 		return m.MoveBookFilesToBookFunc(fileIDs, sourceBookID, targetBookID)
 	}
 	return nil
+}
+
+func (m *MockStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, error) {
+	if m.GetDuplicateFilesByHashFunc != nil {
+		return m.GetDuplicateFilesByHashFunc(limit)
+	}
+	return nil, nil
 }
 
 func (m *MockStore) CreateAIJob(job AIJob, payloadJSON []byte) error {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.61.0
+// version: 1.62.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-04-30
 
@@ -7975,4 +7975,9 @@ func (p *PebbleStore) GetMetadataRejections(_ string) ([]MetadataRejection, erro
 // DeleteMetadataRejections is not supported on PebbleStore.
 func (p *PebbleStore) DeleteMetadataRejections(_ string) error {
 	return fmt.Errorf("RejectedMetadataStore.DeleteMetadataRejections: not supported by PebbleStore")
+}
+
+// GetDuplicateFilesByHash is not supported on PebbleStore.
+func (p *PebbleStore) GetDuplicateFilesByHash(_ int) ([]DuplicateFileGroup, error) {
+	return nil, nil
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.73.0
+// version: 1.74.0
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -6295,6 +6295,84 @@ func (s *SQLiteStore) UpdateBookFileHashes(id, originalHash, postMetadataHash st
 		return fmt.Errorf("UpdateBookFileHashes %s: %w", id, err)
 	}
 	return nil
+}
+
+// GetDuplicateFilesByHash returns groups of book_files that share the same
+// original_file_hash, indicating identical audio content at multiple paths.
+func (s *SQLiteStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	const q = `
+WITH dup_hashes AS (
+  SELECT original_file_hash,
+         COUNT(*)                       AS cnt,
+         COUNT(DISTINCT book_id)        AS bcnt,
+         SUM(COALESCE(file_size, 0))    AS tsz
+  FROM book_files
+  WHERE original_file_hash IS NOT NULL AND original_file_hash != ''
+  GROUP BY original_file_hash
+  HAVING COUNT(*) >= 2
+  ORDER BY cnt DESC, tsz DESC
+  LIMIT ?
+)
+SELECT dh.original_file_hash, dh.cnt, dh.bcnt, dh.tsz,
+       bf.id, bf.book_id,
+       COALESCE(b.title, ''),
+       COALESCE(bf.file_path, ''),
+       COALESCE(b.file_path, ''),
+       COALESCE(bf.file_size, 0)
+FROM dup_hashes dh
+JOIN book_files bf ON bf.original_file_hash = dh.original_file_hash
+JOIN books b ON b.id = bf.book_id AND COALESCE(b.marked_for_deletion, 0) = 0
+ORDER BY dh.cnt DESC, dh.tsz DESC, bf.book_id`
+
+	rows, err := s.db.Query(q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("GetDuplicateFilesByHash query: %w", err)
+	}
+	defer rows.Close()
+
+	groupMap := make(map[string]*DuplicateFileGroup)
+	var order []string
+
+	for rows.Next() {
+		var (
+			hash, fileID, bookID, bookTitle, filePath, bookPath string
+			cnt, bcnt                                           int
+			tsz, fileSize                                       int64
+		)
+		if err := rows.Scan(&hash, &cnt, &bcnt, &tsz,
+			&fileID, &bookID, &bookTitle, &filePath, &bookPath, &fileSize); err != nil {
+			return nil, fmt.Errorf("GetDuplicateFilesByHash scan: %w", err)
+		}
+		if _, seen := groupMap[hash]; !seen {
+			groupMap[hash] = &DuplicateFileGroup{
+				Hash:      hash,
+				FileCount: cnt,
+				BookCount: bcnt,
+				TotalSize: tsz,
+			}
+			order = append(order, hash)
+		}
+		groupMap[hash].Files = append(groupMap[hash].Files, DuplicateFileInfo{
+			BookFileID: fileID,
+			BookID:     bookID,
+			BookTitle:  bookTitle,
+			FilePath:   filePath,
+			BookPath:   bookPath,
+			FileSize:   fileSize,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetDuplicateFilesByHash rows: %w", err)
+	}
+
+	groups := make([]DuplicateFileGroup, 0, len(order))
+	for _, h := range order {
+		groups = append(groups, *groupMap[h])
+	}
+	return groups, nil
 }
 
 // AddMetadataRejection records a rejected metadata candidate for a book.

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.67.0
+// version: 2.68.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 // last-edited: 2026-04-30
 
@@ -861,6 +861,26 @@ type MetadataRejection struct {
 	RejectionReason  string    `json:"rejection_reason"`            // "user_rejected", "below_threshold", "duration_mismatch", "wrong_language", "skipped"
 	Score            float64   `json:"score,omitempty"`
 	RejectedAt       time.Time `json:"rejected_at"`
+}
+
+// DuplicateFileGroup is a set of book_file records that all share the same
+// original_file_hash — i.e. the same physical audio content at different paths.
+type DuplicateFileGroup struct {
+	Hash      string              `json:"hash"`
+	FileCount int                 `json:"file_count"`
+	BookCount int                 `json:"book_count"`       // distinct book IDs
+	TotalSize int64               `json:"total_size_bytes"` // sum of file sizes
+	Files     []DuplicateFileInfo `json:"files"`
+}
+
+// DuplicateFileInfo is one entry within a DuplicateFileGroup.
+type DuplicateFileInfo struct {
+	BookFileID string `json:"book_file_id"`
+	BookID     string `json:"book_id"`
+	BookTitle  string `json:"book_title"`
+	FilePath   string `json:"file_path"`  // book_files.file_path
+	BookPath   string `json:"book_path"`  // books.file_path (directory)
+	FileSize   int64  `json:"file_size_bytes"`
 }
 
 // Global store instance — use GetGlobalStore/SetGlobalStore for concurrent access.

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.27.0
+// version: 1.28.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-04-30
 
@@ -6176,5 +6176,49 @@ c.JSON(http.StatusOK, gin.H{
 "books_merged":  booksMerged,
 "books_skipped": booksSkipped,
 "groups":        results,
+})
+}
+
+// handleScanDuplicateFiles returns groups of book_files that share the same
+// original_file_hash, indicating identical audio content at multiple paths.
+//
+// GET /api/v1/maintenance/duplicate-files
+//
+// Query params:
+//   - limit=50  (max groups returned; default 50)
+//
+// Response: { data: { groups: [...], total_wasted_bytes: N, total_groups: N } }
+func (s *Server) handleScanDuplicateFiles(c *gin.Context) {
+limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+if limit <= 0 {
+limit = 50
+}
+
+store := s.Store()
+if store == nil {
+c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+return
+}
+
+groups, err := store.GetDuplicateFilesByHash(limit)
+if err != nil {
+internalError(c, "failed to scan duplicate files", err)
+return
+}
+
+var totalWasted int64
+for _, g := range groups {
+if g.FileCount > 1 {
+perFile := g.TotalSize / int64(g.FileCount)
+totalWasted += perFile * int64(g.FileCount-1)
+}
+}
+
+c.JSON(http.StatusOK, gin.H{
+"data": gin.H{
+"groups":             groups,
+"total_wasted_bytes": totalWasted,
+"total_groups":       len(groups),
+},
 })
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 1.205.0
+// version: 1.206.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-04-30
 
@@ -2562,6 +2562,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/bulk-deluge-import", s.perm(auth.PermSettingsManage), s.handleBulkDelugeImport)
 			protected.GET("/maintenance/chapter-groups", s.perm(auth.PermSettingsManage), s.handleScanChapterGroups)
 			protected.POST("/maintenance/merge-chapter-groups", s.perm(auth.PermSettingsManage), s.handleMergeChapterGroups)
+			protected.GET("/maintenance/duplicate-files", s.perm(auth.PermSettingsManage), s.handleScanDuplicateFiles)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
 // last-edited: 2026-04-30
 
@@ -285,6 +285,102 @@ function ChapterConsolidationCard() {
   );
 }
 
+// ─── SHADuplicateCard ─────────────────────────────────────────────────────────
+
+function SHADuplicateCard() {
+  const [scanning, setScanning] = useState(false);
+  const [result, setResult] = useState<api.DuplicateFilesResult | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleScan = useCallback(async () => {
+    setScanning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const r = await api.scanDuplicateFiles(50);
+      setResult(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Scan failed');
+    } finally {
+      setScanning(false);
+    }
+  }, []);
+
+  const fmt = (bytes: number) => {
+    if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
+    if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+    return `${(bytes / 1024).toFixed(0)} KB`;
+  };
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardHeader
+        title="SHA Duplicate Detection"
+        subheader="These files have identical content (same SHA-256). Consider consolidating."
+      />
+      <CardContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+          <Button
+            variant="outlined"
+            startIcon={scanning ? <CircularProgress size={14} /> : undefined}
+            disabled={scanning}
+            onClick={handleScan}
+          >
+            {scanning ? 'Scanning…' : 'Scan for SHA Duplicates'}
+          </Button>
+        </Stack>
+
+        {result && (
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            Found <strong>{result.total_groups}</strong> duplicate group(s) —{' '}
+            <strong>{fmt(result.total_wasted_bytes)}</strong> wasted space.
+          </Typography>
+        )}
+
+        {result && result.groups.length > 0 && (
+          <List dense disablePadding>
+            {result.groups.map((g) => (
+              <Box key={g.hash} sx={{ mb: 1 }}>
+                <ListItem
+                  disableGutters
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => setExpanded(expanded === g.hash ? null : g.hash)}
+                >
+                  <ListItemText
+                    primary={`${g.files[0]?.book_title || '(unknown)'} — ${g.file_count} copies`}
+                    secondary={`${fmt(g.total_size_bytes)} total · hash: ${g.hash.slice(0, 12)}…`}
+                  />
+                  <Chip size="small" label={`${g.file_count} files`} sx={{ ml: 1 }} />
+                </ListItem>
+                <Collapse in={expanded === g.hash}>
+                  <List dense disablePadding sx={{ pl: 2 }}>
+                    {g.files.map((f) => (
+                      <ListItem key={f.book_file_id} disableGutters>
+                        <ListItemText
+                          primary={f.file_path || f.book_path}
+                          secondary={f.book_title}
+                        />
+                        <Chip size="small" label={fmt(f.file_size_bytes)} variant="outlined" sx={{ ml: 1 }} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Collapse>
+              </Box>
+            ))}
+          </List>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── MaintenanceTab ───────────────────────────────────────────────────────────
 
 export function MaintenanceTab() {
@@ -382,6 +478,8 @@ export function MaintenanceTab() {
       <MaintenanceWindowCard />
 
       <ChapterConsolidationCard />
+
+      <SHADuplicateCard />
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>

--- a/web/src/components/system/StorageTab.tsx
+++ b/web/src/components/system/StorageTab.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/system/StorageTab.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
+// last-edited: 2026-04-30
 
 import { useState, useEffect } from 'react';
 import {
@@ -13,11 +14,15 @@ import {
   Divider,
   Button,
   CircularProgress,
+  Chip,
+  Tooltip,
 } from '@mui/material';
 import {
   Folder as FolderIcon,
   LibraryBooks as LibraryIcon,
   Refresh as RefreshIcon,
+  Storage as StorageIcon,
+  InfoOutlined as InfoIcon,
 } from '@mui/icons-material';
 import * as api from '../../services/api';
 
@@ -34,6 +39,7 @@ interface StorageInfo {
   bookCount: number;
   folderCount: number;
   folders: ImportPath[];
+  pathPrefixes: Array<{ prefix: string; book_count: number }>;
 }
 
 export function StorageTab() {
@@ -49,9 +55,10 @@ export function StorageTab() {
     setLoading(true);
     setError(null);
     try {
-      const [statusData, foldersData] = await Promise.all([
+      const [statusData, foldersData, dbHealth] = await Promise.all([
         api.getSystemStatus(),
         api.getImportPaths(),
+        api.getDBHealthStats().catch(() => null),
       ]);
       const librarySize =
         statusData.library_size_bytes ?? statusData.library.total_size;
@@ -63,6 +70,7 @@ export function StorageTab() {
         bookCount: libraryBookCount,
         folderCount: statusData.import_paths?.folder_count || 0,
         folders: foldersData,
+        pathPrefixes: dbHealth?.book_path_prefixes ?? [],
       });
     } catch (err) {
       console.error('Failed to fetch storage info:', err);
@@ -246,6 +254,53 @@ export function StorageTab() {
             </CardContent>
           </Card>
         </Grid>
+
+        {/* DB Path Distribution */}
+        {storage.pathPrefixes.length > 0 && (
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Stack direction="row" spacing={2} alignItems="center" mb={2}>
+                  <StorageIcon color="primary" />
+                  <Typography variant="h6">DB Path Distribution</Typography>
+                  <Tooltip title="Shows where books are actually stored in the database. If a path here doesn't match your import folders, those books may have been auto-organized or moved.">
+                    <InfoIcon fontSize="small" color="action" />
+                  </Tooltip>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" mb={2}>
+                  Top path prefixes in the database vs your configured import folders.
+                  Mismatches indicate books that were organized away or are stored under a different root.
+                </Typography>
+                <Stack spacing={1}>
+                  {storage.pathPrefixes.map((p, i) => {
+                    const isConfigured = storage.folders.some(f =>
+                      f.path.startsWith(p.prefix) || p.prefix.startsWith(f.path)
+                    );
+                    return (
+                      <Stack key={i} direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace', flex: 1, mr: 1 }} noWrap>
+                          {p.prefix}
+                        </Typography>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Chip
+                            label={`${p.book_count.toLocaleString()} books`}
+                            size="small"
+                            variant="outlined"
+                          />
+                          {isConfigured ? (
+                            <Chip label="configured" size="small" color="success" variant="outlined" />
+                          ) : (
+                            <Chip label="not in import paths" size="small" color="warning" variant="outlined" />
+                          )}
+                        </Stack>
+                      </Stack>
+                    );
+                  })}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.9.0
+// version: 2.10.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-04-30
 
@@ -4484,6 +4484,43 @@ export async function mergeChapterGroups(params?: {
   const response = await fetch(url, { method: 'POST' });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge chapter groups');
+  }
+  const body_data = await response.json();
+  return body_data.data ?? body_data;
+}
+
+// ─── SHA Duplicate File Detection (FILE-SHA-2) ───────────────────────────────
+
+export interface DuplicateFileInfo {
+  book_file_id: string;
+  book_id: string;
+  book_title: string;
+  file_path: string;
+  book_path: string;
+  file_size_bytes: number;
+}
+
+export interface DuplicateFileGroup {
+  hash: string;
+  file_count: number;
+  book_count: number;
+  total_size_bytes: number;
+  files: DuplicateFileInfo[];
+}
+
+export interface DuplicateFilesResult {
+  groups: DuplicateFileGroup[];
+  total_wasted_bytes: number;
+  total_groups: number;
+}
+
+export async function scanDuplicateFiles(limit?: number): Promise<DuplicateFilesResult> {
+  const q = new URLSearchParams();
+  if (limit != null) q.set('limit', String(limit));
+  const url = `${API_BASE}/maintenance/duplicate-files${q.toString() ? `?${q}` : ''}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to scan duplicate files');
   }
   const body_data = await response.json();
   return body_data.data ?? body_data;

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -3802,6 +3802,7 @@ export interface DBHealthStats {
     ttl_days: number;
     expired_entries: number;
   };
+  book_path_prefixes?: Array<{ prefix: string; book_count: number }>;
 }
 
 export async function getDBHealthStats(): Promise<DBHealthStats> {


### PR DESCRIPTION
## FILE-SHA-2 — Cross-Folder SHA Duplicate Detection

Uses `original_file_hash` on `book_files` to surface identical audio files stored in multiple library paths.

### Changes
- **`GetDuplicateFilesByHash(limit)`** on `BookFileStore` interface + SQLiteStore CTE implementation + PebbleStore stub
- **`DuplicateFileGroup` / `DuplicateFileInfo`** structs in `store.go`
- **`GET /api/v1/maintenance/duplicate-files`** endpoint — returns groups, total wasted bytes
- **`SHADuplicateCard`** in MaintenanceTab — scan button, expandable per-group file list with book titles + sizes

## DIAG-5 — Book Path Prefixes in Storage Tab

Surfaces the `book_path_prefixes` diagnostic already available from `GET /api/v1/diagnostics/db-health`.

### Changes
- `DBHealthStats` type extended with `book_path_prefixes`
- StorageTab fetches db-health alongside status/import paths
- New **DB Path Distribution** card: each prefix with book count + `configured` / `not in import paths` chip so mismatches are immediately obvious

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>