### PR TITLE
feat(cache): metadata_fetch TTL enforcement (CACHE-FOLLOWUP-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@
   enabled/disabled/no-hash/deluge-error for the undo path, verifying the
   destination passed to `MoveStorage` is the restored original path, not the
   centralized `.versions/` path.
+#### May 5, 2026 — CACHE-FOLLOWUP-1: Metadata-fetch TTL enforcement
+
+- **feat(cache)**: `GetCachedMetadataFetchWithMaxAge` centralizes TTL logic and
+  emits `metrics.RecordCacheMiss("metadata_fetch","expired")` on stale entries.
+  `GetCachedMetadataFetch` preserved as a backward-compat `maxAge=0` wrapper.
+- All 7 non-test callers in `server/metadata_handlers.go`,
+  `metafetch/service_fetch.go`, `metafetch/service_search.go`, and
+  `maintenance/jobs/bulk_fetch_metadata.go` migrated to the new function.
+- Three new TTL unit tests: `ZeroMeansInfinite`, `ExpiredReturnsMiss`,
+  `FreshReturnsHit`.
 
 ### Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -517,6 +517,7 @@ next picks up. Full plan in
 - [x] **DIAG-3** Surface `ai_scans.db` and `embeddings.db` stats in Diagnostics — both are opened in `server.go:934-1004` but never shown on the diagnostics or system-info pages — PR #570
 - [x] **DIAG-4** Increase `MetadataFetchCacheTTLDays` default — metadata_fetch cache TTL (configured via `config.AppConfig.MetadataFetchCacheTTLDays`) is expiring too fast; increased default to 30 days — PR #570
 - [x] **DIAG-5** Add path-prefix diagnostic to Storage page UI — `GET /api/v1/diagnostics/db-health` now returns `book_path_prefixes`; surface this in StorageTab so mismatches between configured import paths and actual stored paths are visible without a separate API call
+- [x] **CACHE-FOLLOWUP-1** Metadata-fetch cache TTL enforcement — `GetCachedMetadataFetchWithMaxAge` centralizes the TTL check and emits `metrics.RecordCacheMiss("metadata_fetch","expired")`; `GetCachedMetadataFetch` is a backward-compat maxAge=0 wrapper; all 7 non-test callers updated; 3 new TTL unit tests — PR feat/metadata-fetch-ttl
 
 ---
 

--- a/internal/database/metadata_fetch_cache.go
+++ b/internal/database/metadata_fetch_cache.go
@@ -1,7 +1,7 @@
 // file: internal/database/metadata_fetch_cache.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package database
 
@@ -40,10 +40,10 @@ import (
 // or wholesale invalidation.
 
 // CachedMetadataEntry is the serialized shape of a cache row.
-// The CachedAt timestamp exists so an optional TTL policy can
-// filter stale entries; the current implementation never
-// expires, but the timestamp is recorded for future use and
-// for the diagnostics surface.
+// The CachedAt timestamp is used by GetCachedMetadataFetchWithMaxAge
+// to enforce an optional TTL; callers passing maxAge=0 get the old
+// infinite-TTL behaviour. Recorded since the first version for the
+// diagnostics surface.
 type CachedMetadataEntry struct {
 	BookID    string            `json:"book_id"`
 	Source    string            `json:"source"`
@@ -61,37 +61,61 @@ func metadataFetchCacheKey(bookID, source string) string {
 	return "metadata_fetch_cache:" + bookID + ":" + strings.ToLower(strings.TrimSpace(source))
 }
 
-// GetCachedMetadataFetch looks up a cache entry. Returns nil
-// on miss (not an error). The returned Results slice is the
-// raw JSON payload the caller originally stored — the caller
-// is responsible for unmarshalling it into its own type.
-func GetCachedMetadataFetch(store Store, bookID, source string) (*CachedMetadataEntry, error) {
+// GetCachedMetadataFetchWithMaxAge looks up a cache entry and enforces
+// an optional TTL. maxAge=0 disables the TTL check (infinite TTL,
+// preserving the pre-TTL behaviour).
+//
+// On an expired entry the function records a cache miss with
+// reason="expired" and returns nil, false, nil so the caller
+// falls through to the API path. The entry is NOT deleted — it
+// remains available for diagnostics and will be overwritten on
+// the next successful fetch.
+func GetCachedMetadataFetchWithMaxAge(store Store, bookID, source string, maxAge time.Duration) (*CachedMetadataEntry, bool, error) {
 	if bookID == "" || source == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	start := time.Now()
 	defer func() { metrics.ObserveCacheGetDuration("metadata_fetch", time.Since(start)) }()
 
 	blob, err := store.GetRaw(metadataFetchCacheKey(bookID, source))
 	if err != nil {
-		return nil, fmt.Errorf("cache get: %w", err)
+		return nil, false, fmt.Errorf("cache get: %w", err)
 	}
 	if blob == nil {
 		metrics.RecordCacheMiss("metadata_fetch", "not_found")
-		return nil, nil
+		return nil, false, nil
 	}
 	var entry CachedMetadataEntry
 	if err := json.Unmarshal(blob, &entry); err != nil {
 		// Corrupt entry — treat as a miss and delete it so
 		// the next call writes a fresh row.
-		if err := store.DeleteRaw(metadataFetchCacheKey(bookID, source)); err != nil {
-			slog.Warn("failed to delete corrupt cache entry", "key", metadataFetchCacheKey(bookID, source), "error", err)
+		if delErr := store.DeleteRaw(metadataFetchCacheKey(bookID, source)); delErr != nil {
+			slog.Warn("failed to delete corrupt cache entry", "key", metadataFetchCacheKey(bookID, source), "error", delErr)
 		}
 		metrics.RecordCacheMiss("metadata_fetch", "stale")
-		return nil, nil
+		return nil, false, nil
+	}
+	if maxAge > 0 {
+		age := time.Since(entry.CachedAt)
+		if age > maxAge {
+			metrics.RecordCacheMiss("metadata_fetch", "expired")
+			return nil, false, nil
+		}
 	}
 	metrics.RecordCacheHit("metadata_fetch")
-	return &entry, nil
+	return &entry, true, nil
+}
+
+// GetCachedMetadataFetch looks up a cache entry with no TTL check.
+// Returns nil on miss (not an error). The returned Results slice is
+// the raw JSON payload the caller originally stored — the caller
+// is responsible for unmarshalling it into its own type.
+//
+// Thin wrapper around GetCachedMetadataFetchWithMaxAge(maxAge=0)
+// kept for backward compatibility.
+func GetCachedMetadataFetch(store Store, bookID, source string) (*CachedMetadataEntry, error) {
+	entry, _, err := GetCachedMetadataFetchWithMaxAge(store, bookID, source, 0)
+	return entry, err
 }
 
 // PutCachedMetadataFetch writes a cache entry. The `results`

--- a/internal/database/metadata_fetch_cache_test.go
+++ b/internal/database/metadata_fetch_cache_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/metadata_fetch_cache_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6f5e4d3c-2b1a-0f9e-8d7c-6b5a4f3e2d1c
 
 package database
@@ -7,6 +7,7 @@ package database
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -146,5 +147,89 @@ func TestMetadataFetchCache_CorruptEntry_TreatedAsMiss(t *testing.T) {
 	raw, _ := store.GetRaw(metadataFetchCacheKey("book-1", "Hardcover"))
 	if raw != nil {
 		t.Errorf("expected corrupt entry to be cleaned up, still got %d bytes", len(raw))
+	}
+}
+
+// TestMetadataFetchCache_TTL_ZeroMeansInfinite verifies that maxAge=0 disables
+// the TTL check so even a very old entry is returned as a hit.
+func TestMetadataFetchCache_TTL_ZeroMeansInfinite(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	payload := json.RawMessage(`[{"title":"Old Book"}]`)
+	require.NoError(t, PutCachedMetadataFetch(store, "book-1", "Audible", payload, 0.80))
+
+	// Backdate the entry by 1 year by overwriting with a manipulated timestamp.
+	key := metadataFetchCacheKey("book-1", "audible")
+	blob, err := store.GetRaw(key)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	var entry CachedMetadataEntry
+	require.NoError(t, json.Unmarshal(blob, &entry))
+	entry.CachedAt = time.Now().UTC().Add(-365 * 24 * time.Hour)
+	updated, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, store.SetRaw(key, updated))
+
+	// maxAge=0 → infinite TTL, must return hit.
+	got, hit, err := GetCachedMetadataFetchWithMaxAge(store, "book-1", "Audible", 0)
+	require.NoError(t, err)
+	require.True(t, hit, "expected hit when maxAge=0")
+	require.NotNil(t, got)
+}
+
+// TestMetadataFetchCache_TTL_ExpiredReturnsMiss verifies that an entry older
+// than maxAge is returned as a miss.
+func TestMetadataFetchCache_TTL_ExpiredReturnsMiss(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	payload := json.RawMessage(`[{"title":"Old Book"}]`)
+	require.NoError(t, PutCachedMetadataFetch(store, "book-2", "Audnexus", payload, 0.70))
+
+	// Backdate to 8 days ago.
+	key := metadataFetchCacheKey("book-2", "audnexus")
+	blob, err := store.GetRaw(key)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	var entry CachedMetadataEntry
+	require.NoError(t, json.Unmarshal(blob, &entry))
+	entry.CachedAt = time.Now().UTC().Add(-8 * 24 * time.Hour)
+	updated, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, store.SetRaw(key, updated))
+
+	// maxAge=7d → entry is expired, must return miss.
+	got, hit, err := GetCachedMetadataFetchWithMaxAge(store, "book-2", "Audnexus", 7*24*time.Hour)
+	require.NoError(t, err)
+	require.False(t, hit, "expected miss for expired entry")
+	require.Nil(t, got)
+}
+
+// TestMetadataFetchCache_TTL_FreshReturnsHit verifies that an entry within
+// maxAge is returned as a hit.
+func TestMetadataFetchCache_TTL_FreshReturnsHit(t *testing.T) {
+	store := newCacheTestStore(t)
+
+	payload := json.RawMessage(`[{"title":"Fresh Book"}]`)
+	require.NoError(t, PutCachedMetadataFetch(store, "book-3", "OpenLibrary", payload, 0.90))
+
+	// Backdate to 1 day ago (within a 7d maxAge).
+	key := metadataFetchCacheKey("book-3", "openlibrary")
+	blob, err := store.GetRaw(key)
+	require.NoError(t, err)
+	require.NotNil(t, blob)
+	var entry CachedMetadataEntry
+	require.NoError(t, json.Unmarshal(blob, &entry))
+	entry.CachedAt = time.Now().UTC().Add(-1 * 24 * time.Hour)
+	updated, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, store.SetRaw(key, updated))
+
+	// maxAge=7d → entry is fresh, must return hit.
+	got, hit, err := GetCachedMetadataFetchWithMaxAge(store, "book-3", "OpenLibrary", 7*24*time.Hour)
+	require.NoError(t, err)
+	require.True(t, hit, "expected hit for fresh entry")
+	require.NotNil(t, got)
+	if string(got.Results) != string(payload) {
+		t.Errorf("results = %s, want %s", got.Results, payload)
 	}
 }

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_fetch_metadata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
-// last-edited: 2026-04-28
+// last-edited: 2026-05-05
 
 package jobs
 
@@ -106,14 +106,12 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 			continue
 		}
 		if skipCached {
+			maxAge := time.Duration(ttlDays) * 24 * time.Hour
 			hasFreshCache := false
 			for _, src := range sourceChain {
-				if cached, cerr := database.GetCachedMetadataFetch(store, b.ID, src.Name()); cerr == nil && cached != nil {
-					expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-					if !expired {
-						hasFreshCache = true
-						break
-					}
+				if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, b.ID, src.Name(), maxAge); cerr == nil && cached != nil {
+					hasFreshCache = true
+					break
 				}
 			}
 			if hasFreshCache {
@@ -159,17 +157,15 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 		var sourceName string
 		cacheHit := false
 
+		maxAge := time.Duration(ttlDays) * 24 * time.Hour
 		for _, src := range sourceChain {
-			if cached, cerr := database.GetCachedMetadataFetch(store, bookID, src.Name()); cerr == nil && cached != nil {
-				expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-				if !expired {
-					var cachedResults []metadata.BookMetadata
-					if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
-						metaResults = cachedResults
-						sourceName = src.Name()
-						cacheHit = true
-						break
-					}
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, src.Name(), maxAge); cerr == nil && cached != nil {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+					metaResults = cachedResults
+					sourceName = src.Name()
+					cacheHit = true
+					break
 				}
 			}
 			var fetchErr error

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package metafetch
 
@@ -88,19 +88,13 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		// The cache is shared with the search-dialog path — a bulk library
 		// fetch or a prior search dialog populates it, so a subsequent single-
 		// book fetch can return immediately without another network round-trip.
-		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
-			ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
-			expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-			if expired {
-				log.Printf("[DEBUG] metadata-fetch: cache EXPIRED for (%s, %s) — age=%s",
-					id, src.Name(), time.Since(cached.CachedAt).Round(time.Hour))
-			} else {
-				var cachedResults []metadata.BookMetadata
-				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
-					results = cachedResults
-					log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
-						id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
-				}
+		maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
+		if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
+			var cachedResults []metadata.BookMetadata
+			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+				results = cachedResults
+				log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
+					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_search.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package metafetch
 
@@ -230,17 +230,14 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		// where re-fetching 8000 books hit every external API
 		// 8000 times even for books we'd already matched with
 		// high confidence.
-		if cached, cerr := database.GetCachedMetadataFetch(mfs.db, id, src.Name()); cerr == nil && cached != nil {
-			ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
-			expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-			if !expired {
-				var cachedResults []metadata.BookMetadata
-				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
-					allResults = cachedResults
-					cacheHit = true
-					log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
-						id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
-				}
+		maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
+		if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
+			var cachedResults []metadata.BookMetadata
+			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
+				allResults = cachedResults
+				cacheHit = true
+				log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
+					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
 // search/apply/revert/no-match, bulk fetch and bulk writeback, the
@@ -583,23 +583,17 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 		// for better match quality. Author is used as a filter, not as the primary query.
 		var metaResults []metadata.BookMetadata
 		var sourceName string
-		ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+		maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
 		for _, src := range sourceChain {
 			// Check the persistent fetch cache before hitting the external API.
-			if cached, cerr := database.GetCachedMetadataFetch(s.Store(), bookID, src.Name()); cerr == nil && cached != nil {
-				expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-				if expired {
-					log.Printf("[DEBUG] bulkFetchMetadata: cache EXPIRED for (%s, %s) — age=%s",
-						bookID, src.Name(), time.Since(cached.CachedAt).Round(time.Hour))
-				} else {
-					var cachedResults []metadata.BookMetadata
-					if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
-						metaResults = cachedResults
-						sourceName = src.Name()
-						log.Printf("[DEBUG] bulkFetchMetadata: cache HIT for (%s, %s) — %d results, age=%s",
-							bookID, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
-						break
-					}
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(s.Store(), bookID, src.Name(), maxAge); cerr == nil && cached != nil {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+					metaResults = cachedResults
+					sourceName = src.Name()
+					log.Printf("[DEBUG] bulkFetchMetadata: cache HIT for (%s, %s) — %d results, age=%s",
+						bookID, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+					break
 				}
 			}
 
@@ -946,7 +940,7 @@ func (s *Server) runBulkMetadataFetchAll(
 		return fmt.Errorf("GetAllBooks: %w", err)
 	}
 
-	ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
+	maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
 
 	existingResults, _ := store.GetOperationResults(opID)
 	done := make(map[string]bool, len(existingResults))
@@ -978,12 +972,9 @@ func (s *Server) runBulkMetadataFetchAll(
 		if params.SkipCached {
 			hasFreshCache := false
 			for _, src := range s.metadataFetchService.BuildSourceChain() {
-				if cached, cerr := database.GetCachedMetadataFetch(store, b.ID, src.Name()); cerr == nil && cached != nil {
-					expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-					if !expired {
-						hasFreshCache = true
-						break
-					}
+				if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, b.ID, src.Name(), maxAge); cerr == nil && cached != nil {
+					hasFreshCache = true
+					break
 				}
 			}
 			if hasFreshCache {
@@ -1043,16 +1034,13 @@ func (s *Server) runBulkMetadataFetchAll(
 		cacheHit := false
 
 		for _, src := range sourceChain {
-			if cached, cerr := database.GetCachedMetadataFetch(store, bookID, src.Name()); cerr == nil && cached != nil {
-				expired := ttlDays > 0 && time.Since(cached.CachedAt) > time.Duration(ttlDays)*24*time.Hour
-				if !expired {
-					var cachedResults []metadata.BookMetadata
-					if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
-						metaResults = cachedResults
-						sourceName = src.Name()
-						cacheHit = true
-						break
-					}
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, src.Name(), maxAge); cerr == nil && cached != nil {
+				var cachedResults []metadata.BookMetadata
+				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+					metaResults = cachedResults
+					sourceName = src.Name()
+					cacheHit = true
+					break
 				}
 			}
 			var fetchErr error


### PR DESCRIPTION
## Summary

- Adds `GetCachedMetadataFetchWithMaxAge(store, bookID, source, maxAge)` that centralizes TTL enforcement: entries older than `maxAge` return a miss and record `metrics.RecordCacheMiss("metadata_fetch","expired")` via the existing observability counters.
- `GetCachedMetadataFetch` is now a thin `maxAge=0` wrapper — zero behaviour change for callers that don't need TTL.
- All 7 non-test callers migrated: `server/metadata_handlers.go` (3), `metafetch/service_fetch.go` (1), `metafetch/service_search.go` (1), `maintenance/jobs/bulk_fetch_metadata.go` (2). TTL is read from `config.AppConfig.MetadataFetchCacheTTLDays` (default 180 days).
- Three new unit tests in `internal/database/metadata_fetch_cache_test.go`: `ZeroMeansInfinite`, `ExpiredReturnsMiss`, `FreshReturnsHit`.

## Test plan

- [ ] `go test ./internal/database/...` — all 9 cache tests pass (including 3 new TTL tests)
- [ ] `go build ./...` — clean build
- [ ] `go vet ./internal/...` — no issues
- [ ] Confirm no non-test callers of bare `GetCachedMetadataFetch` remain outside the wrapper itself

Spec: `docs/superpowers/specs/2026-04-27-metadata-fetch-ttl-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)