### PR TITLE
feat(scanner): register scan service in serviceregistry (W1.6 scan)

### DIFF
--- a/internal/scanner/register.go
+++ b/internal/scanner/register.go
@@ -1,0 +1,20 @@
+// file: internal/scanner/register.go
+// version: 1.0.0
+
+package scanner
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "scan",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewScanService(store), nil
+		},
+	})
+}

--- a/internal/scanner/register_test.go
+++ b/internal/scanner/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/scanner/register_test.go
+// version: 1.0.0
+
+package scanner_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/scanner"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestScanRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("scan")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*scanner.ScanService](c, "scan")
+	if svc == nil {
+		t.Fatal("ScanService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/scanner/register.go` + `register_test.go` registering the scan service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/scanner/...` clean
- [x] Local `go test ./internal/scanner/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)