### PR TITLE
refactor(config): extract ConfigUpdateService to internal/config

### DIFF
--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,8 +1,8 @@
-// file: internal/server/config_update_service.go
+// file: internal/config/update_service.go
 // version: 3.0.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 
-package server
+package config
 
 import (
 	"encoding/json"
@@ -11,22 +11,21 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
 
-// ConfigUpdateService handles applying and persisting config changes.
-type ConfigUpdateService struct {
-	db database.Store
+// UpdateService handles applying and persisting config changes.
+type UpdateService struct {
+	DB database.Store
 }
 
-// NewConfigUpdateService creates a new ConfigUpdateService.
-func NewConfigUpdateService(db database.Store) *ConfigUpdateService {
-	return &ConfigUpdateService{db: db}
+// NewUpdateService creates a new UpdateService.
+func NewUpdateService(db database.Store) *UpdateService {
+	return &UpdateService{DB: db}
 }
 
 // ValidateUpdate checks that the payload is non-empty.
-func (cus *ConfigUpdateService) ValidateUpdate(payload map[string]any) error {
+func (us *UpdateService) ValidateUpdate(payload map[string]any) error {
 	if len(payload) == 0 {
 		return fmt.Errorf("no configuration updates provided")
 	}
@@ -34,7 +33,7 @@ func (cus *ConfigUpdateService) ValidateUpdate(payload map[string]any) error {
 }
 
 // MaskSecrets returns a copy of cfg with all secret fields masked for API responses.
-func (cus *ConfigUpdateService) MaskSecrets(cfg config.Config) config.Config {
+func (us *UpdateService) MaskSecrets(cfg Config) Config {
 	masked := cfg
 	if masked.OpenAIAPIKey != "" {
 		masked.OpenAIAPIKey = database.MaskSecret(masked.OpenAIAPIKey)
@@ -67,10 +66,10 @@ var immutableFieldKeys = []string{"database_type", "enable_sqlite"}
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
 // json.Unmarshal only overwrites keys present in the JSON, so absent keys leave
-// AppConfig unchanged. This means any new field added to config.Config is
+// AppConfig unchanged. This means any new field added to Config is
 // automatically handled here with no registration required.
-func (cus *ConfigUpdateService) UpdateConfig(payload map[string]any) (int, map[string]any) {
-	if cus.db == nil {
+func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]any) {
+	if us.DB == nil {
 		return http.StatusInternalServerError, map[string]any{"error": "database not initialized"}
 	}
 	if payload == nil {
@@ -88,16 +87,16 @@ func (cus *ConfigUpdateService) UpdateConfig(payload map[string]any) (int, map[s
 	// flow through the JSON round-trip to avoid plaintext exposure.
 	if val, ok := payloadString(payload, "openai_api_key"); ok {
 		log.Printf("[DEBUG] UpdateConfig: updating OpenAI API key (len=%d)", len(val))
-		config.AppConfig.OpenAIAPIKey = val
+		AppConfig.OpenAIAPIKey = val
 	}
 	if val, ok := payloadString(payload, "google_books_api_key"); ok {
-		config.AppConfig.GoogleBooksAPIKey = val
+		AppConfig.GoogleBooksAPIKey = val
 	}
 	if val, ok := payloadString(payload, "hardcover_api_token"); ok {
-		config.AppConfig.HardcoverAPIToken = val
+		AppConfig.HardcoverAPIToken = val
 	}
 	if val, ok := payloadString(payload, "basic_auth_password"); ok {
-		config.AppConfig.BasicAuthPassword = val
+		AppConfig.BasicAuthPassword = val
 	}
 
 	// Build filtered payload without secrets (already applied above)
@@ -110,20 +109,20 @@ func (cus *ConfigUpdateService) UpdateConfig(payload map[string]any) (int, map[s
 	}
 
 	// Apply all remaining fields via JSON round-trip.
-	// Any field in config.Config with a matching json tag is set automatically.
+	// Any field in Config with a matching json tag is set automatically.
 	payloadJSON, err := json.Marshal(filtered)
 	if err != nil {
 		return http.StatusBadRequest, map[string]any{"error": "failed to encode payload: " + err.Error()}
 	}
-	if err := json.Unmarshal(payloadJSON, &config.AppConfig); err != nil {
+	if err := json.Unmarshal(payloadJSON, &AppConfig); err != nil {
 		return http.StatusBadRequest, map[string]any{"error": "failed to apply config: " + err.Error()}
 	}
 
 	// Post-process: trim root_dir whitespace, derive setup_complete
-	config.AppConfig.RootDir = strings.TrimSpace(config.AppConfig.RootDir)
-	config.AppConfig.SetupComplete = config.AppConfig.RootDir != ""
+	AppConfig.RootDir = strings.TrimSpace(AppConfig.RootDir)
+	AppConfig.SetupComplete = AppConfig.RootDir != ""
 
-	if err := config.SaveConfigToDatabase(cus.db); err != nil {
+	if err := SaveConfigToDatabase(us.DB); err != nil {
 		log.Printf("ERROR: failed to persist config: %v", err)
 		return http.StatusInternalServerError, map[string]any{
 			"error":   "failed to save configuration",
@@ -135,7 +134,7 @@ func (cus *ConfigUpdateService) UpdateConfig(payload map[string]any) (int, map[s
 
 	return http.StatusOK, map[string]any{
 		"message": "configuration updated and saved to database",
-		"config":  cus.MaskSecrets(config.AppConfig),
+		"config":  us.MaskSecrets(AppConfig),
 	}
 }
 
@@ -151,8 +150,8 @@ func payloadString(payload map[string]any, key string) (string, bool) {
 
 // ApplyUpdates applies config updates and persists them.
 // Deprecated: prefer UpdateConfig directly.
-func (cus *ConfigUpdateService) ApplyUpdates(payload map[string]any) error {
-	status, resp := cus.UpdateConfig(payload)
+func (us *UpdateService) ApplyUpdates(payload map[string]any) error {
+	status, resp := us.UpdateConfig(payload)
 	if status >= 400 {
 		if errMsg, ok := resp["error"].(string); ok {
 			return fmt.Errorf("%s", errMsg)

--- a/internal/config/update_service_test.go
+++ b/internal/config/update_service_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/config_update_service_test.go
+// file: internal/config/update_service_test.go
 // version: 1.2.0
 // guid: e5f6g7h8-i9j0-k1l2-m3n4-o5p6q7r8s9t0
 
-package server
+package config
 
 import (
 	"testing"
@@ -10,13 +10,12 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/util"
 
-	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	"github.com/stretchr/testify/mock"
 )
 
-func TestConfigUpdateService_ValidateUpdate_EmptyPayload(t *testing.T) {
-	service := NewConfigUpdateService(nil)
+func TestUpdateService_ValidateUpdate_EmptyPayload(t *testing.T) {
+	service := NewUpdateService(nil)
 
 	err := service.ValidateUpdate(map[string]any{})
 
@@ -25,7 +24,7 @@ func TestConfigUpdateService_ValidateUpdate_EmptyPayload(t *testing.T) {
 	}
 }
 
-func TestConfigUpdateService_ExtractStringField(t *testing.T) {
+func TestUpdateService_ExtractStringField(t *testing.T) {
 	payload := map[string]any{
 		"root_dir": "/library",
 	}
@@ -37,7 +36,7 @@ func TestConfigUpdateService_ExtractStringField(t *testing.T) {
 	}
 }
 
-func TestConfigUpdateService_ExtractBoolField(t *testing.T) {
+func TestUpdateService_ExtractBoolField(t *testing.T) {
 	payload := map[string]any{
 		"auto_organize": true,
 	}
@@ -49,7 +48,7 @@ func TestConfigUpdateService_ExtractBoolField(t *testing.T) {
 	}
 }
 
-func TestConfigUpdateService_ExtractIntField(t *testing.T) {
+func TestUpdateService_ExtractIntField(t *testing.T) {
 	payload := map[string]any{
 		"concurrent_scans": float64(4),
 	}
@@ -61,26 +60,26 @@ func TestConfigUpdateService_ExtractIntField(t *testing.T) {
 	}
 }
 
-func TestConfigUpdateService_ApplyUpdates_Success(t *testing.T) {
+func TestUpdateService_ApplyUpdates_Success(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
-	service := NewConfigUpdateService(mockStore)
+	service := NewUpdateService(mockStore)
 
 	updates := map[string]any{
 		"root_dir": "/new/library",
 	}
 
-	originalDir := config.AppConfig.RootDir
+	originalDir := AppConfig.RootDir
 	defer func() {
-		config.AppConfig.RootDir = originalDir
+		AppConfig.RootDir = originalDir
 	}()
 
 	if err := service.ApplyUpdates(updates); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if config.AppConfig.RootDir != "/new/library" {
-		t.Errorf("expected '/new/library', got %q", config.AppConfig.RootDir)
+	if AppConfig.RootDir != "/new/library" {
+		t.Errorf("expected '/new/library', got %q", AppConfig.RootDir)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.15.0
+// version: 2.16.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-08
+// last-edited: 2026-05-11
 
 package server
 
@@ -153,7 +153,7 @@ type Server struct {
 	scanService            *scanner.ScanService
 	organizeService        *OrganizeService
 	metadataFetchService   *metafetch.Service
-	configUpdateService    *ConfigUpdateService
+	configUpdateService    *config.UpdateService
 	systemService          *sysinfo.SystemService
 	metadataStateService   *MetadataStateService
 	dashboardService       *DashboardService
@@ -303,7 +303,7 @@ func NewServer(store database.Store) *Server {
 		scanService:            scanner.NewScanService(resolvedStore),
 		organizeService:        NewOrganizeService(resolvedStore),
 		metadataFetchService:   metafetch.NewService(resolvedStore),
-		configUpdateService:    NewConfigUpdateService(resolvedStore),
+		configUpdateService:    config.NewUpdateService(resolvedStore),
 		systemService:          sysinfo.NewSystemService(resolvedStore, appVersion, calculateLibrarySizes),
 		metadataStateService:   NewMetadataStateService(resolvedStore),
 		dashboardService:       NewDashboardService(resolvedStore),

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/service_layer_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-05-01
+// last-edited: 2026-05-11
 
 package server
 
@@ -28,7 +28,7 @@ import (
 // TestConfigUpdateService_MaskSecrets tests MaskSecrets method
 func TestConfigUpdateService_MaskSecrets(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	tests := []struct {
 		name     string
@@ -77,7 +77,7 @@ func TestConfigUpdateService_MaskSecrets(t *testing.T) {
 // TestConfigUpdateService_ApplyUpdates_ErrorCases tests error cases for ApplyUpdates
 func TestConfigUpdateService_ApplyUpdates_ErrorCases(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	tests := []struct {
 		name      string
@@ -128,7 +128,7 @@ func TestConfigUpdateService_ApplyUpdates_ArrayFields(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	originalPatterns := config.AppConfig.ExcludePatterns
 	originalExtensions := config.AppConfig.SupportedExtensions
@@ -654,7 +654,7 @@ func TestApplyOverrideToPayload(t *testing.T) {
 // TestConfigUpdateService_UpdateConfig tests UpdateConfig method
 func TestConfigUpdateService_UpdateConfig(t *testing.T) {
 	t.Run("nil db returns error", func(t *testing.T) {
-		svc := &ConfigUpdateService{db: nil}
+		svc := &config.UpdateService{DB: nil}
 		status, resp := svc.UpdateConfig(map[string]any{"root_dir": "/test"})
 		if status != 500 {
 			t.Errorf("expected 500, got %d", status)
@@ -666,7 +666,7 @@ func TestConfigUpdateService_UpdateConfig(t *testing.T) {
 
 	t.Run("database_type rejected", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewConfigUpdateService(mockStore)
+		svc := config.NewUpdateService(mockStore)
 		status, resp := svc.UpdateConfig(map[string]any{"database_type": "mysql"})
 		if status != 400 {
 			t.Errorf("expected 400, got %d", status)
@@ -678,7 +678,7 @@ func TestConfigUpdateService_UpdateConfig(t *testing.T) {
 
 	t.Run("enable_sqlite rejected", func(t *testing.T) {
 		mockStore := mocks.NewMockStore(t)
-		svc := NewConfigUpdateService(mockStore)
+		svc := config.NewUpdateService(mockStore)
 		status, resp := svc.UpdateConfig(map[string]any{"enable_sqlite": true})
 		if status != 400 {
 			t.Errorf("expected 400, got %d", status)
@@ -694,7 +694,7 @@ func TestConfigUpdateService_ApplyUpdates_FieldTypes(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	originalRootDir := config.AppConfig.RootDir
 	originalAutoOrg := config.AppConfig.AutoOrganize
@@ -974,7 +974,7 @@ func TestImportPathService_GetImportPath(t *testing.T) {
 func TestConfigUpdateService_UpdateConfig_AdditionalFields(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	originalPlaylistDir := config.AppConfig.PlaylistDir
 	originalDatabasePath := config.AppConfig.DatabasePath
@@ -1007,7 +1007,7 @@ func TestConfigUpdateService_UpdateConfig_AdditionalFields(t *testing.T) {
 		mockStore2 := mocks.NewMockStore(t)
 		mockStore2.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 		mockStore2.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		svc2 := NewConfigUpdateService(mockStore2)
+		svc2 := config.NewUpdateService(mockStore2)
 
 		status, resp := svc2.UpdateConfig(map[string]any{
 			"database_path": "/new/db/path.db",
@@ -1027,7 +1027,7 @@ func TestConfigUpdateService_UpdateConfig_AdditionalFields(t *testing.T) {
 		mockStore3 := mocks.NewMockStore(t)
 		mockStore3.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 		mockStore3.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		svc3 := NewConfigUpdateService(mockStore3)
+		svc3 := config.NewUpdateService(mockStore3)
 
 		// setup_complete payload is ignored; actual value is derived from root_dir
 		config.AppConfig.RootDir = ""
@@ -1050,7 +1050,7 @@ func TestConfigUpdateService_UpdateConfig_AdditionalFields(t *testing.T) {
 		mockStore4 := mocks.NewMockStore(t)
 		mockStore4.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 		mockStore4.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		svc4 := NewConfigUpdateService(mockStore4)
+		svc4 := config.NewUpdateService(mockStore4)
 
 		config.AppConfig.SetupComplete = true
 		status, resp := svc4.UpdateConfig(map[string]any{
@@ -1071,7 +1071,7 @@ func TestConfigUpdateService_UpdateConfig_AdditionalFields(t *testing.T) {
 		mockStore5 := mocks.NewMockStore(t)
 		mockStore5.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 		mockStore5.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		svc5 := NewConfigUpdateService(mockStore5)
+		svc5 := config.NewUpdateService(mockStore5)
 
 		config.AppConfig.SetupComplete = false
 		status, resp := svc5.UpdateConfig(map[string]any{
@@ -1094,7 +1094,7 @@ func TestConfigUpdateService_UpdateConfig_AllFields(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	// Save original values
 	originalOrgStrat := config.AppConfig.OrganizationStrategy
@@ -1189,7 +1189,7 @@ func TestConfigUpdateService_UpdateConfig_IntConcurrentScans(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("GetSetting", mock.Anything).Return(nil, nil).Maybe()
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	originalConcurrentScans := config.AppConfig.ConcurrentScans
 	defer func() {
@@ -1212,7 +1212,7 @@ func TestConfigUpdateService_ApplyUpdates_OpenAIKey(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	originalKey := config.AppConfig.OpenAIAPIKey
 	originalAI := config.AppConfig.EnableAIParsing
@@ -1239,7 +1239,7 @@ func TestConfigUpdateService_ApplyUpdates_OpenAIKey(t *testing.T) {
 // TestConfigUpdateService_ValidateUpdate tests ValidateUpdate method
 func TestConfigUpdateService_ValidateUpdate(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewConfigUpdateService(mockStore)
+	svc := config.NewUpdateService(mockStore)
 
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Moves `ConfigUpdateService` (renamed to `UpdateService`) and its 5 tests from `internal/server` to `internal/config`
- `server.go` field type changes from `*ConfigUpdateService` → `*config.UpdateService`
- Part of run `2026-05-11-1728-svc-extract` (wave 1 server thinning)

## Test plan

- [x] `internal/config` — `TestUpdateService_*` (5 tests) pass
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)