### PR TITLE
feat(sysinfo): register dashboard service in serviceregistry (W1.7 dashboard)

### DIFF
--- a/internal/sysinfo/register.go
+++ b/internal/sysinfo/register.go
@@ -1,0 +1,20 @@
+// file: internal/sysinfo/register.go
+// version: 1.0.0
+
+package sysinfo
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "dashboard",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewDashboardService(store), nil
+		},
+	})
+}

--- a/internal/sysinfo/register_test.go
+++ b/internal/sysinfo/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/sysinfo/register_test.go
+// version: 1.0.0
+
+package sysinfo_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
+)
+
+func TestDashboardRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("dashboard")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*sysinfo.DashboardService](c, "dashboard")
+	if svc == nil {
+		t.Fatal("DashboardService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/sysinfo/register.go` + `register_test.go` registering the dashboard service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/sysinfo/...` clean
- [x] Local `go test ./internal/sysinfo/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)