### PR TITLE
feat(ops): migrate all remaining scheduler tasks and resume path to v2

### DIFF
--- a/internal/server/scheduler_extra_ops.go
+++ b/internal/server/scheduler_extra_ops.go
@@ -1,0 +1,689 @@
+// file: internal/server/scheduler_extra_ops.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-fedc-ba9876543210
+
+// scheduler_extra_ops registers OperationDefs for the 13 remaining scheduler
+// tasks that previously used the legacy triggerOperation / triggerOperationWithID
+// helpers. Each def extracts the closure logic from scheduler_tasks.go into a
+// typed Run func so the UOS v2 dispatcher can manage lifecycle, cancellation,
+// and concurrency without the old BridgeQueue.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/dedup"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// schedulerExtraOpParams carries the v1 operation ID from the TriggerFn into
+// the Run func, enabling the Run func to write results back to the v1 record.
+type schedulerExtraOpParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}
+
+// --- dedup-llm-review ---
+
+// RegisterDedupLLMReviewOp registers the scheduler.dedup-llm-review OperationDef.
+func (s *Server) RegisterDedupLLMReviewOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.dedup-llm-review",
+		Plugin:          "scheduler",
+		DisplayName:     "Dedup LLM Review",
+		Description:     "Run LLM review on ambiguous dedup candidates.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.dedup-llm-review",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			if s.dedupEngine == nil {
+				_ = progress.Log("info", "Dedup engine not initialized, skipping LLM review", nil)
+				return nil
+			}
+			_ = progress.Log("info", "Starting LLM review of ambiguous dedup candidates", nil)
+			return s.dedupEngine.RunLLMReview(ctx)
+		},
+	})
+}
+
+// --- trash-cleanup ---
+
+// RegisterTrashCleanupOp registers the scheduler.trash-cleanup OperationDef.
+func (s *Server) RegisterTrashCleanupOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.trash-cleanup",
+		Plugin:          "scheduler",
+		DisplayName:     "Trash Cleanup",
+		Description:     "Purge trashed book versions past their 14-day TTL.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.trash-cleanup",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			purged := CleanupTrashedVersions(s.Store())
+			_ = progress.Log("info", fmt.Sprintf("Trash cleanup: purged %d versions", purged), nil)
+			return nil
+		},
+	})
+}
+
+// --- archive-sweep ---
+
+// RegisterArchiveSweepOp registers the scheduler.archive-sweep OperationDef.
+func (s *Server) RegisterArchiveSweepOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.archive-sweep",
+		Plugin:          "scheduler",
+		DisplayName:     "Archive Sweep",
+		Description:     "Remove soft-deleted books past the 30-day retention window.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.archive-sweep",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			cleaned := SweepArchivedBooks(s.Store())
+			_ = progress.Log("info", fmt.Sprintf("Archive sweep: cleaned %d books", cleaned), nil)
+			return nil
+		},
+	})
+}
+
+// --- metadata-upgrade ---
+
+// RegisterMetadataUpgradeOp registers the scheduler.metadata-upgrade OperationDef.
+func (s *Server) RegisterMetadataUpgradeOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.metadata-upgrade",
+		Plugin:          "scheduler",
+		DisplayName:     "Metadata Upgrade",
+		Description:     "Upgrade metadata from lower-quality sources to richer ones when a high-confidence match is available.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.metadata-upgrade",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			if s.metadataFetchService == nil {
+				return fmt.Errorf("metadata fetch service not initialized")
+			}
+			svc := NewMetadataUpgradeService(s.Store(), s.metadataFetchService)
+			_ = progress.Log("info", "Scanning for books with upgradeable metadata sources...", nil)
+			result, err := svc.RunUpgrade(ctx, 200)
+			if err != nil {
+				return err
+			}
+			msg := fmt.Sprintf("Metadata upgrade complete: checked %d, upgraded %d, skipped %d, errors %d",
+				result.Checked, result.Upgraded, result.Skipped, result.Errors)
+			_ = progress.Log("info", msg, nil)
+			_ = progress.UpdateProgress(100, 100, msg)
+			return nil
+		},
+	})
+}
+
+// --- author-split-scan ---
+
+// RegisterAuthorSplitScanOp registers the scheduler.author-split-scan OperationDef.
+func (s *Server) RegisterAuthorSplitScanOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.author-split-scan",
+		Plugin:          "scheduler",
+		DisplayName:     "Author Split Scan",
+		Description:     "Find and split composite author names into individual author records.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.author-split-scan",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("database not initialized")
+			}
+			_ = progress.Log("info", "Starting author split scan", nil)
+			authors, err := store.GetAllAuthors()
+			if err != nil {
+				return fmt.Errorf("failed to get authors: %w", err)
+			}
+			_ = progress.Log("info", fmt.Sprintf("Scanning %d authors for composite names...", len(authors)), nil)
+
+			splitCount := 0
+			booksUpdated := 0
+			errCount := 0
+			total := len(authors)
+
+			for i, author := range authors {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				parts := dedup.SplitCompositeAuthorName(author.Name)
+				if len(parts) <= 1 {
+					if (i+1)%200 == 0 {
+						_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors", i+1, total))
+					}
+					continue
+				}
+
+				// Actually split: create/find individual authors
+				var newAuthors []database.Author
+				for _, name := range parts {
+					name = strings.TrimSpace(name)
+					if name == "" {
+						continue
+					}
+					existing, err := store.GetAuthorByName(name)
+					if err == nil && existing != nil {
+						newAuthors = append(newAuthors, *existing)
+						continue
+					}
+					created, err := store.CreateAuthor(name)
+					if err != nil {
+						errCount++
+						_ = progress.Log("warning", fmt.Sprintf("Failed to create author %q: %v", name, err), nil)
+						continue
+					}
+					newAuthors = append(newAuthors, *created)
+				}
+				if len(newAuthors) == 0 {
+					continue
+				}
+
+				// Re-link all books from composite author to individual authors
+				books, err := store.GetBooksByAuthorIDWithRole(author.ID)
+				if err != nil {
+					errCount++
+					_ = progress.Log("warning", fmt.Sprintf("Failed to get books for author %q: %v", author.Name, err), nil)
+					continue
+				}
+
+				for _, book := range books {
+					bookAuthors, err := store.GetBookAuthors(book.ID)
+					if err != nil {
+						continue
+					}
+					role := "author"
+					for _, ba := range bookAuthors {
+						if ba.AuthorID == author.ID {
+							role = ba.Role
+							break
+						}
+					}
+					var updated []database.BookAuthor
+					for _, ba := range bookAuthors {
+						if ba.AuthorID != author.ID {
+							updated = append(updated, ba)
+						}
+					}
+					for _, na := range newAuthors {
+						alreadyLinked := false
+						for _, ba := range updated {
+							if ba.AuthorID == na.ID {
+								alreadyLinked = true
+								break
+							}
+						}
+						if !alreadyLinked {
+							updated = append(updated, database.BookAuthor{
+								BookID:   book.ID,
+								AuthorID: na.ID,
+								Role:     role,
+								Position: len(updated),
+							})
+						}
+					}
+					if err := store.SetBookAuthors(book.ID, updated); err != nil {
+						errCount++
+						continue
+					}
+					// Update primary AuthorID to first individual author
+					if book.AuthorID != nil && *book.AuthorID == author.ID && len(newAuthors) > 0 {
+						firstID := newAuthors[0].ID
+						book.AuthorID = &firstID
+						_, _ = store.UpdateBook(book.ID, &book)
+					}
+					booksUpdated++
+				}
+
+				// Delete the composite author record
+				if err := store.DeleteAuthor(author.ID); err != nil {
+					_ = progress.Log("warning", fmt.Sprintf("Failed to delete composite author %q: %v", author.Name, err), nil)
+					errCount++
+				} else {
+					splitCount++
+					partNames := fmt.Sprintf("%v", parts)
+					_ = progress.Log("info", fmt.Sprintf("Split %q → %s (%d books updated)", author.Name, partNames, len(books)), nil)
+				}
+
+				if (i+1)%200 == 0 || splitCount%50 == 0 {
+					_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors, split %d so far", i+1, total, splitCount))
+				}
+			}
+
+			// Invalidate dedup cache since authors changed
+			if s.dedupCache != nil {
+				s.dedupCache.Invalidate("author-duplicates")
+			}
+
+			resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors)", splitCount, booksUpdated, errCount)
+			_ = progress.Log("info", resultMsg, nil)
+			_ = progress.UpdateProgress(total, total, resultMsg)
+			return nil
+		},
+	})
+}
+
+// --- db-optimize ---
+
+// RegisterDBOptimizeOp registers the scheduler.db-optimize OperationDef.
+func (s *Server) RegisterDBOptimizeOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.db-optimize",
+		Plugin:          "scheduler",
+		DisplayName:     "Database Optimize",
+		Description:     "Optimize database (VACUUM/compact) for the main, AI scan, and OpenLibrary stores.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.db-optimize",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("database not initialized")
+			}
+
+			storesOptimized := 0
+			storesTotal := 3
+			startTotal := time.Now()
+
+			// 1. Main store
+			_ = progress.Log("info", "Optimizing main database (VACUUM, ANALYZE, WAL checkpoint)...", nil)
+			_ = progress.UpdateProgress(0, storesTotal, "Optimizing main database...")
+			t1 := time.Now()
+			if err := store.Optimize(); err != nil {
+				_ = progress.Log("error", fmt.Sprintf("Main DB optimization failed: %v", err), nil)
+			} else {
+				storesOptimized++
+				_ = progress.Log("info", fmt.Sprintf("Main database optimized in %s", time.Since(t1).Round(time.Millisecond)), nil)
+			}
+
+			// 2. AI scan store
+			_ = progress.UpdateProgress(1, storesTotal, "Optimizing AI scan database...")
+			if s.aiScanStore != nil {
+				t2 := time.Now()
+				if err := s.aiScanStore.Optimize(); err != nil {
+					_ = progress.Log("error", fmt.Sprintf("AI scan DB optimization failed: %v", err), nil)
+				} else {
+					storesOptimized++
+					_ = progress.Log("info", fmt.Sprintf("AI scan database optimized in %s", time.Since(t2).Round(time.Millisecond)), nil)
+				}
+			} else {
+				_ = progress.Log("info", "AI scan store not initialized, skipping", nil)
+			}
+
+			// 3. OpenLibrary store (accessed via olService)
+			_ = progress.UpdateProgress(2, storesTotal, "Optimizing OpenLibrary cache...")
+			if s.olService != nil && s.olService.Store() != nil {
+				t3 := time.Now()
+				if err := s.olService.Store().Optimize(); err != nil {
+					_ = progress.Log("error", fmt.Sprintf("OL cache optimization failed: %v", err), nil)
+				} else {
+					storesOptimized++
+					_ = progress.Log("info", fmt.Sprintf("OpenLibrary cache optimized in %s", time.Since(t3).Round(time.Millisecond)), nil)
+				}
+			} else {
+				_ = progress.Log("info", "OpenLibrary store not initialized, skipping", nil)
+			}
+
+			_ = progress.UpdateProgress(storesTotal, storesTotal,
+				fmt.Sprintf("Database optimization complete: %d/%d stores in %s",
+					storesOptimized, storesTotal, time.Since(startTotal).Round(time.Millisecond)))
+			return nil
+		},
+	})
+}
+
+// --- cleanup-old-backups ---
+
+// RegisterCleanupOldBackupsOp registers the scheduler.cleanup-old-backups OperationDef.
+func (s *Server) RegisterCleanupOldBackupsOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.cleanup-old-backups",
+		Plugin:          "scheduler",
+		DisplayName:     "Cleanup Old Backups",
+		Description:     "Remove old .bak-* backup files past the configured retention period.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.cleanup-old-backups",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			rootDir := config.AppConfig.RootDir
+			if rootDir == "" {
+				_ = progress.Log("info", "No root directory configured, skipping backup cleanup", nil)
+				return nil
+			}
+			retentionDays := config.AppConfig.PurgeSoftDeletedAfterDays
+			if retentionDays <= 0 {
+				retentionDays = 30
+			}
+			maxAge := time.Duration(retentionDays) * 24 * time.Hour
+			removed := 0
+			_ = progress.Log("info", fmt.Sprintf("Scanning %s for .bak-* files older than %d days", rootDir, retentionDays), nil)
+
+			err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				if err != nil || info.IsDir() {
+					return nil
+				}
+				if strings.Contains(info.Name(), ".bak-") {
+					age := time.Since(info.ModTime())
+					if age > maxAge {
+						if rmErr := os.Remove(path); rmErr != nil {
+							log.Printf("[WARN] failed to remove old backup: %s: %v", path, rmErr)
+						} else {
+							removed++
+							log.Printf("[INFO] cleaned up old backup: %s (age: %s)", path, age.Round(time.Hour))
+						}
+					}
+				}
+				return nil
+			})
+			_ = progress.Log("info", fmt.Sprintf("Backup cleanup complete: removed %d file(s)", removed), nil)
+			return err
+		},
+	})
+}
+
+// --- isbn-enrichment ---
+
+// RegisterISBNEnrichmentOp registers the scheduler.isbn-enrichment OperationDef.
+func (s *Server) RegisterISBNEnrichmentOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.isbn-enrichment",
+		Plugin:          "scheduler",
+		DisplayName:     "ISBN Enrichment",
+		Description:     "Enrich missing ISBN identifiers from external metadata sources.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.isbn-enrichment",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p schedulerExtraOpParams
+			if err := json.Unmarshal(rawParams, &p); err != nil {
+				return fmt.Errorf("isbn-enrichment: decode params: %w", err)
+			}
+			progress := registryProgressAdapter{r: reporter}
+			return s.runIsbnEnrichment(ctx, progress, p.LegacyOpID)
+		},
+	})
+}
+
+// --- temp-file-cleanup ---
+
+// RegisterTempFileCleanupOp registers the scheduler.temp-file-cleanup OperationDef.
+func (s *Server) RegisterTempFileCleanupOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.temp-file-cleanup",
+		Plugin:          "scheduler",
+		DisplayName:     "Temp File Cleanup",
+		Description:     "Remove orphaned *.tmp.m4b / *.tmp.m4a files left by crashed ffmpeg operations.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.temp-file-cleanup",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p schedulerExtraOpParams
+			if err := json.Unmarshal(rawParams, &p); err != nil {
+				return fmt.Errorf("temp-file-cleanup: decode params: %w", err)
+			}
+			progress := registryProgressAdapter{r: reporter}
+			removed := cleanupOrphanedTempFiles(config.AppConfig.RootDir, s.activityWriter, p.LegacyOpID)
+			activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+			msg := fmt.Sprintf("Removed %d orphaned temp files", removed)
+			_ = progress.Log("info", msg, nil)
+			activity.EmitInfo(s.activityWriter, p.LegacyOpID, "temp-file-cleanup", "temp-file-cleanup", msg,
+				activity.TagsIf(removed == 0, activity.NoOpTag)...)
+			return nil
+		},
+	})
+}
+
+// --- purge-deleted ---
+
+// RegisterPurgeDeletedOp registers the scheduler.purge-deleted OperationDef.
+func (s *Server) RegisterPurgeDeletedOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.purge-deleted",
+		Plugin:          "scheduler",
+		DisplayName:     "Purge Soft-Deleted",
+		Description:     "Purge soft-deleted books past their retention period.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.purge-deleted",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			var p schedulerExtraOpParams
+			if err := json.Unmarshal(rawParams, &p); err != nil {
+				return fmt.Errorf("purge-deleted: decode params: %w", err)
+			}
+			progress := registryProgressAdapter{r: reporter}
+			_ = progress.Log("info", "Starting purge of soft-deleted books", nil)
+			_ = progress.UpdateProgress(0, 100, "Purging soft-deleted books...")
+			s.runAutoPurgeSoftDeleted(p.LegacyOpID)
+			activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+			_ = progress.Log("info", "Purge complete", nil)
+			_ = progress.UpdateProgress(100, 100, "Purge complete")
+			return nil
+		},
+	})
+}
+
+// --- tombstone-cleanup ---
+
+// RegisterTombstoneCleanupOp registers the scheduler.tombstone-cleanup OperationDef.
+func (s *Server) RegisterTombstoneCleanupOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.tombstone-cleanup",
+		Plugin:          "scheduler",
+		DisplayName:     "Tombstone Cleanup",
+		Description:     "Resolve author tombstone chains (A→B→C becomes A→C).",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         1 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.tombstone-cleanup",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("database not initialized")
+			}
+			_ = progress.Log("info", "Starting author tombstone chain resolution", nil)
+			_ = progress.UpdateProgress(0, 100, "Resolving tombstone chains...")
+			updated, err := store.ResolveTombstoneChains()
+			if err != nil {
+				return fmt.Errorf("tombstone chain resolution failed: %w", err)
+			}
+			resultMsg := fmt.Sprintf("Resolved %d tombstone chains", updated)
+			_ = progress.Log("info", resultMsg, nil)
+			_ = progress.UpdateProgress(100, 100, resultMsg)
+			return nil
+		},
+	})
+}
+
+// --- resolve-production-authors ---
+
+// RegisterResolveProductionAuthorsOp registers the scheduler.resolve-production-authors OperationDef.
+func (s *Server) RegisterResolveProductionAuthorsOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.resolve-production-authors",
+		Plugin:          "scheduler",
+		DisplayName:     "Resolve Production Authors",
+		Description:     "Resolve real authors for production company entries.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.resolve-production-authors",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("database not initialized")
+			}
+			_ = progress.Log("info", "Starting production author resolution", nil)
+			authors, err := store.GetAllAuthors()
+			if err != nil {
+				return fmt.Errorf("failed to get authors: %w", err)
+			}
+
+			var prodAuthors []database.Author
+			for _, a := range authors {
+				if dedup.IsProductionCompany(a.Name) {
+					prodAuthors = append(prodAuthors, a)
+				}
+			}
+
+			_ = progress.Log("info", fmt.Sprintf("Found %d production company authors", len(prodAuthors)), nil)
+			total := len(prodAuthors)
+			resolved := 0
+			for i, author := range prodAuthors {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				books, err := store.GetBooksByAuthorIDWithRole(author.ID)
+				if err != nil {
+					continue
+				}
+				for _, book := range books {
+					if s.metadataFetchService == nil {
+						continue
+					}
+					resp, fetchErr := s.metadataFetchService.FetchMetadataForBookByTitle(book.ID)
+					if fetchErr == nil && resp != nil && resp.Book != nil && resp.Book.AuthorID != nil {
+						newAuthor, _ := store.GetAuthorByID(*resp.Book.AuthorID)
+						if newAuthor != nil && !dedup.IsProductionCompany(newAuthor.Name) {
+							resolved++
+						}
+					}
+				}
+				_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Processed %d/%d production companies (%d books resolved)", i+1, total, resolved))
+			}
+
+			if s.dedupCache != nil {
+				s.dedupCache.Invalidate("author-duplicates")
+			}
+
+			resultMsg := fmt.Sprintf("Resolved %d books across %d production companies", resolved, total)
+			_ = progress.Log("info", resultMsg, nil)
+			_ = progress.UpdateProgress(total, total, resultMsg)
+			return nil
+		},
+	})
+}
+
+// --- metadata-refresh ---
+
+// RegisterMetadataRefreshOp registers the scheduler.metadata-refresh OperationDef.
+func (s *Server) RegisterMetadataRefreshOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "scheduler.metadata-refresh",
+		Plugin:          "scheduler",
+		DisplayName:     "Metadata Refresh",
+		Description:     "Re-fetch metadata for incomplete books.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "scheduler.metadata-refresh",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
+		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
+			progress := registryProgressAdapter{r: reporter}
+			return s.runMetadataRefreshScan(ctx, progress)
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterDedupLLMReviewOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterTrashCleanupOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterArchiveSweepOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMetadataUpgradeOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterAuthorSplitScanOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterDBOptimizeOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterCleanupOldBackupsOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterISBNEnrichmentOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterTempFileCleanupOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterPurgeDeletedOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterTombstoneCleanupOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterResolveProductionAuthorsOp(reg) })
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterMetadataRefreshOp(reg) })
+}

--- a/internal/server/scheduler_tasks.go
+++ b/internal/server/scheduler_tasks.go
@@ -1,7 +1,7 @@
 // file: internal/server/scheduler_tasks.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 4ed1afbd-7c63-487a-9a53-3b1b05eb06ee
-// last-edited: 2026-05-10
+// last-edited: 2026-05-11
 
 package server
 
@@ -9,17 +9,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/dedup"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
-	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -33,12 +26,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Scan library for new/changed audiobooks (incremental by default, use force_update for full rescan)",
 		Category:    "library",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("scan", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				if s.scanService == nil {
-					return fmt.Errorf("scan service not initialized")
-				}
-				return s.scanService.PerformScan(ctx, &scanner.ScanRequest{}, operations.LoggerFromReporter(progress))
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "scan", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "library.scan", libraryScanParams{}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue library.scan: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return config.AppConfig.ScanOnStartup }, // reuse existing field
 		GetInterval:            func() time.Duration { return 0 },                     // manual only by default
@@ -51,12 +51,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Organize audiobooks into folder structure",
 		Category:    "library",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("organize", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				if s.organizeService == nil {
-					return fmt.Errorf("organize service not initialized")
-				}
-				return s.organizeService.PerformOrganize(ctx, &OrganizeRequest{}, operations.LoggerFromReporter(progress))
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "organize", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "library.organize", libraryOrganizeParams{}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue library.organize: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -69,9 +76,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Transcode audiobooks to target format",
 		Category:    "library",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("transcode", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				return fmt.Errorf("transcode requires parameters — use the operations API directly")
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "transcode", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			// Transcode requires specific params — cannot be triggered from the scheduler
+			// without book_id. Mark the operation as failed immediately.
+			_ = store.UpdateOperationError(op.ID, "transcode requires parameters — use the operations API directly")
+			log.Printf("[WARN] transcode task triggered from scheduler (%s) without params — use the operations API", source)
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -89,57 +107,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Refresh author & series dedup cache",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("author-dedup-scan", source, func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				startMsg := fmt.Sprintf("Starting author dedup scan")
-				_ = progress.Log("info", startMsg, nil)
-				_ = progress.UpdateProgress(0, 100, "Fetching authors...")
-				if operations.IsManual(ctx) {
-					activity.EmitInfo(ts.server.activityWriter, opID, "author-dedup-scan", "dedup-refresh", startMsg, activity.AlwaysShow)
-				}
-				authors, err := store.GetAllAuthors()
-				if err != nil {
-					return fmt.Errorf("failed to get authors: %w", err)
-				}
-
-				bookCounts, _ := store.GetAllAuthorBookCounts()
-				booksWithCounts := 0
-				for _, cnt := range bookCounts {
-					if cnt > 0 {
-						booksWithCounts++
-					}
-				}
-				msg := fmt.Sprintf("Fetched %d authors (%d with book counts), running duplicate comparison...", len(authors), booksWithCounts)
-				_ = progress.Log("info", msg, nil)
-				_ = progress.UpdateProgress(25, 100, msg)
-				if operations.IsManual(ctx) {
-					activity.EmitInfo(ts.server.activityWriter, opID, "author-dedup-scan", "dedup-refresh", msg, activity.AlwaysShow)
-				}
-
-				total := len(authors)
-				groups := dedup.FindDuplicateAuthors(authors, 0.85, func(id int) int { return bookCounts[id] },
-					func(current, t int, message string) {
-						pct := 25 + (70 * current / total)
-						_ = progress.UpdateProgress(pct, 100, message)
-						if current%500 == 0 {
-							_ = progress.Log("debug", message, nil)
-						}
-					},
-				)
-
-				resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors", len(groups), total)
-				_ = progress.Log("info", resultMsg, nil)
-				_ = progress.UpdateProgress(100, 100, resultMsg)
-				tags := activity.TagsIf(len(groups) == 0, activity.NoOpTag)
-				if operations.IsManual(ctx) {
-					tags = append(tags, activity.AlwaysShow)
-				}
-				activity.EmitInfo(ts.server.activityWriter, opID, "author-dedup-scan", "dedup-refresh", resultMsg, tags...)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "author-dedup-scan", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := authorDedupScanOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "dedup.author-scan", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue dedup.author-scan: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledDedupRefreshEnabled },
 		GetInterval: func() time.Duration {
@@ -158,14 +139,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Run LLM review on ambiguous dedup candidates",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("dedup-llm-review", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				if ts.server.dedupEngine == nil {
-					_ = progress.Log("info", "Dedup engine not initialized, skipping LLM review", nil)
-					return nil
-				}
-				_ = progress.Log("info", "Starting LLM review of ambiguous dedup candidates", nil)
-				return ts.server.dedupEngine.RunLLMReview(ctx)
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "dedup-llm-review", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.dedup-llm-review", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.dedup-llm-review: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return ts.server.dedupEngine != nil },
 		GetInterval:            func() time.Duration { return 0 },
@@ -178,13 +164,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Merge duplicate series and delete orphans",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("series-prune", source, func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				return s.executeSeriesPrune(ctx, store, progress, opID)
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "series-prune", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := seriesPruneOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "dedup.series-prune", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue dedup.series-prune: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledSeriesPruneEnabled },
 		GetInterval: func() time.Duration {
@@ -203,27 +196,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Strip title/position contamination from series names and run write-back + organize for affected books",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("series-normalize", source, func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				enqueueWB := func(bookID string) {
-					if ts.server.writeBackBatcher != nil {
-						ts.server.writeBackBatcher.Enqueue(bookID)
-					}
-				}
-				affected, err := executeSeriesNormalizeCore(ctx, store, enqueueWB)
-				msg := fmt.Sprintf("Series normalize complete: %d series affected, %d books enqueued for write-back",
-					len(affected), len(affected))
-				_ = progress.Log("info", msg, nil)
-				tags := activity.TagsIf(len(affected) == 0, activity.NoOpTag)
-				if operations.IsManual(ctx) {
-					tags = append(tags, activity.AlwaysShow)
-				}
-				activity.EmitInfo(ts.server.activityWriter, opID, "series-normalize", "series-normalize", msg, tags...)
-				return err
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "series-normalize", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := seriesNormalizeOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "dedup.series-normalize", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue dedup.series-normalize: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -236,7 +222,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Enrich missing ISBN identifiers from external metadata sources",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("isbn-enrichment", source, s.runIsbnEnrichment)
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "isbn-enrichment", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := schedulerExtraOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.isbn-enrichment", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.isbn-enrichment: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return s.metadataFetchService != nil && s.metadataFetchService.ISBNEnrichment() != nil },
 		GetInterval:            func() time.Duration { return 0 },
@@ -251,15 +250,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Remove orphaned *.tmp.m4b / *.tmp.m4a files left by crashed ffmpeg operations",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("temp-file-cleanup", source, func(_ context.Context, progress operations.ProgressReporter, opID string) error {
-				removed := cleanupOrphanedTempFiles(config.AppConfig.RootDir, ts.server.activityWriter, opID)
-				activity.FlushOperation(ts.server.activityWriter, opID)
-				msg := fmt.Sprintf("Removed %d orphaned temp files", removed)
-				_ = progress.Log("info", msg, nil)
-				activity.EmitInfo(ts.server.activityWriter, opID, "temp-file-cleanup", "temp-file-cleanup", msg,
-					activity.TagsIf(removed == 0, activity.NoOpTag)...)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "temp-file-cleanup", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := schedulerExtraOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.temp-file-cleanup", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.temp-file-cleanup: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -272,11 +276,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Purge trashed book versions past their 14-day TTL",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("trash-cleanup", source, func(_ context.Context, progress operations.ProgressReporter) error {
-				purged := CleanupTrashedVersions(s.Store())
-				_ = progress.Log("info", fmt.Sprintf("Trash cleanup: purged %d versions", purged), nil)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "trash-cleanup", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.trash-cleanup", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.trash-cleanup: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -289,11 +301,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Remove soft-deleted books past the 30-day retention window",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("archive-sweep", source, func(_ context.Context, progress operations.ProgressReporter) error {
-				cleaned := SweepArchivedBooks(s.Store())
-				_ = progress.Log("info", fmt.Sprintf("Archive sweep: cleaned %d books", cleaned), nil)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "archive-sweep", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.archive-sweep", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.archive-sweep: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
@@ -306,22 +326,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Upgrade metadata from lower-quality sources (Google Books, Wikipedia) to richer ones (Hardcover, Audible) when a high-confidence match is available",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("metadata-upgrade", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				if s.metadataFetchService == nil {
-					return fmt.Errorf("metadata fetch service not initialized")
-				}
-				svc := NewMetadataUpgradeService(ts.server.Store(), s.metadataFetchService)
-				_ = progress.Log("info", "Scanning for books with upgradeable metadata sources...", nil)
-				result, err := svc.RunUpgrade(ctx, 200)
-				if err != nil {
-					return err
-				}
-				msg := fmt.Sprintf("Metadata upgrade complete: checked %d, upgraded %d, skipped %d, errors %d",
-					result.Checked, result.Upgraded, result.Skipped, result.Errors)
-				_ = progress.Log("info", msg, nil)
-				_ = progress.UpdateProgress(100, 100, msg)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "metadata-upgrade", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.metadata-upgrade", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.metadata-upgrade: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return s.metadataFetchService != nil },
 		GetInterval:            func() time.Duration { return 0 },
@@ -334,141 +351,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Find & split composite author names",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("author-split-scan", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				_ = progress.Log("info", "Starting author split scan", nil)
-				authors, err := store.GetAllAuthors()
-				if err != nil {
-					return fmt.Errorf("failed to get authors: %w", err)
-				}
-				_ = progress.Log("info", fmt.Sprintf("Scanning %d authors for composite names...", len(authors)), nil)
-
-				splitCount := 0
-				booksUpdated := 0
-				errCount := 0
-				total := len(authors)
-
-				for i, author := range authors {
-					if ctx.Err() != nil {
-						return ctx.Err()
-					}
-
-					parts := dedup.SplitCompositeAuthorName(author.Name)
-					if len(parts) <= 1 {
-						if (i+1)%200 == 0 {
-							_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors", i+1, total))
-						}
-						continue
-					}
-
-					// Actually split: create/find individual authors
-					var newAuthors []database.Author
-					for _, name := range parts {
-						name = strings.TrimSpace(name)
-						if name == "" {
-							continue
-						}
-						existing, err := store.GetAuthorByName(name)
-						if err == nil && existing != nil {
-							newAuthors = append(newAuthors, *existing)
-							continue
-						}
-						created, err := store.CreateAuthor(name)
-						if err != nil {
-							errCount++
-							_ = progress.Log("warning", fmt.Sprintf("Failed to create author %q: %v", name, err), nil)
-							continue
-						}
-						newAuthors = append(newAuthors, *created)
-					}
-					if len(newAuthors) == 0 {
-						continue
-					}
-
-					// Re-link all books from composite author to individual authors
-					books, err := store.GetBooksByAuthorIDWithRole(author.ID)
-					if err != nil {
-						errCount++
-						_ = progress.Log("warning", fmt.Sprintf("Failed to get books for author %q: %v", author.Name, err), nil)
-						continue
-					}
-
-					for _, book := range books {
-						bookAuthors, err := store.GetBookAuthors(book.ID)
-						if err != nil {
-							continue
-						}
-						role := "author"
-						for _, ba := range bookAuthors {
-							if ba.AuthorID == author.ID {
-								role = ba.Role
-								break
-							}
-						}
-						var updated []database.BookAuthor
-						for _, ba := range bookAuthors {
-							if ba.AuthorID != author.ID {
-								updated = append(updated, ba)
-							}
-						}
-						for _, na := range newAuthors {
-							alreadyLinked := false
-							for _, ba := range updated {
-								if ba.AuthorID == na.ID {
-									alreadyLinked = true
-									break
-								}
-							}
-							if !alreadyLinked {
-								updated = append(updated, database.BookAuthor{
-									BookID:   book.ID,
-									AuthorID: na.ID,
-									Role:     role,
-									Position: len(updated),
-								})
-							}
-						}
-						if err := store.SetBookAuthors(book.ID, updated); err != nil {
-							errCount++
-							continue
-						}
-						// Update primary AuthorID to first individual author
-						if book.AuthorID != nil && *book.AuthorID == author.ID && len(newAuthors) > 0 {
-							firstID := newAuthors[0].ID
-							book.AuthorID = &firstID
-							_, _ = store.UpdateBook(book.ID, &book)
-						}
-						booksUpdated++
-					}
-
-					// Delete the composite author record
-					if err := store.DeleteAuthor(author.ID); err != nil {
-						_ = progress.Log("warning", fmt.Sprintf("Failed to delete composite author %q: %v", author.Name, err), nil)
-						errCount++
-					} else {
-						splitCount++
-						partNames := fmt.Sprintf("%v", parts)
-						_ = progress.Log("info", fmt.Sprintf("Split %q → %s (%d books updated)", author.Name, partNames, len(books)), nil)
-					}
-
-					if (i+1)%200 == 0 || splitCount%50 == 0 {
-						_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors, split %d so far", i+1, total, splitCount))
-					}
-				}
-
-				// Invalidate dedup cache since authors changed
-				if s.dedupCache != nil {
-					s.dedupCache.Invalidate("author-duplicates")
-				}
-
-				resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors)", splitCount, booksUpdated, errCount)
-				_ = progress.Log("info", resultMsg, nil)
-				_ = progress.UpdateProgress(total, total, resultMsg)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "author-split-scan", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.author-split-scan", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.author-split-scan: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledAuthorSplitEnabled },
 		GetInterval: func() time.Duration {
@@ -487,59 +382,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Optimize database (VACUUM/compact)",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("db-optimize", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-
-				storesOptimized := 0
-				storesTotal := 3
-
-				startTotal := time.Now()
-
-				// 1. Main store
-				_ = progress.Log("info", "Optimizing main database (VACUUM, ANALYZE, WAL checkpoint)...", nil)
-				_ = progress.UpdateProgress(0, storesTotal, "Optimizing main database...")
-				t1 := time.Now()
-				if err := store.Optimize(); err != nil {
-					_ = progress.Log("error", fmt.Sprintf("Main DB optimization failed: %v", err), nil)
-				} else {
-					storesOptimized++
-					_ = progress.Log("info", fmt.Sprintf("Main database optimized in %s", time.Since(t1).Round(time.Millisecond)), nil)
-				}
-
-				// 2. AI scan store
-				_ = progress.UpdateProgress(1, storesTotal, "Optimizing AI scan database...")
-				if s.aiScanStore != nil {
-					t2 := time.Now()
-					if err := s.aiScanStore.Optimize(); err != nil {
-						_ = progress.Log("error", fmt.Sprintf("AI scan DB optimization failed: %v", err), nil)
-					} else {
-						storesOptimized++
-						_ = progress.Log("info", fmt.Sprintf("AI scan database optimized in %s", time.Since(t2).Round(time.Millisecond)), nil)
-					}
-				} else {
-					_ = progress.Log("info", "AI scan store not initialized, skipping", nil)
-				}
-
-				// 3. OpenLibrary store (accessed via olService)
-				_ = progress.UpdateProgress(2, storesTotal, "Optimizing OpenLibrary cache...")
-				if s.olService != nil && s.olService.Store() != nil {
-					t3 := time.Now()
-					if err := s.olService.Store().Optimize(); err != nil {
-						_ = progress.Log("error", fmt.Sprintf("OL cache optimization failed: %v", err), nil)
-					} else {
-						storesOptimized++
-						_ = progress.Log("info", fmt.Sprintf("OpenLibrary cache optimized in %s", time.Since(t3).Round(time.Millisecond)), nil)
-					}
-				} else {
-					_ = progress.Log("info", "OpenLibrary store not initialized, skipping", nil)
-				}
-
-				_ = progress.UpdateProgress(storesTotal, storesTotal, fmt.Sprintf("Database optimization complete: %d/%d stores in %s", storesOptimized, storesTotal, time.Since(startTotal).Round(time.Millisecond)))
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "db-optimize", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.db-optimize", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.db-optimize: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledDbOptimizeEnabled },
 		GetInterval: func() time.Duration {
@@ -558,46 +413,22 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Remove old .bak-* backup files past retention",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("cleanup-old-backups", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				rootDir := config.AppConfig.RootDir
-				if rootDir == "" {
-					_ = progress.Log("info", "No root directory configured, skipping backup cleanup", nil)
-					return nil
-				}
-				retentionDays := config.AppConfig.PurgeSoftDeletedAfterDays
-				if retentionDays <= 0 {
-					retentionDays = 30
-				}
-				maxAge := time.Duration(retentionDays) * 24 * time.Hour
-				removed := 0
-				_ = progress.Log("info", fmt.Sprintf("Scanning %s for .bak-* files older than %d days", rootDir, retentionDays), nil)
-
-				err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
-					if ctx.Err() != nil {
-						return ctx.Err()
-					}
-					if err != nil || info.IsDir() {
-						return nil
-					}
-					if strings.Contains(info.Name(), ".bak-") {
-						age := time.Since(info.ModTime())
-						if age > maxAge {
-							if rmErr := os.Remove(path); rmErr != nil {
-								log.Printf("[WARN] failed to remove old backup: %s: %v", path, rmErr)
-							} else {
-								removed++
-								log.Printf("[INFO] cleaned up old backup: %s (age: %s)", path, age.Round(time.Hour))
-							}
-						}
-					}
-					return nil
-				})
-				_ = progress.Log("info", fmt.Sprintf("Backup cleanup complete: removed %d file(s)", removed), nil)
-				return err
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "cleanup-old-backups", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.cleanup-old-backups", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.cleanup-old-backups: %w", enqErr)
+			}
+			return op, nil
 		},
-		IsEnabled:              func() bool { return config.AppConfig.MaintenanceWindowDbOptimize }, // enabled when maintenance window backup cleanup is on
-		GetInterval:            func() time.Duration { return 0 },                                  // manual or maintenance window only
+		IsEnabled:              func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
+		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
 	})
@@ -607,15 +438,20 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Purge soft-deleted books past retention",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperationWithID("purge-deleted", source, func(ctx context.Context, progress operations.ProgressReporter, opID string) error {
-				_ = progress.Log("info", "Starting purge of soft-deleted books", nil)
-				_ = progress.UpdateProgress(0, 100, "Purging soft-deleted books...")
-				s.runAutoPurgeSoftDeleted(opID)
-				activity.FlushOperation(ts.server.activityWriter, opID)
-				_ = progress.Log("info", "Purge complete", nil)
-				_ = progress.UpdateProgress(100, 100, "Purge complete")
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "purge-deleted", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := schedulerExtraOpParams{LegacyOpID: op.ID}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.purge-deleted", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.purge-deleted: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.PurgeSoftDeletedAfterDays > 0 },
 		GetInterval: func() time.Duration {
@@ -633,22 +469,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Resolve author tombstone chains (A→B→C becomes A→C)",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("tombstone-cleanup", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				_ = progress.Log("info", "Starting author tombstone chain resolution", nil)
-				_ = progress.UpdateProgress(0, 100, "Resolving tombstone chains...")
-				updated, err := store.ResolveTombstoneChains()
-				if err != nil {
-					return fmt.Errorf("tombstone chain resolution failed: %w", err)
-				}
-				resultMsg := fmt.Sprintf("Resolved %d tombstone chains", updated)
-				_ = progress.Log("info", resultMsg, nil)
-				_ = progress.UpdateProgress(100, 100, resultMsg)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "tombstone-cleanup", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.tombstone-cleanup", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.tombstone-cleanup: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 24 * time.Hour },
@@ -661,59 +494,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Resolve real authors for production company entries",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("resolve-production-authors", source, func(ctx context.Context, progress operations.ProgressReporter) error {
-				store := ts.server.Store()
-				if store == nil {
-					return fmt.Errorf("database not initialized")
-				}
-				_ = progress.Log("info", "Starting production author resolution", nil)
-				authors, err := store.GetAllAuthors()
-				if err != nil {
-					return fmt.Errorf("failed to get authors: %w", err)
-				}
-
-				var prodAuthors []database.Author
-				for _, a := range authors {
-					if dedup.IsProductionCompany(a.Name) {
-						prodAuthors = append(prodAuthors, a)
-					}
-				}
-
-				_ = progress.Log("info", fmt.Sprintf("Found %d production company authors", len(prodAuthors)), nil)
-				total := len(prodAuthors)
-				resolved := 0
-				for i, author := range prodAuthors {
-					if ctx.Err() != nil {
-						return ctx.Err()
-					}
-					books, err := store.GetBooksByAuthorIDWithRole(author.ID)
-					if err != nil {
-						continue
-					}
-					for _, book := range books {
-						if s.metadataFetchService == nil {
-							continue
-						}
-						resp, fetchErr := s.metadataFetchService.FetchMetadataForBookByTitle(book.ID)
-						if fetchErr == nil && resp != nil && resp.Book != nil && resp.Book.AuthorID != nil {
-							newAuthor, _ := store.GetAuthorByID(*resp.Book.AuthorID)
-							if newAuthor != nil && !dedup.IsProductionCompany(newAuthor.Name) {
-								resolved++
-							}
-						}
-					}
-					_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Processed %d/%d production companies (%d books resolved)", i+1, total, resolved))
-				}
-
-				if s.dedupCache != nil {
-					s.dedupCache.Invalidate("author-duplicates")
-				}
-
-				resultMsg := fmt.Sprintf("Resolved %d books across %d production companies", resolved, total)
-				_ = progress.Log("info", resultMsg, nil)
-				_ = progress.UpdateProgress(total, total, resultMsg)
-				return nil
-			})
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "resolve-production-authors", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.resolve-production-authors", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.resolve-production-authors: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledResolveProductionAuthorsEnabled },
 		GetInterval: func() time.Duration {
@@ -732,7 +525,19 @@ func (ts *TaskScheduler) registerAllTasks() {
 		Description: "Re-fetch metadata for incomplete books",
 		Category:    "maintenance",
 		TriggerFn: func(source string) (*database.Operation, error) {
-			return ts.triggerOperation("metadata-refresh", source, s.runMetadataRefreshScan)
+			store := ts.server.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "metadata-refresh", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.server.opRegistry.EnqueueOp(context.Background(), "scheduler.metadata-refresh", schedulerExtraOpParams{LegacyOpID: op.ID}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue scheduler.metadata-refresh: %w", enqErr)
+			}
+			return op, nil
 		},
 		IsEnabled: func() bool { return config.AppConfig.ScheduledMetadataRefreshEnabled },
 		GetInterval: func() time.Duration {
@@ -898,4 +703,3 @@ func (ts *TaskScheduler) registerAllTasks() {
 		RunInMaintenanceWindow: func() bool { return true },
 	})
 }
-

--- a/internal/server/scheduler_triggers.go
+++ b/internal/server/scheduler_triggers.go
@@ -1,7 +1,11 @@
 // file: internal/server/scheduler_triggers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 03dbb3f6-0076-484c-b55f-5f59c649402d
-// last-edited: 2026-05-02
+// last-edited: 2026-05-11
+// NOTE: triggerOperation and triggerOperationWithID are now dead code — all
+// TriggerFns in scheduler_tasks.go have been migrated to the hybrid UOS v2
+// pattern (create v1 op record + opRegistry.EnqueueOp). These helpers are
+// retained for the transition period and will be removed once v1 is fully retired.
 
 package server
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-08
+// last-edited: 2026-05-11
 
 package server
 
@@ -95,28 +95,47 @@ func (s *Server) resumeInterruptedOperations() {
 				return s.organizeService.PerformOrganizeWithID(ctx, opID, &OrganizeRequest{}, operations.LoggerFromReporter(progress))
 			}
 		case "bulk_write_back":
+			// Migrated to UOS (library.bulk-write-back); re-enqueue via registry on resume.
 			params, _ := operations.LoadParams[operations.BulkWriteBackParams](store, opID)
 			if params == nil {
 				log.Printf("[WARN] No params for interrupted bulk_write_back %s, marking failed", opID)
 				_ = store.UpdateOperationError(opID, "no saved params, cannot resume")
 				continue
 			}
-			startIdx := 0
-			if checkpoint != nil {
-				startIdx = checkpoint.PhaseIndex
+			if s.opRegistry != nil {
+				enqParams := bulkWriteBackOpParams{BookIDs: params.BookIDs, Rename: params.Rename}
+				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "library.bulk-write-back", enqParams); enqErr != nil {
+					log.Printf("[WARN] Failed to re-enqueue bulk_write_back %s via v2: %v", opID, enqErr)
+					_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())
+				}
+			} else {
+				_ = store.UpdateOperationError(opID, "operation registry not available")
 			}
-			bookIDs := params.BookIDs
-			doRename := params.Rename
-			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
-				return s.runBulkWriteBack(ctx, opID, bookIDs, doRename, startIdx, progress)
-			}
+			continue
 		case "isbn-enrichment":
-			isbnOpID := opID
-			resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
-				return s.runIsbnEnrichment(ctx, progress, isbnOpID)
+			// Migrated to UOS (scheduler.isbn-enrichment); re-enqueue via registry on resume.
+			if s.opRegistry != nil {
+				enqParams := schedulerExtraOpParams{LegacyOpID: opID}
+				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "scheduler.isbn-enrichment", enqParams); enqErr != nil {
+					log.Printf("[WARN] Failed to re-enqueue isbn-enrichment %s via v2: %v", opID, enqErr)
+					_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())
+				}
+			} else {
+				_ = store.UpdateOperationError(opID, "operation registry not available")
 			}
+			continue
 		case "metadata-refresh":
-			resumeFn = s.runMetadataRefreshScan
+			// Migrated to UOS (scheduler.metadata-refresh); re-enqueue via registry on resume.
+			if s.opRegistry != nil {
+				enqParams := schedulerExtraOpParams{LegacyOpID: opID}
+				if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "scheduler.metadata-refresh", enqParams); enqErr != nil {
+					log.Printf("[WARN] Failed to re-enqueue metadata-refresh %s via v2: %v", opID, enqErr)
+					_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())
+				}
+			} else {
+				_ = store.UpdateOperationError(opID, "operation registry not available")
+			}
+			continue
 		case "itunes_path_reconcile":
 			// Migrated to UOS (itunes.path-reconcile); re-enqueue via registry on resume.
 			if s.opRegistry != nil {
@@ -146,25 +165,35 @@ func (s *Server) resumeInterruptedOperations() {
 			_ = operations.ClearState(store, opID)
 			continue
 		default:
-			// Try to resume as a maintenance job
-			if j, jobErr := maintenance.Get(strings.TrimPrefix(opType, "maintenance:")); jobErr == nil && j.CanResume() {
-				capturedOpID := opID
-				capturedJob := j
-				capturedStore := store
-				resumeFn = func(ctx context.Context, progress operations.ProgressReporter) error {
-					ctx = maintenance.WithOperationID(ctx, capturedOpID)
-					adapter := &progressAdapter{ops: progress}
-					return capturedJob.Run(ctx, capturedStore, adapter, false)
+			// Try to resume as a maintenance job via v2 registry (maintenance.job).
+			jobID := strings.TrimPrefix(opType, "maintenance:")
+			if j, jobErr := maintenance.Get(jobID); jobErr == nil && j.CanResume() {
+				if s.opRegistry != nil {
+					enqParams := maintenanceJobOpParams{LegacyOpID: opID, JobID: jobID}
+					if _, enqErr := s.opRegistry.EnqueueOp(context.Background(), "maintenance.job", enqParams); enqErr != nil {
+						log.Printf("[WARN] Failed to re-enqueue maintenance job %s (%s) via v2: %v", opID, jobID, enqErr)
+						_ = store.UpdateOperationError(opID, "failed to resume: "+enqErr.Error())
+					}
+				} else {
+					_ = store.UpdateOperationError(opID, "operation registry not available")
 				}
 			} else {
 				_ = store.UpdateOperationError(opID, "interrupted, cannot resume")
 				_ = operations.ClearState(store, opID)
-				continue
 			}
+			continue
 		}
 
-		if err := s.queue.EnqueueResume(opID, opType, operations.PriorityNormal, resumeFn); err != nil {
-			log.Printf("[WARN] Failed to re-enqueue operation %s: %v", opID, err)
+		// Fallback: v1 queue for scan/organize cases that still use resumeFn.
+		if resumeFn != nil {
+			if s.queue != nil {
+				if err := s.queue.EnqueueResume(opID, opType, operations.PriorityNormal, resumeFn); err != nil {
+					log.Printf("[WARN] Failed to re-enqueue operation %s: %v", opID, err)
+				}
+			} else {
+				log.Printf("[WARN] Cannot resume operation %s (%s): queue not initialized", opID, opType)
+				_ = store.UpdateOperationError(opID, "queue not initialized, cannot resume")
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `internal/server/scheduler_extra_ops.go` with 13 new `OperationDef` registrations covering all scheduler tasks that previously ran through the legacy `BridgeQueue`: `dedup-llm-review`, `trash-cleanup`, `archive-sweep`, `metadata-upgrade`, `author-split-scan`, `db-optimize`, `cleanup-old-backups`, `isbn-enrichment`, `temp-file-cleanup`, `purge-deleted`, `tombstone-cleanup`, `resolve-production-authors`, and `metadata-refresh`
- Rewrites all 19 `TriggerFn` closures in `scheduler_tasks.go` (v1.3.0 → v1.4.0) to use the hybrid UOS v2 pattern: create v1 op record for backward-compat polling, then call `opRegistry.EnqueueOp`; removes all uses of the legacy `triggerOperation`/`triggerOperationWithID` helpers
- Migrates `bulk_write_back`, `isbn-enrichment`, and `metadata-refresh` resume cases in `resumeInterruptedOperations()` to `EnqueueOp + continue` (no longer uses `queue.EnqueueResume`)
- Migrates default maintenance job resume case to use `maintenance.job` via `opRegistry` instead of `queue.EnqueueResume`
- Marks `scheduler_triggers.go` dead-code helpers (retained until v1 is fully retired)

## Test plan

- [x] `make build-api` passes cleanly (zero compiler errors)
- [x] `go vet ./internal/server/` passes with no warnings
- [x] `go test ./internal/operations/...` passes (registry + dispatcher tests)
- [x] All 13 new OperationDefs registered via `addOpRegistrar` in `init()` — picked up automatically at server startup
- [x] No more calls to `triggerOperation`/`triggerOperationWithID` from `scheduler_tasks.go`
- [ ] Deploy and verify scheduler tasks appear in `/api/v1/op-defs` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)