### PR TITLE
feat(ci): add triage-poll.yml (30-min async triage cron)

### DIFF
--- a/.github/workflows/triage-poll.yml
+++ b/.github/workflows/triage-poll.yml
@@ -1,0 +1,26 @@
+# file: .github/workflows/triage-poll.yml
+# version: 1.0.0
+name: Triage poll
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run | draft-only | full"
+        required: false
+        default: draft-only
+        type: choice
+        options:
+          - dry-run
+          - draft-only
+          - full
+
+jobs:
+  triage-poll:
+    uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@b3778b134dd316f334e2eca7d30c6ef2685afd9e
+    with:
+      mode: ${{ inputs.mode || 'draft-only' }}
+      triage_model: o3
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/triage-poll.yml` that runs every 30 minutes on a schedule
- Calls `reusable-triage-poll.yml@b3778b1` in ghcommon
- Uses `o3` model (configurable); OpenAI Batch API gives 50% cost discount
- Zero cost for idle/polling runs — only pays when issues are submitted to OpenAI

## How it works

Each 30-min run does **one** of:
1. Nothing (no untriaged issues, no in-flight batch)
2. Submit a new OpenAI batch + create tracking issue (`burndown:batch-pending`)
3. Poll existing batch → write triage results to issues + close tracking issue

## Test plan

- [ ] Trigger manually with `dry-run` mode to verify idle path
- [ ] Add a test issue to `jdfalk/burndown-tasks` with labels `status:ready` + `repo:audiobook-organizer`, then trigger again

🤖 Generated with [Claude Code](https://claude.com/claude-code)