### PR TITLE
fix(web): centralise localStorage keys as typed constants

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@
 // Trigger CI E2E test run
 
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { STORAGE_KEYS } from './lib/storageKeys';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import {
   Box,
@@ -92,12 +93,12 @@ function App() {
         if (!cancelled) {
           setShowWizard(!setupComplete);
           if (setupComplete) {
-            localStorage.setItem('welcome_wizard_completed', 'true');
+            localStorage.setItem(STORAGE_KEYS.WELCOME_WIZARD_COMPLETED, 'true');
           }
         }
       } catch (_error) {
         const wizardCompleted = localStorage.getItem(
-          'welcome_wizard_completed'
+          STORAGE_KEYS.WELCOME_WIZARD_COMPLETED
         );
         if (!cancelled) {
           setShowWizard(!wizardCompleted);

--- a/web/src/components/AnnouncementBanner.tsx
+++ b/web/src/components/AnnouncementBanner.tsx
@@ -1,11 +1,12 @@
 // file: web/src/components/AnnouncementBanner.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Alert, AlertTitle, Box, IconButton, Collapse } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import { STORAGE_KEYS } from '../lib/storageKeys';
 
 interface Announcement {
   id: string;
@@ -14,11 +15,9 @@ interface Announcement {
   link?: string;
 }
 
-const DISMISSED_KEY = 'dismissed_announcements';
-
 function getDismissed(): Set<string> {
   try {
-    const raw = localStorage.getItem(DISMISSED_KEY);
+    const raw = localStorage.getItem(STORAGE_KEYS.DISMISSED_ANNOUNCEMENTS);
     return raw ? new Set(JSON.parse(raw)) : new Set();
   } catch {
     return new Set();
@@ -28,7 +27,7 @@ function getDismissed(): Set<string> {
 function dismissAnnouncement(id: string) {
   const dismissed = getDismissed();
   dismissed.add(id);
-  localStorage.setItem(DISMISSED_KEY, JSON.stringify([...dismissed]));
+  localStorage.setItem(STORAGE_KEYS.DISMISSED_ANNOUNCEMENTS, JSON.stringify([...dismissed]));
 }
 
 export function AnnouncementBanner() {

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.10.0
+// version: 1.11.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -31,6 +31,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import type { CandidateResult, MetadataCandidate } from '../../services/api';
 import * as api from '../../services/api';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 interface MetadataReviewDialogProps {
   open: boolean;
@@ -60,11 +61,10 @@ const PAGE_SIZE_OPTIONS = [25, 50, 100, 250, 500];
 // language disagrees with the book's are hidden. Preference
 // persists in localStorage so users don't re-enable it on
 // every dialog open.
-const LANGUAGE_FILTER_KEY = 'metadata-review-language-filter';
 
 function loadLanguageFilter(): boolean {
   if (typeof window === 'undefined') return true;
-  const raw = window.localStorage.getItem(LANGUAGE_FILTER_KEY);
+  const raw = window.localStorage.getItem(STORAGE_KEYS.METADATA_REVIEW_LANGUAGE_FILTER);
   return raw === null ? true : raw === 'true';
 }
 
@@ -121,11 +121,10 @@ function normalizeLanguage(lang: string | undefined | null): string {
 // uses session-only state, but the review dialog is opened ad-hoc
 // many times per session — re-picking "250 per page" on every open
 // is annoying.
-const REVIEW_PAGE_SIZE_KEY = 'metadata-review-page-size';
 
 function loadReviewPageSize(): number {
   if (typeof window === 'undefined') return 25;
-  const raw = window.localStorage.getItem(REVIEW_PAGE_SIZE_KEY);
+  const raw = window.localStorage.getItem(STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE);
   const n = raw ? Number(raw) : 25;
   return PAGE_SIZE_OPTIONS.includes(n) ? n : 25;
 }
@@ -1417,7 +1416,7 @@ export function MetadataReviewDialog({
                           setMatchLanguage(next);
                           if (typeof window !== 'undefined') {
                             window.localStorage.setItem(
-                              LANGUAGE_FILTER_KEY,
+                              STORAGE_KEYS.METADATA_REVIEW_LANGUAGE_FILTER,
                               String(next)
                             );
                           }
@@ -1495,7 +1494,7 @@ export function MetadataReviewDialog({
                         setReviewPageSize(next);
                         setServerPage(1);
                         if (typeof window !== 'undefined') {
-                          window.localStorage.setItem(REVIEW_PAGE_SIZE_KEY, String(next));
+                          window.localStorage.setItem(STORAGE_KEYS.METADATA_REVIEW_PAGE_SIZE, String(next));
                         }
                       }}
                       sx={{ minWidth: 100 }}

--- a/web/src/components/audiobooks/SearchBar.tsx
+++ b/web/src/components/audiobooks/SearchBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.tsx
-// version: 2.2.0
+// version: 2.3.0
 // guid: 1d2e3f4a-5b6c-7d8e-9f0a-1b2c3d4e5f6a
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -31,15 +31,15 @@ import {
 } from '@mui/icons-material';
 import { SortField, SortOrder } from '../../types';
 import { parseSearch, SEARCH_FIELDS, type ParsedSearch } from '../../utils/searchParser';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 export type ViewMode = 'grid' | 'list';
 
-const RECENT_SEARCHES_KEY = 'library_recent_searches';
 const MAX_RECENT = 15;
 
 function getRecentSearches(): string[] {
   try {
-    return JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) || '[]');
+    return JSON.parse(localStorage.getItem(STORAGE_KEYS.LIBRARY_RECENT_SEARCHES) || '[]');
   } catch {
     return [];
   }
@@ -49,7 +49,7 @@ function saveRecentSearch(query: string) {
   if (!query.trim()) return;
   const recent = getRecentSearches().filter((s) => s !== query);
   recent.unshift(query);
-  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  localStorage.setItem(STORAGE_KEYS.LIBRARY_RECENT_SEARCHES, JSON.stringify(recent.slice(0, MAX_RECENT)));
 }
 
 // Build autocomplete options: field prefixes, prefix wildcard, + recent searches

--- a/web/src/components/common/ConfigurableTable.tsx
+++ b/web/src/components/common/ConfigurableTable.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/common/ConfigurableTable.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -16,6 +16,7 @@ import {
   Typography,
 } from '@mui/material';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn.js';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 // --- Types ---
 
@@ -97,7 +98,7 @@ export function useConfigurableTable<T>({
 
   const loadState = useCallback((): ColumnState => {
     try {
-      const raw = localStorage.getItem(`table_config_${storageKey}`);
+      const raw = localStorage.getItem(`${STORAGE_KEYS.TABLE_CONFIG}_${storageKey}`);
       if (raw) {
         const parsed = JSON.parse(raw) as ColumnState;
         // Ensure all columns have widths
@@ -120,7 +121,7 @@ export function useConfigurableTable<T>({
 
   // Persist column state
   useEffect(() => {
-    localStorage.setItem(`table_config_${storageKey}`, JSON.stringify(colState));
+    localStorage.setItem(`${STORAGE_KEYS.TABLE_CONFIG}_${storageKey}`, JSON.stringify(colState));
   }, [colState, storageKey]);
 
   const visibleColumns = columns.filter((c) => colState.visible.includes(c.key));

--- a/web/src/components/settings/ITunesImport.tsx
+++ b/web/src/components/settings/ITunesImport.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/settings/ITunesImport.tsx
-// version: 1.14.0
+// version: 1.15.0
 // guid: 4eb9b74d-7192-497b-849a-092833ae63a4
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -77,6 +77,7 @@ import {
 } from '../../services/api';
 import { useOperationsStore } from '../../stores/useOperationsStore';
 import { useToast } from '../toast/ToastProvider';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 interface ITunesImportSettings {
   libraryPath: string;
@@ -106,7 +107,7 @@ export function ITunesImport() {
   const { toast } = useToast();
   const [settings, setSettings] = useState<ITunesImportSettings>(() => {
     try {
-      const saved = localStorage.getItem('itunes_import_settings');
+      const saved = localStorage.getItem(STORAGE_KEYS.ITUNES_IMPORT_SETTINGS);
       if (saved) {
         return { ...defaultSettings, ...JSON.parse(saved) };
       }
@@ -118,7 +119,7 @@ export function ITunesImport() {
   // Persist settings to localStorage
   useEffect(() => {
     try {
-      localStorage.setItem('itunes_import_settings', JSON.stringify(settings));
+      localStorage.setItem(STORAGE_KEYS.ITUNES_IMPORT_SETTINGS, JSON.stringify(settings));
     } catch {
       // ignore
     }

--- a/web/src/components/wizard/WelcomeWizard.tsx
+++ b/web/src/components/wizard/WelcomeWizard.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/wizard/WelcomeWizard.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 import { useState, useEffect } from 'react';
@@ -33,6 +33,7 @@ import {
 } from '@mui/icons-material';
 import { ServerFileBrowser } from '../common/ServerFileBrowser';
 import * as api from '../../services/api';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 interface WelcomeWizardProps {
   open: boolean;
@@ -264,7 +265,7 @@ export function WelcomeWizard({ open, onComplete }: WelcomeWizardProps) {
         // Persist iTunes settings so the Settings page can see them
         const activeMappings = pathMappings.filter((m) => m.from && m.to);
         try {
-          localStorage.setItem('itunes_import_settings', JSON.stringify({
+          localStorage.setItem(STORAGE_KEYS.ITUNES_IMPORT_SETTINGS, JSON.stringify({
             libraryPath: iTunesPath,
             importMode: iTunesImportMode,
             preserveLocation: iTunesImportMode === 'import',
@@ -291,7 +292,7 @@ export function WelcomeWizard({ open, onComplete }: WelcomeWizardProps) {
       }
 
       // Mark wizard as completed (store in localStorage for now)
-      localStorage.setItem('welcome_wizard_completed', 'true');
+      localStorage.setItem(STORAGE_KEYS.WELCOME_WIZARD_COMPLETED, 'true');
 
       onComplete();
     } catch (error) {

--- a/web/src/lib/storageKeys.ts
+++ b/web/src/lib/storageKeys.ts
@@ -1,0 +1,22 @@
+// file: web/src/lib/storageKeys.ts
+// version: 1.0.0
+// guid: 5c8a3d7b-2e1f-4a9c-b3d5-1e8f2a9c7d4b
+// last-edited: 2026-04-30
+
+/** Centralised localStorage key constants. */
+export const STORAGE_KEYS = {
+  WELCOME_WIZARD_COMPLETED: 'welcome_wizard_completed',
+  ITUNES_IMPORT_SETTINGS: 'itunes_import_settings',
+  LIBRARY_PAGE: 'library_page',
+  LIBRARY_ITEMS_PER_PAGE: 'library_items_per_page',
+  ACTIVITY_SOURCE_PREFS: 'activity-source-prefs',
+  ACTIVITY_OPS_PINNED: 'activity-ops-pinned',
+  TABLE_CONFIG: 'table_config',
+  APP_THEME_MODE: 'app-theme-mode',
+  DISMISSED_ANNOUNCEMENTS: 'dismissed_announcements',
+  LIBRARY_RECENT_SEARCHES: 'library_recent_searches',
+  METADATA_REVIEW_LANGUAGE_FILTER: 'metadata-review-language-filter',
+  METADATA_REVIEW_PAGE_SIZE: 'metadata-review-page-size',
+} as const;
+
+export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.5.0
+// version: 2.6.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -45,6 +45,7 @@ import { BatchActivityEntry } from '../components/BatchActivityEntry';
 import * as api from '../services/api';
 import { PendingFileOpsBanner } from '../components/PendingFileOpsBanner';
 import { usePendingFileOps } from '../hooks/usePendingFileOps';
+import { STORAGE_KEYS } from '../lib/storageKeys';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250];
 
@@ -125,7 +126,7 @@ export default function ActivityLog() {
   const [sinceFilter, setSinceFilter] = useState('');
   const [untilFilter, setUntilFilter] = useState('');
   const [excludedSources, setExcludedSources] = useState<Set<string>>(() => {
-    const saved = localStorage.getItem('activity-source-prefs');
+    const saved = localStorage.getItem(STORAGE_KEYS.ACTIVITY_SOURCE_PREFS);
     return saved ? new Set(JSON.parse(saved)) : new Set();
   });
   const [hideNoOp, setHideNoOp] = useState(true);
@@ -138,7 +139,7 @@ export default function ActivityLog() {
 
   // Active ops
   const [activeOps, setActiveOps] = useState<api.ActiveOperationSummary[]>([]);
-  const [pinned, setPinned] = useState(() => localStorage.getItem('activity-ops-pinned') !== 'false');
+  const [pinned, setPinned] = useState(() => localStorage.getItem(STORAGE_KEYS.ACTIVITY_OPS_PINNED) !== 'false');
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const [expandedOpId, setExpandedOpId] = useState<string | null>(searchParams.get('op'));
   const [opLogs, setOpLogs] = useState<string[]>([]);
@@ -176,12 +177,12 @@ export default function ActivityLog() {
 
   // Persist excluded sources
   useEffect(() => {
-    localStorage.setItem('activity-source-prefs', JSON.stringify([...excludedSources]));
+    localStorage.setItem(STORAGE_KEYS.ACTIVITY_SOURCE_PREFS, JSON.stringify([...excludedSources]));
   }, [excludedSources]);
 
   // Persist pin state
   useEffect(() => {
-    localStorage.setItem('activity-ops-pinned', String(pinned));
+    localStorage.setItem(STORAGE_KEYS.ACTIVITY_OPS_PINNED, String(pinned));
   }, [pinned]);
 
   // Load active operations
@@ -547,7 +548,7 @@ export default function ActivityLog() {
               size="small"
               onClick={() => {
                 setExcludedSources(new Set());
-                localStorage.removeItem('activity-source-prefs');
+                localStorage.removeItem(STORAGE_KEYS.ACTIVITY_SOURCE_PREFS);
               }}
             >
               Reset

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.51.1
+// version: 1.52.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -74,6 +74,7 @@ import {
 import { pollOperation } from '../utils/operationPolling';
 import { useOperationsStore } from '../stores/useOperationsStore';
 import AddToPlaylistDialog from '../components/audiobooks/AddToPlaylistDialog';
+import { STORAGE_KEYS } from '../lib/storageKeys';
 
 interface ImportPath {
   id: number;
@@ -189,12 +190,12 @@ export const Library = () => {
     searchParams.get('order') === SortOrder.Descending ? SortOrder.Descending : SortOrder.Ascending;
   const initialPage = Math.max(
     1,
-    parseInt(searchParams.get('page') || localStorage.getItem('library_page') || '1', 10)
+    parseInt(searchParams.get('page') || localStorage.getItem(STORAGE_KEYS.LIBRARY_PAGE) || '1', 10)
   );
   const initialItemsPerPage = Math.max(
     10,
     parseInt(
-      searchParams.get('limit') || localStorage.getItem('library_items_per_page') || '20',
+      searchParams.get('limit') || localStorage.getItem(STORAGE_KEYS.LIBRARY_ITEMS_PER_PAGE) || '20',
       10
     )
   );
@@ -519,7 +520,7 @@ export const Library = () => {
       isInternalUpdate.current = false;
       return;
     }
-    const urlPage = Math.max(1, parseInt(searchParams.get('page') || localStorage.getItem('library_page') || '1', 10));
+    const urlPage = Math.max(1, parseInt(searchParams.get('page') || localStorage.getItem(STORAGE_KEYS.LIBRARY_PAGE) || '1', 10));
     const urlSearch = searchParams.get('search') ?? '';
     const urlSort = (searchParams.get('sort') as SortField) || SortField.Title;
     const urlOrder =
@@ -570,7 +571,7 @@ export const Library = () => {
     prevPageRef.current = page;
     isInternalUpdate.current = true;
     setSearchParams(params, { replace: !pageChanged });
-    localStorage.setItem('library_page', page.toString());
+    localStorage.setItem(STORAGE_KEYS.LIBRARY_PAGE, page.toString());
   }, [filters, itemsPerPage, page, searchQuery, selectedTags, setSearchParams, sortBy, sortOrder, viewMode]);
 
   const loadSoftDeleted = useCallback(async () => {
@@ -2380,7 +2381,7 @@ export const Library = () => {
                   onChange={(e) => {
                     const val = Number(e.target.value);
                     setItemsPerPage(val);
-                    localStorage.setItem('library_items_per_page', String(val));
+                    localStorage.setItem(STORAGE_KEYS.LIBRARY_ITEMS_PER_PAGE, String(val));
                   }}
                   sx={{ minWidth: 150 }}
                 >

--- a/web/src/stores/useAppStore.ts
+++ b/web/src/stores/useAppStore.ts
@@ -1,19 +1,18 @@
 // file: web/src/stores/useAppStore.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
+import { STORAGE_KEYS } from '../lib/storageKeys';
 
 type ThemeMode = 'dark' | 'light';
-
-const THEME_MODE_STORAGE_KEY = 'app-theme-mode';
 
 function readStoredThemeMode(): ThemeMode {
   if (typeof window === 'undefined') {
     return 'dark';
   }
-  const stored = window.localStorage.getItem(THEME_MODE_STORAGE_KEY);
+  const stored = window.localStorage.getItem(STORAGE_KEYS.APP_THEME_MODE);
   return stored === 'light' || stored === 'dark' ? stored : 'dark';
 }
 
@@ -21,7 +20,7 @@ function persistThemeMode(mode: ThemeMode): void {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(THEME_MODE_STORAGE_KEY, mode);
+  window.localStorage.setItem(STORAGE_KEYS.APP_THEME_MODE, mode);
 }
 
 interface Notification {


### PR DESCRIPTION
Creates storageKeys.ts with STORAGE_KEYS constants for all localStorage keys.
All localStorage.getItem/setItem/removeItem calls now use constants instead of
inline string literals. Prevents key typos and centralises storage key management.

Changes:
- New web/src/lib/storageKeys.ts with typed STORAGE_KEYS constants
- Updated all localStorage calls to use STORAGE_KEYS.* references
- Existing key values unchanged to preserve user data
- Full TypeScript type safety for storage key access

Files updated:
- App.tsx
- stores/useAppStore.ts
- components/AnnouncementBanner.tsx
- components/audiobooks/SearchBar.tsx
- components/audiobooks/MetadataReviewDialog.tsx
- components/settings/ITunesImport.tsx
- components/wizard/WelcomeWizard.tsx
- components/common/ConfigurableTable.tsx
- pages/Library.tsx
- pages/ActivityLog.tsx

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
