### PR TITLE
feat(ops): add only_unmatched filter to FilterSpec and batch-fetch-candidates endpoint

### DIFF
--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -1,5 +1,5 @@
 // file: internal/operations/types.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
 // last-edited: 2026-05-11
 //
@@ -22,12 +22,16 @@ type SelectionSpec struct {
 // When Filter is set on a SelectionSpec, the server resolves it to book IDs
 // at operation execution time with IsPrimaryVersion=true always applied.
 type FilterSpec struct {
-	Search       string        `json:"search,omitempty"`
-	LibraryState string        `json:"library_state,omitempty"`
-	Tag          string        `json:"tag,omitempty"`
-	FieldFilters []FieldFilter `json:"field_filters,omitempty"`
-	AuthorID     *int64        `json:"author_id,omitempty"`
-	SeriesID     *int64        `json:"series_id,omitempty"`
+	Search         string        `json:"search,omitempty"`
+	LibraryState   string        `json:"library_state,omitempty"`
+	Tag            string        `json:"tag,omitempty"`
+	FieldFilters   []FieldFilter `json:"field_filters,omitempty"`
+	AuthorID       *int64        `json:"author_id,omitempty"`
+	SeriesID       *int64        `json:"series_id,omitempty"`
+	// OnlyUnmatched restricts the resolved set to books that do not have a
+	// "matched" candidate in the most-recent metadata_candidate_fetch result.
+	// Applied server-side after the primary filter; requires DB access.
+	OnlyUnmatched bool `json:"only_unmatched,omitempty"`
 }
 
 // FieldFilter mirrors the server-side FieldFilter used for advanced search.

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-05-01
+// last-edited: 2026-05-11
 
 package server
 
@@ -55,8 +55,49 @@ type CandidateResult struct {
 }
 
 // batchFetchRequest is the JSON body for handleBatchFetchCandidates.
+// Either BookIDs or Selection must be provided; OnlyUnmatched can be combined
+// with either to exclude books that already have a "matched" candidate.
 type batchFetchRequest struct {
-	BookIDs []string `json:"book_ids" binding:"required"`
+	BookIDs       []string                    `json:"book_ids"`
+	Selection     *operations.SelectionSpec   `json:"selection"`
+	OnlyUnmatched bool                        `json:"only_unmatched"`
+}
+
+// latestMatchedBookIDs returns the set of book IDs whose most-recent
+// metadata_candidate_fetch result has status "matched".  Used to exclude
+// already-matched books when OnlyUnmatched is requested.
+func latestMatchedBookIDs(store database.Store) map[string]bool {
+	allOps, err := store.GetRecentOperations(5000)
+	if err != nil {
+		return nil
+	}
+	type entry struct {
+		status    string
+		createdAt time.Time
+	}
+	latest := map[string]entry{}
+	for _, op := range allOps {
+		if op.Type != "metadata_candidate_fetch" {
+			continue
+		}
+		results, err := store.GetOperationResults(op.ID)
+		if err != nil {
+			continue
+		}
+		for _, r := range results {
+			ex, ok := latest[r.BookID]
+			if !ok || r.CreatedAt.After(ex.createdAt) {
+				latest[r.BookID] = entry{status: r.Status, createdAt: r.CreatedAt}
+			}
+		}
+	}
+	matched := make(map[string]bool, len(latest))
+	for bookID, e := range latest {
+		if e.status == "matched" {
+			matched[bookID] = true
+		}
+	}
+	return matched
 }
 
 // batchApplyRequest is the JSON body for handleBatchApplyCandidates.
@@ -70,17 +111,50 @@ type batchApplyRequest struct {
 func (s *Server) handleBatchFetchCandidates(c *gin.Context) {
 	var req batchFetchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httputil.RespondWithBadRequest(c, "book_ids is required")
-		return
-	}
-	if len(req.BookIDs) == 0 {
-		httputil.RespondWithBadRequest(c, "book_ids must not be empty")
+		httputil.RespondWithBadRequest(c, "invalid request body")
 		return
 	}
 
 	store := s.Store()
 
-	// Exclude books already in an active metadata fetch to avoid duplicate API calls
+	// Resolve the target book IDs — from either explicit list or SelectionSpec.
+	candidateIDs := req.BookIDs
+	if len(candidateIDs) == 0 && req.Selection != nil {
+		resolved, err := operations.ResolveBookIDs(*req.Selection, func(f operations.FilterSpec) ([]string, error) {
+			return s.resolveFilterToBookIDs(c.Request.Context(), f)
+		})
+		if err != nil {
+			httputil.RespondWithBadRequest(c, "failed to resolve selection: "+err.Error())
+			return
+		}
+		candidateIDs = resolved
+	}
+	if len(candidateIDs) == 0 {
+		httputil.RespondWithBadRequest(c, "book_ids or selection is required")
+		return
+	}
+
+	// Optionally exclude books already having a "matched" candidate.
+	if req.OnlyUnmatched {
+		matched := latestMatchedBookIDs(store)
+		filtered := candidateIDs[:0]
+		for _, id := range candidateIDs {
+			if !matched[id] {
+				filtered = append(filtered, id)
+			}
+		}
+		candidateIDs = filtered
+		if len(candidateIDs) == 0 {
+			httputil.RespondWithOK(c, gin.H{
+				"message":      "all selected books already have matched candidates",
+				"operation_id": "",
+				"book_count":   0,
+			})
+			return
+		}
+	}
+
+	// Exclude books already in an active metadata fetch to avoid duplicate API calls.
 	activeOps, _ := store.GetRecentOperations(50)
 	alreadyFetching := make(map[string]bool)
 	for _, op := range activeOps {
@@ -104,7 +178,7 @@ func (s *Server) handleBatchFetchCandidates(c *gin.Context) {
 
 	var bookIDs []string
 	var skippedCount int
-	for _, id := range req.BookIDs {
+	for _, id := range candidateIDs {
 		if alreadyFetching[id] {
 			skippedCount++
 		} else {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.5.0
+// version: 3.6.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 // last-edited: 2026-05-11
 //
@@ -1106,6 +1106,61 @@ type bulkMetadataFetchV2Params struct {
 	SkipCached    bool                     `json:"skip_cached"`
 }
 
+// resolveFilterToBookIDs translates a FilterSpec into a concrete list of primary-
+// version book IDs.  IsPrimaryVersion=true and quarantine exclusion are always
+// applied.  If f.OnlyUnmatched is set, books that already have a "matched"
+// candidate in the most-recent metadata_candidate_fetch result are removed.
+// Per-user FieldFilters are silently dropped (no user context in background ops).
+func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.FilterSpec) ([]string, error) {
+	trueVal := true
+	filters := ListFilters{
+		IsPrimaryVersion: &trueVal,
+		LibraryState:     f.LibraryState,
+		Tag:              f.Tag,
+	}
+	for _, ff := range f.FieldFilters {
+		if IsPerUserField(ff.Field) {
+			continue
+		}
+		filters.FieldFilters = append(filters.FieldFilters, FieldFilter{
+			Field:   ff.Field,
+			Value:   ff.Value,
+			Negated: ff.Negated,
+		})
+	}
+	var authorID, seriesID *int
+	if f.AuthorID != nil {
+		v := int(*f.AuthorID)
+		authorID = &v
+	}
+	if f.SeriesID != nil {
+		v := int(*f.SeriesID)
+		seriesID = &v
+	}
+	books, err := s.audiobookService.GetAudiobooks(ctx, 100000, 0, f.Search, authorID, seriesID, filters)
+	if err != nil {
+		return nil, fmt.Errorf("resolve filter: %w", err)
+	}
+	ids := make([]string, 0, len(books))
+	for _, b := range books {
+		if b.QuarantinedAt != nil {
+			continue
+		}
+		ids = append(ids, b.ID)
+	}
+	if f.OnlyUnmatched {
+		matched := latestMatchedBookIDs(s.Store())
+		filtered := ids[:0]
+		for _, id := range ids {
+			if !matched[id] {
+				filtered = append(filtered, id)
+			}
+		}
+		ids = filtered
+	}
+	return ids, nil
+}
+
 // RegisterBulkMetadataFetchOp registers the "library.bulk-metadata-fetch" v2
 // OperationDef so that POST /api/v1/operations/v2 with def_id "bulk_metadata_fetch"
 // shows in the bell, is resumable, and can be cancelled.
@@ -1147,53 +1202,9 @@ func (s *Server) RegisterBulkMetadataFetchOp(reg *opsregistry.Registry) error {
 
 			progress := registryProgressAdapter{r: reporter}
 
-			// resolveFilter translates a FilterSpec into a concrete book-ID list.
-			// IsPrimaryVersion is always forced true so the count matches the
-			// visible library list. Per-user fields are dropped here because
-			// bulk ops run server-side without a user context.
-			resolveFilter := func(f operations.FilterSpec) ([]string, error) {
-				trueVal := true
-				filters := ListFilters{
-					IsPrimaryVersion: &trueVal,
-					LibraryState:     f.LibraryState,
-					Tag:              f.Tag,
-				}
-				for _, ff := range f.FieldFilters {
-					if IsPerUserField(ff.Field) {
-						continue // no user context in background op
-					}
-					filters.FieldFilters = append(filters.FieldFilters, FieldFilter{
-						Field:   ff.Field,
-						Value:   ff.Value,
-						Negated: ff.Negated,
-					})
-				}
-				// Convert *int64 to *int for the service method signature.
-				var authorID, seriesID *int
-				if f.AuthorID != nil {
-					v := int(*f.AuthorID)
-					authorID = &v
-				}
-				if f.SeriesID != nil {
-					v := int(*f.SeriesID)
-					seriesID = &v
-				}
-				books, err := s.audiobookService.GetAudiobooks(ctx, 100000, 0, f.Search, authorID, seriesID, filters)
-				if err != nil {
-					return nil, fmt.Errorf("resolve filter: %w", err)
-				}
-				ids := make([]string, 0, len(books))
-				for _, b := range books {
-					// Exclude quarantined books (mirrors the /audiobooks/ids endpoint).
-					if b.QuarantinedAt != nil {
-						continue
-					}
-					ids = append(ids, b.ID)
-				}
-				return ids, nil
-			}
-
-			bookIDs, err := operations.ResolveBookIDs(p.Selection, resolveFilter)
+			bookIDs, err := operations.ResolveBookIDs(p.Selection, func(f operations.FilterSpec) ([]string, error) {
+				return s.resolveFilterToBookIDs(ctx, f)
+			})
 			if err != nil {
 				return fmt.Errorf("bulk_metadata_fetch: resolve selection: %w", err)
 			}

--- a/web/src/components/library/LibraryToolbar.tsx
+++ b/web/src/components/library/LibraryToolbar.tsx
@@ -48,6 +48,7 @@ interface LibraryToolbarProps {
   getActiveFilterCount: () => number;
   onBatchEdit: () => void;
   onFetchReview: () => Promise<void>;
+  onFetchAllUnmatched: () => Promise<void>;
   onResumeReview: () => Promise<void>;
   onSearchMetadata: () => void;
   onSaveToFiles: () => void;
@@ -89,6 +90,7 @@ export const LibraryToolbar = ({
   getActiveFilterCount,
   onBatchEdit,
   onFetchReview,
+  onFetchAllUnmatched,
   onResumeReview,
   onSearchMetadata,
   onSaveToFiles,
@@ -152,6 +154,7 @@ export const LibraryToolbar = ({
           <ColumnChooser visibleColumnIds={visibleColumnIds} onToggleColumn={toggleColumn} onResetDefaults={resetColumnsToDefaults} />
           <Button variant="outlined" size="small" startIcon={organizeRunning ? <CircularProgress size={16} /> : undefined} disabled={organizeRunning} onClick={onOrganizeLibrary}>{organizeRunning ? 'Organizing…' : 'Organize Library'}</Button>
           <Button variant="outlined" size="small" startIcon={activeScanOp !== null ? <CircularProgress size={16} /> : <RefreshIcon />} disabled={activeScanOp !== null} onClick={onFullRescan}>{activeScanOp !== null ? 'Scanning…' : 'Full Rescan'}</Button>
+          <Button variant="outlined" size="small" onClick={onFetchAllUnmatched}>Fetch Unmatched</Button>
           <Button startIcon={<DeleteSweepIcon />} onClick={onPurgeOpen} variant="outlined" size="small" color="secondary" disabled={softDeletedCount === 0}>Purge Deleted{softDeletedCount > 0 ? ` (${softDeletedCount})` : ''}</Button>
         </Stack>
       )}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1611,7 +1611,7 @@ export const Library = () => {
   const handleFetchReview = async () => {
     try {
       const ids = effectiveSelectedIds;
-      const resp = await api.batchFetchCandidates(ids);
+      const resp = await api.batchFetchCandidates({ book_ids: ids });
       const opId = resp.operation_id;
       if (!opId) {
         toast('All selected books are already being fetched.', 'info');
@@ -1624,6 +1624,25 @@ export const Library = () => {
         'info',
       );
     } catch { toast('Failed to start metadata fetch', 'error'); }
+  };
+
+  const handleFetchAllUnmatched = async () => {
+    try {
+      const resp = await api.batchFetchCandidates({
+        selection: { filter: { only_unmatched: true } },
+      });
+      if (!resp.operation_id) {
+        toast(resp.message ?? 'All books already have matched candidates.', 'info');
+        return;
+      }
+      startOperationPolling(resp.operation_id, 'metadata_candidate_fetch');
+      toast(
+        `Fetching metadata for ${resp.book_count ?? 'unmatched'} books — check the operations list for progress.`,
+        'info',
+      );
+    } catch {
+      toast('Failed to start unmatched fetch', 'error');
+    }
   };
 
   const handleResumeReview = async () => {
@@ -1672,6 +1691,7 @@ export const Library = () => {
         getActiveFilterCount={getActiveFilterCount}
         onBatchEdit={() => setBatchEditOpen(true)}
         onFetchReview={handleFetchReview}
+        onFetchAllUnmatched={handleFetchAllUnmatched}
         onResumeReview={handleResumeReview}
         onSearchMetadata={() => setBulkSearchOpen(true)}
         onSaveToFiles={() => { setBulkWriteBackResult(null); setBulkWriteBackRename(false); setBulkWriteBackDialogOpen(true); }}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.24.0
+// version: 2.25.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-11
 
@@ -3039,11 +3039,25 @@ export interface BatchFetchResponse {
   total_errors?: number;
 }
 
-export async function batchFetchCandidates(bookIds: string[]): Promise<{ operation_id: string }> {
+export interface BatchFetchRequest {
+  book_ids?: string[];
+  selection?: {
+    book_ids?: string[];
+    filter?: {
+      search?: string;
+      library_state?: string;
+      tag?: string;
+      only_unmatched?: boolean;
+    };
+  };
+  only_unmatched?: boolean;
+}
+
+export async function batchFetchCandidates(req: BatchFetchRequest): Promise<{ operation_id: string; book_count?: number; message?: string }> {
   const response = await fetch(`${API_BASE}/metadata/batch-fetch-candidates`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ book_ids: bookIds }),
+    body: JSON.stringify(req),
   });
   if (!response.ok) throw await buildApiError(response, 'Failed to start batch fetch');
   return response.json();


### PR DESCRIPTION
## Summary
- `FilterSpec` gains `only_unmatched: bool` — composable with all existing filters (search, tag, library_state, field_filters)
- `batchFetchRequest` now accepts `selection` (server-side `SelectionSpec` resolution) alongside explicit `book_ids`, so the client never needs to enumerate 16K IDs
- `latestMatchedBookIDs()` helper scans `operation_results` history to find books whose most-recent `metadata_candidate_fetch` result is `"matched"`; `IsPrimaryVersion=true` always enforced
- `resolveFilterToBookIDs()` extracted from the inline closure in `RegisterBulkMetadataFetchOp` — now shared between the UOS op and the HTTP batch-fetch handler
- **"Fetch Unmatched"** button added to the library-level toolbar (no selection required); sends `{ selection: { filter: { only_unmatched: true } } }` to the backend

## Test plan
- [ ] `make build-api` passes (no unused imports)
- [ ] `make web-build` passes (no TS errors)
- [ ] "Fetch Unmatched" button appears in library toolbar
- [ ] Triggering it starts a `metadata_candidate_fetch` operation visible in the ops list
- [ ] Books already matched are excluded from the operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)