### PR TITLE
feat(ci): split CI into fast parallel PR checks + nightly full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 # file: .github/workflows/ci.yml
-# version: 2.6.0
+# version: 3.0.0
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
+# last-edited: 2026-05-01
 
-# CI should be using the upstream shared ci
+# Fast parallel CI for PRs and pushes.
+# Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
+# in parallel — all with manual actions/cache (no setup-go built-in cache).
+# Full suite (property tests, coverage, E2E) runs via nightly.yml.
 name: Continuous Integration
 
 on:
@@ -10,8 +14,6 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
-  schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
   workflow_dispatch:
 
 concurrency:
@@ -19,24 +21,72 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
   checks: write
-  packages: write
-  id-token: write
-  attestations: write
 
 jobs:
+  # Parallel fast jobs via reusable minimal workflow
   ci:
-    name: Run CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # latest
+    name: Minimal CI
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci-minimal.yml@cf2068996e1ecf737a6e2c269a9429f0764e76cd # feat/reusable-ci-minimal
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'
       node-version: '22'
-      python-version: '3.13'
-      rust-version: '1.76'
-      coverage-threshold: '30'
-      skip-protobuf: false
       system-packages: 'libtag1-dev'
+      frontend-working-dir: 'web'
+      run-frontend: true
     secrets: inherit
+
+  # Project-specific: verify mockery mocks are not stale
+  mocks-check:
+    name: Mock Freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOEXPERIMENT: jsonv2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go (no built-in cache)
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Restore Go cache (manual)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.26-
+            ${{ runner.os }}-go-
+
+      - name: Install system packages
+        run: sudo apt-get update && sudo apt-get install -y libtag1-dev
+
+      - name: Install mockery
+        run: go install github.com/vektra/mockery/v2@latest
+
+      - name: Check mockery mocks are fresh
+        run: |
+          mockery >/dev/null 2>&1 || true
+          if ! git diff --quiet -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; then
+            echo "❌ Committed mocks are stale. Run 'make mocks' and commit."
+            git diff --stat -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go
+            exit 1
+          fi
+          echo "✅ Mocks are up to date"
+
+      - name: Check go generate mocks (database)
+        run: |
+          go generate ./internal/database/...
+          if ! git diff --exit-code internal/database/mocks/; then
+            echo "❌ MockStore is stale. Run 'make mocks' and commit."
+            exit 1
+          fi
+          echo "✅ Database mocks are fresh"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,41 @@
+# file: .github/workflows/nightly.yml
+# version: 1.0.0
+# guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
+# last-edited: 2026-05-01
+
+# Nightly full CI: property tests, coverage check, E2E, staticcheck.
+# Runs the complete reusable-ci.yml suite on a schedule.
+# Does NOT run on PRs — use ci.yml (minimal/fast) for PR feedback.
+name: Nightly Full CI
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # 4 AM UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+  checks: write
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  full-ci:
+    name: Full CI Suite
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # v1.12.0
+    with:
+      go-version: '1.26'
+      go-experiment: 'jsonv2'
+      node-version: '22'
+      python-version: '3.13'
+      rust-version: '1.76'
+      coverage-threshold: '30'
+      skip-protobuf: false
+      system-packages: 'libtag1-dev'
+    secrets: inherit


### PR DESCRIPTION
## Problem

Full CI (`reusable-ci.yml`) was too slow — property tests, E2E, coverage, staticcheck all blocking every PR.

## Solution

### Fast path — `ci.yml` (every PR/push)
Calls new `reusable-ci-minimal.yml` from ghcommon. **4 jobs run in parallel:**

| Job | What it does |
|-----|-------------|
| Go Vet & Build | `go vet ./...` + `go build ./...` |
| Go Tests (short, race) | `go test -short -race ./...` — skips property/slow tests |
| Frontend Lint & Build | `npm run lint` + `npm run build` |
| Frontend Unit Tests | `npm test -- --run` (vitest) |

Plus a **project-specific mocks-check** job (mockery freshness + `go generate` db mocks) also runs in parallel.

### Cache strategy
**`cache: false`** on `setup-go` and `setup-node`. Manual `actions/cache` with explicit keys:
- Go: `{os}-go-{version}-{hash(go.sum)}`
- npm: `{os}-npm-{version}-{hash(package-lock.json)}`

### Nightly — `nightly.yml` (4 AM UTC daily)
Full `reusable-ci.yml`: property tests, E2E, coverage threshold, staticcheck.

### Existing workflows untouched
`reusable-ci.yml` in ghcommon is unchanged — all other consumers unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>