### PR TITLE
refactor(maintenance): move progressAdapter to internal/maintenance as ProgressAdapter

### DIFF
--- a/internal/maintenance/progress.go
+++ b/internal/maintenance/progress.go
@@ -1,0 +1,34 @@
+// file: internal/maintenance/progress.go
+// version: 1.0.0
+// guid: a3b4c5d6-e7f8-9012-3456-7890abcdef12
+// last-edited: 2026-05-11
+
+package maintenance
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+)
+
+// ProgressAdapter adapts operations.ProgressReporter to maintenance.ProgressReporter.
+// It bridges the operations layer's richer progress API to the simpler interface
+// that maintenance jobs consume.
+type ProgressAdapter struct {
+	Ops   operations.ProgressReporter
+	cur   int
+	total int
+}
+
+// SetTotal sets the expected total item count for progress reporting.
+func (a *ProgressAdapter) SetTotal(n int) { a.total = n }
+
+// Increment advances the current count by one and propagates progress to the
+// underlying operations reporter.
+func (a *ProgressAdapter) Increment() {
+	a.cur++
+	_ = a.Ops.UpdateProgress(a.cur, a.total, "")
+}
+
+// Log forwards a log entry to the underlying operations reporter.
+func (a *ProgressAdapter) Log(level, message string, details *string) {
+	_ = a.Ops.Log(level, message, details)
+}

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_dispatcher.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 55555555-5555-5555-5555-555555555555
-// last-edited: 2026-05-01
+// last-edited: 2026-05-11
 
 package server
 
@@ -13,27 +13,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	ulid "github.com/oklog/ulid/v2"
 )
-
-// progressAdapter adapts operations.ProgressReporter to maintenance.ProgressReporter.
-type progressAdapter struct {
-	ops   operations.ProgressReporter
-	cur   int
-	total int
-}
-
-func (a *progressAdapter) SetTotal(n int) { a.total = n }
-
-func (a *progressAdapter) Increment() {
-	a.cur++
-	_ = a.ops.UpdateProgress(a.cur, a.total, "")
-}
-
-func (a *progressAdapter) Log(level, message string, details *string) {
-	_ = a.ops.Log(level, message, details)
-}
 
 // listMaintenanceJobs returns the catalogue of all registered maintenance jobs.
 func (s *Server) listMaintenanceJobs(c *gin.Context) {

--- a/internal/server/maintenance_job_op.go
+++ b/internal/server/maintenance_job_op.go
@@ -1,6 +1,7 @@
 // file: internal/server/maintenance_job_op.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f3a9c21-4b8e-4d56-a123-0e5f6c7d8e9f
+// last-edited: 2026-05-11
 
 package server
 
@@ -49,7 +50,7 @@ func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
 			store := s.Store()
 			ctx = maintenance.WithOperationID(ctx, p.LegacyOpID)
 			progress := registryProgressAdapter{r: reporter}
-			adapter := &progressAdapter{ops: progress}
+			adapter := &maintenance.ProgressAdapter{Ops: progress}
 			return job.Run(ctx, store, adapter, p.DryRun)
 		},
 	})


### PR DESCRIPTION
## Summary
- Moves `progressAdapter` from `internal/server` into `internal/maintenance/progress.go` as exported `ProgressAdapter`
- `internal/server/maintenance_dispatcher.go` updated to use `maintenance.ProgressAdapter`
- `internal/server/maintenance_job_op.go` updated construction site
- `maintenance_fixups.go` assessed: all functions have `*Server` receivers or depend on shared `maintenanceStore` interface — nothing extractable without larger refactor

Part of wave-2 server-thinning sweep (run `2026-05-11-1939-svc-wave2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)