### PR TITLE
refactor(undo): extract undo engine to internal/undo

### DIFF
--- a/internal/server/undo_engine.go
+++ b/internal/server/undo_engine.go
@@ -1,343 +1,50 @@
 // file: internal/server/undo_engine.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 0b8c9d6e-1f7a-4a70-b8c5-3d7e0f1b9a99
 //
-// Undo engine (spec 3.2 task 3). Reverses the destructive changes
-// recorded by a prior operation by walking its operation_changes
-// rows in reverse order and applying the inverse transform.
+// Backward-compatibility wrapper for the undo engine, now in internal/undo.
+// This file re-exports the public API from internal/undo with server-specific
+// callback handling (NotifyDelugeAfterUndo).
 //
-// Supported change_type reversals:
-//   - file_move / organize_rename: os.Rename(new_value → old_value)
-//   - metadata_update / db_update: restore field from old_value
-//   - dir_create: remove directory if empty
-//   - tag_write: no-op (tags are idempotently re-derived)
-//
-// Each change row is marked reverted_at on success; already-reverted
-// rows are skipped (idempotent for resume after crash).
+// The actual undo implementation lives in internal/undo/engine.go
 
 package server
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"time"
-
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/undo"
 )
 
-// UndoResult summarizes the outcome of an undo operation.
-type UndoResult struct {
-	Reverted        int      `json:"reverted"`
-	SkippedConflict int      `json:"skipped_conflict"`
-	SkippedReverted int      `json:"skipped_reverted"`
-	Failed          int      `json:"failed"`
-	Errors          []string `json:"errors,omitempty"`
-}
+// UndoResult is re-exported from the undo package.
+type UndoResult = undo.UndoResult
 
-// RunUndoOperation loads the changes for targetOpID, walks them in
-// reverse order, and applies the inverse of each change. Progress
-// is reported via the callback (step description + percentage).
+// UndoConflictReport is re-exported from the undo package.
+type UndoConflictReport = undo.UndoConflictReport
+
+// UndoConflictItem is re-exported from the undo package.
+type UndoConflictItem = undo.UndoConflictItem
+
+// RunUndoOperation wraps the undo engine with server-specific callback
+// for Deluge integration. It loads the changes for targetOpID, walks them
+// in reverse order, and applies the inverse of each change.
 func RunUndoOperation(
-	store interface { database.BookStore; database.BookVersionStore; database.OperationStore },
+	store interface {
+		database.BookStore
+		database.BookVersionStore
+		database.OperationStore
+	},
 	targetOpID string,
 	progress func(step string, pct int),
 ) (*UndoResult, error) {
-	if progress == nil {
-		progress = func(string, int) {}
-	}
-
-	changes, err := store.GetOperationChanges(targetOpID)
-	if err != nil {
-		return nil, fmt.Errorf("load operation changes: %w", err)
-	}
-	if len(changes) == 0 {
-		return &UndoResult{}, nil
-	}
-
-	// Reverse order: last change undone first.
-	reversed := make([]*database.OperationChange, len(changes))
-	for i, c := range changes {
-		reversed[len(changes)-1-i] = c
-	}
-
-	result := &UndoResult{}
-	total := len(reversed)
-
-	for i, change := range reversed {
-		pct := int(float64(i+1) / float64(total) * 100)
-		progress(fmt.Sprintf("undo %s on %s", change.ChangeType, change.BookID), pct)
-
-		if change.RevertedAt != nil {
-			result.SkippedReverted++
-			continue
-		}
-
-		err := revertChange(store, change)
-		if err != nil {
-			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s/%s: %v", change.BookID, change.ChangeType, err))
-			continue
-		}
-
-		now := time.Now()
-		change.RevertedAt = &now
-		if updateErr := store.CreateOperationChange(change); updateErr != nil {
-			// Best effort — the FS/DB change already succeeded.
-			result.Errors = append(result.Errors, fmt.Sprintf("mark reverted %s: %v", change.ID, updateErr))
-		}
-		result.Reverted++
-	}
-
-	return result, nil
+	return undo.RunUndoOperation(
+		store,
+		targetOpID,
+		progress,
+		NotifyDelugeAfterUndo,
+	)
 }
 
-// revertChange applies the inverse of a single operation change.
-func revertChange(store interface { database.BookStore; database.BookVersionStore; database.OperationStore }, change *database.OperationChange) error {
-	switch change.ChangeType {
-	case "file_move", "organize_rename":
-		if err := revertFileMove(change); err != nil {
-			return err
-		}
-		NotifyDelugeAfterUndo(store, change.BookID, change.OldValue)
-		return nil
-	case "metadata_update", "db_update":
-		return revertMetadataUpdate(store, change)
-	case "dir_create":
-		return revertDirCreate(change)
-	case "tag_write":
-		return nil // tags are re-derived on next metadata apply
-	default:
-		return fmt.Errorf("unknown change_type: %s", change.ChangeType)
-	}
-}
-
-// revertFileMove renames new_value back to old_value. If old_value
-// already exists (conflict), returns an error rather than clobbering.
-func revertFileMove(change *database.OperationChange) error {
-	if change.OldValue == "" || change.NewValue == "" {
-		return fmt.Errorf("missing path in change %s", change.ID)
-	}
-
-	// Check that new_value (the current location) exists.
-	if _, err := os.Stat(change.NewValue); os.IsNotExist(err) {
-		// Already moved back or deleted — idempotent no-op.
-		return nil
-	}
-
-	// Check that old_value (restore target) doesn't already exist.
-	if _, err := os.Stat(change.OldValue); err == nil {
-		return fmt.Errorf("conflict: restore target already exists: %s", change.OldValue)
-	}
-
-	// Ensure parent directory of old_value exists.
-	if err := os.MkdirAll(parentDir(change.OldValue), 0o775); err != nil {
-		return fmt.Errorf("mkdir for restore: %w", err)
-	}
-
-	return os.Rename(change.NewValue, change.OldValue)
-}
-
-// revertMetadataUpdate restores a book field from the change's
-// OldValue. OldValue is either a plain string (for single-field
-// changes) or a JSON object (for multi-field snapshots).
-func revertMetadataUpdate(store database.BookStore, change *database.OperationChange) error {
-	if change.BookID == "" {
-		return fmt.Errorf("no book_id on metadata change %s", change.ID)
-	}
-
-	book, err := store.GetBookByID(change.BookID)
-	if err != nil || book == nil {
-		return fmt.Errorf("book %s not found", change.BookID)
-	}
-
-	if change.FieldName != "" && change.OldValue != "" {
-		applyFieldRestore(book, change.FieldName, change.OldValue)
-	} else if change.OldValue != "" {
-		// Multi-field JSON snapshot.
-		var snapshot map[string]interface{}
-		if err := json.Unmarshal([]byte(change.OldValue), &snapshot); err == nil {
-			for field, val := range snapshot {
-				if s, ok := val.(string); ok {
-					applyFieldRestore(book, field, s)
-				}
-			}
-		}
-	}
-
-	_, err = store.UpdateBook(book.ID, book)
-	return err
-}
-
-// applyFieldRestore sets a single field on a Book from a string value.
-func applyFieldRestore(book *database.Book, field, value string) {
-	switch field {
-	case "title":
-		book.Title = value
-	case "file_path":
-		book.FilePath = value
-	case "format":
-		book.Format = value
-	case "narrator":
-		book.Narrator = &value
-	case "edition":
-		book.Edition = &value
-	case "description":
-		book.Description = &value
-	case "language":
-		book.Language = &value
-	case "publisher":
-		book.Publisher = &value
-	case "genre":
-		book.Genre = &value
-	case "library_state":
-		book.LibraryState = &value
-	}
-}
-
-// revertDirCreate removes a directory if it's empty. Non-empty
-// directories are left alone (the files inside may still be needed).
-func revertDirCreate(change *database.OperationChange) error {
-	if change.NewValue == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(change.NewValue)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // already gone
-		}
-		return err
-	}
-	if len(entries) > 0 {
-		return nil // not empty, leave it
-	}
-	return os.Remove(change.NewValue)
-}
-
-func parentDir(path string) string {
-	for i := len(path) - 1; i >= 0; i-- {
-		if path[i] == '/' {
-			return path[:i]
-		}
-	}
-	return "."
-}
-
-// UndoConflictReport summarizes potential conflicts detected before
-// executing an undo operation. The caller shows this to the user
-// so they can decide whether to proceed.
-type UndoConflictReport struct {
-	TotalChanges    int                `json:"total_changes"`
-	AlreadyReverted int                `json:"already_reverted"`
-	ContentChanged  []UndoConflictItem `json:"content_changed,omitempty"`
-	BookDeleted     []UndoConflictItem `json:"book_deleted,omitempty"`
-	ReOrganized     []UndoConflictItem `json:"re_organized,omitempty"`
-	Safe            int                `json:"safe"`
-}
-
-// UndoConflictItem describes one change that may conflict.
-type UndoConflictItem struct {
-	ChangeID   string `json:"change_id"`
-	BookID     string `json:"book_id"`
-	ChangeType string `json:"change_type"`
-	Reason     string `json:"reason"`
-}
-
-// PreflightUndoConflicts scans the operation's changes and reports
-// which ones can be safely undone vs which have conflicts.
+// PreflightUndoConflicts is re-exported from the undo package.
 func PreflightUndoConflicts(store database.Store, operationID string) (*UndoConflictReport, error) {
-	changes, err := store.GetOperationChanges(operationID)
-	if err != nil {
-		return nil, fmt.Errorf("load changes: %w", err)
-	}
-
-	report := &UndoConflictReport{TotalChanges: len(changes)}
-
-	for _, c := range changes {
-		if c.RevertedAt != nil {
-			report.AlreadyReverted++
-			continue
-		}
-
-		switch c.ChangeType {
-		case "file_move", "organize_rename":
-			if conflict := checkFileMoveConflict(store, c); conflict != nil {
-				switch conflict.Reason {
-				case "content changed":
-					report.ContentChanged = append(report.ContentChanged, *conflict)
-				case "book deleted":
-					report.BookDeleted = append(report.BookDeleted, *conflict)
-				case "re-organized":
-					report.ReOrganized = append(report.ReOrganized, *conflict)
-				default:
-					report.ContentChanged = append(report.ContentChanged, *conflict)
-				}
-			} else {
-				report.Safe++
-			}
-		case "metadata_update", "db_update":
-			if c.BookID != "" {
-				book, _ := store.GetBookByID(c.BookID)
-				if book == nil {
-					report.BookDeleted = append(report.BookDeleted, UndoConflictItem{
-						ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-						Reason: "book deleted",
-					})
-				} else if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
-					report.BookDeleted = append(report.BookDeleted, UndoConflictItem{
-						ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-						Reason: "book deleted",
-					})
-				} else {
-					report.Safe++
-				}
-			} else {
-				report.Safe++
-			}
-		default:
-			report.Safe++
-		}
-	}
-
-	return report, nil
-}
-
-func checkFileMoveConflict(store database.Store, c *database.OperationChange) *UndoConflictItem {
-	if c.NewValue == "" {
-		return nil
-	}
-
-	// Check if the file at new location was modified after the op.
-	info, err := os.Stat(c.NewValue)
-	if os.IsNotExist(err) {
-		return &UndoConflictItem{
-			ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-			Reason: "content changed",
-		}
-	}
-	if err == nil && info.ModTime().After(c.CreatedAt) {
-		return &UndoConflictItem{
-			ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-			Reason: "content changed",
-		}
-	}
-
-	// Check if book was deleted or re-organized.
-	if c.BookID != "" {
-		book, _ := store.GetBookByID(c.BookID)
-		if book == nil || (book.MarkedForDeletion != nil && *book.MarkedForDeletion) {
-			return &UndoConflictItem{
-				ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-				Reason: "book deleted",
-			}
-		}
-		if book.LastOrganizedAt != nil && book.LastOrganizedAt.After(c.CreatedAt) {
-			return &UndoConflictItem{
-				ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
-				Reason: "re-organized",
-			}
-		}
-	}
-
-	return nil
+	return undo.PreflightUndoConflicts(store, operationID)
 }

--- a/internal/undo/engine.go
+++ b/internal/undo/engine.go
@@ -1,0 +1,372 @@
+// file: internal/undo/engine.go
+// version: 1.0.0
+// guid: 2e7a9f1c-3b4d-4e8f-a1c5-7d9e2f4b8c3a
+//
+// Undo engine (spec 3.2 task 3). Reverses the destructive changes
+// recorded by a prior operation by walking its operation_changes
+// rows in reverse order and applying the inverse transform.
+//
+// Supported change_type reversals:
+//   - file_move / organize_rename: os.Rename(new_value → old_value)
+//   - metadata_update / db_update: restore field from old_value
+//   - dir_create: remove directory if empty
+//   - tag_write: no-op (tags are idempotently re-derived)
+//
+// Each change row is marked reverted_at on success; already-reverted
+// rows are skipped (idempotent for resume after crash).
+
+package undo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// UndoResult summarizes the outcome of an undo operation.
+type UndoResult struct {
+	Reverted        int      `json:"reverted"`
+	SkippedConflict int      `json:"skipped_conflict"`
+	SkippedReverted int      `json:"skipped_reverted"`
+	Failed          int      `json:"failed"`
+	Errors          []string `json:"errors,omitempty"`
+}
+
+// OnFileMovedFunc is the callback signature for handling file moves during undo.
+// Called when a file_move or organize_rename change is successfully reverted.
+// store: the database store
+// bookID: the ID of the book being reverted
+// oldFilePath: the path the file was restored to (original location before organize)
+type OnFileMovedFunc func(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, bookID, oldFilePath string)
+
+// RunUndoOperation loads the changes for targetOpID, walks them in
+// reverse order, and applies the inverse of each change. Progress
+// is reported via the callback (step description + percentage).
+//
+// onFileMoved is an optional callback invoked after a file_move or
+// organize_rename change is successfully reverted. Pass nil if no
+// callback is needed.
+func RunUndoOperation(
+	store interface {
+		database.BookStore
+		database.BookVersionStore
+		database.OperationStore
+	},
+	targetOpID string,
+	progress func(step string, pct int),
+	onFileMoved OnFileMovedFunc,
+) (*UndoResult, error) {
+	if progress == nil {
+		progress = func(string, int) {}
+	}
+
+	changes, err := store.GetOperationChanges(targetOpID)
+	if err != nil {
+		return nil, fmt.Errorf("load operation changes: %w", err)
+	}
+	if len(changes) == 0 {
+		return &UndoResult{}, nil
+	}
+
+	// Reverse order: last change undone first.
+	reversed := make([]*database.OperationChange, len(changes))
+	for i, c := range changes {
+		reversed[len(changes)-1-i] = c
+	}
+
+	result := &UndoResult{}
+	total := len(reversed)
+
+	for i, change := range reversed {
+		pct := int(float64(i+1) / float64(total) * 100)
+		progress(fmt.Sprintf("undo %s on %s", change.ChangeType, change.BookID), pct)
+
+		if change.RevertedAt != nil {
+			result.SkippedReverted++
+			continue
+		}
+
+		err := revertChange(store, change, onFileMoved)
+		if err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s/%s: %v", change.BookID, change.ChangeType, err))
+			continue
+		}
+
+		now := time.Now()
+		change.RevertedAt = &now
+		if updateErr := store.CreateOperationChange(change); updateErr != nil {
+			// Best effort — the FS/DB change already succeeded.
+			result.Errors = append(result.Errors, fmt.Sprintf("mark reverted %s: %v", change.ID, updateErr))
+		}
+		result.Reverted++
+	}
+
+	return result, nil
+}
+
+// revertChange applies the inverse of a single operation change.
+func revertChange(
+	store interface {
+		database.BookStore
+		database.BookVersionStore
+		database.OperationStore
+	},
+	change *database.OperationChange,
+	onFileMoved OnFileMovedFunc,
+) error {
+	switch change.ChangeType {
+	case "file_move", "organize_rename":
+		if err := revertFileMove(change); err != nil {
+			return err
+		}
+		if onFileMoved != nil {
+			onFileMoved(store, change.BookID, change.OldValue)
+		}
+		return nil
+	case "metadata_update", "db_update":
+		return revertMetadataUpdate(store, change)
+	case "dir_create":
+		return revertDirCreate(change)
+	case "tag_write":
+		return nil // tags are re-derived on next metadata apply
+	default:
+		return fmt.Errorf("unknown change_type: %s", change.ChangeType)
+	}
+}
+
+// revertFileMove renames new_value back to old_value. If old_value
+// already exists (conflict), returns an error rather than clobbering.
+func revertFileMove(change *database.OperationChange) error {
+	if change.OldValue == "" || change.NewValue == "" {
+		return fmt.Errorf("missing path in change %s", change.ID)
+	}
+
+	// Check that new_value (the current location) exists.
+	if _, err := os.Stat(change.NewValue); os.IsNotExist(err) {
+		// Already moved back or deleted — idempotent no-op.
+		return nil
+	}
+
+	// Check that old_value (restore target) doesn't already exist.
+	if _, err := os.Stat(change.OldValue); err == nil {
+		return fmt.Errorf("conflict: restore target already exists: %s", change.OldValue)
+	}
+
+	// Ensure parent directory of old_value exists.
+	if err := os.MkdirAll(parentDir(change.OldValue), 0o775); err != nil {
+		return fmt.Errorf("mkdir for restore: %w", err)
+	}
+
+	return os.Rename(change.NewValue, change.OldValue)
+}
+
+// revertMetadataUpdate restores a book field from the change's
+// OldValue. OldValue is either a plain string (for single-field
+// changes) or a JSON object (for multi-field snapshots).
+func revertMetadataUpdate(store database.BookStore, change *database.OperationChange) error {
+	if change.BookID == "" {
+		return fmt.Errorf("no book_id on metadata change %s", change.ID)
+	}
+
+	book, err := store.GetBookByID(change.BookID)
+	if err != nil || book == nil {
+		return fmt.Errorf("book %s not found", change.BookID)
+	}
+
+	if change.FieldName != "" && change.OldValue != "" {
+		applyFieldRestore(book, change.FieldName, change.OldValue)
+	} else if change.OldValue != "" {
+		// Multi-field JSON snapshot.
+		var snapshot map[string]interface{}
+		if err := json.Unmarshal([]byte(change.OldValue), &snapshot); err == nil {
+			for field, val := range snapshot {
+				if s, ok := val.(string); ok {
+					applyFieldRestore(book, field, s)
+				}
+			}
+		}
+	}
+
+	_, err = store.UpdateBook(book.ID, book)
+	return err
+}
+
+// applyFieldRestore sets a single field on a Book from a string value.
+func applyFieldRestore(book *database.Book, field, value string) {
+	switch field {
+	case "title":
+		book.Title = value
+	case "file_path":
+		book.FilePath = value
+	case "format":
+		book.Format = value
+	case "narrator":
+		book.Narrator = &value
+	case "edition":
+		book.Edition = &value
+	case "description":
+		book.Description = &value
+	case "language":
+		book.Language = &value
+	case "publisher":
+		book.Publisher = &value
+	case "genre":
+		book.Genre = &value
+	case "library_state":
+		book.LibraryState = &value
+	}
+}
+
+// revertDirCreate removes a directory if it's empty. Non-empty
+// directories are left alone (the files inside may still be needed).
+func revertDirCreate(change *database.OperationChange) error {
+	if change.NewValue == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(change.NewValue)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // already gone
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil // not empty, leave it
+	}
+	return os.Remove(change.NewValue)
+}
+
+func parentDir(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[:i]
+		}
+	}
+	return "."
+}
+
+// UndoConflictReport summarizes potential conflicts detected before
+// executing an undo operation. The caller shows this to the user
+// so they can decide whether to proceed.
+type UndoConflictReport struct {
+	TotalChanges    int                `json:"total_changes"`
+	AlreadyReverted int                `json:"already_reverted"`
+	ContentChanged  []UndoConflictItem `json:"content_changed,omitempty"`
+	BookDeleted     []UndoConflictItem `json:"book_deleted,omitempty"`
+	ReOrganized     []UndoConflictItem `json:"re_organized,omitempty"`
+	Safe            int                `json:"safe"`
+}
+
+// UndoConflictItem describes one change that may conflict.
+type UndoConflictItem struct {
+	ChangeID   string `json:"change_id"`
+	BookID     string `json:"book_id"`
+	ChangeType string `json:"change_type"`
+	Reason     string `json:"reason"`
+}
+
+// PreflightUndoConflicts scans the operation's changes and reports
+// which ones can be safely undone vs which have conflicts.
+func PreflightUndoConflicts(store database.Store, operationID string) (*UndoConflictReport, error) {
+	changes, err := store.GetOperationChanges(operationID)
+	if err != nil {
+		return nil, fmt.Errorf("load changes: %w", err)
+	}
+
+	report := &UndoConflictReport{TotalChanges: len(changes)}
+
+	for _, c := range changes {
+		if c.RevertedAt != nil {
+			report.AlreadyReverted++
+			continue
+		}
+
+		switch c.ChangeType {
+		case "file_move", "organize_rename":
+			if conflict := checkFileMoveConflict(store, c); conflict != nil {
+				switch conflict.Reason {
+				case "content changed":
+					report.ContentChanged = append(report.ContentChanged, *conflict)
+				case "book deleted":
+					report.BookDeleted = append(report.BookDeleted, *conflict)
+				case "re-organized":
+					report.ReOrganized = append(report.ReOrganized, *conflict)
+				default:
+					report.ContentChanged = append(report.ContentChanged, *conflict)
+				}
+			} else {
+				report.Safe++
+			}
+		case "metadata_update", "db_update":
+			if c.BookID != "" {
+				book, _ := store.GetBookByID(c.BookID)
+				if book == nil {
+					report.BookDeleted = append(report.BookDeleted, UndoConflictItem{
+						ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+						Reason: "book deleted",
+					})
+				} else if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+					report.BookDeleted = append(report.BookDeleted, UndoConflictItem{
+						ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+						Reason: "book deleted",
+					})
+				} else {
+					report.Safe++
+				}
+			} else {
+				report.Safe++
+			}
+		default:
+			report.Safe++
+		}
+	}
+
+	return report, nil
+}
+
+func checkFileMoveConflict(store database.Store, c *database.OperationChange) *UndoConflictItem {
+	if c.NewValue == "" {
+		return nil
+	}
+
+	// Check if the file at new location was modified after the op.
+	info, err := os.Stat(c.NewValue)
+	if os.IsNotExist(err) {
+		return &UndoConflictItem{
+			ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+			Reason: "content changed",
+		}
+	}
+	if err == nil && info.ModTime().After(c.CreatedAt) {
+		return &UndoConflictItem{
+			ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+			Reason: "content changed",
+		}
+	}
+
+	// Check if book was deleted or re-organized.
+	if c.BookID != "" {
+		book, _ := store.GetBookByID(c.BookID)
+		if book == nil || (book.MarkedForDeletion != nil && *book.MarkedForDeletion) {
+			return &UndoConflictItem{
+				ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+				Reason: "book deleted",
+			}
+		}
+		if book.LastOrganizedAt != nil && book.LastOrganizedAt.After(c.CreatedAt) {
+			return &UndoConflictItem{
+				ChangeID: c.ID, BookID: c.BookID, ChangeType: c.ChangeType,
+				Reason: "re-organized",
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/undo/engine_test.go
+++ b/internal/undo/engine_test.go
@@ -1,0 +1,289 @@
+// file: internal/undo/engine_test.go
+// version: 1.0.0
+// guid: 3f8b0e2d-4c5e-4f9g-b2d6-8e0f3g5c9d4b
+
+package undo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestRunUndoOperation_FileMove(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, newPath, "audio-content")
+
+	if cerr := store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+	}); cerr != nil {
+		t.Fatalf("create change: %v", cerr)
+	}
+
+	result, err := RunUndoOperation(store, "op1", nil, nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Reverted != 1 {
+		t.Errorf("reverted = %d, want 1", result.Reverted)
+	}
+
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Errorf("old path should exist after undo: %v", err)
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Errorf("new path should not exist after undo")
+	}
+	if got := readTestFile(t, oldPath); got != "audio-content" {
+		t.Errorf("content = %q", got)
+	}
+}
+
+func TestRunUndoOperation_ConflictDetected(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, oldPath, "something-new-at-old-location")
+	writeTestFile(t, newPath, "audio-content")
+
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+	})
+
+	result, err := RunUndoOperation(store, "op1", nil, nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Failed != 1 {
+		t.Errorf("failed = %d, want 1 (conflict)", result.Failed)
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected error message about conflict")
+	}
+}
+
+func TestRunUndoOperation_SkipsAlreadyReverted(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+	writeTestFile(t, newPath, "content")
+
+	now := time.Now()
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  now.Add(-2 * time.Hour),
+		RevertedAt: &now,
+	})
+
+	result, err := RunUndoOperation(store, "op1", nil, nil)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.SkippedReverted != 1 {
+		t.Errorf("skipped_reverted = %d, want 1", result.SkippedReverted)
+	}
+	if result.Reverted != 0 {
+		t.Errorf("reverted = %d, want 0", result.Reverted)
+	}
+}
+
+func TestRunUndoOperation_CallsOnFileMovedCallback(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, newPath, "audio-content")
+
+	if cerr := store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "book123",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  time.Now().Add(-1 * time.Hour),
+	}); cerr != nil {
+		t.Fatalf("create change: %v", cerr)
+	}
+
+	var callbackCalled bool
+	var callbackBookID string
+	var callbackPath string
+
+	callback := func(store interface {
+		database.BookReader
+		database.BookVersionStore
+	}, bookID, oldFilePath string) {
+		callbackCalled = true
+		callbackBookID = bookID
+		callbackPath = oldFilePath
+	}
+
+	result, err := RunUndoOperation(store, "op1", nil, callback)
+	if err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if result.Reverted != 1 {
+		t.Errorf("reverted = %d, want 1", result.Reverted)
+	}
+
+	if !callbackCalled {
+		t.Error("callback was not called")
+	}
+	if callbackBookID != "book123" {
+		t.Errorf("callback bookID = %q, want 'book123'", callbackBookID)
+	}
+	if callbackPath != oldPath {
+		t.Errorf("callback path = %q, want %q", callbackPath, oldPath)
+	}
+}
+
+func TestPreflightUndoConflicts_ReportsContentChanged(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	writeTestFile(t, newPath, "content")
+
+	// Create a change and wait so ModTime is definitely after CreatedAt
+	changeTime := time.Now().Add(-2 * time.Second)
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: "b1",
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  changeTime,
+	})
+
+	// Update file after the operation to simulate content change
+	time.Sleep(100 * time.Millisecond)
+	writeTestFile(t, newPath, "modified-content")
+
+	report, err := PreflightUndoConflicts(store, "op1")
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	if len(report.ContentChanged) == 0 {
+		t.Error("expected content_changed conflict")
+	}
+	if len(report.ContentChanged) > 0 && report.ContentChanged[0].BookID != "b1" {
+		t.Errorf("conflict book_id = %q, want 'b1'", report.ContentChanged[0].BookID)
+	}
+}
+
+func TestPreflightUndoConflicts_ReportsSafeChanges(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "original", "Book.m4b")
+	newPath := filepath.Join(dir, "organized", "Book.m4b")
+
+	// Create the book in the database
+	book, err := store.CreateBook(&database.Book{
+		Title:    "Test Book",
+		FilePath: newPath,
+		Format:   "m4b",
+	})
+	if err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+
+	// Create operation record first with a timestamp
+	changeTime := time.Now().Add(-1 * time.Hour)
+	_ = store.CreateOperationChange(&database.OperationChange{
+		ID: "c1", OperationID: "op1", BookID: book.ID,
+		ChangeType: "file_move",
+		OldValue:   oldPath,
+		NewValue:   newPath,
+		CreatedAt:  changeTime,
+	})
+
+	// Write the file after recording the operation, but with an older ModTime
+	// to simulate a file that hasn't changed since the operation
+	writeTestFile(t, newPath, "content")
+	// Set the ModTime to be before the operation
+	if err := os.Chtimes(newPath, changeTime.Add(-1*time.Minute), changeTime.Add(-1*time.Minute)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	report, err := PreflightUndoConflicts(store, "op1")
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	if report.Safe != 1 {
+		t.Errorf("safe = %d, want 1", report.Safe)
+	}
+	if len(report.ContentChanged) > 0 {
+		t.Errorf("expected no conflicts, got %d content_changed", len(report.ContentChanged))
+	}
+}
+
+// Helper functions
+func writeTestFile(t *testing.T, path, content string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- Moves `RunUndoOperation`, `PreflightUndoConflicts`, `UndoResult`, `UndoConflictReport`, `UndoConflictItem` and all helpers from `internal/server` into new `internal/undo` package
- Circular dep with `NotifyDelugeAfterUndo` resolved via `OnFileMovedFunc` callback parameter
- 6 unit tests added in `internal/undo/engine_test.go`
- `internal/server/undo_engine.go` converted to thin backward-compat wrapper (re-exports from `internal/undo`)

Part of wave-2 server-thinning sweep (run `2026-05-11-1939-svc-wave2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)