### PR TITLE
fix(server): update test stubs to match context.Context SearchByTitle signature

### DIFF
--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store.go
-// version: 1.79.0
+// version: 1.79.1
 // last-edited: 2026-04-30
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -2737,13 +2737,15 @@ func (s *SQLiteStore) CreateBook(book *Book) (*Book, error) {
 	}
 
 	// Record the original import path so full provenance is preserved forever.
+	// book_path_history is created in migration 35; skip gracefully on older schemas.
 	_, err = tx.Exec(
 		`INSERT INTO book_path_history (book_id, old_path, new_path, change_type) VALUES (?, ?, ?, ?)`,
 		book.ID, "", book.FilePath, "import",
 	)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "no such table") {
 		return nil, fmt.Errorf("CreateBook record path: %w", err)
 	}
+	err = nil // reset so defer rollback doesn't fire on a skipped path-history write
 
 	if err = tx.Commit(); err != nil {
 		return nil, fmt.Errorf("CreateBook commit: %w", err)

--- a/internal/server/isbn_enrichment_test.go
+++ b/internal/server/isbn_enrichment_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/isbn_enrichment_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5b7766bc-1f00-4f32-b8ca-8cb0e815c9a1
 
 package server
@@ -20,10 +20,10 @@ type stubSource struct {
 }
 
 func (s *stubSource) Name() string { return s.name }
-func (s *stubSource) SearchByTitle(_ string) ([]metadata.BookMetadata, error) {
+func (s *stubSource) SearchByTitle(_ context.Context, _ string) ([]metadata.BookMetadata, error) {
 	return s.results, nil
 }
-func (s *stubSource) SearchByTitleAndAuthor(_, _ string) ([]metadata.BookMetadata, error) {
+func (s *stubSource) SearchByTitleAndAuthor(_ context.Context, _, _ string) ([]metadata.BookMetadata, error) {
 	return s.results, nil
 }
 

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -1,10 +1,11 @@
 // file: internal/server/metadata_fetch_service_test.go
-// version: 4.3.0
+// version: 4.4.0
 // guid: f6a7b8c9-d0e1-f2a3-b4c5-d6e7f8a9b0c1
 
 package server
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -26,13 +27,13 @@ type mockMetadataSource struct {
 }
 
 func (m *mockMetadataSource) Name() string { return m.name }
-func (m *mockMetadataSource) SearchByTitle(title string) ([]metadata.BookMetadata, error) {
+func (m *mockMetadataSource) SearchByTitle(_ context.Context, title string) ([]metadata.BookMetadata, error) {
 	if m.searchByTitleFunc != nil {
 		return m.searchByTitleFunc(title)
 	}
 	return nil, nil
 }
-func (m *mockMetadataSource) SearchByTitleAndAuthor(title, author string) ([]metadata.BookMetadata, error) {
+func (m *mockMetadataSource) SearchByTitleAndAuthor(_ context.Context, title, author string) ([]metadata.BookMetadata, error) {
 	if m.searchByTitleAndAuthor != nil {
 		return m.searchByTitleAndAuthor(title, author)
 	}


### PR DESCRIPTION
## Summary
Fixes two CI failures on main:

### 1. SearchByTitle context.Context mismatch (build failure)
`stubSource` and `mockMetadataSource` in server tests had `SearchByTitle(string)` / `SearchByTitleAndAuthor(string, string)` signatures, but PR #604 updated the `MetadataSource` interface to require `context.Context` as the first argument. This caused `internal/server` to fail to compile in CI.

**Files fixed:**
- `internal/server/isbn_enrichment_test.go` — update `stubSource` methods
- `internal/server/metadata_fetch_service_test.go` — update `mockMetadataSource` methods

### 2. book_path_history graceful skip (cherry-pick of #619)
Tests without migration 35 fail with `no such table: book_path_history`. The INSERT now skips gracefully when the table is absent.

Fixes CI failures introduced by #604 and #615.