### PR TITLE
fix(metafetch): replace deprecated Book.ITunesPath with BookFile.ITunesPath

### DIFF
--- a/internal/metafetch/batch.go
+++ b/internal/metafetch/batch.go
@@ -1,6 +1,7 @@
 // file: internal/metafetch/batch.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
+// last-edited: 2026-05-01
 
 package metafetch
 
@@ -40,7 +41,8 @@ type CandidateResult struct {
 }
 
 // BuildCandidateBookInfo builds a CandidateBookInfo from a database.Book.
-func BuildCandidateBookInfo(book *database.Book) CandidateBookInfo {
+// store is used to look up the first BookFile for ITunesPath; pass nil to skip.
+func BuildCandidateBookInfo(book *database.Book, store database.Store) CandidateBookInfo {
 	info := CandidateBookInfo{
 		ID:       book.ID,
 		Title:    book.Title,
@@ -50,8 +52,10 @@ func BuildCandidateBookInfo(book *database.Book) CandidateBookInfo {
 	if book.Author != nil {
 		info.Author = book.Author.Name
 	}
-	if book.ITunesPath != nil {
-		info.ITunesPath = *book.ITunesPath
+	if store != nil {
+		if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 {
+			info.ITunesPath = bfs[0].ITunesPath
+		}
 	}
 	if book.CoverURL != nil {
 		info.CoverURL = *book.CoverURL

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 4.64.0
+// version: 4.64.1
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 // last-edited: 2026-05-01
 
@@ -3663,9 +3663,6 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			newBookPath := filepath.Dir(renameResult.Succeeded[0].TargetPath)
 			if newBookPath != book.FilePath {
 				book.FilePath = newBookPath
-				if itunesPath := ComputeITunesPath(book.FilePath); itunesPath != "" {
-					book.ITunesPath = &itunesPath
-				}
 				if _, err := mfs.db.UpdateBook(id, book); err != nil {
 					log.Printf("[WARN] failed to update book path for %s: %v", id, err)
 				} else {
@@ -3676,12 +3673,14 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 		setCheckpoint(mfs.db, id, phaseRename)
 	}
 
-	// Always ensure itunes_path is set if a mapping exists (for already-organized books)
-	if book.ITunesPath == nil || *book.ITunesPath == "" {
-		if itunesPath := ComputeITunesPath(book.FilePath); itunesPath != "" {
-			book.ITunesPath = &itunesPath
-			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-				log.Printf("[WARN] failed to update itunes_path for %s: %v", id, err)
+	// Always ensure itunes_path is set on each BookFile if a mapping exists.
+	for i := range bookFiles {
+		if bookFiles[i].ITunesPath == "" {
+			if itunesPath := ComputeITunesPath(bookFiles[i].FilePath); itunesPath != "" {
+				bookFiles[i].ITunesPath = itunesPath
+				if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
+					log.Printf("[WARN] failed to update itunes_path for book file %s: %v", bookFiles[i].ID, err)
+				}
 			}
 		}
 	}
@@ -3800,8 +3799,9 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		if strings.HasPrefix(entry.SegmentID, "virtual-") {
 			// Virtual entry = single-file book. Update book.FilePath directly to the new file path.
 			book.FilePath = entry.TargetPath
-			if itunesPath := ComputeITunesPath(book.FilePath); itunesPath != "" {
-				book.ITunesPath = &itunesPath
+			// Keep in-memory virtual BookFile in sync so ITunesPath can be computed below.
+			if len(bookFiles) > 0 && bookFiles[0].ID == entry.SegmentID {
+				bookFiles[0].FilePath = entry.TargetPath
 			}
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
 				log.Printf("[WARN] failed to update book path for %s: %v", id, err)
@@ -3843,9 +3843,6 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		newBookPath := filepath.Dir(renameResult.Succeeded[0].TargetPath)
 		if newBookPath != book.FilePath {
 			book.FilePath = newBookPath
-			if itunesPath := ComputeITunesPath(book.FilePath); itunesPath != "" {
-				book.ITunesPath = &itunesPath
-			}
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
 				log.Printf("[WARN] failed to update book path for %s: %v", id, err)
 			} else {
@@ -3854,12 +3851,16 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		}
 	}
 
-	// Always ensure itunes_path is set if a mapping exists (for already-organized books)
-	if book.ITunesPath == nil || *book.ITunesPath == "" {
-		if itunesPath := ComputeITunesPath(book.FilePath); itunesPath != "" {
-			book.ITunesPath = &itunesPath
-			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-				log.Printf("[WARN] failed to update itunes_path for %s: %v", id, err)
+	// Always ensure itunes_path is set on each BookFile if a mapping exists.
+	for i := range bookFiles {
+		if bookFiles[i].ITunesPath == "" {
+			if itunesPath := ComputeITunesPath(bookFiles[i].FilePath); itunesPath != "" {
+				bookFiles[i].ITunesPath = itunesPath
+				if !strings.HasPrefix(bookFiles[i].ID, "virtual-") {
+					if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
+						log.Printf("[WARN] failed to update itunes_path for book file %s: %v", bookFiles[i].ID, err)
+					}
+				}
 			}
 		}
 	}

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,6 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
+// last-edited: 2026-05-01
 
 package metafetch
 
@@ -305,7 +306,6 @@ func TestCollapseEmptySegments(t *testing.T) {
 
 func TestBuildCandidateBookInfo(t *testing.T) {
 	t.Run("full_book", func(t *testing.T) {
-		itunesPath := "/itunes/path"
 		coverURL := "http://cover.jpg"
 		duration := 3600
 		fileSize := int64(1000000)
@@ -317,14 +317,17 @@ func TestBuildCandidateBookInfo(t *testing.T) {
 			FilePath: "/path/to/book.m4b",
 			Format:   "m4b",
 			Author:   &database.Author{Name: "Test Author"},
-			ITunesPath: &itunesPath,
 			CoverURL:   &coverURL,
 			Duration:   &duration,
 			FileSize:   &fileSize,
 			Language:   &language,
 		}
+		store := &database.MockStore{}
+		store.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+			return []database.BookFile{{ITunesPath: "/itunes/path"}}, nil
+		}
 
-		info := BuildCandidateBookInfo(book)
+		info := BuildCandidateBookInfo(book, store)
 		assert.Equal(t, "book-1", info.ID)
 		assert.Equal(t, "Test Book", info.Title)
 		assert.Equal(t, "Test Author", info.Author)
@@ -343,7 +346,7 @@ func TestBuildCandidateBookInfo(t *testing.T) {
 			Title:    "Minimal",
 			FilePath: "/path.m4b",
 		}
-		info := BuildCandidateBookInfo(book)
+		info := BuildCandidateBookInfo(book, nil)
 		assert.Equal(t, "book-2", info.ID)
 		assert.Equal(t, "", info.Author)
 		assert.Equal(t, "", info.ITunesPath)


### PR DESCRIPTION
Removes 11 SA1019 staticcheck warnings from `internal/metafetch`. Part of DEP-1 migration. Re-audit finding R-4/DEP-1a.

## Changes
- `batch.go`: `BuildCandidateBookInfo` now accepts a `database.Store` parameter to look up `ITunesPath` from the first BookFile
- `service.go` (`runApplyPipeline`): remove `book.ITunesPath` write; replace 'always ensure' block with a per-BookFile loop using `UpdateBookFile`
- `service.go` (`RunApplyPipelineRenameOnly`): same pattern; virtual entries skip `UpdateBookFile` (no real DB record) but keep in-memory path in sync
- `service_mock_test.go`: update `TestBuildCandidateBookInfo` to use `MockStore.GetBookFilesFunc`

## Checklist
- [x] `staticcheck ./internal/metafetch/...` — zero SA1019 for `Book.ITunesPath`
- [x] `go build ./...` — clean
- [x] `go test ./internal/metafetch/...` — passes
- [x] Version headers bumped on all changed files