### PR TITLE
fix(ci): update jdfalk/* action pins to current SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.0
+# version: 3.0.1
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
 # last-edited: 2026-05-01
 
@@ -28,7 +28,7 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci-minimal.yml@cf2068996e1ecf737a6e2c269a9429f0764e76cd # feat/reusable-ci-minimal
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci-minimal.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # feat/reusable-ci-minimal
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/frontend-ci.yml
-# version: 2.9.0
+# version: 2.9.1
 # guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
+# last-edited: 2026-05-01
 
 name: Frontend CI
 
@@ -39,7 +40,7 @@ jobs:
 
       - name: Load frontend configuration
         id: frontend-config
-        uses: jdfalk/get-frontend-config-action@3d728dd5c1f057dfdc97fc6eb3ca1e8fe8ba3a1b # v1.1.3
+        uses: jdfalk/get-frontend-config-action@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
         with:
           repository-config: ''
           config-file: '.github/repository-config.yml'
@@ -48,7 +49,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly.yml
-# version: 1.0.0
+# version: 1.0.1
 # guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 # last-edited: 2026-05-01
 
@@ -28,7 +28,7 @@ permissions:
 jobs:
   full-ci:
     name: Full CI Suite
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # v1.12.0
+    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v1.12.0
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.9.1
+# version: 2.9.2
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
+# last-edited: 2026-05-01
 
 name: Prerelease on Merge
 
@@ -27,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@dd8fae111732e9bdc7fed56a0f4d68cb0fd17d34 # v2.13.1
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v2.13.1
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.8.0
+# version: 4.8.1
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
+# last-edited: 2026-05-01
 
 name: Production Release
 
@@ -41,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@c46f978c3de2ddc839f6e8e47c4a1739d932623e # latest
+    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/.github/workflows/test-action-integration.yml
+++ b/.github/workflows/test-action-integration.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/test-action-integration.yml
-# version: 1.3.0
+# version: 1.3.1
 # guid: test-action-integration-001
+# last-edited: 2026-05-01
 
 name: Test Frontend Config Action Integration
 
@@ -37,7 +38,7 @@ jobs:
 
       - name: Get frontend configuration
         id: frontend-config
-        uses: jdfalk/get-frontend-config-action@3d728dd5c1f057dfdc97fc6eb3ca1e8fe8ba3a1b # v1.1.3
+        uses: jdfalk/get-frontend-config-action@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
         with:
           repository-config: ''
           config-file: '.github/repository-config.yml'


### PR DESCRIPTION
## Summary

Updates all `jdfalk/*` action pin SHAs to current main HEAD commits.

### Changes
- `ghcommon` refs (all workflows) → `fe1e308` (post-merge SHA)
- `get-frontend-config-action`: `3d728dd` → `9a5882d`

### Files modified
- `.github/workflows/ci.yml` (3.0.0 → 3.0.1)
- `.github/workflows/frontend-ci.yml` (2.9.0 → 2.9.1)
- `.github/workflows/nightly.yml` (1.0.0 → 1.0.1)
- `.github/workflows/prerelease.yml` (2.9.1 → 2.9.2)
- `.github/workflows/release-prod.yml` (4.8.0 → 4.8.1)
- `.github/workflows/test-action-integration.yml` (1.3.0 → 1.3.1)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>