### PR TITLE
feat(ops): add zero-conflict op_registrars infrastructure for v2 migration

### DIFF
--- a/internal/server/library_core_ops.go
+++ b/internal/server/library_core_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_core_ops.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 
 // library_core_ops registers the scan, organize, and transcode OperationDefs
@@ -238,4 +238,10 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 			return nil
 		},
 	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterLibraryScanOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterLibraryOrganizeOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterLibraryTranscodeOp(reg) })
 }

--- a/internal/server/library_writeback_op.go
+++ b/internal/server/library_writeback_op.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_writeback_op.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 package server
@@ -53,4 +53,8 @@ func (s *Server) RegisterBulkWriteBackOp(reg *opsregistry.Registry) error {
 			return s.runBulkWriteBack(ctx, opID, p.BookIDs, p.Rename, 0, progress)
 		},
 	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterBulkWriteBackOp(reg) })
 }

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1217,6 +1217,10 @@ func (s *Server) RegisterBulkMetadataFetchOp(reg *opsregistry.Registry) error {
 	})
 }
 
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterBulkMetadataFetchOp(reg) })
+}
+
 // runBulkMetadataFetchForBookIDs fetches and caches metadata for a specific set
 // of books identified by ID. It shares resume semantics with runBulkMetadataFetchAll:
 // books that already have an OperationResult row for this opID are skipped.

--- a/internal/server/op_registrars.go
+++ b/internal/server/op_registrars.go
@@ -1,0 +1,24 @@
+// file: internal/server/op_registrars.go
+// version: 1.0.0
+// guid: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
+
+// op_registrars provides a zero-conflict mechanism for registering v2 OperationDefs.
+// Each op file calls addOpRegistrar in an init() function; server.go iterates the
+// slice at startup. New ops never require touching server.go.
+
+package server
+
+import opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+
+// opRegistrar is a function that registers one or more OperationDefs with the
+// UOS-02 registry.
+type opRegistrar func(s *Server, reg *opsregistry.Registry) error
+
+var opRegistrars []opRegistrar
+
+// addOpRegistrar appends a registration function to the global slice.
+// Call from init() in any server package file to wire up a new op without
+// modifying server.go.
+func addOpRegistrar(fn opRegistrar) {
+	opRegistrars = append(opRegistrars, fn)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -355,20 +355,12 @@ func NewServer(store database.Store) *Server {
 		if err := maintenanceplugin.New(server).Register(server.opRegistry); err != nil {
 			log.Printf("[server] maintenance plugin register: %v", err)
 		}
-		if err := server.RegisterBulkMetadataFetchOp(server.opRegistry); err != nil {
-			log.Printf("[server] bulk-metadata-fetch op register: %v", err)
-		}
-		if err := server.RegisterLibraryScanOp(server.opRegistry); err != nil {
-			log.Printf("[server] library.scan op register: %v", err)
-		}
-		if err := server.RegisterLibraryOrganizeOp(server.opRegistry); err != nil {
-			log.Printf("[server] library.organize op register: %v", err)
-		}
-		if err := server.RegisterLibraryTranscodeOp(server.opRegistry); err != nil {
-			log.Printf("[server] library.transcode op register: %v", err)
-		}
-		if err := server.RegisterBulkWriteBackOp(server.opRegistry); err != nil {
-			log.Printf("[server] bulk-write-back op register: %v", err)
+		// Iterate all op registrars. Each file calls addOpRegistrar in its init()
+		// so new ops never require touching this block.
+		for _, reg := range opRegistrars {
+			if err := reg(server, server.opRegistry); err != nil {
+				log.Printf("[server] op registrar: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Adds `op_registrars.go` with `addOpRegistrar()` / `opRegistrars` slice pattern
- `server.go` registration block now iterates the slice instead of calling each `Register*Op` individually — new ops never require touching `server.go`
- Existing `library_core_ops.go`, `library_writeback_op.go`, `metadata_handlers.go` self-register via `init()`
- Unblocks parallel v1→v2 migration PRs that would otherwise conflict in `server.go`

## Test plan
- [ ] `make test` passes
- [ ] All 5 existing v2 ops (scan, organize, transcode, bulk-write-back, bulk-metadata-fetch) still register at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)