### PR TITLE
refactor(importer): extract import services to internal/importer package (PKG-4b)

### DIFF
--- a/internal/importer/path_service.go
+++ b/internal/importer/path_service.go
@@ -1,8 +1,9 @@
-// file: internal/server/import_path_service.go
-// version: 1.2.0
-// guid: d4e5f6g7-h8i9-j0k1-l2m3-n4o5p6q7r8s9
+// file: internal/importer/path_service.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9b
+// last-edited: 2026-05-01
 
-package server
+package importer
 
 import (
 	"errors"

--- a/internal/importer/path_service_test.go
+++ b/internal/importer/path_service_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/import_path_service_test.go
+// file: internal/importer/path_service_test.go
 // version: 1.0.0
-// guid: c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8
+// guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-05-01
 
-package server
+package importer
 
 import (
 	"testing"

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1,8 +1,9 @@
-// file: internal/server/import_service.go
-// version: 1.4.0
-// guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
+// file: internal/importer/service.go
+// version: 1.0.0
+// guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
+// last-edited: 2026-05-01
 
-package server
+package importer
 
 import (
 	"fmt"
@@ -16,21 +17,17 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/versions"
 )
 
-// importServiceStore is the narrow slice of database.Store this service uses.
-// Includes the transitive surfaces required by forwarded helpers:
-// CreateIngestVersion needs BookVersionStore + BookFileStore; ProvisionITLTracksForBook
-// needs ExternalIDStore (plus the AuthorReader + BookFileStore already present).
-// importServiceStore is temporarily widened to database.Store because
-// CreateIngestVersion (in the extracted versions package) requires
-// the full Store interface. A future ISP pass on the versions package
+// Store is the narrow slice of database.Store this service uses.
+// Temporarily widened to database.Store because versions.CreateIngestVersion
+// requires the full Store interface. A future ISP pass on the versions package
 // will re-narrow this.
-type importServiceStore = database.Store
-
+type Store = database.Store
 
 type ImportService struct {
-	db          importServiceStore
+	db          Store
 	provisioner *itunesservice.TrackProvisioner
 }
 
@@ -40,7 +37,7 @@ func (is *ImportService) SetTrackProvisioner(p *itunesservice.TrackProvisioner) 
 	is.provisioner = p
 }
 
-func NewImportService(db importServiceStore) *ImportService {
+func NewImportService(db Store) *ImportService {
 	return &ImportService{db: db}
 }
 
@@ -177,17 +174,15 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 	}
 
 	// Create version row for the imported file (spec 3.1).
-	if _, verErr := CreateIngestVersion(is.db, IngestVersionParams{
+	if _, verErr := versions.CreateIngestVersion(is.db, versions.IngestVersionParams{
 		BookID: created.ID, FilePath: created.FilePath,
 		Format: created.Format, Source: "imported",
 	}); verErr != nil {
 		log.Printf("[WARN] create ingest version for %s: %v", created.ID, verErr)
 	}
 
-	// Provision ITL track via the injected iTunes service (moved from this
-	// package into internal/itunes/service/ during Phase 2 M1 step 1).
-	// Nil provisioner → iTunes disabled or not wired; book is still created
-	// and ITL provisioning can happen later when iTunes comes online.
+	// Provision ITL track via the injected iTunes service.
+	// Nil provisioner → iTunes disabled or not wired; book is still created.
 	if is.provisioner != nil {
 		if err := is.provisioner.ProvisionAll(created); err != nil {
 			log.Printf("[WARN] ITL track provisioning failed for %s: %v", created.ID, err)
@@ -199,4 +194,8 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 		Title:    created.Title,
 		FilePath: created.FilePath,
 	}, nil
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/internal/importer/service_test.go
+++ b/internal/importer/service_test.go
@@ -1,8 +1,9 @@
-// file: internal/server/import_service_test.go
+// file: internal/importer/service_test.go
 // version: 1.0.0
-// guid: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
+// guid: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5b6c
+// last-edited: 2026-05-01
 
-package server
+package importer
 
 import (
 	"testing"

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -43,6 +43,7 @@ import (
 	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/importer"
 )
 
 // DiscoveredTorrent is a Deluge torrent not yet tracked in the library.
@@ -413,7 +414,7 @@ func (s *Server) handleDelugeDiscoverImport(c *gin.Context) {
 		return
 	}
 
-	resp, err := s.importService.ImportFile(&ImportFileRequest{
+	resp, err := s.importService.ImportFile(&importer.ImportFileRequest{
 		FilePath: req.ContentPath,
 		Organize: false,
 	})

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -20,9 +20,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
@@ -293,7 +294,7 @@ func (s *Server) removeImportPath(c *gin.Context) {
 }
 
 func (s *Server) importFile(c *gin.Context) {
-	var req ImportFileRequest
+	var req importer.ImportFileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/metrics"
+	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
@@ -146,8 +147,8 @@ type Server struct {
 	workService            *WorkService
 	authorSeriesService    *AuthorSeriesService
 	filesystemService      *FilesystemService
-	importPathService      *ImportPathService
-	importService          *ImportService
+	importPathService      *importer.ImportPathService
+	importService          *importer.ImportService
 	scanService            *scanner.ScanService
 	organizeService        *OrganizeService
 	metadataFetchService   *metafetch.Service
@@ -287,8 +288,8 @@ func NewServer(store database.Store) *Server {
 		workService:            NewWorkService(resolvedStore),
 		authorSeriesService:    NewAuthorSeriesService(resolvedStore),
 		filesystemService:      NewFilesystemService(resolvedStore),
-		importPathService:      NewImportPathService(resolvedStore),
-		importService:          NewImportService(resolvedStore),
+		importPathService:      importer.NewImportPathService(resolvedStore),
+		importService:          importer.NewImportService(resolvedStore),
 		scanService:            scanner.NewScanService(resolvedStore),
 		organizeService:        NewOrganizeService(resolvedStore),
 		metadataFetchService:   metafetch.NewService(resolvedStore),

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/service_layer_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-02-14
+// last-edited: 2026-05-01
 
 package server
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -270,7 +271,7 @@ func TestAudiobookUpdateService_ExtractOverrides_EdgeCases(t *testing.T) {
 // TestImportPathService_ValidatePath_Whitespace tests whitespace handling
 func TestImportPathService_ValidatePath_Whitespace(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewImportPathService(mockStore)
+	svc := importer.NewImportPathService(mockStore)
 
 	tests := []struct {
 		name    string
@@ -311,8 +312,8 @@ func TestImportPathService_ValidatePath_Whitespace(t *testing.T) {
 				if err == nil {
 					t.Error("expected error, got nil")
 				}
-				if err != ErrImportPathEmpty {
-					t.Errorf("expected ErrImportPathEmpty, got %v", err)
+				if err != importer.ErrImportPathEmpty {
+					t.Errorf("expected importer.ErrImportPathEmpty, got %v", err)
 				}
 			} else {
 				if err != nil {
@@ -852,7 +853,7 @@ func strPtr(s string) *string {
 func TestImportPathService_UpdateImportPathEnabled(t *testing.T) {
 	t.Run("success case", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		importPath := &database.ImportPath{
 			ID:      1,
@@ -877,7 +878,7 @@ func TestImportPathService_UpdateImportPathEnabled(t *testing.T) {
 
 	t.Run("import path not found", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		mockStore.EXPECT().GetImportPathByID(999).Return(nil, nil)
 
@@ -892,7 +893,7 @@ func TestImportPathService_UpdateImportPathEnabled(t *testing.T) {
 
 	t.Run("database error on get", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		mockStore.EXPECT().GetImportPathByID(1).Return(nil, errors.New("database error"))
 
@@ -910,7 +911,7 @@ func TestImportPathService_UpdateImportPathEnabled(t *testing.T) {
 func TestImportPathService_GetImportPath(t *testing.T) {
 	t.Run("success case", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		expectedPath := &database.ImportPath{
 			ID:      1,
@@ -935,7 +936,7 @@ func TestImportPathService_GetImportPath(t *testing.T) {
 
 	t.Run("import path not found", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		mockStore.EXPECT().GetImportPathByID(999).Return(nil, nil)
 
@@ -953,7 +954,7 @@ func TestImportPathService_GetImportPath(t *testing.T) {
 
 	t.Run("database error", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewImportPathService(mockStore)
+		svc := importer.NewImportPathService(mockStore)
 
 		mockStore.EXPECT().GetImportPathByID(1).Return(nil, errors.New("database error"))
 


### PR DESCRIPTION
## Summary
Moves `import_service.go` and `import_path_service.go` from `internal/server/` to `internal/importer/`.

## Changes
- `internal/importer/service.go` + `path_service.go` — moved; no *Server receivers existed
- Test files moved to `internal/importer/`
- Updated server.go, deluge_discovery.go, filesystem_handlers.go, service_layer_test.go
- Replaced thin CreateIngestVersion wrapper with direct versions.CreateIngestVersion import

## Testing
- `go build ./...` ✅  `go vet ./...` ✅

Refs: PKG-4b