### PR TITLE
feat(web): clickable stat chips + removable filter tag bar on dedup

### DIFF
--- a/web/src/components/common/FilterTagBar.test.tsx
+++ b/web/src/components/common/FilterTagBar.test.tsx
@@ -1,0 +1,70 @@
+// file: web/src/components/common/FilterTagBar.test.tsx
+// version: 1.0.0
+// guid: 8d5e9f23-4c7a-5b8d-aef2-1b3c4d5e6f7a
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FilterTagBar } from './FilterTagBar';
+
+describe('FilterTagBar', () => {
+  it('renders nothing when there are no tags', () => {
+    const { container } = render(<FilterTagBar tags={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one chip per tag with the supplied label', () => {
+    const tags = [
+      { id: 'status:pending', label: 'Status: pending', onRemove: vi.fn() },
+      { id: 'layer:exact', label: 'Layer: exact', onRemove: vi.fn() },
+    ];
+    render(<FilterTagBar tags={tags} />);
+    expect(screen.getByText('Status: pending')).toBeInTheDocument();
+    expect(screen.getByText('Layer: exact')).toBeInTheDocument();
+  });
+
+  it('fires onRemove when a chip delete icon is clicked', () => {
+    const onRemove = vi.fn();
+    render(
+      <FilterTagBar
+        tags={[{ id: 'status:pending', label: 'Status: pending', onRemove }]}
+      />
+    );
+    // MUI Chip exposes the delete icon with role=button via test-id-friendly
+    // markup; click the SVG icon that lives inside the chip.
+    const deleteIcons = document.querySelectorAll('.MuiChip-deleteIcon');
+    expect(deleteIcons.length).toBe(1);
+    fireEvent.click(deleteIcons[0]);
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Clear all only when ≥2 tags and a handler is provided', () => {
+    const onClearAll = vi.fn();
+    const oneTag = [
+      { id: 'status:pending', label: 'Status: pending', onRemove: vi.fn() },
+    ];
+    const twoTags = [
+      ...oneTag,
+      { id: 'layer:exact', label: 'Layer: exact', onRemove: vi.fn() },
+    ];
+
+    const { rerender } = render(<FilterTagBar tags={oneTag} onClearAll={onClearAll} />);
+    expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+
+    rerender(<FilterTagBar tags={twoTags} onClearAll={onClearAll} />);
+    const clearAll = screen.getByText('Clear all');
+    fireEvent.click(clearAll);
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Clear all button when no handler is supplied', () => {
+    render(
+      <FilterTagBar
+        tags={[
+          { id: 'status:pending', label: 'Status: pending', onRemove: vi.fn() },
+          { id: 'layer:exact', label: 'Layer: exact', onRemove: vi.fn() },
+        ]}
+      />
+    );
+    expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/common/FilterTagBar.tsx
+++ b/web/src/components/common/FilterTagBar.tsx
@@ -1,0 +1,107 @@
+// file: web/src/components/common/FilterTagBar.tsx
+// version: 1.0.0
+// guid: 7c4f8d12-3b6e-4a5c-9d1e-8f2a3b4c5d6e
+// last-edited: 2026-05-04
+
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close.js';
+
+// Avoid importing the full ChipPropsColorOverrides surface — these are
+// the MUI palette names we actually use across the app for filter chips.
+export type FilterChipColor =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'error'
+  | 'info'
+  | 'success'
+  | 'warning';
+
+export interface FilterTag {
+  /** Stable id for React keying and dedupe; usually `${field}:${value}`. */
+  id: string;
+  /** Human-readable label shown on the chip. */
+  label: string;
+  /** Optional MUI palette color; default `'default'`. */
+  color?: FilterChipColor;
+  /** Removes the filter when the chip's X is clicked. */
+  onRemove: () => void;
+}
+
+interface FilterTagBarProps {
+  tags: FilterTag[];
+  /** Optional "Clear all" handler — when omitted, the button is hidden. */
+  onClearAll?: () => void;
+  /** Hide the prefix label "Filters:" (use when the surrounding layout already labels it). */
+  hideLabel?: boolean;
+  /** Override the prefix label text (default "Filters:"). */
+  label?: string;
+}
+
+/**
+ * EC2-style active-filter strip. Renders an array of currently-applied
+ * filters as removable Chips with X icons and an optional "Clear all"
+ * button. Renders nothing when `tags` is empty so it doesn't reserve
+ * empty visual space.
+ *
+ * Pattern: pages own filter state and derive a FilterTag[] from it on
+ * each render. Clicking the X calls `onRemove`, which the page wires
+ * to the appropriate setState (e.g. `setStatusFilter('')`). This keeps
+ * the component stateless — there is one source of truth (the page's
+ * filter state) and the bar is a pure projection of it.
+ */
+export function FilterTagBar({
+  tags,
+  onClearAll,
+  hideLabel,
+  label = 'Filters:',
+}: FilterTagBarProps) {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  const showClearAll = onClearAll && tags.length >= 2;
+
+  return (
+    <Box
+      sx={{
+        mb: 2,
+        py: 1,
+        px: 1.5,
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexWrap: 'wrap',
+      }}
+    >
+      {!hideLabel && (
+        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+          {label}
+        </Typography>
+      )}
+      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ flex: 1 }}>
+        {tags.map((tag) => (
+          <Chip
+            key={tag.id}
+            label={tag.label}
+            size="small"
+            color={tag.color ?? 'default'}
+            onDelete={tag.onRemove}
+            deleteIcon={<CloseIcon />}
+          />
+        ))}
+      </Stack>
+      {showClearAll && (
+        <Button
+          size="small"
+          onClick={onClearAll}
+          sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+        >
+          Clear all
+        </Button>
+      )}
+    </Box>
+  );
+}

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.20.0
+// version: 3.21.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 // last-edited: 2026-05-04
 
@@ -53,6 +53,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import * as api from '../services/api';
 import type { Book, DedupCandidate, DedupStats, Operation } from '../services/api';
 import { useOperationsStore } from '../stores/useOperationsStore';
+import { FilterTagBar, type FilterTag } from '../components/common/FilterTagBar';
 import HeadphonesIcon from '@mui/icons-material/Headphones';
 import { AudioSampleCompare } from '../components/AudioSampleCompare';
 import type { SampleBook } from '../components/AudioSampleCompare';
@@ -977,7 +978,6 @@ function EmbeddingDedupTab() {
   const pendingCount = stats.filter(s => s.status === 'pending').reduce((sum, s) => sum + s.count, 0);
   const mergedCount = stats.filter(s => s.status === 'merged').reduce((sum, s) => sum + s.count, 0);
   const dismissedCount = stats.filter(s => s.status === 'dismissed').reduce((sum, s) => sum + s.count, 0);
-  const allCount = pendingCount + mergedCount + dismissedCount;
   const exactCount = stats.filter(s => s.layer === 'exact').reduce((sum, s) => sum + s.count, 0);
   const embeddingCount = stats.filter(s => s.layer === 'embedding').reduce((sum, s) => sum + s.count, 0);
   const llmCount = stats.filter(s => s.layer === 'llm').reduce((sum, s) => sum + s.count, 0);
@@ -1400,42 +1400,113 @@ function EmbeddingDedupTab() {
         </DialogActions>
       </Dialog>
 
-      {/* Stats chips — one per status bucket plus per-layer breakdown. */}
+      {/* Stat chips — clickable. Each chip applies its corresponding
+          filter (status or layer); the active filter chip is rendered
+          filled instead of outlined so the user sees which slice they
+          are viewing. The "showing" chip is informational only. The
+          previous Tabs + secondary chip-toggle row below was redundant
+          with this control and was removed — active filters now show
+          up below as removable tags via FilterTagBar. */}
       <Stack direction="row" spacing={1} sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
-        <Chip label={`${pendingCount} pending`} size="small" color="warning" variant="outlined" />
-        <Chip label={`${mergedCount} merged`} size="small" color="success" variant="outlined" />
-        <Chip label={`${dismissedCount} dismissed`} size="small" color="default" variant="outlined" />
-        <Chip label={`${exactCount} exact`} size="small" color="error" variant="outlined" />
-        <Chip label={`${embeddingCount} embedding`} size="small" color="primary" variant="outlined" />
-        <Chip label={`${llmCount} LLM`} size="small" color="secondary" variant="outlined" />
+        <Chip
+          label={`${pendingCount} pending`}
+          size="small"
+          color="warning"
+          variant={statusFilter === 'pending' ? 'filled' : 'outlined'}
+          onClick={() => { setStatusFilter('pending'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
+        <Chip
+          label={`${mergedCount} merged`}
+          size="small"
+          color="success"
+          variant={statusFilter === 'merged' ? 'filled' : 'outlined'}
+          onClick={() => { setStatusFilter('merged'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
+        <Chip
+          label={`${dismissedCount} dismissed`}
+          size="small"
+          color="default"
+          variant={statusFilter === 'dismissed' ? 'filled' : 'outlined'}
+          onClick={() => { setStatusFilter('dismissed'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
+        <Chip
+          label={`${exactCount} exact`}
+          size="small"
+          color="error"
+          variant={layerFilter === 'exact' ? 'filled' : 'outlined'}
+          onClick={() => { setLayerFilter(layerFilter === 'exact' ? '' : 'exact'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
+        <Chip
+          label={`${embeddingCount} embedding`}
+          size="small"
+          color="primary"
+          variant={layerFilter === 'embedding' ? 'filled' : 'outlined'}
+          onClick={() => { setLayerFilter(layerFilter === 'embedding' ? '' : 'embedding'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
+        <Chip
+          label={`${llmCount} LLM`}
+          size="small"
+          color="secondary"
+          variant={layerFilter === 'llm' ? 'filled' : 'outlined'}
+          onClick={() => { setLayerFilter(layerFilter === 'llm' ? '' : 'llm'); setPage(0); }}
+          sx={{ cursor: 'pointer' }}
+        />
         <Chip label={`${total} showing`} size="small" variant="outlined" />
       </Stack>
 
-      {/* Filters — tab labels carry the running per-status count so you
-          can see at a glance how many you've merged/dismissed without
-          needing to click into each bucket. */}
-      <Stack direction="row" spacing={2} sx={{ mb: 2 }} alignItems="center" flexWrap="wrap" useFlexGap>
-        <Tabs value={statusFilter} onChange={(_, v) => { setStatusFilter(v); setPage(0); }}>
-          <Tab value="pending" label={`Pending (${pendingCount})`} />
-          <Tab value="merged" label={`Merged (${mergedCount})`} />
-          <Tab value="dismissed" label={`Dismissed (${dismissedCount})`} />
-          <Tab value="" label={`All (${allCount})`} />
-        </Tabs>
-        <Divider orientation="vertical" flexItem />
-        <Stack direction="row" spacing={0.5}>
-          {(['', 'exact', 'embedding', 'llm'] as const).map((layer) => (
-            <Chip
-              key={layer || 'all'}
-              label={layer || 'All'}
-              size="small"
-              color={layerFilter === layer ? (LAYER_COLORS[layer] || 'default') : 'default'}
-              variant={layerFilter === layer ? 'filled' : 'outlined'}
-              onClick={() => { setLayerFilter(layer); setPage(0); }}
-              sx={{ cursor: 'pointer' }}
-            />
-          ))}
-        </Stack>
-        <Divider orientation="vertical" flexItem />
+      {/* Active filters (removable). The bar hides itself when no
+          filters are active, so it doesn't reserve empty visual space. */}
+      <FilterTagBar
+        tags={(() => {
+          const tags: FilterTag[] = [];
+          if (statusFilter) {
+            tags.push({
+              id: `status:${statusFilter}`,
+              label: `Status: ${statusFilter}`,
+              color:
+                statusFilter === 'pending'
+                  ? 'warning'
+                  : statusFilter === 'merged'
+                  ? 'success'
+                  : 'default',
+              onRemove: () => { setStatusFilter(''); setPage(0); },
+            });
+          }
+          if (layerFilter) {
+            tags.push({
+              id: `layer:${layerFilter}`,
+              label: `Layer: ${layerFilter}`,
+              color: LAYER_COLORS[layerFilter] || 'default',
+              onRemove: () => { setLayerFilter(''); setPage(0); },
+            });
+          }
+          if (searchQuery.trim()) {
+            tags.push({
+              id: 'search',
+              label: `Search: "${searchQuery.trim()}"`,
+              color: 'info',
+              onRemove: () => setSearchQuery(''),
+            });
+          }
+          return tags;
+        })()}
+        onClearAll={() => {
+          setStatusFilter('');
+          setLayerFilter('');
+          setSearchQuery('');
+          setPage(0);
+        }}
+      />
+
+      {/* Search box — live-filters the current page. The query is also
+          mirrored into the FilterTagBar above so it can be cleared via
+          the same X gesture as other filters. */}
+      <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
         <TextField
           size="small"
           placeholder="Search title, author, path…"
@@ -1459,7 +1530,7 @@ function EmbeddingDedupTab() {
               : 'Searches the current page only'
           }
         />
-      </Stack>
+      </Box>
 
       {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>{error}</Alert>}
 


### PR DESCRIPTION
## Summary

EC2-style filter UX on the dedup page. The 7 stat chips at the top become the filter control; active filters render below as removable chips via a new \`FilterTagBar\` component.

- **New** \`FilterTagBar\` — generic component that takes \`{id, label, color, onRemove}[]\` and renders removable chips with an optional \"Clear all\" button. Hides when empty. 5 vitest cases.
- **BookDedup**: stat chips are now clickable and switch filled when active. \`pending\`/\`merged\`/\`dismissed\` apply status; \`exact\`/\`embedding\`/\`llm\` toggle layer. The redundant Tabs row and secondary chip-toggle row are gone. Search input is mirrored into the tag bar.

Component is generic so the same UX rolls out next on Library / Activity / Authors.

## Screenshots
Old: clickable colored stat chips on top, *separate* tabs + chip-toggle filters below, search box pinned right.
New: clickable stat chips on top (filled when active), removable filter tags below them, search box on its own line.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 168 tests pass (5 new for FilterTagBar)
- [ ] Manual: click each stat chip, verify filter applied + tag appears + table updates
- [ ] Manual: type in search, verify tag appears with the query, clearing tag clears search
- [ ] Manual: \"Clear all\" with ≥2 active filters resets everything