### PR TITLE
refactor(organizer): extract file pipeline/checkpoint to internal/organizer

### DIFF
--- a/internal/metafetch/pipeline_checkpoint.go
+++ b/internal/metafetch/pipeline_checkpoint.go
@@ -1,51 +1,40 @@
 // file: internal/metafetch/pipeline_checkpoint.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7f8a9b0c-1d2e-4a70-b8c5-3d7e0f1b9a99
 //
-// Phase checkpoints for the metadata apply pipeline.
+// Thin forwarding layer — the real implementation now lives in
+// internal/organizer/checkpoint.go.
 
 package metafetch
 
 import (
-	"log"
-	"time"
-
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 )
 
+// Constants for phase names (forwarded from organizer).
 const (
-	checkpointPrefix  = "pipeline_checkpoint:"
-	phaseRename       = "rename"
-	phaseTags         = "tags"
-	phaseITunes       = "itunes"
-	checkpointTTLDays = 7
+	checkpointPrefix  = organizer.CheckpointPrefix
+	phaseRename       = organizer.PhaseRename
+	phaseTags         = organizer.PhaseTags
+	phaseITunes       = organizer.PhaseITunes
+	checkpointTTLDays = organizer.CheckpointTTLDays
 )
 
-// setCheckpoint marks a phase as complete for a book.
+// setCheckpoint marks a phase as complete for a book (forwarded to organizer).
 func setCheckpoint(store database.Store, bookID, phase string) {
-	key := checkpointPrefix + bookID + ":" + phase
-	_ = store.SetUserPreferenceForUser("_system", key, time.Now().Format(time.RFC3339))
+	organizer.SetCheckpoint(store, bookID, phase)
 }
 
-// hasCheckpoint returns true if the phase was already completed.
+// hasCheckpoint returns true if the phase was already completed (forwarded to organizer).
 func hasCheckpoint(store database.Store, bookID, phase string) bool {
-	key := checkpointPrefix + bookID + ":" + phase
-	pref, _ := store.GetUserPreferenceForUser("_system", key)
-	return pref != nil && pref.Value != ""
+	return organizer.HasCheckpoint(store, bookID, phase)
 }
 
-// clearCheckpoints removes all phase markers for a book.
-// Called after the full pipeline completes successfully.
+// clearCheckpoints removes all phase markers for a book (forwarded to organizer).
 func clearCheckpoints(store database.Store, bookID string) {
-	for _, phase := range []string{phaseRename, phaseTags, phaseITunes} {
-		key := checkpointPrefix + bookID + ":" + phase
-		_ = store.SetUserPreferenceForUser("_system", key, "")
-	}
+	organizer.ClearCheckpoints(store, bookID)
 }
 
-// CleanupStaleCheckpoints removes checkpoints older than the TTL.
-// Called from the maintenance window.
-func CleanupStaleCheckpoints(store database.Store) int {
-	log.Println("[INFO] Pipeline checkpoint cleanup: stale checkpoints are harmless (self-healing)")
-	return 0
-}
+// CleanupStaleCheckpoints forwards to organizer.CleanupStaleCheckpoints.
+var CleanupStaleCheckpoints = organizer.CleanupStaleCheckpoints

--- a/internal/organizer/checkpoint.go
+++ b/internal/organizer/checkpoint.go
@@ -1,0 +1,76 @@
+// file: internal/organizer/checkpoint.go
+// version: 1.0.0
+// guid: 7f8a9b0c-1d2e-4a70-b8c5-3d7e0f1b9a99
+//
+// Phase checkpoints for the metadata apply pipeline (GFO-4).
+//
+// When metadata is applied to a book, three phases run in sequence:
+//   1. rename — move files to organized paths
+//   2. tags   — write metadata tags to audio files
+//   3. itunes — enqueue iTunes writeback
+//
+// If the server crashes mid-pipeline, the old code re-runs all
+// phases from scratch — including expensive ffmpeg cover embeds
+// that already succeeded. This checkpoint system stores per-book
+// per-phase completion markers in the Store so recovery can skip
+// completed phases.
+//
+// Checkpoint key: pipeline_checkpoint:{bookID}:{phase}
+// Value: completion timestamp (RFC3339)
+// Cleanup: all checkpoints for a book are cleared when the full
+// pipeline completes successfully, or by TTL cleanup (7 days).
+
+package organizer
+
+import (
+	"log"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+const (
+	CheckpointPrefix   = "pipeline_checkpoint:"
+	PhaseRename        = "rename"
+	PhaseTags          = "tags"
+	PhaseITunes        = "itunes"
+	CheckpointTTLDays  = 7
+)
+
+// SetCheckpoint marks a phase as complete for a book.
+func SetCheckpoint(store database.UserPreferenceStore, bookID, phase string) {
+	key := CheckpointPrefix + bookID + ":" + phase
+	_ = store.SetUserPreferenceForUser("_system", key, time.Now().Format(time.RFC3339))
+}
+
+// HasCheckpoint returns true if the phase was already completed.
+func HasCheckpoint(store database.UserPreferenceStore, bookID, phase string) bool {
+	key := CheckpointPrefix + bookID + ":" + phase
+	pref, _ := store.GetUserPreferenceForUser("_system", key)
+	return pref != nil && pref.Value != ""
+}
+
+// ClearCheckpoints removes all phase markers for a book.
+// Called after the full pipeline completes successfully.
+func ClearCheckpoints(store database.UserPreferenceStore, bookID string) {
+	for _, phase := range []string{PhaseRename, PhaseTags, PhaseITunes} {
+		key := CheckpointPrefix + bookID + ":" + phase
+		_ = store.SetUserPreferenceForUser("_system", key, "")
+	}
+}
+
+// CleanupStaleCheckpoints removes checkpoints older than the TTL.
+// Called from the maintenance window.
+func CleanupStaleCheckpoints(store database.Store) int {
+	// This is a best-effort scan. Since we use the _system user's
+	// preference namespace, we can't efficiently enumerate all
+	// checkpoint keys without a prefix scan. For now, stale
+	// checkpoints are harmless (HasCheckpoint just returns true,
+	// causing the phase to be skipped — which is the correct
+	// behavior for a crash-interrupted pipeline that's long past).
+	//
+	// A future optimization: track active pipeline book IDs in a
+	// set and clean up only those.
+	log.Println("[INFO] Pipeline checkpoint cleanup: stale checkpoints are harmless (self-healing)")
+	return 0
+}

--- a/internal/organizer/checkpoint_test.go
+++ b/internal/organizer/checkpoint_test.go
@@ -1,0 +1,76 @@
+// file: internal/organizer/checkpoint_test.go
+// version: 1.0.0
+// guid: 8a9b0c1d-2e3f-4a70-b8c5-3d7e0f1b9a99
+
+package organizer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+func TestCheckpoint_SetAndHas(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	if HasCheckpoint(store, "b1", PhaseRename) {
+		t.Error("should not have checkpoint before set")
+	}
+
+	SetCheckpoint(store, "b1", PhaseRename)
+
+	if !HasCheckpoint(store, "b1", PhaseRename) {
+		t.Error("should have checkpoint after set")
+	}
+	if HasCheckpoint(store, "b1", PhaseTags) {
+		t.Error("different phase should not have checkpoint")
+	}
+	if HasCheckpoint(store, "b2", PhaseRename) {
+		t.Error("different book should not have checkpoint")
+	}
+}
+
+func TestCheckpoint_ClearAll(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	SetCheckpoint(store, "b1", PhaseRename)
+	SetCheckpoint(store, "b1", PhaseTags)
+	SetCheckpoint(store, "b1", PhaseITunes)
+
+	ClearCheckpoints(store, "b1")
+
+	for _, phase := range []string{PhaseRename, PhaseTags, PhaseITunes} {
+		if HasCheckpoint(store, "b1", phase) {
+			t.Errorf("phase %s should be cleared", phase)
+		}
+	}
+}
+
+func TestCheckpoint_Idempotent(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	SetCheckpoint(store, "b1", PhaseRename)
+	SetCheckpoint(store, "b1", PhaseRename) // double-set
+	if !HasCheckpoint(store, "b1", PhaseRename) {
+		t.Error("double-set should still have checkpoint")
+	}
+
+	ClearCheckpoints(store, "b1")
+	ClearCheckpoints(store, "b1") // double-clear
+	if HasCheckpoint(store, "b1", PhaseRename) {
+		t.Error("double-clear should still be cleared")
+	}
+}

--- a/internal/server/pipeline_checkpoint.go
+++ b/internal/server/pipeline_checkpoint.go
@@ -1,76 +1,41 @@
 // file: internal/server/pipeline_checkpoint.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: 7f8a9b0c-1d2e-4a70-b8c5-3d7e0f1b9a99
 //
-// Phase checkpoints for the metadata apply pipeline (GFO-4).
-//
-// When metadata is applied to a book, three phases run in sequence:
-//   1. rename — move files to organized paths
-//   2. tags   — write metadata tags to audio files
-//   3. itunes — enqueue iTunes writeback
-//
-// If the server crashes mid-pipeline, the old code re-runs all
-// phases from scratch — including expensive ffmpeg cover embeds
-// that already succeeded. This checkpoint system stores per-book
-// per-phase completion markers in the Store so recovery can skip
-// completed phases.
-//
-// Checkpoint key: pipeline_checkpoint:{bookID}:{phase}
-// Value: completion timestamp (RFC3339)
-// Cleanup: all checkpoints for a book are cleared when the full
-// pipeline completes successfully, or by TTL cleanup (7 days).
+// Thin forwarding layer — the real implementation now lives in
+// internal/organizer/checkpoint.go. This file provides backward
+// compatibility with the old names.
 
 package server
 
 import (
-	"log"
-	"time"
-
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 )
 
+// Constants for phase names (forwarded from organizer).
 const (
-	checkpointPrefix   = "pipeline_checkpoint:"
-	phaseRename        = "rename"
-	phaseTags          = "tags"
-	phaseITunes        = "itunes"
-	checkpointTTLDays  = 7
+	phaseRename   = organizer.PhaseRename
+	phaseTags     = organizer.PhaseTags
+	phaseITunes   = organizer.PhaseITunes
+	checkpointPrefix = organizer.CheckpointPrefix
+	checkpointTTLDays = organizer.CheckpointTTLDays
 )
 
-// setCheckpoint marks a phase as complete for a book.
+// setCheckpoint marks a phase as complete for a book (forwarded to organizer).
 func setCheckpoint(store database.UserPreferenceStore, bookID, phase string) {
-	key := checkpointPrefix + bookID + ":" + phase
-	_ = store.SetUserPreferenceForUser("_system", key, time.Now().Format(time.RFC3339))
+	organizer.SetCheckpoint(store, bookID, phase)
 }
 
-// hasCheckpoint returns true if the phase was already completed.
+// hasCheckpoint returns true if the phase was already completed (forwarded to organizer).
 func hasCheckpoint(store database.UserPreferenceStore, bookID, phase string) bool {
-	key := checkpointPrefix + bookID + ":" + phase
-	pref, _ := store.GetUserPreferenceForUser("_system", key)
-	return pref != nil && pref.Value != ""
+	return organizer.HasCheckpoint(store, bookID, phase)
 }
 
-// clearCheckpoints removes all phase markers for a book.
-// Called after the full pipeline completes successfully.
+// clearCheckpoints removes all phase markers for a book (forwarded to organizer).
 func clearCheckpoints(store database.UserPreferenceStore, bookID string) {
-	for _, phase := range []string{phaseRename, phaseTags, phaseITunes} {
-		key := checkpointPrefix + bookID + ":" + phase
-		_ = store.SetUserPreferenceForUser("_system", key, "")
-	}
+	organizer.ClearCheckpoints(store, bookID)
 }
 
-// CleanupStaleCheckpoints removes checkpoints older than the TTL.
-// Called from the maintenance window.
-func CleanupStaleCheckpoints(store database.Store) int {
-	// This is a best-effort scan. Since we use the _system user's
-	// preference namespace, we can't efficiently enumerate all
-	// checkpoint keys without a prefix scan. For now, stale
-	// checkpoints are harmless (hasCheckpoint just returns true,
-	// causing the phase to be skipped — which is the correct
-	// behavior for a crash-interrupted pipeline that's long past).
-	//
-	// A future optimization: track active pipeline book IDs in a
-	// set and clean up only those.
-	log.Println("[INFO] Pipeline checkpoint cleanup: stale checkpoints are harmless (self-healing)")
-	return 0
-}
+// CleanupStaleCheckpoints forwards to organizer.CleanupStaleCheckpoints.
+var CleanupStaleCheckpoints = organizer.CleanupStaleCheckpoints

--- a/internal/server/pipeline_checkpoint_test.go
+++ b/internal/server/pipeline_checkpoint_test.go
@@ -1,6 +1,9 @@
 // file: internal/server/pipeline_checkpoint_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 8a9b0c1d-2e3f-4a70-b8c5-3d7e0f1b9a99
+//
+// Tests for the server's pipeline checkpoint forwarding layer.
+// The actual logic is tested in internal/organizer/checkpoint_test.go.
 
 package server
 
@@ -9,15 +12,17 @@ import (
 	"testing"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 )
 
-func TestCheckpoint_SetAndHas(t *testing.T) {
+func TestCheckpointForwarding(t *testing.T) {
 	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
 	if err != nil {
 		t.Fatalf("pebble: %v", err)
 	}
 	t.Cleanup(func() { store.Close() })
 
+	// Test that server functions forward to organizer package
 	if hasCheckpoint(store, "b1", phaseRename) {
 		t.Error("should not have checkpoint before set")
 	}
@@ -27,50 +32,37 @@ func TestCheckpoint_SetAndHas(t *testing.T) {
 	if !hasCheckpoint(store, "b1", phaseRename) {
 		t.Error("should have checkpoint after set")
 	}
-	if hasCheckpoint(store, "b1", phaseTags) {
-		t.Error("different phase should not have checkpoint")
-	}
-	if hasCheckpoint(store, "b2", phaseRename) {
-		t.Error("different book should not have checkpoint")
-	}
-}
-
-func TestCheckpoint_ClearAll(t *testing.T) {
-	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
-	if err != nil {
-		t.Fatalf("pebble: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-
-	setCheckpoint(store, "b1", phaseRename)
-	setCheckpoint(store, "b1", phaseTags)
-	setCheckpoint(store, "b1", phaseITunes)
 
 	clearCheckpoints(store, "b1")
 
-	for _, phase := range []string{phaseRename, phaseTags, phaseITunes} {
-		if hasCheckpoint(store, "b1", phase) {
-			t.Errorf("phase %s should be cleared", phase)
-		}
-	}
-}
-
-func TestCheckpoint_Idempotent(t *testing.T) {
-	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
-	if err != nil {
-		t.Fatalf("pebble: %v", err)
-	}
-	t.Cleanup(func() { store.Close() })
-
-	setCheckpoint(store, "b1", phaseRename)
-	setCheckpoint(store, "b1", phaseRename) // double-set
-	if !hasCheckpoint(store, "b1", phaseRename) {
-		t.Error("double-set should still have checkpoint")
-	}
-
-	clearCheckpoints(store, "b1")
-	clearCheckpoints(store, "b1") // double-clear
 	if hasCheckpoint(store, "b1", phaseRename) {
-		t.Error("double-clear should still be cleared")
+		t.Error("should be cleared after clearCheckpoints")
+	}
+}
+
+func TestCleanupStaleCheckpointsForwarding(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("pebble: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Test that the cleanup function is properly forwarded
+	count := CleanupStaleCheckpoints(store)
+	if count < 0 {
+		t.Errorf("CleanupStaleCheckpoints returned negative count: %d", count)
+	}
+}
+
+func TestConstantsForwarded(t *testing.T) {
+	// Verify constants are correctly forwarded
+	if phaseRename != organizer.PhaseRename {
+		t.Error("phaseRename constant mismatch")
+	}
+	if phaseTags != organizer.PhaseTags {
+		t.Error("phaseTags constant mismatch")
+	}
+	if phaseITunes != organizer.PhaseITunes {
+		t.Error("phaseITunes constant mismatch")
 	}
 }


### PR DESCRIPTION
## Summary
- `SetCheckpoint`, `HasCheckpoint`, `ClearCheckpoints`, `CleanupStaleCheckpoints` moved to `internal/organizer/checkpoint.go`
- File pipeline and file move logic extracted with constructor injection
- Server callers delegate to `internal/organizer`
- 3 unit tests for checkpoint lifecycle

## Test plan
- [ ] `go test ./internal/organizer/...`
- [ ] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)