### PR TITLE
feat(ops): migrate itunes import/sync to UOS v2

### DIFF
--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
-// last-edited: 2026-05-05
+// last-edited: 2026-05-10
 
 // iTunes HTTP handlers. All business logic lives in internal/itunes/service.
 // Handlers that call s.itunesSvc.Importer.* guard with itunesEnabledOrError
@@ -10,7 +10,6 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	stdlog "log"
@@ -25,7 +24,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -269,8 +267,8 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return
 	}
 
@@ -306,12 +304,9 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		PathMappings:     svcMappings,
 	}
 
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.itunesSvc.Importer.Execute(ctx, op.ID, svcReq, operations.LoggerFromReporter(progress))
-	}
-
-	if err := s.queue.Enqueue(op.ID, "itunes_import", operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	params := itunesImportOpParams{LegacyOpID: op.ID, Request: svcReq}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "itunes.import", params); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 
@@ -783,8 +778,8 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return
 	}
 
@@ -835,15 +830,9 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		}
 	}
 
-	lp := libraryPath
-	pm := pathMappings
-	actFn := s.itunesActivityFn
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.itunesSvc.Importer.Sync(ctx, lp, pm, actFn, operations.LoggerFromReporter(progress))
-	}
-
-	if err := s.queue.Enqueue(op.ID, "itunes_sync", operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	syncParams := itunesSyncOpParams{LegacyOpID: op.ID, LibraryPath: libraryPath, PathMappings: pathMappings}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "itunes.sync", syncParams); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 

--- a/internal/server/itunes_ops.go
+++ b/internal/server/itunes_ops.go
@@ -1,0 +1,95 @@
+// file: internal/server/itunes_ops.go
+// version: 1.0.0
+// guid: 4b7e9f2a-1c3d-4e5f-8a9b-0c1d2e3f4a5b
+
+// itunes_ops registers v2 OperationDefs for iTunes import and sync.
+// Both ops use the hybrid migration pattern: a v1 op record is created
+// in the handler so clients can still poll /api/v1/operations/{id}/status,
+// and the v1 op ID is passed into the params struct for use by the Run func.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+type itunesImportOpParams struct {
+	LegacyOpID string                      `json:"legacy_op_id"`
+	Request    itunesservice.ImportRequest `json:"request"`
+}
+
+type itunesSyncOpParams struct {
+	LegacyOpID   string               `json:"legacy_op_id"`
+	LibraryPath  string               `json:"library_path"`
+	PathMappings []itunes.PathMapping `json:"path_mappings"`
+}
+
+// RegisterITunesImportOp registers the "itunes.import" v2 OperationDef.
+func (s *Server) RegisterITunesImportOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "itunes.import",
+		Plugin:          "itunes",
+		DisplayName:     "iTunes Import",
+		Description:     "Import audiobooks from an iTunes XML library file into the database.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "itunes.import",
+		Permissions:     []auth.Permission{auth.PermIntegrationsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkITunes},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p itunesImportOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("itunes-import: decode params: %w", err)
+				}
+			}
+			progress := registryProgressAdapter{r: reporter}
+			return s.itunesSvc.Importer.Execute(ctx, p.LegacyOpID, p.Request, operations.LoggerFromReporter(progress))
+		},
+	})
+}
+
+// RegisterITunesSyncOp registers the "itunes.sync" v2 OperationDef.
+func (s *Server) RegisterITunesSyncOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "itunes.sync",
+		Plugin:          "itunes",
+		DisplayName:     "iTunes Sync",
+		Description:     "Sync the iTunes library XML into the database (incremental, fingerprint-gated).",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "itunes.sync",
+		Permissions:     []auth.Permission{auth.PermIntegrationsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkITunes},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p itunesSyncOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("itunes-sync: decode params: %w", err)
+				}
+			}
+			progress := registryProgressAdapter{r: reporter}
+			return s.itunesSvc.Importer.Sync(ctx, p.LibraryPath, p.PathMappings, s.itunesActivityFn, operations.LoggerFromReporter(progress))
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterITunesImportOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterITunesSyncOp(reg) })
+}

--- a/internal/server/server_middleware.go
+++ b/internal/server/server_middleware.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_middleware.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6a093405-441a-4c14-a9c5-46326ea767c1
-// last-edited: 2026-05-01
+// last-edited: 2026-05-10
 
 package server
 
@@ -19,7 +19,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -159,7 +158,7 @@ func saveDismissedDedupGroups(store database.Store, dismissed map[string]bool) {
 }
 
 func (s *Server) triggerITunesSync() {
-	if s.Store() == nil || s.queue == nil {
+	if s.Store() == nil || s.opRegistry == nil {
 		return
 	}
 
@@ -197,12 +196,9 @@ func (s *Server) triggerITunesSync() {
 		scheduledMappings = append(scheduledMappings, itunes.PathMapping{From: m.From, To: m.To})
 	}
 
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.itunesSvc.Importer.Sync(ctx, libraryPath, scheduledMappings, s.itunesActivityFn, operations.LoggerFromReporter(progress))
-	}
-
-	if err := s.queue.Enqueue(op.ID, "itunes_sync", operations.PriorityNormal, operationFunc); err != nil {
-		itunesTriggerLog.Warn("iTunes sync scheduler: failed to enqueue: %v", err)
+	syncParams := itunesSyncOpParams{LegacyOpID: op.ID, LibraryPath: libraryPath, PathMappings: scheduledMappings}
+	if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "itunes.sync", syncParams); enqErr != nil {
+		itunesTriggerLog.Warn("iTunes sync scheduler: failed to enqueue: %v", enqErr)
 		return
 	}
 


### PR DESCRIPTION
Migrates itunes_import and itunes_sync from v1 queue.Enqueue to v2 opRegistry.EnqueueOp.

- Creates `itunes_ops.go` with OperationDefs for `itunes.import` and `itunes.sync`
- Hybrid approach: v1 op records kept for backward-compat polling via `/api/v1/operations/{id}/status`
- Migrates `handleITunesImport`, `handleITunesSync`, and `triggerITunesSync` from `queue.Enqueue` to `opRegistry.EnqueueOp`
- Also migrates the scheduler-triggered path (`triggerITunesSync` in `server_middleware.go`)
- Replaces `s.queue` nil-guards with `s.opRegistry` nil-guards in handlers
- Removes unused `operations` import from `server_middleware.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)