### PR TITLE
fix(fingerprint,web): URL-safe base64 decode + stable useAsyncAction identity

### DIFF
--- a/internal/fingerprint/fpcalc.go
+++ b/internal/fingerprint/fpcalc.go
@@ -1,5 +1,5 @@
 // file: internal/fingerprint/fpcalc.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
 
 // Package fingerprint generates AcoustID-compatible acoustic fingerprints for
@@ -344,29 +344,42 @@ func HammingSimilarity(a, b string) (float64, error) {
 }
 
 // decodeAnyFingerprint decodes a fingerprint string into its uint32 array.
-// It tries base64 first (ffmpeg chromaprint output), then falls back to the
-// AcoustID base62 encoding.
+// It tries standard and URL-safe base64 first (ffmpeg chromaprint output),
+// then falls back to the AcoustID base62 encoding. URL-safe handling is
+// required because chromaprint/ffmpeg often emits '-' and '_' in place of
+// '+' and '/' depending on version/flags.
 func decodeAnyFingerprint(fp string) ([]uint32, error) {
-	// Try standard base64 (ffmpeg -fp_format base64 output).
-	// The chromaprint base64 format: 4-byte header + uint32 little-endian values.
-	if b, err := base64.StdEncoding.DecodeString(fp); err == nil && len(b) >= 8 {
-		// First 4 bytes are a header (magic + version + algo).
-		payload := b[4:]
-		if len(payload)%4 == 0 {
-			ints := make([]uint32, len(payload)/4)
+	// Try several base64 variants (with/without padding, std/url-safe).
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	}
+	for _, enc := range encodings {
+		b, err := enc.DecodeString(fp)
+		if err != nil {
+			continue
+		}
+		// Chromaprint base64 format: 4-byte header + uint32 little-endian values.
+		if len(b) >= 8 {
+			payload := b[4:]
+			if len(payload)%4 == 0 {
+				ints := make([]uint32, len(payload)/4)
+				for i := range ints {
+					ints[i] = binary.LittleEndian.Uint32(payload[i*4:])
+				}
+				return ints, nil
+			}
+		}
+		// Raw base64 without the 4-byte header (some ffmpeg versions).
+		if len(b) > 0 && len(b)%4 == 0 {
+			ints := make([]uint32, len(b)/4)
 			for i := range ints {
-				ints[i] = binary.LittleEndian.Uint32(payload[i*4:])
+				ints[i] = binary.LittleEndian.Uint32(b[i*4:])
 			}
 			return ints, nil
 		}
-	}
-	// Also try raw base64 without the 4-byte header (some ffmpeg versions).
-	if b, err := base64.StdEncoding.DecodeString(fp); err == nil && len(b) > 0 && len(b)%4 == 0 {
-		ints := make([]uint32, len(b)/4)
-		for i := range ints {
-			ints[i] = binary.LittleEndian.Uint32(b[i*4:])
-		}
-		return ints, nil
 	}
 	// Fall through to AcoustID base62.
 	return decodeBase62Fingerprint(fp)

--- a/internal/fingerprint/fpcalc_decode_test.go
+++ b/internal/fingerprint/fpcalc_decode_test.go
@@ -1,0 +1,57 @@
+// file: internal/fingerprint/fpcalc_decode_test.go
+// version: 1.0.0
+// guid: e2c4a6b8-9d0e-4f1a-8b2c-3d4e5f6a7b8c
+
+package fingerprint
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// TestDecodeAnyFingerprint_URLSafeBase64 ensures fingerprints encoded with the
+// URL-safe base64 alphabet (using '-' and '_' instead of '+' and '/') decode
+// successfully. Regression test for log spam:
+//
+//	[WARN] acoustid backfill: synthesize book signature for ...:
+//	  synthesize signature: decode segment: invalid character '-' in fingerprint
+func TestDecodeAnyFingerprint_URLSafeBase64(t *testing.T) {
+	// Build a payload guaranteed to round-trip through URL-safe base64
+	// and contain at least one '-' or '_' when encoded.
+	payload := make([]byte, 0, 64)
+	// Header (4 bytes) + 15 uint32s = 64 bytes.
+	header := []byte{0xfb, 0x01, 0x00, 0x00}
+	payload = append(payload, header...)
+	for i := uint32(0); i < 15; i++ {
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], 0xFFFFFFF0|i)
+		payload = append(payload, b[:]...)
+	}
+
+	stdEncoded := base64.StdEncoding.EncodeToString(payload)
+	urlEncoded := base64.URLEncoding.EncodeToString(payload)
+	rawURLEncoded := base64.RawURLEncoding.EncodeToString(payload)
+
+	// Sanity: URL-safe encoding should differ from std for this payload.
+	if !strings.ContainsAny(urlEncoded, "-_") {
+		t.Skip("payload happens not to contain URL-safe chars; pick another payload")
+	}
+
+	for name, fp := range map[string]string{
+		"std":    stdEncoded,
+		"url":    urlEncoded,
+		"rawurl": rawURLEncoded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ints, err := decodeAnyFingerprint(fp)
+			if err != nil {
+				t.Fatalf("decodeAnyFingerprint(%s) err: %v", name, err)
+			}
+			if len(ints) != 15 {
+				t.Fatalf("expected 15 ints, got %d", len(ints))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two independent production bugs, fixed together:

### 1. Acoustid backfill log spam (`internal/fingerprint/fpcalc.go`)
Production logs were spammed every backfill cycle with:
```
[WARN] acoustid backfill: synthesize book signature for 01KNDB...:
  synthesize signature: decode segment: invalid character '-' in fingerprint
```
Root cause: `decodeAnyFingerprint()` only tried `base64.StdEncoding`. Segments emitted by ffmpeg/chromaprint using the URL-safe alphabet (`-` / `_`) fell through to the AcoustID base62 decoder, which rejects those chars.

Fix: try `Std`, `URL`, `RawStd`, `RawURL` encodings before base62 fallback. Adds regression test (`fpcalc_decode_test.go`).

### 2. Dedup scan-results infinite re-render (`web/src/hooks/useAsyncAction.ts`)
`useAsyncAction` returned a `run` callback whose `useCallback` deps included the caller-supplied `fn`. Callers all pass inline closures, so `fn` (and therefore `run`) got a new identity every render. Any caller wiring `run` into a `useEffect`/`useCallback` chain (e.g. `DedupAdvancedScanTab`, `BookDedup`) hit an infinite re-render loop, eventually exhausting the browser socket pool with `ERR_INSUFFICIENT_RESOURCES`.

Fix: hold the latest `fn` in a ref; `run` now uses an empty dep array and is stable for component lifetime. No caller changes required.

## Tests
- `go test ./internal/fingerprint/` ✅ (new test passes for std/url/rawurl variants)
- `tsc --noEmit` + `eslint` clean

## Risk
- Low. Decoder change is strictly additive (more accept paths); existing base64/base62 paths unchanged.
- Hook change preserves observable semantics (loading/error/run/clearError) but stabilizes identity.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>