### PR TITLE
refactor(sysinfo): extract DashboardService to internal/sysinfo

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,7 +156,7 @@ type Server struct {
 	configUpdateService    *ConfigUpdateService
 	systemService          *sysinfo.SystemService
 	metadataStateService   *MetadataStateService
-	dashboardService       *DashboardService
+	dashboardService       *sysinfo.DashboardService
 	olService              *metafetch.OpenLibraryService
 	dedupCache             *cache.Cache[gin.H]
 	listCache              *cache.Cache[gin.H]
@@ -306,7 +306,7 @@ func NewServer(store database.Store) *Server {
 		configUpdateService:    NewConfigUpdateService(resolvedStore),
 		systemService:          sysinfo.NewSystemService(resolvedStore, appVersion, calculateLibrarySizes),
 		metadataStateService:   NewMetadataStateService(resolvedStore),
-		dashboardService:       NewDashboardService(resolvedStore),
+		dashboardService:       sysinfo.NewDashboardService(resolvedStore),
 		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),
 		listCache:              cache.New[gin.H]("list", 24*time.Hour),
 		facetsCache:            cache.New[gin.H]("facets", 24*time.Hour),

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1369,7 +1369,7 @@ func TestAudiobookService_GetSoftDeletedBooks_NilDB(t *testing.T) {
 func TestDashboardService_GetHealthCheckResponse_Degraded(t *testing.T) {
 	// Use nil db to trigger the error path in CollectDashboardMetrics
 	// (individual DB call errors are swallowed, only nil db returns error)
-	svc := &DashboardService{db: nil}
+	svc := sysinfo.NewDashboardService(nil)
 
 	resp := svc.GetHealthCheckResponse("1.0.0")
 	if resp.Status != "degraded" {

--- a/internal/sysinfo/dashboard_service.go
+++ b/internal/sysinfo/dashboard_service.go
@@ -1,8 +1,8 @@
-// file: internal/server/dashboard_service.go
+// file: internal/sysinfo/dashboard_service.go
 // version: 1.3.0
 // guid: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
 
-package server
+package sysinfo
 
 import (
 	"fmt"

--- a/internal/sysinfo/dashboard_service_test.go
+++ b/internal/sysinfo/dashboard_service_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/dashboard_service_test.go
+// file: internal/sysinfo/dashboard_service_test.go
 // version: 1.1.0
 // guid: a0b1c2d3-e4f5-6a7b-8c9d-0e1f2a3b4c5d
 
-package server
+package sysinfo
 
 import (
 	"testing"


### PR DESCRIPTION
## Summary

- Moves `DashboardService` (5 methods: CollectDashboardMetrics, GetHealthCheckResponse, CollectLibraryStats, CollectQuickMetrics + all supporting types) from `internal/server` to `internal/sysinfo`
- All 5 unit tests move to `internal/sysinfo/dashboard_service_test.go`
- `server.go` field type changes from `*DashboardService` → `*sysinfo.DashboardService`
- Part of run `2026-05-11-1728-svc-extract` (wave 1 server thinning)

## Test plan

- [x] `internal/sysinfo` — 5 DashboardService tests pass
- [x] Build passes (`go build ./...`)
- [x] Server package still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)