### PR TITLE
feat(ops): migrate folder auto-scan to UOS v2

### DIFF
--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/filesystem_handlers.go
-// version: 2.3.1
+// version: 2.4.0
 // guid: 565db679-19ba-4518-b63e-6892663be41b
 // last-edited: 2026-05-10
 //
@@ -12,7 +12,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -151,108 +150,26 @@ func (s *Server) addImportPath(c *gin.Context) {
 		}
 	}
 
-	// Auto-scan the newly added folder if enabled and operation queue is available
-	if folder.Enabled && s.queue != nil {
+	// Auto-scan the newly added folder if enabled and the v2 op registry is available.
+	if folder.Enabled && s.opRegistry != nil {
 		opID := ulid.Make().String()
 		folderPath := folder.Path
-		op, err := s.Store().CreateOperation(opID, "scan", &folderPath)
+		_, err := s.Store().CreateOperation(opID, "scan", &folderPath)
 		if err == nil {
-			// Create scan operation function
-			operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-				_ = progress.Log("info", fmt.Sprintf("Auto-scanning newly added folder: %s", folderPath), nil)
-
-				// Check if folder exists
-				if _, err := os.Stat(folderPath); os.IsNotExist(err) {
-					return fmt.Errorf("folder does not exist: %s", folderPath)
-				}
-
-				// Scan directory for audiobook files (parallel)
-				workers := config.AppConfig.ConcurrentScans
-				if workers < 1 {
-					workers = 4
-				}
-				scanLog := operations.LoggerFromReporter(progress)
-				books, err := scanner.ScanDirectoryParallel(folderPath, workers, scanLog)
-				if err != nil {
-					return fmt.Errorf("failed to scan folder: %w", err)
-				}
-
-				scanLog.Info("Found %d audiobook files", len(books))
-
-				// Process the books to extract metadata (parallel)
-				if len(books) > 0 {
-					scanLog.Info("Processing metadata for %d books using %d workers", len(books), workers)
-					if err := scanner.ProcessBooksParallel(ctx, books, workers, nil, scanLog); err != nil {
-						return fmt.Errorf("failed to process books: %w", err)
-					}
-					// Auto-organize if enabled
-					if config.AppConfig.AutoOrganize && config.AppConfig.RootDir != "" {
-						org := organizer.NewOrganizer(&config.AppConfig)
-						organized := 0
-						for _, b := range books {
-							// Lookup DB book by file path
-							dbBook, err := s.Store().GetBookByFilePath(b.FilePath)
-							if err != nil || dbBook == nil {
-								continue
-							}
-							newPath, _, err := org.OrganizeBook(dbBook)
-							if err != nil {
-								_ = progress.Log("warn", fmt.Sprintf("Organize failed for %s: %v", dbBook.Title, err), nil)
-								continue
-							}
-							if newPath != dbBook.FilePath {
-								dbBook.FilePath = newPath
-								scanner.ApplyOrganizedFileMetadata(dbBook, newPath)
-								if _, err := s.Store().UpdateBook(dbBook.ID, dbBook); err != nil {
-									_ = progress.Log("warn", fmt.Sprintf("Failed to update path for %s: %v", dbBook.Title, err), nil)
-								} else {
-									organized++
-								}
-							}
-						}
-						_ = progress.Log("info", fmt.Sprintf("Auto-organize complete: %d organized", organized), nil)
-					} else if config.AppConfig.AutoOrganize && config.AppConfig.RootDir == "" {
-						_ = progress.Log("warn", "Auto-organize enabled but root_dir not set", nil)
-					}
-				}
-
-				// Trigger dedup check on newly scanned books
-				if s.dedupEngine != nil && len(books) > 0 {
-					go func() {
-						for _, b := range books {
-							dbBook, err := s.Store().GetBookByFilePath(b.FilePath)
-							if err != nil || dbBook == nil {
-								continue
-							}
-							if _, err := s.dedupEngine.CheckBook(ctx, dbBook.ID); err != nil {
-								log.Printf("[WARN] dedup check failed for scanned book %s: %v", dbBook.ID, err)
-							}
-						}
-					}()
-				}
-
-				// Update book count for this import path
-				folder.BookCount = len(books)
-				now := time.Now()
-				folder.LastScan = &now
-				if err := s.Store().UpdateImportPath(folder.ID, folder); err != nil {
-					_ = progress.Log("warn", fmt.Sprintf("Failed to update book count: %v", err), nil)
-				}
-
-				_ = progress.Log("info", fmt.Sprintf("Auto-scan completed. Total books: %d", len(books)), nil)
-				return nil
+			params := folderAutoScanOpParams{
+				LegacyOpID: opID,
+				FolderPath: folderPath,
+				FolderID:   folder.ID,
 			}
-
-			// Enqueue the scan operation with normal priority
-			_ = s.queue.Enqueue(op.ID, "scan", operations.PriorityNormal, operationFunc)
-
-			httputil.RespondWithCreated(c, gin.H{"importPath": folder, "scan_operation_id": op.ID})
-			return
+			if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "library.folder-auto-scan", params); enqErr == nil {
+				httputil.RespondWithCreated(c, gin.H{"importPath": folder, "scan_operation_id": opID})
+				return
+			}
 		}
 	}
 
-	// Fallback: if enabled but queue unavailable OR operation creation failed, run synchronous scan
-	if folder.Enabled && s.queue == nil {
+	// Fallback: if enabled but op registry unavailable OR operation creation failed, run synchronous scan.
+	if folder.Enabled && s.opRegistry == nil {
 		// Basic scan without progress reporter
 		if _, err := os.Stat(folder.Path); err == nil {
 			books, err := scanner.ScanDirectory(folder.Path, nil)

--- a/internal/server/folder_autoscan_op.go
+++ b/internal/server/folder_autoscan_op.go
@@ -1,0 +1,155 @@
+// file: internal/server/folder_autoscan_op.go
+// version: 1.0.0
+// guid: 7b3e9f2a-4c1d-4e85-a6b8-2f0d5c8e1a93
+// last-edited: 2026-05-10
+//
+// folder_autoscan_op registers the "library.folder-auto-scan" UOS v2 OperationDef.
+// This op is enqueued when a new import path is added to the library; it replicates
+// the richer logic (auto-organize, dedup check, import path update) that previously
+// ran inline via the legacy queue.Enqueue call in filesystem_handlers.go.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+)
+
+// folderAutoScanOpParams holds the parameters for a library.folder-auto-scan run.
+type folderAutoScanOpParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+	FolderPath  string `json:"folder_path"`
+	FolderID    int    `json:"folder_id"`
+}
+
+// RegisterFolderAutoScanOp registers the "library.folder-auto-scan" OperationDef.
+func (s *Server) RegisterFolderAutoScanOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.folder-auto-scan",
+		Plugin:          "library",
+		DisplayName:     "Folder Auto-Scan",
+		Description:     "Auto-scan a newly added import path folder for audiobooks, then optionally organize and dedup.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "", // parallel per-folder scans are fine
+		Permissions:     []auth.Permission{auth.PermScanTrigger},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesRead},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p folderAutoScanOpParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+
+			folderPath := p.FolderPath
+			progress := registryProgressAdapter{r: reporter}
+			scanLog := operations.LoggerFromReporter(progress)
+
+			_ = progress.Log("info", fmt.Sprintf("Auto-scanning newly added folder: %s", folderPath), nil)
+
+			// Check if folder exists.
+			if _, err := os.Stat(folderPath); os.IsNotExist(err) {
+				return fmt.Errorf("folder does not exist: %s", folderPath)
+			}
+
+			// Scan directory for audiobook files (parallel).
+			workers := config.AppConfig.ConcurrentScans
+			if workers < 1 {
+				workers = 4
+			}
+			books, err := scanner.ScanDirectoryParallel(folderPath, workers, scanLog)
+			if err != nil {
+				return fmt.Errorf("failed to scan folder: %w", err)
+			}
+
+			scanLog.Info("Found %d audiobook files", len(books))
+
+			// Process the books to extract metadata (parallel).
+			if len(books) > 0 {
+				scanLog.Info("Processing metadata for %d books using %d workers", len(books), workers)
+				if err := scanner.ProcessBooksParallel(ctx, books, workers, nil, scanLog); err != nil {
+					return fmt.Errorf("failed to process books: %w", err)
+				}
+
+				// Auto-organize if enabled.
+				if config.AppConfig.AutoOrganize && config.AppConfig.RootDir != "" {
+					org := organizer.NewOrganizer(&config.AppConfig)
+					organized := 0
+					for _, b := range books {
+						dbBook, err := s.Store().GetBookByFilePath(b.FilePath)
+						if err != nil || dbBook == nil {
+							continue
+						}
+						newPath, _, err := org.OrganizeBook(dbBook)
+						if err != nil {
+							_ = progress.Log("warn", fmt.Sprintf("Organize failed for %s: %v", dbBook.Title, err), nil)
+							continue
+						}
+						if newPath != dbBook.FilePath {
+							dbBook.FilePath = newPath
+							scanner.ApplyOrganizedFileMetadata(dbBook, newPath)
+							if _, err := s.Store().UpdateBook(dbBook.ID, dbBook); err != nil {
+								_ = progress.Log("warn", fmt.Sprintf("Failed to update path for %s: %v", dbBook.Title, err), nil)
+							} else {
+								organized++
+							}
+						}
+					}
+					_ = progress.Log("info", fmt.Sprintf("Auto-organize complete: %d organized", organized), nil)
+				} else if config.AppConfig.AutoOrganize && config.AppConfig.RootDir == "" {
+					_ = progress.Log("warn", "Auto-organize enabled but root_dir not set", nil)
+				}
+			}
+
+			// Trigger dedup check on newly scanned books (non-blocking goroutine).
+			if s.dedupEngine != nil && len(books) > 0 {
+				go func() {
+					for _, b := range books {
+						dbBook, err := s.Store().GetBookByFilePath(b.FilePath)
+						if err != nil || dbBook == nil {
+							continue
+						}
+						if _, err := s.dedupEngine.CheckBook(ctx, dbBook.ID); err != nil {
+							log.Printf("[WARN] dedup check failed for scanned book %s: %v", dbBook.ID, err)
+						}
+					}
+				}()
+			}
+
+			// Update book count and last-scan timestamp for this import path.
+			if p.FolderID != 0 {
+				folder, err := s.Store().GetImportPathByID(p.FolderID)
+				if err != nil || folder == nil {
+					_ = progress.Log("warn", fmt.Sprintf("Could not reload import path %d for update: %v", p.FolderID, err), nil)
+				} else {
+					folder.BookCount = len(books)
+					now := time.Now()
+					folder.LastScan = &now
+					if err := s.Store().UpdateImportPath(folder.ID, folder); err != nil {
+						_ = progress.Log("warn", fmt.Sprintf("Failed to update book count: %v", err), nil)
+					}
+				}
+			}
+
+			_ = progress.Log("info", fmt.Sprintf("Auto-scan completed. Total books: %d", len(books)), nil)
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterFolderAutoScanOp(reg) })
+}


### PR DESCRIPTION
## Summary

- Creates `folder_autoscan_op.go` with `OperationDef` `library.folder-auto-scan`, registered via `init()` through the `addOpRegistrar` mechanism (no server.go changes needed)
- Moves the full inline scan logic from `filesystem_handlers.go` into the Run func: parallel scan, metadata extract, auto-organize, dedup check, import-path last-scan/book-count update
- Replaces `s.queue.Enqueue(...)` with `s.opRegistry.EnqueueOp(ctx, "library.folder-auto-scan", params)` in the handler
- Keeps the v1 `CreateOperation` call so `scan_operation_id` remains in the HTTP response for backwards compatibility (hybrid approach per design)
- Updates the synchronous fallback condition from `s.queue == nil` to `s.opRegistry == nil` so it's the true complement of the new primary path
- `FolderID` param is `int` to match `ImportPath.ID` and `GetImportPathByID(id int)` — avoids strconv round-trip
- Build verified: `make build-api` passes cleanly

## Test plan
- [ ] `make build-api` passes (verified locally)
- [ ] `POST /api/v1/import-paths` with an enabled path: response includes `scan_operation_id`; op appears in v2 runs list
- [ ] `POST /api/v1/import-paths` with `opRegistry == nil` (test server): falls through to synchronous scan as before
- [ ] `make test` backend unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)