### PR TITLE
refactor(aiscan): extract AI scan pipeline to internal/aiscan package (PKG-2)

### DIFF
--- a/internal/aiscan/cross_validation.go
+++ b/internal/aiscan/cross_validation.go
@@ -1,8 +1,9 @@
-// file: internal/server/cross_validation.go
-// version: 1.0.0
+// file: internal/aiscan/cross_validation.go
+// version: 1.0.1
 // guid: d0e6f2a4-7b8c-9d0e-1f2a-3b4c5d6e7f8a
+// last-edited: 2026-05-05
 
-package server
+package aiscan
 
 import (
 	"encoding/json"

--- a/internal/aiscan/cross_validation_test.go
+++ b/internal/aiscan/cross_validation_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/cross_validation_test.go
-// version: 1.0.0
+// file: internal/aiscan/cross_validation_test.go
+// version: 1.0.1
 // guid: e1f7a3b5-8c9d-0e1f-2a3b-4c5d6e7f8a9b
+// last-edited: 2026-05-05
 
-package server
+package aiscan
 
 import (
 	"testing"

--- a/internal/aiscan/pipeline.go
+++ b/internal/aiscan/pipeline.go
@@ -1,8 +1,9 @@
-// file: internal/server/ai_scan_pipeline.go
-// version: 3.1.0
+// file: internal/aiscan/pipeline.go
+// version: 3.1.1
 // guid: b8c4d0e2-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+// last-edited: 2026-05-05
 
-package server
+package aiscan
 
 import (
 	"context"
@@ -18,8 +19,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 )
 
-// aiScanPipelineStore is the narrow slice of database.Store this service uses.
-type aiScanPipelineStore interface {
+// Store is the narrow slice of database.Store this service uses.
+type Store interface {
 	database.AuthorReader
 	database.OperationStore
 }
@@ -28,21 +29,19 @@ type aiScanPipelineStore interface {
 // PipelineManager coordinates the multi-pass AI author dedup pipeline.
 type PipelineManager struct {
 	scanStore *database.AIScanStore
-	mainStore aiScanPipelineStore
+	mainStore Store
 	parser    *ai.OpenAIParser
-	server    *Server
 	mu        sync.Mutex
 	// cancels tracks cancel functions for active scans, keyed by scan ID.
 	cancels map[int]context.CancelFunc
 }
 
 // NewPipelineManager creates a new pipeline manager.
-func NewPipelineManager(scanStore *database.AIScanStore, mainStore aiScanPipelineStore, parser *ai.OpenAIParser, server *Server) *PipelineManager {
+func NewPipelineManager(scanStore *database.AIScanStore, mainStore Store, parser *ai.OpenAIParser) *PipelineManager {
 	return &PipelineManager{
 		scanStore: scanStore,
 		mainStore: mainStore,
 		parser:    parser,
-		server:    server,
 		cancels:   make(map[int]context.CancelFunc),
 	}
 }

--- a/internal/aiscan/pipeline_test.go
+++ b/internal/aiscan/pipeline_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/ai_scan_pipeline_test.go
-// version: 1.0.0
+// file: internal/aiscan/pipeline_test.go
+// version: 1.0.1
 // guid: c9d5e1f3-6a7b-8c9d-0e1f-2a3b4c5d6e7f
+// last-edited: 2026-05-05
 
-package server
+package aiscan
 
 import (
 	"testing"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package server
 
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/aiscan"
 	"github.com/jdfalk/audiobook-organizer/internal/cache"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -163,7 +164,7 @@ type Server struct {
 	updateScheduler        *updater.Scheduler
 	scheduler              *TaskScheduler
 	aiScanStore            *database.AIScanStore
-	pipelineManager        *PipelineManager
+	pipelineManager        *aiscan.PipelineManager
 	batchPoller            *BatchPoller
 	mergeService           *merge.Service
 	diagnosticsService     *diagnostics.Service
@@ -398,7 +399,7 @@ func NewServer(store database.Store) *Server {
 			server.aiScanStore = aiScanStore
 			aiParserInst := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 			if p, ok := aiParserInst.(*ai.OpenAIParser); ok {
-				server.pipelineManager = NewPipelineManager(aiScanStore, database.GetGlobalStore(), p, server)
+				server.pipelineManager = aiscan.NewPipelineManager(aiScanStore, database.GetGlobalStore(), p)
 				server.batchPoller = NewBatchPoller(database.GetGlobalStore(), p)
 				server.registerBatchPollerHandlers()
 			}


### PR DESCRIPTION
## Summary
Extracts `ai_scan_pipeline.go` and `cross_validation.go` from `internal/server/` into a new `internal/aiscan/` package.

## Changes
- `internal/aiscan/pipeline.go` — moved from `internal/server/ai_scan_pipeline.go`; renamed `aiScanPipelineStore` → `Store`; removed dead `server *Server` field
- `internal/aiscan/cross_validation.go` — co-moved (pipeline.go calls CrossValidate directly)
- `internal/aiscan/pipeline_test.go` + `cross_validation_test.go` — moved test files
- `internal/server/server.go` — added aiscan import; updated type refs; dropped server arg from NewPipelineManager

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅

Part of PKG-extraction sweep to split server package before v1.