### PR TITLE
feat(importer): register importpath service in serviceregistry (W1.5 importpath)

### DIFF
--- a/internal/importer/register.go
+++ b/internal/importer/register.go
@@ -1,0 +1,20 @@
+// file: internal/importer/register.go
+// version: 1.0.0
+
+package importer
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "importpath",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewImportPathService(store), nil
+		},
+	})
+}

--- a/internal/importer/register_test.go
+++ b/internal/importer/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/importer/register_test.go
+// version: 1.0.0
+
+package importer_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/importer"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestImportPathRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("importpath")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*importer.ImportPathService](c, "importpath")
+	if svc == nil {
+		t.Fatal("ImportPathService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/importer/register.go` + `register_test.go` registering the importpath service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/importer/...` clean
- [x] Local `go test ./internal/importer/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)