### PR TITLE
fix(database,web): SHA scan null crash, AIJobsStore 500, and newbooks=0

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.62.0
+// version: 1.63.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-04-30
 
@@ -2571,6 +2571,37 @@ func (p *PebbleStore) GetAllImportPaths() ([]ImportPath, error) {
 			return nil, err
 		}
 		importPaths = append(importPaths, importPath)
+	}
+
+	if len(importPaths) == 0 {
+		return importPaths, nil
+	}
+
+	// Live-count books per import path by iterating all books.
+	// The stored BookCount is stale (set only at creation time), so we
+	// recompute it here to keep the storage page accurate.
+	counts := make(map[int]int, len(importPaths))
+	bookIter, berr := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if berr == nil {
+		defer bookIter.Close()
+		for bookIter.First(); bookIter.Valid(); bookIter.Next() {
+			var b Book
+			if json.Unmarshal(bookIter.Value(), &b) != nil {
+				continue
+			}
+			for _, ip := range importPaths {
+				if ip.Path != "" && strings.HasPrefix(b.FilePath, ip.Path) {
+					counts[ip.ID]++
+					break
+				}
+			}
+		}
+		for i := range importPaths {
+			importPaths[i].BookCount = counts[importPaths[i].ID]
+		}
 	}
 
 	return importPaths, nil
@@ -7905,9 +7936,10 @@ func (p *PebbleStore) MarkAIJobFailed(_, _ string) error {
 	return fmt.Errorf("AIJobsStore.MarkAIJobFailed: not supported by PebbleStore")
 }
 
-// ListAIJobs is not supported on PebbleStore.
+// ListAIJobs is not supported on PebbleStore; returns an empty list so diagnostics
+// pages degrade gracefully instead of showing an error.
 func (p *PebbleStore) ListAIJobs(_, _ string, _, _ int) ([]AIJob, error) {
-	return nil, fmt.Errorf("AIJobsStore.ListAIJobs: not supported by PebbleStore")
+	return []AIJob{}, nil
 }
 
 // KeyCount returns the total number of keys stored in the PebbleDB instance

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
 // last-edited: 2026-04-30
 
@@ -344,9 +344,9 @@ function SHADuplicateCard() {
           </Typography>
         )}
 
-        {result && result.groups.length > 0 && (
+        {result && (result.groups?.length ?? 0) > 0 && (
           <List dense disablePadding>
-            {result.groups.map((g) => (
+            {(result.groups ?? []).map((g) => (
               <Box key={g.hash} sx={{ mb: 1 }}>
                 <ListItem
                   disableGutters

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.10.0
+// version: 2.11.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-04-30
 
@@ -4523,5 +4523,8 @@ export async function scanDuplicateFiles(limit?: number): Promise<DuplicateFiles
     throw await buildApiError(response, 'Failed to scan duplicate files');
   }
   const body_data = await response.json();
-  return body_data.data ?? body_data;
+  const result = body_data.data ?? body_data;
+  // Ensure groups is always an array even if the server returns null.
+  result.groups = result.groups ?? [];
+  return result;
 }


### PR DESCRIPTION
## Summary

Three production bugs fixed in one branch:

### 1. SHA scan null crash
- **Bug**: Clicking "Scan for SHA Duplicates" crashed with `null is not an object (evaluating l.groups.length)`
- **Root cause**: Backend returns `groups: null` (Go nil slice marshals to JSON null) when no duplicates found
- **Fix**: `scanDuplicateFiles()` API helper now normalises `groups` to `[]`; `SHADuplicateCard` uses optional-chaining guard

### 2. Diagnostics page: `ApiError: store does not implement AIJobsStore`
- **Bug**: Diagnostics AI Jobs panel threw 500 every page load in production (PebbleDB)
- **Root cause**: `PebbleStore.ListAIJobs` was a stub returning `fmt.Errorf(...)` 
- **Fix**: Stub now returns `[]AIJob{}, nil` — empty list, no error — so the panel shows "No AI jobs recorded yet"

### 3. Storage page shows 0 books for newbooks
- **Bug**: `/mnt/bigdata/books/newbooks` (7.4T) showed 0 books on the Storage/Library page
- **Root cause**: `PebbleStore.GetAllImportPaths` returned stale `BookCount` from the JSON blob written at path creation; count was never updated
- **Fix**: After loading import paths, iterate all book keys and count how many have a `FilePath` prefix matching each import path (mirrors the SQLite live-count subquery)

## Files changed
- `internal/database/pebble_store.go` — ListAIJobs stub + GetAllImportPaths live count
- `web/src/components/system/MaintenanceTab.tsx` — null-safe groups access
- `web/src/services/api.ts` — normalise groups array in scanDuplicateFiles()