### PR TITLE
docs(audit): add 10 STRUCT bot-task specs + update TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 7.0.0 -->
+<!-- version: 8.0.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-01 -->
 
@@ -139,6 +139,32 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
   → [`2026-04-30-fe-9-localstorage-keys.md`](docs/superpowers/bot-tasks/2026-04-30-fe-9-localstorage-keys.md)
 - [ ] **FE-10** `chore/frontend-coverage-thresholds` — Add Vitest coverage thresholds
   → [`2026-04-30-fe-10-coverage.md`](docs/superpowers/bot-tasks/2026-04-30-fe-10-coverage.md)
+
+### STRUCT — Structural Refactors — 2026-05-01 (10 tasks)
+
+Full audit at [`docs/audits/2026-05-01-structure-audit.md`](docs/audits/2026-05-01-structure-audit.md).
+Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpowers/bot-tasks/).
+
+- [ ] **STRUCT-1** `refactor/struct-1-server-response-helpers` — Adopt existing RespondWith* helpers for 61 direct c.JSON calls
+  → [`2026-05-01-struct-1-server-response-helpers.md`](docs/superpowers/bot-tasks/2026-05-01-struct-1-server-response-helpers.md)
+- [ ] **STRUCT-2** `refactor/struct-2-pagination-helper` — Consolidate 7+ duplicate pagination parsers into shared paginationFromQuery
+  → [`2026-05-01-struct-2-pagination-helper.md`](docs/superpowers/bot-tasks/2026-05-01-struct-2-pagination-helper.md)
+- [ ] **STRUCT-3** `refactor/struct-3-maintenance-fixups-split` — Split 6400-line maintenance_fixups.go into 8 domain files
+  → [`2026-05-01-struct-3-maintenance-fixups-split.md`](docs/superpowers/bot-tasks/2026-05-01-struct-3-maintenance-fixups-split.md)
+- [ ] **STRUCT-4** `refactor/struct-4-metafetch-service-split` — Split 3932-line metafetch/service.go into 8 domain files
+  → [`2026-05-01-struct-4-metafetch-service-split.md`](docs/superpowers/bot-tasks/2026-05-01-struct-4-metafetch-service-split.md)
+- [ ] **STRUCT-5** `refactor/struct-5-ai-retry-helper` — Extract shared withRetry helper from 4 identical AI retry loops
+  → [`2026-05-01-struct-5-ai-retry-helper.md`](docs/superpowers/bot-tasks/2026-05-01-struct-5-ai-retry-helper.md)
+- [ ] **STRUCT-6** `refactor/struct-6-sqlite-store-split` — Split 6976-line sqlite_store.go into 7 domain files
+  → [`2026-05-01-struct-6-sqlite-store-split.md`](docs/superpowers/bot-tasks/2026-05-01-struct-6-sqlite-store-split.md)
+- [ ] **STRUCT-7** `refactor/struct-7-server-go-split` — Split 3401-line server.go into 6 responsibility files
+  → [`2026-05-01-struct-7-server-go-split.md`](docs/superpowers/bot-tasks/2026-05-01-struct-7-server-go-split.md)
+- [ ] **STRUCT-8** `refactor/struct-8-use-async-action-hook` — Extract useAsyncAction hook from 148 setLoading patterns in frontend
+  → [`2026-05-01-struct-8-use-async-action-hook.md`](docs/superpowers/bot-tasks/2026-05-01-struct-8-use-async-action-hook.md)
+- [ ] **STRUCT-9** `refactor/struct-9-frontend-component-splits` — Split Library.tsx (2900 lines) and BookDedup.tsx (2100 lines) into sub-components
+  → [`2026-05-01-struct-9-frontend-component-splits.md`](docs/superpowers/bot-tasks/2026-05-01-struct-9-frontend-component-splits.md)
+- [ ] **STRUCT-10** `refactor/struct-10-narrow-server-interfaces` — Narrow *Server receivers with small local interfaces in 5 handler groups
+  → [`2026-05-01-struct-10-narrow-server-interfaces.md`](docs/superpowers/bot-tasks/2026-05-01-struct-10-narrow-server-interfaces.md)
 
 ---
 

--- a/docs/audits/2026-05-01-structure-audit.md
+++ b/docs/audits/2026-05-01-structure-audit.md
@@ -1,0 +1,337 @@
+<!-- file: docs/audits/2026-05-01-structure-audit.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890 -->
+<!-- last-edited: 2026-05-01 -->
+
+# Structure & Refactor Audit — 2026-05-01
+
+Evidence-based analysis of file size, code duplication, package cohesion, interface
+segregation, and frontend structure. Findings are ranked by impact.
+
+---
+
+## Summary
+
+| Area | Finding | Severity |
+|------|---------|---------|
+| File sizes | 6 files over 1600 lines; two exceed 6000 | 🔴 High |
+| HTTP helpers | 287 `c.JSON(http.` calls; 36 identical "db not initialized" responses | 🔴 High |
+| Pagination | 376 limit/offset mentions with no shared helper | 🟠 Medium |
+| Retry logic | Duplicated in 3+ AI files | 🟠 Medium |
+| server/ package | 105 Go files, 12+ domains in one package | 🟠 Medium |
+| Frontend pages | 4 components over 2700 lines; 148 duplicated loading patterns | 🟠 Medium |
+| Interface use | Full `Store` passed where narrow interface suffices | 🟡 Low |
+| Path normalization | 611 scattered `ToLower/TrimSpace/Clean` calls | 🟡 Low |
+
+---
+
+## 1. Giant Files
+
+### `internal/database/sqlite_store.go` — 6976 lines
+
+Domains crammed into one file:
+
+| Domain | Examples |
+|--------|---------|
+| Schema bootstrap | `createTables`, `ensureExtendedBookColumns` |
+| Auth / sessions / API keys | `CreateUser`, `CreateSession`, `CreateAPIKey`, `CreateInvite` |
+| User state / preferences | `SetUserPosition`, `GetUserBookState`, `SetUserPreference` |
+| Books / segments / files | `CreateBookSegment`, `MergeBookSegments`, `GetBookVersion` |
+| Playlists | `ListUserPlaylists`, `GetPlaylist` |
+| Activity / settings / metadata / cache / ops | scattered throughout |
+| Scan helpers / null converters | repeated inline scan patterns |
+| Stub methods | dozens returning `nil, nil` |
+
+**Proposed split:**
+```
+sqlite_store_core.go          — db open/close/schema/migrations
+sqlite_store_users.go         — auth, sessions, roles, API keys, invites
+sqlite_store_books.go         — book CRUD, segments, files, versions
+sqlite_store_playlists.go     — playlists, positions, user state
+sqlite_store_metadata_ops.go  — metadata fetch cache, AI scan store
+sqlite_store_activity.go      — activity, settings, cache stats
+sqlite_store_util.go          — scan helpers, null converters
+```
+
+---
+
+### `internal/server/maintenance_fixups.go` — 6400 lines
+
+Eight clear maintenance domains:
+
+| Domain | Lines (approx) |
+|--------|---------------|
+| Read-by / narrator fixups | 78–600 |
+| Series cleanup / merge / normalize | 600–1100 |
+| Filesystem repair (backfill, empty folders) | 1100–1700 |
+| Author/narrator swap, version-group fixes | 1700–2100 |
+| Dedup / book merge | 2100–2700 |
+| iTunes path / ITL / backup | 2700–3900 |
+| Wipe endpoints | 3900–4400 |
+| Hash backfill / chapter groups / duplicate files | 4400–6400 |
+
+**Proposed split:**
+```
+maintenance_readby.go    maintenance_series.go
+maintenance_files.go     maintenance_dedup.go
+maintenance_itunes.go    maintenance_scans.go
+maintenance_wipe.go      maintenance_hashes.go
+```
+
+---
+
+### `internal/metafetch/service.go` — 3932 lines
+
+| Domain | Key functions |
+|--------|--------------|
+| Wiring / config setters | `NewService`, `Set*` (lines 58–115) |
+| Enrichment queue / source-chain | lines 118–260 |
+| Fetch / search / apply pipeline | `FetchMetadataForBook`, `ApplyMetadataCandidate`, `persistFetchedMetadata` |
+| Scoring / rerank | `computeF1Base`, `ScoreOneResult`, `RerankTopK` |
+| Normalization / parsing | `NormalizeMetaSeries`, `ParseSeriesFromTitle` |
+| Writeback / tag embedding | `writeBackMetadata`, `BuildTagMap`, `ApplyMetadataFileIO` |
+| Path helpers / ASIN / cleanup | scattered at end |
+
+**Proposed split:**
+```
+service_wiring.go    service_fetch.go     service_search.go
+service_apply.go     service_scoring.go   service_normalize.go
+service_writeback.go service_files.go
+```
+
+---
+
+### `internal/server/server.go` — 3401 lines
+
+| Domain | Lines |
+|--------|-------|
+| Metadata state / provenance helpers | ~139–673 |
+| Library sizing / response enrichment | ~680–768 |
+| Server construction / routing | `NewServer` 886, `Start` 1702, `setupRoutes` 2295 |
+| Indexing / search hooks | `IndexBookByID`, `DeleteIndexedBook` |
+| Operation resume / recovery | `resumeInterruptedOperations` |
+| Middleware / CORS / path protection | scattered |
+
+**Proposed split:**
+```
+server_bootstrap.go       server_metadata_state.go
+server_indexing.go        server_routes.go
+server_startup.go         server_path.go
+```
+
+---
+
+### `internal/server/audiobook_service.go` — 1891 lines
+
+**Proposed split:**
+```
+audiobook_list.go     audiobook_read.go
+audiobook_write.go    audiobook_tags.go
+audiobook_search.go   audiobook_filters.go
+```
+
+---
+
+### `internal/server/scheduler.go` — 1686 lines
+
+**Proposed split:**
+```
+scheduler_registry.go    scheduler_trigger.go
+scheduler_runtime.go     scheduler_maintenance.go
+scheduler_state.go
+```
+
+---
+
+## 2. Common Utility Duplication
+
+### 2a. HTTP JSON response helpers (🔴 HIGH impact)
+
+Evidence:
+```
+$ grep -c 'c\.JSON(http\.' internal/server/**/*.go
+287 total hits
+36 × c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+14 × c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+```
+
+Every handler re-types the same gin response patterns. A small helper file would eliminate ~200 lines:
+
+```go
+// internal/server/response.go (proposed)
+func jsonOK(c *gin.Context, v any)            { c.JSON(http.StatusOK, v) }
+func jsonErr(c *gin.Context, code int, err error) { c.JSON(code, gin.H{"error": err.Error()}) }
+func jsonBadRequest(c *gin.Context, err error)    { jsonErr(c, http.StatusBadRequest, err) }
+func jsonInternalErr(c *gin.Context, err error)   { jsonErr(c, http.StatusInternalServerError, err) }
+func jsonNotFound(c *gin.Context, msg string)     { c.JSON(http.StatusNotFound, gin.H{"error": msg}) }
+func jsonAccepted(c *gin.Context, v any)          { c.JSON(http.StatusAccepted, v) }
+func jsonDBNotInit(c *gin.Context)                { jsonErr(c, http.StatusInternalServerError, ErrDBNotInitialized) }
+```
+
+---
+
+### 2b. Pagination helper (🟠 MEDIUM impact)
+
+Evidence: 376 mentions of `limit`, `offset`, `page` across handlers — each parses and clamps
+query params independently.
+
+```go
+// internal/server/pagination.go (proposed)
+type Pagination struct { Limit, Offset int }
+
+func PaginationFromQuery(c *gin.Context) Pagination {
+    limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+    offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+    if limit <= 0 || limit > 1000 { limit = 50 }
+    if offset < 0 { offset = 0 }
+    return Pagination{Limit: limit, Offset: offset}
+}
+```
+
+---
+
+### 2c. Retry / backoff helper (🟠 MEDIUM impact)
+
+Duplicated in at least 3 AI files:
+- `internal/ai/openai_parser.go`
+- `internal/ai/metadata_llm_review.go`
+- `internal/ai/embedding_client.go`
+
+```go
+// internal/ai/retry.go (proposed)
+func withRetry(ctx context.Context, maxAttempts int, fn func() error) error
+```
+
+---
+
+### 2d. Path / string normalization (🟡 LOW impact)
+
+611 scattered `strings.ToLower`, `strings.TrimSpace`, `filepath.Clean` calls — many are
+fine inline, but a dozen callsites normalize the same "author name" or "file path" with
+slightly different sequences, creating subtle inconsistencies.
+
+Candidates for `internal/util/normalize.go`:
+- `NormalizeAuthorName(s string) string`
+- `NormalizeFilePath(s string) string`
+- `NormalizeSeriesName(s string) string`
+
+---
+
+## 3. Package Cohesion
+
+### `internal/server/` — 105 Go files (🟠 MEDIUM)
+
+This package is both an HTTP transport layer **and** a business orchestration layer.
+It currently covers:
+- HTTP handlers (audiobooks, metadata, iTunes, auth, dedup, entities, playlists)
+- Scheduler
+- Maintenance fixups
+- Reconciliation
+- AI scan pipeline
+- File operations
+- Diagnostics
+
+The clearest extraction would be moving the pure-business-logic layer (currently
+`audiobook_service.go`, `reconcile.go`, `ai_scan_pipeline.go`) into their own packages
+that the HTTP handlers depend on, rather than having it all in one package.
+
+### `internal/database/` — 29 non-test files (✅ Mostly fine)
+
+`Store` is already split into 9+ sub-interfaces (`BookReader`, `BookWriter`,
+`BookFileStore`, etc.). The main issue is that some callers still accept the full
+`database.Store` when they only need one or two sub-interfaces.
+
+### `internal/metafetch/` — 8 files (✅ Fine as package, `service.go` is the problem)
+
+The package itself is well-scoped. Just needs the 3932-line `service.go` split into
+logical files within the same package.
+
+### `internal/itunes/service/` — 17 files (✅ Fine)
+
+Cohesive around iTunes import/sync/repair. The DEP-1 work just completed (removing
+deprecated `Book.ITunesPath`) is the right level of cleanup here.
+
+---
+
+## 4. Interface Segregation
+
+**Already good:**
+- `internal/database/store.go` exports 9 sub-interfaces, combined via `Store`
+- `internal/server/audiobook_service.go` (lines 29–50) defines `audiobookStore` as
+  a narrow composite of only the required sub-interfaces — this is the pattern to follow
+
+**Still wide:**
+- Several handler functions accept `*Server` or `database.Store` when they only need
+  `database.BookReader` or `database.BookFileStore`
+- `maintenance_fixups.go` closures capture `*Server` (14+ hits) rather than declaring
+  their exact dependency surface
+
+**Recommendation:** New handler files should declare a narrow local interface at the
+top (like `audiobook_service.go` does). Existing handlers can be tightened
+incrementally — no big-bang refactor needed.
+
+---
+
+## 5. Frontend Structure
+
+### Oversized page components
+
+| File | Lines |
+|------|-------|
+| `web/src/pages/BookDedup.tsx` | 3656 |
+| `web/src/pages/Library.tsx` | 3333 |
+| `web/src/pages/Settings.tsx` | 2902 |
+| `web/src/pages/BookDetail.tsx` | 2773 |
+
+These are 3–4× larger than healthy React components. Each should be split into
+feature sections (e.g. `Library` → `LibraryTable`, `LibraryFilters`, `LibraryToolbar`,
+`LibraryBulkActions`).
+
+### Loading state duplication — 148 hits
+
+```tsx
+// Pattern repeated 148 times across components:
+const [loading, setLoading] = useState(false);
+// ...
+setLoading(true);
+try { ... } finally { setLoading(false); }
+```
+
+A shared `useAsyncAction` hook would eliminate most of these:
+
+```ts
+// web/src/hooks/useAsyncAction.ts (proposed)
+function useAsyncAction<T>(fn: () => Promise<T>) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const run = async () => {
+    setLoading(true); setError(null);
+    try { return await fn(); }
+    catch (e) { setError(e.message); }
+    finally { setLoading(false); }
+  };
+  return { run, loading, error };
+}
+```
+
+### API call duplication — 488 axios calls
+
+`web/src/lib/api.ts` already exists — check whether it wraps all calls or if some
+components call axios directly. Direct axios calls bypass any centralized error handling.
+
+---
+
+## Prioritized Action Plan
+
+| Priority | Item | Effort | Impact |
+|----------|------|--------|--------|
+| 1 | `server/response.go` HTTP helpers | Small (1 file) | High — eliminates 200+ boilerplate lines |
+| 2 | `server/pagination.go` pagination helper | Small (1 file) | Medium — normalizes 376 callsites |
+| 3 | Split `maintenance_fixups.go` into 8 files | Medium | High — 6400 lines is unmaintainable |
+| 4 | Split `metafetch/service.go` into 8 files | Medium | High — easier to review/test |
+| 5 | `ai/retry.go` retry helper | Small (1 file) | Medium — DRY in AI layer |
+| 6 | Split `sqlite_store.go` into 7 files | Large | Medium — navigation/comprehension |
+| 7 | Split `server.go` into 6 files | Large | Medium — requires careful routing split |
+| 8 | `useAsyncAction` frontend hook | Small (1 file) | Medium — eliminates 148 loading patterns |
+| 9 | Split `BookDedup.tsx` / `Library.tsx` | Medium | Medium — reviewability |
+| 10 | Narrow `*Server` to small interfaces in handlers | Large | Low (correctness already fine) |

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-1-server-response-helpers.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-1-server-response-helpers.md
@@ -1,0 +1,132 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-1-server-response-helpers.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b1c2d3e4-f5a6-7890-bcde-f12345678901 -->
+<!-- last-edited: 2026-05-01 -->
+
+# BOT TASK: STRUCT-1 — Add HTTP response helpers to `internal/server`
+
+**TODO ID:** STRUCT-1
+**Audience:** burndown bot
+**Branch:** `refactor/struct-1-server-response-helpers`
+**PR title:** `refactor(server): add shared HTTP response helper functions`
+
+---
+
+## What This Task Does
+
+`internal/server/error_handler.go` **already exists** with 14 response helpers
+(`RespondWithError`, `RespondWithBadRequest`, `RespondWithNotFound`,
+`RespondWithInternalError`, `RespondWithSuccess`, `RespondWithList`,
+`RespondWithCreated`, `RespondWithOK`, `RespondWithNoContent`, etc.).
+
+Despite these helpers existing, **287 handlers still call `c.JSON(http.Status...)` directly**.
+This task replaces the three highest-frequency direct-call patterns with the existing
+helpers — no new code, just adoption.
+
+**Evidence of the problem:**
+- `c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})` — **36×**
+- `c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})` — **14×**
+- `c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})` — **11×**
+
+---
+
+## What NOT to Do
+
+- **Do NOT** create a new response file — use the existing `error_handler.go` helpers.
+- **Do NOT** change handler logic, only the response call.
+- **Do NOT** change test files.
+
+---
+
+## Step-by-step
+
+### Step 1 — Read the existing helpers
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+cat internal/server/error_handler.go | head -80
+```
+
+Note the exact function signatures (`RespondWithError`, `RespondWithBadRequest`,
+`RespondWithInternalError`, `RespondWithNotFound`, `RespondWithSuccess`).
+
+### Step 2 — Find the 36 "database not initialized" direct calls
+
+```bash
+grep -rn '"database not initialized"' internal/server/ | grep -v '_test' | grep 'c\.JSON'
+```
+
+For each hit, replace:
+```go
+// BEFORE:
+c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+
+// AFTER:
+RespondWithInternalError(c, errors.New("database not initialized"))
+```
+
+Or if the existing helper signature differs, use whatever matches. Add `"errors"` import
+if not already present.
+
+### Step 3 — Find the 14 BadRequest direct calls
+
+```bash
+grep -rn 'c\.JSON(http\.StatusBadRequest, gin\.H{"error": err\.Error' internal/server/ | grep -v '_test'
+```
+
+For each hit, replace:
+```go
+// BEFORE:
+c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+
+// AFTER:
+RespondWithBadRequest(c, err)
+```
+
+### Step 4 — Find the 11 InternalServerError direct calls
+
+```bash
+grep -rn 'c\.JSON(http\.StatusInternalServerError, gin\.H{"error": err\.Error' internal/server/ | grep -v '_test'
+```
+
+For each hit, replace with `RespondWithInternalError(c, err)`.
+
+### Step 5 — Build and test
+
+```bash
+go build ./internal/server/...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+Both must pass.
+
+### Step 6 — Bump version headers on all changed files
+
+Every changed file gets a patch bump on `<!-- version: X.Y.Z -->`.
+
+### Step 7 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-1-server-response-helpers
+git add internal/server/
+git commit -m "refactor(server): adopt existing RespondWith* helpers for common patterns
+
+Replaces 61 direct c.JSON() calls (36 db-not-initialized, 14 bad-request,
+11 internal-error) with the existing error_handler.go helpers. Reduces
+boilerplate and centralises error message wording. Structure audit STRUCT-1.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-1-server-response-helpers
+gh pr create \
+  --title "refactor(server): adopt existing RespondWith* helpers for common patterns" \
+  --body "Replaces 61 direct c.JSON calls with existing error_handler.go helpers. Structure audit STRUCT-1."
+```
+
+---
+
+## Checklist
+
+- [ ] `internal/server/response.go` created with all 8 functions + `ErrDBNotInitialized`
+- [ ] `go build ./internal/server/...` clean
+- [ ] Version header present on new file
+- [ ] PR opened on branch `refactor/struct-1-server-response-helpers`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-10-narrow-server-interfaces.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-10-narrow-server-interfaces.md
@@ -1,0 +1,197 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-10-narrow-server-interfaces.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d0e1f2a3-b4c5-6789-defa-012345678901 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-10 — Narrow `*Server` dependencies with small interfaces
+
+**Priority:** Low  
+**Effort:** Medium  
+**Branch:** `refactor/struct-10-narrow-server-interfaces`
+
+---
+
+## Why This Matters
+
+Most handler functions are declared as `func (s *Server) handlerName(c *gin.Context)`,
+giving every handler access to the entire 80+ field `Server` struct. This makes
+handlers hard to test in isolation and obscures what each handler actually needs.
+
+The codebase already has a good pattern in `internal/server/audiobook_service.go`
+(lines 29–50) where a narrow composite interface is defined locally. We should apply
+the same pattern to the 5–10 most complex handler groups.
+
+**Evidence of current pattern:**
+```bash
+grep -c 'func (s \*Server)' internal/server/*.go
+# Many hits across many files
+```
+
+**Evidence of existing narrow interface pattern:**
+```bash
+grep -n 'type.*interface' internal/server/audiobook_service.go
+```
+
+---
+
+## What This Task Does
+
+For the handler groups listed below, define a small local interface in the handler
+file capturing only the `*Server` fields/methods that group actually uses. Change
+the handler receiver from `*Server` to the new interface type.
+
+This does NOT change behaviour — it only tightens the types.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any handler logic.
+- **Do NOT** change any exported function names or HTTP routes.
+- **Do NOT** change the `Server` struct itself.
+- **Do NOT** change the `setupRoutes` call sites — `*Server` satisfies any interface
+  it implements automatically.
+- **Do NOT** change test files (unless they fail to compile after the interface change).
+
+---
+
+## Handler Groups to Narrow
+
+### Group 1: `organize_handlers.go`
+
+Handlers: `previewRename`, `applyRename`, and related (~lines 27–200).
+
+Uses: only `s.Store()`.
+
+Define at top of file:
+```go
+type organizeStore interface {
+    Store() database.Store
+}
+```
+
+Change receivers:
+```go
+// BEFORE:
+func (s *Server) previewRename(c *gin.Context) {
+
+// AFTER:
+func (s organizeStore) previewRename(c *gin.Context) {
+```
+
+Do this for every handler in the file that uses only `s.Store()`.
+
+### Group 2: `ai_jobs_handlers.go`
+
+Handlers: `handleListAIJobs`, `handleGetAIJob`, and related (~lines 34–150).
+
+Uses: only `s.Store()`.
+
+Define:
+```go
+type aiJobsStore interface {
+    Store() database.Store
+}
+```
+
+### Group 3: `filesystem_handlers.go`
+
+Handlers in this file use `s.Store()` and `s.cfg` (config).
+
+Define:
+```go
+type filesystemDeps interface {
+    Store() database.Store
+    Config() *ServerConfig   // or whatever the field accessor is
+}
+```
+
+### Group 4: `reading_handlers.go`
+
+Uses: `s.Store()`, possibly `s.audiobookService`.
+
+Define a narrow interface for those two.
+
+### Group 5: `activity_handlers.go`
+
+Uses: `s.Store()`.
+
+Define `type activityHandlerStore interface { Store() database.Store }`.
+
+---
+
+## Steps
+
+### Step 1 — Read the existing pattern
+
+```bash
+sed -n '25,55p' internal/server/audiobook_service.go
+```
+
+This shows the narrow composite interface pattern already in use. Your new
+interfaces should follow the same style.
+
+### Step 2 — Inventory each handler file
+
+For each handler group above, run:
+```bash
+grep -n 's\.' internal/server/organize_handlers.go | grep -v '//' | sort -u
+```
+
+This shows every `s.Field` or `s.Method()` access. Build the interface from exactly
+those accesses.
+
+### Step 3 — Add the interface and change receivers (one file at a time)
+
+For each file:
+1. Add the `type XXXDeps interface { ... }` block at the top of the file (after imports).
+2. Change all handler receivers in that file from `(s *Server)` to `(s XXXDeps)`.
+3. Run `go build ./internal/server/...` — fix errors.
+4. `*Server` satisfies the interface implicitly; no call sites need to change.
+
+### Step 4 — Update unit tests if needed
+
+```bash
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|---'
+```
+
+If tests fail because they passed `*Server` directly and now need an interface
+value: no change is needed — `*Server` satisfies the interface automatically in Go.
+If tests used mock structs, update the mock to implement the new interface.
+
+### Step 5 — Final build + test
+
+```bash
+go build ./...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok'
+```
+
+### Step 6 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-10-narrow-server-interfaces
+git add internal/server/
+git commit -m "refactor(server): narrow *Server receivers with local handler interfaces
+
+Defines small local interfaces for 5 handler groups (organize, ai_jobs,
+filesystem, reading, activity) so each handler only depends on the
+fields it actually uses. Follows the existing pattern in audiobook_service.go.
+No behaviour changes. Structure audit STRUCT-10.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-10-narrow-server-interfaces
+gh pr create \
+  --title "refactor(server): narrow *Server receivers with local handler interfaces" \
+  --body "Adds narrow local interfaces for 5 handler groups. No behaviour changes. Structure audit STRUCT-10."
+```
+
+---
+
+## Checklist
+
+- [ ] Narrow interface defined in each of the 5 handler files
+- [ ] Handler receivers updated from `*Server` to the local interface type
+- [ ] `*Server` still satisfies all interfaces (no explicit impl needed)
+- [ ] `go build ./...` clean
+- [ ] Tests pass
+- [ ] PR opened on branch `refactor/struct-10-narrow-server-interfaces`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-2-pagination-helper.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-2-pagination-helper.md
@@ -1,0 +1,174 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-2-pagination-helper.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c3d4e5f6-a7b8-9012-cdef-345678901234 -->
+<!-- last-edited: 2026-05-01 -->
+
+# BOT TASK: STRUCT-2 — Add shared pagination helper to `internal/server`
+
+**TODO ID:** STRUCT-2
+**Audience:** burndown bot
+**Branch:** `refactor/struct-2-pagination-helper`
+**PR title:** `refactor(server): add shared PaginationFromQuery helper`
+
+---
+
+## What This Task Does
+
+`paginationFromQuery` **already exists** in `internal/server/playlist_handlers.go`
+(package-level, accessible to all server files). Seven other handlers have
+independent duplicate implementations with slightly different clamping rules.
+
+This task consolidates: move `paginationFromQuery` to a dedicated
+`internal/server/pagination.go` (with a `Pagination` return type), then update
+the 7+ other duplicate parsers to call it.
+
+**Evidence of duplicate parsers:**
+- `internal/server/dedup_handlers.go:53–67`
+- `internal/server/activity_handlers.go:41–50`
+- `internal/server/metadata_handlers.go:412+`
+- `internal/server/reading_handlers.go:171–176`
+- `internal/server/itunes_handlers.go:535–540`
+- `internal/server/metadata_batch_candidates.go:331–337`
+- `internal/server/maintenance_fixups.go:6192–6195`
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change pagination defaults (limit=50, max=500 — match existing).
+- **Do NOT** remove the existing `paginationFromQuery` from `playlist_handlers.go`
+  until AFTER moving it — or the package will fail to compile.
+- **Do NOT** rename the function in this PR (keep `paginationFromQuery`).
+
+---
+
+## Step-by-step
+
+### Step 1 — Read 3 existing pagination patterns first
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+
+grep -A6 'DefaultQuery.*limit\|Query.*"limit"' internal/server/audiobooks_handlers.go | head -30
+grep -A6 'DefaultQuery.*limit\|Query.*"limit"' internal/server/audiobook_service.go | head -30
+grep -A6 'DefaultQuery.*limit\|Query.*"limit"' internal/server/entities_handlers.go | head -20
+```
+
+Note the patterns: what default values are used for `limit`? What max is clamped to?
+Use `50` as the default limit and `1000` as the max (most common in the codebase).
+
+### Step 2 — Read the existing implementation
+
+```bash
+grep -n 'func paginationFromQuery' internal/server/playlist_handlers.go
+sed -n '415,435p' internal/server/playlist_handlers.go
+```
+
+Note the exact implementation (limit=50 default, max=500).
+
+### Step 3 — Create `internal/server/pagination.go`
+
+Create a new file with just this function (cut-paste from playlist_handlers.go):
+
+```go
+// file: internal/server/pagination.go
+// version: 1.0.0
+// last-edited: 2026-05-01
+// guid: d4e5f6a7-b8c9-0123-defa-456789012345
+
+package server
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// paginationFromQuery parses limit/offset query params with sane defaults + caps.
+// Default limit = 50, max = 500, default offset = 0.
+func paginationFromQuery(c *gin.Context) (int, int) {
+	limit, offset := 50, 0
+	if l := c.Query("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 500 {
+			limit = n
+		}
+	}
+	if o := c.Query("offset"); o != "" {
+		if n, err := strconv.Atoi(o); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return limit, offset
+}
+```
+
+### Step 4 — Remove the copy from playlist_handlers.go
+
+Delete the function body from `internal/server/playlist_handlers.go` (lines ~418-431).
+The package now has exactly one definition.
+
+```bash
+# Verify only one definition remains
+grep -rn 'func paginationFromQuery' internal/server/
+```
+
+Expected: one line only, pointing to `pagination.go`.
+
+### Step 5 — Update the 7 duplicate parsers
+
+For each file below, delete the hand-rolled parser and replace the call with
+`paginationFromQuery(c)`:
+
+- `internal/server/dedup_handlers.go:53–67`
+- `internal/server/activity_handlers.go:41–50`
+- `internal/server/metadata_handlers.go:412+`
+- `internal/server/reading_handlers.go:171–176`
+- `internal/server/itunes_handlers.go:535–540`
+- `internal/server/metadata_batch_candidates.go:331–337`
+- `internal/server/maintenance_fixups.go:6192–6195`
+
+Each caller becomes: `limit, offset := paginationFromQuery(c)`
+
+Remove `"strconv"` import from each file if it was only used for pagination.
+
+### Step 6 — Build and test
+
+```bash
+go build ./internal/server/...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+Both must pass.
+
+### Step 7 — Bump version headers
+
+Bump the patch version on every changed file.
+
+### Step 8 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-2-pagination-helper
+git add internal/server/
+git commit -m "refactor(server): consolidate pagination parsing into shared helper
+
+Moves paginationFromQuery from playlist_handlers.go into a dedicated
+pagination.go and updates 7 duplicate hand-rolled parsers to use it.
+Eliminates inconsistent limit/offset handling. Structure audit STRUCT-2.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-2-pagination-helper
+gh pr create \
+  --title "refactor(server): consolidate pagination parsing into shared helper" \
+  --body "Moves paginationFromQuery to pagination.go, removes 7 duplicate parsers. Structure audit STRUCT-2."
+```
+
+---
+
+## Checklist
+
+- [ ] `internal/server/pagination.go` created with `paginationFromQuery`
+- [ ] Function removed from `playlist_handlers.go`
+- [ ] 7 duplicate parsers replaced
+- [ ] `go build ./internal/server/...` clean
+- [ ] Tests pass
+- [ ] PR opened on branch `refactor/struct-2-pagination-helper`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-3-maintenance-fixups-split.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-3-maintenance-fixups-split.md
@@ -1,0 +1,258 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-3-maintenance-fixups-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e5f6a7b8-c9d0-1234-efab-567890123456 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-3 — Split `maintenance_fixups.go` (6400 lines → 8 files)
+
+**Priority:** High  
+**Effort:** Large (mechanical move — no logic changes)  
+**Branch:** `refactor/struct-3-maintenance-fixups-split`
+
+---
+
+## Why This Matters
+
+`internal/server/maintenance_fixups.go` is **6400+ lines** in a single file. It is
+impossible to navigate, review, or understand. Splitting it into logical sub-files
+makes each maintenance job independently reviewable and reduces merge conflicts.
+
+**Evidence:**
+```bash
+wc -l internal/server/maintenance_fixups.go
+# 6400+
+```
+
+---
+
+## What This Task Does
+
+Split `maintenance_fixups.go` into 8 files by logical domain. **No logic changes
+whatsoever** — only move functions. The package name stays `package server`.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any function signatures or logic.
+- **Do NOT** rename any functions.
+- **Do NOT** extract interfaces or change imports beyond what is forced by the move.
+- **Do NOT** touch any other files in `internal/server/`.
+- **Do NOT** touch test files.
+
+---
+
+## Target File Layout
+
+### File 1: `internal/server/maintenance_readby.go`
+Lines ~78–314 in original. Functions to move:
+- `handleFixReadByNarrator`
+- `parsePattern1`
+- `parsePattern2`
+- `parsePattern3`
+- `titleFromFilePath`
+- `applyReadByFix`
+- `caseInsensitiveIndex`
+- `stringDeref`
+- `countApplied`
+- `countErrors`
+
+### File 2: `internal/server/maintenance_series.go`
+Lines ~357–614 in original. Functions to move:
+- `handleCleanupSeries`
+- `unlinkAndDeleteSeries`
+- `mergeSeriesGroup`
+- `normalizeSeriesName`
+
+### File 3: `internal/server/maintenance_files.go`
+Lines ~662–1000, ~1219–1286, ~1713–1927 in original. Functions to move:
+- `handleBackfillBookFiles`
+- `handleCleanupEmptyFolders`
+- `isDirEmpty`
+- `isGarbageDirectory`
+- `allAlpha`
+- `handleCleanupOrganizeMess`
+- `createBookFilesForBook`
+- `handleEnrichBookFiles`
+- `parseTrackNumberFromFilename`
+- `handleFixBookFilePaths`
+- `isAuthorDirectory`
+- `bestMatchSubdir`
+- `fixAuthorDirPath`
+
+### File 4: `internal/server/maintenance_author_version.go`
+Lines ~1121–1644 in original. Functions to move:
+- `handleFixAuthorNarratorSwap`
+- `handleFixVersionGroups`
+- `extractCoreTitle`
+- `findMajorityCore`
+- `coreTitlesMatch`
+- `longWords`
+- `unlinkVersionGroupOutliers`
+
+### File 5: `internal/server/maintenance_dedup.go`
+Lines ~2217–2829 in original. Functions to move:
+- `handleDedupBooks`
+- `fetchAllBooksPaginated`
+- `isJunkReadByNarrator`
+- `pickKeeperIdx`
+- `bookScore`
+- `mergeDuplicateBook`
+- `mergeBookFields`
+- `softDeleteBook`
+- `normalizeDedupTitle`
+- `filterLive`
+- `handleRefetchMissingAuthors`
+
+### File 6: `internal/server/maintenance_wipe.go`
+Lines ~3037–3373 in original. Functions to move:
+- `handleWipe`
+- `dryRunLabel`
+- `wipeBookFiles`
+- `wipeSegments`
+- `wipeBooks`
+- `wipeAuthors`
+- `wipeSeries`
+- `wipeExternalIDs`
+- `wipeActivity`
+
+### File 7: `internal/server/maintenance_itunes.go`
+Lines ~3404–5168 in original (library states, iTunes paths, composer, relink, repair,
+revert, duration, relink report, deluge import). Functions to move:
+- `handleFixLibraryStates`
+- `handleRecomputeITunesPaths`
+- `handleGenerateITLTests`
+- `handleCleanupBackups`
+- `categorizeComposer`
+- `handleScanComposerTags`
+- `runComposerTagScan`
+- `handleGetComposerScanResults`
+- `humanizeBytes`
+- `handleRelinkMissingToiTunes`
+- `handleRepairMissingFiles`
+- `runMissingFileRepair`
+- `repairOneMissingFile`
+- `handleGetMissingFileRepairResults`
+- `handleRevertMetadataFetch`
+- `handleScanDurationMismatch`
+- `handleRelinkReport`
+- `handleBulkDelugeImport`
+- `runBulkDelugeImport`
+
+### File 8: `internal/server/maintenance_hashes.go`
+Lines ~5927–6388+ in original. Functions to move:
+- `handleBackfillMetadataSourceHash`
+- `bookMetadataSourceAndID`
+- `handleScanChapterGroups`
+- `handleMergeChapterGroups`
+- `handleScanDuplicateFiles`
+- `handleScanMetadataHashDuplicates`
+- `handleGetBookFileHashStats`
+- `handleBackfillFileHashes`
+- `handleGetBookMetadataHashStats`
+
+---
+
+## Steps
+
+### Step 1 — Baseline check
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./internal/server/...
+go test ./internal/server/... -run TestMaintenance -timeout 120s 2>&1 | grep -E 'PASS|FAIL|ok'
+wc -l internal/server/maintenance_fixups.go
+```
+
+Record the line count and whether tests pass.
+
+### Step 2 — Create the 8 new files
+
+For each file listed above:
+1. Create the new `.go` file with the standard version header.
+2. Add `package server` at the top.
+3. Copy (not cut yet) the functions into the new file.
+4. Add only the imports that the moved functions actually use.
+   - Run `go build ./internal/server/...` to check for missing imports.
+   - Fix import errors.
+
+The header template for each new file:
+```go
+// file: internal/server/maintenance_XXX.go
+// version: 1.0.0
+// guid: <generate-a-new-uuid>
+// last-edited: 2026-05-01
+
+package server
+```
+
+### Step 3 — Build after each file
+
+After creating each new file (while originals still exist), run:
+```bash
+go build ./internal/server/...
+```
+
+Fix any "already declared" errors — they mean a helper was accidentally duplicated.
+
+### Step 4 — Remove functions from maintenance_fixups.go
+
+Once ALL 8 new files build cleanly together with the original, delete the moved
+function bodies from `internal/server/maintenance_fixups.go`.
+
+Keep at the top of `maintenance_fixups.go` only:
+- The package declaration and any imports still needed for remaining functions.
+- Any `const` or `var` blocks that are shared across the new files.
+
+### Step 5 — Final build + test
+
+```bash
+go build ./internal/server/...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+Both must pass. `maintenance_fixups.go` should be **empty or nearly empty** after
+the move (or deleted if truly empty — but check that the route registrations are
+not in it first).
+
+### Step 6 — Bump version headers
+
+- All 8 new files: `version: 1.0.0` (already set in header).
+- Any file that was changed: bump patch version.
+
+### Step 7 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-3-maintenance-fixups-split
+git add internal/server/maintenance_*.go
+git commit -m "refactor(server): split maintenance_fixups.go into 8 domain files
+
+Splits the 6400-line maintenance_fixups.go into:
+- maintenance_readby.go (read-by/narrator fix)
+- maintenance_series.go (series cleanup/merge)
+- maintenance_files.go (book file backfill/cleanup)
+- maintenance_author_version.go (author swap, version groups)
+- maintenance_dedup.go (dedup, merge, refetch)
+- maintenance_wipe.go (wipe operations)
+- maintenance_itunes.go (iTunes relink, repair, revert)
+- maintenance_hashes.go (hash scans, chapter groups)
+
+No logic changes. Structure audit STRUCT-3.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-3-maintenance-fixups-split
+gh pr create \
+  --title "refactor(server): split maintenance_fixups.go into 8 domain files" \
+  --body "Splits 6400-line file into 8 focused files. No logic changes. Structure audit STRUCT-3."
+```
+
+---
+
+## Checklist
+
+- [ ] 8 new files created, each with version header and `package server`
+- [ ] `go build ./internal/server/...` clean
+- [ ] `go test ./internal/server/...` passes
+- [ ] Original `maintenance_fixups.go` is empty or deleted
+- [ ] No function renamed or logic changed
+- [ ] PR opened on branch `refactor/struct-3-maintenance-fixups-split`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-4-metafetch-service-split.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-4-metafetch-service-split.md
@@ -1,0 +1,229 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-4-metafetch-service-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f6a7b8c9-d0e1-2345-fabc-678901234567 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-4 — Split `metafetch/service.go` (3932 lines → 8 files)
+
+**Priority:** High  
+**Effort:** Large (mechanical move — no logic changes)  
+**Branch:** `refactor/struct-4-metafetch-service-split`
+
+---
+
+## Why This Matters
+
+`internal/metafetch/service.go` is **3932 lines** in a single file. Functions for
+wiring, fetching, search, scoring, normalisation, writeback, and file I/O are all
+mixed together. Splitting them makes the code navigable and reviewable.
+
+**Evidence:**
+```bash
+wc -l internal/metafetch/service.go
+# 3932+
+```
+
+---
+
+## What This Task Does
+
+Split `service.go` into 8 files by logical domain. **No logic changes** — only move
+functions. The package name stays `package metafetch`.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any function signatures or logic.
+- **Do NOT** rename any functions.
+- **Do NOT** change exported function names (they may be called from other packages).
+- **Do NOT** touch test files.
+
+---
+
+## Target File Layout
+
+### File 1: `internal/metafetch/service_wiring.go`
+Constructor and dependency injection. Functions to move:
+- `NewService`
+- `SetOverrideSources`
+- `SetActivityService`
+- `SetWriteBackBatcher`
+- `SetSafeWriteDeps`
+- `SetOLStore`
+- `SetDedupEngine`
+- `SetMetadataScorer`
+- `SetMetadataLLMScorer`
+- `SetISBNEnrichment`
+- `ISBNEnrichment`
+
+### File 2: `internal/metafetch/service_fetch.go`
+Fetch entry points. Functions to move:
+- `queueISBNEnrichment`
+- `FetchMetadataForBook`
+- `FetchMetadataForBookByTitle`
+
+### File 3: `internal/metafetch/service_search.go`
+Search context and source chain. Functions to move:
+- `buildSearchContext`
+- `BuildSourceChain`
+- `SearchMetadataForBook`
+- `SearchMetadataForBookWithOptions`
+
+### File 4: `internal/metafetch/service_apply.go`
+Apply / persist / candidate application. Functions to move:
+- `ApplyMetadataToBook`
+- `RecordChangeHistory`
+- `syncMetadataToLibraryCopy`
+- `ensureLibraryCopy`
+- `persistFetchedMetadata`
+- `ApplyMetadataCandidate`
+- `checkMetadataSourceHashDuplicates`
+- `ApplyMetadataSystemTags`
+- `MarkNoMatch`
+
+### File 5: `internal/metafetch/service_scoring.go`
+Scoring and ranking. Functions to move:
+- `IsGarbageValue`
+- `IsBetterValue`
+- `IsBetterStringPtr`
+- `computeF1Base`
+- `ApplyNonBaseAdjustments`
+- `durationScoreMultiplier`
+- `computeDurationScore`
+- `pickBestMatchFromScored`
+- `ScoreOneResult`
+- `ScoreBaseCandidates`
+- `bestTitleMatchForBook`
+- `RerankTopK`
+- `ApplySeriesPositionFilter`
+- `BestTitleMatch`
+- `BestTitleMatchWithContext`
+
+### File 6: `internal/metafetch/service_normalize.go`
+Normalisation and parsing. Functions to move:
+- `derefString`
+- `derefIntAsString`
+- `jsonEncodeString`
+- `NormalizeMetaSeries`
+- `ParseSeriesFromTitle`
+- `SignificantWords`
+- `isCompilation`
+- `extractTrailingNumber`
+- `normalizeSeriesNumber`
+
+### File 7: `internal/metafetch/service_writeback.go`
+Write-back, tag maps, segment titles, apply pipeline. Functions to move:
+- `writeBackMetadata`
+- `MetadataSourceTag`
+- `MetadataLanguageTag`
+- `BuildTagMap`
+- `BuildFullTagMap`
+- `FilterUnchangedTags`
+- `generateSegmentTitles`
+- `runApplyPipeline`
+- `WriteBackMetadataForBook`
+
+### File 8: `internal/metafetch/service_files.go`
+File I/O, iTunes path computation. Functions to move:
+- `AudioFilesInDir`
+- `backupFileBeforeWrite`
+- `ApplyMetadataFileIO`
+- `ComputeITunesPath`
+- `removeEmptyDirs`
+
+---
+
+## Steps
+
+### Step 1 — Baseline check
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./internal/metafetch/...
+go test ./internal/metafetch/... -timeout 120s 2>&1 | grep -E 'FAIL|ok'
+wc -l internal/metafetch/service.go
+```
+
+### Step 2 — Keep `service.go` for the `Service` struct and field declarations
+
+Open `service.go` and identify the `type Service struct { ... }` declaration and
+any `const`/`var` at file scope. These stay in `service.go` — do NOT move them.
+
+```bash
+grep -n 'type Service struct\|^const\|^var\|^type ' internal/metafetch/service.go | head -30
+```
+
+### Step 3 — Create the 8 new files
+
+For each file above:
+1. Create the file with the version header and `package metafetch`.
+2. Copy (not cut) the functions.
+3. Add only the imports needed by the copied functions.
+4. Run `go build ./internal/metafetch/...` — fix any import errors.
+
+Header template:
+```go
+// file: internal/metafetch/service_XXX.go
+// version: 1.0.0
+// guid: <generate-a-new-uuid>
+// last-edited: 2026-05-01
+
+package metafetch
+```
+
+### Step 4 — Remove functions from service.go
+
+After all 8 files build cleanly alongside the original, delete the moved functions
+from `service.go`. Only the struct definition, top-level consts/vars, and any
+functions not listed above should remain.
+
+### Step 5 — Final build + test
+
+```bash
+go build ./internal/metafetch/...
+go build ./...
+go test ./internal/metafetch/... -timeout 120s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+All must pass. Also run `go build ./...` to catch cross-package references.
+
+### Step 6 — Bump version headers on all changed files
+
+### Step 7 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-4-metafetch-service-split
+git add internal/metafetch/
+git commit -m "refactor(metafetch): split service.go into 8 domain files
+
+Splits the 3932-line service.go into:
+- service_wiring.go (constructor, DI)
+- service_fetch.go (fetch entry points)
+- service_search.go (search context, source chain)
+- service_apply.go (apply, persist, candidate)
+- service_scoring.go (scoring, ranking)
+- service_normalize.go (normalisation, parsing)
+- service_writeback.go (writeback, tags, pipeline)
+- service_files.go (file I/O, iTunes path)
+
+No logic changes. Structure audit STRUCT-4.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-4-metafetch-service-split
+gh pr create \
+  --title "refactor(metafetch): split service.go into 8 domain files" \
+  --body "Splits 3932-line file into 8 focused files. No logic changes. Structure audit STRUCT-4."
+```
+
+---
+
+## Checklist
+
+- [ ] 8 new files created, each with header and `package metafetch`
+- [ ] `Service` struct and file-scope declarations remain in `service.go`
+- [ ] `go build ./internal/metafetch/...` clean
+- [ ] `go build ./...` clean (cross-package check)
+- [ ] `go test ./internal/metafetch/...` passes
+- [ ] No function renamed or logic changed
+- [ ] PR opened on branch `refactor/struct-4-metafetch-service-split`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-5-ai-retry-helper.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-5-ai-retry-helper.md
@@ -1,0 +1,140 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-5-ai-retry-helper.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e5f6a7b8-c9d0-1234-efab-567890123456 -->
+<!-- last-edited: 2026-05-01 -->
+
+# BOT TASK: STRUCT-5 — Extract shared retry helper to `internal/ai`
+
+**TODO ID:** STRUCT-5
+**Audience:** burndown bot
+**Branch:** `refactor/struct-5-ai-retry-helper`
+**PR title:** `refactor(ai): extract shared retry/backoff helper`
+
+---
+
+## What This Task Does
+
+Creates `internal/ai/retry.go` with a shared `withRetry` function that replaces
+duplicated retry/backoff logic in at least 3 AI files:
+- `internal/ai/openai_parser.go`
+- `internal/ai/metadata_llm_review.go`
+- `internal/ai/embedding_client.go`
+
+---
+
+## What NOT to Do
+
+- **Do NOT** replace call sites in this PR — just create the shared helper.
+- **Do NOT** change the retry behaviour (same delays, same max attempts).
+- **Do NOT** touch test files.
+
+---
+
+## Step-by-step
+
+### Step 1 — Read the existing retry implementations
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+
+grep -n 'retry\|Retry\|attempt\|Attempt\|backoff\|Backoff\|sleep\|Sleep' \
+  internal/ai/openai_parser.go \
+  internal/ai/metadata_llm_review.go \
+  internal/ai/embedding_client.go | grep -v '//'
+```
+
+Then read 15 lines of context around each hit to understand the full pattern:
+```bash
+grep -n 'for.*attempt\|for.*retry\|time\.Sleep' \
+  internal/ai/openai_parser.go \
+  internal/ai/metadata_llm_review.go \
+  internal/ai/embedding_client.go
+```
+
+Note: what are the max attempts and sleep durations in each file? Use the most
+common values for the shared helper's defaults.
+
+### Step 2 — Create `internal/ai/retry.go`
+
+Based on what you read in Step 1, create a retry helper. The typical pattern will
+look like this (adjust delays/attempts to match what the existing code uses):
+
+```go
+// file: internal/ai/retry.go
+// version: 1.0.0
+// last-edited: 2026-05-01
+// guid: f6a7b8c9-d0e1-2345-fabc-678901234567
+
+package ai
+
+import (
+	"context"
+	"time"
+)
+
+// withRetry calls fn up to maxAttempts times, sleeping between attempts with
+// exponential backoff starting at initialDelay. Returns the last error if all
+// attempts fail. Respects ctx cancellation.
+func withRetry(ctx context.Context, maxAttempts int, initialDelay time.Duration, fn func() error) error {
+	var err error
+	delay := initialDelay
+	for i := 0; i < maxAttempts; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if i < maxAttempts-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			delay *= 2
+		}
+	}
+	return err
+}
+```
+
+Adjust `maxAttempts` default, `initialDelay`, and backoff multiplier to match
+what the existing 3 files currently use. If they all differ, use the most
+conservative (highest retry count, longest delay) as the default.
+
+### Step 3 — Build
+
+```bash
+go build ./internal/ai/...
+```
+
+Must compile clean.
+
+### Step 4 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-5-ai-retry-helper
+git add internal/ai/retry.go
+git commit -m "refactor(ai): extract shared retry/backoff helper
+
+Adds retry.go with withRetry() to replace duplicated retry logic in
+openai_parser.go, metadata_llm_review.go, and embedding_client.go.
+Uses exponential backoff with context cancellation support.
+Call-site replacement in follow-up task STRUCT-5b.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-5-ai-retry-helper
+gh pr create \
+  --title "refactor(ai): extract shared retry/backoff helper" \
+  --body "Adds ai/retry.go. Replaces 3 duplicated retry implementations. Part of STRUCT-5 structure audit."
+```
+
+---
+
+## Checklist
+
+- [ ] `internal/ai/retry.go` created
+- [ ] Retry logic matches existing implementations (same defaults)
+- [ ] `go build ./internal/ai/...` clean
+- [ ] PR opened on branch `refactor/struct-5-ai-retry-helper`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-6-sqlite-store-split.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-6-sqlite-store-split.md
@@ -1,0 +1,259 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-6-sqlite-store-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a7b8c9d0-e1f2-3456-abcd-789012345678 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-6 — Split `sqlite_store.go` (6976 lines → 7 files)
+
+**Priority:** High  
+**Effort:** Large (mechanical move — no logic changes)  
+**Branch:** `refactor/struct-6-sqlite-store-split`
+
+---
+
+## Why This Matters
+
+`internal/database/sqlite_store.go` is **6976 lines** — probably the largest file
+in the codebase. All SQLite store methods live in a single file, making it extremely
+difficult to navigate, review, or find any given method.
+
+**Evidence:**
+```bash
+wc -l internal/database/sqlite_store.go
+# ~6976
+```
+
+---
+
+## What This Task Does
+
+Split `sqlite_store.go` into 7 files by domain. **No logic changes** — only move
+functions. Package name stays `package database`.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any method signatures or logic.
+- **Do NOT** rename any functions.
+- **Do NOT** touch the `Store` interface in `store.go` — it does not change.
+- **Do NOT** touch test files.
+- **IMPORTANT:** Three `Book.ITunesPath` nil-check usages (deprecated field, lines
+  ~259, ~2838, ~2996 in current file) must stay exactly as-is — they will be
+  removed in a separate DEP-1e migration task.
+
+---
+
+## Target File Layout
+
+### File 1: `internal/database/sqlite_store_core.go`
+Struct definition, constructor, table creation, schema migrations. Lines ~1–960.
+Functions to move:
+- `NewSQLiteStore` (~361–410)
+- `createTables` (~411–748)
+- `deduplicateSeries` (~749–814)
+- `ensureExtendedBookColumns` (~815–914)
+- `ensureExtendedBookFileColumns` (~915–960)
+- `Close` (~961–965)
+
+Also move any top-level `type`, `const`, and `var` declarations that the above
+methods depend on (e.g., `type rowScanner interface`, `const` select-column lists,
+`type SQLiteStore struct`, `const bookFileCols`).
+
+### File 2: `internal/database/sqlite_store_users.go`
+User accounts, sessions, API keys, invites, preferences. Lines ~967–1280.
+Functions to move:
+- `CreateUser`, `scanUser`, `GetUserByID`, `GetUserByUsername`, `GetUserByEmail`
+- `UpdateUser`
+- `CreateSession`, `GetSession`, `RevokeSession`, `ListUserSessions`, `DeleteExpiredSessions`
+- `ListUsers`, `CountUsers`
+- `GetRoleByID`, `GetRoleByName`, `ListRoles`, `CreateRole`, `UpdateRole`, `DeleteRole`
+- `CreateAPIKey`, `GetAPIKey`, `GetAPIKeyByHash`, `ListAPIKeysForUser`, `ListAllAPIKeys`
+- `RevokeAPIKey`, `SetAPIKeyStatus`, `TouchAPIKeyLastUsed`
+- `CreateInvite`, `GetInvite`, `ListActiveInvites`, `DeleteInvite`, `ConsumeInvite`
+- `SetUserPreferenceForUser`, `GetUserPreferenceForUser`, `GetAllPreferencesForUser`
+- `GetUserPreference`, `SetUserPreference`, `GetAllUserPreferences` (lines ~4152–4188)
+
+### File 3: `internal/database/sqlite_store_books.go`
+All book, author, series, narrator, work, and book-file CRUD. Lines ~1280–3345.
+Functions to move:
+- User positions and book state setters (lines ~1147–1169)
+- Book version methods (lines ~1170–1184)
+- Book segment methods (lines ~1278–1423)
+- `GetAllAuthors`, `GetAuthorByID`, `GetAuthorByName`, `CreateAuthor`, `DeleteAuthor`,
+  `UpdateAuthorName`, `GetAuthorAliases`, `GetAllAuthorAliases`, `CreateAuthorAlias`,
+  `DeleteAuthorAlias`, `FindAuthorByAlias`
+- All series methods: `GetAllSeries`, `DeleteSeries`, `UpdateSeriesName`,
+  `GetAllSeriesBookCounts`, `GetAllSeriesFileCounts`, `GetSeriesByID`, `GetSeriesByName`,
+  `CreateSeries`
+- Work methods: `GetAllWorks`, `GetWorkByID`, `CreateWork`, `UpdateWork`, `DeleteWork`,
+  `GetBooksByWorkID`
+- Core book methods: `GetAllBooks`, `GetAllBookSummaries`, `GetDistinctGenres`,
+  `GetDistinctLanguages`, `GetBookByID`, `GetBookByFilePath`, `GetBookByITunesPersistentID`
+- Book hash lookups: `GetBookByFileHash`, `GetBookByOriginalHash`, `GetBookByOrganizedHash`,
+  `GetBookBySegmentFileHash`, `GetBooksByMetadataSourceHash`
+- Duplicate finders: `GetDuplicateBooks`, `GetBooksByTitleInDir`, `GetFolderDuplicates`,
+  `GetDuplicateBooksByMetadata`
+- Book relations: `GetBooksBySeriesID`, `GetBooksByAuthorID`, `GetBookAuthors`, `SetBookAuthors`,
+  `GetBooksByAuthorIDWithRole`, `GetAllAuthorBookCounts`, `GetAllAuthorFileCounts`
+- Narrator methods: `CreateNarrator`, `GetNarratorByID`, `GetNarratorByName`, `ListNarrators`,
+  `GetBookNarrators`, `SetBookNarrators`
+- Core write methods: `CreateBook`, `UpdateBook`, `UpdateBookRating`, `SetLastWrittenAt`,
+  `MarkITunesSynced`, `GetITunesPurgePendingBooks`, `GetITunesDirtyBooks`, `DeleteBook`
+- Search and count: `SearchBooks`, `CountBooks`, `CountFiles`
+- External IDs / tags / alternative titles (lines ~4579–4903)
+- Blocked hashes, fingerprints (lines ~4426–4495)
+- Deferred iTunes updates (lines ~4497–4577)
+- Book tags: `GetBookUserTags`, `SetBookUserTags`, `AddBookUserTag`, `RemoveBookUserTag`
+- Alternative titles: `GetBookAlternativeTitles`, `AddBookAlternativeTitle`,
+  `RemoveBookAlternativeTitle`, `SetBookAlternativeTitles`
+- All book-file methods (lines ~6001–6499): `GetBookFiles`, `GetAllBookFiles`,
+  `GetBookFilesNeedingDelugeImport`, `GetBookFileByPID`, `GetBookFileByPath`,
+  `GetBookFileByAcoustID`, `GetBookFileByAcoustIDFuzzy`, `DeleteBookFile`,
+  `DeleteBookFilesForBook`, `UpsertBookFile`, `BatchUpsertBookFiles`, `GetBookFileByID`,
+  `MoveBookFilesToBook`, `GetQuarantinedBooks`, `CountQuarantinedBooks`, `MergeChapterBooks`,
+  `FlagMetadataHashDuplicate`
+
+### File 4: `internal/database/sqlite_store_playlists.go`
+Playlists and playback. Functions to move:
+- `CreatePlaylist`, `GetPlaylistByID`, `GetPlaylistBySeriesID`, `AddPlaylistItem`, `GetPlaylistItems`
+- `AddPlaybackEvent`, `ListPlaybackEvents`, `UpdatePlaybackProgress`, `GetPlaybackProgress`
+- `IncrementBookPlayStats`, `GetBookStats`, `IncrementUserListenStats`, `GetUserStats`
+
+### File 5: `internal/database/sqlite_store_metadata.go`
+Metadata field states and change history. Functions to move:
+- `GetMetadataFieldStates`, `UpsertMetadataFieldState`, `DeleteMetadataFieldState`
+- `RecordMetadataChange`, `GetMetadataChangeHistory`, `GetBookChangeHistory`
+- `AddMetadataRejection`, `GetMetadataRejections`, `DeleteMetadataRejections`
+
+### File 6: `internal/database/sqlite_store_activity.go`
+Operations, operation logs, raw KV, operation results/state/params. Functions to move:
+- `CreateOperation`, `GetOperationByID`, `GetRecentOperations`, `ListOperations`
+- `UpdateOperationStatus`, `UpdateOperationError`, `AddOperationLog`, `GetOperationLogs`
+- `SaveOperationSummaryLog`, `GetOperationSummaryLog`, `ListOperationSummaryLogs`
+- `SetRaw`, `GetRaw`, `DeleteRaw`, `ScanPrefix`, `CountPrefix`
+- `CreateOperationResult`, `GetOperationResults`, `GetOperationResultsPage`
+- `GetRecentCompletedOperations`, `ensureOpStateTable`
+- `SaveOperationState`, `GetOperationState`, `SaveOperationParams`, `GetOperationParams`
+- `DeleteOperationState`, `DeleteOperationsByStatus`, `UpdateOperationResultData`
+- `GetInterruptedOperations`, `truncateActivity`
+- `GetScanFailCount`, `IncrScanFailCount`, `ResetScanFailCount`
+
+### File 7: `internal/database/sqlite_store_util.go`
+Scan helpers, fuzzy matching, utility functions. Functions to move:
+- `scanBookSummary`, `scanBook`
+- `nullableString`, `nullableInt`, `nullableFloat`
+- `normalizeTitle`, `jaroWinkler`
+- `fuzzyRankBooks`, `sanitizeFTS5Query`
+- `boolToInt`
+- `scanOperationChanges`, `bookFileScan`
+- `nullableStringVal`, `nullableIntVal`, `nullableInt64Val`, `nullableTimeVal`
+- `TableRowCounts`, `SQLitePageSizeBytes`
+- `BookPathPrefix` type, `GetBookPathPrefixes`
+- `GetAuthorsByBookIDs`, `GetNarratorsByBookIDs`
+
+---
+
+## Steps
+
+### Step 1 — Baseline check
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./internal/database/...
+go test ./internal/database/... -timeout 180s 2>&1 | grep -E 'FAIL|ok'
+wc -l internal/database/sqlite_store.go
+```
+
+### Step 2 — Identify shared declarations to put in sqlite_store_core.go
+
+```bash
+grep -n '^type\|^const\|^var' internal/database/sqlite_store.go | head -30
+```
+
+These top-level declarations (`type rowScanner interface`, `type SQLiteStore struct`,
+`const bookFileCols`, etc.) must go into `sqlite_store_core.go`. Functions that
+USE them can go in any file since they're package-level.
+
+### Step 3 — Create the 7 new files one at a time
+
+Start with `sqlite_store_core.go` (structs and constructors), then proceed in order.
+For each file:
+1. Create it with the version header.
+2. Copy the functions listed above.
+3. Add imports needed by those functions.
+4. Run `go build ./internal/database/...` to check — fix errors.
+
+Header template:
+```go
+// file: internal/database/sqlite_store_XXX.go
+// version: 1.0.0
+// guid: <generate-a-new-uuid>
+// last-edited: 2026-05-01
+
+package database
+```
+
+### Step 4 — Remove functions from sqlite_store.go
+
+After all 7 files build cleanly alongside the original, remove the moved function
+bodies from `sqlite_store.go`.
+
+**CRITICAL:** Do NOT touch these three lines (deprecated Book.ITunesPath usages —
+they will be removed in DEP-1e):
+```bash
+grep -n 'ITunesPath' internal/database/sqlite_store.go
+```
+
+Leave any lines at those locations untouched.
+
+After removal, `sqlite_store.go` should be essentially empty (just package declaration
+plus any declarations that didn't fit above). Delete it if empty; or keep it with
+just a comment pointing to the sub-files.
+
+### Step 5 — Final build + test
+
+```bash
+go build ./internal/database/...
+go build ./...
+go test ./internal/database/... -timeout 180s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+All must pass.
+
+### Step 6 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-6-sqlite-store-split
+git add internal/database/sqlite_store*.go
+git commit -m "refactor(database): split sqlite_store.go into 7 domain files
+
+Splits the 6976-line sqlite_store.go into:
+- sqlite_store_core.go (struct, constructor, schema)
+- sqlite_store_users.go (users, sessions, API keys)
+- sqlite_store_books.go (books, authors, files, series)
+- sqlite_store_playlists.go (playlists, playback)
+- sqlite_store_metadata.go (field states, change history)
+- sqlite_store_activity.go (operations, KV, results)
+- sqlite_store_util.go (scan helpers, fuzzy, utils)
+
+No logic changes. Structure audit STRUCT-6.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-6-sqlite-store-split
+gh pr create \
+  --title "refactor(database): split sqlite_store.go into 7 domain files" \
+  --body "Splits 6976-line file into 7 focused files. No logic changes. Structure audit STRUCT-6."
+```
+
+---
+
+## Checklist
+
+- [ ] 7 new files created with version headers
+- [ ] `SQLiteStore` struct and `rowScanner` interface in `sqlite_store_core.go`
+- [ ] Deprecated `Book.ITunesPath` usages (3 lines) left untouched
+- [ ] `go build ./internal/database/...` clean
+- [ ] `go build ./...` clean
+- [ ] `go test ./internal/database/...` passes
+- [ ] PR opened on branch `refactor/struct-6-sqlite-store-split`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-7-server-go-split.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-7-server-go-split.md
@@ -1,0 +1,230 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-7-server-go-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b8c9d0e1-f2a3-4567-bcde-890123456789 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-7 — Split `server.go` (3401 lines → 6 files)
+
+**Priority:** High  
+**Effort:** Large (mechanical move — no logic changes)  
+**Branch:** `refactor/struct-7-server-go-split`
+
+---
+
+## Why This Matters
+
+`internal/server/server.go` is **3401 lines** mixing server construction, metadata
+helpers, indexing logic, startup/lifecycle, route registration, and path utilities.
+Splitting it makes the responsibilities clear and each section reviewable independently.
+
+**Evidence:**
+```bash
+wc -l internal/server/server.go
+# ~3401
+```
+
+---
+
+## What This Task Does
+
+Split `server.go` into 6 files by responsibility. **No logic changes** — only move
+functions. Package name stays `package server`.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any function signatures or logic.
+- **Do NOT** rename any functions or exported types.
+- **Do NOT** split the `Server` struct itself — it stays in `server.go`.
+- **Do NOT** touch test files.
+
+---
+
+## What Stays in `server.go`
+
+These declarations **must remain** in `server.go` since they define the package's
+core types and are referenced everywhere:
+
+- All `type` declarations: `Server`, `ServerConfig`, `aiParser`,
+  `enrichedBookResponse`, `authorEntry`, `narratorEntry`, `activityServiceLogger`,
+  `serverScanHooks`, `serverOrganizeHooks`, `seriesPruneResult`,
+  `seriesPrunePreviewGroup`, `seriesPrunePreviewResult`, `bulkFetchMetadataRequest`,
+  `bulkFetchMetadataResult`
+- All `var`/`const` at file scope: `cachedLibrarySize`, `cachedImportSize`,
+  `cachedSizeComputedAt`, `cacheLock`, `appVersion`, `librarySizeCacheTTL`
+- `NewServer` (constructor, ~line 888) — keep here
+- `Store` method (~line 868)
+- `publishEvent` (~line 879)
+- `RecordActivity` (~line 770)
+
+---
+
+## Target File Layout
+
+### File 1: `internal/server/server_helpers.go`
+Small utility helpers used across the package. Functions to move:
+- `SetVersion` (~74)
+- `resetLibrarySizeCache` (~79)
+- `stringPtr` (~88)
+- `intPtrHelper` (~92)
+- `boolPtr` (~96)
+- `ptrStr` (~3409)
+- `stringVal` (~274)
+- `intVal` (~281)
+- `nonEmpty` (~675)
+- `calculateLibrarySizes` (~700)
+
+### File 2: `internal/server/server_metadata.go`
+Metadata state encoding/decoding and book enrichment helpers. Functions to move:
+- `metadataStateKey` (~114)
+- `decodeMetadataValue` (~118)
+- `encodeMetadataValue` (~129)
+- `loadLegacyMetadataState` (~141)
+- `loadMetadataState` (~158)
+- `saveMetadataState` (~194)
+- `decodeRawValue` (~246)
+- `updateFetchedMetadataState` (~257)
+- `resolveAuthorAndSeriesNames` (~288)
+- `batchFetchBookAuthorsAndNarrators` (~339)
+- `enrichBookForResponseSingle` (~391)
+- `enrichBookForResponse` (~400)
+- `buildComparisonValuesFromMetadata` (~477)
+- `buildComparisonValuesFromBook` (~511)
+- `buildComparisonValuesFromActivityLog` (~553)
+- `buildMetadataProvenance` (~594)
+- `applyOrganizedFileMetadata` (~682)
+
+### File 3: `internal/server/server_search.go`
+Search index management. Functions to move:
+- `SearchIndex` (~1337)
+- `safeWriteDeps` (~1345)
+- `buildSearchIndexIfEmpty` (~1361)
+- `IndexBookByID` (~1424)
+- `DeleteIndexedBook` (~1438)
+- `OnBookScanned` (~1452)
+- `OnImportDedup` (~1465)
+- `OnCollision` (~1477)
+- `fireDedupOnImport` (~1526)
+
+### File 4: `internal/server/server_lifecycle.go`
+Startup, route setup, and stale operation management. Functions to move:
+- `resumeInterruptedOperations` (~1541)
+- `Start` (~1721)
+- `perm` (~2292)
+- `itunesSvcGuard` (~2303)
+- `setupRoutes` (~2314)
+- `isStaleOperationStatus` (~3006)
+- `operationStartedOrCreatedAt` (~3015)
+- `collectStaleOperations` (~3022)
+- `failStaleOperations` (~3049)
+- `GetDefaultServerConfig` (~3399)
+
+### File 5: `internal/server/server_middleware.go`
+CORS, protected paths, session helpers. Functions to move:
+- `corsMiddleware` (~2813)
+- `filesCommonDir` (~2856)
+- `isProtectedPath` (~2876)
+- `loadDismissedDedupGroups` (~2922)
+- `saveDismissedDedupGroups` (~2939)
+- `triggerITunesSync` (~2955)
+
+### File 6: `internal/server/server_title_helpers.go`
+Title and series extraction helpers. Functions to move:
+- `extractSeriesNameForDedup` (~3082)
+- `computeSeriesPrunePreview` (~3133)
+- `stripChapterFromTitle` (~3224)
+- `stripSubtitle` (~3282)
+- `extractTitleFromSegmentFilename` (~3315)
+- `reassignExternalIDsForFiles` (~3347)
+
+---
+
+## Steps
+
+### Step 1 — Baseline check
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+go build ./internal/server/...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok'
+wc -l internal/server/server.go
+```
+
+### Step 2 — Identify all top-level declarations in server.go
+
+```bash
+grep -n '^type\|^var\|^const\|^func ' internal/server/server.go | head -60
+```
+
+Anything that's a `type`, `var`, or `const` that multiple other files will need —
+leave in `server.go`. Functions in the lists above get moved.
+
+### Step 3 — Create the 6 new files
+
+For each file listed above:
+1. Create it with the version header.
+2. Add `package server` at top.
+3. Copy the listed functions (not cut yet).
+4. Add only the imports those functions need.
+5. `go build ./internal/server/...` — fix errors.
+
+Header template:
+```go
+// file: internal/server/server_XXX.go
+// version: 1.0.0
+// guid: <generate-a-new-uuid>
+// last-edited: 2026-05-01
+
+package server
+```
+
+### Step 4 — Remove functions from server.go
+
+After all 6 files build cleanly, delete the moved function bodies from `server.go`.
+Leave all `type`, `var`, `const` declarations, `NewServer`, `Store`, `publishEvent`,
+and `RecordActivity`.
+
+### Step 5 — Final build + test
+
+```bash
+go build ./internal/server/...
+go build ./...
+go test ./internal/server/... -timeout 120s 2>&1 | grep -E 'FAIL|ok|---'
+```
+
+### Step 6 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-7-server-go-split
+git add internal/server/server*.go
+git commit -m "refactor(server): split server.go into 6 responsibility files
+
+Splits the 3401-line server.go into:
+- server_helpers.go (util/pointer helpers)
+- server_metadata.go (metadata state, book enrichment)
+- server_search.go (search index management)
+- server_lifecycle.go (startup, routes, stale ops)
+- server_middleware.go (CORS, path guards, iTunes sync)
+- server_title_helpers.go (title/series extraction)
+
+Types, vars, consts, NewServer stay in server.go.
+No logic changes. Structure audit STRUCT-7.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-7-server-go-split
+gh pr create \
+  --title "refactor(server): split server.go into 6 responsibility files" \
+  --body "Splits 3401-line file into 6 focused files. Types/constructor remain in server.go. Structure audit STRUCT-7."
+```
+
+---
+
+## Checklist
+
+- [ ] 6 new files created with version headers
+- [ ] `Server` struct, all types, vars, consts, `NewServer` remain in `server.go`
+- [ ] `go build ./internal/server/...` clean
+- [ ] `go build ./...` clean
+- [ ] Tests pass
+- [ ] PR opened on branch `refactor/struct-7-server-go-split`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-8-use-async-action-hook.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-8-use-async-action-hook.md
@@ -1,0 +1,166 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-8-use-async-action-hook.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: g7h8i9j0-k1l2-3456-mnop-789012345678 -->
+<!-- last-edited: 2026-05-01 -->
+
+# BOT TASK: STRUCT-8 — Add `useAsyncAction` React hook
+
+**TODO ID:** STRUCT-8
+**Audience:** burndown bot
+**Branch:** `refactor/struct-8-use-async-action-hook`
+**PR title:** `refactor(web): add useAsyncAction hook to eliminate loading boilerplate`
+
+---
+
+## What This Task Does
+
+Creates `web/src/hooks/useAsyncAction.ts` with a reusable hook that replaces
+148 identical loading-state patterns across React components.
+
+**Evidence:** `grep -rc 'setLoading(true)' web/src/` returns 148 hits.
+
+The repeated pattern:
+```tsx
+const [loading, setLoading] = useState(false);
+const [error, setError] = useState<string | null>(null);
+
+const handleSomething = async () => {
+  setLoading(true);
+  try {
+    await someApiCall();
+  } catch (e) {
+    setError(e instanceof Error ? e.message : String(e));
+  } finally {
+    setLoading(false);
+  }
+};
+```
+
+---
+
+## What NOT to Do
+
+- **Do NOT** replace call sites in this PR — just create the hook.
+- **Do NOT** modify any existing components.
+- **Do NOT** change `web/src/lib/api.ts`.
+
+---
+
+## Step-by-step
+
+### Step 1 — Check existing hooks for naming conflicts
+
+```bash
+ls web/src/hooks/
+grep -rn 'useAsyncAction\|useAsync\b' web/src/ | grep -v node_modules
+```
+
+Expected: no `useAsyncAction` exists yet. If a similar hook exists, extend it.
+
+### Step 2 — Read 2 concrete examples of the pattern
+
+```bash
+grep -B2 -A12 'setLoading(true)' web/src/pages/Library.tsx | head -50
+grep -B2 -A12 'setLoading(true)' web/src/pages/BookDedup.tsx | head -50
+```
+
+This confirms the exact shape of the pattern before writing the hook.
+
+### Step 3 — Create `web/src/hooks/useAsyncAction.ts`
+
+```typescript
+// file: web/src/hooks/useAsyncAction.ts
+// version: 1.0.0
+// last-edited: 2026-05-01
+// guid: h8i9j0k1-l2m3-4567-nopq-890123456789
+
+import { useState, useCallback } from 'react';
+
+interface AsyncActionState {
+  loading: boolean;
+  error: string | null;
+}
+
+interface UseAsyncActionReturn<T> extends AsyncActionState {
+  run: (...args: Parameters<() => Promise<T>>) => Promise<T | undefined>;
+  clearError: () => void;
+}
+
+/**
+ * useAsyncAction wraps an async function with loading and error state.
+ * Eliminates repeated useState(false) / try-finally loading boilerplate.
+ *
+ * @example
+ * const { run: handleSave, loading, error } = useAsyncAction(async () => {
+ *   await api.saveBook(book);
+ * });
+ */
+function useAsyncAction<T = void>(
+  fn: (...args: unknown[]) => Promise<T>
+): UseAsyncActionReturn<T> {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (...args: unknown[]): Promise<T | undefined> => {
+      setLoading(true);
+      setError(null);
+      try {
+        return await fn(...args);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        return undefined;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fn]
+  );
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { loading, error, run, clearError };
+}
+
+export default useAsyncAction;
+export type { AsyncActionState, UseAsyncActionReturn };
+```
+
+### Step 4 — Type-check
+
+```bash
+npx --prefix web tsc --noEmit 2>&1 | grep -E 'error|Error' | grep -v node_modules | head -20
+```
+
+Expected: no new errors introduced.
+
+### Step 5 — Bump version header
+
+File is new at version `1.0.0`. No bump needed.
+
+### Step 6 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-8-use-async-action-hook
+git add web/src/hooks/useAsyncAction.ts
+git commit -m "refactor(web): add useAsyncAction hook to eliminate loading boilerplate
+
+Adds useAsyncAction.ts hook wrapping async functions with loading/error
+state. Replaces 148 repeated useState(false) + try/finally patterns.
+Call-site adoption in follow-up STRUCT-8b.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-8-use-async-action-hook
+gh pr create \
+  --title "refactor(web): add useAsyncAction hook to eliminate loading boilerplate" \
+  --body "Adds useAsyncAction.ts. Part of STRUCT-8 structure audit. 148 call sites to adopt in STRUCT-8b."
+```
+
+---
+
+## Checklist
+
+- [ ] `web/src/hooks/useAsyncAction.ts` created
+- [ ] `npx --prefix web tsc --noEmit` clean
+- [ ] No naming conflict with existing hooks
+- [ ] PR opened on branch `refactor/struct-8-use-async-action-hook`

--- a/docs/superpowers/bot-tasks/2026-05-01-struct-9-frontend-component-splits.md
+++ b/docs/superpowers/bot-tasks/2026-05-01-struct-9-frontend-component-splits.md
@@ -1,0 +1,183 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-01-struct-9-frontend-component-splits.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c9d0e1f2-a3b4-5678-cdef-901234567890 -->
+<!-- last-edited: 2026-05-01 -->
+
+# STRUCT-9 — Split `Library.tsx` and `BookDedup.tsx` into sub-components
+
+**Priority:** Medium  
+**Effort:** Large (UI refactor — extract components, no logic changes)  
+**Branch:** `refactor/struct-9-frontend-component-splits`
+
+---
+
+## Why This Matters
+
+Two frontend pages are monolithic and impossible to review:
+- `web/src/pages/Library.tsx` — **2900+ lines**
+- `web/src/pages/BookDedup.tsx` — **2100+ lines**
+
+Both contain many logically independent sub-sections that can be extracted as
+sub-components without changing any behaviour.
+
+**Evidence:**
+```bash
+wc -l web/src/pages/Library.tsx web/src/pages/BookDedup.tsx
+```
+
+---
+
+## What This Task Does
+
+Extract named subcomponents into files under `web/src/components/library/` and
+`web/src/components/dedup/`. **No logic or state changes** — only lift JSX blocks
+into separate components with their props typed explicitly.
+
+---
+
+## What NOT to Do
+
+- **Do NOT** change any state management logic.
+- **Do NOT** change API calls or data flow.
+- **Do NOT** rename exported page components (`Library`, `BookDedup`).
+- **Do NOT** add new features or UI.
+- **Do NOT** touch test files.
+
+---
+
+## Part A — `Library.tsx` Extractions
+
+### Target directory: `web/src/components/library/`
+
+#### Component 1: `LibraryToolbar.tsx`
+Extract the bulk-action toolbar at lines **~1744–1817** and **~2039–2287**.
+Props: selected books array, bulk action callbacks (delete, tag, move, etc.).
+
+#### Component 2: `LibraryBookGrid.tsx`
+Extract the main book grid at lines **~2305–2328** (the `<BookGrid />` host plus
+sort controls and grid/list toggle).
+Props: books array, current sort/view state, event handlers.
+
+#### Component 3: `LibrarySoftDeletedSection.tsx`
+Extract the soft-deleted books section at lines **~2371–2474**.
+Props: trashed books array, restore/purge callbacks.
+
+#### Component 4: `LibraryDialogs.tsx`
+Extract the dialogs/modals section at lines **~2490–2907+**.
+Props: dialog open/close states, book being acted on, action callbacks.
+
+---
+
+## Part B — `BookDedup.tsx` Extractions
+
+### Target directory: `web/src/components/dedup/`
+
+#### Component 5: `DedupBookTab.tsx`
+Extract the book duplicates tab at lines **~293–516**.
+Props: duplicate groups, callbacks.
+
+#### Component 6: `DedupAdvancedScanTab.tsx`
+Extract the advanced scan tab at lines **~518–750**.
+Props: scan state, trigger callbacks.
+
+#### Component 7: `DedupAuthorTab.tsx`
+Extract the author dedup tab at lines **~757–1208**.
+Props: author groups, merge callbacks.
+
+#### Component 8: `DedupSeriesTab.tsx`
+Extract the series dedup tab at lines **~1210–1500**.
+Props: series groups, merge callbacks.
+
+#### Component 9: `DedupReconcileTab.tsx`
+Extract the reconcile tab at lines **~2113–end**.
+Props: reconcile items, action callbacks.
+
+---
+
+## Steps
+
+### Step 1 — Baseline check
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+npm --prefix web run build 2>&1 | tail -20
+npm --prefix web run test 2>&1 | grep -E 'FAIL|PASS|Tests'
+```
+
+### Step 2 — Create target directories
+
+```bash
+mkdir -p web/src/components/library
+mkdir -p web/src/components/dedup
+```
+
+### Step 3 — Extract Library subcomponents (one at a time)
+
+For each component in Part A:
+1. Create `web/src/components/library/ComponentName.tsx`.
+2. Add the standard file header:
+   ```typescript
+   // file: web/src/components/library/ComponentName.tsx
+   // version: 1.0.0
+   // guid: <generate-a-new-uuid>
+   // last-edited: 2026-05-01
+   ```
+3. Copy the JSX block from `Library.tsx` into the new component.
+4. Identify what props the block needs (state variables and callbacks it references).
+5. Define a TypeScript `interface ComponentNameProps { ... }` and type the component.
+6. Export the component: `export function ComponentName({ ... }: ComponentNameProps) { ... }`
+7. In `Library.tsx`, import the new component and replace the extracted JSX block with `<ComponentName ... />`.
+8. Run `npm --prefix web run build` — fix TypeScript errors before proceeding.
+
+### Step 4 — Extract BookDedup subcomponents (one at a time)
+
+Same process as Step 3 but for `web/src/pages/BookDedup.tsx` and components under
+`web/src/components/dedup/`.
+
+### Step 5 — Final build + lint
+
+```bash
+npm --prefix web run build
+npm --prefix web run lint 2>&1 | grep -E 'error|warning' | grep -v 'warning' | head -20
+```
+
+Build must be clean. No new TypeScript errors.
+
+### Step 6 — Add version headers
+
+Bump patch version on `Library.tsx` and `BookDedup.tsx`. New component files start
+at `1.0.0`.
+
+### Step 7 — Commit and open PR
+
+```bash
+git checkout -b refactor/struct-9-frontend-component-splits
+git add web/src/
+git commit -m "refactor(web): split Library and BookDedup into sub-components
+
+Extracts 9 sub-components from the two largest frontend pages:
+Library.tsx → LibraryToolbar, LibraryBookGrid, LibrarySoftDeletedSection,
+              LibraryDialogs
+BookDedup.tsx → DedupBookTab, DedupAdvancedScanTab, DedupAuthorTab,
+                DedupSeriesTab, DedupReconcileTab
+
+No logic or state changes. Structure audit STRUCT-9.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin refactor/struct-9-frontend-component-splits
+gh pr create \
+  --title "refactor(web): split Library and BookDedup into sub-components" \
+  --body "Extracts 9 sub-components from 2 monolithic page files. No logic changes. Structure audit STRUCT-9."
+```
+
+---
+
+## Checklist
+
+- [ ] `web/src/components/library/` created with 4 component files
+- [ ] `web/src/components/dedup/` created with 5 component files
+- [ ] `Library.tsx` and `BookDedup.tsx` reduced significantly in size
+- [ ] Each extracted component has explicit TypeScript props interface
+- [ ] `npm run build` clean
+- [ ] No new TypeScript errors
+- [ ] PR opened on branch `refactor/struct-9-frontend-component-splits`


### PR DESCRIPTION
## Summary

Adds 10 structural refactor bot-task specs from the 2026-05-01 structure audit.

### Specs added

| ID | Task | Key metric |
|----|------|-----------|
| STRUCT-1 | Adopt existing `RespondWith*` helpers | 61 direct c.JSON calls |
| STRUCT-2 | Consolidate duplicate pagination parsers | 7 duplicates → 1 shared |
| STRUCT-3 | Split `maintenance_fixups.go` | 6400 lines → 8 files |
| STRUCT-4 | Split `metafetch/service.go` | 3932 lines → 8 files |
| STRUCT-5 | Extract shared AI `withRetry` helper | 4 identical loops |
| STRUCT-6 | Split `sqlite_store.go` | 6976 lines → 7 files |
| STRUCT-7 | Split `server.go` | 3401 lines → 6 files |
| STRUCT-8 | Extract `useAsyncAction` hook | 148 setLoading patterns |
| STRUCT-9 | Split Library.tsx + BookDedup.tsx | 5000 lines → 9 sub-components |
| STRUCT-10 | Narrow `*Server` interfaces | 5 handler groups |

Each spec includes exact function names, line ranges from live code, step-by-step instructions, and PR branch name.

`TODO.md` updated to v8.0.0 with all 10 entries and spec links.