### PR TITLE
feat(ops): add NotifyLevel to OperationDef — bell vs activity-only ops

### DIFF
--- a/internal/operations/registry/types.go
+++ b/internal/operations/registry/types.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/types.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
 // last-edited: 2026-05-06
 
@@ -75,6 +75,12 @@ type OperationDef struct {
 
 	// Phases. Optional, for fine-grained resume.
 	Phases []Phase // if set, registry tracks phase progress for resume
+
+	// NotifyLevel controls where this op appears. Default (0) = NotifyAlert:
+	// shows in the bell badge and the activity timeline. NotifyActivity: shows
+	// in the activity timeline only — use for background/single-book ops that
+	// don't need to interrupt the user.
+	NotifyLevel NotifyLevel
 }
 
 // ResumePolicy controls what happens when the server restarts with an
@@ -96,6 +102,17 @@ const (
 	PriorityLow    Priority = 0
 	PriorityNormal Priority = 1
 	PriorityHigh   Priority = 2
+)
+
+// NotifyLevel controls where an operation appears in the UI.
+type NotifyLevel int
+
+const (
+	// NotifyAlert is the default: shows in the bell badge and activity timeline.
+	NotifyAlert NotifyLevel = 0
+	// NotifyActivity shows in the activity timeline only; no bell badge.
+	// Use for background or single-book ops that don't warrant interrupting the user.
+	NotifyActivity NotifyLevel = 1
 )
 
 // ActorMode controls the identity under which a triggered run executes.

--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_v2_handlers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-05-08
 
@@ -29,6 +29,7 @@ type operationV2Response struct {
 	DisplayName     string     `json:"display_name"`
 	Status          string     `json:"status"`
 	Priority        int        `json:"priority"`
+	NotifyLevel     int        `json:"notify_level"`
 	ProgressCurrent *int       `json:"progress_current"`
 	ProgressTotal   *int       `json:"progress_total"`
 	ProgressMessage *string    `json:"progress_message"`
@@ -92,7 +93,7 @@ func (s *Server) handleGetOperationTimeline(c *gin.Context) {
 
 	resp := make([]operationV2Response, 0, len(rows))
 	for _, r := range rows {
-		item := rowToResponse(r, s.displayNameFor(r.DefID))
+		item := rowToResponse(r, s.displayNameFor(r.DefID), s.notifyLevelFor(r.DefID))
 		if r.Status == "running" && s.opRegistry != nil {
 			if ci := s.opRegistry.GetCurrentItem(r.ID); ci != "" {
 				item.CurrentItem = &ci
@@ -130,7 +131,7 @@ func (s *Server) handleGetOperationV2(c *gin.Context) {
 		logResp = append(logResp, logRowToResponse(l))
 	}
 
-	opResp := rowToResponse(*row, s.displayNameFor(row.DefID))
+	opResp := rowToResponse(*row, s.displayNameFor(row.DefID), s.notifyLevelFor(row.DefID))
 	if row.Status == "running" && s.opRegistry != nil {
 		if ci := s.opRegistry.GetCurrentItem(id); ci != "" {
 			opResp.CurrentItem = &ci
@@ -286,24 +287,39 @@ func (s *Server) displayNameFor(defID string) string {
 	return defID
 }
 
+// notifyLevelFor looks up the NotifyLevel for a registered def ID.
+// Returns 0 (NotifyAlert) if the def is not found, preserving old behaviour.
+func (s *Server) notifyLevelFor(defID string) int {
+	if s.opRegistry == nil {
+		return 0
+	}
+	for _, d := range s.opRegistry.ActiveDefs() {
+		if d.ID == defID {
+			return int(d.NotifyLevel)
+		}
+	}
+	return 0
+}
+
 // rowToResponse converts a database.OperationV2Row to the HTTP response shape.
-func rowToResponse(r database.OperationV2Row, displayName string) operationV2Response {
+func rowToResponse(r database.OperationV2Row, displayName string, notifyLevel int) operationV2Response {
 	resp := operationV2Response{
-		ID:          r.ID,
-		DefID:       r.DefID,
-		Plugin:      r.Plugin,
-		DisplayName: displayName,
-		Status:      r.Status,
-		Priority:    r.Priority,
-		ActorUserID: r.ActorUserID,
-		ParentID:    r.ParentID,
-		QueuedAt:    r.QueuedAt,
-		StartedAt:   r.StartedAt,
-		CompletedAt: r.CompletedAt,
+		ID:           r.ID,
+		DefID:        r.DefID,
+		Plugin:       r.Plugin,
+		DisplayName:  displayName,
+		Status:       r.Status,
+		Priority:     r.Priority,
+		NotifyLevel:  notifyLevel,
+		ActorUserID:  r.ActorUserID,
+		ParentID:     r.ParentID,
+		QueuedAt:     r.QueuedAt,
+		StartedAt:    r.StartedAt,
+		CompletedAt:  r.CompletedAt,
 		ErrorMessage: r.ErrorMessage,
-		ResumeCount: r.ResumeCount,
-		TraceID:     r.TraceID,
-		SpanID:      r.SpanID,
+		ResumeCount:  r.ResumeCount,
+		TraceID:      r.TraceID,
+		SpanID:       r.SpanID,
 		CurrentPhase: r.CurrentPhase,
 	}
 	// Convert scalar progress fields to nullable pointers for the JSON contract.

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.8.0
+// version: 3.9.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useState } from 'react';
@@ -106,9 +106,8 @@ function parseMessageDetails(message: string) {
 
 
 export function OperationsIndicator() {
-  const activeOperations = useOperationsStore(
-    (state) => state.activeOperations
-  );
+  const activeOperations = useOperationsStore((state) => state.activeOperations);
+  const alertOperations = useOperationsStore((state) => state.alertOperations);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const navigate = useNavigate();
@@ -130,6 +129,15 @@ export function OperationsIndicator() {
     });
   };
 
+  // Badge only counts alert-level ops (notify_level === 0).
+  // Activity-only ops (single-book fetches, background maintenance) are visible
+  // in the dropdown list but do not increment the badge.
+  const alertInProgress = alertOperations.filter(
+    (op) => !['completed', 'failed', 'canceled'].includes(op.status)
+  );
+  const badgeCount = alertInProgress.length;
+
+  // The dropdown shows all ops regardless of notify level.
   const inProgress = activeOperations.filter(
     (op) => !['completed', 'failed', 'canceled'].includes(op.status)
   );
@@ -138,7 +146,6 @@ export function OperationsIndicator() {
   const terminal = activeOperations.filter((op) =>
     ['completed', 'failed', 'canceled'].includes(op.status)
   );
-  const badgeCount = inProgress.length;
 
   return (
     <>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.23.0
+// version: 2.24.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-08
 
@@ -406,6 +406,8 @@ export interface OperationV2 {
   display_name: string;
   status: 'queued' | 'running' | 'completed' | 'failed' | 'canceled' | 'interrupted_dropped' | 'interrupted_restart';
   priority: number;
+  /** 0 = alert (bell + activity), 1 = activity only */
+  notify_level: number;
   progress_current: number | null;
   progress_total: number | null;
   progress_message: string | null;

--- a/web/src/stores/useOperationsStore.test.ts
+++ b/web/src/stores/useOperationsStore.test.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.test.ts
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-08
 
@@ -35,6 +35,7 @@ describe('useOperationsStore', () => {
       display_name: 'Library Scan',
       status: 'running',
       priority: 10,
+      notify_level: 0,
       progress_current: 75,
       progress_total: 100,
       progress_message: 'Almost done',
@@ -73,6 +74,7 @@ describe('useOperationsStore', () => {
       display_name: 'Library Scan',
       status: 'running',
       priority: 10,
+      notify_level: 0,
       progress_current: 50,
       progress_total: 100,
       progress_message: 'Parent',
@@ -96,6 +98,7 @@ describe('useOperationsStore', () => {
       display_name: 'Index',
       status: 'running',
       priority: 10,
+      notify_level: 0,
       progress_current: 30,
       progress_total: 100,
       progress_message: 'Child',

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 3.1.0
+// version: 3.2.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
@@ -20,11 +20,16 @@ export interface ActiveOperation {
   parent_id?: string | null;
   current_phase?: string | null;
   current_item?: string | null;
+  /** 0 = alert (shows in bell badge), 1 = activity-only (no bell badge) */
+  notify_level?: number;
 }
 
 interface OperationsState {
   operations: Record<string, ActiveOperation>; // Keyed by id
-  activeOperations: ActiveOperation[]; // Derived from operations
+  activeOperations: ActiveOperation[]; // All ops regardless of notify_level
+  /** alertOperations contains only ops with notify_level === 0 (NotifyAlert).
+   *  Use this for the bell badge count. */
+  alertOperations: ActiveOperation[];
   polling: boolean;
   // SSE EventSource instance — kept here so it can be closed on unmount.
   _sseSource: EventSource | null;
@@ -52,6 +57,7 @@ function fromV2(op: api.OperationV2): ActiveOperation {
     parent_id: op.parent_id,
     current_phase: op.current_phase,
     current_item: op.current_item,
+    notify_level: op.notify_level ?? 0,
   };
 }
 
@@ -82,14 +88,22 @@ function formatOpLabel(type: string): string {
   return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-// Helper to derive activeOperations array from operations map
-function deriveActiveOperations(operations: Record<string, ActiveOperation>): ActiveOperation[] {
-  return Object.values(operations);
+// Helper to derive activeOperations and alertOperations arrays from operations map
+function deriveOperationArrays(operations: Record<string, ActiveOperation>): {
+  activeOperations: ActiveOperation[];
+  alertOperations: ActiveOperation[];
+} {
+  const all = Object.values(operations);
+  return {
+    activeOperations: all,
+    alertOperations: all.filter((op) => (op.notify_level ?? 0) === 0),
+  };
 }
 
 export const useOperationsStore = create<OperationsState>()((set, get) => ({
   operations: {},
   activeOperations: [],
+  alertOperations: [],
   polling: false,
   _sseSource: null,
 
@@ -107,7 +121,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
 
         return {
           operations: merged,
-          activeOperations: deriveActiveOperations(merged),
+          ...deriveOperationArrays(merged),
         };
       });
     } catch (err) {
@@ -138,7 +152,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
       const operations = { ...state.operations, [operationId]: op };
       return {
         operations,
-        activeOperations: deriveActiveOperations(operations),
+        ...deriveOperationArrays(operations),
         polling: true,
       };
     });
@@ -152,7 +166,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
       const { [operationId]: _, ...remaining } = state.operations;
       return {
         operations: remaining,
-        activeOperations: deriveActiveOperations(remaining),
+        ...deriveOperationArrays(remaining),
         polling: Object.keys(remaining).length > 0,
       };
     });
@@ -166,7 +180,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
       };
       return {
         operations,
-        activeOperations: deriveActiveOperations(operations),
+        ...deriveOperationArrays(operations),
       };
     });
   },
@@ -195,7 +209,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
               message: (p.message as string | undefined) ?? existing.message,
             };
             const operations = { ...state.operations, [opId]: updated };
-            return { operations, activeOperations: deriveActiveOperations(operations) };
+            return { operations, ...deriveOperationArrays(operations) };
           });
         } else if (name === 'op.terminal' && opId) {
           // Operation reached a terminal state — refresh from server.
@@ -208,7 +222,7 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
             if (!existing) return state;
             const updated: ActiveOperation = { ...existing, current_item: label || null };
             const operations = { ...state.operations, [opId]: updated };
-            return { operations, activeOperations: deriveActiveOperations(operations) };
+            return { operations, ...deriveOperationArrays(operations) };
           });
         }
         // op.log is informational; no store update needed (logs are fetched on-demand).


### PR DESCRIPTION
## Summary
- Adds `NotifyLevel` type (`NotifyAlert=0`, `NotifyActivity=1`) to `OperationDef` in the UOS registry
- Default is `NotifyAlert` — all existing ops are unchanged; no migration needed
- Timeline API enriches each response row with `notify_level` from the registered def at query time
- Frontend: new `alertOperations` slice in `useOperationsStore` (ops with `notify_level===0` only)
- `OperationsIndicator` badge uses `alertOperations.length` — background/single-book ops won't ring the bell

## Test plan
- [ ] Bell badge still increments for scan, organize, bulk-metadata-fetch (all alert-level)
- [ ] Ops marked `NotifyActivity` appear in the dropdown list but do not increment the badge
- [ ] `make build-api` passes
- [ ] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)