### PR TITLE
fix(ci): bump triage-poll to ghcommon@acbc1ec (runner-image v1.7.0)

### DIFF
--- a/.github/workflows/triage-poll.yml
+++ b/.github/workflows/triage-poll.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/triage-poll.yml
-# version: 1.0.0
+# version: 1.0.1
 name: Triage poll
 
 on:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   triage-poll:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@b3778b134dd316f334e2eca7d30c6ef2685afd9e
+    uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@acbc1ec5a64c5fb497a5077c3a56e56d5e7b4873
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       triage_model: o3


### PR DESCRIPTION
## Summary

- Pins `triage-poll.yml` to `jdfalk/ghcommon@acbc1ec` (was `@b3778b1`)
- The old SHA used runner-image **v1.6.0** (`cdce859`) which pre-dated the `triage-poll` subcommand
- The new SHA uses runner-image **v1.7.0** (`d558a336`) which bakes in `burndown triage-poll --from-env` from overnight-burndown PR #38

## Root cause

The workflow was added at ghcommon `b3778b1`, and the very next commit `acbc1ec` updated the image pin to include the `triage-poll` binary. Because audiobook-organizer was pinned at `b3778b1`, every 30-min run failed with "unrecognized subcommand".

## Test plan

- [ ] Trigger `triage-poll` workflow manually after merge — should reach the state machine logic instead of printing help and exiting 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)