### PR TITLE
fix(ui): remove unused setMetadataReviewOpId prop from LibraryDialogs

### DIFF
--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -167,7 +167,6 @@ interface LibraryDialogsProps {
   metadataReviewOpen: boolean;
   setMetadataReviewOpen: (open: boolean) => void;
   metadataReviewOpId: string | null;
-  setMetadataReviewOpId: (id: string) => void;
 
   // Version management
   versionManagingAudiobook: Audiobook | null;
@@ -297,7 +296,6 @@ export const LibraryDialogs = ({
   metadataReviewOpen,
   setMetadataReviewOpen,
   metadataReviewOpId,
-  setMetadataReviewOpId,
   versionManagingAudiobook,
   versionManagementOpen,
   handleVersionManagementClose,

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1837,7 +1837,6 @@ export const Library = () => {
           metadataReviewOpen={metadataReviewOpen}
           setMetadataReviewOpen={setMetadataReviewOpen}
           metadataReviewOpId={metadataReviewOpId}
-          setMetadataReviewOpId={(id) => setMetadataReviewOpId(id)}
 
           versionManagingAudiobook={versionManagingAudiobook}
           versionManagementOpen={versionManagementOpen}


### PR DESCRIPTION
## Summary
- Drops `setMetadataReviewOpId` from `LibraryDialogsProps` interface and destructuring
- Removes the corresponding prop from the `LibraryDialogs` call in `Library.tsx`
- Fixes TS6133 build error introduced by Piece 5 (resume-review simplification)

## Test plan
- [ ] `make web-build` passes (no TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)