### PR TITLE
fix(database,scanner): store import path book count after scan, not on every read

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 // last-edited: 2026-05-01
 
@@ -187,6 +187,10 @@ type ImportPathStore interface {
 	CreateImportPath(path, name string) (*ImportPath, error)
 	UpdateImportPath(id int, importPath *ImportPath) error
 	DeleteImportPath(id int) error
+	// CountBooksByPathPrefix returns the total number of books whose FilePath
+	// starts with the given prefix. Used to persist accurate BookCount on
+	// ImportPath after a scan without doing a live count on every read.
+	CountBooksByPathPrefix(prefix string) (int, error)
 }
 
 // MetadataStore covers MetadataFieldState, change history, and

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -918,6 +918,10 @@ func (m *MockStore) DeleteImportPath(id int) error {
 	return nil
 }
 
+func (m *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	return 0, nil
+}
+
 func (m *MockStore) CreateOperation(id, opType string, folderPath *string) (*Operation, error) {
 	if m.CreateOperationFunc != nil {
 		return m.CreateOperationFunc(id, opType, folderPath)

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -14824,6 +14824,12 @@ func (_c *MockImportPathStore_DeleteImportPath_Call) RunAndReturn(run func(id in
 	return _c
 }
 
+// CountBooksByPathPrefix provides a mock function for the type MockImportPathStore
+func (_mock *MockImportPathStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	ret := _mock.Called(prefix)
+	return ret.Int(0), ret.Error(1)
+}
+
 // GetAllImportPaths provides a mock function for the type MockImportPathStore
 func (_mock *MockImportPathStore) GetAllImportPaths() ([]database.ImportPath, error) {
 	ret := _mock.Called()
@@ -27575,6 +27581,12 @@ func (_c *MockStore_DeleteImportPath_Call) Return(err error) *MockStore_DeleteIm
 func (_c *MockStore_DeleteImportPath_Call) RunAndReturn(run func(id int) error) *MockStore_DeleteImportPath_Call {
 	_c.Call.Return(run)
 	return _c
+}
+
+// CountBooksByPathPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	ret := _mock.Called(prefix)
+	return ret.Int(0), ret.Error(1)
 }
 
 // DeleteInvite provides a mock function for the type MockStore

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.63.0
+// version: 1.64.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-01
 
@@ -2592,38 +2592,35 @@ func (p *PebbleStore) GetAllImportPaths() ([]ImportPath, error) {
 		importPaths = append(importPaths, importPath)
 	}
 
-	if len(importPaths) == 0 {
-		return importPaths, nil
-	}
+	return importPaths, nil
+}
 
-	// Live-count books per import path by iterating all books.
-	// The stored BookCount is stale (set only at creation time), so we
-	// recompute it here to keep the storage page accurate.
-	counts := make(map[int]int, len(importPaths))
-	bookIter, berr := p.db.NewIter(&pebble.IterOptions{
+// CountBooksByPathPrefix returns the number of books whose FilePath starts
+// with prefix. Called by updateImportPathBookCount after each scan to persist
+// an accurate BookCount without live-counting on every read.
+func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	if prefix == "" {
+		return 0, nil
+	}
+	count := 0
+	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
 		UpperBound: []byte("book:;"),
 	})
-	if berr == nil {
-		defer bookIter.Close()
-		for bookIter.First(); bookIter.Valid(); bookIter.Next() {
-			var b Book
-			if json.Unmarshal(bookIter.Value(), &b) != nil {
-				continue
-			}
-			for _, ip := range importPaths {
-				if ip.Path != "" && strings.HasPrefix(b.FilePath, ip.Path) {
-					counts[ip.ID]++
-					break
-				}
-			}
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		var b Book
+		if json.Unmarshal(iter.Value(), &b) != nil {
+			continue
 		}
-		for i := range importPaths {
-			importPaths[i].BookCount = counts[importPaths[i].ID]
+		if strings.HasPrefix(b.FilePath, prefix) {
+			count++
 		}
 	}
-
-	return importPaths, nil
+	return count, nil
 }
 
 func (p *PebbleStore) GetImportPathByID(id int) (*ImportPath, error) {

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.75.0
+// version: 1.76.0
 // last-edited: 2026-05-01
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -3493,7 +3493,18 @@ func (s *SQLiteStore) DeleteImportPath(id int) error {
 	return err
 }
 
-// Operation operations
+// CountBooksByPathPrefix returns the total number of books whose file_path
+// starts with prefix. Used to persist accurate BookCount on ImportPath after
+// a scan without live-counting on every read.
+func (s *SQLiteStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	var count int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM books WHERE file_path LIKE ? || '%'", prefix,
+	).Scan(&count)
+	return count, err
+}
+
+
 
 func (s *SQLiteStore) CreateOperation(id, opType string, folderPath *string) (*Operation, error) {
 	now := time.Now()

--- a/internal/server/scan_service.go
+++ b/internal/server/scan_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/scan_service.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package server
@@ -349,11 +349,20 @@ func (ss *ScanService) autoOrganizeScannedBooks(_ context.Context, books []scann
 	}
 }
 
-func (ss *ScanService) updateImportPathBookCount(folderPath string, bookCount int, log logger.Logger) {
+// updateImportPathBookCount stores the accurate total book count for an import
+// path after a scan. It queries the DB for the real total (not just what was
+// found in this incremental batch) so the stored count stays correct across
+// both full and incremental scans.
+func (ss *ScanService) updateImportPathBookCount(folderPath string, _ int, log logger.Logger) {
+	total, err := ss.db.CountBooksByPathPrefix(folderPath)
+	if err != nil {
+		log.Warn("Failed to count books for folder %s: %v", folderPath, err)
+		return
+	}
 	folders, _ := ss.db.GetAllImportPaths()
 	for _, folder := range folders {
 		if folder.Path == folderPath {
-			folder.BookCount = bookCount
+			folder.BookCount = total
 			if err := ss.db.UpdateImportPath(folder.ID, &folder); err != nil {
 				log.Warn("Failed to update book count for folder %s: %v", folderPath, err)
 			}


### PR DESCRIPTION
## Fix import path book count

The previous approach live-counted books on every `GetAllImportPaths()` call (expensive on every page load). This replaces it with the correct pattern: count once after a scan, store it, read it cheaply.

### Root cause
`updateImportPathBookCount` was passing `len(books)` from the current incremental scan batch — not the total stored in the DB. So after an incremental scan that found 5 new books, the count was stored as 5, not 17000+.

### Changes
- **`ImportPathStore` interface**: `CountBooksByPathPrefix(prefix string) (int, error)`
- **`PebbleStore`**: key-scan implementation; `GetAllImportPaths` reverted to simple read
- **`SQLiteStore`**: `SELECT COUNT(*) WHERE file_path LIKE prefix || '%'`
- **`ScanService.updateImportPathBookCount`**: calls `CountBooksByPathPrefix` for the real total, stores it via `UpdateImportPath`
- Mocks updated