### PR TITLE
fix(metadata): lowercase capitalized error strings (ST1005)

### DIFF
--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -147,7 +147,7 @@ func (c *AudibleClient) LookupByASIN(asin string) (*BookMetadata, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Audible API returned status %d for ASIN %s", resp.StatusCode, asin)
+		return nil, fmt.Errorf("audible API returned status %d for ASIN %s", resp.StatusCode, asin)
 	}
 
 	var result audibleProductResponse
@@ -156,7 +156,7 @@ func (c *AudibleClient) LookupByASIN(asin string) (*BookMetadata, error) {
 	}
 
 	if result.Product.Title == "" {
-		return nil, fmt.Errorf("Audible returned empty product for ASIN %s", asin)
+		return nil, fmt.Errorf("audible returned empty product for ASIN %s", asin)
 	}
 
 	meta := c.productToMetadata(&result.Product)
@@ -177,7 +177,7 @@ func (c *AudibleClient) searchCatalog(ctx context.Context, searchURL string) ([]
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Audible API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("audible API returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audnexus.go
-// version: 2.3.0
+// version: 2.3.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
 
 package metadata
@@ -112,7 +112,7 @@ func (c *AudnexusClient) SearchByTitleAndAuthor(ctx context.Context, title, auth
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Audnexus author search returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("audnexus author search returned status %d", resp.StatusCode)
 	}
 
 	var authors []audnexusAuthor
@@ -182,7 +182,7 @@ func (c *AudnexusClient) LookupByASIN(asin string) (*BookMetadata, error) {
 			return c.bookToMetadata(&book), nil
 		}
 		resp.Body.Close()
-		lastErr = fmt.Errorf("Audnexus book lookup returned status %d (region=%s)", resp.StatusCode, region)
+		lastErr = fmt.Errorf("audnexus book lookup returned status %d (region=%s)", resp.StatusCode, region)
 	}
 	return nil, lastErr
 }

--- a/internal/metadata/googlebooks.go
+++ b/internal/metadata/googlebooks.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/googlebooks.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-f2a3b4c5d6e7
 
 package metadata
@@ -112,7 +112,7 @@ func (c *GoogleBooksClient) search(ctx context.Context, escapedQuery string) ([]
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Google Books API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("google Books API returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/metadata/hardcover.go
+++ b/internal/metadata/hardcover.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/hardcover.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: e7e02554-8931-49ba-9528-d3d51279da1d
 
 package metadata
@@ -257,7 +257,7 @@ func (c *HardcoverClient) search(ctx context.Context, query string) ([]BookMetad
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Hardcover API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("hardcover API returned status %d", resp.StatusCode)
 	}
 
 	var gqlResp hardcoverGraphQLResponse
@@ -272,7 +272,7 @@ func (c *HardcoverClient) search(ctx context.Context, query string) ([]BookMetad
 		for _, e := range gqlResp.Errors {
 			log.Printf("[WARN] Hardcover GraphQL error: %s", e.Message)
 		}
-		return nil, fmt.Errorf("Hardcover GraphQL error: %s", gqlResp.Errors[0].Message)
+		return nil, fmt.Errorf("hardcover GraphQL error: %s", gqlResp.Errors[0].Message)
 	}
 
 	if gqlResp.Data == nil || gqlResp.Data.SearchBooks == nil || gqlResp.Data.SearchBooks.Results == nil {

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.8.0
+// version: 1.8.1
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package metadata
@@ -168,7 +168,7 @@ func (c *OpenLibraryClient) SearchByTitle(ctx context.Context, title string) ([]
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Open Library API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("open Library API returned status %d", resp.StatusCode)
 	}
 
 	// Parse response
@@ -231,7 +231,7 @@ func (c *OpenLibraryClient) SearchByTitleAndAuthor(ctx context.Context, title, a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Open Library API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("open Library API returned status %d", resp.StatusCode)
 	}
 
 	// Parse response
@@ -305,7 +305,7 @@ func (c *OpenLibraryClient) GetBookByISBN(ctx context.Context, isbn string) (*Bo
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Open Library API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("open Library API returned status %d", resp.StatusCode)
 	}
 
 	// Parse response

--- a/internal/metadata/wikipedia.go
+++ b/internal/metadata/wikipedia.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/wikipedia.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 
 package metadata
@@ -124,7 +124,7 @@ func (c *WikipediaClient) search(ctx context.Context, query string) ([]BookMetad
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Wikipedia API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("wikipedia API returned status %d", resp.StatusCode)
 	}
 
 	var mwResp mediawikiSearchResponse


### PR DESCRIPTION
Fixes 12 staticcheck ST1005 warnings across 6 metadata files. Re-audit R-10.

## Changes
- `audible.go` (3 fixes): lowercase `Audible` → `audible`
- `audnexus.go` (2 fixes): lowercase `Audnexus` → `audnexus`
- `googlebooks.go` (1 fix): lowercase `Google` → `google`
- `hardcover.go` (2 fixes): lowercase `Hardcover` → `hardcover`
- `openlibrary.go` (3 fixes): lowercase `Open` → `open`
- `wikipedia.go` (1 fix): lowercase `Wikipedia` → `wikipedia`

All version headers bumped (patch). Build and tests pass.