### PR TITLE
feat(ops): migrate diagnostics-export to UOS v2

### DIFF
--- a/internal/server/diagnostics_handlers.go
+++ b/internal/server/diagnostics_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/diagnostics_handlers.go
-// version: 3.1.0
-// last-edited: 2026-05-01
+// version: 3.2.0
+// last-edited: 2026-05-10
 // guid: a2b3c4d5-e6f7-4890-ab12-cd34ef56gh78
 
 package server
@@ -21,7 +21,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/diagnostics"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -74,38 +73,14 @@ func (s *Server) startDiagnosticsExport(c *gin.Context) {
 		return
 	}
 
-	ds := s.diagnosticsService
-	if ds == nil {
-		ds = diagnostics.NewService(store, nil, config.AppConfig.ITunesLibraryReadPath)
+	params := diagnosticsExportOpParams{
+		LegacyOpID:  opID,
+		Category:    req.Category,
+		Description: req.Description,
 	}
-
-	category := req.Category
-	description := req.Description
-
-	if s.queue != nil {
-		_ = s.queue.Enqueue(opID, "diagnostics_export", 5, func(_ context.Context, _ operations.ProgressReporter) error {
-			zipPath, genErr := ds.GenerateExport(category, description)
-			if genErr != nil {
-				_ = store.UpdateOperationError(opID, genErr.Error())
-				return genErr
-			}
-			resultJSON, _ := json.Marshal(map[string]string{"zip_path": zipPath})
-			_ = store.UpdateOperationResultData(opID, string(resultJSON))
-			_ = store.UpdateOperationStatus(opID, "completed", 100, 100, "Export complete")
-			return nil
-		})
-	} else {
-		// Synchronous fallback if no queue
-		go func() {
-			zipPath, genErr := ds.GenerateExport(category, description)
-			if genErr != nil {
-				_ = store.UpdateOperationError(opID, genErr.Error())
-				return
-			}
-			resultJSON, _ := json.Marshal(map[string]string{"zip_path": zipPath})
-			_ = store.UpdateOperationResultData(opID, string(resultJSON))
-			_ = store.UpdateOperationStatus(opID, "completed", 100, 100, "Export complete")
-		}()
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "diagnostics.export", params); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue diagnostics export", enqErr)
+		return
 	}
 
 	httputil.RespondWithSuccess(c, 202, gin.H{

--- a/internal/server/diagnostics_ops.go
+++ b/internal/server/diagnostics_ops.go
@@ -1,0 +1,73 @@
+// file: internal/server/diagnostics_ops.go
+// version: 1.0.0
+// guid: 7d8e9f0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a
+
+// diagnostics_ops registers the diagnostics export OperationDef (v2 UOS).
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/diagnostics"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+type diagnosticsExportOpParams struct {
+	LegacyOpID  string `json:"legacy_op_id"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+// RegisterDiagnosticsExportOp registers the "diagnostics.export" v2 OperationDef.
+func (s *Server) RegisterDiagnosticsExportOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "diagnostics.export",
+		Plugin:          "diagnostics",
+		DisplayName:     "Export Diagnostics",
+		Description:     "Generate a diagnostics ZIP export for analysis.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "diagnostics.export",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p diagnosticsExportOpParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+			store := s.Store()
+			ds := s.diagnosticsService
+			if ds == nil {
+				ds = diagnostics.NewService(store, nil, config.AppConfig.ITunesLibraryReadPath)
+			}
+			_ = reporter.UpdateProgress(0, 100, "Generating export data")
+			zipPath, genErr := ds.GenerateExport(p.Category, p.Description)
+			if genErr != nil {
+				if store != nil {
+					_ = store.UpdateOperationError(p.LegacyOpID, genErr.Error())
+				}
+				return fmt.Errorf("generate export: %w", genErr)
+			}
+			resultJSON, _ := json.Marshal(map[string]string{"zip_path": zipPath})
+			if store != nil {
+				_ = store.UpdateOperationResultData(p.LegacyOpID, string(resultJSON))
+				_ = store.UpdateOperationStatus(p.LegacyOpID, "completed", 100, 100, "Export complete")
+			}
+			_ = reporter.UpdateProgress(100, 100, "Export complete")
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterDiagnosticsExportOp(reg) })
+}


### PR DESCRIPTION
Migrates diagnostics_export from v1 queue.Enqueue to v2 opRegistry.EnqueueOp.

- Creates diagnostics_ops.go with OperationDef `diagnostics.export`  
- Hybrid approach: v1 op record kept for result-reading compat (downloadDiagnosticsExport reads v1 ResultData)
- Removes queue.Enqueue dependency from diagnostics_handlers.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)