### PR TITLE
fix(activity): BEGIN IMMEDIATE for compact tx (database is locked 500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,26 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.44.0 -->
+<!-- version: 2.44.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-02 -->
+<!-- last-edited: 2026-05-04 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Fixed
+
+#### May 4, 2026 — Activity compaction 500: "database is locked"
+
+- **fix(activity)**: open the activity-log SQLite with `_txlock=immediate` and
+  bump `_busy_timeout` to 30 s. `CompactByDay` begins its tx with a SELECT
+  (read), then upgrades to a write on the first DELETE. Under deferred
+  BEGIN a concurrent `Record()` insert could grab the write lock during the
+  SELECT window, after which our DELETE upgrade returned `SQLITE_BUSY`
+  ("database is locked") instead of waiting. IMMEDIATE acquires the write
+  lock at BEGIN so concurrent writers queue cleanly. Surfaced after the
+  audit-folding change extended each tx's write window on busy prod.
+
+
 
 #### May 2, 2026 — Activity-log "Compact (Everything now)" left audit-tier rows behind
 

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.8.0
+// version: 1.8.1
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -113,9 +113,15 @@ CREATE INDEX IF NOT EXISTS idx_activity_level_timestamp  ON activity_log (level,
 `
 
 // NewActivityStore opens (or creates) the SQLite activity log at dbPath.
-// WAL mode and a 5 s busy timeout are enabled for concurrent access.
+// WAL mode + 30 s busy timeout + BEGIN IMMEDIATE for all transactions.
+// _txlock=immediate is load-bearing: CompactByDay starts a tx with a SELECT
+// (read), then upgrades to a write on the first DELETE. Under deferred BEGIN
+// a concurrent INSERT from Record() can grab the write lock during that
+// SELECT window, after which our DELETE upgrade fails with "database is
+// locked" instead of waiting on busy_timeout. IMMEDIATE acquires the write
+// lock at BEGIN so subsequent writers queue on busy_timeout cleanly.
 func NewActivityStore(dbPath string) (*ActivityStore, error) {
-	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=off", dbPath)
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=30000&_txlock=immediate&_foreign_keys=off", dbPath)
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("activity_store: open %q: %w", dbPath, err)


### PR DESCRIPTION
## Summary

Production hit `activity_store: compact delete old digest: database is locked` on the manual Compact button (500 to the user).

`CompactByDay` begins its tx with a `SELECT existing digest`, then upgrades to a writer on the first `DELETE`. Under SQLite's default deferred `BEGIN`, a concurrent `Record()` insert can grab the write lock inside the SELECT window — our upgrade then bounces off `SQLITE_BUSY` instead of waiting. Hidden until #691 widened each tx's write window by folding audit rows in.

## Fix

- DSN: add `_txlock=immediate` so `BeginTx` acquires the write lock at BEGIN. Concurrent writers queue on `busy_timeout` cleanly.
- Bump `_busy_timeout` 5s → 30s for headroom on busy prod (acoustid backfill, scheduler, request handlers all generate activity).
- Only affects the activity-log sidecar SQLite; PebbleDB is untouched.

## Test plan

- [x] `go test ./internal/database/... -run "Compact|Summarize|Activity"` — green
- [ ] Smoke: hit "Compact → Everything (now)" while acoustid backfill is running; expect 200, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)