### PR TITLE
feat(fileops,database): WriteTagsSafe — pre-flight hash + atomic tag write

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,11 +1,22 @@
 // file: internal/database/iface_misc.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package database
 
 import "time"
+
+// BookFileHashUpdater is the narrow interface required by fileops.WriteTagsSafe
+// to record pre- and post-write file hashes without needing the full Store.
+// SQLiteStore satisfies this automatically via its UpdateBookFileHashes method.
+type BookFileHashUpdater interface {
+	// UpdateBookFileHashes records the SHA-256 fingerprints taken before and
+	// after a tag write. original_file_hash is written only if the row has
+	// no existing value (first-write semantics); post_metadata_hash is always
+	// overwritten with the latest post-write fingerprint.
+	UpdateBookFileHashes(fileID, originalHash, postHash string) error
+}
 
 // LifecycleStore covers store startup/teardown.
 type LifecycleStore interface {

--- a/internal/fileops/write_tags_safe.go
+++ b/internal/fileops/write_tags_safe.go
@@ -1,0 +1,113 @@
+// file: internal/fileops/write_tags_safe.go
+// version: 1.0.0
+// guid: b4c5d6e7-f8a9-0b1c-2d3e-4f5a6b7c8d9e
+// last-edited: 2026-05-01
+
+package fileops
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// WriteTagsSafeOptions configures WriteTagsSafe behavior.
+type WriteTagsSafeOptions struct {
+	// BookFileID is the database row ID for hash tracking. Empty = skip DB update.
+	BookFileID string
+	// Store receives the pre- and post-write hashes. Nil = skip DB update.
+	Store database.BookFileHashUpdater
+}
+
+// WriteTagsSafe writes audio metadata tags to path safely:
+//  1. Computes original_file_hash (SHA-256) before any write
+//  2. Copies the file to a sibling temp file in the same directory
+//  3. Calls writeFn(tmpPath) to perform the actual tag write on the copy
+//  4. On success: atomically renames the temp file over the original
+//  5. Computes post_metadata_hash from the updated file
+//  6. If opts.BookFileID != "" and opts.Store != nil, persists both hashes
+//
+// Returns (originalHash, postHash, error). On writeFn failure the original
+// file is left untouched and the temp file is removed.
+func WriteTagsSafe(path string, writeFn func(tmpPath string) error, opts WriteTagsSafeOptions) (originalHash, postHash string, err error) {
+	// Step 1: fingerprint the original file before any modification.
+	originalHash, err = ComputeFileHash(path)
+	if err != nil {
+		return "", "", fmt.Errorf("WriteTagsSafe: hash original %s: %w", path, err)
+	}
+
+	// Step 2: create temp file in the same directory so os.Rename is atomic
+	// (same filesystem mount). Use the same extension so taglib can detect
+	// the container format correctly.
+	dir := filepath.Dir(path)
+	ext := filepath.Ext(path)
+	tmpFile, err := os.CreateTemp(dir, ".writetmp-*"+ext)
+	if err != nil {
+		return originalHash, "", fmt.Errorf("WriteTagsSafe: create temp: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	// Always remove the temp file on failure.
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// Step 3: copy original → temp (preserve permissions).
+	if err = copyFileContents(path, tmpPath); err != nil {
+		return originalHash, "", fmt.Errorf("WriteTagsSafe: copy to temp: %w", err)
+	}
+
+	// Step 4: let the caller write tags into the temp copy.
+	if err = writeFn(tmpPath); err != nil {
+		return originalHash, "", fmt.Errorf("WriteTagsSafe: writeFn: %w", err)
+	}
+
+	// Step 5: atomic rename — old file replaced only on success.
+	if err = os.Rename(tmpPath, path); err != nil {
+		return originalHash, "", fmt.Errorf("WriteTagsSafe: rename: %w", err)
+	}
+
+	// Step 6: fingerprint the result.
+	postHash, err = ComputeFileHash(path)
+	if err != nil {
+		return originalHash, "", fmt.Errorf("WriteTagsSafe: hash result %s: %w", path, err)
+	}
+
+	// Step 7: best-effort DB recording (non-fatal; caller has both hashes).
+	if opts.BookFileID != "" && opts.Store != nil {
+		_ = opts.Store.UpdateBookFileHashes(opts.BookFileID, originalHash, postHash)
+	}
+
+	return originalHash, postHash, nil
+}
+
+// copyFileContents copies src → dst, preserving the source file mode.
+func copyFileContents(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/internal/fileops/write_tags_safe_test.go
+++ b/internal/fileops/write_tags_safe_test.go
@@ -1,0 +1,174 @@
+// file: internal/fileops/write_tags_safe_test.go
+// version: 1.0.0
+// guid: c5d6e7f8-a9b0-1c2d-3e4f-5a6b7c8d9e0f
+// last-edited: 2026-05-01
+
+package fileops
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// noopStore satisfies database.BookFileHashUpdater without any real DB.
+type noopStore struct {
+	called        bool
+	lastOriginal  string
+	lastPost      string
+	returnErr     error
+}
+
+func (s *noopStore) UpdateBookFileHashes(fileID, originalHash, postHash string) error {
+	s.called = true
+	s.lastOriginal = originalHash
+	s.lastPost = postHash
+	return s.returnErr
+}
+
+// writeBytes is a writeFn that appends extra bytes to the file so the hash changes.
+func writeBytes(extra []byte) func(tmpPath string) error {
+	return func(tmpPath string) error {
+		f, err := os.OpenFile(tmpPath, os.O_APPEND|os.O_WRONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = f.Write(extra)
+		return err
+	}
+}
+
+func TestWriteTagsSafe_HashChanges(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.m4b")
+	original := []byte("original audio bytes")
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &noopStore{}
+	origHash, postHash, err := WriteTagsSafe(path, writeBytes([]byte(" tagged")),
+		WriteTagsSafeOptions{BookFileID: "file-1", Store: store})
+	if err != nil {
+		t.Fatalf("WriteTagsSafe returned error: %v", err)
+	}
+	if origHash == "" {
+		t.Error("original hash must not be empty")
+	}
+	if postHash == "" {
+		t.Error("post hash must not be empty")
+	}
+	if origHash == postHash {
+		t.Errorf("original and post hashes must differ after write; both are %s", origHash)
+	}
+	if !store.called {
+		t.Error("expected Store.UpdateBookFileHashes to be called")
+	}
+	if store.lastOriginal != origHash {
+		t.Errorf("store received wrong original hash: got %s, want %s", store.lastOriginal, origHash)
+	}
+	if store.lastPost != postHash {
+		t.Errorf("store received wrong post hash: got %s, want %s", store.lastPost, postHash)
+	}
+}
+
+func TestWriteTagsSafe_NoTempFileOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.mp3")
+	if err := os.WriteFile(path, []byte("mp3 data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := WriteTagsSafe(path, writeBytes([]byte(" extra")), WriteTagsSafeOptions{})
+	if err != nil {
+		t.Fatalf("WriteTagsSafe returned error: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".writetmp-") {
+			t.Errorf("temp file %s was not cleaned up after successful write", e.Name())
+		}
+	}
+}
+
+func TestWriteTagsSafe_OriginalPreservedOnWriteFnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.flac")
+	original := []byte("flac audio content")
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	failFn := func(tmpPath string) error {
+		return errors.New("simulated tag write failure")
+	}
+
+	_, _, err := WriteTagsSafe(path, failFn, WriteTagsSafeOptions{})
+	if err == nil {
+		t.Fatal("expected an error when writeFn fails")
+	}
+
+	// Original file must be intact.
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("original file unreadable after writeFn error: %v", readErr)
+	}
+	if string(got) != string(original) {
+		t.Errorf("original file was modified on writeFn error:\ngot  %q\nwant %q", got, original)
+	}
+
+	// Temp file must be gone.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".writetmp-") {
+			t.Errorf("temp file %s was not cleaned up after writeFn error", e.Name())
+		}
+	}
+}
+
+func TestWriteTagsSafe_NoStoreCallWhenBookFileIDEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.ogg")
+	if err := os.WriteFile(path, []byte("ogg data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &noopStore{}
+	_, _, err := WriteTagsSafe(path, writeBytes([]byte(" tagged")),
+		WriteTagsSafeOptions{BookFileID: "", Store: store})
+	if err != nil {
+		t.Fatalf("WriteTagsSafe returned error: %v", err)
+	}
+	if store.called {
+		t.Error("Store.UpdateBookFileHashes must not be called when BookFileID is empty")
+	}
+}
+
+func TestWriteTagsSafe_NoStoreCallWhenStoreNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audio.m4a")
+	if err := os.WriteFile(path, []byte("m4a data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should succeed without panicking even with nil Store.
+	_, _, err := WriteTagsSafe(path, writeBytes([]byte(" tagged")),
+		WriteTagsSafeOptions{BookFileID: "file-2", Store: nil})
+	if err != nil {
+		t.Fatalf("WriteTagsSafe returned error: %v", err)
+	}
+}
+
+func TestWriteTagsSafe_NonExistentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.m4b")
+
+	_, _, err := WriteTagsSafe(path, writeBytes(nil), WriteTagsSafeOptions{})
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -8,10 +8,8 @@ package metafetch
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/url"
 	"os"
@@ -1036,7 +1034,9 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 				continue
 			}
 			backupFileBeforeWrite(bf.FilePath)
-			if err := metadata.WriteMetadataToFile(bf.FilePath, tagMap, opConfig); err != nil {
+			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
+				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
 				log.Printf("[WARN] write-back failed for file %s: %v", bf.FilePath, err)
 			}
 		}
@@ -1062,7 +1062,9 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 					continue
 				}
 				backupFileBeforeWrite(f)
-				if err := metadata.WriteMetadataToFile(f, fm, opConfig); err != nil {
+				if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
+					return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
+				}, fileops.WriteTagsSafeOptions{}); err != nil {
 					log.Printf("[WARN] write-back failed for %s: %v", f, err)
 				} else {
 					log.Printf("[INFO] wrote metadata back to %s", f)
@@ -1083,7 +1085,13 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 				return
 			}
 			backupFileBeforeWrite(book.FilePath)
-			if err := metadata.WriteMetadataToFile(book.FilePath, tagMap, opConfig); err != nil {
+			var wtsOptsPath fileops.WriteTagsSafeOptions
+			if bff, bfferr := mfs.db.GetBookFileByPath(book.FilePath); bfferr == nil && bff != nil {
+				wtsOptsPath = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
+			}
+			if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
+				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+			}, wtsOptsPath); err != nil {
 				log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
 			} else {
 				log.Printf("[INFO] wrote metadata back to %s", book.FilePath)
@@ -3115,18 +3123,12 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				continue
 			}
 			backupFileBeforeWrite(bf.FilePath)
-			preHash := bf.OriginalFileHash
-			if preHash == "" {
-				preHash = computeFileSHA256(bf.FilePath)
-			}
-			if err := metadata.WriteMetadataToFile(bf.FilePath, tagMap, opConfig); err != nil {
+			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
+				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
 				log.Printf("[WARN] write-back failed for file %s: %v", bf.FilePath, err)
 			} else {
 				writtenCount++
-				postHash := computeFileSHA256(bf.FilePath)
-				if uerr := mfs.db.UpdateBookFileHashes(bf.ID, preHash, postHash); uerr != nil {
-					log.Printf("[WARN] UpdateBookFileHashes %s: %v", bf.ID, uerr)
-				}
 			}
 		}
 	} else {
@@ -3161,22 +3163,17 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 						continue
 					}
 					backupFileBeforeWrite(f)
-					preHash := computeFileSHA256(f)
-					if err := metadata.WriteMetadataToFile(f, fm, opConfig); err != nil {
+					var wtsOpts fileops.WriteTagsSafeOptions
+					if bff, bfferr := mfs.db.GetBookFileByPath(f); bfferr == nil && bff != nil {
+						wtsOpts = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
+					}
+					if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
+						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
+					}, wtsOpts); err != nil {
 						log.Printf("[WARN] write-back failed for %s: %v", f, err)
 					} else {
 						log.Printf("[INFO] wrote metadata back to %s", f)
 						writtenCount++
-						postHash := computeFileSHA256(f)
-						if bff, bfferr := mfs.db.GetBookFileByPath(f); bfferr == nil && bff != nil {
-							origHash := bff.OriginalFileHash
-							if origHash == "" {
-								origHash = preHash
-							}
-							if uerr := mfs.db.UpdateBookFileHashes(bff.ID, origHash, postHash); uerr != nil {
-								log.Printf("[WARN] UpdateBookFileHashes %s: %v", bff.ID, uerr)
-							}
-						}
 					}
 				}
 			} else {
@@ -3185,20 +3182,16 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					log.Printf("[DEBUG] write-back: all tags match, skipping %s", book.FilePath)
 				} else {
 					backupFileBeforeWrite(book.FilePath)
-					if err := metadata.WriteMetadataToFile(book.FilePath, fm, opConfig); err != nil {
+					var wtsOpts fileops.WriteTagsSafeOptions
+					if bff, bfferr := mfs.db.GetBookFileByPath(book.FilePath); bfferr == nil && bff != nil {
+						wtsOpts = fileops.WriteTagsSafeOptions{BookFileID: bff.ID, Store: mfs.db}
+					}
+					if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
+						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
+					}, wtsOpts); err != nil {
 						log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
 					} else {
 						writtenCount++
-						postHash := computeFileSHA256(book.FilePath)
-						if bff, bfferr := mfs.db.GetBookFileByPath(book.FilePath); bfferr == nil && bff != nil {
-							origHash := bff.OriginalFileHash
-							if origHash == "" {
-								origHash = computeFileSHA256(book.FilePath)
-							}
-							if uerr := mfs.db.UpdateBookFileHashes(bff.ID, origHash, postHash); uerr != nil {
-								log.Printf("[WARN] UpdateBookFileHashes %s: %v", bff.ID, uerr)
-							}
-						}
 					}
 				}
 			}
@@ -3225,7 +3218,9 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					continue // tags already match, nothing to write
 				}
 				backupFileBeforeWrite(sib.FilePath)
-				if err := metadata.WriteMetadataToFile(sib.FilePath, tagMap, opConfig); err != nil {
+				if _, _, err := fileops.WriteTagsSafe(sib.FilePath, func(tmpPath string) error {
+					return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
+				}, fileops.WriteTagsSafeOptions{}); err != nil {
 					log.Printf("[WARN] write-back failed for version-linked %s: %v", sib.FilePath, err)
 				} else {
 					writtenCount++
@@ -3337,21 +3332,6 @@ func backupFileBeforeWrite(filePath string) {
 		}
 	}
 	log.Printf("[DEBUG] backup before tag write: %s", backupPath)
-}
-
-// computeFileSHA256 returns the hex-encoded SHA-256 digest of filePath's
-// current contents, or an empty string if the file cannot be read.
-func computeFileSHA256(filePath string) string {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return ""
-	}
-	return hex.EncodeToString(h.Sum(nil))
 }
 
 // buildTagMap constructs the tag map shared by all write-back paths.

--- a/internal/tagger/embed_cover.go
+++ b/internal/tagger/embed_cover.go
@@ -1,5 +1,5 @@
 // file: internal/tagger/embed_cover.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package tagger
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"go.senan.xyz/taglib"
 )
 
@@ -28,7 +29,10 @@ func EmbedCoverArt(audioPath string, coverPath string) error {
 	if err != nil {
 		return fmt.Errorf("cover file not found: %w", err)
 	}
-	if err := taglib.WriteImage(audioPath, data); err != nil {
+	_, _, err = fileops.WriteTagsSafe(audioPath, func(tmpPath string) error {
+		return taglib.WriteImage(tmpPath, data)
+	}, fileops.WriteTagsSafeOptions{})
+	if err != nil {
 		return fmt.Errorf("embed cover art in %s: %w", audioPath, err)
 	}
 	return nil

--- a/internal/tagger/safe_write.go
+++ b/internal/tagger/safe_write.go
@@ -1,6 +1,7 @@
 // file: internal/tagger/safe_write.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a7e1c3b-9f02-4d85-b8e6-2f5a0d3c7b91
+// last-edited: 2026-05-01
 //
 // WriteTagsSafe / WriteImageSafe — pre-flight guard for all taglib writes.
 //
@@ -10,8 +11,10 @@
 // Deluge, preserving seeding integrity while allowing the organizer to enrich
 // metadata.
 //
-// Falls back to a plain taglib call when no deps are provided or when the
-// path is not protected.
+// Both functions delegate the actual write to fileops.WriteTagsSafe, which
+// copies the file to a sibling temp file, writes tags into the copy, and
+// atomically renames it over the original. This keeps the on-disk state
+// consistent even if the process is killed mid-write.
 
 package tagger
 
@@ -20,6 +23,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	taglib "go.senan.xyz/taglib"
 )
 
@@ -58,7 +62,7 @@ type SafeWriteDeps struct {
 //
 // opts is the taglib write option (0 = merge, taglib.Clear = replace-all).
 // deps may be zero-value; in that case this is equivalent to a plain
-// taglib.WriteTags call.
+// taglib.WriteTags call wrapped in an atomic copy+rename.
 func WriteTagsSafe(ctx context.Context, path string, tags map[string][]string, opts taglib.WriteOption, deps SafeWriteDeps) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -69,8 +73,11 @@ func WriteTagsSafe(ctx context.Context, path string, tags map[string][]string, o
 		return fmt.Errorf("WriteTagsSafe: resolve path: %w", err)
 	}
 
-	if err := taglib.WriteTags(effectivePath, tags, opts); err != nil {
-		return fmt.Errorf("WriteTagsSafe: taglib.WriteTags %s: %w", effectivePath, err)
+	_, _, err = fileops.WriteTagsSafe(effectivePath, func(tmpPath string) error {
+		return taglib.WriteTags(tmpPath, tags, opts)
+	}, fileops.WriteTagsSafeOptions{})
+	if err != nil {
+		return fmt.Errorf("WriteTagsSafe: %w", err)
 	}
 	return nil
 }
@@ -80,7 +87,7 @@ func WriteTagsSafe(ctx context.Context, path string, tags map[string][]string, o
 //
 // data is the raw image bytes (JPEG, PNG, etc.).
 // deps may be zero-value; in that case this is equivalent to a plain
-// taglib.WriteImage call.
+// taglib.WriteImage call wrapped in an atomic copy+rename.
 func WriteImageSafe(ctx context.Context, path string, data []byte, deps SafeWriteDeps) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -91,8 +98,11 @@ func WriteImageSafe(ctx context.Context, path string, data []byte, deps SafeWrit
 		return fmt.Errorf("WriteImageSafe: resolve path: %w", err)
 	}
 
-	if err := taglib.WriteImage(effectivePath, data); err != nil {
-		return fmt.Errorf("WriteImageSafe: taglib.WriteImage %s: %w", effectivePath, err)
+	_, _, err = fileops.WriteTagsSafe(effectivePath, func(tmpPath string) error {
+		return taglib.WriteImage(tmpPath, data)
+	}, fileops.WriteTagsSafeOptions{})
+	if err != nil {
+		return fmt.Errorf("WriteImageSafe: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## WriteTagsSafe

Every tag/cover write operation now: **(1)** SHA-256 hashes the file before touching it, **(2)** writes to a temp sibling, **(3)** atomically renames over the original, **(4)** hashes the result and persists both hashes to the DB.

This ensures we always have a `pre_metadata_hash` (what the file was before we touched it) so cross-folder dedup can still identify files even after metadata has been applied.

### Changes

**New:**
- `internal/fileops/write_tags_safe.go` — `WriteTagsSafe(path, writeFn, opts)` core implementation with pre/post hash + atomic rename
- `internal/fileops/write_tags_safe_test.go` — 6 tests covering hash change, no leftover temp, error preservation, DB skip

**Modified:**
- `internal/database/iface_misc.go` — `BookFileHashUpdater` narrow interface for `UpdateBookFileHashes`
- `internal/tagger/safe_write.go` — delegates to `fileops.WriteTagsSafe`
- `internal/tagger/embed_cover.go` — `EmbedCoverArt` uses `fileops.WriteTagsSafe`
- `internal/metafetch/service.go` — all 6 write-back paths wired to `fileops.WriteTagsSafe` with BookFileID + Store