### PR TITLE
feat(fileops): register filesystem service in serviceregistry (W1.4 filesystem)

### DIFF
--- a/internal/fileops/register.go
+++ b/internal/fileops/register.go
@@ -1,0 +1,20 @@
+// file: internal/fileops/register.go
+// version: 1.0.0
+
+package fileops
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "filesystem",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewFilesystemService(store), nil
+		},
+	})
+}

--- a/internal/fileops/register_test.go
+++ b/internal/fileops/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/fileops/register_test.go
+// version: 1.0.0
+
+package fileops_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/fileops"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestFilesystemRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("filesystem")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*fileops.FilesystemService](c, "filesystem")
+	if svc == nil {
+		t.Fatal("FilesystemService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/fileops/register.go` + `register_test.go` registering the filesystem service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/fileops/...` clean
- [x] Local `go test ./internal/fileops/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)