### PR TITLE
refactor(metafetch): extract MetadataStateService from server

### DIFF
--- a/internal/metafetch/helpers.go
+++ b/internal/metafetch/helpers.go
@@ -152,13 +152,16 @@ func derefStr(s *string) string {
 	return *s
 }
 
-// metadataFieldState represents the state of a single metadata field.
-type metadataFieldState struct {
+// MetadataFieldState represents the state of a single metadata field.
+type MetadataFieldState struct {
 	FetchedValue   any       `json:"fetched_value,omitempty"`
 	OverrideValue  any       `json:"override_value,omitempty"`
 	OverrideLocked bool      `json:"override_locked"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }
+
+// metadataFieldState is an alias for backward compatibility (deprecated).
+type metadataFieldState = MetadataFieldState
 
 func metadataStateKey(bookID string) string {
 	return fmt.Sprintf("metadata_state_%s", bookID)

--- a/internal/metafetch/metadata_state_service.go
+++ b/internal/metafetch/metadata_state_service.go
@@ -1,8 +1,8 @@
-// file: internal/server/metadata_state_service.go
+// file: internal/metafetch/metadata_state_service.go
 // version: 1.2.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
-package server
+package metafetch
 
 import (
 	"encoding/json"
@@ -29,14 +29,6 @@ type MetadataStateService struct {
 // NewMetadataStateService creates a new metadata state service
 func NewMetadataStateService(db metadataStateStore) *MetadataStateService {
 	return &MetadataStateService{db: db}
-}
-
-// metadataFieldState represents the state of a single metadata field
-type metadataFieldState struct {
-	FetchedValue   any       `json:"fetched_value,omitempty"`
-	OverrideValue  any       `json:"override_value,omitempty"`
-	OverrideLocked bool      `json:"override_locked"`
-	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // LoadMetadataState loads the complete metadata state for a book

--- a/internal/metafetch/metadata_state_service_test.go
+++ b/internal/metafetch/metadata_state_service_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/metadata_state_service_test.go
+// file: internal/metafetch/metadata_state_service_test.go
 // version: 1.0.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
-package server
+package metafetch
 
 import (
 	"testing"

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -559,7 +559,7 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 			continue
 		}
 		if state == nil {
-			state = map[string]metadataFieldState{}
+			state = map[string]metafetch.MetadataFieldState{}
 		}
 
 		// Delegate search to service using empty query (uses book's title).

--- a/internal/server/metadata_history_test.go
+++ b/internal/server/metadata_history_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestMetadataStateService_RecordsChangeOnSetOverride(t *testing.T) {
 		},
 	}
 
-	service := NewMetadataStateService(mockDB)
+	service := metafetch.NewMetadataStateService(mockDB)
 	err := service.SetOverride("book1", "title", "New Title", false)
 	require.NoError(t, err)
 
@@ -73,7 +74,7 @@ func TestMetadataStateService_RecordsChangeOnClearOverride(t *testing.T) {
 		},
 	}
 
-	service := NewMetadataStateService(mockDB)
+	service := metafetch.NewMetadataStateService(mockDB)
 	err := service.ClearOverride("book1", "title")
 	require.NoError(t, err)
 
@@ -103,7 +104,7 @@ func TestMetadataStateService_RecordsChangeOnFetch(t *testing.T) {
 		},
 	}
 
-	service := NewMetadataStateService(mockDB)
+	service := metafetch.NewMetadataStateService(mockDB)
 	err := service.UpdateFetchedMetadata("book1", map[string]any{"title": "Fetched Title"})
 	require.NoError(t, err)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,7 +155,7 @@ type Server struct {
 	metadataFetchService   *metafetch.Service
 	configUpdateService    *config.UpdateService
 	systemService          *sysinfo.SystemService
-	metadataStateService   *MetadataStateService
+	metadataStateService   *metafetch.MetadataStateService
 	dashboardService       *sysinfo.DashboardService
 	olService              *metafetch.OpenLibraryService
 	dedupCache             *cache.Cache[gin.H]
@@ -305,7 +305,7 @@ func NewServer(store database.Store) *Server {
 		metadataFetchService:   metafetch.NewService(resolvedStore),
 		configUpdateService:    config.NewUpdateService(resolvedStore),
 		systemService:          sysinfo.NewSystemService(resolvedStore, appVersion, calculateLibrarySizes),
-		metadataStateService:   NewMetadataStateService(resolvedStore),
+		metadataStateService:   metafetch.NewMetadataStateService(resolvedStore),
 		dashboardService:       sysinfo.NewDashboardService(resolvedStore),
 		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),
 		listCache:              cache.New[gin.H]("list", 24*time.Hour),

--- a/internal/server/server_metadata.go
+++ b/internal/server/server_metadata.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 )
 
 func metadataStateKey(bookID string) string {
@@ -45,8 +46,8 @@ func encodeMetadataValue(value any) (*string, error) {
 	return &encoded, nil
 }
 
-func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
-	state := map[string]metadataFieldState{}
+func loadLegacyMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
+	state := map[string]metafetch.MetadataFieldState{}
 
 	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
 	if err != nil {
@@ -62,8 +63,8 @@ func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, erro
 	return state, nil
 }
 
-func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
-	state := map[string]metadataFieldState{}
+func loadMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
+	state := map[string]metafetch.MetadataFieldState{}
 	if database.GetGlobalStore() == nil {
 		return state, fmt.Errorf("database not initialized")
 	}
@@ -73,7 +74,7 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 		return state, err
 	}
 	for _, entry := range stored {
-		state[entry.Field] = metadataFieldState{
+		state[entry.Field] = metafetch.MetadataFieldState{
 			FetchedValue:   decodeMetadataValue(entry.FetchedValue),
 			OverrideValue:  decodeMetadataValue(entry.OverrideValue),
 			OverrideLocked: entry.OverrideLocked,
@@ -98,7 +99,7 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	return legacy, nil
 }
 
-func saveMetadataState(bookID string, state map[string]metadataFieldState) error {
+func saveMetadataState(bookID string, state map[string]metafetch.MetadataFieldState) error {
 	if database.GetGlobalStore() == nil {
 		return fmt.Errorf("database not initialized")
 	}
@@ -167,7 +168,7 @@ func updateFetchedMetadataState(bookID string, values map[string]any) error {
 		return err
 	}
 	if state == nil {
-		state = map[string]metadataFieldState{}
+		state = map[string]metafetch.MetadataFieldState{}
 	}
 	for field, value := range values {
 		entry := state[field]
@@ -459,9 +460,9 @@ func buildComparisonValuesFromActivityLog(as *activity.Service, bookID string, t
 	return compMap
 }
 
-func buildMetadataProvenance(book *database.Book, state map[string]metadataFieldState, meta metadata.Metadata, authorName, seriesName string, comparisonValues map[string]any) map[string]database.MetadataProvenanceEntry {
+func buildMetadataProvenance(book *database.Book, state map[string]metafetch.MetadataFieldState, meta metadata.Metadata, authorName, seriesName string, comparisonValues map[string]any) map[string]database.MetadataProvenanceEntry {
 	if state == nil {
-		state = map[string]metadataFieldState{}
+		state = map[string]metafetch.MetadataFieldState{}
 	}
 
 	provenance := map[string]database.MetadataProvenanceEntry{}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -242,7 +243,7 @@ func TestGetAudiobookTagsReportsEffectiveSourceSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	err = saveMetadataState(created.ID, map[string]metadataFieldState{
+	err = saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
 		"title": {
 			FetchedValue:   "Fetched Title",
 			OverrideValue:  "Override Title",
@@ -678,7 +679,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = saveMetadataState(created.ID, map[string]metadataFieldState{
+	err = saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
 		"publisher": {
 			OverrideValue:  "Manual Publisher",
 			OverrideLocked: true,
@@ -1316,7 +1317,7 @@ func TestGetAudiobookTagsReportsEffectiveSource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	state := map[string]metadataFieldState{
+	state := map[string]metafetch.MetadataFieldState{
 		"title": {
 			FetchedValue:   "Fetched Title",
 			OverrideValue:  "Override Title",

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
 	"github.com/stretchr/testify/mock"
 )
@@ -728,7 +729,7 @@ func TestConfigUpdateService_ApplyUpdates_FieldTypes(t *testing.T) {
 // TestMetadataStateService_UpdateFetchedMetadata tests UpdateFetchedMetadata method
 func TestMetadataStateService_UpdateFetchedMetadata(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
-	svc := NewMetadataStateService(mockStore)
+	svc := metafetch.NewMetadataStateService(mockStore)
 
 	bookID := "01HXZABC123456789"
 


### PR DESCRIPTION
## Summary

- Moves `MetadataStateService` (7 methods) and its 7 tests from `internal/server` to `internal/metafetch`
- Exports `MetadataFieldState` type (was package-private) so `server_metadata.go` and handler tests can reference it
- Updates `server.go`, `server_metadata.go`, `metadata_handlers.go`, and test files to use `metafetch.MetadataStateService`
- Part of run `2026-05-11-1728-svc-extract` (wave 1 server thinning)

## Test plan

- [x] `internal/metafetch` — 7 MetadataStateService tests pass
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)