### PR TITLE
feat(maintenance): add unified maintenance job system

### DIFF
--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,0 +1,47 @@
+// file: internal/maintenance/job.go
+// version: 1.0.0
+// guid: 11111111-1111-1111-1111-111111111111
+// last-edited: 2026-05-03
+
+package maintenance
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+type contextKey string
+
+const opIDKey contextKey = "maintenance_op_id"
+
+// WithOperationID returns a context carrying the given operation ID.
+func WithOperationID(ctx context.Context, opID string) context.Context {
+	return context.WithValue(ctx, opIDKey, opID)
+}
+
+// OperationIDFromCtx returns the operation ID stored in the context, or "".
+func OperationIDFromCtx(ctx context.Context) string {
+	v, _ := ctx.Value(opIDKey).(string)
+	return v
+}
+
+// ProgressReporter is the minimal interface jobs use to report progress.
+type ProgressReporter interface {
+	SetTotal(n int)
+	Increment()
+	Log(level, message string, details *string)
+}
+
+// MaintenanceJob is the interface that every maintenance job must satisfy.
+type MaintenanceJob interface {
+	ID() string
+	Description() string
+	CanResume() bool
+	Run(ctx context.Context, store database.Store, reporter ProgressReporter, dryRun bool) error
+}
+
+var store database.Store
+
+func InjectStore(s database.Store) { store = s }
+func GetStore() database.Store    { return store }

--- a/internal/maintenance/job_test.go
+++ b/internal/maintenance/job_test.go
@@ -1,0 +1,31 @@
+// file: internal/maintenance/job_test.go
+// version: 1.0.0
+// guid: 33333333-3333-3333-3333-333333333333
+// last-edited: 2026-05-03
+
+package maintenance_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func TestContextHelpers(t *testing.T) {
+	ctx := context.Background()
+	if id := maintenance.OperationIDFromCtx(ctx); id != "" {
+		t.Fatalf("expected empty, got %q", id)
+	}
+	ctx = maintenance.WithOperationID(ctx, "op-123")
+	if id := maintenance.OperationIDFromCtx(ctx); id != "op-123" {
+		t.Fatalf("expected op-123, got %q", id)
+	}
+}
+
+func TestGetUnknown(t *testing.T) {
+	_, err := maintenance.Get("does-not-exist-xyzabc")
+	if err == nil {
+		t.Fatal("expected error for unknown job ID")
+	}
+}

--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,0 +1,66 @@
+// file: internal/maintenance/jobs/backfill_book_files.go
+// version: 1.0.0
+// guid: a1000005-0000-0000-0000-000000000005
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+func init() { maintenance.Register(&backfillBookFilesJob{}) }
+
+type backfillBookFilesJob struct{}
+
+func (j *backfillBookFilesJob) ID() string          { return "backfill-book-files" }
+func (j *backfillBookFilesJob) Description() string { return "Create book_files rows for books that have none" }
+func (j *backfillBookFilesJob) CanResume() bool     { return false }
+func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	created := 0
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		book := &books[i]
+		reporter.Increment()
+		files, err := store.GetBookFiles(book.ID)
+		if err != nil {
+			continue
+		}
+		if len(files) > 0 {
+			continue
+		}
+		audioFiles := metafetch.AudioFilesInDir(book.FilePath)
+		for _, fp := range audioFiles {
+			bf := &database.BookFile{
+				ID:       ulid.Make().String(),
+				BookID:   book.ID,
+				FilePath: fp,
+				Format:   filepath.Ext(fp),
+			}
+			if !dryRun {
+				if cerr := store.CreateBookFile(bf); cerr != nil {
+					msg := cerr.Error()
+					reporter.Log("error", "failed to create book file", &msg)
+					continue
+				}
+			}
+			created++
+		}
+	}
+	_ = created
+	reporter.Log("info", "backfill-book-files complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,0 +1,57 @@
+// file: internal/maintenance/jobs/backfill_file_hashes.go
+// version: 1.0.0
+// guid: a1000014-0000-0000-0000-000000000014
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+)
+
+func init() { maintenance.Register(&backfillFileHashesJob{}) }
+
+type backfillFileHashesJob struct{}
+
+func (j *backfillFileHashesJob) ID() string          { return "backfill-file-hashes" }
+func (j *backfillFileHashesJob) Description() string { return "Compute and store file hashes for book_files missing them" }
+func (j *backfillFileHashesJob) CanResume() bool     { return false }
+func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(files))
+	hashed := 0
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		bf := files[i]
+		if bf.FileHash != "" {
+			continue
+		}
+		hash, herr := scanner.ComputeFileHash(bf.FilePath)
+		if herr != nil {
+			msg := herr.Error()
+			reporter.Log("warn", "backfill-file-hashes: hash failed for "+bf.FilePath, &msg)
+			continue
+		}
+		if !dryRun {
+			if serr := store.SetBookFileHash(bf.ID, hash); serr != nil {
+				msg := serr.Error()
+				reporter.Log("error", "backfill-file-hashes: SetBookFileHash failed", &msg)
+				continue
+			}
+		}
+		hashed++
+	}
+	_ = hashed
+	reporter.Log("info", "backfill-file-hashes complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,0 +1,87 @@
+// file: internal/maintenance/jobs/backfill_metadata_source_hash.go
+// version: 1.0.0
+// guid: a1000015-0000-0000-0000-000000000015
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&backfillMetadataSourceHashJob{}) }
+
+type backfillMetadataSourceHashJob struct{}
+
+func (j *backfillMetadataSourceHashJob) ID() string          { return "backfill-metadata-source-hash" }
+func (j *backfillMetadataSourceHashJob) Description() string { return "Compute MetadataSourceHash for books that have one missing" }
+func (j *backfillMetadataSourceHashJob) CanResume() bool     { return false }
+func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	updated := 0
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		book := &books[i]
+		if book.MetadataSourceHash != nil && *book.MetadataSourceHash != "" {
+			continue
+		}
+		src, id := bookMetadataSourceAndID(book)
+		if src == "" || id == "" {
+			continue
+		}
+		raw := fmt.Sprintf("%s:%s", src, id)
+		sum := sha256.Sum256([]byte(raw))
+		hash := fmt.Sprintf("%x", sum)
+		if !dryRun {
+			updBook := *book
+			updBook.MetadataSourceHash = &hash
+			if _, uerr := store.UpdateBook(book.ID, &updBook); uerr != nil {
+				msg := uerr.Error()
+				reporter.Log("error", "backfill-metadata-source-hash: UpdateBook failed", &msg)
+				continue
+			}
+		}
+		updated++
+	}
+	_ = updated
+	reporter.Log("info", "backfill-metadata-source-hash complete", nil)
+	return nil
+}
+
+func bookMetadataSourceAndID(book *database.Book) (string, string) {
+	if book.MetadataSource == nil {
+		return "", ""
+	}
+	src := *book.MetadataSource
+	switch src {
+	case "audible":
+		if book.ASIN != nil && *book.ASIN != "" {
+			return src, *book.ASIN
+		}
+	case "openlibrary":
+		if book.OpenLibraryID != nil && *book.OpenLibraryID != "" {
+			return src, *book.OpenLibraryID
+		}
+	case "google_books":
+		if book.GoogleBooksID != nil && *book.GoogleBooksID != "" {
+			return src, *book.GoogleBooksID
+		}
+	case "hardcover":
+		if book.HardcoverID != nil && *book.HardcoverID != "" {
+			return src, *book.HardcoverID
+		}
+	}
+	return "", ""
+}

--- a/internal/maintenance/jobs/cleanup_backups.go
+++ b/internal/maintenance/jobs/cleanup_backups.go
@@ -1,0 +1,58 @@
+// file: internal/maintenance/jobs/cleanup_backups.go
+// version: 1.0.0
+// guid: a1000021-0000-0000-0000-000000000021
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&cleanupBackupsJob{}) }
+
+var backupFileRe = regexp.MustCompile(`(?i)\.(backup|bak)$|\.bak-\d{8}-\d{6}$`)
+
+type cleanupBackupsJob struct{}
+
+func (j *cleanupBackupsJob) ID() string          { return "cleanup-backups" }
+func (j *cleanupBackupsJob) Description() string { return "Delete .backup and .bak files from the library root" }
+func (j *cleanupBackupsJob) CanResume() bool     { return false }
+func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	root := config.AppConfig.RootDir
+	if root == "" {
+		reporter.Log("warn", "cleanup-backups: RootDir not configured", nil)
+		return nil
+	}
+	removed := 0
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !backupFileRe.MatchString(filepath.Base(path)) {
+			return nil
+		}
+		if !dryRun {
+			if rerr := os.Remove(path); rerr == nil {
+				removed++
+			}
+		} else {
+			removed++
+			reporter.Log("info", "would remove: "+path, nil)
+		}
+		return nil
+	})
+	_ = removed
+	reporter.Log("info", "cleanup-backups complete", nil)
+	return err
+}

--- a/internal/maintenance/jobs/cleanup_empty_folders.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders.go
@@ -1,0 +1,55 @@
+// file: internal/maintenance/jobs/cleanup_empty_folders.go
+// version: 1.0.0
+// guid: a1000006-0000-0000-0000-000000000006
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&cleanupEmptyFoldersJob{}) }
+
+type cleanupEmptyFoldersJob struct{}
+
+func (j *cleanupEmptyFoldersJob) ID() string          { return "cleanup-empty-folders" }
+func (j *cleanupEmptyFoldersJob) Description() string { return "Remove empty directories from the library root" }
+func (j *cleanupEmptyFoldersJob) CanResume() bool     { return false }
+func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	root := config.AppConfig.RootDir
+	if root == "" {
+		reporter.Log("warn", "cleanup-empty-folders: RootDir not configured", nil)
+		return nil
+	}
+	removed := 0
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !d.IsDir() || path == root {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		entries, rerr := os.ReadDir(path)
+		if rerr != nil || len(entries) != 0 {
+			return nil
+		}
+		if !dryRun {
+			if rerr2 := os.Remove(path); rerr2 == nil {
+				removed++
+			}
+		} else {
+			removed++
+		}
+		return nil
+	})
+	_ = removed
+	reporter.Log("info", "cleanup-empty-folders complete", nil)
+	return err
+}

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/cleanup_organize_mess.go
+// version: 1.0.0
+// guid: a1000007-0000-0000-0000-000000000007
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&cleanupOrganizeMess{}) }
+
+type cleanupOrganizeMess struct{}
+
+func (j *cleanupOrganizeMess) ID() string          { return "cleanup-organize-mess" }
+func (j *cleanupOrganizeMess) Description() string { return "Clean up leftover organize artifacts and garbage directories" }
+func (j *cleanupOrganizeMess) CanResume() bool     { return false }
+func (j *cleanupOrganizeMess) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "cleanup-organize-mess: requires server services — use legacy /api/v1/maintenance/cleanup-organize-mess route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/cleanup_series.go
+// version: 1.0.0
+// guid: a1000002-0000-0000-0000-000000000002
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&cleanupSeriesJob{}) }
+
+type cleanupSeriesJob struct{}
+
+func (j *cleanupSeriesJob) ID() string          { return "cleanup-series" }
+func (j *cleanupSeriesJob) Description() string { return "Cleanup and normalize series names" }
+func (j *cleanupSeriesJob) CanResume() bool     { return false }
+func (j *cleanupSeriesJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "cleanup-series: requires server services — use legacy /api/v1/maintenance/cleanup-series route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/dedup_books.go
+// version: 1.0.0
+// guid: a1000010-0000-0000-0000-000000000010
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&dedupBooksJob{}) }
+
+type dedupBooksJob struct{}
+
+func (j *dedupBooksJob) ID() string          { return "dedup-books" }
+func (j *dedupBooksJob) Description() string { return "Detect and merge duplicate books" }
+func (j *dedupBooksJob) CanResume() bool     { return false }
+func (j *dedupBooksJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "dedup-books: requires server services — use legacy /api/v1/maintenance/dedup-books route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/doc.go
+++ b/internal/maintenance/jobs/doc.go
@@ -1,0 +1,8 @@
+// file: internal/maintenance/jobs/doc.go
+// version: 1.0.0
+// guid: 77777777-7777-7777-7777-777777777777
+// last-edited: 2026-05-03
+
+// Package jobs registers all built-in maintenance jobs with the maintenance
+// registry. Import it with a blank import to trigger all init() functions.
+package jobs

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,0 +1,66 @@
+// file: internal/maintenance/jobs/enrich_book_files.go
+// version: 1.0.0
+// guid: a1000009-0000-0000-0000-000000000009
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&enrichBookFilesJob{}) }
+
+var trackNumRe = regexp.MustCompile(`^(\d+)[\s._\-]`)
+
+type enrichBookFilesJob struct{}
+
+func (j *enrichBookFilesJob) ID() string          { return "enrich-book-files" }
+func (j *enrichBookFilesJob) Description() string { return "Backfill track numbers for book_files from filenames" }
+func (j *enrichBookFilesJob) CanResume() bool     { return false }
+func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(files))
+	updated := 0
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		bf := files[i]
+		if bf.TrackNumber != 0 {
+			continue
+		}
+		stem := strings.TrimSuffix(filepath.Base(bf.FilePath), filepath.Ext(bf.FilePath))
+		m := trackNumRe.FindStringSubmatch(stem)
+		if m == nil {
+			continue
+		}
+		n, perr := strconv.Atoi(m[1])
+		if perr != nil || n <= 0 {
+			continue
+		}
+		if !dryRun {
+			bf.TrackNumber = n
+			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+				msg := uerr.Error()
+				reporter.Log("error", "enrich-book-files: UpdateBookFile failed", &msg)
+				continue
+			}
+		}
+		updated++
+	}
+	_ = updated
+	reporter.Log("info", "enrich-book-files complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/fix_author_narrator_swap.go
+// version: 1.0.0
+// guid: a1000003-0000-0000-0000-000000000003
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
+
+type fixAuthorNarratorSwapJob struct{}
+
+func (j *fixAuthorNarratorSwapJob) ID() string          { return "fix-author-narrator-swap" }
+func (j *fixAuthorNarratorSwapJob) Description() string { return "Fix books where author and narrator fields are swapped" }
+func (j *fixAuthorNarratorSwapJob) CanResume() bool     { return false }
+func (j *fixAuthorNarratorSwapJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "fix-author-narrator-swap: complex heuristics — use legacy /api/v1/maintenance/fix-author-narrator-swap route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,0 +1,54 @@
+// file: internal/maintenance/jobs/fix_book_file_paths.go
+// version: 1.0.0
+// guid: a1000011-0000-0000-0000-000000000011
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"os"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixBookFilePathsJob{}) }
+
+type fixBookFilePathsJob struct{}
+
+func (j *fixBookFilePathsJob) ID() string          { return "fix-book-file-paths" }
+func (j *fixBookFilePathsJob) Description() string { return "Mark book_files as missing when they no longer exist on disk" }
+func (j *fixBookFilePathsJob) CanResume() bool     { return false }
+func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(files))
+	marked := 0
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		bf := files[i]
+		if bf.Missing {
+			continue
+		}
+		if _, serr := os.Stat(bf.FilePath); os.IsNotExist(serr) {
+			if !dryRun {
+				bf.Missing = true
+				if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+					msg := uerr.Error()
+					reporter.Log("error", "fix-book-file-paths: UpdateBookFile failed", &msg)
+					continue
+				}
+			}
+			marked++
+		}
+	}
+	_ = marked
+	reporter.Log("info", "fix-book-file-paths complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,0 +1,64 @@
+// file: internal/maintenance/jobs/fix_library_states.go
+// version: 1.0.0
+// guid: a1000008-0000-0000-0000-000000000008
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"os"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixLibraryStatesJob{}) }
+
+type fixLibraryStatesJob struct{}
+
+func (j *fixLibraryStatesJob) ID() string          { return "fix-library-states" }
+func (j *fixLibraryStatesJob) Description() string { return "Reconcile library_state field based on filesystem presence" }
+func (j *fixLibraryStatesJob) CanResume() bool     { return false }
+func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	fixed := 0
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		book := &books[i]
+		_, statErr := os.Stat(book.FilePath)
+		wantState := "present"
+		if os.IsNotExist(statErr) {
+			wantState = "missing"
+		}
+		cur := ""
+		if book.LibraryState != nil {
+			cur = *book.LibraryState
+		}
+		if cur == wantState {
+			continue
+		}
+		if !dryRun {
+			updated := *book
+			updated.LibraryState = &wantState
+			if _, uerr := store.UpdateBook(book.ID, &updated); uerr != nil {
+				msg := uerr.Error()
+				reporter.Log("error", "fix-library-states: UpdateBook failed", &msg)
+			} else {
+				fixed++
+			}
+		} else {
+			fixed++
+		}
+	}
+	_ = fixed
+	reporter.Log("info", "fix-library-states complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/fix_read_by_narrator.go
+// version: 1.0.0
+// guid: a1000001-0000-0000-0000-000000000001
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixReadByNarratorJob{}) }
+
+type fixReadByNarratorJob struct{}
+
+func (j *fixReadByNarratorJob) ID() string          { return "fix-read-by-narrator" }
+func (j *fixReadByNarratorJob) Description() string { return "Fix books where narrator was recorded as author" }
+func (j *fixReadByNarratorJob) CanResume() bool     { return false }
+func (j *fixReadByNarratorJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "fix-read-by-narrator: complex parsing — use legacy /api/v1/maintenance/fix-read-by-narrator route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/fix_version_groups.go
+// version: 1.0.0
+// guid: a1000004-0000-0000-0000-000000000004
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&fixVersionGroupsJob{}) }
+
+type fixVersionGroupsJob struct{}
+
+func (j *fixVersionGroupsJob) ID() string          { return "fix-version-groups" }
+func (j *fixVersionGroupsJob) Description() string { return "Fix and normalize version groups" }
+func (j *fixVersionGroupsJob) CanResume() bool     { return false }
+func (j *fixVersionGroupsJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "fix-version-groups: requires server services — use legacy /api/v1/maintenance/fix-version-groups route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/merge_chapter_groups.go
+++ b/internal/maintenance/jobs/merge_chapter_groups.go
@@ -1,0 +1,58 @@
+// file: internal/maintenance/jobs/merge_chapter_groups.go
+// version: 1.0.0
+// guid: a1000020-0000-0000-0000-000000000020
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+)
+
+func init() { maintenance.Register(&mergeChapterGroupsJob{}) }
+
+type mergeChapterGroupsJob struct{}
+
+func (j *mergeChapterGroupsJob) ID() string          { return "merge-chapter-groups" }
+func (j *mergeChapterGroupsJob) Description() string { return "Merge multi-chapter book files into consolidated book records" }
+func (j *mergeChapterGroupsJob) CanResume() bool     { return false }
+func (j *mergeChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	groups := scanner.DetectChapterGroups(books, 2, 600)
+	reporter.SetTotal(len(groups))
+	merged := 0
+	for _, g := range groups {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		if len(g.BookIDs) < 2 {
+			continue
+		}
+		primaryID := g.BookIDs[0]
+		srcIDs := g.BookIDs[1:]
+		if !dryRun {
+			if merr := store.MergeChapterBooks(primaryID, srcIDs, g.CommonTitle, g.TotalDuration); merr != nil {
+				msg := merr.Error()
+				reporter.Log("error", "merge-chapter-groups: MergeChapterBooks failed", &msg)
+				continue
+			}
+		}
+		merged++
+		detail := fmt.Sprintf("primary=%s srcs=%v title=%q", primaryID, srcIDs, g.CommonTitle)
+		reporter.Log("info", "merged chapter group", &detail)
+	}
+	reporter.Log("info", fmt.Sprintf("merge-chapter-groups complete: %d merged", merged), nil)
+	return nil
+}

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,0 +1,53 @@
+// file: internal/maintenance/jobs/recompute_itunes_paths.go
+// version: 1.0.0
+// guid: a1000013-0000-0000-0000-000000000013
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+)
+
+func init() { maintenance.Register(&recomputeITunesPathsJob{}) }
+
+type recomputeITunesPathsJob struct{}
+
+func (j *recomputeITunesPathsJob) ID() string          { return "recompute-itunes-paths" }
+func (j *recomputeITunesPathsJob) Description() string { return "Recompute iTunes path mapping for all book files" }
+func (j *recomputeITunesPathsJob) CanResume() bool     { return false }
+func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(files))
+	updated := 0
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		bf := files[i]
+		want := metafetch.ComputeITunesPath(bf.FilePath)
+		if want == bf.ITunesPath {
+			continue
+		}
+		if !dryRun {
+			bf.ITunesPath = want
+			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+				msg := uerr.Error()
+				reporter.Log("error", "recompute-itunes-paths: UpdateBookFile failed", &msg)
+				continue
+			}
+		}
+		updated++
+	}
+	_ = updated
+	reporter.Log("info", "recompute-itunes-paths complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,0 +1,42 @@
+// file: internal/maintenance/jobs/refetch_missing_authors.go
+// version: 1.0.0
+// guid: a1000012-0000-0000-0000-000000000012
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&refetchMissingAuthorsJob{}) }
+
+type refetchMissingAuthorsJob struct{}
+
+func (j *refetchMissingAuthorsJob) ID() string          { return "refetch-missing-authors" }
+func (j *refetchMissingAuthorsJob) Description() string { return "Report books missing an author record" }
+func (j *refetchMissingAuthorsJob) CanResume() bool     { return false }
+func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	count := 0
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		if books[i].AuthorID == nil {
+			count++
+			reporter.Log("info", "missing author: "+books[i].Title, nil)
+		}
+	}
+	_ = count
+	reporter.Log("info", "refetch-missing-authors complete", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,0 +1,25 @@
+// file: internal/maintenance/jobs/relink_report.go
+// version: 1.0.0
+// guid: a1000022-0000-0000-0000-000000000022
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&relinkReportJob{}) }
+
+type relinkReportJob struct{}
+
+func (j *relinkReportJob) ID() string          { return "relink-report" }
+func (j *relinkReportJob) Description() string { return "Report missing iTunes-linked files that may be relinkable" }
+func (j *relinkReportJob) CanResume() bool     { return false }
+func (j *relinkReportJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	reporter.Log("warn", "relink-report: requires iTunes service — use legacy /api/v1/maintenance/relink-missing-to-itunes route", nil)
+	return nil
+}

--- a/internal/maintenance/jobs/scan_chapter_groups.go
+++ b/internal/maintenance/jobs/scan_chapter_groups.go
@@ -1,0 +1,41 @@
+// file: internal/maintenance/jobs/scan_chapter_groups.go
+// version: 1.0.0
+// guid: a1000019-0000-0000-0000-000000000019
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+)
+
+func init() { maintenance.Register(&scanChapterGroupsJob{}) }
+
+type scanChapterGroupsJob struct{}
+
+func (j *scanChapterGroupsJob) ID() string          { return "scan-chapter-groups" }
+func (j *scanChapterGroupsJob) Description() string { return "Report books that look like multi-chapter parts of the same audiobook" }
+func (j *scanChapterGroupsJob) CanResume() bool     { return false }
+func (j *scanChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	groups := scanner.DetectChapterGroups(books, 2, 600)
+	reporter.SetTotal(len(groups))
+	for _, g := range groups {
+		reporter.Increment()
+		detail := fmt.Sprintf("title=%q files=%d duration=%.0fs ids=%v", g.CommonTitle, g.FileCount, g.TotalDuration, g.BookIDs)
+		reporter.Log("info", "chapter group detected", &detail)
+	}
+	reporter.Log("info", fmt.Sprintf("scan-chapter-groups complete: %d groups", len(groups)), nil)
+	return nil
+}

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,0 +1,50 @@
+// file: internal/maintenance/jobs/scan_duplicate_files.go
+// version: 1.0.0
+// guid: a1000016-0000-0000-0000-000000000016
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&scanDuplicateFilesJob{}) }
+
+type scanDuplicateFilesJob struct{}
+
+func (j *scanDuplicateFilesJob) ID() string          { return "scan-duplicate-files" }
+func (j *scanDuplicateFilesJob) Description() string { return "Scan for book files sharing the same hash" }
+func (j *scanDuplicateFilesJob) CanResume() bool     { return false }
+func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(files))
+	byHash := map[string][]string{}
+	for i := range files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		if files[i].FileHash == "" {
+			continue
+		}
+		byHash[files[i].FileHash] = append(byHash[files[i].FileHash], files[i].FilePath)
+	}
+	dups := 0
+	for hash, paths := range byHash {
+		if len(paths) > 1 {
+			dups++
+			detail := fmt.Sprintf("hash=%s paths=%v", hash, paths)
+			reporter.Log("warn", "duplicate files detected", &detail)
+		}
+	}
+	reporter.Log("info", fmt.Sprintf("scan-duplicate-files complete: %d duplicate groups", dups), nil)
+	return nil
+}

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,0 +1,52 @@
+// file: internal/maintenance/jobs/scan_duration_mismatch.go
+// version: 1.0.0
+// guid: a1000018-0000-0000-0000-000000000018
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&scanDurationMismatchJob{}) }
+
+type scanDurationMismatchJob struct{}
+
+func (j *scanDurationMismatchJob) ID() string          { return "scan-duration-mismatch" }
+func (j *scanDurationMismatchJob) Description() string { return "Report books whose local duration differs significantly from Audible runtime" }
+func (j *scanDurationMismatchJob) CanResume() bool     { return false }
+func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	mismatches := 0
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		b := &books[i]
+		if b.Duration == nil || b.AudibleRuntimeMin == nil {
+			continue
+		}
+		audibleSec := (*b.AudibleRuntimeMin) * 60
+		delta := *b.Duration - audibleSec
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta > 120 {
+			mismatches++
+			detail := fmt.Sprintf("local=%ds audible=%ds delta=%ds", *b.Duration, audibleSec, delta)
+			reporter.Log("warn", "duration mismatch: "+b.Title, &detail)
+		}
+	}
+	reporter.Log("info", fmt.Sprintf("scan-duration-mismatch complete: %d mismatches", mismatches), nil)
+	return nil
+}

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,0 +1,50 @@
+// file: internal/maintenance/jobs/scan_metadata_hash_dups.go
+// version: 1.0.0
+// guid: a1000017-0000-0000-0000-000000000017
+// last-edited: 2026-05-03
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&scanMetadataHashDupsJob{}) }
+
+type scanMetadataHashDupsJob struct{}
+
+func (j *scanMetadataHashDupsJob) ID() string          { return "scan-metadata-hash-dups" }
+func (j *scanMetadataHashDupsJob) Description() string { return "Scan for books sharing the same metadata source hash" }
+func (j *scanMetadataHashDupsJob) CanResume() bool     { return false }
+func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return err
+	}
+	reporter.SetTotal(len(books))
+	byHash := map[string][]string{}
+	for i := range books {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+		if books[i].MetadataSourceHash == nil || *books[i].MetadataSourceHash == "" {
+			continue
+		}
+		byHash[*books[i].MetadataSourceHash] = append(byHash[*books[i].MetadataSourceHash], books[i].ID)
+	}
+	dups := 0
+	for _, ids := range byHash {
+		if len(ids) > 1 {
+			dups++
+			detail := fmt.Sprintf("book_ids=%v", ids)
+			reporter.Log("warn", "metadata hash duplicate group", &detail)
+		}
+	}
+	reporter.Log("info", fmt.Sprintf("scan-metadata-hash-dups complete: %d duplicate groups", dups), nil)
+	return nil
+}

--- a/internal/maintenance/registry.go
+++ b/internal/maintenance/registry.go
@@ -1,0 +1,45 @@
+// file: internal/maintenance/registry.go
+// version: 1.0.0
+// guid: 22222222-2222-2222-2222-222222222222
+// last-edited: 2026-05-03
+
+package maintenance
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	mu       sync.RWMutex
+	registry []MaintenanceJob
+	byID     = map[string]MaintenanceJob{}
+)
+
+func Register(j MaintenanceJob) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, dup := byID[j.ID()]; dup {
+		panic(fmt.Sprintf("maintenance: duplicate job ID %q", j.ID()))
+	}
+	registry = append(registry, j)
+	byID[j.ID()] = j
+}
+
+func Get(id string) (MaintenanceJob, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	j, ok := byID[id]
+	if !ok {
+		return nil, fmt.Errorf("maintenance: unknown job %q", id)
+	}
+	return j, nil
+}
+
+func All() []MaintenanceJob {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]MaintenanceJob, len(registry))
+	copy(out, registry)
+	return out
+}

--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -1,6 +1,7 @@
 // file: internal/operations/state.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-05-03
 
 package operations
 
@@ -150,6 +151,21 @@ func LoadParams[T any](store database.Store, opID string) (*T, error) {
 		return nil, err
 	}
 	return &params, nil
+}
+
+// LoadRawParams loads an operation's raw JSON parameters.
+// Returns nil if no params are stored.
+func LoadRawParams(store database.OperationStore, opID string) (json.RawMessage, error) {
+	data, err := store.GetOperationParams(opID)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// SaveRawParams persists raw JSON parameters for an operation.
+func SaveRawParams(store database.OperationStore, opID string, raw json.RawMessage) error {
+	return store.SaveOperationParams(opID, raw)
 }
 
 // ClearState removes all persisted state for an operation (called on completion/failure).

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,0 +1,84 @@
+// file: internal/server/maintenance_dispatcher.go
+// version: 1.0.0
+// guid: 55555555-5555-5555-5555-555555555555
+// last-edited: 2026-05-03
+
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// progressAdapter adapts operations.ProgressReporter to maintenance.ProgressReporter.
+type progressAdapter struct {
+	ops   operations.ProgressReporter
+	cur   int
+	total int
+}
+
+func (a *progressAdapter) SetTotal(n int) { a.total = n }
+
+func (a *progressAdapter) Increment() {
+	a.cur++
+	_ = a.ops.UpdateProgress(a.cur, a.total, "")
+}
+
+func (a *progressAdapter) Log(level, message string, details *string) {
+	_ = a.ops.Log(level, message, details)
+}
+
+// listMaintenanceJobs returns the catalogue of all registered maintenance jobs.
+func (s *Server) listMaintenanceJobs(c *gin.Context) {
+	jobs := maintenance.All()
+	type jobDef struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+		CanResume   bool   `json:"can_resume"`
+	}
+	out := make([]jobDef, len(jobs))
+	for i, j := range jobs {
+		out[i] = jobDef{
+			ID:          j.ID(),
+			Description: j.Description(),
+			CanResume:   j.CanResume(),
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"jobs": out})
+}
+
+// runMaintenanceJob enqueues the named maintenance job as an async operation.
+func (s *Server) runMaintenanceJob(c *gin.Context) {
+	jobID := c.Param("job_id")
+	job, err := maintenance.Get(jobID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	var req struct {
+		DryRun bool `json:"dry_run"`
+	}
+	_ = c.ShouldBindJSON(&req)
+
+	opID := ulid.Make().String()
+	opType := "maintenance:" + jobID
+	store := s.Store()
+
+	enqueueFn := operations.OperationFunc(func(ctx context.Context, reporter operations.ProgressReporter) error {
+		ctx = maintenance.WithOperationID(ctx, opID)
+		adapter := &progressAdapter{ops: reporter}
+		return job.Run(ctx, store, adapter, req.DryRun)
+	})
+
+	if err := s.queue.Enqueue(opID, opType, operations.PriorityNormal, enqueueFn); err != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"operation_id": opID})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 1.210.0
+// version: 1.211.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-04-30
+// last-edited: 2026-05-03
 
 package server
 
@@ -33,6 +33,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/diagnostics"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	_ "github.com/jdfalk/audiobook-organizer/internal/maintenance/jobs"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
@@ -942,6 +944,9 @@ func NewServer(store database.Store) *Server {
 	// Propagate rootDir into the store so LibraryStats can split organized vs unorganized.
 	resolvedStore.SetRootDir(config.AppConfig.RootDir)
 
+	// Inject the store into the maintenance package so jobs can access it.
+	maintenance.InjectStore(resolvedStore)
+
 	// Initialize plugin event bus and registry
 	server.eventBus = plugin.NewEventBus()
 	server.pluginRegistry = plugin.Global()
@@ -1686,10 +1691,21 @@ func (s *Server) resumeInterruptedOperations() {
 			_ = operations.ClearState(store, opID)
 			continue
 		default:
-			// Unknown type — mark as failed without noisy logging
-			_ = store.UpdateOperationError(opID, "interrupted, cannot resume")
-			_ = operations.ClearState(store, opID)
-			continue
+			// Try to resume as a maintenance job
+			if j, jobErr := maintenance.Get(strings.TrimPrefix(opType, "maintenance:")); jobErr == nil && j.CanResume() {
+				capturedOpID := opID
+				capturedJob := j
+				capturedStore := store
+				resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
+					ctx = maintenance.WithOperationID(ctx, capturedOpID)
+					adapter := &progressAdapter{ops: progress}
+					return capturedJob.Run(ctx, capturedStore, adapter, false)
+				}
+			} else {
+				_ = store.UpdateOperationError(opID, "interrupted, cannot resume")
+				_ = operations.ClearState(store, opID)
+				continue
+			}
 		}
 
 		if err := oq.EnqueueResume(opID, opType, operations.PriorityNormal, resumeFn); err != nil {
@@ -2630,6 +2646,8 @@ func (s *Server) setupRoutes() {
 			protected.GET("/maintenance/book-file-hash-stats", s.perm(auth.PermSettingsManage), s.handleGetBookFileHashStats)
 			protected.POST("/maintenance/backfill-file-hashes", s.perm(auth.PermSettingsManage), s.handleBackfillFileHashes)
 			protected.GET("/maintenance/book-metadata-hash-stats", s.perm(auth.PermSettingsManage), s.handleGetBookMetadataHashStats)
+			protected.GET("/maintenance/jobs", s.perm(auth.PermSettingsManage), s.listMaintenanceJobs)
+			protected.POST("/maintenance/jobs/:job_id", s.perm(auth.PermSettingsManage), s.runMaintenanceJob)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
-// last-edited: 2026-04-30
+// last-edited: 2026-05-03
 
 import { useEffect, useState, useCallback } from 'react';
 import {
@@ -593,6 +593,78 @@ function MetadataHashDuplicateCard() {
   );
 }
 
+// ─── ManualFixesCard ──────────────────────────────────────────────────────────
+
+function ManualFixesCard() {
+  const [jobs, setJobs] = useState<api.MaintenanceJobDef[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState<string | null>(null);
+  const [opId, setOpId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.listMaintenanceJobs()
+      .then(setJobs)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load jobs'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleRun = async (jobId: string) => {
+    setRunning(jobId);
+    setError(null);
+    setOpId(null);
+    try {
+      const result = await api.runMaintenanceJob(jobId);
+      setOpId(result.operation_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `Failed to run ${jobId}`);
+    } finally {
+      setRunning(null);
+    }
+  };
+
+  return (
+    <Card sx={{ mb: 3 }}>
+      <CardHeader title="Manual Fixes" subheader="One-shot maintenance jobs dispatched as async operations" />
+      <CardContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {opId && (
+          <Alert severity="success" sx={{ mb: 1.5 }} onClose={() => setOpId(null)}>
+            Operation enqueued: {opId}
+          </Alert>
+        )}
+        {loading ? (
+          <CircularProgress size={24} />
+        ) : (
+          <Stack spacing={1}>
+            {jobs.map((job) => (
+              <Box key={job.id} sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="body2" fontWeight="medium">{job.id}</Typography>
+                  <Typography variant="caption" color="text.secondary">{job.description}</Typography>
+                </Box>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={running === job.id ? <CircularProgress size={14} color="inherit" /> : <PlayArrowIcon />}
+                  disabled={running !== null}
+                  onClick={() => handleRun(job.id)}
+                >
+                  {running === job.id ? 'Starting…' : 'Run'}
+                </Button>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── MaintenanceTab ───────────────────────────────────────────────────────────
 
 export function MaintenanceTab() {
@@ -688,6 +760,8 @@ export function MaintenanceTab() {
       </Typography>
 
       <MaintenanceWindowCard />
+
+      <ManualFixesCard />
 
       <ChapterConsolidationCard />
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.12.0
+// version: 2.13.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-04-30
+// last-edited: 2026-05-03
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -4599,3 +4599,36 @@ export async function backfillFileHashes(dryRun = false): Promise<BackfillHashes
   return response.json();
 }
 
+
+// ── Unified Maintenance Jobs ──────────────────────────────────────────────────
+
+export interface MaintenanceJobDef {
+  id: string;
+  description: string;
+  can_resume: boolean;
+}
+
+export interface MaintenanceJobsResult {
+  jobs: MaintenanceJobDef[];
+}
+
+export async function listMaintenanceJobs(): Promise<MaintenanceJobDef[]> {
+  const response = await fetch(`${API_BASE}/maintenance/jobs`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to list maintenance jobs');
+  }
+  const body = await response.json();
+  return (body as MaintenanceJobsResult).jobs ?? [];
+}
+
+export async function runMaintenanceJob(jobId: string, dryRun = false): Promise<{ operation_id: string }> {
+  const response = await fetch(`${API_BASE}/maintenance/jobs/${encodeURIComponent(jobId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dry_run: dryRun }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, `Failed to run maintenance job "${jobId}"`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary

Replaces 14+ individual synchronous maintenance handlers with a self-registering `MaintenanceJob` interface pattern. One dispatcher handles all jobs; each job auto-registers via `init()`; the frontend dynamically renders all registered jobs.

## Changes

### New: `internal/maintenance/`
- `job.go` — `MaintenanceJob` interface + `ProgressReporter`, context helpers for opID, package-level store injection
- `registry.go` — thread-safe `Register`/`Get`/`All` functions
- `job_test.go` — 2 passing tests
- `jobs/` — 22 job files (15 full implementations, 7 stubs pending server-layer refactor):
  - **Implemented:** `fix-library-states`, `scan-duration-mismatch`, `recompute-itunes-paths`, `cleanup-backups`, `scan-duplicate-files`, `scan-metadata-hash-dups`, `backfill-file-hashes`, `backfill-metadata-source-hash`, `merge-chapter-groups`, `scan-chapter-groups`, `fix-book-file-paths`, `backfill-book-files`, `enrich-book-files`, `cleanup-empty-folders`, `refetch-missing-authors`
  - **Stubs** (log warning, redirect to legacy route): `fix-read-by-narrator`, `cleanup-series`, `cleanup-organize-mess`, `fix-version-groups`, `dedup-books`, `relink-report`, `fix-author-narrator-swap`

### Modified: `internal/server/`
- `maintenance_dispatcher.go` — `listMaintenanceJobs` + `runMaintenanceJob` handlers; `progressAdapter` bridges interfaces
- `server.go` — blank import `maintenance/jobs`, `maintenance.InjectStore`, routes `GET/POST /maintenance/jobs[/:job_id]`, generic resume fallback in `resumeInterruptedOperations`

### Modified: `internal/operations/state.go`
- Added `LoadRawParams`/`SaveRawParams` for raw JSON checkpoint params (v1.5.0)

### Modified: Frontend
- `web/src/services/api.ts` — `MaintenanceJobDef`, `listMaintenanceJobs()`, `runMaintenanceJob()` (v2.13.0)
- `web/src/components/system/MaintenanceTab.tsx` — `ManualFixesCard` component with per-job run buttons (v1.5.0)

## Testing
- `make build-api` ✅
- `go test ./internal/maintenance/...` ✅
- `go vet ./...` ✅
- TypeScript: 0 errors

## Notes
- The 7 stub jobs require private server methods to be extracted into the store/service layer before they can be fully implemented (tracked in TODO)
- opType format: `"maintenance:" + jobID` for operation tracking and resume
- Implements spec: `docs/superpowers/specs/2026-04-28-unified-maintenance-system.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>