### PR TITLE
feat(serviceregistry): registry foundation (SERVER-PLUGIN-REG W0.1)

### DIFF
--- a/internal/serviceregistry/container.go
+++ b/internal/serviceregistry/container.go
@@ -1,0 +1,233 @@
+// file: internal/serviceregistry/container.go
+// version: 1.0.0
+
+package serviceregistry
+
+import (
+	"context"
+	"fmt"
+	"slices"
+)
+
+type containerPhase int
+
+const (
+	phaseUnresolved containerPhase = iota
+	phaseResolved
+	phaseBuilt
+	phasePostInit
+	phaseStarted
+	phaseStopped
+)
+
+// Container holds per-instance registry state. Created fresh per
+// NewServer() and per test. The factory list is global; each Container
+// builds its own service instances from it.
+type Container struct {
+	include       map[string]bool
+	overrides     map[string]any
+	built         map[string]any
+	order         []string
+	phase         containerPhase
+	activeBuilder string // name of service whose Build is currently running
+}
+
+// NewContainer creates a new empty Container.
+func NewContainer() *Container {
+	return &Container{
+		include:   map[string]bool{},
+		overrides: map[string]any{},
+		built:     map[string]any{},
+	}
+}
+
+// Include adds service names to the build set. Transitive deps are pulled
+// in at Resolve time. Chainable.
+func (c *Container) Include(names ...string) *Container {
+	for _, n := range names {
+		c.include[n] = true
+	}
+	return c
+}
+
+// IncludeAll adds every registered ServiceDef. Production default.
+func (c *Container) IncludeAll() *Container {
+	for name := range registered {
+		c.include[name] = true
+	}
+	return c
+}
+
+// Override substitutes an instance for the named service. Factory Build
+// is not called. The name is implicitly Included. Treated as a leaf in
+// the dep graph (its declared Needs are ignored). Test-only.
+func (c *Container) Override(name string, instance any) *Container {
+	c.overrides[name] = instance
+	c.include[name] = true
+	return c
+}
+
+// Names returns the resolved build order. Only valid after Resolve.
+func (c *Container) Names() []string {
+	out := make([]string, len(c.order))
+	copy(out, c.order)
+	return out
+}
+
+func (c *Container) requirePhase(want containerPhase, op string) error {
+	if c.phase < want {
+		return fmt.Errorf("%w: %s requires phase >= %d, have %d", ErrWrongPhase, op, want, c.phase)
+	}
+	return nil
+}
+
+// Build runs all ServiceDef.Build funcs in resolved order. Resolve is
+// called implicitly if needed. Each Build runs under activeBuilder
+// tracking so Get[T] can enforce Needs membership.
+func (c *Container) Build(ctx context.Context) error {
+	if c.phase >= phaseBuilt {
+		return nil
+	}
+	if err := c.Resolve(); err != nil {
+		return err
+	}
+	for _, name := range c.order {
+		if instance, isOverride := c.overrides[name]; isOverride {
+			c.built[name] = instance
+			continue
+		}
+		def := registered[name]
+		c.activeBuilder = name
+		instance, err := def.Build(c)
+		c.activeBuilder = ""
+		if err != nil {
+			return fmt.Errorf("serviceregistry: build %q: %w", name, err)
+		}
+		c.built[name] = instance
+	}
+	c.phase = phaseBuilt
+	return nil
+}
+
+// PostInit invokes PostInit() on services that implement PostIniter,
+// in resolved dep order. Get[T] is unrestricted here.
+func (c *Container) PostInit(ctx context.Context) error {
+	if err := c.requirePhase(phaseBuilt, "PostInit"); err != nil {
+		return err
+	}
+	if c.phase >= phasePostInit {
+		return nil
+	}
+	for _, name := range c.order {
+		instance := c.built[name]
+		if pi, ok := instance.(PostIniter); ok {
+			if err := pi.PostInit(ctx, c); err != nil {
+				return fmt.Errorf("serviceregistry: postinit %q: %w", name, err)
+			}
+		}
+	}
+	c.phase = phasePostInit
+	return nil
+}
+
+// Start invokes Start() on services that implement Starter, in resolved
+// order. On error, aborts and calls Stop on already-started services
+// in reverse.
+func (c *Container) Start(ctx context.Context) error {
+	if err := c.requirePhase(phasePostInit, "Start"); err != nil {
+		return err
+	}
+	if c.phase >= phaseStarted {
+		return nil
+	}
+	started := []string{}
+	for _, name := range c.order {
+		instance := c.built[name]
+		s, ok := instance.(Starter)
+		if !ok {
+			continue
+		}
+		if err := s.Start(ctx); err != nil {
+			// Stop already-started services in reverse.
+			for i := len(started) - 1; i >= 0; i-- {
+				if stopper, ok := c.built[started[i]].(Stopper); ok {
+					_ = stopper.Stop(ctx)
+				}
+			}
+			return fmt.Errorf("serviceregistry: start %q: %w", name, err)
+		}
+		started = append(started, name)
+	}
+	c.phase = phaseStarted
+	return nil
+}
+
+// Stop invokes Stop() on services that implement Stopper, in REVERSE
+// resolved order. Best-effort — errors are logged but do not abort.
+func (c *Container) Stop(ctx context.Context) error {
+	if c.phase >= phaseStopped {
+		return nil
+	}
+	var firstErr error
+	for i := len(c.order) - 1; i >= 0; i-- {
+		name := c.order[i]
+		instance, ok := c.built[name]
+		if !ok {
+			continue
+		}
+		s, ok := instance.(Stopper)
+		if !ok {
+			continue
+		}
+		if err := s.Stop(ctx); err != nil {
+			err = fmt.Errorf("serviceregistry: stop %q: %w", name, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	c.phase = phaseStopped
+	return firstErr
+}
+
+// Get returns the instance registered under name, type-asserted to T.
+// Panics on missing service or type mismatch (programmer error — fail
+// fast at startup). During Build, also panics if name is not in the
+// active builder's Needs.
+func Get[T any](c *Container, name string) T {
+	if c.activeBuilder != "" {
+		def := registered[c.activeBuilder]
+		if !slices.Contains(def.Needs, name) {
+			panic(fmt.Sprintf(
+				"serviceregistry: service %q called Get[%T](%q) but %q is not in its Needs",
+				c.activeBuilder, *new(T), name, name))
+		}
+	}
+	instance, ok := c.built[name]
+	if !ok {
+		panic(fmt.Sprintf("serviceregistry: service %q not built (called from %q)",
+			name, c.activeBuilder))
+	}
+	typed, ok := instance.(T)
+	if !ok {
+		panic(fmt.Sprintf("serviceregistry: service %q is %T, not %T",
+			name, instance, *new(T)))
+	}
+	return typed
+}
+
+// TryGet is the non-panicking variant for optional deps. Returns
+// (zero, false) on missing service or type mismatch. Bypasses the
+// Needs check (callers know they may not have declared the dep).
+func TryGet[T any](c *Container, name string) (T, bool) {
+	var zero T
+	instance, ok := c.built[name]
+	if !ok {
+		return zero, false
+	}
+	typed, ok := instance.(T)
+	if !ok {
+		return zero, false
+	}
+	return typed, true
+}

--- a/internal/serviceregistry/container_test.go
+++ b/internal/serviceregistry/container_test.go
@@ -1,0 +1,140 @@
+// file: internal/serviceregistry/container_test.go
+// version: 1.0.0
+
+package serviceregistry
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeService struct {
+	name     string
+	postInit bool
+	started  bool
+	stopped  bool
+}
+
+func (f *fakeService) PostInit(ctx context.Context, c *Container) error { f.postInit = true; return nil }
+func (f *fakeService) Start(ctx context.Context) error                  { f.started = true; return nil }
+func (f *fakeService) Stop(ctx context.Context) error                   { f.stopped = true; return nil }
+
+func TestContainer_Build_RunsInDepOrder(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	order := []string{}
+	Register(ServiceDef{Name: "leaf", Build: func(c *Container) (any, error) {
+		order = append(order, "leaf")
+		return &fakeService{name: "leaf"}, nil
+	}})
+	Register(ServiceDef{Name: "top", Needs: []string{"leaf"}, Build: func(c *Container) (any, error) {
+		_ = Get[*fakeService](c, "leaf") // verify Get works mid-Build
+		order = append(order, "top")
+		return &fakeService{name: "top"}, nil
+	}})
+
+	c := NewContainer().Include("top")
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(order) != 2 || order[0] != "leaf" || order[1] != "top" {
+		t.Fatalf("build order = %v, want [leaf top]", order)
+	}
+}
+
+func TestContainer_Get_UndeclaredDepPanics(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "leaf", Build: func(c *Container) (any, error) {
+		return "leaf-instance", nil
+	}})
+	// "naughty" does NOT declare "leaf" in Needs but tries to Get it.
+	Register(ServiceDef{Name: "naughty", Build: func(c *Container) (any, error) {
+		_ = Get[string](c, "leaf") // should panic
+		return nil, nil
+	}})
+
+	c := NewContainer().Include("leaf", "naughty")
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for undeclared Get")
+		}
+	}()
+	_ = c.Build(t.Context())
+}
+
+func TestContainer_PostInit_RunsAfterAllBuilds(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "a", Build: func(c *Container) (any, error) { return &fakeService{name: "a"}, nil }})
+	Register(ServiceDef{Name: "b", Needs: []string{"a"}, Build: func(c *Container) (any, error) { return &fakeService{name: "b"}, nil }})
+
+	c := NewContainer().Include("a", "b")
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := c.PostInit(t.Context()); err != nil {
+		t.Fatalf("postinit: %v", err)
+	}
+
+	a := Get[*fakeService](c, "a")
+	b := Get[*fakeService](c, "b")
+	if !a.postInit || !b.postInit {
+		t.Fatalf("postinit not called: a=%v b=%v", a.postInit, b.postInit)
+	}
+}
+
+func TestContainer_Stop_ReverseOrder(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	stopOrder := []string{}
+	Register(ServiceDef{Name: "a", Build: func(c *Container) (any, error) {
+		return &recordingService{name: "a", sink: &stopOrder}, nil
+	}})
+	Register(ServiceDef{Name: "b", Needs: []string{"a"}, Build: func(c *Container) (any, error) {
+		return &recordingService{name: "b", sink: &stopOrder}, nil
+	}})
+	Register(ServiceDef{Name: "c", Needs: []string{"b"}, Build: func(c *Container) (any, error) {
+		return &recordingService{name: "c", sink: &stopOrder}, nil
+	}})
+
+	c := NewContainer().Include("c")
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := c.PostInit(t.Context()); err != nil {
+		t.Fatalf("postinit: %v", err)
+	}
+	if err := c.Start(t.Context()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := c.Stop(t.Context()); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	want := []string{"c", "b", "a"}
+	if len(stopOrder) != 3 {
+		t.Fatalf("stop order = %v, want %v", stopOrder, want)
+	}
+	for i := range want {
+		if stopOrder[i] != want[i] {
+			t.Errorf("stopOrder[%d] = %q, want %q", i, stopOrder[i], want[i])
+		}
+	}
+}
+
+type recordingService struct {
+	name string
+	sink *[]string
+}
+
+func (r *recordingService) Start(ctx context.Context) error { return nil }
+func (r *recordingService) Stop(ctx context.Context) error {
+	*r.sink = append(*r.sink, r.name)
+	return nil
+}

--- a/internal/serviceregistry/errors.go
+++ b/internal/serviceregistry/errors.go
@@ -1,0 +1,15 @@
+// file: internal/serviceregistry/errors.go
+// version: 1.0.0
+
+package serviceregistry
+
+import "errors"
+
+var (
+	ErrCycle          = errors.New("serviceregistry: dependency cycle")
+	ErrUnknownService = errors.New("serviceregistry: unknown service")
+	ErrUndeclaredDep  = errors.New("serviceregistry: undeclared dependency")
+	ErrNotBuilt       = errors.New("serviceregistry: service not built")
+	ErrTypeMismatch   = errors.New("serviceregistry: type mismatch")
+	ErrWrongPhase     = errors.New("serviceregistry: operation called in wrong phase")
+)

--- a/internal/serviceregistry/graph.go
+++ b/internal/serviceregistry/graph.go
@@ -1,0 +1,110 @@
+// file: internal/serviceregistry/graph.go
+// version: 1.0.0
+
+package serviceregistry
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Resolve computes the transitive closure of c.include, validates the
+// dep graph, and produces a topologically sorted build order. The ready
+// queue is sorted lexically before processing for deterministic order
+// (stable startup logs, reproducible tests).
+//
+// Returns ErrUnknownService if a dep references an unregistered name.
+// Returns ErrCycle if the dep graph contains a cycle.
+// Idempotent after first successful call.
+func (c *Container) Resolve() error {
+	if c.phase >= phaseResolved {
+		return nil
+	}
+
+	// 1. Transitive closure: walk include set following Needs.
+	//    Overrides short-circuit — they are leaves in the graph.
+	wanted := map[string]bool{}
+	var walk func(name string) error
+	walk = func(name string) error {
+		if wanted[name] {
+			return nil
+		}
+		if _, isOverride := c.overrides[name]; isOverride {
+			wanted[name] = true
+			return nil
+		}
+		def, ok := registered[name]
+		if !ok {
+			return fmt.Errorf("%w: %q (declared as a dep but not registered)", ErrUnknownService, name)
+		}
+		wanted[name] = true
+		for _, dep := range def.Needs {
+			if err := walk(dep); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for name := range c.include {
+		if err := walk(name); err != nil {
+			return err
+		}
+	}
+
+	// 2. Build dep graph over wanted set. Overrides are treated as leaves.
+	incoming := map[string]int{}
+	outgoing := map[string][]string{}
+	for name := range wanted {
+		if _, isOverride := c.overrides[name]; isOverride {
+			incoming[name] = 0
+			continue
+		}
+		def := registered[name]
+		incoming[name] = len(def.Needs)
+		for _, dep := range def.Needs {
+			outgoing[dep] = append(outgoing[dep], name)
+		}
+	}
+
+	// 3. Kahn's algorithm with lex-stable ready queue.
+	ready := []string{}
+	for name, n := range incoming {
+		if n == 0 {
+			ready = append(ready, name)
+		}
+	}
+	sort.Strings(ready)
+	order := make([]string, 0, len(wanted))
+	for len(ready) > 0 {
+		name := ready[0]
+		ready = ready[1:]
+		order = append(order, name)
+
+		// Sort dependents lexically before appending so the queue stays stable.
+		dependents := append([]string{}, outgoing[name]...)
+		sort.Strings(dependents)
+		for _, dep := range dependents {
+			incoming[dep]--
+			if incoming[dep] == 0 {
+				ready = append(ready, dep)
+			}
+		}
+		sort.Strings(ready)
+	}
+
+	// 4. Cycle check.
+	if len(order) != len(wanted) {
+		cycle := []string{}
+		for name := range wanted {
+			if incoming[name] > 0 {
+				cycle = append(cycle, name)
+			}
+		}
+		sort.Strings(cycle)
+		return fmt.Errorf("%w among: %v", ErrCycle, cycle)
+	}
+
+	c.order = order
+	c.phase = phaseResolved
+	return nil
+}

--- a/internal/serviceregistry/graph_test.go
+++ b/internal/serviceregistry/graph_test.go
@@ -1,0 +1,105 @@
+// file: internal/serviceregistry/graph_test.go
+// version: 1.0.0
+
+package serviceregistry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResolve_LexStableOrder(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	// Register A, B, C, D all depending on nothing. Lex order should be A,B,C,D.
+	for _, name := range []string{"zebra", "alpha", "mike", "delta"} {
+		n := name
+		Register(ServiceDef{
+			Name:  n,
+			Build: func(c *Container) (any, error) { return n, nil },
+		})
+	}
+
+	c := NewContainer().IncludeAll()
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := c.Names()
+	want := []string{"alpha", "delta", "mike", "zebra"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestResolve_CycleDetected(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "a", Needs: []string{"b"}, Build: func(c *Container) (any, error) { return nil, nil }})
+	Register(ServiceDef{Name: "b", Needs: []string{"a"}, Build: func(c *Container) (any, error) { return nil, nil }})
+
+	c := NewContainer().Include("a")
+	err := c.Resolve()
+	if !errors.Is(err, ErrCycle) {
+		t.Fatalf("expected ErrCycle, got %v", err)
+	}
+}
+
+func TestResolve_UnknownDep(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "a", Needs: []string{"nonexistent"}, Build: func(c *Container) (any, error) { return nil, nil }})
+
+	c := NewContainer().Include("a")
+	err := c.Resolve()
+	if !errors.Is(err, ErrUnknownService) {
+		t.Fatalf("expected ErrUnknownService, got %v", err)
+	}
+}
+
+func TestResolve_TransitiveClosure(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "leaf", Build: func(c *Container) (any, error) { return "leaf", nil }})
+	Register(ServiceDef{Name: "mid", Needs: []string{"leaf"}, Build: func(c *Container) (any, error) { return "mid", nil }})
+	Register(ServiceDef{Name: "top", Needs: []string{"mid"}, Build: func(c *Container) (any, error) { return "top", nil }})
+
+	// Include only "top" — should pull mid + leaf transitively.
+	c := NewContainer().Include("top")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := c.Names()
+	want := []string{"leaf", "mid", "top"}
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestResolve_OverrideIsLeaf(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	// "real" needs "store"; "store" is not registered, only overridden.
+	Register(ServiceDef{Name: "real", Needs: []string{"store"}, Build: func(c *Container) (any, error) {
+		return Get[string](c, "store"), nil
+	}})
+
+	c := NewContainer().Override("store", "mock-store").Include("real")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := c.Names()
+	// store appears first (no deps), then real.
+	if len(got) != 2 || got[0] != "store" || got[1] != "real" {
+		t.Fatalf("got %v, want [store real]", got)
+	}
+}

--- a/internal/serviceregistry/lifecycle.go
+++ b/internal/serviceregistry/lifecycle.go
@@ -1,0 +1,28 @@
+// file: internal/serviceregistry/lifecycle.go
+// version: 1.0.0
+
+package serviceregistry
+
+import "context"
+
+// PostIniter is implemented by services that need cross-wiring after all
+// Build() calls complete. PostInit runs in resolved dep order. Within
+// PostInit, Get[T] is unrestricted — any built service may be retrieved.
+type PostIniter interface {
+	PostInit(ctx context.Context, c *Container) error
+}
+
+// Starter is implemented by services that run background goroutines or
+// otherwise need an explicit start signal. Start runs in resolved dep
+// order; on error, the container halts and calls Stop on already-started
+// services in reverse.
+type Starter interface {
+	Start(ctx context.Context) error
+}
+
+// Stopper is implemented by services that hold resources requiring
+// explicit release. Stop runs in REVERSE resolved order. Errors are
+// logged but do not abort the sweep.
+type Stopper interface {
+	Stop(ctx context.Context) error
+}

--- a/internal/serviceregistry/registry.go
+++ b/internal/serviceregistry/registry.go
@@ -1,0 +1,48 @@
+// file: internal/serviceregistry/registry.go
+// version: 1.0.0
+
+package serviceregistry
+
+import "fmt"
+
+// ServiceDef describes a registered service.
+type ServiceDef struct {
+	// Name is the registry key. Must be unique. Convention: lowercase,
+	// dot-separated for grouping (e.g. "dedup", "metafetch", "itunes.batcher").
+	Name string
+
+	// Needs lists names of OTHER services this service's Build func will
+	// Get[T]. The container enforces that Build can only Get services listed
+	// here. Needs is the single source of truth for the build-time dep graph.
+	Needs []string
+
+	// Build constructs the service instance. May call Get[T](c, name) for
+	// any name in Needs.
+	Build func(c *Container) (any, error)
+}
+
+var registered = map[string]ServiceDef{}
+
+// Register appends a ServiceDef to the package-level factory list.
+// Called from init() in a domain package's register.go.
+// Panics on duplicate Name or missing required field — caught at startup,
+// never at runtime.
+func Register(def ServiceDef) {
+	if def.Name == "" {
+		panic("serviceregistry: ServiceDef.Name is required")
+	}
+	if def.Build == nil {
+		panic(fmt.Sprintf("serviceregistry: ServiceDef.Build is required (name=%q)", def.Name))
+	}
+	if _, dup := registered[def.Name]; dup {
+		panic(fmt.Sprintf("serviceregistry: duplicate name: %q", def.Name))
+	}
+	registered[def.Name] = def
+}
+
+// ResetForTest clears the package-level factory list. ONLY for tests
+// that need to register isolated ServiceDefs without polluting production
+// registrations. Production code never calls this.
+func ResetForTest() {
+	registered = map[string]ServiceDef{}
+}

--- a/internal/serviceregistry/registry_test.go
+++ b/internal/serviceregistry/registry_test.go
@@ -1,0 +1,46 @@
+// file: internal/serviceregistry/registry_test.go
+// version: 1.0.0
+
+package serviceregistry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegister_DuplicatePanics(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	Register(ServiceDef{Name: "x", Build: func(c *Container) (any, error) { return nil, nil }})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate Register")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "duplicate") {
+			t.Errorf("panic msg = %v, expected duplicate", r)
+		}
+	}()
+	Register(ServiceDef{Name: "x", Build: func(c *Container) (any, error) { return nil, nil }})
+}
+
+func TestRegister_RequiresName(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	defer func() { _ = recover() }()
+	Register(ServiceDef{Build: func(c *Container) (any, error) { return nil, nil }})
+	t.Fatal("expected panic on missing Name")
+}
+
+func TestRegister_RequiresBuild(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	defer func() { _ = recover() }()
+	Register(ServiceDef{Name: "x"})
+	t.Fatal("expected panic on missing Build")
+}


### PR DESCRIPTION
## Summary

Wave 0 of the SERVER-PLUGIN-REG migration. Adds the new internal/serviceregistry package — pure new-package addition with no callers anywhere.

**What it provides:**
- `ServiceDef` + `Register` — `init()`-time registration into a package-level factory map
- `Container` — per-instance state with phase tracking (unresolved → resolved → built → postinit → started → stopped)
- `Get[T]` / `TryGet[T]` — generic typed retrieval; `Get` panics on missing/mismatched type, `TryGet` returns ok=false
- `Resolve` — Kahn's topological sort with lex-stable ready queue + cycle detection
- Optional lifecycle interfaces: `PostIniter`, `Starter`, `Stopper` — picked up by type-assertion in each phase
- Build-strict Get enforcement: during Build, `Get[T]` panics if the name isn't in the active builder's declared `Needs`; in PostInit/handlers, Get is unrestricted

**Test coverage (12 tests, all PASS with -race):**
- `graph_test.go` — lex-stable order, cycle detection, unknown dep, transitive closure, override-as-leaf
- `container_test.go` — build runs deps in order, undeclared Get panics, PostInit after all Builds, Stop reverse order
- `registry_test.go` — duplicate Register panics, missing Name/Build panics

## Local verification

- `go vet ./internal/serviceregistry/...` — clean
- `go test ./internal/serviceregistry/... -v -race` — 12/12 PASS (5.768s)
- `go build ./...` — clean (after sibling cleanup PRs #830 + #831)

The `internal/server` test suite has 10 pre-existing SERVER-THIN-8 timeout failures (`TestITunesImport_*`, `TestOrganizeService_ViaHTTP`, etc.) on origin/main; this PR doesn't touch any code that affects them.

## Plan reference

- Spec: docs/architecture/server-plugin-registry-design.md
- Plan: docs/architecture/server-plugin-registry-plan.md (Task W0.1)

## Test plan
- [x] All 12 new tests pass with `-race`
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)