### PR TITLE
refactor(server): move filesystem/system services to fileops/sysinfo packages (PKG-4e)

### DIFF
--- a/internal/fileops/service.go
+++ b/internal/fileops/service.go
@@ -1,17 +1,16 @@
-// file: internal/server/filesystem_service.go
-// version: 1.2.1
+// file: internal/fileops/service.go
+// version: 1.0.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
-package server
+package fileops
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"errors"
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"

--- a/internal/fileops/service_test.go
+++ b/internal/fileops/service_test.go
@@ -1,12 +1,11 @@
-// file: internal/server/filesystem_service_test.go
-// version: 1.1.0
+// file: internal/fileops/service_test.go
+// version: 1.0.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
-// last-edited: 2026-04-30
+// last-edited: 2026-05-01
 
-package server
+package fileops
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
 	mockStore := new(mocks.MockImportPathStore)
 	fs := NewFilesystemService(mockStore)
 
-	tmpDir, err := ioutil.TempDir("", "test-exclusion")
+	tmpDir, err := os.MkdirTemp("", "test-exclusion")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
@@ -64,7 +63,7 @@ func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
 	mockStore := new(mocks.MockImportPathStore)
 	fs := NewFilesystemService(mockStore)
 
-	tmpDir, err := ioutil.TempDir("", "test-remove-exclusion")
+	tmpDir, err := os.MkdirTemp("", "test-remove-exclusion")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -46,7 +47,7 @@ func (s *Server) browseFilesystem(c *gin.Context) {
 	path := c.Query("path")
 	result, err := s.filesystemService.BrowseDirectory(path)
 	if err != nil {
-		if errors.Is(err, ErrPathNotAllowed) {
+		if errors.Is(err, fileops.ErrPathNotAllowed) {
 			httputil.RespondWithForbidden(c, err.Error())
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
 // version: 2.2.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-05
+// last-edited: 2026-05-01
 
 package server
 
@@ -44,6 +44,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
+	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
 	"github.com/jdfalk/audiobook-organizer/internal/tagger"
 	"github.com/jdfalk/audiobook-organizer/internal/updater"
 	"github.com/quic-go/quic-go/http3"
@@ -148,14 +150,14 @@ type Server struct {
 	batchService           *BatchService
 	workService            *WorkService
 	authorSeriesService    *audiobookspkg.AuthorSeriesService
-	filesystemService      *FilesystemService
+	filesystemService      *fileops.FilesystemService
 	importPathService      *importer.ImportPathService
 	importService          *importer.ImportService
 	scanService            *scanner.ScanService
 	organizeService        *OrganizeService
 	metadataFetchService   *metafetch.Service
 	configUpdateService    *ConfigUpdateService
-	systemService          *SystemService
+	systemService          *sysinfo.SystemService
 	metadataStateService   *MetadataStateService
 	dashboardService       *DashboardService
 	olService              *metafetch.OpenLibraryService
@@ -290,14 +292,14 @@ func NewServer(store database.Store) *Server {
 		batchService:           NewBatchService(resolvedStore),
 		workService:            NewWorkService(resolvedStore),
 		authorSeriesService:    audiobookspkg.NewAuthorSeriesService(resolvedStore),
-		filesystemService:      NewFilesystemService(resolvedStore),
+		filesystemService:      fileops.NewFilesystemService(resolvedStore),
 		importPathService:      importer.NewImportPathService(resolvedStore),
 		importService:          importer.NewImportService(resolvedStore),
 		scanService:            scanner.NewScanService(resolvedStore),
 		organizeService:        NewOrganizeService(resolvedStore),
 		metadataFetchService:   metafetch.NewService(resolvedStore),
 		configUpdateService:    NewConfigUpdateService(resolvedStore),
-		systemService:          NewSystemService(resolvedStore),
+		systemService:          sysinfo.NewSystemService(resolvedStore, appVersion, calculateLibrarySizes),
 		metadataStateService:   NewMetadataStateService(resolvedStore),
 		dashboardService:       NewDashboardService(resolvedStore),
 		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
+	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -327,7 +329,7 @@ func TestImportPathService_ValidatePath_Whitespace(t *testing.T) {
 // TestSystemService_FilterLogsBySearch_CaseInsensitive tests case insensitivity
 func TestSystemService_FilterLogsBySearch_CaseInsensitive(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewSystemService(mockStore)
+	svc := sysinfo.NewSystemService(mockStore, "test", nil)
 
 	logs := []database.OperationLog{
 		{Message: "Starting SCAN operation"},
@@ -380,7 +382,7 @@ func TestSystemService_FilterLogsBySearch_CaseInsensitive(t *testing.T) {
 // TestSystemService_SortLogsByTimestamp_EdgeCases tests edge cases for sorting
 func TestSystemService_SortLogsByTimestamp_EdgeCases(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewSystemService(mockStore)
+	svc := sysinfo.NewSystemService(mockStore, "test", nil)
 
 	now := time.Now()
 
@@ -437,7 +439,7 @@ func TestSystemService_SortLogsByTimestamp_EdgeCases(t *testing.T) {
 // TestSystemService_PaginateLogs_EdgeCases tests edge cases for pagination
 func TestSystemService_PaginateLogs_EdgeCases(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewSystemService(mockStore)
+	svc := sysinfo.NewSystemService(mockStore, "test", nil)
 
 	logs := make([]database.OperationLog, 50)
 	for i := 0; i < 50; i++ {
@@ -508,7 +510,7 @@ func TestSystemService_PaginateLogs_EdgeCases(t *testing.T) {
 // TestSystemService_GetFormattedUptime tests uptime formatting
 func TestSystemService_GetFormattedUptime(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewSystemService(mockStore)
+	svc := sysinfo.NewSystemService(mockStore, "test", nil)
 
 	tests := []struct {
 		name      string
@@ -1504,7 +1506,7 @@ func TestServerHelpers_IntVal(t *testing.T) {
 
 // TestFilesystemService_CreateExclusion_EmptyPath tests empty path error
 func TestFilesystemService_CreateExclusion_EmptyPath(t *testing.T) {
-	svc := &FilesystemService{}
+	svc := fileops.NewFilesystemService(nil)
 
 	err := svc.CreateExclusion("")
 	if err == nil {
@@ -1517,7 +1519,7 @@ func TestFilesystemService_CreateExclusion_EmptyPath(t *testing.T) {
 
 // TestFilesystemService_CreateExclusion_NotDirectory tests file path error
 func TestFilesystemService_CreateExclusion_NotDirectory(t *testing.T) {
-	svc := &FilesystemService{}
+	svc := fileops.NewFilesystemService(nil)
 
 	// Create a real file so stat succeeds but it's not a directory
 	tmpFile := filepath.Join(t.TempDir(), "not_a_dir.txt")
@@ -1534,7 +1536,7 @@ func TestFilesystemService_CreateExclusion_NotDirectory(t *testing.T) {
 
 // TestFilesystemService_RemoveExclusion_EmptyPath tests empty path error
 func TestFilesystemService_RemoveExclusion_EmptyPath(t *testing.T) {
-	svc := &FilesystemService{}
+	svc := fileops.NewFilesystemService(nil)
 
 	err := svc.RemoveExclusion("")
 	if err == nil {

--- a/internal/sysinfo/service.go
+++ b/internal/sysinfo/service.go
@@ -1,8 +1,9 @@
-// file: internal/server/system_service.go
-// version: 1.7.0
+// file: internal/sysinfo/service.go
+// version: 1.0.0
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
+// last-edited: 2026-05-01
 
-package server
+package sysinfo
 
 import (
 	"fmt"
@@ -12,24 +13,39 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
 )
 
-// systemServiceStore is the narrow slice of database.Store this service uses.
-type systemServiceStore interface {
+// SystemServiceStore is the narrow slice of database.Store this service uses.
+type SystemServiceStore interface {
 	database.ImportPathStore
 	database.OperationStore
 	database.StatsStore
 }
 
+// LibrarySizesFn computes library and import-path disk usage.
+type LibrarySizesFn func(rootDir string, importFolders []database.ImportPath) (librarySize, importSize int64)
 
 type SystemService struct {
-	db        systemServiceStore
-	startTime time.Time
+	db          SystemServiceStore
+	version     string
+	libSizesFn  LibrarySizesFn
+	startTime   time.Time
 }
 
-func NewSystemService(db systemServiceStore) *SystemService {
-	return &SystemService{db: db, startTime: time.Now()}
+// NewSystemService constructs a SystemService.
+// version is the application version string (e.g. "1.2.3" or "dev").
+// libSizesFn is called to compute library/import disk sizes; if nil a no-op
+// implementation is used (both sizes returned as 0).
+func NewSystemService(db SystemServiceStore, version string, libSizesFn LibrarySizesFn) *SystemService {
+	if libSizesFn == nil {
+		libSizesFn = func(_ string, _ []database.ImportPath) (int64, int64) { return 0, 0 }
+	}
+	return &SystemService{
+		db:         db,
+		version:    version,
+		libSizesFn: libSizesFn,
+		startTime:  time.Now(),
+	}
 }
 
 type SystemStatus struct {
@@ -51,8 +67,8 @@ type SystemStatus struct {
 	Runtime          SystemRuntimeStatus  `json:"runtime"`
 	Operations       SystemOperationsInfo `json:"operations"`
 	PluginHealth     map[string]string    `json:"plugin_health,omitempty"`
-	AppUptimeSeconds    float64              `json:"app_uptime_seconds"`
-	SystemUptimeSeconds float64              `json:"system_uptime_seconds"`
+	AppUptimeSeconds    float64           `json:"app_uptime_seconds"`
+	SystemUptimeSeconds float64           `json:"system_uptime_seconds"`
 }
 
 type SystemLibraryStatus struct {
@@ -125,7 +141,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	librarySize, importSize := calculateLibrarySizes(rootDir, importFolders)
+	librarySize, importSize := ss.libSizesFn(rootDir, importFolders)
 	// Fall back to DB file sizes when filesystem walk returns 0 (e.g. paths don't exist on this host)
 	if librarySize+importSize == 0 {
 		librarySize = dbStats.OrganizedSize
@@ -135,7 +151,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 
 	status := &SystemStatus{
 		Status:           "running",
-		Version:          appVersion,
+		Version:          ss.version,
 		LibraryBookCount: dbStats.OrganizedBooks,
 		ImportBookCount:  dbStats.UnorganizedBooks,
 		TotalBookCount:   dbStats.TotalBooks,
@@ -164,7 +180,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 			NumGC:           memStats.NumGC,
 			HeapAlloc:       memStats.HeapAlloc,
 			HeapSys:         memStats.HeapSys,
-			SystemTotal:     sysinfo.GetTotalMemory(),
+			SystemTotal:     GetTotalMemory(),
 		},
 		Runtime: SystemRuntimeStatus{
 			GoVersion:    runtime.Version(),
@@ -177,7 +193,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 			Recent: recentOps,
 		},
 		AppUptimeSeconds:    time.Since(ss.startTime).Seconds(),
-		SystemUptimeSeconds: sysinfo.GetSystemUptimeSeconds(),
+		SystemUptimeSeconds: GetSystemUptimeSeconds(),
 	}
 
 	return status, nil

--- a/internal/sysinfo/service_test.go
+++ b/internal/sysinfo/service_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/system_service_test.go
+// file: internal/sysinfo/service_test.go
 // version: 1.0.0
 // guid: g7h8i9j0-k1l2-m3n4-o5p6-q7r8s9t0u1v2
 
-package server
+package sysinfo
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ func TestSystemService_CollectSystemStatus_Success(t *testing.T) {
 			return []database.ImportPath{}, nil
 		},
 	}
-	service := NewSystemService(mockDB)
+	service := NewSystemService(mockDB, "test", nil)
 
 	status, err := service.CollectSystemStatus()
 
@@ -29,7 +29,7 @@ func TestSystemService_CollectSystemStatus_Success(t *testing.T) {
 }
 
 func TestSystemService_FilterLogsBySearch_Match(t *testing.T) {
-	service := NewSystemService(&database.MockStore{})
+	service := NewSystemService(&database.MockStore{}, "test", nil)
 
 	logs := []database.OperationLog{
 		{
@@ -45,7 +45,7 @@ func TestSystemService_FilterLogsBySearch_Match(t *testing.T) {
 }
 
 func TestSystemService_FilterLogsBySearch_NoMatch(t *testing.T) {
-	service := NewSystemService(&database.MockStore{})
+	service := NewSystemService(&database.MockStore{}, "test", nil)
 
 	logs := []database.OperationLog{
 		{
@@ -61,7 +61,7 @@ func TestSystemService_FilterLogsBySearch_NoMatch(t *testing.T) {
 }
 
 func TestSystemService_PaginateLogs_Success(t *testing.T) {
-	service := NewSystemService(&database.MockStore{})
+	service := NewSystemService(&database.MockStore{}, "test", nil)
 
 	logs := make([]database.OperationLog, 100)
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Moves `filesystem_service.go` → `internal/fileops/service.go` and `system_service.go` → `internal/sysinfo/service.go`. No *Server deps in either file — clean extraction. Tests migrated alongside service files.