### PR TITLE
fix(fingerprint): truncate misaligned payload, restrict base62 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.44.2 -->
+<!-- version: 2.44.3 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-04 -->
 
@@ -8,6 +8,21 @@
 ## [Unreleased]
 
 ### Fixed
+
+#### May 4, 2026 — Acoustid backfill spam: `'+' in fingerprint` after the URL-safe fix
+
+- **fix(fingerprint)**: when `StdEncoding` decodes successfully but the
+  resulting byte length isn't aligned to the chromaprint format (4-byte
+  header + N×4 payload), truncate the trailing 1–3 stray bytes instead of
+  falling through to `decodeBase62Fingerprint`. The previous behavior on
+  off-by-one inputs produced the misleading
+  `decode segment: invalid character '+' in fingerprint` (base62 doesn't
+  accept `+`).
+- **fix(fingerprint)**: only fall through to base62 when the input is
+  alphanumeric-only (no `+`, `/`, `-`, `_`, `=`). Inputs containing any
+  base64 special chars now report a clear "not a valid base64 chromaprint
+  payload" error rather than misattributing the failure to base62.
+- Test: `trailing_byte_misalign` covers the off-by-one truncation path.
 
 #### May 4, 2026 — Acoustid backfill log spam (URL-safe + broken padding)
 

--- a/internal/fingerprint/fpcalc.go
+++ b/internal/fingerprint/fpcalc.go
@@ -1,5 +1,5 @@
 // file: internal/fingerprint/fpcalc.go
-// version: 3.2.0
+// version: 3.2.1
 // guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
 
 // Package fingerprint generates AcoustID-compatible acoustic fingerprints for
@@ -393,9 +393,29 @@ func decodeAnyFingerprint(fp string) ([]uint32, error) {
 			}
 			return ints, nil
 		}
+		// Decoded fine but length is not aligned to a chromaprint payload.
+		// Truncate the trailing 1–3 bytes that prevent alignment so we can
+		// still produce a usable signature instead of failing the whole
+		// book. (Most occurrences are off-by-one bytes from a write that
+		// pre-dates the canonical-on-write change.)
+		if len(b) >= 8 {
+			cut := (len(b) - 4) & ^3 // largest multiple of 4 ≤ len-4
+			payload := b[4 : 4+cut]
+			ints := make([]uint32, len(payload)/4)
+			for i := range ints {
+				ints[i] = binary.LittleEndian.Uint32(payload[i*4:])
+			}
+			return ints, nil
+		}
 	}
-	// Last resort: AcoustID base62 (legacy/external strings).
-	return decodeBase62Fingerprint(fp)
+	// Real decode failure — only call base62 if the input looks like base62
+	// (alphanumeric only). Inputs containing '+', '/', '-', or '_' are
+	// definitely base64; falling through to base62 produces misleading
+	// "invalid character" errors.
+	if !strings.ContainsAny(fp, "+/-_=") {
+		return decodeBase62Fingerprint(fp)
+	}
+	return nil, fmt.Errorf("decode fingerprint: not a valid base64 chromaprint payload (len=%d)", len(fp))
 }
 
 // NormalizeFingerprint converts a fingerprint string into the canonical

--- a/internal/fingerprint/fpcalc_decode_test.go
+++ b/internal/fingerprint/fpcalc_decode_test.go
@@ -1,5 +1,5 @@
 // file: internal/fingerprint/fpcalc_decode_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e2c4a6b8-9d0e-4f1a-8b2c-3d4e5f6a7b8c
 
 package fingerprint
@@ -81,6 +81,11 @@ func TestDecodeAnyFingerprint_BrokenPadding(t *testing.T) {
 		"too_many_pad":            urlEncoded + "==",                           // extra padding
 		"whitespace_in_middle":    urlEncoded[:10] + "\n  \t" + urlEncoded[10:],
 		"raw_url_with_extra_pad":  base64.RawURLEncoding.EncodeToString(payload) + "===",
+		// Append a stray byte so decoded length becomes 65 (4-byte header
+		// + 60 bytes payload + 1 stray). Pre-fix this fell to base62 and
+		// produced the misleading "invalid character '+' in fingerprint"
+		// warning. Now we truncate to header + 60 bytes and parse 15 ints.
+		"trailing_byte_misalign": base64.StdEncoding.EncodeToString(append(append([]byte{}, payload...), 0xff)),
 	}
 	for name, fp := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

After #696 the spam pattern shifted from `invalid character '-'` to `invalid character '+' in fingerprint`. `StdEncoding` decoded fine but the byte length wasn't aligned to chromaprint's `header + N*4` format, so we fell through to `decodeBase62Fingerprint`, which rejects `+`. Misleading error.

## Fix

- When the decoded length is ≥ 8 but not header-aligned, truncate the trailing 1–3 stray bytes and parse what we have. These are off-by-one writes that pre-date the canonical-on-write fix in #696.
- Only fall through to base62 when the input is alphanumeric-only. Inputs containing `+`, `/`, `-`, `_`, or `=` get a clear `not a valid base64 chromaprint payload` error instead of base62's misattributed character complaint.

## Test plan

- [x] `TestDecodeAnyFingerprint_BrokenPadding/trailing_byte_misalign` — green
- [x] `go test ./internal/fingerprint/... -run Decode -v` — all green
- [ ] Watch `journalctl | grep "decode segment"` after deploy; expect 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)