### PR TITLE
feat(itunes): primary-only writes + delete/rename hooks + orphan cleanup

### DIFF
--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/audiobook_service_unit_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-01
 
@@ -17,6 +17,57 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// --- iTunes enqueuer wiring on delete paths ---
+
+// fakeITunesEnqueuer captures EnqueueRemove calls for assertion.
+type fakeITunesEnqueuer struct {
+	pids []string
+}
+
+func (f *fakeITunesEnqueuer) EnqueueRemove(pid string) {
+	f.pids = append(f.pids, pid)
+}
+
+func TestAudiobookService_DeleteAudiobook_HardDelete_EnqueuesITunesRemoves(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+	enq := &fakeITunesEnqueuer{}
+	svc.SetITunesEnqueuer(enq)
+
+	pidA, pidB := "deadbeefdeadbeef", "feedfacefeedface"
+	book := &database.Book{ID: "del-itl", Title: "Has iTunes Tracks"}
+	mockStore.EXPECT().GetBookByID("del-itl").Return(book, nil)
+	mockStore.EXPECT().GetBookFiles("del-itl").Return([]database.BookFile{
+		{ID: "f1", ITunesPersistentID: pidA},
+		{ID: "f2", ITunesPersistentID: pidB},
+		{ID: "f3", ITunesPersistentID: ""}, // no PID, ignored
+	}, nil)
+	mockStore.EXPECT().DeleteBook("del-itl").Return(nil)
+
+	_, err := svc.DeleteAudiobook(context.Background(), "del-itl", &DeleteAudiobookOptions{})
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{pidA, pidB}, enq.pids)
+}
+
+func TestAudiobookService_DeleteAudiobook_SoftDelete_EnqueuesITunesRemoves(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewAudiobookService(mockStore)
+	enq := &fakeITunesEnqueuer{}
+	svc.SetITunesEnqueuer(enq)
+
+	pid := "0011223344556677"
+	book := &database.Book{ID: "sd-itl", Title: "Soft Delete Has Tracks"}
+	mockStore.EXPECT().GetBookByID("sd-itl").Return(book, nil)
+	mockStore.EXPECT().UpdateBook("sd-itl", mock.AnythingOfType("*database.Book")).Return(book, nil)
+	mockStore.EXPECT().GetBookFiles("sd-itl").Return([]database.BookFile{
+		{ID: "f1", ITunesPersistentID: pid},
+	}, nil)
+
+	_, err := svc.DeleteAudiobook(context.Background(), "sd-itl", &DeleteAudiobookOptions{SoftDelete: true})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{pid}, enq.pids)
+}
 
 // --- GetAudiobooks ---
 

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service.go
-// version: 1.23.1
+// version: 1.24.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package audiobooks
@@ -49,6 +49,13 @@ type audiobookStore interface {
 	database.UserPositionStore
 }
 
+// ITunesEnqueuer is the narrow surface AudiobookService uses to push
+// iTunes mutations from delete/purge paths. Satisfied by
+// *itunesservice.WriteBackBatcher. Optional — nil-safe.
+type ITunesEnqueuer interface {
+	EnqueueRemove(pid string)
+}
+
 // AudiobookService handles all audiobook business logic
 type AudiobookService struct {
 	store           audiobookStore
@@ -60,6 +67,10 @@ type AudiobookService struct {
 	// Wired in by the Server after Bleve opens in Start(), which is
 	// after NewAudiobookService runs in NewServer.
 	searchIndex *search.BleveIndex
+	// itunesEnqueuer is wired by the Server after the WriteBackBatcher
+	// is constructed. Nil-safe — when nil the delete/purge paths skip
+	// the iTunes side-effect (e.g. tests, iTunes disabled in config).
+	itunesEnqueuer ITunesEnqueuer
 }
 
 // SetActivityService wires the activity service for snapshot fallback in GetAudiobookTags.
@@ -71,6 +82,12 @@ func (svc *AudiobookService) SetActivityService(as *activity.Service) {
 // Calling with nil reverts to the Store.SearchBooks fallback.
 func (svc *AudiobookService) SetSearchIndex(idx *search.BleveIndex) {
 	svc.searchIndex = idx
+}
+
+// SetITunesEnqueuer wires (or re-wires) the iTunes write-back batcher.
+// Nil disables iTunes side-effects in delete/purge paths.
+func (svc *AudiobookService) SetITunesEnqueuer(e ITunesEnqueuer) {
+	svc.itunesEnqueuer = e
 }
 
 // NewAudiobookService creates a new AudiobookService instance
@@ -1147,14 +1164,12 @@ func (svc *AudiobookService) PurgeSoftDeletedBooks(ctx context.Context, deleteFi
 			}
 		}
 
-		// Protect books with iTunes PIDs from import paths — these are the
-		// canonical link to the iTunes library. Purging them would cause
-		// reimport on the next iTunes sync.
-		if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" &&
-			book.ITunesImportSource != nil && *book.ITunesImportSource != "" {
-			log.Printf("[DEBUG] purge: skipping %s (has iTunes PID %s)", book.ID, *book.ITunesPersistentID)
-			continue
-		}
+		// Defense-in-depth: enqueue iTunes removes for any PIDs still
+		// on this book. Soft-delete already enqueues these but if the
+		// book was soft-deleted before that hook existed, this is the
+		// last chance to clean iTunes before the row vanishes.
+		bookCopy := book
+		svc.enqueueITunesRemovesForBook(book.ID, &bookCopy)
 
 		// Step 1: Create tombstone (snapshot of book for rollback)
 		if err := svc.store.CreateBookTombstone(&book); err != nil {
@@ -1688,6 +1703,11 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 			}
 		}
 
+		// Remove the book's tracks from iTunes. Soft-delete is treated
+		// as "user no longer wants this in their library" and the
+		// iTunes side should reflect that immediately.
+		svc.enqueueITunesRemovesForBook(id, book)
+
 		svc.InvalidateBookCaches()
 		return map[string]any{
 			"message":     "audiobook soft deleted",
@@ -1708,6 +1728,13 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 		}
 	}
 
+	// Capture iTunes PIDs BEFORE the DB row vanishes so we can
+	// enqueue iTunes removes after the hard delete succeeds.
+	var itunesPIDs []string
+	if svc.itunesEnqueuer != nil {
+		itunesPIDs = svc.collectITunesPIDsForBook(id, book)
+	}
+
 	if err := svc.store.DeleteBook(id); err != nil {
 		if err.Error() == "book not found" {
 			return nil, fmt.Errorf("audiobook not found")
@@ -1715,11 +1742,47 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 		return nil, err
 	}
 
+	if svc.itunesEnqueuer != nil {
+		for _, pid := range itunesPIDs {
+			svc.itunesEnqueuer.EnqueueRemove(pid)
+		}
+	}
+
 	svc.InvalidateBookCaches()
 	return map[string]any{
 		"message": "audiobook deleted",
 		"blocked": blocked,
 	}, nil
+}
+
+// collectITunesPIDsForBook returns every PID stored on the book's
+// book_files plus the legacy Book.ITunesPersistentID field. Used by
+// hard-delete to pre-capture PIDs before the row is gone, and by the
+// orphan-cleanup endpoint.
+func (svc *AudiobookService) collectITunesPIDsForBook(bookID string, book *database.Book) []string {
+	pids := []string{}
+	files, _ := svc.store.GetBookFiles(bookID)
+	for _, f := range files {
+		if f.ITunesPersistentID != "" {
+			pids = append(pids, f.ITunesPersistentID)
+		}
+	}
+	if book != nil && book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
+		pids = append(pids, *book.ITunesPersistentID)
+	}
+	return pids
+}
+
+// enqueueITunesRemovesForBook is a soft-delete helper: it pulls the
+// PIDs and enqueues each via the wired batcher. No-op if the batcher
+// isn't wired.
+func (svc *AudiobookService) enqueueITunesRemovesForBook(bookID string, book *database.Book) {
+	if svc.itunesEnqueuer == nil {
+		return
+	}
+	for _, pid := range svc.collectITunesPIDsForBook(bookID, book) {
+		svc.itunesEnqueuer.EnqueueRemove(pid)
+	}
 }
 
 // ApplyOverrideToPayload applies an override value to the update payload

--- a/internal/itunes/service/track_provisioner.go
+++ b/internal/itunes/service/track_provisioner.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/track_provisioner.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8e768742-5ace-4e4b-8495-9550ed4620b5
 //
 // TrackProvisioner generates ITL tracks for books that weren't imported
@@ -73,6 +73,14 @@ func (p *TrackProvisioner) Provision(book *database.Book, bookFile *database.Boo
 	}
 	if bookFile.ITunesPersistentID != "" {
 		return nil // already has a PID
+	}
+	// Only the primary version of a book gets written into iTunes.
+	// Non-primary versions (alternate formats, lower-quality rips, the
+	// "loser" side of a merge) must NOT generate PIDs or get added to
+	// the ITL — historically this was the source of large amounts of
+	// duplicate iTunes tracks for the same audiobook.
+	if book != nil && book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
+		return nil
 	}
 
 	// Generate a new PID

--- a/internal/itunes/service/track_provisioner_mock_test.go
+++ b/internal/itunes/service/track_provisioner_mock_test.go
@@ -123,6 +123,24 @@ func TestProvision_SkipsAlreadyHasPID(t *testing.T) {
 	// Mock would fail on any unexpected call — verifies no store access
 }
 
+// TestProvision_SkipsNonPrimary asserts non-primary book versions never
+// get a PID generated or an iTunes EnqueueAdd. Past behavior (no filter)
+// was the source of large amounts of duplicate iTunes tracks.
+func TestProvision_SkipsNonPrimary(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	enq := &mockEnqueuer{}
+	p := newTrackProvisioner(m, enq, Config{AutoWriteBack: true})
+
+	notPrimary := false
+	book := &database.Book{ID: "b1", IsPrimaryVersion: &notPrimary}
+	file := &database.BookFile{ID: "f1"}
+
+	err := p.Provision(book, file)
+	require.NoError(t, err)
+	assert.Empty(t, enq.adds, "non-primary book must not enqueue ITL add")
+	// Mock would fail on any unexpected store call — verifies no PID side-effects.
+}
+
 // ---------------------------------------------------------------------------
 // Provision — happy path
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/writeback_batcher.go
-// version: 4.0.1
+// version: 4.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -247,6 +247,14 @@ func (b *WriteBackBatcher) flush() {
 	for _, id := range bookIDs {
 		book, err := store.GetBookByID(id)
 		if err != nil || book == nil {
+			continue
+		}
+		// Only primary versions are written to iTunes. A non-primary
+		// version of a book that was somehow enqueued (e.g. via a
+		// metadata edit on the alternate format) must NOT push to
+		// iTunes — its PID, if any, was created in error and the
+		// orphan-cleanup pass will remove it.
+		if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
 			continue
 		}
 

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
 // last-edited: 2026-05-01
 
@@ -16,6 +16,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -424,10 +425,122 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 	}
 
 	httputil.RespondWithOK(c, gin.H{
-		"success":       true,
-		"updated_count": itlResult.UpdatedCount,
-		"total_books":   len(itlUpdates),
-		"message":       fmt.Sprintf("ITL write-back complete: %d tracks updated out of %d books with iTunes PIDs", itlResult.UpdatedCount, len(itlUpdates)),
+		"success":              true,
+		"updated_count":        itlResult.UpdatedCount,
+		"file_pid_pairs":       len(itlUpdates),
+		"primary_book_count":   len(writtenBookIDs),
+		"message":              fmt.Sprintf("ITL write-back complete: %d ITL chunks updated across %d (file,PID) pairs from %d primary books", itlResult.UpdatedCount, len(itlUpdates), len(writtenBookIDs)),
+	})
+}
+
+// handleITunesCleanupOrphans removes iTunes tracks that should not be in the
+// library: tracks owned by non-primary book versions, tracks owned by
+// soft-deleted books, and tracks present in the ITL but with no matching
+// row in the DB ("true orphans" left behind by past hard-deletes that did
+// not fire an iTunes remove hook). Each candidate PID is enqueued via the
+// WriteBackBatcher; the actual ITL mutation happens on the next flush.
+func (s *Server) handleITunesCleanupOrphans(c *gin.Context) {
+	if !s.itunesEnabledOrError(c) {
+		return
+	}
+	if s.Store() == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	if s.writeBackBatcher == nil {
+		httputil.RespondWithBadRequest(c, "iTunes write-back batcher not configured")
+		return
+	}
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		httputil.RespondWithBadRequest(c, "no ITL library path configured")
+		return
+	}
+
+	// Build the set of "valid" PIDs from the DB: every primary,
+	// non-soft-deleted book contributes its book_files PIDs.
+	allBooks, err := s.Store().GetAllBooks(1_000_000, 0)
+	if err != nil {
+		httputil.InternalError(c, "failed to enumerate books", err)
+		return
+	}
+	validPIDs := make(map[string]bool)
+	var nonPrimaryPIDs []string
+	for i := range allBooks {
+		b := &allBooks[i]
+		files, _ := s.Store().GetBookFiles(b.ID)
+		isPrimary := b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+		isSoftDeleted := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+		if isPrimary && !isSoftDeleted {
+			for _, f := range files {
+				if f.ITunesPersistentID != "" {
+					validPIDs[strings.ToLower(f.ITunesPersistentID)] = true
+				}
+			}
+		} else {
+			// Non-primary OR soft-deleted: collect for removal.
+			for _, f := range files {
+				if f.ITunesPersistentID != "" {
+					nonPrimaryPIDs = append(nonPrimaryPIDs, f.ITunesPersistentID)
+				}
+			}
+		}
+	}
+
+	// Soft-deleted books are excluded from GetAllBooks above (filter is
+	// COALESCE(marked_for_deletion,0)=0). Pull them separately.
+	softDeleted, _ := s.Store().ListSoftDeletedBooks(1_000_000, 0, nil)
+	var softDeletedPIDs []string
+	for i := range softDeleted {
+		b := &softDeleted[i]
+		files, _ := s.Store().GetBookFiles(b.ID)
+		for _, f := range files {
+			if f.ITunesPersistentID != "" {
+				softDeletedPIDs = append(softDeletedPIDs, f.ITunesPersistentID)
+			}
+		}
+	}
+
+	// Walk the ITL master list and find any PID NOT in validPIDs —
+	// those are true orphans (DB row was hard-deleted in the past
+	// without firing the EnqueueRemove hook).
+	var truePIDOrphans []string
+	if library, parseErr := itunes.ParseLibrary(itlPath); parseErr == nil {
+		for _, track := range library.Tracks {
+			if track.PersistentID == "" {
+				continue
+			}
+			if !validPIDs[strings.ToLower(track.PersistentID)] {
+				truePIDOrphans = append(truePIDOrphans, track.PersistentID)
+			}
+		}
+	}
+
+	enqueued := 0
+	for _, pid := range nonPrimaryPIDs {
+		s.writeBackBatcher.EnqueueRemove(pid)
+		enqueued++
+	}
+	for _, pid := range softDeletedPIDs {
+		s.writeBackBatcher.EnqueueRemove(pid)
+		enqueued++
+	}
+	for _, pid := range truePIDOrphans {
+		s.writeBackBatcher.EnqueueRemove(pid)
+		enqueued++
+	}
+
+	stdlog.Printf("[INFO] iTunes cleanup-orphans: enqueued %d removes (non_primary=%d soft_deleted=%d true_orphans=%d)",
+		enqueued, len(nonPrimaryPIDs), len(softDeletedPIDs), len(truePIDOrphans))
+
+	httputil.RespondWithOK(c, gin.H{
+		"success":         true,
+		"enqueued":        enqueued,
+		"non_primary":     len(nonPrimaryPIDs),
+		"soft_deleted":    len(softDeletedPIDs),
+		"true_orphans":    len(truePIDOrphans),
+		"valid_pid_count": len(validPIDs),
+		"message":         fmt.Sprintf("enqueued %d iTunes removes (non_primary=%d soft_deleted=%d true_orphans=%d). The next batcher flush will splice them out of the ITL.", enqueued, len(nonPrimaryPIDs), len(softDeletedPIDs), len(truePIDOrphans)),
 	})
 }
 

--- a/internal/server/organize_handlers.go
+++ b/internal/server/organize_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_handlers.go
-// version: 2.1.1
+// version: 2.2.0
 // last-edited: 2026-05-10
 // guid: 1522f0ec-663c-4527-a6d0-645658206a24
 //
@@ -85,6 +85,13 @@ func (s *Server) applyRename(c *gin.Context) {
 		}
 		httputil.InternalError(c, "failed to apply rename", err)
 		return
+	}
+
+	// Rename moved the file on disk → push a location update to iTunes
+	// so the ITL keeps pointing at the right path. The batcher already
+	// filters non-primary books and is nil-safe.
+	if s.writeBackBatcher != nil {
+		s.writeBackBatcher.Enqueue(id)
 	}
 
 	httputil.RespondWithOK(c, result)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -583,6 +583,9 @@ func NewServer(store database.Store) *Server {
 	server.organizeService.SetQueue(server.queue)
 	server.mergeService.SetWriteBackBatcher(server.writeBackBatcher)
 	server.quarantineSvc.SetWriteBackBatcher(server.writeBackBatcher)
+	if server.audiobookService != nil && server.writeBackBatcher != nil {
+		server.audiobookService.SetITunesEnqueuer(server.writeBackBatcher)
+	}
 
 	// Wire iTunes-specific organizer callbacks now that itunesSvc is ready.
 	if server.itunesSvc.Enabled() {

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1046,6 +1046,7 @@ func (s *Server) setupRoutes() {
 				itunesGroup.POST("/import", s.perm(auth.PermLibraryEditMetadata), s.handleITunesImport)
 				itunesGroup.POST("/write-back", s.perm(auth.PermLibraryEditMetadata), s.handleITunesWriteBack)
 				itunesGroup.POST("/write-back-all", s.perm(auth.PermLibraryEditMetadata), s.handleITunesWriteBackAll)
+				itunesGroup.POST("/cleanup-orphans", s.perm(auth.PermLibraryEditMetadata), s.handleITunesCleanupOrphans)
 				itunesGroup.POST("/write-back/preview", s.perm(auth.PermLibraryEditMetadata), s.handleITunesWriteBackPreview)
 				itunesGroup.GET("/books", s.perm(auth.PermLibraryView), s.handleListITunesBooks)
 				itunesGroup.GET("/import-status/:id", s.perm(auth.PermLibraryView), s.handleITunesImportStatus)


### PR DESCRIPTION
## Why

Two intertwined iTunes-write bugs were causing the library to grow ~1.6x larger than the actual primary book count and to retain tracks after books were deleted:

1. **Non-primary book versions were being written to iTunes.** Only `CollectITLUpdatesWithBookIDs` had the primary-version filter; `TrackProvisioner.Provision` (creates PIDs at import time) and `WriteBackBatcher.flush` (per-book metadata edits) did not. Every duplicate format of a book was getting its own iTunes track.
2. **Deletes never propagated to iTunes.** `AudiobookService.DeleteAudiobook` (both soft and hard paths) and `PurgeSoftDeletedBooks` did not enqueue iTunes `EnqueueRemove` for the book's PIDs, leaving orphan tracks. `PurgeSoftDeletedBooks` actually had a backwards guard that *skipped* purge for any book with an iTunes PID, treating iTunes as canonical.
3. **File renames didn't update iTunes.** `applyRename` moved the file on disk but never enqueued a write-back, so iTunes location pointers went stale.

## What

- `TrackProvisioner.Provision` and `WriteBackBatcher.flush` skip non-primary book versions.
- `AudiobookService.DeleteAudiobook` (soft + hard) enqueues iTunes removes for every PID on the book before the DB row vanishes. Hard path captures PIDs *before* `DeleteBook` to avoid losing them; nil-guarded so unit tests without an enqueuer still pass.
- `PurgeSoftDeletedBooks`: removed the backwards "iTunes PID = canonical" guard; added defense-in-depth EnqueueRemove inside the purge loop.
- `applyRename` now calls `writeBackBatcher.Enqueue(bookID)` after a successful move.
- New `POST /api/v1/itunes/cleanup-orphans` one-shot endpoint scans three orphan categories — non-primary still holding PIDs, soft-deleted still holding PIDs, and "true orphans" (PIDs in the ITL with no matching DB row) — and enqueues removes for all of them.
- Cleaned up misleading "books" wording in `handleITunesWriteBackAll` (reports file/PID pair count + primary-book count separately).
- Added positive tests:
  - `TestProvision_SkipsNonPrimary`
  - `TestAudiobookService_DeleteAudiobook_HardDelete_EnqueuesITunesRemoves`
  - `TestAudiobookService_DeleteAudiobook_SoftDelete_EnqueuesITunesRemoves`

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- New tests + existing audiobook/itunes/server tests pass (one pre-existing unrelated failure in `TestHandleHardDeleteVersion` that exists on main — not introduced by this PR).

## Rollout

After merge + deploy:
1. `POST /api/v1/itunes/cleanup-orphans` to enqueue removes for the existing orphan tracks.
2. Wait for batcher flush (or `POST /api/v1/itunes/write-back-all`).
3. Verify ITL still opens in iTunes and Apple Devices syncs cleanly.

The verifier gate inside `ApplyITLOperations` will abort the write if the cleanup would introduce dangling refs, so worst case is "cleanup didn't apply."