### PR TITLE
feat(ops): migrate OpenLibrary ops to UOS v2

### DIFF
--- a/internal/server/openlibrary_ops.go
+++ b/internal/server/openlibrary_ops.go
@@ -1,0 +1,103 @@
+// file: internal/server/openlibrary_ops.go
+// version: 1.0.0
+// guid: 3c7e9a21-f4b5-4d68-8e2f-1a6c0b9d7f43
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/openlibrary"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+type olDownloadOpParams struct {
+	LegacyOpID string   `json:"legacy_op_id"`
+	Types      []string `json:"types"`
+	TargetDir  string   `json:"target_dir"`
+}
+
+type olImportOpParams struct {
+	LegacyOpID string   `json:"legacy_op_id"`
+	Types      []string `json:"types"`
+	TargetDir  string   `json:"target_dir"`
+}
+
+// RegisterOLDownloadOp registers the "openlibrary.download" v2 OperationDef.
+func (s *Server) RegisterOLDownloadOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "openlibrary.download",
+		Plugin:          "openlibrary",
+		DisplayName:     "OpenLibrary Dump Download",
+		Description:     "Download OpenLibrary data dump files (editions, authors, works).",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         8 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "openlibrary.download",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapNetworkOpenLibrary, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p olDownloadOpParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+			tracker := s.olService.Tracker
+			for i, dumpType := range p.Types {
+				if reporter.IsCanceled() {
+					return fmt.Errorf("download canceled")
+				}
+				_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("Starting OL dump download: %s", dumpType))
+				_ = reporter.UpdateProgress(i, len(p.Types), fmt.Sprintf("Downloading %s...", dumpType))
+				if err := openlibrary.DownloadDump(dumpType, p.TargetDir, tracker); err != nil {
+					_ = reporter.Log(slog.LevelError, fmt.Sprintf("OL dump download failed for %s: %v", dumpType, err))
+					return fmt.Errorf("download failed for %s: %w", dumpType, err)
+				}
+				_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("OL dump download complete: %s", dumpType))
+			}
+			_ = reporter.UpdateProgress(len(p.Types), len(p.Types), "All downloads complete")
+			return nil
+		},
+	})
+}
+
+// RegisterOLImportOp registers the "openlibrary.import" v2 OperationDef.
+func (s *Server) RegisterOLImportOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "openlibrary.import",
+		Plugin:          "openlibrary",
+		DisplayName:     "OpenLibrary Dump Import",
+		Description:     "Import OpenLibrary data dump files into the local search store.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         12 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "openlibrary.import",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesRead},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p olImportOpParams
+			if len(rawParams) > 0 {
+				_ = json.Unmarshal(rawParams, &p)
+			}
+			svc := s.olService
+			if err := svc.EnsureStore(p.TargetDir); err != nil {
+				return fmt.Errorf("failed to open store: %w", err)
+			}
+			progress := registryProgressAdapter{r: reporter}
+			return s.executeOLImport(ctx, progress, svc, p.TargetDir, p.Types)
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterOLDownloadOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterOLImportOp(reg) })
+}

--- a/internal/server/openlibrary_service.go
+++ b/internal/server/openlibrary_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/openlibrary_service.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package server
@@ -95,44 +95,9 @@ func (s *Server) startOLDownload(c *gin.Context) {
 		_, _ = store.CreateOperation(opID, "ol_dump_download", &folderPath)
 	}
 
-	oq := s.queue
-	if oq != nil {
-		err := oq.Enqueue(opID, "ol_dump_download", operations.PriorityNormal,
-			func(ctx context.Context, progress operations.ProgressReporter) error {
-				for i, dumpType := range req.Types {
-					if progress != nil && progress.IsCanceled() {
-						return fmt.Errorf("download canceled")
-					}
-					if progress != nil {
-						_ = progress.Log("info", fmt.Sprintf("Starting OL dump download: %s", dumpType), nil)
-						_ = progress.UpdateProgress(i, len(req.Types), fmt.Sprintf("Downloading %s...", dumpType))
-					}
-					err := openlibrary.DownloadDump(dumpType, targetDir, tracker)
-					if err != nil {
-						if progress != nil {
-							_ = progress.Log("error", fmt.Sprintf("OL dump download failed for %s: %v", dumpType, err), nil)
-						}
-						return fmt.Errorf("download failed for %s: %w", dumpType, err)
-					}
-					if progress != nil {
-						_ = progress.Log("info", fmt.Sprintf("OL dump download complete: %s", dumpType), nil)
-					}
-				}
-				if progress != nil {
-					_ = progress.UpdateProgress(len(req.Types), len(req.Types), "All downloads complete")
-				}
-				return nil
-			},
-		)
-		if err != nil {
-			log.Printf("[WARN] Failed to enqueue OL download, running directly: %v", err)
-			go func() {
-				for _, dumpType := range req.Types {
-					_ = openlibrary.DownloadDump(dumpType, targetDir, tracker)
-				}
-			}()
-		}
-	} else {
+	params := olDownloadOpParams{LegacyOpID: opID, Types: req.Types, TargetDir: targetDir}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "openlibrary.download", params); enqErr != nil {
+		log.Printf("[WARN] Failed to enqueue OL download, running directly: %v", enqErr)
 		go func() {
 			for _, dumpType := range req.Types {
 				_ = openlibrary.DownloadDump(dumpType, targetDir, tracker)
@@ -168,23 +133,9 @@ func (s *Server) startOLImport(c *gin.Context) {
 		_, _ = store.CreateOperation(opID, "ol_dump_import", &folderPath)
 	}
 
-	oq := s.queue
-	if oq != nil {
-		typesStr := strings.Join(req.Types, ",")
-		err := oq.Enqueue(opID, "ol_dump_import", operations.PriorityNormal,
-			func(ctx context.Context, progress operations.ProgressReporter) error {
-				return s.executeOLImport(ctx, progress, svc, targetDir, req.Types)
-			},
-		)
-		if err != nil {
-			log.Printf("[WARN] Failed to enqueue OL import, running directly: %v", err)
-			go func() {
-				_ = s.executeOLImport(context.Background(), nil, svc, targetDir, req.Types)
-			}()
-		}
-		_ = typesStr // used for logging if needed
-	} else {
-		// Fallback: no queue, run directly
+	importParams := olImportOpParams{LegacyOpID: opID, Types: req.Types, TargetDir: targetDir}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "openlibrary.import", importParams); enqErr != nil {
+		log.Printf("[WARN] Failed to enqueue OL import, running directly: %v", enqErr)
 		go func() {
 			_ = s.executeOLImport(context.Background(), nil, svc, targetDir, req.Types)
 		}()


### PR DESCRIPTION
## Summary

- Creates `openlibrary_ops.go` with `OperationDef`s for `openlibrary.download` and `openlibrary.import`, auto-registered via `init()`/`addOpRegistrar`
- Hybrid approach: v1 `store.CreateOperation` records kept for backward compat; goroutine fallback preserved for edge cases where `EnqueueOp` fails
- Removes `oq.Enqueue` dependency from `openlibrary_service.go`

## Test plan

- [ ] `make build-api` passes (verified locally)
- [ ] `POST /api/v1/openlibrary/download` returns 202 and enqueues `openlibrary.download` op
- [ ] `POST /api/v1/openlibrary/import` returns 202 and enqueues `openlibrary.import` op
- [ ] Both ops appear in the operations UI with correct display names
- [ ] Download cancellation via `IsCanceled()` is honored between dump types

🤖 Generated with [Claude Code](https://claude.com/claude-code)