### PR TITLE
feat(ops): register library.bulk-write-back as v2 OperationDef

### DIFF
--- a/internal/server/library_writeback_op.go
+++ b/internal/server/library_writeback_op.go
@@ -1,0 +1,56 @@
+// file: internal/server/library_writeback_op.go
+// version: 1.0.0
+// guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// bulkWriteBackOpParams is the JSON params for the library.bulk-write-back op.
+type bulkWriteBackOpParams struct {
+	BookIDs []string `json:"book_ids"`
+	Rename  bool     `json:"rename"`
+}
+
+// RegisterBulkWriteBackOp registers the "library.bulk-write-back" v2 OperationDef.
+// The HTTP handler handleBulkWriteBack pre-filters books and passes the resulting
+// book IDs as params; the Run func executes the actual tag-write work.
+func (s *Server) RegisterBulkWriteBackOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.bulk-write-back",
+		Plugin:          "library",
+		DisplayName:     "Bulk Tag Write-back",
+		Description:     "Write metadata from the database back to audio file tags for a set of audiobooks.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         6 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeRestart,
+		ConcurrencyKey:  "library.bulk-write-back",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p bulkWriteBackOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("bulk-write-back: decode params: %w", err)
+				}
+			}
+			if len(p.BookIDs) == 0 {
+				return nil
+			}
+			opID := ulid.Make().String()
+			progress := registryProgressAdapter{r: reporter}
+			return s.runBulkWriteBack(ctx, opID, p.BookIDs, p.Rename, 0, progress)
+		},
+	})
+}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1368,8 +1368,8 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
 
@@ -1454,36 +1454,22 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 		return
 	}
 
-	// Create the operation
-	opID := ulid.Make().String()
-	op, err := store.CreateOperation(opID, "bulk_write_back", nil)
-	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
-		return
-	}
-
 	doRename := req.Rename
 	bookIDs := make([]string, len(filtered))
 	for i, b := range filtered {
 		bookIDs[i] = b.ID
 	}
 
-	// Persist params so the operation can be resumed across a restart.
-	if err := operations.SaveParams(store, op.ID, operations.BulkWriteBackParams{BookIDs: bookIDs, Rename: doRename}); err != nil {
-		log.Printf("[WARN] failed to save bulk_write_back params for %s: %v", op.ID, err)
-	}
-
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.runBulkWriteBack(ctx, op.ID, bookIDs, doRename, 0, progress)
-	}
-
-	if err := s.queue.Enqueue(op.ID, "bulk_write_back", operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	rawParams, _ := json.Marshal(bulkWriteBackOpParams{BookIDs: bookIDs, Rename: doRename})
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.bulk-write-back", rawParams)
+	if err != nil {
+		httputil.InternalError(c, "enqueue failed", err)
 		return
 	}
 
 	httputil.RespondWithSuccess(c, 202, gin.H{
-		"operation_id":    op.ID,
+		"operation_id":    opID,
+		"id":              opID,
 		"estimated_books": estimatedBooks,
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -367,6 +367,9 @@ func NewServer(store database.Store) *Server {
 		if err := server.RegisterLibraryTranscodeOp(server.opRegistry); err != nil {
 			log.Printf("[server] library.transcode op register: %v", err)
 		}
+		if err := server.RegisterBulkWriteBackOp(server.opRegistry); err != nil {
+			log.Printf("[server] bulk-write-back op register: %v", err)
+		}
 	}
 
 	// Construct the iTunes service. Phase 2 M1 step 1 enables it via New()


### PR DESCRIPTION
## Summary
- Registers `library.bulk-write-back` as a proper v2 OperationDef
- Converts `handleBulkWriteBack` HTTP handler into a thin shim calling `opRegistry.EnqueueOp()`
- Pre-filtering of books still happens in the HTTP handler (needed for dry-run response)
- Op now appears in v2 operations timeline and SSE stream

## Test plan
- [ ] `POST /api/v1/audiobooks/bulk-write-back` returns `{"op_id": "...", "id": "...", "estimated_books": N}`
- [ ] `GET /api/v1/operations/timeline` shows the bulk-write-back op
- [ ] `make build-api` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)