### PR TITLE
feat(deluge): wire move_storage into centralization path (TODO 3.1-deluge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 2.44.6 -->
+<!-- version: 2.44.5 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-05 -->
 
@@ -61,6 +62,17 @@ a cheaper or more capable model independently. Tests assert each `Parse*`
 path on `OpenAIParser` sends the correct model string from config.
 
 Spec: `docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md`
+#### May 5, 2026 — TODO 3.1-deluge: wire move_storage into centralization path
+
+- **feat(deluge)**: `internal/server/deluge_integration.go` — `NotifyDelugeAfterOrganize`
+  tells Deluge to follow a book that was just moved into the library by the organize
+  pipeline. Gated by `DelugeMoveEnabled`; skipped when the active BookVersion has no
+  `TorrentHash`. Best-effort: Deluge errors are logged and do not fail the organize.
+- **feat(server)**: `internal/server/organize_handlers.go` — `organizeBook` handler calls
+  `NotifyDelugeAfterOrganize` after a successful version-aware organize move so that torrent
+  clients keep seeding from the new library path.
+- **test(deluge)**: `internal/server/deluge_centralization_test.go` — 4 new tests covering
+  enabled/disabled/no-hash/error scenarios per spec (TODO 3.1-deluge).
 
 ### Tests
 

--- a/TODO.md
+++ b/TODO.md
@@ -842,6 +842,8 @@ Every plan in chronological order. ✅ = implemented, ⏳ = design done, plan wr
 - [x] [2026-04-10 Metadata candidate scoring PR2](docs/superpowers/plans/2026-04-10-metadata-candidate-scoring-pr2.md)
 - ⏳ [2026-04-15 Library centralization](docs/superpowers/plans/2026-04-15-library-centralization.md) — tasks 1-9 done (deluge integration deferred)
 - [x] [2026-04-15 Bulk organize undo](docs/superpowers/plans/2026-04-15-bulk-organize-undo.md) — complete (tasks 1-6 + torrent move_storage PR)
+- [x] [2026-04-15 Library centralization](docs/superpowers/plans/2026-04-15-library-centralization.md) — all tasks done including deluge integration (PR feat/deluge-centralization)
+- ⏳ [2026-04-15 Bulk organize undo](docs/superpowers/plans/2026-04-15-bulk-organize-undo.md) — tasks 1-6 done (torrent move_storage deferred)
 - [x] [2026-04-15 Smart + static playlists](docs/superpowers/plans/2026-04-15-smart-and-static-playlists.md) — complete (9/9 tasks)
 - [x] [2026-04-15 Read/unread tracking](docs/superpowers/plans/2026-04-15-read-unread-tracking.md) — complete (8/8 tasks)
 - [x] [2026-04-15 Multi-user support](docs/superpowers/plans/2026-04-15-multi-user-support.md) — complete (8/8, OAuth deferred)

--- a/internal/server/deluge_centralization_test.go
+++ b/internal/server/deluge_centralization_test.go
@@ -1,0 +1,198 @@
+// file: internal/server/deluge_centralization_test.go
+// version: 1.0.0
+// guid: 3b7c4d2a-1e5f-4870-b8c5-9f0e1d2c3a4b
+// last-edited: 2026-05-05
+//
+// Tests for NotifyDelugeAfterOrganize: the integration between the
+// library centralization (organize) pipeline and Deluge's move_storage.
+//
+// These tests verify the four spec-required scenarios:
+//  1. Enabled + TorrentHash → MoveStorage is called
+//  2. Disabled + TorrentHash → MoveStorage is NOT called
+//  3. Enabled + empty TorrentHash → MoveStorage is NOT called
+//  4. MoveStorage error → centralization still succeeds (best-effort)
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
+)
+
+// mockDelugeServer spins up a minimal JSON-RPC stub for Deluge.
+// It counts core.move_storage calls and can be configured to return
+// an error response for that method.
+type mockDelugeServer struct {
+	moveStorageCalls atomic.Int32
+	returnError      bool
+	server           *httptest.Server
+}
+
+func newMockDelugeServer(t *testing.T, returnError bool) *mockDelugeServer {
+	t.Helper()
+	m := &mockDelugeServer{returnError: returnError}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string        `json:"method"`
+			Params []interface{} `json:"params"`
+			ID     int64         `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		switch req.Method {
+		case "auth.login":
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": req.ID, "result": true})
+		case "core.move_storage":
+			m.moveStorageCalls.Add(1)
+			if m.returnError {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":    req.ID,
+					"error": map[string]interface{}{"code": -1, "message": "deluge offline"},
+				})
+			} else {
+				json.NewEncoder(w).Encode(map[string]interface{}{"id": req.ID, "result": nil})
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+// wireMockDeluge points the global Deluge client at mock and enables
+// DelugeMoveEnabled. Returns a cleanup function.
+func wireMockDeluge(t *testing.T, mock *mockDelugeServer) {
+	t.Helper()
+	client, err := deluge.New(mock.server.URL, "deluge")
+	if err != nil {
+		t.Fatalf("create mock deluge client: %v", err)
+	}
+
+	origClient := globalDelugeClient
+	origURL := config.AppConfig.DelugeWebURL
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeWebURL = mock.server.URL
+	config.AppConfig.DelugeMoveEnabled = true
+	t.Cleanup(func() {
+		globalDelugeClient = origClient
+		config.AppConfig.DelugeWebURL = origURL
+		config.AppConfig.DelugeMoveEnabled = origMove
+	})
+}
+
+// newTestStoreWithVersion creates a PebbleStore, inserts a book and an
+// active BookVersion with the given torrentHash, and returns the store.
+func newTestStoreWithVersion(t *testing.T, bookID, torrentHash string) *database.PebbleStore {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	_, err = store.CreateBook(&database.Book{
+		ID:       bookID,
+		Title:    "Test Book",
+		FilePath: "/old/path/book.m4b",
+	})
+	if err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+	_, err = store.CreateBookVersion(&database.BookVersion{
+		BookID:      bookID,
+		Status:      database.BookVersionStatusActive,
+		Format:      "m4b",
+		Source:      "deluge",
+		TorrentHash: torrentHash,
+	})
+	if err != nil {
+		t.Fatalf("create book version: %v", err)
+	}
+	return store
+}
+
+// TestNotifyDelugeAfterOrganize_CallsMoveStorage verifies that when
+// DelugeMoveEnabled=true and the active BookVersion has a TorrentHash,
+// NotifyDelugeAfterOrganize calls core.move_storage exactly once.
+func TestNotifyDelugeAfterOrganize_CallsMoveStorage(t *testing.T) {
+	mock := newMockDelugeServer(t, false)
+	wireMockDeluge(t, mock)
+
+	store := newTestStoreWithVersion(t, "book1", "abc123deadbeef")
+	NotifyDelugeAfterOrganize(store, "book1", "/new/library/path/book.m4b")
+
+	if got := mock.moveStorageCalls.Load(); got != 1 {
+		t.Errorf("expected 1 move_storage call, got %d", got)
+	}
+}
+
+// TestNotifyDelugeAfterOrganize_SkipsWhenDisabled verifies that when
+// DelugeMoveEnabled=false, MoveStorage is never called even if a
+// TorrentHash is present.
+func TestNotifyDelugeAfterOrganize_SkipsWhenDisabled(t *testing.T) {
+	mock := newMockDelugeServer(t, false)
+	// Wire the client but override DelugeMoveEnabled to false.
+	client, err := deluge.New(mock.server.URL, "deluge")
+	if err != nil {
+		t.Fatalf("create mock deluge client: %v", err)
+	}
+	origClient := globalDelugeClient
+	origMove := config.AppConfig.DelugeMoveEnabled
+	globalDelugeClient = client
+	config.AppConfig.DelugeMoveEnabled = false
+	t.Cleanup(func() {
+		globalDelugeClient = origClient
+		config.AppConfig.DelugeMoveEnabled = origMove
+	})
+
+	store := newTestStoreWithVersion(t, "book2", "abc123deadbeef")
+	NotifyDelugeAfterOrganize(store, "book2", "/new/library/path/book.m4b")
+
+	if got := mock.moveStorageCalls.Load(); got != 0 {
+		t.Errorf("expected 0 move_storage calls when disabled, got %d", got)
+	}
+}
+
+// TestNotifyDelugeAfterOrganize_SkipsWhenNoTorrentHash verifies that
+// when the active BookVersion has an empty TorrentHash, MoveStorage is
+// not called (the book was not torrent-sourced).
+func TestNotifyDelugeAfterOrganize_SkipsWhenNoTorrentHash(t *testing.T) {
+	mock := newMockDelugeServer(t, false)
+	wireMockDeluge(t, mock)
+
+	store := newTestStoreWithVersion(t, "book3", "") // empty hash
+	NotifyDelugeAfterOrganize(store, "book3", "/new/library/path/book.m4b")
+
+	if got := mock.moveStorageCalls.Load(); got != 0 {
+		t.Errorf("expected 0 move_storage calls for non-torrent book, got %d", got)
+	}
+}
+
+// TestNotifyDelugeAfterOrganize_DelugeErrorIsBestEffort verifies that
+// a MoveStorage error from Deluge does NOT cause NotifyDelugeAfterOrganize
+// to return an error — the call is best-effort and the organize already
+// succeeded when this function is invoked.
+func TestNotifyDelugeAfterOrganize_DelugeErrorIsBestEffort(t *testing.T) {
+	mock := newMockDelugeServer(t, true) // configured to return error
+	wireMockDeluge(t, mock)
+
+	store := newTestStoreWithVersion(t, "book4", "abc123deadbeef")
+
+	// Must not panic. NotifyDelugeAfterOrganize has no return value by
+	// design — errors are logged but never surfaced to the caller.
+	NotifyDelugeAfterOrganize(store, "book4", "/new/library/path/book.m4b")
+
+	// The call was still attempted (error came from Deluge, not a skip).
+	if got := mock.moveStorageCalls.Load(); got != 1 {
+		t.Errorf("expected 1 move_storage attempt even on error, got %d", got)
+	}
+}

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -196,6 +196,32 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 	protected.POST("/discovery/import", s.perm("settings.manage"), s.handleDiscoveryImport)
 }
 
+// NotifyDelugeAfterOrganize tells Deluge to follow a book that was
+// just moved into the library by the organize pipeline.
+//
+// Called after the file move succeeds and the Book record has been
+// updated to point at newPath. It looks up the active BookVersion(s)
+// for the book; for each with a non-empty TorrentHash it calls
+// NotifyDelugeMoveStorage so the torrent client keeps seeding from
+// the new location.
+//
+// Best-effort: errors are logged but do not bubble up — the organize
+// operation already succeeded.
+func NotifyDelugeAfterOrganize(store interface {
+	database.BookVersionStore
+}, bookID, newPath string) {
+	versions, err := store.GetBookVersionsByBookID(bookID)
+	if err != nil {
+		log.Printf("[WARN] deluge-organize: failed to load versions for book %s: %v", bookID, err)
+		return
+	}
+	for _, v := range versions {
+		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
+			NotifyDelugeMoveStorage(v.TorrentHash, newPath)
+		}
+	}
+}
+
 // NotifyDelugeAfterUndo checks whether the reverted operation moved
 // Deluge-sourced files and updates the torrent storage path.
 //

--- a/internal/server/organize_handlers.go
+++ b/internal/server/organize_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/organize_handlers.go
-// version: 2.2.0
-// last-edited: 2026-05-10
+// version: 2.3.0
+// last-edited: 2026-05-05
 // guid: 1522f0ec-663c-4527-a6d0-645658206a24
 //
 // Organize/rename HTTP handlers split out of server.go: preview/apply
@@ -243,6 +243,11 @@ func (s *Server) organizeBook(c *gin.Context) {
 	if _, updateErr := s.Store().UpdateBook(createdBook.ID, createdBook); updateErr != nil {
 		log.Printf("[WARN] organize: failed to stamp organized book %s: %v", createdBook.ID, updateErr)
 	}
+
+	// Notify Deluge that the file moved so the torrent client keeps
+	// seeding from the new library path. Best-effort — errors are logged
+	// inside NotifyDelugeAfterOrganize; the organize itself already succeeded.
+	NotifyDelugeAfterOrganize(s.Store(), book.ID, newPath)
 
 	s.publishEvent(c.Request.Context(), plugin.NewEvent(plugin.EventFileOrganized, createdBook.ID, map[string]any{
 		"old_path":         oldPath,


### PR DESCRIPTION
## Summary

- Adds `NotifyDelugeAfterOrganize` to `internal/server/deluge_integration.go` — after the organize pipeline moves a torrent-sourced book into the library, this helper looks up the active `BookVersion` by `bookID` and calls `NotifyDelugeMoveStorage` for any version with a non-empty `TorrentHash`
- Wires the call into `organizeBook` handler (`organize_handlers.go`) after a successful version-aware move (the `!alreadyInRoot` path)
- Gated by `DelugeMoveEnabled` config flag (default false); best-effort — Deluge errors are logged but never bubble up
- 4 new tests in `deluge_centralization_test.go`: enabled/disabled/no-hash/error scenarios per spec

Closes TODO 3.1-deluge.

Spec: `docs/superpowers/specs/2026-04-27-deluge-move-storage-integration-design.md`
Bot-task: `docs/superpowers/bot-tasks/2026-04-27-deluge-centralization.md`

## Test plan

- [x] `TestNotifyDelugeAfterOrganize_CallsMoveStorage` — MoveStorage called when enabled + hash present
- [x] `TestNotifyDelugeAfterOrganize_SkipsWhenDisabled` — MoveStorage not called when `DelugeMoveEnabled=false`
- [x] `TestNotifyDelugeAfterOrganize_SkipsWhenNoTorrentHash` — MoveStorage not called for non-torrent books
- [x] `TestNotifyDelugeAfterOrganize_DelugeErrorIsBestEffort` — Deluge RPC error does not surface; organize succeeds
- [x] `go build ./...` clean
- [x] `go vet ./internal/server/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)