### PR TITLE
feat(maintenance): fully implement 7 stub maintenance jobs

### DIFF
--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/job.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 11111111-1111-1111-1111-111111111111
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package maintenance
 
@@ -31,6 +31,18 @@ type ProgressReporter interface {
 	SetTotal(n int)
 	Increment()
 	Log(level, message string, details *string)
+}
+
+// WriteBackEnqueuer is the narrow interface jobs use for iTunes write-back.
+// Satisfied by *itunesservice.WriteBackBatcher.
+type WriteBackEnqueuer interface {
+	Enqueue(bookID string)
+	EnqueueRemove(pid string)
+}
+
+// EnqueuerInjectable is implemented by jobs that need the write-back enqueuer.
+type EnqueuerInjectable interface {
+	InjectEnqueuer(e WriteBackEnqueuer)
 }
 
 // MaintenanceJob is the interface that every maintenance job must satisfy.

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,15 +1,23 @@
 // file: internal/maintenance/jobs/cleanup_organize_mess.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000007-0000-0000-0000-000000000007
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"os"
+"path/filepath"
+"regexp"
+"sort"
+"strings"
+"unicode"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/config"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&cleanupOrganizeMess{}) }
@@ -17,9 +25,131 @@ func init() { maintenance.Register(&cleanupOrganizeMess{}) }
 type cleanupOrganizeMess struct{}
 
 func (j *cleanupOrganizeMess) ID() string          { return "cleanup-organize-mess" }
-func (j *cleanupOrganizeMess) Description() string { return "Clean up leftover organize artifacts and garbage directories" }
-func (j *cleanupOrganizeMess) CanResume() bool     { return false }
-func (j *cleanupOrganizeMess) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "cleanup-organize-mess: requires server services — use legacy /api/v1/maintenance/cleanup-organize-mess route", nil)
-	return nil
+func (j *cleanupOrganizeMess) Description() string {
+return "Clean up leftover organize artifacts and garbage directories"
+}
+func (j *cleanupOrganizeMess) CanResume() bool { return false }
+
+func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+rootDir := config.AppConfig.RootDir
+if rootDir == "" {
+return fmt.Errorf("root_dir is not configured")
+}
+if _, err := os.Stat(rootDir); err != nil {
+return fmt.Errorf("root_dir not accessible: %w", err)
+}
+
+var dirs []string
+walkErr := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+if err != nil {
+return nil
+}
+if !info.IsDir() {
+return nil
+}
+if path == rootDir {
+return nil
+}
+if strings.HasPrefix(filepath.Base(path), ".") {
+return filepath.SkipDir
+}
+dirs = append(dirs, path)
+return nil
+})
+if walkErr != nil {
+return fmt.Errorf("failed to walk root directory: %w", walkErr)
+}
+
+sort.Slice(dirs, func(i, j int) bool {
+return len(dirs[i]) > len(dirs[j])
+})
+
+reporter.SetTotal(len(dirs))
+
+emptyRemoved := 0
+garbageFound := 0
+
+for _, dir := range dirs {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+name := filepath.Base(dir)
+if reason := comIsGarbageDirectory(name); reason != "" {
+garbageFound++
+reporter.Log("warn", fmt.Sprintf("Garbage dir %q: %s", dir, reason), nil)
+}
+
+empty, checkErr := comIsDirEmpty(dir)
+if checkErr != nil {
+reporter.Log("error", fmt.Sprintf("Stat error for %q: %v", dir, checkErr), nil)
+reporter.Increment()
+continue
+}
+if !empty {
+reporter.Increment()
+continue
+}
+
+if !dryRun {
+if removeErr := os.Remove(dir); removeErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to remove %q: %v", dir, removeErr), nil)
+} else {
+emptyRemoved++
+}
+} else {
+emptyRemoved++
+}
+reporter.Increment()
+}
+
+reporter.Log("info", fmt.Sprintf("Done: garbage_dirs=%d empty_removed=%d dryRun=%v", garbageFound, emptyRemoved, dryRun), nil)
+return nil
+}
+
+func comIsDirEmpty(dir string) (bool, error) {
+entries, err := os.ReadDir(dir)
+if err != nil {
+return false, err
+}
+for _, e := range entries {
+if !strings.HasPrefix(e.Name(), ".") {
+return false, nil
+}
+}
+return true, nil
+}
+
+func comIsGarbageDirectory(name string) string {
+if name == "" {
+return ""
+}
+chapterFragmentRe := regexp.MustCompile(`^\d{1,3}[_ ][_\-\s]`)
+if chapterFragmentRe.MatchString(name) {
+return "starts with chapter number fragment"
+}
+pureNumericRe := regexp.MustCompile(`^\d+$`)
+if pureNumericRe.MatchString(name) {
+return "purely numeric directory name"
+}
+doubleSegmentRe := regexp.MustCompile(` - \d{1,3} - `)
+if doubleSegmentRe.MatchString(name) {
+return "contains double-nested chapter segment pattern"
+}
+trimmed := strings.TrimSpace(name)
+if len([]rune(trimmed)) <= 2 && !comAllAlpha(trimmed) {
+return "suspiciously short non-alphabetic directory name"
+}
+return ""
+}
+
+func comAllAlpha(s string) bool {
+for _, r := range s {
+if !unicode.IsLetter(r) {
+return false
+}
+}
+return len(s) > 0
 }

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,15 +1,19 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000002-0000-0000-0000-000000000002
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"regexp"
+"strings"
+"unicode"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&cleanupSeriesJob{}) }
@@ -17,9 +21,167 @@ func init() { maintenance.Register(&cleanupSeriesJob{}) }
 type cleanupSeriesJob struct{}
 
 func (j *cleanupSeriesJob) ID() string          { return "cleanup-series" }
-func (j *cleanupSeriesJob) Description() string { return "Cleanup and normalize series names" }
+func (j *cleanupSeriesJob) Description() string { return "Remove 1-book series and merge duplicate series" }
 func (j *cleanupSeriesJob) CanResume() bool     { return false }
-func (j *cleanupSeriesJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "cleanup-series: requires server services — use legacy /api/v1/maintenance/cleanup-series route", nil)
-	return nil
+
+func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+allSeries, err := store.GetAllSeries()
+if err != nil {
+return fmt.Errorf("failed to list series: %w", err)
+}
+
+bookCounts, err := store.GetAllSeriesBookCounts()
+if err != nil {
+return fmt.Errorf("failed to get series book counts: %w", err)
+}
+
+reporter.SetTotal(len(allSeries))
+
+// Phase 1: single-book series
+var singleApplied, singleFound int
+deletedIDs := make(map[int]bool)
+
+for _, ser := range allSeries {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+count := bookCounts[ser.ID]
+if count != 1 {
+reporter.Increment()
+continue
+}
+
+books, bErr := store.GetBooksBySeriesID(ser.ID)
+if bErr != nil || len(books) == 0 {
+reporter.Increment()
+continue
+}
+book := books[0]
+if book.SeriesSequence != nil && *book.SeriesSequence > 1 {
+reporter.Increment()
+continue
+}
+
+singleFound++
+if !dryRun {
+if applyErr := csUnlinkAndDeleteSeries(store, &book, ser.ID); applyErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to remove 1-book series %d (%q): %v", ser.ID, ser.Name, applyErr), nil)
+} else {
+deletedIDs[ser.ID] = true
+singleApplied++
+}
+}
+reporter.Increment()
+}
+
+// Phase 2: duplicate series by normalized name
+normGroups := make(map[string][]database.Series)
+for _, ser := range allSeries {
+if deletedIDs[ser.ID] {
+continue
+}
+key := csNormalizeSeriesName(ser.Name)
+normGroups[key] = append(normGroups[key], ser)
+}
+
+var dupApplied, dupFound int
+for normName, group := range normGroups {
+if len(group) < 2 {
+continue
+}
+dupFound++
+
+keepIdx := 0
+for i, ser := range group {
+if bookCounts[ser.ID] > bookCounts[group[keepIdx].ID] {
+keepIdx = i
+}
+}
+keeper := group[keepIdx]
+
+var mergeIDs []int
+for i, ser := range group {
+if i != keepIdx {
+mergeIDs = append(mergeIDs, ser.ID)
+}
+}
+
+if !dryRun {
+if mergeErr := csMergeSeriesGroup(store, keeper.ID, mergeIDs); mergeErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to merge series group %q: %v", normName, mergeErr), nil)
+} else {
+dupApplied++
+}
+}
+}
+
+reporter.Log("info", fmt.Sprintf("Done: single_found=%d single_applied=%d dup_groups_found=%d dup_applied=%d dryRun=%v",
+singleFound, singleApplied, dupFound, dupApplied, dryRun), nil)
+return nil
+}
+
+func csUnlinkAndDeleteSeries(store database.Store, book *database.Book, seriesID int) error {
+current, err := store.GetBookByID(book.ID)
+if err != nil {
+return fmt.Errorf("GetBookByID: %w", err)
+}
+if current == nil {
+return fmt.Errorf("book %s not found", book.ID)
+}
+current.SeriesID = nil
+current.SeriesSequence = nil
+if _, err = store.UpdateBook(book.ID, current); err != nil {
+return fmt.Errorf("UpdateBook: %w", err)
+}
+if err = store.DeleteSeries(seriesID); err != nil {
+return fmt.Errorf("DeleteSeries: %w", err)
+}
+return nil
+}
+
+func csMergeSeriesGroup(store database.Store, keepID int, mergeIDs []int) error {
+for _, fromID := range mergeIDs {
+books, err := store.GetBooksBySeriesID(fromID)
+if err != nil {
+return fmt.Errorf("GetBooksBySeriesID(%d): %w", fromID, err)
+}
+for _, book := range books {
+current, err := store.GetBookByID(book.ID)
+if err != nil {
+return fmt.Errorf("GetBookByID(%s): %w", book.ID, err)
+}
+if current == nil {
+continue
+}
+current.SeriesID = &keepID
+if _, err = store.UpdateBook(book.ID, current); err != nil {
+return fmt.Errorf("UpdateBook(%s): %w", book.ID, err)
+}
+}
+if err = store.DeleteSeries(fromID); err != nil {
+return fmt.Errorf("DeleteSeries(%d): %w", fromID, err)
+}
+}
+return nil
+}
+
+var csNonAlphanumRE = regexp.MustCompile(`[^\p{L}\p{N}\s]+`)
+
+func csNormalizeSeriesName(name string) string {
+s := strings.ToLower(strings.TrimSpace(name))
+if strings.HasPrefix(s, "the ") {
+s = s[4:]
+}
+for _, suffix := range []string{" series", " saga", " trilogy", " duology", " quartet"} {
+if strings.HasSuffix(s, suffix) {
+s = s[:len(s)-len(suffix)]
+break
+}
+}
+s = csNonAlphanumRE.ReplaceAllString(s, " ")
+fields := strings.FieldsFunc(s, unicode.IsSpace)
+return strings.Join(fields, " ")
 }

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,25 +1,497 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000010-0000-0000-0000-000000000010
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"log"
+"path/filepath"
+"regexp"
+"strings"
+"time"
+"unicode"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&dedupBooksJob{}) }
 
-type dedupBooksJob struct{}
+type dedupBooksJob struct {
+enqueuer maintenance.WriteBackEnqueuer
+}
+
+func (j *dedupBooksJob) InjectEnqueuer(e maintenance.WriteBackEnqueuer) { j.enqueuer = e }
 
 func (j *dedupBooksJob) ID() string          { return "dedup-books" }
 func (j *dedupBooksJob) Description() string { return "Detect and merge duplicate books" }
 func (j *dedupBooksJob) CanResume() bool     { return false }
-func (j *dedupBooksJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "dedup-books: requires server services — use legacy /api/v1/maintenance/dedup-books route", nil)
-	return nil
+
+func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+allBooks, err := ddFetchAllBooksPaginated(store)
+if err != nil {
+return fmt.Errorf("failed to list books: %w", err)
+}
+reporter.SetTotal(len(allBooks))
+
+deletedIDs := make(map[string]bool)
+
+// Phase 1: Delete junk "read by narrator" records
+phase1 := 0
+for i := range allBooks {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+book := &allBooks[i]
+if deletedIDs[book.ID] {
+continue
+}
+if !ddIsJunkReadByNarrator(book) {
+continue
+}
+if !dryRun {
+if delErr := ddSoftDeleteBook(store, book.ID); delErr != nil {
+reporter.Log("error", fmt.Sprintf("phase1 delete %s: %v", book.ID, delErr), nil)
+continue
+}
+}
+deletedIDs[book.ID] = true
+phase1++
+}
+
+// Phase 2: Merge books with the same file_path
+pathGroups := make(map[string][]database.Book)
+for i := range allBooks {
+book := &allBooks[i]
+if deletedIDs[book.ID] || book.FilePath == "" {
+continue
+}
+pathGroups[book.FilePath] = append(pathGroups[book.FilePath], *book)
+}
+
+phase2 := 0
+for fp, group := range pathGroups {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+if len(group) < 2 {
+continue
+}
+live := ddFilterLive(group, deletedIDs)
+if len(live) < 2 {
+continue
+}
+keepIdx := ddPickKeeperIdx(live)
+keeper := &live[keepIdx]
+for i := range live {
+if i == keepIdx {
+continue
+}
+dup := &live[i]
+if mergeErr := ddMergeDuplicateBook(store, keeper, dup, dryRun, j.enqueuer); mergeErr != nil {
+reporter.Log("error", fmt.Sprintf("phase2 merge %s->%s fp=%s: %v", dup.ID, keeper.ID, fp, mergeErr), nil)
+continue
+}
+deletedIDs[dup.ID] = true
+phase2++
+}
+}
+
+// Phase 3: Merge books with same normalised title + author in same dir
+type titleAuthorKey struct {
+NormTitle string
+AuthorID  int
+Dir       string
+}
+taGroups := make(map[titleAuthorKey][]database.Book)
+for i := range allBooks {
+book := &allBooks[i]
+if deletedIDs[book.ID] {
+continue
+}
+normTitle := ddNormalizeDedupTitle(book.Title)
+if normTitle == "" {
+continue
+}
+authorID := 0
+if book.AuthorID != nil {
+authorID = *book.AuthorID
+}
+dir := ""
+if book.FilePath != "" {
+dir = filepath.Dir(book.FilePath)
+}
+key := titleAuthorKey{NormTitle: normTitle, AuthorID: authorID, Dir: dir}
+taGroups[key] = append(taGroups[key], *book)
+}
+
+phase3 := 0
+for key, group := range taGroups {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+if len(group) < 2 {
+continue
+}
+live := ddFilterLive(group, deletedIDs)
+if len(live) < 2 {
+continue
+}
+if key.AuthorID == 0 {
+titles := make(map[string]bool)
+for _, b := range live {
+titles[strings.ToLower(strings.TrimSpace(b.Title))] = true
+}
+if len(titles) > 1 {
+continue
+}
+}
+keepIdx := ddPickKeeperIdx(live)
+keeper := &live[keepIdx]
+for i := range live {
+if i == keepIdx {
+continue
+}
+dup := &live[i]
+if mergeErr := ddMergeDuplicateBook(store, keeper, dup, dryRun, j.enqueuer); mergeErr != nil {
+reporter.Log("error", fmt.Sprintf("phase3 merge %s->%s: %v", dup.ID, keeper.ID, mergeErr), nil)
+continue
+}
+deletedIDs[dup.ID] = true
+phase3++
+}
+}
+
+// Phase 4: Clean up duplicate version group entries
+vgGroups := make(map[string][]database.Book)
+for i := range allBooks {
+book := &allBooks[i]
+if deletedIDs[book.ID] || book.VersionGroupID == nil || *book.VersionGroupID == "" {
+continue
+}
+vgGroups[*book.VersionGroupID] = append(vgGroups[*book.VersionGroupID], *book)
+}
+
+phase4 := 0
+for vgID, group := range vgGroups {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+seen := make(map[string]bool)
+var dupeIDs []string
+for _, b := range group {
+if seen[b.ID] {
+dupeIDs = append(dupeIDs, b.ID)
+}
+seen[b.ID] = true
+}
+if len(dupeIDs) == 0 {
+continue
+}
+if !dryRun {
+for _, dupID := range dupeIDs {
+current, gbErr := store.GetBookByID(dupID)
+if gbErr != nil || current == nil {
+continue
+}
+current.VersionGroupID = nil
+current.IsPrimaryVersion = nil
+if _, upErr := store.UpdateBook(dupID, current); upErr != nil {
+reporter.Log("error", fmt.Sprintf("phase4 unlink vg %s from book %s: %v", vgID, dupID, upErr), nil)
+continue
+}
+phase4++
+}
+} else {
+phase4 += len(dupeIDs)
+}
+}
+
+for range allBooks {
+reporter.Increment()
+}
+
+reporter.Log("info", fmt.Sprintf(
+"Done: phase1_junk=%d phase2_path=%d phase3_title=%d phase4_vg=%d dryRun=%v",
+phase1, phase2, phase3, phase4, dryRun), nil)
+return nil
+}
+
+func ddFetchAllBooksPaginated(store database.Store) ([]database.Book, error) {
+const pageSize = 500
+var all []database.Book
+offset := 0
+for {
+page, err := store.GetAllBooks(pageSize, offset)
+if err != nil {
+return nil, err
+}
+all = append(all, page...)
+if len(page) < pageSize {
+break
+}
+offset += pageSize
+}
+return all, nil
+}
+
+func ddIsJunkReadByNarrator(book *database.Book) bool {
+t := strings.ToLower(strings.TrimSpace(book.Title))
+if t != "read by narrator" {
+return false
+}
+if book.AuthorID != nil {
+return false
+}
+if book.SeriesID != nil {
+return false
+}
+if book.Description != nil && strings.TrimSpace(*book.Description) != "" {
+return false
+}
+if book.ISBN10 != nil || book.ISBN13 != nil || book.ASIN != nil {
+return false
+}
+if book.ITunesPersistentID != nil {
+return false
+}
+return true
+}
+
+func ddPickKeeperIdx(books []database.Book) int {
+best := 0
+for i := 1; i < len(books); i++ {
+if ddBookScore(&books[i]) > ddBookScore(&books[best]) {
+best = i
+}
+}
+return best
+}
+
+func ddBookScore(b *database.Book) int {
+score := 0
+if b.AuthorID != nil {
+score += 100
+}
+if b.SeriesID != nil {
+score += 20
+}
+if b.Description != nil && *b.Description != "" {
+score += 10
+}
+if b.Narrator != nil && *b.Narrator != "" {
+score += 5
+}
+if b.Duration != nil {
+score += 5
+}
+if b.ISBN10 != nil || b.ISBN13 != nil || b.ASIN != nil {
+score += 10
+}
+if b.ITunesPersistentID != nil {
+score += 10
+}
+if b.Publisher != nil && *b.Publisher != "" {
+score += 3
+}
+if b.Language != nil && *b.Language != "" {
+score += 2
+}
+if b.Genre != nil && *b.Genre != "" {
+score += 2
+}
+if b.CoverURL != nil && *b.CoverURL != "" {
+score += 3
+}
+if b.CreatedAt != nil {
+score -= int(b.CreatedAt.Unix() / 1_000_000)
+}
+return score
+}
+
+func ddMergeDuplicateBook(store database.Store, keeper *database.Book, dup *database.Book, dryRun bool, enqueuer maintenance.WriteBackEnqueuer) error {
+if dryRun {
+return nil
+}
+
+dupMappings, _ := store.GetExternalIDsForBook(dup.ID)
+var dupPIDs []string
+for _, m := range dupMappings {
+if m.Source == "itunes" && m.ExternalID != "" && !m.Tombstoned {
+dupPIDs = append(dupPIDs, m.ExternalID)
+}
+}
+
+files, err := store.GetBookFiles(dup.ID)
+if err == nil {
+for i := range files {
+f := &files[i]
+f.BookID = keeper.ID
+if upErr := store.UpsertBookFile(f); upErr != nil {
+log.Printf("[WARN] dedup-books: UpsertBookFile %s -> keeper %s: %v", f.ID, keeper.ID, upErr)
+}
+}
+}
+
+if reassignErr := store.ReassignExternalIDs(dup.ID, keeper.ID); reassignErr != nil {
+log.Printf("[WARN] dedup-books: ReassignExternalIDs %s -> %s: %v", dup.ID, keeper.ID, reassignErr)
+}
+
+if enqueuer != nil && len(dupPIDs) > 0 {
+for _, pid := range dupPIDs {
+enqueuer.EnqueueRemove(pid)
+}
+log.Printf("[INFO] dedup-books: queued %d ITL removals for dup %s", len(dupPIDs), dup.ID)
+}
+
+tags, tagsErr := store.GetBookUserTags(dup.ID)
+if tagsErr == nil && len(tags) > 0 {
+for _, tag := range tags {
+_ = store.AddBookUserTag(keeper.ID, tag)
+}
+}
+
+current, gbErr := store.GetBookByID(keeper.ID)
+if gbErr != nil {
+return fmt.Errorf("GetBookByID keeper %s: %w", keeper.ID, gbErr)
+}
+if current == nil {
+return fmt.Errorf("keeper book %s not found", keeper.ID)
+}
+
+ddMergeBookFields(current, dup)
+
+if _, upErr := store.UpdateBook(keeper.ID, current); upErr != nil {
+return fmt.Errorf("UpdateBook keeper %s: %w", keeper.ID, upErr)
+}
+
+return ddSoftDeleteBook(store, dup.ID)
+}
+
+func ddMergeBookFields(dst, src *database.Book) {
+if dst.AuthorID == nil && src.AuthorID != nil {
+dst.AuthorID = src.AuthorID
+}
+if dst.SeriesID == nil && src.SeriesID != nil {
+dst.SeriesID = src.SeriesID
+if dst.SeriesSequence == nil && src.SeriesSequence != nil {
+dst.SeriesSequence = src.SeriesSequence
+}
+}
+if dst.Narrator == nil && src.Narrator != nil && *src.Narrator != "" {
+dst.Narrator = src.Narrator
+}
+if dst.Description == nil && src.Description != nil && *src.Description != "" {
+dst.Description = src.Description
+}
+if dst.Duration == nil && src.Duration != nil {
+dst.Duration = src.Duration
+}
+if dst.Publisher == nil && src.Publisher != nil {
+dst.Publisher = src.Publisher
+}
+if dst.Language == nil && src.Language != nil {
+dst.Language = src.Language
+}
+if dst.Genre == nil && src.Genre != nil {
+dst.Genre = src.Genre
+}
+if dst.ISBN10 == nil && src.ISBN10 != nil {
+dst.ISBN10 = src.ISBN10
+}
+if dst.ISBN13 == nil && src.ISBN13 != nil {
+dst.ISBN13 = src.ISBN13
+}
+if dst.ASIN == nil && src.ASIN != nil {
+dst.ASIN = src.ASIN
+}
+if dst.ITunesPersistentID == nil && src.ITunesPersistentID != nil {
+dst.ITunesPersistentID = src.ITunesPersistentID
+}
+if dst.ITunesDateAdded == nil && src.ITunesDateAdded != nil {
+dst.ITunesDateAdded = src.ITunesDateAdded
+}
+if dst.ITunesPlayCount == nil && src.ITunesPlayCount != nil {
+dst.ITunesPlayCount = src.ITunesPlayCount
+}
+if dst.ITunesRating == nil && src.ITunesRating != nil {
+dst.ITunesRating = src.ITunesRating
+}
+if dst.ITunesBookmark == nil && src.ITunesBookmark != nil {
+dst.ITunesBookmark = src.ITunesBookmark
+}
+if dst.CoverURL == nil && src.CoverURL != nil {
+dst.CoverURL = src.CoverURL
+}
+if dst.OpenLibraryID == nil && src.OpenLibraryID != nil {
+dst.OpenLibraryID = src.OpenLibraryID
+}
+if dst.GoogleBooksID == nil && src.GoogleBooksID != nil {
+dst.GoogleBooksID = src.GoogleBooksID
+}
+if dst.HardcoverID == nil && src.HardcoverID != nil {
+dst.HardcoverID = src.HardcoverID
+}
+if dst.WorkID == nil && src.WorkID != nil {
+dst.WorkID = src.WorkID
+}
+if (dst.VersionGroupID == nil || *dst.VersionGroupID == "") && src.VersionGroupID != nil && *src.VersionGroupID != "" {
+dst.VersionGroupID = src.VersionGroupID
+}
+}
+
+func ddSoftDeleteBook(store database.Store, bookID string) error {
+current, err := store.GetBookByID(bookID)
+if err != nil {
+return fmt.Errorf("GetBookByID %s: %w", bookID, err)
+}
+if current == nil {
+return nil
+}
+t := true
+now := time.Now()
+current.MarkedForDeletion = &t
+current.MarkedForDeletionAt = &now
+if _, upErr := store.UpdateBook(bookID, current); upErr != nil {
+log.Printf("[WARN] dedup-books: soft-delete failed for %s (%v), falling back to hard delete", bookID, upErr)
+return store.DeleteBook(bookID)
+}
+return nil
+}
+
+var ddNonAlphanumRE = regexp.MustCompile(`[^\p{L}\p{N}\s]+`)
+
+func ddNormalizeDedupTitle(title string) string {
+s := strings.ToLower(strings.TrimSpace(title))
+if s == "" {
+return ""
+}
+s = strings.ReplaceAll(s, "(unabridged)", "")
+reLeadNum := regexp.MustCompile(`^\s*(\(\d+[/\-]\d+\)|\d+[\.\-\s])\s*`)
+s = reLeadNum.ReplaceAllString(s, "")
+s = ddNonAlphanumRE.ReplaceAllString(s, " ")
+fields := strings.FieldsFunc(s, unicode.IsSpace)
+return strings.Join(fields, " ")
+}
+
+func ddFilterLive(books []database.Book, deletedIDs map[string]bool) []database.Book {
+out := books[:0:len(books)]
+for _, b := range books {
+if !deletedIDs[b.ID] {
+out = append(out, b)
+}
+}
+return out
 }

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,15 +1,17 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000003-0000-0000-0000-000000000003
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"strings"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
@@ -17,9 +19,74 @@ func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
 type fixAuthorNarratorSwapJob struct{}
 
 func (j *fixAuthorNarratorSwapJob) ID() string          { return "fix-author-narrator-swap" }
-func (j *fixAuthorNarratorSwapJob) Description() string { return "Fix books where author and narrator fields are swapped" }
-func (j *fixAuthorNarratorSwapJob) CanResume() bool     { return false }
-func (j *fixAuthorNarratorSwapJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "fix-author-narrator-swap: complex heuristics — use legacy /api/v1/maintenance/fix-author-narrator-swap route", nil)
-	return nil
+func (j *fixAuthorNarratorSwapJob) Description() string {
+return "Fix books where author and narrator fields are swapped"
+}
+func (j *fixAuthorNarratorSwapJob) CanResume() bool { return false }
+
+func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+const batchSize = 500
+offset := 0
+var found, applied int
+
+for {
+batch, err := store.GetAllBooks(batchSize, offset)
+if err != nil {
+return fmt.Errorf("failed to list books: %w", err)
+}
+if len(batch) == 0 {
+break
+}
+
+reporter.SetTotal(offset + len(batch))
+
+for i := range batch {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+book := &batch[i]
+if book.AuthorID == nil || book.Narrator == nil || *book.Narrator == "" {
+reporter.Increment()
+continue
+}
+
+author, aErr := store.GetAuthorByID(*book.AuthorID)
+if aErr != nil || author == nil {
+reporter.Increment()
+continue
+}
+
+if !strings.EqualFold(author.Name, *book.Narrator) {
+reporter.Increment()
+continue
+}
+
+found++
+if !dryRun {
+current, getErr := store.GetBookByID(book.ID)
+if getErr != nil || current == nil {
+reporter.Log("error", fmt.Sprintf("Failed to fetch book %s: %v", book.ID, getErr), nil)
+} else {
+current.AuthorID = nil
+if _, updateErr := store.UpdateBook(book.ID, current); updateErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to update book %s: %v", book.ID, updateErr), nil)
+} else {
+applied++
+}
+}
+}
+reporter.Increment()
+}
+
+if len(batch) < batchSize {
+break
+}
+offset += batchSize
+}
+
+reporter.Log("info", fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun), nil)
+return nil
 }

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,15 +1,18 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000001-0000-0000-0000-000000000001
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"path/filepath"
+"strings"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&fixReadByNarratorJob{}) }
@@ -17,9 +20,190 @@ func init() { maintenance.Register(&fixReadByNarratorJob{}) }
 type fixReadByNarratorJob struct{}
 
 func (j *fixReadByNarratorJob) ID() string          { return "fix-read-by-narrator" }
-func (j *fixReadByNarratorJob) Description() string { return "Fix books where narrator was recorded as author" }
-func (j *fixReadByNarratorJob) CanResume() bool     { return false }
-func (j *fixReadByNarratorJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "fix-read-by-narrator: complex parsing — use legacy /api/v1/maintenance/fix-read-by-narrator route", nil)
-	return nil
+func (j *fixReadByNarratorJob) Description() string {
+return "Fix books where title/author metadata is swapped (title starts with 'read by')"
+}
+func (j *fixReadByNarratorJob) CanResume() bool { return false }
+
+func (j *fixReadByNarratorJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+allBooks, err := store.GetAllBooks(0, 0)
+if err != nil {
+return fmt.Errorf("failed to list books: %w", err)
+}
+reporter.SetTotal(len(allBooks))
+
+var applied, found int
+for i := range allBooks {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+book := &allBooks[i]
+titleLower := strings.ToLower(book.Title)
+
+authorName := ""
+if book.AuthorID != nil {
+if author, aErr := store.GetAuthorByID(*book.AuthorID); aErr == nil && author != nil {
+authorName = author.Name
+}
+}
+
+var fix *rbnrFixResult
+switch {
+case strings.Contains(titleLower, " - read by "):
+fix = rbnrPattern2(book, authorName)
+case strings.HasPrefix(titleLower, "read by ") && strings.HasPrefix(strings.ToLower(authorName), "read by "):
+fix = rbnrPattern3(book, authorName)
+case strings.HasPrefix(titleLower, "read by "):
+fix = rbnrPattern1(book, authorName)
+}
+
+if fix == nil {
+reporter.Increment()
+continue
+}
+if fix.NewTitle == book.Title && fix.NewNarrator == rbnrStringDeref(book.Narrator) {
+reporter.Increment()
+continue
+}
+
+found++
+if !dryRun {
+if applyErr := rbnrApplyFix(store, book, fix); applyErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to fix book %s: %v", book.ID, applyErr), nil)
+} else {
+applied++
+}
+}
+reporter.Increment()
+}
+
+reporter.Log("info", fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun), nil)
+return nil
+}
+
+type rbnrFixResult struct {
+BookID      string
+Pattern     string
+OldTitle    string
+OldAuthor   string
+OldNarrator *string
+NewTitle    string
+NewNarrator string
+FilePath    string
+}
+
+func rbnrPattern1(book *database.Book, authorName string) *rbnrFixResult {
+narrator := strings.TrimSpace(book.Title[len("read by "):])
+if narrator == "" {
+return nil
+}
+newTitle := strings.TrimRight(authorName, "_")
+newTitle = strings.TrimSpace(newTitle)
+if newTitle == "" {
+return nil
+}
+return &rbnrFixResult{
+BookID:      book.ID,
+Pattern:     "read_by_swap",
+OldTitle:    book.Title,
+OldAuthor:   authorName,
+OldNarrator: book.Narrator,
+NewTitle:    newTitle,
+NewNarrator: narrator,
+FilePath:    book.FilePath,
+}
+}
+
+func rbnrPattern2(book *database.Book, authorName string) *rbnrFixResult {
+idx := rbnrCaseInsensitiveIndex(book.Title, " - read by ")
+if idx < 0 {
+return nil
+}
+beforeReadBy := book.Title[:idx]
+lastDash := strings.LastIndex(beforeReadBy, " - ")
+var newTitle, narrator string
+if lastDash >= 0 {
+newTitle = strings.TrimSpace(beforeReadBy[:lastDash])
+narrator = strings.TrimSpace(beforeReadBy[lastDash+3:])
+} else {
+newTitle = strings.TrimSpace(beforeReadBy)
+narrator = ""
+}
+if newTitle == "" {
+return nil
+}
+return &rbnrFixResult{
+BookID:      book.ID,
+Pattern:     "title_dash_read_by",
+OldTitle:    book.Title,
+OldAuthor:   authorName,
+OldNarrator: book.Narrator,
+NewTitle:    newTitle,
+NewNarrator: narrator,
+FilePath:    book.FilePath,
+}
+}
+
+func rbnrPattern3(book *database.Book, authorName string) *rbnrFixResult {
+narrator := strings.TrimSpace(book.Title[len("read by "):])
+newTitle := rbnrTitleFromFilePath(book.FilePath)
+if newTitle == "" {
+base := filepath.Base(book.FilePath)
+ext := filepath.Ext(base)
+newTitle = strings.TrimSpace(strings.TrimSuffix(base, ext))
+}
+if newTitle == "" || strings.HasPrefix(strings.ToLower(newTitle), "read by ") {
+return nil
+}
+return &rbnrFixResult{
+BookID:      book.ID,
+Pattern:     "both_broken",
+OldTitle:    book.Title,
+OldAuthor:   authorName,
+OldNarrator: book.Narrator,
+NewTitle:    newTitle,
+NewNarrator: narrator,
+FilePath:    book.FilePath,
+}
+}
+
+func rbnrTitleFromFilePath(fp string) string {
+if fp == "" {
+return ""
+}
+dir := filepath.Dir(fp)
+title := filepath.Base(dir)
+if title == "." || title == "/" || title == "" {
+return ""
+}
+return title
+}
+
+func rbnrApplyFix(store database.Store, book *database.Book, fix *rbnrFixResult) error {
+current, err := store.GetBookByID(book.ID)
+if err != nil {
+return fmt.Errorf("GetBookByID: %w", err)
+}
+if current == nil {
+return fmt.Errorf("book %s not found", book.ID)
+}
+current.Title = fix.NewTitle
+if fix.NewNarrator != "" {
+current.Narrator = &fix.NewNarrator
+}
+_, err = store.UpdateBook(book.ID, current)
+return err
+}
+
+func rbnrCaseInsensitiveIndex(s, substr string) int {
+return strings.Index(strings.ToLower(s), strings.ToLower(substr))
+}
+
+func rbnrStringDeref(s *string) string {
+if s == nil {
+return ""
+}
+return *s
 }

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,15 +1,22 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000004-0000-0000-0000-000000000004
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"os"
+"path/filepath"
+"regexp"
+"strings"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+"github.com/oklog/ulid/v2"
 )
 
 func init() { maintenance.Register(&fixVersionGroupsJob{}) }
@@ -19,7 +26,287 @@ type fixVersionGroupsJob struct{}
 func (j *fixVersionGroupsJob) ID() string          { return "fix-version-groups" }
 func (j *fixVersionGroupsJob) Description() string { return "Fix and normalize version groups" }
 func (j *fixVersionGroupsJob) CanResume() bool     { return false }
-func (j *fixVersionGroupsJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "fix-version-groups: requires server services — use legacy /api/v1/maintenance/fix-version-groups route", nil)
-	return nil
+
+func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+allBooks, err := store.GetAllBooks(0, 0)
+if err != nil {
+return fmt.Errorf("failed to list books: %w", err)
+}
+reporter.SetTotal(len(allBooks))
+
+// Phase 1: title mismatch within version groups
+groupMap := make(map[string][]database.Book)
+for i := range allBooks {
+b := &allBooks[i]
+if b.VersionGroupID == nil || *b.VersionGroupID == "" {
+continue
+}
+groupMap[*b.VersionGroupID] = append(groupMap[*b.VersionGroupID], *b)
+}
+
+var mismatchFixed, mismatchErrors int
+for groupID, books := range groupMap {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+if len(books) < 2 {
+continue
+}
+
+cores := make([]vgBookCore, len(books))
+for i, b := range books {
+cores[i] = vgBookCore{book: b, core: vgExtractCoreTitle(b.Title)}
+}
+majorityCore := vgFindMajorityCore(cores)
+
+var outliers []database.Book
+for _, bc := range cores {
+if !vgCoreTitlesMatch(bc.core, majorityCore) {
+outliers = append(outliers, bc.book)
+}
+}
+
+if len(outliers) == 0 {
+continue
+}
+
+if !dryRun {
+if applyErr := vgUnlinkOutliers(store, outliers); applyErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to unlink outliers in group %s: %v", groupID, applyErr), nil)
+mismatchErrors++
+} else {
+mismatchFixed++
+}
+} else {
+mismatchFixed++
+}
+}
+
+// Phase 2: author-directory file_path detection
+var authorDirFixed, authorDirErrors int
+for i := range allBooks {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+b := &allBooks[i]
+reporter.Increment()
+
+if b.FilePath == "" {
+continue
+}
+fi, statErr := os.Stat(b.FilePath)
+if statErr != nil || !fi.IsDir() {
+continue
+}
+if !vgIsAuthorDirectory(b.FilePath) {
+continue
+}
+
+suggested := vgBestMatchSubdir(b.FilePath, b.Title)
+if !dryRun && suggested != "" {
+if fixErr := vgFixAuthorDirPath(store, b, suggested); fixErr != nil {
+reporter.Log("error", fmt.Sprintf("Failed to fix author-dir path for book %s: %v", b.ID, fixErr), nil)
+authorDirErrors++
+} else {
+authorDirFixed++
+}
+} else if suggested != "" {
+authorDirFixed++
+}
+}
+
+reporter.Log("info", fmt.Sprintf("Done: mismatch_fixed=%d mismatch_errors=%d author_dir_fixed=%d author_dir_errors=%d dryRun=%v",
+mismatchFixed, mismatchErrors, authorDirFixed, authorDirErrors, dryRun), nil)
+return nil
+}
+
+type vgBookCore struct {
+book database.Book
+core string
+}
+
+var vgParentheticalRE = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
+var vgLeadingNumberRE = regexp.MustCompile(`^\d+[\s.\-–]+`)
+
+func vgExtractCoreTitle(title string) string {
+s := title
+for {
+trimmed := vgParentheticalRE.ReplaceAllString(s, "")
+if trimmed == s {
+break
+}
+s = strings.TrimSpace(trimmed)
+}
+s = vgLeadingNumberRE.ReplaceAllString(s, "")
+return strings.TrimSpace(s)
+}
+
+func vgFindMajorityCore(cores []vgBookCore) string {
+counts := make(map[string]int)
+for _, bc := range cores {
+counts[bc.core]++
+}
+best := ""
+bestCount := 0
+for core, count := range counts {
+if count > bestCount {
+bestCount = count
+best = core
+}
+}
+return best
+}
+
+func vgCoreTitlesMatch(a, b string) bool {
+aLow := strings.ToLower(a)
+bLow := strings.ToLower(b)
+if aLow == bLow {
+return true
+}
+if strings.Contains(aLow, bLow) || strings.Contains(bLow, aLow) {
+return true
+}
+aWords := vgLongWords(aLow)
+bWords := vgLongWords(bLow)
+for w := range aWords {
+if bWords[w] {
+return true
+}
+}
+return false
+}
+
+func vgLongWords(s string) map[string]bool {
+set := make(map[string]bool)
+for _, w := range strings.Fields(s) {
+w = strings.Trim(w, ".,;:!?\"'")
+if len([]rune(w)) >= 4 {
+set[w] = true
+}
+}
+return set
+}
+
+func vgUnlinkOutliers(store database.Store, outliers []database.Book) error {
+for _, ob := range outliers {
+current, err := store.GetBookByID(ob.ID)
+if err != nil {
+return fmt.Errorf("GetBookByID(%s): %w", ob.ID, err)
+}
+if current == nil {
+return fmt.Errorf("book %s not found", ob.ID)
+}
+newGroupID := ulid.Make().String()
+current.VersionGroupID = &newGroupID
+if _, err = store.UpdateBook(ob.ID, current); err != nil {
+return fmt.Errorf("UpdateBook(%s): %w", ob.ID, err)
+}
+}
+return nil
+}
+
+func vgIsAuthorDirectory(dir string) bool {
+entries, err := os.ReadDir(dir)
+if err != nil {
+return false
+}
+bookSubdirs := 0
+for _, e := range entries {
+if !e.IsDir() {
+continue
+}
+subPath := filepath.Join(dir, e.Name())
+if len(metafetch.AudioFilesInDir(subPath)) > 0 {
+bookSubdirs++
+if bookSubdirs >= 2 {
+return true
+}
+}
+}
+return false
+}
+
+func vgBestMatchSubdir(parent, title string) string {
+entries, err := os.ReadDir(parent)
+if err != nil {
+return ""
+}
+titleWords := vgLongWords(strings.ToLower(vgExtractCoreTitle(title)))
+bestPath := ""
+bestScore := 0
+for _, e := range entries {
+if !e.IsDir() {
+continue
+}
+sub := filepath.Join(parent, e.Name())
+if len(metafetch.AudioFilesInDir(sub)) == 0 {
+continue
+}
+dirWords := vgLongWords(strings.ToLower(e.Name()))
+score := 0
+for w := range titleWords {
+if dirWords[w] {
+score++
+}
+}
+if score > bestScore {
+bestScore = score
+bestPath = sub
+}
+}
+if bestScore == 0 {
+return ""
+}
+return bestPath
+}
+
+func vgFixAuthorDirPath(store database.Store, book *database.Book, subdir string) error {
+current, err := store.GetBookByID(book.ID)
+if err != nil {
+return fmt.Errorf("GetBookByID: %w", err)
+}
+if current == nil {
+return fmt.Errorf("book %s not found", book.ID)
+}
+current.FilePath = subdir
+if _, err = store.UpdateBook(book.ID, current); err != nil {
+return fmt.Errorf("UpdateBook: %w", err)
+}
+if err = store.DeleteBookFilesForBook(book.ID); err != nil {
+return fmt.Errorf("DeleteBookFilesForBook: %w", err)
+}
+newFiles := metafetch.AudioFilesInDir(subdir)
+if len(newFiles) == 0 {
+return nil
+}
+return vgCreateBookFiles(store, current, newFiles)
+}
+
+func vgCreateBookFiles(store database.Store, book *database.Book, filePaths []string) error {
+for _, fp := range filePaths {
+ext := strings.ToLower(filepath.Ext(fp))
+format := strings.TrimPrefix(ext, ".")
+var fileSize int64
+if info, err := os.Stat(fp); err == nil {
+fileSize = info.Size()
+}
+bf := &database.BookFile{
+ID:               ulid.Make().String(),
+BookID:           book.ID,
+FilePath:         fp,
+OriginalFilename: filepath.Base(fp),
+Format:           format,
+FileSize:         fileSize,
+}
+if err := store.CreateBookFile(bf); err != nil {
+return fmt.Errorf("CreateBookFile(%q): %w", fp, err)
+}
+}
+return nil
 }

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,15 +1,23 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package jobs
 
 import (
-	"context"
+"context"
+"fmt"
+"os"
+"path/filepath"
+"regexp"
+"sort"
+"strconv"
+"strings"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+"github.com/jdfalk/audiobook-organizer/internal/config"
+"github.com/jdfalk/audiobook-organizer/internal/database"
+"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 )
 
 func init() { maintenance.Register(&relinkReportJob{}) }
@@ -19,7 +27,245 @@ type relinkReportJob struct{}
 func (j *relinkReportJob) ID() string          { return "relink-report" }
 func (j *relinkReportJob) Description() string { return "Report missing iTunes-linked files that may be relinkable" }
 func (j *relinkReportJob) CanResume() bool     { return false }
-func (j *relinkReportJob) Run(_ context.Context, _ database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	reporter.Log("warn", "relink-report: requires iTunes service — use legacy /api/v1/maintenance/relink-missing-to-itunes route", nil)
-	return nil
+
+func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
+iTunesRoot := config.AppConfig.ITunesMediaRoot
+organizerRoot := config.AppConfig.RootDir
+
+if iTunesRoot == "" {
+return fmt.Errorf("itunes_media_root not configured")
+}
+if organizerRoot == "" {
+return fmt.Errorf("root_dir not configured")
+}
+
+allBooks, err := store.GetAllBooks(0, 0)
+if err != nil {
+return fmt.Errorf("failed to list books: %w", err)
+}
+reporter.SetTotal(len(allBooks))
+
+var resolved, unresolved, skipped int
+
+for i := range allBooks {
+select {
+case <-ctx.Done():
+return ctx.Err()
+default:
+}
+
+book := &allBooks[i]
+fp := book.FilePath
+
+if !strings.HasPrefix(fp, organizerRoot) {
+skipped++
+reporter.Increment()
+continue
+}
+if _, statErr := os.Stat(fp); statErr == nil {
+skipped++
+reporter.Increment()
+continue
+}
+
+rel := strings.TrimPrefix(fp, organizerRoot)
+rel = strings.TrimPrefix(rel, string(os.PathSeparator))
+authorName := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+if authorName == "" || authorName == filepath.Base(fp) {
+if book.Author != nil {
+authorName = book.Author.Name
+} else if book.AuthorID != nil {
+if a, aErr := store.GetAuthorByID(*book.AuthorID); aErr == nil && a != nil {
+authorName = a.Name
+}
+}
+}
+if authorName == "" {
+reporter.Log("warn", fmt.Sprintf("No author for missing book %s (%q)", book.ID, book.Title), nil)
+unresolved++
+reporter.Increment()
+continue
+}
+
+matches := rrFindInITunes(iTunesRoot, authorName, book.Title)
+
+switch len(matches) {
+case 0:
+unresolved++
+case 1:
+resolved++
+reporter.Log("info", fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, matches[0]), nil)
+default:
+if best := rrDisambiguate(matches, authorName, book.Title); best != "" {
+resolved++
+reporter.Log("info", fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, best), nil)
+} else {
+unresolved++
+}
+}
+reporter.Increment()
+}
+
+reporter.Log("info", fmt.Sprintf("Done: resolved=%d unresolved=%d skipped=%d", resolved, unresolved, skipped), nil)
+return nil
+}
+
+var rrAudioExts = map[string]bool{
+".mp3": true, ".m4b": true, ".m4a": true,
+".flac": true, ".opus": true, ".ogg": true,
+}
+
+func rrFindInITunes(iTunesRoot, authorName, title string) []string {
+titlePrefix := title
+if len(titlePrefix) > 25 {
+titlePrefix = titlePrefix[:25]
+}
+titlePrefixLower := strings.ToLower(titlePrefix)
+authorWord := authorName
+if idx := strings.Index(authorName, " "); idx > 0 {
+authorWord = authorName[:idx]
+}
+authorWordLower := strings.ToLower(authorWord)
+
+dirMatches := map[string]struct{}{}
+entries, err := os.ReadDir(iTunesRoot)
+if err != nil {
+return nil
+}
+
+for _, entry := range entries {
+if !entry.IsDir() {
+continue
+}
+if !strings.Contains(strings.ToLower(entry.Name()), authorWordLower) {
+continue
+}
+authorDir := filepath.Join(iTunesRoot, entry.Name())
+albumEntries, err := os.ReadDir(authorDir)
+if err != nil {
+continue
+}
+for _, album := range albumEntries {
+albumPath := filepath.Join(authorDir, album.Name())
+if album.IsDir() {
+if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+dirMatches[albumPath] = struct{}{}
+continue
+}
+_ = filepath.WalkDir(albumPath, func(path string, d os.DirEntry, err error) error {
+if err != nil || d.IsDir() {
+return nil
+}
+if !rrAudioExts[strings.ToLower(filepath.Ext(path))] {
+return nil
+}
+if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+dirMatches[albumPath] = struct{}{}
+return filepath.SkipDir
+}
+return nil
+})
+} else {
+if !rrAudioExts[strings.ToLower(filepath.Ext(albumPath))] {
+continue
+}
+if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+dirMatches[albumPath] = struct{}{}
+}
+}
+}
+}
+
+result := make([]string, 0, len(dirMatches))
+for d := range dirMatches {
+result = append(result, d)
+}
+sort.Strings(result)
+return result
+}
+
+var rrLeadingNumRE = regexp.MustCompile(`^\d+\s*[-.]?\s*`)
+var rrTrailingNumRE = regexp.MustCompile(`\s+\d+$`)
+
+func rrDisambiguate(matches []string, authorName, title string) string {
+titleLower := strings.ToLower(title)
+type candidate struct {
+path  string
+score int
+}
+cands := make([]candidate, 0, len(matches))
+for _, p := range matches {
+base := filepath.Base(p)
+ext := filepath.Ext(base)
+stemRaw := strings.TrimSuffix(base, ext)
+leadingNum := rrLeadingNumRE.FindString(stemRaw)
+stemNoNum := rrLeadingNumRE.ReplaceAllString(stemRaw, "")
+stemLower := strings.ToLower(stemNoNum)
+stemNorm := strings.ReplaceAll(strings.ReplaceAll(stemLower, "_", " "), ":", " ")
+sc := 0
+switch {
+case stemNorm == titleLower:
+sc += 100
+case strings.HasPrefix(stemNorm, titleLower):
+rest := stemNorm[len(titleLower):]
+switch {
+case regexp.MustCompile(`^\s+book\s+\d`).MatchString(rest),
+regexp.MustCompile(`^\s+\d+$`).MatchString(rest):
+sc += 20
+default:
+sc += 60
+}
+case strings.HasPrefix(titleLower, stemNorm) && len(stemNorm) >= 10:
+sc += 80
+case strings.Contains(stemNorm, titleLower):
+sc += 10
+}
+if rrTrailingNumRE.MatchString(stemNorm) {
+sc -= 30
+}
+if leadingNum == "" {
+sc += 20
+} else {
+if n, err := strconv.Atoi(strings.TrimSpace(
+strings.TrimRight(strings.TrimRight(leadingNum, " "), "-."))); err == nil {
+sc -= n * 2
+}
+}
+authorDir := filepath.Base(filepath.Dir(p))
+if strings.EqualFold(authorDir, authorName) {
+sc += 40
+} else if strings.Contains(strings.ToLower(authorDir), strings.ToLower(authorName)) {
+sc += 20
+}
+sc -= len(base) / 8
+cands = append(cands, candidate{path: p, score: sc})
+}
+sort.Slice(cands, func(i, j int) bool { return cands[i].score > cands[j].score })
+if len(cands) > 1 {
+stemOf := func(p string) string {
+b := filepath.Base(p)
+s := strings.TrimSuffix(b, filepath.Ext(b))
+s = strings.ToLower(rrLeadingNumRE.ReplaceAllString(s, ""))
+s = strings.ReplaceAll(strings.ReplaceAll(s, "_", " "), ":", " ")
+return s
+}
+first := stemOf(cands[0].path)
+allSame := true
+for _, c := range cands[1:] {
+if stemOf(c.path) != first {
+allSame = false
+break
+}
+}
+if allSame {
+return cands[0].path
+}
+}
+if len(cands) >= 2 && cands[0].score-cands[1].score >= 15 {
+return cands[0].path
+}
+if len(cands) == 1 {
+return cands[0].path
+}
+return ""
 }

--- a/internal/maintenance/registry.go
+++ b/internal/maintenance/registry.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/registry.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 22222222-2222-2222-2222-222222222222
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package maintenance
 
@@ -24,6 +24,21 @@ func Register(j MaintenanceJob) {
 	}
 	registry = append(registry, j)
 	byID[j.ID()] = j
+}
+
+var enqueuer WriteBackEnqueuer
+
+// InjectEnqueuer injects the write-back enqueuer into all registered jobs
+// that implement EnqueuerInjectable.
+func InjectEnqueuer(e WriteBackEnqueuer) {
+	mu.Lock()
+	defer mu.Unlock()
+	enqueuer = e
+	for _, j := range registry {
+		if ei, ok := j.(EnqueuerInjectable); ok {
+			ei.InjectEnqueuer(e)
+		}
+	}
 }
 
 func Get(id string) (MaintenanceJob, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 1.211.0
+// version: 1.212.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package server
 
@@ -946,6 +946,9 @@ func NewServer(store database.Store) *Server {
 
 	// Inject the store into the maintenance package so jobs can access it.
 	maintenance.InjectStore(resolvedStore)
+	if server.writeBackBatcher != nil {
+		maintenance.InjectEnqueuer(server.writeBackBatcher)
+	}
 
 	// Initialize plugin event bus and registry
 	server.eventBus = plugin.NewEventBus()


### PR DESCRIPTION
Completes the unified maintenance job system from #635 by implementing all 7 previously stubbed jobs. Adds WriteBackEnqueuer injection for dedup-books. All jobs now run async via the unified dispatcher.