### PR TITLE
fix(relink): normalize colon to underscore in iTunes title comparison

### DIFF
--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package jobs
 
@@ -184,6 +184,18 @@ func rmt_updateBookFiles(store database.Store, bookID, newFP string, fi os.FileI
 	}
 }
 
+// normalizeForFilename normalizes a string for iTunes/macOS filename comparison.
+// macOS HFS+ and iTunes replace ": " and ":" with "_ " and "_" respectively
+// because colons are illegal in filenames. This function applies the same
+// transformation so that "Mistborn: The Final Empire" matches the file
+// "Mistborn_ The Final Empire.m4b".
+func normalizeForFilename(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, ": ", "_ ")
+	s = strings.ReplaceAll(s, ":", "_")
+	return strings.TrimSpace(s)
+}
+
 // rmt_findInITunes searches iTunesRoot for iTunes album directories matching author+title.
 func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string]bool) []string {
 	iTunesRoot = filepath.Clean(iTunesRoot)
@@ -191,7 +203,8 @@ func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string
 	if len(titlePrefix) > 25 {
 		titlePrefix = titlePrefix[:25]
 	}
-	titlePrefixLower := strings.ToLower(titlePrefix)
+	// Normalize for macOS/iTunes filename encoding: ":" → "_", ": " → "_ "
+	titlePrefixLower := normalizeForFilename(titlePrefix)
 
 	authorWord := authorName
 	if idx := strings.Index(authorName, " "); idx > 0 {
@@ -221,7 +234,7 @@ func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string
 		for _, album := range albumEntries {
 			albumPath := filepath.Join(authorDir, album.Name())
 			if album.IsDir() {
-				if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+				if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
 					dirMatches[albumPath] = struct{}{}
 					continue
 				}
@@ -232,7 +245,7 @@ func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string
 					if !audioExts[strings.ToLower(filepath.Ext(path))] {
 						return nil
 					}
-					if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+					if strings.Contains(normalizeForFilename(filepath.Base(path)), titlePrefixLower) {
 						dirMatches[albumPath] = struct{}{}
 						return filepath.SkipDir
 					}
@@ -242,7 +255,7 @@ func rmt_findInITunes(iTunesRoot, authorName, title string, audioExts map[string
 				if !audioExts[strings.ToLower(filepath.Ext(albumPath))] {
 					continue
 				}
-				if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+				if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
 					dirMatches[albumPath] = struct{}{}
 				}
 			}

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-05-01
+// last-edited: 2026-05-05
 
 package jobs
 
@@ -123,7 +123,8 @@ titlePrefix := title
 if len(titlePrefix) > 25 {
 titlePrefix = titlePrefix[:25]
 }
-titlePrefixLower := strings.ToLower(titlePrefix)
+// Normalize for macOS/iTunes filename encoding: ":" → "_", ": " → "_ "
+titlePrefixLower := normalizeForFilename(titlePrefix)
 authorWord := authorName
 if idx := strings.Index(authorName, " "); idx > 0 {
 authorWord = authorName[:idx]
@@ -151,7 +152,7 @@ continue
 for _, album := range albumEntries {
 albumPath := filepath.Join(authorDir, album.Name())
 if album.IsDir() {
-if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
 dirMatches[albumPath] = struct{}{}
 continue
 }
@@ -162,7 +163,7 @@ return nil
 if !rrAudioExts[strings.ToLower(filepath.Ext(path))] {
 return nil
 }
-if strings.Contains(strings.ToLower(filepath.Base(path)), titlePrefixLower) {
+if strings.Contains(normalizeForFilename(filepath.Base(path)), titlePrefixLower) {
 dirMatches[albumPath] = struct{}{}
 return filepath.SkipDir
 }
@@ -172,7 +173,7 @@ return nil
 if !rrAudioExts[strings.ToLower(filepath.Ext(albumPath))] {
 continue
 }
-if strings.Contains(strings.ToLower(album.Name()), titlePrefixLower) {
+if strings.Contains(normalizeForFilename(album.Name()), titlePrefixLower) {
 dirMatches[albumPath] = struct{}{}
 }
 }

--- a/internal/maintenance/jobs/relink_title_normalization_test.go
+++ b/internal/maintenance/jobs/relink_title_normalization_test.go
@@ -1,0 +1,59 @@
+// file: internal/maintenance/jobs/relink_title_normalization_test.go
+// version: 1.0.0
+// guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+// last-edited: 2026-05-05
+
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeForFilename(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"Mistborn: The Final Empire", "mistborn_ the final empire"},
+		{"Mistborn:The Final Empire", "mistborn_the final empire"},
+		{"The Name of the Wind", "the name of the wind"},
+		{"SHOGUN", "shogun"},
+		{"  Leading Space  ", "leading space"},
+		{"A: B: C", "a_ b_ c"},
+	}
+	for _, tc := range cases {
+		got := normalizeForFilename(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeForFilename(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestFindInITunes_ColonTitleMatchesUnderscoreFilename(t *testing.T) {
+	// Build fake iTunes root:
+	//   <root>/Brandon Sanderson/Mistborn_ The Final Empire.m4b
+	iTunesRoot := t.TempDir()
+	authorDir := filepath.Join(iTunesRoot, "Brandon Sanderson")
+	if err := os.MkdirAll(authorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fname := "Mistborn_ The Final Empire.m4b"
+	if err := os.WriteFile(filepath.Join(authorDir, fname), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	audioExts := map[string]bool{".mp3": true, ".m4b": true, ".m4a": true, ".flac": true, ".opus": true, ".ogg": true}
+
+	// The book's title has a colon; the file has an underscore.
+	results := rmt_findInITunes(iTunesRoot, "Brandon Sanderson", "Mistborn: The Final Empire", audioExts)
+
+	if len(results) == 0 {
+		t.Fatalf("expected a match for colon-title vs underscore-filename, got none")
+	}
+	if !strings.Contains(results[0], "Mistborn_") && !strings.Contains(results[0], "Brandon Sanderson") {
+		t.Errorf("unexpected match path: %v", results)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `normalizeForFilename(s string) string` helper (lowercases, `: ` → `_ `, `:` → `_`) as a package-level function in `internal/maintenance/jobs/relink_missing_to_itunes.go`
- Applies normalization to both the search title prefix and every filename/dirname candidate in `rmt_findInITunes` (relink job) and `rrFindInITunes` (relink report)
- Leaves `rmt_disambiguate` / `rrDisambiguate` unchanged (they already normalize `_` → ` ` on both sides internally)

## Test plan
- [x] `go test ./internal/maintenance/jobs/...` passes
- [x] `TestNormalizeForFilename` all 6 cases pass
- [x] `TestFindInITunes_ColonTitleMatchesUnderscoreFilename` passes
- [ ] Verified on production: relink "Mistborn: The Final Empire" finds correct iTunes file

🤖 Generated with [Claude Code](https://claude.com/claude-code)