### PR TITLE
feat(ops): migrate maintenance dispatcher, window, and watcher scan to v2

### DIFF
--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,12 +1,11 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 55555555-5555-5555-5555-555555555555
 // last-edited: 2026-05-01
 
 package server
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -110,13 +109,11 @@ func (s *Server) runMaintenanceJob(c *gin.Context) {
 		return
 	}
 
-	enqueueFn := operations.OperationFunc(func(ctx context.Context, reporter operations.ProgressReporter) error {
-		ctx = maintenance.WithOperationID(ctx, opID)
-		adapter := &progressAdapter{ops: reporter}
-		return job.Run(ctx, store, adapter, req.DryRun)
-	})
-
-	if err := s.queue.Enqueue(opID, opType, operations.PriorityNormal, enqueueFn); err != nil {
+	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "maintenance.job", maintenanceJobOpParams{
+		LegacyOpID: opID,
+		JobID:      jobID,
+		DryRun:     req.DryRun,
+	}); err != nil {
 		httputil.RespondWithConflict(c, err.Error())
 		return
 	}

--- a/internal/server/maintenance_job_op.go
+++ b/internal/server/maintenance_job_op.go
@@ -1,0 +1,60 @@
+// file: internal/server/maintenance_job_op.go
+// version: 1.0.0
+// guid: 7f3a9c21-4b8e-4d56-a123-0e5f6c7d8e9f
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+type maintenanceJobOpParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+	JobID       string `json:"job_id"`
+	DryRun      bool   `json:"dry_run"`
+}
+
+// RegisterMaintenanceJobOp registers the "maintenance.job" OperationDef which runs
+// any named maintenance job by ID.
+func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "maintenance.job",
+		Plugin:          "maintenance",
+		DisplayName:     "Maintenance Job",
+		Description:     "Run a named maintenance job.",
+		DefaultPriority: opsregistry.PriorityNormal,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "", // parallel maintenance jobs allowed
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p maintenanceJobOpParams
+			if err := json.Unmarshal(rawParams, &p); err != nil {
+				return fmt.Errorf("maintenance.job: decode params: %w", err)
+			}
+			job, err := maintenance.Get(p.JobID)
+			if err != nil {
+				return fmt.Errorf("maintenance.job: job %q not found: %w", p.JobID, err)
+			}
+			store := s.Store()
+			ctx = maintenance.WithOperationID(ctx, p.LegacyOpID)
+			progress := registryProgressAdapter{r: reporter}
+			adapter := &progressAdapter{ops: progress}
+			return job.Run(ctx, store, adapter, p.DryRun)
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMaintenanceJobOp(reg) })
+}

--- a/internal/server/scheduler_maintenance.go
+++ b/internal/server/scheduler_maintenance.go
@@ -1,5 +1,5 @@
 // file: internal/server/scheduler_maintenance.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8822f62e-ed51-4df4-b9d1-4aa41f62139a
 // last-edited: 2026-05-02
 
@@ -8,12 +8,9 @@ package server
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -137,20 +134,19 @@ func (ts *TaskScheduler) isTaskRunning(name string) bool {
 	return false
 }
 
-// RunMaintenanceWindow runs all maintenance-window-eligible tasks in order.
+// RunMaintenanceWindow enqueues the maintenance-window operation via the v2 registry.
 // Step 1: auto-update (if enabled). Step 2+: maintenance tasks in fixed order.
 func (ts *TaskScheduler) RunMaintenanceWindow(ctx context.Context) error {
 	store := ts.server.Store()
 	if store == nil {
 		return fmt.Errorf("database not initialized")
 	}
-	if ts.server.queue == nil {
-		return fmt.Errorf("operation queue not initialized")
+	if ts.server.opRegistry == nil {
+		return fmt.Errorf("operation registry not initialized")
 	}
 
 	opID := ulid.Make().String()
-	op, err := store.CreateOperation(opID, "maintenance-window", nil)
-	if err != nil {
+	if _, err := store.CreateOperation(opID, "maintenance-window", nil); err != nil {
 		return fmt.Errorf("failed to create maintenance-window operation: %w", err)
 	}
 
@@ -158,162 +154,13 @@ func (ts *TaskScheduler) RunMaintenanceWindow(ctx context.Context) error {
 	// while the async operation is still running.
 	ts.saveLastMaintenanceRun()
 
-	_ = ts.server.queue.Enqueue(op.ID, "maintenance-window", operations.PriorityNormal,
-		func(innerCtx context.Context, progress operations.ProgressReporter) error {
-			ignoreWindow := ctx.Value(ignoreWindowKey) != nil
-
-			// Step 1: Auto-update (if enabled and not already completed post-restart)
-			if config.AppConfig.AutoUpdateEnabled {
-				updateDone, _ := store.GetSetting("maintenance_window_update_completed")
-				today := time.Now().Format("2006-01-02")
-				if updateDone == nil || updateDone.Value != today {
-					_ = progress.Log("info", "Running auto-update (step 1)", nil)
-					_ = progress.UpdateProgress(0, 100, "Running auto-update...")
-					_ = store.SetSetting("maintenance_window_update_completed", today, "string", false)
-					if ts.server.updater != nil {
-						channel := config.AppConfig.AutoUpdateChannel
-						info, checkErr := ts.server.updater.CheckForUpdate(channel)
-						if checkErr != nil {
-							_ = progress.Log("warning", fmt.Sprintf("Auto-update check failed: %v", checkErr), nil)
-						} else if info != nil && info.UpdateAvailable {
-							_ = progress.Log("info", fmt.Sprintf("Update available: %s, applying...", info.LatestVersion), nil)
-							if applyErr := ts.server.updater.DownloadAndReplace(info); applyErr != nil {
-								_ = progress.Log("error", fmt.Sprintf("Auto-update apply failed: %v", applyErr), nil)
-							} else {
-								_ = progress.Log("info", "Update applied, server will restart", nil)
-								go ts.server.updater.RestartSelf()
-								return nil // Exit — server restarting
-							}
-						} else {
-							_ = progress.Log("info", "No update available", nil)
-						}
-					}
-					_ = progress.Log("info", "Auto-update step complete", nil)
-				} else {
-					_ = progress.Log("info", "Auto-update already completed today, skipping", nil)
-				}
-			}
-
-			// Step 2+: Maintenance tasks in order
-			var eligible []string
-			for _, name := range ts.maintenanceOrder {
-				task, ok := ts.tasks[name]
-				if !ok {
-					continue
-				}
-				if task.IsEnabled() && task.RunInMaintenanceWindow != nil && task.RunInMaintenanceWindow() {
-					eligible = append(eligible, name)
-				}
-			}
-
-			mwTag := "mw:" + opID
-			taskSource := operations.TriggerScheduled
-			if ignoreWindow {
-				taskSource = operations.TriggerManual
-			}
-			windowStartTags := []string{activity.Scheduled, mwTag}
-			if ignoreWindow {
-				windowStartTags = []string{activity.AlwaysShow, mwTag}
-			}
-
-			_ = progress.Log("info", fmt.Sprintf("Maintenance window starting: %d tasks eligible: %s", len(eligible), strings.Join(eligible, ", ")), nil)
-			activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
-				fmt.Sprintf("Maintenance window starting: %d tasks: %s", len(eligible), strings.Join(eligible, ", ")),
-				windowStartTags...)
-
-			type taskFailure struct{ name, errMsg string }
-			var failures []taskFailure
-			var skipped []string
-			ran := 0
-
-			for i, name := range eligible {
-				// Check if window is still open (skip for manual "Run Now" triggers)
-				if !ignoreWindow && !isInMaintenanceWindow() {
-					remaining := eligible[i:]
-					_ = progress.Log("warning", fmt.Sprintf("Maintenance window closed after task %d/%d, skipping: %s", i, len(eligible), strings.Join(remaining, ", ")), nil)
-					skipped = append(skipped, remaining...)
-					break
-				}
-
-				// Duplicate prevention: skip if already running from interval ticker
-				if ts.isTaskRunning(name) {
-					_ = progress.Log("info", fmt.Sprintf("Task %s already running (interval), skipping", name), nil)
-					skipped = append(skipped, name)
-					continue
-				}
-
-				_ = progress.UpdateProgress(i, len(eligible), fmt.Sprintf("Running task %d/%d: %s", i+1, len(eligible), name))
-				_ = progress.Log("info", fmt.Sprintf("Starting maintenance task: %s", name), nil)
-				ran++
-
-				taskOp, taskErr := ts.runTask(name, taskSource)
-				if taskErr != nil {
-					errMsg := taskErr.Error()
-					failures = append(failures, taskFailure{name, errMsg})
-					_ = progress.Log("error", fmt.Sprintf("Task %s failed to start: %v", name, taskErr), nil)
-					activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, name,
-						fmt.Sprintf("Task %s failed to start: %s", name, errMsg),
-						activity.Scheduled, mwTag)
-				} else if taskOp != nil {
-					// Wait for the task operation to complete before starting next
-					ts.waitForOperation(innerCtx, taskOp.ID)
-					completedOp, _ := store.GetOperationByID(taskOp.ID)
-					if completedOp != nil && completedOp.Status == "failed" {
-						errMsg := ""
-						if completedOp.ErrorMessage != nil {
-							errMsg = *completedOp.ErrorMessage
-						}
-						failures = append(failures, taskFailure{name, errMsg})
-						_ = progress.Log("warning", fmt.Sprintf("Task %s operation failed: %s", name, errMsg), nil)
-						activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, name,
-							fmt.Sprintf("Task %s failed: %s", name, errMsg),
-							windowStartTags...)
-					} else {
-						msg := completedOp.Message
-						_ = progress.Log("info", fmt.Sprintf("Task %s completed: %s (op: %s)", name, msg, taskOp.ID), nil)
-						activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, name,
-							fmt.Sprintf("Task %s ok: %s", name, msg),
-							windowStartTags...)
-					}
-				} else {
-					_ = progress.Log("info", fmt.Sprintf("Task %s triggered (no operation)", name), nil)
-					activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, name,
-						fmt.Sprintf("Task %s triggered", name),
-						windowStartTags...)
-				}
-			}
-
-			summaryParts := []string{fmt.Sprintf("%d/%d tasks ran", ran, len(eligible))}
-			if len(failures) > 0 {
-				failNames := make([]string, len(failures))
-				for i, f := range failures {
-					if f.errMsg != "" {
-						failNames[i] = f.name + ": " + f.errMsg
-					} else {
-						failNames[i] = f.name
-					}
-				}
-				summaryParts = append(summaryParts, fmt.Sprintf("%d failed: %s", len(failures), strings.Join(failNames, "; ")))
-			}
-			if len(skipped) > 0 {
-				summaryParts = append(summaryParts, fmt.Sprintf("%d skipped: %s", len(skipped), strings.Join(skipped, ", ")))
-			}
-			summary := strings.Join(summaryParts, ", ")
-
-			if len(failures) > 0 {
-				_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed with errors")
-				activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
-					"Maintenance window done (errors): "+summary,
-					windowStartTags...)
-				return fmt.Errorf("maintenance window: %s", summary)
-			}
-			_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed successfully")
-			activity.EmitInfo(ts.server.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
-				"Maintenance window done: "+summary,
-				windowStartTags...)
-			return nil
-		},
-	)
+	ignoreWindow := ctx.Value(ignoreWindowKey) != nil
+	if _, err := ts.server.opRegistry.EnqueueOp(context.Background(), "maintenance.window", maintenanceWindowOpParams{
+		LegacyOpID:   opID,
+		IgnoreWindow: ignoreWindow,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue maintenance-window: %w", err)
+	}
 	return nil
 }
 

--- a/internal/server/scheduler_maintenance_window_op.go
+++ b/internal/server/scheduler_maintenance_window_op.go
@@ -1,0 +1,219 @@
+// file: internal/server/scheduler_maintenance_window_op.go
+// version: 1.0.0
+// guid: 2a4b6c8d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+type maintenanceWindowOpParams struct {
+	LegacyOpID   string `json:"legacy_op_id"`
+	IgnoreWindow bool   `json:"ignore_window"`
+}
+
+// RegisterMaintenanceWindowOp registers the "maintenance.window" OperationDef which
+// runs all maintenance-window-eligible tasks in order, respecting the configured
+// maintenance window unless IgnoreWindow is set.
+func (s *Server) RegisterMaintenanceWindowOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "maintenance.window",
+		Plugin:          "maintenance",
+		DisplayName:     "Maintenance Window",
+		Description:     "Run all maintenance-window-eligible tasks in order.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         12 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "maintenance.window",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p maintenanceWindowOpParams
+			if err := json.Unmarshal(rawParams, &p); err != nil {
+				return fmt.Errorf("maintenance.window: decode params: %w", err)
+			}
+
+			opID := p.LegacyOpID
+			ignoreWindow := p.IgnoreWindow
+			ts := s.scheduler
+
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("maintenance.window: database not initialized")
+			}
+			if ts == nil {
+				return fmt.Errorf("maintenance.window: scheduler not initialized")
+			}
+
+			progress := registryProgressAdapter{r: reporter}
+
+			// Step 1: Auto-update (if enabled and not already completed post-restart)
+			if config.AppConfig.AutoUpdateEnabled {
+				updateDone, _ := store.GetSetting("maintenance_window_update_completed")
+				today := time.Now().Format("2006-01-02")
+				if updateDone == nil || updateDone.Value != today {
+					_ = progress.Log("info", "Running auto-update (step 1)", nil)
+					_ = progress.UpdateProgress(0, 100, "Running auto-update...")
+					_ = store.SetSetting("maintenance_window_update_completed", today, "string", false)
+					if s.updater != nil {
+						channel := config.AppConfig.AutoUpdateChannel
+						info, checkErr := s.updater.CheckForUpdate(channel)
+						if checkErr != nil {
+							_ = progress.Log("warning", fmt.Sprintf("Auto-update check failed: %v", checkErr), nil)
+						} else if info != nil && info.UpdateAvailable {
+							_ = progress.Log("info", fmt.Sprintf("Update available: %s, applying...", info.LatestVersion), nil)
+							if applyErr := s.updater.DownloadAndReplace(info); applyErr != nil {
+								_ = progress.Log("error", fmt.Sprintf("Auto-update apply failed: %v", applyErr), nil)
+							} else {
+								_ = progress.Log("info", "Update applied, server will restart", nil)
+								go s.updater.RestartSelf()
+								return nil // Exit — server restarting
+							}
+						} else {
+							_ = progress.Log("info", "No update available", nil)
+						}
+					}
+					_ = progress.Log("info", "Auto-update step complete", nil)
+				} else {
+					_ = progress.Log("info", "Auto-update already completed today, skipping", nil)
+				}
+			}
+
+			// Step 2+: Maintenance tasks in order
+			var eligible []string
+			for _, name := range ts.maintenanceOrder {
+				task, ok := ts.tasks[name]
+				if !ok {
+					continue
+				}
+				if task.IsEnabled() && task.RunInMaintenanceWindow != nil && task.RunInMaintenanceWindow() {
+					eligible = append(eligible, name)
+				}
+			}
+
+			mwTag := "mw:" + opID
+			taskSource := operations.TriggerScheduled
+			if ignoreWindow {
+				taskSource = operations.TriggerManual
+			}
+			windowStartTags := []string{activity.Scheduled, mwTag}
+			if ignoreWindow {
+				windowStartTags = []string{activity.AlwaysShow, mwTag}
+			}
+
+			_ = progress.Log("info", fmt.Sprintf("Maintenance window starting: %d tasks eligible: %s", len(eligible), strings.Join(eligible, ", ")), nil)
+			activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
+				fmt.Sprintf("Maintenance window starting: %d tasks: %s", len(eligible), strings.Join(eligible, ", ")),
+				windowStartTags...)
+
+			type taskFailure struct{ name, errMsg string }
+			var failures []taskFailure
+			var skipped []string
+			ran := 0
+
+			for i, name := range eligible {
+				// Check if window is still open (skip for manual "Run Now" triggers)
+				if !ignoreWindow && !isInMaintenanceWindow() {
+					remaining := eligible[i:]
+					_ = progress.Log("warning", fmt.Sprintf("Maintenance window closed after task %d/%d, skipping: %s", i, len(eligible), strings.Join(remaining, ", ")), nil)
+					skipped = append(skipped, remaining...)
+					break
+				}
+
+				// Duplicate prevention: skip if already running from interval ticker
+				if ts.isTaskRunning(name) {
+					_ = progress.Log("info", fmt.Sprintf("Task %s already running (interval), skipping", name), nil)
+					skipped = append(skipped, name)
+					continue
+				}
+
+				_ = progress.UpdateProgress(i, len(eligible), fmt.Sprintf("Running task %d/%d: %s", i+1, len(eligible), name))
+				_ = progress.Log("info", fmt.Sprintf("Starting maintenance task: %s", name), nil)
+				ran++
+
+				taskOp, taskErr := ts.runTask(name, taskSource)
+				if taskErr != nil {
+					errMsg := taskErr.Error()
+					failures = append(failures, taskFailure{name, errMsg})
+					_ = progress.Log("error", fmt.Sprintf("Task %s failed to start: %v", name, taskErr), nil)
+					activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, name,
+						fmt.Sprintf("Task %s failed to start: %s", name, errMsg),
+						activity.Scheduled, mwTag)
+				} else if taskOp != nil {
+					// Wait for the task operation to complete before starting next
+					ts.waitForOperation(ctx, taskOp.ID)
+					completedOp, _ := store.GetOperationByID(taskOp.ID)
+					if completedOp != nil && completedOp.Status == "failed" {
+						errMsg := ""
+						if completedOp.ErrorMessage != nil {
+							errMsg = *completedOp.ErrorMessage
+						}
+						failures = append(failures, taskFailure{name, errMsg})
+						_ = progress.Log("warning", fmt.Sprintf("Task %s operation failed: %s", name, errMsg), nil)
+						activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, name,
+							fmt.Sprintf("Task %s failed: %s", name, errMsg),
+							windowStartTags...)
+					} else {
+						msg := completedOp.Message
+						_ = progress.Log("info", fmt.Sprintf("Task %s completed: %s (op: %s)", name, msg, taskOp.ID), nil)
+						activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, name,
+							fmt.Sprintf("Task %s ok: %s", name, msg),
+							windowStartTags...)
+					}
+				} else {
+					_ = progress.Log("info", fmt.Sprintf("Task %s triggered (no operation)", name), nil)
+					activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, name,
+						fmt.Sprintf("Task %s triggered", name),
+						windowStartTags...)
+				}
+			}
+
+			summaryParts := []string{fmt.Sprintf("%d/%d tasks ran", ran, len(eligible))}
+			if len(failures) > 0 {
+				failNames := make([]string, len(failures))
+				for i, f := range failures {
+					if f.errMsg != "" {
+						failNames[i] = f.name + ": " + f.errMsg
+					} else {
+						failNames[i] = f.name
+					}
+				}
+				summaryParts = append(summaryParts, fmt.Sprintf("%d failed: %s", len(failures), strings.Join(failNames, "; ")))
+			}
+			if len(skipped) > 0 {
+				summaryParts = append(summaryParts, fmt.Sprintf("%d skipped: %s", len(skipped), strings.Join(skipped, ", ")))
+			}
+			summary := strings.Join(summaryParts, ", ")
+
+			if len(failures) > 0 {
+				_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed with errors")
+				activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
+					"Maintenance window done (errors): "+summary,
+					windowStartTags...)
+				return fmt.Errorf("maintenance window: %s", summary)
+			}
+			_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed successfully")
+			activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
+				"Maintenance window done: "+summary,
+				windowStartTags...)
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMaintenanceWindowOp(reg) })
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-08
 
@@ -34,7 +34,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/transcode"
 	"github.com/jdfalk/audiobook-organizer/internal/watcher"
-	ulid "github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
@@ -522,21 +521,11 @@ func (s *Server) Start(cfg ServerConfig) error {
 							Data: map[string]any{"path": path},
 						})
 					}
-					if s.scanService != nil && s.queue != nil {
+					if s.scanService != nil && s.opRegistry != nil {
 						go func() {
 							scanPath := path
-							id := ulid.Make().String()
-							op, opErr := s.Store().CreateOperation(id, "scan", &scanPath)
-							if opErr != nil {
-								watchLog.Error("Auto-scan: failed to create operation: %v", opErr)
-								return
-							}
-							scanReq := &scanner.ScanRequest{FolderPath: &scanPath}
-							opFunc := func(ctx context.Context, progress operations.ProgressReporter) error {
-								return s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
-							}
-							if enqueueErr := s.queue.Enqueue(op.ID, "scan", operations.PriorityLow, opFunc); enqueueErr != nil {
-								watchLog.Error("Auto-scan: failed to enqueue: %v", enqueueErr)
+							if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{FolderPath: &scanPath}); enqErr != nil {
+								watchLog.Error("Auto-scan: failed to enqueue: %v", enqErr)
 							}
 						}()
 					}


### PR DESCRIPTION
## Summary

- **maintenance_job_op.go** (new): registers `maintenance.job` OperationDef — runs any named maintenance job by ID; `runMaintenanceJob` HTTP handler now calls `opRegistry.EnqueueOp` instead of `queue.Enqueue`
- **scheduler_maintenance_window_op.go** (new): registers `maintenance.window` OperationDef (12h timeout, ConcurrencyKey prevents double-run, `IgnoreWindow` param captures the caller-ctx value at enqueue time)
- **maintenance_dispatcher.go**: replace queue.Enqueue with EnqueueOp; drop unused `context` import; bump 1.3.0 → 1.4.0
- **scheduler_maintenance.go**: replace queue.Enqueue closure with EnqueueOp; `IgnoreWindow` extracted from ctx before enqueueing; bump 1.0.0 → 1.1.0
- **server_lifecycle.go**: file-watcher auto-scan uses pure v2 `opRegistry.EnqueueOp("library.scan")`; drops orphan v1 op creation; removes now-unused `ulid` import; bump 1.8.0 → 1.9.0

## Test plan

- [ ] `make build-api` passes (verified locally)
- [ ] Trigger a maintenance job via the UI and confirm it completes
- [ ] Trigger a maintenance window run and confirm all eligible tasks execute in order
- [ ] Drop a file into a watched folder and confirm auto-scan fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)