### PR TITLE
fix(web): repair Library.bulkFetch test mock + assertion

### DIFF
--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -75,6 +75,8 @@ vi.mock('../services/api', () => {
       failed: 0,
       errors: [],
     }),
+    getOperationTimeline: vi.fn().mockResolvedValue([]),
+    getActiveOperations: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -112,7 +114,7 @@ describe('Library bulk metadata fetch', () => {
 
     const fetchMock = vi.mocked(api.batchFetchCandidates);
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(['id-1', 'id-2']);
+      expect(fetchMock).toHaveBeenCalledWith({ book_ids: ['id-1', 'id-2'] });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds missing \`getOperationTimeline\` + \`getActiveOperations\` mocks (useOperationsStore polls them on Library mount)
- Updates stale assertion: \`batchFetchCandidates\` is called as \`({ book_ids })\` not bare array

Pre-existing failures surfaced when PR #832 re-ran frontend CI.

## Test plan
- [x] \`npm test -- --run src/pages/Library.bulkFetch.test.tsx\` — 2/2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)