### PR TITLE
feat(ops): migrate batch-save to UOS v2, wire bulk-metadata-fetch HTTP handler

### DIFF
--- a/internal/server/batch_save_op.go
+++ b/internal/server/batch_save_op.go
@@ -1,0 +1,156 @@
+// file: internal/server/batch_save_op.go
+// version: 1.0.0
+// guid: 3f2a1b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c
+// last-edited: 2026-05-10
+//
+// batch_save_op registers the "metadata.batch-save" v2 OperationDef.
+// The HTTP handler batchWriteBackAudiobooks creates a v1 op record for
+// backward-compatible polling, then enqueues the run here.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// batchSaveOpParams is the JSON params for the metadata.batch-save op.
+type batchSaveOpParams struct {
+	LegacyOpID string   `json:"legacy_op_id"`
+	BookIDs    []string `json:"book_ids"`
+	Organize   bool     `json:"organize"`
+	Force      bool     `json:"force"`
+}
+
+// RegisterBatchSaveToFilesOp registers the "metadata.batch-save" v2 OperationDef.
+// The HTTP handler batchWriteBackAudiobooks pre-creates a v1 op record for
+// backwards-compatible progress polling, then enqueues here via opRegistry.
+func (s *Server) RegisterBatchSaveToFilesOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "metadata.batch-save",
+		Plugin:          "metadata",
+		DisplayName:     "Batch Save to Files",
+		Description:     "Write metadata from database back to audio file tags for a set of books, with optional re-organize.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "metadata.batch-save",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p batchSaveOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("batch-save: decode params: %w", err)
+				}
+			}
+
+			store := s.Store()
+			progress := registryProgressAdapter{r: reporter}
+			opID := p.LegacyOpID
+			bookIDs := p.BookIDs
+			totalBooks := len(bookIDs)
+
+			_ = progress.UpdateProgress(0, totalBooks, "starting save to files")
+
+			written, organized, failed, skipped := 0, 0, 0, 0
+			org := organizer.NewOrganizer(&config.AppConfig)
+			log2 := logger.NewWithActivityLog("batch-write-back", store)
+
+			for i, id := range bookIDs {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				book, err := store.GetBookByID(id)
+				if err != nil || book == nil {
+					failed++
+					_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("book %s not found", id), nil)
+					continue
+				}
+
+				// Skip if already written and metadata hasn't changed since last write
+				if !p.Force && book.LastWrittenAt != nil && !book.UpdatedAt.After(*book.LastWrittenAt) {
+					skipped++
+					_ = progress.UpdateProgress(i+1, totalBooks,
+						fmt.Sprintf("processed %d/%d (skipped: %d — already up to date)", i+1, totalBooks, skipped))
+					continue
+				}
+
+				// Write tags
+				_, wbErr := s.metadataFetchService.WriteBackMetadataForBook(id)
+				if wbErr != nil {
+					failed++
+					detail := wbErr.Error()
+					_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("write-back failed for %s", book.Title), &detail)
+					continue
+				}
+				written++
+				// Stamp last_written_at on the book the user sees (may differ from library copy)
+				_ = store.SetLastWrittenAt(id, time.Now())
+
+				// Organize
+				if p.Organize {
+					book, _ = store.GetBookByID(id)
+					if book != nil {
+						oldPath := book.FilePath
+						alreadyInRoot := config.AppConfig.RootDir != "" && strings.HasPrefix(oldPath, config.AppConfig.RootDir)
+						var newPath string
+						var orgErr error
+						if alreadyInRoot {
+							newPath, orgErr = s.organizeService.ReOrganizeInPlace(book, log2)
+						} else {
+							bookFiles, _ := store.GetBookFiles(id)
+							isDir := len(bookFiles) > 1
+							if !isDir {
+								if info, statErr := os.Stat(oldPath); statErr == nil && info.IsDir() {
+									isDir = true
+								}
+							}
+							if isDir {
+								newPath, orgErr = s.organizeService.OrganizeDirectoryBook(org, book, log2)
+							} else {
+								newPath, _, orgErr = org.OrganizeBook(book)
+							}
+						}
+						if orgErr != nil {
+							detail := orgErr.Error()
+							_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("organize failed for %s", book.Title), &detail)
+						} else if newPath != "" && newPath != oldPath {
+							organized++
+						}
+					}
+				}
+
+				// Enqueue ITL write-back
+				if s.writeBackBatcher != nil {
+					s.writeBackBatcher.Enqueue(id)
+				}
+
+				_ = progress.UpdateProgress(i+1, totalBooks,
+					fmt.Sprintf("processed %d/%d (written: %d, organized: %d, failed: %d)",
+						i+1, totalBooks, written, organized, failed))
+			}
+
+			_ = progress.UpdateProgress(totalBooks, totalBooks,
+				fmt.Sprintf("complete: written %d, organized %d, skipped %d, failed %d", written, organized, skipped, failed))
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterBatchSaveToFilesOp(reg) })
+}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.6.0
+// version: 3.7.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
-// last-edited: 2026-05-11
+// last-edited: 2026-05-10
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
 // search/apply/revert/no-match, bulk fetch and bulk writeback, the
@@ -18,7 +18,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,12 +31,10 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
-	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
-	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -836,40 +833,25 @@ func (s *Server) handleBulkMetadataFetchAll(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
 		return
 	}
-
-	params := operations.BulkMetadataFetchParams{
+	params := bulkMetadataFetchV2Params{
 		PreferAudible: c.DefaultQuery("prefer_audible", "false") == "true",
 		SkipCached:    c.DefaultQuery("skip_cached", "false") == "true",
 	}
-
-	store := s.Store()
-	opID := ulid.Make().String()
-	if _, err := store.CreateOperation(opID, "bulk_metadata_fetch", nil); err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
-		return
-	}
-	if err := operations.SaveParams(store, opID, params); err != nil {
-		log.Printf("[WARN] bulk-metadata-fetch: failed to save params for %s: %v", opID, err)
-	}
-
-	capturedParams := params
-	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		return s.runBulkMetadataFetchAll(ctx, opID, capturedParams, store, progress)
-	}
-	if err := s.queue.Enqueue(opID, "bulk_metadata_fetch", operations.PriorityNormal, opFunc); err != nil {
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.bulk-metadata-fetch", params)
+	if err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
-
 	log.Printf("[INFO] bulk-metadata-fetch: queued %s prefer_audible=%v skip_cached=%v",
 		opID, params.PreferAudible, params.SkipCached)
 	httputil.RespondWithSuccess(c, http.StatusAccepted, gin.H{
 		"operation_id":   opID,
-		"message":        "bulk metadata fetch started — poll GET /api/v1/operations/" + opID + " for progress",
+		"op_id":          opID,
+		"message":        "bulk metadata fetch started — poll GET /api/v1/operations/v2/" + opID + " for progress",
 		"prefer_audible": params.PreferAudible,
 		"skip_cached":    params.SkipCached,
 	})
@@ -1694,99 +1676,15 @@ func (s *Server) batchWriteBackAudiobooks(c *gin.Context) {
 	bookIDs := make([]string, len(req.BookIDs))
 	copy(bookIDs, req.BookIDs)
 	totalBooks := len(bookIDs)
-	force := req.Force
-	mfs := s.metadataFetchService
-	orgSvc := s.organizeService
 
-	opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		_ = progress.UpdateProgress(0, totalBooks, "starting save to files")
-
-		written, organized, failed, skipped := 0, 0, 0, 0
-		org := organizer.NewOrganizer(&config.AppConfig)
-		log2 := logger.NewWithActivityLog("batch-write-back", store)
-
-		for i, id := range bookIDs {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-
-			book, err := store.GetBookByID(id)
-			if err != nil || book == nil {
-				failed++
-				_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("book %s not found", id), nil)
-				continue
-			}
-
-			// Skip if already written and metadata hasn't changed since last write
-			if !force && book.LastWrittenAt != nil && !book.UpdatedAt.After(*book.LastWrittenAt) {
-				skipped++
-				_ = progress.UpdateProgress(i+1, totalBooks,
-					fmt.Sprintf("processed %d/%d (skipped: %d — already up to date)", i+1, totalBooks, skipped))
-				continue
-			}
-
-			// Write tags
-			_, wbErr := mfs.WriteBackMetadataForBook(id)
-			if wbErr != nil {
-				failed++
-				detail := wbErr.Error()
-				_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("write-back failed for %s", book.Title), &detail)
-				continue
-			}
-			written++
-			// Stamp last_written_at on the book the user sees (may differ from library copy)
-			_ = store.SetLastWrittenAt(id, time.Now())
-
-			// Organize
-			if doOrganize {
-				book, _ = store.GetBookByID(id)
-				if book != nil {
-					oldPath := book.FilePath
-					alreadyInRoot := config.AppConfig.RootDir != "" && strings.HasPrefix(oldPath, config.AppConfig.RootDir)
-					var newPath string
-					var orgErr error
-					if alreadyInRoot {
-						newPath, orgErr = orgSvc.ReOrganizeInPlace(book, log2)
-					} else {
-						bookFiles, _ := store.GetBookFiles(id)
-						isDir := len(bookFiles) > 1
-						if !isDir {
-							if info, statErr := os.Stat(oldPath); statErr == nil && info.IsDir() {
-								isDir = true
-							}
-						}
-						if isDir {
-							newPath, orgErr = orgSvc.OrganizeDirectoryBook(org, book, log2)
-						} else {
-							newPath, _, orgErr = org.OrganizeBook(book)
-						}
-					}
-					if orgErr != nil {
-						detail := orgErr.Error()
-						_ = store.AddOperationLog(opID, "warn", fmt.Sprintf("organize failed for %s", book.Title), &detail)
-					} else if newPath != "" && newPath != oldPath {
-						organized++
-					}
-				}
-			}
-
-			// Enqueue ITL write-back
-			if s.writeBackBatcher != nil {
-				s.writeBackBatcher.Enqueue(id)
-			}
-
-			_ = progress.UpdateProgress(i+1, totalBooks,
-				fmt.Sprintf("processed %d/%d (written: %d, organized: %d, failed: %d)",
-					i+1, totalBooks, written, organized, failed))
-		}
-
-		_ = progress.UpdateProgress(totalBooks, totalBooks,
-			fmt.Sprintf("complete: written %d, organized %d, skipped %d, failed %d", written, organized, skipped, failed))
-		return nil
+	params := batchSaveOpParams{
+		LegacyOpID: opID,
+		BookIDs:    bookIDs,
+		Organize:   doOrganize,
+		Force:      req.Force,
 	}
-
-	if err := s.queue.Enqueue(opID, "batch_save_to_files", operations.PriorityNormal, opFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "metadata.batch-save", params); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 


### PR DESCRIPTION
Two metadata operation migrations:

1. **batch_save_to_files → metadata.batch-save**: Creates `OperationDef` `metadata.batch-save` in new file `batch_save_op.go`. The HTTP handler `batchWriteBackAudiobooks` keeps the v1 op record (`CreateOperation`) for backward-compatible polling, then enqueues via `opRegistry.EnqueueOp`. The full opFunc body (lines 1701–1786) is moved faithfully into the Run func; `doOrganize`→`p.Organize`, `bookIDs`→`p.BookIDs`, `force`→`p.Force`, etc. Uses `registryProgressAdapter` for progress reporting.

2. **handleBulkMetadataFetchAll → pure v2**: Rewrites the handler to call the already-registered `library.bulk-metadata-fetch` OperationDef via `opRegistry.EnqueueOp`. No v1 op record is created — the v2 Run func generates its own internal ULID for `OperationResult` resume tracking. Response includes both `operation_id` and `op_id` for client compat. Drops the now-unused `s.queue` path.

Removes now-unused `os`, `logger`, `organizer` imports from `metadata_handlers.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)