### PR TITLE
fix(ci): pin prerelease workflow to ghcommon v2.13.1

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.9.0
+# version: 2.9.1
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 name: Prerelease on Merge
@@ -27,7 +27,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@dd8fae111732e9bdc7fed56a0f4d68cb0fd17d34 # v2.13.1
     with:
       release-type: 'auto'
       prerelease: true


### PR DESCRIPTION
## Problem
`prerelease.yml` was pinned to `jdfalk/ghcommon` SHA `c46f978` which contained:
```yaml
if: ${{ secrets.CI_APP_ID != '' }}
```
GitHub Actions does not allow the `secrets` context in `if:` conditions within called reusable workflows, producing:
> Unrecognized named-value: 'secrets'

## Fix
Pin to `dd8fae1` (ghcommon v2.13.1) which uses an env-bridge guard step to check for the secret without referencing `secrets.*` in an `if:` condition.