### PR TITLE
refactor(ai): extract shared retry/backoff helper

### DIFF
--- a/internal/ai/retry.go
+++ b/internal/ai/retry.go
@@ -1,0 +1,36 @@
+// file: internal/ai/retry.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-2345-fabc-678901234567
+// last-edited: 2026-05-01
+
+package ai
+
+import (
+	"context"
+	"time"
+)
+
+// withRetry calls fn up to maxRetries+1 times with quadratic backoff.
+// Backoff formula: attempt^2 * 2 seconds (attempt 1: 2s, attempt 2: 8s, attempt 3: 18s, etc).
+// Returns result on first success. Respects ctx cancellation.
+// Generic return type T supports callers with different result types.
+func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error)) (T, error) {
+	var lastErr error
+	var zero T
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(attempt*attempt) * 2 * time.Second
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+	}
+	return zero, lastErr
+}


### PR DESCRIPTION
Adds ai/retry.go with withRetry() generic function to replace duplicated retry logic in openai_parser.go, metadata_llm_review.go, and embedding_client.go. Uses quadratic backoff (attempt^2 * 2s) with context cancellation support. Part of STRUCT-5 structure audit. Call-site replacement in follow-up task STRUCT-5b.