### PR TITLE
feat(config): register configupdate service in serviceregistry (W1.9 configupdate)

### DIFF
--- a/internal/config/register.go
+++ b/internal/config/register.go
@@ -1,0 +1,20 @@
+// file: internal/config/register.go
+// version: 1.0.0
+
+package config
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "configupdate",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewUpdateService(store), nil
+		},
+	})
+}

--- a/internal/config/register_test.go
+++ b/internal/config/register_test.go
@@ -1,0 +1,25 @@
+// file: internal/config/register_test.go
+// version: 1.0.0
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestConfigUpdateRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("configupdate")
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*config.UpdateService](c, "configupdate")
+	if svc == nil {
+		t.Fatal("UpdateService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/config/register.go` + `register_test.go` registering the configupdate service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/config/...` clean
- [x] Local `go test ./internal/config/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)