### PR TITLE
feat(audiobooks): register audiobook service in serviceregistry (W1.1 audiobook)

### DIFF
--- a/internal/audiobooks/register.go
+++ b/internal/audiobooks/register.go
@@ -1,0 +1,20 @@
+// file: internal/audiobooks/register.go
+// version: 1.0.0
+
+package audiobooks
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "audiobook",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewAudiobookService(store), nil
+		},
+	})
+}

--- a/internal/audiobooks/register_test.go
+++ b/internal/audiobooks/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/audiobooks/register_test.go
+// version: 1.0.0
+
+package audiobooks_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/audiobooks"
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestAudiobookRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("audiobook")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*audiobooks.AudiobookService](c, "audiobook")
+	if svc == nil {
+		t.Fatal("AudiobookService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/audiobooks/register.go` + `register_test.go` registering the audiobook service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/audiobooks/...` clean
- [x] Local `go test ./internal/audiobooks/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)