### PR TITLE
feat(maintenance): convert recompute-itunes-paths to MaintenanceJob (ASYNC-W3-5)

### DIFF
--- a/internal/maintenance/jobs/cleanup_empty_folders_test.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders_test.go
@@ -1,8 +1,9 @@
 // file: internal/maintenance/jobs/cleanup_empty_folders_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e6f7a8b9-c0d1-2345-efab-678901234f01
 // last-edited: 2026-05-05
 
+// Shared test helpers (noopReporter, blank jobs import) live in testhelpers_test.go.
 package jobs_test
 
 import (
@@ -16,15 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// noopReporter satisfies maintenance.ProgressReporter with no-op implementations.
-type noopReporter struct {
-	logs []string
-}
-
-func (r *noopReporter) SetTotal(_ int)                              {}
-func (r *noopReporter) Increment()                                  {}
-func (r *noopReporter) Log(_ string, msg string, _ *string)         { r.logs = append(r.logs, msg) }
 
 func TestCleanupEmptyFoldersJob_Registered(t *testing.T) {
 	job, err := maintenance.Get("cleanup-empty-folders")

--- a/internal/maintenance/jobs/fix_author_narrator_swap_test.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap_test.go
@@ -3,6 +3,8 @@
 // guid: a7b8c9d0-e1f2-3456-abcd-789012345678
 // last-edited: 2026-05-05
 
+// Shared test helpers (noopReporter, assertJobRegistered, blank jobs import)
+// live in testhelpers_test.go.
 package jobs_test
 
 import (
@@ -14,14 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// assertJobRegistered verifies the job is present in the global registry.
-func assertJobRegistered(t *testing.T, id string) {
-	t.Helper()
-	j, err := maintenance.Get(id)
-	require.NoError(t, err, "job %q should be registered", id)
-	assert.Equal(t, id, j.ID())
-}
 
 func TestFixAuthorNarratorSwapJob_Registered(t *testing.T) {
 	assertJobRegistered(t, "fix-author-narrator-swap")

--- a/internal/maintenance/jobs/fix_read_by_narrator_test.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator_test.go
@@ -4,8 +4,8 @@
 // last-edited: 2026-05-05
 
 // Package jobs_test exercises the fix-read-by-narrator maintenance job.
-// Importing the jobs package (via the blank import below) triggers all
-// init() functions, registering every job with the maintenance registry.
+// Shared test helpers (noopReporter, assertJobRegistered, blank jobs import)
+// live in testhelpers_test.go.
 package jobs_test
 
 import (
@@ -14,7 +14,6 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-	_ "github.com/jdfalk/audiobook-organizer/internal/maintenance/jobs" // register all jobs
 )
 
 func TestFixReadByNarratorJob_Registered(t *testing.T) {

--- a/internal/maintenance/jobs/recompute_itunes_paths_test.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths_test.go
@@ -1,0 +1,152 @@
+// file: internal/maintenance/jobs/recompute_itunes_paths_test.go
+// version: 1.0.0
+// guid: b7c8d9e0-f1a2-3456-bcde-789012345012
+// last-edited: 2026-05-05
+
+// Package jobs_test exercises the recompute-itunes-paths maintenance job.
+// noopReporter and the blank jobs import are provided by fix_read_by_narrator_test.go.
+package jobs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+)
+
+func TestRecomputeItunesPathsJob_Registered(t *testing.T) {
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+	if j.ID() != "recompute-itunes-paths" {
+		t.Fatalf("unexpected ID: %q", j.ID())
+	}
+	if j.Name() == "" {
+		t.Fatal("Name() must not be empty")
+	}
+	if j.Description() == "" {
+		t.Fatal("Description() must not be empty")
+	}
+	if j.Category() == "" {
+		t.Fatal("Category() must not be empty")
+	}
+}
+
+func TestRecomputeItunesPathsJob_DefaultParams(t *testing.T) {
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+	params := j.DefaultParams()
+	if params == nil {
+		t.Fatal("DefaultParams() must not be nil")
+	}
+}
+
+func TestRecomputeItunesPathsJob_EmptyStore(t *testing.T) {
+	// No book files → no-op, no error.
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+			return []database.BookFile{}, nil
+		},
+	}
+
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+
+	if err = j.Run(context.Background(), store, &noopReporter{}, true); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+}
+
+func TestRecomputeItunesPathsJob_DryRunDoesNotUpdate(t *testing.T) {
+	// File with a mismatched itunes_path; in dry-run no UpdateBookFile should be called.
+	files := []database.BookFile{
+		{ID: "bf-1", BookID: "book-1", FilePath: "/books/author/title/chapter.mp3", ITunesPath: "/old/path.mp3"},
+	}
+
+	var updateCalled bool
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+			return files, nil
+		},
+		UpdateBookFileFunc: func(id string, file *database.BookFile) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+
+	if err = j.Run(context.Background(), store, &noopReporter{}, true /* dryRun */); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if updateCalled {
+		t.Fatal("dry_run=true: UpdateBookFile must not be called")
+	}
+}
+
+func TestRecomputeItunesPathsJob_SkipsAlreadyCorrect(t *testing.T) {
+	// When computed path == stored path, UpdateBookFile must not be called.
+	// Use an empty ITunesPath so ComputeITunesPath returns "" and both sides match.
+	files := []database.BookFile{
+		{ID: "bf-2", BookID: "book-2", FilePath: "/books/author/title/chapter.mp3", ITunesPath: ""},
+	}
+
+	var updateCalled bool
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+			return files, nil
+		},
+		UpdateBookFileFunc: func(id string, file *database.BookFile) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+
+	if err = j.Run(context.Background(), store, &noopReporter{}, false); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if updateCalled {
+		t.Fatal("itunes_path already correct: UpdateBookFile must not be called")
+	}
+}
+
+func TestRecomputeItunesPathsJob_CancelRespected(t *testing.T) {
+	files := make([]database.BookFile, 5)
+	for i := range files {
+		files[i] = database.BookFile{ID: "bf-cancel-" + string(rune('0'+i)), FilePath: "/books/b/c.mp3"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+			return files, nil
+		},
+	}
+
+	j, err := maintenance.Get("recompute-itunes-paths")
+	if err != nil {
+		t.Fatalf("job not registered: %v", err)
+	}
+
+	runErr := j.Run(ctx, store, &noopReporter{}, false)
+	// Must return context.Canceled or nil — must not panic or hang.
+	if runErr != nil && runErr != context.Canceled {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+}

--- a/internal/maintenance/jobs/testhelpers_test.go
+++ b/internal/maintenance/jobs/testhelpers_test.go
@@ -1,0 +1,39 @@
+// file: internal/maintenance/jobs/testhelpers_test.go
+// version: 1.0.0
+// guid: c8d9e0f1-a2b3-4567-cdef-890123456789
+// last-edited: 2026-05-05
+
+// Package jobs_test shared test helpers.
+// This file is the single source of truth for shared test helpers used by all
+// jobs_test files. Definitions here replace duplicate copies that previously
+// lived in fix_read_by_narrator_test.go, fix_author_narrator_swap_test.go, and
+// cleanup_empty_folders_test.go.
+package jobs_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/jdfalk/audiobook-organizer/internal/maintenance/jobs" // register all jobs
+)
+
+// noopReporter satisfies maintenance.ProgressReporter for test use.
+// The logs field captures log messages emitted by the job under test.
+type noopReporter struct {
+	logs []string
+}
+
+func (r *noopReporter) SetTotal(_ int)                      {}
+func (r *noopReporter) Increment()                          {}
+func (r *noopReporter) Log(_ string, msg string, _ *string) { r.logs = append(r.logs, msg) }
+
+// assertJobRegistered verifies the job is present in the global registry.
+func assertJobRegistered(t *testing.T, id string) {
+	t.Helper()
+	j, err := maintenance.Get(id)
+	require.NoError(t, err, "job %q should be registered", id)
+	assert.Equal(t, id, j.ID())
+}


### PR DESCRIPTION
## Summary

- `recompute-itunes-paths` job already existed in `internal/maintenance/jobs/` — adds the missing test coverage
- Adds `recompute_itunes_paths_test.go` with 6 tests: registration, default params, empty-store no-op, dry-run guard (no DB writes), already-correct skip, and context-cancellation
- Consolidates `noopReporter` / `assertJobRegistered` into a shared `testhelpers_test.go` to fix pre-existing redeclaration compile errors across 3 test files
- Adds `GetAllBookFilesFunc` field to `MockStore` so job tests can inject fixture data
- Reads iTunes data from DB (`book_files.itunes_path`) computed via `metafetch.ComputeITunesPath` — no remote Windows machine access at runtime
- Server.go blank import for jobs package already in place

## Test plan

- [x] `go test ./internal/maintenance/jobs/... -run TestRecomputeItunesPaths` — 6/6 pass
- [x] `go test ./internal/maintenance/jobs/...` — full suite passes (no regressions)
- [x] `go build ./...` — clean
- [x] `go vet ./internal/maintenance/jobs/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>