### PR TITLE
feat(ops): SelectionSpec replaces crossPageIds and /audiobooks/ids endpoints

### DIFF
--- a/internal/operations/selection.go
+++ b/internal/operations/selection.go
@@ -1,0 +1,21 @@
+// file: internal/operations/selection.go
+// version: 1.0.0
+// guid: a2b3c4d5-e6f7-8901-bcde-f12345678901
+// last-edited: 2026-05-11
+//
+// ResolveBookIDs resolves a SelectionSpec to a concrete list of book IDs.
+// When the spec carries a FilterSpec the caller-provided resolve func is
+// invoked; otherwise the explicit BookIDs slice is returned as-is.
+
+package operations
+
+// ResolveBookIDs resolves a SelectionSpec to a list of book IDs.
+// The resolve func must return IDs of primary-version books matching the
+// FilterSpec. It is only called when spec.Filter is non-nil; callers that
+// supply a filter must ensure the func applies IsPrimaryVersion=true.
+func ResolveBookIDs(spec SelectionSpec, resolve func(FilterSpec) ([]string, error)) ([]string, error) {
+	if spec.Filter != nil {
+		return resolve(*spec.Filter)
+	}
+	return spec.BookIDs, nil
+}

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -1,0 +1,38 @@
+// file: internal/operations/types.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
+// last-edited: 2026-05-11
+//
+// SelectionSpec and related types for server-side bulk operation targeting.
+// A SelectionSpec describes which books an operation targets without requiring
+// the client to enumerate all IDs upfront.
+
+package operations
+
+// SelectionSpec describes which books an operation targets.
+// Exactly one of BookIDs or Filter must be non-nil/non-empty.
+// When Filter is set the server resolves it to book IDs at execution time
+// with IsPrimaryVersion=true always applied.
+type SelectionSpec struct {
+	BookIDs []string    `json:"book_ids,omitempty"`
+	Filter  *FilterSpec `json:"filter,omitempty"`
+}
+
+// FilterSpec mirrors the query params accepted by GET /api/v1/audiobooks.
+// When Filter is set on a SelectionSpec, the server resolves it to book IDs
+// at operation execution time with IsPrimaryVersion=true always applied.
+type FilterSpec struct {
+	Search       string        `json:"search,omitempty"`
+	LibraryState string        `json:"library_state,omitempty"`
+	Tag          string        `json:"tag,omitempty"`
+	FieldFilters []FieldFilter `json:"field_filters,omitempty"`
+	AuthorID     *int64        `json:"author_id,omitempty"`
+	SeriesID     *int64        `json:"series_id,omitempty"`
+}
+
+// FieldFilter mirrors the server-side FieldFilter used for advanced search.
+type FieldFilter struct {
+	Field   string `json:"field"`
+	Value   string `json:"value"`
+	Negated bool   `json:"negated"`
+}

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
@@ -133,67 +133,6 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 	httputil.RespondWithOK(c, resp)
 }
 
-// listAudiobookIDs returns only the IDs (no full book objects) for all books
-// matching the active filters. No pagination cap is applied — this endpoint
-// exists specifically for "select all across all pages" use cases where the
-// 500-row pagination limit would silently truncate the selection.
-// Always filters to primary versions only, matching the behaviour of the
-// main library list endpoint.
-func (s *Server) listAudiobookIDs(c *gin.Context) {
-	authorID := httputil.ParseQueryIntPtr(c, "author_id")
-	seriesID := httputil.ParseQueryIntPtr(c, "series_id")
-
-	sortOrder := httputil.ParseQueryString(c, "sort_order")
-	if sortOrder != "" && sortOrder != "asc" && sortOrder != "desc" {
-		sortOrder = "asc"
-	}
-	trueVal := true
-	filters := ListFilters{
-		IsPrimaryVersion: &trueVal,
-		LibraryState:     httputil.ParseQueryString(c, "library_state"),
-		Tag:              httputil.ParseQueryString(c, "tag"),
-		SortBy:           httputil.ParseQueryString(c, "sort_by"),
-		SortOrder:        sortOrder,
-	}
-	if filtersJSON := c.Query("filters"); filtersJSON != "" {
-		var fieldFilters []FieldFilter
-		if err := json.Unmarshal([]byte(filtersJSON), &fieldFilters); err != nil {
-			httputil.RespondWithBadRequest(c, "invalid filters parameter: "+err.Error())
-			return
-		}
-		for _, ff := range fieldFilters {
-			if IsPerUserField(ff.Field) {
-				filters.PerUserFilters = append(filters.PerUserFilters, ff)
-			} else {
-				filters.FieldFilters = append(filters.FieldFilters, ff)
-			}
-		}
-	}
-	if caller, ok := servermiddleware.CurrentUser(c); ok && caller != nil {
-		filters.UserID = caller.ID
-	}
-
-	search := c.Query("search")
-
-	// Fetch up to 100 000 books — IDs only returned so memory is manageable.
-	books, err := s.audiobookService.GetAudiobooks(c.Request.Context(), 100000, 0, search, authorID, seriesID, filters)
-	if err != nil {
-		httputil.InternalError(c, "failed to list audiobook IDs", err)
-		return
-	}
-
-	// Exclude quarantined books unless explicitly requested.
-	showQuarantined := c.Query("show_quarantined") == "true"
-	ids := make([]string, 0, len(books))
-	for _, b := range books {
-		if !showQuarantined && b.QuarantinedAt != nil {
-			continue
-		}
-		ids = append(ids, b.ID)
-	}
-
-	httputil.RespondWithOK(c, gin.H{"ids": ids, "total": len(ids)})
-}
 
 func (s *Server) listSoftDeletedAudiobooks(c *gin.Context) {
 	params := httputil.ParsePaginationParams(c)

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
 // last-edited: 2026-05-05
 
@@ -646,38 +646,6 @@ func (s *Server) handleListITunesBooks(c *gin.Context) {
 	})
 }
 
-// handleListITunesBooksIDs returns all book IDs that have an iTunes persistent
-// ID, without any pagination cap. Accepts an optional search query param.
-// Used by the iTunes sync dialog "Select All" action.
-func (s *Server) handleListITunesBooksIDs(c *gin.Context) {
-	if s.Store() == nil {
-		httputil.RespondWithInternalError(c, "database not initialized")
-		return
-	}
-
-	search := c.Query("search")
-
-	var allBooks []database.Book
-	var err error
-	if search != "" {
-		allBooks, err = s.Store().SearchBooks(search, 0, 0)
-	} else {
-		allBooks, err = s.Store().GetAllBooks(0, 0)
-	}
-	if err != nil {
-		httputil.InternalError(c, "failed to list books", err)
-		return
-	}
-
-	ids := make([]string, 0)
-	for _, book := range allBooks {
-		if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
-			ids = append(ids, book.ID)
-		}
-	}
-
-	httputil.RespondWithOK(c, gin.H{"ids": ids, "total": len(ids)})
-}
 
 // handleITunesImportStatus returns the status of an iTunes import operation.
 func (s *Server) handleITunesImportStatus(c *gin.Context) {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
-// last-edited: 2026-05-05
+// last-edited: 2026-05-11
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
 // search/apply/revert/no-match, bulk fetch and bulk writeback, the
@@ -1096,10 +1096,14 @@ func (a registryProgressAdapter) Log(level, message string, details *string) err
 func (a registryProgressAdapter) IsCanceled() bool { return a.r.IsCanceled() }
 
 // bulkMetadataFetchV2Params is the JSON params for the v2 bulk_metadata_fetch op.
+// Selection replaces the old BookIDs field: the client sends either
+//   - book_ids: an explicit list of IDs (page-level selection), or
+//   - filter: a FilterSpec that the server resolves to IDs at run time
+//     with IsPrimaryVersion=true always applied.
 type bulkMetadataFetchV2Params struct {
-	BookIDs       []string `json:"book_ids"`
-	PreferAudible bool     `json:"prefer_audible"`
-	SkipCached    bool     `json:"skip_cached"`
+	Selection     operations.SelectionSpec `json:"selection"`
+	PreferAudible bool                     `json:"prefer_audible"`
+	SkipCached    bool                     `json:"skip_cached"`
 }
 
 // RegisterBulkMetadataFetchOp registers the "library.bulk-metadata-fetch" v2
@@ -1143,8 +1147,59 @@ func (s *Server) RegisterBulkMetadataFetchOp(reg *opsregistry.Registry) error {
 
 			progress := registryProgressAdapter{r: reporter}
 
-			if len(p.BookIDs) > 0 {
-				return s.runBulkMetadataFetchForBookIDs(ctx, opID, p.BookIDs, fetchParams, store, progress)
+			// resolveFilter translates a FilterSpec into a concrete book-ID list.
+			// IsPrimaryVersion is always forced true so the count matches the
+			// visible library list. Per-user fields are dropped here because
+			// bulk ops run server-side without a user context.
+			resolveFilter := func(f operations.FilterSpec) ([]string, error) {
+				trueVal := true
+				filters := ListFilters{
+					IsPrimaryVersion: &trueVal,
+					LibraryState:     f.LibraryState,
+					Tag:              f.Tag,
+				}
+				for _, ff := range f.FieldFilters {
+					if IsPerUserField(ff.Field) {
+						continue // no user context in background op
+					}
+					filters.FieldFilters = append(filters.FieldFilters, FieldFilter{
+						Field:   ff.Field,
+						Value:   ff.Value,
+						Negated: ff.Negated,
+					})
+				}
+				// Convert *int64 to *int for the service method signature.
+				var authorID, seriesID *int
+				if f.AuthorID != nil {
+					v := int(*f.AuthorID)
+					authorID = &v
+				}
+				if f.SeriesID != nil {
+					v := int(*f.SeriesID)
+					seriesID = &v
+				}
+				books, err := s.audiobookService.GetAudiobooks(ctx, 100000, 0, f.Search, authorID, seriesID, filters)
+				if err != nil {
+					return nil, fmt.Errorf("resolve filter: %w", err)
+				}
+				ids := make([]string, 0, len(books))
+				for _, b := range books {
+					// Exclude quarantined books (mirrors the /audiobooks/ids endpoint).
+					if b.QuarantinedAt != nil {
+						continue
+					}
+					ids = append(ids, b.ID)
+				}
+				return ids, nil
+			}
+
+			bookIDs, err := operations.ResolveBookIDs(p.Selection, resolveFilter)
+			if err != nil {
+				return fmt.Errorf("bulk_metadata_fetch: resolve selection: %w", err)
+			}
+
+			if len(bookIDs) > 0 {
+				return s.runBulkMetadataFetchForBookIDs(ctx, opID, bookIDs, fetchParams, store, progress)
 			}
 			return s.runBulkMetadataFetchAll(ctx, opID, fetchParams, store, progress)
 		},

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-08
 
@@ -865,7 +865,6 @@ func (s *Server) setupRoutes() {
 			// Audiobook routes
 			protected.GET("/audiobooks", s.perm(auth.PermLibraryView), s.listAudiobooks)
 			// /audiobooks/search removed — use GET /audiobooks?search= instead
-			protected.GET("/audiobooks/ids", s.perm(auth.PermLibraryView), s.listAudiobookIDs)
 			protected.GET("/audiobooks/count", s.perm(auth.PermLibraryView), s.countAudiobooks)
 			protected.GET("/audiobooks/facets", s.perm(auth.PermLibraryView), s.audiobookFacets)
 			protected.GET("/audiobooks/duplicates", s.perm(auth.PermLibraryView), s.listDuplicateAudiobooks)
@@ -1072,7 +1071,6 @@ func (s *Server) setupRoutes() {
 				itunesGroup.GET("/library-stats", s.perm(auth.PermLibraryView), s.handleITunesLibraryStats)
 				itunesGroup.POST("/write-back/preview", s.perm(auth.PermLibraryEditMetadata), s.handleITunesWriteBackPreview)
 				itunesGroup.GET("/books", s.perm(auth.PermLibraryView), s.handleListITunesBooks)
-				itunesGroup.GET("/books/ids", s.perm(auth.PermLibraryView), s.handleListITunesBooksIDs)
 				itunesGroup.GET("/import-status/:id", s.perm(auth.PermLibraryView), s.handleITunesImportStatus)
 				itunesGroup.POST("/import-status/bulk", s.perm(auth.PermLibraryEditMetadata), s.handleITunesImportStatusBulk)
 				itunesGroup.GET("/library-status", s.perm(auth.PermLibraryView), s.handleITunesLibraryStatus)

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-05-11
 
@@ -68,8 +68,7 @@ interface LibraryBookGridProps {
   effectiveSelectedCount: number;
   handleClearSelection: () => void;
   showSelectAllBanner: boolean;
-  handleSelectAllItems: () => Promise<void>;
-  selectingAll: boolean;
+  handleSelectAllItems: () => void;
   handleEdit: (book: Audiobook) => void;
   handleDelete: (book: Audiobook) => void;
   handleClick: (book: Audiobook) => void;
@@ -138,7 +137,6 @@ export const LibraryBookGrid = ({
   handleClearSelection,
   showSelectAllBanner,
   handleSelectAllItems,
-  selectingAll,
   handleEdit,
   handleDelete,
   handleClick,
@@ -292,10 +290,9 @@ export const LibraryBookGrid = ({
               size="small"
               variant="text"
               sx={{ textTransform: 'none', fontWeight: 'bold' }}
-              onClick={() => { void handleSelectAllItems(); }}
-              disabled={selectingAll}
+              onClick={() => handleSelectAllItems()}
             >
-              {selectingAll ? 'Loading\u2026' : `Select all ${totalCount.toLocaleString()} items`}
+              {`Select all ${totalCount.toLocaleString()} items`}
             </Button>
           </Box>
         )}

--- a/web/src/components/settings/ITunesImport.tsx
+++ b/web/src/components/settings/ITunesImport.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/ITunesImport.tsx
-// version: 1.18.0
+// version: 1.19.0
 // guid: 4eb9b74d-7192-497b-849a-092833ae63a4
-// last-edited: 2026-05-05
+// last-edited: 2026-05-11
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -60,7 +60,6 @@ import {
   cancelOperation,
   getConfig,
   getITunesBooks,
-  getITunesBookIds,
   getITunesImportStatus,
   getITunesLibraryStatus,
   importITunesLibrary,
@@ -158,7 +157,6 @@ export function ITunesImport() {
   const [browseSearch, setBrowseSearch] = useState('');
   const [browsePage, setBrowsePage] = useState(0);
   const [browseRowsPerPage, setBrowseRowsPerPage] = useState(25);
-  const [browseSelectingAll, setBrowseSelectingAll] = useState(false);
   const [browseSelected, setBrowseSelected] = useState<Set<string>>(new Set());
   const [browseLoading, setBrowseLoading] = useState(false);
   const [syncAllCount, setSyncAllCount] = useState<number | null>(null);
@@ -1156,23 +1154,7 @@ export function ITunesImport() {
                     >
                       Select All Visible
                     </Button>
-                    <Button
-                      size="small"
-                      disabled={browseSelectingAll}
-                      onClick={async () => {
-                        setBrowseSelectingAll(true);
-                        try {
-                          const result = await getITunesBookIds(browseSearch || undefined);
-                          setBrowseSelected(new Set(result.ids));
-                        } catch {
-                          // ignore; user can retry
-                        } finally {
-                          setBrowseSelectingAll(false);
-                        }
-                      }}
-                    >
-                      {browseSelectingAll ? 'Loading…' : `Select All (${browseTotal.toLocaleString()})`}
-                    </Button>
+
                     <Button size="small" onClick={() => setBrowseSelected(new Set())}>
                       Deselect All
                     </Button>

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.61.0
+// version: 1.62.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-05-11
 
@@ -131,7 +131,6 @@ export const Library = () => {
 
   const [audiobooks, setAudiobooks] = useState<Audiobook[]>([]);
   const [totalCount, setTotalCount] = useState(0); // Total matching books (server-reported, all pages)
-  const [selectingAll, setSelectingAll] = useState(false); // Loading state for "select all" cross-page fetch
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState(initialSearch);
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -145,10 +144,11 @@ export const Library = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [editingAudiobook, setEditingAudiobook] = useState<Audiobook | null>(null);
   const [selectedAudiobooks, setSelectedAudiobooks] = useState<Audiobook[]>([]);
-  // crossPageIds is set when the user clicks "select all across all pages".
-  // When non-null it overrides selectedAudiobooks as the source of IDs for
-  // bulk operations, bypassing the per-page 500-row pagination limit.
-  const [crossPageIds, setCrossPageIds] = useState<string[] | null>(null);
+  // crossPageFilter is set when the user clicks "select all across all pages".
+  // When non-null it carries the current filter state so the server can
+  // resolve the full matching book ID list at operation execution time —
+  // no 61K-ID array in browser memory. Set to null to clear cross-page mode.
+  const [crossPageFilter, setCrossPageFilter] = useState<api.SelectionSpec['filter'] | null>(null);
   const [batchEditOpen, setBatchEditOpen] = useState(false);
   const [versionManagementOpen, setVersionManagementOpen] = useState(false);
   const [versionManagingAudiobook, setVersionManagingAudiobook] = useState<Audiobook | null>(null);
@@ -513,9 +513,10 @@ export const Library = () => {
   }, []);
 
   const selectedIds = new Set(selectedAudiobooks.map((book) => book.id));
-  // effectiveSelectedIds is used by bulk operations; crossPageIds wins when set.
-  const effectiveSelectedIds: string[] = crossPageIds ?? selectedAudiobooks.map((b) => b.id);
-  const effectiveSelectedCount = crossPageIds?.length ?? selectedAudiobooks.length;
+  // effectiveSelectedIds is used by bulk operations that still need explicit IDs.
+  // When crossPageFilter is set, we don't have IDs locally — use totalCount for display.
+  const effectiveSelectedIds: string[] = selectedAudiobooks.map((b) => b.id);
+  const effectiveSelectedCount = crossPageFilter !== null ? totalCount : selectedAudiobooks.length;
   const hasSelection = effectiveSelectedCount > 0;
   const allOnPageSelected =
     audiobooks.length > 0 && audiobooks.every((book) => selectedIds.has(book.id));
@@ -528,7 +529,7 @@ export const Library = () => {
 
   const handleToggleSelect = (audiobook: Audiobook, event?: React.MouseEvent) => {
     // Any individual toggle exits cross-page-select-all mode.
-    setCrossPageIds(null);
+    setCrossPageFilter(null);
     const clickedIndex = audiobooks.findIndex((b) => b.id === audiobook.id);
 
     // Shift-click: select range from last selected to clicked
@@ -558,7 +559,7 @@ export const Library = () => {
   };
 
   const handleSelectAllOnPage = () => {
-    setCrossPageIds(null);
+    setCrossPageFilter(null);
     setSelectedAudiobooks((prev) => {
       const byId = new Map(prev.map((book) => [book.id, book]));
       audiobooks.forEach((book) => {
@@ -571,7 +572,7 @@ export const Library = () => {
   };
 
   const handleToggleSelectAllOnPage = () => {
-    setCrossPageIds(null);
+    setCrossPageFilter(null);
     if (allOnPageSelected) {
       setSelectedAudiobooks((prev) =>
         prev.filter((book) => !audiobooks.some((pageBook) => pageBook.id === book.id))
@@ -582,7 +583,7 @@ export const Library = () => {
   };
 
   const handleClearSelection = () => {
-    setCrossPageIds(null);
+    setCrossPageFilter(null);
     setSelectedAudiobooks([]);
   };
 
@@ -600,9 +601,10 @@ export const Library = () => {
     return fieldFilters;
   }, [filters, parsedSearch]);
 
-  // Fetch all matching IDs for cross-page "select all" — bypasses the 500-row
-  // pagination cap by using the IDs-only endpoint.
-  const handleSelectAllItems = useCallback(async () => {
+  // Build a cross-page selection filter for "select all across all pages".
+  // Instead of fetching 61K IDs, we store the current filter state and pass
+  // it to bulk operations so the server resolves the set at execution time.
+  const handleSelectAllItems = useCallback(() => {
     const fieldFilters = buildFieldFilters();
     const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
     const tagFilter =
@@ -610,28 +612,19 @@ export const Library = () => {
       parsedSearch?.fieldFilters.find((f) => f.field === 'tag' && !f.negated)?.value;
     const libraryState = filters.libraryState === 'deleted' ? undefined : filters.libraryState;
 
-    setSelectingAll(true);
-    try {
-      const result = await api.getAudiobookIds({
-        search: searchText || undefined,
-        sortBy,
-        sortOrder,
-        tag: tagFilter,
-        libraryState,
-        filters: fieldFilters.length > 0 ? JSON.stringify(fieldFilters) : undefined,
-      });
-      setCrossPageIds(result.ids);
-    } catch (e) {
-      console.error('Failed to select all items', e);
-    } finally {
-      setSelectingAll(false);
-    }
-  }, [buildFieldFilters, debouncedSearch, filters, parsedSearch, selectedTags, sortBy, sortOrder]);
+    const filterSpec: api.SelectionSpec['filter'] = {};
+    if (searchText) filterSpec.search = searchText;
+    if (tagFilter) filterSpec.tag = tagFilter;
+    if (libraryState) filterSpec.library_state = libraryState;
+    if (fieldFilters.length > 0) filterSpec.field_filters = fieldFilters;
+
+    setCrossPageFilter(filterSpec);
+  }, [buildFieldFilters, debouncedSearch, filters, parsedSearch, selectedTags]);
 
   // True when all items on the current page are selected but not all items globally,
   // and the user hasn't already selected all pages.
   const showSelectAllBanner =
-    allOnPageSelected && crossPageIds === null && effectiveSelectedCount < totalCount && totalCount > audiobooks.length;
+    allOnPageSelected && crossPageFilter === null && selectedAudiobooks.length < totalCount && totalCount > audiobooks.length;
 
   const loadAudiobooks = useCallback(async () => {
     setLoading(true);
@@ -907,14 +900,17 @@ export const Library = () => {
 
   const handleBatchDelete = async () => {
     if (!hasSelection) return;
+    // Cross-page filter delete is not yet supported — it would require iterating
+    // potentially 60K+ books per-ID. Ask the user to narrow the selection.
+    if (crossPageFilter !== null) {
+      toast('Cross-page delete is not yet supported. Narrow your selection to the current page first.', 'info');
+      setBatchDeleteDialogOpen(false);
+      return;
+    }
     setBatchDeleteInProgress(true);
     try {
-      // When cross-page selection is active, send all IDs; backend skips already-deleted.
-      const idsToDelete = crossPageIds
-        ?? selectedAudiobooks.filter((book) => !book.marked_for_deletion).map((b) => b.id);
-      const activeBooks = crossPageIds
-        ? crossPageIds.map((id) => ({ id }))
-        : selectedAudiobooks.filter((book) => !book.marked_for_deletion);
+      const activeBooks = selectedAudiobooks.filter((book) => !book.marked_for_deletion);
+      const idsToDelete = activeBooks.map((b) => b.id);
       const results = await Promise.all(
         idsToDelete.map((id) => api.deleteBook(id, { softDelete: true, blockHash: true }))
       );
@@ -928,7 +924,7 @@ export const Library = () => {
       } else {
         toast(baseMessage, 'success');
       }
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
       setSelectedAudiobooks([]);
       await loadAudiobooks();
       await loadSoftDeleted();
@@ -949,7 +945,7 @@ export const Library = () => {
       await Promise.all(deletedBooks.map((book) => api.restoreSoftDeletedBook(book.id)));
       toast(`Restored ${deletedBooks.length} selected audiobooks.`, 'success');
       setSelectedAudiobooks([]);
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -969,7 +965,7 @@ export const Library = () => {
       await api.mergeBooks(keepId, mergeIds);
       toast(`Merged ${selectedAudiobooks.length} books as versions.`, 'success');
       setSelectedAudiobooks([]);
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
       setMergeDialogOpen(false);
       await loadAudiobooks();
     } catch (error) {
@@ -1050,7 +1046,7 @@ export const Library = () => {
       }
       loadAudiobooks();
       setSelectedAudiobooks([]);
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
       setBatchEditOpen(false);
     } catch (error) {
       console.error('Failed to batch update audiobooks:', error);
@@ -1101,13 +1097,18 @@ export const Library = () => {
       return;
     }
     try {
-      await api.startBulkMetadataFetch(effectiveSelectedIds);
+      // Build a SelectionSpec: use a filter for cross-page selections so the
+      // server resolves IDs at execution time; use explicit IDs for page selections.
+      const selection: api.SelectionSpec = crossPageFilter !== null
+        ? { filter: crossPageFilter }
+        : { book_ids: effectiveSelectedIds };
+      await api.startBulkMetadataFetch(selection);
       toast(
         `Metadata fetch queued for ${effectiveSelectedCount.toLocaleString()} books — watch the bell for progress.`,
         'success'
       );
       setSelectedAudiobooks([]);
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
     } catch (error) {
       console.error('Failed to start bulk metadata fetch:', error);
       toast('Failed to start bulk metadata fetch.', 'error');
@@ -1127,7 +1128,7 @@ export const Library = () => {
     const ids = effectiveSelectedIds.filter((id) => {
       // When cross-page selection is active, we can't filter by marked_for_deletion.
       // Pass all selected IDs; the backend skips deleted books gracefully.
-      if (crossPageIds !== null) return true;
+      if (crossPageFilter !== null) return true;
       const book = selectedAudiobooks.find((b) => b.id === id);
       return book ? !book.marked_for_deletion : true;
     });
@@ -1144,7 +1145,7 @@ export const Library = () => {
       }
       toast(`Saving ${ids.length} books to files…`, 'success');
       setBulkWriteBackDialogOpen(false);
-      setCrossPageIds(null);
+      setCrossPageFilter(null);
       setSelectedAudiobooks([]);
     } catch (error) {
       console.error('Failed to start save to files:', error);
@@ -1349,7 +1350,7 @@ export const Library = () => {
       } else if (!encounteredError) {
         toast(`Successfully organized ${completed} audiobooks.`, 'success');
         setSelectedAudiobooks([]);
-        setCrossPageIds(null);
+        setCrossPageFilter(null);
       }
 
       if (!bulkOrganizeCancelRef.current && !encounteredError) {
@@ -1724,7 +1725,6 @@ export const Library = () => {
           handleClearSelection={handleClearSelection}
           showSelectAllBanner={showSelectAllBanner}
           handleSelectAllItems={handleSelectAllItems}
-          selectingAll={selectingAll}
           handleEdit={handleEdit}
           handleDelete={handleDelete}
           handleClick={handleClick}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.23.0
+// version: 2.24.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-08
+// last-edited: 2026-05-11
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -1479,47 +1479,35 @@ export async function removeImportPath(id: number): Promise<void> {
   }
 }
 
-// getAudiobookIds returns all book IDs matching the given filters, with no
-// pagination cap. Used for cross-page "select all" without the 500-row limit.
-export async function getAudiobookIds(options?: {
-  sortBy?: string;
-  sortOrder?: string;
-  tag?: string;
-  libraryState?: string;
-  filters?: string;
-  search?: string;
-}): Promise<{ ids: string[]; total: number }> {
-  const params = new URLSearchParams();
-  if (options?.sortBy) params.set('sort_by', options.sortBy);
-  if (options?.sortOrder) params.set('sort_order', options.sortOrder);
-  if (options?.tag) params.set('tag', options.tag);
-  if (options?.libraryState) params.set('library_state', options.libraryState);
-  if (options?.filters) params.set('filters', options.filters);
-  if (options?.search) params.set('search', options.search);
-  const response = await fetch(`${API_BASE}/audiobooks/ids?${params.toString()}`);
-  if (!response.ok) throw await buildApiError(response, 'Failed to fetch audiobook IDs');
-  const body = await response.json();
-  return body?.data ?? { ids: [], total: 0 };
+// SelectionSpec describes which books an operation targets.
+// Either book_ids (explicit list) or filter (resolved server-side) must be set.
+export interface SelectionSpec {
+  book_ids?: string[];
+  filter?: {
+    search?: string;
+    library_state?: string;
+    tag?: string;
+    field_filters?: Array<{ field: string; value: string; negated: boolean }>;
+    author_id?: number;
+    series_id?: number;
+  };
 }
 
-// getITunesBooksIds returns all book IDs that have iTunes persistent IDs, with
-// no pagination cap. Used by the iTunes sync dialog "Select All".
-export async function getITunesBookIds(search?: string): Promise<{ ids: string[]; total: number }> {
-  const params = new URLSearchParams();
-  if (search) params.set('search', search);
-  const response = await fetch(`${API_BASE}/itunes/books/ids?${params.toString()}`);
-  if (!response.ok) throw await buildApiError(response, 'Failed to fetch iTunes book IDs');
-  const body = await response.json();
-  return body?.data ?? { ids: [], total: 0 };
-}
-
-// startBulkMetadataFetch enqueues a v2 bulk metadata fetch operation for the
-// given book IDs. Returns the operation ID for polling via the bell.
-export async function startBulkMetadataFetch(bookIds: string[]): Promise<{ operation_id: string }> {
+// startBulkMetadataFetch enqueues a v2 bulk metadata fetch operation.
+// Pass a SelectionSpec with either book_ids (explicit page-level selection)
+// or filter (cross-page selection, resolved server-side with IsPrimaryVersion=true).
+// Returns the operation ID for polling via the bell.
+export async function startBulkMetadataFetch(
+  selection: SelectionSpec,
+  options?: { prefer_audible?: boolean; skip_cached?: boolean }
+): Promise<{ operation_id: string }> {
   const response = await fetch(`${API_BASE}/operations/v2`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ def_id: 'library.bulk-metadata-fetch', params: { book_ids: bookIds } }),
+    body: JSON.stringify({
+      def_id: 'library.bulk-metadata-fetch',
+      params: { selection, ...options },
+    }),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to start bulk metadata fetch');
   const body = await response.json();


### PR DESCRIPTION
## Summary
- Defines `SelectionSpec { book_ids | filter }` in `internal/operations` package with `types.go` and `selection.go`
- `ResolveBookIDs` helper resolves filter → IDs server-side with `IsPrimaryVersion=true` always applied (quarantined books excluded)
- Per-user field filters (read_status, progress_pct, last_played) are skipped in background op resolver (no user context)
- Removes `GET /audiobooks/ids` and `GET /itunes/books/ids` endpoints
- `Library.tsx`: `crossPageIds: string[]` replaced by `crossPageFilter: SelectionSpec['filter']` — tiny filter object instead of 61K IDs in browser memory
- `handleSelectAllItems`: no longer async — just captures current filter state into `crossPageFilter`, no network call
- `handleBulkFetchMetadata`: passes `{ filter: crossPageFilter }` or `{ book_ids: effectiveSelectedIds }` to `api.startBulkMetadataFetch`
- Cross-page bulk delete shows info toast (not yet supported — would require per-ID iteration of 60K+ books)
- `ITunesImport.tsx`: removes "Select All (N)" button that called the deleted `/itunes/books/ids` endpoint
- `api.ts`: replaces `getAudiobookIds`, `getITunesBookIds`, and old `startBulkMetadataFetch(bookIds[])` with `startBulkMetadataFetch(selection, options?)`

## Test plan
- [ ] Apply a filter (e.g. NOT review:matched), select all on page → banner appears → click "Select all N items" → count shows totalCount
- [ ] With cross-page filter set: bulk metadata fetch → watch bell → correct book count in progress
- [ ] Page-level selection still works (explicit book_ids path)
- [ ] Cross-page delete shows info toast rather than silently operating on page-only selection
- [ ] `make build-api` compiles clean
- [ ] `cd web && npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)