### PR TITLE
docs(uos): promote pkg/plugin/sdk to stable public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,31 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.47.0 -->
+<!-- version: 2.48.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-07 -->
+<!-- last-edited: 2026-05-08 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features
+
+#### May 8, 2026 — UOS-15: Promote pkg/plugin/sdk to stable public API
+
+- **docs(uos)**: Promotes `pkg/plugin/sdk` to STABLE contract. No production
+  code changes; docs-only + CI lint.
+- **docs/development/writing-a-plugin.md** — new: full tutorial covering Plugin
+  lifecycle, OperationDef contract, ResumePolicy decision tree, Isolate flag,
+  capability declarations, schedules/triggers, testing patterns, and a worked
+  60-line example.
+- **pkg/plugin/sdk/doc.go** — updated (v2.0.0): expanded package godoc with
+  30-line minimal plugin example and explicit stability contract listing all
+  stable identifiers.
+- **tools/cmd/sdkguard/main.go** — new: CI tool that shells to `go list -deps
+  ./pkg/plugin/sdk/...` and asserts no unexpected `internal/` packages appear in
+  the dependency tree. Uses an allowlist for the established backplane
+  (operations/registry, auth, and transitive deps).
+- **Makefile** — new `sdkguard` target; added to `ci` dependency chain alongside
+  `oplint`.
 
 #### May 7, 2026 — UOS-12: Migrate 26 maintenance ops to UOS plugin
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.10.0
+# version: 2.11.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-05-06
+# last-edited: 2026-05-08
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -16,7 +16,7 @@ export GOEXPERIMENT := jsonv2
 .PHONY: all build build-api run run-api install clean help \
         web-install web-build web-dev web-test web-lint \
         test test-all test-frontend test-e2e coverage coverage-check ci \
-        vet mocks mocks-check check-mock-fresh staticcheck oplint \
+        vet mocks mocks-check check-mock-fresh staticcheck oplint sdkguard \
         docker docker-run docker-stop \
         release-dry-run release-snapshot version \
         build-mtls-bridge build-mtls-bridge-windows
@@ -48,6 +48,7 @@ help:
 	@echo "  make test-e2e       - Run Playwright E2E tests"
 	@echo "  make coverage       - Generate coverage report"
 	@echo "  make coverage-check - Verify 30% coverage threshold"
+	@echo "  make sdkguard       - Assert pkg/plugin/sdk has no unexpected internal/ deps"
 	@echo "  make ci             - Full CI: all tests + coverage check"
 	@echo ""
 	@echo "Docker:"
@@ -202,6 +203,12 @@ oplint:
 	@go run ./tools/cmd/oplint ./internal/plugins/...
 	@echo "✅ Plugin import lint passed"
 
+## sdkguard: Assert pkg/plugin/sdk has no unexpected internal/ dependencies
+sdkguard:
+	@echo "🔍 Running SDK guard (asserting no new internal/ deps in pkg/plugin/sdk)..."
+	@go run ./tools/cmd/sdkguard/main.go
+	@echo "✅ SDK guard passed"
+
 ## test-all: Run all tests (backend + frontend)
 test-all: test web-test
 
@@ -237,8 +244,8 @@ coverage-check:
 	fi; \
 	echo "✅ Coverage $$coverage% meets 30% threshold"
 
-## ci: Full CI check (vet + mocks-check + mock freshness + staticcheck + all tests + coverage)
-ci: mocks-check check-mock-fresh staticcheck test-all coverage-check
+## ci: Full CI check (vet + mocks-check + mock freshness + staticcheck + sdkguard + all tests + coverage)
+ci: mocks-check check-mock-fresh staticcheck sdkguard test-all coverage-check
 	@echo "✅ All CI checks passed!"
 
 ## build-mtls-bridge: Build the mTLS bridge binary (macOS)

--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ mock generation.
 | CI/CD | GitHub Actions, GoReleaser |
 | Deployment | Docker (multi-stage), systemd, launchd |
 
+## Plugin Development
+
+Background operations are implemented as UOS plugins using the stable
+`pkg/plugin/sdk` public API. See
+[docs/development/writing-a-plugin.md](docs/development/writing-a-plugin.md)
+for a full tutorial covering lifecycle, `ResumePolicy` selection, capability
+declarations, schedules/triggers, testing patterns, and a worked example.
+
 ## Documentation
 
 - [Architecture](docs/architecture.md)
@@ -257,6 +265,7 @@ mock generation.
 - [PebbleDB Keyspace Schema](docs/database-pebble-schema.md)
 - [MVP Specification](docs/mvp-specification.md)
 - [Implementation Plan](docs/mvp-implementation-plan.md)
+- [Writing a Plugin](docs/development/writing-a-plugin.md)
 - [QA Checklist](docs/qa-checklist.md)
 
 ## License

--- a/docs/development/writing-a-plugin.md
+++ b/docs/development/writing-a-plugin.md
@@ -1,0 +1,438 @@
+<!--
+file: docs/development/writing-a-plugin.md
+version: 1.0.0
+guid: f7a8b9c0-d1e2-3456-g789-h0123456789ab
+last-edited: 2026-05-08
+-->
+
+# Writing a Plugin for Audiobook Organizer
+
+This guide explains how to register background operations using the
+[`pkg/plugin/sdk`](../../pkg/plugin/sdk/) package — the stable public API for
+plugin authors.
+
+## Contents
+
+1. [Core concepts](#1-core-concepts)
+2. [Lifecycle: Plugin.Register → Registry.RegisterOp](#2-lifecycle)
+3. [Picking a ResumePolicy](#3-resumepolicy-decision-tree)
+4. [When to set Isolate: true](#4-isolation)
+5. [Capability declarations](#5-capability-declarations)
+6. [Schedules, triggers, and ad-hoc invocation](#6-schedules-triggers-and-ad-hoc-invocation)
+7. [Testing your plugin](#7-testing-your-plugin)
+8. [Worked example: import-counter plugin](#8-worked-example)
+
+---
+
+## 1. Core Concepts
+
+**Plugin** — a struct that satisfies `sdk.Plugin`. It holds any dependencies the
+operation needs (database handles, API clients, etc.) and calls
+`Registry.RegisterOp` during startup.
+
+**OperationDef** — the static description of one unit of async work. It declares
+an ID, priority, resume semantics, capabilities, and a `Run` function. Every
+field is set once at registration; nothing mutates it afterward.
+
+**Registry** — the narrow interface given to `Plugin.Register`. It exposes two
+methods:
+
+- `RegisterOp(def OperationDef) error` — registers the def; call during startup.
+- `EnqueueOp(ctx, defID, params, opts...) (runID string, err error)` — enqueues
+  a new run of a previously-registered op.
+
+**Reporter** — the per-run handle passed to `Run`. Use it to emit progress,
+structured logs, and checkpoints.
+
+---
+
+## 2. Lifecycle
+
+The startup sequence is:
+
+```
+server.New()
+  └─ pluginRegistry.Register(myPlugin)
+       └─ myPlugin.Register(r Registry)
+            └─ r.RegisterOp(def1)
+            └─ r.RegisterOp(def2)
+            ...
+```
+
+`Register` is called once, synchronously, before any requests are served.
+It must not start goroutines, block on I/O, or call `EnqueueOp` — it only
+registers definitions.
+
+Typical plugin skeleton:
+
+```go
+type Plugin struct {
+    store database.Store
+    // ... other deps
+}
+
+func New(store database.Store) *Plugin { return &Plugin{store: store} }
+
+func (p *Plugin) ID()      string { return "myplug" }
+func (p *Plugin) Name()    string { return "My Plugin" }
+func (p *Plugin) Version() string { return "1.0.0" }
+
+func (p *Plugin) Register(r sdk.Registry) error {
+    defs := []sdk.OperationDef{
+        p.scanDef(),
+        p.cleanupDef(),
+    }
+    for _, d := range defs {
+        if err := r.RegisterOp(d); err != nil {
+            return fmt.Errorf("register %s: %w", d.ID, err)
+        }
+    }
+    return nil
+}
+```
+
+The `ID()` value is used as the `Plugin` field in every `OperationDef`. Keep
+IDs lowercase, slug-style (e.g., `"acoustid"`, `"itunes"`). IDs must be globally
+unique across all plugins; collisions cause `RegisterOp` to return an error.
+
+---
+
+## 3. ResumePolicy Decision Tree
+
+`ResumePolicy` controls what happens when the server restarts with an in-flight
+run. It is **required** — `RegisterOp` rejects `ResumeUnspecified`.
+
+```
+Is the operation idempotent?
+  ├─ Yes → Can it safely re-run from zero every restart?
+  │         ├─ Yes → ResumeRequeue   (re-enqueue as a fresh run)
+  │         └─ No  → ResumeRestart  (reload last checkpoint, call Run again)
+  └─ No → Is partial work harmful if abandoned?
+            ├─ Yes → ResumeAsk      (surface in UI, wait for user)
+            └─ No  → ResumeDrop    (abandon and mark interrupted_dropped)
+```
+
+| Policy         | Use when                                                     |
+|----------------|--------------------------------------------------------------|
+| `ResumeRequeue`  | Full re-scan is cheap; idempotent writes only              |
+| `ResumeRestart`  | Operation checkpoints progress; can resume mid-way         |
+| `ResumeDrop`     | Short maintenance tasks; losing a partial run is fine      |
+| `ResumeAsk`      | Irreversible actions where partial completion needs review |
+
+**Real-world examples from this codebase:**
+
+- `dedup.embed-scan` uses `ResumeRequeue` — embedding is idempotent (already-embedded
+  books are skipped cheaply).
+- `maintenance.purge-deleted` uses `ResumeDrop` — a 30-minute cleanup window; if
+  the server restarts mid-run the next scheduled execution handles the remainder.
+- `maintenance.bulk-write-back` uses `ResumeRestart` with checkpoints — file writes
+  are non-idempotent, so a crash should resume from the last checkpoint, not restart.
+
+---
+
+## 4. Isolation
+
+`Isolate: true` runs the operation as a subprocess. Use it when:
+
+- The operation runs for hours (e.g., full library re-encode).
+- It spawns external processes (ffmpeg, AtomicParsley) that can leak file
+  descriptors.
+- A memory leak or panic in the operation must not affect the main server.
+- You declare `CapSubprocessSpawn` — ops with that capability should be isolated.
+
+`Isolate: false` (default) runs the `Run` function as an in-process goroutine.
+This is appropriate for most operations: database scans, API calls, quick
+maintenance tasks.
+
+When `Isolate: true`, the default timeout increases from 120 minutes to 6 hours.
+Both are capped at 24 hours. Set an explicit `Timeout` if your operation has
+tighter bounds.
+
+---
+
+## 5. Capability Declarations
+
+Capabilities are a coarse-grained permission vocabulary declared statically in
+`OperationDef.Capabilities`. They are lint-enforced today and will be
+runtime-enforced in a future release.
+
+| Capability              | Meaning                                    |
+|-------------------------|--------------------------------------------|
+| `CapLibraryRead`        | Read book records from the database        |
+| `CapLibraryWrite`       | Write/update book records                  |
+| `CapFilesRead`          | Read from the filesystem                   |
+| `CapFilesWrite`         | Write to the filesystem                    |
+| `CapFilesExecute`       | Execute subprocess binaries                |
+| `CapNetworkOpenAI`      | Call the OpenAI API                        |
+| `CapNetworkAudible`     | Call the Audible API                       |
+| `CapNetworkOpenLibrary` | Call the Open Library API                  |
+| `CapNetworkGoogleBooks` | Call the Google Books API                  |
+| `CapNetworkITunes`      | Communicate with the iTunes/Music service  |
+| `CapNetworkGeneric`     | Other external network calls               |
+| `CapScheduleCron`       | Op has a cron schedule                     |
+| `CapScheduleEvent`      | Op fires on an event subscription          |
+| `CapSubprocessSpawn`    | Spawns external processes                  |
+| `CapDBMigrate`          | Runs database schema migrations            |
+
+Declare the minimal set your operation actually uses. Over-declaration is a code
+smell; under-declaration will fail CI once runtime enforcement lands.
+
+---
+
+## 6. Schedules, Triggers, and Ad-hoc Invocation
+
+### Scheduled operations
+
+Set `Schedule` to a cron expression (5-field, UTC). The registry runs the op
+automatically:
+
+```go
+sched := "0 3 * * *"   // 03:00 daily, UTC
+sdk.OperationDef{
+    ID:           "myplug.nightly-sweep",
+    Schedule:     &sched,
+    Capabilities: []sdk.Capability{sdk.CapScheduleCron},
+    // ...
+}
+```
+
+Ops with a `Schedule` should also declare `CapScheduleCron`.
+
+### Event-triggered operations
+
+Subscribe to an event on the internal bus with `Triggers`:
+
+```go
+sdk.OperationDef{
+    ID: "myplug.on-import",
+    Triggers: []sdk.EventSubscription{
+        {
+            EventName: "book.imported",
+            Handler: func(ctx context.Context, payload any) error {
+                // payload is the event data
+                return nil
+            },
+        },
+    },
+    Capabilities: []sdk.Capability{sdk.CapScheduleEvent},
+    // ...
+}
+```
+
+The event bus wiring (`Reporter.Trigger`) is implemented in UOS-05. Until then,
+`Trigger` calls are accepted but do not fan out.
+
+### Ad-hoc invocation
+
+Any op can be started by calling `Registry.EnqueueOp`:
+
+```go
+runID, err := registry.EnqueueOp(ctx, "myplug.scan",
+    json.RawMessage(`{"mode":"full"}`),
+    sdk.WithActor(userID),
+    sdk.WithPriority(sdk.PriorityHigh),
+)
+```
+
+`WithParent`, `WithActor`, and `WithPriority` are the available option
+constructors.
+
+---
+
+## 7. Testing Your Plugin
+
+### Unit tests: OperationDef shape
+
+The cheapest test verifies registration and OperationDef contract compliance.
+Use a `stubRegistry` that records which ops were registered:
+
+```go
+type stubRegistry struct{ ops []sdk.OperationDef }
+
+func (r *stubRegistry) RegisterOp(d sdk.OperationDef) error {
+    r.ops = append(r.ops, d)
+    return nil
+}
+func (r *stubRegistry) EnqueueOp(_ context.Context, _ string, _ any, _ ...sdk.EnqueueOption) (string, error) {
+    return "", nil
+}
+
+func TestPlugin_Register(t *testing.T) {
+    p := myplug.New(/* stub deps */)
+    r := &stubRegistry{}
+    if err := p.Register(r); err != nil {
+        t.Fatalf("Register: %v", err)
+    }
+
+    // Check every op has an explicit ResumePolicy.
+    for _, op := range r.ops {
+        if op.ResumePolicy == sdk.ResumeUnspecified {
+            t.Errorf("op %s: ResumePolicy not set", op.ID)
+        }
+        if op.ID == "" || op.Plugin == "" {
+            t.Errorf("op %s: missing ID or Plugin", op.ID)
+        }
+    }
+}
+```
+
+### Table-driven OperationDef tests
+
+For each OperationDef method, write a table-driven sub-test:
+
+```go
+tests := []struct {
+    name        string
+    def         func(*Plugin) sdk.OperationDef
+    wantID      string
+    wantResume  sdk.ResumePolicy
+    wantCaps    []sdk.Capability
+}{
+    {
+        name:       "scan",
+        def:        (*Plugin).scanDef,
+        wantID:     "myplug.scan",
+        wantResume: sdk.ResumeRequeue,
+        wantCaps:   []sdk.Capability{sdk.CapLibraryRead},
+    },
+    // ...
+}
+for _, tc := range tests {
+    t.Run(tc.name, func(t *testing.T) {
+        p := &Plugin{}
+        d := tc.def(p)
+        if d.ID != tc.wantID { t.Errorf("ID: got %q, want %q", d.ID, tc.wantID) }
+        if d.ResumePolicy != tc.wantResume {
+            t.Errorf("ResumePolicy: got %v, want %v", d.ResumePolicy, tc.wantResume)
+        }
+        // ...
+    })
+}
+```
+
+### Integration tests using a real registry
+
+Wire up a real `registry.Registry` with in-memory deps to verify the `Run`
+function executes without error:
+
+```go
+func TestScanDef_RunSmoke(t *testing.T) {
+    store := testutil.NewInMemoryStore(t)
+    p := New(store)
+    // Build a minimal registry and enqueue.
+    reg := registry.New(/* opts */)
+    if err := p.Register(reg); err != nil {
+        t.Fatal(err)
+    }
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+    runID, err := reg.EnqueueOp(ctx, "myplug.scan", nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := reg.WaitForRun(ctx, runID); err != nil {
+        t.Fatalf("run %s: %v", runID, err)
+    }
+}
+```
+
+See `internal/plugins/dedup/plugin_test.go` and
+`internal/plugins/itunes/plugin_test.go` for real examples of the
+stub-registry pattern used in production plugins.
+
+---
+
+## 8. Worked Example
+
+Below is a complete, minimal plugin (~60 lines) that records per-book import
+counts in a custom database table. It uses `CapLibraryWrite` and runs whenever
+a scan operation is invoked ad-hoc or on schedule.
+
+```go
+// Package importcounter is an example UOS plugin.
+// It records how many times each book has been scanned.
+package importcounter
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "log/slog"
+    "time"
+
+    "github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// Store is the minimal interface the plugin needs from the database layer.
+type Store interface {
+    GetAllBooks(offset, limit int) ([]Book, error)
+    IncrementImportCount(bookID string) error
+}
+
+type Book struct{ ID string }
+
+// Plugin implements sdk.Plugin for import counting.
+type Plugin struct{ store Store }
+
+func New(store Store) *Plugin { return &Plugin{store: store} }
+
+func (p *Plugin) ID() string      { return "importcounter" }
+func (p *Plugin) Name() string    { return "Import Counter" }
+func (p *Plugin) Version() string { return "1.0.0" }
+
+func (p *Plugin) Register(r sdk.Registry) error {
+    sched := "0 1 * * *" // 01:00 daily
+    return r.RegisterOp(sdk.OperationDef{
+        ID:              "importcounter.scan",
+        Plugin:          "importcounter",
+        DisplayName:     "Record import counts",
+        Description:     "Increments the import counter for every book in the library.",
+        ResumePolicy:    sdk.ResumeRequeue,
+        DefaultPriority: sdk.PriorityLow,
+        ConcurrencyKey:  "importcounter.scan",
+        Cancellable:     true,
+        Isolate:         false,
+        Timeout:         30 * time.Minute,
+        Schedule:        &sched,
+        Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite, sdk.CapScheduleCron},
+        Run:             p.run,
+    })
+}
+
+func (p *Plugin) run(ctx context.Context, _ json.RawMessage, rep sdk.Reporter) error {
+    _ = rep.Log(slog.LevelInfo, "import-counter: starting")
+    books, err := p.store.GetAllBooks(0, 0)
+    if err != nil {
+        return fmt.Errorf("load books: %w", err)
+    }
+    for i, b := range books {
+        if rep.IsCanceled() {
+            return context.Canceled
+        }
+        if err := p.store.IncrementImportCount(b.ID); err != nil {
+            rep.Logger().Error("increment failed", "book_id", b.ID, "err", err)
+        }
+        _ = rep.UpdateProgress(i+1, len(books),
+            fmt.Sprintf("processed %d/%d books", i+1, len(books)))
+    }
+    _ = rep.Log(slog.LevelInfo, fmt.Sprintf("import-counter: updated %d books", len(books)))
+    return nil
+}
+```
+
+**What this demonstrates:**
+
+- Minimal `sdk.Plugin` implementation with all four interface methods.
+- One `OperationDef` with explicit `ResumePolicy`, `ConcurrencyKey`, `Capabilities`,
+  and `Schedule`.
+- Cancellation check inside the loop (`rep.IsCanceled()`).
+- Progress reporting with `rep.UpdateProgress`.
+- Structured logging via `rep.Logger()` and `rep.Log`.
+- Dependency injection through a narrow `Store` interface — the plugin does not
+  import any concrete database package.
+
+**Where to put it in the tree:**
+
+Production plugins live under `internal/plugins/<name>/`. They import
+`pkg/plugin/sdk` and nothing else from the public tree. All dependencies are
+injected by the server at startup.

--- a/pkg/plugin/sdk/doc.go
+++ b/pkg/plugin/sdk/doc.go
@@ -1,9 +1,79 @@
 // file: pkg/plugin/sdk/doc.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-06
+// last-edited: 2026-05-08
 
-// Package sdk provides the stable public API for audiobook-organizer plugins.
+// Package sdk provides the STABLE public API for audiobook-organizer plugins.
+//
 // Plugin authors should import only this package (plus stdlib and log/slog).
-// See: docs/superpowers/specs/2026-05-04-unified-operations-system.md §1
+// The internal backplane (internal/operations/registry, internal/auth) is the
+// implementation detail; this package exposes type aliases and constants that
+// form the stable contract. Breaking changes to the types below will increment
+// the major version.
+//
+// # Minimal plugin example
+//
+// The following 30-line example is a complete, compilable plugin.
+// It registers one operation that logs a greeting and exits.
+//
+//	package greeter
+//
+//	import (
+//	    "context"
+//	    "encoding/json"
+//	    "log/slog"
+//	    "time"
+//
+//	    "github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+//	)
+//
+//	type Plugin struct{}
+//
+//	func New() *Plugin { return &Plugin{} }
+//
+//	func (p *Plugin) ID()      string { return "greeter" }
+//	func (p *Plugin) Name()    string { return "Greeter" }
+//	func (p *Plugin) Version() string { return "1.0.0" }
+//
+//	func (p *Plugin) Register(r sdk.Registry) error {
+//	    return r.RegisterOp(sdk.OperationDef{
+//	        ID:              "greeter.hello",
+//	        Plugin:          "greeter",
+//	        DisplayName:     "Say hello",
+//	        Description:     "Logs a greeting and exits.",
+//	        ResumePolicy:    sdk.ResumeDrop,
+//	        DefaultPriority: sdk.PriorityLow,
+//	        ConcurrencyKey:  "greeter.hello",
+//	        Cancellable:     false,
+//	        Isolate:         false,
+//	        Timeout:         30 * time.Second,
+//	        Capabilities:    nil,
+//	        Run: func(_ context.Context, _ json.RawMessage, rep sdk.Reporter) error {
+//	            return rep.Log(slog.LevelInfo, "hello from greeter plugin")
+//	        },
+//	    })
+//	}
+//
+// # Stability contract
+//
+// This package is STABLE as of UOS-15. The following identifiers will not be
+// removed or have their signatures changed in a backwards-incompatible way
+// without a major-version bump:
+//
+//   - Plugin interface (ID, Name, Version, Register)
+//   - Registry interface (RegisterOp, EnqueueOp)
+//   - OperationDef struct and all exported fields
+//   - Reporter interface (UpdateProgress, Log, Logger, Checkpoint, IsCanceled, RunPhase, Trigger)
+//   - ResumePolicy constants (ResumeRestart, ResumeRequeue, ResumeDrop, ResumeAsk)
+//   - Priority constants (PriorityLow, PriorityNormal, PriorityHigh)
+//   - ActorMode constants (ActorContext, ActorSystem)
+//   - Capability constants (all Cap* identifiers)
+//   - EnqueueOption type and option constructors (WithParent, WithActor, WithPriority)
+//   - Error variables (ErrCanceled, ErrQuiesced, ErrPluginCapabilityMissing)
+//
+// # Further reading
+//
+// See docs/development/writing-a-plugin.md for the full tutorial covering
+// lifecycle, ResumePolicy decision tree, isolation, capability declarations,
+// schedules/triggers, and testing patterns.
 package sdk

--- a/tools/cmd/sdkguard/main.go
+++ b/tools/cmd/sdkguard/main.go
@@ -1,0 +1,107 @@
+// file: tools/cmd/sdkguard/main.go
+// version: 1.0.0
+// guid: e8f9a0b1-c2d3-4567-e890-f12345678901
+// last-edited: 2026-05-08
+
+// Package main implements sdkguard, a CI tool that asserts pkg/plugin/sdk has
+// no unexpected internal/ dependencies.
+//
+// The SDK is a stable public contract backed by type aliases into
+// internal/operations/registry and internal/auth. Those "allowed internals" are
+// part of the SDK's own implementation contract and are explicitly whitelisted.
+// Any OTHER internal/ import appearing in the dependency tree of pkg/plugin/sdk
+// is a violation — it means a new internal dependency was added without review.
+//
+// Usage:
+//
+//	go run ./tools/cmd/sdkguard/main.go            # check pkg/plugin/sdk
+//	go run ./tools/cmd/sdkguard/main.go -module=./pkg/plugin/sdk/...
+//
+// Exit codes:
+//
+//	0 — all clear
+//	1 — one or more forbidden internal/ packages found in the dep tree
+//	2 — usage / invocation error
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// module is the Go pattern passed to `go list -deps`.
+const defaultModule = "./pkg/plugin/sdk/..."
+
+// allowedInternals lists the internal/ packages that are part of the SDK's
+// stable backplane. These are the type-alias targets (internal/operations/registry,
+// internal/auth) and their own transitive dependencies. Any internal/ package
+// NOT in this set is a forbidden accretion.
+//
+// To update this list: run `go list -deps ./pkg/plugin/sdk/... | grep '/internal/'`
+// and verify each entry is an approved backplane package, then add it here.
+var allowedInternals = map[string]bool{
+	"github.com/jdfalk/audiobook-organizer/internal/operations/registry": true,
+	"github.com/jdfalk/audiobook-organizer/internal/auth":                true,
+	"github.com/jdfalk/audiobook-organizer/internal/models":              true,
+	"github.com/jdfalk/audiobook-organizer/internal/database":            true,
+	"github.com/jdfalk/audiobook-organizer/internal/metrics":             true,
+	"github.com/jdfalk/audiobook-organizer/internal/util":                true,
+	"github.com/jdfalk/audiobook-organizer/internal/fingerprint":         true,
+	"github.com/jdfalk/audiobook-organizer/internal/matcher":             true,
+}
+
+func main() {
+	moduleFlag := flag.String("module", defaultModule, "Go package pattern to inspect")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: sdkguard [-module=<pattern>]\n\n")
+		fmt.Fprintf(os.Stderr, "Asserts that pkg/plugin/sdk has no unexpected internal/ dependencies.\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	violations, err := run(*moduleFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sdkguard: error: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(violations) > 0 {
+		fmt.Fprintf(os.Stderr, "sdkguard: FAIL — forbidden internal/ packages in %s dep tree:\n\n", *moduleFlag)
+		for _, v := range violations {
+			fmt.Fprintf(os.Stderr, "  %s\n", v)
+		}
+		fmt.Fprintf(os.Stderr, "\nTo fix: remove the import or add it to the allowedInternals list in\n")
+		fmt.Fprintf(os.Stderr, "tools/cmd/sdkguard/main.go (with a comment explaining why it is allowed).\n")
+		os.Exit(1)
+	}
+
+	fmt.Printf("sdkguard: OK — %s has no forbidden internal/ dependencies\n", *moduleFlag)
+}
+
+// run shells out to `go list -deps <module>` and scans the output for
+// project-local internal/ packages not on the allowlist. It returns a slice
+// of violation strings (one per forbidden package).
+func run(module string) ([]string, error) {
+	cmd := exec.Command("go", "list", "-deps", module)
+	cmd.Env = os.Environ()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list -deps %s: %w\n%s", module, err, string(out))
+	}
+
+	const modulePrefix = "github.com/jdfalk/audiobook-organizer/internal/"
+	var violations []string
+	for _, line := range strings.Split(string(out), "\n") {
+		pkg := strings.TrimSpace(line)
+		if !strings.HasPrefix(pkg, modulePrefix) {
+			continue
+		}
+		if !allowedInternals[pkg] {
+			violations = append(violations, pkg)
+		}
+	}
+	return violations, nil
+}


### PR DESCRIPTION
## Summary
- Adds `docs/development/writing-a-plugin.md` — full tutorial covering Plugin lifecycle, `OperationDef` contract, `ResumePolicy` decision tree, `Isolate` flag, capability declarations, schedules/triggers, testing patterns, and a worked 60-line example plugin
- Adds `pkg/plugin/sdk/doc.go` v2.0.0 — expanded package godoc with 30-line minimal plugin example and explicit stability contract listing all guaranteed identifiers
- Adds `tools/cmd/sdkguard/main.go` — CI tool that shells to `go list -deps ./pkg/plugin/sdk/...` and asserts no unexpected `internal/` packages appear in the dep tree (allowlist covers the established backplane: operations/registry, auth, and transitive deps)
- Updates `Makefile` with new `sdkguard` target wired into `make ci`
- Updates `README.md` with Plugin Development section linking to the tutorial

## Test plan
- [x] `make sdkguard` passes (verified locally)
- [x] `go doc ./pkg/plugin/sdk` renders correctly (verified locally)
- [x] `go vet ./tools/cmd/sdkguard/...` passes
- [ ] `make ci` passes in GitHub Actions (pre-existing `dedupplugin.New` build error in main is unrelated to this PR)

## Notes on sdkguard design
The SDK type-aliases into `internal/operations/registry` and `internal/auth`, which transitively pull in several other internal packages. These are the SDK's stable backplane and are explicitly allowlisted. The guard's purpose is to prevent *new* accretions — any `internal/` package added that isn't in the allowlist will fail CI with a clear error message pointing to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)