### PR TITLE
fix(activity): compact audit-tier rows into daily digest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,25 @@ docs/reports/
 /itunes-sync-tests
 /itl-diff
 /verify-suite
+
+# >>> jdfalk managed ignore block (sync-gitignore.py) >>>
+# AI agent scratch / state (may contain PII, machine paths, secrets)
+.claude/notes/
+.claude/state/
+.claude/worktrees/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.copilot/
+.aider*
+.cursor/
+.windsurf/
+.remember/
+.superpowers/
+
+# Per-session copilot transcripts
+copilot-session-*.md
+
+# OS junk
+.DS_Store
+Thumbs.db
+# <<< jdfalk managed ignore block (sync-gitignore.py) <<<

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,23 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.43.0 -->
+<!-- version: 2.44.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-02 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+#### May 2, 2026 — Activity-log "Compact (Everything now)" left audit-tier rows behind
+
+- **fix(activity)**: `CompactByDay` now folds `tier='audit'` entries into the
+  daily digest (previously skipped, leaving pages of un-compactable rows on
+  the Activity page after a manual "Everything (now)" compact). Forensic
+  fields (`tier`, `operation_id`) preserved on each `DigestItem`; audit items
+  sort first so they survive the 500-item digest cap. Frontend digest
+  expander surfaces the new audit chip + operation_id. Test:
+  `TestCompactByDay_FoldsAuditTier`.
 
 ### Added / Changed
 

--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_compact_test.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package database
@@ -14,9 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCompactByDay_BasicCompaction inserts 5 entries across 2 days (change tier)
-// plus 1 audit entry, compacts, and verifies 2 digests created, 5 entries
-// deleted, and the audit entry survives.
+// TestCompactByDay_BasicCompaction inserts 5 change-tier entries across 2
+// days plus 1 audit entry on day 1, compacts, and verifies 2 digests
+// created, 6 entries deleted (audit folds into day 1's digest), and the
+// audit entry is reflected in that digest.
 func TestCompactByDay_BasicCompaction(t *testing.T) {
 	s := newTestActivityStore(t)
 
@@ -54,28 +55,31 @@ func TestCompactByDay_BasicCompaction(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// 1 audit entry (must survive)
+	// 1 audit entry on day 1 — folds into day 1's digest with forensic
+	// fields (operation_id, tier='audit') preserved as DigestItem.
 	_, err := s.Record(ActivityEntry{
-		Tier:      "audit",
-		Type:      "user_login",
-		Level:     "info",
-		Source:    "auth",
-		Summary:   "user logged in",
-		Timestamp: day1.Add(30 * time.Minute),
+		Tier:        "audit",
+		Type:        "user_login",
+		Level:       "info",
+		Source:      "auth",
+		OperationID: "op-login-42",
+		Summary:     "user logged in",
+		Timestamp:   day1.Add(30 * time.Minute),
 	})
 	require.NoError(t, err)
 
 	result, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.DaysCompacted)
-	assert.Equal(t, 5, result.EntriesDeleted)
+	assert.Equal(t, 6, result.EntriesDeleted, "5 change + 1 audit folded")
 
-	// Should now have: 2 digest rows + 1 audit row = 3 total
+	// Should now have: 2 digest rows total — audit folded into day 1.
 	all, total, err := s.Query(ActivityFilter{Limit: 50})
 	require.NoError(t, err)
-	assert.Equal(t, 3, total)
+	assert.Equal(t, 2, total)
 
-	var digestCount, auditCount int
+	var digestCount, auditSurvived int
+	var day1Digest DigestDetails
 	for _, e := range all {
 		switch e.Tier {
 		case "digest":
@@ -83,7 +87,6 @@ func TestCompactByDay_BasicCompaction(t *testing.T) {
 			assert.Equal(t, "daily_digest", e.Type)
 			assert.Equal(t, "compaction", e.Source)
 
-			// Verify digest details structure
 			require.NotNil(t, e.Details)
 			detailsJSON, err := json.Marshal(e.Details)
 			require.NoError(t, err)
@@ -94,12 +97,28 @@ func TestCompactByDay_BasicCompaction(t *testing.T) {
 			assert.Greater(t, dd.OriginalCount, 0)
 			assert.NotEmpty(t, dd.Counts)
 			assert.NotEmpty(t, dd.Items)
+
+			if dd.Date == "2025-06-10" {
+				day1Digest = dd
+			}
 		case "audit":
-			auditCount++
+			auditSurvived++
 		}
 	}
 	assert.Equal(t, 2, digestCount, "expected 2 digest rows")
-	assert.Equal(t, 1, auditCount, "audit entry must survive")
+	assert.Equal(t, 0, auditSurvived, "audit entry must be folded, not survive raw")
+
+	// Day 1 digest must reflect 4 entries (3 change + 1 audit), keep the
+	// audit's operation_id, and place audit first in items.
+	require.Equal(t, "2025-06-10", day1Digest.Date)
+	assert.Equal(t, 4, day1Digest.OriginalCount)
+	assert.Equal(t, 1, day1Digest.Counts["user_login"])
+	assert.Equal(t, 3, day1Digest.Counts["metadata_applied"])
+	require.NotEmpty(t, day1Digest.Items)
+	first := day1Digest.Items[0]
+	assert.Equal(t, "audit", first.Tier, "audit items must sort first")
+	assert.Equal(t, "user_login", first.Type)
+	assert.Equal(t, "op-login-42", first.OperationID, "operation_id preserved")
 }
 
 // TestCompactByDay_Idempotent verifies that compacting twice is a no-op the
@@ -134,35 +153,50 @@ func TestCompactByDay_Idempotent(t *testing.T) {
 	assert.Equal(t, 0, r2.EntriesDeleted)
 }
 
-// TestCompactByDay_SkipsAuditTier verifies that audit-tier entries are never
-// compacted.
-func TestCompactByDay_SkipsAuditTier(t *testing.T) {
+// TestCompactByDay_FoldsAuditTier verifies that audit-tier entries are
+// folded into the daily digest (preserving forensic fields) rather than
+// left as raw rows. This is the regression test for the "Compact →
+// Everything (now)" button leaving pages of audit entries behind.
+func TestCompactByDay_FoldsAuditTier(t *testing.T) {
 	s := newTestActivityStore(t)
 
 	ts := time.Date(2025, 4, 15, 8, 0, 0, 0, time.UTC)
 	olderThan := time.Date(2025, 4, 16, 0, 0, 0, 0, time.UTC)
 
 	_, err := s.Record(ActivityEntry{
-		Tier:      "audit",
-		Type:      "permission_change",
-		Level:     "info",
-		Source:    "admin",
-		Summary:   "permissions updated",
-		Timestamp: ts,
+		Tier:        "audit",
+		Type:        "permission_change",
+		Level:       "info",
+		Source:      "admin",
+		OperationID: "op-perm-7",
+		Summary:     "permissions updated",
+		Timestamp:   ts,
 	})
 	require.NoError(t, err)
 
 	result, err := s.CompactByDay(context.Background(), olderThan)
 	require.NoError(t, err)
-	assert.Equal(t, 0, result.DaysCompacted)
-	assert.Equal(t, 0, result.EntriesDeleted)
+	assert.Equal(t, 1, result.DaysCompacted)
+	assert.Equal(t, 1, result.EntriesDeleted)
 
-	// Original entry still exists
+	// Original audit row gone, replaced by a single digest row.
 	all, total, err := s.Query(ActivityFilter{Limit: 50})
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
-	assert.Len(t, all, 1)
-	assert.Equal(t, "audit", all[0].Tier)
+	require.Len(t, all, 1)
+	assert.Equal(t, "digest", all[0].Tier)
+
+	// Digest must carry the audit item with its operation_id and tier.
+	detailsJSON, err := json.Marshal(all[0].Details)
+	require.NoError(t, err)
+	var dd DigestDetails
+	require.NoError(t, json.Unmarshal(detailsJSON, &dd))
+	require.Len(t, dd.Items, 1)
+	item := dd.Items[0]
+	assert.Equal(t, "audit", item.Tier)
+	assert.Equal(t, "permission_change", item.Type)
+	assert.Equal(t, "op-perm-7", item.OperationID)
+	assert.Equal(t, 1, dd.Counts["permission_change"])
 }
 
 // TestCompactByDay_TruncatesLargeDays inserts 600 entries on one day and

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.7.1
+// version: 1.8.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -59,11 +59,13 @@ type CompactResult struct {
 
 // DigestItem represents a single compacted entry within a daily digest.
 type DigestItem struct {
-	Type    string `json:"type"`
-	Book    string `json:"book,omitempty"`
-	BookID  string `json:"book_id,omitempty"`
-	Summary string `json:"summary"`
-	Details string `json:"details,omitempty"`
+	Type        string `json:"type"`
+	Tier        string `json:"tier,omitempty"`
+	Book        string `json:"book,omitempty"`
+	BookID      string `json:"book_id,omitempty"`
+	OperationID string `json:"operation_id,omitempty"`
+	Summary     string `json:"summary"`
+	Details     string `json:"details,omitempty"`
 }
 
 // DigestDetails is the JSON structure stored in a daily digest row's details column.
@@ -529,9 +531,12 @@ func nullableJSON(v map[string]any) (any, error) {
 	return string(b), nil
 }
 
-// CompactByDay collapses old change/debug entries into one daily_digest row per
-// UTC day. Audit-tier entries are never touched. Each day is processed in its
-// own transaction for atomicity.
+// CompactByDay collapses old change, debug, and audit entries into one
+// daily_digest row per UTC day. Audit entries are folded into the digest
+// (preserving their type, summary, and operation_id in DigestItem) so the
+// audit record survives compaction in summarized form. Existing 'digest'
+// rows are never re-compacted. Each day is processed in its own transaction
+// for atomicity.
 func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
 	var result CompactResult
 
@@ -540,7 +545,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 		SELECT id, timestamp, tier, type, level, source, operation_id,
 		       book_id, summary, details, tags
 		FROM   activity_log
-		WHERE  tier IN ('change', 'debug')
+		WHERE  tier IN ('change', 'debug', 'audit')
 		  AND  compacted = 0
 		  AND  timestamp < ?
 		ORDER BY timestamp ASC`,
@@ -613,23 +618,30 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			counts[e.Type]++
 		}
 
-		// Build items — error/warn first, then the rest.
-		var errItems, normalItems []DigestItem
+		// Build items — audit first (forensic record must survive
+		// truncation), then error/warn, then the rest.
+		var auditItems, errItems, normalItems []DigestItem
 		for _, e := range dg.entries {
 			item := DigestItem{
-				Type:    e.Type,
-				Book:    extractBookName(e),
-				BookID:  e.BookID,
-				Summary: extractItemSummary(e),
+				Type:        e.Type,
+				Tier:        e.Tier,
+				Book:        extractBookName(e),
+				BookID:      e.BookID,
+				OperationID: e.OperationID,
+				Summary:     extractItemSummary(e),
 			}
-			if e.Level == "error" || e.Level == "warn" {
+			switch {
+			case e.Tier == "audit":
+				auditItems = append(auditItems, item)
+			case e.Level == "error" || e.Level == "warn":
 				item.Details = extractErrorDetails(e)
 				errItems = append(errItems, item)
-			} else {
+			default:
 				normalItems = append(normalItems, item)
 			}
 		}
-		items := append(errItems, normalItems...)
+		items := append(auditItems, errItems...)
+		items = append(items, normalItems...)
 
 		truncated := false
 		truncatedCount := 0

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1080,7 +1080,7 @@ export default function ActivityLog() {
                     date?: string;
                     original_count?: number;
                     counts?: Record<string, number>;
-                    items?: Array<{ type: string; book?: string; book_id?: string; summary: string; details?: string }>;
+                    items?: Array<{ type: string; tier?: string; book?: string; book_id?: string; operation_id?: string; summary: string; details?: string }>;
                     truncated?: boolean;
                     truncated_count?: number;
                   } | undefined;
@@ -1140,6 +1140,9 @@ export default function ActivityLog() {
                                   }}
                                 >
                                   <Chip size="small" label={item.type.replace(/_/g, ' ')} sx={{ minWidth: 100 }} />
+                                  {item.tier === 'audit' && (
+                                    <Chip size="small" label="audit" sx={{ bgcolor: '#7c4dff', color: 'white', fontSize: '0.65rem' }} />
+                                  )}
                                   {item.book_id ? (
                                     <Typography
                                       variant="body2"
@@ -1157,6 +1160,11 @@ export default function ActivityLog() {
                                   <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
                                     {item.summary}
                                   </Typography>
+                                  {item.operation_id && (
+                                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', fontSize: '0.65rem' }}>
+                                      {item.operation_id}
+                                    </Typography>
+                                  )}
                                   {item.details && (
                                     <Typography variant="caption" color="error.main">
                                       {item.details}


### PR DESCRIPTION
## Summary

- The Activity page's **Compact → Everything (now)** button silently left every `tier='audit'` row in place because `CompactByDay` only matched `'change'` and `'debug'`. After every "compact everything" the user still saw pages of audit rows.
- `CompactByDay` now folds audit entries into the daily digest, preserving the forensic record: each `DigestItem` carries the original `tier` and `operation_id`. Audit items sort **first** in `Items`, so they survive the `maxDigestItems=500` cap ahead of warn/error/info.
- Frontend digest expander surfaces the new `audit` chip and the `operation_id` next to each item.

## Test plan

- [x] `go test ./internal/database/... -run Compact -v` — 5/5 pass (incl. new `TestCompactByDay_FoldsAuditTier` and updated `TestCompactByDay_BasicCompaction`)
- [x] `go test ./internal/database/... ./internal/server/... -count=1` — all green
- [x] `make build` — frontend + backend embedded build green
- [ ] Smoke: hit "Compact → Everything (now)" on a library with audit rows; confirm digest count includes them and audit rows are gone from the list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)