### PR TITLE
fix(database): handle time.Parse errors in row scanners

### DIFF
--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 1.7.0
+// version: 1.8.0
 // last-edited: 2026-04-30
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"strings"
@@ -270,10 +271,16 @@ FROM embeddings WHERE id = ?`, id)
 	}
 	e.Vector = decodeVector(vectorBlob)
 	if e.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAtS); err != nil {
-		e.CreatedAt, _ = time.Parse("2006-01-02T15:04:05Z", createdAtS)
+		if e.CreatedAt, err = time.Parse("2006-01-02T15:04:05Z", createdAtS); err != nil {
+			log.Printf("WARN: parse CreatedAt %q: %v (using zero time)", createdAtS, err)
+			e.CreatedAt = time.Time{}
+		}
 	}
 	if e.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAtS); err != nil {
-		e.UpdatedAt, _ = time.Parse("2006-01-02T15:04:05Z", updatedAtS)
+		if e.UpdatedAt, err = time.Parse("2006-01-02T15:04:05Z", updatedAtS); err != nil {
+			log.Printf("WARN: parse UpdatedAt %q: %v (using zero time)", updatedAtS, err)
+			e.UpdatedAt = time.Time{}
+		}
 	}
 	return &e, nil
 }
@@ -308,10 +315,16 @@ FROM embeddings WHERE entity_type = ?`, entityType)
 		}
 		e.Vector = decodeVector(vectorBlob)
 		if e.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAtS); err != nil {
-			e.CreatedAt, _ = time.Parse("2006-01-02T15:04:05Z", createdAtS)
+			if e.CreatedAt, err = time.Parse("2006-01-02T15:04:05Z", createdAtS); err != nil {
+				log.Printf("WARN: scan embedding parse CreatedAt %q: %v (using zero time)", createdAtS, err)
+				e.CreatedAt = time.Time{}
+			}
 		}
 		if e.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAtS); err != nil {
-			e.UpdatedAt, _ = time.Parse("2006-01-02T15:04:05Z", updatedAtS)
+			if e.UpdatedAt, err = time.Parse("2006-01-02T15:04:05Z", updatedAtS); err != nil {
+				log.Printf("WARN: scan embedding parse UpdatedAt %q: %v (using zero time)", updatedAtS, err)
+				e.UpdatedAt = time.Time{}
+			}
 		}
 		results = append(results, e)
 	}
@@ -519,10 +532,16 @@ func scanCandidate(scan func(...any) error) (DedupCandidate, error) {
 	}
 	var err error
 	if c.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAtS); err != nil {
-		c.CreatedAt, _ = time.Parse("2006-01-02T15:04:05Z", createdAtS)
+		if c.CreatedAt, err = time.Parse("2006-01-02T15:04:05Z", createdAtS); err != nil {
+			log.Printf("WARN: scanCandidate parse CreatedAt %q: %v (using zero time)", createdAtS, err)
+			c.CreatedAt = time.Time{}
+		}
 	}
 	if c.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAtS); err != nil {
-		c.UpdatedAt, _ = time.Parse("2006-01-02T15:04:05Z", updatedAtS)
+		if c.UpdatedAt, err = time.Parse("2006-01-02T15:04:05Z", updatedAtS); err != nil {
+			log.Printf("WARN: scanCandidate parse UpdatedAt %q: %v (using zero time)", updatedAtS, err)
+			c.UpdatedAt = time.Time{}
+		}
 	}
 	return c, nil
 }

--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.77.0
+// version: 1.78.0
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -4307,8 +4307,14 @@ func (s *SQLiteStore) GetLibraryFingerprint(path string) (*LibraryFingerprintRec
 	if err != nil {
 		return nil, err
 	}
-	rec.ModTime, _ = time.Parse(time.RFC3339, modTimeStr)
-	rec.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAtStr)
+	rec.ModTime, err = time.Parse(time.RFC3339, modTimeStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse ModTime %q: %w", modTimeStr, err)
+	}
+	rec.UpdatedAt, err = time.Parse(time.RFC3339, updatedAtStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse UpdatedAt %q: %w", updatedAtStr, err)
+	}
 	return &rec, nil
 }
 
@@ -4340,7 +4346,10 @@ func (s *SQLiteStore) GetPendingDeferredITunesUpdates() ([]DeferredITunesUpdate,
 		if err := rows.Scan(&d.ID, &d.BookID, &d.PersistentID, &d.OldPath, &d.NewPath, &d.UpdateType, &createdAtStr); err != nil {
 			return nil, err
 		}
-		d.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
+		d.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse CreatedAt %q: %w", createdAtStr, err)
+		}
 		results = append(results, d)
 	}
 	return results, rows.Err()
@@ -4375,9 +4384,15 @@ func (s *SQLiteStore) GetDeferredITunesUpdatesByBookID(bookID string) ([]Deferre
 		if err := rows.Scan(&d.ID, &d.BookID, &d.PersistentID, &d.OldPath, &d.NewPath, &d.UpdateType, &createdAtStr, &appliedAtStr); err != nil {
 			return nil, err
 		}
-		d.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
+		d.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse CreatedAt %q: %w", createdAtStr, err)
+		}
 		if appliedAtStr != nil {
-			t, _ := time.Parse(time.RFC3339, *appliedAtStr)
+			t, err := time.Parse(time.RFC3339, *appliedAtStr)
+			if err != nil {
+				return nil, fmt.Errorf("parse AppliedAt %q: %w", *appliedAtStr, err)
+			}
 			d.AppliedAt = &t
 		}
 		results = append(results, d)
@@ -4441,8 +4456,14 @@ func (s *SQLiteStore) GetExternalIDsForBook(bookID string) ([]ExternalIDMapping,
 			m.FilePath = filePath.String
 		}
 		m.Tombstoned = tombstoned != 0
-		m.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
-		m.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAtStr)
+		m.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse CreatedAt %q: %w", createdAtStr, err)
+		}
+		m.UpdatedAt, err = time.Parse(time.RFC3339, updatedAtStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse UpdatedAt %q: %w", updatedAtStr, err)
+		}
 		results = append(results, m)
 	}
 	return results, rows.Err()
@@ -5080,7 +5101,10 @@ func (s *SQLiteStore) GetBookPathHistory(bookID string) ([]BookPathChange, error
 		if err := rows.Scan(&c.ID, &c.BookID, &c.OldPath, &c.NewPath, &c.ChangeType, &createdAtStr); err != nil {
 			return nil, err
 		}
-		c.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
+		c.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse CreatedAt %q: %w", createdAtStr, err)
+		}
 		results = append(results, c)
 	}
 	return results, rows.Err()


### PR DESCRIPTION
## Summary
Adds proper error handling for time.Parse calls in the database layer.

## Changes
- sqlite_store.go: 5 functions now return parse errors instead of silently discarding them (GetLibraryFingerprint, GetPendingDeferredITunesUpdates, GetDeferredITunesUpdatesByBookID, GetExternalIDsForBook, GetBookPathHistory)
- embedding_store.go: Fixed fallback timestamp parsing to log warnings and use zero time only if both format attempts fail

## Verification
- go build ./... succeeds
- go vet ./... clean  
- go test ./internal/database/... all pass (98.857s)

Part of audit task DB-5.
