### PR TITLE
feat(batch): register batch service in serviceregistry (W1.2 batch)

### DIFF
--- a/internal/batch/register.go
+++ b/internal/batch/register.go
@@ -1,0 +1,20 @@
+// file: internal/batch/register.go
+// version: 1.0.0
+
+package batch
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "batch",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewBatchService(store), nil
+		},
+	})
+}

--- a/internal/batch/register_test.go
+++ b/internal/batch/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/batch/register_test.go
+// version: 1.0.0
+
+package batch_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/batch"
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestBatchRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("batch")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*batch.BatchService](c, "batch")
+	if svc == nil {
+		t.Fatal("BatchService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/batch/register.go` + `register_test.go` registering the batch service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/batch/...` clean
- [x] Local `go test ./internal/batch/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)