### PR TITLE
feat(uos): land *_v2 schema migrations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,36 +1,43 @@
-# Plan: Fingerprint rescan endpoint + unified per-book fingerprint spec
+<!-- file: PLAN.md -->
+<!-- version: 2.0.0 -->
+<!-- guid: 7d8e9f10-2345-4abc-9def-0123456789ab -->
+<!-- last-edited: 2026-05-05 -->
+
+# Plan: UOS-01 Schema Migrations
 
 ## Goal
 
-1. **Bot-task spec** for "unified per-book audio fingerprint synthesis +
-   book-level matching" — fills the documented gap where today's matcher only
-   compares per-file segments and has no canonical book-level signature.
-2. **HTTP endpoint** (`POST /api/v1/dedup/fingerprint-rescan`) that
-   force-(re)generates per-file AcoustID segments on demand.
+Implement bot-task `docs/superpowers/bot-tasks/2026-05-04-uos-01-schema.md`
+on branch `feat/uos-01-schema` by adding the exact `*_v2` core schema from
+spec §2.1 as a reversible migration. No runtime code should use the new tables
+in this task.
 
-## Files
+## Files To Change
 
-- **NEW** `docs/superpowers/bot-tasks/2026-05-03-unified-book-fingerprint.md`
-- **NEW** `internal/server/fingerprint_rescan.go` — handler + worker
-- **EDIT** `internal/server/server_lifecycle.go` — register route under `/dedup`
-- **EDIT** `internal/server/acoustid_backfill.go` — extract shared per-file helper
-- **NEW** `internal/server/fingerprint_rescan_test.go`
+- `internal/database/migrations.go`
+  - Add the next migration entry.
+  - Add `migrationNNNUp` and `migrationNNNDown` helpers, or follow the local
+    migration pattern if migrations are split elsewhere.
+- `internal/database/migrations_extra_test.go` or a new focused test file under
+  `internal/database/`
+  - Verify every `*_v2` table and required column type.
+  - Verify every named index.
+  - Verify `core_schema_meta_v2` rejects a second row.
+  - Verify down migration drops all new tables and indexes.
 
-## Endpoint
+## Ordered Steps
 
-```
-POST /api/v1/dedup/fingerprint-rescan
-Auth: PermScanTrigger
-Body: { "scope": "missing"|"all"|"books", "book_ids": [...], "force": bool }
-202 Accepted: { "operation_id": "..." }
-```
-
-## Test
-
-- Unit tests via mockery store
-- `make build-api`
-- `make test-short ./internal/server/...`
+1. Inspect the existing migration registration and migration test helpers.
+2. Pick the next migration number after the existing list.
+3. Add the schema SQL exactly from spec §2.1, plus the single
+   `core_schema_meta_v2` seed row.
+4. Add the reversible down migration in dependency-safe drop order.
+5. Add focused tests for table columns, indexes, single-row meta behavior, and
+   down migration cleanup.
+6. Run the required task checks as far as practical locally:
+   `go test ./internal/database/...`, `make build`, and `make ci`.
 
 ## Rollback
 
-Additive route, no migrations. Revert the branch.
+Revert the migration entry, migration functions, and focused tests. The down
+migration also drops every new `*_v2` table and index added by this task.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1,7 +1,7 @@
 // file: internal/database/migrations.go
-// version: 1.37.0
+// version: 1.38.0
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
-// last-edited: 2026-05-03
+// last-edited: 2026-05-05
 
 package database
 
@@ -388,6 +388,12 @@ var migrations = []Migration{
 		Description: "Add book signature columns for unified per-book audio fingerprint",
 		Up:          migration058Up,
 		Down:        nil,
+	},
+	{
+		Version:     59,
+		Description: "Add Unified Operations System v2 core schema",
+		Up:          migration059Up,
+		Down:        migration059Down,
 	},
 }
 
@@ -2814,5 +2820,150 @@ func migration058Up(store Store) error {
 		}
 	}
 	log.Println("  - Added book_sig_v1, book_sig_segments, book_sig_built_at to books")
+	return nil
+}
+
+// migration059Up adds the UOS v2 core schema described in
+// docs/superpowers/specs/2026-05-04-unified-operations-system.md §2.1.
+func migration059Up(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil
+	}
+
+	stmts := []string{
+		`CREATE TABLE op_definitions_v2 (
+    id              TEXT PRIMARY KEY,
+    plugin          TEXT NOT NULL,
+    display_name    TEXT NOT NULL,
+    description     TEXT NOT NULL,
+    capabilities    TEXT NOT NULL,
+    permissions     TEXT NOT NULL,
+    cancellable     BOOLEAN NOT NULL,
+    isolate         BOOLEAN NOT NULL,
+    resume_policy   TEXT NOT NULL,
+    schedule_cron   TEXT,
+    triggers        TEXT NOT NULL,
+    depends_on      TEXT NOT NULL,
+    phases          TEXT NOT NULL,
+    timeout_seconds INTEGER NOT NULL,
+    registered_at   TIMESTAMP NOT NULL
+)`,
+		`CREATE TABLE operations_v2 (
+    id                  TEXT PRIMARY KEY,
+    def_id              TEXT NOT NULL,
+    plugin              TEXT NOT NULL,
+    parent_id           TEXT,
+    actor_user_id       TEXT,
+    trace_id            TEXT NOT NULL,
+    span_id             TEXT NOT NULL,
+    parent_span_id      TEXT,
+    status              TEXT NOT NULL,
+    priority            INTEGER NOT NULL,
+    progress_current    INTEGER NOT NULL DEFAULT 0,
+    progress_total      INTEGER NOT NULL DEFAULT 0,
+    progress_message    TEXT NOT NULL DEFAULT '',
+    current_phase       TEXT,
+    params              TEXT NOT NULL DEFAULT '{}',
+    error_message       TEXT,
+    result_data         TEXT,
+    queued_at           TIMESTAMP NOT NULL,
+    started_at          TIMESTAMP,
+    completed_at        TIMESTAMP,
+    last_progress_at    TIMESTAMP,
+    last_checkpoint_at  TIMESTAMP,
+    high_water_progress INTEGER NOT NULL DEFAULT 0,
+    resume_count        INTEGER NOT NULL DEFAULT 0
+)`,
+		`CREATE INDEX idx_operations_v2_status ON operations_v2(status, queued_at)`,
+		`CREATE INDEX idx_operations_v2_parent ON operations_v2(parent_id)`,
+		`CREATE INDEX idx_operations_v2_def    ON operations_v2(def_id, completed_at DESC)`,
+		`CREATE TABLE op_logs_v2 (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id TEXT NOT NULL,
+    level        TEXT NOT NULL,
+    message      TEXT NOT NULL,
+    attrs        TEXT NOT NULL DEFAULT '{}',
+    created_at   TIMESTAMP NOT NULL
+)`,
+		`CREATE INDEX idx_op_logs_v2_op_time ON op_logs_v2(operation_id, created_at)`,
+		`CREATE TABLE op_errors_v2 (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_id TEXT NOT NULL,
+    plugin       TEXT NOT NULL,
+    def_id       TEXT NOT NULL,
+    message      TEXT NOT NULL,
+    attrs        TEXT NOT NULL DEFAULT '{}',
+    occurred_at  TIMESTAMP NOT NULL
+)`,
+		`CREATE INDEX idx_op_errors_v2_def     ON op_errors_v2(def_id, occurred_at DESC)`,
+		`CREATE INDEX idx_op_errors_v2_plugin  ON op_errors_v2(plugin, occurred_at DESC)`,
+		`CREATE TABLE op_state_v2 (
+    operation_id TEXT PRIMARY KEY,
+    phase        TEXT,
+    state_blob   BLOB NOT NULL,
+    schema_version INTEGER NOT NULL,
+    written_at   TIMESTAMP NOT NULL
+)`,
+		`CREATE TABLE op_strikes_v2 (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    def_id      TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    details     TEXT NOT NULL DEFAULT '{}',
+    occurred_at TIMESTAMP NOT NULL
+)`,
+		`CREATE INDEX idx_op_strikes_v2_def_time ON op_strikes_v2(def_id, occurred_at DESC)`,
+		`CREATE TABLE plugin_schema_v2 (
+    plugin               TEXT NOT NULL,
+    migration_version    INTEGER NOT NULL,
+    applied_at           TIMESTAMP NOT NULL,
+    PRIMARY KEY (plugin, migration_version)
+)`,
+		`CREATE TABLE core_schema_meta_v2 (
+    id                INTEGER PRIMARY KEY CHECK (id = 1),
+    core_schema_version INTEGER NOT NULL
+)`,
+		`INSERT INTO core_schema_meta_v2 (id, core_schema_version) VALUES (1, 1)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			return fmt.Errorf("migration 059 failed running %q: %w", stmt, err)
+		}
+	}
+	log.Println("  - Added UOS v2 core schema")
+	return nil
+}
+
+// migration059Down removes the UOS v2 core schema added by migration059Up.
+func migration059Down(store Store) error {
+	sqliteStore, ok := store.(*SQLiteStore)
+	if !ok {
+		return nil
+	}
+
+	stmts := []string{
+		`DROP TABLE IF EXISTS core_schema_meta_v2`,
+		`DROP TABLE IF EXISTS plugin_schema_v2`,
+		`DROP INDEX IF EXISTS idx_op_strikes_v2_def_time`,
+		`DROP TABLE IF EXISTS op_strikes_v2`,
+		`DROP TABLE IF EXISTS op_state_v2`,
+		`DROP INDEX IF EXISTS idx_op_errors_v2_plugin`,
+		`DROP INDEX IF EXISTS idx_op_errors_v2_def`,
+		`DROP TABLE IF EXISTS op_errors_v2`,
+		`DROP INDEX IF EXISTS idx_op_logs_v2_op_time`,
+		`DROP TABLE IF EXISTS op_logs_v2`,
+		`DROP INDEX IF EXISTS idx_operations_v2_def`,
+		`DROP INDEX IF EXISTS idx_operations_v2_parent`,
+		`DROP INDEX IF EXISTS idx_operations_v2_status`,
+		`DROP TABLE IF EXISTS operations_v2`,
+		`DROP TABLE IF EXISTS op_definitions_v2`,
+	}
+	for _, stmt := range stmts {
+		if _, err := sqliteStore.db.Exec(stmt); err != nil {
+			return fmt.Errorf("migration 059 down failed running %q: %w", stmt, err)
+		}
+	}
+	log.Println("  - Removed UOS v2 core schema")
 	return nil
 }

--- a/internal/database/uos_schema_v2_migration_test.go
+++ b/internal/database/uos_schema_v2_migration_test.go
@@ -1,0 +1,212 @@
+// file: internal/database/uos_schema_v2_migration_test.go
+// version: 1.0.0
+// guid: 8f9a0b1c-2d3e-4f5a-9b0c-1d2e3f4a5b6c
+// last-edited: 2026-05-05
+
+package database
+
+import "testing"
+
+func TestMigration059UOSSchemaV2(t *testing.T) {
+	store, cleanup := setupTestDB(t)
+	defer cleanup()
+	sqliteStore := store.(*SQLiteStore)
+
+	if err := migration059Up(store); err != nil {
+		t.Fatalf("migration059Up failed: %v", err)
+	}
+
+	expectedTables := map[string]map[string]string{
+		"op_definitions_v2": {
+			"id":              "TEXT",
+			"plugin":          "TEXT",
+			"display_name":    "TEXT",
+			"description":     "TEXT",
+			"capabilities":    "TEXT",
+			"permissions":     "TEXT",
+			"cancellable":     "BOOLEAN",
+			"isolate":         "BOOLEAN",
+			"resume_policy":   "TEXT",
+			"schedule_cron":   "TEXT",
+			"triggers":        "TEXT",
+			"depends_on":      "TEXT",
+			"phases":          "TEXT",
+			"timeout_seconds": "INTEGER",
+			"registered_at":   "TIMESTAMP",
+		},
+		"operations_v2": {
+			"id":                  "TEXT",
+			"def_id":              "TEXT",
+			"plugin":              "TEXT",
+			"parent_id":           "TEXT",
+			"actor_user_id":       "TEXT",
+			"trace_id":            "TEXT",
+			"span_id":             "TEXT",
+			"parent_span_id":      "TEXT",
+			"status":              "TEXT",
+			"priority":            "INTEGER",
+			"progress_current":    "INTEGER",
+			"progress_total":      "INTEGER",
+			"progress_message":    "TEXT",
+			"current_phase":       "TEXT",
+			"params":              "TEXT",
+			"error_message":       "TEXT",
+			"result_data":         "TEXT",
+			"queued_at":           "TIMESTAMP",
+			"started_at":          "TIMESTAMP",
+			"completed_at":        "TIMESTAMP",
+			"last_progress_at":    "TIMESTAMP",
+			"last_checkpoint_at":  "TIMESTAMP",
+			"high_water_progress": "INTEGER",
+			"resume_count":        "INTEGER",
+		},
+		"op_logs_v2": {
+			"id":           "INTEGER",
+			"operation_id": "TEXT",
+			"level":        "TEXT",
+			"message":      "TEXT",
+			"attrs":        "TEXT",
+			"created_at":   "TIMESTAMP",
+		},
+		"op_errors_v2": {
+			"id":           "INTEGER",
+			"operation_id": "TEXT",
+			"plugin":       "TEXT",
+			"def_id":       "TEXT",
+			"message":      "TEXT",
+			"attrs":        "TEXT",
+			"occurred_at":  "TIMESTAMP",
+		},
+		"op_state_v2": {
+			"operation_id":   "TEXT",
+			"phase":          "TEXT",
+			"state_blob":     "BLOB",
+			"schema_version": "INTEGER",
+			"written_at":     "TIMESTAMP",
+		},
+		"op_strikes_v2": {
+			"id":           "INTEGER",
+			"def_id":       "TEXT",
+			"operation_id": "TEXT",
+			"kind":         "TEXT",
+			"details":      "TEXT",
+			"occurred_at":  "TIMESTAMP",
+		},
+		"plugin_schema_v2": {
+			"plugin":            "TEXT",
+			"migration_version": "INTEGER",
+			"applied_at":        "TIMESTAMP",
+		},
+		"core_schema_meta_v2": {
+			"id":                  "INTEGER",
+			"core_schema_version": "INTEGER",
+		},
+	}
+
+	for tableName, expectedColumns := range expectedTables {
+		actualColumns := tableColumns(t, sqliteStore, tableName)
+		if len(actualColumns) != len(expectedColumns) {
+			t.Fatalf("%s: expected %d columns, got %d (%v)", tableName, len(expectedColumns), len(actualColumns), actualColumns)
+		}
+		for columnName, expectedType := range expectedColumns {
+			actualType, ok := actualColumns[columnName]
+			if !ok {
+				t.Fatalf("%s: missing column %s", tableName, columnName)
+			}
+			if actualType != expectedType {
+				t.Fatalf("%s.%s: expected type %s, got %s", tableName, columnName, expectedType, actualType)
+			}
+		}
+	}
+
+	expectedIndexes := []string{
+		"idx_operations_v2_status",
+		"idx_operations_v2_parent",
+		"idx_operations_v2_def",
+		"idx_op_logs_v2_op_time",
+		"idx_op_errors_v2_def",
+		"idx_op_errors_v2_plugin",
+		"idx_op_strikes_v2_def_time",
+	}
+	for _, indexName := range expectedIndexes {
+		if !sqliteObjectExists(t, sqliteStore, "index", indexName) {
+			t.Fatalf("expected index %s to exist", indexName)
+		}
+	}
+
+	var coreSchemaVersion int
+	if err := sqliteStore.db.QueryRow(`SELECT core_schema_version FROM core_schema_meta_v2 WHERE id = 1`).Scan(&coreSchemaVersion); err != nil {
+		t.Fatalf("core_schema_meta_v2 seed row missing: %v", err)
+	}
+	if coreSchemaVersion != 1 {
+		t.Fatalf("expected core_schema_version 1, got %d", coreSchemaVersion)
+	}
+
+	if _, err := sqliteStore.db.Exec(`DELETE FROM core_schema_meta_v2`); err != nil {
+		t.Fatalf("failed to clear core_schema_meta_v2 for check test: %v", err)
+	}
+	if _, err := sqliteStore.db.Exec(`INSERT INTO core_schema_meta_v2 (id, core_schema_version) VALUES (1, 1)`); err != nil {
+		t.Fatalf("expected first core_schema_meta_v2 insert to succeed: %v", err)
+	}
+	if _, err := sqliteStore.db.Exec(`INSERT INTO core_schema_meta_v2 (id, core_schema_version) VALUES (2, 1)`); err == nil {
+		t.Fatal("expected second core_schema_meta_v2 insert to fail")
+	}
+
+	if err := migration059Down(store); err != nil {
+		t.Fatalf("migration059Down failed: %v", err)
+	}
+	for tableName := range expectedTables {
+		if sqliteObjectExists(t, sqliteStore, "table", tableName) {
+			t.Fatalf("expected table %s to be dropped", tableName)
+		}
+	}
+	for _, indexName := range expectedIndexes {
+		if sqliteObjectExists(t, sqliteStore, "index", indexName) {
+			t.Fatalf("expected index %s to be dropped", indexName)
+		}
+	}
+}
+
+func tableColumns(t *testing.T, store *SQLiteStore, tableName string) map[string]string {
+	t.Helper()
+
+	rows, err := store.db.Query(`PRAGMA table_info(` + tableName + `)`)
+	if err != nil {
+		t.Fatalf("failed to inspect %s columns: %v", tableName, err)
+	}
+	defer rows.Close()
+
+	columns := make(map[string]string)
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			columnType string
+			notNull    int
+			defaultVal any
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultVal, &pk); err != nil {
+			t.Fatalf("failed to scan %s column info: %v", tableName, err)
+		}
+		columns[name] = columnType
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("failed reading %s column info: %v", tableName, err)
+	}
+	return columns
+}
+
+func sqliteObjectExists(t *testing.T, store *SQLiteStore, objectType, objectName string) bool {
+	t.Helper()
+
+	var count int
+	if err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = ? AND name = ?`,
+		objectType,
+		objectName,
+	).Scan(&count); err != nil {
+		t.Fatalf("failed to inspect sqlite_master for %s %s: %v", objectType, objectName, err)
+	}
+	return count > 0
+}


### PR DESCRIPTION
## Summary

- Implements UOS Phase A task 01 from `docs/superpowers/bot-tasks/2026-05-04-uos-00-index.md`.
- Adds migration 59 for the UOS `*_v2` core schema tables and indexes from `docs/superpowers/specs/2026-05-04-unified-operations-system.md` §2.1.
- Seeds the single `core_schema_meta_v2` row with `core_schema_version = 1`.
- Adds focused migration tests for table columns/types, named indexes, `core_schema_meta_v2` single-row enforcement, and down-migration cleanup.

## References

- Bot task: `docs/superpowers/bot-tasks/2026-05-04-uos-01-schema.md`
- Task index: `docs/superpowers/bot-tasks/2026-05-04-uos-00-index.md` task 01
- Human spec: `docs/superpowers/specs/2026-05-04-unified-operations-system.md` §2.1
- Implementation files: `internal/database/migrations.go`, `internal/database/uos_schema_v2_migration_test.go`, `PLAN.md`

## Notes

- The bot-task path `internal/database/migrations/` does not exist in this checkout; the existing migration list and migration functions live in `internal/database/migrations.go`, so this PR follows that repo-local pattern.
- This PR does not modify the existing `operations` or `operation_logs` tables.

## Testing

- `go test ./internal/database -run TestMigration059UOSSchemaV2 -count=1`
- `go test ./internal/database/...`
- `make build`
- `TMPDIR=/Users/jdfalk/repos/github.com/jdfalk/.worktrees/.tmp-uos-01 GOFLAGS=-p=1 make ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)