### PR TITLE
fix(make): staticcheck target no longer prints both messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,11 @@ check-mock-fresh:
 ## staticcheck: Run staticcheck (install: go install honnef.co/go/tools/cmd/staticcheck@latest)
 staticcheck:
 	@echo "==> Running staticcheck..."
-	@command -v staticcheck >/dev/null 2>&1 && staticcheck ./... || echo "==> staticcheck not installed, skipping."
-	@echo "==> staticcheck passed."
+	@if command -v staticcheck >/dev/null 2>&1; then \
+		staticcheck ./... && echo "==> staticcheck passed."; \
+	else \
+		echo "==> staticcheck not installed, skipping."; \
+	fi
 
 ## oplint: Run plugin import lint
 oplint:


### PR DESCRIPTION
## Summary
- Makefile staticcheck target previously printed `==> staticcheck not installed, skipping.` AND `==> staticcheck passed.` on the same run
- Replaced the `cmd && tool || echo` followed by unconditional `echo passed` with an if/else block — exactly one message prints, and 'passed' only prints when staticcheck actually returns 0

## Test plan
- [x] When staticcheck installed and clean: prints 'passed' only
- [x] When staticcheck missing: prints 'not installed, skipping.' only

🤖 Generated with [Claude Code](https://claude.com/claude-code)