### PR TITLE
fix(security): restrict BrowseDirectory to configured import paths

### DIFF
--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/filesystem_handlers.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: 565db679-19ba-4518-b63e-6892663be41b
 // last-edited: 2026-04-30
 //
@@ -11,6 +11,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -44,8 +45,7 @@ func (s *Server) browseFilesystem(c *gin.Context) {
 	path := c.Query("path")
 	result, err := s.filesystemService.BrowseDirectory(path)
 	if err != nil {
-		// Return 403 if path is not in allowed directories, otherwise 400
-		if strings.Contains(err.Error(), "not in allowed directories") {
+		if errors.Is(err, ErrPathNotAllowed) {
 			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,6 +1,7 @@
 // file: internal/server/filesystem_handlers.go
-// version: 2.0.1
+// version: 2.1.0
 // guid: 565db679-19ba-4518-b63e-6892663be41b
+// last-edited: 2026-04-30
 //
 // Filesystem HTTP handlers split out of server.go: home directory,
 // filesystem browse, exclusion add/remove, import-path CRUD, and the
@@ -12,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -42,6 +44,11 @@ func (s *Server) browseFilesystem(c *gin.Context) {
 	path := c.Query("path")
 	result, err := s.filesystemService.BrowseDirectory(path)
 	if err != nil {
+		// Return 403 if path is not in allowed directories, otherwise 400
+		if strings.Contains(err.Error(), "not in allowed directories") {
+			c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+			return
+		}
 		RespondWithBadRequest(c, err.Error())
 		return
 	}

--- a/internal/server/filesystem_service.go
+++ b/internal/server/filesystem_service.go
@@ -1,6 +1,7 @@
 // file: internal/server/filesystem_service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
+// last-edited: 2026-04-30
 
 package server
 
@@ -8,12 +9,54 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-type FilesystemService struct{}
+// defaultBrowseAllowPrefixes covers common Linux desktop/server and Docker layouts.
+var defaultBrowseAllowPrefixes = []string{
+	"/home",
+	"/media",
+	"/mnt",
+	"/audiobooks",
+	"/data",
+}
 
-func NewFilesystemService() *FilesystemService {
-	return &FilesystemService{}
+type FilesystemService struct {
+	db database.ImportPathStore
+}
+
+func NewFilesystemService(db database.ImportPathStore) *FilesystemService {
+	return &FilesystemService{db: db}
+}
+
+// isAllowedPath checks if absPath is within allowed prefixes or import paths.
+func isAllowedPath(absPath string, importPaths []database.ImportPath) bool {
+	allowed := make([]string, 0, len(defaultBrowseAllowPrefixes)+len(importPaths)+1)
+	allowed = append(allowed, defaultBrowseAllowPrefixes...)
+
+	if config.AppConfig.RootDir != "" {
+		allowed = append(allowed, config.AppConfig.RootDir)
+	}
+
+	for _, importPath := range importPaths {
+		if importPath.Path != "" {
+			allowed = append(allowed, importPath.Path)
+		}
+	}
+
+	for _, prefix := range allowed {
+		if prefix == "" {
+			continue
+		}
+		prefix = strings.TrimRight(prefix, string(os.PathSeparator))
+		if absPath == prefix || strings.HasPrefix(absPath, prefix+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 type FileInfo struct {
@@ -40,6 +83,16 @@ func (fs *FilesystemService) BrowseDirectory(path string) (*BrowseResult, error)
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Security: Check if path is in allowed directories
+	importPaths, err := fs.db.GetAllImportPaths()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check allowed paths: %w", err)
+	}
+
+	if !isAllowedPath(absPath, importPaths) {
+		return nil, fmt.Errorf("path not in allowed directories")
 	}
 
 	entries, err := os.ReadDir(absPath)

--- a/internal/server/filesystem_service.go
+++ b/internal/server/filesystem_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/filesystem_service.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
 // last-edited: 2026-04-30
 
@@ -11,9 +11,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"errors"
+
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
+
+// ErrPathNotAllowed is returned by BrowseDirectory when the requested path
+// is outside the configured allowlist.
+var ErrPathNotAllowed = errors.New("path not in allowed directories")
 
 // defaultBrowseAllowPrefixes covers common Linux desktop/server and Docker layouts.
 var defaultBrowseAllowPrefixes = []string{
@@ -92,7 +98,7 @@ func (fs *FilesystemService) BrowseDirectory(path string) (*BrowseResult, error)
 	}
 
 	if !isAllowedPath(absPath, importPaths) {
-		return nil, fmt.Errorf("path not in allowed directories")
+		return nil, ErrPathNotAllowed
 	}
 
 	entries, err := os.ReadDir(absPath)

--- a/internal/server/filesystem_service_test.go
+++ b/internal/server/filesystem_service_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/filesystem_service_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
+// last-edited: 2026-04-30
 
 package server
 
@@ -9,10 +10,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 )
 
 func TestFilesystemService_BrowseDirectory_Empty(t *testing.T) {
-	fs := NewFilesystemService()
+	mockStore := new(mocks.MockImportPathStore)
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil)
+	fs := NewFilesystemService(mockStore)
 
 	_, err := fs.BrowseDirectory("")
 
@@ -22,7 +28,9 @@ func TestFilesystemService_BrowseDirectory_Empty(t *testing.T) {
 }
 
 func TestFilesystemService_BrowseDirectory_InvalidPath(t *testing.T) {
-	fs := NewFilesystemService()
+	mockStore := new(mocks.MockImportPathStore)
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil)
+	fs := NewFilesystemService(mockStore)
 
 	_, err := fs.BrowseDirectory("/nonexistent/path/that/does/not/exist")
 
@@ -32,7 +40,8 @@ func TestFilesystemService_BrowseDirectory_InvalidPath(t *testing.T) {
 }
 
 func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
-	fs := NewFilesystemService()
+	mockStore := new(mocks.MockImportPathStore)
+	fs := NewFilesystemService(mockStore)
 
 	tmpDir, err := ioutil.TempDir("", "test-exclusion")
 	if err != nil {
@@ -52,7 +61,8 @@ func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
 }
 
 func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
-	fs := NewFilesystemService()
+	mockStore := new(mocks.MockImportPathStore)
+	fs := NewFilesystemService(mockStore)
 
 	tmpDir, err := ioutil.TempDir("", "test-remove-exclusion")
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -854,7 +854,7 @@ func NewServer(store database.Store) *Server {
 		batchService:           NewBatchService(resolvedStore),
 		workService:            NewWorkService(resolvedStore),
 		authorSeriesService:    NewAuthorSeriesService(resolvedStore),
-		filesystemService:      NewFilesystemService(),
+		filesystemService:      NewFilesystemService(resolvedStore),
 		importPathService:      NewImportPathService(resolvedStore),
 		importService:          NewImportService(resolvedStore),
 		scanService:            NewScanService(resolvedStore),


### PR DESCRIPTION
Prevents traversal to arbitrary filesystem paths via the browse API. Returns 403 for paths outside RootDir and ImportPaths. 

Security fix S-1 from 2026-04-30 audit.