### PR TITLE
fix(server): thread context through AudiobookUpdateService

### DIFF
--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_handlers.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 5d3a6a95-4ac8-42c2-a7fe-5ff4857dd31a
 //
 // AI-related HTTP handlers split out of server.go: filename parsing,
@@ -201,7 +201,7 @@ func (s *Server) parseAudiobookWithAI(c *gin.Context) {
 	}
 
 	// Route through the service layer for proper multi-author/narrator handling
-	updatedBook, err := s.audiobookUpdateService.UpdateAudiobook(id, payload)
+	updatedBook, err := s.audiobookUpdateService.UpdateAudiobook(c.Request.Context(), id, payload)
 	if err != nil {
 		internalError(c, "failed to update audiobook", err)
 		return

--- a/internal/server/audiobook_update_service.go
+++ b/internal/server/audiobook_update_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobook_update_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6g7-h8i9-j0k1-l2m3n4o5p6q7
 
 package server
@@ -56,7 +56,7 @@ func (aus *AudiobookUpdateService) ExtractOverrides(payload map[string]any) (map
 }
 
 // UpdateAudiobook is the main business logic method
-func (aus *AudiobookUpdateService) UpdateAudiobook(id string, payload map[string]any) (*database.Book, error) {
+func (aus *AudiobookUpdateService) UpdateAudiobook(ctx context.Context, id string, payload map[string]any) (*database.Book, error) {
 	if id == "" {
 		return nil, fmt.Errorf("audiobook ID is required")
 	}
@@ -170,5 +170,5 @@ func (aus *AudiobookUpdateService) UpdateAudiobook(id string, payload map[string
 		RawPayload: rawPayload,
 	}
 
-	return aus.audiobookService.UpdateAudiobook(context.Background(), id, req)
+	return aus.audiobookService.UpdateAudiobook(ctx, id, req)
 }

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
@@ -1182,7 +1182,7 @@ func (s *Server) updateAudiobook(c *gin.Context) {
 		oldBook, _ = s.Store().GetBookByID(id)
 	}
 
-	updatedBook, err := s.audiobookUpdateService.UpdateAudiobook(id, payload)
+	updatedBook, err := s.audiobookUpdateService.UpdateAudiobook(c.Request.Context(), id, payload)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			RespondWithNotFound(c, "audiobook", id)


### PR DESCRIPTION
Replaces context.Background() with request context in AudiobookUpdateService. Cancelled HTTP requests now propagate cancellation to DB and HTTP sub-calls, preventing resource leaks on client disconnect.

Changes:
- AudiobookUpdateService.UpdateAudiobook() now accepts context.Context as first parameter
- HTTP handlers (updateAudiobook, AI handlers) pass c.Request.Context() down
- Request cancellation now properly cascades to in-flight database queries and HTTP calls

Fixes: CTX-1 from 2026-04-30 audit