### PR TITLE
fix(database,scanner,server): track source_import_path to fix book count after auto-organize

### DIFF
--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -109,12 +109,13 @@ type MockStore struct {
 	GetBookChangeHistoryFunc     func(bookID string, limit int) ([]MetadataChangeRecord, error)
 
 	// Import Paths
-	GetAllImportPathsFunc   func() ([]ImportPath, error)
-	GetImportPathByIDFunc   func(id int) (*ImportPath, error)
-	GetImportPathByPathFunc func(path string) (*ImportPath, error)
-	CreateImportPathFunc    func(path, name string) (*ImportPath, error)
-	UpdateImportPathFunc    func(id int, importPath *ImportPath) error
-	DeleteImportPathFunc    func(id int) error
+	GetAllImportPathsFunc         func() ([]ImportPath, error)
+	GetImportPathByIDFunc         func(id int) (*ImportPath, error)
+	GetImportPathByPathFunc       func(path string) (*ImportPath, error)
+	CreateImportPathFunc          func(path, name string) (*ImportPath, error)
+	UpdateImportPathFunc          func(id int, importPath *ImportPath) error
+	DeleteImportPathFunc          func(id int) error
+	CountBooksByPathPrefixFunc    func(prefix string) (int, error)
 
 	// Operations
 	CreateOperationFunc           func(id, opType string, folderPath *string) (*Operation, error)
@@ -919,6 +920,9 @@ func (m *MockStore) DeleteImportPath(id int) error {
 }
 
 func (m *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	if m.CountBooksByPathPrefixFunc != nil {
+		return m.CountBooksByPathPrefixFunc(prefix)
+	}
 	return 0, nil
 }
 

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3153,6 +3153,68 @@ func (_c *MockBookReader_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID
 	return _c
 }
 
+// GetBooksByMetadataSourceHash provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+	ret := _mock.Called(hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByMetadataSourceHash")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+		return returnFunc(hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+		r0 = returnFunc(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockBookReader_GetBooksByMetadataSourceHash_Call struct {
+	*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBookReader_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+	return &MockBookReader_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBooksBySeriesID provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
 	ret := _mock.Called(seriesID)
@@ -4206,60 +4268,6 @@ func (_c *MockBookWriter_DeleteBook_Call) RunAndReturn(run func(id string) error
 	return _c
 }
 
-// FlagMetadataHashDuplicate provides a mock function for the type MockBookWriter
-func (_mock *MockBookWriter) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
-	ret := _mock.Called(primaryID, duplicateID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FlagMetadataHashDuplicate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(primaryID, duplicateID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockBookWriter_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
-type MockBookWriter_FlagMetadataHashDuplicate_Call struct {
-	*mock.Call
-}
-
-// FlagMetadataHashDuplicate is a helper method to define mock.On call
-//   - primaryID string
-//   - duplicateID string
-func (_e *MockBookWriter_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookWriter_FlagMetadataHashDuplicate_Call {
-	return &MockBookWriter_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
-}
-
-func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookWriter_FlagMetadataHashDuplicate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // DeleteBookTombstone provides a mock function for the type MockBookWriter
 func (_mock *MockBookWriter) DeleteBookTombstone(id string) error {
 	ret := _mock.Called(id)
@@ -4307,6 +4315,63 @@ func (_c *MockBookWriter_DeleteBookTombstone_Call) Return(err error) *MockBookWr
 }
 
 func (_c *MockBookWriter_DeleteBookTombstone_Call) RunAndReturn(run func(id string) error) *MockBookWriter_DeleteBookTombstone_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FlagMetadataHashDuplicate provides a mock function for the type MockBookWriter
+func (_mock *MockBookWriter) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookWriter_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockBookWriter_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockBookWriter_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	return &MockBookWriter_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4487,6 +4552,75 @@ func (_c *MockBookWriter_MarkITunesSynced_Call) Return(n int64, err error) *Mock
 }
 
 func (_c *MockBookWriter_MarkITunesSynced_Call) RunAndReturn(run func(bookIDs []string) (int64, error)) *MockBookWriter_MarkITunesSynced_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MergeChapterBooks provides a mock function for the type MockBookWriter
+func (_mock *MockBookWriter) MergeChapterBooks(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error {
+	ret := _mock.Called(primaryID, srcIDs, commonTitle, totalDuration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MergeChapterBooks")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []string, string, float64) error); ok {
+		r0 = returnFunc(primaryID, srcIDs, commonTitle, totalDuration)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookWriter_MergeChapterBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MergeChapterBooks'
+type MockBookWriter_MergeChapterBooks_Call struct {
+	*mock.Call
+}
+
+// MergeChapterBooks is a helper method to define mock.On call
+//   - primaryID string
+//   - srcIDs []string
+//   - commonTitle string
+//   - totalDuration float64
+func (_e *MockBookWriter_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockBookWriter_MergeChapterBooks_Call {
+	return &MockBookWriter_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
+}
+
+func (_c *MockBookWriter_MergeChapterBooks_Call) Run(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64)) *MockBookWriter_MergeChapterBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 float64
+		if args[3] != nil {
+			arg3 = args[3].(float64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookWriter_MergeChapterBooks_Call) Return(err error) *MockBookWriter_MergeChapterBooks_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookWriter_MergeChapterBooks_Call) RunAndReturn(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error) *MockBookWriter_MergeChapterBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5155,60 +5289,6 @@ func (_c *MockBookStore_DeleteBook_Call) RunAndReturn(run func(id string) error)
 	return _c
 }
 
-// FlagMetadataHashDuplicate provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
-	ret := _mock.Called(primaryID, duplicateID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FlagMetadataHashDuplicate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(primaryID, duplicateID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockBookStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
-type MockBookStore_FlagMetadataHashDuplicate_Call struct {
-	*mock.Call
-}
-
-// FlagMetadataHashDuplicate is a helper method to define mock.On call
-//   - primaryID string
-//   - duplicateID string
-func (_e *MockBookStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookStore_FlagMetadataHashDuplicate_Call {
-	return &MockBookStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
-}
-
-func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockBookStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // DeleteBookTombstone provides a mock function for the type MockBookStore
 func (_mock *MockBookStore) DeleteBookTombstone(id string) error {
 	ret := _mock.Called(id)
@@ -5256,6 +5336,63 @@ func (_c *MockBookStore_DeleteBookTombstone_Call) Return(err error) *MockBookSto
 }
 
 func (_c *MockBookStore_DeleteBookTombstone_Call) RunAndReturn(run func(id string) error) *MockBookStore_DeleteBookTombstone_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FlagMetadataHashDuplicate provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockBookStore_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockBookStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	return &MockBookStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockBookStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockBookStore_FlagMetadataHashDuplicate_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5956,6 +6093,68 @@ func (_c *MockBookStore_GetBooksByAuthorID_Call) Return(books []database.Book, e
 }
 
 func (_c *MockBookStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockBookStore_GetBooksByAuthorID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByMetadataSourceHash provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+	ret := _mock.Called(hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByMetadataSourceHash")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+		return returnFunc(hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+		r0 = returnFunc(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockBookStore_GetBooksByMetadataSourceHash_Call struct {
+	*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBookStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+	return &MockBookStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6924,6 +7123,75 @@ func (_c *MockBookStore_MarkITunesSynced_Call) Return(n int64, err error) *MockB
 }
 
 func (_c *MockBookStore_MarkITunesSynced_Call) RunAndReturn(run func(bookIDs []string) (int64, error)) *MockBookStore_MarkITunesSynced_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MergeChapterBooks provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) MergeChapterBooks(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error {
+	ret := _mock.Called(primaryID, srcIDs, commonTitle, totalDuration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MergeChapterBooks")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []string, string, float64) error); ok {
+		r0 = returnFunc(primaryID, srcIDs, commonTitle, totalDuration)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookStore_MergeChapterBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MergeChapterBooks'
+type MockBookStore_MergeChapterBooks_Call struct {
+	*mock.Call
+}
+
+// MergeChapterBooks is a helper method to define mock.On call
+//   - primaryID string
+//   - srcIDs []string
+//   - commonTitle string
+//   - totalDuration float64
+func (_e *MockBookStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockBookStore_MergeChapterBooks_Call {
+	return &MockBookStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
+}
+
+func (_c *MockBookStore_MergeChapterBooks_Call) Run(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64)) *MockBookStore_MergeChapterBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 float64
+		if args[3] != nil {
+			arg3 = args[3].(float64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_MergeChapterBooks_Call) Return(err error) *MockBookStore_MergeChapterBooks_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookStore_MergeChapterBooks_Call) RunAndReturn(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error) *MockBookStore_MergeChapterBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -13192,6 +13460,68 @@ func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(r
 	return _c
 }
 
+// GetDuplicateFilesByHash provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) GetDuplicateFilesByHash(limit int) ([]database.DuplicateFileGroup, error) {
+	ret := _mock.Called(limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDuplicateFilesByHash")
+	}
+
+	var r0 []database.DuplicateFileGroup
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.DuplicateFileGroup, error)); ok {
+		return returnFunc(limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []database.DuplicateFileGroup); ok {
+		r0 = returnFunc(limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.DuplicateFileGroup)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookFileStore_GetDuplicateFilesByHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateFilesByHash'
+type MockBookFileStore_GetDuplicateFilesByHash_Call struct {
+	*mock.Call
+}
+
+// GetDuplicateFilesByHash is a helper method to define mock.On call
+//   - limit int
+func (_e *MockBookFileStore_Expecter) GetDuplicateFilesByHash(limit interface{}) *MockBookFileStore_GetDuplicateFilesByHash_Call {
+	return &MockBookFileStore_GetDuplicateFilesByHash_Call{Call: _e.mock.On("GetDuplicateFilesByHash", limit)}
+}
+
+func (_c *MockBookFileStore_GetDuplicateFilesByHash_Call) Run(run func(limit int)) *MockBookFileStore_GetDuplicateFilesByHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookFileStore_GetDuplicateFilesByHash_Call) Return(duplicateFileGroups []database.DuplicateFileGroup, err error) *MockBookFileStore_GetDuplicateFilesByHash_Call {
+	_c.Call.Return(duplicateFileGroups, err)
+	return _c
+}
+
+func (_c *MockBookFileStore_GetDuplicateFilesByHash_Call) RunAndReturn(run func(limit int) ([]database.DuplicateFileGroup, error)) *MockBookFileStore_GetDuplicateFilesByHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MoveBookFilesToBook provides a mock function for the type MockBookFileStore
 func (_mock *MockBookFileStore) MoveBookFilesToBook(fileIDs []string, sourceBookID string, targetBookID string) error {
 	ret := _mock.Called(fileIDs, sourceBookID, targetBookID)
@@ -14705,6 +15035,66 @@ func (_m *MockImportPathStore) EXPECT() *MockImportPathStore_Expecter {
 	return &MockImportPathStore_Expecter{mock: &_m.Mock}
 }
 
+// CountBooksByPathPrefix provides a mock function for the type MockImportPathStore
+func (_mock *MockImportPathStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	ret := _mock.Called(prefix)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountBooksByPathPrefix")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
+		return returnFunc(prefix)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
+		r0 = returnFunc(prefix)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(prefix)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockImportPathStore_CountBooksByPathPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountBooksByPathPrefix'
+type MockImportPathStore_CountBooksByPathPrefix_Call struct {
+	*mock.Call
+}
+
+// CountBooksByPathPrefix is a helper method to define mock.On call
+//   - prefix string
+func (_e *MockImportPathStore_Expecter) CountBooksByPathPrefix(prefix interface{}) *MockImportPathStore_CountBooksByPathPrefix_Call {
+	return &MockImportPathStore_CountBooksByPathPrefix_Call{Call: _e.mock.On("CountBooksByPathPrefix", prefix)}
+}
+
+func (_c *MockImportPathStore_CountBooksByPathPrefix_Call) Run(run func(prefix string)) *MockImportPathStore_CountBooksByPathPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockImportPathStore_CountBooksByPathPrefix_Call) Return(n int, err error) *MockImportPathStore_CountBooksByPathPrefix_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockImportPathStore_CountBooksByPathPrefix_Call) RunAndReturn(run func(prefix string) (int, error)) *MockImportPathStore_CountBooksByPathPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateImportPath provides a mock function for the type MockImportPathStore
 func (_mock *MockImportPathStore) CreateImportPath(path string, name string) (*database.ImportPath, error) {
 	ret := _mock.Called(path, name)
@@ -14822,12 +15212,6 @@ func (_c *MockImportPathStore_DeleteImportPath_Call) Return(err error) *MockImpo
 func (_c *MockImportPathStore_DeleteImportPath_Call) RunAndReturn(run func(id int) error) *MockImportPathStore_DeleteImportPath_Call {
 	_c.Call.Return(run)
 	return _c
-}
-
-// CountBooksByPathPrefix provides a mock function for the type MockImportPathStore
-func (_mock *MockImportPathStore) CountBooksByPathPrefix(prefix string) (int, error) {
-	ret := _mock.Called(prefix)
-	return ret.Int(0), ret.Error(1)
 }
 
 // GetAllImportPaths provides a mock function for the type MockImportPathStore
@@ -25189,6 +25573,66 @@ func (_c *MockStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *Mock
 	return _c
 }
 
+// CountBooksByPathPrefix provides a mock function for the type MockStore
+func (_mock *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
+	ret := _mock.Called(prefix)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountBooksByPathPrefix")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
+		return returnFunc(prefix)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
+		r0 = returnFunc(prefix)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(prefix)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CountBooksByPathPrefix_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountBooksByPathPrefix'
+type MockStore_CountBooksByPathPrefix_Call struct {
+	*mock.Call
+}
+
+// CountBooksByPathPrefix is a helper method to define mock.On call
+//   - prefix string
+func (_e *MockStore_Expecter) CountBooksByPathPrefix(prefix interface{}) *MockStore_CountBooksByPathPrefix_Call {
+	return &MockStore_CountBooksByPathPrefix_Call{Call: _e.mock.On("CountBooksByPathPrefix", prefix)}
+}
+
+func (_c *MockStore_CountBooksByPathPrefix_Call) Run(run func(prefix string)) *MockStore_CountBooksByPathPrefix_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CountBooksByPathPrefix_Call) Return(n int, err error) *MockStore_CountBooksByPathPrefix_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountBooksByPathPrefix_Call) RunAndReturn(run func(prefix string) (int, error)) *MockStore_CountBooksByPathPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountFiles provides a mock function for the type MockStore
 func (_mock *MockStore) CountFiles() (int, error) {
 	ret := _mock.Called()
@@ -27214,60 +27658,6 @@ func (_c *MockStore_DeleteBook_Call) RunAndReturn(run func(id string) error) *Mo
 	return _c
 }
 
-// FlagMetadataHashDuplicate provides a mock function for the type MockStore
-func (_mock *MockStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
-	ret := _mock.Called(primaryID, duplicateID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FlagMetadataHashDuplicate")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(primaryID, duplicateID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
-type MockStore_FlagMetadataHashDuplicate_Call struct {
-	*mock.Call
-}
-
-// FlagMetadataHashDuplicate is a helper method to define mock.On call
-//   - primaryID string
-//   - duplicateID string
-func (_e *MockStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockStore_FlagMetadataHashDuplicate_Call {
-	return &MockStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
-}
-
-func (_c *MockStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(string, string) error) *MockStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // DeleteBookFile provides a mock function for the type MockStore
 func (_mock *MockStore) DeleteBookFile(id string) error {
 	ret := _mock.Called(id)
@@ -27581,12 +27971,6 @@ func (_c *MockStore_DeleteImportPath_Call) Return(err error) *MockStore_DeleteIm
 func (_c *MockStore_DeleteImportPath_Call) RunAndReturn(run func(id int) error) *MockStore_DeleteImportPath_Call {
 	_c.Call.Return(run)
 	return _c
-}
-
-// CountBooksByPathPrefix provides a mock function for the type MockStore
-func (_mock *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
-	ret := _mock.Called(prefix)
-	return ret.Int(0), ret.Error(1)
 }
 
 // DeleteInvite provides a mock function for the type MockStore
@@ -28223,6 +28607,63 @@ func (_c *MockStore_FindAuthorByAlias_Call) Return(author *database.Author, err 
 }
 
 func (_c *MockStore_FindAuthorByAlias_Call) RunAndReturn(run func(aliasName string) (*database.Author, error)) *MockStore_FindAuthorByAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FlagMetadataHashDuplicate provides a mock function for the type MockStore
+func (_mock *MockStore) FlagMetadataHashDuplicate(primaryID string, duplicateID string) error {
+	ret := _mock.Called(primaryID, duplicateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlagMetadataHashDuplicate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(primaryID, duplicateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_FlagMetadataHashDuplicate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FlagMetadataHashDuplicate'
+type MockStore_FlagMetadataHashDuplicate_Call struct {
+	*mock.Call
+}
+
+// FlagMetadataHashDuplicate is a helper method to define mock.On call
+//   - primaryID string
+//   - duplicateID string
+func (_e *MockStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockStore_FlagMetadataHashDuplicate_Call {
+	return &MockStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) Run(run func(primaryID string, duplicateID string)) *MockStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockStore_FlagMetadataHashDuplicate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockStore_FlagMetadataHashDuplicate_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -32139,6 +32580,68 @@ func (_c *MockStore_GetBooksByAuthorIDWithRole_Call) RunAndReturn(run func(autho
 	return _c
 }
 
+// GetBooksByMetadataSourceHash provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
+	ret := _mock.Called(hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByMetadataSourceHash")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
+		return returnFunc(hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
+		r0 = returnFunc(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
+type MockStore_GetBooksByMetadataSourceHash_Call struct {
+	*mock.Call
+}
+
+// GetBooksByMetadataSourceHash is a helper method to define mock.On call
+//   - hash string
+func (_e *MockStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockStore_GetBooksByMetadataSourceHash_Call {
+	return &MockStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBooksBySeriesID provides a mock function for the type MockStore
 func (_mock *MockStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
 	ret := _mock.Called(seriesID)
@@ -32850,6 +33353,68 @@ func (_c *MockStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database
 }
 
 func (_c *MockStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockStore_GetDuplicateBooksByMetadata_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetDuplicateFilesByHash provides a mock function for the type MockStore
+func (_mock *MockStore) GetDuplicateFilesByHash(limit int) ([]database.DuplicateFileGroup, error) {
+	ret := _mock.Called(limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDuplicateFilesByHash")
+	}
+
+	var r0 []database.DuplicateFileGroup
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.DuplicateFileGroup, error)); ok {
+		return returnFunc(limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) []database.DuplicateFileGroup); ok {
+		r0 = returnFunc(limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.DuplicateFileGroup)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetDuplicateFilesByHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateFilesByHash'
+type MockStore_GetDuplicateFilesByHash_Call struct {
+	*mock.Call
+}
+
+// GetDuplicateFilesByHash is a helper method to define mock.On call
+//   - limit int
+func (_e *MockStore_Expecter) GetDuplicateFilesByHash(limit interface{}) *MockStore_GetDuplicateFilesByHash_Call {
+	return &MockStore_GetDuplicateFilesByHash_Call{Call: _e.mock.On("GetDuplicateFilesByHash", limit)}
+}
+
+func (_c *MockStore_GetDuplicateFilesByHash_Call) Run(run func(limit int)) *MockStore_GetDuplicateFilesByHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetDuplicateFilesByHash_Call) Return(duplicateFileGroups []database.DuplicateFileGroup, err error) *MockStore_GetDuplicateFilesByHash_Call {
+	_c.Call.Return(duplicateFileGroups, err)
+	return _c
+}
+
+func (_c *MockStore_GetDuplicateFilesByHash_Call) RunAndReturn(run func(limit int) ([]database.DuplicateFileGroup, error)) *MockStore_GetDuplicateFilesByHash_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -38677,6 +39242,75 @@ func (_c *MockStore_MergeBookSegments_Call) RunAndReturn(run func(bookNumericID 
 	return _c
 }
 
+// MergeChapterBooks provides a mock function for the type MockStore
+func (_mock *MockStore) MergeChapterBooks(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error {
+	ret := _mock.Called(primaryID, srcIDs, commonTitle, totalDuration)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MergeChapterBooks")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []string, string, float64) error); ok {
+		r0 = returnFunc(primaryID, srcIDs, commonTitle, totalDuration)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_MergeChapterBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MergeChapterBooks'
+type MockStore_MergeChapterBooks_Call struct {
+	*mock.Call
+}
+
+// MergeChapterBooks is a helper method to define mock.On call
+//   - primaryID string
+//   - srcIDs []string
+//   - commonTitle string
+//   - totalDuration float64
+func (_e *MockStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockStore_MergeChapterBooks_Call {
+	return &MockStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
+}
+
+func (_c *MockStore_MergeChapterBooks_Call) Run(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64)) *MockStore_MergeChapterBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 float64
+		if args[3] != nil {
+			arg3 = args[3].(float64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_MergeChapterBooks_Call) Return(err error) *MockStore_MergeChapterBooks_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_MergeChapterBooks_Call) RunAndReturn(run func(primaryID string, srcIDs []string, commonTitle string, totalDuration float64) error) *MockStore_MergeChapterBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MoveBookFilesToBook provides a mock function for the type MockStore
 func (_mock *MockStore) MoveBookFilesToBook(fileIDs []string, sourceBookID string, targetBookID string) error {
 	ret := _mock.Called(fileIDs, sourceBookID, targetBookID)
@@ -42760,190 +43394,4 @@ func (_c *MockStore_UpsertMetadataFieldState_Call) Return(err error) *MockStore_
 func (_c *MockStore_UpsertMetadataFieldState_Call) RunAndReturn(run func(state *database.MetadataFieldState) error) *MockStore_UpsertMetadataFieldState_Call {
 	_c.Call.Return(run)
 	return _c
-}
-
-// GetBooksByMetadataSourceHash provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
-ret := _mock.Called(hash)
-
-if len(ret) == 0 {
-panic("no return value specified for GetBooksByMetadataSourceHash")
-}
-
-var r0 []database.Book
-var r1 error
-if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
-return returnFunc(hash)
-}
-if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
-r0 = returnFunc(hash)
-} else {
-if ret.Get(0) != nil {
-r0 = ret.Get(0).([]database.Book)
-}
-}
-if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-r1 = returnFunc(hash)
-} else {
-r1 = ret.Error(1)
-}
-return r0, r1
-}
-
-// MockBookReader_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
-type MockBookReader_GetBooksByMetadataSourceHash_Call struct {
-*mock.Call
-}
-
-// GetBooksByMetadataSourceHash is a helper method to define mock.On call
-//   - hash string
-func (_e *MockBookReader_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookReader_GetBooksByMetadataSourceHash_Call {
-return &MockBookReader_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
-}
-
-func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
-_c.Call.Run(func(args mock.Arguments) {
-var arg0 string
-if args[0] != nil {
-arg0 = args[0].(string)
-}
-run(
-arg0,
-)
-})
-return _c
-}
-
-func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(books, err)
-return _c
-}
-
-func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(run)
-return _c
-}
-
-// GetBooksByMetadataSourceHash provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
-ret := _mock.Called(hash)
-
-if len(ret) == 0 {
-panic("no return value specified for GetBooksByMetadataSourceHash")
-}
-
-var r0 []database.Book
-var r1 error
-if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
-return returnFunc(hash)
-}
-if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
-r0 = returnFunc(hash)
-} else {
-if ret.Get(0) != nil {
-r0 = ret.Get(0).([]database.Book)
-}
-}
-if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-r1 = returnFunc(hash)
-} else {
-r1 = ret.Error(1)
-}
-return r0, r1
-}
-
-// MockBookStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
-type MockBookStore_GetBooksByMetadataSourceHash_Call struct {
-*mock.Call
-}
-
-// GetBooksByMetadataSourceHash is a helper method to define mock.On call
-//   - hash string
-func (_e *MockBookStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookStore_GetBooksByMetadataSourceHash_Call {
-return &MockBookStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
-}
-
-func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Run(func(args mock.Arguments) {
-var arg0 string
-if args[0] != nil {
-arg0 = args[0].(string)
-}
-run(
-arg0,
-)
-})
-return _c
-}
-
-func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(books, err)
-return _c
-}
-
-func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(run)
-return _c
-}
-
-// GetBooksByMetadataSourceHash provides a mock function for the type MockStore
-func (_mock *MockStore) GetBooksByMetadataSourceHash(hash string) ([]database.Book, error) {
-ret := _mock.Called(hash)
-
-if len(ret) == 0 {
-panic("no return value specified for GetBooksByMetadataSourceHash")
-}
-
-var r0 []database.Book
-var r1 error
-if returnFunc, ok := ret.Get(0).(func(string) ([]database.Book, error)); ok {
-return returnFunc(hash)
-}
-if returnFunc, ok := ret.Get(0).(func(string) []database.Book); ok {
-r0 = returnFunc(hash)
-} else {
-if ret.Get(0) != nil {
-r0 = ret.Get(0).([]database.Book)
-}
-}
-if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-r1 = returnFunc(hash)
-} else {
-r1 = ret.Error(1)
-}
-return r0, r1
-}
-
-// MockStore_GetBooksByMetadataSourceHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByMetadataSourceHash'
-type MockStore_GetBooksByMetadataSourceHash_Call struct {
-*mock.Call
-}
-
-// GetBooksByMetadataSourceHash is a helper method to define mock.On call
-//   - hash string
-func (_e *MockStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockStore_GetBooksByMetadataSourceHash_Call {
-return &MockStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
-}
-
-func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Run(run func(hash string)) *MockStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Run(func(args mock.Arguments) {
-var arg0 string
-if args[0] != nil {
-arg0 = args[0].(string)
-}
-run(
-arg0,
-)
-})
-return _c
-}
-
-func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Return(books []database.Book, err error) *MockStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(books, err)
-return _c
-}
-
-func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockStore_GetBooksByMetadataSourceHash_Call {
-_c.Call.Return(run)
-return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -2595,9 +2595,10 @@ func (p *PebbleStore) GetAllImportPaths() ([]ImportPath, error) {
 	return importPaths, nil
 }
 
-// CountBooksByPathPrefix returns the number of books whose FilePath starts
-// with prefix. Called by updateImportPathBookCount after each scan to persist
-// an accurate BookCount without live-counting on every read.
+// CountBooksByPathPrefix returns the number of books that originated from the
+// given import path. It checks SourceImportPath first (set on books discovered
+// after the source-import-path change), then falls back to FilePath for older
+// records. This keeps counts correct after auto-organize relocates books.
 func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	if prefix == "" {
 		return 0, nil
@@ -2616,7 +2617,11 @@ func (p *PebbleStore) CountBooksByPathPrefix(prefix string) (int, error) {
 		if json.Unmarshal(iter.Value(), &b) != nil {
 			continue
 		}
-		if strings.HasPrefix(b.FilePath, prefix) {
+		if b.SourceImportPath != nil && *b.SourceImportPath != "" {
+			if strings.HasPrefix(*b.SourceImportPath, prefix) {
+				count++
+			}
+		} else if strings.HasPrefix(b.FilePath, prefix) {
 			count++
 		}
 	}

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -763,6 +763,8 @@ func (s *SQLiteStore) ensureExtendedBookColumns() error {
 		"user_rating_performance":      "REAL",
 		"user_rating_notes":            "TEXT",
 		"metadata_source_hash":         "TEXT",
+		"merged_into_book_id":          "TEXT",
+		"source_import_path":           "TEXT",
 	}
 
 	// Fetch existing columns
@@ -804,6 +806,7 @@ func (s *SQLiteStore) ensureExtendedBookColumns() error {
 		"CREATE INDEX IF NOT EXISTS idx_books_organized_hash ON books(organized_file_hash)",
 		"CREATE INDEX IF NOT EXISTS idx_books_library_state ON books(library_state)",
 		"CREATE INDEX IF NOT EXISTS idx_books_marked_for_deletion ON books(marked_for_deletion)",
+		"CREATE INDEX IF NOT EXISTS idx_books_source_import_path ON books(source_import_path)",
 	}
 	for _, stmt := range indexStatements {
 		if _, err := s.db.Exec(stmt); err != nil {
@@ -2669,8 +2672,9 @@ func (s *SQLiteStore) CreateBook(book *Book) (*Book, error) {
 		bit_depth, quality, is_primary_version, version_group_id, version_notes,
 		original_file_hash, organized_file_hash, library_state, quantity, marked_for_deletion, marked_for_deletion_at,
 		created_at, updated_at, cover_url, narrators_json,
-		last_organize_operation_id, last_organized_at, itunes_sync_status
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		last_organize_operation_id, last_organized_at, itunes_sync_status,
+		source_import_path
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := s.db.Exec(query,
 		book.ID, book.Title, book.AuthorID, book.SeriesID, book.SeriesSequence, book.FilePath, book.OriginalFilename,
 		book.Format, book.Duration, book.WorkID, book.Narrator, book.Edition, book.Description, book.Language, book.Publisher, book.Genre,
@@ -2683,6 +2687,7 @@ func (s *SQLiteStore) CreateBook(book *Book) (*Book, error) {
 		book.OriginalFileHash, book.OrganizedFileHash, book.LibraryState, book.Quantity, book.MarkedForDeletion, book.MarkedForDeletionAt,
 		book.CreatedAt, book.UpdatedAt, book.CoverURL, book.NarratorsJSON,
 		book.LastOrganizeOperationID, book.LastOrganizedAt, book.ITunesSyncStatus,
+		book.SourceImportPath,
 	)
 	if err != nil {
 		return nil, err
@@ -2817,7 +2822,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		audible_rating_count = ?, audible_num_reviews = ?,
 		google_rating_average = ?, google_rating_count = ?,
 		user_rating_overall = ?, user_rating_story = ?, user_rating_performance = ?, user_rating_notes = ?,
-		metadata_source_hash = ?
+		metadata_source_hash = ?,
+		source_import_path = COALESCE(source_import_path, ?)
 	WHERE id = ?`
 	result, err := s.db.Exec(query,
 		book.Title, book.AuthorID, book.SeriesID, book.SeriesSequence,
@@ -2839,7 +2845,8 @@ func (s *SQLiteStore) UpdateBook(id string, book *Book) (*Book, error) {
 		book.AudibleRatingCount, book.AudibleNumReviews,
 		book.GoogleRatingAverage, book.GoogleRatingCount,
 		book.UserRatingOverall, book.UserRatingStory, book.UserRatingPerformance, book.UserRatingNotes,
-		book.MetadataSourceHash, id,
+		book.MetadataSourceHash,
+		book.SourceImportPath, id,
 	)
 	if err != nil {
 		return nil, err
@@ -3493,13 +3500,18 @@ func (s *SQLiteStore) DeleteImportPath(id int) error {
 	return err
 }
 
-// CountBooksByPathPrefix returns the total number of books whose file_path
-// starts with prefix. Used to persist accurate BookCount on ImportPath after
-// a scan without live-counting on every read.
+// CountBooksByPathPrefix returns the total number of books that originated from
+// the given import path. It checks source_import_path first (set on books
+// discovered after this change), and falls back to file_path for older records
+// that pre-date the field. This ensures the count remains correct even after
+// auto-organize relocates books to RootDir.
 func (s *SQLiteStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	var count int
 	err := s.db.QueryRow(
-		"SELECT COUNT(*) FROM books WHERE file_path LIKE ? || '%'", prefix,
+		`SELECT COUNT(*) FROM books
+		  WHERE source_import_path LIKE ? || '%'
+		     OR (source_import_path IS NULL AND file_path LIKE ? || '%')`,
+		prefix, prefix,
 	).Scan(&count)
 	return count, err
 }

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -234,6 +234,12 @@ type Book struct {
 	CoverURL *string `json:"cover_url,omitempty"`
 	// Narrators as JSON array
 	NarratorsJSON *string `json:"narrators_json,omitempty"`
+	// SourceImportPath is the top-level import-path folder this book was FIRST
+	// discovered in (e.g. "/mnt/bigdata/books/newbooks"). Set on CreateBook only;
+	// never mutated on UpdateBook. Survives auto-organize moves so that
+	// CountBooksByPathPrefix can correctly count books even after they have been
+	// relocated to RootDir.
+	SourceImportPath *string `json:"source_import_path,omitempty"`
 	// Scan cache for incremental scanning (set by scanner, not user-facing)
 	LastScanMtime *int64 `json:"last_scan_mtime,omitempty"`
 	LastScanSize  *int64 `json:"last_scan_size,omitempty"`

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -122,9 +122,10 @@ type Book struct {
 	OpenLibraryID   string
 	HardcoverID     string
 	SegmentFiles    []string // For multi-file books grouped by album in mixed directories
-	GoogleBooksID   string
-	FileHash        string // Pre-computed hash from ProcessFile (avoids double-read)
-	LibraryState    string // If set, overrides the default "imported" state in saveBookToDatabase
+	GoogleBooksID      string
+	FileHash           string // Pre-computed hash from ProcessFile (avoids double-read)
+	LibraryState       string // If set, overrides the default "imported" state in saveBookToDatabase
+	SourceImportPath   string // Top-level import path this file was discovered in; set by scan_service
 }
 
 // ScanDirectory scans the given directory for audiobook files.
@@ -1473,6 +1474,7 @@ func saveBookToDatabase(book *Book) error {
 			OrganizedFileHash: organizedFileHash,
 			LibraryState:      stringPtr(ls),
 			Quantity:          intPtr(1),
+			SourceImportPath:  nullablePtr(book.SourceImportPath),
 		}
 
 		// Re-link by embedded AUDIOBOOK_ORGANIZER_ID: if the file contains our ID tag,
@@ -1949,6 +1951,10 @@ func preserveExistingFields(scanned *database.Book, existing *database.Book) {
 	// Preserve series sequence if scan has nil/zero and existing has a value
 	if (scanned.SeriesSequence == nil || *scanned.SeriesSequence == 0) && existing.SeriesSequence != nil && *existing.SeriesSequence != 0 {
 		scanned.SeriesSequence = existing.SeriesSequence
+	}
+	// Preserve SourceImportPath — once set it must never be overwritten
+	if scanned.SourceImportPath == nil && existing.SourceImportPath != nil {
+		scanned.SourceImportPath = existing.SourceImportPath
 	}
 }
 

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -947,6 +947,7 @@ func TestWriteBackMetadataForBook_SingleFile(t *testing.T) {
 	mockStore.On("GetAuthorByID", 42).Return(author, nil)
 	mockStore.On("GetBookNarrators", book.ID).Return([]database.BookNarrator{}, nil)
 	mockStore.On("GetBookFiles", book.ID).Return([]database.BookFile{}, nil)
+	mockStore.On("GetBookFileByPath", book.FilePath).Return((*database.BookFile)(nil), nil)
 	mockStore.On("RecordMetadataChange", mock.AnythingOfType("*database.MetadataChangeRecord")).Return(nil)
 
 	svc := metafetch.NewService(mockStore)

--- a/internal/server/scan_service.go
+++ b/internal/server/scan_service.go
@@ -290,6 +290,19 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 
 	// Process the books to extract metadata (parallel)
 	if len(books) > 0 {
+		// Tag every book with its source import path before saving to DB.
+		// This must happen before ProcessBooksParallel (which calls CreateBook)
+		// so that source_import_path is set on first insert and survives organize.
+		// Only apply when the folder being scanned is NOT the organized library root,
+		// otherwise we'd overwrite the original import path on re-scans.
+		if folderPath != config.AppConfig.RootDir {
+			for i := range books {
+				if books[i].SourceImportPath == "" {
+					books[i].SourceImportPath = folderPath
+				}
+			}
+		}
+
 		log.Info("Processing metadata for %d books using %d workers", len(books), workers)
 		if err := scanner.ProcessBooksParallel(ctx, books, workers, progressCallback, log.With("scanner")); err != nil {
 			log.Error("Failed to process books: %v", err)

--- a/internal/server/scan_service_unit_test.go
+++ b/internal/server/scan_service_unit_test.go
@@ -104,6 +104,12 @@ func TestScanService_UpdateImportPathBookCount(t *testing.T) {
 	var updatedCount int
 
 	mockDB := &database.MockStore{
+		CountBooksByPathPrefixFunc: func(prefix string) (int, error) {
+			if prefix == "/path/b" {
+				return 42, nil
+			}
+			return 0, nil
+		},
 		GetAllImportPathsFunc: func() ([]database.ImportPath, error) {
 			return []database.ImportPath{
 				{ID: 1, Path: "/path/a", BookCount: 0},


### PR DESCRIPTION
## Summary

Fixes the Settings → Library import paths page showing 0 books after `auto_organize` moves files out of source directories.

### Root Cause
`auto_organize: true` moves books from source dirs (e.g. `/mnt/bigdata/books/newbooks`) into `audiobook-organizer/`. After the move, `book.FilePath` no longer starts with the source path, so `CountBooksByPathPrefix` returned 0.

### Fix
- Added `SourceImportPath` field to `Book` and `scanner.Book` — stamped once on `CreateBook`, never overwritten
- `CountBooksByPathPrefix` now checks `source_import_path` first, falls back to `file_path`
- `scan_service.go` stamps `SourceImportPath = folderPath` before `ProcessBooksParallel`

### Also Fixed (pre-existing test failures)
- `merged_into_book_id` missing from SQLite migrations map → `GetBookByID` failed in fresh test DBs
- Stale mockery-generated mocks (missing `GetDuplicateFilesByHash`, `CountBooksByPathPrefix`)
- `TestWriteBackMetadataForBook_SingleFile`: missing `GetBookFileByPath` mock expectation
- `TestScanService_UpdateImportPathBookCount`: `MockStore.CountBooksByPathPrefix` hardcoded to 0; added `CountBooksByPathPrefixFunc` hook

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>