### PR TITLE
feat(work): register work service in serviceregistry (W1.3 work)

### DIFF
--- a/internal/work/register.go
+++ b/internal/work/register.go
@@ -1,0 +1,20 @@
+// file: internal/work/register.go
+// version: 1.0.0
+
+package work
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "work",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewWorkService(store), nil
+		},
+	})
+}

--- a/internal/work/register_test.go
+++ b/internal/work/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/work/register_test.go
+// version: 1.0.0
+
+package work_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+	"github.com/jdfalk/audiobook-organizer/internal/work"
+)
+
+func TestWorkRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("work")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*work.WorkService](c, "work")
+	if svc == nil {
+		t.Fatal("WorkService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/work/register.go` + `register_test.go` registering the work service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/work/...` clean
- [x] Local `go test ./internal/work/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)