### PR TITLE
fix(database): fix TestStoreAdditionalCoverageSQLite after recent migrations

### DIFF
--- a/internal/database/sqlite_store.go
+++ b/internal/database/sqlite_store.go
@@ -1,5 +1,6 @@
 // file: internal/database/sqlite_store.go
-// version: 1.81.0
+
+// version: 1.81.1
 // last-edited: 2026-05-01
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
@@ -3175,9 +3176,11 @@ func (s *SQLiteStore) DeleteBook(id string) error {
 		return fmt.Errorf("DeleteBook rows affected: %w", err)
 	}
 	if rowsAffected == 0 {
-		return fmt.Errorf("book not found")
+		// Set outer err so the deferred rollback fires and releases the transaction.
+		err = fmt.Errorf("book not found")
+		return err
 	}
-	if _, err := tx.Exec("DELETE FROM metadata_states WHERE book_id = ?", id); err != nil {
+	if _, err = tx.Exec("DELETE FROM metadata_states WHERE book_id = ?", id); err != nil {
 		return fmt.Errorf("DeleteBook metadata delete: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Diagnoses and fixes the `TestStoreAdditionalCoverageSQLite` failure in `internal/database`. Re-audit TEST-2.

## Root Cause

`DeleteBook` had two bugs introduced by the transaction-wrapping refactor (2cdeb863):

**Bug 1 (test-breaking):** When `rowsAffected == 0`, the function returned a bare `fmt.Errorf("book not found")` without setting the outer `err` variable. The deferred rollback closure checked `if err != nil`, saw nil, and skipped rollback — leaving the SQLite write transaction open. The next write operation (`DeleteWork`) then failed with `database is locked` after the 5 000 ms busy_timeout.

**Bug 2:** The `metadata_states` delete used `:=` in the if-init, shadowing the outer `err`, preventing the deferred rollback from firing on metadata-delete failure.

## Fix

- Set outer `err` before returning `book not found` so the deferred rollback fires
- Use `=` (not `:=`) in the `metadata_states` delete so errors propagate to the rollback closure

## Verification

```
go test ./internal/database/... -run TestStoreAdditionalCoverageSQLite  → PASS (0.07s, was 5.4s timeout)
go test ./internal/database/... -timeout 180s -count=1  → ok (all tests pass)
```