### PR TITLE
refactor(metabatch): extract metadata batch candidates to internal/metabatch

### DIFF
--- a/internal/metabatch/candidates.go
+++ b/internal/metabatch/candidates.go
@@ -1,0 +1,171 @@
+// file: internal/metabatch/candidates.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
+// last-edited: 2026-05-11
+//
+// Package metabatch contains pure service types and logic for the
+// metadata candidate batch fetch / apply pipeline. HTTP handlers live
+// in internal/server and import from here; this package has no
+// dependency on *Server or gin.
+
+package metabatch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+)
+
+// BookFilesGetter is the narrow interface needed by BuildCandidateBookInfo
+// to look up file records for a book. Satisfied by database.Store and any
+// type that embeds it.
+type BookFilesGetter interface {
+	GetBookFiles(bookID string) ([]database.BookFile, error)
+}
+
+// CandidateBookInfo contains summary info about a book used in candidate results.
+type CandidateBookInfo struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Author     string `json:"author"`
+	FilePath   string `json:"file_path"`
+	ITunesPath string `json:"itunes_path,omitempty"`
+	CoverURL   string `json:"cover_url,omitempty"`
+	Format     string `json:"format,omitempty"`
+	Duration   int    `json:"duration_seconds,omitempty"`
+	FileSize   int64  `json:"file_size_bytes,omitempty"`
+	// Language is the book's current language as stored on the
+	// Book row (ISO code or full name, whatever was last applied).
+	// Used by the review dialog's language filter to hide
+	// candidates whose language disagrees with the book's — the
+	// motivating Spanish/English "Ancillary Sword" screenshot fix.
+	// Empty when the book has no language set, in which case the
+	// filter is a no-op for that row.
+	Language string `json:"language,omitempty"`
+}
+
+// CandidateResult holds the metadata candidate search result for a single book.
+type CandidateResult struct {
+	Book      CandidateBookInfo            `json:"book"`
+	Candidate *metafetch.MetadataCandidate `json:"candidate,omitempty"`
+	Status    string                       `json:"status"` // "matched", "no_match", "error"
+	Error     string                       `json:"error_message,omitempty"`
+}
+
+// BatchFetchRequest is the JSON body for the batch candidate fetch handler.
+// Either BookIDs or Selection must be provided; OnlyUnmatched can be combined
+// with either to exclude books that already have a "matched" candidate.
+type BatchFetchRequest struct {
+	BookIDs       []string                  `json:"book_ids"`
+	Selection     *operations.SelectionSpec `json:"selection"`
+	OnlyUnmatched bool                      `json:"only_unmatched"`
+}
+
+// BatchApplyRequest is the JSON body for the batch candidate apply handler.
+type BatchApplyRequest struct {
+	OperationID string   `json:"operation_id" binding:"required"`
+	BookIDs     []string `json:"book_ids" binding:"required"`
+}
+
+// LatestMatchedBookIDs returns the set of book IDs whose most-recent
+// metadata_candidate_fetch result has status "matched". Used to exclude
+// already-matched books when OnlyUnmatched is requested.
+func LatestMatchedBookIDs(store database.Store) map[string]bool {
+	allOps, err := store.GetRecentOperations(5000)
+	if err != nil {
+		return nil
+	}
+	type entry struct {
+		status    string
+		createdAt time.Time
+	}
+	latest := map[string]entry{}
+	for _, op := range allOps {
+		if op.Type != "metadata_candidate_fetch" {
+			continue
+		}
+		results, err := store.GetOperationResults(op.ID)
+		if err != nil {
+			continue
+		}
+		for _, r := range results {
+			ex, ok := latest[r.BookID]
+			if !ok || r.CreatedAt.After(ex.createdAt) {
+				latest[r.BookID] = entry{status: r.Status, createdAt: r.CreatedAt}
+			}
+		}
+	}
+	matched := make(map[string]bool, len(latest))
+	for bookID, e := range latest {
+		if e.status == "matched" {
+			matched[bookID] = true
+		}
+	}
+	return matched
+}
+
+// BuildCandidateBookInfo builds a CandidateBookInfo from a database.Book.
+// store is used to look up BookFile.ITunesPath (the authoritative field).
+func BuildCandidateBookInfo(store BookFilesGetter, book *database.Book) CandidateBookInfo {
+	info := CandidateBookInfo{
+		ID:       book.ID,
+		Title:    book.Title,
+		FilePath: book.FilePath,
+		Format:   book.Format,
+	}
+	if book.Author != nil {
+		info.Author = book.Author.Name
+	}
+	if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 {
+		info.ITunesPath = bfs[0].ITunesPath
+	}
+	if book.CoverURL != nil {
+		info.CoverURL = *book.CoverURL
+	}
+	if book.Duration != nil {
+		info.Duration = *book.Duration
+	}
+	if book.FileSize != nil {
+		info.FileSize = *book.FileSize
+	}
+	if book.Language != nil {
+		info.Language = *book.Language
+	}
+	return info
+}
+
+// CountByStatus counts CandidateResults with the given status.
+func CountByStatus(results []CandidateResult, status string) int {
+	n := 0
+	for _, r := range results {
+		if r.Status == status {
+			n++
+		}
+	}
+	return n
+}
+
+// LoadRejectedCandidateKeys finds previously rejected candidates for a book.
+// Uses a dedicated rejection key prefix for fast lookup instead of scanning
+// all operation results.
+func LoadRejectedCandidateKeys(store database.RawKVStore, bookID string) map[string]bool {
+	keys := make(map[string]bool)
+	// Scan only rejection keys for this specific book.
+	pairs, err := store.ScanPrefix(fmt.Sprintf("rejected_candidate:%s:", bookID))
+	if err != nil {
+		return keys
+	}
+	for _, kv := range pairs {
+		// Key format: rejected_candidate:{bookID}:{source}|{title}
+		// Value is just "1" — we only need the key.
+		keyStr := kv.Key
+		prefix := fmt.Sprintf("rejected_candidate:%s:", bookID)
+		if len(keyStr) > len(prefix) {
+			keys[keyStr[len(prefix):]] = true
+		}
+	}
+	return keys
+}

--- a/internal/metabatch/candidates_test.go
+++ b/internal/metabatch/candidates_test.go
@@ -1,0 +1,336 @@
+// file: internal/metabatch/candidates_test.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-05-11
+
+package metabatch_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metabatch"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+)
+
+// ---------------------------------------------------------------------------
+// CountByStatus
+// ---------------------------------------------------------------------------
+
+func TestCountByStatus_Empty(t *testing.T) {
+	if got := metabatch.CountByStatus(nil, "matched"); got != 0 {
+		t.Fatalf("expected 0 for nil slice, got %d", got)
+	}
+}
+
+func TestCountByStatus_Mixed(t *testing.T) {
+	results := []metabatch.CandidateResult{
+		{Status: "matched"},
+		{Status: "matched"},
+		{Status: "no_match"},
+		{Status: "error"},
+		{Status: "matched"},
+	}
+	if got := metabatch.CountByStatus(results, "matched"); got != 3 {
+		t.Errorf("matched: want 3, got %d", got)
+	}
+	if got := metabatch.CountByStatus(results, "no_match"); got != 1 {
+		t.Errorf("no_match: want 1, got %d", got)
+	}
+	if got := metabatch.CountByStatus(results, "error"); got != 1 {
+		t.Errorf("error: want 1, got %d", got)
+	}
+	if got := metabatch.CountByStatus(results, "unknown"); got != 0 {
+		t.Errorf("unknown: want 0, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BuildCandidateBookInfo
+// ---------------------------------------------------------------------------
+
+// mockBookFileStore satisfies database.BookFileStore for testing.
+type mockBookFileStore struct {
+	files []database.BookFile
+	err   error
+}
+
+func (m *mockBookFileStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	return m.files, m.err
+}
+
+func TestBuildCandidateBookInfo_BasicFields(t *testing.T) {
+	coverURL := "https://example.com/cover.jpg"
+	duration := 3600
+	fileSize := int64(123456789)
+	lang := "en"
+
+	book := &database.Book{
+		ID:       "book-001",
+		Title:    "The Hobbit",
+		FilePath: "/books/hobbit.m4b",
+		Format:   "m4b",
+		CoverURL: &coverURL,
+		Duration: &duration,
+		FileSize: &fileSize,
+		Language: &lang,
+	}
+	book.Author = &database.Author{Name: "J.R.R. Tolkien"}
+
+	store := &mockBookFileStore{
+		files: []database.BookFile{
+			{ITunesPath: "/itunes/hobbit.m4b"},
+		},
+	}
+
+	info := metabatch.BuildCandidateBookInfo(store, book)
+
+	if info.ID != "book-001" {
+		t.Errorf("ID: want book-001, got %s", info.ID)
+	}
+	if info.Title != "The Hobbit" {
+		t.Errorf("Title: want 'The Hobbit', got %s", info.Title)
+	}
+	if info.Author != "J.R.R. Tolkien" {
+		t.Errorf("Author: want 'J.R.R. Tolkien', got %s", info.Author)
+	}
+	if info.CoverURL != coverURL {
+		t.Errorf("CoverURL: want %s, got %s", coverURL, info.CoverURL)
+	}
+	if info.Duration != duration {
+		t.Errorf("Duration: want %d, got %d", duration, info.Duration)
+	}
+	if info.FileSize != fileSize {
+		t.Errorf("FileSize: want %d, got %d", fileSize, info.FileSize)
+	}
+	if info.Language != lang {
+		t.Errorf("Language: want %s, got %s", lang, info.Language)
+	}
+	if info.ITunesPath != "/itunes/hobbit.m4b" {
+		t.Errorf("ITunesPath: want /itunes/hobbit.m4b, got %s", info.ITunesPath)
+	}
+}
+
+func TestBuildCandidateBookInfo_NilOptionalFields(t *testing.T) {
+	book := &database.Book{
+		ID:       "book-002",
+		Title:    "Dune",
+		FilePath: "/books/dune.m4b",
+	}
+	store := &mockBookFileStore{}
+
+	info := metabatch.BuildCandidateBookInfo(store, book)
+
+	if info.ID != "book-002" {
+		t.Errorf("ID: want book-002, got %s", info.ID)
+	}
+	if info.CoverURL != "" {
+		t.Errorf("CoverURL should be empty, got %s", info.CoverURL)
+	}
+	if info.Author != "" {
+		t.Errorf("Author should be empty when nil, got %s", info.Author)
+	}
+	if info.Language != "" {
+		t.Errorf("Language should be empty when nil, got %s", info.Language)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadRejectedCandidateKeys
+// ---------------------------------------------------------------------------
+
+// mockRawKVStore satisfies database.RawKVStore for testing.
+type mockRawKVStore struct {
+	pairs []database.KVPair
+	err   error
+}
+
+func (m *mockRawKVStore) SetRaw(_ string, _ []byte) error { return nil }
+func (m *mockRawKVStore) GetRaw(_ string) ([]byte, error) { return nil, nil }
+func (m *mockRawKVStore) DeleteRaw(_ string) error        { return nil }
+func (m *mockRawKVStore) CountPrefix(_ string) (int64, error) {
+	return int64(len(m.pairs)), nil
+}
+func (m *mockRawKVStore) ScanPrefix(_ string) ([]database.KVPair, error) {
+	return m.pairs, m.err
+}
+
+func TestLoadRejectedCandidateKeys_NoRejections(t *testing.T) {
+	store := &mockRawKVStore{}
+	keys := metabatch.LoadRejectedCandidateKeys(store, "book-001")
+	if len(keys) != 0 {
+		t.Errorf("want empty map, got %v", keys)
+	}
+}
+
+func TestLoadRejectedCandidateKeys_WithRejections(t *testing.T) {
+	bookID := "book-99"
+	prefix := fmt.Sprintf("rejected_candidate:%s:", bookID)
+	store := &mockRawKVStore{
+		pairs: []database.KVPair{
+			{Key: prefix + "audible|Project Hail Mary", Value: []byte("1")},
+			{Key: prefix + "hardcover|The Martian", Value: []byte("1")},
+		},
+	}
+	keys := metabatch.LoadRejectedCandidateKeys(store, bookID)
+	if !keys["audible|Project Hail Mary"] {
+		t.Error("expected 'audible|Project Hail Mary' to be in rejected keys")
+	}
+	if !keys["hardcover|The Martian"] {
+		t.Error("expected 'hardcover|The Martian' to be in rejected keys")
+	}
+}
+
+func TestLoadRejectedCandidateKeys_StoreError(t *testing.T) {
+	store := &mockRawKVStore{err: fmt.Errorf("db error")}
+	keys := metabatch.LoadRejectedCandidateKeys(store, "book-001")
+	if len(keys) != 0 {
+		t.Errorf("want empty map on store error, got %v", keys)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LatestMatchedBookIDs
+// ---------------------------------------------------------------------------
+
+// latestMatchedStore is a minimal Store stub for LatestMatchedBookIDs tests.
+type latestMatchedStore struct {
+	database.MockStore
+	ops     []database.Operation
+	opsErr  error
+	results map[string][]database.OperationResult
+}
+
+func (s *latestMatchedStore) GetRecentOperations(limit int) ([]database.Operation, error) {
+	return s.ops, s.opsErr
+}
+
+func (s *latestMatchedStore) GetOperationResults(opID string) ([]database.OperationResult, error) {
+	if s.results != nil {
+		return s.results[opID], nil
+	}
+	return nil, nil
+}
+
+func TestLatestMatchedBookIDs_StoreError(t *testing.T) {
+	store := &latestMatchedStore{opsErr: fmt.Errorf("db error")}
+	result := metabatch.LatestMatchedBookIDs(store)
+	if result != nil {
+		t.Errorf("expected nil on store error, got %v", result)
+	}
+}
+
+func TestLatestMatchedBookIDs_NoOps(t *testing.T) {
+	store := &latestMatchedStore{}
+	result := metabatch.LatestMatchedBookIDs(store)
+	if len(result) != 0 {
+		t.Errorf("expected empty map with no ops, got %v", result)
+	}
+}
+
+func TestLatestMatchedBookIDs_MatchedAndUnmatched(t *testing.T) {
+	now := time.Now()
+	store := &latestMatchedStore{
+		ops: []database.Operation{
+			{ID: "op-1", Type: "metadata_candidate_fetch"},
+		},
+		results: map[string][]database.OperationResult{
+			"op-1": {
+				{BookID: "book-a", Status: "matched", CreatedAt: now},
+				{BookID: "book-b", Status: "no_match", CreatedAt: now},
+				{BookID: "book-c", Status: "error", CreatedAt: now},
+			},
+		},
+	}
+	result := metabatch.LatestMatchedBookIDs(store)
+	if !result["book-a"] {
+		t.Error("expected book-a in matched set")
+	}
+	if result["book-b"] {
+		t.Error("expected book-b NOT in matched set (status=no_match)")
+	}
+	if result["book-c"] {
+		t.Error("expected book-c NOT in matched set (status=error)")
+	}
+}
+
+func TestLatestMatchedBookIDs_LatestWins(t *testing.T) {
+	// book-x was matched in op-1 but rejected in op-2 (newer). Should not be matched.
+	early := time.Now().Add(-1 * time.Hour)
+	late := time.Now()
+	store := &latestMatchedStore{
+		ops: []database.Operation{
+			{ID: "op-1", Type: "metadata_candidate_fetch"},
+			{ID: "op-2", Type: "metadata_candidate_fetch"},
+		},
+		results: map[string][]database.OperationResult{
+			"op-1": {
+				{BookID: "book-x", Status: "matched", CreatedAt: early},
+			},
+			"op-2": {
+				{BookID: "book-x", Status: "rejected", CreatedAt: late},
+			},
+		},
+	}
+	result := metabatch.LatestMatchedBookIDs(store)
+	if result["book-x"] {
+		t.Error("expected book-x NOT in matched set — latest result is 'rejected'")
+	}
+}
+
+func TestLatestMatchedBookIDs_IgnoresNonCandidateFetchOps(t *testing.T) {
+	now := time.Now()
+	store := &latestMatchedStore{
+		ops: []database.Operation{
+			{ID: "op-scan", Type: "scan"},
+			{ID: "op-fetch", Type: "metadata_candidate_fetch"},
+		},
+		results: map[string][]database.OperationResult{
+			"op-scan": {
+				{BookID: "book-z", Status: "matched", CreatedAt: now},
+			},
+			"op-fetch": {
+				{BookID: "book-y", Status: "matched", CreatedAt: now},
+			},
+		},
+	}
+	result := metabatch.LatestMatchedBookIDs(store)
+	if result["book-z"] {
+		t.Error("expected book-z NOT in matched set — it came from a non-candidate-fetch op")
+	}
+	if !result["book-y"] {
+		t.Error("expected book-y in matched set — it came from a candidate-fetch op")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CandidateResult round-trip assertions
+// ---------------------------------------------------------------------------
+
+func TestCandidateResult_ZeroValue(t *testing.T) {
+	var cr metabatch.CandidateResult
+	if cr.Status != "" {
+		t.Errorf("expected empty status, got %q", cr.Status)
+	}
+	if cr.Candidate != nil {
+		t.Error("expected nil Candidate on zero value")
+	}
+}
+
+func TestCandidateResult_WithCandidate(t *testing.T) {
+	score := 0.95
+	cr := metabatch.CandidateResult{
+		Status: "matched",
+		Book:   metabatch.CandidateBookInfo{ID: "b1", Title: "Ender's Game"},
+		Candidate: &metafetch.MetadataCandidate{
+			Source: "audible",
+			Title:  "Ender's Game",
+			Score:  score,
+		},
+	}
+	if cr.Candidate.Score != score {
+		t.Errorf("expected score %.2f, got %.2f", score, cr.Candidate.Score)
+	}
+}

--- a/internal/metabatch/fetch_op.go
+++ b/internal/metabatch/fetch_op.go
@@ -1,0 +1,24 @@
+// file: internal/metabatch/fetch_op.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-05-11
+//
+// FetchOpParams holds the serializable parameters for the
+// metadata.candidate-fetch v2 OperationDef. Kept here so the
+// server package (which owns the handler and op registration) and
+// any future recovery/replay tooling share the same type.
+
+package metabatch
+
+// FetchOpParams is the JSON params for the metadata.candidate-fetch
+// v2 OperationDef. LegacyOpID is the v1 operation record ID written
+// by the HTTP handler — OperationResult rows are keyed on this so
+// that handleGetPendingReview, handleGetOperationResults, and the
+// dedup scan in handleBatchFetchCandidates all continue working
+// unchanged.
+type FetchOpParams struct {
+	LegacyOpID  string   `json:"legacy_op_id"`
+	BookIDs     []string `json:"book_ids"`
+	TotalBooks  int      `json:"total_books"`
+	AlreadyDone int      `json:"already_done"` // used by resume path
+}

--- a/internal/metabatch/upgrade.go
+++ b/internal/metabatch/upgrade.go
@@ -1,0 +1,179 @@
+// file: internal/metabatch/upgrade.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-05-11
+//
+// Background job that upgrades metadata from lower-quality sources
+// (primarily Google Books) to richer ones (Hardcover, Audible/Audnexus)
+// when a high-confidence match is available. Backlog 7.4.
+//
+// The upgrade targets books tagged with `metadata:source:google_books`
+// (or any other source considered "lower quality"). For each candidate,
+// the job re-runs the full metadata search pipeline against ALL
+// configured sources. If the best result comes from a source OTHER
+// than the current one and its confidence score exceeds a threshold,
+// the upgrade is applied automatically.
+//
+// The job leverages the metadata fetch cache (PR #250) so re-fetches
+// for already-queried sources are free. Only sources that returned
+// empty on the initial fetch will actually hit the API.
+
+package metabatch
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+)
+
+// MetadataUpgradeService finds books with low-quality metadata
+// sources and attempts to upgrade them to richer sources.
+type MetadataUpgradeService struct {
+	DB      database.Store
+	Fetcher *metafetch.Service
+}
+
+// NewMetadataUpgradeService creates an upgrade service. The fetcher
+// provides the search + apply pipeline; the db provides the tag
+// lookup for finding eligible books.
+func NewMetadataUpgradeService(db database.Store, fetcher *metafetch.Service) *MetadataUpgradeService {
+	return &MetadataUpgradeService{DB: db, Fetcher: fetcher}
+}
+
+// LowQualitySources lists the metadata sources that are considered
+// "lower quality" — books whose metadata came from these sources
+// are candidates for upgrade. The tag namespace is
+// metadata:source:<slug> (all lowercase, spaces → underscores).
+var LowQualitySources = []string{
+	"google_books",
+	"wikipedia",
+}
+
+// UpgradeResult summarizes what the upgrade job did.
+type UpgradeResult struct {
+	Checked  int `json:"checked"`
+	Upgraded int `json:"upgraded"`
+	Skipped  int `json:"skipped"`
+	Errors   int `json:"errors"`
+}
+
+// MinUpgradeConfidence is the minimum score a non-current-source
+// candidate must achieve to trigger an automatic metadata apply.
+// Set conservatively high to avoid upgrading to a worse match.
+const MinUpgradeConfidence = 0.90
+
+// RunUpgrade scans for books tagged with low-quality metadata
+// sources and attempts to find a better match from other sources.
+// Respects context cancellation so it can be run as a long-running
+// operation with a kill switch.
+func (s *MetadataUpgradeService) RunUpgrade(ctx context.Context, limit int) (*UpgradeResult, error) {
+	if s.Fetcher == nil {
+		return nil, fmt.Errorf("metadata fetch service not configured")
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+
+	result := &UpgradeResult{}
+
+	for _, sourceSlug := range LowQualitySources {
+		tag := "metadata:source:" + sourceSlug
+		bookIDs, err := s.DB.GetBooksByTag(tag)
+		if err != nil {
+			log.Printf("[WARN] metadata-upgrade: GetBooksByTag(%s): %v", tag, err)
+			continue
+		}
+		log.Printf("[INFO] metadata-upgrade: found %d books tagged %s", len(bookIDs), tag)
+
+		for _, bookID := range bookIDs {
+			if ctx.Err() != nil {
+				return result, ctx.Err()
+			}
+			if result.Checked >= limit {
+				break
+			}
+			result.Checked++
+
+			upgraded, upgradeErr := s.tryUpgradeBook(ctx, bookID, sourceSlug)
+			if upgradeErr != nil {
+				log.Printf("[WARN] metadata-upgrade: book %s: %v", bookID, upgradeErr)
+				result.Errors++
+				continue
+			}
+			if upgraded {
+				result.Upgraded++
+			} else {
+				result.Skipped++
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// tryUpgradeBook re-searches metadata for a single book and
+// applies the best non-current-source result if it's confident
+// enough. Returns true if an upgrade was applied.
+func (s *MetadataUpgradeService) tryUpgradeBook(ctx context.Context, bookID, currentSourceSlug string) (bool, error) {
+	book, err := s.DB.GetBookByID(bookID)
+	if err != nil || book == nil {
+		return false, fmt.Errorf("book not found: %s", bookID)
+	}
+
+	// Run the full search pipeline — this goes through the
+	// metadata fetch cache, so sources that were already queried
+	// (and returned non-empty) won't hit the API again. Sources
+	// that returned empty last time WILL be retried because the
+	// cache only stores non-empty results.
+	resp, err := s.Fetcher.SearchMetadataForBook(bookID, book.Title)
+	if err != nil {
+		return false, fmt.Errorf("search failed: %w", err)
+	}
+	if resp == nil || len(resp.Results) == 0 {
+		return false, nil // no results at all
+	}
+
+	// Find the best candidate from a source OTHER than the current one.
+	var bestCandidate *metafetch.MetadataCandidate
+	for i := range resp.Results {
+		c := &resp.Results[i]
+		candidateSlug := strings.ToLower(strings.ReplaceAll(c.Source, " ", "_"))
+		if strings.HasPrefix(candidateSlug, "audnexus") {
+			candidateSlug = "audnexus"
+		}
+		// Skip candidates from the same source we're trying to upgrade FROM.
+		if candidateSlug == currentSourceSlug {
+			continue
+		}
+		if c.Score < MinUpgradeConfidence {
+			continue
+		}
+		if bestCandidate == nil || c.Score > bestCandidate.Score {
+			bestCandidate = c
+		}
+	}
+
+	if bestCandidate == nil {
+		return false, nil // no better source found above threshold
+	}
+
+	// Apply the upgrade. ApplyMetadataCandidate handles:
+	// - change history recording
+	// - metadata field application
+	// - provenance tagging (metadata:source:*, metadata:language:*)
+	// - cache invalidation
+	// - ISBN enrichment queueing
+	// - file I/O queueing (cover embed, tag write, rename)
+	_, applyErr := s.Fetcher.ApplyMetadataCandidate(bookID, *bestCandidate, nil)
+	if applyErr != nil {
+		return false, fmt.Errorf("apply failed: %w", applyErr)
+	}
+
+	log.Printf("[INFO] metadata-upgrade: upgraded %s from %s → %s (score=%.2f, title=%q)",
+		bookID, currentSourceSlug, bestCandidate.Source, bestCandidate.Score, bestCandidate.Title)
+	return true, nil
+}

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,10 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 2.2.0
+// version: 3.0.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-05-11
+//
+// HTTP handlers for the metadata candidate batch fetch / apply pipeline.
+// Pure service types and logic live in internal/metabatch.
 
 package server
 
@@ -19,90 +22,23 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/metabatch"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 )
 
-// CandidateBookInfo contains summary info about a book used in candidate results.
-type CandidateBookInfo struct {
-	ID         string `json:"id"`
-	Title      string `json:"title"`
-	Author     string `json:"author"`
-	FilePath   string `json:"file_path"`
-	ITunesPath string `json:"itunes_path,omitempty"`
-	CoverURL   string `json:"cover_url,omitempty"`
-	Format     string `json:"format,omitempty"`
-	Duration   int    `json:"duration_seconds,omitempty"`
-	FileSize   int64  `json:"file_size_bytes,omitempty"`
-	// Language is the book's current language as stored on the
-	// Book row (ISO code or full name, whatever was last applied).
-	// Used by the review dialog's language filter to hide
-	// candidates whose language disagrees with the book's — the
-	// motivating Spanish/English "Ancillary Sword" screenshot fix.
-	// Empty when the book has no language set, in which case the
-	// filter is a no-op for that row.
-	Language string `json:"language,omitempty"`
-}
-
-// CandidateResult holds the metadata candidate search result for a single book.
-type CandidateResult struct {
-	Book      CandidateBookInfo            `json:"book"`
-	Candidate *metafetch.MetadataCandidate `json:"candidate,omitempty"`
-	Status    string                       `json:"status"` // "matched", "no_match", "error"
-	Error     string                       `json:"error_message,omitempty"`
-}
+// Re-export metabatch types under server-local aliases so existing
+// JSON serialisation and test references continue to compile unchanged.
+type CandidateBookInfo = metabatch.CandidateBookInfo
+type CandidateResult = metabatch.CandidateResult
 
 // batchFetchRequest is the JSON body for handleBatchFetchCandidates.
 // Either BookIDs or Selection must be provided; OnlyUnmatched can be combined
 // with either to exclude books that already have a "matched" candidate.
-type batchFetchRequest struct {
-	BookIDs       []string                    `json:"book_ids"`
-	Selection     *operations.SelectionSpec   `json:"selection"`
-	OnlyUnmatched bool                        `json:"only_unmatched"`
-}
-
-// latestMatchedBookIDs returns the set of book IDs whose most-recent
-// metadata_candidate_fetch result has status "matched".  Used to exclude
-// already-matched books when OnlyUnmatched is requested.
-func latestMatchedBookIDs(store database.Store) map[string]bool {
-	allOps, err := store.GetRecentOperations(5000)
-	if err != nil {
-		return nil
-	}
-	type entry struct {
-		status    string
-		createdAt time.Time
-	}
-	latest := map[string]entry{}
-	for _, op := range allOps {
-		if op.Type != "metadata_candidate_fetch" {
-			continue
-		}
-		results, err := store.GetOperationResults(op.ID)
-		if err != nil {
-			continue
-		}
-		for _, r := range results {
-			ex, ok := latest[r.BookID]
-			if !ok || r.CreatedAt.After(ex.createdAt) {
-				latest[r.BookID] = entry{status: r.Status, createdAt: r.CreatedAt}
-			}
-		}
-	}
-	matched := make(map[string]bool, len(latest))
-	for bookID, e := range latest {
-		if e.status == "matched" {
-			matched[bookID] = true
-		}
-	}
-	return matched
-}
+type batchFetchRequest = metabatch.BatchFetchRequest
 
 // batchApplyRequest is the JSON body for handleBatchApplyCandidates.
-type batchApplyRequest struct {
-	OperationID string   `json:"operation_id" binding:"required"`
-	BookIDs     []string `json:"book_ids" binding:"required"`
-}
+type batchApplyRequest = metabatch.BatchApplyRequest
 
 // handleBatchFetchCandidates creates a background operation that spawns parallel
 // workers to fetch metadata candidates for the given book IDs.
@@ -134,7 +70,7 @@ func (s *Server) handleBatchFetchCandidates(c *gin.Context) {
 
 	// Optionally exclude books already having a "matched" candidate.
 	if req.OnlyUnmatched {
-		matched := latestMatchedBookIDs(store)
+		matched := metabatch.LatestMatchedBookIDs(store)
 		filtered := candidateIDs[:0]
 		for _, id := range candidateIDs {
 			if !matched[id] {
@@ -258,7 +194,7 @@ func (s *Server) fetchCandidateForBook(
 		}
 	}
 
-	bookInfo := buildCandidateBookInfo(store, book)
+	bookInfo := metabatch.BuildCandidateBookInfo(store, book)
 
 	// Wait for rate limiter before making external requests.
 	if err := limiter.Wait(ctx); err != nil {
@@ -292,7 +228,7 @@ func (s *Server) fetchCandidateForBook(
 
 	// Load previously rejected candidates for this book (across all operations)
 	// and filter them out so we pick the next best match.
-	rejectedKeys := loadRejectedCandidateKeys(store, bookID)
+	rejectedKeys := metabatch.LoadRejectedCandidateKeys(store, bookID)
 	var filtered []metafetch.MetadataCandidate
 	for _, c := range resp.Results {
 		key := c.Source + "|" + c.Title
@@ -315,36 +251,6 @@ func (s *Server) fetchCandidateForBook(
 		Candidate: &topCandidate,
 		Status:    "matched",
 	}
-}
-
-// buildCandidateBookInfo builds a CandidateBookInfo from a database.Book.
-// store is used to look up BookFile.ITunesPath (the authoritative field).
-func buildCandidateBookInfo(store database.BookFileStore, book *database.Book) CandidateBookInfo {
-	info := CandidateBookInfo{
-		ID:       book.ID,
-		Title:    book.Title,
-		FilePath: book.FilePath,
-		Format:   book.Format,
-	}
-	if book.Author != nil {
-		info.Author = book.Author.Name
-	}
-	if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 {
-		info.ITunesPath = bfs[0].ITunesPath
-	}
-	if book.CoverURL != nil {
-		info.CoverURL = *book.CoverURL
-	}
-	if book.Duration != nil {
-		info.Duration = *book.Duration
-	}
-	if book.FileSize != nil {
-		info.FileSize = *book.FileSize
-	}
-	if book.Language != nil {
-		info.Language = *book.Language
-	}
-	return info
 }
 
 // handleGetOperationResults returns a paginated page of candidate results for an operation.
@@ -428,9 +334,9 @@ func (s *Server) handleGetOperationResults(c *gin.Context) {
 		Results:      candidateResults,
 		Total:        totalCount,
 		TotalCount:   totalCount,
-		Matched:      countByStatus(candidateResults, "matched"),
-		NoMatch:      countByStatus(candidateResults, "no_match"),
-		Errors:       countByStatus(candidateResults, "error"),
+		Matched:      metabatch.CountByStatus(candidateResults, "matched"),
+		NoMatch:      metabatch.CountByStatus(candidateResults, "no_match"),
+		Errors:       metabatch.CountByStatus(candidateResults, "error"),
 		TotalMatched: totalMatched,
 		TotalNoMatch: totalNoMatch,
 		TotalErrors:  totalErrors,
@@ -537,17 +443,6 @@ func (s *Server) handleGetLatestMetadataFetch(c *gin.Context) {
 	}{Operations: out, Count: len(out)})
 }
 
-// countByStatus counts CandidateResults with the given status.
-func countByStatus(results []CandidateResult, status string) int {
-	n := 0
-	for _, r := range results {
-		if r.Status == status {
-			n++
-		}
-	}
-	return n
-}
-
 // handleBatchApplyCandidates applies stored metadata candidates for the selected books.
 func (s *Server) handleBatchApplyCandidates(c *gin.Context) {
 	var req batchApplyRequest
@@ -646,28 +541,6 @@ func (s *Server) handleBatchApplyCandidates(c *gin.Context) {
 		ErrorCount:  len(errors),
 		OperationID: req.OperationID,
 	})
-}
-
-// loadRejectedCandidateKeys finds previously rejected candidates for a book.
-// Uses a dedicated rejection key prefix for fast lookup instead of scanning
-// all operation results.
-func loadRejectedCandidateKeys(store database.RawKVStore, bookID string) map[string]bool {
-	keys := make(map[string]bool)
-	// Scan only rejection keys for this specific book
-	pairs, err := store.ScanPrefix(fmt.Sprintf("rejected_candidate:%s:", bookID))
-	if err != nil {
-		return keys
-	}
-	for _, kv := range pairs {
-		// Key format: rejected_candidate:{bookID}:{source}|{title}
-		// Value is just "1" — we only need the key
-		keyStr := string(kv.Key)
-		prefix := fmt.Sprintf("rejected_candidate:%s:", bookID)
-		if len(keyStr) > len(prefix) {
-			keys[keyStr[len(prefix):]] = true
-		}
-	}
-	return keys
 }
 
 // handleRejectCandidates stores rejected candidates so future fetches exclude them.

--- a/internal/server/metadata_candidate_op.go
+++ b/internal/server/metadata_candidate_op.go
@@ -1,6 +1,10 @@
 // file: internal/server/metadata_candidate_op.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 3f7e2c91-b4a0-4d8e-9c5f-1a6b7d8e0f23
+// last-edited: 2026-05-11
+//
+// Registers the metadata.candidate-fetch v2 OperationDef. Pure params
+// type moved to internal/metabatch.FetchOpParams.
 
 package server
 
@@ -15,21 +19,14 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/metabatch"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"golang.org/x/time/rate"
 )
 
-// metadataCandidateFetchOpParams is the JSON params for the
-// metadata.candidate-fetch v2 OperationDef. LegacyOpID is the v1 operation
-// record ID written by the HTTP handler — OperationResult rows are keyed on
-// this so that handleGetPendingReview, handleGetOperationResults, and the
-// dedup scan in handleBatchFetchCandidates all continue working unchanged.
-type metadataCandidateFetchOpParams struct {
-	LegacyOpID  string   `json:"legacy_op_id"`
-	BookIDs     []string `json:"book_ids"`
-	TotalBooks  int      `json:"total_books"`
-	AlreadyDone int      `json:"already_done"` // used by resume path
-}
+// metadataCandidateFetchOpParams is a server-local alias for the shared params
+// type so callers in this package do not need to qualify the package name.
+type metadataCandidateFetchOpParams = metabatch.FetchOpParams
 
 // RegisterMetadataCandidateFetchOp registers the "metadata.candidate-fetch"
 // v2 OperationDef. The HTTP handler creates a v1 op record for backward

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/metabatch"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
@@ -1131,7 +1132,7 @@ func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.Filter
 		ids = append(ids, b.ID)
 	}
 	if f.OnlyUnmatched {
-		matched := latestMatchedBookIDs(s.Store())
+		matched := metabatch.LatestMatchedBookIDs(s.Store())
 		filtered := ids[:0]
 		for _, id := range ids {
 			if !matched[id] {

--- a/internal/server/metadata_upgrade.go
+++ b/internal/server/metadata_upgrade.go
@@ -1,178 +1,20 @@
 // file: internal/server/metadata_upgrade.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: 4a3b2c1d-0e9f-8a7b-6c5d-4e3f2a1b0c9d
+// last-edited: 2026-05-11
 //
-// Background job that upgrades metadata from lower-quality sources
-// (primarily Google Books) to richer ones (Hardcover, Audible/Audnexus)
-// when a high-confidence match is available. Backlog 7.4.
-//
-// The upgrade targets books tagged with `metadata:source:google_books`
-// (or any other source considered "lower quality"). For each candidate,
-// the job re-runs the full metadata search pipeline against ALL
-// configured sources. If the best result comes from a source OTHER
-// than the current one and its confidence score exceeds a threshold,
-// the upgrade is applied automatically.
-//
-// The job leverages the metadata fetch cache (PR #250) so re-fetches
-// for already-queried sources are free. Only sources that returned
-// empty on the initial fetch will actually hit the API.
+// Re-exports MetadataUpgradeService from internal/metabatch so existing
+// server wiring code continues to compile without changes. All logic
+// has moved to internal/metabatch/upgrade.go.
 
 package server
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
+import "github.com/jdfalk/audiobook-organizer/internal/metabatch"
 
-	"github.com/jdfalk/audiobook-organizer/internal/database"
-	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
-)
+// MetadataUpgradeService is a server-local alias for the metabatch type,
+// preserving backward compatibility for any server wiring that references it.
+type MetadataUpgradeService = metabatch.MetadataUpgradeService
 
-// MetadataUpgradeService finds books with low-quality metadata
-// sources and attempts to upgrade them to richer sources.
-type MetadataUpgradeService struct {
-	db      database.Store
-	fetcher *metafetch.Service
-}
-
-// NewMetadataUpgradeService creates an upgrade service. The fetcher
-// provides the search + apply pipeline; the db provides the tag
-// lookup for finding eligible books.
-func NewMetadataUpgradeService(db database.Store, fetcher *metafetch.Service) *MetadataUpgradeService {
-	return &MetadataUpgradeService{db: db, fetcher: fetcher}
-}
-
-// lowQualitySources lists the metadata sources that are considered
-// "lower quality" — books whose metadata came from these sources
-// are candidates for upgrade. The tag namespace is
-// metadata:source:<slug> (all lowercase, spaces → underscores).
-var lowQualitySources = []string{
-	"google_books",
-	"wikipedia",
-}
-
-// UpgradeResult summarizes what the upgrade job did.
-type UpgradeResult struct {
-	Checked  int `json:"checked"`
-	Upgraded int `json:"upgraded"`
-	Skipped  int `json:"skipped"`
-	Errors   int `json:"errors"`
-}
-
-// minUpgradeConfidence is the minimum score a non-current-source
-// candidate must achieve to trigger an automatic metadata apply.
-// Set conservatively high to avoid upgrading to a worse match.
-const minUpgradeConfidence = 0.90
-
-// RunUpgrade scans for books tagged with low-quality metadata
-// sources and attempts to find a better match from other sources.
-// Respects context cancellation so it can be run as a long-running
-// operation with a kill switch.
-func (s *MetadataUpgradeService) RunUpgrade(ctx context.Context, limit int) (*UpgradeResult, error) {
-	if s.fetcher == nil {
-		return nil, fmt.Errorf("metadata fetch service not configured")
-	}
-	if limit <= 0 {
-		limit = 200
-	}
-
-	result := &UpgradeResult{}
-
-	for _, sourceSlug := range lowQualitySources {
-		tag := "metadata:source:" + sourceSlug
-		bookIDs, err := s.db.GetBooksByTag(tag)
-		if err != nil {
-			log.Printf("[WARN] metadata-upgrade: GetBooksByTag(%s): %v", tag, err)
-			continue
-		}
-		log.Printf("[INFO] metadata-upgrade: found %d books tagged %s", len(bookIDs), tag)
-
-		for _, bookID := range bookIDs {
-			if ctx.Err() != nil {
-				return result, ctx.Err()
-			}
-			if result.Checked >= limit {
-				break
-			}
-			result.Checked++
-
-			upgraded, upgradeErr := s.tryUpgradeBook(ctx, bookID, sourceSlug)
-			if upgradeErr != nil {
-				log.Printf("[WARN] metadata-upgrade: book %s: %v", bookID, upgradeErr)
-				result.Errors++
-				continue
-			}
-			if upgraded {
-				result.Upgraded++
-			} else {
-				result.Skipped++
-			}
-		}
-	}
-
-	return result, nil
-}
-
-// tryUpgradeBook re-searches metadata for a single book and
-// applies the best non-current-source result if it's confident
-// enough. Returns true if an upgrade was applied.
-func (s *MetadataUpgradeService) tryUpgradeBook(ctx context.Context, bookID, currentSourceSlug string) (bool, error) {
-	book, err := s.db.GetBookByID(bookID)
-	if err != nil || book == nil {
-		return false, fmt.Errorf("book not found: %s", bookID)
-	}
-
-	// Run the full search pipeline — this goes through the
-	// metadata fetch cache, so sources that were already queried
-	// (and returned non-empty) won't hit the API again. Sources
-	// that returned empty last time WILL be retried because the
-	// cache only stores non-empty results.
-	resp, err := s.fetcher.SearchMetadataForBook(bookID, book.Title)
-	if err != nil {
-		return false, fmt.Errorf("search failed: %w", err)
-	}
-	if resp == nil || len(resp.Results) == 0 {
-		return false, nil // no results at all
-	}
-
-	// Find the best candidate from a source OTHER than the current one.
-	var bestCandidate *metafetch.MetadataCandidate
-	for i := range resp.Results {
-		c := &resp.Results[i]
-		candidateSlug := strings.ToLower(strings.ReplaceAll(c.Source, " ", "_"))
-		if strings.HasPrefix(candidateSlug, "audnexus") {
-			candidateSlug = "audnexus"
-		}
-		// Skip candidates from the same source we're trying to upgrade FROM.
-		if candidateSlug == currentSourceSlug {
-			continue
-		}
-		if c.Score < minUpgradeConfidence {
-			continue
-		}
-		if bestCandidate == nil || c.Score > bestCandidate.Score {
-			bestCandidate = c
-		}
-	}
-
-	if bestCandidate == nil {
-		return false, nil // no better source found above threshold
-	}
-
-	// Apply the upgrade. ApplyMetadataCandidate handles:
-	// - change history recording
-	// - metadata field application
-	// - provenance tagging (metadata:source:*, metadata:language:*)
-	// - cache invalidation
-	// - ISBN enrichment queueing
-	// - file I/O queueing (cover embed, tag write, rename)
-	_, applyErr := s.fetcher.ApplyMetadataCandidate(bookID, *bestCandidate, nil)
-	if applyErr != nil {
-		return false, fmt.Errorf("apply failed: %w", applyErr)
-	}
-
-	log.Printf("[INFO] metadata-upgrade: upgraded %s from %s → %s (score=%.2f, title=%q)",
-		bookID, currentSourceSlug, bestCandidate.Source, bestCandidate.Score, bestCandidate.Title)
-	return true, nil
-}
+// NewMetadataUpgradeService is a convenience alias for the constructor in
+// internal/metabatch.
+var NewMetadataUpgradeService = metabatch.NewMetadataUpgradeService


### PR DESCRIPTION
## Summary
- New `internal/metabatch` package (not `internal/metadata` to avoid circular import with metafetch)
- `CandidateBookInfo`, `CandidateResult`, `BatchFetchRequest`, `LatestMatchedBookIDs`, `BuildCandidateBookInfo` extracted
- `MetadataUpgradeService` extracted with 0 `*Server` dependencies
- `FetchOpParams` exported for operation parameter passing
- 12 unit tests for candidate building and batch fetch logic

## Test plan
- [ ] `go test ./internal/metabatch/...`
- [ ] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)