### PR TITLE
refactor(web): split Library and BookDedup into sub-components (STRUCT-9)

### DIFF
--- a/web/src/components/dedup/DedupBookTab.tsx
+++ b/web/src/components/dedup/DedupBookTab.tsx
@@ -1,0 +1,268 @@
+// file: web/src/components/dedup/DedupBookTab.tsx
+// version: 1.0.0
+// guid: 71F51230-1BB6-4864-A1EB-120EE776D673
+// last-edited: 2026-05-01
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Button,
+  Alert,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Card,
+  CardContent,
+  CardActions,
+  Stack,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  Checkbox,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Divider,
+} from '@mui/material';
+import MergeIcon from '@mui/icons-material/MergeType';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import FolderIcon from '@mui/icons-material/Folder';
+import * as api from '../../services/api';
+import type { Book, Operation } from '../../services/api';
+import {
+  cleanDisplayTitle,
+  OperationProgress,
+  usePagination,
+  PaginationControls,
+  runOperationWithPolling,
+} from './dedupHelpers';
+
+export function DedupBookTab() {
+  const [groups, setGroups] = useState<Book[][]>([]);
+  const [totalDuplicates, setTotalDuplicates] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeOp, setActiveOp] = useState<Operation | null>(null);
+  const [mergeSuccess, setMergeSuccess] = useState<string | null>(null);
+  const [keepSelections, setKeepSelections] = useState<Record<string, string>>({});
+  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const pagination = usePagination(groups.length);
+
+  const fetchDuplicates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.getBookDuplicates();
+      setGroups(data.groups || []);
+      setTotalDuplicates(data.duplicate_count || 0);
+      const defaults: Record<string, string> = {};
+      (data.groups || []).forEach((g, i) => {
+        if (g.length > 0) defaults[`group-${i}`] = g[0].id;
+      });
+      setKeepSelections(defaults);
+      setSelectedGroups(new Set());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch duplicates');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchDuplicates(); }, [fetchDuplicates]);
+
+  const handleMerge = async (group: Book[], groupKey: string) => {
+    const keepId = keepSelections[groupKey];
+    if (!keepId) return;
+    const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
+    setMergeSuccess(null);
+    await runOperationWithPolling(
+      () => api.mergeBooks(keepId, mergeIds),
+      setActiveOp,
+      (final) => {
+        if (final.status === 'failed') {
+          setError(final.error_message || 'Merge failed');
+        } else {
+          setMergeSuccess(`Merged duplicates of "${group[0]?.title}"`);
+          setGroups((prev) => prev.filter((_, i) => `group-${i}` !== groupKey));
+          setSelectedGroups((prev) => { const next = new Set(prev); next.delete(groupKey); return next; });
+        }
+      },
+      setError,
+    );
+  };
+
+  const handleMergeSelected = async () => {
+    setMergeSuccess(null);
+    for (let i = 0; i < groups.length; i++) {
+      const groupKey = `group-${i}`;
+      if (!selectedGroups.has(groupKey)) continue;
+      const group = groups[i];
+      const keepId = keepSelections[groupKey];
+      if (!keepId) continue;
+      const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
+      try {
+        const initial = await api.mergeBooks(keepId, mergeIds);
+        setActiveOp(initial);
+        await api.pollOperation(initial.id, (update) => setActiveOp(update));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : `Failed to merge "${group[0]?.title}"`);
+      }
+    }
+    setActiveOp(null);
+    setMergeSuccess(`Merged ${selectedGroups.size} selected group(s)`);
+    fetchDuplicates();
+  };
+
+  const handleMergeAll = async () => {
+    setConfirmOpen(false);
+    setMergeSuccess(null);
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i];
+      const groupKey = `group-${i}`;
+      const keepId = keepSelections[groupKey];
+      if (!keepId) continue;
+      const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
+      try {
+        const initial = await api.mergeBooks(keepId, mergeIds);
+        setActiveOp(initial);
+        await api.pollOperation(initial.id, (update) => setActiveOp(update));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : `Failed to merge "${group[0]?.title}"`);
+      }
+    }
+    setActiveOp(null);
+    setMergeSuccess('Merged all duplicate books');
+    fetchDuplicates();
+  };
+
+  const toggleGroup = (key: string) => {
+    setSelectedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selectedGroups.size === groups.length) {
+      setSelectedGroups(new Set());
+    } else {
+      setSelectedGroups(new Set(groups.map((_, i) => `group-${i}`)));
+    }
+  };
+
+  const busy = activeOp !== null;
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ flexGrow: 1 }}>
+          Detects books with identical titles and authors at different file paths.
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          {groups.length > 0 && (
+            <>
+              <Button size="small" onClick={toggleAll} disabled={busy}>
+                {selectedGroups.size === groups.length ? 'Deselect All' : 'Select All'}
+              </Button>
+              {selectedGroups.size > 0 && (
+                <Button variant="contained" color="primary" startIcon={<MergeIcon />}
+                  onClick={handleMergeSelected} disabled={busy}>
+                  Merge Selected ({selectedGroups.size})
+                </Button>
+              )}
+              <Button variant="contained" color="warning" startIcon={<MergeIcon />}
+                onClick={() => setConfirmOpen(true)} disabled={busy}>
+                Merge All ({totalDuplicates})
+              </Button>
+            </>
+          )}
+          <Tooltip title="Refresh"><IconButton onClick={fetchDuplicates} disabled={loading || busy}><RefreshIcon /></IconButton></Tooltip>
+        </Stack>
+      </Box>
+
+      <OperationProgress operation={activeOp} />
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>{error}</Alert>}
+      {mergeSuccess && <Alert severity="success" sx={{ mb: 2 }} icon={<CheckCircleIcon />} onClose={() => setMergeSuccess(null)}>{mergeSuccess}</Alert>}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}><CircularProgress /></Box>
+      ) : groups.length === 0 ? (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 1 }} />
+          <Typography variant="h6">No duplicate books found</Typography>
+        </Paper>
+      ) : (
+        <>
+        <PaginationControls total={groups.length} page={pagination.page} rowsPerPage={pagination.rowsPerPage}
+          onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
+        <Stack spacing={2}>
+          {groups.slice(pagination.startIdx, pagination.endIdx).map((group, sliceIdx) => {
+            const idx = pagination.startIdx + sliceIdx;
+            const groupKey = `group-${idx}`;
+            return (
+              <Card key={groupKey} variant="outlined">
+                <CardContent>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Checkbox
+                      checked={selectedGroups.has(groupKey)}
+                      onChange={() => toggleGroup(groupKey)}
+                      disabled={busy}
+                      size="small"
+                    />
+                    <Typography variant="subtitle1" fontWeight="bold">{cleanDisplayTitle(group[0]?.title || 'Unknown')}</Typography>
+                    <Chip label={`${group.length} copies`} size="small" color="warning" variant="outlined" />
+                  </Box>
+                  <Divider sx={{ my: 1 }} />
+                  <RadioGroup value={keepSelections[groupKey] || ''}
+                    onChange={(e) => setKeepSelections((prev) => ({ ...prev, [groupKey]: e.target.value }))}>
+                    {group.map((book) => (
+                      <FormControlLabel key={book.id} value={book.id} control={<Radio size="small" />}
+                        label={
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <FolderIcon fontSize="small" color="action" />
+                            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{book.file_path}</Typography>
+                            {book.itunes_persistent_id && <Chip label="iTunes" size="small" color="info" variant="outlined" />}
+                            {book.format && <Chip label={book.format} size="small" variant="outlined" />}
+                          </Box>
+                        } />
+                    ))}
+                  </RadioGroup>
+                </CardContent>
+                <CardActions>
+                  <Button startIcon={<MergeIcon />} variant="contained" size="small"
+                    onClick={() => handleMerge(group, groupKey)} disabled={busy}>
+                    Merge
+                  </Button>
+                </CardActions>
+              </Card>
+            );
+          })}
+        </Stack>
+        <PaginationControls total={groups.length} page={pagination.page} rowsPerPage={pagination.rowsPerPage}
+          onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
+        </>
+      )}
+
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle>Confirm Merge All</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will merge {groups.length} groups. This action cannot be undone. Are you sure?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+          <Button onClick={handleMergeAll} color="warning" variant="contained">Confirm</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/web/src/components/dedup/dedupHelpers.tsx
+++ b/web/src/components/dedup/dedupHelpers.tsx
@@ -1,0 +1,95 @@
+// file: web/src/components/dedup/dedupHelpers.tsx
+// version: 1.0.0
+// guid: 8C089ABB-8110-41B2-A660-7064FB18C63A
+// last-edited: 2026-05-01
+
+import { useState, useEffect } from 'react';
+import {
+  Paper,
+  Stack,
+  Box,
+  Typography,
+  LinearProgress,
+  TablePagination,
+} from '@mui/material';
+import * as api from '../../services/api';
+import type { Operation } from '../../services/api';
+
+export function cleanDisplayTitle(title: string): string {
+  return title
+    .replace(/\s*\((un)?abridged\)/gi, '')
+    .replace(/^\[.*?\]\s*/g, '')
+    .trim();
+}
+
+export function OperationProgress({ operation, label }: { operation: Operation | null; label?: string }) {
+  if (!operation || operation.status === 'completed' || operation.status === 'failed' || operation.status === 'cancelled') return null;
+  const pct = operation.total > 0 ? Math.round((operation.progress / operation.total) * 100) : 0;
+  return (
+    <Paper sx={{ p: 2, mb: 2 }}>
+      <Stack spacing={1}>
+        {label && <Typography variant="caption" color="text.secondary" fontWeight="bold">{label}</Typography>}
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="body2">{operation.message || 'Processing...'}</Typography>
+          <Typography variant="caption">{pct}%</Typography>
+        </Box>
+        <LinearProgress variant={operation.total > 0 ? 'determinate' : 'indeterminate'} value={pct} />
+      </Stack>
+    </Paper>
+  );
+}
+
+export async function runOperationWithPolling(
+  startFn: () => Promise<Operation>,
+  setOp: (op: Operation | null) => void,
+  onComplete: (op: Operation) => void,
+  onError: (msg: string) => void,
+) {
+  try {
+    const initial = await startFn();
+    setOp(initial);
+    const final = await api.pollOperation(initial.id, (update) => setOp(update));
+    setOp(null);
+    onComplete(final);
+  } catch (err) {
+    setOp(null);
+    onError(err instanceof Error ? err.message : 'Operation failed');
+  }
+}
+
+export const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+export function usePagination(totalItems: number) {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
+
+  useEffect(() => { setPage(0); }, [totalItems]);
+
+  const startIdx = page * rowsPerPage;
+  const endIdx = startIdx + rowsPerPage;
+
+  return { page, setPage, rowsPerPage, setRowsPerPage, startIdx, endIdx };
+}
+
+export function PaginationControls({ total, page, rowsPerPage, onPageChange, onRowsPerPageChange }: {
+  total: number;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (page: number) => void;
+  onRowsPerPageChange: (rpp: number) => void;
+}) {
+  if (total <= PAGE_SIZE_OPTIONS[0]) return null;
+  return (
+    <TablePagination
+      component="div"
+      count={total}
+      page={page}
+      onPageChange={(_, p) => onPageChange(p)}
+      rowsPerPage={rowsPerPage}
+      onRowsPerPageChange={(e) => { onRowsPerPageChange(parseInt(e.target.value, 10)); onPageChange(0); }}
+      rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+      labelRowsPerPage="Groups per page:"
+      sx={{ mt: 2 }}
+    />
+  );
+}

--- a/web/src/components/library/LibrarySoftDeletedSection.tsx
+++ b/web/src/components/library/LibrarySoftDeletedSection.tsx
@@ -1,0 +1,158 @@
+// file: web/src/components/library/LibrarySoftDeletedSection.tsx
+// version: 1.0.0
+// guid: 26804E8D-51BA-462C-9BBE-45ED69E17B9F
+// last-edited: 2026-05-01
+
+import {
+  Paper,
+  Stack,
+  Typography,
+  Button,
+  Chip,
+  Collapse,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
+import type { Audiobook } from '../../types';
+
+export interface LibrarySoftDeletedSectionProps {
+  softDeletedCount: number;
+  softDeletedBooks: Audiobook[];
+  softDeletedLoading: boolean;
+  softDeletedExpanded: boolean;
+  restoringBookId: string | null;
+  purgeInProgress: boolean;
+  purgingBookId: string | null;
+  onToggleExpanded: () => void;
+  onRefresh: () => void;
+  onRestoreOne: (book: Audiobook) => void;
+  onPurgeOne: (book: Audiobook) => void;
+}
+
+export function LibrarySoftDeletedSection({
+  softDeletedCount,
+  softDeletedBooks,
+  softDeletedLoading,
+  softDeletedExpanded,
+  restoringBookId,
+  purgeInProgress,
+  purgingBookId,
+  onToggleExpanded,
+  onRefresh,
+  onRestoreOne,
+  onPurgeOne,
+}: LibrarySoftDeletedSectionProps) {
+  return (
+    <Paper sx={{ p: 2, mt: 3 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        spacing={2}
+        sx={{ cursor: 'pointer' }}
+        onClick={onToggleExpanded}
+      >
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <ExpandMoreIcon
+            sx={{
+              transform: softDeletedExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s',
+            }}
+          />
+          <Typography variant="h6">Soft-Deleted Books</Typography>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Chip
+            label={`${softDeletedCount} ${softDeletedCount === 1 ? 'item' : 'items'}`}
+            color={softDeletedCount > 0 ? 'warning' : 'default'}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRefresh();
+            }}
+            disabled={softDeletedLoading}
+          >
+            {softDeletedLoading ? 'Refreshing...' : 'Refresh'}
+          </Button>
+        </Stack>
+      </Stack>
+      <Collapse in={softDeletedExpanded}>
+        {softDeletedLoading ? (
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            Loading soft-deleted books...
+          </Typography>
+        ) : softDeletedBooks.length === 0 ? (
+          <Alert severity="info" sx={{ mt: 2 }}>
+            No soft-deleted books at the moment.
+          </Alert>
+        ) : (
+          <List dense sx={{ mt: 1 }}>
+            {softDeletedBooks.map((book) => {
+              const deletedAt =
+                book.marked_for_deletion_at && new Date(book.marked_for_deletion_at);
+              return (
+                <ListItem key={book.id} alignItems="flex-start">
+                  <ListItemText
+                    primary={book.title || 'Untitled'}
+                    secondary={
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2" color="text.secondary">
+                          {book.author || 'Unknown Author'}
+                        </Typography>
+                        {deletedAt && (
+                          <Typography variant="caption" color="text.secondary">
+                            Soft deleted at {deletedAt.toLocaleString()}
+                          </Typography>
+                        )}
+                        {book.file_path && (
+                          <Typography variant="caption" color="text.secondary">
+                            {book.file_path}
+                          </Typography>
+                        )}
+                      </Stack>
+                    }
+                  />
+                  <ListItemSecondaryAction>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      sx={{ mr: 1 }}
+                      onClick={() => onRestoreOne(book)}
+                      disabled={
+                        restoringBookId === book.id ||
+                        purgeInProgress ||
+                        purgingBookId === book.id
+                      }
+                    >
+                      {restoringBookId === book.id ? 'Restoring...' : 'Restore'}
+                    </Button>
+                    <Button
+                      size="small"
+                      color="error"
+                      variant="outlined"
+                      onClick={() => onPurgeOne(book)}
+                      disabled={purgingBookId === book.id || purgeInProgress}
+                    >
+                      {purgingBookId === book.id ? 'Purging...' : 'Purge now'}
+                    </Button>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+      </Collapse>
+    </Paper>
+  );
+}

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.17.0
+// version: 3.18.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
@@ -22,8 +22,6 @@ import {
   CardContent,
   CardActions,
   Stack,
-  Radio,
-  RadioGroup,
   FormControlLabel,
   Tab,
   Tabs,
@@ -68,6 +66,7 @@ import MicIcon from '@mui/icons-material/Mic';
 import BusinessIcon from '@mui/icons-material/Business';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import type { SuggestionRoles } from '../services/api';
+import { DedupBookTab } from '../components/dedup/DedupBookTab';
 
 /** Strip "(Unabridged)", "(Abridged)", and leading "[Series X]" from display titles */
 function cleanDisplayTitle(title: string): string {
@@ -291,229 +290,7 @@ function PaginationControls({ total, page, rowsPerPage, onPageChange, onRowsPerP
 }
 
 // ---- Book Dedup Tab ----
-function BookDedupTab() {
-  const [groups, setGroups] = useState<Book[][]>([]);
-  const [totalDuplicates, setTotalDuplicates] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [activeOp, setActiveOp] = useState<Operation | null>(null);
-  const [mergeSuccess, setMergeSuccess] = useState<string | null>(null);
-  const [keepSelections, setKeepSelections] = useState<Record<string, string>>({});
-  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const pagination = usePagination(groups.length);
-
-  const fetchDuplicates = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await api.getBookDuplicates();
-      setGroups(data.groups || []);
-      setTotalDuplicates(data.duplicate_count || 0);
-      const defaults: Record<string, string> = {};
-      (data.groups || []).forEach((g, i) => {
-        if (g.length > 0) defaults[`group-${i}`] = g[0].id;
-      });
-      setKeepSelections(defaults);
-      setSelectedGroups(new Set());
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch duplicates');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => { fetchDuplicates(); }, [fetchDuplicates]);
-
-  const handleMerge = async (group: Book[], groupKey: string) => {
-    const keepId = keepSelections[groupKey];
-    if (!keepId) return;
-    const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
-    setMergeSuccess(null);
-    await runOperationWithPolling(
-      () => api.mergeBooks(keepId, mergeIds),
-      setActiveOp,
-      (final) => {
-        if (final.status === 'failed') {
-          setError(final.error_message || 'Merge failed');
-        } else {
-          setMergeSuccess(`Merged duplicates of "${group[0]?.title}"`);
-          setGroups((prev) => prev.filter((_, i) => `group-${i}` !== groupKey));
-          setSelectedGroups((prev) => { const next = new Set(prev); next.delete(groupKey); return next; });
-        }
-      },
-      setError,
-    );
-  };
-
-  const handleMergeSelected = async () => {
-    setMergeSuccess(null);
-    for (let i = 0; i < groups.length; i++) {
-      const groupKey = `group-${i}`;
-      if (!selectedGroups.has(groupKey)) continue;
-      const group = groups[i];
-      const keepId = keepSelections[groupKey];
-      if (!keepId) continue;
-      const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
-      try {
-        const initial = await api.mergeBooks(keepId, mergeIds);
-        setActiveOp(initial);
-        await api.pollOperation(initial.id, (update) => setActiveOp(update));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : `Failed to merge "${group[0]?.title}"`);
-      }
-    }
-    setActiveOp(null);
-    setMergeSuccess(`Merged ${selectedGroups.size} selected group(s)`);
-    fetchDuplicates();
-  };
-
-  const handleMergeAll = async () => {
-    setConfirmOpen(false);
-    setMergeSuccess(null);
-    for (let i = 0; i < groups.length; i++) {
-      const group = groups[i];
-      const groupKey = `group-${i}`;
-      const keepId = keepSelections[groupKey];
-      if (!keepId) continue;
-      const mergeIds = group.filter((b) => b.id !== keepId).map((b) => b.id);
-      try {
-        const initial = await api.mergeBooks(keepId, mergeIds);
-        setActiveOp(initial);
-        await api.pollOperation(initial.id, (update) => setActiveOp(update));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : `Failed to merge "${group[0]?.title}"`);
-      }
-    }
-    setActiveOp(null);
-    setMergeSuccess('Merged all duplicate books');
-    fetchDuplicates();
-  };
-
-  const toggleGroup = (key: string) => {
-    setSelectedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key); else next.add(key);
-      return next;
-    });
-  };
-
-  const toggleAll = () => {
-    if (selectedGroups.size === groups.length) {
-      setSelectedGroups(new Set());
-    } else {
-      setSelectedGroups(new Set(groups.map((_, i) => `group-${i}`)));
-    }
-  };
-
-  const busy = activeOp !== null;
-
-  return (
-    <Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <Typography variant="body2" color="text.secondary" sx={{ flexGrow: 1 }}>
-          Detects books with identical titles and authors at different file paths.
-        </Typography>
-        <Stack direction="row" spacing={1}>
-          {groups.length > 0 && (
-            <>
-              <Button size="small" onClick={toggleAll} disabled={busy}>
-                {selectedGroups.size === groups.length ? 'Deselect All' : 'Select All'}
-              </Button>
-              {selectedGroups.size > 0 && (
-                <Button variant="contained" color="primary" startIcon={<MergeIcon />}
-                  onClick={handleMergeSelected} disabled={busy}>
-                  Merge Selected ({selectedGroups.size})
-                </Button>
-              )}
-              <Button variant="contained" color="warning" startIcon={<MergeIcon />}
-                onClick={() => setConfirmOpen(true)} disabled={busy}>
-                Merge All ({totalDuplicates})
-              </Button>
-            </>
-          )}
-          <Tooltip title="Refresh"><IconButton onClick={fetchDuplicates} disabled={loading || busy}><RefreshIcon /></IconButton></Tooltip>
-        </Stack>
-      </Box>
-
-      <OperationProgress operation={activeOp} />
-      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>{error}</Alert>}
-      {mergeSuccess && <Alert severity="success" sx={{ mb: 2 }} icon={<CheckCircleIcon />} onClose={() => setMergeSuccess(null)}>{mergeSuccess}</Alert>}
-
-      {loading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}><CircularProgress /></Box>
-      ) : groups.length === 0 ? (
-        <Paper sx={{ p: 4, textAlign: 'center' }}>
-          <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 1 }} />
-          <Typography variant="h6">No duplicate books found</Typography>
-        </Paper>
-      ) : (
-        <>
-        <PaginationControls total={groups.length} page={pagination.page} rowsPerPage={pagination.rowsPerPage}
-          onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
-        <Stack spacing={2}>
-          {groups.slice(pagination.startIdx, pagination.endIdx).map((group, sliceIdx) => {
-            const idx = pagination.startIdx + sliceIdx;
-            const groupKey = `group-${idx}`;
-            return (
-              <Card key={groupKey} variant="outlined">
-                <CardContent>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                    <Checkbox
-                      checked={selectedGroups.has(groupKey)}
-                      onChange={() => toggleGroup(groupKey)}
-                      disabled={busy}
-                      size="small"
-                    />
-                    <Typography variant="subtitle1" fontWeight="bold">{cleanDisplayTitle(group[0]?.title || 'Unknown')}</Typography>
-                    <Chip label={`${group.length} copies`} size="small" color="warning" variant="outlined" />
-                  </Box>
-                  <Divider sx={{ my: 1 }} />
-                  <RadioGroup value={keepSelections[groupKey] || ''}
-                    onChange={(e) => setKeepSelections((prev) => ({ ...prev, [groupKey]: e.target.value }))}>
-                    {group.map((book) => (
-                      <FormControlLabel key={book.id} value={book.id} control={<Radio size="small" />}
-                        label={
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <FolderIcon fontSize="small" color="action" />
-                            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{book.file_path}</Typography>
-                            {book.itunes_persistent_id && <Chip label="iTunes" size="small" color="info" variant="outlined" />}
-                            {book.format && <Chip label={book.format} size="small" variant="outlined" />}
-                          </Box>
-                        } />
-                    ))}
-                  </RadioGroup>
-                </CardContent>
-                <CardActions>
-                  <Button startIcon={<MergeIcon />} variant="contained" size="small"
-                    onClick={() => handleMerge(group, groupKey)} disabled={busy}>
-                    Merge
-                  </Button>
-                </CardActions>
-              </Card>
-            );
-          })}
-        </Stack>
-        <PaginationControls total={groups.length} page={pagination.page} rowsPerPage={pagination.rowsPerPage}
-          onPageChange={pagination.setPage} onRowsPerPageChange={pagination.setRowsPerPage} />
-        </>
-      )}
-
-      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle>Confirm Merge All</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            This will merge {groups.length} groups. This action cannot be undone. Are you sure?
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
-          <Button onClick={handleMergeAll} color="warning" variant="contained">Confirm</Button>
-        </DialogActions>
-      </Dialog>
-    </Box>
-  );
-}
+// Moved to web/src/components/dedup/DedupBookTab.tsx
 
 // ---- Advanced Book Dedup Scan Tab ----
 function BookDedupScanTab() {
@@ -3644,7 +3421,7 @@ export function BookDedup() {
         <Tab icon={<Badge color="default"><FingerprintIcon /></Badge>} label="Embedding" iconPosition="start" />
       </Tabs>
 
-      {tab === 0 && <BookDedupTab />}
+      {tab === 0 && <DedupBookTab />}
       {tab === 1 && <BookDedupScanTab />}
       {tab === 2 && <AuthorDedupTab />}
       {tab === 3 && <SeriesDedupTab />}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.54.0
+// version: 1.55.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -55,6 +55,7 @@ import { FilterPanel } from '../components/FilterPanel';
 import { BookGrid } from '../components/BookGrid';
 import { BatchToolbar } from '../components/BatchToolbar';
 import { ServerFileBrowser } from '../components/common/ServerFileBrowser';
+import { LibrarySoftDeletedSection } from '../components/library/LibrarySoftDeletedSection';
 import { MetadataEditDialog } from '../components/audiobooks/MetadataEditDialog';
 import { BatchEditDialog } from '../components/audiobooks/BatchEditDialog';
 import { VersionManagement } from '../components/audiobooks/VersionManagement';
@@ -2368,110 +2369,19 @@ export const Library = () => {
           </Stack>
         )}
 
-        <Paper sx={{ p: 2, mt: 3 }}>
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            spacing={2}
-            sx={{ cursor: 'pointer' }}
-            onClick={() => setSoftDeletedExpanded(!softDeletedExpanded)}
-          >
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <ExpandMoreIcon
-                sx={{
-                  transform: softDeletedExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                  transition: 'transform 0.2s',
-                }}
-              />
-              <Typography variant="h6">Soft-Deleted Books</Typography>
-            </Stack>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Chip
-                label={`${softDeletedCount} ${softDeletedCount === 1 ? 'item' : 'items'}`}
-                color={softDeletedCount > 0 ? 'warning' : 'default'}
-              />
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<RefreshIcon />}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  loadSoftDeleted();
-                }}
-                disabled={softDeletedLoading}
-              >
-                {softDeletedLoading ? 'Refreshing...' : 'Refresh'}
-              </Button>
-            </Stack>
-          </Stack>
-          <Collapse in={softDeletedExpanded}>
-            {softDeletedLoading ? (
-              <Typography variant="body2" sx={{ mt: 2 }}>
-                Loading soft-deleted books...
-              </Typography>
-            ) : softDeletedBooks.length === 0 ? (
-              <Alert severity="info" sx={{ mt: 2 }}>
-                No soft-deleted books at the moment.
-              </Alert>
-            ) : (
-              <List dense sx={{ mt: 1 }}>
-                {softDeletedBooks.map((book) => {
-                  const deletedAt =
-                    book.marked_for_deletion_at && new Date(book.marked_for_deletion_at);
-                  return (
-                    <ListItem key={book.id} alignItems="flex-start">
-                      <ListItemText
-                        primary={book.title || 'Untitled'}
-                        secondary={
-                          <Stack spacing={0.5}>
-                            <Typography variant="body2" color="text.secondary">
-                              {book.author || 'Unknown Author'}
-                            </Typography>
-                            {deletedAt && (
-                              <Typography variant="caption" color="text.secondary">
-                                Soft deleted at {deletedAt.toLocaleString()}
-                              </Typography>
-                            )}
-                            {book.file_path && (
-                              <Typography variant="caption" color="text.secondary">
-                                {book.file_path}
-                              </Typography>
-                            )}
-                          </Stack>
-                        }
-                      />
-                      <ListItemSecondaryAction>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          sx={{ mr: 1 }}
-                          onClick={() => handleRestoreOne(book)}
-                          disabled={
-                            restoringBookId === book.id ||
-                            purgeInProgress ||
-                            purgingBookId === book.id
-                          }
-                        >
-                          {restoringBookId === book.id ? 'Restoring...' : 'Restore'}
-                        </Button>
-                        <Button
-                          size="small"
-                          color="error"
-                          variant="outlined"
-                          onClick={() => handlePurgeOne(book)}
-                          disabled={purgingBookId === book.id || purgeInProgress}
-                        >
-                          {purgingBookId === book.id ? 'Purging...' : 'Purge now'}
-                        </Button>
-                      </ListItemSecondaryAction>
-                    </ListItem>
-                  );
-                })}
-              </List>
-            )}
-          </Collapse>
-        </Paper>
+        <LibrarySoftDeletedSection
+          softDeletedCount={softDeletedCount}
+          softDeletedBooks={softDeletedBooks}
+          softDeletedLoading={softDeletedLoading}
+          softDeletedExpanded={softDeletedExpanded}
+          restoringBookId={restoringBookId}
+          purgeInProgress={purgeInProgress}
+          purgingBookId={purgingBookId}
+          onToggleExpanded={() => setSoftDeletedExpanded(!softDeletedExpanded)}
+          onRefresh={loadSoftDeleted}
+          onRestoreOne={handleRestoreOne}
+          onPurgeOne={handlePurgeOne}
+        />
 
         <FilterSidebar
           open={filterOpen}


### PR DESCRIPTION
Extracts sub-components from the two largest frontend page files to improve maintainability and code organization.

## Progress

### Completed
- ✅ LibrarySoftDeletedSection from Library.tsx
- ✅ DedupBookTab from BookDedup.tsx  
- ✅ dedupHelpers.tsx with shared utilities

### Remaining
- ⏳ DedupAdvancedScanTab
- ⏳ DedupAuthorTab
- ⏳ DedupSeriesTab
- ⏳ DedupReconcileTab
- ⏳ Library toolbar/dialogs components (complex, may split into follow-up PR)

## Impact

- Library.tsx: 3333→3243 lines (-90 lines, -2.7%)
- BookDedup.tsx: 3656→3424 lines (-232 lines, -6.3%)

## Testing

- ✅ TypeScript compilation clean
- ✅ Vite build successful
- ✅ No logic or state changes

Related: Structure audit STRUCT-9

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>