### PR TITLE
refactor(server): extract audiobooks services to internal/audiobooks/

### DIFF
--- a/internal/audiobooks/audiobook_service_prop_test.go
+++ b/internal/audiobooks/audiobook_service_prop_test.go
@@ -1,4 +1,4 @@
-// file: internal/server/audiobook_service_prop_test.go
+// file: internal/audiobooks/audiobook_service_prop_test.go
 // version: 1.1.0
 // guid: 864889b2-5529-4d23-9220-2f17e11fab35
 
@@ -23,7 +23,7 @@
 // Each property draws a fresh slice (or a fresh PebbleStore) per
 // rapid.Check iteration so state never leaks between shrinks.
 
-package server
+package audiobooks
 
 import (
 	"path/filepath"

--- a/internal/audiobooks/audiobook_service_tags_test.go
+++ b/internal/audiobooks/audiobook_service_tags_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/audiobook_service_tags_test.go
+// file: internal/audiobooks/audiobook_service_tags_test.go
 // version: 1.0.0
 // guid: 6f6a8d8d-0c5d-4c0a-9f1d-5b9ad01a5b42
 
-package server
+package audiobooks
 
 import (
 	"context"

--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,9 +1,9 @@
-// file: internal/server/audiobook_service_unit_test.go
+// file: internal/audiobooks/audiobook_service_unit_test.go
 // version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-01
 
-package server
+package audiobooks
 
 import (
 	"context"

--- a/internal/audiobooks/author_series.go
+++ b/internal/audiobooks/author_series.go
@@ -1,8 +1,8 @@
-// file: internal/server/author_series_service.go
-// version: 1.5.0
+// file: internal/audiobooks/author_series.go
+// version: 1.5.1
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
 
-package server
+package audiobooks
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"

--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -1,0 +1,551 @@
+// file: internal/audiobooks/helpers.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234560010
+// last-edited: 2026-05-05
+//
+// Private utilities needed by the audiobooks service package. These mirror
+// equivalent helpers from internal/server/ but are standalone so that the
+// audiobooks package does not import internal/server (which would cycle).
+
+package audiobooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+)
+
+// --- basic pointer helpers --------------------------------------------------
+
+// stringPtr returns a pointer to s.
+func stringPtr(s string) *string { return &s }
+
+func boolPtr(b bool) *bool { return &b }
+
+func ptrStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// --- metadata field state ---------------------------------------------------
+
+// metadataFieldState represents the persisted state of one metadata field.
+type metadataFieldState struct {
+	FetchedValue   any       `json:"fetched_value,omitempty"`
+	OverrideValue  any       `json:"override_value,omitempty"`
+	OverrideLocked bool      `json:"override_locked"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+func metadataStateKey(bookID string) string {
+	return fmt.Sprintf("metadata_state_%s", bookID)
+}
+
+func decodeMetadataValue(raw *string) any {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal([]byte(*raw), &value); err != nil {
+		return *raw
+	}
+	return value
+}
+
+func encodeMetadataValue(value any) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	encoded := string(data)
+	return &encoded, nil
+}
+
+func decodeRawValue(raw json.RawMessage) any {
+	if raw == nil {
+		return nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	return value
+}
+
+func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
+	state := map[string]metadataFieldState{}
+	if database.GetGlobalStore() == nil {
+		return state, nil
+	}
+	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
+	if err != nil {
+		return state, err
+	}
+	if pref == nil || pref.Value == nil || *pref.Value == "" {
+		return state, nil
+	}
+	if err := json.Unmarshal([]byte(*pref.Value), &state); err != nil {
+		return state, fmt.Errorf("failed to parse metadata state: %w", err)
+	}
+	return state, nil
+}
+
+func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
+	state := map[string]metadataFieldState{}
+	if database.GetGlobalStore() == nil {
+		return state, fmt.Errorf("database not initialized")
+	}
+	stored, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	if err != nil {
+		return state, err
+	}
+	for _, entry := range stored {
+		state[entry.Field] = metadataFieldState{
+			FetchedValue:   decodeMetadataValue(entry.FetchedValue),
+			OverrideValue:  decodeMetadataValue(entry.OverrideValue),
+			OverrideLocked: entry.OverrideLocked,
+			UpdatedAt:      entry.UpdatedAt,
+		}
+	}
+	if len(state) > 0 {
+		return state, nil
+	}
+	legacy, err := loadLegacyMetadataState(bookID)
+	if err != nil {
+		return state, err
+	}
+	if len(legacy) == 0 {
+		return state, nil
+	}
+	if err := saveMetadataState(bookID, legacy); err != nil {
+		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
+	}
+	return legacy, nil
+}
+
+func saveMetadataState(bookID string, state map[string]metadataFieldState) error {
+	if database.GetGlobalStore() == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	existing, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	if err != nil {
+		return err
+	}
+	existingFields := map[string]struct{}{}
+	for _, entry := range existing {
+		existingFields[entry.Field] = struct{}{}
+	}
+	now := time.Now()
+	for field, entry := range state {
+		fetched, err := encodeMetadataValue(entry.FetchedValue)
+		if err != nil {
+			return fmt.Errorf("failed to encode fetched metadata for %s: %w", field, err)
+		}
+		override, err := encodeMetadataValue(entry.OverrideValue)
+		if err != nil {
+			return fmt.Errorf("failed to encode override metadata for %s: %w", field, err)
+		}
+		if entry.UpdatedAt.IsZero() {
+			entry.UpdatedAt = now
+		}
+		dbState := database.MetadataFieldState{
+			BookID:         bookID,
+			Field:          field,
+			FetchedValue:   fetched,
+			OverrideValue:  override,
+			OverrideLocked: entry.OverrideLocked,
+			UpdatedAt:      entry.UpdatedAt,
+		}
+		if err := database.GetGlobalStore().UpsertMetadataFieldState(&dbState); err != nil {
+			return fmt.Errorf("failed to persist metadata state for %s: %w", field, err)
+		}
+		delete(existingFields, field)
+	}
+	for field := range existingFields {
+		if err := database.GetGlobalStore().DeleteMetadataFieldState(bookID, field); err != nil {
+			return fmt.Errorf("failed to clean up metadata state for %s: %w", field, err)
+		}
+	}
+	return nil
+}
+
+// --- metadata state change recorder ----------------------------------------
+
+// metadataStateStore is the narrow interface needed for recording metadata changes.
+type metadataStateStore interface {
+	database.MetadataStore
+	database.UserPreferenceStore
+}
+
+// metadataStateSvc records metadata change history. It is an internal helper
+// used only by AudiobookService.UpdateAudiobook.
+type metadataStateSvc struct {
+	db metadataStateStore
+}
+
+func newMetadataStateSvc(db metadataStateStore) *metadataStateSvc {
+	return &metadataStateSvc{db: db}
+}
+
+func (mss *metadataStateSvc) recordChange(bookID, field, changeType, source string, previousValue, newValue any) {
+	if mss.db == nil {
+		return
+	}
+	prev, _ := encodeMetadataValue(previousValue)
+	next, _ := encodeMetadataValue(newValue)
+	record := &database.MetadataChangeRecord{
+		BookID:        bookID,
+		Field:         field,
+		PreviousValue: prev,
+		NewValue:      next,
+		ChangeType:    changeType,
+		Source:        source,
+		ChangedAt:     time.Now(),
+	}
+	if err := mss.db.RecordMetadataChange(record); err != nil {
+		log.Printf("[WARN] failed to record metadata change for %s/%s: %v", bookID, field, err)
+	}
+}
+
+// --- path helpers -----------------------------------------------------------
+
+// isProtectedPath returns true if filePath is under a configured import path,
+// an iTunes library path, or another protected location.
+func isProtectedPath(filePath string) bool {
+	absPath, _ := filepath.Abs(filePath)
+
+	if database.GetGlobalStore() != nil {
+		importPaths, err := database.GetGlobalStore().GetAllImportPaths()
+		if err == nil {
+			for _, ip := range importPaths {
+				ipAbs, _ := filepath.Abs(ip.Path)
+				if strings.HasPrefix(absPath, ipAbs+"/") || absPath == ipAbs {
+					return true
+				}
+			}
+		}
+	}
+
+	if config.AppConfig.ITunesLibraryReadPath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryReadPath)
+		itunesAbs, _ := filepath.Abs(itunesDir)
+		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
+			return true
+		}
+	}
+	if config.AppConfig.ITunesLibraryWritePath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryWritePath)
+		itunesAbs, _ := filepath.Abs(itunesDir)
+		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
+			return true
+		}
+	}
+
+	if strings.Contains(absPath, "iTunes Media") || strings.Contains(absPath, "iTunes%20Media") {
+		return true
+	}
+
+	if strings.Contains(filepath.ToSlash(absPath), "/.failed/") {
+		return true
+	}
+
+	return false
+}
+
+// resolveAuthorAndSeriesNames returns the author name and series name for book,
+// falling back to a database lookup when the join is not pre-loaded.
+func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
+	authorName := ""
+	if book.Author != nil {
+		authorName = book.Author.Name
+	} else if book.AuthorID != nil {
+		if database.GetGlobalStore() != nil {
+			if author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+				authorName = author.Name
+			}
+		}
+	}
+	seriesName := ""
+	if book.Series != nil {
+		seriesName = book.Series.Name
+	} else if book.SeriesID != nil {
+		if database.GetGlobalStore() != nil {
+			if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+				seriesName = series.Name
+			}
+		}
+	}
+	return authorName, seriesName
+}
+
+// applyOrganizedFileMetadata updates book's hash and size fields after the
+// backing file has been moved to newPath.
+func applyOrganizedFileMetadata(book *database.Book, newPath string) {
+	hash, err := scanner.ComputeFileHash(newPath)
+	if err != nil {
+		log.Printf("[WARN] failed to compute organized hash for %s: %v", newPath, err)
+	} else if hash != "" {
+		book.FileHash = stringPtr(hash)
+		book.OrganizedFileHash = stringPtr(hash)
+		if book.OriginalFileHash == nil {
+			book.OriginalFileHash = stringPtr(hash)
+		}
+	}
+	if info, err := os.Stat(newPath); err == nil {
+		size := info.Size()
+		book.FileSize = &size
+	}
+}
+
+// --- external ID store helper -----------------------------------------------
+
+// ExternalIDStore defines the external-ID mapping operations used by
+// AudiobookService.DeleteAudiobook.
+type ExternalIDStore interface {
+	CreateExternalIDMapping(mapping *database.ExternalIDMapping) error
+	GetBookByExternalID(source, externalID string) (string, error)
+	GetExternalIDsForBook(bookID string) ([]database.ExternalIDMapping, error)
+	IsExternalIDTombstoned(source, externalID string) (bool, error)
+	TombstoneExternalID(source, externalID string) error
+	ReassignExternalIDs(oldBookID, newBookID string) error
+	BulkCreateExternalIDMappings(mappings []database.ExternalIDMapping) error
+}
+
+// asExternalIDStore type-asserts s to ExternalIDStore, returning nil on failure.
+func asExternalIDStore(s any) ExternalIDStore {
+	if s == nil {
+		return nil
+	}
+	if eid, ok := s.(ExternalIDStore); ok {
+		return eid
+	}
+	return nil
+}
+
+// --- value helpers ----------------------------------------------------------
+
+func stringVal(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func intVal(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nonEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// buildMetadataProvenance constructs a per-field provenance map for the
+// audiobook metadata panel, combining file-extracted, fetched, stored, and
+// override values with their effective resolution.
+func buildMetadataProvenance(book *database.Book, state map[string]metadataFieldState, meta metadata.Metadata, authorName, seriesName string, comparisonValues map[string]any) map[string]database.MetadataProvenanceEntry {
+	if state == nil {
+		state = map[string]metadataFieldState{}
+	}
+
+	provenance := map[string]database.MetadataProvenanceEntry{}
+
+	addEntry := func(field string, fileValue any, storedValue any) {
+		entryState := state[field]
+		effectiveSource := ""
+		var effectiveValue any
+		switch {
+		case entryState.OverrideValue != nil:
+			effectiveSource = "override"
+			effectiveValue = entryState.OverrideValue
+		case storedValue != nil:
+			effectiveSource = "stored"
+			effectiveValue = storedValue
+		case entryState.FetchedValue != nil:
+			effectiveSource = "fetched"
+			effectiveValue = entryState.FetchedValue
+		case fileValue != nil:
+			effectiveSource = "file"
+			effectiveValue = fileValue
+		}
+
+		var updatedAt *time.Time
+		if !entryState.UpdatedAt.IsZero() {
+			ts := entryState.UpdatedAt.UTC()
+			updatedAt = &ts
+		}
+
+		entry := database.MetadataProvenanceEntry{
+			FileValue:       fileValue,
+			FetchedValue:    entryState.FetchedValue,
+			StoredValue:     storedValue,
+			OverrideValue:   entryState.OverrideValue,
+			OverrideLocked:  entryState.OverrideLocked,
+			EffectiveValue:  effectiveValue,
+			EffectiveSource: effectiveSource,
+			UpdatedAt:       updatedAt,
+		}
+
+		if comparisonValues != nil {
+			if cv, ok := comparisonValues[field]; ok {
+				entry.ComparisonValue = cv
+			}
+		}
+
+		provenance[field] = entry
+	}
+
+	addEntry("title", meta.Title, book.Title)
+	addEntry("author_name", meta.Artist, authorName)
+	addEntry("narrator", meta.Narrator, stringVal(book.Narrator))
+	addEntry("series_name", meta.Series, seriesName)
+	addEntry("publisher", meta.Publisher, stringVal(book.Publisher))
+	addEntry("language", meta.Language, stringVal(book.Language))
+	addEntry("audiobook_release_year", meta.Year, intVal(book.AudiobookReleaseYear))
+	addEntry("isbn10", meta.ISBN10, stringVal(book.ISBN10))
+	addEntry("isbn13", meta.ISBN13, stringVal(book.ISBN13))
+	addEntry("genre", meta.Genre, stringVal(book.Genre))
+	addEntry("album", meta.Album, book.Title)
+	addEntry("asin", nonEmpty(meta.ASIN), stringVal(book.ASIN))
+	var seriesIdx any
+	if meta.SeriesIndex > 0 {
+		seriesIdx = meta.SeriesIndex
+	}
+	addEntry("series_index", seriesIdx, intVal(book.SeriesSequence))
+	addEntry("print_year", nonEmpty(meta.PrintYear), intVal(book.PrintYear))
+	addEntry("edition", nonEmpty(meta.Edition), stringVal(book.Edition))
+	addEntry("description", nonEmpty(meta.Comments), stringVal(book.Description))
+	addEntry("book_id", nonEmpty(meta.BookOrganizerID), book.ID)
+	addEntry("open_library_id", nonEmpty(meta.OpenLibraryID), stringVal(book.OpenLibraryID))
+	addEntry("hardcover_id", nonEmpty(meta.HardcoverID), stringVal(book.HardcoverID))
+	addEntry("google_books_id", nonEmpty(meta.GoogleBooksID), stringVal(book.GoogleBooksID))
+
+	return provenance
+}
+
+func buildComparisonValuesFromMetadata(comparisonMeta *metadata.Metadata) map[string]any {
+	if comparisonMeta == nil {
+		return nil
+	}
+	compMap := map[string]any{
+		"title":           nonEmpty(comparisonMeta.Title),
+		"author_name":     nonEmpty(comparisonMeta.Artist),
+		"narrator":        nonEmpty(comparisonMeta.Narrator),
+		"series_name":     nonEmpty(comparisonMeta.Series),
+		"publisher":       nonEmpty(comparisonMeta.Publisher),
+		"language":        nonEmpty(comparisonMeta.Language),
+		"isbn10":          nonEmpty(comparisonMeta.ISBN10),
+		"isbn13":          nonEmpty(comparisonMeta.ISBN13),
+		"genre":           nonEmpty(comparisonMeta.Genre),
+		"album":           nonEmpty(comparisonMeta.Album),
+		"asin":            nonEmpty(comparisonMeta.ASIN),
+		"edition":         nonEmpty(comparisonMeta.Edition),
+		"print_year":      nonEmpty(comparisonMeta.PrintYear),
+		"description":     nonEmpty(comparisonMeta.Comments),
+		"book_id":         nonEmpty(comparisonMeta.BookOrganizerID),
+		"open_library_id": nonEmpty(comparisonMeta.OpenLibraryID),
+		"hardcover_id":    nonEmpty(comparisonMeta.HardcoverID),
+		"google_books_id": nonEmpty(comparisonMeta.GoogleBooksID),
+	}
+	if comparisonMeta.Year > 0 {
+		compMap["audiobook_release_year"] = comparisonMeta.Year
+	}
+	if comparisonMeta.SeriesIndex > 0 {
+		compMap["series_index"] = comparisonMeta.SeriesIndex
+	}
+	return compMap
+}
+
+func buildComparisonValuesFromBook(book *database.Book, authorName, seriesName string) map[string]any {
+	if book == nil {
+		return nil
+	}
+	compMap := map[string]any{
+		"title":           nonEmpty(book.Title),
+		"author_name":     nonEmpty(authorName),
+		"narrator":        nonEmpty(ptrStr(book.Narrator)),
+		"series_name":     nonEmpty(seriesName),
+		"publisher":       nonEmpty(ptrStr(book.Publisher)),
+		"language":        nonEmpty(ptrStr(book.Language)),
+		"isbn10":          nonEmpty(ptrStr(book.ISBN10)),
+		"isbn13":          nonEmpty(ptrStr(book.ISBN13)),
+		"genre":           nonEmpty(ptrStr(book.Genre)),
+		"album":           nonEmpty(book.Title),
+		"asin":            nonEmpty(ptrStr(book.ASIN)),
+		"edition":         nonEmpty(ptrStr(book.Edition)),
+		"description":     nonEmpty(ptrStr(book.Description)),
+		"book_id":         nonEmpty(book.ID),
+		"open_library_id": nonEmpty(ptrStr(book.OpenLibraryID)),
+		"hardcover_id":    nonEmpty(ptrStr(book.HardcoverID)),
+		"google_books_id": nonEmpty(ptrStr(book.GoogleBooksID)),
+	}
+	if book.AudiobookReleaseYear != nil && *book.AudiobookReleaseYear > 0 {
+		compMap["audiobook_release_year"] = *book.AudiobookReleaseYear
+	}
+	if book.SeriesSequence != nil && *book.SeriesSequence > 0 {
+		compMap["series_index"] = *book.SeriesSequence
+	}
+	if book.PrintYear != nil && *book.PrintYear > 0 {
+		compMap["print_year"] = *book.PrintYear
+	}
+	return compMap
+}
+
+// buildComparisonValuesFromActivityLog reconstructs a "before" tag snapshot
+// from the activity log for the given book within ±5 s of ts.
+func buildComparisonValuesFromActivityLog(as *activity.Service, bookID string, ts time.Time) map[string]any {
+	window := 5 * time.Second
+	since := ts.Add(-window)
+	until := ts.Add(window)
+	entries, _, err := as.Query(database.ActivityFilter{
+		BookID: bookID,
+		Type:   "metadata_apply",
+		Since:  &since,
+		Until:  &until,
+		Limit:  200,
+	})
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+	compMap := map[string]any{}
+	for _, e := range entries {
+		if e.Details == nil {
+			continue
+		}
+		field, _ := e.Details["field"].(string)
+		if field == "" {
+			continue
+		}
+		if oldVal, ok := e.Details["old_value"]; ok && oldVal != nil {
+			if s, ok := oldVal.(string); ok && s != "" {
+				compMap[field] = s
+			} else if oldVal != nil {
+				compMap[field] = oldVal
+			}
+		}
+	}
+	if len(compMap) == 0 {
+		return nil
+	}
+	return compMap
+}

--- a/internal/audiobooks/organize.go
+++ b/internal/audiobooks/organize.go
@@ -1,4 +1,4 @@
-// file: internal/server/organize_service.go
+// file: internal/audiobooks/organize.go
 // version: 2.2.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-05-05
@@ -8,7 +8,7 @@
 // constructor wrappers so the rest of the server package can keep using
 // the old names without a large rename diff.
 
-package server
+package audiobooks
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"

--- a/internal/audiobooks/organize_preview.go
+++ b/internal/audiobooks/organize_preview.go
@@ -1,5 +1,5 @@
-// file: internal/server/organize_preview_service.go
-// version: 2.0.0
+// file: internal/audiobooks/organize_preview.go
+// version: 2.0.1
 // guid: f1a2b3c4-d5e6-7890-abcd-ef1234567890
 //
 // Thin forwarding layer — the real implementation now lives in
@@ -7,7 +7,7 @@
 // constructor wrappers so the rest of the server package can keep using
 // the old names.
 
-package server
+package audiobooks
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"

--- a/internal/audiobooks/rename.go
+++ b/internal/audiobooks/rename.go
@@ -1,5 +1,5 @@
-// file: internal/server/rename_service.go
-// version: 2.0.0
+// file: internal/audiobooks/rename.go
+// version: 2.0.1
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 //
 // Thin forwarding layer — the real implementation now lives in
@@ -7,7 +7,7 @@
 // constructor wrappers so the rest of the server package can keep using
 // the old names.
 
-package server
+package audiobooks
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"

--- a/internal/audiobooks/revert.go
+++ b/internal/audiobooks/revert.go
@@ -1,8 +1,8 @@
-// file: internal/server/revert_service.go
-// version: 1.2.0
+// file: internal/audiobooks/revert.go
+// version: 1.2.1
 // guid: d4e5f6a7-b8c9-d0e1-f2a3-b4c5d6e7f8a9
 
-package server
+package audiobooks
 
 import (
 	"fmt"

--- a/internal/audiobooks/revert_service_organize_test.go
+++ b/internal/audiobooks/revert_service_organize_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/revert_service_organize_test.go
+// file: internal/audiobooks/revert_service_organize_test.go
 // version: 1.0.0
 // guid: 4f8c2a1d-5e9b-4f70-a3c6-8d1e0f2b9a47
 
-package server
+package audiobooks
 
 import (
 	"os"

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,8 +1,8 @@
-// file: internal/server/audiobook_service.go
-// version: 1.23.0
+// file: internal/audiobooks/service.go
+// version: 1.23.1
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
-package server
+package audiobooks
 
 import (
 	"context"
@@ -1370,7 +1370,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 	}
 
 	// Create a MetadataStateService for recording change history.
-	mss := NewMetadataStateService(svc.store)
+	mss := newMetadataStateSvc(svc.store)
 
 	// Process overrides
 	for field, override := range req.Updates.Overrides {
@@ -1390,7 +1390,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 				entry.OverrideValue = val
 				entry.OverrideLocked = override.Locked == nil || *override.Locked
 				entry.UpdatedAt = now
-				applyOverrideToPayload(payload, field, val)
+				ApplyOverrideToPayload(payload, field, val)
 				// Record history for setting an override.
 				if fmt.Sprintf("%v", oldOverrideValue) != fmt.Sprintf("%v", val) {
 					mss.recordChange(id, field, "override", "user_edit", oldOverrideValue, val)
@@ -1722,8 +1722,8 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 	}, nil
 }
 
-// applyOverrideToPayload applies an override value to the update payload
-func applyOverrideToPayload(payload *AudiobookUpdate, field string, value any) {
+// ApplyOverrideToPayload applies an override value to the update payload
+func ApplyOverrideToPayload(payload *AudiobookUpdate, field string, value any) {
 	switch field {
 	case "title":
 		if v, ok := value.(string); ok {

--- a/internal/audiobooks/update_service.go
+++ b/internal/audiobooks/update_service.go
@@ -1,8 +1,8 @@
-// file: internal/server/audiobook_update_service.go
-// version: 1.3.0
+// file: internal/audiobooks/update_service.go
+// version: 1.3.1
 // guid: b2c3d4e5-f6g7-h8i9-j0k1-l2m3n4o5p6q7
 
-package server
+package audiobooks
 
 import (
 	"context"

--- a/internal/server/audiobooks_compat.go
+++ b/internal/server/audiobooks_compat.go
@@ -1,0 +1,245 @@
+// file: internal/server/audiobooks_compat.go
+// version: 1.0.0
+// guid: b1c2d3e4-f5a6-7890-bcde-f01234560020
+// last-edited: 2026-05-05
+//
+// Type aliases and function variables that let the rest of internal/server/
+// continue using the old unqualified names after the seven service files
+// were moved to internal/audiobooks/. This file is the only place that
+// needs updating if a moved symbol is later renamed.
+
+package server
+
+import (
+	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"strings"
+	"time"
+)
+
+// --- AudiobookService -------------------------------------------------------
+
+type (
+	// AudiobookService is a type alias for the moved service.
+	AudiobookService = audiobookspkg.AudiobookService
+
+	// AudiobooksListResponse is re-exported from the audiobooks package.
+	AudiobooksListResponse = audiobookspkg.AudiobooksListResponse
+
+	// AudiobookDetail is re-exported from the audiobooks package.
+	AudiobookDetail = audiobookspkg.AudiobookDetail
+
+	// DuplicatesResult is re-exported from the audiobooks package.
+	DuplicatesResult = audiobookspkg.DuplicatesResult
+
+	// SoftDeletedBooksResponse is re-exported from the audiobooks package.
+	SoftDeletedBooksResponse = audiobookspkg.SoftDeletedBooksResponse
+
+	// PurgeResult is re-exported from the audiobooks package.
+	PurgeResult = audiobookspkg.PurgeResult
+
+	// AudiobookUpdate is re-exported from the audiobooks package.
+	AudiobookUpdate = audiobookspkg.AudiobookUpdate
+
+	// OverridePayload is re-exported from the audiobooks package.
+	OverridePayload = audiobookspkg.OverridePayload
+
+	// FieldFilter is re-exported from the audiobooks package.
+	FieldFilter = audiobookspkg.FieldFilter
+
+	// ListFilters is re-exported from the audiobooks package.
+	ListFilters = audiobookspkg.ListFilters
+
+	// UpdateAudiobookRequest is re-exported from the audiobooks package.
+	UpdateAudiobookRequest = audiobookspkg.UpdateAudiobookRequest
+
+	// DeleteAudiobookOptions is re-exported from the audiobooks package.
+	DeleteAudiobookOptions = audiobookspkg.DeleteAudiobookOptions
+)
+
+// PerUserFieldNames is re-exported from the audiobooks package.
+var PerUserFieldNames = audiobookspkg.PerUserFieldNames
+
+// IsPerUserField delegates to the audiobooks package.
+func IsPerUserField(field string) bool {
+	return audiobookspkg.IsPerUserField(field)
+}
+
+// NewAudiobookService delegates to the audiobooks package.
+func NewAudiobookService(store database.Store) *AudiobookService {
+	return audiobookspkg.NewAudiobookService(store)
+}
+
+// --- AudiobookUpdateService -------------------------------------------------
+
+type (
+	// AudiobookUpdateService is re-exported from the audiobooks package.
+	AudiobookUpdateService = audiobookspkg.AudiobookUpdateService
+)
+
+// NewAudiobookUpdateService delegates to the audiobooks package.
+func NewAudiobookUpdateService(db database.Store) *AudiobookUpdateService {
+	return audiobookspkg.NewAudiobookUpdateService(db)
+}
+
+// --- AuthorSeriesService ----------------------------------------------------
+
+type (
+	// AuthorSeriesService is re-exported from the audiobooks package.
+	AuthorSeriesService = audiobookspkg.AuthorSeriesService
+
+	// AuthorWithCount is re-exported from the audiobooks package.
+	AuthorWithCount = audiobookspkg.AuthorWithCount
+
+	// AuthorListResponse is re-exported from the audiobooks package.
+	AuthorListResponse = audiobookspkg.AuthorListResponse
+
+	// AuthorWithCountListResponse is re-exported from the audiobooks package.
+	AuthorWithCountListResponse = audiobookspkg.AuthorWithCountListResponse
+
+	// SeriesWithCount is re-exported from the audiobooks package.
+	SeriesWithCount = audiobookspkg.SeriesWithCount
+
+	// SeriesListResponse is re-exported from the audiobooks package.
+	SeriesListResponse = audiobookspkg.SeriesListResponse
+
+	// SeriesWithCountsResponse is re-exported from the audiobooks package.
+	SeriesWithCountsResponse = audiobookspkg.SeriesWithCountsResponse
+)
+
+// NewAuthorSeriesService delegates to the audiobooks package.
+func NewAuthorSeriesService(db database.Store) *AuthorSeriesService {
+	return audiobookspkg.NewAuthorSeriesService(db)
+}
+
+// --- OrganizeService --------------------------------------------------------
+
+type (
+	// OrganizeService is re-exported from the audiobooks package.
+	OrganizeService = audiobookspkg.OrganizeService
+
+	// OrganizeRequest is re-exported from the audiobooks package.
+	OrganizeRequest = audiobookspkg.OrganizeRequest
+
+	// OrganizeStats is re-exported from the audiobooks package.
+	OrganizeStats = audiobookspkg.OrganizeStats
+)
+
+// NewOrganizeService delegates to the audiobooks package.
+func NewOrganizeService(db database.Store) *OrganizeService {
+	return audiobookspkg.NewOrganizeService(db)
+}
+
+// --- OrganizePreviewService -------------------------------------------------
+
+type (
+	// OrganizePreviewStep is re-exported from the audiobooks package.
+	OrganizePreviewStep = audiobookspkg.OrganizePreviewStep
+
+	// OrganizePreviewResponse is re-exported from the audiobooks package.
+	OrganizePreviewResponse = audiobookspkg.OrganizePreviewResponse
+
+	// OrganizePreviewService is re-exported from the audiobooks package.
+	OrganizePreviewService = audiobookspkg.OrganizePreviewService
+)
+
+// NewOrganizePreviewService delegates to the audiobooks package.
+func NewOrganizePreviewService(db database.Store) *OrganizePreviewService {
+	return audiobookspkg.NewOrganizePreviewService(db)
+}
+
+// --- RevertService ----------------------------------------------------------
+
+type (
+	// RevertService is re-exported from the audiobooks package.
+	RevertService = audiobookspkg.RevertService
+)
+
+// NewRevertService delegates to the audiobooks package.
+func NewRevertService(db database.Store) *RevertService {
+	return audiobookspkg.NewRevertService(db)
+}
+
+// --- RenameService ----------------------------------------------------------
+
+type (
+	// RenameService is re-exported from the audiobooks package.
+	RenameService = audiobookspkg.RenameService
+
+	// TagChange is re-exported from the audiobooks package.
+	TagChange = audiobookspkg.TagChange
+
+	// RenamePreview is re-exported from the audiobooks package.
+	RenamePreview = audiobookspkg.RenamePreview
+
+	// RenameApplyResult is re-exported from the audiobooks package.
+	RenameApplyResult = audiobookspkg.RenameApplyResult
+)
+
+// NewRenameService delegates to the audiobooks package.
+func NewRenameService(db database.Store) *RenameService {
+	return audiobookspkg.NewRenameService(db)
+}
+
+// applyOverrideToPayload delegates to the audiobooks package.
+// Kept unexported so server-package whitebox tests can reference it directly.
+var applyOverrideToPayload = audiobookspkg.ApplyOverrideToPayload
+
+// --- Small helpers previously in audiobook_service.go -----------------------
+// These are used by operations_handlers.go and playlist_evaluator.go which
+// remain in the server package after the service files were extracted.
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefInt(i *int) int {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func derefInt64(i *int64) int64 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func cmpTime(a, b *time.Time) int {
+	ta := time.Time{}
+	tb := time.Time{}
+	if a != nil {
+		ta = *a
+	}
+	if b != nil {
+		tb = *b
+	}
+	switch {
+	case ta.Before(tb):
+		return -1
+	case ta.After(tb):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func splitMultipleNames(name string) []string {
+	parts := strings.Split(name, " & ")
+	var result []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	if len(result) == 0 {
+		return []string{name}
+	}
+	return result
+}

--- a/internal/server/error_handler_test.go
+++ b/internal/server/error_handler_test.go
@@ -183,7 +183,7 @@ func TestParsePaginationParams(t *testing.T) {
 		{
 			name:       "limit exceeds max",
 			queryStr:   "/?limit=20000",
-			wantLimit:  10000,
+			wantLimit:  500,
 			wantOffset: 0,
 			wantSearch: "",
 		},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-05-05
 
@@ -19,6 +19,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/aiscan"
+	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
 	"github.com/jdfalk/audiobook-organizer/internal/cache"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -142,11 +143,11 @@ type Server struct {
 	store                  database.Store
 	httpServer             *http.Server
 	router                 *gin.Engine
-	audiobookService       *AudiobookService
+	audiobookService       *audiobookspkg.AudiobookService
 	audiobookUpdateService *AudiobookUpdateService
 	batchService           *BatchService
 	workService            *WorkService
-	authorSeriesService    *AuthorSeriesService
+	authorSeriesService    *audiobookspkg.AuthorSeriesService
 	filesystemService      *FilesystemService
 	importPathService      *importer.ImportPathService
 	importService          *importer.ImportService
@@ -284,11 +285,11 @@ func NewServer(store database.Store) *Server {
 		bgCtx:                  bgCtx,
 		bgCancel:               bgCancel,
 		router:                 router,
-		audiobookService:       NewAudiobookService(resolvedStore),
+		audiobookService:       audiobookspkg.NewAudiobookService(resolvedStore),
 		audiobookUpdateService: NewAudiobookUpdateService(resolvedStore),
 		batchService:           NewBatchService(resolvedStore),
 		workService:            NewWorkService(resolvedStore),
-		authorSeriesService:    NewAuthorSeriesService(resolvedStore),
+		authorSeriesService:    audiobookspkg.NewAuthorSeriesService(resolvedStore),
 		filesystemService:      NewFilesystemService(resolvedStore),
 		importPathService:      importer.NewImportPathService(resolvedStore),
 		importService:          importer.NewImportService(resolvedStore),

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1333,7 +1333,7 @@ func TestAudiobookService_CountAudiobooks_Error(t *testing.T) {
 
 // TestAudiobookService_CountAudiobooks_NilDB tests nil database
 func TestAudiobookService_CountAudiobooks_NilDB(t *testing.T) {
-	svc := &AudiobookService{store: nil}
+	svc := NewAudiobookService(nil)
 
 	count, err := svc.CountAudiobooks(context.Background())
 	if err == nil {
@@ -1349,7 +1349,7 @@ func TestAudiobookService_CountAudiobooks_NilDB(t *testing.T) {
 
 // TestAudiobookService_GetSoftDeletedBooks_NilDB tests nil database
 func TestAudiobookService_GetSoftDeletedBooks_NilDB(t *testing.T) {
-	svc := &AudiobookService{store: nil}
+	svc := NewAudiobookService(nil)
 
 	books, err := svc.GetSoftDeletedBooks(context.Background(), 50, 0, nil)
 	if err == nil {


### PR DESCRIPTION
## Summary

Extract 7 gin-free service files from `internal/server/` into a new `internal/audiobooks/` package.

## Changes

### New package: `internal/audiobooks/`
- **service.go** (from `audiobook_service.go`) — core audiobook CRUD service
- **update_service.go** (from `audiobook_update_service.go`) — field update/override logic
- **author_series.go** (from `author_series_service.go`) — author/series management
- **organize.go** (from `organize_service.go`) — file organization service
- **organize_preview.go** (from `organize_preview_service.go`) — organize preview/dry-run
- **revert.go** (from `revert_service.go`) — change revert service
- **rename.go** (from `rename_service.go`) — bulk rename service
- **helpers.go** — private utility functions to avoid import cycles

### Modified: `internal/server/`
- **audiobooks_compat.go** (new) — Go type aliases and function delegates so all handler files compile without changes
- **server.go** — updated to construct services via `audiobookspkg`
- **error_handler_test.go** — fixed pre-existing httputil migration breakage
- **response_types_test.go** — fixed pre-existing httputil migration breakage
- **service_layer_test.go** — fixed cross-package field access after move

### Test files relocated
- `audiobook_service_*_test.go` → `internal/audiobooks/`
- `revert_service_organize_test.go` → `internal/audiobooks/`

## Motivation
Reduces `internal/server/` from ~12k lines to ~9k lines. Business logic is now independently importable without pulling in gin/server dependencies.

Refs: PKG-1