### PR TITLE
chore(web): remove console.log calls from production code

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.51.0
+// version: 1.51.1
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -454,7 +454,6 @@ export const Library = () => {
           if (previousState && previousState !== 'open') {
             toast('Connection restored.', 'success');
           }
-          console.log('EventSource connection established');
         }
 
         if (status.state === 'reconnecting' && status.delayMs) {
@@ -1151,8 +1150,7 @@ export const Library = () => {
 
   const handleFetchMetadata = async (audiobook: Audiobook) => {
     try {
-      const result = await api.fetchBookMetadata(audiobook.id);
-      console.log(`Metadata fetched from ${result.source}:`, result.book);
+      await api.fetchBookMetadata(audiobook.id);
       // Reload audiobooks to show updated data
       loadAudiobooks();
     } catch (error) {
@@ -1527,8 +1525,7 @@ export const Library = () => {
 
   const handleParseWithAI = async (audiobook: Audiobook) => {
     try {
-      const result = await api.parseAudiobookWithAI(audiobook.id);
-      console.log(`AI parsing completed with ${result.confidence} confidence:`, result.book);
+      await api.parseAudiobookWithAI(audiobook.id);
       // Reload audiobooks to show updated data
       loadAudiobooks();
     } catch (error) {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.42.0
+// version: 1.42.1
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 import { useState, useEffect, useMemo, useRef, ChangeEvent } from 'react';
@@ -1097,10 +1097,6 @@ export function Settings() {
   const loadConfig = async () => {
     try {
       const config = await api.getConfig();
-      console.log(
-        '[Settings] Loaded config, OpenAI key:',
-        config.openai_api_key
-      );
       // Store masked key if present
       if (config.openai_api_key && config.openai_api_key.includes('***')) {
         setSavedApiKeyMask(config.openai_api_key);
@@ -1846,15 +1842,7 @@ export function Settings() {
           .filter(Boolean),
       };
 
-      console.log(
-        'Saving config with OpenAI key:',
-        settings.openaiApiKey
-          ? `***${settings.openaiApiKey.slice(-4)}`
-          : '(empty)'
-      );
-      console.log('Full updates object:', updates);
       const response = await api.updateConfig(updates);
-      console.log('Save response:', response);
 
       let nextSettings = settings;
       if (settings.openaiApiKey && response.openai_api_key) {


### PR DESCRIPTION
Removes 7 debug console.log calls from production frontend code.

- Deleted debug trace logs from Settings.tsx and Library.tsx
- console.error calls in catch blocks retained for error reporting
- Build passes, TypeScript errors resolved
- Browser console stays clean in production

FE-7 from 2026-04-30 audit.