### PR TITLE
chore(gitignore): ignore all of .claude/notes/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,7 +185,7 @@ local.env
 .remember/
 .superpowers/
 .claude/scheduled_tasks.lock
-.claude/notes/migrate-loop-resume.md
+.claude/notes/
 
 # Build output
 bin/


### PR DESCRIPTION
Replaces the single-file ignore (`.claude/notes/migrate-loop-resume.md`) with a directory-wide ignore.

`.claude/notes/` is scratch space per CLAUDE.md and frequently contains PII (machine paths, server IPs, infra details, references to credentials). Nothing in the directory is currently tracked, so this is a no-op for history and only prevents future accidental commits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>