### PR TITLE
feat(uos): delete v1 OperationQueue + legacy endpoints (UOS-14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
 - **Makefile** — new `sdkguard` target; added to `ci` dependency chain alongside
   `oplint`.
 
+#### May 8, 2026 — UOS-14: Delete v1 legacy API wrappers and deprecated endpoints
+
+- **feat(uos)**: Removed `getActiveOperations()`, `getRecentCompletedOperations()`, and `ActiveOperationSummary` type from `web/src/services/api.ts` (deprecated since UOS-13, no remaining callers).
+- **feat(uos)**: `GET /api/v1/operations/active` and `GET /api/v1/operations/recent` now return 410 Gone with redirect hint to `/api/v1/operations/timeline`.
+- **fix(uos)**: Moved dedup plugin registration to after engine+store init; fixed missing `embeddingStore` arg to `dedupplugin.New()`.
+- **fix(uos)**: Deleted unreachable `triggerEmbedScanLegacy` (pre-UOS-07 reference copy).
+- **fix(uos)**: Cleaned up `server_lifecycle.go` UOS-14 straggler comments.
+- Updated test fixtures that mocked deleted v1 API functions.
+
 #### May 7, 2026 — UOS-12: Migrate 26 maintenance ops to UOS plugin
 
 - **feat(uos)**: Created `internal/plugins/maintenance/` UOS plugin registering 26

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.15.0 -->
+<!-- version: 8.16.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-05-06 -->
+<!-- last-edited: 2026-05-08 -->
 
 # Project TODO
 
@@ -647,6 +647,7 @@ since it was last edited on 2026-04-11).
   - [x] **UOS-04** Public plugin SDK at `pkg/plugin/sdk` + import lint tool (merged 2026-05-06)
   - [x] **UOS-06** SSE EventHub + /operations/timeline + introspection endpoints + frontend SSE store integration (merged 2026-05-06)
   - [x] **UOS-07** Canary — migrate `dedup.embed-scan` as the first live plugin op (merged 2026-05-06)
+  - [x] **UOS-14** Delete v1 legacy API wrappers (`getActiveOperations`, `getRecentCompletedOperations`, `ActiveOperationSummary`) + return 410 Gone for `/operations/active` and `/operations/recent` (PR in progress 2026-05-08)
   - [ ] **UOS-05**, **UOS-09** and beyond (see bot-task index)
 - [ ] **1.15** **UOS amendment — `Reporter.SetCurrentItem(label)` for live "currently working on" ticker** — Sonarr/Radarr-style high-frequency current-item display under the progress bar. New SDK Reporter method that's purely ephemeral (in-memory on the registry's run handle, no DB write); SSE event `op.current_item` patches the frontend store; timeline endpoint returns the cached value so refresh / new tab / re-login re-hydrates. Survives refresh; survives a brief gap on server restart (next per-item iteration repopulates). If we ever want it to survive restart, retrofit is a single column add to `operations_v2` flushed at 30s cadence — explicit out of v1. Implementation footprint: amend §1 (Reporter) + §9 (timeline payload) + UOS-03/UOS-06 bot-tasks. Spec: [`docs/superpowers/bot-tasks/2026-05-05-uos-amendment-current-item.md`](docs/superpowers/bot-tasks/2026-05-05-uos-amendment-current-item.md).
 - [ ] **1.16** **Resizable + dynamically-sortable columns everywhere** — every page that renders a table (library, dedup, activity, iTunes write-back preview, metadata review, etc.) should have draggable column dividers and click-to-sort headers, persisted per-user. Today some pages have it, most don't, and the inconsistency is jarring. Build a single `<ResizableSortableTable>` component (or extend the existing `ConfigurableTable`); roll across pages in follow-ups. Acceptance: every column on every page resizes; every column on every page sorts; user-resized widths and sort states persist via `localStorage` keyed on page+column.

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,12 +1,11 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-06
+// last-edited: 2026-05-08
 
 package server
 
 import (
-	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -18,11 +17,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
-	ulid "github.com/oklog/ulid/v2"
 )
 
 // listDedupCandidates handles GET /api/v1/dedup/candidates.
@@ -1045,83 +1041,6 @@ func (s *Server) triggerEmbedScan(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
-}
-
-// triggerEmbedScanLegacy is the pre-UOS-07 inline implementation, kept for
-// reference until the old queue is fully removed in UOS-14.
-func (s *Server) triggerEmbedScanLegacy(c *gin.Context) {
-	if s.dedupEngine == nil {
-		httputil.RespondWithServiceUnavailable(c, "dedup engine not available (embedding may be disabled or API key not configured)")
-		return
-	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
-		return
-	}
-
-	opID := ulid.Make().String()
-	op, err := s.Store().CreateOperation(opID, "embed-scan", nil)
-	if err != nil {
-		httputil.InternalError(c, "failed to create embed-scan operation", err)
-		return
-	}
-
-	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		_ = progress.UpdateProgress(0, 100, "Loading books for embedding...")
-
-		books, err := s.Store().GetAllBooks(0, 0)
-		if err != nil {
-			return fmt.Errorf("load books: %w", err)
-		}
-		total := len(books)
-		if total == 0 {
-			_ = progress.UpdateProgress(100, 100, "No books to embed")
-			return nil
-		}
-
-		var embedded, cached, skipped, errs int
-		for i, book := range books {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			status, err := s.dedupEngine.EmbedBook(ctx, book.ID)
-			if err != nil {
-				log.Printf("[embed-scan] embed error for %s: %v", book.ID, err)
-				errs++
-			} else {
-				switch status {
-				case dedup.EmbedStatusEmbedded:
-					embedded++
-				case dedup.EmbedStatusCached:
-					cached++
-				default:
-					skipped++
-				}
-			}
-
-			if i%50 == 0 || i == total-1 {
-				pct := 1 + (98 * (i + 1) / total)
-				_ = progress.UpdateProgress(pct, 100,
-					fmt.Sprintf("Embedding books: %d / %d (new=%d cached=%d skipped=%d errors=%d)",
-						i+1, total, embedded, cached, skipped, errs))
-			}
-		}
-
-		_ = progress.UpdateProgress(100, 100,
-			fmt.Sprintf("Embedding complete — %d new, %d cached, %d skipped, %d errors (of %d books)",
-				embedded, cached, skipped, errs, total))
-		return nil
-	}
-
-	if err := s.queue.Enqueue(opID, "embed-scan", operations.PriorityLow, opFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue embed scan", err)
-		return
-	}
-
-	httputil.RespondWithSuccess(c, http.StatusAccepted, op)
 }
 
 // triggerBookSignatureScan handles POST /api/v1/dedup/scan-book-signature.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-07
+// last-edited: 2026-05-08
 
 package server
 
@@ -274,8 +274,9 @@ func NewServer(store database.Store) *Server {
 	router := gin.New() // don't use gin.Default() — we add our own middleware
 
 	// Custom logger that skips noisy polling endpoints
+	// (UOS-14: /operations/active removed; SkipPaths entry removed)
 	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: []string{"/api/v1/operations/active"},
+		SkipPaths: []string{"/api/v1/operations/events"},
 	}))
 	router.Use(gin.Recovery())
 	router.Use(corsMiddleware())
@@ -345,16 +346,6 @@ func NewServer(store database.Store) *Server {
 	// Plugins register their defs in their own bot-tasks (UOS-03+).
 	server.opHub = opsregistry.NewEventHub()
 	server.opRegistry = opsregistry.New(resolvedStore, slog.Default(), 8, server.opHub)
-
-	// Register UOS plugins. Dedup embed-scan is the canary (UOS-07).
-	// Additional plugins registered in UOS-09 through UOS-12.
-	// Guard on dedupEngine: tests don't initialize the embedding subsystem,
-	// so we skip registration to avoid unexpected mock store calls.
-	if server.dedupEngine != nil {
-		if err := dedupplugin.New(server.dedupEngine, resolvedStore).Register(server.opRegistry); err != nil {
-			log.Printf("[server] dedup plugin register: %v", err)
-		}
-	}
 
 	// UOS-12: maintenance plugin — 26 ops migrated from scheduler_tasks.go.
 	// Guard on RootDir: tests don't configure AppConfig, so RootDir is ""
@@ -563,6 +554,12 @@ func NewServer(store database.Store) *Server {
 
 				log.Println("[INFO] Embedding store and dedup engine initialized")
 				server.metadataFetchService.SetDedupEngine(server.dedupEngine)
+
+				// Register UOS dedup plugin (UOS-07). Done here so the engine
+				// and embeddingStore are both available.
+				if err := dedupplugin.New(server.dedupEngine, resolvedStore, server.embeddingStore).Register(server.opRegistry); err != nil {
+					log.Printf("[server] dedup plugin register: %v", err)
+				}
 
 				// Dedup-on-import is now wired via SetScanHooks below
 				// (together with the activity recorder).

--- a/internal/server/server_coverage_test.go
+++ b/internal/server/server_coverage_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/server_coverage_test.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
+// last-edited: 2026-05-08
 
 package server
 
@@ -577,24 +578,20 @@ func TestCoverageStartOrganize(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 11. GET /api/v1/operations/active  (active operations)
+// 11. GET /api/v1/operations/active  (deprecated — returns 410 Gone since UOS-14)
 // ---------------------------------------------------------------------------
 
 func TestCoverageListActiveOperations(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	t.Run("no active operations", func(t *testing.T) {
+	t.Run("returns 410 gone", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/operations/active", nil)
 		w := httptest.NewRecorder()
 		server.router.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		data := resp["data"].(map[string]any)
-		ops := data["operations"].([]any)
-		assert.NotNil(t, ops)
+		// UOS-14: this endpoint is removed; it now returns 410 Gone.
+		assert.Equal(t, http.StatusGone, w.Code)
 	})
 }
 

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/server_extra_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 61a2d3c4-80ab-4f6f-8c39-15a2ac5b7f0c
+// last-edited: 2026-05-08
 
 package server
 
@@ -273,10 +274,11 @@ func TestOperationEndpointsErrors(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 
+	// /operations/active returns 410 Gone since UOS-14
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/operations/active", nil)
 	w = httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusGone, w.Code)
 	server.queue = origQueue
 
 	req = httptest.NewRequest(http.MethodDelete, "/api/v1/operations/bad-id", nil)

--- a/internal/server/server_handlers_test.go
+++ b/internal/server/server_handlers_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/server_handlers_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
+// last-edited: 2026-05-08
 
 package server
 
@@ -177,11 +178,11 @@ func TestOperationEndpoints(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	// List active operations
+	// /operations/active returns 410 Gone since UOS-14 (removed in favour of /operations/timeline)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/operations/active", nil)
 	w := httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusGone, w.Code)
 
 	// Test get operation status
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/operations/nonexistent/status", nil)

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-07
+// last-edited: 2026-05-08
 
 package server
 
@@ -75,7 +75,7 @@ func (s *Server) resumeInterruptedOperations() {
 		var resumeFn operations.OperationFunc
 		switch opType {
 		case "itunes_import":
-			// v1 straggler — cases removed when migrated to UOS; delete in UOS-14
+			// Migrated to UOS (itunes.import); re-enqueue via registry on resume.
 			if s.opRegistry != nil {
 				_, _ = s.opRegistry.EnqueueOp(context.Background(), "itunes.import", nil)
 			} else {
@@ -124,7 +124,7 @@ func (s *Server) resumeInterruptedOperations() {
 		case "metadata-refresh":
 			resumeFn = s.runMetadataRefreshScan
 		case "itunes_path_reconcile":
-			// v1 straggler — cases removed when migrated to UOS; delete in UOS-14
+			// Migrated to UOS (itunes.path-reconcile); re-enqueue via registry on resume.
 			if s.opRegistry != nil {
 				_, _ = s.opRegistry.EnqueueOp(context.Background(), "itunes.path-reconcile", nil)
 			} else {
@@ -132,7 +132,7 @@ func (s *Server) resumeInterruptedOperations() {
 			}
 			continue
 		case "itunes_path_repair":
-			// v1 straggler — cases removed when migrated to UOS; delete in UOS-14
+			// Migrated to UOS (itunes.path-repair); re-enqueue via registry on resume.
 			if s.opRegistry != nil {
 				_, _ = s.opRegistry.EnqueueOp(context.Background(), "itunes.path-repair", nil)
 			} else {
@@ -147,8 +147,6 @@ func (s *Server) resumeInterruptedOperations() {
 			// stuck reconcile_scans that the cancel API couldn't actually
 			// kill. Letting the scheduler re-run it tomorrow is fine.
 			"reconcile_scan":
-			// UOS-12 migrated ops removed — see maintenance plugin (internal/plugins/maintenance);
-			// remaining legacy op IDs above will be cleaned up in UOS-14.
 			// These are not resumable — mark as failed silently.
 			_ = store.UpdateOperationError(opID, fmt.Sprintf("interrupted during %s, please retry", opType))
 			_ = operations.ClearState(store, opID)
@@ -1006,12 +1004,18 @@ func (s *Server) setupRoutes() {
 
 			// Operation routes
 			protected.GET("/operations", s.perm(auth.PermLibraryView), s.listOperations)
-			protected.GET("/operations/active", s.perm(auth.PermLibraryView), s.listActiveOperations)
+			// UOS-14: /operations/active and /operations/recent are removed — return 410 Gone.
+			// Use GET /operations/timeline instead.
+			protected.GET("/operations/active", s.perm(auth.PermLibraryView), func(c *gin.Context) {
+				c.JSON(http.StatusGone, gin.H{"error": "gone", "message": "this endpoint has been removed; use GET /api/v1/operations/timeline instead"})
+			})
+			protected.GET("/operations/recent", s.perm(auth.PermLibraryView), func(c *gin.Context) {
+				c.JSON(http.StatusGone, gin.H{"error": "gone", "message": "this endpoint has been removed; use GET /api/v1/operations/timeline instead"})
+			})
 			protected.GET("/operations/stale", s.perm(auth.PermLibraryView), s.listStaleOperations)
 			protected.POST("/operations/scan", s.perm(auth.PermScanTrigger), s.startScan)
 			protected.POST("/operations/organize", s.perm(auth.PermScanTrigger), s.startOrganize)
 			protected.POST("/operations/transcode", s.perm(auth.PermScanTrigger), s.startTranscode)
-			protected.GET("/operations/recent", s.perm(auth.PermLibraryView), s.handleGetRecentOperations)
 
 			// UOS-06: operations v2 SSE + timeline + introspection endpoints
 			protected.GET("/operations/timeline", s.perm(auth.PermLibraryView), s.handleGetOperationTimeline)

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/server_more_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 18a6b0a3-7e78-4e0f-8b8e-0e4c1dbde6de
+// last-edited: 2026-05-08
 
 //go:build !windows
 
@@ -699,6 +700,9 @@ func TestStartOrganizeOperation(t *testing.T) {
 }
 
 func TestListActiveOperations(t *testing.T) {
+	// UOS-14: /operations/active is removed (410 Gone); the queue still works,
+	// but callers should use /operations/timeline instead. This test only
+	// verifies the 410 response and that the queue itself still accepts ops.
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
@@ -717,7 +721,8 @@ func TestListActiveOperations(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/operations/active", nil)
 	w := httptest.NewRecorder()
 	server.router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
+	// Endpoint removed in UOS-14; returns 410 Gone
+	require.Equal(t, http.StatusGone, w.Code)
 
 	close(block)
 	waitForOperationStatus(t, opID, 5*time.Second)

--- a/internal/server/server_queue_test.go
+++ b/internal/server/server_queue_test.go
@@ -128,9 +128,7 @@ func TestGetOperationsWithQueueMock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockStore := dbmocks.NewMockStore(t)
-			database.SetGlobalStore(mockStore)
-
+			// The 410 handler returns before any DB or queue call, so no mock needed.
 			server := &Server{
 				router: gin.New(),
 			}

--- a/internal/server/server_queue_test.go
+++ b/internal/server/server_queue_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	dbmocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	queuemocks "github.com/jdfalk/audiobook-organizer/internal/operations/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -108,93 +107,34 @@ func TestCancelOperationWithQueueMock(t *testing.T) {
 	}
 }
 
-// TestGetOperationsWithQueueMock verifies GET /operations/active returns the
-// active operation list from the queue, returning an empty array when nil.
+// TestGetOperationsWithQueueMock verifies GET /operations/active returns 410 Gone
+// since UOS-14 removed this endpoint. Use GET /operations/timeline instead.
 func TestGetOperationsWithQueueMock(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name           string
-		mockStoreSetup func(*dbmocks.MockStore)
 		mockQueueSetup func(*queuemocks.MockQueue)
-		expectedStatus int
-		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
 	}{
 		{
-			name: "successfully get active operations",
-			mockStoreSetup: func(m *dbmocks.MockStore) {
-				// listActiveOperations calls GetOperationByID for each operation
-				m.EXPECT().GetOperationByID("op1").Return(&database.Operation{
-					ID:       "op1",
-					Type:     "scan",
-					Status:   "running",
-					Progress: 5,
-					Total:    10,
-					Message:  "scanning files",
-				}, nil).Once()
-				m.EXPECT().GetOperationByID("op2").Return(&database.Operation{
-					ID:       "op2",
-					Type:     "organize",
-					Status:   "queued",
-					Progress: 0,
-					Total:    0,
-					Message:  "",
-				}, nil).Once()
-			},
-			mockQueueSetup: func(m *queuemocks.MockQueue) {
-				m.EXPECT().ActiveOperations().Return([]operations.ActiveOperation{
-					{ID: "op1", Type: "scan"},
-					{ID: "op2", Type: "organize"},
-				}).Once()
-			},
-			expectedStatus: http.StatusOK,
-			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
-				body := w.Body.String()
-				assert.Contains(t, body, "op1")
-				assert.Contains(t, body, "op2")
-				assert.Contains(t, body, "scan")
-				assert.Contains(t, body, "organize")
-			},
+			name:           "with queue - returns 410 gone",
+			mockQueueSetup: nil,
 		},
 		{
-			name: "empty active operations list",
-			mockStoreSetup: func(m *dbmocks.MockStore) {
-				// No database expectations needed
-			},
-			mockQueueSetup: func(m *queuemocks.MockQueue) {
-				m.EXPECT().ActiveOperations().Return([]operations.ActiveOperation{}).Once()
-			},
-			expectedStatus: http.StatusOK,
-			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
-				assert.Contains(t, w.Body.String(), "[]")
-			},
-		},
-		{
-			name: "nil queue returns empty array",
-			mockStoreSetup: func(m *dbmocks.MockStore) {
-				// No database expectations needed
-			},
-			mockQueueSetup: nil, // Don't set up queue
-			expectedStatus: http.StatusOK,
-			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
-				assert.Contains(t, w.Body.String(), "[]")
-			},
+			name:           "nil queue - returns 410 gone",
+			mockQueueSetup: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create mock store
 			mockStore := dbmocks.NewMockStore(t)
-			tt.mockStoreSetup(mockStore)
 			database.SetGlobalStore(mockStore)
 
-			// Create server
 			server := &Server{
 				router: gin.New(),
 			}
 
-			// Create and setup mock queue (or leave nil)
 			if tt.mockQueueSetup != nil {
 				mockQueue := queuemocks.NewMockQueue(t)
 				tt.mockQueueSetup(mockQueue)
@@ -204,14 +144,13 @@ func TestGetOperationsWithQueueMock(t *testing.T) {
 			}
 			server.setupRoutes()
 
-			// Make request
+			// UOS-14: /operations/active is removed; must return 410 Gone
 			req := httptest.NewRequest("GET", "/api/v1/operations/active", nil)
 			w := httptest.NewRecorder()
 			server.router.ServeHTTP(w, req)
 
-			// Assert
-			assert.Equal(t, tt.expectedStatus, w.Code)
-			tt.checkResponse(t, w)
+			assert.Equal(t, http.StatusGone, w.Code)
+			assert.Contains(t, w.Body.String(), "gone")
 		})
 	}
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,7 @@
 // file: web/src/App.test.tsx
-// version: 1.0.6
+// version: 1.0.7
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+// last-edited: 2026-05-08
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -38,7 +39,6 @@ vi.mock('./services/api', () => ({
   }),
   getImportPaths: vi.fn().mockResolvedValue([{ path: '/tmp' }]),
   countBooks: vi.fn().mockResolvedValue(0),
-  getActiveOperations: vi.fn().mockResolvedValue([]),
   getOperationLogsTail: vi.fn().mockResolvedValue([]),
   getAuthors: vi.fn().mockResolvedValue([]),
   getSeries: vi.fn().mockResolvedValue([]),

--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -1,6 +1,7 @@
 // file: web/src/pages/Library.bulkFetch.test.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5b7b0d6f-5c2b-4d57-9b6c-8dbb7a9e9e2c
+// last-edited: 2026-05-08
 
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -22,7 +23,6 @@ vi.mock('../services/api', () => {
   }
   return {
     ApiError,
-    getActiveOperations: vi.fn().mockResolvedValue([]),
     getOperationLogsTail: vi.fn().mockResolvedValue([]),
     getBooks: vi.fn().mockResolvedValue({
       items: [

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,6 +1,7 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
+// last-edited: 2026-05-08
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -21,7 +22,6 @@ vi.mock('../services/api', () => {
   }
   return {
     ApiError,
-    getActiveOperations: vi.fn().mockResolvedValue([]),
     getOperationLogsTail: vi.fn().mockResolvedValue([]),
     getBooks: vi.fn().mockResolvedValue({
       items: [

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.20.0
+// version: 2.21.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-06
+// last-edited: 2026-05-08
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -396,16 +396,6 @@ export interface OperationLog {
   message: string;
   details?: string;
   created_at: string;
-}
-
-// Active operations (subset when listing current queue state)
-export interface ActiveOperationSummary {
-  id: string;
-  type: string;
-  status: string;
-  progress: number;
-  total: number;
-  message: string;
 }
 
 // Operations V2 (UOS-05: new timeline endpoint)
@@ -1677,27 +1667,6 @@ export async function getBookChanges(bookId: string): Promise<OperationChange[]>
   }
   const data = await response.json();
   return data.changes || [];
-}
-
-/**
- * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
- * No remaining UI callers as of UOS-13; kept alive only for backwards compat.
- * Will be deleted in UOS-14.
- */
-export async function getActiveOperations(): Promise<ActiveOperationSummary[]> {
-  const response = await fetch(`${API_BASE}/operations/active`);
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to fetch active operations');
-  }
-  const body = await response.json();
-  // Backend wraps every successful response in `{ data: ... }` via
-  // RespondWithOK; the actual payload is `{ data: { operations: [...] } }`.
-  // The previous read used top-level `body.operations`, which was always
-  // undefined, so this function silently returned `[]` — making the
-  // Activity page's "Active Operations" section permanently empty AND
-  // breaking the bell icon's auto-discovery of in-flight ops triggered
-  // outside of the dedup page.
-  return body?.data?.operations || body?.operations || [];
 }
 
 // System
@@ -3110,18 +3079,6 @@ export async function batchUnrejectCandidates(operationId: string, bookIds: stri
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to unreject candidates');
   return response.json();
-}
-
-/**
- * @deprecated UI now reads exclusively from the v2 SSE + /operations/timeline (UOS-13).
- * No remaining UI callers as of UOS-13; kept alive only for backwards compat.
- * Will be deleted in UOS-14.
- */
-export async function getRecentCompletedOperations(): Promise<Operation[]> {
-  const response = await fetch(`${API_BASE}/operations/recent`);
-  if (!response.ok) throw await buildApiError(response, 'Failed to get recent operations');
-  const data = await response.json();
-  return data.operations || [];
 }
 
 export async function revertToSnapshot(bookId: string, timestamp: string): Promise<{ message: string; book: Book }> {

--- a/web/src/stores/useOperationsStore.test.ts
+++ b/web/src/stores/useOperationsStore.test.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.test.ts
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-08
 
@@ -56,9 +56,7 @@ describe('useOperationsStore', () => {
     await useOperationsStore.getState().loadFromServer();
 
     expect(api.getOperationTimeline).toHaveBeenCalledTimes(1);
-    // v1 endpoints must NOT be called
-    expect(api.getActiveOperations).not.toHaveBeenCalled();
-    expect(api.getRecentCompletedOperations).not.toHaveBeenCalled();
+    // v1 endpoints are deleted in UOS-14; only v2 timeline is called
 
     const ops = useOperationsStore.getState().activeOperations;
     expect(ops).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Replaces `/operations/active` and `/operations/recent` v1 routes with `410 Gone` handlers redirecting callers to `GET /api/v1/operations/timeline` (UOS-14 spec)
- Deletes deprecated `getActiveOperations()`, `getRecentCompletedOperations()`, and `ActiveOperationSummary` from `web/src/services/api.ts`
- Removes the pre-UOS-07 `triggerEmbedScanLegacy` dead function from `dedup_handlers.go` and its unused imports
- Updates all server-package tests that expected `200 OK` from `/operations/active` to expect `410 Gone`
- Updates SkipPaths from `/operations/active` (no longer polled) to `/operations/events` (SSE stream, now the high-frequency endpoint)
- Fixes a dead dedup-plugin registration block in `server.go` that was guarded by a nil check that could never be true at that call site; moves registration to after `dedupEngine` and `embeddingStore` are initialised

## Scope notes

- **`server.queue` field not removed**: ~30 handler files still use `s.queue.Enqueue()` for op types without v2 plugin equivalents. Removing the queue is post-UOS-14 work once all op types have v2 plugins.
- **`make oplint` already exists**: Found at Makefile line 200 — no changes needed to the Makefile.
- **TypeScript check**: `npx tsc --noEmit` was not run in the worktree because `node_modules` is not present there. API deletions were validated by grepping all consumers; none remain after the mock cleanups.

## Pre-existing test flakiness

`TestITunesDisabled_ReturnsServiceUnavailable` fails in the full server-package suite (passes in isolation) due to `database.SetGlobalStore()` global state contamination across parallel tests. This is a pre-existing issue not introduced or worsened by this PR — one `SetGlobalStore` call was actually _removed_ from `TestGetOperationsWithQueueMock` as part of this PR's cleanup.

## Test plan

- [x] `go test ./internal/server/ -run TestCancelOperationWithQueueMock` — passes
- [x] `go test ./internal/server/ -run TestGetOperationsWithQueueMock` — passes (410)
- [x] `go test ./internal/server/ -run TestListActiveOperations` — passes (410)
- [x] `go test ./internal/server/ -run TestITunesDisabled_ReturnsServiceUnavailable` — passes in isolation (pre-existing suite flakiness)
- [x] `go build ./...` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)