### PR TITLE
feat(ops): register library.scan/organize/transcode as v2 OperationDefs

### DIFF
--- a/internal/server/library_core_ops.go
+++ b/internal/server/library_core_ops.go
@@ -1,0 +1,241 @@
+// file: internal/server/library_core_ops.go
+// version: 1.0.0
+// guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+
+// library_core_ops registers the scan, organize, and transcode OperationDefs
+// that previously went through the legacy BridgeQueue.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+	"github.com/jdfalk/audiobook-organizer/internal/transcode"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+type libraryScanParams struct {
+	FolderPath  *string `json:"folder_path,omitempty"`
+	ForceUpdate *bool   `json:"force_update,omitempty"`
+}
+
+type libraryOrganizeParams struct {
+	FolderPath         *string  `json:"folder_path,omitempty"`
+	BookIDs            []string `json:"book_ids,omitempty"`
+	FetchMetadataFirst bool     `json:"fetch_metadata_first"`
+	SyncITunesFirst    bool     `json:"sync_itunes_first"`
+}
+
+type libraryTranscodeParams struct {
+	BookID       string `json:"book_id"`
+	OutputFormat string `json:"output_format"`
+	Bitrate      int    `json:"bitrate"`
+	KeepOriginal bool   `json:"keep_original"`
+}
+
+// RegisterLibraryScanOp registers the "library.scan" v2 OperationDef.
+func (s *Server) RegisterLibraryScanOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.scan",
+		Plugin:          "library",
+		DisplayName:     "Library Scan",
+		Description:     "Scan the library root directory for new, changed, or removed audiobook files.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "library.scan",
+		Permissions:     []auth.Permission{auth.PermScanTrigger},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p libraryScanParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+			scanReq := &scanner.ScanRequest{
+				FolderPath:  p.FolderPath,
+				ForceUpdate: p.ForceUpdate,
+			}
+			progress := registryProgressAdapter{r: reporter}
+			return s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
+		},
+	})
+}
+
+// RegisterLibraryOrganizeOp registers the "library.organize" v2 OperationDef.
+func (s *Server) RegisterLibraryOrganizeOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.organize",
+		Plugin:          "library",
+		DisplayName:     "Organize Library",
+		Description:     "Move audiobook files into the canonical directory structure based on current metadata.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "library.organize",
+		Permissions:     []auth.Permission{auth.PermScanTrigger},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p libraryOrganizeParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+			opID := ulid.Make().String()
+			progress := registryProgressAdapter{r: reporter}
+			organizeReq := &OrganizeRequest{
+				FolderPath:         p.FolderPath,
+				BookIDs:            p.BookIDs,
+				FetchMetadataFirst: p.FetchMetadataFirst,
+				SyncITunesFirst:    p.SyncITunesFirst,
+				OperationID:        opID,
+			}
+			return s.organizeService.PerformOrganize(ctx, organizeReq, operations.LoggerFromReporter(progress))
+		},
+	})
+}
+
+// RegisterLibraryTranscodeOp registers the "library.transcode" v2 OperationDef.
+func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.transcode",
+		Plugin:          "library",
+		DisplayName:     "Transcode to M4B",
+		Description:     "Transcode an audiobook file to M4B format and register it as a new version.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         6 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "", // transcodes can run in parallel
+		Permissions:     []auth.Permission{auth.PermLibraryOrganize},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p libraryTranscodeParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("transcode: decode params: %w", err)
+				}
+			}
+			if p.BookID == "" {
+				return fmt.Errorf("transcode: book_id is required")
+			}
+
+			progress := registryProgressAdapter{r: reporter}
+
+			opts := transcode.TranscodeOpts{
+				BookID:       p.BookID,
+				OutputFormat: p.OutputFormat,
+				Bitrate:      p.Bitrate,
+				KeepOriginal: p.KeepOriginal,
+			}
+
+			outputPath, err := transcode.Transcode(ctx, opts, s.Store(), progress)
+			if err != nil {
+				return err
+			}
+
+			originalBook, err := s.Store().GetBookByID(p.BookID)
+			if err != nil {
+				return fmt.Errorf("failed to get original book: %w", err)
+			}
+
+			groupID := ""
+			if originalBook.VersionGroupID != nil && *originalBook.VersionGroupID != "" {
+				groupID = *originalBook.VersionGroupID
+			} else {
+				groupID = ulid.Make().String()
+			}
+
+			notPrimary := false
+			origNotes := "Original format"
+			originalBook.IsPrimaryVersion = &notPrimary
+			originalBook.VersionGroupID = &groupID
+			originalBook.VersionNotes = &origNotes
+			if _, err := s.Store().UpdateBook(p.BookID, originalBook); err != nil {
+				progress.Log("warn", fmt.Sprintf("Failed to update original book version info: %v", err), nil)
+			}
+
+			m4bFormat := "m4b"
+			aacCodec := "aac"
+			bitrateVal := opts.Bitrate
+			if bitrateVal <= 0 {
+				bitrateVal = 128
+			}
+			isPrimary := true
+			m4bNotes := "Transcoded to M4B"
+
+			newBook := &database.Book{
+				ID:                   ulid.Make().String(),
+				Title:                originalBook.Title,
+				FilePath:             outputPath,
+				Format:               m4bFormat,
+				Codec:                &aacCodec,
+				Bitrate:              &bitrateVal,
+				AuthorID:             originalBook.AuthorID,
+				SeriesID:             originalBook.SeriesID,
+				SeriesSequence:       originalBook.SeriesSequence,
+				Duration:             originalBook.Duration,
+				Narrator:             originalBook.Narrator,
+				Publisher:            originalBook.Publisher,
+				PrintYear:            originalBook.PrintYear,
+				AudiobookReleaseYear: originalBook.AudiobookReleaseYear,
+				ISBN10:               originalBook.ISBN10,
+				ISBN13:               originalBook.ISBN13,
+				ASIN:                 originalBook.ASIN,
+				Language:             originalBook.Language,
+				CoverURL:             originalBook.CoverURL,
+				IsPrimaryVersion:     &isPrimary,
+				VersionGroupID:       &groupID,
+				VersionNotes:         &m4bNotes,
+			}
+			if _, err := s.Store().CreateBook(newBook); err != nil {
+				progress.Log("warn", fmt.Sprintf("Failed to create M4B version record, updating original: %v", err), nil)
+				isPrim := true
+				fallbackNotes := fmt.Sprintf("Transcoded to M4B (in-place, original was at %s)", originalBook.FilePath)
+				originalBook.FilePath = outputPath
+				originalBook.Format = m4bFormat
+				originalBook.Codec = &aacCodec
+				originalBook.Bitrate = &bitrateVal
+				originalBook.IsPrimaryVersion = &isPrim
+				originalBook.VersionGroupID = &groupID
+				originalBook.VersionNotes = &fallbackNotes
+				if _, updateErr := s.Store().UpdateBook(p.BookID, originalBook); updateErr != nil {
+					return updateErr
+				}
+				return nil
+			}
+
+			progress.Log("info", fmt.Sprintf("Created M4B version %s (group %s), original %s demoted to non-primary", newBook.ID, groupID, p.BookID), nil)
+
+			if !config.AppConfig.ITLWriteBackEnabled &&
+				originalBook.ITunesPersistentID != nil &&
+				*originalBook.ITunesPersistentID != "" {
+				if err := s.Store().CreateDeferredITunesUpdate(
+					originalBook.ID,
+					*originalBook.ITunesPersistentID,
+					originalBook.FilePath,
+					newBook.FilePath,
+					"transcode",
+				); err != nil {
+					progress.Log("warn", fmt.Sprintf("Failed to create deferred iTunes update: %v", err), nil)
+				} else {
+					progress.Log("info", "M4B created. iTunes library update deferred until write-back is enabled.", nil)
+				}
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -30,267 +30,58 @@ import (
 )
 
 func (s *Server) startScan(c *gin.Context) {
-	if s.Store() == nil {
-		httputil.RespondWithInternalError(c, "database not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
-		return
+	body, _ := c.GetRawData()
+	if len(body) == 0 {
+		body = []byte("{}")
 	}
-
-	var req struct {
-		FolderPath  *string `json:"folder_path"`
-		Priority    *int    `json:"priority"`
-		ForceUpdate *bool   `json:"force_update"`
-	}
-	_ = c.ShouldBindJSON(&req)
-
-	id := ulid.Make().String()
-	op, err := s.Store().CreateOperation(id, "scan", req.FolderPath)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.scan", body)
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
+		httputil.InternalError(c, "enqueue failed", err)
 		return
 	}
-
-	// Determine priority (default to normal)
-	priority := operations.PriorityNormal
-	if req.Priority != nil {
-		priority = *req.Priority
-	}
-
-	// Create operation function that delegates to service
-	scanReq := &scanner.ScanRequest{
-		FolderPath:  req.FolderPath,
-		Priority:    req.Priority,
-		ForceUpdate: req.ForceUpdate,
-	}
-
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
-	}
-
-	// Enqueue the operation
-	if err := s.queue.Enqueue(op.ID, "scan", priority, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
-		return
-	}
-
-	httputil.RespondWithSuccess(c, 202, op)
+	c.JSON(202, gin.H{"op_id": opID, "id": opID})
 }
 
 func (s *Server) startOrganize(c *gin.Context) {
-	if s.Store() == nil {
-		httputil.RespondWithInternalError(c, "database not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
-		return
+	body, _ := c.GetRawData()
+	if len(body) == 0 {
+		body = []byte("{}")
 	}
-
-	var req struct {
-		FolderPath         *string  `json:"folder_path"`
-		Priority           *int     `json:"priority"`
-		BookIDs            []string `json:"book_ids"`
-		FetchMetadataFirst bool     `json:"fetch_metadata_first"`
-		SyncITunesFirst    bool     `json:"sync_itunes_first"`
-	}
-	_ = c.ShouldBindJSON(&req)
-
-	id := ulid.Make().String()
-	op, err := s.Store().CreateOperation(id, "organize", req.FolderPath)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.organize", body)
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
+		httputil.InternalError(c, "enqueue failed", err)
 		return
 	}
-
-	// Determine priority (default to normal)
-	priority := operations.PriorityNormal
-	if req.Priority != nil {
-		priority = *req.Priority
-	}
-
-	// Create operation function that delegates to service
-	organizeReq := &OrganizeRequest{
-		FolderPath:         req.FolderPath,
-		Priority:           req.Priority,
-		BookIDs:            req.BookIDs,
-		FetchMetadataFirst: req.FetchMetadataFirst,
-		SyncITunesFirst:    req.SyncITunesFirst,
-		OperationID:        op.ID,
-	}
-
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.organizeService.PerformOrganize(ctx, organizeReq, operations.LoggerFromReporter(progress))
-	}
-
-	// Enqueue the operation
-	if err := s.queue.Enqueue(op.ID, "organize", priority, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
-		return
-	}
-
-	httputil.RespondWithSuccess(c, 202, op)
+	c.JSON(202, gin.H{"op_id": opID, "id": opID})
 }
 
 func (s *Server) startTranscode(c *gin.Context) {
-	if s.Store() == nil {
-		httputil.RespondWithInternalError(c, "database not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
-		return
+	body, _ := c.GetRawData()
+	var check struct {
+		BookID string `json:"book_id"`
 	}
-
-	var req struct {
-		BookID       string `json:"book_id"`
-		OutputFormat string `json:"output_format"`
-		Bitrate      int    `json:"bitrate"`
-		KeepOriginal *bool  `json:"keep_original"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil || req.BookID == "" {
+	if err := json.Unmarshal(body, &check); err != nil || check.BookID == "" {
 		httputil.RespondWithBadRequest(c, "book_id is required")
 		return
 	}
-
-	// Verify the book exists
-	if _, err := s.Store().GetBookByID(req.BookID); err != nil {
-		httputil.RespondWithNotFound(c, "book", req.BookID)
-		return
-	}
-
-	id := ulid.Make().String()
-	op, err := s.Store().CreateOperation(id, "transcode", nil)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.transcode", body)
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
+		httputil.InternalError(c, "enqueue failed", err)
 		return
 	}
-
-	keepOriginal := true
-	if req.KeepOriginal != nil {
-		keepOriginal = *req.KeepOriginal
-	}
-
-	opts := transcode.TranscodeOpts{
-		BookID:       req.BookID,
-		OutputFormat: req.OutputFormat,
-		Bitrate:      req.Bitrate,
-		KeepOriginal: keepOriginal,
-	}
-
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		outputPath, err := transcode.Transcode(ctx, opts, s.Store(), progress)
-		if err != nil {
-			return err
-		}
-
-		// Get the original book to preserve its data
-		originalBook, err := s.Store().GetBookByID(req.BookID)
-		if err != nil {
-			return fmt.Errorf("failed to get original book: %w", err)
-		}
-
-		// Set up version group if not already set
-		groupID := ""
-		if originalBook.VersionGroupID != nil && *originalBook.VersionGroupID != "" {
-			groupID = *originalBook.VersionGroupID
-		} else {
-			groupID = ulid.Make().String()
-		}
-
-		// Mark original as non-primary version (modify fetched book to preserve all fields)
-		notPrimary := false
-		origNotes := "Original format"
-		originalBook.IsPrimaryVersion = &notPrimary
-		originalBook.VersionGroupID = &groupID
-		originalBook.VersionNotes = &origNotes
-		if _, err := s.Store().UpdateBook(req.BookID, originalBook); err != nil {
-			progress.Log("warn", fmt.Sprintf("Failed to update original book version info: %v", err), nil)
-		}
-
-		// Create a new book record for the M4B version
-		m4bFormat := "m4b"
-		aacCodec := "aac"
-		bitrateVal := opts.Bitrate
-		if bitrateVal <= 0 {
-			bitrateVal = 128
-		}
-		isPrimary := true
-		m4bNotes := "Transcoded to M4B"
-
-		newBook := &database.Book{
-			ID:                   ulid.Make().String(),
-			Title:                originalBook.Title,
-			FilePath:             outputPath,
-			Format:               m4bFormat,
-			Codec:                &aacCodec,
-			Bitrate:              &bitrateVal,
-			AuthorID:             originalBook.AuthorID,
-			SeriesID:             originalBook.SeriesID,
-			SeriesSequence:       originalBook.SeriesSequence,
-			Duration:             originalBook.Duration,
-			Narrator:             originalBook.Narrator,
-			Publisher:            originalBook.Publisher,
-			PrintYear:            originalBook.PrintYear,
-			AudiobookReleaseYear: originalBook.AudiobookReleaseYear,
-			ISBN10:               originalBook.ISBN10,
-			ISBN13:               originalBook.ISBN13,
-			ASIN:                 originalBook.ASIN,
-			Language:             originalBook.Language,
-			CoverURL:             originalBook.CoverURL,
-			IsPrimaryVersion:     &isPrimary,
-			VersionGroupID:       &groupID,
-			VersionNotes:         &m4bNotes,
-		}
-		if _, err := s.Store().CreateBook(newBook); err != nil {
-			// Fallback: update original in-place but preserve all existing fields
-			progress.Log("warn", fmt.Sprintf("Failed to create M4B version record, updating original: %v", err), nil)
-			isPrim := true
-			fallbackNotes := fmt.Sprintf("Transcoded to M4B (in-place, original was at %s)", originalBook.FilePath)
-			originalBook.FilePath = outputPath
-			originalBook.Format = m4bFormat
-			originalBook.Codec = &aacCodec
-			originalBook.Bitrate = &bitrateVal
-			originalBook.IsPrimaryVersion = &isPrim
-			originalBook.VersionGroupID = &groupID
-			originalBook.VersionNotes = &fallbackNotes
-			if _, updateErr := s.Store().UpdateBook(req.BookID, originalBook); updateErr != nil {
-				return updateErr
-			}
-			return nil
-		}
-
-		progress.Log("info", fmt.Sprintf("Created M4B version %s (group %s), original %s demoted to non-primary", newBook.ID, groupID, req.BookID), nil)
-
-		// If iTunes write-back is disabled and the original book came from iTunes,
-		// store a deferred update so the path change is applied on the next sync.
-		if !config.AppConfig.ITLWriteBackEnabled &&
-			originalBook.ITunesPersistentID != nil &&
-			*originalBook.ITunesPersistentID != "" {
-			if err := s.Store().CreateDeferredITunesUpdate(
-				originalBook.ID,
-				*originalBook.ITunesPersistentID,
-				originalBook.FilePath,
-				newBook.FilePath,
-				"transcode",
-			); err != nil {
-				progress.Log("warn", fmt.Sprintf("Failed to create deferred iTunes update: %v", err), nil)
-			} else {
-				progress.Log("info", "M4B created. iTunes library update deferred until write-back is enabled.", nil)
-			}
-		}
-
-		return nil
-	}
-
-	if err := s.queue.Enqueue(op.ID, "transcode", operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
-		return
-	}
-
-	httputil.RespondWithSuccess(c, 202, op)
+	c.JSON(202, gin.H{"op_id": opID, "id": opID})
 }
 
 func (s *Server) getOperationStatus(c *gin.Context) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.9.0
+// version: 2.10.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-05-08
 
@@ -357,6 +357,15 @@ func NewServer(store database.Store) *Server {
 		}
 		if err := server.RegisterBulkMetadataFetchOp(server.opRegistry); err != nil {
 			log.Printf("[server] bulk-metadata-fetch op register: %v", err)
+		}
+		if err := server.RegisterLibraryScanOp(server.opRegistry); err != nil {
+			log.Printf("[server] library.scan op register: %v", err)
+		}
+		if err := server.RegisterLibraryOrganizeOp(server.opRegistry); err != nil {
+			log.Printf("[server] library.organize op register: %v", err)
+		}
+		if err := server.RegisterLibraryTranscodeOp(server.opRegistry); err != nil {
+			log.Printf("[server] library.transcode op register: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Registers `library.scan`, `library.organize`, `library.transcode` as proper v2 OperationDefs
- Converts `startScan`, `startOrganize`, `startTranscode` HTTP handlers into thin shims calling `opRegistry.EnqueueOp()`
- All three ops now appear in the v2 operations timeline and SSE stream with cancellation support
- Responses include both `op_id` and `id` keys for backward compatibility with existing frontend code

## Test plan
- [ ] `POST /api/v1/operations/scan` returns `{"op_id": "...", "id": "..."}`
- [ ] `GET /api/v1/operations/timeline` shows the scan op
- [ ] `make build-api` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)