### PR TITLE
refactor(deluge): extract deluge discovery/import to internal/deluge

### DIFF
--- a/internal/deluge/discovery.go
+++ b/internal/deluge/discovery.go
@@ -1,0 +1,350 @@
+// file: internal/deluge/discovery.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-05-11
+//
+// Four-tier matching to decide if a labeled Deluge torrent is already in
+// the library — run in order, stop on first hit:
+//
+//  1. Hash    — GetBookVersionByTorrentHash: exact, works regardless of where
+//               the file moved after organize.
+//  2. Path    — filepath.Join(save_path, name) is a prefix of Book.FilePath:
+//               catches books still sitting in the download directory.
+//  3. Title   — parse the torrent name into candidate title strings, check
+//               against a normalised set of Book.Title values. When a title
+//               match fires, Tier 4 SHA-verifies the actual files.
+//  4. SHA256  — SHA256 each audio file found under content_path, query
+//               GetBookByFileHash for each. A hash hit confirms the fuzzy
+//               title match; a miss means it's a different edition/version.
+//
+// A torrent that passes all four tiers is returned as a discovery candidate.
+
+package deluge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
+)
+
+// DiscoveredTorrent is a Deluge torrent not yet tracked in the library.
+type DiscoveredTorrent struct {
+	Hash        string  `json:"hash"`
+	Name        string  `json:"name"`
+	SavePath    string  `json:"save_path"`
+	ContentPath string  `json:"content_path"` // filepath.Join(save_path, name) — import this
+	Label       string  `json:"label"`
+	State       string  `json:"state"`
+	Progress    float64 `json:"progress"`
+	TotalSize   int64   `json:"total_size"`
+	MatchTier   string  `json:"match_tier,omitempty"` // debug: which tier matched (empty = new)
+}
+
+// LibraryIndex is a pre-built lookup structure used by all match tiers.
+type LibraryIndex struct {
+	// Tier 2: normalised current file paths → present
+	Paths map[string]struct{}
+	// Tier 3: normalised book titles → present
+	Titles map[string]struct{}
+}
+
+// BookLister is the narrow interface needed to build a library index.
+type BookLister interface {
+	GetAllBooks(limit, offset int) ([]database.Book, error)
+}
+
+// BuildLibraryIndex builds a LibraryIndex from all books in the store.
+func BuildLibraryIndex(store BookLister) LibraryIndex {
+	idx := LibraryIndex{
+		Paths:  make(map[string]struct{}),
+		Titles: make(map[string]struct{}),
+	}
+	books, err := store.GetAllBooks(100000, 0)
+	if err != nil {
+		log.Printf("[WARN] deluge discovery: failed to load books: %v", err)
+		return idx
+	}
+	for _, b := range books {
+		if b.FilePath != "" {
+			idx.Paths[b.FilePath] = struct{}{}
+		}
+		if b.Title != "" {
+			idx.Titles[NormalizeTitle(b.Title)] = struct{}{}
+		}
+	}
+	return idx
+}
+
+// ContentFingerprintStore is the subset of database.Store needed for
+// content fingerprint / hash lookups.
+type ContentFingerprintStore interface {
+	GetBookByFileHash(hash string) (*database.Book, error)
+	GetBookFileByAcoustID(fp string) (*database.BookFile, error)
+	GetBookFileByAcoustIDFuzzy(fp string, minSim float64) (*database.BookFile, error)
+}
+
+// DiscoveryStore is the subset of database.Store needed by DiscoverUnimported.
+type DiscoveryStore interface {
+	BookLister
+	GetBookVersionByTorrentHash(hash string) (*database.BookVersion, error)
+	ContentFingerprintStore
+}
+
+// DiscoverUnimported fetches labeled torrents and returns those not already
+// in the library according to the four-tier matching strategy.
+func DiscoverUnimported(store DiscoveryStore, client *Client, label string) ([]DiscoveredTorrent, error) {
+	torrents, err := client.ListTorrentsByLabel(label)
+	if err != nil {
+		return nil, err
+	}
+	if len(torrents) == 0 {
+		return []DiscoveredTorrent{}, nil
+	}
+
+	idx := BuildLibraryIndex(store)
+
+	var unimported []DiscoveredTorrent
+	for _, t := range torrents {
+		// Tier 1: torrent hash lookup (O(1), authoritative).
+		if t.Hash != "" {
+			if ver, _ := store.GetBookVersionByTorrentHash(t.Hash); ver != nil {
+				continue // already tracked
+			}
+		}
+
+		// Tier 2: content path prefix against current file paths.
+		contentPath := filepath.Join(t.SavePath, t.Name)
+		if IsPathTracked(contentPath, idx.Paths) {
+			continue
+		}
+
+		// Tier 3: torrent name → title candidates against known titles.
+		// When a title match fires, Tier 4 verifies actual file content.
+		if IsTitleTracked(t.Name, idx.Titles) {
+			if IsContentFingerprintTracked(store, contentPath) {
+				continue // same audio stream — already in library
+			}
+			// Title matched but audio differs → different edition, surface it.
+		}
+
+		unimported = append(unimported, DiscoveredTorrent{
+			Hash:        t.Hash,
+			Name:        t.Name,
+			SavePath:    t.SavePath,
+			ContentPath: contentPath,
+			Label:       t.Label,
+			State:       t.State,
+			Progress:    t.Progress,
+			TotalSize:   t.TotalSize,
+		})
+	}
+	return unimported, nil
+}
+
+// IsContentFingerprintTracked walks contentPath for the first audio file,
+// fingerprints it with fpcalc, and checks the library via exact then fuzzy
+// AcoustID match. Returns true if the audio stream is already tracked.
+//
+// Falls back to SHA-256 walking when fpcalc is not installed so the pipeline
+// is never blocked by a missing dependency.
+func IsContentFingerprintTracked(store ContentFingerprintStore, contentPath string) bool {
+	if !fingerprint.Available() {
+		// fpcalc not installed — fall back to SHA-256 content walk.
+		hashLookup := func(hash string) bool {
+			b, _ := store.GetBookByFileHash(hash)
+			return b != nil
+		}
+		return IsContentHashTracked(contentPath, hashLookup)
+	}
+
+	// Find the first audio file under contentPath to fingerprint.
+	var firstAudio string
+	_ = filepath.Walk(contentPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || firstAudio != "" {
+			return nil
+		}
+		if _, ok := AudioExtensions[strings.ToLower(filepath.Ext(path))]; ok {
+			firstAudio = path
+		}
+		return nil
+	})
+	if firstAudio == "" {
+		return false
+	}
+
+	segs, err := fingerprint.FileSegments(firstAudio, 0)
+	if err != nil {
+		log.Printf("[WARN] deluge discovery: fingerprint %s: %v", firstAudio, err)
+		return false
+	}
+	// Use the intro segment (seg[0]) for exact and fuzzy lookups.
+	introFP := segs[0]
+	if introFP == "" {
+		return false
+	}
+
+	// Exact match first (O(1) index lookup).
+	if f, _ := store.GetBookFileByAcoustID(introFP); f != nil {
+		return true
+	}
+
+	// Fuzzy fallback — catches minor encoding variations.
+	f, _ := store.GetBookFileByAcoustIDFuzzy(introFP, fingerprint.FuzzyMinSimilarity)
+	return f != nil
+}
+
+// IsPathTracked returns true if contentPath is a prefix of any known file path.
+//
+// Callers MUST pass filepath.Join(save_path, torrent_name) — NOT save_path
+// alone. A shared download directory is a prefix of everything in it, so
+// using raw save_path would mark every torrent as tracked once any file from
+// that directory exists in the DB.
+func IsPathTracked(contentPath string, known map[string]struct{}) bool {
+	if contentPath == "" {
+		return false
+	}
+	prefix := strings.TrimRight(contentPath, "/") + "/"
+	for p := range known {
+		if strings.HasPrefix(p, prefix) || p == contentPath {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTitleTracked parses a torrent name into candidate titles and checks each
+// against the normalised DB title set.
+func IsTitleTracked(torrentName string, titles map[string]struct{}) bool {
+	for _, candidate := range ParseTorrentNameCandidates(torrentName) {
+		if _, ok := titles[candidate]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// AudioExtensions is the set of file extensions we hash for content matching.
+var AudioExtensions = map[string]struct{}{
+	".m4b": {}, ".m4a": {}, ".mp3": {}, ".flac": {}, ".aax": {},
+	".aac": {}, ".ogg": {}, ".opus": {}, ".wav": {},
+}
+
+// IsContentHashTracked walks contentPath, SHA256s each audio file, and calls
+// lookup for each hash. Returns true as soon as any hash is found in the DB.
+func IsContentHashTracked(contentPath string, lookup func(string) bool) bool {
+	found := false
+	_ = filepath.Walk(contentPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || found {
+			return nil
+		}
+		if _, ok := AudioExtensions[strings.ToLower(filepath.Ext(path))]; !ok {
+			return nil
+		}
+		hash, hashErr := SHA256File(path)
+		if hashErr != nil {
+			log.Printf("[WARN] deluge discovery: sha256 %s: %v", path, hashErr)
+			return nil
+		}
+		if lookup(hash) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// SHA256File returns the hex-encoded SHA256 of a file's contents.
+func SHA256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// stripBrackets removes common annotation brackets: [Unabridged], {MP3}, (2023).
+var stripBrackets = regexp.MustCompile(`[\[\]{}(][^\[\]{}()]*[\]\})]`)
+
+// metaSuffixes are noise tokens appended to torrent names.
+var metaSuffixes = regexp.MustCompile(`(?i)\b(unabridged|abridged|m4b|mp3|aax|flac|aac|ogg|retail|repack|\d{4})\b.*$`)
+
+// ParseTorrentNameCandidates returns a set of normalised title strings derived
+// from a torrent name. The typical formats handled:
+//
+//	"Author - Title"              → ["title", "author"]
+//	"Title - Author"              → ["title", "author"]
+//	"Title by Author [M4B]"       → ["title"]
+//	"Author.Title.Year.M4B"       → ["author title"] (dots-as-spaces)
+//	"Title (Author) [Unabridged]" → ["title"]
+func ParseTorrentNameCandidates(name string) []string {
+	seen := make(map[string]struct{})
+	add := func(s string) {
+		s = NormalizeTitle(s)
+		if len(s) >= 3 {
+			seen[s] = struct{}{}
+		}
+	}
+
+	// Strip bracket annotations first.
+	clean := stripBrackets.ReplaceAllString(name, " ")
+	// Remove file-format / year suffixes.
+	clean = metaSuffixes.ReplaceAllString(clean, "")
+	clean = strings.TrimSpace(clean)
+
+	// Try dash-separated "Author - Title" or "Title - Author".
+	if parts := strings.SplitN(clean, " - ", 2); len(parts) == 2 {
+		add(parts[0])
+		add(parts[1])
+	}
+
+	// Try "Title by Author".
+	if idx := strings.Index(strings.ToLower(clean), " by "); idx > 0 {
+		add(clean[:idx])
+	}
+
+	// Try dot-separated names (common for scene releases).
+	if strings.ContainsRune(clean, '.') && !strings.ContainsRune(clean, ' ') {
+		add(strings.ReplaceAll(clean, ".", " "))
+	}
+
+	// Always include the whole cleaned name as a fallback candidate.
+	add(clean)
+
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	return out
+}
+
+// NormalizeTitle lowercases, strips punctuation, and collapses whitespace so
+// that "The Way of Kings" and "the way of kings!" both normalise to the same
+// string for comparison.
+func NormalizeTitle(s string) string {
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			prevSpace = false
+		} else if !prevSpace {
+			b.WriteRune(' ')
+			prevSpace = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/deluge/discovery_test.go
+++ b/internal/deluge/discovery_test.go
@@ -1,0 +1,205 @@
+// file: internal/deluge/discovery_test.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
+// last-edited: 2026-05-11
+//
+// Tests for the four-tier discovery matching helpers in internal/deluge/discovery.go.
+
+package deluge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDlDir = "/mnt/bigdata/books/deluge"
+
+// ---------------------------------------------------------------------------
+// NormalizeTitle
+// ---------------------------------------------------------------------------
+
+func TestNormalizeTitle_Basic(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"The Way of Kings", "the way of kings"},
+		{"The Way of Kings!", "the way of kings"},
+		{"Dune (2023)", "dune 2023"},
+		{"Foundation - Isaac Asimov", "foundation isaac asimov"},
+		{"", ""},
+		{"  spaces  ", "spaces"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, NormalizeTitle(c.in), "NormalizeTitle(%q)", c.in)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsPathTracked (Tier 2)
+// ---------------------------------------------------------------------------
+
+func TestIsPathTracked_EmptyContentPath(t *testing.T) {
+	known := map[string]struct{}{testDlDir + "/Dune/Dune.m4b": {}}
+	assert.False(t, IsPathTracked("", known))
+}
+
+func TestIsPathTracked_ExactMatch(t *testing.T) {
+	known := map[string]struct{}{testDlDir + "/Dune.m4b": {}}
+	assert.True(t, IsPathTracked(testDlDir+"/Dune.m4b", known))
+}
+
+func TestIsPathTracked_ContentDirPrefixMatch(t *testing.T) {
+	known := map[string]struct{}{testDlDir + "/Dune/Dune.m4b": {}}
+	assert.True(t, IsPathTracked(testDlDir+"/Dune", known))
+}
+
+func TestIsPathTracked_UnimportedTorrent(t *testing.T) {
+	known := map[string]struct{}{testDlDir + "/Dune/Dune.m4b": {}}
+	assert.False(t, IsPathTracked(testDlDir+"/Foundation", known))
+}
+
+func TestIsPathTracked_PartialNameNotMatched(t *testing.T) {
+	// "Du" must NOT match "Dune" — we check full path prefix with trailing /
+	known := map[string]struct{}{testDlDir + "/Dune/Dune.m4b": {}}
+	assert.False(t, IsPathTracked(testDlDir+"/Du", known))
+}
+
+func TestIsPathTracked_TrailingSlashNormalized(t *testing.T) {
+	known := map[string]struct{}{testDlDir + "/Dune/Dune.m4b": {}}
+	assert.True(t, IsPathTracked(testDlDir+"/Dune/", known))
+}
+
+// ---------------------------------------------------------------------------
+// ParseTorrentNameCandidates (Tier 3 helper)
+// ---------------------------------------------------------------------------
+
+func TestParseTorrentNameCandidates_DashSeparated(t *testing.T) {
+	candidates := ParseTorrentNameCandidates("Brandon Sanderson - The Way of Kings")
+	assert.Contains(t, candidates, NormalizeTitle("Brandon Sanderson"))
+	assert.Contains(t, candidates, NormalizeTitle("The Way of Kings"))
+}
+
+func TestParseTorrentNameCandidates_ByKeyword(t *testing.T) {
+	candidates := ParseTorrentNameCandidates("The Way of Kings by Brandon Sanderson [M4B]")
+	assert.Contains(t, candidates, NormalizeTitle("The Way of Kings"))
+}
+
+func TestParseTorrentNameCandidates_DotSeparated(t *testing.T) {
+	candidates := ParseTorrentNameCandidates("Dune.Frank.Herbert.2023.M4B")
+	assert.Contains(t, candidates, "dune frank herbert")
+}
+
+func TestParseTorrentNameCandidates_UnabridgedStripped(t *testing.T) {
+	candidates := ParseTorrentNameCandidates("Dune [Unabridged]")
+	// "unabridged" must be stripped; only "dune" remains
+	for _, c := range candidates {
+		assert.NotContains(t, c, "unabridged")
+	}
+	assert.Contains(t, candidates, "dune")
+}
+
+// ---------------------------------------------------------------------------
+// IsTitleTracked (Tier 3)
+// ---------------------------------------------------------------------------
+
+func TestIsTitleTracked_Hit(t *testing.T) {
+	titles := map[string]struct{}{
+		NormalizeTitle("The Way of Kings"): {},
+	}
+	assert.True(t, IsTitleTracked("Brandon Sanderson - The Way of Kings [M4B]", titles))
+}
+
+func TestIsTitleTracked_Miss(t *testing.T) {
+	titles := map[string]struct{}{
+		NormalizeTitle("Dune"): {},
+	}
+	assert.False(t, IsTitleTracked("Brandon Sanderson - The Way of Kings", titles))
+}
+
+func TestIsTitleTracked_EmptyTitles(t *testing.T) {
+	assert.False(t, IsTitleTracked("Brandon Sanderson - The Way of Kings", map[string]struct{}{}))
+}
+
+// ---------------------------------------------------------------------------
+// SHA256File + IsContentHashTracked (Tier 4)
+// ---------------------------------------------------------------------------
+
+func TestSHA256File_BasicHash(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.m4b")
+	require.NoError(t, os.WriteFile(f, []byte("audiodata"), 0o644))
+
+	hash1, err := SHA256File(f)
+	require.NoError(t, err)
+	assert.Len(t, hash1, 64) // hex-encoded SHA256 = 64 chars
+
+	// Same content → same hash.
+	hash2, err := SHA256File(f)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+func TestSHA256File_DifferentContent(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.m4b")
+	f2 := filepath.Join(dir, "b.m4b")
+	require.NoError(t, os.WriteFile(f1, []byte("data1"), 0o644))
+	require.NoError(t, os.WriteFile(f2, []byte("data2"), 0o644))
+
+	h1, _ := SHA256File(f1)
+	h2, _ := SHA256File(f2)
+	assert.NotEqual(t, h1, h2)
+}
+
+func TestSHA256File_MissingFile(t *testing.T) {
+	_, err := SHA256File("/nonexistent/file.m4b")
+	assert.Error(t, err)
+}
+
+func TestIsContentHashTracked_MatchFound(t *testing.T) {
+	dir := t.TempDir()
+	audio := filepath.Join(dir, "book.m4b")
+	require.NoError(t, os.WriteFile(audio, []byte("audiodata"), 0o644))
+
+	expected, _ := SHA256File(audio)
+	lookup := func(h string) bool { return h == expected }
+
+	assert.True(t, IsContentHashTracked(dir, lookup))
+}
+
+func TestIsContentHashTracked_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "book.m4b"), []byte("audiodata"), 0o644))
+
+	lookup := func(h string) bool { return false }
+	assert.False(t, IsContentHashTracked(dir, lookup))
+}
+
+func TestIsContentHashTracked_SkipsNonAudioFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("text"), 0o644))
+
+	called := false
+	lookup := func(h string) bool { called = true; return true }
+	assert.False(t, IsContentHashTracked(dir, lookup))
+	assert.False(t, called, "lookup should not be called for non-audio files")
+}
+
+func TestIsContentHashTracked_MissingDir(t *testing.T) {
+	lookup := func(h string) bool { return true }
+	assert.False(t, IsContentHashTracked("/nonexistent/path", lookup))
+}
+
+// ---------------------------------------------------------------------------
+// AudioExtensions
+// ---------------------------------------------------------------------------
+
+func TestAudioExtensions_ContainsExpectedFormats(t *testing.T) {
+	expected := []string{".m4b", ".m4a", ".mp3", ".flac", ".aax", ".aac", ".ogg", ".opus", ".wav"}
+	for _, ext := range expected {
+		_, ok := AudioExtensions[ext]
+		assert.True(t, ok, "AudioExtensions should contain %q", ext)
+	}
+}

--- a/internal/deluge/import.go
+++ b/internal/deluge/import.go
@@ -1,0 +1,163 @@
+// file: internal/deluge/import.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-05-11
+//
+// ImportToLibrary copies a Deluge-managed file into the library root,
+// updates the BookFile record, and optionally tells Deluge to move
+// the torrent storage to the new directory.
+
+package deluge
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// ImportToLibrary copies a file from a Deluge-managed path into the library root,
+// updates the BookFile record in the database, and optionally tells Deluge to move
+// the torrent storage to the new directory.
+//
+// Parameters:
+//   - cfg: app config (used for RootDir and DelugeMoveEnabled)
+//   - delugeClient: Deluge JSON-RPC client (may be nil; if nil, MoveStorage is skipped)
+//   - store: database store (used to call UpdateBookFile)
+//   - bookFile: the BookFile to import; its FilePath must point to the source file.
+//     After a successful return, bookFile.FilePath is updated to the new path.
+//
+// Returns the new absolute file path and nil on success.
+// Returns an error if the source file cannot be read or the destination cannot be written.
+// A MoveStorage failure is NOT returned as an error — it is logged only.
+//
+// Idempotent: if bookFile.ImportedFromDelugeAt is already set, returns the current
+// FilePath immediately without repeating the copy or DB update.
+func ImportToLibrary(
+	cfg *config.Config,
+	delugeClient *Client,
+	store database.Store,
+	bookFile *database.BookFile,
+) (newPath string, err error) {
+	if bookFile == nil {
+		return "", fmt.Errorf("ImportToLibrary: bookFile is nil")
+	}
+
+	// Idempotency guard: already imported.
+	if bookFile.ImportedFromDelugeAt != nil {
+		log.Printf("[INFO] ImportToLibrary: %s already imported at %s, skipping",
+			bookFile.FilePath, bookFile.ImportedFromDelugeAt.Format(time.RFC3339))
+		return bookFile.FilePath, nil
+	}
+
+	src := bookFile.FilePath
+	if src == "" {
+		return "", fmt.Errorf("ImportToLibrary: bookFile.FilePath is empty")
+	}
+
+	// Determine destination directory inside RootDir.
+	// If the source is already under RootDir, preserve relative structure.
+	// If it is outside, place it directly under RootDir using just the filename.
+	var destDir string
+	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
+	if relErr == nil && !filepath.IsAbs(rel) && !isParentTraversal(rel) {
+		// Source is under RootDir (or a sub-path of it) — preserve structure.
+		destDir = filepath.Join(cfg.RootDir, rel)
+	} else {
+		// Source is outside RootDir — place directly under RootDir.
+		destDir = cfg.RootDir
+	}
+
+	dest := filepath.Join(destDir, filepath.Base(src))
+
+	// Do not copy if source and destination are the same path.
+	if src == dest {
+		log.Printf("[INFO] ImportToLibrary: source and dest are the same (%s), skipping copy", src)
+		return src, nil
+	}
+
+	// Create destination directory if it does not exist.
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", fmt.Errorf("ImportToLibrary: create dest dir %s: %w", destDir, err)
+	}
+
+	// Attempt reflink copy (Linux: ioctl FICLONE; macOS: clonefile).
+	// Falls back to io.Copy on any error.
+	copyErr := reflinkCopy(src, dest)
+	if copyErr != nil {
+		log.Printf("[DEBUG] ImportToLibrary: reflink failed (%v), falling back to io.Copy", copyErr)
+		if err := ioCopy(src, dest); err != nil {
+			return "", fmt.Errorf("ImportToLibrary: copy %s -> %s: %w", src, dest, err)
+		}
+	}
+
+	// Update the BookFile record.
+	now := time.Now()
+	bookFile.DelugeOriginalPath = src
+	bookFile.FilePath = dest
+	bookFile.ImportedFromDelugeAt = &now
+
+	if err := store.UpdateBookFile(bookFile.ID, bookFile); err != nil {
+		// The file has been copied but the DB update failed. Log it — the
+		// caller is responsible for retry or rollback.
+		return dest, fmt.Errorf("ImportToLibrary: UpdateBookFile %s: %w", bookFile.ID, err)
+	}
+
+	log.Printf("[INFO] ImportToLibrary: copied %s -> %s", src, dest)
+
+	// Best-effort: tell Deluge to move the torrent storage.
+	if cfg.DelugeMoveEnabled && bookFile.DelugeHash != "" && delugeClient != nil {
+		moveErr := delugeClient.MoveStorage([]string{bookFile.DelugeHash}, filepath.Dir(dest))
+		if moveErr != nil {
+			log.Printf("[WARN] ImportToLibrary: MoveStorage for hash %s failed (non-fatal): %v",
+				bookFile.DelugeHash, moveErr)
+			// Do NOT return this error. MoveStorage is best-effort.
+		} else {
+			log.Printf("[INFO] ImportToLibrary: MoveStorage for hash %s -> %s succeeded",
+				bookFile.DelugeHash, filepath.Dir(dest))
+		}
+	}
+
+	return dest, nil
+}
+
+// isParentTraversal returns true if the rel path starts with ".." (escapes root).
+func isParentTraversal(rel string) bool {
+	return len(rel) >= 2 && rel[:2] == ".."
+}
+
+// reflinkCopy attempts a copy-on-write clone of src to dest using OS-specific
+// syscalls. Returns an error if the reflink is not supported or fails.
+func reflinkCopy(src, dest string) error {
+	return reflinkCopyOS(src, dest)
+}
+
+// ioCopy copies src to dest using standard io.Copy (read all bytes, write all bytes).
+func ioCopy(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+	return nil
+}

--- a/internal/deluge/import_test.go
+++ b/internal/deluge/import_test.go
@@ -1,0 +1,141 @@
+// file: internal/deluge/import_test.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678902
+// last-edited: 2026-05-11
+//
+// Tests for ImportToLibrary in internal/deluge/import.go.
+
+package deluge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// fakeDelugStore is a minimal database.Store for import tests.
+type fakeDelugStore struct {
+	database.Store
+	updated *database.BookFile
+}
+
+func (f *fakeDelugStore) UpdateBookFile(id string, file *database.BookFile) error {
+	f.updated = file
+	return nil
+}
+
+func TestImportToLibrary_BasicCopy(t *testing.T) {
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "book.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootDir := t.TempDir()
+	cfg := &config.Config{RootDir: rootDir, DelugeMoveEnabled: false}
+	store := &fakeDelugStore{}
+	bf := &database.BookFile{ID: "id-001", FilePath: srcFile}
+
+	newPath, err := ImportToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("ImportToLibrary: %v", err)
+	}
+	if _, statErr := os.Stat(newPath); statErr != nil {
+		t.Errorf("destination file does not exist: %v", statErr)
+	}
+	if store.updated == nil {
+		t.Fatal("UpdateBookFile was not called")
+	}
+	if store.updated.FilePath != newPath {
+		t.Errorf("FilePath = %q, want %q", store.updated.FilePath, newPath)
+	}
+	if store.updated.DelugeOriginalPath != srcFile {
+		t.Errorf("DelugeOriginalPath = %q, want %q", store.updated.DelugeOriginalPath, srcFile)
+	}
+	if store.updated.ImportedFromDelugeAt == nil {
+		t.Error("ImportedFromDelugeAt is nil, want non-nil")
+	}
+}
+
+func TestImportToLibrary_SamePath_NoOp(t *testing.T) {
+	rootDir := t.TempDir()
+	srcFile := filepath.Join(rootDir, "book.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{RootDir: rootDir}
+	store := &fakeDelugStore{}
+	bf := &database.BookFile{ID: "id-002", FilePath: srcFile}
+
+	newPath, err := ImportToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("ImportToLibrary: %v", err)
+	}
+	if newPath != srcFile {
+		t.Errorf("newPath = %q, want %q (same as src)", newPath, srcFile)
+	}
+	if store.updated != nil {
+		t.Error("UpdateBookFile should not be called when src == dest")
+	}
+}
+
+func TestImportToLibrary_Idempotent(t *testing.T) {
+	rootDir := t.TempDir()
+	srcFile := filepath.Join(rootDir, "imported.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{RootDir: rootDir}
+	store := &fakeDelugStore{}
+	importedAt := time.Now().Add(-time.Hour)
+	bf := &database.BookFile{ID: "id-003", FilePath: srcFile, ImportedFromDelugeAt: &importedAt}
+
+	newPath, err := ImportToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("ImportToLibrary: %v", err)
+	}
+	if newPath != srcFile {
+		t.Errorf("newPath = %q, want %q (unchanged)", newPath, srcFile)
+	}
+	if store.updated != nil {
+		t.Error("UpdateBookFile should not be called on already-imported file")
+	}
+}
+
+func TestImportToLibrary_NilBookFile(t *testing.T) {
+	cfg := &config.Config{RootDir: t.TempDir()}
+	store := &fakeDelugStore{}
+
+	_, err := ImportToLibrary(cfg, nil, store, nil)
+	if err == nil {
+		t.Error("expected error for nil bookFile")
+	}
+}
+
+func TestImportToLibrary_MoveStorageNilClient_OK(t *testing.T) {
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "book.m4b")
+	if err := os.WriteFile(srcFile, []byte("audio data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rootDir := t.TempDir()
+	cfg := &config.Config{RootDir: rootDir, DelugeMoveEnabled: true}
+	store := &fakeDelugStore{}
+	bf := &database.BookFile{ID: "id-004", FilePath: srcFile, DelugeHash: "abc123"}
+
+	// nil client → MoveStorage skipped, but copy still succeeds.
+	newPath, err := ImportToLibrary(cfg, nil, store, bf)
+	if err != nil {
+		t.Fatalf("ImportToLibrary: %v", err)
+	}
+	if _, statErr := os.Stat(newPath); statErr != nil {
+		t.Errorf("destination file does not exist: %v", statErr)
+	}
+}

--- a/internal/deluge/import_unix.go
+++ b/internal/deluge/import_unix.go
@@ -1,0 +1,57 @@
+// file: internal/deluge/import_unix.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-123456789012
+// last-edited: 2026-05-11
+
+//go:build darwin || linux
+
+package deluge
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// reflinkCopyOS attempts a reflink copy using OS-specific syscalls.
+//
+// On Linux it tries the FICLONE ioctl (requires btrfs, XFS, OCFS2, or ZFS).
+// On macOS it tries the APFS clonefile ioctl.
+// Returns an error if the filesystem does not support reflinks or the call fails;
+// the caller should then fall back to io.Copy.
+func reflinkCopyOS(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open src: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+	defer out.Close()
+
+	srcFd := int(in.Fd())
+	dstFd := int(out.Fd())
+
+	// Linux: FICLONE ioctl (copy-on-write clone).
+	const FICLONE = 0x40049409
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), FICLONE, uintptr(srcFd))
+	if errno == 0 {
+		return nil
+	}
+
+	// macOS: APFS clonefile ioctl.
+	const APFS_CLONE = 0xC0084A6D
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), APFS_CLONE, uintptr(unsafe.Pointer(&srcFd)))
+	if errno == 0 {
+		return nil
+	}
+
+	// Both reflink attempts failed — remove the empty dest file so ioCopy can create a fresh one.
+	out.Close()
+	_ = os.Remove(dest)
+	return fmt.Errorf("reflink not supported on this filesystem (errno: %v)", errno)
+}

--- a/internal/deluge/import_windows.go
+++ b/internal/deluge/import_windows.go
@@ -1,0 +1,16 @@
+// file: internal/deluge/import_windows.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-def0-234567890123
+// last-edited: 2026-05-11
+
+//go:build windows
+
+package deluge
+
+import "fmt"
+
+// reflinkCopyOS always returns an error on Windows (no reflink support).
+// The caller falls back to io.Copy.
+func reflinkCopyOS(src, dest string) error {
+	return fmt.Errorf("reflink not supported on Windows")
+}

--- a/internal/deluge/importer_adapter.go
+++ b/internal/deluge/importer_adapter.go
@@ -1,0 +1,69 @@
+// file: internal/deluge/importer_adapter.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-2345-f012-456789012345
+// last-edited: 2026-05-11
+//
+// LibraryImporterAdapter implements tagger.LibraryImporter on top of
+// ImportToLibrary. It is wired into the Server at startup so
+// the metadata and tagger packages can perform the pre-flight copy without
+// importing internal/server themselves.
+
+package deluge
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// LibraryImporterAdapter satisfies tagger.LibraryImporter using the
+// ImportToLibrary function and its wired Store + DelugeClient.
+type LibraryImporterAdapter struct {
+	store        database.Store
+	delugeClient *Client
+	cfg          *config.Config
+}
+
+// NewLibraryImporterAdapter creates a new adapter. delugeClient may be nil
+// (Deluge MoveStorage will be skipped but the copy still succeeds).
+// cfg is passed by pointer; callers should use &config.AppConfig.
+func NewLibraryImporterAdapter(store database.Store, delugeClient *Client, cfg *config.Config) *LibraryImporterAdapter {
+	return &LibraryImporterAdapter{
+		store:        store,
+		delugeClient: delugeClient,
+		cfg:          cfg,
+	}
+}
+
+// ImportPath implements tagger.LibraryImporter.
+//
+// It looks up the BookFile record by path and delegates to ImportToLibrary.
+// If no matching record exists, it synthesises a minimal one so the copy
+// still happens (the DB update step within ImportToLibrary will then fail
+// and surface an error, which the caller should handle).
+func (a *LibraryImporterAdapter) ImportPath(ctx context.Context, srcPath string) (string, error) {
+	if a == nil || a.store == nil || a.cfg == nil {
+		return srcPath, fmt.Errorf("LibraryImporterAdapter: not fully initialised")
+	}
+
+	bf, err := a.store.GetBookFileByPath(srcPath)
+	if err != nil {
+		return srcPath, fmt.Errorf("LibraryImporterAdapter: look up BookFile for %s: %w", srcPath, err)
+	}
+	if bf == nil {
+		// File is protected but has no DB record yet. This can happen during
+		// scan/ingest before the record is committed. Log and skip — the write
+		// proceeds in-place rather than failing the entire operation.
+		log.Printf("[WARN] LibraryImporterAdapter: no BookFile record found for protected path %s; writing in-place", srcPath)
+		return srcPath, nil
+	}
+
+	newPath, err := ImportToLibrary(a.cfg, a.delugeClient, a.store, bf)
+	if err != nil {
+		return srcPath, fmt.Errorf("LibraryImporterAdapter: ImportToLibrary for %s: %w", srcPath, err)
+	}
+	return newPath, nil
+}

--- a/internal/deluge/integration.go
+++ b/internal/deluge/integration.go
@@ -1,0 +1,182 @@
+// file: internal/deluge/integration.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-1234-ef01-345678901234
+// last-edited: 2026-05-11
+//
+// Deluge integration for library centralization.
+//
+// When a book version that came from Deluge is swapped, trashed,
+// or its files are reorganized, we need to update the torrent's
+// save_path in Deluge so it keeps seeding from the new location.
+//
+// The Deluge client is optional — if not configured, the
+// integration is silently skipped.
+
+package deluge
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"sync"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+var (
+	globalDelugeClient   *Client
+	globalDelugeClientMu sync.Mutex
+)
+
+// GetClient returns the Deluge client, initializing it if needed.
+// Returns nil if Deluge is not configured.
+func GetClient() *Client {
+	globalDelugeClientMu.Lock()
+	defer globalDelugeClientMu.Unlock()
+	if globalDelugeClient != nil {
+		return globalDelugeClient
+	}
+	url := config.AppConfig.DelugeWebURL
+	pass := config.AppConfig.DelugeWebPassword
+	// Fall back to download_client.torrent.deluge config.
+	if url == "" {
+		dc := config.AppConfig.DownloadClient.Torrent.Deluge
+		if dc.Host != "" {
+			port := dc.Port
+			if port == 0 {
+				port = 8112
+			}
+			url = fmt.Sprintf("http://%s:%d", dc.Host, port)
+			pass = dc.Password
+		}
+	}
+	if url == "" {
+		return nil
+	}
+	if pass == "" {
+		pass = "deluge"
+	}
+	c, err := New(url, pass)
+	if err != nil {
+		log.Printf("[WARN] failed to create deluge client: %v", err)
+		return nil
+	}
+	globalDelugeClient = c
+	return c
+}
+
+// SetGlobalClientForTest replaces the global deluge client for testing.
+// Returns a restore func that must be deferred by the caller.
+func SetGlobalClientForTest(c *Client) func() {
+	globalDelugeClientMu.Lock()
+	orig := globalDelugeClient
+	globalDelugeClient = c
+	globalDelugeClientMu.Unlock()
+	return func() {
+		globalDelugeClientMu.Lock()
+		globalDelugeClient = orig
+		globalDelugeClientMu.Unlock()
+	}
+}
+
+// NotifyDelugeMoveStorage tells Deluge to move a torrent's storage
+// to a new path. Called after a version swap or organize moves files
+// that belong to a Deluge-sourced version.
+//
+// torrentHash is the infohash from BookVersion.TorrentHash.
+// newPath is the directory where the files now live.
+//
+// Silently no-ops if Deluge is not configured or the torrent hash
+// is empty.
+func NotifyDelugeMoveStorage(torrentHash, newPath string) {
+	if torrentHash == "" {
+		return
+	}
+	if !config.AppConfig.DelugeMoveEnabled {
+		log.Printf("[INFO] deluge move_storage skipped (deluge_move_enabled=false): %s → %s", torrentHash, newPath)
+		return
+	}
+	c := GetClient()
+	if c == nil {
+		return
+	}
+	// Deluge expects the parent directory, not the file path.
+	dir := filepath.Dir(newPath)
+	if err := c.MoveStorage([]string{torrentHash}, dir); err != nil {
+		log.Printf("[WARN] deluge move_storage %s → %s: %v", torrentHash, dir, err)
+	} else {
+		log.Printf("[INFO] deluge move_storage %s → %s", torrentHash, dir)
+	}
+}
+
+// NotifyDelugeAfterOrganize tells Deluge to follow a book that was
+// just moved into the library by the organize pipeline.
+//
+// Called after the file move succeeds and the Book record has been
+// updated to point at newPath. It looks up the active BookVersion(s)
+// for the book; for each with a non-empty TorrentHash it calls
+// NotifyDelugeMoveStorage so the torrent client keeps seeding from
+// the new location.
+//
+// Best-effort: errors are logged but do not bubble up — the organize
+// operation already succeeded.
+func NotifyDelugeAfterOrganize(store interface {
+	database.BookVersionStore
+}, bookID, newPath string) {
+	versions, err := store.GetBookVersionsByBookID(bookID)
+	if err != nil {
+		log.Printf("[WARN] deluge-organize: failed to load versions for book %s: %v", bookID, err)
+		return
+	}
+	for _, v := range versions {
+		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
+			NotifyDelugeMoveStorage(v.TorrentHash, newPath)
+		}
+	}
+}
+
+// NotifyDelugeAfterUndo checks whether the reverted operation moved
+// Deluge-sourced files and updates the torrent storage path.
+//
+// oldFilePath is the path the file was restored to (the original location
+// before the organize operation ran). This is the destination Deluge needs
+// to know about — NOT book.FilePath, which may not yet be updated in the DB
+// at the point this is called from the undo engine.
+func NotifyDelugeAfterUndo(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, bookID, oldFilePath string) {
+	if oldFilePath == "" {
+		return
+	}
+	_, _ = store.GetBookByID(bookID) // ensure book exists; ignore result
+	versions, _ := store.GetBookVersionsByBookID(bookID)
+	for _, v := range versions {
+		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
+			// Use oldFilePath (the restored destination), not book.FilePath,
+			// because the DB FilePath may not have been updated yet when this
+			// is called immediately after the file rename-back.
+			NotifyDelugeMoveStorage(v.TorrentHash, oldFilePath)
+		}
+	}
+}
+
+// NotifyDelugeAfterVersionSwap checks whether the swapped versions
+// have torrent hashes and updates Deluge accordingly.
+func NotifyDelugeAfterVersionSwap(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, fromVer, toVer *database.BookVersion, bookFilePath string) {
+	if toVer != nil && toVer.TorrentHash != "" {
+		NotifyDelugeMoveStorage(toVer.TorrentHash, bookFilePath)
+	}
+	if fromVer != nil && fromVer.TorrentHash != "" {
+		// The "from" version moved into .versions/{id}/ — tell Deluge.
+		book, _ := store.GetBookByID(fromVer.BookID)
+		if book != nil {
+			slotDir := filepath.Join(filepath.Dir(book.FilePath), ".versions", fromVer.ID)
+			NotifyDelugeMoveStorage(fromVer.TorrentHash, slotDir)
+		}
+	}
+}

--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 )
 

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -1,346 +1,25 @@
 // file: internal/server/deluge_discovery.go
-// version: 2.4.0
+// version: 3.0.0
 // guid: e6f7a8b9-c0d1-2e3f-4a5b-6c7d8e9f0a1b
-// last-edited: 2026-05-01
+// last-edited: 2026-05-11
 //
-// Deluge label-based audiobook discovery.
+// Deluge label-based audiobook discovery — HTTP handlers.
 //
-// Four-tier matching to decide if a labeled Deluge torrent is already in
-// the library — run in order, stop on first hit:
-//
-//  1. Hash    — GetBookVersionByTorrentHash: exact, works regardless of where
-//               the file moved after organize. Requires the torrent was
-//               previously imported via the Deluge flow (hash stored then).
-//  2. Path    — filepath.Join(save_path, name) is a prefix of Book.FilePath:
-//               catches books still sitting in the download directory.
-//  3. Title   — parse the torrent name into candidate title strings, check
-//               against a normalised set of Book.Title values. When a title
-//               match fires, Tier 4 SHA-verifies the actual files.
-//  4. SHA256  — SHA256 each audio file found under content_path, query
-//               GetBookByFileHash for each. A hash hit confirms the fuzzy
-//               title match; a miss means it's a different edition/version
-//               and the torrent IS a new candidate even though titles match.
-//
-// A torrent that passes all four tiers is returned as a discovery candidate.
+// Discovery and matching service logic lives in internal/deluge/discovery.go.
+// This file contains only the *Server HTTP handlers that delegate to that package.
 
 package server
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"io"
-	"log"
 	"net/http"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"unicode"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
-	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
 )
-
-// DiscoveredTorrent is a Deluge torrent not yet tracked in the library.
-type DiscoveredTorrent struct {
-	Hash        string  `json:"hash"`
-	Name        string  `json:"name"`
-	SavePath    string  `json:"save_path"`
-	ContentPath string  `json:"content_path"` // filepath.Join(save_path, name) — import this
-	Label       string  `json:"label"`
-	State       string  `json:"state"`
-	Progress    float64 `json:"progress"`
-	TotalSize   int64   `json:"total_size"`
-	MatchTier   string  `json:"match_tier,omitempty"` // debug: which tier matched (empty = new)
-}
-
-// libraryIndex is a pre-built lookup structure used by all three match tiers.
-type libraryIndex struct {
-	// Tier 2: normalised current file paths → present
-	paths map[string]struct{}
-	// Tier 3: normalised book titles → present
-	titles map[string]struct{}
-}
-
-func (s *Server) buildLibraryIndex() libraryIndex {
-	idx := libraryIndex{
-		paths:  make(map[string]struct{}),
-		titles: make(map[string]struct{}),
-	}
-	books, err := s.Store().GetAllBooks(100000, 0)
-	if err != nil {
-		log.Printf("[WARN] deluge discovery: failed to load books: %v", err)
-		return idx
-	}
-	for _, b := range books {
-		if b.FilePath != "" {
-			idx.paths[b.FilePath] = struct{}{}
-		}
-		if b.Title != "" {
-			idx.titles[normalizeTitle(b.Title)] = struct{}{}
-		}
-	}
-	return idx
-}
-
-// discoverUnimported fetches labeled torrents and returns those not already
-// in the library according to the three-tier matching strategy.
-func (s *Server) discoverUnimported(client *delugeclient.Client, label string) ([]DiscoveredTorrent, error) {
-	torrents, err := client.ListTorrentsByLabel(label)
-	if err != nil {
-		return nil, err
-	}
-	if len(torrents) == 0 {
-		return []DiscoveredTorrent{}, nil
-	}
-
-	idx := s.buildLibraryIndex()
-
-	var unimported []DiscoveredTorrent
-	for _, t := range torrents {
-		// Tier 1: torrent hash lookup (O(1), authoritative).
-		if t.Hash != "" {
-			if ver, _ := s.Store().GetBookVersionByTorrentHash(t.Hash); ver != nil {
-				continue // already tracked
-			}
-		}
-
-		// Tier 2: content path prefix against current file paths.
-		contentPath := filepath.Join(t.SavePath, t.Name)
-		if isPathTracked(contentPath, idx.paths) {
-			continue
-		}
-
-		// Tier 3: torrent name → title candidates against known titles.
-		// When a title match fires, Tier 4 verifies actual file content.
-		if isTitleTracked(t.Name, idx.titles) {
-			if s.isContentFingerprintTracked(contentPath) {
-				continue // same audio stream — already in library
-			}
-			// Title matched but audio differs → different edition, surface it.
-		}
-
-		unimported = append(unimported, DiscoveredTorrent{
-			Hash:        t.Hash,
-			Name:        t.Name,
-			SavePath:    t.SavePath,
-			ContentPath: contentPath,
-			Label:       t.Label,
-			State:       t.State,
-			Progress:    t.Progress,
-			TotalSize:   t.TotalSize,
-		})
-	}
-	return unimported, nil
-}
-
-// isContentFingerprintTracked walks contentPath for the first audio file,
-// fingerprints it with fpcalc, and checks the library via exact then fuzzy
-// AcoustID match. Returns true if the audio stream is already tracked.
-//
-// Falls back to SHA-256 walking when fpcalc is not installed so the pipeline
-// is never blocked by a missing dependency.
-func (s *Server) isContentFingerprintTracked(contentPath string) bool {
-	if !fingerprint.Available() {
-		// fpcalc not installed — fall back to SHA-256 content walk.
-		hashLookup := func(hash string) bool {
-			b, _ := s.Store().GetBookByFileHash(hash)
-			return b != nil
-		}
-		return isContentHashTracked(contentPath, hashLookup)
-	}
-
-	// Find the first audio file under contentPath to fingerprint.
-	var firstAudio string
-	_ = filepath.Walk(contentPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || firstAudio != "" {
-			return nil
-		}
-		if _, ok := audioExtensions[strings.ToLower(filepath.Ext(path))]; ok {
-			firstAudio = path
-		}
-		return nil
-	})
-	if firstAudio == "" {
-		return false
-	}
-
-	segs, err := fingerprint.FileSegments(firstAudio, 0)
-	if err != nil {
-		log.Printf("[WARN] deluge discovery: fingerprint %s: %v", firstAudio, err)
-		return false
-	}
-	// Use the intro segment (seg[0]) for exact and fuzzy lookups.
-	introFP := segs[0]
-	if introFP == "" {
-		return false
-	}
-
-	// Exact match first (O(1) index lookup).
-	if f, _ := s.Store().GetBookFileByAcoustID(introFP); f != nil {
-		return true
-	}
-
-	// Fuzzy fallback — catches minor encoding variations.
-	f, _ := s.Store().GetBookFileByAcoustIDFuzzy(introFP, fingerprint.FuzzyMinSimilarity)
-	return f != nil
-}
-
-// isPathTracked returns true if contentPath is a prefix of any known file path.
-//
-// Callers MUST pass filepath.Join(save_path, torrent_name) — NOT save_path
-// alone. A shared download directory is a prefix of everything in it, so
-// using raw save_path would mark every torrent as tracked once any file from
-// that directory exists in the DB.
-func isPathTracked(contentPath string, known map[string]struct{}) bool {
-	if contentPath == "" {
-		return false
-	}
-	prefix := strings.TrimRight(contentPath, "/") + "/"
-	for p := range known {
-		if strings.HasPrefix(p, prefix) || p == contentPath {
-			return true
-		}
-	}
-	return false
-}
-
-// isTitleTracked parses a torrent name into candidate titles and checks each
-// against the normalised DB title set.
-func isTitleTracked(torrentName string, titles map[string]struct{}) bool {
-	for _, candidate := range parseTorrentNameCandidates(torrentName) {
-		if _, ok := titles[candidate]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-// audioExtensions is the set of file extensions we hash for content matching.
-var audioExtensions = map[string]struct{}{
-	".m4b": {}, ".m4a": {}, ".mp3": {}, ".flac": {}, ".aax": {},
-	".aac": {}, ".ogg": {}, ".opus": {}, ".wav": {},
-}
-
-// isContentHashTracked walks contentPath, SHA256s each audio file, and calls
-// lookup for each hash. Returns true as soon as any hash is found in the DB.
-func isContentHashTracked(contentPath string, lookup func(string) bool) bool {
-	found := false
-	_ = filepath.Walk(contentPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || found {
-			return nil
-		}
-		if _, ok := audioExtensions[strings.ToLower(filepath.Ext(path))]; !ok {
-			return nil
-		}
-		hash, hashErr := sha256File(path)
-		if hashErr != nil {
-			log.Printf("[WARN] deluge discovery: sha256 %s: %v", path, hashErr)
-			return nil
-		}
-		if lookup(hash) {
-			found = true
-		}
-		return nil
-	})
-	return found
-}
-
-// sha256File returns the hex-encoded SHA256 of a file's contents.
-func sha256File(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-// stripBrackets removes common annotation brackets: [Unabridged], {MP3}, (2023).
-var stripBrackets = regexp.MustCompile(`[\[\]{}(][^\[\]{}()]*[\]\})]`)
-
-// metaSuffixes are noise tokens appended to torrent names.
-var metaSuffixes = regexp.MustCompile(`(?i)\b(unabridged|abridged|m4b|mp3|aax|flac|aac|ogg|retail|repack|\d{4})\b.*$`)
-
-// parseTorrentNameCandidates returns a set of normalised title strings derived
-// from a torrent name. The typical formats handled:
-//
-//	"Author - Title"              → ["title", "author"]
-//	"Title - Author"              → ["title", "author"]
-//	"Title by Author [M4B]"       → ["title"]
-//	"Author.Title.Year.M4B"       → ["author title"] (dots-as-spaces)
-//	"Title (Author) [Unabridged]" → ["title"]
-func parseTorrentNameCandidates(name string) []string {
-	seen := make(map[string]struct{})
-	add := func(s string) {
-		s = normalizeTitle(s)
-		if len(s) >= 3 {
-			seen[s] = struct{}{}
-		}
-	}
-
-	// Strip bracket annotations first.
-	clean := stripBrackets.ReplaceAllString(name, " ")
-	// Remove file-format / year suffixes.
-	clean = metaSuffixes.ReplaceAllString(clean, "")
-	clean = strings.TrimSpace(clean)
-
-	// Try dash-separated "Author - Title" or "Title - Author".
-	if parts := strings.SplitN(clean, " - ", 2); len(parts) == 2 {
-		add(parts[0])
-		add(parts[1])
-	}
-
-	// Try "Title by Author".
-	if idx := strings.Index(strings.ToLower(clean), " by "); idx > 0 {
-		add(clean[:idx])
-	}
-
-	// Try dot-separated names (common for scene releases).
-	if strings.ContainsRune(clean, '.') && !strings.ContainsRune(clean, ' ') {
-		add(strings.ReplaceAll(clean, ".", " "))
-	}
-
-	// Always include the whole cleaned name as a fallback candidate.
-	add(clean)
-
-	out := make([]string, 0, len(seen))
-	for s := range seen {
-		out = append(out, s)
-	}
-	return out
-}
-
-// normalizeTitle lowercases, strips punctuation, and collapses whitespace so
-// that "The Way of Kings" and "the way of kings!" both normalise to the same
-// string for comparison.
-func normalizeTitle(s string) string {
-	var b strings.Builder
-	prevSpace := false
-	for _, r := range strings.ToLower(s) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-			prevSpace = false
-		} else if !prevSpace {
-			b.WriteRune(' ')
-			prevSpace = true
-		}
-	}
-	return strings.TrimSpace(b.String())
-}
-
-// ---------------------------------------------------------------------------
-// HTTP handlers
-// ---------------------------------------------------------------------------
 
 // handleDelugeDiscover returns Deluge torrents not yet in the library.
 // GET /api/v1/deluge/discover?label=audiobooks
@@ -360,16 +39,16 @@ func (s *Server) handleDelugeDiscover(c *gin.Context) {
 		label = config.AppConfig.DelugeDiscoveryLabel
 	}
 
-	unimported, err := s.discoverUnimported(client, label)
+	unimported, err := delugeclient.DiscoverUnimported(s.Store(), client, label)
 	if err != nil {
 		httputil.RespondWithError(c, http.StatusBadGateway, err.Error(), "BAD_GATEWAY")
 		return
 	}
 
 	httputil.RespondWithOK(c, struct {
-		Label      string              `json:"label"`
-		Candidates []DiscoveredTorrent `json:"candidates"`
-		Count      int                 `json:"count"`
+		Label      string                       `json:"label"`
+		Candidates []delugeclient.DiscoveredTorrent `json:"candidates"`
+		Count      int                          `json:"count"`
 	}{Label: label, Candidates: unimported, Count: len(unimported)})
 }
 
@@ -487,7 +166,7 @@ func (s *Server) handleDiscoveryImport(c *gin.Context) {
 			skipped++
 			continue
 		}
-		newPath, importErr := importToLibrary(&config.AppConfig, client, store, f)
+		newPath, importErr := delugeclient.ImportToLibrary(&config.AppConfig, client, store, f)
 		if importErr != nil {
 			results = append(results, result{FileID: f.ID, Path: f.FilePath, Error: importErr.Error()})
 			failed++

--- a/internal/server/deluge_discovery_test.go
+++ b/internal/server/deluge_discovery_test.go
@@ -1,6 +1,9 @@
 // file: internal/server/deluge_discovery_test.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
+// last-edited: 2026-05-11
+//
+// Tests for the discovery helpers — now delegates to internal/deluge/discovery.go.
 
 package server
 
@@ -11,51 +14,53 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 )
 
 // The shared download dir — every torrent has this as save_path.
 const dlDir = "/mnt/bigdata/books/deluge"
 
 // ---------------------------------------------------------------------------
-// Tier 2: isPathTracked
+// Tier 2: IsPathTracked
 // ---------------------------------------------------------------------------
 
 func TestIsPathTracked_EmptyContentPath(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune/Dune.m4b": {}}
-	assert.False(t, isPathTracked("", known))
+	assert.False(t, deluge.IsPathTracked("", known))
 }
 
 func TestIsPathTracked_ExactMatch(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune.m4b": {}}
-	assert.True(t, isPathTracked(dlDir+"/Dune.m4b", known))
+	assert.True(t, deluge.IsPathTracked(dlDir+"/Dune.m4b", known))
 }
 
 func TestIsPathTracked_ContentDirPrefixMatch(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune/Dune.m4b": {}}
-	assert.True(t, isPathTracked(dlDir+"/Dune", known))
+	assert.True(t, deluge.IsPathTracked(dlDir+"/Dune", known))
 }
 
 func TestIsPathTracked_UnimportedTorrent(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune/Dune.m4b": {}}
-	assert.False(t, isPathTracked(dlDir+"/Foundation", known))
+	assert.False(t, deluge.IsPathTracked(dlDir+"/Foundation", known))
 }
 
 func TestIsPathTracked_EmptyKnown(t *testing.T) {
-	assert.False(t, isPathTracked(dlDir+"/Dune", map[string]struct{}{}))
+	assert.False(t, deluge.IsPathTracked(dlDir+"/Dune", map[string]struct{}{}))
 }
 
 func TestIsPathTracked_PartialNameNotMatched(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune/Dune.m4b": {}}
-	assert.False(t, isPathTracked(dlDir+"/Du", known))
+	assert.False(t, deluge.IsPathTracked(dlDir+"/Du", known))
 }
 
 func TestIsPathTracked_TrailingSlashNormalized(t *testing.T) {
 	known := map[string]struct{}{dlDir + "/Dune/Dune.m4b": {}}
-	assert.True(t, isPathTracked(dlDir+"/Dune/", known))
+	assert.True(t, deluge.IsPathTracked(dlDir+"/Dune/", known))
 }
 
 // ---------------------------------------------------------------------------
-// Tier 3: isTitleTracked / parseTorrentNameCandidates / normalizeTitle
+// Tier 3: IsTitleTracked / ParseTorrentNameCandidates / NormalizeTitle
 // ---------------------------------------------------------------------------
 
 func TestNormalizeTitle(t *testing.T) {
@@ -66,42 +71,42 @@ func TestNormalizeTitle(t *testing.T) {
 		{"Foundation - Isaac Asimov", "foundation isaac asimov"},
 	}
 	for _, c := range cases {
-		assert.Equal(t, c.want, normalizeTitle(c.in), c.in)
+		assert.Equal(t, c.want, deluge.NormalizeTitle(c.in), c.in)
 	}
 }
 
 func TestParseTorrentNameCandidates_DashSeparated(t *testing.T) {
-	candidates := parseTorrentNameCandidates("Brandon Sanderson - The Way of Kings")
-	assert.Contains(t, candidates, normalizeTitle("Brandon Sanderson"))
-	assert.Contains(t, candidates, normalizeTitle("The Way of Kings"))
+	candidates := deluge.ParseTorrentNameCandidates("Brandon Sanderson - The Way of Kings")
+	assert.Contains(t, candidates, deluge.NormalizeTitle("Brandon Sanderson"))
+	assert.Contains(t, candidates, deluge.NormalizeTitle("The Way of Kings"))
 }
 
 func TestParseTorrentNameCandidates_ByKeyword(t *testing.T) {
-	candidates := parseTorrentNameCandidates("The Way of Kings by Brandon Sanderson [M4B]")
-	assert.Contains(t, candidates, normalizeTitle("The Way of Kings"))
+	candidates := deluge.ParseTorrentNameCandidates("The Way of Kings by Brandon Sanderson [M4B]")
+	assert.Contains(t, candidates, deluge.NormalizeTitle("The Way of Kings"))
 }
 
 func TestParseTorrentNameCandidates_DotSeparated(t *testing.T) {
-	candidates := parseTorrentNameCandidates("Dune.Frank.Herbert.2023.M4B")
+	candidates := deluge.ParseTorrentNameCandidates("Dune.Frank.Herbert.2023.M4B")
 	assert.Contains(t, candidates, "dune frank herbert")
 }
 
 func TestIsTitleTracked_Hit(t *testing.T) {
 	titles := map[string]struct{}{
-		normalizeTitle("The Way of Kings"): {},
+		deluge.NormalizeTitle("The Way of Kings"): {},
 	}
-	assert.True(t, isTitleTracked("Brandon Sanderson - The Way of Kings [M4B]", titles))
+	assert.True(t, deluge.IsTitleTracked("Brandon Sanderson - The Way of Kings [M4B]", titles))
 }
 
 func TestIsTitleTracked_Miss(t *testing.T) {
 	titles := map[string]struct{}{
-		normalizeTitle("Dune"): {},
+		deluge.NormalizeTitle("Dune"): {},
 	}
-	assert.False(t, isTitleTracked("Brandon Sanderson - The Way of Kings", titles))
+	assert.False(t, deluge.IsTitleTracked("Brandon Sanderson - The Way of Kings", titles))
 }
 
 // ---------------------------------------------------------------------------
-// Tier 4: isContentHashTracked / sha256File
+// Tier 4: IsContentHashTracked / SHA256File
 // ---------------------------------------------------------------------------
 
 func TestSha256File(t *testing.T) {
@@ -109,17 +114,17 @@ func TestSha256File(t *testing.T) {
 	f := filepath.Join(dir, "test.m4b")
 	require.NoError(t, os.WriteFile(f, []byte("audiodata"), 0o644))
 
-	hash1, err := sha256File(f)
+	hash1, err := deluge.SHA256File(f)
 	require.NoError(t, err)
 	assert.Len(t, hash1, 64) // hex SHA256
 
 	// Same content → same hash.
-	hash2, _ := sha256File(f)
+	hash2, _ := deluge.SHA256File(f)
 	assert.Equal(t, hash1, hash2)
 }
 
 func TestSha256File_Missing(t *testing.T) {
-	_, err := sha256File("/nonexistent/file.m4b")
+	_, err := deluge.SHA256File("/nonexistent/file.m4b")
 	assert.Error(t, err)
 }
 
@@ -128,10 +133,10 @@ func TestIsContentHashTracked_MatchFound(t *testing.T) {
 	audio := filepath.Join(dir, "book.m4b")
 	require.NoError(t, os.WriteFile(audio, []byte("audiodata"), 0o644))
 
-	expected, _ := sha256File(audio)
+	expected, _ := deluge.SHA256File(audio)
 	lookup := func(h string) bool { return h == expected }
 
-	assert.True(t, isContentHashTracked(dir, lookup))
+	assert.True(t, deluge.IsContentHashTracked(dir, lookup))
 }
 
 func TestIsContentHashTracked_NoMatch(t *testing.T) {
@@ -139,7 +144,7 @@ func TestIsContentHashTracked_NoMatch(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "book.m4b"), []byte("audiodata"), 0o644))
 
 	lookup := func(h string) bool { return false }
-	assert.False(t, isContentHashTracked(dir, lookup))
+	assert.False(t, deluge.IsContentHashTracked(dir, lookup))
 }
 
 func TestIsContentHashTracked_SkipsNonAudioFiles(t *testing.T) {
@@ -149,12 +154,12 @@ func TestIsContentHashTracked_SkipsNonAudioFiles(t *testing.T) {
 
 	called := false
 	lookup := func(h string) bool { called = true; return true }
-	assert.False(t, isContentHashTracked(dir, lookup))
+	assert.False(t, deluge.IsContentHashTracked(dir, lookup))
 	assert.False(t, called, "lookup should not be called for non-audio files")
 }
 
 func TestIsContentHashTracked_MissingDir(t *testing.T) {
 	// Walk on a nonexistent dir returns false without panicking.
 	lookup := func(h string) bool { return true }
-	assert.False(t, isContentHashTracked("/nonexistent/path", lookup))
+	assert.False(t, deluge.IsContentHashTracked("/nonexistent/path", lookup))
 }

--- a/internal/server/deluge_import.go
+++ b/internal/server/deluge_import.go
@@ -1,159 +1,27 @@
 // file: internal/server/deluge_import.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: f3e7a9c1-2b4d-5086-d9f2-4e1c7b0a3e58
+// last-edited: 2026-05-11
+//
+// Thin shim: importToLibrary delegates to deluge.ImportToLibrary.
+// The implementation has moved to internal/deluge/import.go.
 
 package server
 
 import (
-	"fmt"
-	"io"
-	"log"
-	"os"
-	"path/filepath"
-	"time"
-
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 )
 
-// importToLibrary copies a file from a Deluge-managed path into the library root,
-// updates the BookFile record in the database, and optionally tells Deluge to move
-// the torrent storage to the new directory.
-//
-// Parameters:
-//   - cfg: app config (used for RootDir and DelugeMoveEnabled)
-//   - delugeClient: Deluge JSON-RPC client (may be nil; if nil, MoveStorage is skipped)
-//   - store: database store (used to call UpdateBookFile)
-//   - bookFile: the BookFile to import; its FilePath must point to the source file.
-//     After a successful return, bookFile.FilePath is updated to the new path.
-//
-// Returns the new absolute file path and nil on success.
-// Returns an error if the source file cannot be read or the destination cannot be written.
-// A MoveStorage failure is NOT returned as an error — it is logged only.
-//
-// Idempotent: if bookFile.ImportedFromDelugeAt is already set, returns the current
-// FilePath immediately without repeating the copy or DB update.
+// importToLibrary is a package-level shim for backward-compatibility within
+// the server package. All callers outside this package should use
+// deluge.ImportToLibrary directly.
 func importToLibrary(
 	cfg *config.Config,
 	delugeClient *deluge.Client,
 	store database.Store,
 	bookFile *database.BookFile,
-) (newPath string, err error) {
-	if bookFile == nil {
-		return "", fmt.Errorf("importToLibrary: bookFile is nil")
-	}
-
-	// Idempotency guard: already imported.
-	if bookFile.ImportedFromDelugeAt != nil {
-		log.Printf("[INFO] importToLibrary: %s already imported at %s, skipping",
-			bookFile.FilePath, bookFile.ImportedFromDelugeAt.Format(time.RFC3339))
-		return bookFile.FilePath, nil
-	}
-
-	src := bookFile.FilePath
-	if src == "" {
-		return "", fmt.Errorf("importToLibrary: bookFile.FilePath is empty")
-	}
-
-	// Determine destination directory inside RootDir.
-	// If the source is already under RootDir, preserve relative structure.
-	// If it is outside, place it directly under RootDir using just the filename.
-	var destDir string
-	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
-	if relErr == nil && !filepath.IsAbs(rel) && !isParentTraversal(rel) {
-		// Source is under RootDir (or a sub-path of it) — preserve structure.
-		destDir = filepath.Join(cfg.RootDir, rel)
-	} else {
-		// Source is outside RootDir — place directly under RootDir.
-		destDir = cfg.RootDir
-	}
-
-	dest := filepath.Join(destDir, filepath.Base(src))
-
-	// Do not copy if source and destination are the same path.
-	if src == dest {
-		log.Printf("[INFO] importToLibrary: source and dest are the same (%s), skipping copy", src)
-		return src, nil
-	}
-
-	// Create destination directory if it does not exist.
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
-		return "", fmt.Errorf("importToLibrary: create dest dir %s: %w", destDir, err)
-	}
-
-	// Attempt reflink copy (Linux: ioctl FICLONE; macOS: clonefile).
-	// Falls back to io.Copy on any error.
-	copyErr := reflinkCopy(src, dest)
-	if copyErr != nil {
-		log.Printf("[DEBUG] importToLibrary: reflink failed (%v), falling back to io.Copy", copyErr)
-		if err := ioCopy(src, dest); err != nil {
-			return "", fmt.Errorf("importToLibrary: copy %s -> %s: %w", src, dest, err)
-		}
-	}
-
-	// Update the BookFile record.
-	now := time.Now()
-	bookFile.DelugeOriginalPath = src
-	bookFile.FilePath = dest
-	bookFile.ImportedFromDelugeAt = &now
-
-	if err := store.UpdateBookFile(bookFile.ID, bookFile); err != nil {
-		// The file has been copied but the DB update failed. Log it — the
-		// caller is responsible for retry or rollback.
-		return dest, fmt.Errorf("importToLibrary: UpdateBookFile %s: %w", bookFile.ID, err)
-	}
-
-	log.Printf("[INFO] importToLibrary: copied %s -> %s", src, dest)
-
-	// Best-effort: tell Deluge to move the torrent storage.
-	if cfg.DelugeMoveEnabled && bookFile.DelugeHash != "" && delugeClient != nil {
-		moveErr := delugeClient.MoveStorage([]string{bookFile.DelugeHash}, filepath.Dir(dest))
-		if moveErr != nil {
-			log.Printf("[WARN] importToLibrary: MoveStorage for hash %s failed (non-fatal): %v",
-				bookFile.DelugeHash, moveErr)
-			// Do NOT return this error. MoveStorage is best-effort.
-		} else {
-			log.Printf("[INFO] importToLibrary: MoveStorage for hash %s -> %s succeeded",
-				bookFile.DelugeHash, filepath.Dir(dest))
-		}
-	}
-
-	return dest, nil
-}
-
-// isParentTraversal returns true if the rel path starts with ".." (escapes root).
-func isParentTraversal(rel string) bool {
-	return len(rel) >= 2 && rel[:2] == ".."
-}
-
-// reflinkCopy attempts a copy-on-write clone of src to dest using OS-specific
-// syscalls. Returns an error if the reflink is not supported or fails.
-func reflinkCopy(src, dest string) error {
-	return reflinkCopyOS(src, dest)
-}
-
-// ioCopy copies src to dest using standard io.Copy (read all bytes, write all bytes).
-func ioCopy(src, dest string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("open src: %w", err)
-	}
-	defer in.Close()
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("create dest: %w", err)
-	}
-	defer func() {
-		cerr := out.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-
-	if _, err = io.Copy(out, in); err != nil {
-		return fmt.Errorf("io.Copy: %w", err)
-	}
-	return nil
+) (string, error) {
+	return deluge.ImportToLibrary(cfg, delugeClient, store, bookFile)
 }

--- a/internal/server/deluge_import_test.go
+++ b/internal/server/deluge_import_test.go
@@ -1,6 +1,9 @@
 // file: internal/server/deluge_import_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: e1b5d8f2-3c7a-4091-a2e9-6f4d0c8b3a15
+// last-edited: 2026-05-11
+//
+// Tests for ImportToLibrary — delegates to internal/deluge/import.go.
 
 package server
 
@@ -12,6 +15,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 )
 
 // fakeStore is a minimal database.Store implementation for testing.
@@ -49,9 +53,9 @@ func TestImportToLibrary_FallbackToCopy(t *testing.T) {
 		// DelugeHash intentionally empty so MoveStorage is skipped.
 	}
 
-	newPath, err := importToLibrary(cfg, nil, store, bf)
+	newPath, err := deluge.ImportToLibrary(cfg, nil, store, bf)
 	if err != nil {
-		t.Fatalf("importToLibrary returned error: %v", err)
+		t.Fatalf("ImportToLibrary returned error: %v", err)
 	}
 
 	// Verify destination file exists.
@@ -94,9 +98,9 @@ func TestImportToLibrary_SameSourceAndDest(t *testing.T) {
 		FilePath: srcFile,
 	}
 
-	newPath, err := importToLibrary(cfg, nil, store, bf)
+	newPath, err := deluge.ImportToLibrary(cfg, nil, store, bf)
 	if err != nil {
-		t.Fatalf("importToLibrary returned error: %v", err)
+		t.Fatalf("ImportToLibrary returned error: %v", err)
 	}
 	if newPath != srcFile {
 		t.Errorf("expected newPath = %q (same as src), got %q", srcFile, newPath)
@@ -128,9 +132,9 @@ func TestImportToLibrary_Idempotent(t *testing.T) {
 		ImportedFromDelugeAt: &importedAt,
 	}
 
-	newPath, err := importToLibrary(cfg, nil, store, bf)
+	newPath, err := deluge.ImportToLibrary(cfg, nil, store, bf)
 	if err != nil {
-		t.Fatalf("importToLibrary returned error: %v", err)
+		t.Fatalf("ImportToLibrary returned error: %v", err)
 	}
 	if newPath != srcFile {
 		t.Errorf("expected newPath = %q (unchanged), got %q", srcFile, newPath)
@@ -141,7 +145,7 @@ func TestImportToLibrary_Idempotent(t *testing.T) {
 	}
 }
 
-// Test 4: MoveStorage failure is best-effort — importToLibrary must not return an error.
+// Test 4: MoveStorage failure is best-effort — ImportToLibrary must not return an error.
 func TestImportToLibrary_MoveStorageFailureIsNonFatal(t *testing.T) {
 	srcDir := t.TempDir()
 	srcFile := filepath.Join(srcDir, "book.m4b")
@@ -163,9 +167,9 @@ func TestImportToLibrary_MoveStorageFailureIsNonFatal(t *testing.T) {
 
 	// delugeClient is nil, so MoveStorage is skipped (not called).
 	// The function should still succeed.
-	newPath, err := importToLibrary(cfg, nil, store, bf)
+	newPath, err := deluge.ImportToLibrary(cfg, nil, store, bf)
 	if err != nil {
-		t.Fatalf("importToLibrary returned error even with nil delugeClient: %v", err)
+		t.Fatalf("ImportToLibrary returned error even with nil delugeClient: %v", err)
 	}
 	if _, statErr := os.Stat(newPath); statErr != nil {
 		t.Errorf("destination file does not exist: %v", statErr)

--- a/internal/server/deluge_import_unix.go
+++ b/internal/server/deluge_import_unix.go
@@ -1,56 +1,11 @@
 // file: internal/server/deluge_import_unix.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: a9c2e5f7-1d3b-4087-b8a6-5f2c0e9d1b74
+// last-edited: 2026-05-11
+//
+// reflinkCopyOS has moved to internal/deluge/import_unix.go.
+// This file is retained as a placeholder to preserve build-tag coverage.
 
 //go:build darwin || linux
 
 package server
-
-import (
-	"fmt"
-	"os"
-	"syscall"
-	"unsafe"
-)
-
-// reflinkCopyOS attempts a reflink copy using OS-specific syscalls.
-//
-// On Linux it tries the FICLONE ioctl (requires btrfs, XFS, OCFS2, or ZFS).
-// On macOS it tries the APFS clonefile ioctl.
-// Returns an error if the filesystem does not support reflinks or the call fails;
-// the caller should then fall back to io.Copy.
-func reflinkCopyOS(src, dest string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("open src: %w", err)
-	}
-	defer in.Close()
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("create dest: %w", err)
-	}
-	defer out.Close()
-
-	srcFd := int(in.Fd())
-	dstFd := int(out.Fd())
-
-	// Linux: FICLONE ioctl (copy-on-write clone).
-	const FICLONE = 0x40049409
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), FICLONE, uintptr(srcFd))
-	if errno == 0 {
-		return nil
-	}
-
-	// macOS: APFS clonefile ioctl.
-	const APFS_CLONE = 0xC0084A6D
-	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), APFS_CLONE, uintptr(unsafe.Pointer(&srcFd)))
-	if errno == 0 {
-		return nil
-	}
-
-	// Both reflink attempts failed — remove the empty dest file so ioCopy can create a fresh one.
-	out.Close()
-	_ = os.Remove(dest)
-	return fmt.Errorf("reflink not supported on this filesystem (errno: %v)", errno)
-}

--- a/internal/server/deluge_import_windows.go
+++ b/internal/server/deluge_import_windows.go
@@ -1,15 +1,11 @@
 // file: internal/server/deluge_import_windows.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: d4e5f6a7-8b9c-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-05-11
+//
+// reflinkCopyOS has moved to internal/deluge/import_windows.go.
+// This file is retained as a placeholder to preserve build-tag coverage.
 
 //go:build windows
 
 package server
-
-import "fmt"
-
-// reflinkCopyOS always returns an error on Windows (no reflink support).
-// The caller falls back to io.Copy.
-func reflinkCopyOS(src, dest string) error {
-	return fmt.Errorf("reflink not supported on Windows")
-}

--- a/internal/server/deluge_importer_adapter.go
+++ b/internal/server/deluge_importer_adapter.go
@@ -1,69 +1,25 @@
 // file: internal/server/deluge_importer_adapter.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7b3e9f21-4a0c-4d87-b5e8-1f6d2c0a3b74
+// last-edited: 2026-05-11
 //
-// LibraryImporterAdapter implements tagger.LibraryImporter on top of
-// importToLibrary (DELUGE-3). It is wired into the Server at startup so
-// the metadata and tagger packages can perform the pre-flight copy without
-// importing internal/server themselves.
+// LibraryImporterAdapter has moved to internal/deluge/importer_adapter.go.
+// This file re-exports the type and constructor for backward-compatibility
+// within the server package.
 
 package server
 
 import (
-	"context"
-	"fmt"
-	"log"
-
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 )
 
-// LibraryImporterAdapter satisfies tagger.LibraryImporter using the server's
-// importToLibrary function and its wired Store + DelugeClient.
-type LibraryImporterAdapter struct {
-	store        database.Store
-	delugeClient *deluge.Client
-	cfg          *config.Config
-}
+// LibraryImporterAdapter is re-exported from internal/deluge for backward
+// compatibility. Use deluge.LibraryImporterAdapter directly in new code.
+type LibraryImporterAdapter = deluge.LibraryImporterAdapter
 
-// NewLibraryImporterAdapter creates a new adapter. delugeClient may be nil
-// (Deluge MoveStorage will be skipped but the copy still succeeds).
-// cfg is passed by pointer; callers should use &config.AppConfig.
+// NewLibraryImporterAdapter creates a new adapter. See deluge.NewLibraryImporterAdapter.
 func NewLibraryImporterAdapter(store database.Store, delugeClient *deluge.Client, cfg *config.Config) *LibraryImporterAdapter {
-	return &LibraryImporterAdapter{
-		store:        store,
-		delugeClient: delugeClient,
-		cfg:          cfg,
-	}
-}
-
-// ImportPath implements tagger.LibraryImporter.
-//
-// It looks up the BookFile record by path and delegates to importToLibrary.
-// If no matching record exists, it synthesises a minimal one so the copy
-// still happens (the DB update step within importToLibrary will then fail
-// and surface an error, which the caller should handle).
-func (a *LibraryImporterAdapter) ImportPath(ctx context.Context, srcPath string) (string, error) {
-	if a == nil || a.store == nil || a.cfg == nil {
-		return srcPath, fmt.Errorf("LibraryImporterAdapter: not fully initialised")
-	}
-
-	bf, err := a.store.GetBookFileByPath(srcPath)
-	if err != nil {
-		return srcPath, fmt.Errorf("LibraryImporterAdapter: look up BookFile for %s: %w", srcPath, err)
-	}
-	if bf == nil {
-		// File is protected but has no DB record yet. This can happen during
-		// scan/ingest before the record is committed. Log and skip — the write
-		// proceeds in-place rather than failing the entire operation.
-		log.Printf("[WARN] LibraryImporterAdapter: no BookFile record found for protected path %s; writing in-place", srcPath)
-		return srcPath, nil
-	}
-
-	newPath, err := importToLibrary(a.cfg, a.delugeClient, a.store, bf)
-	if err != nil {
-		return srcPath, fmt.Errorf("LibraryImporterAdapter: importToLibrary for %s: %w", srcPath, err)
-	}
-	return newPath, nil
+	return deluge.NewLibraryImporterAdapter(store, delugeClient, cfg)
 }

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,25 +1,24 @@
 // file: internal/server/deluge_integration.go
-// version: 1.6.0
+// version: 2.0.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
-// last-edited: 2026-05-05
+// last-edited: 2026-05-11
 //
-// Deluge integration for library centralization (backlog 6.1).
+// Deluge integration — HTTP handlers and thin shims.
 //
-// When a book version that came from Deluge is swapped, trashed,
-// or its files are reorganized, we need to update the torrent's
-// save_path in Deluge so it keeps seeding from the new location.
-//
-// The Deluge client is optional — if not configured, the
-// integration is silently skipped.
+// Service logic (GetClient, NotifyDeluge*, etc.) has moved to
+// internal/deluge/integration.go. This file contains:
+//   - getDelugeClient() — package-level shim for server-internal callers
+//   - HTTP handlers: handleDelugeTestConnection, handleDelugeListTorrents,
+//     handleDelugeStatus, registerDelugeRoutes
+//   - Package-level re-exports: NotifyDelugeMoveStorage, NotifyDelugeAfterOrganize,
+//     NotifyDelugeAfterUndo, NotifyDelugeAfterVersionSwap (for callers still
+//     referencing the server package — prefer deluge.* directly in new code)
 
 package server
 
 import (
 	"fmt"
-	"log"
 	"net/http"
-	"path/filepath"
-	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
@@ -28,76 +27,40 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 )
 
-var (
-	globalDelugeClient   *deluge.Client
-	globalDelugeClientMu sync.Mutex
-)
-
-// getDelugeClient returns the Deluge client, initializing it if
-// needed. Returns nil if Deluge is not configured.
+// getDelugeClient is a package-level shim so server-internal code that still
+// calls getDelugeClient() continues to compile without change. Prefer
+// deluge.GetClient() in new code outside this package.
 func getDelugeClient() *deluge.Client {
-	globalDelugeClientMu.Lock()
-	defer globalDelugeClientMu.Unlock()
-	if globalDelugeClient != nil {
-		return globalDelugeClient
-	}
-	url := config.AppConfig.DelugeWebURL
-	pass := config.AppConfig.DelugeWebPassword
-	// Fall back to download_client.torrent.deluge config.
-	if url == "" {
-		dc := config.AppConfig.DownloadClient.Torrent.Deluge
-		if dc.Host != "" {
-			port := dc.Port
-			if port == 0 {
-				port = 8112
-			}
-			url = fmt.Sprintf("http://%s:%d", dc.Host, port)
-			pass = dc.Password
-		}
-	}
-	if url == "" {
-		return nil
-	}
-	if pass == "" {
-		pass = "deluge"
-	}
-	c, err := deluge.New(url, pass)
-	if err != nil {
-		log.Printf("[WARN] failed to create deluge client: %v", err)
-		return nil
-	}
-	globalDelugeClient = c
-	return c
+	return deluge.GetClient()
 }
 
-// NotifyDelugeMoveStorage tells Deluge to move a torrent's storage
-// to a new path. Called after a version swap or organize moves files
-// that belong to a Deluge-sourced version.
-//
-// torrentHash is the infohash from BookVersion.TorrentHash.
-// newPath is the directory where the files now live.
-//
-// Silently no-ops if Deluge is not configured or the torrent hash
-// is empty.
+// NotifyDelugeMoveStorage re-exports deluge.NotifyDelugeMoveStorage for callers
+// within the server package that predate the extraction.
 func NotifyDelugeMoveStorage(torrentHash, newPath string) {
-	if torrentHash == "" {
-		return
-	}
-	if !config.AppConfig.DelugeMoveEnabled {
-		log.Printf("[INFO] deluge move_storage skipped (deluge_move_enabled=false): %s → %s", torrentHash, newPath)
-		return
-	}
-	c := getDelugeClient()
-	if c == nil {
-		return
-	}
-	// Deluge expects the parent directory, not the file path.
-	dir := filepath.Dir(newPath)
-	if err := c.MoveStorage([]string{torrentHash}, dir); err != nil {
-		log.Printf("[WARN] deluge move_storage %s → %s: %v", torrentHash, dir, err)
-	} else {
-		log.Printf("[INFO] deluge move_storage %s → %s", torrentHash, dir)
-	}
+	deluge.NotifyDelugeMoveStorage(torrentHash, newPath)
+}
+
+// NotifyDelugeAfterOrganize re-exports deluge.NotifyDelugeAfterOrganize.
+func NotifyDelugeAfterOrganize(store interface {
+	database.BookVersionStore
+}, bookID, newPath string) {
+	deluge.NotifyDelugeAfterOrganize(store, bookID, newPath)
+}
+
+// NotifyDelugeAfterUndo re-exports deluge.NotifyDelugeAfterUndo.
+func NotifyDelugeAfterUndo(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, bookID, oldFilePath string) {
+	deluge.NotifyDelugeAfterUndo(store, bookID, oldFilePath)
+}
+
+// NotifyDelugeAfterVersionSwap re-exports deluge.NotifyDelugeAfterVersionSwap.
+func NotifyDelugeAfterVersionSwap(store interface {
+	database.BookReader
+	database.BookVersionStore
+}, fromVer, toVer *database.BookVersion, bookFilePath string) {
+	deluge.NotifyDelugeAfterVersionSwap(store, fromVer, toVer, bookFilePath)
 }
 
 // handleDelugeTestConnection tests the Deluge Web UI connection.
@@ -194,75 +157,4 @@ func (s *Server) registerDelugeRoutes(protected *gin.RouterGroup) {
 
 	// Bulk-import pending Deluge files (settings.manage permission).
 	protected.POST("/discovery/import", s.perm("settings.manage"), s.handleDiscoveryImport)
-}
-
-// NotifyDelugeAfterOrganize tells Deluge to follow a book that was
-// just moved into the library by the organize pipeline.
-//
-// Called after the file move succeeds and the Book record has been
-// updated to point at newPath. It looks up the active BookVersion(s)
-// for the book; for each with a non-empty TorrentHash it calls
-// NotifyDelugeMoveStorage so the torrent client keeps seeding from
-// the new location.
-//
-// Best-effort: errors are logged but do not bubble up — the organize
-// operation already succeeded.
-func NotifyDelugeAfterOrganize(store interface {
-	database.BookVersionStore
-}, bookID, newPath string) {
-	versions, err := store.GetBookVersionsByBookID(bookID)
-	if err != nil {
-		log.Printf("[WARN] deluge-organize: failed to load versions for book %s: %v", bookID, err)
-		return
-	}
-	for _, v := range versions {
-		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
-			NotifyDelugeMoveStorage(v.TorrentHash, newPath)
-		}
-	}
-}
-
-// NotifyDelugeAfterUndo checks whether the reverted operation moved
-// Deluge-sourced files and updates the torrent storage path.
-//
-// oldFilePath is the path the file was restored to (the original location
-// before the organize operation ran). This is the destination Deluge needs
-// to know about — NOT book.FilePath, which may not yet be updated in the DB
-// at the point this is called from the undo engine.
-func NotifyDelugeAfterUndo(store interface {
-	database.BookReader
-	database.BookVersionStore
-}, bookID, oldFilePath string) {
-	if oldFilePath == "" {
-		return
-	}
-	_, _ = store.GetBookByID(bookID) // ensure book exists; ignore result
-	versions, _ := store.GetBookVersionsByBookID(bookID)
-	for _, v := range versions {
-		if v.TorrentHash != "" && v.Status == database.BookVersionStatusActive {
-			// Use oldFilePath (the restored destination), not book.FilePath,
-			// because the DB FilePath may not have been updated yet when this
-			// is called immediately after the file rename-back.
-			NotifyDelugeMoveStorage(v.TorrentHash, oldFilePath)
-		}
-	}
-}
-
-// NotifyDelugeAfterVersionSwap checks whether the swapped versions
-// have torrent hashes and updates Deluge accordingly.
-func NotifyDelugeAfterVersionSwap(store interface {
-	database.BookReader
-	database.BookVersionStore
-}, fromVer, toVer *database.BookVersion, bookFilePath string) {
-	if toVer != nil && toVer.TorrentHash != "" {
-		NotifyDelugeMoveStorage(toVer.TorrentHash, bookFilePath)
-	}
-	if fromVer != nil && fromVer.TorrentHash != "" {
-		// The "from" version moved into .versions/{id}/ — tell Deluge.
-		book, _ := store.GetBookByID(fromVer.BookID)
-		if book != nil {
-			slotDir := filepath.Join(filepath.Dir(book.FilePath), ".versions", fromVer.ID)
-			NotifyDelugeMoveStorage(fromVer.TorrentHash, slotDir)
-		}
-	}
 }

--- a/internal/server/deluge_integration_test.go
+++ b/internal/server/deluge_integration_test.go
@@ -1,7 +1,11 @@
 // file: internal/server/deluge_integration_test.go
-// version: 1.2.0
+// version: 2.0.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-05-05
+// last-edited: 2026-05-11
+//
+// Integration tests for Deluge notification helpers and HTTP handlers.
+// Service logic moved to internal/deluge/integration.go; tests updated to
+// use deluge.SetGlobalClientForTest for client injection.
 
 package server
 
@@ -20,25 +24,24 @@ import (
 
 func TestNotifyDelugeMoveStorage_EmptyHash(t *testing.T) {
 	// Should silently no-op with empty hash.
-	NotifyDelugeMoveStorage("", "/some/path")
+	deluge.NotifyDelugeMoveStorage("", "/some/path")
 }
 
 func TestNotifyDelugeMoveStorage_NoClient(t *testing.T) {
-	// Save and clear the global client.
-	orig := globalDelugeClient
-	globalDelugeClient = nil
+	// Inject nil client and clear config so GetClient returns nil.
+	restore := deluge.SetGlobalClientForTest(nil)
 	origURL := config.AppConfig.DelugeWebURL
 	config.AppConfig.DelugeWebURL = ""
 	origHost := config.AppConfig.DownloadClient.Torrent.Deluge.Host
 	config.AppConfig.DownloadClient.Torrent.Deluge.Host = ""
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeWebURL = origURL
 		config.AppConfig.DownloadClient.Torrent.Deluge.Host = origHost
 	}()
 
 	// Should silently no-op when Deluge is not configured.
-	NotifyDelugeMoveStorage("abc123", "/new/path")
+	deluge.NotifyDelugeMoveStorage("abc123", "/new/path")
 }
 
 func TestNotifyDelugeMoveStorage_WithMockServer(t *testing.T) {
@@ -68,16 +71,15 @@ func TestNotifyDelugeMoveStorage_WithMockServer(t *testing.T) {
 		t.Fatalf("create client: %v", err)
 	}
 
-	orig := globalDelugeClient
-	globalDelugeClient = client
+	restore := deluge.SetGlobalClientForTest(client)
 	origMove := config.AppConfig.DelugeMoveEnabled
 	config.AppConfig.DelugeMoveEnabled = true
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeMoveEnabled = origMove
 	}()
 
-	NotifyDelugeMoveStorage("abc123", "/new/path/to/book.m4b")
+	deluge.NotifyDelugeMoveStorage("abc123", "/new/path/to/book.m4b")
 
 	if !calledMoveStorage {
 		t.Error("expected MoveStorage to be called")
@@ -187,14 +189,13 @@ func TestNotifyDelugeAfterVersionSwap(t *testing.T) {
 	})
 
 	// With no Deluge client configured, should not panic.
-	orig := globalDelugeClient
-	globalDelugeClient = nil
+	restore := deluge.SetGlobalClientForTest(nil)
 	origURL := config.AppConfig.DelugeWebURL
 	config.AppConfig.DelugeWebURL = ""
 	origHost := config.AppConfig.DownloadClient.Torrent.Deluge.Host
 	config.AppConfig.DownloadClient.Torrent.Deluge.Host = ""
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeWebURL = origURL
 		config.AppConfig.DownloadClient.Torrent.Deluge.Host = origHost
 	}()
@@ -203,7 +204,7 @@ func TestNotifyDelugeAfterVersionSwap(t *testing.T) {
 	toVer := &database.BookVersion{ID: "v2", BookID: "b1", TorrentHash: "def456"}
 
 	// Should not panic even without Deluge configured.
-	NotifyDelugeAfterVersionSwap(store, fromVer, toVer, "/lib/books/b1/book.m4b")
+	deluge.NotifyDelugeAfterVersionSwap(store, fromVer, toVer, "/lib/books/b1/book.m4b")
 }
 
 // ---------------------------------------------------------------------------
@@ -266,18 +267,17 @@ func TestNotifyDelugeAfterUndo_Enabled(t *testing.T) {
 		t.Fatalf("create client: %v", err)
 	}
 
-	orig := globalDelugeClient
+	restore := deluge.SetGlobalClientForTest(client)
 	origMove := config.AppConfig.DelugeMoveEnabled
-	globalDelugeClient = client
 	config.AppConfig.DelugeMoveEnabled = true
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeMoveEnabled = origMove
 	}()
 
 	// The undo restores the file to the original path.
 	restoredPath := "/library/Author/Title/book.m4b"
-	NotifyDelugeAfterUndo(store, book.ID, restoredPath)
+	deluge.NotifyDelugeAfterUndo(store, book.ID, restoredPath)
 
 	if len(gotHashes) == 0 {
 		t.Fatal("expected MoveStorage to be called")
@@ -320,16 +320,15 @@ func TestNotifyDelugeAfterUndo_Disabled(t *testing.T) {
 	defer srv.Close()
 
 	client, _ := deluge.New(srv.URL, "deluge")
-	orig := globalDelugeClient
+	restore := deluge.SetGlobalClientForTest(client)
 	origMove := config.AppConfig.DelugeMoveEnabled
-	globalDelugeClient = client
 	config.AppConfig.DelugeMoveEnabled = false // disabled
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeMoveEnabled = origMove
 	}()
 
-	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+	deluge.NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
 
 	if calledMoveStorage {
 		t.Error("MoveStorage should NOT be called when DelugeMoveEnabled=false")
@@ -365,16 +364,15 @@ func TestNotifyDelugeAfterUndo_NoHash(t *testing.T) {
 	defer srv.Close()
 
 	client, _ := deluge.New(srv.URL, "deluge")
-	orig := globalDelugeClient
+	restore := deluge.SetGlobalClientForTest(client)
 	origMove := config.AppConfig.DelugeMoveEnabled
-	globalDelugeClient = client
 	config.AppConfig.DelugeMoveEnabled = true
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeMoveEnabled = origMove
 	}()
 
-	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+	deluge.NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
 
 	if calledMoveStorage {
 		t.Error("MoveStorage should NOT be called when TorrentHash is empty")
@@ -425,16 +423,15 @@ func TestNotifyDelugeAfterUndo_DelugeError(t *testing.T) {
 		t.Fatalf("create client: %v", err)
 	}
 
-	orig := globalDelugeClient
+	restore := deluge.SetGlobalClientForTest(client)
 	origMove := config.AppConfig.DelugeMoveEnabled
-	globalDelugeClient = client
 	config.AppConfig.DelugeMoveEnabled = true
 	defer func() {
-		globalDelugeClient = orig
+		restore()
 		config.AppConfig.DelugeMoveEnabled = origMove
 	}()
 
 	// Must not panic or return error — best-effort, log only.
-	NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
+	deluge.NotifyDelugeAfterUndo(store, book.ID, "/library/Author/Title/book.m4b")
 	// If we reach here, the test passes (no panic, no error propagation).
 }

--- a/internal/server/organize_handlers.go
+++ b/internal/server/organize_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/organize_handlers.go
-// version: 2.3.0
-// last-edited: 2026-05-05
+// version: 2.4.0
+// last-edited: 2026-05-11
 // guid: 1522f0ec-663c-4527-a6d0-645658206a24
 //
 // Organize/rename HTTP handlers split out of server.go: preview/apply
@@ -17,9 +17,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
+	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
@@ -247,7 +248,7 @@ func (s *Server) organizeBook(c *gin.Context) {
 	// Notify Deluge that the file moved so the torrent client keeps
 	// seeding from the new library path. Best-effort — errors are logged
 	// inside NotifyDelugeAfterOrganize; the organize itself already succeeded.
-	NotifyDelugeAfterOrganize(s.Store(), book.ID, newPath)
+	deluge.NotifyDelugeAfterOrganize(s.Store(), book.ID, newPath)
 
 	s.publishEvent(c.Request.Context(), plugin.NewEvent(plugin.EventFileOrganized, createdBook.ID, map[string]any{
 		"old_path":         oldPath,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -768,7 +768,7 @@ func NewServer(store database.Store) *Server {
 	// config.ProtectedPaths. If Deluge is not configured, the cache still works
 	// for the static paths (e.g. iTunes library root).
 	{
-		dc := getDelugeClient()
+		dc := deluge.GetClient()
 		server.protectedPathCache = deluge.NewProtectedPathCache(dc, config.AppConfig.ProtectedPaths)
 		log.Printf("[INFO] ProtectedPathCache initialized (%d static extra paths)", len(config.AppConfig.ProtectedPaths))
 
@@ -776,7 +776,7 @@ func NewServer(store database.Store) *Server {
 		// all taglib writes (metadata apply, single-tag patch) check for Deluge-
 		// protected paths before writing. This uses the same ProtectedPathCache
 		// and a LibraryImporterAdapter backed by the server's store.
-		importer := NewLibraryImporterAdapter(resolvedStore, dc, &config.AppConfig)
+		importer := deluge.NewLibraryImporterAdapter(resolvedStore, dc, &config.AppConfig)
 		deps := tagger.SafeWriteDeps{
 			ProtectedCache: server.protectedPathCache,
 			Importer:       importer,

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_search.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
-// last-edited: 2026-05-01
+// last-edited: 2026-05-11
 
 package server
 
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
 	"github.com/jdfalk/audiobook-organizer/internal/tagger"
 )
@@ -29,7 +30,7 @@ func (s *Server) safeWriteDeps() tagger.SafeWriteDeps {
 		return tagger.SafeWriteDeps{}
 	}
 	store := s.Store()
-	importer := NewLibraryImporterAdapter(store, getDelugeClient(), &config.AppConfig)
+	importer := deluge.NewLibraryImporterAdapter(store, deluge.GetClient(), &config.AppConfig)
 	return tagger.SafeWriteDeps{
 		ProtectedCache: s.protectedPathCache,
 		Importer:       importer,

--- a/internal/server/undo_engine.go
+++ b/internal/server/undo_engine.go
@@ -1,10 +1,11 @@
 // file: internal/server/undo_engine.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 0b8c9d6e-1f7a-4a70-b8c5-3d7e0f1b9a99
+// last-edited: 2026-05-11
 //
 // Backward-compatibility wrapper for the undo engine, now in internal/undo.
 // This file re-exports the public API from internal/undo with server-specific
-// callback handling (NotifyDelugeAfterUndo).
+// callback handling (deluge.NotifyDelugeAfterUndo).
 //
 // The actual undo implementation lives in internal/undo/engine.go
 
@@ -12,6 +13,7 @@ package server
 
 import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/undo"
 )
 
@@ -40,7 +42,7 @@ func RunUndoOperation(
 		store,
 		targetOpID,
 		progress,
-		NotifyDelugeAfterUndo,
+		deluge.NotifyDelugeAfterUndo,
 	)
 }
 


### PR DESCRIPTION
## Summary
- New `internal/deluge` package: `DiscoveredTorrent`, 4-tier matching, `BuildLibraryIndex`, `ImportToLibrary`
- `LibraryImporterAdapter` implements the importer interface for library-side moves
- `NotifyDelugeAfterUndo`, `NotifyDelugeAfterOrganize` — integration callbacks without `*Server`
- Platform-specific files (`deluge_import_unix.go`, `deluge_import_windows.go`) left as thin server wrappers
- Server callers updated to delegate to `internal/deluge`

## Test plan
- [ ] `go test ./internal/deluge/...`
- [ ] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)