### PR TITLE
fix(burndown): update ghcommon SHA + switch to draft-only mode

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.0.0
+# version: 1.1.0
 name: Nightly burndown
 
 on:
@@ -10,7 +10,7 @@ on:
       mode:
         description: "dry-run | draft-only | full"
         required: false
-        default: dry-run
+        default: draft-only
         type: choice
         options:
           - dry-run
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@1a52124c9513b0fd05734602734704d81e2cc7ad
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@42a1744274df75b76e8a8cb22d439f19c3aeb319
     with:
-      mode: ${{ inputs.mode || 'dry-run' }}
+      mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Update ghcommon ref to `42a1744` (staged artifact upload + graceful aggregate fallback)
- Switch default nightly mode from `dry-run` → `draft-only` — bot now creates draft PRs for review

## Test plan
- [ ] Trigger `nightly-burndown` via `workflow_dispatch` — should run triage, dispatch tasks, aggregate emits a real digest with dry-run-only tasks listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)