### PR TITLE
fix(web): unwrap data envelope in getActiveOperations

### DIFF
--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.14.0
+// version: 2.15.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-04
 
@@ -1606,8 +1606,15 @@ export async function getActiveOperations(): Promise<ActiveOperationSummary[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch active operations');
   }
-  const data = await response.json();
-  return data.operations || [];
+  const body = await response.json();
+  // Backend wraps every successful response in `{ data: ... }` via
+  // RespondWithOK; the actual payload is `{ data: { operations: [...] } }`.
+  // The previous read used top-level `body.operations`, which was always
+  // undefined, so this function silently returned `[]` — making the
+  // Activity page's "Active Operations" section permanently empty AND
+  // breaking the bell icon's auto-discovery of in-flight ops triggered
+  // outside of the dedup page.
+  return body?.data?.operations || body?.operations || [];
 }
 
 // System


### PR DESCRIPTION
## Summary

The backend wraps every successful response in \`{ data: ... }\` via \`RespondWithOK\`. \`getActiveOperations()\` was reading \`body.operations\` (top-level), which was always undefined, so the function silently fell back to \`[]\`.

Effect:
- Activity page's \"Active Operations\" section was always empty even when ops were running. Users couldn't click into a row to see the operation's logs.
- Bell icon's 15s background sweep that auto-discovers ops triggered outside the dedup page (e.g. via the AcoustID button before #700, or any backend-initiated op) never saw anything.

Fix reads \`body.data.operations\` first, falls back to \`body.operations\` for defensive compatibility.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 168 tests pass
- [ ] Manual: trigger an AcoustID scan, confirm it shows up in the Activity page's Active Operations section, click the row to expand and view logs.