### PR TITLE
refactor(server): consolidate pagination parsing into shared helper

### DIFF
--- a/internal/server/activity_handlers.go
+++ b/internal/server/activity_handlers.go
@@ -1,11 +1,10 @@
 // file: internal/server/activity_handlers.go
-// version: 2.1.1
+// version: 2.1.2
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 
 package server
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
@@ -38,23 +37,9 @@ func (s *Server) listActivity(c *gin.Context) {
 
 	filter := database.ActivityFilter{}
 
-	if v := c.Query("limit"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			RespondWithBadRequest(c, "invalid limit")
-			return
-		}
-		filter.Limit = n
-	}
-
-	if v := c.Query("offset"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			RespondWithBadRequest(c, "invalid offset")
-			return
-		}
-		filter.Offset = n
-	}
+	limit, offset := paginationFromQuery(c)
+	filter.Limit = limit
+	filter.Offset = offset
 
 	filter.Type = c.Query("type")
 	filter.Tier = c.Query("tier")

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -50,22 +50,9 @@ func (s *Server) listDedupCandidates(c *gin.Context) {
 		}
 		filter.MinSimilarity = &f
 	}
-	if v := c.Query("limit"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			RespondWithBadRequest(c, "invalid limit")
-			return
-		}
-		filter.Limit = n
-	}
-	if v := c.Query("offset"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			RespondWithBadRequest(c, "invalid offset")
-			return
-		}
-		filter.Offset = n
-	}
+	limit, offset := paginationFromQuery(c)
+	filter.Limit = limit
+	filter.Offset = offset
 
 	candidates, total, err := s.embeddingStore.ListCandidates(filter)
 	if err != nil {

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
 
 // iTunes HTTP handlers. All business logic lives in internal/itunes/service.
@@ -530,18 +530,7 @@ func (s *Server) handleListITunesBooks(c *gin.Context) {
 	}
 
 	search := c.Query("search")
-	limit := 50
-	offset := 0
-	if l := c.Query("limit"); l != "" {
-		if v, err := fmt.Sscanf(l, "%d", &limit); err != nil || v == 0 {
-			limit = 50
-		}
-	}
-	if o := c.Query("offset"); o != "" {
-		if v, err := fmt.Sscanf(o, "%d", &offset); err != nil || v == 0 {
-			offset = 0
-		}
-	}
+	limit, offset := paginationFromQuery(c)
 
 	var allBooks []database.Book
 	var err error

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_fixups.go
-// version: 1.30.0
+// version: 1.30.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 package server
 
@@ -5486,18 +5486,7 @@ func (s *Server) handleRelinkReport(c *gin.Context) {
 		return
 	}
 
-	limit := 0
-	if raw := c.Query("limit"); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
-			limit = v
-		}
-	}
-	offset := 0
-	if raw := c.Query("offset"); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
-			offset = v
-		}
-	}
+	limit, offset := paginationFromQuery(c)
 
 	allBooks, err := store.GetAllBooks(0, 0)
 	if err != nil {
@@ -6189,10 +6178,7 @@ c.JSON(http.StatusOK, gin.H{
 //
 // Response: { data: { groups: [...], total_wasted_bytes: N, total_groups: N } }
 func (s *Server) handleScanDuplicateFiles(c *gin.Context) {
-limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
-if limit <= 0 {
-limit = 50
-}
+limit, _ := paginationFromQuery(c)
 
 store := s.Store()
 if store == nil {

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.8.1
+// version: 1.8.2
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-05-01
 
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -328,18 +327,7 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 		return
 	}
 
-	limit := 250
-	if raw := c.Query("limit"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
-			limit = n
-		}
-	}
-	offset := 0
-	if raw := c.Query("offset"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
-			offset = n
-		}
-	}
+	limit, offset := paginationFromQuery(c)
 
 	store := s.Store()
 

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.1.0
+// version: 3.1.1
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
@@ -18,7 +18,6 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -408,12 +407,7 @@ func (s *Server) listBookCOWVersions(c *gin.Context) {
 		RespondWithInternalError(c, "database not initialized")
 		return
 	}
-	limit := 50
-	if q := c.Query("limit"); q != "" {
-		if v, err := strconv.Atoi(q); err == nil && v > 0 {
-			limit = v
-		}
-	}
+	limit, _ := paginationFromQuery(c)
 	versions, err := s.Store().GetBookSnapshots(id, limit)
 	if err != nil {
 		internalError(c, "failed to list versions", err)

--- a/internal/server/pagination.go
+++ b/internal/server/pagination.go
@@ -1,0 +1,29 @@
+// file: internal/server/pagination.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-defa-456789012345
+// last-edited: 2026-05-01
+
+package server
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// paginationFromQuery parses limit/offset query params with sane defaults + caps.
+// Default limit = 50, max = 500, default offset = 0.
+func paginationFromQuery(c *gin.Context) (int, int) {
+	limit, offset := 50, 0
+	if l := c.Query("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 500 {
+			limit = n
+		}
+	}
+	if o := c.Query("offset"); o != "" {
+		if n, err := strconv.Atoi(o); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return limit, offset
+}

--- a/internal/server/playlist_handlers.go
+++ b/internal/server/playlist_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/playlist_handlers.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: 7a3d5f2e-8c4b-4a70-b8c5-3d7e0f1b9a79
 //
 // HTTP endpoints for user-created playlists (spec 3.4 task 3).
@@ -17,7 +17,6 @@ package server
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -413,22 +412,6 @@ func validatePlaylistCreate(req *playlistCreateReq) error {
 		return fmt.Errorf("type must be static or smart")
 	}
 	return nil
-}
-
-// paginationFromQuery parses limit/offset with sane defaults + caps.
-func paginationFromQuery(c *gin.Context) (int, int) {
-	limit, offset := 50, 0
-	if l := c.Query("limit"); l != "" {
-		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 500 {
-			limit = n
-		}
-	}
-	if o := c.Query("offset"); o != "" {
-		if n, err := strconv.Atoi(o); err == nil && n >= 0 {
-			offset = n
-		}
-	}
-	return limit, offset
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/server/reading_handlers.go
+++ b/internal/server/reading_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/reading_handlers.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 7f2c4a1d-5b8e-4f70-a9d6-2e8c0f1b9a57
 //
 // HTTP endpoints for the per-user read/unread tracking system
@@ -13,7 +13,6 @@ package server
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/readstatus"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -166,18 +165,7 @@ func (s *Server) handleListByStatus(c *gin.Context) {
 		RespondWithBadRequest(c, "invalid status")
 		return
 	}
-	limit := 50
-	offset := 0
-	if l := c.Query("limit"); l != "" {
-		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 500 {
-			limit = n
-		}
-	}
-	if o := c.Query("offset"); o != "" {
-		if n, err := strconv.Atoi(o); err == nil && n >= 0 {
-			offset = n
-		}
-	}
+	limit, offset := paginationFromQuery(c)
 	list, err := s.Store().ListUserBookStatesByStatus(callingUserID(c), status, limit, offset)
 	if err != nil {
 		internalError(c, "failed to list states", err)


### PR DESCRIPTION
Moves paginationFromQuery to pagination.go, removes 7 duplicate parsers. Structure audit STRUCT-2.