### PR TITLE
fix(uos): bridge queue to v2 store — retire server.queue type assertions

### DIFF
--- a/internal/operations/bridge.go
+++ b/internal/operations/bridge.go
@@ -1,0 +1,85 @@
+// file: internal/operations/bridge.go
+// version: 1.0.0
+// guid: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
+// last-edited: 2026-05-08
+
+package operations
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// BridgeQueue wraps an OperationQueue and dual-writes run lifecycle events
+// to operations_v2 so legacy ops appear in the v2 timeline (UOS-14).
+// All functional behaviour is delegated to the inner queue.
+type BridgeQueue struct {
+	inner   *OperationQueue
+	v2Store database.OpsV2Store
+}
+
+// NewBridgeQueue creates a BridgeQueue. v2Store must not be nil.
+func NewBridgeQueue(inner *OperationQueue, v2Store database.OpsV2Store) *BridgeQueue {
+	return &BridgeQueue{inner: inner, v2Store: v2Store}
+}
+
+// Enqueue inserts a queued row in operations_v2, wraps fn to update the row
+// as the op transitions to running/completed/failed, then delegates to inner.
+func (b *BridgeQueue) Enqueue(id, opType string, priority int, fn OperationFunc) error {
+	now := time.Now().UTC()
+	row := database.OperationV2Row{
+		ID:       id,
+		DefID:    "legacy." + opType,
+		Plugin:   "legacy",
+		TraceID:  id,
+		SpanID:   id,
+		Status:   "queued",
+		Priority: priority,
+		Params:   "{}",
+		QueuedAt: now,
+	}
+	if err := b.v2Store.InsertOperationV2(row); err != nil {
+		log.Printf("[WARN] bridge: insert operations_v2 for %s/%s: %v", opType, id, err)
+	}
+	return b.inner.Enqueue(id, opType, priority, b.wrapFn(id, fn))
+}
+
+// EnqueueResume re-enqueues an already-existing DB record. The v2 row may not
+// exist for ops that pre-date the bridge; status updates are best-effort.
+func (b *BridgeQueue) EnqueueResume(id, opType string, priority int, fn OperationFunc) error {
+	return b.inner.EnqueueResume(id, opType, priority, b.wrapFn(id, fn))
+}
+
+func (b *BridgeQueue) Cancel(id string) error { return b.inner.Cancel(id) }
+
+func (b *BridgeQueue) ActiveOperations() []ActiveOperation { return b.inner.ActiveOperations() }
+
+func (b *BridgeQueue) Shutdown(timeout time.Duration) error { return b.inner.Shutdown(timeout) }
+
+func (b *BridgeQueue) SetStore(store database.OperationStore) { b.inner.SetStore(store) }
+
+func (b *BridgeQueue) SetOperationTimeout(d time.Duration) { b.inner.SetOperationTimeout(d) }
+
+func (b *BridgeQueue) SetActivityLogger(l ActivityLogger) { b.inner.SetActivityLogger(l) }
+
+// wrapFn returns an OperationFunc that updates the operations_v2 row around fn.
+func (b *BridgeQueue) wrapFn(id string, fn OperationFunc) OperationFunc {
+	return func(ctx context.Context, progress ProgressReporter) error {
+		startedAt := time.Now().UTC()
+		_ = b.v2Store.UpdateOperationV2Status(id, "running", &startedAt, nil, nil)
+
+		err := fn(ctx, progress)
+
+		completedAt := time.Now().UTC()
+		if err != nil {
+			msg := err.Error()
+			_ = b.v2Store.UpdateOperationV2Status(id, "failed", nil, &completedAt, &msg)
+		} else {
+			_ = b.v2Store.UpdateOperationV2Status(id, "completed", nil, &completedAt, nil)
+		}
+		return err
+	}
+}

--- a/internal/operations/mocks/mock_queue.go
+++ b/internal/operations/mocks/mock_queue.go
@@ -205,6 +205,146 @@ func (_c *MockQueue_Enqueue_Call) RunAndReturn(run func(id string, opType string
 	return _c
 }
 
+// EnqueueResume provides a mock function for the type MockQueue
+func (_mock *MockQueue) EnqueueResume(id string, opType string, priority int, fn operations.OperationFunc) error {
+	ret := _mock.Called(id, opType, priority, fn)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnqueueResume")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, operations.OperationFunc) error); ok {
+		r0 = returnFunc(id, opType, priority, fn)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockQueue_EnqueueResume_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnqueueResume'
+type MockQueue_EnqueueResume_Call struct {
+	*mock.Call
+}
+
+// EnqueueResume is a helper method to define mock.On call
+//   - id string
+//   - opType string
+//   - priority int
+//   - fn operations.OperationFunc
+func (_e *MockQueue_Expecter) EnqueueResume(id interface{}, opType interface{}, priority interface{}, fn interface{}) *MockQueue_EnqueueResume_Call {
+	return &MockQueue_EnqueueResume_Call{Call: _e.mock.On("EnqueueResume", id, opType, priority, fn)}
+}
+
+func (_c *MockQueue_EnqueueResume_Call) Run(run func(id string, opType string, priority int, fn operations.OperationFunc)) *MockQueue_EnqueueResume_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 operations.OperationFunc
+		if args[3] != nil {
+			arg3 = args[3].(operations.OperationFunc)
+		}
+		run(arg0, arg1, arg2, arg3)
+	})
+	return _c
+}
+
+func (_c *MockQueue_EnqueueResume_Call) Return(err error) *MockQueue_EnqueueResume_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockQueue_EnqueueResume_Call) RunAndReturn(run func(string, string, int, operations.OperationFunc) error) *MockQueue_EnqueueResume_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetActivityLogger provides a mock function for the type MockQueue
+func (_mock *MockQueue) SetActivityLogger(l operations.ActivityLogger) {
+	_mock.Called(l)
+	return
+}
+
+// MockQueue_SetActivityLogger_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetActivityLogger'
+type MockQueue_SetActivityLogger_Call struct {
+	*mock.Call
+}
+
+// SetActivityLogger is a helper method to define mock.On call
+//   - l operations.ActivityLogger
+func (_e *MockQueue_Expecter) SetActivityLogger(l interface{}) *MockQueue_SetActivityLogger_Call {
+	return &MockQueue_SetActivityLogger_Call{Call: _e.mock.On("SetActivityLogger", l)}
+}
+
+func (_c *MockQueue_SetActivityLogger_Call) Run(run func(l operations.ActivityLogger)) *MockQueue_SetActivityLogger_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 operations.ActivityLogger
+		if args[0] != nil {
+			arg0 = args[0].(operations.ActivityLogger)
+		}
+		run(arg0)
+	})
+	return _c
+}
+
+func (_c *MockQueue_SetActivityLogger_Call) Return() *MockQueue_SetActivityLogger_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockQueue_SetActivityLogger_Call) RunAndReturn(run func(operations.ActivityLogger)) *MockQueue_SetActivityLogger_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetOperationTimeout provides a mock function for the type MockQueue
+func (_mock *MockQueue) SetOperationTimeout(d time.Duration) {
+	_mock.Called(d)
+	return
+}
+
+// MockQueue_SetOperationTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetOperationTimeout'
+type MockQueue_SetOperationTimeout_Call struct {
+	*mock.Call
+}
+
+// SetOperationTimeout is a helper method to define mock.On call
+//   - d time.Duration
+func (_e *MockQueue_Expecter) SetOperationTimeout(d interface{}) *MockQueue_SetOperationTimeout_Call {
+	return &MockQueue_SetOperationTimeout_Call{Call: _e.mock.On("SetOperationTimeout", d)}
+}
+
+func (_c *MockQueue_SetOperationTimeout_Call) Run(run func(d time.Duration)) *MockQueue_SetOperationTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 time.Duration
+		if args[0] != nil {
+			arg0 = args[0].(time.Duration)
+		}
+		run(arg0)
+	})
+	return _c
+}
+
+func (_c *MockQueue_SetOperationTimeout_Call) Return() *MockQueue_SetOperationTimeout_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockQueue_SetOperationTimeout_Call) RunAndReturn(run func(time.Duration)) *MockQueue_SetOperationTimeout_Call {
+	_c.Run(run)
+	return _c
+}
+
 // SetStore provides a mock function for the type MockQueue
 func (_mock *MockQueue) SetStore(store database.OperationStore) {
 	_mock.Called(store)

--- a/internal/operations/queue.go
+++ b/internal/operations/queue.go
@@ -1,5 +1,5 @@
 // file: internal/operations/queue.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: 7d6e5f4a-3c2b-1a09-8f7e-6d5c4b3a2190
 
 package operations
@@ -59,10 +59,13 @@ type QueuedOperation struct {
 // Queue defines the interface for operation queue management
 type Queue interface {
 	Enqueue(id, opType string, priority int, fn OperationFunc) error
+	EnqueueResume(id, opType string, priority int, fn OperationFunc) error
 	Cancel(id string) error
 	ActiveOperations() []ActiveOperation
 	Shutdown(timeout time.Duration) error
 	SetStore(store database.OperationStore)
+	SetOperationTimeout(d time.Duration)
+	SetActivityLogger(l ActivityLogger)
 }
 
 // OperationQueue manages async operations with priority handling

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-05-08
 
@@ -373,12 +373,11 @@ func NewServer(store database.Store) *Server {
 	// later in this function (kept for the GlobalQueue back-compat) is
 	// a no-op once this assignment lands.
 	if server.queue == nil {
-		server.queue = operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
+		innerQ := operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
+		server.queue = operations.NewBridgeQueue(innerQ, resolvedStore)
 		// Long-running maintenance ops (path repair scans 80K+ files
 		// across many spinning disks) need more than the 2-hour default.
-		if oq, ok := server.queue.(*operations.OperationQueue); ok {
-			oq.SetOperationTimeout(6 * time.Hour)
-		}
+		server.queue.SetOperationTimeout(6 * time.Hour)
 		operations.GlobalQueue = server.queue
 	}
 	itunesSvc, err := itunesservice.New(itunesservice.Deps{
@@ -629,7 +628,8 @@ func NewServer(store database.Store) *Server {
 	realtime.SetGlobalHub(server.hub)
 
 	if server.queue == nil {
-		server.queue = operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
+		innerQ := operations.NewOperationQueue(resolvedStore, 8, nil, server.hub)
+		server.queue = operations.NewBridgeQueue(innerQ, resolvedStore)
 		operations.GlobalQueue = server.queue
 	}
 
@@ -688,9 +688,7 @@ func NewServer(store database.Store) *Server {
 	// Wire activity log dual-write hooks
 	if server.activityService != nil {
 		// Task 10: Operation changes → activity log (injected via interface)
-		if oq, ok := server.queue.(*operations.OperationQueue); ok {
-			oq.SetActivityLogger(&activityServiceLogger{svc: server.activityService})
-		}
+		server.queue.SetActivityLogger(&activityServiceLogger{svc: server.activityService})
 
 		// Task 11/14: Metadata fetch service → activity log
 		server.metadataFetchService.SetActivityService(server.activityService)

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-08
 
@@ -50,11 +50,6 @@ func (s *Server) resumeInterruptedOperations() {
 	interrupted, err := store.GetInterruptedOperations()
 	if err != nil {
 		log.Printf("[WARN] Failed to query interrupted operations: %v", err)
-		return
-	}
-
-	oq, ok := s.queue.(*operations.OperationQueue)
-	if !ok {
 		return
 	}
 
@@ -169,7 +164,7 @@ func (s *Server) resumeInterruptedOperations() {
 			}
 		}
 
-		if err := oq.EnqueueResume(opID, opType, operations.PriorityNormal, resumeFn); err != nil {
+		if err := s.queue.EnqueueResume(opID, opType, operations.PriorityNormal, resumeFn); err != nil {
 			log.Printf("[WARN] Failed to re-enqueue operation %s: %v", opID, err)
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `internal/operations/bridge.go`: `BridgeQueue` wraps `*OperationQueue` and dual-writes queued/running/completed/failed lifecycle events to `operations_v2` so legacy operations appear in the v2 timeline (UOS-14 follow-up).
- Expands `Queue` interface with `SetOperationTimeout`, `SetActivityLogger`, and `EnqueueResume` — the three methods that were previously accessed via unsafe type assertions on `*OperationQueue`.
- Removes all three `s.queue.(*operations.OperationQueue)` type assertions from `server.go` and `server_lifecycle.go`, replaced by direct interface calls.
- Updates `MockQueue` to implement the expanded interface.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/operations/...` passes (including mock coverage test)
- [x] Server test suite timeout confirmed as pre-existing (fails identically on main without these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)