### PR TITLE
feat(ops): migrate AI author ops to UOS v2

### DIFF
--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/ai_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 5d3a6a95-4ac8-42c2-a7fe-5ff4857dd31a
 //
 // AI-related HTTP handlers split out of server.go: filename parsing,
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -443,8 +442,8 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return
 	}
 
@@ -518,18 +517,9 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		switch mode {
-		case "groups":
-			return s.aiReviewGroupsMode(ctx, progress, parser, store, opID, dedupGroups)
-		case "full":
-			return s.aiReviewFullMode(ctx, progress, parser, store, opID)
-		}
-		return fmt.Errorf("unknown mode: %s", mode)
-	}
-
-	if err := s.queue.Enqueue(opID, opType, operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	reviewParams := aiReviewOpParams{LegacyOpID: op.ID, Mode: mode, DedupGroups: dedupGroups}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "ai.author-review", reviewParams); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 
@@ -711,14 +701,7 @@ func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.Progr
 
 func (s *Server) applyAIAuthorReview(c *gin.Context) {
 	var req struct {
-		Suggestions []struct {
-			GroupIndex    int    `json:"group_index"`
-			Action        string `json:"action"`
-			CanonicalName string `json:"canonical_name"`
-			KeepID        int    `json:"keep_id"`
-			MergeIDs      []int  `json:"merge_ids"`
-			Rename        bool   `json:"rename"`
-		} `json:"suggestions"`
+		Suggestions []aiMergeApplySuggestion `json:"suggestions"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
@@ -730,8 +713,8 @@ func (s *Server) applyAIAuthorReview(c *gin.Context) {
 		return
 	}
 
-	if s.queue == nil {
-		httputil.RespondWithInternalError(c, "operation queue not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return
 	}
 
@@ -743,181 +726,9 @@ func (s *Server) applyAIAuthorReview(c *gin.Context) {
 		return
 	}
 
-	suggestions := req.Suggestions
-
-	operationFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-		total := len(suggestions)
-		applied := 0
-		var applyErrors []string
-
-		_ = progress.Log("info", fmt.Sprintf("Starting AI author review apply: %d suggestion(s)", total), nil)
-
-		for i, sug := range suggestions {
-			if progress.IsCanceled() {
-				_ = progress.Log("warn", "Operation cancelled by user", nil)
-				return fmt.Errorf("cancelled")
-			}
-
-			_ = progress.UpdateProgress(i, total, fmt.Sprintf("Applying suggestion %d/%d...", i+1, total))
-
-			switch sug.Action {
-			case "skip":
-				_ = progress.Log("info", fmt.Sprintf("Skipped group %d", sug.GroupIndex), nil)
-				continue
-
-			case "rename":
-				if sug.KeepID > 0 && sug.CanonicalName != "" {
-					if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
-						applyErrors = append(applyErrors, fmt.Sprintf("rename author %d: %v", sug.KeepID, err))
-					} else {
-						applied++
-						_ = progress.Log("info", fmt.Sprintf("Renamed author %d to \"%s\"", sug.KeepID, sug.CanonicalName), nil)
-					}
-				}
-
-			case "merge":
-				// Rename canonical if needed
-				if sug.Rename && sug.KeepID > 0 && sug.CanonicalName != "" {
-					if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
-						applyErrors = append(applyErrors, fmt.Sprintf("rename before merge %d: %v", sug.KeepID, err))
-					}
-				}
-
-				// Merge variant authors
-				for _, mergeID := range sug.MergeIDs {
-					if mergeID == sug.KeepID {
-						continue
-					}
-					books, err := store.GetBooksByAuthorIDWithRole(mergeID)
-					if err != nil {
-						applyErrors = append(applyErrors, fmt.Sprintf("get books for author %d: %v", mergeID, err))
-						continue
-					}
-
-					// Snapshot affected books
-					_ = progress.Log("info", fmt.Sprintf("Snapshotting %d books before merge of author %d", len(books), mergeID), nil)
-
-					for _, book := range books {
-						bookAuthors, err := store.GetBookAuthors(book.ID)
-						if err != nil {
-							continue
-						}
-						hasKeep := false
-						for _, ba := range bookAuthors {
-							if ba.AuthorID == sug.KeepID {
-								hasKeep = true
-								break
-							}
-						}
-						var newAuthors []database.BookAuthor
-						for _, ba := range bookAuthors {
-							if ba.AuthorID == mergeID {
-								if !hasKeep {
-									ba.AuthorID = sug.KeepID
-									newAuthors = append(newAuthors, ba)
-									hasKeep = true
-								}
-							} else {
-								newAuthors = append(newAuthors, ba)
-							}
-						}
-						if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
-							applyErrors = append(applyErrors, fmt.Sprintf("update book %s: %v", book.ID, err))
-						}
-					}
-
-					if err := store.DeleteAuthor(mergeID); err != nil {
-						applyErrors = append(applyErrors, fmt.Sprintf("delete author %d: %v", mergeID, err))
-					} else {
-						_ = store.CreateAuthorTombstone(mergeID, sug.KeepID)
-					}
-				}
-				applied++
-				_ = progress.Log("info", fmt.Sprintf("Merged group %d: %d variants into \"%s\"", sug.GroupIndex, len(sug.MergeIDs), sug.CanonicalName), nil)
-
-			case "alias":
-				// Keep canonical author, add variants as aliases instead of merging
-				if sug.KeepID > 0 && sug.CanonicalName != "" {
-					if sug.Rename {
-						if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
-							applyErrors = append(applyErrors, fmt.Sprintf("rename for alias %d: %v", sug.KeepID, err))
-						}
-					}
-					for _, mergeID := range sug.MergeIDs {
-						if mergeID == sug.KeepID {
-							continue
-						}
-						variant, err := store.GetAuthorByID(mergeID)
-						if err != nil || variant == nil {
-							continue
-						}
-						if _, err := store.CreateAuthorAlias(sug.KeepID, variant.Name, "pen_name"); err != nil {
-							applyErrors = append(applyErrors, fmt.Sprintf("create alias for author %d: %v", sug.KeepID, err))
-						}
-						// Re-link books and delete the variant author
-						books, err := store.GetBooksByAuthorIDWithRole(mergeID)
-						if err != nil {
-							continue
-						}
-						for _, book := range books {
-							bookAuthors, err := store.GetBookAuthors(book.ID)
-							if err != nil {
-								continue
-							}
-							hasKeep := false
-							for _, ba := range bookAuthors {
-								if ba.AuthorID == sug.KeepID {
-									hasKeep = true
-									break
-								}
-							}
-							var newAuthors []database.BookAuthor
-							for _, ba := range bookAuthors {
-								if ba.AuthorID == mergeID {
-									if !hasKeep {
-										ba.AuthorID = sug.KeepID
-										newAuthors = append(newAuthors, ba)
-										hasKeep = true
-									}
-								} else {
-									newAuthors = append(newAuthors, ba)
-								}
-							}
-							if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
-								applyErrors = append(applyErrors, fmt.Sprintf("update book %s for alias: %v", book.ID, err))
-							}
-						}
-						if err := store.DeleteAuthor(mergeID); err != nil {
-							applyErrors = append(applyErrors, fmt.Sprintf("delete aliased author %d: %v", mergeID, err))
-						} else {
-							_ = store.CreateAuthorTombstone(mergeID, sug.KeepID)
-						}
-					}
-					applied++
-					_ = progress.Log("info", fmt.Sprintf("Created aliases for group %d: canonical \"%s\"", sug.GroupIndex, sug.CanonicalName), nil)
-				}
-
-			case "split":
-				_ = progress.Log("info", fmt.Sprintf("Split action for group %d — manual intervention needed", sug.GroupIndex), nil)
-				applied++
-			}
-		}
-
-		s.dedupCache.InvalidateAll()
-
-		resultMsg := fmt.Sprintf("AI review applied: %d actions, %d errors", applied, len(applyErrors))
-		_ = progress.Log("info", resultMsg, nil)
-		if len(applyErrors) > 0 {
-			errDetail := strings.Join(applyErrors[:min(len(applyErrors), 10)], "; ")
-			_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
-		}
-
-		_ = progress.UpdateProgress(total, total, resultMsg)
-		return nil
-	}
-
-	if err := s.queue.Enqueue(opID, "ai-author-merge-apply", operations.PriorityNormal, operationFunc); err != nil {
-		httputil.InternalError(c, "failed to enqueue operation", err)
+	applyParams := aiMergeApplyOpParams{LegacyOpID: op.ID, Suggestions: req.Suggestions}
+	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "ai.author-merge-apply", applyParams); enqErr != nil {
+		httputil.InternalError(c, "failed to enqueue operation", enqErr)
 		return
 	}
 

--- a/internal/server/ai_ops.go
+++ b/internal/server/ai_ops.go
@@ -1,0 +1,297 @@
+// file: internal/server/ai_ops.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
+
+// ai_ops registers the ai.author-review and ai.author-merge-apply
+// OperationDefs that previously went through the legacy BridgeQueue.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/dedup"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// aiReviewOpParams holds the serializable parameters for the ai.author-review op.
+type aiReviewOpParams struct {
+	LegacyOpID  string                  `json:"legacy_op_id"`
+	Mode        string                  `json:"mode"`
+	DedupGroups []dedup.AuthorDedupGroup `json:"dedup_groups,omitempty"`
+}
+
+// aiMergeApplySuggestion is the per-item suggestion for the merge-apply op.
+// This struct is shared between the HTTP request body and the op params so it
+// is JSON-serializable end-to-end.
+type aiMergeApplySuggestion struct {
+	GroupIndex    int    `json:"group_index"`
+	Action        string `json:"action"`
+	CanonicalName string `json:"canonical_name"`
+	KeepID        int    `json:"keep_id"`
+	MergeIDs      []int  `json:"merge_ids"`
+	Rename        bool   `json:"rename"`
+}
+
+// aiMergeApplyOpParams holds the serializable parameters for the ai.author-merge-apply op.
+type aiMergeApplyOpParams struct {
+	LegacyOpID  string                    `json:"legacy_op_id"`
+	Suggestions []aiMergeApplySuggestion  `json:"suggestions"`
+}
+
+// RegisterAIAuthorReviewOp registers the "ai.author-review" v2 OperationDef.
+func (s *Server) RegisterAIAuthorReviewOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "ai.author-review",
+		Plugin:          "ai",
+		DisplayName:     "AI Author Duplicate Review",
+		Description:     "Uses AI to review and identify duplicate author entries in the library.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "ai.author-review",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p aiReviewOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("ai.author-review: decode params: %w", err)
+				}
+			}
+			if p.LegacyOpID == "" {
+				return fmt.Errorf("ai.author-review: legacy_op_id is required")
+			}
+			if p.Mode == "" {
+				p.Mode = "groups"
+			}
+
+			parser := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
+			store := s.Store()
+			progress := registryProgressAdapter{r: reporter}
+
+			switch p.Mode {
+			case "groups":
+				return s.aiReviewGroupsMode(ctx, progress, parser, store, p.LegacyOpID, p.DedupGroups)
+			case "full":
+				return s.aiReviewFullMode(ctx, progress, parser, store, p.LegacyOpID)
+			default:
+				return fmt.Errorf("ai.author-review: unknown mode: %s", p.Mode)
+			}
+		},
+	})
+}
+
+// RegisterAIAuthorMergeApplyOp registers the "ai.author-merge-apply" v2 OperationDef.
+func (s *Server) RegisterAIAuthorMergeApplyOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "ai.author-merge-apply",
+		Plugin:          "ai",
+		DisplayName:     "AI Author Merge Apply",
+		Description:     "Applies AI-suggested author merge, rename, alias, and split actions to the library.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "ai.author-merge-apply",
+		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p aiMergeApplyOpParams
+			if len(rawParams) > 0 {
+				if err := json.Unmarshal(rawParams, &p); err != nil {
+					return fmt.Errorf("ai.author-merge-apply: decode params: %w", err)
+				}
+			}
+			if p.LegacyOpID == "" {
+				return fmt.Errorf("ai.author-merge-apply: legacy_op_id is required")
+			}
+
+			store := s.Store()
+			progress := registryProgressAdapter{r: reporter}
+			suggestions := p.Suggestions
+			total := len(suggestions)
+			applied := 0
+			var applyErrors []string
+
+			_ = progress.Log("info", fmt.Sprintf("Starting AI author review apply: %d suggestion(s)", total), nil)
+
+			for i, sug := range suggestions {
+				if progress.IsCanceled() {
+					_ = progress.Log("warn", "Operation cancelled by user", nil)
+					return fmt.Errorf("cancelled")
+				}
+
+				_ = progress.UpdateProgress(i, total, fmt.Sprintf("Applying suggestion %d/%d...", i+1, total))
+
+				switch sug.Action {
+				case "skip":
+					_ = progress.Log("info", fmt.Sprintf("Skipped group %d", sug.GroupIndex), nil)
+					continue
+
+				case "rename":
+					if sug.KeepID > 0 && sug.CanonicalName != "" {
+						if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
+							applyErrors = append(applyErrors, fmt.Sprintf("rename author %d: %v", sug.KeepID, err))
+						} else {
+							applied++
+							_ = progress.Log("info", fmt.Sprintf("Renamed author %d to \"%s\"", sug.KeepID, sug.CanonicalName), nil)
+						}
+					}
+
+				case "merge":
+					// Rename canonical if needed
+					if sug.Rename && sug.KeepID > 0 && sug.CanonicalName != "" {
+						if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
+							applyErrors = append(applyErrors, fmt.Sprintf("rename before merge %d: %v", sug.KeepID, err))
+						}
+					}
+
+					// Merge variant authors
+					for _, mergeID := range sug.MergeIDs {
+						if mergeID == sug.KeepID {
+							continue
+						}
+						books, err := store.GetBooksByAuthorIDWithRole(mergeID)
+						if err != nil {
+							applyErrors = append(applyErrors, fmt.Sprintf("get books for author %d: %v", mergeID, err))
+							continue
+						}
+
+						_ = progress.Log("info", fmt.Sprintf("Snapshotting %d books before merge of author %d", len(books), mergeID), nil)
+
+						for _, book := range books {
+							bookAuthors, err := store.GetBookAuthors(book.ID)
+							if err != nil {
+								continue
+							}
+							hasKeep := false
+							for _, ba := range bookAuthors {
+								if ba.AuthorID == sug.KeepID {
+									hasKeep = true
+									break
+								}
+							}
+							var newAuthors []database.BookAuthor
+							for _, ba := range bookAuthors {
+								if ba.AuthorID == mergeID {
+									if !hasKeep {
+										ba.AuthorID = sug.KeepID
+										newAuthors = append(newAuthors, ba)
+										hasKeep = true
+									}
+								} else {
+									newAuthors = append(newAuthors, ba)
+								}
+							}
+							if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
+								applyErrors = append(applyErrors, fmt.Sprintf("update book %s: %v", book.ID, err))
+							}
+						}
+
+						if err := store.DeleteAuthor(mergeID); err != nil {
+							applyErrors = append(applyErrors, fmt.Sprintf("delete author %d: %v", mergeID, err))
+						} else {
+							_ = store.CreateAuthorTombstone(mergeID, sug.KeepID)
+						}
+					}
+					applied++
+					_ = progress.Log("info", fmt.Sprintf("Merged group %d: %d variants into \"%s\"", sug.GroupIndex, len(sug.MergeIDs), sug.CanonicalName), nil)
+
+				case "alias":
+					// Keep canonical author, add variants as aliases instead of merging
+					if sug.KeepID > 0 && sug.CanonicalName != "" {
+						if sug.Rename {
+							if err := store.UpdateAuthorName(sug.KeepID, dedup.NormalizeAuthorName(sug.CanonicalName)); err != nil {
+								applyErrors = append(applyErrors, fmt.Sprintf("rename for alias %d: %v", sug.KeepID, err))
+							}
+						}
+						for _, mergeID := range sug.MergeIDs {
+							if mergeID == sug.KeepID {
+								continue
+							}
+							variant, err := store.GetAuthorByID(mergeID)
+							if err != nil || variant == nil {
+								continue
+							}
+							if _, err := store.CreateAuthorAlias(sug.KeepID, variant.Name, "pen_name"); err != nil {
+								applyErrors = append(applyErrors, fmt.Sprintf("create alias for author %d: %v", sug.KeepID, err))
+							}
+							// Re-link books and delete the variant author
+							books, err := store.GetBooksByAuthorIDWithRole(mergeID)
+							if err != nil {
+								continue
+							}
+							for _, book := range books {
+								bookAuthors, err := store.GetBookAuthors(book.ID)
+								if err != nil {
+									continue
+								}
+								hasKeep := false
+								for _, ba := range bookAuthors {
+									if ba.AuthorID == sug.KeepID {
+										hasKeep = true
+										break
+									}
+								}
+								var newAuthors []database.BookAuthor
+								for _, ba := range bookAuthors {
+									if ba.AuthorID == mergeID {
+										if !hasKeep {
+											ba.AuthorID = sug.KeepID
+											newAuthors = append(newAuthors, ba)
+											hasKeep = true
+										}
+									} else {
+										newAuthors = append(newAuthors, ba)
+									}
+								}
+								if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
+									applyErrors = append(applyErrors, fmt.Sprintf("update book %s for alias: %v", book.ID, err))
+								}
+							}
+							if err := store.DeleteAuthor(mergeID); err != nil {
+								applyErrors = append(applyErrors, fmt.Sprintf("delete aliased author %d: %v", mergeID, err))
+							} else {
+								_ = store.CreateAuthorTombstone(mergeID, sug.KeepID)
+							}
+						}
+						applied++
+						_ = progress.Log("info", fmt.Sprintf("Created aliases for group %d: canonical \"%s\"", sug.GroupIndex, sug.CanonicalName), nil)
+					}
+
+				case "split":
+					_ = progress.Log("info", fmt.Sprintf("Split action for group %d — manual intervention needed", sug.GroupIndex), nil)
+					applied++
+				}
+			}
+
+			s.dedupCache.InvalidateAll()
+
+			resultMsg := fmt.Sprintf("AI review applied: %d actions, %d errors", applied, len(applyErrors))
+			_ = progress.Log("info", resultMsg, nil)
+			if len(applyErrors) > 0 {
+				errDetail := strings.Join(applyErrors[:min(len(applyErrors), 10)], "; ")
+				_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
+			}
+
+			_ = progress.UpdateProgress(total, total, resultMsg)
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterAIAuthorReviewOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterAIAuthorMergeApplyOp(reg) })
+}


### PR DESCRIPTION
## Summary

Migrates AI author review (groups/full modes) and merge-apply from v1 queue.Enqueue to v2 opRegistry.EnqueueOp.

- Creates `ai_ops.go` with OperationDefs for `ai.author-review` and `ai.author-merge-apply`, with `init()` registrars
- Defines `aiMergeApplySuggestion` as a named struct shared between request binding and op params (replaces anonymous struct)
- Serializes `dedupGroups` into params for groups mode (preserves the "no groups" 200 short-circuit in the handler; avoids redundant re-computation)
- Replaces `s.queue == nil` guards with `s.opRegistry == nil`
- Legacy v1 op records kept for backward-compat polling
- Large inline closure bodies moved to OperationDef Run functions

## Test plan

- [ ] `make build-api` passes (verified locally)
- [ ] POST `/api/v1/ai/review-duplicate-authors` with `{"mode":"groups"}` enqueues an `ai.author-review` op
- [ ] POST `/api/v1/ai/review-duplicate-authors` with `{"mode":"full"}` enqueues an `ai.author-review` op
- [ ] POST `/api/v1/ai/apply-author-review` with suggestions enqueues an `ai.author-merge-apply` op
- [ ] Concurrent same-mode review returns 202 with the existing op (dedup check preserved)
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)