### PR TITLE
refactor(dedup): extract duplicate detection to internal/dedup

### DIFF
--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -1,0 +1,248 @@
+// file: internal/dedup/book_dedup.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-123456789012
+
+// Package dedup: book_dedup.go contains the extracted execution logic for the
+// "dedup.book-scan" and "dedup.book-merge" async operations.  The *Server
+// wrappers in internal/server/duplicates_ops.go are now thin callers that hand
+// results back to server-owned state (dedupCache, etc.).
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// BookDupGroup is a group of books that are likely duplicates of each other.
+type BookDupGroup struct {
+	Books      []database.Book `json:"books"`
+	Confidence string          `json:"confidence"` // "high", "medium", "low"
+	Reason     string          `json:"reason"`
+	GroupKey   string          `json:"group_key"`
+}
+
+// BookScanResult is the result of ScanBookDuplicates.
+type BookScanResult struct {
+	Groups         []BookDupGroup
+	TotalDuplicates int
+}
+
+// ScanBookDuplicates runs the three-tier duplicate-book scan (hash, folder,
+// metadata fuzzy) against store, filters out keys present in dismissed, and
+// returns a consolidated list of BookDupGroup values along with the total
+// number of duplicate books (i.e. sum of len(group.Books)-1 across all
+// groups).
+//
+// dismissed maps stable group keys (sorted book IDs joined by "+") to true;
+// any group whose key is in the map is silently dropped.
+//
+// progress may be nil; all calls are guarded.
+func ScanBookDuplicates(
+	_ context.Context,
+	store database.Store,
+	dismissed map[string]bool,
+	progress ProgressReporter,
+) (BookScanResult, error) {
+	report := func(pct int, msg string) {
+		if progress != nil {
+			_ = progress.UpdateProgress(pct, 100, msg)
+		}
+	}
+
+	report(0, "Scanning for duplicate books...")
+
+	// Step 1: Hash-based duplicates (high confidence)
+	report(10, "Finding hash-based duplicates...")
+	hashGroups, err := store.GetDuplicateBooks()
+	if err != nil {
+		return BookScanResult{}, fmt.Errorf("hash-based dedup failed: %w", err)
+	}
+
+	// Step 2: Folder duplicates (same title in same folder)
+	report(30, "Finding folder-based duplicates...")
+	folderGroups, err := store.GetFolderDuplicates()
+	if err != nil {
+		log.Printf("[WARN] folder dedup failed: %v", err)
+		folderGroups = nil
+	}
+
+	// Step 3: Metadata-based fuzzy matching
+	report(50, "Finding metadata-based duplicates...")
+	metadataGroups, err := store.GetDuplicateBooksByMetadata(0.85)
+	if err != nil {
+		log.Printf("[WARN] metadata dedup failed: %v", err)
+		metadataGroups = nil
+	}
+
+	report(80, "Merging results...")
+
+	// Combine all groups, deduplicating by book ID.
+	seenBookIDs := map[string]bool{}
+	var allGroups []BookDupGroup
+
+	addGroups := func(groups [][]database.Book, confidence, reason string) {
+		for _, group := range groups {
+			// Skip if every book in this group has already been claimed.
+			allSeen := true
+			for _, b := range group {
+				if !seenBookIDs[b.ID] {
+					allSeen = false
+					break
+				}
+			}
+			if allSeen {
+				continue
+			}
+			// Generate a stable group key from sorted book IDs.
+			ids := make([]string, len(group))
+			for i, b := range group {
+				ids[i] = b.ID
+			}
+			groupKey := strings.Join(ids, "+")
+			if dismissed[groupKey] {
+				continue
+			}
+			allGroups = append(allGroups, BookDupGroup{
+				Books:      group,
+				Confidence: confidence,
+				Reason:     reason,
+				GroupKey:   groupKey,
+			})
+			for _, b := range group {
+				seenBookIDs[b.ID] = true
+			}
+		}
+	}
+
+	addGroups(hashGroups, "high", "Identical file hash")
+	addGroups(folderGroups, "medium", "Same title in same folder")
+	addGroups(metadataGroups, "low", "Similar title and author")
+
+	totalDuplicates := 0
+	for _, g := range allGroups {
+		totalDuplicates += len(g.Books) - 1
+	}
+
+	report(100, fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(allGroups), totalDuplicates))
+
+	return BookScanResult{
+		Groups:          allGroups,
+		TotalDuplicates: totalDuplicates,
+	}, nil
+}
+
+// BookMergeResult summarises the outcome of MergeBooks.
+type BookMergeResult struct {
+	// UpdatedKeepBook is the keep book after iTunes metadata has been transferred
+	// in and the UpdateBook call has been issued.  Callers may use it to
+	// invalidate caches or issue further side-effects.
+	UpdatedKeepBook *database.Book
+	MergedCount     int
+	Errors          []string
+}
+
+// MergeBooks transfers useful metadata from each merge book to the keep book,
+// deletes the merge books, and records OperationChange rows.  It does NOT
+// invalidate any server-side cache — the caller is responsible for that.
+//
+// opID is the legacy operation ID written into OperationChange records.
+// keepID is the ID of the book to keep; every ID in mergeIDs is deleted.
+func MergeBooks(
+	_ context.Context,
+	store database.Store,
+	opID, keepID string,
+	mergeIDs []string,
+	progress ProgressReporter,
+) (BookMergeResult, error) {
+	keepBook, err := store.GetBookByID(keepID)
+	if err != nil || keepBook == nil {
+		return BookMergeResult{}, fmt.Errorf("keep book %s not found", keepID)
+	}
+
+	if progress != nil {
+		_ = progress.Log("info",
+			fmt.Sprintf("Merging %d book(s) into %q", len(mergeIDs), keepBook.Title), nil)
+		_ = progress.UpdateProgress(0, len(mergeIDs), "Starting book merge...")
+	}
+
+	kBook, err := store.GetBookByID(keepID)
+	if err != nil || kBook == nil {
+		return BookMergeResult{}, fmt.Errorf("keep book %s not found", keepID)
+	}
+
+	var result BookMergeResult
+	for i, mergeID := range mergeIDs {
+		if progress != nil && progress.IsCanceled() {
+			return result, fmt.Errorf("cancelled")
+		}
+		if mergeID == keepID {
+			continue
+		}
+		mergeBook, err := store.GetBookByID(mergeID)
+		if err != nil || mergeBook == nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("book %s not found", mergeID))
+			continue
+		}
+
+		// Transfer useful iTunes metadata from merge book to keep book (first-win).
+		if (kBook.ITunesPersistentID == nil || *kBook.ITunesPersistentID == "") &&
+			mergeBook.ITunesPersistentID != nil && *mergeBook.ITunesPersistentID != "" {
+			kBook.ITunesPersistentID = mergeBook.ITunesPersistentID
+		}
+		if kBook.ITunesPlayCount == nil && mergeBook.ITunesPlayCount != nil {
+			kBook.ITunesPlayCount = mergeBook.ITunesPlayCount
+		}
+		if kBook.ITunesRating == nil && mergeBook.ITunesRating != nil {
+			kBook.ITunesRating = mergeBook.ITunesRating
+		}
+		if kBook.ITunesDateAdded == nil && mergeBook.ITunesDateAdded != nil {
+			kBook.ITunesDateAdded = mergeBook.ITunesDateAdded
+		}
+		if kBook.ITunesLastPlayed == nil && mergeBook.ITunesLastPlayed != nil {
+			kBook.ITunesLastPlayed = mergeBook.ITunesLastPlayed
+		}
+		if kBook.ITunesBookmark == nil && mergeBook.ITunesBookmark != nil {
+			kBook.ITunesBookmark = mergeBook.ITunesBookmark
+		}
+
+		if err := store.DeleteBook(mergeID); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("failed to delete book %s: %v", mergeID, err))
+		} else {
+			_ = store.CreateOperationChange(&database.OperationChange{
+				ID:          ulid.Make().String(),
+				OperationID: opID,
+				BookID:      mergeID,
+				ChangeType:  "book_delete",
+				FieldName:   "book",
+				OldValue:    fmt.Sprintf("%s (%s)", mergeBook.Title, mergeBook.FilePath),
+				NewValue:    fmt.Sprintf("merged_into:%s", keepID),
+			})
+			result.MergedCount++
+		}
+
+		if progress != nil {
+			_ = progress.UpdateProgress(i+1, len(mergeIDs),
+				fmt.Sprintf("Merged %d/%d books", i+1, len(mergeIDs)))
+		}
+	}
+
+	if _, err := store.UpdateBook(kBook.ID, kBook); err != nil {
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("failed to update keep book: %v", err))
+	}
+
+	if progress != nil {
+		msg := fmt.Sprintf("Book merge complete: merged %d, %d errors",
+			result.MergedCount, len(result.Errors))
+		_ = progress.Log("info", msg, nil)
+	}
+
+	result.UpdatedKeepBook = kBook
+	return result, nil
+}

--- a/internal/dedup/book_dedup_test.go
+++ b/internal/dedup/book_dedup_test.go
@@ -1,0 +1,212 @@
+// file: internal/dedup/book_dedup_test.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-1234-efab-345678901234
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── stub progress reporter ────────────────────────────────────────────────────
+
+type stubProgress struct {
+	logs      []string
+	canceled  bool
+	lastPct   int
+	lastMsg   string
+}
+
+func (sp *stubProgress) UpdateProgress(current, total int, message string) error {
+	if total > 0 {
+		sp.lastPct = current * 100 / total
+	}
+	sp.lastMsg = message
+	return nil
+}
+
+func (sp *stubProgress) Log(level, message string, _ *string) error {
+	sp.logs = append(sp.logs, level+": "+message)
+	return nil
+}
+
+func (sp *stubProgress) IsCanceled() bool { return sp.canceled }
+
+// ── ScanBookDuplicates ────────────────────────────────────────────────────────
+
+func TestScanBookDuplicates_Empty(t *testing.T) {
+	// All three store methods return empty lists — result should be zero groups.
+	mock := &database.MockStore{}
+	mock.GetDuplicateBooksFunc = func() ([][]database.Book, error) { return nil, nil }
+
+	result, err := ScanBookDuplicates(context.Background(), mock, nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Groups)
+	assert.Equal(t, 0, result.TotalDuplicates)
+}
+
+func TestScanBookDuplicates_HashGroup(t *testing.T) {
+	// Two books with the same hash → one high-confidence group with 1 duplicate.
+	bookA := database.Book{ID: "AAA", Title: "Book A"}
+	bookB := database.Book{ID: "BBB", Title: "Book B"}
+
+	mock := &database.MockStore{}
+	mock.GetDuplicateBooksFunc = func() ([][]database.Book, error) {
+		return [][]database.Book{{bookA, bookB}}, nil
+	}
+
+	progress := &stubProgress{}
+	result, err := ScanBookDuplicates(context.Background(), mock, nil, progress)
+	require.NoError(t, err)
+	require.Len(t, result.Groups, 1)
+	assert.Equal(t, "high", result.Groups[0].Confidence)
+	assert.Equal(t, "Identical file hash", result.Groups[0].Reason)
+	assert.Equal(t, 1, result.TotalDuplicates)
+	// Group key should be the two IDs joined.
+	assert.Equal(t, "AAA+BBB", result.Groups[0].GroupKey)
+}
+
+func TestScanBookDuplicates_DismissedGroupSkipped(t *testing.T) {
+	bookA := database.Book{ID: "AAA", Title: "Book A"}
+	bookB := database.Book{ID: "BBB", Title: "Book B"}
+
+	mock := &database.MockStore{}
+	mock.GetDuplicateBooksFunc = func() ([][]database.Book, error) {
+		return [][]database.Book{{bookA, bookB}}, nil
+	}
+
+	// The group key is "AAA+BBB"; mark it dismissed.
+	dismissed := map[string]bool{"AAA+BBB": true}
+
+	result, err := ScanBookDuplicates(context.Background(), mock, dismissed, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Groups, "dismissed group should be excluded")
+}
+
+func TestScanBookDuplicates_DeduplicationAcrossTiers(t *testing.T) {
+	// The same pair of books appears in both hash and folder groups.
+	// They should only appear once (in the high-confidence tier).
+	bookA := database.Book{ID: "AAA", Title: "Book A"}
+	bookB := database.Book{ID: "BBB", Title: "Book B"}
+
+	mock := &database.MockStore{}
+	mock.GetDuplicateBooksFunc = func() ([][]database.Book, error) {
+		return [][]database.Book{{bookA, bookB}}, nil
+	}
+	// GetFolderDuplicates is hard-coded nil in MockStore, so the pair cannot
+	// be emitted a second time — this test validates that the tier ordering
+	// and the seenBookIDs guard work correctly even when the store returns nil
+	// for lower-confidence tiers.
+
+	result, err := ScanBookDuplicates(context.Background(), mock, nil, nil)
+	require.NoError(t, err)
+	assert.Len(t, result.Groups, 1, "one group expected, no duplication across tiers")
+}
+
+// ── MergeBooks ────────────────────────────────────────────────────────────────
+
+func TestMergeBooks_BasicMerge(t *testing.T) {
+	keepBook := &database.Book{ID: "KEEP", Title: "Keep Me"}
+	mergeBook := &database.Book{ID: "MERGE1", Title: "Merge Me"}
+
+	deleted := []string{}
+	var updatedBook *database.Book
+
+	mock := &database.MockStore{}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "KEEP":
+			return keepBook, nil
+		case "MERGE1":
+			return mergeBook, nil
+		}
+		return nil, nil
+	}
+	mock.DeleteBookFunc = func(id string) error {
+		deleted = append(deleted, id)
+		return nil
+	}
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		updatedBook = book
+		return book, nil
+	}
+
+	progress := &stubProgress{}
+	result, err := MergeBooks(context.Background(), mock, "op1", "KEEP", []string{"MERGE1"}, progress)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.MergedCount)
+	assert.Empty(t, result.Errors)
+	assert.Contains(t, deleted, "MERGE1")
+	assert.NotNil(t, updatedBook)
+	assert.Equal(t, "KEEP", updatedBook.ID)
+}
+
+func TestMergeBooks_ITunesMetadataTransfer(t *testing.T) {
+	// The keep book has no iTunes fields; the merge book has all of them.
+	// After the merge, the keep book should have the merge book's iTunes data.
+	iTunesPID := "PID123"
+	playCount := 5
+	rating := 80
+
+	keepBook := &database.Book{ID: "KEEP", Title: "Keep"}
+	mergeBook := &database.Book{
+		ID:                 "MERGE",
+		Title:              "Merge",
+		ITunesPersistentID: &iTunesPID,
+		ITunesPlayCount:    &playCount,
+		ITunesRating:       &rating,
+	}
+
+	var updatedBook *database.Book
+	mock := &database.MockStore{}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "KEEP":
+			return keepBook, nil
+		case "MERGE":
+			return mergeBook, nil
+		}
+		return nil, nil
+	}
+	mock.DeleteBookFunc = func(id string) error { return nil }
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		updatedBook = book
+		return book, nil
+	}
+
+	_, err := MergeBooks(context.Background(), mock, "op2", "KEEP", []string{"MERGE"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, updatedBook)
+	require.NotNil(t, updatedBook.ITunesPersistentID)
+	assert.Equal(t, iTunesPID, *updatedBook.ITunesPersistentID)
+	require.NotNil(t, updatedBook.ITunesPlayCount)
+	assert.Equal(t, playCount, *updatedBook.ITunesPlayCount)
+}
+
+func TestMergeBooks_SkipsSelfMerge(t *testing.T) {
+	// If mergeIDs contains the keepID, it should be silently skipped.
+	keepBook := &database.Book{ID: "KEEP", Title: "Keep"}
+	deleted := []string{}
+
+	mock := &database.MockStore{}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return keepBook, nil
+	}
+	mock.DeleteBookFunc = func(id string) error {
+		deleted = append(deleted, id)
+		return nil
+	}
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		return book, nil
+	}
+
+	result, err := MergeBooks(context.Background(), mock, "op3", "KEEP", []string{"KEEP"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.MergedCount, "self-merge should be skipped")
+	assert.Empty(t, deleted)
+}

--- a/internal/dedup/op_params.go
+++ b/internal/dedup/op_params.go
@@ -1,0 +1,58 @@
+// file: internal/dedup/op_params.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+
+// Package dedup: op_params.go defines the JSON-unmarshal parameter structs for
+// each of the 8 async dedup OperationDef Run functions. They are kept here so
+// the extracted logic functions can reference them directly and so server-side
+// wrappers can unmarshal into the same types.
+package dedup
+
+// BookDedupScanParams are the parameters for the "dedup.book-scan" operation.
+type BookDedupScanParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}
+
+// BookMergeParams are the parameters for the "dedup.book-merge" operation.
+type BookMergeParams struct {
+	LegacyOpID string   `json:"legacy_op_id"`
+	KeepID     string   `json:"keep_id"`
+	MergeIDs   []string `json:"merge_ids"`
+	Detail     string   `json:"detail"`
+}
+
+// AuthorDedupScanParams are the parameters for the "dedup.author-scan" operation.
+type AuthorDedupScanParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}
+
+// SeriesDedupScanParams are the parameters for the "dedup.series-scan" operation.
+type SeriesDedupScanParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}
+
+// SeriesDedupParams are the parameters for the "dedup.series-dedup" operation.
+type SeriesDedupParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+	Detail     string `json:"detail"`
+}
+
+// SeriesPruneParams are the parameters for the "dedup.series-prune" operation.
+type SeriesPruneParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+	Detail     string `json:"detail"`
+}
+
+// SeriesMergeParams are the parameters for the "dedup.series-merge" operation.
+type SeriesMergeParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+	KeepID     int    `json:"keep_id"`
+	MergeIDs   []int  `json:"merge_ids"`
+	CustomName string `json:"custom_name"`
+	Detail     string `json:"detail"`
+}
+
+// SeriesNormalizeParams are the parameters for the "dedup.series-normalize" operation.
+type SeriesNormalizeParams struct {
+	LegacyOpID string `json:"legacy_op_id"`
+}

--- a/internal/dedup/progress.go
+++ b/internal/dedup/progress.go
@@ -1,0 +1,20 @@
+// file: internal/dedup/progress.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+// Package dedup: ProgressReporter is a minimal reporting interface used by the
+// extracted dedup operation functions. The server's registryProgressAdapter
+// satisfies this interface automatically.
+package dedup
+
+// ProgressReporter is implemented by anything that can relay progress updates,
+// log messages, and cancellation signals to the caller.
+type ProgressReporter interface {
+	// UpdateProgress reports current position within a [0, total] range.
+	UpdateProgress(current, total int, message string) error
+	// Log emits a log message at the given level ("info", "warn", "error", "debug").
+	// details is an optional extra string (may be nil).
+	Log(level, message string, details *string) error
+	// IsCanceled reports whether the caller has requested cancellation.
+	IsCanceled() bool
+}

--- a/internal/dedup/series_dedup.go
+++ b/internal/dedup/series_dedup.go
@@ -1,0 +1,566 @@
+// file: internal/dedup/series_dedup.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-defa-234567890123
+
+// Package dedup: series_dedup.go contains the extracted execution logic for the
+// "dedup.series-scan", "dedup.series-dedup", and "dedup.series-merge" async
+// operations.  The *Server wrappers in internal/server/duplicates_ops.go are
+// now thin callers that write results into the server-owned dedupCache.
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/util"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// ── series scan ───────────────────────────────────────────────────────────────
+
+// SeriesBookSummary is a lightweight book reference used inside SeriesDupGroup.
+type SeriesBookSummary struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	CoverURL string `json:"cover_url,omitempty"`
+}
+
+// SeriesWithBooks enriches a database.Series with its first few books and the
+// author name derived from the authorID.
+type SeriesWithBooks struct {
+	database.Series
+	Books      []SeriesBookSummary `json:"books"`
+	AuthorName string              `json:"author_name,omitempty"`
+}
+
+// SeriesDupGroup is a group of series that are likely duplicates of each other.
+type SeriesDupGroup struct {
+	Name          string            `json:"name"`
+	Count         int               `json:"count"`
+	Series        []SeriesWithBooks `json:"series"`
+	SuggestedName string            `json:"suggested_name,omitempty"`
+	MatchType     string            `json:"match_type"` // "exact" | "subseries"
+}
+
+// SeriesScanResult is the return value of ScanSeriesDuplicates.
+type SeriesScanResult struct {
+	Groups      []SeriesDupGroup
+	TotalSeries int
+}
+
+// isGarbageSeries returns true for series names that consist only of digits or
+// are blank — these are noise that should be excluded from duplicate grouping.
+func isGarbageSeries(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if len(trimmed) == 0 {
+		return true
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// ExtractSeriesNameForDedup tries to extract a canonical series name from
+// patterns like "Book Title: Series Name" or "Series Name, Book N".
+// It returns the candidate name and true on success, or ("", false) when no
+// pattern matches.
+func ExtractSeriesNameForDedup(name string) (string, bool) {
+	// Pattern: "Book Title: Series Name"
+	if idx := strings.LastIndex(name, ": "); idx > 0 {
+		after := strings.TrimSpace(name[idx+2:])
+		before := strings.TrimSpace(name[:idx])
+		if len(after) > 3 && len(after) < len(before) {
+			return after, true
+		}
+		if len(before) > 3 && len(before) < len(after) {
+			return before, true
+		}
+	}
+	// Pattern: "Series Name, Book N" / "Series Name, Vol N" etc.
+	commaPatterns := []string{", book ", ", vol ", ", volume ", ", #"}
+	lower := strings.ToLower(name)
+	for _, pat := range commaPatterns {
+		if idx := strings.Index(lower, pat); idx > 0 {
+			return strings.TrimSpace(name[:idx]), true
+		}
+	}
+	return "", false
+}
+
+// enrichSeries loads books (up to 5) and author name for each series.
+func enrichSeries(store database.Store, seriesList []database.Series, authorNameMap map[int]string) []SeriesWithBooks {
+	result := make([]SeriesWithBooks, 0, len(seriesList))
+	for _, s := range seriesList {
+		authorName := ""
+		if s.AuthorID != nil {
+			authorName = authorNameMap[*s.AuthorID]
+		}
+		sw := SeriesWithBooks{Series: s, AuthorName: authorName}
+		if books, err := store.GetBooksBySeriesID(s.ID); err == nil {
+			limit := 5
+			if len(books) < limit {
+				limit = len(books)
+			}
+			for _, b := range books[:limit] {
+				cover := ""
+				if b.CoverURL != nil {
+					cover = *b.CoverURL
+				}
+				sw.Books = append(sw.Books, SeriesBookSummary{
+					ID:       b.ID,
+					Title:    b.Title,
+					CoverURL: cover,
+				})
+			}
+		}
+		result = append(result, sw)
+	}
+	return result
+}
+
+// ScanSeriesDuplicates groups all non-garbage series by exact normalised name
+// and by sub-series pattern, enriches each group with book/author info, and
+// returns the consolidated result.
+func ScanSeriesDuplicates(
+	_ context.Context,
+	store database.Store,
+	progress ProgressReporter,
+) (SeriesScanResult, error) {
+	report := func(pct int, msg string) {
+		if progress != nil {
+			_ = progress.UpdateProgress(pct, 100, msg)
+		}
+	}
+
+	report(0, "Fetching series...")
+
+	allSeries, err := store.GetAllSeries()
+	if err != nil {
+		return SeriesScanResult{}, err
+	}
+	report(10, fmt.Sprintf("Loaded %d series, grouping...", len(allSeries)))
+
+	// Build exact-match groups (normalised name → series list).
+	exactGroups := make(map[string][]database.Series)
+	for _, s := range allSeries {
+		if isGarbageSeries(s.Name) {
+			continue
+		}
+		key := util.NormalizeString(s.Name)
+		exactGroups[key] = append(exactGroups[key], s)
+	}
+
+	report(20, "Building author lookup...")
+
+	allAuthors, _ := store.GetAllAuthors()
+	authorNameMap := make(map[int]string, len(allAuthors))
+	for _, a := range allAuthors {
+		authorNameMap[a.ID] = a.Name
+	}
+
+	var result []SeriesDupGroup
+	seen := make(map[int]bool)
+
+	report(30, "Finding exact duplicates...")
+
+	groupKeys := make([]string, 0, len(exactGroups))
+	for k := range exactGroups {
+		groupKeys = append(groupKeys, k)
+	}
+
+	processed := 0
+	totalGroups := len(groupKeys)
+	for _, k := range groupKeys {
+		group := exactGroups[k]
+		if len(group) < 2 {
+			continue
+		}
+		for _, s := range group {
+			seen[s.ID] = true
+		}
+		suggested, _ := ExtractSeriesNameForDedup(group[0].Name)
+		result = append(result, SeriesDupGroup{
+			Name:          group[0].Name,
+			Count:         len(group),
+			Series:        enrichSeries(store, group, authorNameMap),
+			SuggestedName: suggested,
+			MatchType:     "exact",
+		})
+		processed++
+		if processed%10 == 0 {
+			pct := 30 + (processed*40)/maxInt(totalGroups, 1)
+			if progress != nil {
+				_ = progress.UpdateProgress(minInt(pct, 70), 100,
+					fmt.Sprintf("Processing groups... (%d/%d)", processed, totalGroups))
+			}
+		}
+	}
+
+	report(70, "Finding sub-series patterns...")
+
+	seriesByNormalizedName := make(map[string][]database.Series)
+	for _, s := range allSeries {
+		seriesByNormalizedName[util.NormalizeString(s.Name)] =
+			append(seriesByNormalizedName[util.NormalizeString(s.Name)], s)
+	}
+
+	for _, s := range allSeries {
+		if seen[s.ID] || isGarbageSeries(s.Name) {
+			continue
+		}
+		suggested, ok := ExtractSeriesNameForDedup(s.Name)
+		if !ok {
+			continue
+		}
+		suggestedKey := util.NormalizeString(suggested)
+		if matches, exists := seriesByNormalizedName[suggestedKey]; exists {
+			group := []database.Series{s}
+			seen[s.ID] = true
+			for _, m := range matches {
+				if !seen[m.ID] {
+					group = append(group, m)
+					seen[m.ID] = true
+				}
+			}
+			if len(group) >= 2 {
+				result = append(result, SeriesDupGroup{
+					Name:          s.Name,
+					Count:         len(group),
+					Series:        enrichSeries(store, group, authorNameMap),
+					SuggestedName: suggested,
+					MatchType:     "subseries",
+				})
+			}
+		}
+	}
+
+	report(100, fmt.Sprintf("Found %d duplicate groups", len(result)))
+
+	return SeriesScanResult{
+		Groups:      result,
+		TotalSeries: len(allSeries),
+	}, nil
+}
+
+// ── series dedup (bulk merge by normalised name) ──────────────────────────────
+
+// SeriesDedupResult summarises the outcome of DedupSeries.
+type SeriesDedupResult struct {
+	TotalMerged int
+	Errors      []string
+}
+
+// DedupSeries groups all series by normalised name and merges every duplicate
+// group, keeping the series with the lowest ID (preferring one with an author).
+// It does NOT invalidate the server cache — the caller must do that.
+func DedupSeries(
+	_ context.Context,
+	store database.Store,
+	progress ProgressReporter,
+) (SeriesDedupResult, error) {
+	if progress != nil {
+		_ = progress.Log("info", "Starting series deduplication...", nil)
+	}
+
+	allSeries, err := store.GetAllSeries()
+	if err != nil {
+		return SeriesDedupResult{}, fmt.Errorf("failed to get series: %w", err)
+	}
+
+	if progress != nil {
+		_ = progress.UpdateProgress(0, len(allSeries),
+			fmt.Sprintf("Scanning %d series for duplicates...", len(allSeries)))
+	}
+
+	// Group by normalised name.
+	groups := make(map[string][]database.Series)
+	for _, s := range allSeries {
+		key := util.NormalizeString(s.Name)
+		groups[key] = append(groups[key], s)
+	}
+
+	var dupGroups [][]database.Series
+	for _, group := range groups {
+		if len(group) >= 2 {
+			dupGroups = append(dupGroups, group)
+		}
+	}
+
+	if progress != nil {
+		msg := fmt.Sprintf("Found %d duplicate groups to merge", len(dupGroups))
+		_ = progress.Log("info", msg, nil)
+		_ = progress.UpdateProgress(0, len(dupGroups), msg)
+	}
+
+	var result SeriesDedupResult
+	for gi, group := range dupGroups {
+		if progress != nil && progress.IsCanceled() {
+			_ = progress.Log("warn", "Operation cancelled by user", nil)
+			return result, fmt.Errorf("cancelled")
+		}
+
+		// Pick the "best" canonical: prefer one with an authorID, then lowest ID.
+		keepIdx := 0
+		for i, s := range group {
+			if s.AuthorID != nil && group[keepIdx].AuthorID == nil {
+				keepIdx = i
+			} else if (s.AuthorID != nil) == (group[keepIdx].AuthorID != nil) && s.ID < group[keepIdx].ID {
+				keepIdx = i
+			}
+		}
+		keepID := group[keepIdx].ID
+
+		for i, s := range group {
+			if i == keepIdx {
+				continue
+			}
+			books, err := store.GetBooksBySeriesID(s.ID)
+			if err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("failed to get books for series %d: %v", s.ID, err))
+				continue
+			}
+			for _, book := range books {
+				book.SeriesID = &keepID
+				if _, err := store.UpdateBook(book.ID, &book); err != nil {
+					result.Errors = append(result.Errors,
+						fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
+				}
+			}
+			if err := store.DeleteSeries(s.ID); err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("failed to delete series %d: %v", s.ID, err))
+			} else {
+				result.TotalMerged++
+			}
+		}
+
+		if progress != nil {
+			_ = progress.UpdateProgress(gi+1, len(dupGroups),
+				fmt.Sprintf("Merged %d/%d groups (%d series merged)", gi+1, len(dupGroups), result.TotalMerged))
+		}
+	}
+
+	if progress != nil {
+		msg := fmt.Sprintf("Series deduplication complete: merged %d duplicates, %d errors",
+			result.TotalMerged, len(result.Errors))
+		_ = progress.Log("info", msg, nil)
+		if len(result.Errors) > 0 {
+			errDetail := strings.Join(result.Errors[:minInt(len(result.Errors), 10)], "; ")
+			_ = progress.Log("warn", fmt.Sprintf("Merge errors: %s", errDetail), nil)
+		}
+	}
+
+	return result, nil
+}
+
+// ── series merge (explicit keep + merge IDs) ─────────────────────────────────
+
+// SeriesMergeResult summarises the outcome of MergeSeries.
+type SeriesMergeResult struct {
+	MergedCount int
+	Errors      []string
+}
+
+// MergeSeries reassigns all books from each series in mergeIDs to keepID,
+// optionally renames the kept series to customName, and relinks authors.
+// It does NOT invalidate the server cache — the caller must do that.
+//
+// opID is written into OperationChange records for audit.
+func MergeSeries(
+	_ context.Context,
+	store database.Store,
+	opID string,
+	keepID int,
+	mergeIDs []int,
+	customName string,
+	progress ProgressReporter,
+) (SeriesMergeResult, error) {
+	customName = strings.TrimSpace(customName)
+
+	keepSeries, err := store.GetSeriesByID(keepID)
+	if err != nil || keepSeries == nil {
+		return SeriesMergeResult{}, fmt.Errorf("keep series %d not found", keepID)
+	}
+
+	keepName := keepSeries.Name
+	if customName != "" {
+		keepName = customName
+	}
+
+	// Rename the kept series if requested.
+	if customName != "" {
+		oldName := keepSeries.Name
+		if err := store.UpdateSeriesName(keepID, customName); err != nil {
+			return SeriesMergeResult{}, fmt.Errorf("failed to rename series to %q: %w", customName, err)
+		}
+		_ = store.CreateOperationChange(&database.OperationChange{
+			ID:          ulid.Make().String(),
+			OperationID: opID,
+			ChangeType:  "metadata_update",
+			FieldName:   "series_name",
+			OldValue:    oldName,
+			NewValue:    customName,
+		})
+		if progress != nil {
+			_ = progress.Log("info",
+				fmt.Sprintf("Renamed series from %q to %q", oldName, customName), nil)
+		}
+	}
+
+	if progress != nil {
+		_ = progress.Log("info",
+			fmt.Sprintf("Merging %d series into %q", len(mergeIDs), keepName), nil)
+		_ = progress.UpdateProgress(0, len(mergeIDs), "Starting series merge...")
+	}
+
+	// Collect all unique author IDs from the full set of series (keep + merge).
+	allAuthorIDs := make(map[int]bool)
+	allSeriesIDs := append([]int{keepID}, mergeIDs...)
+	for _, sid := range allSeriesIDs {
+		s, err := store.GetSeriesByID(sid)
+		if err == nil && s != nil && s.AuthorID != nil {
+			allAuthorIDs[*s.AuthorID] = true
+		}
+	}
+
+	var result SeriesMergeResult
+	for i, mergeID := range mergeIDs {
+		if progress != nil && progress.IsCanceled() {
+			return result, fmt.Errorf("cancelled")
+		}
+		if mergeID == keepID {
+			continue
+		}
+		books, err := store.GetBooksBySeriesID(mergeID)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("failed to get books for series %d: %v", mergeID, err))
+			continue
+		}
+
+		for _, book := range books {
+			oldSeriesID := ""
+			if book.SeriesID != nil {
+				oldSeriesID = fmt.Sprintf("%d", *book.SeriesID)
+			}
+			book.SeriesID = &keepID
+			if _, err := store.UpdateBook(book.ID, &book); err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
+			} else {
+				_ = store.CreateOperationChange(&database.OperationChange{
+					ID:          ulid.Make().String(),
+					OperationID: opID,
+					BookID:      book.ID,
+					ChangeType:  "metadata_update",
+					FieldName:   "series_id",
+					OldValue:    oldSeriesID,
+					NewValue:    fmt.Sprintf("%d", keepID),
+				})
+			}
+		}
+
+		// Record the series deletion.
+		mergeSeries, _ := store.GetSeriesByID(mergeID)
+		mergeSeriesName := ""
+		if mergeSeries != nil {
+			mergeSeriesName = mergeSeries.Name
+		}
+		if err := store.DeleteSeries(mergeID); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("failed to delete series %d: %v", mergeID, err))
+		} else {
+			result.MergedCount++
+			_ = store.CreateOperationChange(&database.OperationChange{
+				ID:          ulid.Make().String(),
+				OperationID: opID,
+				BookID:      "",
+				ChangeType:  "series_delete",
+				FieldName:   "series",
+				OldValue:    fmt.Sprintf("%d:%s", mergeID, mergeSeriesName),
+				NewValue:    fmt.Sprintf("merged_into:%d", keepID),
+			})
+		}
+
+		if progress != nil {
+			_ = progress.UpdateProgress(i+1, len(mergeIDs),
+				fmt.Sprintf("Merged %d/%d series", i+1, len(mergeIDs)))
+		}
+	}
+
+	// Link all books in the kept series to every unique author collected above.
+	if len(allAuthorIDs) > 1 {
+		if progress != nil {
+			_ = progress.Log("info",
+				fmt.Sprintf("Linking books to %d authors", len(allAuthorIDs)), nil)
+		}
+		allBooks, err := store.GetBooksBySeriesID(keepID)
+		if err == nil {
+			for _, book := range allBooks {
+				existing, _ := store.GetBookAuthors(book.ID)
+				existingMap := make(map[int]bool)
+				for _, ba := range existing {
+					existingMap[ba.AuthorID] = true
+				}
+				authors := existing
+				var addedAuthors []int
+				for aid := range allAuthorIDs {
+					if !existingMap[aid] {
+						authors = append(authors, database.BookAuthor{BookID: book.ID, AuthorID: aid})
+						addedAuthors = append(addedAuthors, aid)
+					}
+				}
+				if len(authors) > len(existing) {
+					if err := store.SetBookAuthors(book.ID, authors); err != nil {
+						result.Errors = append(result.Errors,
+							fmt.Sprintf("failed to set authors for book %s: %v", book.ID, err))
+					} else {
+						_ = store.CreateOperationChange(&database.OperationChange{
+							ID:          ulid.Make().String(),
+							OperationID: opID,
+							BookID:      book.ID,
+							ChangeType:  "author_link",
+							FieldName:   "book_authors",
+							OldValue:    fmt.Sprintf("%d authors", len(existing)),
+							NewValue:    fmt.Sprintf("%d authors (added %v)", len(authors), addedAuthors),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if progress != nil {
+		msg := fmt.Sprintf("Series merge complete: merged %d, %d errors",
+			result.MergedCount, len(result.Errors))
+		_ = progress.Log("info", msg, nil)
+		if len(result.Errors) > 0 {
+			errDetail := strings.Join(result.Errors[:minInt(len(result.Errors), 10)], "; ")
+			_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
+		}
+	}
+
+	return result, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/dedup/series_dedup_test.go
+++ b/internal/dedup/series_dedup_test.go
@@ -1,0 +1,238 @@
+// file: internal/dedup/series_dedup_test.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-2345-fabc-456789012345
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── ExtractSeriesNameForDedup ─────────────────────────────────────────────────
+
+func TestExtractSeriesNameForDedup(t *testing.T) {
+	tests := []struct {
+		input     string
+		want      string
+		wantMatch bool
+	}{
+		// Colon pattern: after-part is shorter → it's the series
+		{"The Great War: Darkness", "Darkness", true},
+		// Colon pattern: before-part is shorter → it's the series
+		// "Long" (4 chars) < "A Very Long Subtitle That Goes On And On" so "Long" wins
+		{"Long: A Very Long Subtitle That Goes On And On", "Long", true},
+		// Comma-book pattern
+		{"Shadow of the Wind, Book 2", "Shadow of the Wind", true},
+		// Comma-vol pattern
+		{"Discworld, Vol 5", "Discworld", true},
+		// Comma-hash pattern (", #" in the list)
+		{"Farseer, #3", "Farseer", true},
+		// No pattern → false
+		{"Just A Plain Series Name", "", false},
+		// Too short after-colon part (≤3 chars)
+		{"Something: No", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := ExtractSeriesNameForDedup(tt.input)
+		if tt.wantMatch {
+			assert.True(t, ok, "expected match for %q", tt.input)
+			assert.Equal(t, tt.want, got, "input %q", tt.input)
+		} else {
+			assert.False(t, ok, "expected no match for %q", tt.input)
+		}
+	}
+}
+
+// ── isGarbageSeries ───────────────────────────────────────────────────────────
+
+func TestIsGarbageSeries(t *testing.T) {
+	assert.True(t, isGarbageSeries(""))
+	assert.True(t, isGarbageSeries("   "))
+	assert.True(t, isGarbageSeries("1234"))
+	assert.False(t, isGarbageSeries("The Expanse"))
+	assert.False(t, isGarbageSeries("Book 1"))
+}
+
+// ── ScanSeriesDuplicates ─────────────────────────────────────────────────────
+
+func TestScanSeriesDuplicates_ExactDuplicates(t *testing.T) {
+	// Two series with exactly the same name → one "exact" group.
+	// NormalizeString only trims/lowercases, so names must be literally equal
+	// (after trim+lowercase) to land in the same bucket.
+	seriesA := database.Series{ID: 1, Name: "The Expanse"}
+	seriesB := database.Series{ID: 2, Name: "the expanse"} // same after NormalizeString
+
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{seriesA, seriesB}, nil
+	}
+	mock.GetAllAuthorsFunc = func() ([]database.Author, error) { return nil, nil }
+
+	result, err := ScanSeriesDuplicates(context.Background(), mock, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.TotalSeries)
+	require.Len(t, result.Groups, 1, "one exact-duplicate group expected")
+	assert.Equal(t, "exact", result.Groups[0].MatchType)
+	assert.Equal(t, 2, result.Groups[0].Count)
+}
+
+func TestScanSeriesDuplicates_GarbageFiltered(t *testing.T) {
+	// Numeric-only series names should be excluded from grouping entirely.
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{
+			{ID: 1, Name: "1234"},
+			{ID: 2, Name: "5678"},
+		}, nil
+	}
+	mock.GetAllAuthorsFunc = func() ([]database.Author, error) { return nil, nil }
+
+	result, err := ScanSeriesDuplicates(context.Background(), mock, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Groups, "garbage series should produce no duplicate groups")
+}
+
+func TestScanSeriesDuplicates_SubseriesPattern(t *testing.T) {
+	// "Shadow of the Wind, Book 2" should detect "Shadow of the Wind" as a
+	// parent and group with a series named exactly "Shadow of the Wind".
+	parent := database.Series{ID: 1, Name: "Shadow of the Wind"}
+	child := database.Series{ID: 2, Name: "Shadow of the Wind, Book 2"}
+
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{parent, child}, nil
+	}
+	mock.GetAllAuthorsFunc = func() ([]database.Author, error) { return nil, nil }
+
+	result, err := ScanSeriesDuplicates(context.Background(), mock, nil)
+	require.NoError(t, err)
+	// Either an exact group or a subseries group should be produced.
+	assert.NotEmpty(t, result.Groups, "subseries should form at least one group")
+}
+
+// ── DedupSeries ──────────────────────────────────────────────────────────────
+
+func TestDedupSeries_MergesDuplicates(t *testing.T) {
+	// Series 1 and 2 have the same normalised name → 2 should be merged into 1.
+	seriesA := database.Series{ID: 1, Name: "Foundation"}
+	seriesB := database.Series{ID: 2, Name: "Foundation"}
+
+	var deletedIDs []int
+	var updatedBooks []database.Book
+
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{seriesA, seriesB}, nil
+	}
+	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
+		if id == 2 {
+			return []database.Book{{ID: "BOOK1", SeriesID: &id}}, nil
+		}
+		return nil, nil
+	}
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		updatedBooks = append(updatedBooks, *book)
+		return book, nil
+	}
+	mock.DeleteSeriesFunc = func(id int) error {
+		deletedIDs = append(deletedIDs, id)
+		return nil
+	}
+
+	result, err := DedupSeries(context.Background(), mock, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.TotalMerged)
+	assert.Empty(t, result.Errors)
+	assert.Contains(t, deletedIDs, 2)
+	// The book should have been reassigned to series 1.
+	require.Len(t, updatedBooks, 1)
+	require.NotNil(t, updatedBooks[0].SeriesID)
+	assert.Equal(t, 1, *updatedBooks[0].SeriesID)
+}
+
+func TestDedupSeries_NoDuplicates(t *testing.T) {
+	mock := &database.MockStore{}
+	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
+		return []database.Series{
+			{ID: 1, Name: "Alpha"},
+			{ID: 2, Name: "Beta"},
+		}, nil
+	}
+
+	result, err := DedupSeries(context.Background(), mock, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.TotalMerged)
+}
+
+// ── MergeSeries ───────────────────────────────────────────────────────────────
+
+func TestMergeSeries_BasicMerge(t *testing.T) {
+	keepID := 10
+	mergeID := 20
+
+	keepSeries := &database.Series{ID: keepID, Name: "Original"}
+	mergeSeries := &database.Series{ID: mergeID, Name: "Duplicate"}
+
+	var deletedIDs []int
+	var updatedBooks []database.Book
+
+	mock := &database.MockStore{}
+	mock.GetSeriesByIDFunc = func(id int) (*database.Series, error) {
+		switch id {
+		case keepID:
+			return keepSeries, nil
+		case mergeID:
+			return mergeSeries, nil
+		}
+		return nil, nil
+	}
+	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
+		if id == mergeID {
+			return []database.Book{{ID: "BOOK_X", SeriesID: &id}}, nil
+		}
+		return nil, nil
+	}
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		updatedBooks = append(updatedBooks, *book)
+		return book, nil
+	}
+	mock.DeleteSeriesFunc = func(id int) error {
+		deletedIDs = append(deletedIDs, id)
+		return nil
+	}
+
+	result, err := MergeSeries(context.Background(), mock, "op1", keepID, []int{mergeID}, "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.MergedCount)
+	assert.Empty(t, result.Errors)
+	assert.Contains(t, deletedIDs, mergeID)
+	require.Len(t, updatedBooks, 1)
+	assert.Equal(t, keepID, *updatedBooks[0].SeriesID)
+}
+
+func TestMergeSeries_CustomRename(t *testing.T) {
+	keepID := 10
+	keepSeries := &database.Series{ID: keepID, Name: "Old Name"}
+
+	var renamedTo string
+	mock := &database.MockStore{}
+	mock.GetSeriesByIDFunc = func(id int) (*database.Series, error) {
+		return keepSeries, nil
+	}
+	mock.UpdateSeriesNameFunc = func(id int, name string) error {
+		renamedTo = name
+		return nil
+	}
+	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) { return nil, nil }
+	mock.DeleteSeriesFunc = func(id int) error { return nil }
+
+	result, err := MergeSeries(context.Background(), mock, "op2", keepID, []int{}, "New Name", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.MergedCount, "no series to merge, just rename")
+	assert.Equal(t, "New Name", renamedTo)
+}

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,10 +1,24 @@
 // file: internal/server/duplicates_ops.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
 
 // duplicates_ops registers v2 OperationDefs for the 8 async dedup operations
-// that previously used s.queue.Enqueue. HTTP handlers in duplicates_handlers.go
+// that previously used s.queue.Enqueue.  HTTP handlers in duplicates_handlers.go
 // create v1 op records for backward compatibility and then enqueue these defs.
+//
+// Param structs have been moved to internal/dedup/op_params.go (exported names).
+// Execution logic for book-scan, book-merge, series-scan, series-dedup, and
+// series-merge has been extracted to internal/dedup/book_dedup.go and
+// internal/dedup/series_dedup.go.  The Run bodies here are now thin wrappers
+// that unmarshal params, call the domain function, and write results into
+// server-owned state (dedupCache, etc.).
+//
+// Three ops are left as-is because they depend on server-owned services:
+//   - dedup.author-scan: already calls dedup.FindDuplicateAuthors; the only
+//     server-side step (filterReviewedAuthorGroups) cannot be extracted without
+//     pulling the entire server into the dedup package.
+//   - dedup.series-prune: a one-liner to s.executeSeriesPrune.
+//   - dedup.series-normalize: uses s.organizeService and s.runBulkWriteBack.
 
 package server
 
@@ -12,62 +26,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
-	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
-	"github.com/jdfalk/audiobook-organizer/internal/util"
-	ulid "github.com/oklog/ulid/v2"
 )
-
-// ── param structs ─────────────────────────────────────────────────────────────
-
-type bookDedupScanOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-}
-
-type bookMergeOpParams struct {
-	LegacyOpID string   `json:"legacy_op_id"`
-	KeepID     string   `json:"keep_id"`
-	MergeIDs   []string `json:"merge_ids"`
-	Detail     string   `json:"detail"`
-}
-
-type authorDedupScanOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-}
-
-type seriesDedupScanOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-}
-
-type seriesDedupOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-	Detail     string `json:"detail"`
-}
-
-type seriesPruneOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-	Detail     string `json:"detail"`
-}
-
-type seriesMergeOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-	KeepID     int    `json:"keep_id"`
-	MergeIDs   []int  `json:"merge_ids"`
-	CustomName string `json:"custom_name"`
-	Detail     string `json:"detail"`
-}
-
-type seriesNormalizeOpParams struct {
-	LegacyOpID string `json:"legacy_op_id"`
-}
 
 // ── OperationDef registrations ────────────────────────────────────────────────
 
@@ -87,7 +54,7 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p bookDedupScanOpParams
+			var p dedup.BookDedupScanParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.book-scan: decode params: %w", err)
 			}
@@ -96,97 +63,19 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("dedup.book-scan: database not initialized")
 			}
 			progress := registryProgressAdapter{r: reporter}
-
-			_ = progress.UpdateProgress(0, 100, "Scanning for duplicate books...")
-
-			// Step 1: Hash-based duplicates (high confidence)
-			_ = progress.UpdateProgress(10, 100, "Finding hash-based duplicates...")
-			hashGroups, err := store.GetDuplicateBooks()
-			if err != nil {
-				return fmt.Errorf("hash-based dedup failed: %w", err)
-			}
-
-			// Step 2: Folder duplicates (same title in same folder)
-			_ = progress.UpdateProgress(30, 100, "Finding folder-based duplicates...")
-			folderGroups, err := store.GetFolderDuplicates()
-			if err != nil {
-				log.Printf("[WARN] folder dedup failed: %v", err)
-				folderGroups = nil
-			}
-
-			// Step 3: Metadata-based fuzzy matching
-			_ = progress.UpdateProgress(50, 100, "Finding metadata-based duplicates...")
-			metadataGroups, err := store.GetDuplicateBooksByMetadata(0.85)
-			if err != nil {
-				log.Printf("[WARN] metadata dedup failed: %v", err)
-				metadataGroups = nil
-			}
-
-			_ = progress.UpdateProgress(80, 100, "Merging results...")
-
-			// Load dismissed groups
 			dismissed := loadDismissedDedupGroups(store)
 
-			// Combine all groups, deduplicating by book ID
-			seenBookIDs := map[string]bool{}
-			type dupGroup struct {
-				Books      []database.Book `json:"books"`
-				Confidence string          `json:"confidence"` // "high", "medium", "low"
-				Reason     string          `json:"reason"`
-				GroupKey   string          `json:"group_key"`
-			}
-			var allGroups []dupGroup
-
-			addGroups := func(groups [][]database.Book, confidence, reason string) {
-				for _, group := range groups {
-					allSeen := true
-					for _, b := range group {
-						if !seenBookIDs[b.ID] {
-							allSeen = false
-							break
-						}
-					}
-					if allSeen {
-						continue
-					}
-					// Generate a stable group key from sorted book IDs
-					ids := make([]string, len(group))
-					for i, b := range group {
-						ids[i] = b.ID
-					}
-					groupKey := strings.Join(ids, "+")
-					if dismissed[groupKey] {
-						continue
-					}
-					allGroups = append(allGroups, dupGroup{
-						Books:      group,
-						Confidence: confidence,
-						Reason:     reason,
-						GroupKey:   groupKey,
-					})
-					for _, b := range group {
-						seenBookIDs[b.ID] = true
-					}
-				}
+			result, err := dedup.ScanBookDuplicates(ctx, store, dismissed, progress)
+			if err != nil {
+				return err
 			}
 
-			addGroups(hashGroups, "high", "Identical file hash")
-			addGroups(folderGroups, "medium", "Same title in same folder")
-			addGroups(metadataGroups, "low", "Similar title and author")
-
-			totalDuplicates := 0
-			for _, g := range allGroups {
-				totalDuplicates += len(g.Books) - 1
+			cacheVal := gin.H{
+				"groups":          result.Groups,
+				"group_count":     len(result.Groups),
+				"duplicate_count": result.TotalDuplicates,
 			}
-
-			result := gin.H{
-				"groups":          allGroups,
-				"group_count":     len(allGroups),
-				"duplicate_count": totalDuplicates,
-			}
-			s.dedupCache.SetWithTTL("book-dedup-scan", result, 30*time.Minute)
-
-			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(allGroups), totalDuplicates))
+			s.dedupCache.SetWithTTL("book-dedup-scan", cacheVal, 30*time.Minute)
 			return nil
 		},
 	})
@@ -208,7 +97,7 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p bookMergeOpParams
+			var p dedup.BookMergeParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.book-merge: decode params: %w", err)
 			}
@@ -217,84 +106,11 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("dedup.book-merge: database not initialized")
 			}
 			progress := registryProgressAdapter{r: reporter}
-			opID := p.LegacyOpID
-			keepID := p.KeepID
-			mergeIDs := p.MergeIDs
 
-			keepBook, err := store.GetBookByID(keepID)
-			if err != nil || keepBook == nil {
-				return fmt.Errorf("keep book %s not found", keepID)
+			_, err := dedup.MergeBooks(ctx, store, p.LegacyOpID, p.KeepID, p.MergeIDs, progress)
+			if err != nil {
+				return err
 			}
-
-			_ = progress.Log("info", fmt.Sprintf("Merging %d book(s) into \"%s\"", len(mergeIDs), keepBook.Title), nil)
-			_ = progress.UpdateProgress(0, len(mergeIDs), "Starting book merge...")
-
-			kBook, err := store.GetBookByID(keepID)
-			if err != nil || kBook == nil {
-				return fmt.Errorf("keep book %s not found", keepID)
-			}
-
-			merged := 0
-			var mergeErrors []string
-			for i, mergeID := range mergeIDs {
-				if progress.IsCanceled() {
-					return fmt.Errorf("cancelled")
-				}
-				if mergeID == keepID {
-					continue
-				}
-				mergeBook, err := store.GetBookByID(mergeID)
-				if err != nil || mergeBook == nil {
-					mergeErrors = append(mergeErrors, fmt.Sprintf("book %s not found", mergeID))
-					continue
-				}
-
-				// Transfer useful metadata
-				if (kBook.ITunesPersistentID == nil || *kBook.ITunesPersistentID == "") &&
-					mergeBook.ITunesPersistentID != nil && *mergeBook.ITunesPersistentID != "" {
-					kBook.ITunesPersistentID = mergeBook.ITunesPersistentID
-				}
-				if kBook.ITunesPlayCount == nil && mergeBook.ITunesPlayCount != nil {
-					kBook.ITunesPlayCount = mergeBook.ITunesPlayCount
-				}
-				if kBook.ITunesRating == nil && mergeBook.ITunesRating != nil {
-					kBook.ITunesRating = mergeBook.ITunesRating
-				}
-				if kBook.ITunesDateAdded == nil && mergeBook.ITunesDateAdded != nil {
-					kBook.ITunesDateAdded = mergeBook.ITunesDateAdded
-				}
-				if kBook.ITunesLastPlayed == nil && mergeBook.ITunesLastPlayed != nil {
-					kBook.ITunesLastPlayed = mergeBook.ITunesLastPlayed
-				}
-				if kBook.ITunesBookmark == nil && mergeBook.ITunesBookmark != nil {
-					kBook.ITunesBookmark = mergeBook.ITunesBookmark
-				}
-
-				if err := store.DeleteBook(mergeID); err != nil {
-					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to delete book %s: %v", mergeID, err))
-				} else {
-					_ = store.CreateOperationChange(&database.OperationChange{
-						ID:          ulid.Make().String(),
-						OperationID: opID,
-						BookID:      mergeID,
-						ChangeType:  "book_delete",
-						FieldName:   "book",
-						OldValue:    fmt.Sprintf("%s (%s)", mergeBook.Title, mergeBook.FilePath),
-						NewValue:    fmt.Sprintf("merged_into:%s", keepID),
-					})
-					merged++
-				}
-
-				_ = progress.UpdateProgress(i+1, len(mergeIDs),
-					fmt.Sprintf("Merged %d/%d books", i+1, len(mergeIDs)))
-			}
-
-			if _, err := store.UpdateBook(kBook.ID, kBook); err != nil {
-				mergeErrors = append(mergeErrors, fmt.Sprintf("failed to update keep book: %v", err))
-			}
-
-			resultMsg := fmt.Sprintf("Book merge complete: merged %d, %d errors", merged, len(mergeErrors))
-			_ = progress.Log("info", resultMsg, nil)
 			s.dedupCache.InvalidateAll()
 			return nil
 		},
@@ -302,6 +118,9 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 }
 
 // RegisterAuthorDedupScanOp registers the "dedup.author-scan" v2 OperationDef.
+// NOTE: The author-scan logic is not extracted because the only server-side
+// step beyond calling dedup.FindDuplicateAuthors is s.filterReviewedAuthorGroups,
+// which depends on server-owned state that cannot be cleanly injected.
 func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 	return reg.RegisterOp(opsregistry.OperationDef{
 		ID:              "dedup.author-scan",
@@ -317,7 +136,7 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p authorDedupScanOpParams
+			var p dedup.AuthorDedupScanParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.author-scan: decode params: %w", err)
 			}
@@ -343,14 +162,13 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			_ = progress.UpdateProgress(20, 100, "Finding duplicate authors...")
 
 			progressFn := func(current, total int, message string) {
-				// Map author comparison progress to 20-90% range
 				pct := 20 + (current*70)/max(total, 1)
 				_ = progress.UpdateProgress(pct, 100, message)
 			}
 
 			groups := dedup.FindDuplicateAuthors(authors, 0.9, bookCountFn, progressFn)
 
-			// Filter out groups already reviewed by AI scans
+			// Filter out groups already reviewed by AI scans (server-owned state).
 			groups = s.filterReviewedAuthorGroups(groups)
 
 			result := gin.H{"groups": groups, "count": len(groups)}
@@ -378,7 +196,7 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p seriesDedupScanOpParams
+			var p dedup.SeriesDedupScanParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.series-scan: decode params: %w", err)
 			}
@@ -388,170 +206,17 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 			}
 			progress := registryProgressAdapter{r: reporter}
 
-			_ = progress.UpdateProgress(0, 100, "Fetching series...")
-
-			allSeries, err := store.GetAllSeries()
+			result, err := dedup.ScanSeriesDuplicates(ctx, store, progress)
 			if err != nil {
 				return err
 			}
-			_ = progress.UpdateProgress(10, 100, fmt.Sprintf("Loaded %d series, grouping...", len(allSeries)))
 
-			isGarbageSeries := func(name string) bool {
-				trimmed := strings.TrimSpace(name)
-				if len(trimmed) == 0 {
-					return true
-				}
-				for _, r := range trimmed {
-					if r < '0' || r > '9' {
-						return false
-					}
-				}
-				return true
+			resp := gin.H{
+				"groups":       result.Groups,
+				"count":        len(result.Groups),
+				"total_series": result.TotalSeries,
 			}
-
-			exactGroups := make(map[string][]database.Series)
-			for _, s := range allSeries {
-				if isGarbageSeries(s.Name) {
-					continue
-				}
-				key := util.NormalizeString(s.Name)
-				exactGroups[key] = append(exactGroups[key], s)
-			}
-
-			_ = progress.UpdateProgress(20, 100, "Building author lookup...")
-
-			type seriesBookSummary struct {
-				ID       string `json:"id"`
-				Title    string `json:"title"`
-				CoverURL string `json:"cover_url,omitempty"`
-			}
-			type seriesWithBooks struct {
-				database.Series
-				Books      []seriesBookSummary `json:"books"`
-				AuthorName string              `json:"author_name,omitempty"`
-			}
-
-			allAuthors, _ := store.GetAllAuthors()
-			authorNameMap := make(map[int]string, len(allAuthors))
-			for _, a := range allAuthors {
-				authorNameMap[a.ID] = a.Name
-			}
-
-			type seriesDupGroup struct {
-				Name          string            `json:"name"`
-				Count         int               `json:"count"`
-				Series        []seriesWithBooks `json:"series"`
-				SuggestedName string            `json:"suggested_name,omitempty"`
-				MatchType     string            `json:"match_type"`
-			}
-
-			enrichSeries := func(seriesList []database.Series) []seriesWithBooks {
-				result := make([]seriesWithBooks, 0, len(seriesList))
-				for _, s := range seriesList {
-					authorName := ""
-					if s.AuthorID != nil {
-						authorName = authorNameMap[*s.AuthorID]
-					}
-					sw := seriesWithBooks{Series: s, AuthorName: authorName}
-					if books, err := store.GetBooksBySeriesID(s.ID); err == nil {
-						limit := 5
-						if len(books) < limit {
-							limit = len(books)
-						}
-						for _, b := range books[:limit] {
-							cover := ""
-							if b.CoverURL != nil {
-								cover = *b.CoverURL
-							}
-							sw.Books = append(sw.Books, seriesBookSummary{
-								ID:       b.ID,
-								Title:    b.Title,
-								CoverURL: cover,
-							})
-						}
-					}
-					result = append(result, sw)
-				}
-				return result
-			}
-
-			var result []seriesDupGroup
-			seen := make(map[int]bool)
-
-			_ = progress.UpdateProgress(30, 100, "Finding exact duplicates...")
-
-			groupKeys := make([]string, 0, len(exactGroups))
-			for k := range exactGroups {
-				groupKeys = append(groupKeys, k)
-			}
-
-			processed := 0
-			totalGroups := len(groupKeys)
-			for _, k := range groupKeys {
-				group := exactGroups[k]
-				if len(group) < 2 {
-					continue
-				}
-				for _, s := range group {
-					seen[s.ID] = true
-				}
-				suggested, _ := extractSeriesNameForDedup(group[0].Name)
-				result = append(result, seriesDupGroup{
-					Name:          group[0].Name,
-					Count:         len(group),
-					Series:        enrichSeries(group),
-					SuggestedName: suggested,
-					MatchType:     "exact",
-				})
-				processed++
-				if processed%10 == 0 {
-					pct := 30 + (processed*40)/max(totalGroups, 1)
-					_ = progress.UpdateProgress(min(pct, 70), 100, fmt.Sprintf("Processing groups... (%d/%d)", processed, totalGroups))
-				}
-			}
-
-			_ = progress.UpdateProgress(70, 100, "Finding sub-series patterns...")
-
-			seriesByNormalizedName := make(map[string][]database.Series)
-			for _, s := range allSeries {
-				seriesByNormalizedName[util.NormalizeString(s.Name)] = append(
-					seriesByNormalizedName[util.NormalizeString(s.Name)], s)
-			}
-
-			for _, s := range allSeries {
-				if seen[s.ID] || isGarbageSeries(s.Name) {
-					continue
-				}
-				suggested, ok := extractSeriesNameForDedup(s.Name)
-				if !ok {
-					continue
-				}
-				suggestedKey := util.NormalizeString(suggested)
-				if matches, exists := seriesByNormalizedName[suggestedKey]; exists {
-					group := []database.Series{s}
-					seen[s.ID] = true
-					for _, m := range matches {
-						if !seen[m.ID] {
-							group = append(group, m)
-							seen[m.ID] = true
-						}
-					}
-					if len(group) >= 2 {
-						result = append(result, seriesDupGroup{
-							Name:          s.Name,
-							Count:         len(group),
-							Series:        enrichSeries(group),
-							SuggestedName: suggested,
-							MatchType:     "subseries",
-						})
-					}
-				}
-			}
-
-			resp := gin.H{"groups": result, "count": len(result), "total_series": len(allSeries)}
 			s.dedupCache.Set("series-duplicates", resp)
-
-			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups", len(result)))
 			return nil
 		},
 	})
@@ -573,7 +238,7 @@ func (s *Server) RegisterSeriesDedupOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p seriesDedupOpParams
+			var p dedup.SeriesDedupParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.series-dedup: decode params: %w", err)
 			}
@@ -583,83 +248,9 @@ func (s *Server) RegisterSeriesDedupOp(reg *opsregistry.Registry) error {
 			}
 			progress := registryProgressAdapter{r: reporter}
 
-			_ = progress.Log("info", "Starting series deduplication...", nil)
-
-			allSeries, err := store.GetAllSeries()
+			_, err := dedup.DedupSeries(ctx, store, progress)
 			if err != nil {
-				return fmt.Errorf("failed to get series: %w", err)
-			}
-
-			_ = progress.UpdateProgress(0, len(allSeries), fmt.Sprintf("Scanning %d series for duplicates...", len(allSeries)))
-
-			// Group by normalized name only
-			groups := make(map[string][]database.Series)
-			for _, s := range allSeries {
-				key := util.NormalizeString(s.Name)
-				groups[key] = append(groups[key], s)
-			}
-
-			// Count total duplicate groups
-			var dupGroups [][]database.Series
-			for _, group := range groups {
-				if len(group) >= 2 {
-					dupGroups = append(dupGroups, group)
-				}
-			}
-
-			msg := fmt.Sprintf("Found %d duplicate groups to merge", len(dupGroups))
-			_ = progress.Log("info", msg, nil)
-			_ = progress.UpdateProgress(0, len(dupGroups), msg)
-
-			totalMerged := 0
-			var mergeErrors []string
-			for gi, group := range dupGroups {
-				if progress.IsCanceled() {
-					_ = progress.Log("warn", "Operation cancelled by user", nil)
-					return fmt.Errorf("cancelled")
-				}
-
-				keepIdx := 0
-				for i, s := range group {
-					if s.AuthorID != nil && group[keepIdx].AuthorID == nil {
-						keepIdx = i
-					} else if (s.AuthorID != nil) == (group[keepIdx].AuthorID != nil) && s.ID < group[keepIdx].ID {
-						keepIdx = i
-					}
-				}
-				keepID := group[keepIdx].ID
-
-				for i, s := range group {
-					if i == keepIdx {
-						continue
-					}
-					books, err := store.GetBooksBySeriesID(s.ID)
-					if err != nil {
-						mergeErrors = append(mergeErrors, fmt.Sprintf("failed to get books for series %d: %v", s.ID, err))
-						continue
-					}
-					for _, book := range books {
-						book.SeriesID = &keepID
-						if _, err := store.UpdateBook(book.ID, &book); err != nil {
-							mergeErrors = append(mergeErrors, fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
-						}
-					}
-					if err := store.DeleteSeries(s.ID); err != nil {
-						mergeErrors = append(mergeErrors, fmt.Sprintf("failed to delete series %d: %v", s.ID, err))
-					} else {
-						totalMerged++
-					}
-				}
-
-				_ = progress.UpdateProgress(gi+1, len(dupGroups),
-					fmt.Sprintf("Merged %d/%d groups (%d series merged)", gi+1, len(dupGroups), totalMerged))
-			}
-
-			resultMsg := fmt.Sprintf("Series deduplication complete: merged %d duplicates, %d errors", totalMerged, len(mergeErrors))
-			_ = progress.Log("info", resultMsg, nil)
-			if len(mergeErrors) > 0 {
-				errDetail := strings.Join(mergeErrors[:min(len(mergeErrors), 10)], "; ")
-				_ = progress.Log("warn", fmt.Sprintf("Merge errors: %s", errDetail), nil)
+				return err
 			}
 			s.dedupCache.InvalidateAll()
 			return nil
@@ -668,6 +259,8 @@ func (s *Server) RegisterSeriesDedupOp(reg *opsregistry.Registry) error {
 }
 
 // RegisterSeriesPruneOp registers the "dedup.series-prune" v2 OperationDef.
+// NOTE: series-prune logic is not extracted because it is entirely implemented
+// by s.executeSeriesPrune in duplicates_handlers.go.
 func (s *Server) RegisterSeriesPruneOp(reg *opsregistry.Registry) error {
 	return reg.RegisterOp(opsregistry.OperationDef{
 		ID:              "dedup.series-prune",
@@ -683,7 +276,7 @@ func (s *Server) RegisterSeriesPruneOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p seriesPruneOpParams
+			var p dedup.SeriesPruneParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.series-prune: decode params: %w", err)
 			}
@@ -713,7 +306,7 @@ func (s *Server) RegisterSeriesMergeOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p seriesMergeOpParams
+			var p dedup.SeriesMergeParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.series-merge: decode params: %w", err)
 			}
@@ -722,155 +315,10 @@ func (s *Server) RegisterSeriesMergeOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("dedup.series-merge: database not initialized")
 			}
 			progress := registryProgressAdapter{r: reporter}
-			opID := p.LegacyOpID
-			keepID := p.KeepID
-			mergeIDs := p.MergeIDs
-			customName := strings.TrimSpace(p.CustomName)
 
-			keepSeries, err := store.GetSeriesByID(keepID)
-			if err != nil || keepSeries == nil {
-				return fmt.Errorf("keep series %d not found", keepID)
-			}
-
-			keepName := keepSeries.Name
-			if customName != "" {
-				keepName = customName
-			}
-
-			// Rename the kept series if a custom name was provided
-			if customName != "" {
-				oldName := keepSeries.Name
-				if err := store.UpdateSeriesName(keepID, customName); err != nil {
-					return fmt.Errorf("failed to rename series to %q: %w", customName, err)
-				}
-				_ = store.CreateOperationChange(&database.OperationChange{
-					ID:          ulid.Make().String(),
-					OperationID: opID,
-					ChangeType:  "metadata_update",
-					FieldName:   "series_name",
-					OldValue:    oldName,
-					NewValue:    customName,
-				})
-				_ = progress.Log("info", fmt.Sprintf("Renamed series from %q to %q", oldName, customName), nil)
-			}
-
-			_ = progress.Log("info", fmt.Sprintf("Merging %d series into \"%s\"", len(mergeIDs), keepName), nil)
-			_ = progress.UpdateProgress(0, len(mergeIDs), "Starting series merge...")
-
-			// Collect all unique author IDs from all series being merged (including keep)
-			allAuthorIDs := make(map[int]bool)
-			allSeriesIDs := append([]int{keepID}, mergeIDs...)
-			for _, sid := range allSeriesIDs {
-				s, err := store.GetSeriesByID(sid)
-				if err == nil && s != nil && s.AuthorID != nil {
-					allAuthorIDs[*s.AuthorID] = true
-				}
-			}
-
-			merged := 0
-			var mergeErrors []string
-			for i, mergeID := range mergeIDs {
-				if progress.IsCanceled() {
-					return fmt.Errorf("cancelled")
-				}
-				if mergeID == keepID {
-					continue
-				}
-				books, err := store.GetBooksBySeriesID(mergeID)
-				if err != nil {
-					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to get books for series %d: %v", mergeID, err))
-					continue
-				}
-
-				for _, book := range books {
-					oldSeriesID := ""
-					if book.SeriesID != nil {
-						oldSeriesID = fmt.Sprintf("%d", *book.SeriesID)
-					}
-					book.SeriesID = &keepID
-					if _, err := store.UpdateBook(book.ID, &book); err != nil {
-						mergeErrors = append(mergeErrors, fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
-					} else {
-						_ = store.CreateOperationChange(&database.OperationChange{
-							ID:          ulid.Make().String(),
-							OperationID: opID,
-							BookID:      book.ID,
-							ChangeType:  "metadata_update",
-							FieldName:   "series_id",
-							OldValue:    oldSeriesID,
-							NewValue:    fmt.Sprintf("%d", keepID),
-						})
-					}
-				}
-
-				// Record the series deletion
-				mergeSeries, _ := store.GetSeriesByID(mergeID)
-				mergeSeriesName := ""
-				if mergeSeries != nil {
-					mergeSeriesName = mergeSeries.Name
-				}
-				if err := store.DeleteSeries(mergeID); err != nil {
-					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to delete series %d: %v", mergeID, err))
-				} else {
-					merged++
-					_ = store.CreateOperationChange(&database.OperationChange{
-						ID:          ulid.Make().String(),
-						OperationID: opID,
-						BookID:      "",
-						ChangeType:  "series_delete",
-						FieldName:   "series",
-						OldValue:    fmt.Sprintf("%d:%s", mergeID, mergeSeriesName),
-						NewValue:    fmt.Sprintf("merged_into:%d", keepID),
-					})
-				}
-
-				_ = progress.UpdateProgress(i+1, len(mergeIDs),
-					fmt.Sprintf("Merged %d/%d series", i+1, len(mergeIDs)))
-			}
-
-			// Link all books in the kept series to all unique authors
-			if len(allAuthorIDs) > 1 {
-				_ = progress.Log("info", fmt.Sprintf("Linking books to %d authors", len(allAuthorIDs)), nil)
-				allBooks, err := store.GetBooksBySeriesID(keepID)
-				if err == nil {
-					for _, book := range allBooks {
-						existing, _ := store.GetBookAuthors(book.ID)
-						existingMap := make(map[int]bool)
-						for _, ba := range existing {
-							existingMap[ba.AuthorID] = true
-						}
-						authors := existing
-						var addedAuthors []int
-						for aid := range allAuthorIDs {
-							if !existingMap[aid] {
-								authors = append(authors, database.BookAuthor{BookID: book.ID, AuthorID: aid})
-								addedAuthors = append(addedAuthors, aid)
-							}
-						}
-						if len(authors) > len(existing) {
-							if err := store.SetBookAuthors(book.ID, authors); err != nil {
-								mergeErrors = append(mergeErrors, fmt.Sprintf("failed to set authors for book %s: %v", book.ID, err))
-							} else {
-								_ = store.CreateOperationChange(&database.OperationChange{
-									ID:          ulid.Make().String(),
-									OperationID: opID,
-									BookID:      book.ID,
-									ChangeType:  "author_link",
-									FieldName:   "book_authors",
-									OldValue:    fmt.Sprintf("%d authors", len(existing)),
-									NewValue:    fmt.Sprintf("%d authors (added %v)", len(authors), addedAuthors),
-								})
-							}
-						}
-					}
-				}
-			}
-
-			resultMsg := fmt.Sprintf("Series merge complete: merged %d, %d errors", merged, len(mergeErrors))
-			_ = progress.Log("info", resultMsg, nil)
-			if len(mergeErrors) > 0 {
-				errDetail := strings.Join(mergeErrors[:min(len(mergeErrors), 10)], "; ")
-				_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
+			_, err := dedup.MergeSeries(ctx, store, p.LegacyOpID, p.KeepID, p.MergeIDs, p.CustomName, progress)
+			if err != nil {
+				return err
 			}
 			s.dedupCache.InvalidateAll()
 			return nil
@@ -879,6 +327,8 @@ func (s *Server) RegisterSeriesMergeOp(reg *opsregistry.Registry) error {
 }
 
 // RegisterSeriesNormalizeOp registers the "dedup.series-normalize" v2 OperationDef.
+// NOTE: series-normalize is not extracted because it depends on server-owned
+// services: s.organizeService.ReOrganizeInPlace and s.runBulkWriteBack.
 func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 	return reg.RegisterOp(opsregistry.OperationDef{
 		ID:              "dedup.series-normalize",
@@ -894,7 +344,7 @@ func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 		Permissions:     []auth.Permission{auth.PermLibraryEditMetadata},
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapFilesWrite},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
-			var p seriesNormalizeOpParams
+			var p dedup.SeriesNormalizeParams
 			if err := json.Unmarshal(rawParams, &p); err != nil {
 				return fmt.Errorf("dedup.series-normalize: decode params: %w", err)
 			}
@@ -957,3 +407,21 @@ func init() {
 	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterSeriesMergeOp(reg) })
 	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterSeriesNormalizeOp(reg) })
 }
+
+// ── local type aliases for backward compatibility ─────────────────────────────
+// duplicates_handlers.go and scheduler_tasks.go reference the old unexported
+// param struct names.  These aliases keep those files compiling without
+// modification while the canonical definitions live in internal/dedup/op_params.go.
+
+type bookDedupScanOpParams = dedup.BookDedupScanParams
+type bookMergeOpParams = dedup.BookMergeParams
+type authorDedupScanOpParams = dedup.AuthorDedupScanParams
+type seriesDedupScanOpParams = dedup.SeriesDedupScanParams
+type seriesDedupOpParams = dedup.SeriesDedupParams
+type seriesPruneOpParams = dedup.SeriesPruneParams
+type seriesMergeOpParams = dedup.SeriesMergeParams
+type seriesNormalizeOpParams = dedup.SeriesNormalizeParams
+
+// ── kept for reference: unused import guard ───────────────────────────────────
+
+var _ = strings.Join // strings is used by series-normalize progress messages


### PR DESCRIPTION
## Summary
- New `internal/dedup` package: `ScanBookDuplicates`, `MergeBooks`, `ScanSeriesDuplicates`, `DedupSeries`, `MergeSeries`
- 8 exported param structs in `op_params.go` replace inline anonymous structs
- `ProgressReporter` interface extracted for testability
- `BackfillVersionMarker`, `NewDedupScanProgressLogger` for backfill tracking
- 17 unit tests for book/series duplicate detection and merge logic

## Test plan
- [ ] `go test ./internal/dedup/...`
- [ ] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)