### PR TITLE
fix(server): replace deprecated Book.ITunesPath reads in server handlers

### DIFF
--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,6 +1,7 @@
 // file: internal/server/itl_rebuild.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
+// last-edited: 2026-05-01
 //
 // iTunes library rebuild service: diffs the current DB state
 // against the current ITL file and computes the minimal set of
@@ -45,10 +46,18 @@ type ITLRebuildResult struct {
 	Error   string            `json:"error,omitempty"`
 }
 
+// itlRebuildStore is the minimal store interface needed by the ITL rebuild
+// functions: read access to books plus the ability to look up book files
+// (for sourcing ITunesPath from BookFile rather than the deprecated Book field).
+type itlRebuildStore interface {
+	database.BookReader
+	GetBookFiles(bookID string) ([]database.BookFile, error)
+}
+
 // computeITLDiff reads the current ITL and the current DB state,
 // and returns the ITLOperationSet that would synchronize them
 // plus a preview of what that set contains.
-func computeITLDiff(store database.BookReader, itlPath string) (*itunes.ITLOperationSet, *ITLRebuildPreview, error) {
+func computeITLDiff(store itlRebuildStore, itlPath string) (*itunes.ITLOperationSet, *ITLRebuildPreview, error) {
 	// Parse the current ITL to get all existing tracks.
 	lib, err := itunes.ParseITL(itlPath)
 	if err != nil {
@@ -158,8 +167,8 @@ func computeITLDiff(store database.BookReader, itlPath string) (*itunes.ITLOpera
 
 		// Location update.
 		wantLoc := ""
-		if book.ITunesPath != nil && *book.ITunesPath != "" {
-			wantLoc = *book.ITunesPath
+		if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 && bfs[0].ITunesPath != "" {
+			wantLoc = bfs[0].ITunesPath
 		}
 		if wantLoc != "" && track.Location != wantLoc {
 			ops.LocationUpdates = append(ops.LocationUpdates, itunes.ITLLocationUpdate{
@@ -180,17 +189,15 @@ func computeITLDiff(store database.BookReader, itlPath string) (*itunes.ITLOpera
 // buildNewTrackFromBook constructs an ITLNewTrack from a database
 // Book for insertion into the ITL. Fills as many fields as
 // possible from the book's metadata.
-func buildNewTrackFromBook(store database.BookReader, book *database.Book) itunes.ITLNewTrack {
+func buildNewTrackFromBook(store itlRebuildStore, book *database.Book) itunes.ITLNewTrack {
 	authorName, _ := resolveAuthorAndSeriesNames(book)
 	genre := "Audiobook"
 	if book.Genre != nil && *book.Genre != "" {
 		genre = *book.Genre
 	}
-	location := ""
-	if book.ITunesPath != nil {
-		location = *book.ITunesPath
-	} else {
-		location = book.FilePath
+	location := book.FilePath
+	if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 && bfs[0].ITunesPath != "" {
+		location = bfs[0].ITunesPath
 	}
 	totalTime := 0
 	if book.Duration != nil {

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.8.0
+// version: 1.8.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-04-28
+// last-edited: 2026-05-01
 
 package server
 
@@ -228,7 +228,7 @@ func (s *Server) fetchCandidateForBook(
 		}
 	}
 
-	bookInfo := buildCandidateBookInfo(book)
+	bookInfo := buildCandidateBookInfo(store, book)
 
 	// Wait for rate limiter before making external requests.
 	if err := limiter.Wait(ctx); err != nil {
@@ -288,7 +288,8 @@ func (s *Server) fetchCandidateForBook(
 }
 
 // buildCandidateBookInfo builds a CandidateBookInfo from a database.Book.
-func buildCandidateBookInfo(book *database.Book) CandidateBookInfo {
+// store is used to look up BookFile.ITunesPath (the authoritative field).
+func buildCandidateBookInfo(store database.BookFileStore, book *database.Book) CandidateBookInfo {
 	info := CandidateBookInfo{
 		ID:       book.ID,
 		Title:    book.Title,
@@ -298,8 +299,8 @@ func buildCandidateBookInfo(book *database.Book) CandidateBookInfo {
 	if book.Author != nil {
 		info.Author = book.Author.Name
 	}
-	if book.ITunesPath != nil {
-		info.ITunesPath = *book.ITunesPath
+	if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 {
+		info.ITunesPath = bfs[0].ITunesPath
 	}
 	if book.CoverURL != nil {
 		info.CoverURL = *book.CoverURL


### PR DESCRIPTION
Removes 6 SA1019 warnings in `itl_rebuild.go` (4 reads) and `metadata_batch_candidates.go` (2 reads). Uses `GetBookFiles` to source `ITunesPath` from `BookFile` instead of the deprecated `Book` field. Re-audit DEP-1c.