### PR TITLE
fix(fingerprint): tolerant decoder + canonical write (stop backfill spam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.44.1 -->
+<!-- version: 2.44.2 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-04 -->
 
@@ -8,6 +8,24 @@
 ## [Unreleased]
 
 ### Fixed
+
+#### May 4, 2026 — Acoustid backfill log spam (URL-safe + broken padding)
+
+- **fix(fingerprint)**: rewrite `decodeAnyFingerprint` as a single tolerant
+  pass — strip whitespace + existing `=` padding, translate URL-safe alphabet
+  (`-`/`_`) to standard, re-pad to multiple of 4, decode with `StdEncoding`.
+  The previous loop tried 4 base64 variants but each is strict about padding
+  length, so chromaprint output with a wrong-length `=` padding fell through
+  to the AcoustID base62 decoder which rejected `-`/`_`. That produced log
+  spam: `synthesize signature: decode segment: invalid character '-' in
+  fingerprint`, repeated per-book per-cycle.
+- **fix(fingerprint)**: add `NormalizeFingerprint(fp string) string` and call
+  it on the writer path (`fingerprintBookFile`) so newly-stored segments are
+  always canonical (standard alphabet + correct padding). Database stops
+  accumulating divergent encodings going forward; existing rows still work
+  via the tolerant reader.
+- Tests: `TestDecodeAnyFingerprint_BrokenPadding` covers strip_padding,
+  too_few_pad, too_many_pad, whitespace_in_middle, raw_url_with_extra_pad.
 
 #### May 4, 2026 — Activity compaction 500: "database is locked"
 

--- a/internal/fingerprint/fpcalc.go
+++ b/internal/fingerprint/fpcalc.go
@@ -1,5 +1,5 @@
 // file: internal/fingerprint/fpcalc.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
 
 // Package fingerprint generates AcoustID-compatible acoustic fingerprints for
@@ -344,33 +344,46 @@ func HammingSimilarity(a, b string) (float64, error) {
 }
 
 // decodeAnyFingerprint decodes a fingerprint string into its uint32 array.
-// It tries standard and URL-safe base64 first (ffmpeg chromaprint output),
-// then falls back to the AcoustID base62 encoding. URL-safe handling is
-// required because chromaprint/ffmpeg often emits '-' and '_' in place of
-// '+' and '/' depending on version/flags.
+//
+// Production data accumulated multiple ffmpeg/chromaprint output dialects:
+// standard alphabet, URL-safe alphabet (`-`/`_`), with-padding, without-
+// padding, and — critically — *wrong-length* padding. The previous
+// implementation looped four base64 variants but each one is strict about
+// padding length, so a URL-safe string with a single trailing `=` (when two
+// were needed) failed all four and fell to `decodeBase62Fingerprint`, which
+// rejects `-`/`_`. That produced the
+// `invalid character '-' in fingerprint` warn-spam in prod.
+//
+// We now do a single tolerant pass: strip whitespace and any existing `=`
+// padding, translate URL-safe chars to the standard alphabet, re-pad to a
+// multiple of 4, and decode with `StdEncoding`. The base62 decoder is kept
+// as a last-resort for legacy/external AcoustID fingerprints.
 func decodeAnyFingerprint(fp string) ([]uint32, error) {
-	// Try several base64 variants (with/without padding, std/url-safe).
-	encodings := []*base64.Encoding{
-		base64.StdEncoding,
-		base64.URLEncoding,
-		base64.RawStdEncoding,
-		base64.RawURLEncoding,
-	}
-	for _, enc := range encodings {
-		b, err := enc.DecodeString(fp)
-		if err != nil {
-			continue
+	// Strip whitespace + existing padding, normalize URL-safe alphabet.
+	canonical := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\n', '\r', '\t', '=':
+			return -1
+		case '-':
+			return '+'
+		case '_':
+			return '/'
 		}
-		// Chromaprint base64 format: 4-byte header + uint32 little-endian values.
-		if len(b) >= 8 {
+		return r
+	}, fp)
+	if pad := len(canonical) % 4; pad > 0 {
+		canonical += strings.Repeat("=", 4-pad)
+	}
+
+	if b, err := base64.StdEncoding.DecodeString(canonical); err == nil {
+		// Chromaprint format: 4-byte header + uint32 little-endian values.
+		if len(b) >= 8 && (len(b)-4)%4 == 0 {
 			payload := b[4:]
-			if len(payload)%4 == 0 {
-				ints := make([]uint32, len(payload)/4)
-				for i := range ints {
-					ints[i] = binary.LittleEndian.Uint32(payload[i*4:])
-				}
-				return ints, nil
+			ints := make([]uint32, len(payload)/4)
+			for i := range ints {
+				ints[i] = binary.LittleEndian.Uint32(payload[i*4:])
 			}
+			return ints, nil
 		}
 		// Raw base64 without the 4-byte header (some ffmpeg versions).
 		if len(b) > 0 && len(b)%4 == 0 {
@@ -381,8 +394,44 @@ func decodeAnyFingerprint(fp string) ([]uint32, error) {
 			return ints, nil
 		}
 	}
-	// Fall through to AcoustID base62.
+	// Last resort: AcoustID base62 (legacy/external strings).
 	return decodeBase62Fingerprint(fp)
+}
+
+// NormalizeFingerprint converts a fingerprint string into the canonical
+// base64 form (standard alphabet, with `=` padding) that the rest of this
+// codebase uses, without round-tripping through the decoded uint32 array
+// (which would risk dropping or mis-attributing the chromaprint header
+// byte).
+//
+// Used by the writer path so the database stops accumulating divergent
+// encodings (URL-safe alphabet, missing or wrong-length padding). The
+// reader (decodeAnyFingerprint) tolerates both forms, so existing rows are
+// not affected.
+func NormalizeFingerprint(fp string) string {
+	if fp == "" {
+		return ""
+	}
+	canonical := strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\n', '\r', '\t', '=':
+			return -1
+		case '-':
+			return '+'
+		case '_':
+			return '/'
+		}
+		return r
+	}, fp)
+	if pad := len(canonical) % 4; pad > 0 {
+		canonical += strings.Repeat("=", 4-pad)
+	}
+	// Validate by decoding; on failure keep the raw input so we never
+	// destroy data that may still be readable by some other path.
+	if _, err := base64.StdEncoding.DecodeString(canonical); err != nil {
+		return fp
+	}
+	return canonical
 }
 
 // decodeBase62Fingerprint base62-decodes an AcoustID fingerprint string into

--- a/internal/fingerprint/fpcalc_decode_test.go
+++ b/internal/fingerprint/fpcalc_decode_test.go
@@ -1,5 +1,5 @@
 // file: internal/fingerprint/fpcalc_decode_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e2c4a6b8-9d0e-4f1a-8b2c-3d4e5f6a7b8c
 
 package fingerprint
@@ -48,6 +48,45 @@ func TestDecodeAnyFingerprint_URLSafeBase64(t *testing.T) {
 			ints, err := decodeAnyFingerprint(fp)
 			if err != nil {
 				t.Fatalf("decodeAnyFingerprint(%s) err: %v", name, err)
+			}
+			if len(ints) != 15 {
+				t.Fatalf("expected 15 ints, got %d", len(ints))
+			}
+		})
+	}
+}
+
+// TestDecodeAnyFingerprint_BrokenPadding is the regression for the prod
+// log-spam after the URL-safe fix shipped: chromaprint output sometimes
+// arrives with the URL-safe alphabet *and* wrong-length `=` padding. Both
+// `URLEncoding` (needs correct padding) and `RawURLEncoding` (needs no
+// padding) reject those, and the loop in v3.1 fell through to the base62
+// decoder which barfs on `-`/`_`. v3.2 normalizes padding before decoding.
+func TestDecodeAnyFingerprint_BrokenPadding(t *testing.T) {
+	payload := make([]byte, 0, 64)
+	payload = append(payload, 0xfb, 0x01, 0x00, 0x00)
+	for i := uint32(0); i < 15; i++ {
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], 0xFFFFFFF0|i)
+		payload = append(payload, b[:]...)
+	}
+	urlEncoded := base64.URLEncoding.EncodeToString(payload)
+	if !strings.ContainsAny(urlEncoded, "-_") {
+		t.Skip("payload happens not to contain URL-safe chars")
+	}
+
+	cases := map[string]string{
+		"strip_padding":           strings.TrimRight(urlEncoded, "="),
+		"too_few_pad":             strings.TrimRight(urlEncoded, "=") + "=",   // 1 `=` when input needs 0/2
+		"too_many_pad":            urlEncoded + "==",                           // extra padding
+		"whitespace_in_middle":    urlEncoded[:10] + "\n  \t" + urlEncoded[10:],
+		"raw_url_with_extra_pad":  base64.RawURLEncoding.EncodeToString(payload) + "===",
+	}
+	for name, fp := range cases {
+		t.Run(name, func(t *testing.T) {
+			ints, err := decodeAnyFingerprint(fp)
+			if err != nil {
+				t.Fatalf("decodeAnyFingerprint(%s) err: %v (input %q)", name, err, fp)
 			}
 			if len(ints) != 15 {
 				t.Fatalf("expected 15 ints, got %d", len(ints))

--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/server/acoustid_backfill.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 package server
 
@@ -57,13 +57,17 @@ func fingerprintBookFile(store database.Store, f database.BookFile, force bool) 
 	}
 
 	updated := f
-	updated.AcoustIDSeg0 = segs[0]
-	updated.AcoustIDSeg1 = segs[1]
-	updated.AcoustIDSeg2 = segs[2]
-	updated.AcoustIDSeg3 = segs[3]
-	updated.AcoustIDSeg4 = segs[4]
-	updated.AcoustIDSeg5 = segs[5]
-	updated.AcoustIDSeg6 = segs[6]
+	// Normalize at write time: chromaprint/ffmpeg dialects produce
+	// URL-safe alphabet and varying padding, which the database has been
+	// accumulating since fingerprinting started. Canonicalize here so new
+	// rows are uniform.
+	updated.AcoustIDSeg0 = fingerprint.NormalizeFingerprint(segs[0])
+	updated.AcoustIDSeg1 = fingerprint.NormalizeFingerprint(segs[1])
+	updated.AcoustIDSeg2 = fingerprint.NormalizeFingerprint(segs[2])
+	updated.AcoustIDSeg3 = fingerprint.NormalizeFingerprint(segs[3])
+	updated.AcoustIDSeg4 = fingerprint.NormalizeFingerprint(segs[4])
+	updated.AcoustIDSeg5 = fingerprint.NormalizeFingerprint(segs[5])
+	updated.AcoustIDSeg6 = fingerprint.NormalizeFingerprint(segs[6])
 	if err := store.UpdateBookFile(f.ID, &updated); err != nil {
 		log.Printf("[WARN] fingerprint: update %s: %v", f.ID, err)
 		return fingerprintOutcomeFailed


### PR DESCRIPTION
## Summary

#692's URL-safe fix wasn't enough. Each of the four base64 variants is strict about `=` padding length, and production fingerprints arrive with URL-safe alphabet **and** wrong-length padding. All four variants failed, we fell through to `decodeBase62Fingerprint`, which barfs on `-`/`_` — spam continued.

## Fix

- Replace the loop with one tolerant pass: strip whitespace + existing `=`, translate URL-safe alphabet → standard, re-pad to multiple of 4, decode `StdEncoding`. Base62 stays as last-resort for legacy/external strings.
- Add `NormalizeFingerprint(fp string) string` and apply on the writer path (`fingerprintBookFile`). Database stops accumulating divergent encodings; existing rows still work via the tolerant reader.

## Test plan

- [x] `TestDecodeAnyFingerprint_URLSafeBase64` — std, url, rawurl all green
- [x] `TestDecodeAnyFingerprint_BrokenPadding` — strip_padding, too_few_pad, too_many_pad, whitespace_in_middle, raw_url_with_extra_pad
- [x] `go test ./internal/fingerprint/... ./internal/server/...` — green
- [ ] Watch `journalctl -u audiobook-organizer.service | grep "decode segment"` for ~5 min after deploy; expect 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)