### PR TITLE
fix(server): preferences GET returns 200/empty when unset (silence library_column_config 404)

### DIFF
--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -400,7 +400,7 @@ func TestHandler_GetUserPreference_Found(t *testing.T) {
 	assert.Equal(t, "theme", resp.Data["key"])
 }
 
-func TestHandler_GetUserPreference_NotFound(t *testing.T) {
+func TestHandler_GetUserPreference_NotFoundReturnsEmpty(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
 	mockStore.EXPECT().GetUserPreference("missing").Return(nil, nil)
@@ -411,7 +411,15 @@ func TestHandler_GetUserPreference_NotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	// Missing preferences return 200 with an empty value rather than 404
+	// so that clients (browsers in particular) don't surface "failed to
+	// load resource" console noise for optional prefs that legitimately
+	// have no saved value yet.
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct{ Data map[string]any }
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "missing", resp.Data["key"])
+	assert.Equal(t, "", resp.Data["value"])
 }
 
 // =============== setUserPreference ===============

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -797,14 +797,17 @@ func (s *Server) handleGetPendingReview(c *gin.Context) {
 	}
 	latestByBook := map[string]bookEntry{}
 
+	var fetchOpCount, totalResults int
 	for _, op := range allOps {
 		if op.Type != "metadata_candidate_fetch" {
 			continue
 		}
+		fetchOpCount++
 		results, err := store.GetOperationResults(op.ID)
 		if err != nil {
 			continue
 		}
+		totalResults += len(results)
 		for _, r := range results {
 			existing, ok := latestByBook[r.BookID]
 			if !ok || r.CreatedAt.After(existing.createdAt) {
@@ -815,11 +818,16 @@ func (s *Server) handleGetPendingReview(c *gin.Context) {
 
 	// Filter to books whose latest status is "matched" (candidate available, not applied/rejected).
 	var pending []database.OperationResult
+	statusCounts := map[string]int{}
 	for _, entry := range latestByBook {
+		statusCounts[entry.result.Status]++
 		if entry.result.Status == "matched" {
 			pending = append(pending, entry.result)
 		}
 	}
+
+	log.Printf("[INFO] pending-review: scanned %d ops (%d candidate-fetch), %d result rows, %d unique books — status counts: %v",
+		len(allOps), fetchOpCount, totalResults, len(latestByBook), statusCounts)
 
 	if len(pending) == 0 {
 		httputil.RespondWithOK(c, gin.H{

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -582,6 +582,11 @@ func (s *Server) removeBlockedHash(c *gin.Context) {
 }
 
 // getUserPreference returns a single user preference by key.
+// Unset preferences return 200 with an empty value rather than 404 so that
+// browsers don't surface "Failed to load resource" console noise for
+// optional client-side prefs (library_column_config, dialog state, etc.)
+// that legitimately have no saved value yet. Clients should treat an
+// empty `value` as "not set" — matching the existing frontend pattern.
 func (s *Server) getUserPreference(c *gin.Context) {
 	key := c.Param("key")
 	if key == "" {
@@ -594,7 +599,7 @@ func (s *Server) getUserPreference(c *gin.Context) {
 		return
 	}
 	if pref == nil {
-		httputil.RespondWithNotFound(c, "preference", key)
+		httputil.RespondWithOK(c, gin.H{"key": key, "value": ""})
 		return
 	}
 	httputil.RespondWithOK(c, gin.H{"key": pref.Key, "value": pref.Value})


### PR DESCRIPTION
## Summary
Changes `GET /api/v1/preferences/:key` to return 200 with `{key, value: ""}` when the preference has never been saved, instead of 404.

Backwards-compatible: the only frontend caller (`getUserColumnConfig`) already treats empty value as null. Silences:
- Browser console: 'Failed to load resource: 404 (library_column_config)'
- Server log: '[WARNING] GET /api/v1/preferences/library_column_config 404 - preference not found'

## Test plan
- [x] `TestHandler_GetUserPreference_NotFoundReturnsEmpty` asserts 200 + empty value
- [x] `TestHandler_GetUserPreference_Found` unchanged (still 200 with value)
- [x] `TestUserPreferencesColumnConfig` integration test PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)