### PR TITLE
feat(database,server,web): auto-flag metadata hash duplicates at import/apply (MATCH-4)

### DIFF
--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package database
 
@@ -77,6 +77,10 @@ type BookWriter interface {
 	// merged_into_book_id=primaryID), and updates the primary book's duration
 	// (rounded to nearest second) and title. Runs in a single transaction.
 	MergeChapterBooks(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error
+	// FlagMetadataHashDuplicate marks duplicateID as absorbed into primaryID by
+	// setting merged_into_book_id=primaryID and is_primary_version=0 on the
+	// duplicate. Used by MATCH-4 auto-dedup at metadata-apply time.
+	FlagMetadataHashDuplicate(primaryID, duplicateID string) error
 }
 
 // BookStore combines BookReader and BookWriter for callers that need both.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.45.0
+// version: 1.46.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package database
 
@@ -1744,6 +1744,8 @@ func (m *MockStore) ResetScanFailCount(pathHash string) error              { ret
 func (m *MockStore) MergeChapterBooks(_ string, _ []string, _ string, _ float64) error {
 	return nil
 }
+
+func (m *MockStore) FlagMetadataHashDuplicate(_, _ string) error { return nil }
 
 func (m *MockStore) Optimize() error {
 	return nil

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -4206,6 +4206,60 @@ func (_c *MockBookWriter_DeleteBook_Call) RunAndReturn(run func(id string) error
 	return _c
 }
 
+// FlagMetadataHashDuplicate provides a mock function for the type MockBookWriter
+func (_mock *MockBookWriter) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookWriter_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockBookWriter_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockBookWriter_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	return &MockBookWriter_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteBookTombstone provides a mock function for the type MockBookWriter
 func (_mock *MockBookWriter) DeleteBookTombstone(id string) error {
 	ret := _mock.Called(id)
@@ -5097,6 +5151,60 @@ func (_c *MockBookStore_DeleteBook_Call) Return(err error) *MockBookStore_Delete
 }
 
 func (_c *MockBookStore_DeleteBook_Call) RunAndReturn(run func(id string) error) *MockBookStore_DeleteBook_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FlagMetadataHashDuplicate provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockBookStore_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockBookStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	return &MockBookStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockBookStore_FlagMetadataHashDuplicate_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -27096,6 +27204,60 @@ func (_c *MockStore_DeleteBook_Call) Return(err error) *MockStore_DeleteBook_Cal
 }
 
 func (_c *MockStore_DeleteBook_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteBook_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FlagMetadataHashDuplicate provides a mock function for the type MockStore
+func (_mock *MockStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockStore_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockStore_FlagMetadataHashDuplicate_Call {
+	return &MockStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockStore_FlagMetadataHashDuplicate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.62.0
+// version: 1.63.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package database
 
@@ -2540,11 +2540,30 @@ func (p *PebbleStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) 
 		}
 
 		if book.MetadataSourceHash != nil && *book.MetadataSourceHash == hash {
-			books = append(books, book)
+			if book.MergedIntoBookID == nil {
+				books = append(books, book)
+			}
 		}
 	}
 
 	return books, nil
+}
+
+// FlagMetadataHashDuplicate marks duplicateID as absorbed into primaryID.
+// PebbleStore stub — metadata dedup is only performed by SQLiteStore in production.
+func (p *PebbleStore) FlagMetadataHashDuplicate(primaryID, duplicateID string) error {
+	book, err := p.GetBookByID(duplicateID)
+	if err != nil {
+		return err
+	}
+	if book == nil {
+		return nil
+	}
+	f := false
+	book.MergedIntoBookID = &primaryID
+	book.IsPrimaryVersion = &f
+	_, err = p.UpdateBook(duplicateID, book)
+	return err
 }
 
 // Import path operations

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/sqlite_store.go
-// version: 1.74.0
-// last-edited: 2026-04-30
+// version: 1.75.0
+// last-edited: 2026-05-01
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
@@ -1992,11 +1992,11 @@ func (s *SQLiteStore) GetBookByOrganizedHash(hash string) (*Book, error) {
 	return &book, nil
 }
 
-// GetBooksByMetadataSourceHash returns all books whose metadata_source_hash
+// GetBooksByMetadataSourceHash returns all non-merged books whose metadata_source_hash
 // matches the given value. Typically returns 0 or 1 books; 2+ means duplicates
 // were applied from the exact same external record.
 func (s *SQLiteStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) {
-	query := fmt.Sprintf(`SELECT %s FROM books WHERE metadata_source_hash = ? ORDER BY created_at`, bookSelectColumns)
+	query := fmt.Sprintf(`SELECT %s FROM books WHERE metadata_source_hash = ? AND merged_into_book_id IS NULL ORDER BY created_at`, bookSelectColumns)
 	rows, err := s.db.Query(query, hash)
 	if err != nil {
 		return nil, err
@@ -6240,6 +6240,16 @@ func (s *SQLiteStore) MergeChapterBooks(primaryID string, srcIDs []string, commo
 	}
 
 	return tx.Commit()
+}
+
+// FlagMetadataHashDuplicate marks duplicateID as absorbed into primaryID.
+// Sets merged_into_book_id=primaryID and is_primary_version=0 on the duplicate.
+func (s *SQLiteStore) FlagMetadataHashDuplicate(primaryID, duplicateID string) error {
+	_, err := s.db.Exec(
+		`UPDATE books SET merged_into_book_id = ?, is_primary_version = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		primaryID, duplicateID,
+	)
+	return err
 }
 
 // SQLiteTableStat holds a row count for a single table.

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 4.62.0
+// version: 4.63.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package metafetch
 
@@ -2781,20 +2781,62 @@ func metadataCanonicalID(c MetadataCandidate) string {
 	return ""
 }
 
-// checkMetadataSourceHashDuplicates logs a warning if other books share the
-// same metadata_source_hash. Full dedup candidate creation is handled by
-// the dedup engine's checkExactMetadataSourceHash pass which runs after apply.
+// checkMetadataSourceHashDuplicates auto-flags any existing non-merged book
+// that shares the same metadata_source_hash as bookID (MATCH-4). The book
+// with the most book_files is kept as primary; all others get
+// merged_into_book_id set to point at it.
 func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 	matches, err := mfs.db.GetBooksByMetadataSourceHash(hash)
 	if err != nil {
-		log.Printf("[WARN] metadata-source-hash dedup query failed for book %s: %v", bookID, err)
+		log.Printf("[WARN] MATCH-4: metadata-source-hash dedup query failed for book %s: %v", bookID, err)
 		return
 	}
-	for _, other := range matches {
-		if other.ID == bookID {
+
+	// Build the full set of non-merged books sharing this hash; ensure bookID is included.
+	allMap := make(map[string]database.Book, len(matches)+1)
+	for _, b := range matches {
+		allMap[b.ID] = b
+	}
+	if _, ok := allMap[bookID]; !ok {
+		if self, err := mfs.db.GetBookByID(bookID); err == nil && self != nil {
+			allMap[bookID] = *self
+		}
+	}
+
+	if len(allMap) < 2 {
+		return // no duplicates
+	}
+
+	// Pick primary: book with the most book_files. On tie, prefer earlier created_at.
+	primaryID := bookID
+	maxFiles := -1
+	for id, b := range allMap {
+		files, err := mfs.db.GetBookFiles(id)
+		n := 0
+		if err == nil {
+			n = len(files)
+		}
+		isBetter := n > maxFiles
+		if n == maxFiles && b.CreatedAt != nil {
+			if cur, ok := allMap[primaryID]; ok && cur.CreatedAt != nil && b.CreatedAt.Before(*cur.CreatedAt) {
+				isBetter = true
+			}
+		}
+		if isBetter {
+			maxFiles = n
+			primaryID = id
+		}
+	}
+
+	for id := range allMap {
+		if id == primaryID {
 			continue
 		}
-		log.Printf("[INFO] MATCH-1: book %s and %s share metadata_source_hash %s — possible duplicate, dedup engine will create candidate", bookID, other.ID, hash)
+		if err := mfs.db.FlagMetadataHashDuplicate(primaryID, id); err != nil {
+			log.Printf("[WARN] MATCH-4: failed to flag book %s as duplicate of %s: %v", id, primaryID, err)
+		} else {
+			log.Printf("[INFO] MATCH-4: auto-flagged book %s as merged into primary %s (hash %s)", id, primaryID, hash)
+		}
 	}
 }
 

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.28.0
+// version: 1.29.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package server
 
@@ -6220,5 +6220,85 @@ c.JSON(http.StatusOK, gin.H{
 "total_wasted_bytes": totalWasted,
 "total_groups":       len(groups),
 },
+})
+}
+
+// ── MATCH-4: metadata-hash duplicate scan ─────────────────────────────────────
+
+// metadataHashDupBook is the per-book entry returned in a metadata-hash duplicate group.
+type metadataHashDupBook struct {
+ID        string `json:"id"`
+Title     string `json:"title"`
+FileCount int    `json:"file_count"`
+}
+
+// metadataHashDupGroup is one group of books that share a metadata_source_hash.
+type metadataHashDupGroup struct {
+Hash  string                `json:"hash"`
+Books []metadataHashDupBook `json:"books"`
+}
+
+// handleScanMetadataHashDuplicates scans all books, groups them by
+// metadata_source_hash, and returns groups where count > 1.
+//
+// GET /api/v1/maintenance/metadata-hash-duplicates
+//
+// Response: { "groups": [...], "total_duplicate_books": N }
+func (s *Server) handleScanMetadataHashDuplicates(c *gin.Context) {
+store := s.Store()
+if store == nil {
+c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+return
+}
+
+all, err := store.GetAllBooks(0, 0)
+if err != nil {
+internalError(c, "failed to list books", err)
+return
+}
+
+grouped := make(map[string][]database.Book)
+for _, b := range all {
+if b.MetadataSourceHash == nil || *b.MetadataSourceHash == "" {
+continue
+}
+if b.MergedIntoBookID != nil {
+continue
+}
+grouped[*b.MetadataSourceHash] = append(grouped[*b.MetadataSourceHash], b)
+}
+
+fileCountMap := make(map[string]int)
+for hash, books := range grouped {
+if len(books) < 2 {
+delete(grouped, hash)
+continue
+}
+for _, b := range books {
+files, fErr := store.GetBookFiles(b.ID)
+if fErr == nil {
+fileCountMap[b.ID] = len(files)
+}
+}
+}
+
+result := make([]metadataHashDupGroup, 0, len(grouped))
+totalDup := 0
+for hash, books := range grouped {
+entry := metadataHashDupGroup{Hash: hash}
+for _, b := range books {
+entry.Books = append(entry.Books, metadataHashDupBook{
+ID:        b.ID,
+Title:     b.Title,
+FileCount: fileCountMap[b.ID],
+})
+}
+result = append(result, entry)
+totalDup += len(books)
+}
+
+c.JSON(http.StatusOK, gin.H{
+"groups":               result,
+"total_duplicate_books": totalDup,
 })
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 1.206.0
+// version: 1.207.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package server
 
@@ -2563,6 +2563,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/maintenance/chapter-groups", s.perm(auth.PermSettingsManage), s.handleScanChapterGroups)
 			protected.POST("/maintenance/merge-chapter-groups", s.perm(auth.PermSettingsManage), s.handleMergeChapterGroups)
 			protected.GET("/maintenance/duplicate-files", s.perm(auth.PermSettingsManage), s.handleScanDuplicateFiles)
+			protected.GET("/maintenance/metadata-hash-duplicates", s.perm(auth.PermSettingsManage), s.handleScanMetadataHashDuplicates)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 import { useEffect, useState, useCallback } from 'react';
 import {
@@ -381,6 +381,96 @@ function SHADuplicateCard() {
   );
 }
 
+// ─── MetadataHashDuplicateCard ────────────────────────────────────────────────
+
+function MetadataHashDuplicateCard() {
+  const [scanning, setScanning] = useState(false);
+  const [result, setResult] = useState<api.MetadataHashDuplicatesResult | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleScan = useCallback(async () => {
+    setScanning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const r = await api.findMetadataHashDuplicates();
+      setResult(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Scan failed');
+    } finally {
+      setScanning(false);
+    }
+  }, []);
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardHeader
+        title="Metadata Hash Duplicates"
+        subheader="Books that share the same metadata source hash (same ASIN/ISBN from the same provider)."
+        action={
+          result != null && result.total_duplicate_books > 0 ? (
+            <Chip color="warning" label={`${result.total_duplicate_books} duplicates`} size="small" />
+          ) : result != null ? (
+            <Chip color="success" label="No duplicates" size="small" />
+          ) : null
+        }
+      />
+      <CardContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+          <Button
+            variant="outlined"
+            startIcon={scanning ? <CircularProgress size={14} /> : undefined}
+            disabled={scanning}
+            onClick={handleScan}
+          >
+            {scanning ? 'Scanning…' : 'Scan for Metadata Hash Duplicates'}
+          </Button>
+        </Stack>
+
+        {result && result.groups.length > 0 && (
+          <List dense disablePadding>
+            {result.groups.map((g) => (
+              <Box key={g.hash} sx={{ mb: 1 }}>
+                <ListItem
+                  disableGutters
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() => setExpanded(expanded === g.hash ? null : g.hash)}
+                >
+                  <ListItemText
+                    primary={`${g.books[0]?.title || '(unknown)'} — ${g.books.length} copies`}
+                    secondary={`hash: ${g.hash.slice(0, 16)}…`}
+                  />
+                  <Chip size="small" label={`${g.books.length} books`} sx={{ ml: 1 }} />
+                </ListItem>
+                <Collapse in={expanded === g.hash}>
+                  <List dense disablePadding sx={{ pl: 2 }}>
+                    {g.books.map((b) => (
+                      <ListItem key={b.id} disableGutters>
+                        <ListItemText
+                          primary={b.title}
+                          secondary={`ID: ${b.id}`}
+                        />
+                        <Chip size="small" label={`${b.file_count} files`} variant="outlined" sx={{ ml: 1 }} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </Collapse>
+              </Box>
+            ))}
+          </List>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── MaintenanceTab ───────────────────────────────────────────────────────────
 
 export function MaintenanceTab() {
@@ -480,6 +570,8 @@ export function MaintenanceTab() {
       <ChapterConsolidationCard />
 
       <SHADuplicateCard />
+
+      <MetadataHashDuplicateCard />
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.10.0
+// version: 2.11.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -4524,4 +4524,30 @@ export async function scanDuplicateFiles(limit?: number): Promise<DuplicateFiles
   }
   const body_data = await response.json();
   return body_data.data ?? body_data;
+}
+
+// ── MATCH-4: metadata-hash duplicate scan ─────────────────────────────────────
+
+export interface MetadataHashDupBook {
+  id: string;
+  title: string;
+  file_count: number;
+}
+
+export interface MetadataHashDupGroup {
+  hash: string;
+  books: MetadataHashDupBook[];
+}
+
+export interface MetadataHashDuplicatesResult {
+  groups: MetadataHashDupGroup[];
+  total_duplicate_books: number;
+}
+
+export async function findMetadataHashDuplicates(): Promise<MetadataHashDuplicatesResult> {
+  const response = await fetch(`${API_BASE}/maintenance/metadata-hash-duplicates`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to scan metadata-hash duplicates');
+  }
+  return response.json();
 }


### PR DESCRIPTION
## MATCH-4 — Metadata Hash Duplicate Detection

When the same metadata URL/response is applied to two different books, they are automatically flagged as duplicates with a canonical primary chosen by highest file count.

### Changes

**Backend:**
- `iface_book.go`: `FlagMetadataHashDuplicate(primaryID, duplicateID string)` added to `BookWriter`
- `sqlite_store.go`: Full implementation — sets `merged_into_book_id` + `is_primary_version=0`; `GetBooksByMetadataSourceHash` excludes already-merged books
- `pebble_store.go`: Stub via `UpdateBook`; mock stubs updated
- `metafetch/service.go`: `checkMetadataSourceHashDuplicates` now performs full MATCH-4 merge logic (was log-only)
- `maintenance_fixups.go` + `server.go`: `GET /api/v1/maintenance/metadata-hash-duplicates` endpoint

**Frontend:**
- `api.ts`: `findMetadataHashDuplicates()` helper + result types
- `MaintenanceTab.tsx`: `MetadataHashDuplicateCard` with scan + expandable results