### PR TITLE
fix(server): replace JSON heartbeat with SSE comment keep-alive

### DIFF
--- a/internal/realtime/events.go
+++ b/internal/realtime/events.go
@@ -1,5 +1,5 @@
 // file: internal/realtime/events.go
-// version: 1.1.2
+// version: 1.2.0
 // guid: 9e8d7f6a-5c4b-3a21-0f9e-8d7c6b5a4392
 
 package realtime
@@ -249,24 +249,9 @@ func (h *EventHub) HandleSSE(c *gin.Context) {
 	}
 
 	// Keep connection alive and stream events
-	// Use 5 second heartbeat to prevent Safari from closing idle connections
-	// Safari is particularly aggressive about closing SSE connections
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	// Send initial heartbeat immediately after connection
-	initialHeartbeat := map[string]interface{}{
-		"type":      "heartbeat",
-		"timestamp": time.Now(),
-	}
-	if data, err := json.Marshal(initialHeartbeat); err == nil {
-		if _, err := c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", data))); err != nil {
-			log.Printf("Error writing initial heartbeat to client %s: %v", clientID, err)
-			return
-		}
-		c.Writer.Flush()
-		log.Printf("Sent initial heartbeat to client %s", clientID)
-	}
+	// Use 25 second heartbeat (SSE comment) to prevent proxies from closing idle connections
+	heartbeat := time.NewTicker(25 * time.Second)
+	defer heartbeat.Stop()
 
 	for {
 		select {
@@ -290,20 +275,15 @@ func (h *EventHub) HandleSSE(c *gin.Context) {
 
 			// Flush immediately
 			c.Writer.Flush()
-		case <-ticker.C:
-			// Send heartbeat to keep connection alive
-			heartbeat := map[string]interface{}{
-				"type":      "heartbeat",
-				"timestamp": time.Now(),
+		case <-heartbeat.C:
+			// Send SSE comment line to keep connection alive through proxies
+			// Comments are ignored by clients but prevent proxy timeouts
+			_, err := c.Writer.Write([]byte(": ping\n\n"))
+			if err != nil {
+				log.Printf("Error writing heartbeat to client %s: %v", clientID, err)
+				return
 			}
-			if data, err := json.Marshal(heartbeat); err == nil {
-				if _, err := c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", data))); err != nil {
-					log.Printf("Error writing heartbeat to client %s: %v", clientID, err)
-					return
-				}
-				c.Writer.Flush()
-				_ = clientID // heartbeat sent
-			}
+			c.Writer.Flush()
 		}
 	}
 }

--- a/internal/realtime/events_test.go
+++ b/internal/realtime/events_test.go
@@ -1,5 +1,5 @@
 // file: internal/realtime/events_test.go
-// version: 1.1.2
+// version: 1.2.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
 
 package realtime
@@ -652,8 +652,8 @@ func TestHandleSSE_Heartbeat(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest("GET", "/events", nil)
 
-	// Use longer timeout to allow heartbeat to fire (30s ticker + buffer)
-	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+	// Use longer timeout to allow heartbeat to fire (25s ticker + buffer)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	c.Request = c.Request.WithContext(ctx)
 
@@ -664,16 +664,16 @@ func TestHandleSSE_Heartbeat(t *testing.T) {
 		done <- true
 	}()
 
-	// Wait for heartbeat (30s + buffer)
-	time.Sleep(31 * time.Second)
+	// Wait for heartbeat (25s + buffer)
+	time.Sleep(26 * time.Second)
 
 	cancel() // Cancel to stop the handler
 	<-done
 
-	// Check response body contains heartbeat
+	// Check response body contains SSE comment heartbeat (": ping")
 	body := w.Body.String()
-	if !strings.Contains(body, "heartbeat") {
-		t.Error("Expected heartbeat in response body")
+	if !strings.Contains(body, ": ping") {
+		t.Errorf("Expected SSE comment heartbeat (': ping') in response body, got: %q", body)
 	}
 }
 


### PR DESCRIPTION
Replaces 5s JSON data heartbeat with 25s SSE comment line. Comments are ignored by clients but prevent proxy timeouts. SRV-2 from 2026-04-30 audit.