### PR TITLE
refactor(scanner): extract ScanService to internal/scanner package (PKG-4a)

### DIFF
--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,12 +1,14 @@
-// file: internal/server/scan_service.go
-// version: 1.5.0
+// file: internal/scanner/service.go
+// version: 1.5.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-05-05
 
-package server
+package scanner
 
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,8 +19,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
-	"github.com/jdfalk/audiobook-organizer/internal/organizer"
-	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 )
 
 // scanServiceStore is the narrow slice of database.Store this service uses.
@@ -30,13 +30,18 @@ type scanServiceStore interface {
 	database.MaintenanceStore
 }
 
-
+// ScanService orchestrates multi-folder audiobook scanning.
 type ScanService struct {
 	db             scanServiceStore
 	PostScanFn     func() // optional hook called after each full scan completes
 	activityWriter *activity.Writer
+	// AutoOrganizeFn is an optional hook called after books are processed in a
+	// folder. The server layer wires in the auto-organize logic here to avoid
+	// an import cycle (organizer → scanner → organizer).
+	AutoOrganizeFn func(ctx context.Context, books []Book, log logger.Logger)
 }
 
+// NewScanService creates a new ScanService backed by the given store.
 func NewScanService(db scanServiceStore) *ScanService {
 	return &ScanService{db: db}
 }
@@ -46,12 +51,14 @@ func (ss *ScanService) SetActivityWriter(w *activity.Writer) {
 	ss.activityWriter = w
 }
 
+// ScanRequest holds parameters for a scan operation.
 type ScanRequest struct {
 	FolderPath  *string
 	Priority    *int
 	ForceUpdate *bool
 }
 
+// ScanStats accumulates per-scan book counts by source.
 type ScanStats struct {
 	TotalBooks   int
 	LibraryBooks int
@@ -143,8 +150,8 @@ func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req
 	}
 
 	// Install scan cache into the scanner package so workers can skip unchanged files.
-	scanner.SetScanCache(scanCache)
-	defer scanner.ClearScanCache()
+	SetScanCache(scanCache)
+	defer ClearScanCache()
 
 	// Scan each folder
 	stats := &ScanStats{}
@@ -253,7 +260,7 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 	if workers < 1 {
 		workers = 4
 	}
-	books, err := scanner.ScanDirectoryParallel(folderPath, workers, log.With("scanner"))
+	books, err := ScanDirectoryParallel(folderPath, workers, log.With("scanner"))
 	if err != nil {
 		return fmt.Errorf("failed to scan folder: %w", err)
 	}
@@ -304,62 +311,22 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 		}
 
 		log.Info("Processing metadata for %d books using %d workers", len(books), workers)
-		if err := scanner.ProcessBooksParallel(ctx, books, workers, progressCallback, log.With("scanner")); err != nil {
+		if err := ProcessBooksParallel(ctx, books, workers, progressCallback, log.With("scanner")); err != nil {
 			log.Error("Failed to process books: %v", err)
 		} else {
 			log.Info("Successfully processed %d books", len(books))
 		}
 
-		// Auto-organize if enabled
-		ss.autoOrganizeScannedBooks(ctx, books, log)
+		// Auto-organize if enabled (via server-layer hook to avoid import cycle)
+		if ss.AutoOrganizeFn != nil {
+			ss.AutoOrganizeFn(ctx, books, log)
+		}
 	}
 
 	// Update book count for this import path
 	ss.updateImportPathBookCount(folderPath, len(books), log)
 
 	return nil
-}
-
-func (ss *ScanService) autoOrganizeScannedBooks(_ context.Context, books []scanner.Book, log logger.Logger) {
-	if len(books) == 0 {
-		return
-	}
-	if config.AppConfig.AutoOrganize && config.AppConfig.RootDir != "" {
-		org := organizer.NewOrganizer(&config.AppConfig)
-		organized := 0
-		for i := range books {
-			if log.IsCanceled() {
-				break
-			}
-			// Lookup DB book by file path
-			dbBook, err := ss.db.GetBookByFilePath(books[i].FilePath)
-			if err != nil || dbBook == nil {
-				continue
-			}
-			newPath, _, err := org.OrganizeBook(dbBook)
-			if err != nil {
-				log.Warn("Organize failed for %s: %v", dbBook.Title, err)
-				continue
-			}
-			// Update DB path if changed
-			if newPath != dbBook.FilePath {
-				oldPath := dbBook.FilePath
-				dbBook.FilePath = newPath
-				applyOrganizedFileMetadata(dbBook, newPath)
-				if _, err := ss.db.UpdateBook(dbBook.ID, dbBook); err != nil {
-					log.Error("Failed to update path for %s: %v — rolling back", dbBook.Title, err)
-					if rbErr := os.Rename(newPath, oldPath); rbErr != nil {
-						log.Error("CRITICAL: rollback failed for %s: file at %s, DB expects %s", dbBook.ID, newPath, oldPath)
-					}
-				} else {
-					organized++
-				}
-			}
-		}
-		log.Info("Auto-organize complete: %d organized", organized)
-	} else if config.AppConfig.AutoOrganize && config.AppConfig.RootDir == "" {
-		log.Warn("Auto-organize enabled but root_dir not set")
-	}
 }
 
 // updateImportPathBookCount stores the accurate total book count for an import
@@ -402,4 +369,23 @@ func (ss *ScanService) reportCompletion(totalFilesAcrossFolders int, finalProces
 	}
 	log.UpdateProgress(finalProcessed, finalTotal, completionMsg)
 	log.Info("%s", completionMsg)
+}
+
+// ApplyOrganizedFileMetadata updates a book's hash and size fields to reflect
+// a newly-organized file path. It is exported so server-layer code can reuse it.
+func ApplyOrganizedFileMetadata(book *database.Book, newPath string) {
+	hash, err := ComputeFileHash(newPath)
+	if err != nil {
+		log.Printf("[WARN] failed to compute organized hash for %s: %v", newPath, err)
+	} else if hash != "" {
+		book.FileHash = stringPtr(hash)
+		book.OrganizedFileHash = stringPtr(hash)
+		if book.OriginalFileHash == nil {
+			book.OriginalFileHash = stringPtr(hash)
+		}
+	}
+	if info, err := os.Stat(newPath); err == nil {
+		size := info.Size()
+		book.FileSize = &size
+	}
 }

--- a/internal/scanner/service_test.go
+++ b/internal/scanner/service_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/scan_service_test.go
+// file: internal/scanner/service_test.go
 // version: 1.1.0
 // guid: b2c3d4e5-f6a7-b8c9-d0e1-f2a3b4c5d6e7
+// last-edited: 2026-05-05
 
-package server
+package scanner
 
 import (
 	"context"
@@ -72,4 +73,3 @@ func TestScanService_PerformScan_NoFolders(t *testing.T) {
 		t.Errorf("expected no error for empty folders, got %v", err)
 	}
 }
-

--- a/internal/scanner/service_unit_test.go
+++ b/internal/scanner/service_unit_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/scan_service_unit_test.go
+// file: internal/scanner/service_unit_test.go
 // version: 1.0.0
 // guid: e2f3a4b5-c6d7-8e9f-0a1b-3c4d5e6f7a8b
+// last-edited: 2026-05-05
 
-package server
+package scanner
 
 import (
 	"context"
@@ -188,7 +189,6 @@ func TestScanService_ReportCompletion_Messages(t *testing.T) {
 			log := logger.New("test")
 
 			// reportCompletion should not panic; verify it runs without error.
-			// The method logs its message, so we just confirm no crash.
 			ss.reportCompletion(tt.stats.TotalBooks, tt.stats.TotalBooks, &tt.stats, log)
 		})
 	}

--- a/internal/server/e2e_workflow_test.go
+++ b/internal/server/e2e_workflow_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/e2e_workflow_test.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-5678-cdef-901234567012
 
 package server
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,9 +136,9 @@ func TestE2E_ScanAndFetchMetadata(t *testing.T) {
 	env.CopyFixture("test_sample.m4b", env.ImportDir, "The Hobbit.m4b")
 
 	// Step 1: Scan
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/filesystem_handlers.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 565db679-19ba-4518-b63e-6892663be41b
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 //
 // Filesystem HTTP handlers split out of server.go: home directory,
 // filesystem browse, exclusion add/remove, import-path CRUD, and the
@@ -184,7 +184,7 @@ func (s *Server) addImportPath(c *gin.Context) {
 							}
 							if newPath != dbBook.FilePath {
 								dbBook.FilePath = newPath
-								applyOrganizedFileMetadata(dbBook, newPath)
+								scanner.ApplyOrganizedFileMetadata(dbBook, newPath)
 								if _, err := s.Store().UpdateBook(dbBook.ID, dbBook); err != nil {
 									_ = progress.Log("warn", fmt.Sprintf("Failed to update path for %s: %v", dbBook.Title, err), nil)
 								} else {
@@ -255,7 +255,7 @@ func (s *Server) addImportPath(c *gin.Context) {
 							}
 							if newPath != dbBook.FilePath {
 								dbBook.FilePath = newPath
-								applyOrganizedFileMetadata(dbBook, newPath)
+								scanner.ApplyOrganizedFileMetadata(dbBook, newPath)
 								_, _ = s.Store().UpdateBook(dbBook.ID, dbBook)
 							}
 						}

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -24,6 +24,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/transcode"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -59,7 +60,7 @@ func (s *Server) startScan(c *gin.Context) {
 	}
 
 	// Create operation function that delegates to service
-	scanReq := &ScanRequest{
+	scanReq := &scanner.ScanRequest{
 		FolderPath:  req.FolderPath,
 		Priority:    req.Priority,
 		ForceUpdate: req.ForceUpdate,

--- a/internal/server/organize_service.go
+++ b/internal/server/organize_service.go
@@ -1,6 +1,7 @@
 // file: internal/server/organize_service.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
+// last-edited: 2026-05-05
 //
 // Thin forwarding layer — the real implementation now lives in
 // internal/organizer/service.go. This file provides type aliases and
@@ -13,6 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 )
 
 // Type aliases — allow existing server code to keep using the old names.
@@ -28,7 +30,7 @@ func NewOrganizeService(db database.Store) *OrganizeService {
 	// Wire server-specific callbacks. iTunes callbacks are set later in
 	// Server.New() after itunesSvc is constructed (see server.go).
 	svc.ApplyOrganizedFileMetadata = func(book *database.Book, newPath string) {
-		applyOrganizedFileMetadata(book, newPath)
+		scanner.ApplyOrganizedFileMetadata(book, newPath)
 	}
 	svc.ComputeITunesPath = metafetch.ComputeITunesPath
 	svc.FetchMetadataForBook = func(bookID string) (interface{}, error) {

--- a/internal/server/scan_edge_cases_test.go
+++ b/internal/server/scan_edge_cases_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/scan_edge_cases_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9012-3456-789012abcdef
 
 package server
@@ -15,6 +15,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestScanService_EmptyDirectory(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := emptyDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -49,7 +50,7 @@ func TestScanService_DeepNestedDirectories(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -76,7 +77,7 @@ func TestScanService_SpecialCharsInFilenames(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -98,7 +99,7 @@ func TestScanService_UnsupportedFileExtensions(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -118,7 +119,7 @@ func TestScanService_RescanUpdatesExistingBooks(t *testing.T) {
 	folderPath := env.ImportDir
 
 	// First scan
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -127,7 +128,7 @@ func TestScanService_RescanUpdatesExistingBooks(t *testing.T) {
 	require.Len(t, books1, 1)
 
 	// Second scan (should not create duplicate)
-	err = svc.PerformScan(context.Background(), &ScanRequest{
+	err = svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -166,7 +167,7 @@ func TestScanService_NonexistentScanFolder(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := "/nonexistent/scan/path"
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	// Should complete without error (logs warning about missing folder)
@@ -188,7 +189,7 @@ func TestScanService_MultiChapterAudiobook(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -211,7 +212,7 @@ func TestScanService_RealLibrivoxFiles(t *testing.T) {
 
 	// Scan the smallest librivox directory (mobydick2 ~45MB, 6 files)
 	svc := NewScanService(env.Store)
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &librivoxDir,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -247,7 +248,7 @@ func TestScanService_LongFilePaths(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)

--- a/internal/server/scan_edge_cases_test.go
+++ b/internal/server/scan_edge_cases_test.go
@@ -28,7 +28,7 @@ func TestScanService_EmptyDirectory(t *testing.T) {
 	emptyDir := filepath.Join(env.TempDir, "empty")
 	require.NoError(t, os.MkdirAll(emptyDir, 0755))
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := emptyDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -48,7 +48,7 @@ func TestScanService_DeepNestedDirectories(t *testing.T) {
 	deepPath := filepath.Join(env.ImportDir, "Level1", "Level2", "Level3", "Level4")
 	env.CopyFixture("test_sample.m4b", deepPath, "Deep Book.m4b")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -75,7 +75,7 @@ func TestScanService_SpecialCharsInFilenames(t *testing.T) {
 		env.CreateFakeAudiobook(env.ImportDir, name)
 	}
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -97,7 +97,7 @@ func TestScanService_UnsupportedFileExtensions(t *testing.T) {
 	env.CreateFakeAudiobook(env.ImportDir, "image.jpg")
 	env.CreateFakeAudiobook(env.ImportDir, "document.pdf")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -115,7 +115,7 @@ func TestScanService_RescanUpdatesExistingBooks(t *testing.T) {
 
 	env.CopyFixture("test_sample.m4b", env.ImportDir, "MyBook.m4b")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 
 	// First scan
@@ -165,7 +165,7 @@ func TestScanService_NonexistentScanFolder(t *testing.T) {
 	env, cleanup := testutil.SetupIntegration(t)
 	defer cleanup()
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := "/nonexistent/scan/path"
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -187,7 +187,7 @@ func TestScanService_MultiChapterAudiobook(t *testing.T) {
 		env.CreateFakeAudiobook(bookDir, fmt.Sprintf("Chapter %02d.mp3", i))
 	}
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -211,7 +211,7 @@ func TestScanService_RealLibrivoxFiles(t *testing.T) {
 	}
 
 	// Scan the smallest librivox directory (mobydick2 ~45MB, 6 files)
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &librivoxDir,
 	}, logger.New("test"))
@@ -246,7 +246,7 @@ func TestScanService_LongFilePaths(t *testing.T) {
 	longDir := filepath.Join(env.ImportDir, longAuthor, longTitle)
 	env.CreateFakeAudiobook(longDir, strings.Repeat("C", 50)+".m4b")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,

--- a/internal/server/scan_integration_test.go
+++ b/internal/server/scan_integration_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/scan_integration_test.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-2345-fabc-678901234def
 
 package server
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func TestScanService_ScanWithRealFiles(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -52,7 +53,7 @@ func TestScanService_AutoOrganize(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	folderPath := env.ImportDir
-	err := svc.PerformScan(context.Background(), &ScanRequest{
+	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
 	}, logger.New("test"))
 	require.NoError(t, err)
@@ -83,7 +84,7 @@ func TestScanService_MultipleFolders(t *testing.T) {
 
 	svc := NewScanService(env.Store)
 	forceUpdate := true
-	err = svc.PerformScan(context.Background(), &ScanRequest{
+	err = svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		ForceUpdate: &forceUpdate,
 	}, logger.New("test"))
 	require.NoError(t, err)

--- a/internal/server/scan_integration_test.go
+++ b/internal/server/scan_integration_test.go
@@ -26,7 +26,7 @@ func TestScanService_ScanWithRealFiles(t *testing.T) {
 	env.CopyFixture("test_sample.mp3", filepath.Join(env.ImportDir, "Herbert", "Dune"), "Dune.mp3")
 	env.CopyFixture("test_sample.flac", filepath.Join(env.ImportDir, "Asimov", "Foundation"), "Foundation.flac")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -51,7 +51,7 @@ func TestScanService_AutoOrganize(t *testing.T) {
 
 	env.CopyFixture("test_sample.m4b", env.ImportDir, "The Hobbit.m4b")
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	folderPath := env.ImportDir
 	err := svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		FolderPath: &folderPath,
@@ -82,7 +82,7 @@ func TestScanService_MultipleFolders(t *testing.T) {
 	_, err = env.Store.CreateImportPath(dir2, "Import 2")
 	require.NoError(t, err)
 
-	svc := NewScanService(env.Store)
+	svc := scanner.NewScanService(env.Store)
 	forceUpdate := true
 	err = svc.PerformScan(context.Background(), &scanner.ScanRequest{
 		ForceUpdate: &forceUpdate,

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,6 +1,7 @@
 // file: internal/server/scheduler.go
-// version: 1.19.2
+// version: 1.19.3
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-05-05
 
 package server
 
@@ -23,6 +24,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/reconcile"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -110,7 +112,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 				if s.scanService == nil {
 					return fmt.Errorf("scan service not initialized")
 				}
-				return s.scanService.PerformScan(ctx, &ScanRequest{}, operations.LoggerFromReporter(progress))
+				return s.scanService.PerformScan(ctx, &scanner.ScanRequest{}, operations.LoggerFromReporter(progress))
 			})
 		},
 		IsEnabled:              func() bool { return config.AppConfig.ScanOnStartup }, // reuse existing field

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -147,7 +148,7 @@ type Server struct {
 	filesystemService      *FilesystemService
 	importPathService      *ImportPathService
 	importService          *ImportService
-	scanService            *ScanService
+	scanService            *scanner.ScanService
 	organizeService        *OrganizeService
 	metadataFetchService   *metafetch.Service
 	configUpdateService    *ConfigUpdateService
@@ -288,7 +289,7 @@ func NewServer(store database.Store) *Server {
 		filesystemService:      NewFilesystemService(resolvedStore),
 		importPathService:      NewImportPathService(resolvedStore),
 		importService:          NewImportService(resolvedStore),
-		scanService:            NewScanService(resolvedStore),
+		scanService:            scanner.NewScanService(resolvedStore),
 		organizeService:        NewOrganizeService(resolvedStore),
 		metadataFetchService:   metafetch.NewService(resolvedStore),
 		configUpdateService:    NewConfigUpdateService(resolvedStore),
@@ -655,6 +656,49 @@ func NewServer(store database.Store) *Server {
 
 	// Wire post-scan auto-quarantine hook.
 	server.scanService.PostScanFn = server.autoQuarantineFailedScans
+
+	// Wire post-folder auto-organize hook (breaks scanner→organizer import cycle).
+	server.scanService.AutoOrganizeFn = func(ctx context.Context, books []scanner.Book, l logger.Logger) {
+		if len(books) == 0 {
+			return
+		}
+		if !config.AppConfig.AutoOrganize || config.AppConfig.RootDir == "" {
+			if config.AppConfig.AutoOrganize {
+				l.Warn("Auto-organize enabled but root_dir not set")
+			}
+			return
+		}
+		org := organizer.NewOrganizer(&config.AppConfig)
+		organized := 0
+		for i := range books {
+			if l.IsCanceled() {
+				break
+			}
+			dbBook, err := server.store.GetBookByFilePath(books[i].FilePath)
+			if err != nil || dbBook == nil {
+				continue
+			}
+			newPath, _, err := org.OrganizeBook(dbBook)
+			if err != nil {
+				l.Warn("Organize failed for %s: %v", dbBook.Title, err)
+				continue
+			}
+			if newPath != dbBook.FilePath {
+				oldPath := dbBook.FilePath
+				dbBook.FilePath = newPath
+				scanner.ApplyOrganizedFileMetadata(dbBook, newPath)
+				if _, err := server.store.UpdateBook(dbBook.ID, dbBook); err != nil {
+					l.Error("Failed to update path for %s: %v — rolling back", dbBook.Title, err)
+					if rbErr := os.Rename(newPath, oldPath); rbErr != nil {
+						l.Error("CRITICAL: rollback failed for %s: file at %s, DB expects %s", dbBook.ID, newPath, oldPath)
+					}
+				} else {
+					organized++
+				}
+			}
+		}
+		l.Info("Auto-organize complete: %d organized", organized)
+	}
 
 	// Note: the search index is opened in Start(), not here, so
 	// tests that construct a Server without calling Start don't

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func TestServerHelpers(t *testing.T) {
 	require.NoError(t, os.WriteFile(filePath, []byte("audio"), 0o644))
 
 	book := &database.Book{FilePath: filePath}
-	applyOrganizedFileMetadata(book, filePath)
+	scanner.ApplyOrganizedFileMetadata(book, filePath)
 	if book.FileHash == nil || book.OrganizedFileHash == nil || book.OriginalFileHash == nil {
 		t.Fatal("expected hashes to be set")
 	}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package server
 
@@ -33,6 +33,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/reconcile"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/transcode"
 	"github.com/jdfalk/audiobook-organizer/internal/watcher"
 	ulid "github.com/oklog/ulid/v2"
@@ -105,7 +106,7 @@ func (s *Server) resumeInterruptedOperations() {
 			}
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
 				forceUpdate := params.ForceUpdate
-				return s.scanService.PerformScanWithID(ctx, opID, &ScanRequest{
+				return s.scanService.PerformScanWithID(ctx, opID, &scanner.ScanRequest{
 					FolderPath:  params.FolderPath,
 					ForceUpdate: &forceUpdate,
 				}, operations.LoggerFromReporter(progress))
@@ -545,7 +546,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 								watchLog.Error("Auto-scan: failed to create operation: %v", opErr)
 								return
 							}
-							scanReq := &ScanRequest{FolderPath: &scanPath}
+							scanReq := &scanner.ScanRequest{FolderPath: &scanPath}
 							opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
 								return s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
 							}

--- a/internal/server/server_metadata.go
+++ b/internal/server/server_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_metadata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 588350bc-83db-47ed-9590-2b6513aadcda
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package server
 
@@ -16,7 +16,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 )
 
 func metadataStateKey(bookID string) string {
@@ -538,21 +537,4 @@ func buildMetadataProvenance(book *database.Book, state map[string]metadataField
 	addEntry("google_books_id", nonEmpty(meta.GoogleBooksID), stringVal(book.GoogleBooksID))
 
 	return provenance
-}
-
-func applyOrganizedFileMetadata(book *database.Book, newPath string) {
-	hash, err := scanner.ComputeFileHash(newPath)
-	if err != nil {
-		log.Printf("[WARN] failed to compute organized hash for %s: %v", newPath, err)
-	} else if hash != "" {
-		book.FileHash = stringPtr(hash)
-		book.OrganizedFileHash = stringPtr(hash)
-		if book.OriginalFileHash == nil {
-			book.OriginalFileHash = stringPtr(hash)
-		}
-	}
-	if info, err := os.Stat(newPath); err == nil {
-		size := info.Size()
-		book.FileSize = &size
-	}
 }


### PR DESCRIPTION
## Summary
Moves `scan_service.go` from `internal/server/` to `internal/scanner/service.go`.

## Changes
- `internal/scanner/service.go` — moved from `internal/server/scan_service.go`
- `internal/scanner/service_test.go` + `service_unit_test.go` — moved test files
- `internal/server/server.go` — `*ScanService` → `*scanner.ScanService`, added `AutoOrganizeFn` callback hook to avoid circular import with organizer package
- Updated all callers: `operations_handlers.go`, `scheduler.go`, `server_lifecycle.go`, `server_metadata.go`, `filesystem_handlers.go`, `organize_service.go`, 3 server test files

## Key Decision
`autoOrganizeScannedBooks` would create a circular dep (organizer→scanner→organizer). Resolved with an `AutoOrganizeFn func(...)` callback wired by server at startup.

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅
- 11 ScanService unit tests pass in `internal/scanner/`

Part of PKG-extraction sweep.