### PR TITLE
perf(database): add GetAuthorsByBookIDs and GetNarratorsByBookIDs to Store interface

### DIFF
--- a/internal/database/iface_author.go
+++ b/internal/database/iface_author.go
@@ -1,8 +1,11 @@
 // file: internal/database/iface_author.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2e3b78c0-c989-48c0-a324-b88ea52b1ccd
+// last-edited: 2026-04-30
 
 package database
+
+import "context"
 
 // AuthorReader is the read-only author slice (authors + aliases + book-author joins).
 type AuthorReader interface {
@@ -17,6 +20,9 @@ type AuthorReader interface {
 	GetAllAuthorBookCounts() (map[int]int, error)
 	GetAllAuthorFileCounts() (map[int]int, error)
 	GetAuthorTombstone(oldID int) (int, error)
+	// GetAuthorsByBookIDs returns a map from bookID → []Author for all given book IDs.
+	// Returns an empty map (not nil) if bookIDs is empty.
+	GetAuthorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error)
 }
 
 // AuthorWriter is the write-only author slice.

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,10 +1,11 @@
 // file: internal/database/iface_misc.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 // last-edited: 2026-04-30
 
 package database
 
+import "context"
 import "time"
 
 // BookFileHashUpdater is the narrow interface required by fileops.WriteTagsSafe
@@ -32,6 +33,9 @@ type NarratorStore interface {
 	ListNarrators() ([]Narrator, error)
 	GetBookNarrators(bookID string) ([]BookNarrator, error)
 	SetBookNarrators(bookID string, narrators []BookNarrator) error
+	// GetNarratorsByBookIDs returns a map from bookID → []Narrator for all given book IDs.
+	// Returns an empty map (not nil) if bookIDs is empty.
+	GetNarratorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Narrator, error)
 }
 
 // WorkStore covers Work CRUD.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,11 +1,12 @@
 // file: internal/database/mock_store.go
-// version: 1.47.0
+// version: 1.48.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-04-30
 
 package database
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -2382,4 +2383,12 @@ func (m *MockStore) DeleteMetadataRejections(bookID string) error {
 		return m.DeleteMetadataRejectionsFunc(bookID)
 	}
 	return nil
+}
+
+func (m *MockStore) GetAuthorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error) {
+	return make(map[string][]Author), nil
+}
+
+func (m *MockStore) GetNarratorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Narrator, error) {
+	return make(map[string][]Narrator), nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	"context"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -43852,4 +43853,22 @@ func (_c *MockStore_UpsertMetadataFieldState_Call) Return(err error) *MockStore_
 func (_c *MockStore_UpsertMetadataFieldState_Call) RunAndReturn(run func(state *database.MetadataFieldState) error) *MockStore_UpsertMetadataFieldState_Call {
 	_c.Call.Return(run)
 	return _c
+}
+
+// GetAuthorsByBookIDs provides a mock function for the type MockStore
+func (_mock *MockStore) GetAuthorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]database.Author, error) {
+args := _mock.Called(ctx, bookIDs)
+if args.Get(0) == nil {
+return nil, args.Error(1)
+}
+return args.Get(0).(map[string][]database.Author), args.Error(1)
+}
+
+// GetNarratorsByBookIDs provides a mock function for the type MockStore
+func (_mock *MockStore) GetNarratorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]database.Narrator, error) {
+args := _mock.Called(ctx, bookIDs)
+if args.Get(0) == nil {
+return nil, args.Error(1)
+}
+return args.Get(0).(map[string][]database.Narrator), args.Error(1)
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.65.0
+// version: 1.66.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-04-30
 
@@ -8244,4 +8244,15 @@ func (p *PebbleStore) GetBookMetadataHashStats() (*BookMetadataHashStats, error)
 		stats.ByLibrary = append(stats.ByLibrary, *row)
 	}
 	return stats, nil
+}
+// GetAuthorsByBookIDs returns a map from bookID → []Author for all given book IDs.
+// TODO: Implement in N1-3
+func (p *PebbleStore) GetAuthorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error) {
+panic("not implemented")
+}
+
+// GetNarratorsByBookIDs returns a map from bookID → []Narrator for all given book IDs.
+// TODO: Implement in N1-3
+func (p *PebbleStore) GetNarratorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Narrator, error) {
+panic("not implemented")
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,11 +1,12 @@
 // file: internal/database/sqlite_store.go
-// version: 1.77.0
+// version: 1.78.0
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
 package database
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -6707,4 +6708,16 @@ func (s *SQLiteStore) GetBookPathPrefixes(limit int) ([]BookPathPrefix, error) {
 		out = append(out, p)
 	}
 	return out, rows.Err()
+}
+
+// GetAuthorsByBookIDs returns a map from bookID → []Author for all given book IDs.
+// TODO: Implement in N1-2
+func (s *SQLiteStore) GetAuthorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error) {
+panic("not implemented")
+}
+
+// GetNarratorsByBookIDs returns a map from bookID → []Narrator for all given book IDs.
+// TODO: Implement in N1-2
+func (s *SQLiteStore) GetNarratorsByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Narrator, error) {
+panic("not implemented")
 }


### PR DESCRIPTION
## Summary
Adds two new batch-fetch methods to the Store interface to eliminate N+1 author/narrator queries in list endpoints.

## Changes
- GetAuthorsByBookIDs(ctx, []string) → map[string][]Author added to Store interface
- GetNarratorsByBookIDs(ctx, []string) → map[string][]Narrator added to Store interface
- MockStore stub implementations added
- No real implementations yet (those are N1-2 SQLite, N1-3 Pebble)

Part of audit task N1-1. Follow-up PRs: N1-2, N1-3, N1-4.