### PR TITLE
refactor(playlist): extract evaluator to internal/playlist

### DIFF
--- a/internal/playlist/evaluator.go
+++ b/internal/playlist/evaluator.go
@@ -1,4 +1,4 @@
-// file: internal/server/playlist_evaluator.go
+// file: internal/playlist/evaluator.go
 // version: 1.1.1
 // guid: 9c2d5f1e-6b4a-4a70-b8c5-3d7e0f1b9a68
 //
@@ -21,7 +21,7 @@
 // evaluator returns an error — iTunes sync and the HTTP GET path
 // both retry after the index opens.
 
-package server
+package playlist
 
 import (
 	"encoding/json"
@@ -349,6 +349,13 @@ func compareBookField(a, b *database.Book, field string) int {
 func derefTime(p *time.Time) time.Time {
 	if p == nil {
 		return time.Time{}
+	}
+	return *p
+}
+
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
 	}
 	return *p
 }

--- a/internal/playlist/evaluator_prop_test.go
+++ b/internal/playlist/evaluator_prop_test.go
@@ -1,4 +1,4 @@
-// file: internal/server/playlist_evaluator_prop_test.go
+// file: internal/playlist/evaluator_prop_test.go
 // version: 1.3.0
 // guid: bcc094f5-1645-44d3-be21-3087888fdaea
 
@@ -16,7 +16,7 @@
 // THIS iteration's books only, which breaks when alice state from prior
 // iterations lingers. That test uses per-iteration fixtures with rt.Cleanup.
 
-package server
+package playlist
 
 import (
 	"path/filepath"

--- a/internal/playlist/evaluator_test.go
+++ b/internal/playlist/evaluator_test.go
@@ -1,8 +1,8 @@
-// file: internal/server/playlist_evaluator_test.go
+// file: internal/playlist/evaluator_test.go
 // version: 1.0.0
 // guid: 9d3e5f2a-7b4a-4a70-b8c5-3d7e0f1b9a69
 
-package server
+package playlist
 
 import (
 	"path/filepath"

--- a/internal/server/playlist_handlers.go
+++ b/internal/server/playlist_handlers.go
@@ -1,13 +1,13 @@
 // file: internal/server/playlist_handlers.go
-// version: 2.1.0
-// last-edited: 2026-05-01
+// version: 2.2.0
+// last-edited: 2026-05-11
 // guid: 7a3d5f2e-8c4b-4a70-b8c5-3d7e0f1b9a79
 //
 // HTTP endpoints for user-created playlists (spec 3.4 task 3).
 // Supports:
 //   - Static playlists: user-curated ordered book lists
 //   - Smart playlists: DSL queries evaluated on demand via
-//     EvaluateSmartPlaylist (delegates to Bleve + per-user filter)
+//     playlist.EvaluateSmartPlaylist (delegates to Bleve + per-user filter)
 //
 // Create/update/delete are gated on `playlists.create` once 3.7
 // permission wiring ships. GET paths require `library.view`.
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/playlist"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 )
 
@@ -132,7 +133,7 @@ func (s *Server) handleGetPlaylist(c *gin.Context) {
 	case database.UserPlaylistTypeStatic:
 		resp["book_ids"] = pl.BookIDs
 	case database.UserPlaylistTypeSmart:
-		bookIDs, evalErr := EvaluateSmartPlaylist(
+		bookIDs, evalErr := playlist.EvaluateSmartPlaylist(
 			s.Store(), s.SearchIndex(),
 			pl.Query, pl.SortJSON, pl.Limit,
 			callingUserID(c),
@@ -141,7 +142,7 @@ func (s *Server) handleGetPlaylist(c *gin.Context) {
 			// Surface as 503 when the index is unavailable — this is
 			// a transient condition during startup. Actual query
 			// errors are 400 (user's smart-playlist DSL is busted).
-			if evalErr == ErrSearchIndexUnavailable {
+			if evalErr == playlist.ErrSearchIndexUnavailable {
 				httputil.RespondWithError(c, 503, evalErr.Error(), "SERVICE_UNAVAILABLE")
 				return
 			}
@@ -352,13 +353,13 @@ func (s *Server) handleMaterializePlaylist(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "only smart playlists can be materialized")
 		return
 	}
-	bookIDs, evalErr := EvaluateSmartPlaylist(
+	bookIDs, evalErr := playlist.EvaluateSmartPlaylist(
 		s.Store(), s.SearchIndex(),
 		src.Query, src.SortJSON, src.Limit,
 		callingUserID(c),
 	)
 	if evalErr != nil {
-		if evalErr == ErrSearchIndexUnavailable {
+		if evalErr == playlist.ErrSearchIndexUnavailable {
 			httputil.RespondWithError(c, 503, evalErr.Error(), "SERVICE_UNAVAILABLE")
 			return
 		}


### PR DESCRIPTION
## Summary

- Moves `EvaluateSmartPlaylist` function, `ErrSearchIndexUnavailable`, and all helpers + prop tests (3 files total) from `internal/server` to `internal/playlist`
- `playlist_handlers.go` updated to import from `internal/playlist`
- 11 unit tests + 5 property-based tests now live in the `playlist` package
- Part of run `2026-05-11-1728-svc-extract` (wave 1 server thinning)

## Test plan

- [x] `internal/playlist` — 18 evaluator tests (unit + prop) pass
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)