### PR TITLE
refactor(search): move quoteIfNeeded helper to internal/search

### DIFF
--- a/internal/search/query_parser.go
+++ b/internal/search/query_parser.go
@@ -1,5 +1,5 @@
 // file: internal/search/query_parser.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3c4a1d8f-5b2e-4f70-a7c6-2f8d0e1b9a57
 //
 // Parser for the library search DSL (spec 3.4 / DES-1 v1.1).
@@ -433,4 +433,13 @@ func (p *parser) parseRange(field string) (Node, error) {
 		Field: field, Op: "range",
 		RangeMin: minVal, RangeMax: maxVal,
 	}, nil
+}
+
+// QuoteIfNeeded wraps a string in quotes if it contains spaces.
+// Used by query builders to ensure multi-word values are treated as single tokens.
+func QuoteIfNeeded(s string) string {
+	if strings.Contains(s, " ") {
+		return `"` + s + `"`
+	}
+	return s
 }

--- a/internal/server/similar_books.go
+++ b/internal/server/similar_books.go
@@ -1,5 +1,5 @@
 // file: internal/server/similar_books.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3a1b2c0d-4e5f-4a70-b8c5-3d7e0f1b9a99
 // last-edited: 2026-05-01
 //
@@ -39,13 +39,13 @@ func (s *Server) handleSimilarBooks(c *gin.Context) {
 	if book.AuthorID != nil {
 		author, _ := s.Store().GetAuthorByID(*book.AuthorID)
 		if author != nil && author.Name != "" {
-			queryParts = append(queryParts, "author:"+quoteIfNeeded(author.Name))
+			queryParts = append(queryParts, "author:"+search.QuoteIfNeeded(author.Name))
 		}
 	}
 	if book.SeriesID != nil {
 		series, _ := s.Store().GetSeriesByID(*book.SeriesID)
 		if series != nil && series.Name != "" {
-			queryParts = append(queryParts, "series:"+quoteIfNeeded(series.Name))
+			queryParts = append(queryParts, "series:"+search.QuoteIfNeeded(series.Name))
 		}
 	}
 
@@ -105,11 +105,4 @@ func (s *Server) handleSimilarBooks(c *gin.Context) {
 		Books []database.Book `json:"books"`
 		Count int             `json:"count"`
 	}{Books: similar, Count: len(similar)})
-}
-
-func quoteIfNeeded(s string) string {
-	if strings.Contains(s, " ") {
-		return `"` + s + `"`
-	}
-	return s
 }


### PR DESCRIPTION
## Summary
- Moves `quoteIfNeeded` from `internal/server/similar_books.go` to `internal/search` as exported `QuoteIfNeeded`
- Handler now calls `search.QuoteIfNeeded` — proper domain placement for a query-building helper
- Version bumped on both modified files

Part of wave-2 server-thinning sweep (run `2026-05-11-1939-svc-wave2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)