### PR TITLE
perf(database): define BookSummary struct for list query projection

### DIFF
--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.69.0
+// version: 2.70.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 // last-edited: 2026-04-30
 
@@ -250,6 +250,38 @@ type Book struct {
 	Series               *Series                            `json:"series,omitempty" db:"-"`
 	MetadataProvenance   map[string]MetadataProvenanceEntry `json:"metadata_provenance,omitempty" db:"-"`
 	MetadataProvenanceAt *time.Time                         `json:"metadata_provenance_at,omitempty" db:"-"`
+}
+
+// BookSummary represents the subset of Book fields needed for library list views.
+// It excludes heavy fields like full descriptions, raw cover bytes, and embeddings.
+// This struct is designed for use in paginated list queries to improve performance
+// by avoiding unnecessary data transfer. Companion field to Book for read-only
+// projection use cases (PROJ-2 SQL query optimization).
+type BookSummary struct {
+	ID                  string     `json:"id"`
+	Title               string     `json:"title"`
+	AuthorID            *int       `json:"author_id,omitempty"`
+	SeriesID            *int       `json:"series_id,omitempty"`
+	SeriesSequence      *int       `json:"series_sequence,omitempty"`
+	FilePath            string     `json:"file_path"`
+	Format              string     `json:"format,omitempty"`
+	Duration            *int       `json:"duration,omitempty"`
+	OriginalFilename    *string    `json:"original_filename,omitempty"`
+	FileSize            *int64     `json:"file_size,omitempty"`
+	FileHash            *string    `json:"file_hash,omitempty"`
+	OriginalFileHash    *string    `json:"original_file_hash,omitempty"`
+	OrganizedFileHash   *string    `json:"organized_file_hash,omitempty"`
+	LibraryState        *string    `json:"library_state,omitempty"`
+	QuarantinedAt       *time.Time `json:"quarantined_at,omitempty"`
+	QuarantineReason    *string    `json:"quarantine_reason,omitempty"`
+	CoverURL            *string    `json:"cover_url,omitempty"`
+	Narrator            *string    `json:"narrator,omitempty"`
+	CreatedAt           *time.Time `json:"created_at,omitempty"`
+	UpdatedAt           *time.Time `json:"updated_at,omitempty"`
+	MetadataUpdatedAt   *time.Time `json:"metadata_updated_at,omitempty"`
+	IsPrimaryVersion    *bool      `json:"is_primary_version,omitempty"`
+	VersionGroupID      *string    `json:"version_group_id,omitempty"`
+	MetadataReviewStatus *string   `json:"metadata_review_status,omitempty"`
 }
 
 // MetadataProvenanceEntry represents the source breakdown for a metadata field.


### PR DESCRIPTION
## Summary

Defines BookSummary struct with only the columns needed for the library list view.

## Changes

- BookSummary struct added to database models (store.go)
- Only list-view fields included: id, title, author_id, series_id, series_sequence, file_path, format, duration, original_filename, file_size, file hashes, library_state, quarantine info, cover_url, narrator, timestamps, version info, and metadata_review_status
- Heavy fields excluded: full description body, raw cover bytes, embeddings
- Struct tags match actual DB column names

## Purpose

Prerequisite for PROJ-2 (optimized list query). This struct defines the projection used when fetching books for paginated list views, reducing data transfer and improving query performance.

## Related

- Part of audit task PROJ-1 (struct definition only, no SQL query yet)
- PROJ-2 will create the optimized SQL query using this struct