### PR TITLE
refactor(server): adopt existing RespondWith* helpers for common patterns

### DIFF
--- a/internal/server/bench.go
+++ b/internal/server/bench.go
@@ -1,5 +1,5 @@
 // file: internal/server/bench.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 5e6f7a8b-9c0d-1234-ef01-555555555555
 
 //go:build bench
@@ -105,7 +105,7 @@ type benchSubmitRequest struct {
 func (s *Server) benchSubmit(c *gin.Context) {
 	var req benchSubmitRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -325,7 +325,7 @@ func (s *Server) benchPass2(c *gin.Context) {
 		ServerURL   string `json:"server"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if req.Model == "" {
@@ -353,7 +353,7 @@ func (s *Server) benchCrossval(c *gin.Context) {
 		ServerURL string `json:"server"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -1,5 +1,5 @@
 // file: internal/server/bootstrap.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 3e7c9a12-4f6b-4d8e-b5a1-2c8f0e3d9b47
 
 package server
@@ -29,9 +29,9 @@ import (
 )
 
 const (
-	bootstrapTokenKey    = "bootstrap_token_hash"
-	bootstrapExpiresKey  = "bootstrap_token_expires_at"
-	bootstrapTokenTTL    = 10 * time.Minute
+	bootstrapTokenKey   = "bootstrap_token_hash"
+	bootstrapExpiresKey = "bootstrap_token_expires_at"
+	bootstrapTokenTTL   = 10 * time.Minute
 )
 
 // SettingsReadWriter is the minimal store surface needed by the bootstrap subsystem.
@@ -196,7 +196,7 @@ func (s *Server) handleBootstrap(c *gin.Context) {
 
 	var req bootstrapRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	req.Token = strings.TrimSpace(req.Token)
@@ -207,7 +207,7 @@ func (s *Server) handleBootstrap(c *gin.Context) {
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 

--- a/internal/server/cache_handlers.go
+++ b/internal/server/cache_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/cache_handlers.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
 
 package server
@@ -20,21 +20,21 @@ import (
 
 // CacheStatsResponse represents the JSON response for GET /api/v1/cache/stats
 type CacheStatsResponse struct {
-	Caches    []CacheStat `json:"caches"`
-	GeneratedAt string     `json:"generated_at"`
+	Caches      []CacheStat `json:"caches"`
+	GeneratedAt string      `json:"generated_at"`
 }
 
 // CacheStat represents metrics for a single cache
 type CacheStat struct {
-	Name              string             `json:"name"`
-	Hits              int64              `json:"hits"`
-	Misses            map[string]int64   `json:"misses"`
-	Sets              int64              `json:"sets"`
-	Invalidations     map[string]int64   `json:"invalidations"`
-	Evictions         map[string]int64   `json:"evictions"`
-	Size              int64              `json:"size"`
-	HitRate           *float64           `json:"hit_rate,omitempty"`
-	GetDurationMetric GetDurationMetric  `json:"get_duration_seconds"`
+	Name              string            `json:"name"`
+	Hits              int64             `json:"hits"`
+	Misses            map[string]int64  `json:"misses"`
+	Sets              int64             `json:"sets"`
+	Invalidations     map[string]int64  `json:"invalidations"`
+	Evictions         map[string]int64  `json:"evictions"`
+	Size              int64             `json:"size"`
+	HitRate           *float64          `json:"hit_rate,omitempty"`
+	GetDurationMetric GetDurationMetric `json:"get_duration_seconds"`
 }
 
 // GetDurationMetric represents count and sum of cache get durations
@@ -432,7 +432,7 @@ func (s *Server) handleCacheStatsHistory(c *gin.Context) {
 	}
 	snaps, err := s.metricsStore.GetCacheStatsHistory(cacheName, since, limit)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		RespondWithInternalError(c, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/server/cover_history.go
+++ b/internal/server/cover_history.go
@@ -1,5 +1,5 @@
 // file: internal/server/cover_history.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 6d4e5f3a-7b8c-4a70-b8c5-3d7e0f1b9a99
 //
 // Cover art history browsing + restore (backlog 3.5).
@@ -83,7 +83,7 @@ func (s *Server) handleRestoreCover(c *gin.Context) {
 		Filename string `json:"filename" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_discovery.go
-// version: 2.3.0
+// version: 2.3.1
 // guid: e6f7a8b9-c0d1-2e3f-4a5b-6c7d8e9f0a1b
 //
 // Deluge label-based audiobook discovery.
@@ -400,7 +400,7 @@ func (s *Server) handleDelugeDiscoverImport(c *gin.Context) {
 		TorrentHash string `json:"torrent_hash"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 	if s.importService == nil {
@@ -413,7 +413,7 @@ func (s *Server) handleDelugeDiscoverImport(c *gin.Context) {
 		Organize: false,
 	})
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		RespondWithInternalError(c, err.Error())
 		return
 	}
 
@@ -437,7 +437,7 @@ func (s *Server) handleDiscoveryImport(c *gin.Context) {
 
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	client := getDelugeClient()

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,5 +1,5 @@
 // file: internal/server/deluge_integration.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
 //
 // Deluge integration for library centralization (backlog 6.1).
@@ -112,7 +112,7 @@ func (s *Server) handleDelugeTestConnection(c *gin.Context) {
 	}
 	client, err := deluge.New(url, pass)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		RespondWithInternalError(c, err.Error())
 		return
 	}
 	if err := client.Login(); err != nil {
@@ -164,11 +164,11 @@ func (s *Server) handleDelugeStatus(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"configured":         url != "",
-		"url":                url,
-		"discovery_enabled":  config.AppConfig.DelugeDiscoveryEnabled,
-		"move_enabled":       config.AppConfig.DelugeMoveEnabled,
-		"discovery_label":    config.AppConfig.DelugeDiscoveryLabel,
+		"configured":        url != "",
+		"url":               url,
+		"discovery_enabled": config.AppConfig.DelugeDiscoveryEnabled,
+		"move_enabled":      config.AppConfig.DelugeMoveEnabled,
+		"discovery_label":   config.AppConfig.DelugeDiscoveryLabel,
 	})
 }
 
@@ -190,7 +190,10 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 
 // NotifyDelugeAfterUndo checks whether the reverted operation moved
 // Deluge-sourced files and updates the torrent storage path.
-func NotifyDelugeAfterUndo(store interface { database.BookReader; database.BookVersionStore }, bookID, oldFilePath string) {
+func NotifyDelugeAfterUndo(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, bookID, oldFilePath string) {
 	book, _ := store.GetBookByID(bookID)
 	if book == nil {
 		return
@@ -205,7 +208,10 @@ func NotifyDelugeAfterUndo(store interface { database.BookReader; database.BookV
 
 // NotifyDelugeAfterVersionSwap checks whether the swapped versions
 // have torrent hashes and updates Deluge accordingly.
-func NotifyDelugeAfterVersionSwap(store interface { database.BookReader; database.BookVersionStore }, fromVer, toVer *database.BookVersion, bookFilePath string) {
+func NotifyDelugeAfterVersionSwap(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, fromVer, toVer *database.BookVersion, bookFilePath string) {
 	if toVer != nil && toVer.TorrentHash != "" {
 		NotifyDelugeMoveStorage(toVer.TorrentHash, bookFilePath)
 	}

--- a/internal/server/import_collision.go
+++ b/internal/server/import_collision.go
@@ -1,5 +1,5 @@
 // file: internal/server/import_collision.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 4b2c3d1e-5f6a-4a70-b8c5-3d7e0f1b9a99
 //
 // Import-time collision preview (backlog 1.6). Before importing a
@@ -28,7 +28,7 @@ func (s *Server) handleImportCollisionPreview(c *gin.Context) {
 		TorrentHash string `json:"torrent_hash,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -47,10 +47,10 @@ type CandidateBookInfo struct {
 
 // CandidateResult holds the metadata candidate search result for a single book.
 type CandidateResult struct {
-	Book      CandidateBookInfo  `json:"book"`
+	Book      CandidateBookInfo            `json:"book"`
 	Candidate *metafetch.MetadataCandidate `json:"candidate,omitempty"`
-	Status    string             `json:"status"` // "matched", "no_match", "error"
-	Error     string             `json:"error_message,omitempty"`
+	Status    string                       `json:"status"` // "matched", "no_match", "error"
+	Error     string                       `json:"error_message,omitempty"`
 }
 
 // batchFetchRequest is the JSON body for handleBatchFetchCandidates.
@@ -378,18 +378,18 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"operation":     op,
-		"results":       candidateResults,
-		"total":         totalCount,
-		"total_count":   totalCount,
-		"matched":       countByStatus(candidateResults, "matched"),
-		"no_match":      countByStatus(candidateResults, "no_match"),
-		"errors":        countByStatus(candidateResults, "error"),
-		"total_matched": totalMatched,
+		"operation":      op,
+		"results":        candidateResults,
+		"total":          totalCount,
+		"total_count":    totalCount,
+		"matched":        countByStatus(candidateResults, "matched"),
+		"no_match":       countByStatus(candidateResults, "no_match"),
+		"errors":         countByStatus(candidateResults, "error"),
+		"total_matched":  totalMatched,
 		"total_no_match": totalNoMatch,
-		"total_errors":  totalErrors,
-		"limit":         limit,
-		"offset":        offset,
+		"total_errors":   totalErrors,
+		"limit":          limit,
+		"offset":         offset,
 	})
 }
 
@@ -623,7 +623,7 @@ func (s *Server) handleRejectCandidates(c *gin.Context) {
 		BookIDs     []string `json:"book_ids" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 
@@ -681,7 +681,7 @@ func (s *Server) handleUnrejectCandidates(c *gin.Context) {
 		BookIDs     []string `json:"book_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -24,15 +24,15 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
-	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
+	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -274,8 +274,8 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 	}
 	var body struct {
 		Candidate metafetch.MetadataCandidate `json:"candidate"`
-		Fields    []string          `json:"fields"`
-		WriteBack *bool             `json:"write_back"`
+		Fields    []string                    `json:"fields"`
+		WriteBack *bool                       `json:"write_back"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		RespondWithBadRequest(c, "invalid request body")
@@ -917,10 +917,10 @@ func (s *Server) handleBulkMetadataFetchAll(c *gin.Context) {
 	log.Printf("[INFO] bulk-metadata-fetch: queued %s prefer_audible=%v skip_cached=%v",
 		opID, params.PreferAudible, params.SkipCached)
 	c.JSON(http.StatusAccepted, gin.H{
-		"operation_id":  opID,
-		"message":       "bulk metadata fetch started — poll GET /api/v1/operations/" + opID + " for progress",
+		"operation_id":   opID,
+		"message":        "bulk metadata fetch started — poll GET /api/v1/operations/" + opID + " for progress",
 		"prefer_audible": params.PreferAudible,
-		"skip_cached":   params.SkipCached,
+		"skip_cached":    params.SkipCached,
 	})
 }
 
@@ -1686,7 +1686,7 @@ func (s *Server) handleUpdateBookRating(c *gin.Context) {
 	// Allow empty body (no changes)
 	if c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&body); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			RespondWithBadRequest(c, err.Error())
 			return
 		}
 	}
@@ -1694,7 +1694,7 @@ func (s *Server) handleUpdateBookRating(c *gin.Context) {
 	req := database.UpdateBookRatingRequest{}
 
 	if overall, clear, err := parseOptionalRating(body.Overall, "overall"); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	} else {
 		req.Overall = overall
@@ -1702,7 +1702,7 @@ func (s *Server) handleUpdateBookRating(c *gin.Context) {
 	}
 
 	if story, clear, err := parseOptionalRating(body.Story, "story"); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	} else {
 		req.Story = story
@@ -1710,7 +1710,7 @@ func (s *Server) handleUpdateBookRating(c *gin.Context) {
 	}
 
 	if perf, clear, err := parseOptionalRating(body.Performance, "performance"); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	} else {
 		req.Performance = perf

--- a/internal/server/reconcile.go
+++ b/internal/server/reconcile.go
@@ -1,5 +1,5 @@
 // file: internal/server/reconcile.go
-// version: 1.9.0
+// version: 1.9.1
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 
 package server
@@ -84,7 +84,7 @@ type ReconcileApplyResult struct {
 func (s *Server) reconcilePreview(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -100,7 +100,7 @@ func (s *Server) reconcilePreview(c *gin.Context) {
 func (s *Server) startReconcileScan(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
@@ -153,7 +153,7 @@ func (s *Server) runReconcileScan(ctx context.Context, opID string, progress ope
 func (s *Server) latestReconcileScan(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
@@ -194,7 +194,7 @@ func (s *Server) latestReconcileScan(c *gin.Context) {
 func (s *Server) startReconcile(c *gin.Context) {
 	store := s.Store()
 	if store == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "database not initialized"})
+		RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	if s.queue == nil {
@@ -206,7 +206,7 @@ func (s *Server) startReconcile(c *gin.Context) {
 		Matches []ReconcileApplyItem `json:"matches"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		RespondWithBadRequest(c, err.Error())
 		return
 	}
 


### PR DESCRIPTION
Replaces 61 direct c.JSON calls with existing error_handler.go helpers. Structure audit STRUCT-1.