### PR TITLE
feat(util): add normalize.go path/string normalization helpers (STRUCT-12)

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.68.0
+// version: 1.69.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-02
 
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -913,7 +914,7 @@ func (p *PebbleStore) CreateWork(work *Work) (*Work, error) {
 		return nil, err
 	}
 	// Basic title index (case-insensitive normalized) for future lookup
-	normTitle := strings.ToLower(strings.TrimSpace(work.Title))
+	normTitle := util.NormalizeString(work.Title)
 	if normTitle != "" {
 		idxKey := []byte(fmt.Sprintf("work:title:%s:%s", normTitle, work.ID))
 		if err := batch.Set(idxKey, []byte(work.ID), nil); err != nil {
@@ -946,8 +947,8 @@ func (p *PebbleStore) UpdateWork(id string, work *Work) (*Work, error) {
 		batch.Close()
 		return nil, err
 	}
-	oldNorm := strings.ToLower(strings.TrimSpace(old.Title))
-	newNorm := strings.ToLower(strings.TrimSpace(work.Title))
+	oldNorm := util.NormalizeString(old.Title)
+	newNorm := util.NormalizeString(work.Title)
 	if oldNorm != newNorm {
 		if oldNorm != "" {
 			if err := batch.Delete([]byte(fmt.Sprintf("work:title:%s:%s", oldNorm, id)), nil); err != nil {
@@ -982,7 +983,7 @@ func (p *PebbleStore) DeleteWork(id string) error {
 		batch.Close()
 		return err
 	}
-	norm := strings.ToLower(strings.TrimSpace(work.Title))
+	norm := util.NormalizeString(work.Title)
 	if norm != "" {
 		if err := batch.Delete([]byte(fmt.Sprintf("work:title:%s:%s", norm, id)), nil); err != nil {
 			batch.Close()
@@ -6739,7 +6740,7 @@ func (p *PebbleStore) AddBookTag(bookID, tag string) error {
 // source field so a user-claimed tag can promote to system or vice
 // versa without needing a delete-first step.
 func (p *PebbleStore) AddBookTagWithSource(bookID, tag, source string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -6771,7 +6772,7 @@ func (p *PebbleStore) AddBookTagWithSource(bookID, tag, source string) error {
 
 // RemoveBookTag removes a tag from a book regardless of source.
 func (p *PebbleStore) RemoveBookTag(bookID, tag string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -6798,7 +6799,7 @@ func (p *PebbleStore) RemoveBookTag(bookID, tag string) error {
 //
 // If `source` is empty, all sources match.
 func (p *PebbleStore) RemoveBookTagsByPrefix(bookID, prefix, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	prefix = util.NormalizeString(prefix)
 	if prefix == "" {
 		return fmt.Errorf("prefix cannot be empty")
 	}
@@ -6892,7 +6893,7 @@ func (p *PebbleStore) SetBookTags(bookID string, tags []string) error {
 	// Normalize incoming tags.
 	normalized := make(map[string]bool)
 	for _, t := range tags {
-		t = strings.ToLower(strings.TrimSpace(t))
+		t = util.NormalizeString(t)
 		if t != "" {
 			normalized[t] = true
 		}
@@ -6961,7 +6962,7 @@ func (p *PebbleStore) ListAllTags() ([]TagWithCount, error) {
 
 // GetBooksByTag returns all book IDs that have the given tag.
 func (p *PebbleStore) GetBooksByTag(tag string) ([]string, error) {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return nil, fmt.Errorf("tag cannot be empty")
 	}
@@ -7030,7 +7031,7 @@ var (
 // pebbleAddTag upserts a tag for any entity type. Serializes a
 // BookTag with the source field so it survives round-trips.
 func (p *PebbleStore) pebbleAddTag(ks pebbleTagKeyspace, entityID, tag, source string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -7056,7 +7057,7 @@ func (p *PebbleStore) pebbleAddTag(ks pebbleTagKeyspace, entityID, tag, source s
 }
 
 func (p *PebbleStore) pebbleRemoveTag(ks pebbleTagKeyspace, entityID, tag string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -7126,7 +7127,7 @@ func (p *PebbleStore) pebbleGetTagsDetailed(ks pebbleTagKeyspace, entityID strin
 }
 
 func (p *PebbleStore) pebbleRemoveTagsByPrefix(ks pebbleTagKeyspace, entityID, prefix, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	prefix = util.NormalizeString(prefix)
 	if prefix == "" {
 		return fmt.Errorf("prefix cannot be empty")
 	}
@@ -7155,7 +7156,7 @@ func (p *PebbleStore) pebbleSetTags(ks pebbleTagKeyspace, entityID string, tags 
 	}
 	normalized := make(map[string]bool)
 	for _, t := range tags {
-		t = strings.ToLower(strings.TrimSpace(t))
+		t = util.NormalizeString(t)
 		if t != "" {
 			normalized[t] = true
 		}
@@ -7216,7 +7217,7 @@ func (p *PebbleStore) pebbleListAllTags(ks pebbleTagKeyspace) ([]TagWithCount, e
 }
 
 func (p *PebbleStore) pebbleEntitiesByTag(ks pebbleTagKeyspace, tag string) ([]string, error) {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return nil, fmt.Errorf("tag cannot be empty")
 	}

--- a/internal/database/sqlite_store_tags.go
+++ b/internal/database/sqlite_store_tags.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store_tags.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-05-02
 
@@ -7,7 +7,8 @@ package database
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 )
 
 // Hash Blocklist Methods
@@ -33,7 +34,7 @@ func (s *SQLiteStore) AddBookTag(bookID, tag string) error {
 // source ("user" or "system"). Later writes overwrite the source
 // so a user can claim a system tag or vice versa.
 func (s *SQLiteStore) AddBookTagWithSource(bookID, tag, source string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -50,7 +51,7 @@ func (s *SQLiteStore) AddBookTagWithSource(bookID, tag, source string) error {
 
 // RemoveBookTag removes a tag from a book regardless of source.
 func (s *SQLiteStore) RemoveBookTag(bookID, tag string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -68,7 +69,7 @@ func (s *SQLiteStore) RemoveBookTag(bookID, tag string) error {
 // `metadata:source:*` system tags first so each book has exactly
 // one source tag at a time. Empty `source` matches all sources.
 func (s *SQLiteStore) RemoveBookTagsByPrefix(bookID, prefix, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	prefix = util.NormalizeString(prefix)
 	if prefix == "" {
 		return fmt.Errorf("prefix cannot be empty")
 	}
@@ -155,7 +156,7 @@ func (s *SQLiteStore) SetBookTags(bookID string, tags []string) error {
 	}
 
 	for _, tag := range tags {
-		tag = strings.ToLower(strings.TrimSpace(tag))
+		tag = util.NormalizeString(tag)
 		if tag == "" {
 			continue
 		}
@@ -200,7 +201,7 @@ func (s *SQLiteStore) ListAllTags() ([]TagWithCount, error) {
 
 // GetBooksByTag returns all book IDs that have the given tag.
 func (s *SQLiteStore) GetBooksByTag(tag string) ([]string, error) {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return nil, fmt.Errorf("tag cannot be empty")
 	}
@@ -235,7 +236,7 @@ func (s *SQLiteStore) GetBooksByTag(tag string) ([]string, error) {
 // interface exposes typed wrappers below.
 
 func (s *SQLiteStore) addTagGeneric(table, idCol string, id any, tag, source string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -252,7 +253,7 @@ func (s *SQLiteStore) addTagGeneric(table, idCol string, id any, tag, source str
 }
 
 func (s *SQLiteStore) removeTagGeneric(table, idCol string, id any, tag string) error {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return fmt.Errorf("tag cannot be empty")
 	}
@@ -262,7 +263,7 @@ func (s *SQLiteStore) removeTagGeneric(table, idCol string, id any, tag string) 
 }
 
 func (s *SQLiteStore) removeTagsByPrefixGeneric(table, idCol string, id any, prefix, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	prefix = util.NormalizeString(prefix)
 	if prefix == "" {
 		return fmt.Errorf("prefix cannot be empty")
 	}
@@ -335,7 +336,7 @@ func (s *SQLiteStore) setTagsGeneric(table, idCol string, id any, tags []string)
 		table, idCol,
 	)
 	for _, tag := range tags {
-		tag = strings.ToLower(strings.TrimSpace(tag))
+		tag = util.NormalizeString(tag)
 		if tag == "" {
 			continue
 		}
@@ -398,7 +399,7 @@ func (s *SQLiteStore) ListAllAuthorTags() ([]TagWithCount, error) {
 	return s.listAllTagsGeneric("author_tags")
 }
 func (s *SQLiteStore) GetAuthorsByTag(tag string) ([]int, error) {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return nil, fmt.Errorf("tag cannot be empty")
 	}
@@ -445,7 +446,7 @@ func (s *SQLiteStore) ListAllSeriesTags() ([]TagWithCount, error) {
 	return s.listAllTagsGeneric("series_tags")
 }
 func (s *SQLiteStore) GetSeriesByTag(tag string) ([]int, error) {
-	tag = strings.ToLower(strings.TrimSpace(tag))
+	tag = util.NormalizeString(tag)
 	if tag == "" {
 		return nil, fmt.Errorf("tag cannot be empty")
 	}

--- a/internal/database/tag_helpers.go
+++ b/internal/database/tag_helpers.go
@@ -1,10 +1,14 @@
 // file: internal/database/tag_helpers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 package database
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/util"
+)
 
 // Tag helpers for the "exactly one tag in this namespace" idiom.
 //
@@ -33,8 +37,8 @@ import "strings"
 // programmer bugs ("metadata:source:audible" with prefix
 // "metadata:language:" would delete every language tag).
 func EnsureSingletonBookTag(store Store, bookID, prefix, fullTag, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
-	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	prefix = util.NormalizeString(prefix)
+	fullTag = util.NormalizeString(fullTag)
 	if prefix == "" || fullTag == "" {
 		return nil
 	}
@@ -85,8 +89,8 @@ func EnsureSingletonBookTag(store Store, bookID, prefix, fullTag, source string)
 // EnsureSingletonAuthorTag mirrors EnsureSingletonBookTag for
 // authors — same semantics, keyed by author integer ID.
 func EnsureSingletonAuthorTag(store Store, authorID int, prefix, fullTag, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
-	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	prefix = util.NormalizeString(prefix)
+	fullTag = util.NormalizeString(fullTag)
 	if prefix == "" || fullTag == "" {
 		return nil
 	}
@@ -128,8 +132,8 @@ func EnsureSingletonAuthorTag(store Store, authorID int, prefix, fullTag, source
 // EnsureSingletonSeriesTag mirrors EnsureSingletonBookTag for
 // series — same semantics, keyed by series integer ID.
 func EnsureSingletonSeriesTag(store Store, seriesID int, prefix, fullTag, source string) error {
-	prefix = strings.ToLower(strings.TrimSpace(prefix))
-	fullTag = strings.ToLower(strings.TrimSpace(fullTag))
+	prefix = util.NormalizeString(prefix)
+	fullTag = util.NormalizeString(fullTag)
 	if prefix == "" || fullTag == "" {
 		return nil
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.38.0
+// version: 1.39.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-01
+// last-edited: 2026-05-02
 
 package scanner
 
@@ -29,6 +29,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/matcher"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -996,7 +997,7 @@ func looksLikePersonName(s string) bool {
 
 // looksLikeTitleCandidate flags titles that commonly begin with articles.
 func looksLikeTitleCandidate(s string) bool {
-	lower := strings.ToLower(strings.TrimSpace(s))
+	lower := util.NormalizeString(s)
 	return strings.HasPrefix(lower, "the ") || strings.HasPrefix(lower, "a ") || strings.HasPrefix(lower, "an ")
 }
 
@@ -1280,8 +1281,8 @@ func groupFilesIntoBooks(files []string) []Book {
 			break
 		}
 		if firstAlbum == "" {
-			firstAlbum = strings.ToLower(strings.TrimSpace(album))
-		} else if strings.ToLower(strings.TrimSpace(album)) != firstAlbum {
+			firstAlbum = util.NormalizeString(album)
+		} else if util.NormalizeString(album) != firstAlbum {
 			allSame = false
 			break
 		}
@@ -1305,7 +1306,7 @@ func groupFilesIntoBooks(files []string) []Book {
 		if album == "" {
 			noAlbum = append(noAlbum, f)
 		} else {
-			key := strings.ToLower(strings.TrimSpace(album))
+			key := util.NormalizeString(album)
 			albumGroups[key] = append(albumGroups[key], f)
 		}
 	}
@@ -1323,7 +1324,7 @@ func groupFilesIntoBooks(files []string) []Book {
 			}
 			// Merge playlist groups into albumGroups
 			for title, groupFiles := range plGroups {
-				key := "pl:" + strings.ToLower(strings.TrimSpace(title))
+				key := "pl:" + util.NormalizeString(title)
 				albumGroups[key] = append(albumGroups[key], groupFiles...)
 			}
 			// Reduce noAlbum to only unclaimed files
@@ -1377,12 +1378,12 @@ func saveBookToDatabase(book *Book) error {
 		// Attempt Work association (normalize title + author)
 		var workID *string
 		if book.Title != "" {
-			canonical := strings.ToLower(strings.TrimSpace(book.Title))
+			canonical := util.NormalizeString(book.Title)
 			// Simple heuristic: try existing works then create new.
 			works, err := database.GetGlobalStore().GetAllWorks()
 			if err == nil { // non-critical
 				for _, w := range works {
-					if strings.ToLower(strings.TrimSpace(w.Title)) == canonical && ((authorID == nil && w.AuthorID == nil) || (authorID != nil && w.AuthorID != nil && *authorID == *w.AuthorID)) {
+					if util.NormalizeString(w.Title) == canonical && ((authorID == nil && w.AuthorID == nil) || (authorID != nil && w.AuthorID != nil && *authorID == *w.AuthorID)) {
 						wid := w.ID
 						workID = &wid
 						break
@@ -1400,7 +1401,7 @@ func saveBookToDatabase(book *Book) error {
 					works, lookupErr := database.GetGlobalStore().GetAllWorks()
 					if lookupErr == nil {
 						for _, w := range works {
-							if strings.ToLower(strings.TrimSpace(w.Title)) == canonical &&
+							if util.NormalizeString(w.Title) == canonical &&
 								((authorID == nil && w.AuthorID == nil) ||
 									(authorID != nil && w.AuthorID != nil && *authorID == *w.AuthorID)) {
 								wid := w.ID

--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/duplicates_handlers.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: 47a3e3fb-f5cf-4970-a2fc-d2ef481368c9
-// last-edited: 2026-05-01
+// last-edited: 2026-05-02
 //
 // SQL-backed duplicate detection handlers split out of server.go:
 // find, list, merge, skip, dismiss, pair-level actions, and series
@@ -27,6 +27,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -532,7 +533,7 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 			if isGarbageSeries(s.Name) {
 				continue
 			}
-			key := strings.ToLower(strings.TrimSpace(s.Name))
+			key := util.NormalizeString(s.Name)
 			exactGroups[key] = append(exactGroups[key], s)
 		}
 
@@ -632,8 +633,8 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 
 		seriesByNormalizedName := make(map[string][]database.Series)
 		for _, s := range allSeries {
-			seriesByNormalizedName[strings.ToLower(strings.TrimSpace(s.Name))] = append(
-				seriesByNormalizedName[strings.ToLower(strings.TrimSpace(s.Name))], s)
+			seriesByNormalizedName[util.NormalizeString(s.Name)] = append(
+				seriesByNormalizedName[util.NormalizeString(s.Name)], s)
 		}
 
 		for _, s := range allSeries {
@@ -644,7 +645,7 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 			if !ok {
 				continue
 			}
-			suggestedKey := strings.ToLower(strings.TrimSpace(suggested))
+			suggestedKey := util.NormalizeString(suggested)
 			if matches, exists := seriesByNormalizedName[suggestedKey]; exists {
 				group := []database.Series{s}
 				seen[s.ID] = true
@@ -780,7 +781,7 @@ func (s *Server) deduplicateSeriesHandler(c *gin.Context) {
 		// Group by normalized name only
 		groups := make(map[string][]database.Series)
 		for _, s := range allSeries {
-			key := strings.ToLower(strings.TrimSpace(s.Name))
+			key := util.NormalizeString(s.Name)
 			groups[key] = append(groups[key], s)
 		}
 
@@ -927,7 +928,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface { datab
 		if s.AuthorID != nil {
 			aid = *s.AuthorID
 		}
-		key := groupKey{name: strings.ToLower(strings.TrimSpace(s.Name)), authorID: aid}
+		key := groupKey{name: util.NormalizeString(s.Name), authorID: aid}
 		groups[key] = append(groups[key], s)
 	}
 

--- a/internal/util/normalize.go
+++ b/internal/util/normalize.go
@@ -1,0 +1,51 @@
+// file: internal/util/normalize.go
+// version: 1.0.0
+// guid: a3f7e2d1-9b4c-4e8a-b6f0-2c5d7a1e3f9b
+// last-edited: 2026-05-02
+
+// Package util provides shared string and path normalization helpers.
+package util
+
+import (
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// NormalizePath cleans a filepath and lowercases it for consistent comparison.
+func NormalizePath(p string) string {
+	return strings.ToLower(filepath.Clean(p))
+}
+
+// NormalizeTitle trims whitespace and lowercases a title for comparison.
+func NormalizeTitle(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// NormalizeAuthor trims whitespace and lowercases an author name for comparison.
+func NormalizeAuthor(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// NormalizeString trims whitespace and lowercases any generic string.
+func NormalizeString(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// CollapseSpaces replaces runs of whitespace with a single space and trims.
+func CollapseSpaces(s string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range strings.TrimSpace(s) {
+		if unicode.IsSpace(r) {
+			if !prevSpace {
+				b.WriteRune(' ')
+			}
+			prevSpace = true
+		} else {
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	return b.String()
+}

--- a/internal/util/normalize_test.go
+++ b/internal/util/normalize_test.go
@@ -1,0 +1,93 @@
+// file: internal/util/normalize_test.go
+// version: 1.0.0
+// guid: b4e8f3a2-0c5d-4f9b-a7e1-3d6c8b2e4f0a
+// last-edited: 2026-05-02
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/util"
+)
+
+func TestNormalizePath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/foo/Bar/BAZ.mp3", "/foo/bar/baz.mp3"},
+		{"./Audio/Book/../file.MP3", "audio/file.mp3"},
+		{"/Audiobooks/Author/Title/", "/audiobooks/author/title"},
+		{"UPPER/lower/Mixed.go", "upper/lower/mixed.go"},
+	}
+	for _, c := range cases {
+		if got := util.NormalizePath(c.in); got != c.want {
+			t.Errorf("NormalizePath(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"  The Hobbit  ", "the hobbit"},
+		{"DUNE", "dune"},
+		{"Foundation and Empire", "foundation and empire"},
+		{"\tWhitespace\n", "whitespace"},
+	}
+	for _, c := range cases {
+		if got := util.NormalizeTitle(c.in); got != c.want {
+			t.Errorf("NormalizeTitle(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeAuthor(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"  J.R.R. Tolkien  ", "j.r.r. tolkien"},
+		{"TOLKIEN", "tolkien"},
+		{"Isaac Asimov", "isaac asimov"},
+		{"\tFrank Herbert\n", "frank herbert"},
+	}
+	for _, c := range cases {
+		if got := util.NormalizeAuthor(c.in); got != c.want {
+			t.Errorf("NormalizeAuthor(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeString(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"  Hello World  ", "hello world"},
+		{"SCIENCE-FICTION", "science-fiction"},
+		{"Mystery", "mystery"},
+		{"  ", ""},
+	}
+	for _, c := range cases {
+		if got := util.NormalizeString(c.in); got != c.want {
+			t.Errorf("NormalizeString(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCollapseSpaces(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"  hello   world  ", "hello world"},
+		{"no  extra\t\tspaces", "no extra spaces"},
+		{"single", "single"},
+		{"   ", ""},
+		{"a\nb\tc", "a b c"},
+	}
+	for _, c := range cases {
+		if got := util.CollapseSpaces(c.in); got != c.want {
+			t.Errorf("CollapseSpaces(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Creates internal/util/normalize.go with NormalizePath, NormalizeTitle, NormalizeAuthor, NormalizeString, and CollapseSpaces helpers. Migrates the highest-density repeated patterns in the top callsite files. Eliminates repeated strings.ToLower(strings.TrimSpace(...)) chains.