### PR TITLE
fix(web): stabilize useAsyncAction.run identity to prevent fetch loop

### DIFF
--- a/web/src/hooks/useAsyncAction.ts
+++ b/web/src/hooks/useAsyncAction.ts
@@ -1,9 +1,9 @@
 // file: web/src/hooks/useAsyncAction.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: h8i9j0k1-l2m3-4567-nopq-890123456789
-// last-edited: 2026-05-01
+// last-edited: 2026-05-04
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 interface AsyncActionState {
   loading: boolean;
@@ -19,6 +19,12 @@ interface UseAsyncActionReturn<T> extends AsyncActionState {
  * useAsyncAction wraps an async function with loading and error state.
  * Eliminates repeated useState(false) / try-finally loading boilerplate.
  *
+ * The returned `run` callback has a STABLE identity across renders, even when
+ * `fn` is an inline arrow function. This is critical: callers commonly pass
+ * `run` (or a wrapper) as a useEffect dependency, and an unstable identity
+ * triggers an infinite render loop that exhausts browser network sockets
+ * (ERR_INSUFFICIENT_RESOURCES).
+ *
  * @example
  * const { run: handleSave, loading, error } = useAsyncAction(async () => {
  *   await api.saveBook(book);
@@ -30,12 +36,17 @@ export function useAsyncAction<T = void>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
   const run = useCallback(
     async (...args: unknown[]): Promise<T | undefined> => {
       setLoading(true);
       setError(null);
       try {
-        return await fn(...args);
+        return await fnRef.current(...args);
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
         return undefined;
@@ -43,7 +54,7 @@ export function useAsyncAction<T = void>(
         setLoading(false);
       }
     },
-    [fn]
+    []
   );
 
   const clearError = useCallback(() => setError(null), []);


### PR DESCRIPTION
## Problem

The dedup advanced scan tab was firing thousands of GET requests to `/api/v1/audiobooks/duplicates/scan-results` until the browser ran out of network sockets and started throwing `ERR_INSUFFICIENT_RESOURCES`. The page never finished loading, and as a side effect the user's actual scan POST couldn't even get out, so dedup scans never appeared in the active-operations indicator.

## Root cause

`useAsyncAction` wrapped `run` in `useCallback(..., [fn])`. Callers commonly pass an inline arrow:

```tsx
const { run: performFetch } = useAsyncAction(async () => { ... });
const fetchResults = useCallback(() => performFetch(), [performFetch]);
useEffect(() => { fetchResults(); }, [fetchResults]);
```

Each render creates a new `fn` identity → new `run` → new `fetchResults` → `useEffect` re-fires → setState in the action → re-render → repeat forever.

## Fix

Capture `fn` in a ref and update it via `useEffect`. `run` now has a stable identity across renders while still calling the latest closure. No caller changes needed.

## Verification

- `npm run build` clean
- All three `useAsyncAction` callers (`BookDedup.tsx`, `DedupAdvancedScanTab.tsx`, the hook itself) compile
- Manual: opening `/dedup` → advanced scan tab now issues exactly one GET on mount

## Side benefit

Dedup scans should now show up in the operations indicator again, because the POST `/scan` request can actually leave the browser.