### PR TITLE
perf(scanner): replace filepath.Walk with filepath.WalkDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ## [Unreleased]
 
+### Performance
+
+#### May 5, 2026 — SCAN-1: Replace filepath.Walk with filepath.WalkDir in scanner
+
+- **perf(scanner)**: `countFilesAcrossFolders` now uses `filepath.WalkDir`
+  instead of `filepath.Walk`. `filepath.WalkDir` passes `fs.DirEntry` to the
+  callback, avoiding an extra `os.Stat` syscall per file. On large libraries
+  (10k+ files) this reduces syscall overhead noticeably.
+
 ### Features
 
 #### May 5, 2026 — ASYNC-W2-2: cleanup-empty-folders as MaintenanceJob

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.10.0 -->
+<!-- version: 8.11.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-05 -->
 
@@ -299,7 +299,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 
 ### SCAN — Scanner Efficiency (1 task)
 
-- [ ] **SCAN-1** `perf/scanner-walkdir` — Replace filepath.Walk with filepath.WalkDir
+- [x] **SCAN-1** `perf/scanner-walkdir` — Replace filepath.Walk with filepath.WalkDir
   → [`2026-04-30-scan-1-walkdir.md`](docs/superpowers/bot-tasks/2026-04-30-scan-1-walkdir.md)
 
 ### SRV — Server Response Optimization (2 tasks)

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,13 +1,13 @@
 // file: internal/scanner/service.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-05-05
-
 package scanner
 
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -224,8 +224,8 @@ func (ss *ScanService) countFilesAcrossFolders(foldersToScan []string, log logge
 			continue
 		}
 		fileCount := 0
-		_ = filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() {
+		_ = filepath.WalkDir(folderPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
 				return nil
 			}
 			ext := strings.ToLower(filepath.Ext(path))


### PR DESCRIPTION
## Summary

- Replaces `filepath.Walk` with `filepath.WalkDir` in `countFilesAcrossFolders` (`internal/scanner/service.go`)
- `filepath.WalkDir` passes `fs.DirEntry` to the callback, avoiding an extra `os.Stat` syscall per file
- On large libraries (10k+ files) this reduces syscall overhead noticeably
- No change to which files are included/excluded; scan results are identical

## Test plan

- [x] `go vet ./internal/scanner/` — passes with no warnings
- [x] `go test ./internal/scanner/...` — all tests pass (17s)

## References

- Bot task: `docs/superpowers/bot-tasks/2026-04-30-scan-1-walkdir.md`
- TODO: SCAN-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)