### PR TITLE
chore(burndown): pin to ghcommon@c9c38d4 (pre-baked binary image)

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.1.0
+# version: 1.2.0
 name: Nightly burndown
 
 on:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@42a1744274df75b76e8a8cb22d439f19c3aeb319
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@c9c38d4389df8a5c7640b971adb7b8f5052c60a2
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Pins `nightly-burndown.yml` to `ghcommon@c9c38d4` which uses a new burndown-runner-image build with the binary pre-baked at `/usr/local/bin/burndown`
- Triage, dispatch, and aggregate jobs no longer checkout overnight-burndown or run `go build` — saves ~6 min per run

🤖 Generated with [Claude Code](https://claude.com/claude-code)