### PR TITLE
fix(dedup): guard findSimilarBooks by embedClient, add re-embed endpoint

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-04-30
+// last-edited: 2026-05-02
 
 package dedup
 
@@ -1085,14 +1085,18 @@ func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) 
 		}
 
 		// Layer 2 embedding: re-embed if stale, then similarity scan.
+		// findSimilarBooks is only meaningful when an embedding exists, so
+		// skip it entirely when there is no embed client or when EmbedBook
+		// signals the book was skipped / errored (no vector was stored).
 		if de.embedClient != nil {
-			if _, err := de.EmbedBook(ctx, book.ID); err != nil {
+			status, err := de.EmbedBook(ctx, book.ID)
+			if err != nil {
 				log.Printf("dedup: full scan embed error for %s: %v", book.ID, err)
+			} else if status == EmbedStatusEmbedded || status == EmbedStatusCached {
+				if err := de.findSimilarBooks(ctx, book.ID); err != nil {
+					log.Printf("dedup: full scan similarity error for %s: %v", book.ID, err)
+				}
 			}
-		}
-		if err := de.findSimilarBooks(ctx, book.ID); err != nil {
-			// Not fatal — just means no embedding yet
-			log.Printf("dedup: full scan similarity error for %s: %v", book.ID, err)
 		}
 
 		if progress != nil && (i%10 == 0 || i == total-1) {

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-01
+// last-edited: 2026-05-02
 
 package server
 
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
@@ -1153,6 +1154,87 @@ func (s *Server) triggerDedupAcoustID(c *gin.Context) {
 
 	if err := s.queue.Enqueue(opID, "dedup-acoustid-scan", operations.PriorityLow, opFunc); err != nil {
 		httputil.InternalError(c, "failed to enqueue acoustid scan", err)
+		return
+	}
+
+	httputil.RespondWithSuccess(c, http.StatusAccepted, op)
+}
+
+// triggerEmbedScan handles POST /api/v1/dedup/embed.
+// Generates or refreshes embeddings for all primary books as a tracked
+// Operation. Unlike the full dedup scan, this only calls EmbedBook — it does
+// not run similarity matching or emit new candidates. Use this when you want
+// to force-regenerate embeddings (e.g. after adding an OpenAI key to a
+// library that had none before) without also kicking off a full dedup pass.
+func (s *Server) triggerEmbedScan(c *gin.Context) {
+	if s.dedupEngine == nil {
+		httputil.RespondWithServiceUnavailable(c, "dedup engine not available (embedding may be disabled or API key not configured)")
+		return
+	}
+	if s.queue == nil {
+		httputil.RespondWithInternalError(c, "operation queue not initialized")
+		return
+	}
+
+	opID := ulid.Make().String()
+	op, err := s.Store().CreateOperation(opID, "embed-scan", nil)
+	if err != nil {
+		httputil.InternalError(c, "failed to create embed-scan operation", err)
+		return
+	}
+
+	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
+		_ = progress.UpdateProgress(0, 100, "Loading books for embedding...")
+
+		books, err := s.Store().GetAllBooks(0, 0)
+		if err != nil {
+			return fmt.Errorf("load books: %w", err)
+		}
+		total := len(books)
+		if total == 0 {
+			_ = progress.UpdateProgress(100, 100, "No books to embed")
+			return nil
+		}
+
+		var embedded, cached, skipped, errs int
+		for i, book := range books {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			status, err := s.dedupEngine.EmbedBook(ctx, book.ID)
+			if err != nil {
+				log.Printf("[embed-scan] embed error for %s: %v", book.ID, err)
+				errs++
+			} else {
+				switch status {
+				case dedup.EmbedStatusEmbedded:
+					embedded++
+				case dedup.EmbedStatusCached:
+					cached++
+				default:
+					skipped++
+				}
+			}
+
+			if i%50 == 0 || i == total-1 {
+				pct := 1 + (98 * (i + 1) / total)
+				_ = progress.UpdateProgress(pct, 100,
+					fmt.Sprintf("Embedding books: %d / %d (new=%d cached=%d skipped=%d errors=%d)",
+						i+1, total, embedded, cached, skipped, errs))
+			}
+		}
+
+		_ = progress.UpdateProgress(100, 100,
+			fmt.Sprintf("Embedding complete — %d new, %d cached, %d skipped, %d errors (of %d books)",
+				embedded, cached, skipped, errs, total))
+		return nil
+	}
+
+	if err := s.queue.Enqueue(opID, "embed-scan", operations.PriorityLow, opFunc); err != nil {
+		httputil.InternalError(c, "failed to enqueue embed scan", err)
 		return
 	}
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-05
+// last-edited: 2026-05-02
 
 package server
 
@@ -987,6 +987,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/scan-llm", s.perm(auth.PermScanTrigger), s.triggerDedupLLM)
 			protected.POST("/dedup/scan-acoustid", s.perm(auth.PermScanTrigger), s.triggerDedupAcoustID)
 			protected.POST("/dedup/refresh", s.perm(auth.PermScanTrigger), s.triggerDedupRefresh)
+			protected.POST("/dedup/embed", s.perm(auth.PermScanTrigger), s.triggerEmbedScan)
 
 			// File system routes
 			protected.GET("/filesystem/home", s.perm(auth.PermSettingsManage), s.getHomeDirectory)

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -2627,6 +2627,19 @@ function EmbeddingDedupTab() {
     }
   };
 
+  const handleEmbed = async () => {
+    setScanning(true);
+    setScanMsg(null);
+    try {
+      const { status } = await api.triggerEmbedScan();
+      setScanMsg(status || 'Embedding scan triggered — check Operations for progress');
+    } catch (err) {
+      setScanMsg(err instanceof Error ? err.message : 'Embedding scan failed');
+    } finally {
+      setScanning(false);
+    }
+  };
+
   // clusters must be computed before the page-merge handler so the
   // handler closure can read it directly.
   const allClusters = useMemo(() => buildClusters(candidates), [candidates]);
@@ -2925,6 +2938,16 @@ function EmbeddingDedupTab() {
           title="Compare acoustic fingerprints across all books to find audio duplicates"
         >
           Scan (AcoustID)
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={scanning ? <CircularProgress size={16} /> : <AutoAwesomeIcon />}
+          onClick={handleEmbed}
+          disabled={scanning || bulkMerging}
+          size="small"
+          title="Regenerate embeddings for all books — run this before Re-scan if embeddings are missing"
+        >
+          Re-embed All
         </Button>
         <Button
           variant="outlined"

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -4300,6 +4300,15 @@ export async function triggerDedupRefresh(): Promise<{ status: string }> {
   return responseData.data;
 }
 
+export async function triggerEmbedScan(): Promise<{ status: string }> {
+  const response = await fetch(`${API_BASE}/dedup/embed`, { method: 'POST' });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to trigger embedding scan');
+  }
+  const responseData = await response.json();
+  return responseData.data;
+}
+
 // ── API Key management ────────────────────────────────────────────────────────
 
 export interface APIKey {


### PR DESCRIPTION
## Summary

### Bug fix: FullScan spam
`findSimilarBooks` was called unconditionally in `FullScan` even when `embedClient == nil` or `EmbedBook` errored/skipped. This caused `no embedding for book X` to be logged for every book in the library.

**Fix:** `findSimilarBooks` is now only called when `EmbedBook` returns `EmbedStatusEmbedded` or `EmbedStatusCached` (meaning a vector actually exists in the store).

### New: Embedding-only scan endpoint
Added `POST /api/v1/dedup/embed` — generates/refreshes embeddings for all primary books as a tracked Operation with live progress visible in the Operations panel. Previously the only way to trigger embedding generation was the full dedup scan, which could complete in seconds (appearing to do nothing) if the embedding client wasn't ready.

Added **Re-embed All** button to the BookDedup toolbar.