### PR TITLE
feat(itunes): clarify write-back dialog — drop xml input, 4-column resizable preview

### DIFF
--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 // iTunes HTTP handlers. All business logic lives in internal/itunes/service.
 // Handlers that call s.itunesSvc.Importer.* guard with itunesEnabledOrError
@@ -16,6 +16,7 @@ import (
 	stdlog "log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -92,19 +93,47 @@ type ITunesWriteBackResponse struct {
 }
 
 // ITunesBookMapping is a single book-to-iTunes-path mapping used in preview.
+//
+// Four path columns surface the full picture so users can see exactly what
+// is currently in iTunes vs what AO has on disk vs what AO would write back:
+//
+//   - ITunesPath               — what iTunes currently has, e.g. W:/foo/bar.m4b
+//   - ITunesPathTranslated     — local equivalent of ITunesPath after applying
+//                                forward path mappings (so users can stat it)
+//   - AOPath                   — where AO has the file on disk (book.FilePath)
+//   - AOITunesTranslatedPath   — what AO will write into the iTunes ITL when
+//                                write-back runs (ReverseRemapPath of AOPath)
+//
+// PathDiffers is true iff AOITunesTranslatedPath != ITunesPath — i.e. the
+// thing AO wants to write does not match what iTunes already has.
+//
+// Backwards compatibility: LocalPath is preserved as an alias of AOPath so
+// older clients keep working through the migration. Remove once no caller
+// reads it.
 type ITunesBookMapping struct {
-	BookID             string `json:"book_id"`
-	Title              string `json:"title"`
-	Author             string `json:"author"`
-	ITunesPersistentID string `json:"itunes_persistent_id"`
-	LocalPath          string `json:"local_path"`
-	ITunesPath         string `json:"itunes_path,omitempty"`
-	PathDiffers        bool   `json:"path_differs,omitempty"`
+	BookID                 string `json:"book_id"`
+	Title                  string `json:"title"`
+	Author                 string `json:"author"`
+	ITunesPersistentID     string `json:"itunes_persistent_id"`
+	ITunesPath             string `json:"itunes_path,omitempty"`
+	ITunesPathTranslated   string `json:"itunes_path_translated,omitempty"`
+	AOPath                 string `json:"ao_path"`
+	AOITunesTranslatedPath string `json:"ao_itunes_translated_path,omitempty"`
+	PathDiffers            bool   `json:"path_differs,omitempty"`
+
+	// LocalPath duplicates AOPath for backwards compatibility with the
+	// previous response shape. Will be removed once no caller reads it.
+	LocalPath string `json:"local_path"`
 }
 
 // ITunesWriteBackPreviewRequest is the wire type for POST /itunes/write-back-preview.
+//
+// LibraryPath is now optional — when empty, the handler uses the configured
+// ITunesLibraryReadPath. The dialog used to require the user to type this
+// path on every preview, which was confusing because the actual write-back
+// always targets the configured ITunesLibraryWritePath (.itl) regardless.
 type ITunesWriteBackPreviewRequest struct {
-	LibraryPath string   `json:"library_path" binding:"required"`
+	LibraryPath string   `json:"library_path,omitempty"`
 	BookIDs     []string `json:"book_ids,omitempty"`
 }
 
@@ -446,12 +475,26 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 		return
 	}
 
-	if _, err := os.Stat(req.LibraryPath); os.IsNotExist(err) {
+	// Fall back to the configured read path when the request omits one.
+	// The dialog no longer requires users to type the .xml path — they
+	// configure it once in Settings and the preview endpoint uses it
+	// directly. The actual write-back always targets the configured
+	// ITunesLibraryWritePath (.itl) regardless of this read path.
+	libraryPath := strings.TrimSpace(req.LibraryPath)
+	if libraryPath == "" {
+		libraryPath = config.AppConfig.ITunesLibraryReadPath
+	}
+	if libraryPath == "" {
+		httputil.RespondWithBadRequest(c, "no iTunes library path configured (set ITunesLibraryReadPath in settings)")
+		return
+	}
+
+	if _, err := os.Stat(libraryPath); os.IsNotExist(err) {
 		httputil.RespondWithBadRequest(c, "iTunes library file not found")
 		return
 	}
 
-	library, err := itunes.ParseLibrary(req.LibraryPath)
+	library, err := itunes.ParseLibrary(libraryPath)
 	if err != nil {
 		httputil.InternalError(c, "failed to parse iTunes library", err)
 		return
@@ -497,6 +540,11 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 	for _, m := range config.AppConfig.ITunesPathMappings {
 		previewMappings = append(previewMappings, itunes.PathMapping{From: m.From, To: m.To})
 	}
+	// Forward-mapper for translating an iTunes location into its local
+	// equivalent. Wraps the existing ImportOptions.RemapPath because that
+	// is the canonical forward direction; the receiver pattern is
+	// historical and not worth refactoring here.
+	forwardOpts := itunes.ImportOptions{PathMappings: previewMappings}
 
 	items := make([]ITunesBookMapping, 0, len(books))
 	for _, book := range books {
@@ -508,15 +556,22 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 				author = a.Name
 			}
 		}
-		reverseMapped := itunes.ReverseRemapPath(book.FilePath, previewMappings)
+		aoITunesTranslated := itunes.ReverseRemapPath(book.FilePath, previewMappings)
+		itunesTranslated := ""
+		if itunesPath != "" {
+			itunesTranslated = forwardOpts.RemapPath(itunesPath)
+		}
 		items = append(items, ITunesBookMapping{
-			BookID:             book.ID,
-			Title:              book.Title,
-			Author:             author,
-			ITunesPersistentID: persistentID,
-			LocalPath:          book.FilePath,
-			ITunesPath:         itunesPath,
-			PathDiffers:        reverseMapped != itunesPath,
+			BookID:                 book.ID,
+			Title:                  book.Title,
+			Author:                 author,
+			ITunesPersistentID:     persistentID,
+			ITunesPath:             itunesPath,
+			ITunesPathTranslated:   itunesTranslated,
+			AOPath:                 book.FilePath,
+			AOITunesTranslatedPath: aoITunesTranslated,
+			PathDiffers:            aoITunesTranslated != itunesPath,
+			LocalPath:              book.FilePath,
 		})
 	}
 

--- a/web/src/components/settings/ITunesImport.tsx
+++ b/web/src/components/settings/ITunesImport.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/settings/ITunesImport.tsx
-// version: 1.15.0
+// version: 1.16.0
 // guid: 4eb9b74d-7192-497b-849a-092833ae63a4
+// last-edited: 2026-05-05
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -12,7 +13,6 @@ import {
   CardContent,
   CardHeader,
   Checkbox,
-  Chip,
   Divider,
   Dialog,
   DialogActions,
@@ -54,6 +54,7 @@ import SyncIcon from '@mui/icons-material/Sync.js';
 import IconButton from '@mui/material/IconButton';
 import { ITunesConflictDialog, type ConflictItem } from './ITunesConflictDialog';
 import { ServerFileBrowser } from '../common/ServerFileBrowser';
+import { WriteBackPreviewTable } from './WriteBackPreviewTable';
 import {
   ApiError,
   cancelOperation,
@@ -143,6 +144,13 @@ export function ITunesImport() {
     useState<ITunesWriteBackResponse | null>(null);
   const [writeBackBackup, setWriteBackBackup] = useState(true);
   const [writeBackLibraryPath, setWriteBackLibraryPath] = useState(settings.libraryPath || '');
+  // Configured paths sourced from server config — purely informational
+  // banners on the dialog. The dialog no longer asks the user to type a
+  // .xml path; both paths live in Settings (Paths tab) and the dialog
+  // shows what's currently configured so users can see at a glance
+  // which file the preview reads and which file write-back targets.
+  const [configuredReadPath, setConfiguredReadPath] = useState<string>('');
+  const [configuredWritePath, setConfiguredWritePath] = useState<string>('');
   const [writeBackMode, setWriteBackMode] = useState(0); // 0=manual, 1=sync all, 2=browse
   const [previewItems, setPreviewItems] = useState<ITunesBookMapping[]>([]);
   const [browseItems, setBrowseItems] = useState<ITunesBookMapping[]>([]);
@@ -173,11 +181,15 @@ export function ITunesImport() {
     };
   }, []);
 
-  // Pre-fill library path from server config if not already set
+  // Pre-fill library path from server config + capture both configured
+  // paths for the write-back dialog's info banner. Read-path is used as
+  // a fallback when the user hasn't manually entered one in localStorage;
+  // write-path is purely informational (the .itl that write-back targets).
   useEffect(() => {
-    if (!settings.libraryPath) {
-      getConfig().then((cfg) => {
+    getConfig()
+      .then((cfg) => {
         if (cfg.itunes_library_read_path) {
+          setConfiguredReadPath(cfg.itunes_library_read_path);
           setSettings((prev) => {
             if (!prev.libraryPath) {
               return { ...prev, libraryPath: cfg.itunes_library_read_path! };
@@ -185,8 +197,13 @@ export function ITunesImport() {
             return prev;
           });
         }
-      }).catch(() => { /* ignore */ });
-    }
+        if (cfg.itunes_library_write_path) {
+          setConfiguredWritePath(cfg.itunes_library_write_path);
+        }
+      })
+      .catch(() => {
+        /* ignore — banners just hide */
+      });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Keep writeBackLibraryPath in sync when settings.libraryPath changes
@@ -347,15 +364,16 @@ export function ITunesImport() {
     }, 300);
   };
 
+  // The library-path field has been removed from the dialog; the backend
+  // falls back to the configured ITunesLibraryReadPath when the request
+  // omits one. We pass undefined (not the locally-cached path) so the
+  // dialog always reflects the latest server-side config without needing
+  // to reload after the user changes it in Settings.
   const handlePreviewAll = async () => {
-    if (!writeBackLibraryPath.trim()) {
-      setWriteBackNotice({ severity: 'error', message: 'Library path is required.' });
-      return;
-    }
     setWriteBackLoading(true);
     setWriteBackNotice(null);
     try {
-      const result = await previewITunesWriteBack(writeBackLibraryPath);
+      const result = await previewITunesWriteBack(undefined);
       const differing = (result.items || []).filter((item) => item.path_differs);
       setPreviewItems(result.items || []);
       setSyncAllCount(differing.length);
@@ -367,10 +385,6 @@ export function ITunesImport() {
   };
 
   const handlePreviewManual = async () => {
-    if (!writeBackLibraryPath.trim()) {
-      setWriteBackNotice({ severity: 'error', message: 'Library path is required.' });
-      return;
-    }
     const ids = parseWriteBackIds(writeBackIds);
     if (ids.length === 0) {
       setWriteBackNotice({ severity: 'error', message: 'Enter one or more IDs to preview.' });
@@ -379,7 +393,7 @@ export function ITunesImport() {
     setWriteBackLoading(true);
     setWriteBackNotice(null);
     try {
-      const result = await previewITunesWriteBack(writeBackLibraryPath, ids);
+      const result = await previewITunesWriteBack(undefined, ids);
       setPreviewItems(result.items || []);
       if (result.items.length === 0) {
         setWriteBackNotice({ severity: 'warning', message: 'No books found with iTunes persistent IDs for those IDs.' });
@@ -397,16 +411,15 @@ export function ITunesImport() {
   };
 
   const executeWriteBack = async (bookIds: string[], forceOverwrite = false) => {
-    if (!writeBackLibraryPath.trim()) {
-      setWriteBackNotice({ severity: 'error', message: 'Library path is required.' });
-      return;
-    }
     setWriteBackLoading(true);
     setWriteBackNotice(null);
     setWriteBackResult(null);
     try {
+      // library_path is sent for backwards compatibility with older backends
+      // but is ignored by the current handler — write-back always targets
+      // the configured ITunesLibraryWritePath (.itl).
       const result = await writeBackITunesLibrary({
-        library_path: writeBackLibraryPath,
+        library_path: writeBackLibraryPath || configuredReadPath || '',
         audiobook_ids: bookIds,
         create_backup: writeBackBackup,
         force_overwrite: forceOverwrite,
@@ -981,14 +994,35 @@ export function ITunesImport() {
                   )}
                 </Alert>
               )}
-              <TextField
-                label="Library.xml Path"
-                value={writeBackLibraryPath}
-                onChange={(event) => setWriteBackLibraryPath(event.target.value)}
-                fullWidth
-                size="small"
-                placeholder="/Users/username/Music/iTunes/Library.xml"
-              />
+              {/* Configured paths banner. The dialog no longer accepts a
+                  Library.xml path on every preview — both paths live on
+                  the Settings → Paths tab. The banner shows the user
+                  which file we'll read for the comparison and which file
+                  write-back will modify, so they can verify before
+                  clicking Sync. */}
+              <Alert severity="info" icon={false} sx={{ '& .MuiAlert-message': { width: '100%' } }}>
+                <Stack spacing={0.5}>
+                  <Stack direction="row" spacing={1} alignItems="baseline">
+                    <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 110 }}>
+                      Reading from:
+                    </Typography>
+                    <Typography variant="caption" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                      {configuredReadPath || '(not configured — set in Settings → Paths)'}
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" spacing={1} alignItems="baseline">
+                    <Typography variant="caption" sx={{ fontWeight: 600, minWidth: 110 }}>
+                      Writing to:
+                    </Typography>
+                    <Typography variant="caption" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                      {configuredWritePath || '(not configured — write-back will fail until set in Settings → Paths)'}
+                    </Typography>
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary">
+                    Write-back always targets the .itl binary — iTunes ignores Library.xml for inbound changes.
+                  </Typography>
+                </Stack>
+              </Alert>
               <FormControlLabel
                 control={
                   <Checkbox
@@ -1040,38 +1074,10 @@ export function ITunesImport() {
                     </Button>
                   </Stack>
                   {previewItems.length > 0 && (
-                    <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 400 }}>
-                      <Table size="small" stickyHeader>
-                        <TableHead>
-                          <TableRow>
-                            <TableCell>Title</TableCell>
-                            <TableCell>Author</TableCell>
-                            <TableCell>Local Path</TableCell>
-                            <TableCell>iTunes Path</TableCell>
-                            <TableCell>Status</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {previewItems.map((item) => (
-                            <TableRow key={item.book_id} sx={item.path_differs ? { bgcolor: 'warning.50' } : undefined}>
-                              <TableCell>{item.title}</TableCell>
-                              <TableCell>{item.author}</TableCell>
-                              <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                <Tooltip title={item.local_path}><span>{item.local_path}</span></Tooltip>
-                              </TableCell>
-                              <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                <Tooltip title={item.itunes_path || '(not in library)'}><span>{item.itunes_path || '(not in library)'}</span></Tooltip>
-                              </TableCell>
-                              <TableCell>
-                                {item.path_differs
-                                  ? <Chip label="Differs" color="warning" size="small" />
-                                  : <Chip label="Match" color="success" size="small" />}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
+                    <WriteBackPreviewTable
+                      storageKey="itunes-writeback-preview-manual"
+                      items={previewItems}
+                    />
                   )}
                 </Stack>
               )}
@@ -1094,7 +1100,7 @@ export function ITunesImport() {
                     <Button
                       variant="outlined"
                       onClick={handlePreviewAll}
-                      disabled={writeBackLoading || !writeBackLibraryPath.trim()}
+                      disabled={writeBackLoading}
                     >
                       Preview All
                     </Button>
@@ -1114,38 +1120,10 @@ export function ITunesImport() {
                     </Button>
                   </Stack>
                   {previewItems.length > 0 && (
-                    <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 400 }}>
-                      <Table size="small" stickyHeader>
-                        <TableHead>
-                          <TableRow>
-                            <TableCell>Title</TableCell>
-                            <TableCell>Author</TableCell>
-                            <TableCell>Local Path</TableCell>
-                            <TableCell>iTunes Path</TableCell>
-                            <TableCell>Status</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {previewItems.map((item) => (
-                            <TableRow key={item.book_id} sx={item.path_differs ? { bgcolor: 'warning.50' } : undefined}>
-                              <TableCell>{item.title}</TableCell>
-                              <TableCell>{item.author}</TableCell>
-                              <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                <Tooltip title={item.local_path}><span>{item.local_path}</span></Tooltip>
-                              </TableCell>
-                              <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                <Tooltip title={item.itunes_path || '(not in library)'}><span>{item.itunes_path || '(not in library)'}</span></Tooltip>
-                              </TableCell>
-                              <TableCell>
-                                {item.path_differs
-                                  ? <Chip label="Differs" color="warning" size="small" />
-                                  : <Chip label="Match" color="success" size="small" />}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
+                    <WriteBackPreviewTable
+                      storageKey="itunes-writeback-preview-syncall"
+                      items={previewItems}
+                    />
                   )}
                 </Stack>
               )}
@@ -1305,7 +1283,7 @@ export function ITunesImport() {
           <DialogTitle>Confirm Write-Back</DialogTitle>
           <DialogContent>
             <Typography>
-              This will update {pendingWriteBackIds.length} book path{pendingWriteBackIds.length !== 1 ? 's' : ''} in your iTunes Library.xml.
+              This will update {pendingWriteBackIds.length} book path{pendingWriteBackIds.length !== 1 ? 's' : ''} in your iTunes library (.itl).
               {writeBackBackup ? ' A backup will be created first.' : ' No backup will be created.'}
             </Typography>
           </DialogContent>

--- a/web/src/components/settings/WriteBackPreviewTable.tsx
+++ b/web/src/components/settings/WriteBackPreviewTable.tsx
@@ -1,0 +1,228 @@
+// file: web/src/components/settings/WriteBackPreviewTable.tsx
+// version: 1.0.0
+// guid: e8a9b0c1-d2e3-4f5a-6b7c-8d9e0f1a2b3c
+// last-edited: 2026-05-05
+
+import {
+  Box,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  ColumnPicker,
+  ResizableHeaderCell,
+  useConfigurableTable,
+  type ColumnDef,
+} from '../common/ConfigurableTable';
+import type { ITunesBookMapping } from '../../services/api';
+
+/**
+ * Shared preview table for the iTunes write-back dialog. Renders the four
+ * path columns (iTunes-current vs AO-going-to-write) plus title/author/
+ * status, with click-to-sort and drag-to-resize headers. Column widths
+ * persist per-user via localStorage.
+ *
+ * The four paths exposed to the user:
+ *   - iTunes Library Path           — what iTunes currently has (W:/...)
+ *   - iTunes Library Translated     — local equivalent of the iTunes path
+ *                                     (so the user can stat it / open it)
+ *   - Local Path                    — where this app has the file on disk
+ *   - Local → iTunes Path           — what this app will write to iTunes
+ *
+ * Status: "Differs" iff the last column != the first. That's the whole
+ * reason the user opened this dialog.
+ */
+export interface WriteBackPreviewTableProps {
+  /** Storage key for column-state persistence (must be unique per usage). */
+  storageKey: string;
+  /** Rows to render. Empty array renders an empty state. */
+  items: ITunesBookMapping[];
+  /** Optional max table height for scroll. Default 400. */
+  maxHeight?: number | string;
+}
+
+const truncatedCell = (value?: string, fallback = '(not in library)') => {
+  const display = value || fallback;
+  return (
+    <Tooltip title={display}>
+      <Typography
+        variant="body2"
+        component="span"
+        sx={{
+          display: 'block',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {display}
+      </Typography>
+    </Tooltip>
+  );
+};
+
+const COLUMNS: ColumnDef<ITunesBookMapping>[] = [
+  {
+    key: 'title',
+    label: 'Title',
+    defaultWidth: 220,
+    minWidth: 100,
+    sortable: true,
+    sortValue: (r) => (r.title || '').toLowerCase(),
+    render: (r) => truncatedCell(r.title, '(no title)'),
+  },
+  {
+    key: 'author',
+    label: 'Author',
+    defaultWidth: 160,
+    minWidth: 80,
+    sortable: true,
+    sortValue: (r) => (r.author || '').toLowerCase(),
+    render: (r) => truncatedCell(r.author, '(unknown)'),
+  },
+  {
+    key: 'itunes_path',
+    label: 'iTunes Library Path',
+    defaultWidth: 240,
+    minWidth: 120,
+    sortable: true,
+    sortValue: (r) => (r.itunes_path || '').toLowerCase(),
+    render: (r) => truncatedCell(r.itunes_path),
+  },
+  {
+    key: 'itunes_path_translated',
+    label: 'iTunes Library Translated',
+    defaultWidth: 240,
+    minWidth: 120,
+    sortable: true,
+    sortValue: (r) => (r.itunes_path_translated || '').toLowerCase(),
+    render: (r) => truncatedCell(r.itunes_path_translated),
+  },
+  {
+    key: 'ao_path',
+    label: 'Local Path',
+    defaultWidth: 240,
+    minWidth: 120,
+    sortable: true,
+    sortValue: (r) => (r.ao_path || r.local_path || '').toLowerCase(),
+    render: (r) => truncatedCell(r.ao_path || r.local_path),
+  },
+  {
+    key: 'ao_itunes_translated_path',
+    label: 'Local → iTunes Path',
+    defaultWidth: 240,
+    minWidth: 120,
+    sortable: true,
+    sortValue: (r) => (r.ao_itunes_translated_path || '').toLowerCase(),
+    render: (r) => truncatedCell(r.ao_itunes_translated_path),
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    defaultWidth: 110,
+    minWidth: 80,
+    sortable: true,
+    sortValue: (r) => (r.path_differs ? 0 : 1),
+    render: (r) =>
+      r.path_differs ? (
+        <Chip label="Differs" color="warning" size="small" />
+      ) : (
+        <Chip label="Match" color="success" size="small" />
+      ),
+  },
+];
+
+export function WriteBackPreviewTable({
+  storageKey,
+  items,
+  maxHeight = 400,
+}: WriteBackPreviewTableProps) {
+  const {
+    visibleColumns,
+    sortField,
+    sortDir,
+    columnWidths,
+    handleSort,
+    toggleColumn,
+    isColumnVisible,
+    startResize,
+    sortRows,
+    resetColumns,
+  } = useConfigurableTable<ITunesBookMapping>({
+    storageKey,
+    columns: COLUMNS,
+    defaultSortField: 'status',
+    defaultSortDir: 'asc',
+  });
+
+  const sorted = sortRows(items);
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+          Drag column edges to resize · Click a header to sort
+        </Typography>
+        <ColumnPicker
+          columns={COLUMNS.map((c) => ({ key: c.key, label: c.label }))}
+          isVisible={isColumnVisible}
+          onToggle={toggleColumn}
+          onReset={resetColumns}
+        />
+      </Stack>
+      <TableContainer component={Paper} variant="outlined" sx={{ maxHeight }}>
+        <Table size="small" stickyHeader sx={{ tableLayout: 'fixed' }}>
+          <TableHead>
+            <TableRow>
+              {visibleColumns.map((col) => (
+                <ResizableHeaderCell
+                  key={col.key}
+                  columnKey={col.key}
+                  label={col.label}
+                  width={columnWidths[col.key] ?? col.defaultWidth ?? 150}
+                  align={col.align}
+                  sortable={col.sortable !== false}
+                  sortActive={sortField === col.key}
+                  sortDirection={sortDir}
+                  onSort={() => handleSort(col.key)}
+                  onStartResize={startResize}
+                />
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sorted.map((item) => (
+              <TableRow
+                key={item.book_id}
+                sx={item.path_differs ? { bgcolor: 'warning.50' } : undefined}
+              >
+                {visibleColumns.map((col) => (
+                  <TableCell
+                    key={col.key}
+                    sx={{
+                      width: columnWidths[col.key] ?? col.defaultWidth ?? 150,
+                      maxWidth:
+                        columnWidths[col.key] ?? col.defaultWidth ?? 150,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {col.render(item)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.15.0
+// version: 2.16.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-04
+// last-edited: 2026-05-05
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -2021,14 +2021,23 @@ export async function writeBackITunesLibrary(
   return body.data;
 }
 
+// ITunesBookMapping mirrors the backend ITunesBookMapping struct. Four
+// path columns surface the full picture: what iTunes currently has, the
+// local equivalent of that, where AO has the file on disk, and what AO
+// would write back into iTunes. local_path is preserved as an alias of
+// ao_path for callers that still read the older field name.
 export interface ITunesBookMapping {
   book_id: string;
   title: string;
   author: string;
   itunes_persistent_id: string;
+  itunes_path?: string;
+  itunes_path_translated?: string;
+  ao_path: string;
+  ao_itunes_translated_path?: string;
+  path_differs?: boolean;
+  /** @deprecated Use ao_path. Kept for backwards compatibility during migration. */
   local_path: string;
-  itunes_path: string;
-  path_differs: boolean;
 }
 
 export async function getITunesBooks(
@@ -2048,14 +2057,18 @@ export async function getITunesBooks(
   return body.data;
 }
 
+// previewITunesWriteBack accepts an optional libraryPath. When omitted (or
+// empty) the backend uses the configured ITunesLibraryReadPath — the dialog
+// no longer asks the user for this on every preview because it's a
+// configure-once value that lives in Settings.
 export async function previewITunesWriteBack(
-  libraryPath: string,
+  libraryPath?: string,
   bookIds?: string[]
 ): Promise<{ items: ITunesBookMapping[]; total: number }> {
   const response = await fetch(`${API_BASE}/itunes/write-back/preview`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ library_path: libraryPath, book_ids: bookIds }),
+    body: JSON.stringify({ library_path: libraryPath || undefined, book_ids: bookIds }),
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to preview write-back');


### PR DESCRIPTION
## Summary

The Write Back to iTunes dialog had two confusing things:
1. A \`Library.xml Path\` input on every preview — even though the actual write-back goes to \`.itl\` and the user already configures both paths on the Settings → Paths tab.
2. A 4-column path table that mashed \"AO's local path\" and \"iTunes's recorded path\" into ambiguous \"Local Path\" / \"iTunes Path\" headers — the user couldn't tell what was current vs. what was about to be written.

## What changed

**Backend** (\`internal/server/itunes_handlers.go\`):
- \`ITunesWriteBackPreviewRequest.LibraryPath\` is now optional. When omitted, falls back to the configured \`ITunesLibraryReadPath\`.
- \`ITunesBookMapping\` gains four explicit path fields:
  - \`itunes_path\` — what iTunes currently has
  - \`itunes_path_translated\` — local equivalent (forward remap)
  - \`ao_path\` — where this app has the file
  - \`ao_itunes_translated_path\` — what we'll write back
  - \`local_path\` preserved as alias of \`ao_path\` for compat

**Frontend**:
- New \`WriteBackPreviewTable\` component using the existing \`useConfigurableTable\` hook → every column resizable + sortable, persisted per-user.
- Library.xml TextField removed; replaced by a read-only banner showing configured Reading-from / Writing-to paths sourced from \`/api/v1/config\`, plus the note \"Write-back always targets the .itl binary — iTunes ignores Library.xml for inbound changes.\"
- Used in both Mode 0 (Enter IDs) and Mode 1 (Sync All) preview panels.

Column labels use \"Local Path\" / \"Local → iTunes Path\" rather than \"AO Path\" / \"AO iTunes Translated Path\" — dodging the awkward \"AO\" branding while TODO §1.17 (proper rename) is pending.

## Test plan

- [x] \`go test ./internal/server/... ./internal/itunes/...\` — pass
- [x] \`tsc --noEmit\` — clean
- [x] \`vitest run\` — 168/168 pass
- [ ] Manual: open dialog, confirm both configured paths show on the banner; preview a sync; confirm 4 path columns; drag a header edge to resize; click a header to sort; refresh page; columns retain widths.