### PR TITLE
fix(ops): unblock queue — 8 workers + skip reconcile_scan auto-resume

### DIFF
--- a/internal/operations/queue.go
+++ b/internal/operations/queue.go
@@ -1,5 +1,5 @@
 // file: internal/operations/queue.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 7d6e5f4a-3c2b-1a09-8f7e-6d5c4b3a2190
 
 package operations
@@ -94,7 +94,12 @@ type OperationProgress struct {
 // NewOperationQueue creates a new operation queue
 func NewOperationQueue(store database.OperationStore, workers int, activityLogger ActivityLogger, hub *realtime.EventHub) *OperationQueue {
 	if workers <= 0 {
-		workers = 2 // Default to 2 workers
+		// Default to 8 workers — bumped from 2 after the 2026-05-04
+		// queue-jam incident: a single long-running, ctx-ignoring op
+		// (reconcile_scan) parked both workers for ~45 minutes and
+		// stalled every other queued operation. 8 workers gives enough
+		// head-room that one stuck job doesn't deadlock the whole queue.
+		workers = 8
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/operations/queue_test.go
+++ b/internal/operations/queue_test.go
@@ -54,21 +54,21 @@ func TestNewOperationQueue(t *testing.T) {
 		}
 	})
 
-	t.Run("defaults to 2 workers when 0 specified", func(t *testing.T) {
+	t.Run("defaults to 8 workers when 0 specified", func(t *testing.T) {
 		q := NewOperationQueue(store, 0, nil, nil)
 		defer q.Shutdown(time.Second)
 
-		if q.workers != 2 {
-			t.Errorf("expected 2 workers, got %d", q.workers)
+		if q.workers != 8 {
+			t.Errorf("expected 8 workers, got %d", q.workers)
 		}
 	})
 
-	t.Run("defaults to 2 workers when negative specified", func(t *testing.T) {
+	t.Run("defaults to 8 workers when negative specified", func(t *testing.T) {
 		q := NewOperationQueue(store, -1, nil, nil)
 		defer q.Shutdown(time.Second)
 
-		if q.workers != 2 {
-			t.Errorf("expected 2 workers, got %d", q.workers)
+		if q.workers != 8 {
+			t.Errorf("expected 8 workers, got %d", q.workers)
 		}
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -343,7 +343,7 @@ func NewServer(store database.Store) *Server {
 	// later in this function (kept for the GlobalQueue back-compat) is
 	// a no-op once this assignment lands.
 	if server.queue == nil {
-		server.queue = operations.NewOperationQueue(resolvedStore, 2, nil, server.hub)
+		server.queue = operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
 		// Long-running maintenance ops (path repair scans 80K+ files
 		// across many spinning disks) need more than the 2-hour default.
 		if oq, ok := server.queue.(*operations.OperationQueue); ok {
@@ -583,7 +583,7 @@ func NewServer(store database.Store) *Server {
 	realtime.SetGlobalHub(server.hub)
 
 	if server.queue == nil {
-		server.queue = operations.NewOperationQueue(resolvedStore, 2, nil, server.hub)
+		server.queue = operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
 		operations.GlobalQueue = server.queue
 	}
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-02
+// last-edited: 2026-05-04
 
 package server
 
@@ -30,7 +30,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metrics"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/realtime"
-	"github.com/jdfalk/audiobook-organizer/internal/reconcile"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
@@ -138,12 +137,6 @@ func (s *Server) resumeInterruptedOperations() {
 			}
 		case "metadata-refresh":
 			resumeFn = s.runMetadataRefreshScan
-		case "reconcile_scan":
-			scanOpID := opID
-			store := s.Store()
-			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
-				return reconcile.RunReconcileScan(store, ctx, scanOpID, progress)
-			}
 		case "itunes_path_reconcile":
 			reconcileOpID := opID
 			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
@@ -161,7 +154,14 @@ func (s *Server) resumeInterruptedOperations() {
 			"purge-deleted", "tombstone-cleanup",
 			"author-dedup-scan", "author-split-scan", "series-prune", "series-normalize",
 			"db-optimize", "cleanup-old-backups", "batch_poller",
-			"itunes_sync":
+			"itunes_sync",
+			// reconcile_scan: a 271K-file hash sweep that ignores ctx, runs
+			// nightly via the scheduler, and pins both queue workers for ~45min
+			// when auto-resumed. Repeated quick deploys produced a queue jam
+			// where new ops (AcoustID, embed, etc.) sat queued behind two
+			// stuck reconcile_scans that the cancel API couldn't actually
+			// kill. Letting the scheduler re-run it tomorrow is fine.
+			"reconcile_scan":
 			// These are not resumable — mark as failed silently
 			_ = store.UpdateOperationError(opID, fmt.Sprintf("interrupted during %s, please retry", opType))
 			_ = operations.ClearState(store, opID)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func run() int {
 	// Early initialization of operation queue (without store). This allows
 	// code paths that enqueue operations prior to full server startup to avoid nil checks.
 	if operations.GlobalQueue == nil {
-		operations.InitializeQueue(nil, 2) // store will be attached later once initialized
+		operations.InitializeQueue(nil, 8) // store will be attached later once initialized
 	}
 
 	if err := executeCmd(); err != nil {


### PR DESCRIPTION
## Summary

Two queue-jam fixes after a 2026-05-04 incident where every user-triggered op sat queued for >10 minutes behind two stuck reconcile_scan ops.

**Root cause:** \`reconcile.RunReconcileScan\` hashes ~271K untracked audio files and ignores \`ctx\`. Both queue workers parked on it, the cancel API couldn't free them (worker stays inside \`op.Func\` until it returns), and every server restart re-resumed the same two interrupted scans.

- **8 workers** by default (was 2). Enough head-room that one stuck job doesn't deadlock the queue.
- **\`reconcile_scan\` no longer auto-resumes** on startup. Moved into the existing \"not resumable, mark failed silently\" list. The scheduler runs it nightly anyway.
- queue_test.go updated to match the new default.

Tactical unblock — structural fix is teaching reconcile to honor \`ctx\` + a config-driven worker count, both follow-ups.

## Test plan

- [x] \`go test ./internal/operations/... ./internal/server/...\`
- [ ] Manual on prod: trigger an AcoustID scan, confirm it picks up immediately rather than queueing behind reconcile.