### PR TITLE
fix(web): track dedup/embed operations in bell icon immediately

### DIFF
--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.4.0
+// version: 3.5.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useEffect, useState } from 'react';
@@ -51,6 +51,18 @@ function formatOperationType(type: string): string {
       return 'Metadata Fetch (Batch)';
     case 'ol_dump_import':
       return 'Open Library Import';
+    case 'dedup-scan':
+      return 'Dedup Scan';
+    case 'dedup-llm-review':
+      return 'Dedup AI Review';
+    case 'dedup-acoustid-scan':
+      return 'AcoustID Scan';
+    case 'dedup-book-signature-scan':
+      return 'Book Signature Scan';
+    case 'embed-scan':
+      return 'Embedding Rescan';
+    case 'fingerprint-rescan':
+      return 'Fingerprint Rescan';
     default:
       return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
   }

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.19.0
+// version: 3.20.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
-// last-edited: 2026-05-01
+// last-edited: 2026-05-04
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
@@ -51,7 +51,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import * as api from '../services/api';
-import type { Book, DedupCandidate, DedupStats } from '../services/api';
+import type { Book, DedupCandidate, DedupStats, Operation } from '../services/api';
+import { useOperationsStore } from '../stores/useOperationsStore';
 import HeadphonesIcon from '@mui/icons-material/Headphones';
 import { AudioSampleCompare } from '../components/AudioSampleCompare';
 import type { SampleBook } from '../components/AudioSampleCompare';
@@ -816,13 +817,24 @@ function EmbeddingDedupTab() {
     setCompareCluster({ a: toSample(cluster.bookIds[0]), b: toSample(cluster.bookIds[1]) });
   };
 
+  // trackOp registers the returned op with the operations store so the bell
+  // icon and Activity page surface it within one poll cycle, instead of
+  // waiting up to 15s for the next background ActiveOperations sweep.
+  // Returns a user-facing message that names the op type and id.
+  const trackOp = (op: Operation, label: string): string => {
+    if (op?.id && op?.type) {
+      useOperationsStore.getState().startPolling(op.id, op.type);
+      return `${label} started — see bell icon for progress (op ${op.id.slice(-6)})`;
+    }
+    return `${label} started`;
+  };
+
   const handleScan = async () => {
     setScanning(true);
     setScanMsg(null);
     try {
-      const { status } = await api.triggerDedupScan();
-      setScanMsg(status || 'Scan triggered');
-      // Refresh after a short delay
+      const op = await api.triggerDedupScan();
+      setScanMsg(trackOp(op, 'Dedup scan'));
       setTimeout(() => { loadCandidates(); loadStats(); }, 2000);
     } catch (err) {
       setScanMsg(err instanceof Error ? err.message : 'Scan failed');
@@ -835,8 +847,8 @@ function EmbeddingDedupTab() {
     setScanning(true);
     setScanMsg(null);
     try {
-      const { status } = await api.triggerDedupLLM();
-      setScanMsg(status || 'AI review triggered');
+      const op = await api.triggerDedupLLM();
+      setScanMsg(trackOp(op, 'AI review'));
       setTimeout(() => { loadCandidates(); loadStats(); }, 3000);
     } catch (err) {
       setScanMsg(err instanceof Error ? err.message : 'AI review failed');
@@ -849,8 +861,8 @@ function EmbeddingDedupTab() {
     setScanning(true);
     setScanMsg(null);
     try {
-      const { status } = await api.triggerDedupAcoustID();
-      setScanMsg(status || 'AcoustID scan triggered');
+      const op = await api.triggerDedupAcoustID();
+      setScanMsg(trackOp(op, 'AcoustID scan'));
       setTimeout(() => { loadCandidates(); loadStats(); }, 3000);
     } catch (err) {
       setScanMsg(err instanceof Error ? err.message : 'AcoustID scan failed');
@@ -863,8 +875,8 @@ function EmbeddingDedupTab() {
     setScanning(true);
     setScanMsg(null);
     try {
-      const { status } = await api.triggerEmbedScan();
-      setScanMsg(status || 'Embedding scan triggered — check Operations for progress');
+      const op = await api.triggerEmbedScan();
+      setScanMsg(trackOp(op, 'Embedding rescan'));
     } catch (err) {
       setScanMsg(err instanceof Error ? err.message : 'Embedding scan failed');
     } finally {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.13.0
+// version: 2.14.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-03
+// last-edited: 2026-05-04
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -4260,7 +4260,13 @@ export async function removeFromDedupCluster(
   return responseData.data;
 }
 
-export async function triggerDedupScan(): Promise<{ status: string }> {
+// All trigger* dedup endpoints return the full Operation row (id, type,
+// status, progress, ...). Returning the bare Operation lets callers
+// register the op with useOperationsStore.startPolling immediately so the
+// bell icon and Activity page surface the op without waiting for the next
+// 15s background sweep — that wait is what made fast scans look invisible
+// after the user clicked "Re-scan" or "Re-embed All".
+export async function triggerDedupScan(): Promise<Operation> {
   const response = await fetch(`${API_BASE}/dedup/scan`, { method: 'POST' });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger dedup scan');
@@ -4269,7 +4275,7 @@ export async function triggerDedupScan(): Promise<{ status: string }> {
   return responseData.data;
 }
 
-export async function triggerDedupLLM(): Promise<{ status: string }> {
+export async function triggerDedupLLM(): Promise<Operation> {
   const response = await fetch(`${API_BASE}/dedup/scan-llm`, {
     method: 'POST',
   });
@@ -4280,7 +4286,7 @@ export async function triggerDedupLLM(): Promise<{ status: string }> {
   return responseData.data;
 }
 
-export async function triggerDedupAcoustID(): Promise<{ status: string }> {
+export async function triggerDedupAcoustID(): Promise<Operation> {
   const response = await fetch(`${API_BASE}/dedup/scan-acoustid`, { method: 'POST' });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger AcoustID scan');
@@ -4289,7 +4295,7 @@ export async function triggerDedupAcoustID(): Promise<{ status: string }> {
   return responseData.data;
 }
 
-export async function triggerDedupRefresh(): Promise<{ status: string }> {
+export async function triggerDedupRefresh(): Promise<Operation> {
   const response = await fetch(`${API_BASE}/dedup/refresh`, {
     method: 'POST',
   });
@@ -4300,7 +4306,7 @@ export async function triggerDedupRefresh(): Promise<{ status: string }> {
   return responseData.data;
 }
 
-export async function triggerEmbedScan(): Promise<{ status: string }> {
+export async function triggerEmbedScan(): Promise<Operation> {
   const response = await fetch(`${API_BASE}/dedup/embed`, { method: 'POST' });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to trigger embedding scan');

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
@@ -43,6 +43,12 @@ function formatOpLabel(type: string): string {
     series_normalize: 'Series Normalize',
     transcode: 'Transcode',
     ol_dump_import: 'Open Library Import',
+    'dedup-scan': 'Dedup Scan',
+    'dedup-llm-review': 'Dedup AI Review',
+    'dedup-acoustid-scan': 'AcoustID Scan',
+    'dedup-book-signature-scan': 'Book Signature Scan',
+    'embed-scan': 'Embedding Rescan',
+    'fingerprint-rescan': 'Fingerprint Rescan',
   };
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }


### PR DESCRIPTION
## Summary

Clicking Re-scan / Re-embed All / AI Review / AcoustID Scan on the dedup page already kicked off a tracked Operation server-side, but the frontend wrappers were typed as \`Promise<{ status }>\`, throwing away the operation_id. The bell icon's 15s background poll eventually noticed — except for fast ops, which completed before the next sweep, so the user saw nothing happen.

- \`triggerDedupScan\`, \`triggerDedupLLM\`, \`triggerDedupAcoustID\`, \`triggerDedupRefresh\`, \`triggerEmbedScan\` now return the full \`Operation\`.
- \`BookDedup\` handlers register the returned op with \`useOperationsStore.startPolling(op.id, op.type)\` so the bell badge increments within ~1s of the click.
- Adds labels for the dedup/embed/fingerprint op types in both the store and the indicator so they no longer render as raw type strings.
- Inline scanMsg now includes the last 6 chars of the op id so the user can correlate it with the bell entry.

This is a partial answer to issue #2 in the recent dedup feedback. The full unified-operations system (#6) is still a separate brainstorm.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 163 tests pass
- [ ] Click each button on /book-dedup, confirm bell badge increments and the op appears in the dropdown with progress