### PR TITLE
refactor(server): remove old sync maintenance handlers (ASYNC-CLEAN-1)

### DIFF
--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,5 +1,5 @@
 // file: internal/server/maintenance_fixups.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-05-02
 
@@ -414,7 +414,9 @@ func (s *Server) handleGetComposerScanResults(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
 		return
 	}
-	if op.Type != "composer_tag_scan" {
+	// Accept both the legacy "composer_tag_scan" type (pre-ASYNC-CLEAN-1) and
+	// the new "maintenance:scan-composer-tags" type created by the job dispatcher.
+	if op.Type != "composer_tag_scan" && op.Type != "maintenance:scan-composer-tags" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not a composer_tag_scan operation"})
 		return
 	}
@@ -479,7 +481,9 @@ func (s *Server) handleGetMissingFileRepairResults(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "operation not found"})
 		return
 	}
-	if op.Type != "missing-file-repair" {
+	// Accept both the legacy "missing-file-repair" type (pre-ASYNC-CLEAN-1) and
+	// the new "maintenance:repair-missing-files" type created by the job dispatcher.
+	if op.Type != "missing-file-repair" && op.Type != "maintenance:repair-missing-files" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not a missing-file-repair operation"})
 		return
 	}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1077,6 +1077,9 @@ func (s *Server) setupRoutes() {
 			// Result-getter GETs (not job triggers — these poll async results)
 			protected.GET("/maintenance/scan-composer-tags/:id", s.perm(auth.PermSettingsManage), s.handleGetComposerScanResults)
 			protected.GET("/maintenance/repair-missing-files/:id", s.perm(auth.PermSettingsManage), s.handleGetMissingFileRepairResults)
+			// Hash stats endpoints
+			protected.GET("/maintenance/book-file-hash-stats", s.perm(auth.PermSettingsManage), s.handleGetBookFileHashStats)
+			protected.GET("/maintenance/book-metadata-hash-stats", s.perm(auth.PermSettingsManage), s.handleGetBookMetadataHashStats)
 			// Unified maintenance job dispatcher
 			protected.GET("/maintenance/jobs", s.perm(auth.PermSettingsManage), s.listMaintenanceJobs)
 			protected.POST("/maintenance/jobs/:job_id", s.runMaintenanceJob)


### PR DESCRIPTION
All 29 maintenance operations now handled by MaintenanceJob plugins via the unified dispatcher. Removes ~29 old synchronous POST handlers and their route registrations from server.go and maintenance_fixups.go (6400→555 lines).

Keeps: maintenance-window routes, result-getter GETs (scan-composer-tags/:id, repair-missing-files/:id), book-hash-stats, wipe endpoint. Moves mergeSeriesGroupHelper to duplicates_handlers.go. Routes legacy composer_tag_scan/missing_file_repair ops to non-resumable list. Deletes maintenance_fixups_test.go (all 16 tests covered removed functions).
