### PR TITLE
fix(library): always filter to primary versions in /audiobooks/ids endpoint

### DIFF
--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
@@ -137,6 +137,8 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 // matching the active filters. No pagination cap is applied — this endpoint
 // exists specifically for "select all across all pages" use cases where the
 // 500-row pagination limit would silently truncate the selection.
+// Always filters to primary versions only, matching the behaviour of the
+// main library list endpoint.
 func (s *Server) listAudiobookIDs(c *gin.Context) {
 	authorID := httputil.ParseQueryIntPtr(c, "author_id")
 	seriesID := httputil.ParseQueryIntPtr(c, "series_id")
@@ -145,8 +147,9 @@ func (s *Server) listAudiobookIDs(c *gin.Context) {
 	if sortOrder != "" && sortOrder != "asc" && sortOrder != "desc" {
 		sortOrder = "asc"
 	}
+	trueVal := true
 	filters := ListFilters{
-		IsPrimaryVersion: httputil.ParseQueryBoolPtr(c, "is_primary_version"),
+		IsPrimaryVersion: &trueVal,
 		LibraryState:     httputil.ParseQueryString(c, "library_state"),
 		Tag:              httputil.ParseQueryString(c, "tag"),
 		SortBy:           httputil.ParseQueryString(c, "sort_by"),


### PR DESCRIPTION
## Summary
- `/audiobooks/ids` was reading `is_primary_version` as an optional query param — frontend never sent it, so the endpoint returned all 61K file records instead of primary books only
- Non-primary book records have no `metadata_review_status`, so they all passed `NOT review:matched`, making the selection chip show 61,345 when the banner correctly showed 16,813
- Fix: hard-wire `IsPrimaryVersion=true` in `listAudiobookIDs` — this endpoint exists solely to back "select all across pages", which must match the library grid (primary-only view)

## Test plan
- [ ] Apply `NOT review:matched` filter in Library — should show ~16,813 books
- [ ] Click "Select all 16,813 items" banner — chip should show 16,813 (not 61,345)
- [ ] Verify regular pagination still works with other filters (author, series, tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)