### PR TITLE
fix(database): thread context through ActivityStore transactions

### DIFF
--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -1,10 +1,11 @@
 // file: internal/activity/service.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package activity
 
 import (
+	"context"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -35,8 +36,8 @@ func (s *Service) Query(filter database.ActivityFilter) ([]database.ActivityEntr
 
 // Summarize collapses old entries in the given tier that are older than olderThan.
 // Returns the count of original rows deleted.
-func (s *Service) Summarize(olderThan time.Time, tier string) (int, error) {
-	return s.store.Summarize(olderThan, tier)
+func (s *Service) Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error) {
+	return s.store.Summarize(ctx, olderThan, tier)
 }
 
 // Prune hard-deletes all entries of the given tier older than olderThan.
@@ -46,8 +47,8 @@ func (s *Service) Prune(olderThan time.Time, tier string) (int, error) {
 }
 
 // CompactByDay groups old change/debug entries by UTC day into digest rows.
-func (s *Service) CompactByDay(olderThan time.Time) (database.CompactResult, error) {
-	return s.store.CompactByDay(olderThan)
+func (s *Service) CompactByDay(ctx context.Context, olderThan time.Time) (database.CompactResult, error) {
+	return s.store.CompactByDay(ctx, olderThan)
 }
 
 // GetDistinctSources returns all unique sources with their entry counts,

--- a/internal/activity/service_test.go
+++ b/internal/activity/service_test.go
@@ -1,10 +1,11 @@
 // file: internal/activity/service_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 package activity
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,7 +65,7 @@ func TestService_RecordAndQuery(t *testing.T) {
 
 	// Summarize realtime entries older than 1 hour in the future (captures all).
 	future := time.Now().UTC().Add(time.Hour)
-	deleted, err := svc.Summarize(future, "realtime")
+	deleted, err := svc.Summarize(context.Background(), future, "realtime")
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleted)
 

--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,10 +1,11 @@
 // file: internal/database/activity_compact_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package database
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func TestCompactByDay_BasicCompaction(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := s.CompactByDay(olderThan)
+	result, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.DaysCompacted)
 	assert.Equal(t, 5, result.EntriesDeleted)
@@ -121,13 +122,13 @@ func TestCompactByDay_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 
 	// First compaction
-	r1, err := s.CompactByDay(olderThan)
+	r1, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r1.DaysCompacted)
 	assert.Equal(t, 1, r1.EntriesDeleted)
 
 	// Second compaction — should be no-op
-	r2, err := s.CompactByDay(olderThan)
+	r2, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 0, r2.DaysCompacted)
 	assert.Equal(t, 0, r2.EntriesDeleted)
@@ -151,7 +152,7 @@ func TestCompactByDay_SkipsAuditTier(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	result, err := s.CompactByDay(olderThan)
+	result, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.DaysCompacted)
 	assert.Equal(t, 0, result.EntriesDeleted)
@@ -185,7 +186,7 @@ func TestCompactByDay_TruncatesLargeDays(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	result, err := s.CompactByDay(olderThan)
+	result, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.DaysCompacted)
 	assert.Equal(t, 600, result.EntriesDeleted)
@@ -243,7 +244,7 @@ func TestCompactByDay_MergesIntoExistingDigest(t *testing.T) {
 	}
 
 	// First compaction — 3 entries compacted into 1 digest.
-	r1, err := s.CompactByDay(initialCutoff)
+	r1, err := s.CompactByDay(context.Background(), initialCutoff)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r1.DaysCompacted, "first run should create 1 digest")
 	assert.Equal(t, 3, r1.EntriesDeleted)
@@ -267,7 +268,7 @@ func TestCompactByDay_MergesIntoExistingDigest(t *testing.T) {
 
 	// Second compaction — must MERGE the 5 late entries into the
 	// existing digest, not skip them.
-	r2, err := s.CompactByDay(initialCutoff)
+	r2, err := s.CompactByDay(context.Background(), initialCutoff)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r2.DaysCompacted, "second run should merge into existing digest (counted as 1 day compacted)")
 	assert.Equal(t, 5, r2.EntriesDeleted, "all 5 late entries must be deleted")

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.7.0
+// version: 1.7.1
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -267,7 +267,7 @@ func (s *ActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
 // Summarize collapses old unpruned entries (older than olderThan, matching tier)
 // into one summary row per (operation_id, type) group. Returns the count of
 // original rows deleted.
-func (s *ActivityStore) Summarize(olderThan time.Time, tier string) (int, error) {
+func (s *ActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error) {
 	var err error
 	defer func() {
 		if err != nil {
@@ -315,7 +315,7 @@ func (s *ActivityStore) Summarize(olderThan time.Time, tier string) (int, error)
 	totalDeleted := 0
 
 	for _, g := range groups {
-		tx, err := s.db.BeginTx(context.Background(), nil)
+		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
 			return totalDeleted, fmt.Errorf("activity_store: summarize begin tx: %w", err)
 		}
@@ -325,7 +325,7 @@ func (s *ActivityStore) Summarize(olderThan time.Time, tier string) (int, error)
 		)
 
 		// Insert summary row
-		_, txErr := tx.ExecContext(context.Background(), `
+		_, txErr := tx.ExecContext(ctx, `
 			INSERT INTO activity_log
 				(timestamp, tier, type, level, source, operation_id,
 				 summary, pruned_at)
@@ -342,14 +342,14 @@ func (s *ActivityStore) Summarize(olderThan time.Time, tier string) (int, error)
 		// Delete originals
 		var res sql.Result
 		if g.opID.Valid {
-			res, txErr = tx.ExecContext(context.Background(), `
+			res, txErr = tx.ExecContext(ctx, `
 				DELETE FROM activity_log
 				WHERE tier = ? AND type = ? AND operation_id = ?
 				  AND timestamp < ? AND pruned_at IS NULL`,
 				tier, g.typ, g.opID.String, olderThan.UTC(),
 			)
 		} else {
-			res, txErr = tx.ExecContext(context.Background(), `
+			res, txErr = tx.ExecContext(ctx, `
 				DELETE FROM activity_log
 				WHERE tier = ? AND type = ? AND operation_id IS NULL
 				  AND timestamp < ? AND pruned_at IS NULL`,
@@ -532,7 +532,7 @@ func nullableJSON(v map[string]any) (any, error) {
 // CompactByDay collapses old change/debug entries into one daily_digest row per
 // UTC day. Audit-tier entries are never touched. Each day is processed in its
 // own transaction for atomicity.
-func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error) {
+func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
 	var result CompactResult
 
 	// 1. Fetch all compactable entries.
@@ -662,7 +662,7 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 		}
 
 		// Transaction: merge-or-insert digest + delete originals.
-		tx, err := s.db.BeginTx(context.Background(), nil)
+		tx, err := s.db.BeginTx(ctx, nil)
 		if err != nil {
 			return result, fmt.Errorf("activity_store: compact begin tx: %w", err)
 		}
@@ -682,7 +682,7 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 			existingID          int64
 			existingDetailsJSON sql.NullString
 		)
-		err = tx.QueryRowContext(context.Background(), `
+		err = tx.QueryRowContext(ctx, `
 			SELECT id, details FROM activity_log
 			WHERE tier = 'digest' AND type = 'daily_digest'
 			  AND date(timestamp) = ?
@@ -734,7 +734,7 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 			detailsBytes = merged
 
 			// Delete the old digest row — we'll insert the combined one below.
-			if _, delErr := tx.ExecContext(context.Background(), `DELETE FROM activity_log WHERE id = ?`, existingID); delErr != nil {
+			if _, delErr := tx.ExecContext(ctx, `DELETE FROM activity_log WHERE id = ?`, existingID); delErr != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
 					log.Printf("CompactByDay rollback on delete old digest: %v", rbErr)
 				}
@@ -742,7 +742,7 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 			}
 		}
 
-		_, err = tx.ExecContext(context.Background(), `
+		_, err = tx.ExecContext(ctx, `
 			INSERT INTO activity_log
 				(timestamp, tier, type, level, source, summary, details, compacted)
 			VALUES (?, 'digest', 'daily_digest', 'info', 'compaction', ?, ?, 1)`,
@@ -770,7 +770,7 @@ func (s *ActivityStore) CompactByDay(olderThan time.Time) (CompactResult, error)
 			for j, id := range batch {
 				args[j] = id
 			}
-			delRes, delErr := tx.ExecContext(context.Background(), "DELETE FROM activity_log WHERE id IN ("+placeholders+")", args...)
+			delRes, delErr := tx.ExecContext(ctx, "DELETE FROM activity_log WHERE id IN ("+placeholders+")", args...)
 			if delErr != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
 					log.Printf("CompactByDay rollback on delete originals: %v", rbErr)

--- a/internal/database/activity_store_test.go
+++ b/internal/database/activity_store_test.go
@@ -1,10 +1,11 @@
 // file: internal/database/activity_store_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: f3a1b2c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 
 package database
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -209,7 +210,7 @@ func TestActivityStore_Summarize(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	deleted, err := s.Summarize(cutoff, "realtime")
+	deleted, err := s.Summarize(context.Background(), cutoff, "realtime")
 	require.NoError(t, err)
 	assert.Equal(t, 5, deleted, "all 5 old originals should be deleted")
 

--- a/internal/server/activity_handlers.go
+++ b/internal/server/activity_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/activity_handlers.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 
 package server
@@ -184,7 +184,7 @@ func (s *Server) compactActivity(c *gin.Context) {
 
 	// 0 means "compact everything up to now"
 	cutoff := time.Now().AddDate(0, 0, -req.OlderThanDays)
-	result, err := s.activityService.CompactByDay(cutoff)
+	result, err := s.activityService.CompactByDay(c.Request.Context(), cutoff)
 	if err != nil {
 		internalError(c, "activity compaction failed", err)
 		return

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler.go
-// version: 1.19.1
+// version: 1.19.2
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -1126,7 +1126,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 						compactionDays = 14
 					}
 					compactionCutoff := time.Now().AddDate(0, 0, -compactionDays)
-					compacted, err := ts.server.activityService.CompactByDay(compactionCutoff)
+					compacted, err := ts.server.activityService.CompactByDay(ctx, compactionCutoff)
 					if err != nil {
 						return fmt.Errorf("compact activity: %w", err)
 					}
@@ -1137,7 +1137,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 						changeDays = 90
 					}
 					changeCutoff := time.Now().AddDate(0, 0, -changeDays)
-					summarized, err := ts.server.activityService.Summarize(changeCutoff, "change")
+					summarized, err := ts.server.activityService.Summarize(ctx, changeCutoff, "change")
 					if err != nil {
 						return fmt.Errorf("summarize activity: %w", err)
 					}


### PR DESCRIPTION
Replaces 8 `context.Background()` calls in `activity_store.go` with a passed-in `context.Context`. HTTP handler callers pass `r.Context()`. Scheduler goroutine callers pass the existing closure `ctx`. Mirrors the DB-2 fix applied to `sqlite_store.go`. Re-audit CTX-4.