### PR TITLE
feat(ops): migrate metadata candidate fetch to UOS v2

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-05-11
 
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -215,70 +213,19 @@ func (s *Server) handleBatchFetchCandidates(c *gin.Context) {
 		_ = store.SaveOperationParams(opID, paramsJSON)
 	}
 
-	mfs := s.metadataFetchService
-
-	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		_ = progress.UpdateProgress(0, totalBooks, "starting metadata candidate fetch")
-
-		// Rate limiter: 10 requests per second globally across all workers.
-		limiter := rate.NewLimiter(rate.Limit(10), 1)
-
-		// Buffered channel for work distribution.
-		workCh := make(chan string, len(bookIDs))
-		for _, id := range bookIDs {
-			workCh <- id
-		}
-		close(workCh)
-
-		var completed int64
-		var wg sync.WaitGroup
-
-		numWorkers := 8
-		if numWorkers > totalBooks {
-			numWorkers = totalBooks
-		}
-
-		for i := 0; i < numWorkers; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for bookID := range workCh {
-					if ctx.Err() != nil {
-						return
-					}
-
-					result := s.fetchCandidateForBook(ctx, mfs, store, limiter, opID, bookID)
-					resultJSON, err := json.Marshal(result)
-					if err != nil {
-						log.Printf("[WARN] failed to marshal candidate result for book %s: %v", bookID, err)
-						continue
-					}
-
-					opResult := &database.OperationResult{
-						OperationID: opID,
-						BookID:      bookID,
-						ResultJSON:  string(resultJSON),
-						Status:      result.Status,
-					}
-					if err := store.CreateOperationResult(opResult); err != nil {
-						log.Printf("[WARN] failed to store candidate result for book %s: %v", bookID, err)
-					}
-
-					done := atomic.AddInt64(&completed, 1)
-					_ = progress.UpdateProgress(int(done), totalBooks, fmt.Sprintf("fetched %d/%d", done, totalBooks))
-				}
-			}()
-		}
-
-		wg.Wait()
-
-		finalCount := atomic.LoadInt64(&completed)
-		_ = progress.UpdateProgress(int(finalCount), totalBooks, "completed")
-		return nil
+	// Enqueue via v2 opRegistry. The Run func in metadata_candidate_op.go
+	// handles all fetch work and writes OperationResult rows under opID so that
+	// all existing v1 readers (handleGetPendingReview, handleGetOperationResults,
+	// handleGetLatestMetadataFetch) continue working without changes.
+	// The v2 run ID returned by EnqueueOp is intentionally discarded — clients
+	// track progress via the v1 opID returned in the response below.
+	params := metadataCandidateFetchOpParams{
+		LegacyOpID: opID,
+		BookIDs:    bookIDs,
+		TotalBooks: totalBooks,
 	}
-
-	if err := s.queue.Enqueue(opID, "metadata_candidate_fetch", operations.PriorityNormal, opFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "metadata.candidate-fetch", params); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 
@@ -929,53 +876,26 @@ func (s *Server) resumeInterruptedMetadataFetch() {
 
 		log.Printf("[INFO] resuming metadata fetch %s: %d/%d books remaining", op.ID, len(remaining), len(allBookIDs))
 
-		// Re-enqueue the remaining books as a continuation of the same operation
+		// Re-enqueue the remaining books via v2 opRegistry as a continuation of the
+		// same v1 operation. The Run func in metadata_candidate_op.go handles all
+		// fetch work and writes OperationResult rows under the original opID.
 		opID := op.ID
 		totalBooks := len(allBookIDs)
 		alreadyDone := len(allBookIDs) - len(remaining)
-		mfs := s.metadataFetchService
 
-		opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-			_ = progress.UpdateProgress(alreadyDone, totalBooks, fmt.Sprintf("resuming: %d/%d already fetched", alreadyDone, totalBooks))
+		// Mark the v1 record as running so handleGetLatestMetadataFetch can surface
+		// it during the resume window before the Run func transitions it itself.
+		_ = store.UpdateOperationStatus(opID, "running", alreadyDone, totalBooks,
+			fmt.Sprintf("resuming: %d/%d already fetched", alreadyDone, totalBooks))
 
-			limiter := rate.NewLimiter(rate.Limit(10), 1)
-			var completed int64 = int64(alreadyDone)
-			const numWorkers = 8
-			ch := make(chan string, len(remaining))
-			for _, id := range remaining {
-				ch <- id
-			}
-			close(ch)
-
-			var wg sync.WaitGroup
-			for w := 0; w < numWorkers; w++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					for bookID := range ch {
-						if ctx.Err() != nil {
-							return
-						}
-						_ = limiter.Wait(ctx)
-						result := s.fetchCandidateForBook(ctx, mfs, store, limiter, opID, bookID)
-						resultJSON, _ := json.Marshal(result)
-						_ = store.CreateOperationResult(&database.OperationResult{
-							OperationID: opID,
-							BookID:      bookID,
-							ResultJSON:  string(resultJSON),
-							Status:      result.Status,
-						})
-						done := atomic.AddInt64(&completed, 1)
-						_ = progress.UpdateProgress(int(done), totalBooks, fmt.Sprintf("fetched %d/%d", done, totalBooks))
-					}
-				}()
-			}
-			wg.Wait()
-			return nil
+		resumeParams := metadataCandidateFetchOpParams{
+			LegacyOpID:  opID,
+			BookIDs:     remaining,
+			TotalBooks:  totalBooks,
+			AlreadyDone: alreadyDone,
 		}
-
-		if err := s.queue.Enqueue(opID, "metadata_candidate_fetch", operations.PriorityNormal, opFunc); err != nil {
-			log.Printf("[WARN] failed to re-enqueue metadata fetch %s: %v", opID, err)
+		if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "metadata.candidate-fetch", resumeParams); enqErr != nil {
+			log.Printf("[WARN] failed to re-enqueue metadata fetch %s: %v", opID, enqErr)
 			_ = store.UpdateOperationStatus(opID, "failed", alreadyDone, totalBooks, "failed to resume")
 		}
 	}

--- a/internal/server/metadata_candidate_op.go
+++ b/internal/server/metadata_candidate_op.go
@@ -1,0 +1,143 @@
+// file: internal/server/metadata_candidate_op.go
+// version: 1.0.0
+// guid: 3f7e2c91-b4a0-4d8e-9c5f-1a6b7d8e0f23
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"golang.org/x/time/rate"
+)
+
+// metadataCandidateFetchOpParams is the JSON params for the
+// metadata.candidate-fetch v2 OperationDef. LegacyOpID is the v1 operation
+// record ID written by the HTTP handler — OperationResult rows are keyed on
+// this so that handleGetPendingReview, handleGetOperationResults, and the
+// dedup scan in handleBatchFetchCandidates all continue working unchanged.
+type metadataCandidateFetchOpParams struct {
+	LegacyOpID  string   `json:"legacy_op_id"`
+	BookIDs     []string `json:"book_ids"`
+	TotalBooks  int      `json:"total_books"`
+	AlreadyDone int      `json:"already_done"` // used by resume path
+}
+
+// RegisterMetadataCandidateFetchOp registers the "metadata.candidate-fetch"
+// v2 OperationDef. The HTTP handler creates a v1 op record for backward
+// compatibility, then enqueues this def. The Run func writes OperationResult
+// rows under the v1 opID so that all existing readers work without changes.
+func (s *Server) RegisterMetadataCandidateFetchOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "metadata.candidate-fetch",
+		Plugin:          "metadata",
+		DisplayName:     "Fetch Metadata Candidates",
+		Description:     "Fetch and cache metadata candidates for a set of audiobooks (rate-limited, parallel). Results are stored in v1 OperationResult rows for review.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         8 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "metadata.candidate-fetch",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkGeneric},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p metadataCandidateFetchOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("metadata-candidate-fetch: decode params: %w", err)
+				}
+			}
+			if len(p.BookIDs) == 0 {
+				return nil
+			}
+
+			store := s.Store()
+			mfs := s.metadataFetchService
+			progress := registryProgressAdapter{r: reporter}
+			totalBooks := p.TotalBooks
+			if totalBooks == 0 {
+				totalBooks = len(p.BookIDs)
+			}
+			opID := p.LegacyOpID
+
+			// Transition v1 op record to running so that handleGetLatestMetadataFetch
+			// can surface it and the dedup scan in handleBatchFetchCandidates sees it
+			// as an active fetch. This mirrors what the legacy v1 queue did automatically.
+			_ = store.UpdateOperationStatus(opID, "running", p.AlreadyDone, totalBooks,
+				fmt.Sprintf("starting: %d books to fetch", len(p.BookIDs)))
+			_ = progress.UpdateProgress(p.AlreadyDone, totalBooks, fmt.Sprintf("starting: %d books to fetch", len(p.BookIDs)))
+
+			// Rate limiter: 10 requests per second globally across all workers.
+			limiter := rate.NewLimiter(rate.Limit(10), 1)
+
+			workCh := make(chan string, len(p.BookIDs))
+			for _, id := range p.BookIDs {
+				workCh <- id
+			}
+			close(workCh)
+
+			var completed int64 = int64(p.AlreadyDone)
+			var wg sync.WaitGroup
+			numWorkers := 8
+			if numWorkers > len(p.BookIDs) {
+				numWorkers = len(p.BookIDs)
+			}
+
+			for i := 0; i < numWorkers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for bookID := range workCh {
+						if ctx.Err() != nil {
+							return
+						}
+						result := s.fetchCandidateForBook(ctx, mfs, store, limiter, opID, bookID)
+						resultJSON, err := json.Marshal(result)
+						if err != nil {
+							log.Printf("[WARN] metadata-candidate-fetch: marshal result for book %s: %v", bookID, err)
+							continue
+						}
+						if err := store.CreateOperationResult(&database.OperationResult{
+							OperationID: opID,
+							BookID:      bookID,
+							ResultJSON:  string(resultJSON),
+							Status:      result.Status,
+						}); err != nil {
+							log.Printf("[WARN] metadata-candidate-fetch: store result for book %s: %v", bookID, err)
+						}
+						done := atomic.AddInt64(&completed, 1)
+						_ = progress.UpdateProgress(int(done), totalBooks, fmt.Sprintf("fetched %d/%d", done, totalBooks))
+					}
+				}()
+			}
+			wg.Wait()
+
+			finalCount := atomic.LoadInt64(&completed)
+			// Transition v1 op record to its terminal state.
+			finalStatus := "completed"
+			if ctx.Err() != nil {
+				finalStatus = "canceled"
+			}
+			_ = store.UpdateOperationStatus(opID, finalStatus, int(finalCount), totalBooks, finalStatus)
+			_ = progress.UpdateProgress(int(finalCount), totalBooks, "completed")
+			log.Printf("[INFO] metadata-candidate-fetch %s: done — %d/%d books, status=%s",
+				opID, finalCount, totalBooks, finalStatus)
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error {
+		return s.RegisterMetadataCandidateFetchOp(reg)
+	})
+}


### PR DESCRIPTION
## Summary

- Creates `internal/server/metadata_candidate_op.go` with `OperationDef` `metadata.candidate-fetch` registered via `addOpRegistrar`/`init()` — no changes to `server.go`
- Hybrid approach: v1 `store.CreateOperation` + `OperationResult` rows kept for `handleGetPendingReview` and `handleGetOperationResults` compatibility; clients continue to track the v1 `opID` returned in the HTTP response
- `Run` func explicitly transitions v1 op status (`pending → running → completed/canceled`) to match the lifecycle management the legacy `v1 queue` performed automatically — prevents the op from appearing stuck in `pending` to `handleGetLatestMetadataFetch` and the dedup scan in `handleBatchFetchCandidates`
- Both enqueue sites migrated: initial HTTP handler enqueue and `resumeInterruptedMetadataFetch` resume path
- Removes now-unused `sync`, `sync/atomic` imports from `metadata_batch_candidates.go`

## Test plan

- [ ] `make build-api` passes (verified)
- [ ] Trigger a batch candidate fetch from the UI and confirm the operation appears in the Resume Review picker
- [ ] Confirm dedup: re-triggering a fetch for the same books while one is running skips them
- [ ] Confirm resume: restart server during a fetch and verify `resumeInterruptedMetadataFetch` re-enqueues remaining books

🤖 Generated with [Claude Code](https://claude.com/claude-code)