### PR TITLE
feat(ops): Resume Review without operation picker (pending-review endpoint)

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 1.9.0
+// version: 2.0.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-05-01
 
@@ -905,4 +905,88 @@ func (s *Server) resumeInterruptedMetadataFetch() {
 			_ = store.UpdateOperationStatus(opID, "failed", alreadyDone, totalBooks, "failed to resume")
 		}
 	}
+}
+
+// handleGetPendingReview implements POST /api/v1/metadata/pending-review.
+// It scans all completed metadata_candidate_fetch operations, deduplicates
+// by book_id (latest status per book), and returns books whose latest
+// result status is "matched" (candidate found, not yet applied/rejected).
+// It creates a new aggregate "pending-review" operation so the standard
+// MetadataReviewDialog can be used without modification.
+func (s *Server) handleGetPendingReview(c *gin.Context) {
+	store := s.Store()
+
+	// Load all operations and find metadata_candidate_fetch ones.
+	allOps, err := store.GetRecentOperations(5000)
+	if err != nil {
+		httputil.InternalError(c, "failed to list operations", err)
+		return
+	}
+
+	// Collect the latest OperationResult per book_id across all candidate-fetch ops.
+	type bookEntry struct {
+		result    database.OperationResult
+		createdAt time.Time
+	}
+	latestByBook := map[string]bookEntry{}
+
+	for _, op := range allOps {
+		if op.Type != "metadata_candidate_fetch" {
+			continue
+		}
+		results, err := store.GetOperationResults(op.ID)
+		if err != nil {
+			continue
+		}
+		for _, r := range results {
+			existing, ok := latestByBook[r.BookID]
+			if !ok || r.CreatedAt.After(existing.createdAt) {
+				latestByBook[r.BookID] = bookEntry{result: r, createdAt: r.CreatedAt}
+			}
+		}
+	}
+
+	// Filter to books whose latest status is "matched" (candidate available, not applied/rejected).
+	var pending []database.OperationResult
+	for _, entry := range latestByBook {
+		if entry.result.Status == "matched" {
+			pending = append(pending, entry.result)
+		}
+	}
+
+	if len(pending) == 0 {
+		httputil.RespondWithOK(c, gin.H{
+			"operation_id": "",
+			"total_books":  0,
+			"message":      "no books with pending metadata candidates",
+		})
+		return
+	}
+
+	// Create an aggregate operation record so MetadataReviewDialog can use its
+	// standard operationId-based flow (apply, reject, pagination).
+	newOpID := ulid.Make().String()
+	if _, err := store.CreateOperation(newOpID, "metadata_candidate_fetch", nil); err != nil {
+		httputil.InternalError(c, "failed to create aggregate operation", err)
+		return
+	}
+
+	// Copy the latest CandidateResult rows under the new operation ID.
+	for _, r := range pending {
+		_ = store.CreateOperationResult(&database.OperationResult{
+			OperationID: newOpID,
+			BookID:      r.BookID,
+			ResultJSON:  r.ResultJSON,
+			Status:      r.Status,
+		})
+	}
+
+	// Mark the aggregate op as completed immediately — all results are already loaded.
+	_ = store.UpdateOperationStatus(newOpID, "completed", len(pending), len(pending), "")
+
+	httputil.RespondWithOK(c, gin.H{
+		"operation_id": newOpID,
+		"total_books":  len(pending),
+		"message":      fmt.Sprintf("%d book(s) have pending metadata candidates", len(pending)),
+	})
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-08
 
@@ -1155,6 +1155,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/metadata/bulk-fetch", s.perm(auth.PermLibraryEditMetadata), s.bulkFetchMetadata)
 			protected.POST("/metadata/batch-fetch-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleBatchFetchCandidates)
 			protected.GET("/metadata/recent-fetches", s.perm(auth.PermLibraryView), s.handleGetLatestMetadataFetch)
+			protected.POST("/metadata/pending-review", s.perm(auth.PermLibraryView), s.handleGetPendingReview)
 			protected.POST("/metadata/batch-apply-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleBatchApplyCandidates)
 			protected.POST("/metadata/batch-reject-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleRejectCandidates)
 			protected.POST("/metadata/batch-unreject-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleUnrejectCandidates)

--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
 // last-edited: 2026-05-11
 
@@ -13,7 +13,6 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
-  DialogContentText,
   DialogActions,
   TextField,
   IconButton,
@@ -170,11 +169,6 @@ interface LibraryDialogsProps {
   metadataReviewOpId: string | null;
   setMetadataReviewOpId: (id: string) => void;
 
-  // Resume review picker
-  resumeReviewPickerOpen: boolean;
-  setResumeReviewPickerOpen: (open: boolean) => void;
-  recentFetches: api.MetadataFetchSummary[];
-
   // Version management
   versionManagingAudiobook: Audiobook | null;
   versionManagementOpen: boolean;
@@ -304,9 +298,6 @@ export const LibraryDialogs = ({
   setMetadataReviewOpen,
   metadataReviewOpId,
   setMetadataReviewOpId,
-  resumeReviewPickerOpen,
-  setResumeReviewPickerOpen,
-  recentFetches,
   versionManagingAudiobook,
   versionManagementOpen,
   handleVersionManagementClose,
@@ -832,72 +823,6 @@ export const LibraryDialogs = ({
       }}
       toast={toast}
     />
-
-    {/* Resume Review picker: lists recent completed
-        metadata_candidate_fetch ops with their result counts.
-        Click a row to open the MetadataReviewDialog for that
-        specific operation. Solves the "fired two fetches, first
-        one's results are lost in the UI" scenario. */}
-    <Dialog
-      open={resumeReviewPickerOpen}
-      onClose={() => setResumeReviewPickerOpen(false)}
-      maxWidth="sm"
-      fullWidth
-    >
-      <DialogTitle>Resume metadata review</DialogTitle>
-      <DialogContent>
-        <DialogContentText sx={{ mb: 2 }}>
-          Pick a completed metadata fetch to review. Results stay in
-          the operation log until you review them, so even older
-          fetches can still be opened if you never got around to it.
-        </DialogContentText>
-        {recentFetches.length === 0 ? (
-          <Typography color="text.secondary">No recent fetches found.</Typography>
-        ) : (
-          <Stack spacing={1}>
-            {recentFetches.map((op) => (
-              <Box
-                key={op.id}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  p: 1.5,
-                  border: 1,
-                  borderColor: 'divider',
-                  borderRadius: 1,
-                  cursor: 'pointer',
-                  '&:hover': { borderColor: 'primary.main' },
-                }}
-                onClick={() => {
-                  setMetadataReviewOpId(op.id);
-                  setMetadataReviewOpen(true);
-                  setResumeReviewPickerOpen(false);
-                }}
-              >
-                <Box sx={{ minWidth: 0, flex: 1 }}>
-                  <Typography variant="body2" fontWeight="medium" noWrap>
-                    {new Date(op.completed_at || op.created_at).toLocaleString()}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {op.matched_count} matched &middot;{' '}
-                    {op.no_match_count} no match &middot;{' '}
-                    {op.error_count} error{' '}
-                    ({op.result_count} total)
-                  </Typography>
-                </Box>
-                <Button size="small" variant="contained">
-                  Review
-                </Button>
-              </Box>
-            ))}
-          </Stack>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={() => setResumeReviewPickerOpen(false)}>Close</Button>
-      </DialogActions>
-    </Dialog>
 
     <VersionManagement
       audiobookId={versionManagingAudiobook?.id || ''}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.61.0
+// version: 1.62.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-05-11
 
@@ -225,8 +225,6 @@ export const Library = () => {
     searchParams.get('reviewOp')
   );
   const [metadataReviewOpen, setMetadataReviewOpen] = useState(!!searchParams.get('reviewOp'));
-  const [resumeReviewPickerOpen, setResumeReviewPickerOpen] = useState(false);
-  const [recentFetches, setRecentFetches] = useState<api.MetadataFetchSummary[]>([]);
   const [mergeInProgress, setMergeInProgress] = useState(false);
   const sseStatusRef = useRef<EventSourceStatus['state'] | null>(null);
 
@@ -1629,15 +1627,15 @@ export const Library = () => {
 
   const handleResumeReview = async () => {
     try {
-      const list = await api.getRecentMetadataFetches();
-      if (list.length === 0) {
-        toast('No recent metadata fetch with results found. Start a Fetch & Review first.', 'info');
+      const result = await api.getPendingReview();
+      if (!result.operation_id || result.total_books === 0) {
+        toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
         return;
       }
-      setRecentFetches(list);
-      setResumeReviewPickerOpen(true);
+      setMetadataReviewOpId(result.operation_id);
+      setMetadataReviewOpen(true);
     } catch {
-      toast('Failed to load recent metadata fetches', 'error');
+      toast('Failed to load pending review', 'error');
     }
   };
 
@@ -1840,9 +1838,7 @@ export const Library = () => {
           setMetadataReviewOpen={setMetadataReviewOpen}
           metadataReviewOpId={metadataReviewOpId}
           setMetadataReviewOpId={(id) => setMetadataReviewOpId(id)}
-          resumeReviewPickerOpen={resumeReviewPickerOpen}
-          setResumeReviewPickerOpen={setResumeReviewPickerOpen}
-          recentFetches={recentFetches}
+
           versionManagingAudiobook={versionManagingAudiobook}
           versionManagementOpen={versionManagementOpen}
           handleVersionManagementClose={handleVersionManagementClose}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.23.0
+// version: 2.24.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-08
 
@@ -3096,6 +3096,12 @@ export async function getRecentMetadataFetches(): Promise<MetadataFetchSummary[]
   if (!response.ok) throw await buildApiError(response, 'Failed to list recent metadata fetches');
   const data = await response.json();
   return data.operations || [];
+}
+
+export async function getPendingReview(): Promise<{ operation_id: string; total_books: number; message: string }> {
+  const response = await fetch(`${API_BASE}/metadata/pending-review`, { method: 'POST' });
+  if (!response.ok) throw await buildApiError(response, 'Failed to get pending review');
+  return response.json();
 }
 
 export async function batchApplyCandidates(operationId: string, bookIds: string[]): Promise<{ applied: number }> {


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/metadata/pending-review` — scans all completed `metadata_candidate_fetch` ops, deduplicates by book_id (latest result wins), creates a synthetic aggregate operation containing all unmatched books with candidates
- Clicking **Resume Review** now calls this endpoint and opens `MetadataReviewDialog` directly with the returned `operation_id` — no picker dialog
- Removes the operation picker dialog from `LibraryDialogs.tsx` (was a source of confusion)
- Standard apply/reject/bulk-apply continue to work unchanged via the aggregate operation

## Behavior change
Before: Resume Review → picker showing list of past fetch operations → pick one → review  
After: Resume Review → instant open of review dialog with all unmatched books across all past fetches

## Test plan
- [ ] `POST /api/v1/metadata/pending-review` returns `{operation_id, total_books, message}` with a valid new op ID
- [ ] Resume Review button opens MetadataReviewDialog with all pending books
- [ ] Apply/reject work correctly on the aggregate operation
- [ ] If no pending books, toast "No books with pending metadata candidates found"
- [ ] `make build-api` + `npm run typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)