### PR TITLE
chore(backlog): op-scoped log tagging + broken-files card / repair

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.6.0 -->
+<!-- version: 8.7.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-04 -->
 
@@ -631,6 +631,8 @@ since it was last edited on 2026-04-11).
 - [x] **1.9** Series-aware bulk merge (#232)
 - [x] **1.10** Export dedup state as CSV/JSON (#231)
 - [ ] **1.11** **Async embed via OpenAI Batch API for nightly re-scans** — submit FullScan as a single Batch job (`endpoint=/v1/embeddings`), 50% discount + 24h SLA, results routed via the existing universal batch poller. Sync path stays for interactive callers. Spec: [`docs/superpowers/bot-tasks/2026-05-04-async-embed-batch-api.md`](docs/superpowers/bot-tasks/2026-05-04-async-embed-batch-api.md)
+- [ ] **1.12** **Tag operation log lines with the originating operation ID** — pipe `op.ID` into a context-bound logger, replace bare `log.Printf` inside operation funcs with op-scoped calls, and write each line into `operation_logs` so the Activity-page log view shows everything (ffmpeg warnings, fingerprint failures, etc.) instead of only the explicit `progress.Log()` calls. Spec: [`docs/superpowers/bot-tasks/2026-05-04-tag-operation-logs.md`](docs/superpowers/bot-tasks/2026-05-04-tag-operation-logs.md)
+- [ ] **1.13** **Broken-files dashboard card + repair pipeline** — persist per-file ffmpeg / fingerprint errors to a new `book_file_errors` table associated with the book, surface a dashboard card ("N books with broken files"), add a `has_file_errors` library facet, and wire a repair pipeline (remux / restore-from-version / mark-ignored / delete-and-rescan). Pairs with 1.12. Spec: [`docs/superpowers/bot-tasks/2026-05-04-broken-files-card-and-repair.md`](docs/superpowers/bot-tasks/2026-05-04-broken-files-card-and-repair.md)
 
 ### 2. Known Bugs — all closed in #227
 

--- a/docs/superpowers/bot-tasks/2026-05-04-broken-files-card-and-repair.md
+++ b/docs/superpowers/bot-tasks/2026-05-04-broken-files-card-and-repair.md
@@ -1,0 +1,120 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-04-broken-files-card-and-repair.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b7e2f54a-9c83-4d6b-be1a-2c3d4e5f6789 -->
+<!-- last-edited: 2026-05-04 -->
+
+# BOT TASK: Broken-files dashboard card + repair pipeline
+
+## Branch
+
+```
+feat/broken-files-card
+```
+
+## Problem
+
+We used to surface a "you have N authors that look like duplicates" card on
+the dashboard. That one wasn't super useful in the end, but the *pattern*
+is — a glanceable card that exposes a piece of background-discovered
+trouble the user can act on.
+
+Right now, AcoustID / fingerprint / metadata flows generate ffmpeg-style
+errors like:
+
+```
+acoustid_backfill.go:55: [WARN] fingerprint: /mnt/bigdata/.../06 Phantom Menace.mp3:
+  ffmpeg chromaprint .../06 Phantom Menace.mp3@0.00:
+  [mp3 @ 0x...] Failed to find two consecutive MPEG audio frames.
+[in#0 @ 0x...] Error opening input: Invalid data found when processing input
+Error opening input file /mnt/bigdata/.../06 Phantom Menace.mp3.
+Error opening input files: Invalid data found when processing input
+```
+
+These warnings vanish into journalctl. Nothing in the UI tells the user
+"you have N files ffmpeg can't read"; nothing in the DB says "this book's
+file 06.mp3 is broken". Two consequences:
+
+1. The user can't filter the library to "books with broken files" and act
+   on them in bulk.
+2. There's no repair pipeline: re-encode, replace from a known-good copy,
+   delete-and-rescan, etc. The user has to find each broken file by hand.
+
+## Goal
+
+1. **Persist** every per-file processing error to the DB, associated with
+   the file (and its parent book). At minimum: file path, error class
+   (e.g. `ffmpeg_invalid_data`, `corrupt_mp3_frames`, `missing_fingerprint`),
+   raw error message, when it was last observed, how many times.
+2. **Surface** a dashboard card: "N books have files with errors → review".
+3. **Filter** the library page by a "has broken files" facet.
+4. **Repair pipeline** with at least these options per book/file:
+   - Re-extract from source if a versioned copy exists (`.versions/`).
+   - Trigger `make_safe` / `WriteTagsSafe`-style remux to fix container.
+   - Mark file as `ignored` (suppress future scans against it).
+   - Delete + rescan if the user has decided to drop the bad copy.
+
+## Files (likely)
+
+- `internal/database/migrations/` — new migration:
+  - `book_file_errors` table: `(file_path TEXT PK, book_id TEXT, error_class TEXT,
+    last_message TEXT, occurrences INT, first_seen, last_seen)`.
+- `internal/fingerprint/*.go` and `internal/server/acoustid_backfill.go`
+  — when ffmpeg returns non-zero / chromaprint fails, classify the error
+  and call a new store method `RecordFileError`.
+- `internal/database/store.go` (or a sidecar) — `RecordFileError`,
+  `ListBooksWithFileErrors`, `ClearFileError(filePath)`.
+- `internal/server/dashboard_handlers.go` — extend the dashboard summary
+  to include `broken_file_count`.
+- Frontend:
+  - `web/src/pages/Dashboard.tsx` — new card "N books with broken files",
+    routes to library filter.
+  - `web/src/pages/Library.tsx` — facet filter `has_file_errors=true`,
+    column for error class.
+  - `web/src/pages/BookDetail.tsx` — Errors tab (or section in Files tab)
+    listing per-file errors with repair actions.
+- New `internal/repair/` package — repair pipeline orchestrator:
+  - `Repair.RemuxFile(ctx, path)`
+  - `Repair.RestoreFromVersion(ctx, bookID, fileID)`
+  - `Repair.MarkIgnored(filePath)`
+  - `Repair.DeleteAndRescan(filePath)`
+
+## Constraints
+
+- **No re-classification on every read.** The `error_class` is computed
+  once at the producing site (the fingerprint/ffmpeg wrapper), not at
+  query time. Frontend just renders the stored class.
+- **De-dupe on file path.** A book with the same broken file scanned 50
+  times shouldn't make 50 rows; bump `occurrences` and `last_seen`.
+- **Source-of-truth for "broken" is `last_seen`.** A successful re-scan
+  clears the row (or sets a `resolved_at`).
+- **Repair is opt-in per book.** No automatic remux without user click.
+
+## Out of scope
+
+- Auto-repair without user consent.
+- Tracking transient/retryable errors (network blips). Only persistent
+  file-level failures (ffmpeg invalid-data, corrupt frames, etc.).
+- Backfilling errors from past journalctl. Forward-only.
+
+## Test strategy
+
+- Inject a corrupt MP3 fixture; run the fingerprint pass; assert one
+  `book_file_errors` row with the right class.
+- Re-run on the same path; assert `occurrences=2`, no new row.
+- Run the dashboard summary endpoint; assert `broken_file_count` is 1.
+- Run the repair Remux path against the fixture; assert success → row
+  deleted (or `resolved_at` set).
+
+## Rollback
+
+The migration adds a new table — drop it on revert. Repair package and
+frontend additions are pure adds; no existing flow changes.
+
+## Notes
+
+- Pairs naturally with the operation-log tagging spec
+  (`2026-05-04-tag-operation-logs.md`): once op-scoped logs land, the
+  Errors tab on a book can deep-link into the operation that surfaced
+  the failure.
+- Dashboard card pattern: copy the styling of the old "duplicate authors"
+  card so it feels native.

--- a/docs/superpowers/bot-tasks/2026-05-04-tag-operation-logs.md
+++ b/docs/superpowers/bot-tasks/2026-05-04-tag-operation-logs.md
@@ -1,0 +1,92 @@
+<!-- file: docs/superpowers/bot-tasks/2026-05-04-tag-operation-logs.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a4c8d92e-5b71-4f6a-8c3d-e9f2a4b5c6d7 -->
+<!-- last-edited: 2026-05-04 -->
+
+# BOT TASK: Tag operation log lines with the originating operation ID
+
+## Branch
+
+```
+feat/op-id-log-tagging
+```
+
+## Problem
+
+Operations like `dedup-acoustid-scan` spawn deep call chains
+(`acoustid_backfill.go`, ffmpeg subprocess wrappers, fingerprint
+extractors). When these emit log lines via the standard `log.Printf`
+or even via `internal/logger`, the lines look like this in journalctl:
+
+```
+acoustid_backfill.go:55: [WARN] fingerprint: <path>: ffmpeg chromaprint
+                                <path>@0.00: [mp3 @ 0x...] Failed to find
+                                two consecutive MPEG audio frames.
+```
+
+There is no operation ID attached. When the user opens the operation in
+the Activity page and clicks "expand to see logs", the in-DB
+`operation_logs` table has whatever the operation's `ProgressReporter`
+explicitly logged via `progress.Log(...)`, but every fmt.Printf and
+log.Printf scattered through the implementation is invisible to that
+view. They only show up in journalctl, ungrouped.
+
+The user's request: any log line emitted while inside an operation's
+goroutine should be tagged with that operation's ID, AND those lines
+should land in `operation_logs` so the Activity-page log view actually
+reflects what's happening inside the scan.
+
+## Goal
+
+1. Pipe `op.ID` into a context-bound logger that all internal calls use.
+2. Funnel that logger's output to both (a) journalctl with `op=<id>`
+   prefix and (b) the `operation_logs` table associated with the op.
+3. Replace direct `log.Printf` / `fmt.Printf` inside operation
+   implementations with structured `slog`-style calls that carry the op
+   context.
+
+## Files (likely)
+
+- `internal/logger/logger.go` — add `WithOperation(id)` returning a
+  scoped logger that prepends `op=<id>` and writes to operation_logs.
+- `internal/operations/queue.go` — when dispatching an op, install the
+  logger as the request-scoped logger via context (e.g.
+  `ctx = logger.WithContext(ctx, opLogger)`). The reporter already
+  exposes the logger via `LoggerFromReporter(progress)`.
+- `internal/dedup/engine.go`, `internal/server/acoustid_backfill.go`,
+  `internal/fingerprint/*.go`, etc. — replace bare `log.Printf` with
+  `logger.FromContext(ctx).Warn/Info/...`. This is a parallel-sweep
+  candidate.
+- DB write side: extend OperationLogger to write each line into
+  `operation_logs` so the Activity page's existing log-fetch endpoint
+  surfaces them.
+
+## Out of scope
+
+- Changing how journalctl receives logs.
+- Backporting old log lines.
+- Catching ffmpeg's own stdout/stderr (separate concern — those would
+  need explicit wiring through cmd.Stdout/cmd.Stderr).
+
+## Rough plan
+
+1. Land logger context plumbing in a small PR with a couple of
+   high-traffic call sites (acoustid_backfill, fingerprint extractor)
+   converted as proof.
+2. Use `/parallel-sweep` to convert the remaining `log.Printf` sites
+   inside operation funcs.
+3. Add a vitest/Go test that asserts a sample operation produces
+   `operation_logs` rows containing the expected lines.
+
+## Test strategy
+
+- Backend test: run a tiny operation that emits 3 log lines; assert all
+  3 appear in `operation_logs` with the correct `operation_id`.
+- Manual: run AcoustID scan, click the row in Activity, confirm the
+  inline log view shows ffmpeg warnings prefixed with the op ID.
+
+## Rollback
+
+Logger plumbing and call-site rewrites are independent — revert by
+branch. The DB rows accumulated during the rollout are harmless to
+keep.

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.14.0
+// version: 2.15.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-04
 
@@ -1606,8 +1606,15 @@ export async function getActiveOperations(): Promise<ActiveOperationSummary[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch active operations');
   }
-  const data = await response.json();
-  return data.operations || [];
+  const body = await response.json();
+  // Backend wraps every successful response in `{ data: ... }` via
+  // RespondWithOK; the actual payload is `{ data: { operations: [...] } }`.
+  // The previous read used top-level `body.operations`, which was always
+  // undefined, so this function silently returned `[]` — making the
+  // Activity page's "Active Operations" section permanently empty AND
+  // breaking the bell icon's auto-discovery of in-flight ops triggered
+  // outside of the dedup page.
+  return body?.data?.operations || body?.operations || [];
 }
 
 // System


### PR DESCRIPTION
Two backlog specs. Linked from TODO.md §1.12 and §1.13. No code changes.