### PR TITLE
feat(metafetch): register metadatastate service in serviceregistry (W1.10 metadatastate)

### DIFF
--- a/internal/metafetch/register.go
+++ b/internal/metafetch/register.go
@@ -1,0 +1,20 @@
+// file: internal/metafetch/register.go
+// version: 1.0.0
+
+package metafetch
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "metadatastate",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewMetadataStateService(store), nil
+		},
+	})
+}

--- a/internal/metafetch/register_test.go
+++ b/internal/metafetch/register_test.go
@@ -1,0 +1,28 @@
+// file: internal/metafetch/register_test.go
+// version: 1.0.0
+
+package metafetch_test
+
+import (
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func TestMetadataStateRegistration(t *testing.T) {
+	c := serviceregistry.NewContainer().
+		Override("store", mocks.NewMockStore(t)).
+		Include("metadatastate")
+	if err := c.Resolve(); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := c.Build(t.Context()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	svc := serviceregistry.Get[*metafetch.MetadataStateService](c, "metadatastate")
+	if svc == nil {
+		t.Fatal("MetadataStateService is nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/metafetch/register.go` + `register_test.go` registering the metadatastate service via `init()` factory
- Part of SERVER-PLUGIN-REG Wave 1 (leaf services). Pure additive change.

## Test plan
- [x] Local `go vet ./internal/metafetch/...` clean
- [x] Local `go test ./internal/metafetch/... -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)