### PR TITLE
refactor(metafetch): move executeOLImport to OpenLibraryService.Import method

### DIFF
--- a/internal/metafetch/openlibrary.go
+++ b/internal/metafetch/openlibrary.go
@@ -1,10 +1,12 @@
 // file: internal/metafetch/openlibrary.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package metafetch
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/openlibrary"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
 )
 
 // OpenLibraryService manages the Open Library data dump lifecycle.
@@ -96,3 +99,82 @@ type UploadedFileInfo struct {
 
 // ValidDumpTypes lists the valid dump type names.
 var ValidDumpTypes = map[string]bool{"editions": true, "authors": true, "works": true}
+
+// Import performs the actual Open Library dump import logic.
+// It imports the specified dump types from targetDir concurrently,
+// updating the progress reporter as it goes.
+func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.ProgressReporter, targetDir string, types []string) error {
+	if progress != nil {
+		_ = progress.UpdateProgress(0, len(types), fmt.Sprintf("Starting Open Library import (%d dump types)", len(types)))
+	}
+
+	var importWg sync.WaitGroup
+	var importErr error
+	var mu sync.Mutex
+
+	for i, dumpType := range types {
+		svc.Mu.Lock()
+		if svc.Importing[dumpType] {
+			svc.Mu.Unlock()
+			log.Printf("[WARN] OL import already in progress for %s", dumpType)
+			continue
+		}
+		svc.Importing[dumpType] = true
+		svc.Mu.Unlock()
+
+		if progress != nil {
+			_ = progress.Log("info", fmt.Sprintf("Starting %s import", dumpType), nil)
+		}
+
+		importWg.Add(1)
+		go func(dt string, idx int) {
+			defer importWg.Done()
+			defer func() {
+				svc.Mu.Lock()
+				delete(svc.Importing, dt)
+				svc.Mu.Unlock()
+			}()
+
+			filePath := filepath.Join(targetDir, openlibrary.DumpFilename(dt))
+			log.Printf("[INFO] Starting OL dump import: %s from %s", dt, filePath)
+
+			lastReported := 0
+			err := svc.OLStore.ImportDump(dt, filePath, func(count int) {
+				if count-lastReported >= 50000 {
+					lastReported = count
+					if progress != nil {
+						msg := fmt.Sprintf("Importing %s: %dk records", dt, count/1000)
+						_ = progress.UpdateProgress(idx, len(types), msg)
+					}
+					log.Printf("[INFO] OL %s import progress: %d records", dt, count)
+				}
+			})
+
+			if err != nil {
+				log.Printf("[ERROR] OL dump import failed for %s: %v", dt, err)
+				if progress != nil {
+					_ = progress.Log("error", fmt.Sprintf("%s import failed: %v", dt, err), nil)
+				}
+				mu.Lock()
+				importErr = err
+				mu.Unlock()
+			} else {
+				log.Printf("[INFO] OL dump import complete: %s", dt)
+				if progress != nil {
+					_ = progress.Log("info", fmt.Sprintf("%s import complete", dt), nil)
+				}
+			}
+		}(dumpType, i)
+	}
+	importWg.Wait()
+
+	if progress != nil {
+		if importErr != nil {
+			_ = progress.UpdateProgress(len(types), len(types), fmt.Sprintf("Import finished with errors: %v", importErr))
+		} else {
+			_ = progress.UpdateProgress(len(types), len(types), "All Open Library dump imports complete")
+		}
+	}
+	log.Printf("[INFO] All OL dump imports complete")
+	return importErr
+}

--- a/internal/server/openlibrary_ops.go
+++ b/internal/server/openlibrary_ops.go
@@ -92,7 +92,7 @@ func (s *Server) RegisterOLImportOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("failed to open store: %w", err)
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return s.executeOLImport(ctx, progress, svc, p.TargetDir, p.Types)
+			return svc.Import(ctx, progress, p.TargetDir, p.Types)
 		},
 	})
 }

--- a/internal/server/openlibrary_service.go
+++ b/internal/server/openlibrary_service.go
@@ -1,5 +1,5 @@
 // file: internal/server/openlibrary_service.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package server
@@ -13,14 +13,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/openlibrary"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -137,87 +135,11 @@ func (s *Server) startOLImport(c *gin.Context) {
 	if _, enqErr := s.opRegistry.EnqueueOp(c.Request.Context(), "openlibrary.import", importParams); enqErr != nil {
 		log.Printf("[WARN] Failed to enqueue OL import, running directly: %v", enqErr)
 		go func() {
-			_ = s.executeOLImport(context.Background(), nil, svc, targetDir, req.Types)
+			_ = svc.Import(context.Background(), nil, targetDir, req.Types)
 		}()
 	}
 
 	httputil.RespondWithSuccess(c, http.StatusAccepted, gin.H{"message": "import started", "types": req.Types, "operation_id": opID})
-}
-
-func (s *Server) executeOLImport(ctx context.Context, progress operations.ProgressReporter, svc *metafetch.OpenLibraryService, targetDir string, types []string) error {
-	if progress != nil {
-		_ = progress.UpdateProgress(0, len(types), fmt.Sprintf("Starting Open Library import (%d dump types)", len(types)))
-	}
-
-	var importWg sync.WaitGroup
-	var importErr error
-	var mu sync.Mutex
-
-	for i, dumpType := range types {
-		svc.Mu.Lock()
-		if svc.Importing[dumpType] {
-			svc.Mu.Unlock()
-			log.Printf("[WARN] OL import already in progress for %s", dumpType)
-			continue
-		}
-		svc.Importing[dumpType] = true
-		svc.Mu.Unlock()
-
-		if progress != nil {
-			_ = progress.Log("info", fmt.Sprintf("Starting %s import", dumpType), nil)
-		}
-
-		importWg.Add(1)
-		go func(dt string, idx int) {
-			defer importWg.Done()
-			defer func() {
-				svc.Mu.Lock()
-				delete(svc.Importing, dt)
-				svc.Mu.Unlock()
-			}()
-
-			filePath := filepath.Join(targetDir, openlibrary.DumpFilename(dt))
-			log.Printf("[INFO] Starting OL dump import: %s from %s", dt, filePath)
-
-			lastReported := 0
-			err := svc.OLStore.ImportDump(dt, filePath, func(count int) {
-				if count-lastReported >= 50000 {
-					lastReported = count
-					if progress != nil {
-						msg := fmt.Sprintf("Importing %s: %dk records", dt, count/1000)
-						_ = progress.UpdateProgress(idx, len(types), msg)
-					}
-					log.Printf("[INFO] OL %s import progress: %d records", dt, count)
-				}
-			})
-
-			if err != nil {
-				log.Printf("[ERROR] OL dump import failed for %s: %v", dt, err)
-				if progress != nil {
-					_ = progress.Log("error", fmt.Sprintf("%s import failed: %v", dt, err), nil)
-				}
-				mu.Lock()
-				importErr = err
-				mu.Unlock()
-			} else {
-				log.Printf("[INFO] OL dump import complete: %s", dt)
-				if progress != nil {
-					_ = progress.Log("info", fmt.Sprintf("%s import complete", dt), nil)
-				}
-			}
-		}(dumpType, i)
-	}
-	importWg.Wait()
-
-	if progress != nil {
-		if importErr != nil {
-			_ = progress.UpdateProgress(len(types), len(types), fmt.Sprintf("Import finished with errors: %v", importErr))
-		} else {
-			_ = progress.UpdateProgress(len(types), len(types), "All Open Library dump imports complete")
-		}
-	}
-	log.Printf("[INFO] All OL dump imports complete")
-	return importErr
 }
 
 func (s *Server) uploadOLDump(c *gin.Context) {


### PR DESCRIPTION
## Summary
- Moves `executeOLImport` from `internal/server` into `internal/metafetch` as `OpenLibraryService.Import(ctx, progress, targetDir, types)`
- HTTP handlers remain in `internal/server/openlibrary_service.go` — only the import orchestration logic moves
- `internal/server/openlibrary_ops.go` updated to call `svc.Import(...)`
- Removes unused `sync` and `operations` imports from server handler file

Part of wave-2 server-thinning sweep (run `2026-05-11-1939-svc-wave2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)