### PR TITLE
feat(ai): per-feature LLM model knob (TODO AI-MODEL-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@
 - **refactor(activity)**: `batcher.go` — added `"scan-file-processed"` noun → `"files scanned"`.
 - **feat(activity)**: `writer.go` — added `Chan()` accessor returning the read-only entry channel.
 - **test(scanner)**: `service_unit_test.go` — `TestScanService_ProgressCallback_UsesLogBatch` ACT-BATCH-FU-2 regression guard.
+#### May 5, 2026 — AI-MODEL-1: Per-feature LLM model knob
+
+Adds four new config fields (`dedup_review_model`, `metadata_review_model`,
+`filename_parse_model`, `cover_art_model`) to `Config`, all defaulting to
+`gpt-5-mini` to preserve existing behavior. Replaces every hardcoded
+`"gpt-5-mini"` in `openai_parser.go`, `openai_batch.go`,
+`metadata_llm_review.go`, and `dedup/engine.go` with config-driven getters,
+allowing operators to direct individual AI features (e.g. dedup review) at
+a cheaper or more capable model independently. Tests assert each `Parse*`
+path on `OpenAIParser` sends the correct model string from config.
+
+Spec: `docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md`
 
 ### Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.9.0 -->
+<!-- version: 8.10.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-05 -->
 
@@ -25,6 +25,12 @@ future agent) can scan the entire workspace in one page.
 **Production:** PebbleDB, Linux, HTTPS at `172.16.2.30:8484`, mTLS bridge active
 **Latest shipped release:** v0.221.0 (2026-04-29) — PRs #507–#521; PRs #561–#563 merged 2026-04-30; PRs #570–#573 merged 2026-04-30
 **In flight:** User Ratings UI, ASYNC spec revision, iTunes relink unresolved cases (6,719 files)
+
+---
+
+## AI Model Configuration
+
+- [x] **AI-MODEL-1** Per-feature LLM model knob — adds `DedupReviewModel`, `MetadataReviewModel`, `FilenameParseModel`, `CoverArtModel` to `config.Config` (defaults `gpt-5-mini`). Replaces hardcoded literals in `openai_parser.go`, `openai_batch.go`, `metadata_llm_review.go`, and `dedup/engine.go` with config getters. PR feat/per-feature-llm-model.
 
 ---
 

--- a/internal/ai/metadata_llm_review.go
+++ b/internal/ai/metadata_llm_review.go
@@ -1,5 +1,5 @@
 // file: internal/ai/metadata_llm_review.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: e4f92b17-3c8a-4d65-a1f3-9b2e07d84c61
 
 package ai
@@ -155,7 +155,7 @@ Include one score per input candidate, using the same index as the input.`
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.model),
+			Model:               shared.ChatModel(p.metadataReviewModel()), // metadata LLM review uses MetadataReviewModel
 			MaxCompletionTokens: param.NewOpt[int64](8000),
 			PromptCacheKey:      param.NewOpt("audiobook-metadata-score-v1"),
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{

--- a/internal/ai/openai_batch.go
+++ b/internal/ai/openai_batch.go
@@ -1,5 +1,5 @@
 // file: internal/ai/openai_batch.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e
 
 package ai
@@ -182,7 +182,7 @@ Only include groups where you find actual duplicates or issues.`
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body: map[string]interface{}{
-			"model": p.model,
+			"model": p.metadataReviewModel(), // batch author dedup uses MetadataReviewModel
 			"messages": []map[string]string{
 				{"role": "system", "content": systemPrompt},
 				{"role": "user", "content": userPrompt},
@@ -346,7 +346,7 @@ Return ONLY valid JSON: {"suggestions": [{"group_index": N, "action": "merge|spl
 		Method:   "POST",
 		URL:      "/v1/chat/completions",
 		Body: map[string]interface{}{
-			"model": p.model,
+			"model": p.metadataReviewModel(), // batch author dedup uses MetadataReviewModel
 			"messages": []map[string]string{
 				{"role": "system", "content": systemPrompt},
 				{"role": "user", "content": userPrompt},
@@ -519,6 +519,6 @@ Return ONLY valid JSON: {"suggestions": [{"author_ids": [1, 42], "action": "merg
 
 	batchJSON, _ := json.Marshal(inputs)
 	user = fmt.Sprintf("Find duplicate authors in this list:\n\n%s", string(batchJSON))
-	model = shared.ChatModel(p.model)
+	model = shared.ChatModel(p.metadataReviewModel()) // BuildAuthorDedupMessages uses MetadataReviewModel
 	return
 }

--- a/internal/ai/openai_parser.go
+++ b/internal/ai/openai_parser.go
@@ -1,5 +1,5 @@
 // file: internal/ai/openai_parser.go
-// version: 13.2.0
+// version: 13.3.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
 
 package ai
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/cache"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
@@ -36,7 +37,7 @@ type ParsedMetadata struct {
 // OpenAIParser handles AI-powered metadata parsing using OpenAI
 type OpenAIParser struct {
 	client        *openai.Client
-	model         string
+	cfg           *config.Config // Per-feature model selection; may be nil (falls back to gpt-5-mini)
 	maxRetries    int
 	enabled       bool
 	responseCache *cache.Cache[*ParsedMetadata] // Application-level response cache
@@ -45,10 +46,38 @@ type OpenAIParser struct {
 // Default cache TTL for AI responses (24 hours — metadata doesn't change often)
 const aiResponseCacheTTL = 24 * time.Hour
 
-// NewOpenAIParser creates a new OpenAI parser
-func NewOpenAIParser(apiKey string, enabled bool) *OpenAIParser {
+// defaultModel is the fallback when cfg is nil or the per-feature field is empty.
+const defaultModel = "gpt-5-mini"
+
+// filenameParseModel returns the configured model for filename/audiobook parsing.
+func (p *OpenAIParser) filenameParseModel() string {
+	if p.cfg != nil && p.cfg.FilenameParseModel != "" {
+		return p.cfg.FilenameParseModel
+	}
+	return defaultModel
+}
+
+// coverArtModel returns the configured model for cover-art parsing.
+func (p *OpenAIParser) coverArtModel() string {
+	if p.cfg != nil && p.cfg.CoverArtModel != "" {
+		return p.cfg.CoverArtModel
+	}
+	return defaultModel
+}
+
+// metadataReviewModel returns the configured model for metadata review operations.
+func (p *OpenAIParser) metadataReviewModel() string {
+	if p.cfg != nil && p.cfg.MetadataReviewModel != "" {
+		return p.cfg.MetadataReviewModel
+	}
+	return defaultModel
+}
+
+// NewOpenAIParser creates a new OpenAI parser.
+// cfg may be nil; when provided, per-feature model fields override the default.
+func NewOpenAIParser(cfg *config.Config, apiKey string, enabled bool) *OpenAIParser {
 	if !enabled || apiKey == "" {
-		return &OpenAIParser{enabled: false}
+		return &OpenAIParser{enabled: false, cfg: cfg}
 	}
 
 	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
@@ -60,7 +89,7 @@ func NewOpenAIParser(apiKey string, enabled bool) *OpenAIParser {
 
 	return &OpenAIParser{
 		client:        &client,
-		model:         "gpt-5-mini", // Primary model for all AI operations
+		cfg:           cfg,
 		maxRetries:    2,
 		enabled:       true,
 		responseCache: cache.New[*ParsedMetadata]("ai_response", aiResponseCacheTTL),
@@ -139,7 +168,7 @@ Set confidence based on clarity of the filename structure.`
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:          shared.ChatModel(p.model),
+		Model:          shared.ChatModel(p.filenameParseModel()), // filename parsing uses FilenameParseModel
 		MaxCompletionTokens: param.NewOpt[int64](500),
 		PromptCacheKey: param.NewOpt("audiobook-filename-parser-v1"),
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -242,7 +271,7 @@ Set confidence based on how much context was available and how unambiguous it is
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:          shared.ChatModel(p.model),
+		Model:          shared.ChatModel(p.filenameParseModel()), // audiobook context parsing uses FilenameParseModel
 		MaxCompletionTokens: param.NewOpt[int64](500),
 		PromptCacheKey: param.NewOpt("audiobook-context-parser-v1"),
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -333,7 +362,7 @@ Set confidence based on clarity of the filename structure.`
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:          shared.ChatModel(p.model),
+			Model:          shared.ChatModel(p.filenameParseModel()), // batch filename parsing uses FilenameParseModel
 			MaxCompletionTokens: param.NewOpt[int64](2000),
 			PromptCacheKey: param.NewOpt("audiobook-batch-parser-v1"),
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -400,7 +429,7 @@ Set confidence based on how clearly the text is readable on the cover.`
 				openai.TextContentPart("Read the metadata from this audiobook cover image."),
 			}),
 		},
-		Model:          shared.ChatModel(p.model),
+		Model:          shared.ChatModel(p.coverArtModel()), // cover art parsing uses CoverArtModel
 		PromptCacheKey:      param.NewOpt("audiobook-cover-parser-v1"),
 		MaxCompletionTokens: param.NewOpt[int64](500),
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -548,7 +577,7 @@ The roles object fields are all optional — only include roles that are detecte
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.model),
+			Model:               shared.ChatModel(p.metadataReviewModel()), // author dedup review uses MetadataReviewModel
 			MaxCompletionTokens: param.NewOpt[int64](32000),
 			PromptCacheKey:      param.NewOpt("audiobook-author-dedup-v4"),
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -682,7 +711,7 @@ The roles object fields are all optional — only include roles that are detecte
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.model),
+			Model:               shared.ChatModel(p.metadataReviewModel()), // author discovery review uses MetadataReviewModel
 			MaxCompletionTokens: param.NewOpt[int64](16000),
 			PromptCacheKey:      param.NewOpt("audiobook-author-discover-v4"),
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{

--- a/internal/ai/openai_parser_test.go
+++ b/internal/ai/openai_parser_test.go
@@ -1,5 +1,5 @@
 // file: internal/ai/openai_parser_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package ai
@@ -15,29 +15,31 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 )
 
 func TestNewOpenAIParser_Disabled(t *testing.T) {
 	// Test with empty API key
-	parser := NewOpenAIParser("", true)
+	parser := NewOpenAIParser(nil, "", true)
 	if parser.enabled {
 		t.Error("Expected parser to be disabled with empty API key")
 	}
 
 	// Test with enabled=false
-	parser = NewOpenAIParser("test-key", false)
+	parser = NewOpenAIParser(nil, "test-key", false)
 	if parser.enabled {
 		t.Error("Expected parser to be disabled when enabled=false")
 	}
 }
 
 func TestNewOpenAIParser_Enabled(t *testing.T) {
-	parser := NewOpenAIParser("test-api-key", true)
+	parser := NewOpenAIParser(nil, "test-api-key", true)
 	if !parser.enabled {
 		t.Error("Expected parser to be enabled with valid API key")
 	}
-	if parser.model != "gpt-5-mini" {
-		t.Errorf("Expected model gpt-5-mini, got %s", parser.model)
+	if parser.filenameParseModel() != "gpt-5-mini" {
+		t.Errorf("Expected model gpt-5-mini, got %s", parser.filenameParseModel())
 	}
 	if parser.maxRetries != 2 {
 		t.Errorf("Expected maxRetries 2, got %d", parser.maxRetries)
@@ -76,7 +78,7 @@ func TestIsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := NewOpenAIParser(tt.apiKey, tt.enabled)
+			parser := NewOpenAIParser(nil, tt.apiKey, tt.enabled)
 			if got := parser.IsEnabled(); got != tt.want {
 				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
 			}
@@ -85,7 +87,7 @@ func TestIsEnabled(t *testing.T) {
 }
 
 func TestParseFilename_Disabled(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 	ctx := context.Background()
 
 	_, err := parser.ParseFilename(ctx, "test.mp3")
@@ -98,7 +100,7 @@ func TestParseFilename_Disabled(t *testing.T) {
 }
 
 func TestParseBatch_Disabled(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 	ctx := context.Background()
 
 	_, err := parser.ParseBatch(ctx, []string{"test1.mp3", "test2.mp3"})
@@ -111,7 +113,7 @@ func TestParseBatch_Disabled(t *testing.T) {
 }
 
 func TestParseBatch_EmptyInput(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 	ctx := context.Background()
 
 	results, err := parser.ParseBatch(ctx, []string{})
@@ -124,7 +126,7 @@ func TestParseBatch_EmptyInput(t *testing.T) {
 }
 
 func TestTestConnection_Disabled(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 	ctx := context.Background()
 
 	err := parser.TestConnection(ctx)
@@ -217,7 +219,7 @@ func TestParsedMetadata_JSONOmitEmpty(t *testing.T) {
 
 func TestTestConnection_Timeout(t *testing.T) {
 	// This test verifies the timeout logic exists
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create a context that's already cancelled
 	ctx, cancel := context.WithCancel(context.Background())
@@ -233,7 +235,7 @@ func TestTestConnection_Timeout(t *testing.T) {
 
 func TestParseBatch_BatchSizeLimit(t *testing.T) {
 	// Test that batch size is limited to maxBatchSize (20)
-	_ = NewOpenAIParser("test-key", true)
+	_ = NewOpenAIParser(nil, "test-key", true)
 
 	// Create 25 filenames
 	filenames := make([]string, 25)
@@ -249,22 +251,22 @@ func TestParseBatch_BatchSizeLimit(t *testing.T) {
 }
 
 func TestOpenAIParser_ModelConfiguration(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
-	// Verify default model is set
-	if parser.model == "" {
+	// Verify default model is set (nil cfg falls back to defaultModel constant)
+	if parser.filenameParseModel() == "" {
 		t.Error("Expected model to be set")
 	}
 
 	// Verify it's the expected model
 	expectedModel := "gpt-5-mini"
-	if parser.model != expectedModel {
-		t.Errorf("Expected model %s, got %s", expectedModel, parser.model)
+	if parser.filenameParseModel() != expectedModel {
+		t.Errorf("Expected model %s, got %s", expectedModel, parser.filenameParseModel())
 	}
 }
 
 func TestOpenAIParser_RetryConfiguration(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Verify default maxRetries is set
 	expectedRetries := 2
@@ -293,7 +295,7 @@ func hasSubstring(s, substr string) bool {
 // TestParseFilename_APIError tests API error handling
 func TestParseFilename_APIError(t *testing.T) {
 	// Create parser with invalid API key to trigger error
-	parser := NewOpenAIParser("invalid-key-format", true)
+	parser := NewOpenAIParser(nil, "invalid-key-format", true)
 	ctx := context.Background()
 
 	_, err := parser.ParseFilename(ctx, "Test Book - Test Author.mp3")
@@ -327,7 +329,7 @@ func TestParseFilename_InvalidJSON(t *testing.T) {
 // TestParseBatch_APIError tests batch API error handling
 func TestParseBatch_APIError(t *testing.T) {
 	// Create parser with invalid API key to trigger error
-	parser := NewOpenAIParser("invalid-key-format", true)
+	parser := NewOpenAIParser(nil, "invalid-key-format", true)
 	ctx := context.Background()
 
 	filenames := []string{
@@ -362,7 +364,7 @@ func TestParseBatch_InvalidJSONResponse(t *testing.T) {
 
 // TestParseBatch_SingleFile tests batch with single file
 func TestParseBatch_SingleFile(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Verify parser accepts single file in batch
 	filenames := []string{"Single Book - Author.mp3"}
@@ -379,7 +381,7 @@ func TestParseBatch_SingleFile(t *testing.T) {
 
 // TestParseBatch_ExactlyMaxSize tests batch with exactly 20 files
 func TestParseBatch_ExactlyMaxSize(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create exactly 20 filenames (the max batch size)
 	filenames := make([]string, 20)
@@ -398,7 +400,7 @@ func TestParseBatch_ExactlyMaxSize(t *testing.T) {
 
 // TestParseBatch_OverMaxSize tests batch size limiting
 func TestParseBatch_OverMaxSize(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create 25 filenames (over the max of 20)
 	filenames := make([]string, 25)
@@ -514,7 +516,7 @@ func TestParsedMetadata_ZeroValues(t *testing.T) {
 
 // TestParseFilename_ContextCancellation tests context cancellation handling
 func TestParseFilename_ContextCancellation(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create an already-cancelled context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -529,7 +531,7 @@ func TestParseFilename_ContextCancellation(t *testing.T) {
 
 // TestParseBatch_ContextCancellation tests batch context cancellation
 func TestParseBatch_ContextCancellation(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create an already-cancelled context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -545,7 +547,7 @@ func TestParseBatch_ContextCancellation(t *testing.T) {
 
 // TestOpenAIParser_ClientNilWhenDisabled tests client is nil when disabled
 func TestOpenAIParser_ClientNilWhenDisabled(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 
 	if parser.client != nil {
 		t.Error("Expected client to be nil when disabled")
@@ -581,10 +583,10 @@ func TestParsedMetadata_ConfidenceLevels(t *testing.T) {
 
 // TestOpenAIParser_StructFields tests parser struct has expected fields
 func TestOpenAIParser_StructFields(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
-	// Verify struct fields are initialized
-	if parser.model == "" {
+	// Verify model is accessible (nil cfg → falls back to defaultModel)
+	if parser.filenameParseModel() == "" {
 		t.Error("Expected model to be set")
 	}
 	if parser.maxRetries == 0 {
@@ -601,7 +603,7 @@ func TestOpenAIParser_StructFields(t *testing.T) {
 // TestNewOpenAIParser_BothDisabledConditions tests both disabled conditions
 func TestNewOpenAIParser_BothDisabledConditions(t *testing.T) {
 	// Both conditions that disable the parser
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 
 	if parser.enabled {
 		t.Error("Expected parser to be disabled")
@@ -613,7 +615,7 @@ func TestNewOpenAIParser_BothDisabledConditions(t *testing.T) {
 
 // TestParseBatch_LargeInputTruncation tests that large inputs are truncated
 func TestParseBatch_LargeInputTruncation(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 
 	// Create 100 filenames (way over the max of 20)
 	filenames := make([]string, 100)
@@ -865,7 +867,7 @@ func TestParsedMetadata_EdgeCaseValues(t *testing.T) {
 
 // TestOpenAIParser_ErrorMessageFormat tests error message formatting
 func TestOpenAIParser_ErrorMessageFormat(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 
 	testCases := []struct {
 		name          string
@@ -912,7 +914,7 @@ func TestOpenAIParser_ErrorMessageFormat(t *testing.T) {
 
 // TestParseBatch_EmptyStringFilenames tests batch with empty filename strings
 func TestParseBatch_EmptyStringFilenames(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -927,7 +929,7 @@ func TestParseBatch_EmptyStringFilenames(t *testing.T) {
 
 // TestParseFilename_EmptyFilename tests parsing an empty filename
 func TestParseFilename_EmptyFilename(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -941,7 +943,7 @@ func TestParseFilename_EmptyFilename(t *testing.T) {
 
 // TestParseFilename_VeryLongFilename tests parsing a very long filename
 func TestParseFilename_VeryLongFilename(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -988,7 +990,7 @@ func TestParseFilename_Integration(t *testing.T) {
 		t.Skip("Skipping integration test: OPENAI_API_KEY not set")
 	}
 
-	parser := NewOpenAIParser(apiKey, true)
+	parser := NewOpenAIParser(nil, apiKey, true)
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -1044,7 +1046,7 @@ func TestParseBatch_Integration(t *testing.T) {
 		t.Skip("Skipping integration test: OPENAI_API_KEY not set")
 	}
 
-	parser := NewOpenAIParser(apiKey, true)
+	parser := NewOpenAIParser(nil, apiKey, true)
 	ctx := context.Background()
 
 	filenames := []string{
@@ -1092,7 +1094,7 @@ func TestTestConnection_Integration(t *testing.T) {
 		t.Skip("Skipping integration test: OPENAI_API_KEY not set")
 	}
 
-	parser := NewOpenAIParser(apiKey, true)
+	parser := NewOpenAIParser(nil, apiKey, true)
 	ctx := context.Background()
 
 	err := parser.TestConnection(ctx)
@@ -1253,10 +1255,10 @@ func TestOpenAIParser_DefaultValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			parser := NewOpenAIParser(tc.apiKey, tc.enabled)
+			parser := NewOpenAIParser(nil, tc.apiKey, tc.enabled)
 
-			if tc.wantModel != "" && parser.model != tc.wantModel {
-				t.Errorf("Expected model '%s', got '%s'", tc.wantModel, parser.model)
+			if tc.wantModel != "" && parser.filenameParseModel() != tc.wantModel {
+				t.Errorf("Expected model '%s', got '%s'", tc.wantModel, parser.filenameParseModel())
 			}
 			if tc.wantRetry != 0 && parser.maxRetries != tc.wantRetry {
 				t.Errorf("Expected maxRetries %d, got %d", tc.wantRetry, parser.maxRetries)
@@ -1314,7 +1316,7 @@ func TestParsedMetadata_CompletenessCoverage(t *testing.T) {
 
 // TestParseBatch_NilFilenames tests nil slice handling
 func TestParseBatch_NilFilenames(t *testing.T) {
-	parser := NewOpenAIParser("test-key", true)
+	parser := NewOpenAIParser(nil, "test-key", true)
 	ctx := context.Background()
 
 	// nil slice should be handled like empty slice
@@ -1539,7 +1541,7 @@ func TestParseBatchMetadataFromJSON_ErrorWrapping(t *testing.T) {
 // --- ParseAudiobook tests ---
 
 func TestParseAudiobook_Disabled(t *testing.T) {
-	parser := NewOpenAIParser("", false)
+	parser := NewOpenAIParser(nil, "", false)
 	ctx := context.Background()
 
 	_, err := parser.ParseAudiobook(ctx, AudiobookContext{FilePath: "/test/path.mp3"})
@@ -1580,7 +1582,7 @@ func TestParseAudiobook_WithFakeServer(t *testing.T) {
 	os.Setenv("OPENAI_BASE_URL", server.URL)
 	defer os.Unsetenv("OPENAI_BASE_URL")
 
-	parser := NewOpenAIParser("fake-key", true)
+	parser := NewOpenAIParser(nil, "fake-key", true)
 	ctx := context.Background()
 
 	abCtx := AudiobookContext{
@@ -1653,7 +1655,7 @@ func TestParseAudiobook_MinimalContext(t *testing.T) {
 	os.Setenv("OPENAI_BASE_URL", server.URL)
 	defer os.Unsetenv("OPENAI_BASE_URL")
 
-	parser := NewOpenAIParser("fake-key", true)
+	parser := NewOpenAIParser(nil, "fake-key", true)
 	ctx := context.Background()
 
 	abCtx := AudiobookContext{
@@ -1678,6 +1680,115 @@ func TestParseAudiobook_MinimalContext(t *testing.T) {
 	}
 	if strings.Contains(capturedBody, "File count") {
 		t.Error("Prompt should not contain 'File count' when file count is 0")
+	}
+}
+
+// TestOpenAIParser_UsesConfiguredModels verifies that each Parse* method sends
+// the model string from the corresponding config field to the OpenAI API.
+func TestOpenAIParser_UsesConfiguredModels(t *testing.T) {
+	// Minimal JSON response accepted by all Parse* methods
+	successResponse := `{
+		"id": "chatcmpl-test",
+		"object": "chat.completion",
+		"model": "test-model",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "{\"title\":\"T\",\"author\":\"A\",\"confidence\":\"high\"}"},
+			"finish_reason": "stop"
+		}]
+	}`
+
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		invoke        func(p *OpenAIParser, srv *httptest.Server) error
+		wantModelFrag string
+	}{
+		{
+			name: "ParseFilename uses FilenameParseModel",
+			cfg:  &config.Config{FilenameParseModel: "test-filename-model"},
+			invoke: func(p *OpenAIParser, _ *httptest.Server) error {
+				_, err := p.ParseFilename(context.Background(), "MyBook.mp3")
+				return err
+			},
+			wantModelFrag: "test-filename-model",
+		},
+		{
+			name: "ParseBatch uses FilenameParseModel",
+			cfg:  &config.Config{FilenameParseModel: "test-batch-model"},
+			invoke: func(p *OpenAIParser, _ *httptest.Server) error {
+				batchResp := `{"results":[{"title":"T","author":"A","confidence":"high"}]}`
+				_ = batchResp // the mock returns successResponse which parseBatch accepts
+				_, err := p.ParseBatch(context.Background(), []string{"file1.mp3"})
+				return err
+			},
+			wantModelFrag: "test-batch-model",
+		},
+		{
+			name: "ParseCoverArt uses CoverArtModel",
+			cfg:  &config.Config{CoverArtModel: "test-cover-model"},
+			invoke: func(p *OpenAIParser, _ *httptest.Server) error {
+				_, err := p.ParseCoverArt(context.Background(), []byte{0xFF, 0xD8}, "image/jpeg")
+				return err
+			},
+			wantModelFrag: "test-cover-model",
+		},
+		{
+			name: "ReviewAuthorDuplicates uses MetadataReviewModel",
+			cfg:  &config.Config{MetadataReviewModel: "test-metadata-model"},
+			invoke: func(p *OpenAIParser, _ *httptest.Server) error {
+				// ReviewAuthorDuplicates expects {"suggestions":[...]}
+				// We override the mock per subtest below.
+				_, err := p.ReviewAuthorDuplicates(context.Background(), []AuthorDedupInput{
+					{Index: 0, CanonicalName: "Test Author", BookCount: 1},
+				})
+				return err
+			},
+			wantModelFrag: "test-metadata-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedModel string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				var req struct {
+					Model    string                   `json:"model"`
+					Messages []map[string]interface{} `json:"messages"`
+				}
+				_ = json.Unmarshal(body, &req)
+				capturedModel = req.Model
+
+				// Select response body based on request content
+				resp := successResponse
+				bodyStr := string(body)
+				switch {
+				case strings.Contains(bodyStr, "Review these") || strings.Contains(bodyStr, "Find duplicate"):
+					// ReviewAuthorDuplicates / DiscoverAuthorDuplicates
+					resp = `{"id":"chatcmpl-test","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"{\"suggestions\":[]}"},"finish_reason":"stop"}]}`
+				case strings.Contains(bodyStr, "Parse these audiobook filenames"):
+					// ParseBatch — needs {"results":[...]}
+					resp = `{"id":"chatcmpl-test","object":"chat.completion","model":"test","choices":[{"index":0,"message":{"role":"assistant","content":"{\"results\":[{\"title\":\"T\",\"author\":\"A\",\"confidence\":\"high\"}]}"},"finish_reason":"stop"}]}`
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(resp))
+			}))
+			defer srv.Close()
+
+			t.Setenv("OPENAI_BASE_URL", srv.URL)
+
+			p := NewOpenAIParser(tt.cfg, "test-api-key", true)
+			if err := tt.invoke(p, srv); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if capturedModel != tt.wantModelFrag {
+				t.Errorf("model sent to API = %q, want %q", capturedModel, tt.wantModelFrag)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.44.0
+// version: 1.45.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-05-01
 
@@ -131,6 +131,13 @@ type Config struct {
 	// AI-powered parsing
 	EnableAIParsing bool   `json:"enable_ai_parsing"`
 	OpenAIAPIKey    string `json:"openai_api_key"`
+
+	// Per-feature OpenAI model selection. Default to gpt-5-mini for all four
+	// to preserve historical behavior. See spec docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md.
+	DedupReviewModel    string `json:"dedup_review_model"    mapstructure:"dedup_review_model"`
+	MetadataReviewModel string `json:"metadata_review_model" mapstructure:"metadata_review_model"`
+	FilenameParseModel  string `json:"filename_parse_model"  mapstructure:"filename_parse_model"`
+	CoverArtModel       string `json:"cover_art_model"       mapstructure:"cover_art_model"`
 
 	// Performance
 	ConcurrentScans int `json:"concurrent_scans"`
@@ -380,6 +387,12 @@ func InitConfig() {
 	viper.SetDefault("enable_ai_parsing", true)
 	viper.SetDefault("openai_api_key", "")
 
+	// Per-feature model defaults — gpt-5-mini preserves historical behavior
+	viper.SetDefault("dedup_review_model", "gpt-5-mini")
+	viper.SetDefault("metadata_review_model", "gpt-5-mini")
+	viper.SetDefault("filename_parse_model", "gpt-5-mini")
+	viper.SetDefault("cover_art_model", "gpt-5-mini")
+
 	// Set performance defaults — scale with available CPUs
 	defaultWorkers := runtime.NumCPU()
 	if defaultWorkers < 4 {
@@ -549,8 +562,12 @@ func InitConfig() {
 		GoogleBooksAPIKey: viper.GetString("google_books_api_key"),
 
 		// AI parsing
-		EnableAIParsing: viper.GetBool("enable_ai_parsing"),
-		OpenAIAPIKey:    viper.GetString("openai_api_key"),
+		EnableAIParsing:     viper.GetBool("enable_ai_parsing"),
+		OpenAIAPIKey:        viper.GetString("openai_api_key"),
+		DedupReviewModel:    viper.GetString("dedup_review_model"),
+		MetadataReviewModel: viper.GetString("metadata_review_model"),
+		FilenameParseModel:  viper.GetString("filename_parse_model"),
+		CoverArtModel:       viper.GetString("cover_art_model"),
 
 		// Performance
 		ConcurrentScans:                  viper.GetInt("concurrent_scans"),
@@ -939,8 +956,12 @@ func ResetToDefaults() {
 		OpenLibraryDumpDir:     "",
 
 		// AI parsing
-		EnableAIParsing: true,
-		OpenAIAPIKey:    "",
+		EnableAIParsing:     true,
+		OpenAIAPIKey:        "",
+		DedupReviewModel:    "gpt-5-mini",
+		MetadataReviewModel: "gpt-5-mini",
+		FilenameParseModel:  "gpt-5-mini",
+		CoverArtModel:       "gpt-5-mini",
 
 		// Performance
 		ConcurrentScans:         max(runtime.NumCPU(), 4),

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-05-04
 
@@ -1564,7 +1564,11 @@ func (de *Engine) RunLLMReview(ctx context.Context) error {
 		Store:  de.aiJobsStore,
 		Client: &ai.AIJobsBatchClient{Parser: de.llmParser},
 	}
-	jobID, err := ai.SubmitDedupReviewJob(ctx, deps, "gpt-5-mini", inputs, byIndexIDs)
+	model := config.AppConfig.DedupReviewModel // per-feature model knob (AI-MODEL-1)
+	if model == "" {
+		model = "gpt-5-mini"
+	}
+	jobID, err := ai.SubmitDedupReviewJob(ctx, deps, model, inputs, byIndexIDs)
 	if err != nil {
 		return fmt.Errorf("submit dedup review job: %w", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scanner.go
-// version: 1.39.0
+// version: 1.40.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-05-02
 
@@ -320,7 +320,7 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 		if config.AppConfig.OpenAIAPIKey == "" {
 			scanLog.Warn("AI parsing enabled but OpenAI API key is not configured")
 		} else {
-			aiParser = ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, true)
+			aiParser = ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, true)
 			if aiParser != nil && aiParser.IsEnabled() {
 				aiEnabled = true
 				scanLog.Debug("OpenAI parser initialized for filename metadata fallback")

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_handlers.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 5d3a6a95-4ac8-42c2-a7fe-5ff4857dd31a
 //
 // AI-related HTTP handlers split out of server.go: filename parsing,
@@ -42,7 +42,7 @@ func (s *Server) parseFilenameWithAI(c *gin.Context) {
 	}
 
 	// Create AI parser
-	parser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
+	parser := ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 	if !parser.IsEnabled() {
 		httputil.RespondWithBadRequest(c, "AI parsing is not enabled or API key not configured")
 		return
@@ -77,7 +77,7 @@ func (s *Server) testAIConnection(c *gin.Context) {
 	}
 
 	// Create parser with the provided/configured API key
-	parser := ai.NewOpenAIParser(apiKey, true)
+	parser := ai.NewOpenAIParser(&config.AppConfig, apiKey, true)
 	if err := parser.TestConnection(c.Request.Context()); err != nil {
 		log.Printf("[ERROR] connection test failed: %v", err)
 		httputil.RespondWithInternalError(c, "connection test failed")

--- a/internal/server/scheduler_tasks.go
+++ b/internal/server/scheduler_tasks.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler_tasks.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4ed1afbd-7c63-487a-9a53-3b1b05eb06ee
 // last-edited: 2026-05-02
 
@@ -867,7 +867,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 				return nil, fmt.Errorf("failed to create operation: %w", err)
 			}
 			if err := ts.server.queue.Enqueue(op.ID, "ai-dedup-batch", operations.PriorityLow, func(ctx context.Context, progress operations.ProgressReporter) error {
-				parser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
+				parser := ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 				if !parser.IsEnabled() {
 					return fmt.Errorf("AI parsing is not enabled")
 				}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-05-01
 
@@ -79,7 +79,7 @@ type aiParser interface {
 }
 
 var newAIParser = func(apiKey string, enabled bool) aiParser {
-	return ai.NewOpenAIParser(apiKey, enabled)
+	return ai.NewOpenAIParser(&config.AppConfig, apiKey, enabled)
 }
 
 // enrichedBookResponse wraps a Book with resolved names for JSON responses.
@@ -459,7 +459,7 @@ func NewServer(store database.Store) *Server {
 					WithCache(embeddingStore)
 				// Dedup Layer 3 uses a dedicated chat parser so it can call
 				// OpenAIParser.ReviewDedupPairs during maintenance runs.
-				llmParser := ai.NewOpenAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
+				llmParser := ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
 				server.dedupEngine = dedup.NewEngine(
 					embeddingStore,
 					database.GetGlobalStore(),


### PR DESCRIPTION
## Summary

- Adds `DedupReviewModel`, `MetadataReviewModel`, `FilenameParseModel`, `CoverArtModel` to `config.Config` (all default `gpt-5-mini`, preserves existing behavior)
- `NewOpenAIParser` now accepts `*config.Config` as first arg; `nil` falls back to `defaultModel` constant; all 5 production callsites updated
- Replaces every hardcoded `"gpt-5-mini"` in `openai_parser.go`, `openai_batch.go`, `metadata_llm_review.go`, and `dedup/engine.go` with the appropriate config getter
- `TestOpenAIParser_UsesConfiguredModels` (4 subtests) asserts each `Parse*` path sends the correct model string to the API

Spec: `docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/ai/... ./internal/config/... ./internal/dedup/... ./internal/server/... ./internal/scanner/...` — clean
- [x] `go test ./internal/ai/... ./internal/config/...` — all pass (57s for AI package)
- [x] `TestOpenAIParser_UsesConfiguredModels` — 4/4 subtests pass
- [ ] `make ci` — run on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)