### PR TITLE
feat(maintenance): convert fix-library-states to MaintenanceJob

### DIFF
--- a/internal/maintenance/jobs/cleanup_organize_mess_test.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess_test.go
@@ -1,0 +1,115 @@
+// file: internal/maintenance/jobs/cleanup_organize_mess_test.go
+// version: 1.0.0
+// guid: b9c0d1e2-f3a4-5678-bcde-901234567234
+// last-edited: 2026-05-05
+
+// Shared test helpers (noopReporter, blank jobs import) live in testhelpers_test.go.
+package jobs_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupOrganizeMessJob_Registered(t *testing.T) {
+	assertJobRegistered(t, "cleanup-organize-mess")
+	job, err := maintenance.Get("cleanup-organize-mess")
+	require.NoError(t, err)
+	assert.Equal(t, "Cleanup Organize Mess", job.Name())
+	assert.Equal(t, "cleanup", job.Category())
+}
+
+func TestCleanupOrganizeMessJob_DryRunDoesNotDelete(t *testing.T) {
+	root := t.TempDir()
+	// Create a directory that looks like a garbage/chapter-fragment dir.
+	garbageDir := filepath.Join(root, "01_ bad fragment dir")
+	require.NoError(t, os.MkdirAll(garbageDir, 0o755))
+
+	orig := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	defer func() { config.AppConfig.RootDir = orig }()
+
+	job, err := maintenance.Get("cleanup-organize-mess")
+	require.NoError(t, err)
+
+	reporter := &noopReporter{}
+	require.NoError(t, job.Run(context.Background(), nil, reporter, true /* dryRun */))
+
+	// Dry-run must not delete anything.
+	_, err = os.Stat(garbageDir)
+	assert.NoError(t, err, "dry-run must not delete any directory")
+}
+
+func TestCleanupOrganizeMessJob_RemovesEmptyGarbageDirs(t *testing.T) {
+	root := t.TempDir()
+	// Create a purely numeric directory (garbage pattern).
+	numericDir := filepath.Join(root, "123")
+	require.NoError(t, os.MkdirAll(numericDir, 0o755))
+
+	// Create a legitimate non-garbage directory with a file.
+	legitDir := filepath.Join(root, "Author - Title")
+	require.NoError(t, os.MkdirAll(legitDir, 0o755))
+	f, createErr := os.Create(filepath.Join(legitDir, "book.m4b"))
+	require.NoError(t, createErr)
+	f.Close()
+
+	orig := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	defer func() { config.AppConfig.RootDir = orig }()
+
+	job, err := maintenance.Get("cleanup-organize-mess")
+	require.NoError(t, err)
+
+	reporter := &noopReporter{}
+	require.NoError(t, job.Run(context.Background(), nil, reporter, false /* dryRun */))
+
+	// The legitimate directory must remain untouched.
+	_, err = os.Stat(legitDir)
+	assert.NoError(t, err, "legitimate directory must remain")
+}
+
+func TestCleanupOrganizeMessJob_CancelContext(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "01_fragment"), 0o755))
+
+	orig := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	defer func() { config.AppConfig.RootDir = orig }()
+
+	job, err := maintenance.Get("cleanup-organize-mess")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	reporter := &noopReporter{}
+	// Should return without panic.
+	_ = job.Run(ctx, nil, reporter, false)
+}
+
+func TestCleanupOrganizeMessJob_LogsGarbageDirs(t *testing.T) {
+	root := t.TempDir()
+	// Double-nested chapter segment pattern.
+	doubleDir := filepath.Join(root, "Title - 01 - Chapter")
+	require.NoError(t, os.MkdirAll(doubleDir, 0o755))
+
+	orig := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	defer func() { config.AppConfig.RootDir = orig }()
+
+	job, err := maintenance.Get("cleanup-organize-mess")
+	require.NoError(t, err)
+
+	reporter := &noopReporter{}
+	require.NoError(t, job.Run(context.Background(), nil, reporter, true /* dryRun */))
+
+	// Should have logged at least one message about garbage detection.
+	assert.NotEmpty(t, reporter.logs, "expected at least one log entry for garbage dirs")
+}

--- a/internal/maintenance/jobs/fix_library_states_test.go
+++ b/internal/maintenance/jobs/fix_library_states_test.go
@@ -1,0 +1,161 @@
+// file: internal/maintenance/jobs/fix_library_states_test.go
+// version: 1.0.0
+// guid: e2f3a4b5-c6d7-8901-efab-234567890567
+// last-edited: 2026-05-05
+
+// Package jobs_test exercises the fix-library-states maintenance job.
+package jobs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noopReporter and assertJobRegistered are defined in testhelpers_test.go.
+
+func TestFixLibraryStatesJob_Registered(t *testing.T) {
+	assertJobRegistered(t, "fix-library-states")
+}
+
+func TestFixLibraryStatesJob_Metadata(t *testing.T) {
+	j, err := maintenance.Get("fix-library-states")
+	require.NoError(t, err)
+	assert.Equal(t, "fix-library-states", j.ID())
+	assert.NotEmpty(t, j.Name())
+	assert.NotEmpty(t, j.Description())
+	assert.Equal(t, "library", j.Category())
+	assert.NotNil(t, j.DefaultParams())
+}
+
+func TestFixLibraryStatesJob_DryRun_NoUpdate(t *testing.T) {
+	// Book with disagreeing library_state — dry_run must not call UpdateBook.
+	missing := "missing"
+	book := database.Book{
+		ID:           "book-dry",
+		Title:        "Dry Book",
+		FilePath:     "", // no file path → state should be "missing"
+		LibraryState: &missing,
+	}
+
+	var updateCalled bool
+	store := &database.MockStore{
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			if offset > 0 {
+				return nil, nil
+			}
+			return []database.Book{book}, nil
+		},
+		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
+			updateCalled = true
+			return b, nil
+		},
+	}
+
+	j, err := maintenance.Get("fix-library-states")
+	require.NoError(t, err)
+	err = j.Run(context.Background(), store, &noopReporter{}, true /* dryRun */)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "dry_run=true: UpdateBook must not be called")
+}
+
+func TestFixLibraryStatesJob_Apply_UpdatesBook(t *testing.T) {
+	// Book whose state says "present" but FilePath is empty (no file) → should become "missing".
+	present := "present"
+	book := database.Book{
+		ID:           "book-apply",
+		Title:        "Apply Book",
+		FilePath:     "", // does not exist → wantState = "missing"
+		LibraryState: &present,
+	}
+
+	var updatedState string
+	store := &database.MockStore{
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			if offset > 0 {
+				return nil, nil
+			}
+			return []database.Book{book}, nil
+		},
+		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
+			if b.LibraryState != nil {
+				updatedState = *b.LibraryState
+			}
+			return b, nil
+		},
+	}
+
+	j, err := maintenance.Get("fix-library-states")
+	require.NoError(t, err)
+	err = j.Run(context.Background(), store, &noopReporter{}, false /* apply */)
+	require.NoError(t, err)
+	assert.Equal(t, "missing", updatedState, "book with no file path should be set to missing")
+}
+
+func TestFixLibraryStatesJob_NoChanges_WhenStateCorrect(t *testing.T) {
+	// Book already has correct state — UpdateBook must not be called.
+	missing := "missing"
+	book := database.Book{
+		ID:           "book-correct",
+		Title:        "Correct State Book",
+		FilePath:     "", // does not exist → wantState = "missing" (already correct)
+		LibraryState: &missing,
+	}
+
+	var updateCalled bool
+	store := &database.MockStore{
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			if offset > 0 {
+				return nil, nil
+			}
+			return []database.Book{book}, nil
+		},
+		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
+			updateCalled = true
+			return b, nil
+		},
+	}
+
+	j, err := maintenance.Get("fix-library-states")
+	require.NoError(t, err)
+	err = j.Run(context.Background(), store, &noopReporter{}, false /* apply */)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "book already in correct state: UpdateBook must not be called")
+}
+
+func TestFixLibraryStatesJob_Cancellation(t *testing.T) {
+	present := "present"
+	books := make([]database.Book, 5)
+	for i := range books {
+		books[i] = database.Book{
+			ID:           "book-cancel-" + string(rune('0'+i)),
+			Title:        "Cancel Book",
+			FilePath:     "", // triggers state change detection
+			LibraryState: &present,
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	store := &database.MockStore{
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			if offset > 0 {
+				return nil, nil
+			}
+			return books, nil
+		},
+	}
+
+	j, err := maintenance.Get("fix-library-states")
+	require.NoError(t, err)
+	err = j.Run(ctx, store, &noopReporter{}, false)
+	// Should return ctx.Err() or nil — must not panic or hang.
+	if err != nil {
+		assert.ErrorIs(t, err, context.Canceled)
+	}
+}


### PR DESCRIPTION
Moves business logic into a self-registering MaintenanceJob. Checks disk presence vs stored library_state with IsCanceled() checks, checkpoint every 100 books, and resume support. Old route untouched. (ASYNC-W2-4)

## Changes
- `fix_library_states.go` already existed and compiles (implementation was complete)
- Added `fix_library_states_test.go` with 6 tests: registration, metadata, dry-run no-op, apply update, correct-state no-op, and cancellation
- Blank import in `server.go` was already present

## Tests
All 6 `TestFixLibraryStates*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)