### PR TITLE
feat(uos): drop frontend dual-source; v2 is sole source

### DIFF
--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,8 +1,8 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.6.0
+// version: 3.7.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Badge,
@@ -18,8 +18,6 @@ import {
   Typography,
 } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications.js';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle.js';
-import ErrorIcon from '@mui/icons-material/Error.js';
 import CancelIcon from '@mui/icons-material/Cancel.js';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew.js';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty.js';
@@ -29,8 +27,6 @@ import {
 } from '../../stores/useOperationsStore';
 import {
   cancelOperation,
-  getRecentCompletedOperations,
-  type Operation,
 } from '../../services/api';
 import { getUndoPreflight, revertOperation as revertOp } from '../../services/versionApi';
 
@@ -127,31 +123,10 @@ export function OperationsIndicator() {
   );
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
-  const [recentOps, setRecentOps] = useState<Operation[]>([]);
   const navigate = useNavigate();
 
   // Active ops are now discovered exclusively via SSE (op.created) and
   // loadFromServer (v2 timeline). No v1 polling loop needed here.
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchRecentOps = async () => {
-      try {
-        const ops = await getRecentCompletedOperations();
-        if (!cancelled) setRecentOps(ops.slice(0, 10));
-      } catch {
-        // Ignore
-      }
-    };
-
-    void fetchRecentOps();
-    const interval = setInterval(fetchRecentOps, 30000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
 
   const handleCancel = async (opId: string) => {
     setCancelling((prev) => new Set(prev).add(opId));
@@ -393,65 +368,24 @@ export function OperationsIndicator() {
             );
           })}
 
-          {/* Completed/failed (from active store) */}
-          {terminal.length > 0 && inProgress.length > 0 && <Divider />}
-          {terminal.map((op: ActiveOperation) => {
-            const details = parseMessageDetails(op.message);
-            return (
-              <Box
-                key={op.id}
-                sx={{ px: 2, py: 1, opacity: 0.7, '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' } }}
+          {/* Recent completed operations — read from v2 store (terminal ops).
+              V1 getRecentCompletedOperations() is no longer called (UOS-13). */}
+          {terminal.length === 0 && inProgress.length === 0 && (
+            <>
+              <Divider />
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ px: 2, py: 1.5, textAlign: 'center', fontSize: '0.8rem' }}
               >
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Typography variant="caption" fontWeight="bold">
-                    {formatOperationType(op.type)}
-                  </Typography>
-                  {op.status === 'completed' && <CheckCircleIcon color="success" sx={{ fontSize: 16 }} />}
-                  {op.status === 'failed' && <ErrorIcon color="error" sx={{ fontSize: 16 }} />}
-                  {op.status === 'canceled' && <CancelIcon color="disabled" sx={{ fontSize: 16 }} />}
-                </Box>
-                {details.imported !== null && (
-                  <Typography variant="caption" color="text.secondary" display="block">
-                    {details.imported} imported
-                    {details.skipped! > 0 ? `, ${details.skipped} skipped` : ''}
-                    {details.failed! > 0 ? `, ${details.failed} failed` : ''}
-                  </Typography>
-                )}
-                {!details.imported && op.message && (
-                  <Typography variant="caption" color="text.secondary" display="block" noWrap title={op.message}>
-                    {op.message}
-                  </Typography>
-                )}
-              </Box>
-            );
-          })}
-
-          {/* Recent completed operations section */}
-          <Divider />
-          <Box sx={{ px: 2, pt: 1.5, pb: 0.5, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
-              Recent
-            </Typography>
-            {recentOps.length > 0 && (
-              <Button size="small" sx={{ fontSize: '0.65rem', py: 0, minHeight: 20, textTransform: 'none' }} onClick={() => setRecentOps([])}>
-                Clear
-              </Button>
-            )}
-          </Box>
-
-          {recentOps.length === 0 && (
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ px: 2, py: 1.5, textAlign: 'center', fontSize: '0.8rem' }}
-            >
-              No recent operations
-            </Typography>
+                No recent operations
+              </Typography>
+            </>
           )}
 
-          {recentOps.map((op: Operation) => (
+          {terminal.map((op: ActiveOperation) => (
             <Box
-              key={op.id}
+              key={`recent-${op.id}`}
               onClick={() => {
                 setAnchorEl(null);
                 navigate(`/activity?op=${op.id}`);
@@ -469,9 +403,6 @@ export function OperationsIndicator() {
                   {formatOperationType(op.type)}
                 </Typography>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    {op.completed_at ? timeAgo(op.completed_at) : op.created_at ? timeAgo(op.created_at) : ''}
-                  </Typography>
                   <Chip
                     label={op.status}
                     size="small"

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.5.0
+// version: 3.6.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useEffect, useState } from 'react';
@@ -29,7 +29,6 @@ import {
 } from '../../stores/useOperationsStore';
 import {
   cancelOperation,
-  getActiveOperations,
   getRecentCompletedOperations,
   type Operation,
 } from '../../services/api';
@@ -126,43 +125,13 @@ export function OperationsIndicator() {
   const activeOperations = useOperationsStore(
     (state) => state.activeOperations
   );
-  const startPolling = useOperationsStore((state) => state.startPolling);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const [recentOps, setRecentOps] = useState<Operation[]>([]);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const checkActiveOps = async () => {
-      try {
-        const ops = await getActiveOperations();
-        if (cancelled) return;
-        const store = useOperationsStore.getState();
-        for (const op of ops) {
-          const alreadyTracked = store.activeOperations.some(
-            (a) => a.id === op.id
-          );
-          if (
-            !alreadyTracked &&
-            !['completed', 'failed', 'canceled'].includes(op.status)
-          ) {
-            startPolling(op.id, op.type, true);
-          }
-        }
-      } catch {
-        // Ignore
-      }
-    };
-
-    void checkActiveOps();
-    const interval = setInterval(checkActiveOps, 15000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, [startPolling]);
+  // Active ops are now discovered exclusively via SSE (op.created) and
+  // loadFromServer (v2 timeline). No v1 polling loop needed here.
 
   useEffect(() => {
     let cancelled = false;

--- a/web/src/components/settings/ITunesImport.tsx
+++ b/web/src/components/settings/ITunesImport.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/settings/ITunesImport.tsx
-// version: 1.16.0
+// version: 1.17.0
 // guid: 4eb9b74d-7192-497b-849a-092833ae63a4
 // last-edited: 2026-05-05
 
@@ -58,7 +58,6 @@ import { WriteBackPreviewTable } from './WriteBackPreviewTable';
 import {
   ApiError,
   cancelOperation,
-  getActiveOperations,
   getConfig,
   getITunesBooks,
   getITunesImportStatus,
@@ -232,24 +231,20 @@ export function ITunesImport() {
     return () => clearInterval(interval);
   }, [settings.libraryPath]);
 
-  // Detect an already-running iTunes import on mount
+  // Detect an already-running iTunes import on mount — read from v2 store (UOS-13).
   useEffect(() => {
     let cancelled = false;
     const detectRunningImport = async () => {
-      try {
-        const ops = await getActiveOperations();
-        if (cancelled) return;
-        const running = ops.find(
-          (op) =>
-            op.type === 'itunes_import' &&
-            !['completed', 'failed', 'canceled'].includes(op.status)
-        );
-        if (running) {
-          setImporting(true);
-          await pollImportStatus(running.id);
-        }
-      } catch {
-        // Ignore — API may not be ready
+      const ops = useOperationsStore.getState().activeOperations;
+      if (cancelled) return;
+      const running = ops.find(
+        (op) =>
+          op.type === 'itunes_import' &&
+          !['completed', 'failed', 'canceled'].includes(op.status)
+      );
+      if (running) {
+        setImporting(true);
+        await pollImportStatus(running.id);
       }
     };
     detectRunningImport();

--- a/web/src/components/settings/OpenLibraryDumps.tsx
+++ b/web/src/components/settings/OpenLibraryDumps.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/settings/OpenLibraryDumps.tsx
-// version: 2.1.0
+// version: 2.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -24,7 +24,6 @@ import {
   startOLDumpImport,
   uploadOLDump,
   deleteOLDumpData,
-  getActiveOperations,
   OLDumpStatus,
   OLDumpTypeStatus,
   OLDownloadProgress,
@@ -167,24 +166,17 @@ export function OpenLibraryDumps() {
     refresh();
   }, [refresh]);
 
-  // Detect running OL import on mount
+  // Detect running OL import on mount — read from v2 store (UOS-13).
   useEffect(() => {
-    const detectRunningImport = async () => {
-      try {
-        const ops = await getActiveOperations();
-        const running = ops.find(
-          (op) =>
-            op.type === 'ol_dump_import' &&
-            !['completed', 'failed', 'canceled'].includes(op.status)
-        );
-        if (running) {
-          setImporting(true);
-        }
-      } catch {
-        // Ignore
-      }
-    };
-    detectRunningImport();
+    const ops = useOperationsStore.getState().activeOperations;
+    const running = ops.find(
+      (op) =>
+        op.type === 'ol_dump_import' &&
+        !['completed', 'failed', 'canceled'].includes(op.status)
+    );
+    if (running) {
+      setImporting(true);
+    }
   }, []);
 
   // Poll while downloading or importing
@@ -195,18 +187,17 @@ export function OpenLibraryDumps() {
     if (hasActiveDownload || importing) {
       pollRef.current = setInterval(() => {
         refresh();
-        // Check if import operation is still running
+        // Check if import operation is still running — read from v2 store (UOS-13).
         if (importing) {
-          getActiveOperations().then((ops) => {
-            const running = ops.find(
-              (op) =>
-                op.type === 'ol_dump_import' &&
-                !['completed', 'failed', 'canceled'].includes(op.status)
-            );
-            if (!running) {
-              setImporting(false);
-            }
-          }).catch((err) => console.error('Failed to poll import status:', err));
+          const ops = useOperationsStore.getState().activeOperations;
+          const running = ops.find(
+            (op) =>
+              op.type === 'ol_dump_import' &&
+              !['completed', 'failed', 'canceled'].includes(op.status)
+          );
+          if (!running) {
+            setImporting(false);
+          }
         }
       }, 3000);
     } else if (pollRef.current) {

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.7.0
+// version: 2.8.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -145,6 +145,10 @@ export default function ActivityLog() {
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const [expandedOpId, setExpandedOpId] = useState<string | null>(searchParams.get('op'));
   const [opLogs, setOpLogs] = useState<string[]>([]);
+
+  // Tree collapse state: set of parent op IDs that are collapsed.
+  // Parents with ≥3 children start collapsed by default (computed on render).
+  const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set());
   const opLogsRef = useRef<HTMLDivElement>(null);
 
   // Sources
@@ -600,9 +604,33 @@ export default function ActivityLog() {
                 </IconButton>
               </Tooltip>
             </Stack>
-            <Button size="small" variant="outlined" onClick={handleClearStale}>
-              Clear Stale
-            </Button>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                variant="text"
+                onClick={() => {
+                  // Collapse all parents that have children
+                  const parents = new Set(
+                    activeOps
+                      .filter((op) => op.parent_id && activeOps.some((p) => p.id === op.parent_id))
+                      .map((op) => op.parent_id as string)
+                  );
+                  setCollapsedParents(parents);
+                }}
+              >
+                Collapse All
+              </Button>
+              <Button
+                size="small"
+                variant="text"
+                onClick={() => setCollapsedParents(new Set())}
+              >
+                Expand All
+              </Button>
+              <Button size="small" variant="outlined" onClick={handleClearStale}>
+                Clear Stale
+              </Button>
+            </Stack>
           </Stack>
 
           {activeOps.length === 0 ? (
@@ -616,6 +644,24 @@ export default function ActivityLog() {
                 // Create a map for quick parent lookup
                 const opsById = Object.fromEntries(activeOps.map((op) => [op.id, op]));
 
+                // Count children per parent
+                const childrenCount: Record<string, number> = {};
+                for (const op of activeOps) {
+                  if (op.parent_id) {
+                    childrenCount[op.parent_id] = (childrenCount[op.parent_id] ?? 0) + 1;
+                  }
+                }
+
+                // Compute initial default-collapsed parents (≥3 children).
+                // We do this once on first render only via a deferred check so
+                // we don't fight user overrides.
+                const defaultCollapsed = new Set<string>();
+                for (const [parentId, count] of Object.entries(childrenCount)) {
+                  if (count >= 3) defaultCollapsed.add(parentId);
+                }
+                // Merge with existing collapsed state on first render only.
+                // (We use a ref to track if we've done the initial merge.)
+
                 // Helper to get depth based on parent chain
                 const getDepth = (op: typeof activeOps[0]): number => {
                   let depth = 0;
@@ -627,10 +673,30 @@ export default function ActivityLog() {
                   return depth;
                 };
 
-                return activeOps.map((op) => {
+                // Helper: is this op hidden because an ancestor is collapsed?
+                const isHiddenByCollapse = (op: typeof activeOps[0]): boolean => {
+                  let current = op;
+                  while (current.parent_id && opsById[current.parent_id]) {
+                    const parentId = current.parent_id;
+                    const effectiveCollapsed = collapsedParents.size > 0
+                      ? collapsedParents.has(parentId)
+                      : defaultCollapsed.has(parentId);
+                    if (effectiveCollapsed) return true;
+                    current = opsById[parentId];
+                  }
+                  return false;
+                };
+
+                return activeOps
+                  .filter((op) => !isHiddenByCollapse(op))
+                  .map((op) => {
                   const pct = op.total > 0 ? Math.round((op.progress / op.total) * 100) : 0;
                   const depth = getDepth(op);
                   const indent = depth * 24; // 24px per level for indentation
+                  const hasChildren = (childrenCount[op.id] ?? 0) > 0;
+                  const effectiveCollapsed = collapsedParents.size > 0
+                    ? collapsedParents.has(op.id)
+                    : defaultCollapsed.has(op.id);
 
                   return (
                     <Paper
@@ -653,6 +719,27 @@ export default function ActivityLog() {
                               ↳
                             </Typography>
                           )}
+                          {hasChildren && (
+                            <Typography
+                              variant="caption"
+                              sx={{ cursor: 'pointer', color: 'text.secondary', fontSize: '0.85rem', userSelect: 'none' }}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setCollapsedParents((prev) => {
+                                  const next = new Set(prev);
+                                  // When user interacts, migrate defaultCollapsed into state first
+                                  if (next.size === 0) {
+                                    for (const id of defaultCollapsed) next.add(id);
+                                  }
+                                  if (next.has(op.id)) next.delete(op.id);
+                                  else next.add(op.id);
+                                  return next;
+                                });
+                              }}
+                            >
+                              {effectiveCollapsed ? '▸' : '▾'}
+                            </Typography>
+                          )}
                           <Typography variant="subtitle2" fontWeight="bold">
                             {op.type.replace(/_/g, ' ')}
                           </Typography>
@@ -660,7 +747,6 @@ export default function ActivityLog() {
                             size="small"
                             label={op.status === 'queued' ? 'pending' : op.status}
                             color={op.status === 'queued' ? 'default' : 'info'}
-                            icon={op.status === 'queued' ? undefined : undefined}
                           />
                         </Stack>
                         <Button

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.8.0
+// version: 2.9.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -147,8 +147,11 @@ export default function ActivityLog() {
   const [opLogs, setOpLogs] = useState<string[]>([]);
 
   // Tree collapse state: set of parent op IDs that are collapsed.
-  // Parents with ≥3 children start collapsed by default (computed on render).
+  // Seeded on first render with ops: parents with ≥3 children start collapsed.
+  // After seeding, collapsedParents.size > 0 means "some parents collapsed",
+  // and new Set() unambiguously means "all expanded" (not "use defaults").
   const [collapsedParents, setCollapsedParents] = useState<Set<string>>(new Set());
+  const collapsedInitializedRef = useRef(false);
   const opLogsRef = useRef<HTMLDivElement>(null);
 
   // Sources
@@ -191,6 +194,27 @@ export default function ActivityLog() {
     localStorage.setItem(STORAGE_KEYS.ACTIVITY_OPS_PINNED, String(pinned));
   }, [pinned]);
 
+  // Seed collapsedParents with default-collapsed parents (≥3 children) on
+  // first render that has ops. Uses a ref guard so user interactions after
+  // initial seed are not overwritten. This makes "Expand All" work correctly:
+  // setCollapsedParents(new Set()) = size 0 = all expanded (no fallback needed).
+  useEffect(() => {
+    if (collapsedInitializedRef.current || activeOps.length === 0) return;
+    const childrenCount: Record<string, number> = {};
+    for (const op of activeOps) {
+      if (op.parent_id) {
+        childrenCount[op.parent_id] = (childrenCount[op.parent_id] ?? 0) + 1;
+      }
+    }
+    const defaults = new Set<string>();
+    for (const [id, count] of Object.entries(childrenCount)) {
+      if (count >= 3) defaults.add(id);
+    }
+    if (defaults.size > 0) {
+      collapsedInitializedRef.current = true;
+      setCollapsedParents(defaults);
+    }
+  }, [activeOps]);
 
   // Load logs for expanded operation
   useEffect(() => {
@@ -652,16 +676,6 @@ export default function ActivityLog() {
                   }
                 }
 
-                // Compute initial default-collapsed parents (≥3 children).
-                // We do this once on first render only via a deferred check so
-                // we don't fight user overrides.
-                const defaultCollapsed = new Set<string>();
-                for (const [parentId, count] of Object.entries(childrenCount)) {
-                  if (count >= 3) defaultCollapsed.add(parentId);
-                }
-                // Merge with existing collapsed state on first render only.
-                // (We use a ref to track if we've done the initial merge.)
-
                 // Helper to get depth based on parent chain
                 const getDepth = (op: typeof activeOps[0]): number => {
                   let depth = 0;
@@ -674,14 +688,13 @@ export default function ActivityLog() {
                 };
 
                 // Helper: is this op hidden because an ancestor is collapsed?
+                // collapsedParents is seeded on first render (see useEffect above),
+                // so size === 0 reliably means "user clicked Expand All".
                 const isHiddenByCollapse = (op: typeof activeOps[0]): boolean => {
                   let current = op;
                   while (current.parent_id && opsById[current.parent_id]) {
                     const parentId = current.parent_id;
-                    const effectiveCollapsed = collapsedParents.size > 0
-                      ? collapsedParents.has(parentId)
-                      : defaultCollapsed.has(parentId);
-                    if (effectiveCollapsed) return true;
+                    if (collapsedParents.has(parentId)) return true;
                     current = opsById[parentId];
                   }
                   return false;
@@ -694,9 +707,7 @@ export default function ActivityLog() {
                   const depth = getDepth(op);
                   const indent = depth * 24; // 24px per level for indentation
                   const hasChildren = (childrenCount[op.id] ?? 0) > 0;
-                  const effectiveCollapsed = collapsedParents.size > 0
-                    ? collapsedParents.has(op.id)
-                    : defaultCollapsed.has(op.id);
+                  const effectiveCollapsed = collapsedParents.has(op.id);
 
                   return (
                     <Paper
@@ -727,10 +738,6 @@ export default function ActivityLog() {
                                 e.stopPropagation();
                                 setCollapsedParents((prev) => {
                                   const next = new Set(prev);
-                                  // When user interacts, migrate defaultCollapsed into state first
-                                  if (next.size === 0) {
-                                    for (const id of defaultCollapsed) next.add(id);
-                                  }
                                   if (next.has(op.id)) next.delete(op.id);
                                   else next.add(op.id);
                                   return next;

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.56.0
+// version: 1.57.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-05-11
 
@@ -281,42 +281,39 @@ export const Library = () => {
 
   // SSE subscription for live operation progress & logs + historical hydration
   useEffect(() => {
-    // Fetch active operations to hydrate UI on reload
+    // Hydrate UI from v2 store on reload (UOS-13: no v1 getActiveOperations call).
+    // The store is already populated via SSE + loadFromServer at app level.
     (async () => {
-      try {
-        const active = await api.getActiveOperations();
-        for (const op of active) {
-          const partial: api.Operation = {
-            id: op.id,
-            type: op.type,
-            status: op.status,
-            progress: op.progress,
-            total: op.total,
-            message: op.message,
-            created_at: new Date().toISOString(),
-          } as api.Operation;
-          if (op.type === 'scan') setActiveScanOp(partial);
-          if (op.type === 'organize') setActiveOrganizeOp(partial);
-          // Hydrate historical tail logs (last 100)
-          try {
-            const hist = await api.getOperationLogsTail(op.id, 100);
-            if (hist && hist.length) {
-              setOperationLogs((prev) => ({
-                ...prev,
-                [op.id]: hist.map((h: api.OperationLog) => ({
-                  level: h.level,
-                  message: h.message,
-                  details: h.details,
-                  timestamp: Date.parse(h.created_at) || Date.now(),
-                })),
-              }));
-            }
-          } catch (_e) {
-            // ignore hydration errors
+      const active = useOperationsStore.getState().activeOperations;
+      for (const op of active) {
+        const partial: api.Operation = {
+          id: op.id,
+          type: op.type,
+          status: op.status,
+          progress: op.progress,
+          total: op.total,
+          message: op.message,
+          created_at: new Date().toISOString(),
+        } as api.Operation;
+        if (op.type === 'scan') setActiveScanOp(partial);
+        if (op.type === 'organize') setActiveOrganizeOp(partial);
+        // Hydrate historical tail logs (last 100)
+        try {
+          const hist = await api.getOperationLogsTail(op.id, 100);
+          if (hist && hist.length) {
+            setOperationLogs((prev) => ({
+              ...prev,
+              [op.id]: hist.map((h: api.OperationLog) => ({
+                level: h.level,
+                message: h.message,
+                details: h.details,
+                timestamp: Date.parse(h.created_at) || Date.now(),
+              })),
+            }));
           }
+        } catch (_e) {
+          // ignore hydration errors
         }
-      } catch {
-        // ignore
       }
     })();
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.19.0
+// version: 2.20.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-06
 
@@ -1681,8 +1681,8 @@ export async function getBookChanges(bookId: string): Promise<OperationChange[]>
 
 /**
  * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
- * This wrapper is kept alive for callers outside useOperationsStore; it will be
- * deleted in UOS-14.
+ * No remaining UI callers as of UOS-13; kept alive only for backwards compat.
+ * Will be deleted in UOS-14.
  */
 export async function getActiveOperations(): Promise<ActiveOperationSummary[]> {
   const response = await fetch(`${API_BASE}/operations/active`);
@@ -3114,8 +3114,8 @@ export async function batchUnrejectCandidates(operationId: string, bookIds: stri
 
 /**
  * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
- * This wrapper is kept alive for OperationsIndicator's "Recent" section; it will be
- * deleted in UOS-14.
+ * No remaining UI callers as of UOS-13; kept alive only for backwards compat.
+ * Will be deleted in UOS-14.
  */
 export async function getRecentCompletedOperations(): Promise<Operation[]> {
   const response = await fetch(`${API_BASE}/operations/recent`);

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.18.0
+// version: 2.19.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-06
 
@@ -1679,6 +1679,11 @@ export async function getBookChanges(bookId: string): Promise<OperationChange[]>
   return data.changes || [];
 }
 
+/**
+ * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
+ * This wrapper is kept alive for callers outside useOperationsStore; it will be
+ * deleted in UOS-14.
+ */
 export async function getActiveOperations(): Promise<ActiveOperationSummary[]> {
   const response = await fetch(`${API_BASE}/operations/active`);
   if (!response.ok) {
@@ -3107,6 +3112,11 @@ export async function batchUnrejectCandidates(operationId: string, bookIds: stri
   return response.json();
 }
 
+/**
+ * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
+ * This wrapper is kept alive for OperationsIndicator's "Recent" section; it will be
+ * deleted in UOS-14.
+ */
 export async function getRecentCompletedOperations(): Promise<Operation[]> {
   const response = await fetch(`${API_BASE}/operations/recent`);
   if (!response.ok) throw await buildApiError(response, 'Failed to get recent operations');

--- a/web/src/stores/useOperationsStore.test.ts
+++ b/web/src/stores/useOperationsStore.test.ts
@@ -1,7 +1,7 @@
 // file: web/src/stores/useOperationsStore.test.ts
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-06
+// last-edited: 2026-05-08
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useOperationsStore } from './useOperationsStore';
@@ -27,16 +27,7 @@ describe('useOperationsStore', () => {
     });
   });
 
-  it('dedupes operations by id when same op appears in both v1 and v2', async () => {
-    const v1Op: api.ActiveOperationSummary = {
-      id: 'op-1',
-      type: 'scan',
-      status: 'running',
-      progress: 50,
-      total: 100,
-      message: 'Scanning books...',
-    };
-
+  it('loadFromServer reads exclusively from v2 timeline endpoint', async () => {
     const v2Op: api.OperationV2 = {
       id: 'op-1',
       def_id: 'scan-def',
@@ -60,77 +51,20 @@ describe('useOperationsStore', () => {
       span_id: null,
     };
 
-    vi.mocked(api.getActiveOperations).mockResolvedValue([v1Op]);
-    vi.mocked(api.getRecentCompletedOperations).mockResolvedValue([]);
     vi.mocked(api.getOperationTimeline).mockResolvedValue([v2Op]);
 
     await useOperationsStore.getState().loadFromServer();
 
+    expect(api.getOperationTimeline).toHaveBeenCalledTimes(1);
+    // v1 endpoints must NOT be called
+    expect(api.getActiveOperations).not.toHaveBeenCalled();
+    expect(api.getRecentCompletedOperations).not.toHaveBeenCalled();
+
     const ops = useOperationsStore.getState().activeOperations;
     expect(ops).toHaveLength(1);
     expect(ops[0].id).toBe('op-1');
-    // v2 should win on collision
-    expect(ops[0]._source).toBe('v2');
     expect(ops[0].message).toBe('Almost done');
     expect(ops[0].progress).toBe(75);
-  });
-
-  it('v2 endpoint 404 falls back to v1 gracefully', async () => {
-    const v1Op: api.ActiveOperationSummary = {
-      id: 'op-1',
-      type: 'organize',
-      status: 'running',
-      progress: 10,
-      total: 20,
-      message: 'Organizing...',
-    };
-
-    vi.mocked(api.getActiveOperations).mockResolvedValue([v1Op]);
-    vi.mocked(api.getRecentCompletedOperations).mockResolvedValue([]);
-    vi.mocked(api.getOperationTimeline).mockResolvedValue([]); // 404 returns []
-
-    await useOperationsStore.getState().loadFromServer();
-
-    const ops = useOperationsStore.getState().activeOperations;
-    expect(ops).toHaveLength(1);
-    expect(ops[0].id).toBe('op-1');
-    expect(ops[0]._source).toBe('v1');
-  });
-
-  it('handles v1 endpoint failure gracefully', async () => {
-    const v2Op: api.OperationV2 = {
-      id: 'op-1',
-      def_id: 'scan-def',
-      plugin: 'library_scanner',
-      display_name: 'Library Scan',
-      status: 'running',
-      priority: 10,
-      progress_current: 50,
-      progress_total: 100,
-      progress_message: 'Scanning',
-      current_phase: null,
-      current_item: null,
-      actor_user_id: null,
-      parent_id: null,
-      queued_at: '2026-05-06T09:00:00Z',
-      started_at: '2026-05-06T09:01:00Z',
-      completed_at: null,
-      error_message: null,
-      resume_count: 0,
-      trace_id: null,
-      span_id: null,
-    };
-
-    vi.mocked(api.getActiveOperations).mockRejectedValue(new Error('Network error'));
-    vi.mocked(api.getRecentCompletedOperations).mockRejectedValue(new Error('Network error'));
-    vi.mocked(api.getOperationTimeline).mockResolvedValue([v2Op]);
-
-    // Should not throw, just log error
-    await useOperationsStore.getState().loadFromServer();
-
-    // We don't check the result since the error path logs to console.error
-    // Just verify it doesn't crash
-    expect(true).toBe(true);
   });
 
   it('stores parent_id and v2 fields from v2 operations', async () => {
@@ -180,17 +114,38 @@ describe('useOperationsStore', () => {
       span_id: null,
     };
 
-    vi.mocked(api.getActiveOperations).mockResolvedValue([]);
-    vi.mocked(api.getRecentCompletedOperations).mockResolvedValue([]);
     vi.mocked(api.getOperationTimeline).mockResolvedValue([parentV2, childV2]);
 
     await useOperationsStore.getState().loadFromServer();
 
     const ops = useOperationsStore.getState().activeOperations;
+    expect(ops).toHaveLength(2);
     const child = ops.find((op) => op.id === 'child-op');
     expect(child).toBeDefined();
     expect(child?.parent_id).toBe('parent-op');
     expect(child?.current_phase).toBe('phase-1');
     expect(child?.current_item).toBe('item-1');
+  });
+
+  it('gracefully handles timeline endpoint failure', async () => {
+    vi.mocked(api.getOperationTimeline).mockRejectedValue(new Error('Network error'));
+
+    // Should not throw, just log error
+    await expect(useOperationsStore.getState().loadFromServer()).resolves.toBeUndefined();
+
+    // Operations remain empty on failure
+    expect(useOperationsStore.getState().activeOperations).toHaveLength(0);
+  });
+
+  it('startPolling inserts optimistic entry immediately', () => {
+    vi.mocked(api.getOperationTimeline).mockResolvedValue([]);
+
+    useOperationsStore.getState().startPolling('op-99', 'scan');
+
+    const ops = useOperationsStore.getState().activeOperations;
+    expect(ops).toHaveLength(1);
+    expect(ops[0].id).toBe('op-99');
+    expect(ops[0].status).toBe('queued');
+    expect(ops[0].type).toBe('scan');
   });
 });

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 2.1.0
+// version: 3.0.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
@@ -16,9 +16,7 @@ export interface ActiveOperation {
   message: string;
   startedAt?: number; // timestamp ms
   resumed?: boolean;
-  // Runtime field added when operation comes from v2 source
-  _source?: 'v1' | 'v2';
-  // V2 fields (optional, populated when coming from v2)
+  // V2 fields (populated from v2 timeline/SSE)
   parent_id?: string | null;
   current_phase?: string | null;
   current_item?: string | null;
@@ -42,19 +40,6 @@ interface OperationsState {
   closeSSE: () => void;
 }
 
-// Converts v1 operation (ActiveOperationSummary) to unified ActiveOperation
-function fromV1(op: api.ActiveOperationSummary): ActiveOperation {
-  return {
-    id: op.id,
-    type: op.type,
-    status: op.status,
-    progress: op.progress,
-    total: op.total,
-    message: op.message,
-    _source: 'v1',
-  };
-}
-
 // Converts v2 operation to unified ActiveOperation
 function fromV2(op: api.OperationV2): ActiveOperation {
   return {
@@ -64,7 +49,6 @@ function fromV2(op: api.OperationV2): ActiveOperation {
     progress: op.progress_current ?? 0,
     total: op.progress_total ?? 0,
     message: op.progress_message ?? op.display_name ?? '',
-    _source: 'v2',
     parent_id: op.parent_id,
     current_phase: op.current_phase,
     current_item: op.current_item,
@@ -111,36 +95,12 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
 
   loadFromServer: async () => {
     try {
-      // Load from both v1 and v2 in parallel
-      const [v1Active, v1Recent, v2Ops] = await Promise.all([
-        api.getActiveOperations(),
-        api.getRecentCompletedOperations(),
-        api.getOperationTimeline(15),
-      ]);
+      // Load exclusively from v2 timeline endpoint.
+      const v2Ops = await api.getOperationTimeline(15);
 
       set(() => {
-        // Start with empty operations map
         const merged: Record<string, ActiveOperation> = {};
 
-        // Add v1 active operations
-        for (const op of v1Active) {
-          merged[op.id] = fromV1(op);
-        }
-
-        // Add v1 recent (completed) operations
-        for (const op of v1Recent) {
-          merged[op.id] = {
-            id: op.id,
-            type: op.type,
-            status: op.status,
-            progress: op.progress,
-            total: op.total,
-            message: op.message,
-            _source: 'v1',
-          };
-        }
-
-        // Merge v2 operations (v2 wins on id collision)
         for (const op of v2Ops) {
           merged[op.id] = fromV2(op);
         }
@@ -161,6 +121,8 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
 
     notify(resumed ? `${label} resumed` : `${label} started`, 'info');
 
+    // Insert an optimistic entry so the bell shows activity immediately.
+    // The SSE op.created/op.updated events will update it with real data.
     const op: ActiveOperation = {
       id: operationId,
       type,
@@ -181,41 +143,8 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
       };
     });
 
-    const poll = async () => {
-      try {
-        const status = await api.getOperationStatus(operationId);
-        const updated: ActiveOperation = {
-          id: operationId,
-          type,
-          status: status.status,
-          progress: status.progress,
-          total: status.total,
-          message: status.message,
-          resumed,
-        };
-
-        get().updateOperation(updated);
-
-        if (['completed', 'failed', 'canceled'].includes(status.status)) {
-          const n = useAppStore.getState().addNotification;
-          if (status.status === 'completed') {
-            n(`${label} completed`, 'success');
-          } else if (status.status === 'failed') {
-            n(`${label} failed`, 'error');
-          } else {
-            n(`${label} canceled`, 'info');
-          }
-          setTimeout(() => get().removeOperation(operationId), 10000);
-          return;
-        }
-
-        setTimeout(poll, 2000);
-      } catch {
-        setTimeout(poll, 5000);
-      }
-    };
-
-    setTimeout(poll, 1000);
+    // Trigger a server load shortly after to catch any v2 op registration.
+    setTimeout(() => get().loadFromServer(), 1500);
   },
 
   removeOperation: (operationId: string) => {


### PR DESCRIPTION
## Summary
- Removes v1 polling and dual-source merge logic from useOperationsStore
- UI now reads exclusively from v2 SSE + /operations/timeline
- `startPolling` becomes an optimistic-entry shim (fires `loadFromServer` after 1.5s) — callers unchanged
- Adds trigger-lineage tree rendering to ActivityLog: collapse state, expand/collapse-all buttons, default-collapse for parents with ≥3 children
- Marks v1 API wrappers `@deprecated` (not deleted — UOS-14)
- Removes redundant `checkActiveOps` v1 polling loop from OperationsIndicator (SSE `op.created` handles discovery)
- Rewrites useOperationsStore.test.ts: v2-only assertions, no v1 mock calls

## Test plan
- [x] `npx tsc --noEmit` clean (only pre-existing module-not-found errors; no new errors)
- [x] `npx vitest run` 172/172 tests pass (25 test files)
- [ ] Manual: trigger itunes.import, observe child ops cascade in timeline tree
- [ ] Manual: refresh Activity page during scan, tree reconstructs correctly from SSE

🤖 Generated with Claude Code