### PR TITLE
feat(deluge): wire MoveStorage into undo path (3.2-deluge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.44.4 -->
+<!-- version: 2.44.5 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-05 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Features
+
+#### May 5, 2026 — 3.2-deluge: Wire MoveStorage into undo path
+
+- **feat(deluge)**: `NotifyDelugeAfterUndo` now uses the restored original
+  file path (the undo destination) instead of `book.FilePath` from the DB,
+  ensuring Deluge is told the correct post-restore location when a
+  torrent-sourced book is reverted.
+- **test(deluge)**: 4 new cases in `deluge_integration_test.go` covering
+  enabled/disabled/no-hash/deluge-error for the undo path, verifying the
+  destination passed to `MoveStorage` is the restored original path, not the
+  centralized `.versions/` path.
 
 ### Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -834,7 +834,7 @@ Every plan in chronological order. ✅ = implemented, ⏳ = design done, plan wr
 - [x] [2026-04-10 Metadata candidate scoring PR1](docs/superpowers/plans/2026-04-10-metadata-candidate-scoring-pr1.md)
 - [x] [2026-04-10 Metadata candidate scoring PR2](docs/superpowers/plans/2026-04-10-metadata-candidate-scoring-pr2.md)
 - ⏳ [2026-04-15 Library centralization](docs/superpowers/plans/2026-04-15-library-centralization.md) — tasks 1-9 done (deluge integration deferred)
-- ⏳ [2026-04-15 Bulk organize undo](docs/superpowers/plans/2026-04-15-bulk-organize-undo.md) — tasks 1-6 done (torrent move_storage deferred)
+- [x] [2026-04-15 Bulk organize undo](docs/superpowers/plans/2026-04-15-bulk-organize-undo.md) — complete (tasks 1-6 + torrent move_storage PR)
 - [x] [2026-04-15 Smart + static playlists](docs/superpowers/plans/2026-04-15-smart-and-static-playlists.md) — complete (9/9 tasks)
 - [x] [2026-04-15 Read/unread tracking](docs/superpowers/plans/2026-04-15-read-unread-tracking.md) — complete (8/8 tasks)
 - [x] [2026-04-15 Multi-user support](docs/superpowers/plans/2026-04-15-multi-user-support.md) — complete (8/8, OAuth deferred)

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,7 +1,7 @@
 // file: internal/server/deluge_integration.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 //
 // Deluge integration for library centralization (backlog 6.1).
 //
@@ -198,18 +198,26 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 
 // NotifyDelugeAfterUndo checks whether the reverted operation moved
 // Deluge-sourced files and updates the torrent storage path.
+//
+// oldFilePath is the path the file was restored to (the original location
+// before the organize operation ran). This is the destination Deluge needs
+// to know about — NOT book.FilePath, which may not yet be updated in the DB
+// at the point this is called from the undo engine.
 func NotifyDelugeAfterUndo(store interface {
 	database.BookReader
 	database.BookVersionStore
 }, bookID, oldFilePath string) {
-	book, _ := store.GetBookByID(bookID)
-	if book == nil {
+	if oldFilePath == "" {
 		return
 	}
+	_, _ = store.GetBookByID(bookID) // ensure book exists; ignore result
 	versions, _ := store.GetBookVersionsByBookID(bookID)
 	for _, v := range versions {
 		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
-			NotifyDelugeMoveStorage(v.TorrentHash, book.FilePath)
+			// Use oldFilePath (the restored destination), not book.FilePath,
+			// because the DB FilePath may not have been updated yet when this
+			// is called immediately after the file rename-back.
+			NotifyDelugeMoveStorage(v.TorrentHash, oldFilePath)
 		}
 	}
 }

--- a/internal/server/deluge_integration_test.go
+++ b/internal/server/deluge_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/deluge_integration_test.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-05-03
+// last-edited: 2026-05-05
 
 package server
 
@@ -204,4 +204,237 @@ func TestNotifyDelugeAfterVersionSwap(t *testing.T) {
 
 	// Should not panic even without Deluge configured.
 	NotifyDelugeAfterVersionSwap(store, fromVer, toVer, "/lib/books/b1/book.m4b")
+}
+
+// ---------------------------------------------------------------------------
+// NotifyDelugeAfterUndo — 4 cases from spec 3.2-deluge
+// ---------------------------------------------------------------------------
+
+// Case 1: DelugeMoveEnabled=true, TorrentHash set — MoveStorage is called
+// with the *restored original path*, not the centralized path.
+func TestNotifyDelugeAfterUndo_Enabled(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir() + "/db")
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	book, _ := store.CreateBook(&database.Book{
+		Title:    "Test Book",
+		FilePath: "/library/.versions/v1/book.m4b", // centralized (pre-undo) path
+		Format:   "m4b",
+	})
+	bv, _ := store.CreateBookVersion(&database.BookVersion{
+		BookID:      book.ID,
+		TorrentHash: "abc123",
+		Format:      "m4b",
+		Status:      database.BookVersionStatusActive,
+	})
+	_ = bv
+
+	// Start a mock Deluge server that records the move_storage call.
+	var gotHashes []string
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string        `json:"method"`
+			Params []interface{} `json:"params"`
+			ID     int64         `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "auth.login":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": req.ID, "result": true})
+		case "core.move_storage":
+			if len(req.Params) == 2 {
+				if hashes, ok := req.Params[0].([]interface{}); ok {
+					for _, h := range hashes {
+						gotHashes = append(gotHashes, h.(string))
+					}
+				}
+				gotPath, _ = req.Params[1].(string)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": req.ID, "result": nil})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := deluge.New(srv.URL, "deluge")
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	orig := globalDelugeClient
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeMoveEnabled = true
+	defer func() {
+		globalDelugeClient = orig
+		config.AppConfig.DelugeMoveEnabled = origMove
+	}()
+
+	// The undo restores the file to the original path.
+	restoredPath := "/library/Author/Title/book.m4b"
+	NotifyDelugeAfterUndo(store, book.ID, restoredPath)
+
+	if len(gotHashes) == 0 {
+		t.Fatal("expected MoveStorage to be called")
+	}
+	if gotHashes[0] != "abc123" {
+		t.Errorf("hash = %q, want abc123", gotHashes[0])
+	}
+	// Deluge gets the parent directory of the restored file path.
+	wantDir := filepath.Dir(restoredPath)
+	if gotPath != wantDir {
+		t.Errorf("dest = %q, want %q (restored dir, not centralized dir)", gotPath, wantDir)
+	}
+}
+
+// Case 2: DelugeMoveEnabled=false — MoveStorage is NOT called.
+func TestNotifyDelugeAfterUndo_Disabled(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir() + "/db")
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "Test Book", FilePath: "/library/.versions/v1/book.m4b", Format: "m4b",
+	})
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: book.ID, TorrentHash: "abc123", Format: "m4b",
+		Status: database.BookVersionStatusActive,
+	})
+
+	var calledMoveStorage bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct{ Method string `json:"method"` }
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "core.move_storage" {
+			calledMoveStorage = true
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 0, "result": true})
+	}))
+	defer srv.Close()
+
+	client, _ := deluge.New(srv.URL, "deluge")
+	orig := globalDelugeClient
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeMoveEnabled = false // disabled
+	defer func() {
+		globalDelugeClient = orig
+		config.AppConfig.DelugeMoveEnabled = origMove
+	}()
+
+	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+
+	if calledMoveStorage {
+		t.Error("MoveStorage should NOT be called when DelugeMoveEnabled=false")
+	}
+}
+
+// Case 3: TorrentHash is empty — MoveStorage is NOT called.
+func TestNotifyDelugeAfterUndo_NoHash(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir() + "/db")
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "Test Book", FilePath: "/library/.versions/v1/book.m4b", Format: "m4b",
+	})
+	// BookVersion with no TorrentHash.
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: book.ID, TorrentHash: "", Format: "m4b",
+		Status: database.BookVersionStatusActive,
+	})
+
+	var calledMoveStorage bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct{ Method string `json:"method"` }
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Method == "core.move_storage" {
+			calledMoveStorage = true
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 0, "result": true})
+	}))
+	defer srv.Close()
+
+	client, _ := deluge.New(srv.URL, "deluge")
+	orig := globalDelugeClient
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeMoveEnabled = true
+	defer func() {
+		globalDelugeClient = orig
+		config.AppConfig.DelugeMoveEnabled = origMove
+	}()
+
+	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+
+	if calledMoveStorage {
+		t.Error("MoveStorage should NOT be called when TorrentHash is empty")
+	}
+}
+
+// Case 4: Deluge returns an error — NotifyDelugeAfterUndo must not propagate
+// the error (best-effort, non-fatal).
+func TestNotifyDelugeAfterUndo_DelugeError(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir() + "/db")
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	book, _ := store.CreateBook(&database.Book{
+		Title: "Test Book", FilePath: "/library/.versions/v1/book.m4b", Format: "m4b",
+	})
+	_, _ = store.CreateBookVersion(&database.BookVersion{
+		BookID: book.ID, TorrentHash: "abc123", Format: "m4b",
+		Status: database.BookVersionStatusActive,
+	})
+
+	// Deluge returns an error for move_storage.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     int64  `json:"id"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "auth.login":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": req.ID, "result": true})
+		case "core.move_storage":
+			// Simulate Deluge error.
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":    req.ID,
+				"error": map[string]interface{}{"code": 1, "message": "torrent not found"},
+			})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := deluge.New(srv.URL, "deluge")
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	orig := globalDelugeClient
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeMoveEnabled = true
+	defer func() {
+		globalDelugeClient = orig
+		config.AppConfig.DelugeMoveEnabled = origMove
+	}()
+
+	// Must not panic or return error — best-effort, log only.
+	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+	// If we reach here, the test passes (no panic, no error propagation).
 }


### PR DESCRIPTION
## Summary

- Fixes `NotifyDelugeAfterUndo` to pass the **restored original path** (the undo destination) to `MoveStorage` instead of `book.FilePath` from the DB. The DB field may not be updated yet at the point this is called, so using `oldFilePath` (the `change.OldValue` passed from the undo engine) is correct.
- Adds 4 test cases covering all required scenarios: enabled, disabled, no-hash, and Deluge error (best-effort non-fatal).

## Test plan

- [x] `TestNotifyDelugeAfterUndo_Enabled` — MoveStorage called with restored dir, not centralized `.versions/` dir
- [x] `TestNotifyDelugeAfterUndo_Disabled` — MoveStorage NOT called when `DelugeMoveEnabled=false`
- [x] `TestNotifyDelugeAfterUndo_NoHash` — MoveStorage NOT called when `TorrentHash` is empty
- [x] `TestNotifyDelugeAfterUndo_DelugeError` — Deluge RPC error is non-fatal (no panic, no error returned)
- [x] All pre-existing undo and deluge integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>