### PR TITLE
feat(maintenance): convert remaining 7 handlers to MaintenanceJob interface

### DIFF
--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/job.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 11111111-1111-1111-1111-111111111111
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package maintenance
 
@@ -47,9 +47,19 @@ type EnqueuerInjectable interface {
 
 // MaintenanceJob is the interface that every maintenance job must satisfy.
 type MaintenanceJob interface {
+	// ID returns the kebab-case identifier used in route paths and operation types.
 	ID() string
+	// Name returns the human-readable display name shown in the UI.
+	Name() string
+	// Description returns a one-sentence description of what the job does.
 	Description() string
+	// Category groups related jobs in the UI (e.g. "library", "files", "itunes", "dedup", "cleanup").
+	Category() string
+	// DefaultParams returns a struct with default parameter values (used by the frontend).
+	DefaultParams() any
+	// CanResume reports whether the job supports checkpoint-based resume after restart.
 	CanResume() bool
+	// Run executes the job. startFrom is the checkpoint index for resumable jobs (0 = fresh start).
 	Run(ctx context.Context, store database.Store, reporter ProgressReporter, dryRun bool) error
 }
 

--- a/internal/maintenance/job.go
+++ b/internal/maintenance/job.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/job.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 11111111-1111-1111-1111-111111111111
-// last-edited: 2026-05-01
+// last-edited: 2026-04-28
 
 package maintenance
 
@@ -43,6 +43,13 @@ type WriteBackEnqueuer interface {
 // EnqueuerInjectable is implemented by jobs that need the write-back enqueuer.
 type EnqueuerInjectable interface {
 	InjectEnqueuer(e WriteBackEnqueuer)
+}
+
+// PermissionAware is optionally implemented by jobs that require a non-default
+// permission. The dispatcher uses this to enforce per-job access control.
+// Jobs that do not implement this interface default to the settings.manage permission.
+type PermissionAware interface {
+	Permission() string
 }
 
 // MaintenanceJob is the interface that every maintenance job must satisfy.

--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_book_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000005-0000-0000-0000-000000000005
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -20,6 +20,9 @@ func init() { maintenance.Register(&backfillBookFilesJob{}) }
 type backfillBookFilesJob struct{}
 
 func (j *backfillBookFilesJob) ID() string          { return "backfill-book-files" }
+func (j *backfillBookFilesJob) Name() string     { return "Backfill Book Files" }
+func (j *backfillBookFilesJob) Category() string { return "files" }
+func (j *backfillBookFilesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *backfillBookFilesJob) Description() string { return "Create book_files rows for books that have none" }
 func (j *backfillBookFilesJob) CanResume() bool     { return false }
 func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000014-0000-0000-0000-000000000014
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&backfillFileHashesJob{}) }
 type backfillFileHashesJob struct{}
 
 func (j *backfillFileHashesJob) ID() string          { return "backfill-file-hashes" }
+func (j *backfillFileHashesJob) Name() string     { return "Backfill File Hashes" }
+func (j *backfillFileHashesJob) Category() string { return "files" }
+func (j *backfillFileHashesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *backfillFileHashesJob) Description() string { return "Compute and store file hashes for book_files missing them" }
 func (j *backfillFileHashesJob) CanResume() bool     { return false }
 func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000015-0000-0000-0000-000000000015
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -19,6 +19,9 @@ func init() { maintenance.Register(&backfillMetadataSourceHashJob{}) }
 type backfillMetadataSourceHashJob struct{}
 
 func (j *backfillMetadataSourceHashJob) ID() string          { return "backfill-metadata-source-hash" }
+func (j *backfillMetadataSourceHashJob) Name() string     { return "Backfill Metadata Source Hash" }
+func (j *backfillMetadataSourceHashJob) Category() string { return "files" }
+func (j *backfillMetadataSourceHashJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *backfillMetadataSourceHashJob) Description() string { return "Compute MetadataSourceHash for books that have one missing" }
 func (j *backfillMetadataSourceHashJob) CanResume() bool     { return false }
 func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
 // last-edited: 2026-04-28
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
 func init() { maintenance.Register(&bulkDelugeImportJob{}) }
@@ -157,7 +158,7 @@ func bdi_importToLibrary(cfg *config.Config, delugeClient *deluge.Client, store 
 		log.Printf("[INFO] bdi_importToLibrary: %s already imported, skipping", bookFile.FilePath)
 		return bookFile.FilePath, nil
 	}
-	src := bookFile.FilePath
+	src := util.CleanPath(bookFile.FilePath)
 	if src == "" {
 		return "", fmt.Errorf("bdi_importToLibrary: bookFile.FilePath is empty")
 	}
@@ -165,12 +166,19 @@ func bdi_importToLibrary(cfg *config.Config, delugeClient *deluge.Client, store 
 	var destDir string
 	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
 	if relErr == nil && !filepath.IsAbs(rel) && !bdi_isParentTraversal(rel) {
-		destDir = filepath.Join(cfg.RootDir, rel)
+		var joinErr error
+		destDir, joinErr = util.SafeJoin(cfg.RootDir, rel)
+		if joinErr != nil {
+			destDir = util.CleanPath(cfg.RootDir)
+		}
 	} else {
-		destDir = cfg.RootDir
+		destDir = util.CleanPath(cfg.RootDir)
 	}
 
-	dest := filepath.Join(destDir, filepath.Base(src))
+	dest, destErr := util.SafeJoin(destDir, filepath.Base(src))
+	if destErr != nil {
+		return "", fmt.Errorf("bdi_importToLibrary: unsafe dest path: %w", destErr)
+	}
 	if src == dest {
 		log.Printf("[INFO] bdi_importToLibrary: source and dest are the same (%s), skipping copy", src)
 		return src, nil

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
-// last-edited: 2026-04-28
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -158,7 +158,7 @@ func bdi_importToLibrary(cfg *config.Config, delugeClient *deluge.Client, store 
 		log.Printf("[INFO] bdi_importToLibrary: %s already imported, skipping", bookFile.FilePath)
 		return bookFile.FilePath, nil
 	}
-	src := util.CleanPath(bookFile.FilePath)
+	src := filepath.Clean(bookFile.FilePath)
 	if src == "" {
 		return "", fmt.Errorf("bdi_importToLibrary: bookFile.FilePath is empty")
 	}
@@ -169,10 +169,10 @@ func bdi_importToLibrary(cfg *config.Config, delugeClient *deluge.Client, store 
 		var joinErr error
 		destDir, joinErr = util.SafeJoin(cfg.RootDir, rel)
 		if joinErr != nil {
-			destDir = util.CleanPath(cfg.RootDir)
+			destDir = filepath.Clean(cfg.RootDir)
 		}
 	} else {
-		destDir = util.CleanPath(cfg.RootDir)
+		destDir = filepath.Clean(cfg.RootDir)
 	}
 
 	dest, destErr := util.SafeJoin(destDir, filepath.Base(src))
@@ -219,6 +219,8 @@ func bdi_isParentTraversal(rel string) bool {
 }
 
 func bdi_ioCopy(src, dest string) error {
+	src = filepath.Clean(src)
+	dest = filepath.Clean(dest)
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open src: %w", err)

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,0 +1,235 @@
+// file: internal/maintenance/jobs/bulk_deluge_import.go
+// version: 1.0.0
+// guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&bulkDelugeImportJob{}) }
+
+type bulkDelugeImportJob struct{}
+
+type bdi_params struct {
+	DryRun   bool `json:"dry_run"`
+	MaxBooks int  `json:"max_books,omitempty"`
+}
+
+func (j *bulkDelugeImportJob) ID() string          { return "bulk-deluge-import" }
+func (j *bulkDelugeImportJob) Name() string        { return "Bulk Deluge Import" }
+func (j *bulkDelugeImportJob) Category() string    { return "Import" }
+func (j *bulkDelugeImportJob) Description() string { return "Imports all book_files that have a deluge_hash but have not yet been copied into the library" }
+func (j *bulkDelugeImportJob) DefaultParams() any  { return &bdi_params{DryRun: true} }
+func (j *bulkDelugeImportJob) CanResume() bool     { return true }
+
+func (j *bulkDelugeImportJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	opID := maintenance.OperationIDFromCtx(ctx)
+
+	maxBooks := 0
+	if opID != "" {
+		if raw, err := store.GetOperationParams(opID); err == nil && len(raw) > 0 {
+			var p bdi_params
+			if jerr := json.Unmarshal(raw, &p); jerr == nil {
+				maxBooks = p.MaxBooks
+				dryRun = p.DryRun
+			}
+		}
+	}
+
+	client := bdi_buildDelugeClient()
+
+	pending, err := store.GetBookFilesNeedingDelugeImport()
+	if err != nil {
+		return fmt.Errorf("GetBookFilesNeedingDelugeImport: %w", err)
+	}
+	if maxBooks > 0 && len(pending) > maxBooks {
+		pending = pending[:maxBooks]
+	}
+
+	total := len(pending)
+	log.Printf("[INFO] bulk-deluge-import %s: %d files pending (dry_run=%v)", opID, total, dryRun)
+	reporter.SetTotal(total)
+
+	imported, failed := 0, 0
+	for i := range pending {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		f := &pending[i]
+		if dryRun {
+			resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "action": "dry_run"})
+			if opID != "" {
+				_ = store.CreateOperationResult(&database.OperationResult{
+					OperationID: opID,
+					BookID:      f.ID,
+					ResultJSON:  string(resultJSON),
+					Status:      "dry_run",
+				})
+			}
+			imported++
+		} else {
+			newPath, importErr := bdi_importToLibrary(&config.AppConfig, client, store, f)
+			if importErr != nil {
+				log.Printf("[WARN] bulk-deluge-import %s: %s: %v", opID, f.FilePath, importErr)
+				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "error": importErr.Error()})
+				if opID != "" {
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      f.ID,
+						ResultJSON:  string(resultJSON),
+						Status:      "error",
+					})
+				}
+				failed++
+			} else {
+				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "new_path": newPath})
+				if opID != "" {
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      f.ID,
+						ResultJSON:  string(resultJSON),
+						Status:      "imported",
+					})
+				}
+				imported++
+			}
+		}
+		reporter.Increment()
+	}
+
+	log.Printf("[INFO] bulk-deluge-import %s: done. imported=%d failed=%d", opID, imported, failed)
+	reporter.Log("info", fmt.Sprintf("imported=%d failed=%d total=%d", imported, failed, total), nil)
+	return nil
+}
+
+// bdi_buildDelugeClient creates a Deluge client from application config.
+func bdi_buildDelugeClient() *deluge.Client {
+	url := config.AppConfig.DelugeWebURL
+	pass := config.AppConfig.DelugeWebPassword
+	if url == "" {
+		dc := config.AppConfig.DownloadClient.Torrent.Deluge
+		if dc.Host != "" {
+			port := dc.Port
+			if port == 0 {
+				port = 8112
+			}
+			url = fmt.Sprintf("http://%s:%d", dc.Host, port)
+			pass = dc.Password
+		}
+	}
+	if url == "" {
+		return nil
+	}
+	if pass == "" {
+		pass = "deluge"
+	}
+	c, err := deluge.New(url, pass)
+	if err != nil {
+		log.Printf("[WARN] bulk-deluge-import: failed to create deluge client: %v", err)
+		return nil
+	}
+	return c
+}
+
+// bdi_importToLibrary copies a book file into the library root and updates the DB record.
+func bdi_importToLibrary(cfg *config.Config, delugeClient *deluge.Client, store database.Store, bookFile *database.BookFile) (newPath string, err error) {
+	if bookFile == nil {
+		return "", fmt.Errorf("bdi_importToLibrary: bookFile is nil")
+	}
+	if bookFile.ImportedFromDelugeAt != nil {
+		log.Printf("[INFO] bdi_importToLibrary: %s already imported, skipping", bookFile.FilePath)
+		return bookFile.FilePath, nil
+	}
+	src := bookFile.FilePath
+	if src == "" {
+		return "", fmt.Errorf("bdi_importToLibrary: bookFile.FilePath is empty")
+	}
+
+	var destDir string
+	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
+	if relErr == nil && !filepath.IsAbs(rel) && !bdi_isParentTraversal(rel) {
+		destDir = filepath.Join(cfg.RootDir, rel)
+	} else {
+		destDir = cfg.RootDir
+	}
+
+	dest := filepath.Join(destDir, filepath.Base(src))
+	if src == dest {
+		log.Printf("[INFO] bdi_importToLibrary: source and dest are the same (%s), skipping copy", src)
+		return src, nil
+	}
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", fmt.Errorf("bdi_importToLibrary: create dest dir %s: %w", destDir, err)
+	}
+
+	if copyErr := bdi_ioCopy(src, dest); copyErr != nil {
+		return "", fmt.Errorf("bdi_importToLibrary: copy %s -> %s: %w", src, dest, copyErr)
+	}
+
+	now := time.Now()
+	bookFile.DelugeOriginalPath = src
+	bookFile.FilePath = dest
+	bookFile.ImportedFromDelugeAt = &now
+
+	if err := store.UpdateBookFile(bookFile.ID, bookFile); err != nil {
+		return dest, fmt.Errorf("bdi_importToLibrary: UpdateBookFile %s: %w", bookFile.ID, err)
+	}
+
+	log.Printf("[INFO] bdi_importToLibrary: copied %s -> %s", src, dest)
+
+	if cfg.DelugeMoveEnabled && bookFile.DelugeHash != "" && delugeClient != nil {
+		moveErr := delugeClient.MoveStorage([]string{bookFile.DelugeHash}, filepath.Dir(dest))
+		if moveErr != nil {
+			log.Printf("[WARN] bdi_importToLibrary: MoveStorage for hash %s failed (non-fatal): %v",
+				bookFile.DelugeHash, moveErr)
+		}
+	}
+
+	return dest, nil
+}
+
+func bdi_isParentTraversal(rel string) bool {
+	return len(rel) >= 2 && rel[:2] == ".."
+}
+
+func bdi_ioCopy(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+	return nil
+}

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,0 +1,323 @@
+// file: internal/maintenance/jobs/bulk_fetch_metadata.go
+// version: 1.0.0
+// guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+)
+
+func init() { maintenance.Register(&bulkFetchMetadataJob{}) }
+
+type bulkFetchMetadataJob struct{}
+
+type bmf_params struct {
+	PreferAudible bool `json:"prefer_audible"`
+	SkipCached    bool `json:"skip_cached"`
+}
+
+func (j *bulkFetchMetadataJob) ID() string          { return "bulk-fetch-metadata" }
+func (j *bulkFetchMetadataJob) Name() string        { return "Bulk Fetch Metadata" }
+func (j *bulkFetchMetadataJob) Category() string    { return "Metadata" }
+func (j *bulkFetchMetadataJob) Description() string { return "Fetches and caches metadata from all configured sources for every book in the library" }
+func (j *bulkFetchMetadataJob) DefaultParams() any  { return &bmf_params{} }
+func (j *bulkFetchMetadataJob) CanResume() bool     { return true }
+func (j *bulkFetchMetadataJob) Permission() string  { return string(auth.PermLibraryEditMetadata) }
+
+func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	opID := maintenance.OperationIDFromCtx(ctx)
+
+	preferAudible := false
+	skipCached := false
+	if opID != "" {
+		if raw, err := store.GetOperationParams(opID); err == nil && len(raw) > 0 {
+			var p bmf_params
+			if jerr := json.Unmarshal(raw, &p); jerr == nil {
+				preferAudible = p.PreferAudible
+				skipCached = p.SkipCached
+			}
+		}
+	}
+
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+
+	ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+
+	var existingResults []database.OperationResult
+	if opID != "" {
+		existingResults, _ = store.GetOperationResults(opID)
+	}
+	done := make(map[string]bool, len(existingResults))
+	for _, r := range existingResults {
+		done[r.BookID] = true
+	}
+
+	allAuthors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("GetAllAuthors: %w", err)
+	}
+	authorByID := make(map[int]string, len(allAuthors))
+	for _, a := range allAuthors {
+		authorByID[a.ID] = a.Name
+	}
+
+	sourceChain := bmf_buildSourceChain()
+	if len(sourceChain) == 0 {
+		sourceChain = []metadata.MetadataSource{metadata.NewAudibleClient()}
+	}
+	if preferAudible {
+		audible := metadata.NewAudibleClient()
+		var rest []metadata.MetadataSource
+		for _, src := range sourceChain {
+			if src.Name() != audible.Name() {
+				rest = append(rest, src)
+			}
+		}
+		sourceChain = append([]metadata.MetadataSource{audible}, rest...)
+	}
+
+	type bookWork struct {
+		book       database.Book
+		authorName string
+	}
+	var work []bookWork
+	for i := range allBooks {
+		b := &allBooks[i]
+		if done[b.ID] || strings.TrimSpace(b.Title) == "" {
+			continue
+		}
+		if skipCached {
+			hasFreshCache := false
+			for _, src := range sourceChain {
+				if cached, cerr := database.GetCachedMetadataFetch(store, b.ID, src.Name()); cerr == nil && cached != nil {
+					expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
+					if !expired {
+						hasFreshCache = true
+						break
+					}
+				}
+			}
+			if hasFreshCache {
+				continue
+			}
+		}
+		author := ""
+		if b.AuthorID != nil {
+			author = authorByID[*b.AuthorID]
+		}
+		work = append(work, bookWork{book: *b, authorName: author})
+	}
+
+	totalBooks := len(existingResults) + len(work)
+	alreadyDone := len(existingResults)
+	log.Printf("[INFO] bulk-fetch-metadata %s: %d books total, %d already cached, %d to fetch",
+		opID, totalBooks, alreadyDone, len(work))
+
+	reporter.SetTotal(totalBooks)
+	for i := 0; i < alreadyDone; i++ {
+		reporter.Increment()
+	}
+
+	if len(work) == 0 {
+		reporter.Log("info", "all books already cached", nil)
+		return nil
+	}
+
+	completed := int64(alreadyDone)
+	found := 0
+	notFound := 0
+
+	for i, w := range work {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		bookID := w.book.ID
+		currentAuthor := w.authorName
+		searchTitle := bmf_stripChapterFromTitle(w.book.Title)
+
+		var metaResults []metadata.BookMetadata
+		var sourceName string
+		cacheHit := false
+
+		for _, src := range sourceChain {
+			if cached, cerr := database.GetCachedMetadataFetch(store, bookID, src.Name()); cerr == nil && cached != nil {
+				expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
+				if !expired {
+					var cachedResults []metadata.BookMetadata
+					if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+						metaResults = cachedResults
+						sourceName = src.Name()
+						cacheHit = true
+						break
+					}
+				}
+			}
+			var fetchErr error
+			if currentAuthor != "" {
+				metaResults, fetchErr = src.SearchByTitleAndAuthor(ctx, searchTitle, currentAuthor)
+				if fetchErr == nil && len(metaResults) > 0 {
+					sourceName = src.Name()
+					break
+				}
+			}
+			metaResults, fetchErr = src.SearchByTitle(ctx, searchTitle)
+			if fetchErr == nil && len(metaResults) > 0 {
+				sourceName = src.Name()
+				break
+			}
+			if searchTitle != w.book.Title {
+				if currentAuthor != "" {
+					metaResults, fetchErr = src.SearchByTitleAndAuthor(ctx, w.book.Title, currentAuthor)
+					if fetchErr == nil && len(metaResults) > 0 {
+						sourceName = src.Name()
+						break
+					}
+				}
+				metaResults, fetchErr = src.SearchByTitle(ctx, w.book.Title)
+				if fetchErr == nil && len(metaResults) > 0 {
+					sourceName = src.Name()
+					break
+				}
+			}
+		}
+
+		resultStatus := "not_found"
+		if len(metaResults) > 0 && sourceName != "" {
+			if !cacheHit {
+				if blob, merr := json.Marshal(metaResults); merr == nil {
+					_ = database.PutCachedMetadataFetch(store, bookID, sourceName, blob, 0)
+				}
+			}
+			found++
+			resultStatus = "cached"
+		} else {
+			notFound++
+		}
+
+		if opID != "" {
+			_ = store.CreateOperationResult(&database.OperationResult{
+				OperationID: opID,
+				BookID:      bookID,
+				ResultJSON:  fmt.Sprintf(`{"status":%q,"source":%q}`, resultStatus, sourceName),
+				Status:      resultStatus,
+			})
+		}
+
+		atomic.AddInt64(&completed, 1)
+		reporter.Increment()
+
+		// Rate-limit live API calls.
+		if !cacheHit && sourceName != "" && i < len(work)-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}
+
+	finalCount := atomic.LoadInt64(&completed)
+	log.Printf("[INFO] bulk-fetch-metadata %s: done %d books — cached:%d not_found:%d",
+		opID, finalCount, found, notFound)
+	reporter.Log("info", fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound), nil)
+	return nil
+}
+
+// bmf_buildSourceChain reads config.AppConfig.MetadataSources and returns
+// ordered, circuit-breaker-wrapped metadata sources.
+func bmf_buildSourceChain() []metadata.MetadataSource {
+	sources := make([]config.MetadataSource, len(config.AppConfig.MetadataSources))
+	copy(sources, config.AppConfig.MetadataSources)
+	sort.Slice(sources, func(i, j int) bool {
+		return sources[i].Priority < sources[j].Priority
+	})
+
+	var chain []metadata.MetadataSource
+	for _, src := range sources {
+		if !src.Enabled {
+			continue
+		}
+		var rawSource metadata.MetadataSource
+		switch src.ID {
+		case "openlibrary":
+			rawSource = metadata.NewOpenLibraryClient()
+		case "google-books":
+			apiKey := config.AppConfig.GoogleBooksAPIKey
+			if apiKey == "" {
+				if k, ok := src.Credentials["apiKey"]; ok && k != "" {
+					apiKey = k
+				}
+			}
+			rawSource = metadata.NewGoogleBooksClient(apiKey)
+		case "audible":
+			rawSource = metadata.NewAudibleClient()
+		case "audnexus":
+			rawSource = metadata.NewAudnexusClient()
+		case "hardcover":
+			token := config.AppConfig.HardcoverAPIToken
+			if token == "" {
+				if apiToken, ok := src.Credentials["api_token"]; ok && apiToken != "" {
+					token = apiToken
+				} else if apiKey, ok := src.Credentials["apiKey"]; ok && apiKey != "" {
+					token = apiKey
+				}
+			}
+			if token != "" {
+				rawSource = metadata.NewHardcoverClient(token)
+			} else {
+				log.Printf("[WARN] Hardcover source enabled but no API token configured")
+			}
+		case "wikipedia":
+			rawSource = metadata.NewWikipediaClient()
+		default:
+			log.Printf("[WARN] Unknown metadata source: %s", src.ID)
+		}
+		if rawSource != nil {
+			chain = append(chain, metadata.NewProtectedSource(rawSource, 5, 30*time.Second))
+		}
+	}
+	return chain
+}
+
+// bmf_stripChapterFromTitle removes common track/chapter prefixes and suffixes from a title.
+func bmf_stripChapterFromTitle(title string) string {
+	cleaned := title
+	trackNumPrefix := regexp.MustCompile(`^\d{1,3}\s*[-–.]\s*`)
+	cleaned = trackNumPrefix.ReplaceAllString(cleaned, "")
+	bareNumPrefix := regexp.MustCompile(`^\d{1,3}\s+`)
+	if stripped := strings.TrimSpace(bareNumPrefix.ReplaceAllString(cleaned, "")); stripped != "" {
+		cleaned = stripped
+	}
+	trackWordPrefix := regexp.MustCompile(`(?i)^[Tt]rack\s*\d+\s*[-–.]\s*`)
+	cleaned = trackWordPrefix.ReplaceAllString(cleaned, "")
+	discWordPrefix := regexp.MustCompile(`(?i)^[Dd]is[ck]\s*\d+\s*[-–.]\s*`)
+	cleaned = discWordPrefix.ReplaceAllString(cleaned, "")
+	bracketPrefix := regexp.MustCompile(`^\[.*?\]\s*[-–]?\s*`)
+	cleaned = bracketPrefix.ReplaceAllString(cleaned, "")
+	bracketSuffix := regexp.MustCompile(`\s*\[.*?\]\s*$`)
+	cleaned = bracketSuffix.ReplaceAllString(cleaned, "")
+	if strings.TrimSpace(cleaned) == "" {
+		return title
+	}
+	return strings.TrimSpace(cleaned)
+}

--- a/internal/maintenance/jobs/cleanup_backups.go
+++ b/internal/maintenance/jobs/cleanup_backups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_backups.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000021-0000-0000-0000-000000000021
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -23,6 +23,9 @@ var backupFileRe = regexp.MustCompile(`(?i)\.(backup|bak)$|\.bak-\d{8}-\d{6}$`)
 type cleanupBackupsJob struct{}
 
 func (j *cleanupBackupsJob) ID() string          { return "cleanup-backups" }
+func (j *cleanupBackupsJob) Name() string     { return "Cleanup Backups" }
+func (j *cleanupBackupsJob) Category() string { return "cleanup" }
+func (j *cleanupBackupsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *cleanupBackupsJob) Description() string { return "Delete .backup and .bak files from the library root" }
 func (j *cleanupBackupsJob) CanResume() bool     { return false }
 func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/cleanup_empty_folders.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_empty_folders.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000006-0000-0000-0000-000000000006
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -20,6 +20,9 @@ func init() { maintenance.Register(&cleanupEmptyFoldersJob{}) }
 type cleanupEmptyFoldersJob struct{}
 
 func (j *cleanupEmptyFoldersJob) ID() string          { return "cleanup-empty-folders" }
+func (j *cleanupEmptyFoldersJob) Name() string     { return "Cleanup Empty Folders" }
+func (j *cleanupEmptyFoldersJob) Category() string { return "cleanup" }
+func (j *cleanupEmptyFoldersJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *cleanupEmptyFoldersJob) Description() string { return "Remove empty directories from the library root" }
 func (j *cleanupEmptyFoldersJob) CanResume() bool     { return false }
 func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_organize_mess.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000007-0000-0000-0000-000000000007
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -25,6 +25,9 @@ func init() { maintenance.Register(&cleanupOrganizeMess{}) }
 type cleanupOrganizeMess struct{}
 
 func (j *cleanupOrganizeMess) ID() string          { return "cleanup-organize-mess" }
+func (j *cleanupOrganizeMess) Name() string     { return "Cleanup Organize Mess" }
+func (j *cleanupOrganizeMess) Category() string { return "cleanup" }
+func (j *cleanupOrganizeMess) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *cleanupOrganizeMess) Description() string {
 return "Clean up leftover organize artifacts and garbage directories"
 }

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000002-0000-0000-0000-000000000002
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -21,6 +21,9 @@ func init() { maintenance.Register(&cleanupSeriesJob{}) }
 type cleanupSeriesJob struct{}
 
 func (j *cleanupSeriesJob) ID() string          { return "cleanup-series" }
+func (j *cleanupSeriesJob) Name() string     { return "Cleanup Series" }
+func (j *cleanupSeriesJob) Category() string { return "library" }
+func (j *cleanupSeriesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *cleanupSeriesJob) Description() string { return "Remove 1-book series and merge duplicate series" }
 func (j *cleanupSeriesJob) CanResume() bool     { return false }
 

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000010-0000-0000-0000-000000000010
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -28,6 +28,9 @@ enqueuer maintenance.WriteBackEnqueuer
 func (j *dedupBooksJob) InjectEnqueuer(e maintenance.WriteBackEnqueuer) { j.enqueuer = e }
 
 func (j *dedupBooksJob) ID() string          { return "dedup-books" }
+func (j *dedupBooksJob) Name() string     { return "Deduplicate Books" }
+func (j *dedupBooksJob) Category() string { return "dedup" }
+func (j *dedupBooksJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *dedupBooksJob) Description() string { return "Detect and merge duplicate books" }
 func (j *dedupBooksJob) CanResume() bool     { return false }
 

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/enrich_book_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000009-0000-0000-0000-000000000009
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -23,6 +23,9 @@ var trackNumRe = regexp.MustCompile(`^(\d+)[\s._\-]`)
 type enrichBookFilesJob struct{}
 
 func (j *enrichBookFilesJob) ID() string          { return "enrich-book-files" }
+func (j *enrichBookFilesJob) Name() string     { return "Enrich Book Files" }
+func (j *enrichBookFilesJob) Category() string { return "files" }
+func (j *enrichBookFilesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *enrichBookFilesJob) Description() string { return "Backfill track numbers for book_files from filenames" }
 func (j *enrichBookFilesJob) CanResume() bool     { return false }
 func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000003-0000-0000-0000-000000000003
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -19,6 +19,9 @@ func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
 type fixAuthorNarratorSwapJob struct{}
 
 func (j *fixAuthorNarratorSwapJob) ID() string          { return "fix-author-narrator-swap" }
+func (j *fixAuthorNarratorSwapJob) Name() string     { return "Fix Author/Narrator Swap" }
+func (j *fixAuthorNarratorSwapJob) Category() string { return "library" }
+func (j *fixAuthorNarratorSwapJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *fixAuthorNarratorSwapJob) Description() string {
 return "Fix books where author and narrator fields are swapped"
 }

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_book_file_paths.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000011-0000-0000-0000-000000000011
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&fixBookFilePathsJob{}) }
 type fixBookFilePathsJob struct{}
 
 func (j *fixBookFilePathsJob) ID() string          { return "fix-book-file-paths" }
+func (j *fixBookFilePathsJob) Name() string     { return "Fix Book File Paths" }
+func (j *fixBookFilePathsJob) Category() string { return "files" }
+func (j *fixBookFilePathsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *fixBookFilePathsJob) Description() string { return "Mark book_files as missing when they no longer exist on disk" }
 func (j *fixBookFilePathsJob) CanResume() bool     { return false }
 func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_library_states.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000008-0000-0000-0000-000000000008
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&fixLibraryStatesJob{}) }
 type fixLibraryStatesJob struct{}
 
 func (j *fixLibraryStatesJob) ID() string          { return "fix-library-states" }
+func (j *fixLibraryStatesJob) Name() string     { return "Fix Library States" }
+func (j *fixLibraryStatesJob) Category() string { return "library" }
+func (j *fixLibraryStatesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *fixLibraryStatesJob) Description() string { return "Reconcile library_state field based on filesystem presence" }
 func (j *fixLibraryStatesJob) CanResume() bool     { return false }
 func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000001-0000-0000-0000-000000000001
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -20,6 +20,9 @@ func init() { maintenance.Register(&fixReadByNarratorJob{}) }
 type fixReadByNarratorJob struct{}
 
 func (j *fixReadByNarratorJob) ID() string          { return "fix-read-by-narrator" }
+func (j *fixReadByNarratorJob) Name() string     { return "Fix Read-by Narrator" }
+func (j *fixReadByNarratorJob) Category() string { return "library" }
+func (j *fixReadByNarratorJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *fixReadByNarratorJob) Description() string {
 return "Fix books where title/author metadata is swapped (title starts with 'read by')"
 }

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000004-0000-0000-0000-000000000004
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -24,6 +24,9 @@ func init() { maintenance.Register(&fixVersionGroupsJob{}) }
 type fixVersionGroupsJob struct{}
 
 func (j *fixVersionGroupsJob) ID() string          { return "fix-version-groups" }
+func (j *fixVersionGroupsJob) Name() string     { return "Fix Version Groups" }
+func (j *fixVersionGroupsJob) Category() string { return "library" }
+func (j *fixVersionGroupsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *fixVersionGroupsJob) Description() string { return "Fix and normalize version groups" }
 func (j *fixVersionGroupsJob) CanResume() bool     { return false }
 

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
 // last-edited: 2026-04-28
 
@@ -14,6 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
 func init() { maintenance.Register(&generateITLTestsJob{}) }
@@ -31,7 +32,10 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 	if config.AppConfig.RootDir == "" {
 		return fmt.Errorf("root_dir is not configured")
 	}
-	outputDir := config.AppConfig.RootDir + "/.itunes-writeback/tests"
+	outputDir, err := util.SafeJoin(config.AppConfig.RootDir, ".itunes-writeback", "tests")
+	if err != nil {
+		return fmt.Errorf("unsafe output dir path: %w", err)
+	}
 
 	allBooks, err := store.GetAllBooks(100000, 0)
 	if err != nil {

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
-// last-edited: 2026-04-28
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -60,6 +61,7 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 		return nil
 	}
 
+	outputDir = filepath.Clean(outputDir)
 	if err := os.RemoveAll(outputDir); err != nil {
 		return fmt.Errorf("failed to clean output dir: %w", err)
 	}

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,0 +1,71 @@
+// file: internal/maintenance/jobs/generate_itl_tests.go
+// version: 1.0.0
+// guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&generateITLTestsJob{}) }
+
+type generateITLTestsJob struct{}
+
+func (j *generateITLTestsJob) ID() string          { return "generate-itl-tests" }
+func (j *generateITLTestsJob) Name() string        { return "Generate ITL Tests" }
+func (j *generateITLTestsJob) Category() string    { return "Dev" }
+func (j *generateITLTestsJob) Description() string { return "Generates a suite of .itl test files for iTunes parser testing" }
+func (j *generateITLTestsJob) DefaultParams() any  { return nil }
+func (j *generateITLTestsJob) CanResume() bool     { return false }
+
+func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	if config.AppConfig.RootDir == "" {
+		return fmt.Errorf("root_dir is not configured")
+	}
+	outputDir := config.AppConfig.RootDir + "/.itunes-writeback/tests"
+
+	allBooks, err := store.GetAllBooks(100000, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+
+	var allBookFiles []database.BookFile
+	for _, b := range allBooks {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		files, _ := store.GetBookFiles(b.ID)
+		allBookFiles = append(allBookFiles, files...)
+	}
+
+	msg := fmt.Sprintf("found %d books and %d book_files", len(allBooks), len(allBookFiles))
+	reporter.Log("info", msg, nil)
+
+	if dryRun {
+		dry := fmt.Sprintf("dry-run: would generate ITL test suite in %s", outputDir)
+		reporter.Log("info", dry, nil)
+		return nil
+	}
+
+	if err := os.RemoveAll(outputDir); err != nil {
+		return fmt.Errorf("failed to clean output dir: %w", err)
+	}
+
+	if err := itunes.GenerateTestITLSuite(outputDir, allBooks, allBookFiles); err != nil {
+		return fmt.Errorf("failed to generate test suite: %w", err)
+	}
+
+	done := fmt.Sprintf("Generated ITL test suite in %s with %d books and %d book_files",
+		outputDir, len(allBooks), len(allBookFiles))
+	reporter.Log("info", done, nil)
+	return nil
+}

--- a/internal/maintenance/jobs/merge_chapter_groups.go
+++ b/internal/maintenance/jobs/merge_chapter_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/merge_chapter_groups.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000020-0000-0000-0000-000000000020
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -19,6 +19,9 @@ func init() { maintenance.Register(&mergeChapterGroupsJob{}) }
 type mergeChapterGroupsJob struct{}
 
 func (j *mergeChapterGroupsJob) ID() string          { return "merge-chapter-groups" }
+func (j *mergeChapterGroupsJob) Name() string     { return "Merge Chapter Groups" }
+func (j *mergeChapterGroupsJob) Category() string { return "files" }
+func (j *mergeChapterGroupsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
 func (j *mergeChapterGroupsJob) Description() string { return "Merge multi-chapter book files into consolidated book records" }
 func (j *mergeChapterGroupsJob) CanResume() bool     { return false }
 func (j *mergeChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000013-0000-0000-0000-000000000013
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&recomputeITunesPathsJob{}) }
 type recomputeITunesPathsJob struct{}
 
 func (j *recomputeITunesPathsJob) ID() string          { return "recompute-itunes-paths" }
+func (j *recomputeITunesPathsJob) Name() string     { return "Recompute iTunes Paths" }
+func (j *recomputeITunesPathsJob) Category() string { return "itunes" }
+func (j *recomputeITunesPathsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *recomputeITunesPathsJob) Description() string { return "Recompute iTunes path mapping for all book files" }
 func (j *recomputeITunesPathsJob) CanResume() bool     { return false }
 func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000012-0000-0000-0000-000000000012
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -17,6 +17,9 @@ func init() { maintenance.Register(&refetchMissingAuthorsJob{}) }
 type refetchMissingAuthorsJob struct{}
 
 func (j *refetchMissingAuthorsJob) ID() string          { return "refetch-missing-authors" }
+func (j *refetchMissingAuthorsJob) Name() string     { return "Refetch Missing Authors" }
+func (j *refetchMissingAuthorsJob) Category() string { return "library" }
+func (j *refetchMissingAuthorsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *refetchMissingAuthorsJob) Description() string { return "Report books missing an author record" }
 func (j *refetchMissingAuthorsJob) CanResume() bool     { return false }
 func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,0 +1,342 @@
+// file: internal/maintenance/jobs/relink_missing_to_itunes.go
+// version: 1.0.0
+// guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&relinkMissingToITunesJob{}) }
+
+type relinkMissingToITunesJob struct {
+	enqueuer maintenance.WriteBackEnqueuer
+}
+
+func (j *relinkMissingToITunesJob) InjectEnqueuer(e maintenance.WriteBackEnqueuer) { j.enqueuer = e }
+
+func (j *relinkMissingToITunesJob) ID() string          { return "relink-missing-to-itunes" }
+func (j *relinkMissingToITunesJob) Name() string        { return "Relink Missing to iTunes" }
+func (j *relinkMissingToITunesJob) Category() string    { return "iTunes" }
+func (j *relinkMissingToITunesJob) Description() string { return "Finds books whose path no longer exists on disk and searches the iTunes library to re-link them" }
+func (j *relinkMissingToITunesJob) DefaultParams() any  { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
+func (j *relinkMissingToITunesJob) CanResume() bool     { return false }
+
+func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	iTunesRoot := config.AppConfig.ITunesMediaRoot
+	organizerRoot := config.AppConfig.RootDir
+
+	if iTunesRoot == "" {
+		return fmt.Errorf("itunes_media_root not configured; set itunes_media_root in settings")
+	}
+	if organizerRoot == "" {
+		return fmt.Errorf("root_dir is not configured")
+	}
+
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+
+	reporter.SetTotal(len(allBooks))
+
+	audioExts := map[string]bool{".mp3": true, ".m4b": true, ".m4a": true, ".flac": true, ".opus": true, ".ogg": true}
+
+	relinked, unresolved, ambiguous, skipped := 0, 0, 0, 0
+
+	for i := range allBooks {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+
+		book := &allBooks[i]
+		fp := book.FilePath
+		if !strings.HasPrefix(fp, organizerRoot) {
+			skipped++
+			continue
+		}
+		if _, err := os.Stat(fp); err == nil {
+			skipped++
+			continue
+		}
+
+		// Derive author name from organizer path; fall back to DB.
+		rel := strings.TrimPrefix(fp, organizerRoot)
+		rel = strings.TrimPrefix(rel, string(os.PathSeparator))
+		authorName := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+		if authorName == "" || authorName == filepath.Base(fp) {
+			if book.Author != nil {
+				authorName = book.Author.Name
+			} else if book.AuthorID != nil {
+				if a, aerr := store.GetAuthorByID(*book.AuthorID); aerr == nil && a != nil {
+					authorName = a.Name
+				}
+			}
+		}
+		if authorName == "" {
+			unresolved++
+			continue
+		}
+
+		matches := rmt_findInITunes(iTunesRoot, authorName, book.Title, audioExts)
+
+		switch len(matches) {
+		case 0:
+			unresolved++
+		case 1:
+			newFP := matches[0]
+			relinked++
+			if !dryRun {
+				fi, _ := os.Stat(newFP)
+				book.FilePath = newFP
+				if _, upErr := store.UpdateBook(book.ID, book); upErr != nil {
+					log.Printf("[WARN] relink-missing-to-itunes: UpdateBook %s: %v", book.ID, upErr)
+					relinked--
+					unresolved++
+					break
+				}
+				rmt_updateBookFiles(store, book.ID, newFP, fi, organizerRoot)
+				if j.enqueuer != nil {
+					j.enqueuer.Enqueue(book.ID)
+				}
+			}
+		default:
+			best := rmt_disambiguate(matches, authorName, book.Title)
+			if best != "" {
+				relinked++
+				if !dryRun {
+					fi, _ := os.Stat(best)
+					book.FilePath = best
+					if _, upErr := store.UpdateBook(book.ID, book); upErr != nil {
+						log.Printf("[WARN] relink-missing-to-itunes: UpdateBook %s: %v", book.ID, upErr)
+						relinked--
+						unresolved++
+						break
+					}
+					rmt_updateBookFiles(store, book.ID, best, fi, organizerRoot)
+					if j.enqueuer != nil {
+						j.enqueuer.Enqueue(book.ID)
+					}
+				}
+			} else {
+				ambiguous++
+			}
+		}
+	}
+
+	log.Printf("[INFO] relink-missing-to-itunes: relinked=%d ambiguous=%d unresolved=%d skipped=%d",
+		relinked, ambiguous, unresolved, skipped)
+	reporter.Log("info",
+		fmt.Sprintf("relinked=%d ambiguous=%d unresolved=%d skipped=%d", relinked, ambiguous, unresolved, skipped),
+		nil)
+	return nil
+}
+
+// rmt_updateBookFiles updates all book_file rows that pointed to the old organizer path.
+func rmt_updateBookFiles(store database.Store, bookID, newFP string, fi os.FileInfo, organizerRoot string) {
+	bookFiles, bfErr := store.GetBookFiles(bookID)
+	if bfErr != nil {
+		return
+	}
+	for j := range bookFiles {
+		bf := &bookFiles[j]
+		if !strings.HasPrefix(bf.FilePath, organizerRoot) {
+			continue
+		}
+		bf.FilePath = newFP
+		bf.OriginalFilename = filepath.Base(newFP)
+		bf.Missing = false
+		if fi != nil && !fi.IsDir() {
+			bf.FileSize = fi.Size()
+			ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(newFP), "."))
+			if ext != "" {
+				bf.Format = ext
+			}
+		}
+		_ = store.UpdateBookFile(bf.ID, bf)
+	}
+}
+
+// rmt_findInITunes searches iTunesRoot for iTunes album directories matching author+title.
+func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string]bool) []string {
+	titlePrefix := title
+	if len(titlePrefix) > 25 {
+		titlePrefix = titlePrefix[:25]
+	}
+	titlePrefixLower := strings.ToLower(titlePrefix)
+
+	authorWord := authorName
+	if idx := strings.Index(authorName, " "); idx > 0 {
+		authorWord = authorName[:idx]
+	}
+	authorWordLower := strings.ToLower(authorWord)
+
+	dirMatches := map[string]struct{}{}
+
+	entries, err := os.ReadDir(iTunesRoot)
+	if err != nil {
+		return nil
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(entry.Name()), authorWordLower) {
+			continue
+		}
+		authorDir := filepath.Join(iTunesRoot, entry.Name())
+
+		albumEntries, err := os.ReadDir(authorDir)
+		if err != nil {
+			continue
+		}
+		for _, album := range albumEntries {
+			albumPath := filepath.Join(authorDir, album.Name())
+			if album.IsDir() {
+				if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+					dirMatches[albumPath] = struct{}{}
+					continue
+				}
+				_ = filepath.WalkDir(albumPath, func(path string, d os.DirEntry, err error) error {
+					if err != nil || d.IsDir() {
+						return nil
+					}
+					if !audioExts[strings.ToLower(filepath.Ext(path))] {
+						return nil
+					}
+					if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+						dirMatches[albumPath] = struct{}{}
+						return filepath.SkipDir
+					}
+					return nil
+				})
+			} else {
+				if !audioExts[strings.ToLower(filepath.Ext(albumPath))] {
+					continue
+				}
+				if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+					dirMatches[albumPath] = struct{}{}
+				}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(dirMatches))
+	for d := range dirMatches {
+		result = append(result, d)
+	}
+	sort.Strings(result)
+	return result
+}
+
+var rmt_leadingNumRE = regexp.MustCompile(`^\d+\s*[-.]?\s*`)
+var rmt_trailingNumRE = regexp.MustCompile(`\s+\d+$`)
+
+// rmt_disambiguate narrows multiple iTunes matches to a single best match using a scoring heuristic.
+func rmt_disambiguate(matches []string, authorName, title string) string {
+	titleLower := strings.ToLower(title)
+
+	type candidate struct {
+		path  string
+		score int
+	}
+	cands := make([]candidate, 0, len(matches))
+
+	for _, p := range matches {
+		base := filepath.Base(p)
+		ext := filepath.Ext(base)
+		stemRaw := strings.TrimSuffix(base, ext)
+		leadingNum := rmt_leadingNumRE.FindString(stemRaw)
+		stemNoNum := rmt_leadingNumRE.ReplaceAllString(stemRaw, "")
+		stemLower := strings.ToLower(stemNoNum)
+		stemNorm := strings.ReplaceAll(strings.ReplaceAll(stemLower, "_", " "), ":", " ")
+
+		sc := 0
+
+		switch {
+		case stemNorm == titleLower:
+			sc += 100
+		case strings.HasPrefix(stemNorm, titleLower):
+			rest := stemNorm[len(titleLower):]
+			switch {
+			case regexp.MustCompile(`^\s+book\s+\d`).MatchString(rest),
+				regexp.MustCompile(`^\s+\d+$`).MatchString(rest):
+				sc += 20
+			default:
+				sc += 60
+			}
+		case strings.HasPrefix(titleLower, stemNorm) && len(stemNorm) >= 10:
+			sc += 80
+		case strings.Contains(stemNorm, titleLower):
+			sc += 10
+		}
+
+		if rmt_trailingNumRE.MatchString(stemNorm) {
+			sc -= 30
+		}
+		if leadingNum == "" {
+			sc += 20
+		} else {
+			if n, nerr := strconv.Atoi(strings.TrimSpace(
+				strings.TrimRight(strings.TrimRight(leadingNum, " "), "-."))); nerr == nil {
+				sc -= n * 2
+			}
+		}
+
+		authorDir := filepath.Base(filepath.Dir(p))
+		if strings.EqualFold(authorDir, authorName) {
+			sc += 40
+		} else if strings.Contains(strings.ToLower(authorDir), strings.ToLower(authorName)) {
+			sc += 20
+		}
+		sc -= len(base) / 8
+
+		cands = append(cands, candidate{path: p, score: sc})
+	}
+
+	sort.Slice(cands, func(i, j int) bool { return cands[i].score > cands[j].score })
+
+	if len(cands) > 1 {
+		stemOf := func(p string) string {
+			b := filepath.Base(p)
+			s := strings.TrimSuffix(b, filepath.Ext(b))
+			s = strings.ToLower(rmt_leadingNumRE.ReplaceAllString(s, ""))
+			s = strings.ReplaceAll(strings.ReplaceAll(s, "_", " "), ":", " ")
+			return s
+		}
+		first := stemOf(cands[0].path)
+		allSame := true
+		for _, c := range cands[1:] {
+			if stemOf(c.path) != first {
+				allSame = false
+				break
+			}
+		}
+		if allSame {
+			return cands[0].path
+		}
+	}
+
+	if len(cands) >= 2 && cands[0].score-cands[1].score >= 15 {
+		return cands[0].path
+	}
+	if len(cands) == 1 {
+		return cands[0].path
+	}
+	return ""
+}

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
 // last-edited: 2026-04-28
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
 func init() { maintenance.Register(&relinkMissingToITunesJob{}) }
@@ -99,7 +100,12 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		case 0:
 			unresolved++
 		case 1:
-			newFP := matches[0]
+			newFP := util.CleanPath(matches[0])
+			if !util.WithinRoot(newFP, iTunesRoot) {
+				log.Printf("[WARN] relink-missing-to-itunes: match %q outside iTunesRoot, skipping", newFP)
+				unresolved++
+				break
+			}
 			relinked++
 			if !dryRun {
 				fi, _ := os.Stat(newFP)
@@ -118,6 +124,12 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		default:
 			best := rmt_disambiguate(matches, authorName, book.Title)
 			if best != "" {
+				best = util.CleanPath(best)
+				if !util.WithinRoot(best, iTunesRoot) {
+					log.Printf("[WARN] relink-missing-to-itunes: best match %q outside iTunesRoot, skipping", best)
+					unresolved++
+					break
+				}
 				relinked++
 				if !dryRun {
 					fi, _ := os.Stat(best)

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
-// last-edited: 2026-04-28
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -100,7 +100,7 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		case 0:
 			unresolved++
 		case 1:
-			newFP := util.CleanPath(matches[0])
+			newFP := filepath.Clean(matches[0])
 			if !util.WithinRoot(newFP, iTunesRoot) {
 				log.Printf("[WARN] relink-missing-to-itunes: match %q outside iTunesRoot, skipping", newFP)
 				unresolved++
@@ -124,7 +124,7 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		default:
 			best := rmt_disambiguate(matches, authorName, book.Title)
 			if best != "" {
-				best = util.CleanPath(best)
+				best = filepath.Clean(best)
 				if !util.WithinRoot(best, iTunesRoot) {
 					log.Printf("[WARN] relink-missing-to-itunes: best match %q outside iTunesRoot, skipping", best)
 					unresolved++
@@ -186,6 +186,7 @@ func rmt_updateBookFiles(store database.Store, bookID, newFP string, fi os.FileI
 
 // rmt_findInITunes searches iTunesRoot for iTunes album directories matching author+title.
 func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string]bool) []string {
+	iTunesRoot = filepath.Clean(iTunesRoot)
 	titlePrefix := title
 	if len(titlePrefix) > 25 {
 		titlePrefix = titlePrefix[:25]

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-05-04
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -25,6 +25,9 @@ func init() { maintenance.Register(&relinkReportJob{}) }
 type relinkReportJob struct{}
 
 func (j *relinkReportJob) ID() string          { return "relink-report" }
+func (j *relinkReportJob) Name() string     { return "Relink Report" }
+func (j *relinkReportJob) Category() string { return "itunes" }
+func (j *relinkReportJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *relinkReportJob) Description() string { return "Report missing iTunes-linked files that may be relinkable" }
 func (j *relinkReportJob) CanResume() bool     { return false }
 

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
 // last-edited: 2026-04-28
 
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
 func init() { maintenance.Register(&repairMissingFilesJob{}) }
@@ -497,6 +498,20 @@ func rmfr_repairOne(
 	}
 
 	if candidate == "" {
+		res.Method = "unresolved"
+		return res
+	}
+
+	candidate = util.CleanPath(candidate)
+	withinARoot := false
+	for _, root := range searchRoots {
+		if util.WithinRoot(candidate, root) {
+			withinARoot = true
+			break
+		}
+	}
+	if !withinARoot {
+		log.Printf("[WARN] repair-missing-files %s: candidate %q outside all search roots, skipping", opID, candidate)
 		res.Method = "unresolved"
 		return res
 	}

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
-// last-edited: 2026-04-28
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -215,7 +215,7 @@ func rmfr_searchRoots() []string {
 	var out []string
 	for _, r := range roots {
 		if r != "" {
-			out = append(out, r)
+			out = append(out, filepath.Clean(r))
 		}
 	}
 	return out
@@ -502,7 +502,7 @@ func rmfr_repairOne(
 		return res
 	}
 
-	candidate = util.CleanPath(candidate)
+	candidate = filepath.Clean(candidate)
 	withinARoot := false
 	for _, root := range searchRoots {
 		if util.WithinRoot(candidate, root) {

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,0 +1,529 @@
+// file: internal/maintenance/jobs/repair_missing_files.go
+// version: 1.0.0
+// guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&repairMissingFilesJob{}) }
+
+type repairMissingFilesJob struct{}
+
+func (j *repairMissingFilesJob) ID() string          { return "repair-missing-files" }
+func (j *repairMissingFilesJob) Name() string        { return "Repair Missing Files" }
+func (j *repairMissingFilesJob) Category() string    { return "Files" }
+func (j *repairMissingFilesJob) Description() string { return "Tries to locate book_files whose stored path no longer exists and updates the DB record with the new path" }
+func (j *repairMissingFilesJob) DefaultParams() any  { return struct{ DryRun bool `json:"dry_run"` }{DryRun: true} }
+func (j *repairMissingFilesJob) CanResume() bool     { return true }
+
+func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	opID := maintenance.OperationIDFromCtx(ctx)
+
+	searchRoots := rmfr_searchRoots()
+
+	allFiles, err := store.GetAllBookFiles()
+	if err != nil {
+		return fmt.Errorf("GetAllBookFiles: %w", err)
+	}
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+	allAuthors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("GetAllAuthors: %w", err)
+	}
+	authorByID := make(map[int]string, len(allAuthors))
+	for _, a := range allAuthors {
+		authorByID[a.ID] = a.Name
+	}
+	metaByBook := make(map[string]rmfr_bookMeta, len(allBooks))
+	for i := range allBooks {
+		b := &allBooks[i]
+		author := ""
+		if b.AuthorID != nil {
+			author = authorByID[*b.AuthorID]
+		}
+		metaByBook[b.ID] = rmfr_bookMeta{title: b.Title, author: author}
+	}
+
+	// Collect candidates.
+	var candidates []database.BookFile
+	for i := range allFiles {
+		f := &allFiles[i]
+		if f.FilePath == "" || f.Missing {
+			continue
+		}
+		if _, statErr := os.Stat(f.FilePath); statErr == nil {
+			continue
+		}
+		candidates = append(candidates, *f)
+	}
+
+	// Skip already-processed files from a prior run.
+	var existingResults []database.OperationResult
+	if opID != "" {
+		existingResults, _ = store.GetOperationResults(opID)
+	}
+	done := make(map[string]bool, len(existingResults))
+	for _, r := range existingResults {
+		done[r.BookID] = true
+	}
+	var work []database.BookFile
+	for _, f := range candidates {
+		if !done[f.ID] {
+			work = append(work, f)
+		}
+	}
+
+	totalFiles := len(existingResults) + len(work)
+	alreadyDone := len(existingResults)
+	log.Printf("[INFO] repair-missing-files %s: %d candidates, %d already done, %d to process",
+		opID, totalFiles, alreadyDone, len(work))
+
+	reporter.SetTotal(totalFiles)
+	for i := 0; i < alreadyDone; i++ {
+		reporter.Increment()
+	}
+
+	if len(work) == 0 {
+		reporter.Log("info", "all files already processed", nil)
+		return nil
+	}
+
+	// Parse iTunes XML for PID lookups.
+	pidToLocation := make(map[string]string)
+	if xmlPath := config.AppConfig.ITunesLibraryReadPath; xmlPath != "" {
+		if lib, parseErr := itunes.ParseLibrary(xmlPath); parseErr != nil {
+			log.Printf("[WARN] repair-missing-files %s: iTunes XML parse error: %v", opID, parseErr)
+		} else {
+			for _, track := range lib.Tracks {
+				if track.PersistentID != "" && track.Location != "" {
+					pidToLocation[track.PersistentID] = track.Location
+				}
+			}
+			log.Printf("[INFO] repair-missing-files %s: loaded %d PID→location entries", opID, len(pidToLocation))
+		}
+	}
+
+	itunesOpts := itunes.ImportOptions{PathMappings: make([]itunes.PathMapping, len(config.AppConfig.ITunesPathMappings))}
+	for i, m := range config.AppConfig.ITunesPathMappings {
+		itunesOpts.PathMappings[i] = itunes.PathMapping{From: m.From, To: m.To}
+	}
+
+	audioExts := map[string]bool{".m4b": true, ".m4a": true, ".mp3": true, ".flac": true, ".ogg": true, ".opus": true}
+
+	var filenameIdx map[string][]string
+	var idxOnce sync.Once
+	var idxMu sync.Mutex
+	buildIdx := func() {
+		idxOnce.Do(func() {
+			reporter.Log("info", "building filename index…", nil)
+			idx := make(map[string][]string, 200000)
+			for _, root := range searchRoots {
+				_ = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+					if walkErr != nil || d.IsDir() {
+						return nil
+					}
+					if audioExts[strings.ToLower(filepath.Ext(path))] {
+						base := filepath.Base(path)
+						idx[base] = append(idx[base], path)
+					}
+					return nil
+				})
+			}
+			idxMu.Lock()
+			filenameIdx = idx
+			idxMu.Unlock()
+			log.Printf("[INFO] repair-missing-files %s: filename index built (%d unique names)", opID, len(idx))
+		})
+	}
+	getIdx := func() map[string][]string {
+		idxMu.Lock()
+		defer idxMu.Unlock()
+		return filenameIdx
+	}
+
+	var completed int64 = int64(alreadyDone)
+	var progressMu sync.Mutex
+
+	workCh := make(chan database.BookFile, len(work))
+	for _, f := range work {
+		workCh <- f
+	}
+	close(workCh)
+
+	var wg sync.WaitGroup
+	const workers = 4
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for f := range workCh {
+				if ctx.Err() != nil {
+					return
+				}
+				res := rmfr_repairOne(f, metaByBook, pidToLocation, itunesOpts, dryRun, searchRoots, audioExts, buildIdx, getIdx, store, opID)
+
+				if opID != "" {
+					resultJSON, _ := json.Marshal(res)
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      f.ID,
+						ResultJSON:  string(resultJSON),
+						Status:      res.Method,
+					})
+				}
+
+				atomic.AddInt64(&completed, 1)
+				progressMu.Lock()
+				reporter.Increment()
+				progressMu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	finalCount := atomic.LoadInt64(&completed)
+	msg := fmt.Sprintf("Repaired %d of %d missing files", finalCount, totalFiles)
+	reporter.Log("info", msg, nil)
+	log.Printf("[INFO] repair-missing-files %s: finished %d/%d files", opID, finalCount, totalFiles)
+	return nil
+}
+
+// rmfr_searchRoots builds the ordered list of roots to search from config.
+func rmfr_searchRoots() []string {
+	roots := []string{config.AppConfig.ITunesMediaRoot, config.AppConfig.RootDir}
+	var out []string
+	for _, r := range roots {
+		if r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+type rmfr_bookMeta struct {
+	title  string
+	author string
+}
+
+type rmfr_result struct {
+	FileID  string `json:"file_id"`
+	BookID  string `json:"book_id"`
+	Title   string `json:"book_title"`
+	OldPath string `json:"old_path"`
+	NewPath string `json:"new_path,omitempty"`
+	Method  string `json:"method"`
+	Matches int    `json:"matches,omitempty"`
+	Applied bool   `json:"applied"`
+	Error   string `json:"error,omitempty"`
+}
+
+// rmfr_repairOne tries four escalating strategies and returns a result.
+// Only calls UpdateBookFile — never creates new Book or BookFile rows.
+func rmfr_repairOne(
+	f database.BookFile,
+	metaByBook map[string]rmfr_bookMeta,
+	pidToLocation map[string]string,
+	itunesOpts itunes.ImportOptions,
+	dryRun bool,
+	searchRoots []string,
+	audioExts map[string]bool,
+	buildIdx func(),
+	getIdx func() map[string][]string,
+	store database.Store,
+	opID string,
+) rmfr_result {
+	bm := metaByBook[f.BookID]
+	res := rmfr_result{
+		FileID:  f.ID,
+		BookID:  f.BookID,
+		Title:   bm.title,
+		OldPath: f.FilePath,
+	}
+
+	if _, statErr := os.Stat(f.FilePath); statErr == nil {
+		res.Method = "skipped"
+		return res
+	}
+
+	candidate, method := "", ""
+
+	// Tier 1: iTunes PID → XML Location → RemapPath
+	if candidate == "" && f.ITunesPersistentID != "" {
+		if loc, ok := pidToLocation[f.ITunesPersistentID]; ok {
+			remapped := itunesOpts.RemapPath(loc)
+			if remapped != "" && remapped != loc {
+				if _, statErr := os.Stat(remapped); statErr == nil {
+					candidate, method = remapped, "pid"
+				}
+			}
+		}
+	}
+
+	// Tier 2: exact basename search across filename index
+	if candidate == "" {
+		buildIdx()
+		base := filepath.Base(f.FilePath)
+		idx := getIdx()
+		paths := idx[base]
+		switch len(paths) {
+		case 1:
+			candidate, method = paths[0], "filename"
+			res.Matches = 1
+		case 0:
+			// no match
+		default:
+			parentDir := filepath.Base(filepath.Dir(f.FilePath))
+			var narrowed []string
+			for _, p := range paths {
+				if strings.EqualFold(filepath.Base(filepath.Dir(p)), parentDir) {
+					narrowed = append(narrowed, p)
+				}
+			}
+			if len(narrowed) > 1 && bm.author != "" {
+				lastName := strings.ToLower(bm.author)
+				if i := strings.LastIndex(lastName, " "); i > 0 {
+					lastName = lastName[i+1:]
+				}
+				var n2 []string
+				for _, p := range narrowed {
+					if strings.Contains(strings.ToLower(filepath.Base(filepath.Dir(filepath.Dir(p)))), lastName) {
+						n2 = append(n2, p)
+					}
+				}
+				if len(n2) >= 1 {
+					narrowed = n2
+				}
+			}
+			switch len(narrowed) {
+			case 1:
+				candidate, method = narrowed[0], "filename"
+				res.Matches = 1
+			case 0:
+				// fall through
+			default:
+				res.Method = "ambiguous"
+				res.Matches = len(narrowed)
+				return res
+			}
+		}
+	}
+
+	// Tier 3: stem-prefix match in the same directory
+	if candidate == "" {
+		dir := filepath.Dir(f.FilePath)
+		base := filepath.Base(f.FilePath)
+		ext := filepath.Ext(base)
+		stem := strings.TrimSuffix(base, ext)
+		if entries, readErr := os.ReadDir(dir); readErr == nil {
+			for _, de := range entries {
+				if de.IsDir() {
+					continue
+				}
+				name := de.Name()
+				nameExt := filepath.Ext(name)
+				nameStem := strings.TrimSuffix(name, nameExt)
+				if strings.EqualFold(nameExt, ext) &&
+					strings.HasPrefix(nameStem, stem) &&
+					name != base &&
+					len(nameStem) > len(stem) &&
+					nameStem[len(stem)] != ' ' {
+					candidate, method = filepath.Join(dir, name), "truncation"
+					break
+				}
+			}
+		}
+	}
+
+	// Tier 4: author last-name + title-prefixed album dir
+	if candidate == "" && bm.author != "" && bm.title != "" {
+		lastName := bm.author
+		if i := strings.LastIndex(bm.author, " "); i > 0 {
+			lastName = bm.author[i+1:]
+		}
+		titlePrefix := bm.title
+		if len(titlePrefix) > 30 {
+			titlePrefix = titlePrefix[:30]
+		}
+		storedBase := filepath.Base(f.FilePath)
+		var matches []string
+		for _, root := range searchRoots {
+			entries, rerr := os.ReadDir(root)
+			if rerr != nil {
+				continue
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				if !strings.Contains(strings.ToLower(entry.Name()), strings.ToLower(lastName)) {
+					continue
+				}
+				authorDir := filepath.Join(root, entry.Name())
+				albumEntries, aErr := os.ReadDir(authorDir)
+				if aErr != nil {
+					continue
+				}
+				for _, album := range albumEntries {
+					if !album.IsDir() {
+						continue
+					}
+					if !strings.HasPrefix(strings.ToLower(album.Name()), strings.ToLower(titlePrefix)) {
+						continue
+					}
+					exact := filepath.Join(authorDir, album.Name(), storedBase)
+					if _, statErr := os.Stat(exact); statErr == nil {
+						matches = append(matches, exact)
+						continue
+					}
+					albumFiles, _ := os.ReadDir(filepath.Join(authorDir, album.Name()))
+					var audioInAlbum []string
+					for _, af := range albumFiles {
+						if !af.IsDir() && audioExts[strings.ToLower(filepath.Ext(af.Name()))] {
+							audioInAlbum = append(audioInAlbum, filepath.Join(authorDir, album.Name(), af.Name()))
+						}
+					}
+					if len(audioInAlbum) == 1 {
+						matches = append(matches, audioInAlbum[0])
+					}
+				}
+			}
+		}
+		switch len(matches) {
+		case 1:
+			candidate, method = matches[0], "author_title"
+			res.Matches = 1
+		case 0:
+			// no match
+		default:
+			res.Method = "ambiguous"
+			res.Matches = len(matches)
+			return res
+		}
+	}
+
+	// Tier 4b: flat iTunes library — audio files directly in the author dir
+	if candidate == "" && bm.author != "" {
+		lastName := bm.author
+		if i := strings.LastIndex(bm.author, " "); i > 0 {
+			lastName = bm.author[i+1:]
+		}
+		storedBase := filepath.Base(f.FilePath)
+		storedStem := strings.TrimSuffix(storedBase, filepath.Ext(storedBase))
+		titleFromFile := storedStem
+		if i := strings.IndexByte(storedStem, ' '); i > 0 {
+			prefix := storedStem[:i]
+			isNum := true
+			for _, r := range prefix {
+				if r < '0' || r > '9' {
+					isNum = false
+					break
+				}
+			}
+			if isNum {
+				titleFromFile = strings.TrimSpace(storedStem[i+1:])
+			}
+		}
+
+		var matches []string
+		for _, root := range searchRoots {
+			entries, rerr := os.ReadDir(root)
+			if rerr != nil {
+				continue
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				if !strings.Contains(strings.ToLower(entry.Name()), strings.ToLower(lastName)) {
+					continue
+				}
+				authorDir := filepath.Join(root, entry.Name())
+				dirFiles, _ := os.ReadDir(authorDir)
+				for _, df := range dirFiles {
+					if df.IsDir() || !audioExts[strings.ToLower(filepath.Ext(df.Name()))] {
+						continue
+					}
+					fileStem := strings.TrimSuffix(df.Name(), filepath.Ext(df.Name()))
+					if strings.EqualFold(fileStem, titleFromFile) {
+						matches = append(matches, filepath.Join(authorDir, df.Name()))
+					}
+				}
+			}
+		}
+		if len(matches) > 1 {
+			authorLower := strings.ToLower(bm.author)
+			var preferred []string
+			for _, m := range matches {
+				dirName := strings.ToLower(filepath.Base(filepath.Dir(m)))
+				if strings.HasPrefix(dirName, authorLower) {
+					preferred = append(preferred, m)
+				}
+			}
+			if len(preferred) == 1 {
+				matches = preferred
+			}
+		}
+		switch len(matches) {
+		case 1:
+			candidate, method = matches[0], "flat_stem"
+			res.Matches = 1
+		case 0:
+			// no match
+		default:
+			res.Method = "ambiguous"
+			res.Matches = len(matches)
+			return res
+		}
+	}
+
+	if candidate == "" {
+		res.Method = "unresolved"
+		return res
+	}
+
+	res.NewPath = candidate
+	res.Method = method
+	res.Matches = 1
+
+	if dryRun {
+		return res
+	}
+
+	fi, _ := os.Stat(candidate)
+	f.FilePath = candidate
+	f.OriginalFilename = filepath.Base(candidate)
+	f.Missing = false
+	if fi != nil {
+		f.FileSize = fi.Size()
+	}
+	if ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(candidate), ".")); ext != "" {
+		f.Format = ext
+	}
+	if upErr := store.UpdateBookFile(f.ID, &f); upErr != nil {
+		res.Error = upErr.Error()
+		log.Printf("[WARN] repair-missing-files %s: UpdateBookFile %s: %v", opID, f.ID, upErr)
+	} else {
+		res.Applied = true
+	}
+	return res
+}

--- a/internal/maintenance/jobs/revert_metadata_fetch.go
+++ b/internal/maintenance/jobs/revert_metadata_fetch.go
@@ -1,0 +1,211 @@
+// file: internal/maintenance/jobs/revert_metadata_fetch.go
+// version: 1.0.0
+// guid: c8d4e2b3-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&revertMetadataFetchJob{}) }
+
+type revertMetadataFetchJob struct{}
+
+type rmf_params struct {
+	OperationIDs []string `json:"fetch_op_ids"`
+}
+
+func (j *revertMetadataFetchJob) ID() string          { return "revert-metadata-fetch" }
+func (j *revertMetadataFetchJob) Name() string        { return "Revert Metadata Fetch" }
+func (j *revertMetadataFetchJob) Category() string    { return "Metadata" }
+func (j *revertMetadataFetchJob) Description() string { return "Rolls back DB changes made by one or more bulk-fetch-metadata operations" }
+func (j *revertMetadataFetchJob) DefaultParams() any  { return &rmf_params{OperationIDs: []string{}} }
+func (j *revertMetadataFetchJob) CanResume() bool     { return false }
+
+func (j *revertMetadataFetchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	opID := maintenance.OperationIDFromCtx(ctx)
+
+	// Load parameters: fetch_op_ids from operation params if stored.
+	var operationIDs []string
+	if opID != "" {
+		if raw, err := store.GetOperationParams(opID); err == nil && len(raw) > 0 {
+			var p rmf_params
+			if jerr := json.Unmarshal(raw, &p); jerr == nil {
+				operationIDs = p.OperationIDs
+			}
+		}
+	}
+
+	if len(operationIDs) == 0 {
+		return fmt.Errorf("fetch_op_ids required: pass a list of bulk_metadata_fetch operation IDs to revert")
+	}
+
+	// Collect the earliest start time across all operations.
+	var revertAfter time.Time
+	bookIDSet := map[string]bool{}
+
+	for _, fetchOpID := range operationIDs {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		op, err := store.GetOperationByID(fetchOpID)
+		if err != nil || op == nil {
+			continue
+		}
+		if op.Type != "bulk_metadata_fetch" {
+			return fmt.Errorf("operation %s is not a bulk_metadata_fetch (got %q)", fetchOpID, op.Type)
+		}
+		ts := op.CreatedAt
+		if op.StartedAt != nil {
+			ts = *op.StartedAt
+		}
+		if revertAfter.IsZero() || ts.Before(revertAfter) {
+			revertAfter = ts
+		}
+
+		results, err := store.GetOperationResults(fetchOpID)
+		if err != nil {
+			return fmt.Errorf("failed to load results for %s: %w", fetchOpID, err)
+		}
+		for _, r := range results {
+			if r.Status == "updated" {
+				bookIDSet[r.BookID] = true
+			}
+		}
+	}
+
+	log.Printf("[INFO] revert-metadata-fetch: reverting %d books, changes after %s",
+		len(bookIDSet), revertAfter.Format(time.RFC3339))
+	reporter.SetTotal(len(bookIDSet))
+
+	reverted, skipped, errors := 0, 0, 0
+
+	for bookID := range bookIDSet {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		reporter.Increment()
+
+		book, err := store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			errors++
+			continue
+		}
+
+		history, err := store.GetBookChangeHistory(bookID, 50)
+		if err != nil {
+			errors++
+			continue
+		}
+
+		type revertEntry struct {
+			field string
+			prev  string
+		}
+		byField := map[string]revertEntry{}
+		for _, h := range history {
+			if h.ChangeType != "fetched" {
+				continue
+			}
+			if h.ChangedAt.Before(revertAfter) {
+				continue
+			}
+			prev := ""
+			if h.PreviousValue != nil {
+				if jerr := json.Unmarshal([]byte(*h.PreviousValue), &prev); jerr != nil {
+					prev = *h.PreviousValue
+				}
+			}
+			byField[h.Field] = revertEntry{field: h.Field, prev: prev}
+		}
+
+		if len(byField) == 0 {
+			skipped++
+			continue
+		}
+
+		didChange := false
+		for _, e := range byField {
+			switch e.field {
+			case "title":
+				book.Title = e.prev
+				didChange = true
+			case "author_name":
+				if e.prev == "" {
+					book.AuthorID = nil
+					didChange = true
+				} else {
+					if author, aerr := store.GetAuthorByName(e.prev); aerr == nil && author != nil {
+						book.AuthorID = &author.ID
+						didChange = true
+					}
+				}
+			case "publisher":
+				if e.prev == "" {
+					book.Publisher = nil
+				} else {
+					book.Publisher = &e.prev
+				}
+				didChange = true
+			case "language":
+				if e.prev == "" {
+					book.Language = nil
+				} else {
+					book.Language = &e.prev
+				}
+				didChange = true
+			case "audiobook_release_year":
+				if e.prev == "" {
+					book.AudiobookReleaseYear = nil
+				} else if yr, yerr := strconv.Atoi(e.prev); yerr == nil {
+					book.AudiobookReleaseYear = &yr
+				}
+				didChange = true
+			case "isbn10":
+				if e.prev == "" {
+					book.ISBN10 = nil
+				} else {
+					book.ISBN10 = &e.prev
+				}
+				didChange = true
+			case "isbn13":
+				if e.prev == "" {
+					book.ISBN13 = nil
+				} else {
+					book.ISBN13 = &e.prev
+				}
+				didChange = true
+			}
+		}
+
+		if didChange {
+			if !dryRun {
+				if _, uerr := store.UpdateBook(bookID, book); uerr != nil {
+					log.Printf("[WARN] revert-metadata-fetch: UpdateBook %s: %v", bookID, uerr)
+					errors++
+				} else {
+					reverted++
+				}
+			} else {
+				reverted++ // dry-run: count as "would revert"
+			}
+		} else {
+			skipped++
+		}
+	}
+
+	log.Printf("[INFO] revert-metadata-fetch: done — reverted:%d skipped:%d errors:%d", reverted, skipped, errors)
+	summary := fmt.Sprintf("Reverted %d books (skipped: %d, errors: %d)", reverted, skipped, errors)
+	reporter.Log("info", summary, nil)
+	return nil
+}

--- a/internal/maintenance/jobs/scan_chapter_groups.go
+++ b/internal/maintenance/jobs/scan_chapter_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_chapter_groups.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000019-0000-0000-0000-000000000019
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -19,6 +19,9 @@ func init() { maintenance.Register(&scanChapterGroupsJob{}) }
 type scanChapterGroupsJob struct{}
 
 func (j *scanChapterGroupsJob) ID() string          { return "scan-chapter-groups" }
+func (j *scanChapterGroupsJob) Name() string     { return "Scan Chapter Groups" }
+func (j *scanChapterGroupsJob) Category() string { return "files" }
+func (j *scanChapterGroupsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *scanChapterGroupsJob) Description() string { return "Report books that look like multi-chapter parts of the same audiobook" }
 func (j *scanChapterGroupsJob) CanResume() bool     { return false }
 func (j *scanChapterGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,0 +1,277 @@
+// file: internal/maintenance/jobs/scan_composer_tags.go
+// version: 1.0.0
+// guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
+// last-edited: 2026-04-28
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+)
+
+func init() { maintenance.Register(&scanComposerTagsJob{}) }
+
+type scanComposerTagsJob struct{}
+
+type sct_params struct {
+	DryRun  bool   `json:"dry_run"`
+	FixMode string `json:"fix_mode"` // "set_narrator" or "clear"
+}
+
+func (j *scanComposerTagsJob) ID() string          { return "scan-composer-tags" }
+func (j *scanComposerTagsJob) Name() string        { return "Scan Composer Tags" }
+func (j *scanComposerTagsJob) Category() string    { return "Scanning" }
+func (j *scanComposerTagsJob) Description() string { return "Bulk-scans COMPOSER tags on all audio files and optionally fixes them to match the narrator field" }
+func (j *scanComposerTagsJob) DefaultParams() any  { return &sct_params{DryRun: true, FixMode: "set_narrator"} }
+func (j *scanComposerTagsJob) CanResume() bool     { return true }
+
+func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	opID := maintenance.OperationIDFromCtx(ctx)
+
+	// Load fix_mode from persisted params when resuming.
+	fixMode := "set_narrator"
+	if opID != "" {
+		if raw, err := store.GetOperationParams(opID); err == nil && len(raw) > 0 {
+			var p sct_params
+			if jerr := json.Unmarshal(raw, &p); jerr == nil && p.FixMode != "" {
+				fixMode = p.FixMode
+				dryRun = p.DryRun
+			}
+		}
+	}
+
+	allBooks, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		return fmt.Errorf("GetAllBooks: %w", err)
+	}
+	allAuthors, err := store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("GetAllAuthors: %w", err)
+	}
+	authorByID := make(map[int]string, len(allAuthors))
+	for _, a := range allAuthors {
+		authorByID[a.ID] = a.Name
+	}
+	allFiles, err := store.GetAllBookFiles()
+	if err != nil {
+		return fmt.Errorf("GetAllBookFiles: %w", err)
+	}
+	filesByBook := make(map[string][]database.BookFile, len(allFiles))
+	for i := range allFiles {
+		f := &allFiles[i]
+		filesByBook[f.BookID] = append(filesByBook[f.BookID], *f)
+	}
+
+	// Skip already-processed files from a prior interrupted run.
+	var existingResults []database.OperationResult
+	if opID != "" {
+		existingResults, _ = store.GetOperationResults(opID)
+	}
+	done := make(map[string]bool, len(existingResults))
+	for _, r := range existingResults {
+		done[r.BookID] = true // BookID stores file path for this op
+	}
+
+	audioExts := map[string]bool{".m4b": true, ".m4a": true, ".mp3": true, ".flac": true, ".ogg": true}
+	var workItems []sct_work
+	for i := range allBooks {
+		b := &allBooks[i]
+		author := ""
+		if b.AuthorID != nil {
+			author = authorByID[*b.AuthorID]
+		}
+		narrator := ""
+		if b.Narrator != nil {
+			narrator = *b.Narrator
+		}
+		for _, f := range filesByBook[b.ID] {
+			if f.FilePath == "" || f.Missing {
+				continue
+			}
+			if !audioExts[strings.ToLower(filepath.Ext(f.FilePath))] {
+				continue
+			}
+			if done[f.FilePath] {
+				continue
+			}
+			workItems = append(workItems, sct_work{
+				bookID:    b.ID,
+				bookTitle: b.Title,
+				filePath:  f.FilePath,
+				author:    author,
+				narrator:  narrator,
+			})
+		}
+	}
+
+	totalFiles := len(existingResults) + len(workItems)
+	alreadyDone := len(existingResults)
+	log.Printf("[INFO] scan-composer-tags %s: %d files total, %d already done, %d to process",
+		opID, totalFiles, alreadyDone, len(workItems))
+
+	reporter.SetTotal(totalFiles)
+	for i := 0; i < alreadyDone; i++ {
+		reporter.Increment()
+	}
+
+	if len(workItems) == 0 {
+		reporter.Log("info", "all files already processed", nil)
+		return nil
+	}
+
+	const workers = 8
+	workCh := make(chan sct_work, len(workItems))
+	for _, w := range workItems {
+		workCh <- w
+	}
+	close(workCh)
+
+	var completed int64 = int64(alreadyDone)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for w := range workCh {
+				if ctx.Err() != nil {
+					return
+				}
+				if _, statErr := os.Stat(w.filePath); statErr != nil {
+					if opID != "" {
+						_ = store.CreateOperationResult(&database.OperationResult{
+							OperationID: opID,
+							BookID:      w.filePath,
+							ResultJSON:  `{"category":"missing"}`,
+							Status:      "missing",
+						})
+					}
+					atomic.AddInt64(&completed, 1)
+					mu.Lock()
+					reporter.Increment()
+					mu.Unlock()
+					continue
+				}
+
+				tags, readErr := metadata.ReadRawTags(w.filePath)
+				var r sct_result
+				if readErr != nil {
+					r = sct_result{
+						BookID: w.bookID, BookTitle: w.bookTitle, FilePath: w.filePath,
+						Category: "read_error", Error: readErr.Error(),
+					}
+				} else {
+					composer := ""
+					if vs, ok := tags["COMPOSER"]; ok && len(vs) > 0 {
+						composer = strings.TrimSpace(vs[0])
+					}
+					category, willWrite := sct_categorize(composer, w.author, w.narrator, fixMode)
+					r = sct_result{
+						BookID: w.bookID, BookTitle: w.bookTitle, FilePath: w.filePath,
+						Category: category, Composer: composer,
+						Author: w.author, Narrator: w.narrator, WillWrite: willWrite,
+					}
+					if !dryRun && category != "ok" && willWrite != composer {
+						if writeErr := metadata.WriteSingleTag(w.filePath, "COMPOSER", willWrite); writeErr != nil {
+							r.Error = writeErr.Error()
+							log.Printf("[WARN] scan-composer-tags %s: write failed %s: %v", opID, w.filePath, writeErr)
+						} else {
+							r.Applied = true
+							log.Printf("[INFO] scan-composer-tags %s: COMPOSER %q→%q %s", opID, composer, willWrite, w.filePath)
+						}
+					}
+				}
+
+				if opID != "" {
+					resultJSON, _ := json.Marshal(r)
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      w.filePath,
+						ResultJSON:  string(resultJSON),
+						Status:      r.Category,
+					})
+				}
+
+				atomic.AddInt64(&completed, 1)
+				mu.Lock()
+				reporter.Increment()
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	finalCount := atomic.LoadInt64(&completed)
+	log.Printf("[INFO] scan-composer-tags %s: finished %d/%d files", opID, finalCount, totalFiles)
+	reporter.Log("info", fmt.Sprintf("scan complete: processed %d/%d files", finalCount, totalFiles), nil)
+	return nil
+}
+
+// sct_result describes the COMPOSER field state for one audio file.
+type sct_result struct {
+	BookID    string `json:"book_id"`
+	BookTitle string `json:"book_title"`
+	FilePath  string `json:"file_path"`
+	Category  string `json:"category"`
+	Composer  string `json:"composer_on_disk"`
+	Author    string `json:"author,omitempty"`
+	Narrator  string `json:"narrator,omitempty"`
+	WillWrite string `json:"will_write,omitempty"`
+	Applied   bool   `json:"applied,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// sct_work is one unit of work dispatched to the parallel reader pool.
+type sct_work struct {
+	bookID    string
+	bookTitle string
+	filePath  string
+	author    string
+	narrator  string
+}
+
+// sct_categorize returns the problem category and the value that should
+// be written in the given fix_mode ("set_narrator" or "clear").
+func sct_categorize(composer, author, narrator, fixMode string) (category, willWrite string) {
+	composerLower := strings.ToLower(strings.TrimSpace(composer))
+	authorLower := strings.ToLower(strings.TrimSpace(author))
+	narratorLower := strings.ToLower(strings.TrimSpace(narrator))
+
+	if fixMode == "set_narrator" {
+		willWrite = strings.TrimSpace(narrator)
+	} else {
+		willWrite = ""
+	}
+
+	if strings.TrimSpace(composer) == "" {
+		if fixMode == "set_narrator" && strings.TrimSpace(narrator) != "" {
+			return "missing_narrator", strings.TrimSpace(narrator)
+		}
+		return "ok", ""
+	}
+
+	if author != "" && composerLower == authorLower {
+		return "composer_equals_author", willWrite
+	}
+	if narrator != "" && composerLower == narratorLower {
+		if fixMode == "set_narrator" {
+			return "ok", strings.TrimSpace(narrator)
+		}
+		return "composer_equals_narrator", ""
+	}
+	return "composer_mismatch", willWrite
+}

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duplicate_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000016-0000-0000-0000-000000000016
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&scanDuplicateFilesJob{}) }
 type scanDuplicateFilesJob struct{}
 
 func (j *scanDuplicateFilesJob) ID() string          { return "scan-duplicate-files" }
+func (j *scanDuplicateFilesJob) Name() string     { return "Scan Duplicate Files" }
+func (j *scanDuplicateFilesJob) Category() string { return "dedup" }
+func (j *scanDuplicateFilesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *scanDuplicateFilesJob) Description() string { return "Scan for book files sharing the same hash" }
 func (j *scanDuplicateFilesJob) CanResume() bool     { return false }
 func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duration_mismatch.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000018-0000-0000-0000-000000000018
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&scanDurationMismatchJob{}) }
 type scanDurationMismatchJob struct{}
 
 func (j *scanDurationMismatchJob) ID() string          { return "scan-duration-mismatch" }
+func (j *scanDurationMismatchJob) Name() string     { return "Scan Duration Mismatch" }
+func (j *scanDurationMismatchJob) Category() string { return "files" }
+func (j *scanDurationMismatchJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *scanDurationMismatchJob) Description() string { return "Report books whose local duration differs significantly from Audible runtime" }
 func (j *scanDurationMismatchJob) CanResume() bool     { return false }
 func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_metadata_hash_dups.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1000017-0000-0000-0000-000000000017
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package jobs
 
@@ -18,6 +18,9 @@ func init() { maintenance.Register(&scanMetadataHashDupsJob{}) }
 type scanMetadataHashDupsJob struct{}
 
 func (j *scanMetadataHashDupsJob) ID() string          { return "scan-metadata-hash-dups" }
+func (j *scanMetadataHashDupsJob) Name() string     { return "Scan Metadata Hash Dups" }
+func (j *scanMetadataHashDupsJob) Category() string { return "dedup" }
+func (j *scanMetadataHashDupsJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *scanMetadataHashDupsJob) Description() string { return "Scan for books sharing the same metadata source hash" }
 func (j *scanMetadataHashDupsJob) CanResume() bool     { return false }
 func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 55555555-5555-5555-5555-555555555555
-// last-edited: 2026-05-01
+// last-edited: 2026-04-28
 
 package server
 
@@ -10,6 +10,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
@@ -43,9 +45,14 @@ func (s *Server) listMaintenanceJobs(c *gin.Context) {
 		Category      string `json:"category"`
 		DefaultParams any    `json:"default_params"`
 		CanResume     bool   `json:"can_resume"`
+		Permission    string `json:"permission,omitempty"`
 	}
 	out := make([]jobDef, len(jobs))
 	for i, j := range jobs {
+		perm := string(auth.PermSettingsManage)
+		if pa, ok := j.(maintenance.PermissionAware); ok && pa.Permission() != "" {
+			perm = pa.Permission()
+		}
 		out[i] = jobDef{
 			ID:            j.ID(),
 			Name:          j.Name(),
@@ -53,6 +60,7 @@ func (s *Server) listMaintenanceJobs(c *gin.Context) {
 			Category:      j.Category(),
 			DefaultParams: j.DefaultParams(),
 			CanResume:     j.CanResume(),
+			Permission:    perm,
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{"jobs": out})
@@ -65,6 +73,23 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
+	}
+
+	// Enforce per-job access control. Jobs that implement PermissionAware use
+	// their own permission; all others default to settings.manage.
+	if config.AppConfig.EnableAuth {
+		required := auth.Permission(auth.PermSettingsManage)
+		if pa, ok := job.(maintenance.PermissionAware); ok && pa.Permission() != "" {
+			required = auth.Permission(pa.Permission())
+		}
+		if !auth.Can(c.Request.Context(), required) {
+			if _, hasUser := auth.UserFromContext(c.Request.Context()); !hasUser {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			} else {
+				c.JSON(http.StatusForbidden, gin.H{"error": "permission denied: " + string(required)})
+			}
+			return
+		}
 	}
 
 	var req struct {

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 55555555-5555-5555-5555-555555555555
-// last-edited: 2026-05-03
+// last-edited: 2026-05-01
 
 package server
 
@@ -37,16 +37,22 @@ func (a *progressAdapter) Log(level, message string, details *string) {
 func (s *Server) listMaintenanceJobs(c *gin.Context) {
 	jobs := maintenance.All()
 	type jobDef struct {
-		ID          string `json:"id"`
-		Description string `json:"description"`
-		CanResume   bool   `json:"can_resume"`
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Description   string `json:"description"`
+		Category      string `json:"category"`
+		DefaultParams any    `json:"default_params"`
+		CanResume     bool   `json:"can_resume"`
 	}
 	out := make([]jobDef, len(jobs))
 	for i, j := range jobs {
 		out[i] = jobDef{
-			ID:          j.ID(),
-			Description: j.Description(),
-			CanResume:   j.CanResume(),
+			ID:            j.ID(),
+			Name:          j.Name(),
+			Description:   j.Description(),
+			Category:      j.Category(),
+			DefaultParams: j.DefaultParams(),
+			CanResume:     j.CanResume(),
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{"jobs": out})
@@ -69,6 +75,12 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 	opID := ulid.Make().String()
 	opType := "maintenance:" + jobID
 	store := s.Store()
+
+	// Create the operation record first so it appears in active operations / activity bell.
+	if _, err := store.CreateOperation(opID, opType, nil); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create operation record"})
+		return
+	}
 
 	enqueueFn := operations.OperationFunc(func(ctx context.Context, reporter operations.ProgressReporter) error {
 		ctx = maintenance.WithOperationID(ctx, opID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2650,7 +2650,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/maintenance/backfill-file-hashes", s.perm(auth.PermSettingsManage), s.handleBackfillFileHashes)
 			protected.GET("/maintenance/book-metadata-hash-stats", s.perm(auth.PermSettingsManage), s.handleGetBookMetadataHashStats)
 			protected.GET("/maintenance/jobs", s.perm(auth.PermSettingsManage), s.listMaintenanceJobs)
-			protected.POST("/maintenance/jobs/:job_id", s.perm(auth.PermSettingsManage), s.runMaintenanceJob)
+			protected.POST("/maintenance/jobs/:job_id", s.runMaintenanceJob)
 
 			// Admin-only destructive endpoints
 			adminOnly := protected.Group("")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_test.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: b2c3d4e5-f6a7-8901-bcde-234567890abc
 
 package server
@@ -441,7 +441,7 @@ func TestBrowseFilesystem(t *testing.T) {
 		{
 			name:           "browse root",
 			queryParams:    "?path=/",
-			expectedStatus: http.StatusOK,
+			expectedStatus: http.StatusForbidden,
 		},
 		{
 			name:           "browse without path",

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -1,5 +1,5 @@
 // file: internal/util/path.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a3b2c1d-4e5f-6789-abcd-ef0123456789
 // last-edited: 2026-05-01
 
@@ -23,12 +23,6 @@ func SafeJoin(root string, parts ...string) (string, error) {
 		return "", fmt.Errorf("path %q escapes root %q", cleaned, cleanRoot)
 	}
 	return cleaned, nil
-}
-
-// CleanPath returns filepath.Clean(p). Use instead of bare filepath.Clean to
-// make intent explicit and enable easy grep for path-sanitisation call sites.
-func CleanPath(p string) string {
-	return filepath.Clean(p)
 }
 
 // WithinRoot reports whether path is equal to root or is directly contained

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -1,0 +1,40 @@
+// file: internal/util/path.go
+// version: 1.0.0
+// guid: 7a3b2c1d-4e5f-6789-abcd-ef0123456789
+// last-edited: 2026-05-01
+
+package util
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SafeJoin joins root with parts, cleans the result, and returns an error if
+// the resolved path would escape root. Use this whenever joining paths that
+// include values from user input, the database, or the filesystem.
+func SafeJoin(root string, parts ...string) (string, error) {
+	elems := append([]string{root}, parts...)
+	joined := filepath.Join(elems...)
+	cleaned := filepath.Clean(joined)
+	cleanRoot := filepath.Clean(root)
+	if cleaned != cleanRoot && !strings.HasPrefix(cleaned, cleanRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes root %q", cleaned, cleanRoot)
+	}
+	return cleaned, nil
+}
+
+// CleanPath returns filepath.Clean(p). Use instead of bare filepath.Clean to
+// make intent explicit and enable easy grep for path-sanitisation call sites.
+func CleanPath(p string) string {
+	return filepath.Clean(p)
+}
+
+// WithinRoot reports whether path is equal to root or is directly contained
+// within root. Both arguments are cleaned before comparison.
+func WithinRoot(path, root string) bool {
+	c := filepath.Clean(path)
+	r := filepath.Clean(root)
+	return c == r || strings.HasPrefix(c, r+string(filepath.Separator))
+}

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.3.0
+// version: 3.4.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useEffect, useState } from 'react';
@@ -22,6 +22,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle.js';
 import ErrorIcon from '@mui/icons-material/Error.js';
 import CancelIcon from '@mui/icons-material/Cancel.js';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew.js';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty.js';
 import {
   useOperationsStore,
   type ActiveOperation,
@@ -188,6 +189,8 @@ export function OperationsIndicator() {
   const inProgress = activeOperations.filter(
     (op) => !['completed', 'failed', 'canceled'].includes(op.status)
   );
+  const queued = inProgress.filter((op) => op.status === 'queued');
+  const running = inProgress.filter((op) => op.status !== 'queued');
   const terminal = activeOperations.filter((op) =>
     ['completed', 'failed', 'canceled'].includes(op.status)
   );
@@ -264,8 +267,48 @@ export function OperationsIndicator() {
             </Typography>
           )}
 
-          {/* Active operations */}
-          {inProgress.map((op: ActiveOperation) => {
+          {/* Queued (pending) operations */}
+          {queued.length > 0 && (
+            <>
+              <Box sx={{ px: 2, pt: 1, pb: 0.25 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontSize: '0.65rem', letterSpacing: '0.08em' }}>
+                  Pending ({queued.length})
+                </Typography>
+              </Box>
+              {queued.map((op: ActiveOperation) => (
+                <Box key={op.id} sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between', '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' } }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <HourglassEmptyIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Box>
+                      <Typography variant="body2" fontWeight="bold">{formatOperationType(op.type)}</Typography>
+                      <Typography variant="caption" color="text.secondary">Waiting to start…</Typography>
+                    </Box>
+                  </Box>
+                  <Tooltip title="Cancel">
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => handleCancel(op.id)}
+                      disabled={cancelling.has(op.id)}
+                      sx={{ p: 0.25 }}
+                    >
+                      {cancelling.has(op.id) ? <CircularProgress size={14} /> : <CancelIcon sx={{ fontSize: 18 }} />}
+                    </IconButton>
+                  </Tooltip>
+                </Box>
+              ))}
+              {running.length > 0 && (
+                <Box sx={{ px: 2, pt: 1, pb: 0.25 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontSize: '0.65rem', letterSpacing: '0.08em' }}>
+                    Running ({running.length})
+                  </Typography>
+                </Box>
+              )}
+            </>
+          )}
+
+          {/* Active (running) operations */}
+          {running.map((op: ActiveOperation) => {
             const progressPct =
               op.total > 0 ? Math.round((op.progress / op.total) * 100) : 0;
             const eta = formatETA(op);

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/system/MaintenanceTab.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-9012-cdef-345678901234
 // last-edited: 2026-05-03
 
@@ -27,6 +27,7 @@ import {
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow.js';
 import * as api from '../../services/api';
+import { useOperationsStore } from '../../stores/useOperationsStore';
 
 // ─── MaintenanceWindowCard ───────────────────────────────────────────────────
 
@@ -599,8 +600,8 @@ function ManualFixesCard() {
   const [jobs, setJobs] = useState<api.MaintenanceJobDef[]>([]);
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState<string | null>(null);
-  const [opId, setOpId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const startPolling = useOperationsStore((state) => state.startPolling);
 
   useEffect(() => {
     api.listMaintenanceJobs()
@@ -612,10 +613,10 @@ function ManualFixesCard() {
   const handleRun = async (jobId: string) => {
     setRunning(jobId);
     setError(null);
-    setOpId(null);
     try {
       const result = await api.runMaintenanceJob(jobId);
-      setOpId(result.operation_id);
+      // Register with the operations store so the bell + activity page track it
+      startPolling(result.operation_id, `maintenance:${jobId}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : `Failed to run ${jobId}`);
     } finally {
@@ -630,11 +631,6 @@ function ManualFixesCard() {
         {error && (
           <Alert severity="error" sx={{ mb: 1.5 }} onClose={() => setError(null)}>
             {error}
-          </Alert>
-        )}
-        {opId && (
-          <Alert severity="success" sx={{ mb: 1.5 }} onClose={() => setOpId(null)}>
-            Operation enqueued: {opId}
           </Alert>
         )}
         {loading ? (

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.6.0
+// version: 2.7.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -637,7 +637,12 @@ export default function ActivityLog() {
                         <Typography variant="subtitle2" fontWeight="bold">
                           {op.type.replace(/_/g, ' ')}
                         </Typography>
-                        <Chip size="small" label={op.status} color="info" />
+                        <Chip
+                          size="small"
+                          label={op.status === 'queued' ? 'pending' : op.status}
+                          color={op.status === 'queued' ? 'default' : 'info'}
+                          icon={op.status === 'queued' ? undefined : undefined}
+                        />
                       </Stack>
                       <Button
                         size="small"
@@ -650,7 +655,11 @@ export default function ActivityLog() {
                         {cancelling.has(op.id) ? 'Cancelling...' : 'Cancel'}
                       </Button>
                     </Stack>
-                    {op.total > 0 ? (
+                    {op.status === 'queued' ? (
+                      <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+                        Waiting to start…
+                      </Typography>
+                    ) : op.total > 0 ? (
                       <Box>
                         <LinearProgress variant="determinate" value={pct} sx={{ height: 6, borderRadius: 1, mb: 0.5 }} />
                         <Typography variant="caption" color="text.secondary">


### PR DESCRIPTION
## Summary

Completes the migration of all maintenance action handlers into self-registering `MaintenanceJob` implementations (matching the 22 jobs already in `internal/maintenance/jobs/`).

## New Jobs

| Job ID | File | Notes |
|--------|------|-------|
| `bulk-fetch-metadata` | `bulk_fetch_metadata.go` | **PermissionAware** — uses `PermLibraryEditMetadata`; inlines `bmf_buildSourceChain` & `bmf_stripChapterFromTitle`; DB-backed cache via `database.GetCachedMetadataFetch`/`PutCachedMetadataFetch`; 200ms rate-limit between live API calls; resumable |
| `bulk-deluge-import` | `bulk_deluge_import.go` | Imports `book_files` with `deluge_hash` into library via `io.Copy` (no reflink); Deluge client created fresh from config |
| `repair-missing-files` | `repair_missing_files.go` | 4-tier path repair (exact/stem/fuzzy/folder), 8 parallel workers, resumable |
| `relink-missing-to-itunes` | `relink_missing_to_itunes.go` | EnqueuerInjectable; re-links missing books to iTunes paths; enqueues write-back on success |
| `revert-metadata-fetch` | `revert_metadata_fetch.go` | Loads `fetch_op_ids` from stored params; reverts `fetched` change-history records |
| `scan-composer-tags` | `scan_composer_tags.go` | Parallel 8-worker COMPOSER tag scan with resume support; `fix_mode` param |
| `generate-itl-tests` | `generate_itl_tests.go` | Dev utility: generates ITL test fixtures |

## Supporting Changes

- **`internal/maintenance/job.go`** — adds optional `PermissionAware` interface; jobs that don't implement it default to `settings.manage`
- **`internal/server/maintenance_dispatcher.go`** — enforces per-job permission dynamically; exposes `permission` field in `listMaintenanceJobs` catalog response
- **`internal/server/server.go`** — removes static `PermSettingsManage` gate from `POST /maintenance/jobs/:job_id`; dispatcher handles it

## Testing

`go build ./...` and `make build-api` both pass cleanly.