### PR TITLE
refactor(itunes): remove unused test helpers and fix S1010

### DIFF
--- a/internal/itunes/generate_test_itls.go
+++ b/internal/itunes/generate_test_itls.go
@@ -17,7 +17,6 @@ package itunes
 
 import (
 	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -215,131 +214,9 @@ func GenerateTestITLSuite(
 // createBlankTemplate reads the production ITL, strips all track and playlist
 // chunks from the payload, and writes the result. This preserves the hdfm
 // header, msdh container structure, encryption, and compression.
-func createBlankTemplate(templatePath, outputPath string) error {
-	data, err := os.ReadFile(templatePath)
-	if err != nil {
-		return fmt.Errorf("reading template: %w", err)
-	}
 
-	hdr, err := parseHdfmHeader(data)
-	if err != nil {
-		return err
-	}
 
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed := itlInflate(decrypted)
 
-	// Strip all track data from the payload.
-	stripped := stripTracks(decompressed)
-
-	// The hdfm header remainder contains track count at offset 41 and
-	// playlist count at offset 45 (both big-endian). Zero them.
-	if len(hdr.headerRemainder) > 48 {
-		hdr.headerRemainder[41] = 0
-		hdr.headerRemainder[42] = 0
-		hdr.headerRemainder[43] = 0
-		hdr.headerRemainder[44] = 0
-		hdr.headerRemainder[45] = 0
-		hdr.headerRemainder[46] = 0
-		hdr.headerRemainder[47] = 0
-		hdr.headerRemainder[48] = 0
-	}
-
-	return writeITLFileRaw(outputPath, hdr, stripped, wasCompressed)
-}
-
-// stripTracks removes all track data from the decompressed payload.
-// For LE format (msdh containers): finds the track-list msdh (blockType=0x01)
-// and replaces its content with just the mlth header (empty track list).
-// For BE format (hdsm containers or bare chunks): removes htim/hohm chunks.
-func stripTracks(data []byte) []byte {
-	if detectLE(data) {
-		return stripTracksLE(data)
-	}
-	return stripTracksBE(data)
-}
-
-// stripTracksLE handles the LE msdh container format.
-// Walks top-level msdh blocks:
-//   - blockType=1 (tracks): keep msdh header + mlth header with count=0
-//   - blockType=2 (playlists): keep msdh header only (playlists reference
-//     track IDs that no longer exist, so they must be removed)
-//   - All other blockTypes: keep intact
-func stripTracksLE(data []byte) []byte {
-	var out []byte
-	offset := 0
-
-	for offset+16 <= len(data) {
-		tag := readTag(data, offset)
-		if tag != "msdh" {
-			out = append(out, data[offset:]...)
-			break
-		}
-		headerLen := int(readUint32LE(data, offset+4))
-		totalLen := int(readUint32LE(data, offset+8))
-
-		if totalLen < 16 || offset+totalLen > len(data) {
-			out = append(out, data[offset:]...)
-			break
-		}
-
-		// Strip ALL msdh content — keep only the 96-byte headers.
-		// Albums, artists, playlists, artwork all reference tracks;
-		// removing tracks but keeping references = "damaged".
-		emptyMsdh := make([]byte, headerLen)
-		copy(emptyMsdh, data[offset:offset+headerLen])
-		writeUint32LE(emptyMsdh, 8, uint32(headerLen))
-		out = append(out, emptyMsdh...)
-
-		offset += totalLen
-	}
-
-	return out
-}
-
-// stripTracksBE handles the BE format (hdsm containers or bare chunks).
-func stripTracksBE(data []byte) []byte {
-	var out []byte
-	offset := 0
-	inTrackSection := false
-
-	for offset+8 <= len(data) {
-		tag := readTag(data, offset)
-		if tag == "" {
-			out = append(out, data[offset:]...)
-			break
-		}
-		length := int(readUint32BE(data, offset+4))
-		if length < 8 || offset+length > len(data) {
-			out = append(out, data[offset:]...)
-			break
-		}
-
-		switch tag {
-		case "htim":
-			inTrackSection = true
-			offset += length
-		case "hohm":
-			if inTrackSection {
-				offset += length
-			} else {
-				out = append(out, data[offset:offset+length]...)
-				offset += length
-			}
-		case "hpim":
-			inTrackSection = false
-			out = append(out, data[offset:offset+length]...)
-			offset += length
-		default:
-			inTrackSection = false
-			out = append(out, data[offset:offset+length]...)
-			offset += length
-		}
-	}
-
-	return out
-}
 
 // writeITLFileRaw compresses, encrypts, and writes an ITL file.
 func writeITLFileRaw(outputPath string, hdr *hdfmHeader, payload []byte, compress bool) error {
@@ -770,22 +647,6 @@ func writeTestInfo(dir string, info testInfo) error {
 // Helpers
 // ---------------------------------------------------------------------------
 
-func kindFromFormat(format string) string {
-	switch strings.ToLower(format) {
-	case "m4b", "m4a", "aac":
-		return "AAC audio file"
-	case "mp3":
-		return "MPEG audio file"
-	case "ogg":
-		return "Ogg Vorbis file"
-	case "flac":
-		return "FLAC audio file"
-	case "wav":
-		return "WAV audio file"
-	default:
-		return "AAC audio file"
-	}
-}
 
 // randomPID returns a cryptographically random 8-byte persistent ID.
 func randomPID() [8]byte {
@@ -794,9 +655,5 @@ func randomPID() [8]byte {
 	return pid
 }
 
-// pidHex returns the hex string of a PID.
-func pidHex(pid [8]byte) string {
-	return hex.EncodeToString(pid[:])
-}
 
 // hexToPID is defined in itl.go — reuse that.

--- a/internal/itunes/import.go
+++ b/internal/itunes/import.go
@@ -69,7 +69,7 @@ func extractPathPrefixes(locations []string) []string {
 		if len(parts) >= 3 {
 			prefix = "file://localhost/" + parts[0] + "/" + parts[1] + "/" + parts[2]
 		} else {
-			prefix = "file://localhost/" + strings.Join(parts[:len(parts)], "/")
+			prefix = "file://localhost/" + strings.Join(parts[:], "/")
 		}
 		if !seen[prefix] {
 			seen[prefix] = true

--- a/internal/itunes/itl_convert_test.go
+++ b/internal/itunes/itl_convert_test.go
@@ -309,7 +309,6 @@ func TestParseITLAsLibrary_PlayDateConversion(t *testing.T) {
 	// Unix epoch  + 2082844800 seconds offset from Mac epoch
 	// So Mac seconds 3786825600 → Unix seconds 1704067200 (2024-01-01).
 	const macSecs = 3786825600
-	const expectedUnix = int64(macSecs) - int64(2082844800) // = 1703980800
 
 	// Re-derive: macEpoch is 1904-01-01. Unix epoch is 1970-01-01.
 	// Difference in seconds: (1970-1904) * 365.25 * 86400 ≈ 2082844800.

--- a/internal/itunes/itl_le_remove_by_pid.go
+++ b/internal/itunes/itl_le_remove_by_pid.go
@@ -19,13 +19,6 @@ import (
 	"strings"
 )
 
-// logRemoveSkipped is preserved for backward compat with tests; v1.2.0
-// no longer skips removes. Tests can override to capture warnings if a
-// future safety gate re-introduces a skip path.
-var logRemoveSkipped = func(n int) {
-	log.Printf("[INFO] iTunes write-back: removing %d track(s) (safe path)", n)
-}
-
 // RemoveTracksByPIDLE removes tracks identified by the given persistent IDs
 // from an LE-format ITL payload, atomically:
 //

--- a/internal/itunes/sync_diagnostic_tests.go
+++ b/internal/itunes/sync_diagnostic_tests.go
@@ -23,8 +23,6 @@
 package itunes
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -670,20 +668,3 @@ This folder contains {{N}} variant iTunes Library.itl files. Each
 - The 32-36 mith-field variants need follow-up format research.
 `
 
-// pidHexDeterministic returns a deterministic 8-byte PID; placeholder for
-// when AddTracksLE supports pre-set PIDs.
-func pidHexDeterministic(seed string) string {
-	out := make([]byte, 8)
-	for i, c := range []byte(seed) {
-		out[i%8] ^= c
-	}
-	return hex.EncodeToString(out)
-}
-
-// _randPID is the same shape as crypto/rand.Read but kept as a sanity
-// check that crypto/rand is the source for buildMithLE.
-func _randPID() [8]byte {
-	var p [8]byte
-	_, _ = rand.Read(p[:])
-	return p
-}

--- a/internal/itunes/xml_export_test.go
+++ b/internal/itunes/xml_export_test.go
@@ -313,27 +313,6 @@ func TestEncodeWindowsPathToURL(t *testing.T) {
 	}
 }
 
-// isValidXML checks whether data is well-formed XML by stripping the DOCTYPE
-// (which Go's xml.Decoder does not handle) and parsing the rest.
-func isValidXML(data []byte) bool {
-	// Remove DOCTYPE line since Go's xml package doesn't support it
-	content := string(data)
-	if idx := strings.Index(content, "<!DOCTYPE"); idx >= 0 {
-		end := strings.Index(content[idx:], ">")
-		if end >= 0 {
-			content = content[:idx] + content[idx+end+1:]
-		}
-	}
-	decoder := xml.NewDecoder(strings.NewReader(content))
-	for {
-		_, err := decoder.Token()
-		if err != nil {
-			// io.EOF means we consumed all tokens successfully
-			return err.Error() == "EOF"
-		}
-	}
-}
-
 // isValidPlist is a simple check that the data looks like a valid plist.
 func isValidPlist(data []byte) bool {
 	s := string(data)


### PR DESCRIPTION
## Summary

Mechanical staticcheck cleanup in `internal/itunes/`. **12 warnings → 0. No behavior change. 6 files, +1 / -192 lines.**

Mostly removing unused test/diagnostic helpers from `generate_test_itls.go` and `sync_diagnostic_tests.go` — both files generate hand-crafted iTunes Library.itl test fixtures and accumulated dead helper funcs across earlier iterations of the iTunes import pipeline.

## What was removed and why

### Unused funcs/consts/vars (U1000) — confirmed zero callers

- **`generate_test_itls.go`** — delete 6 funcs (~143 lines): `createBlankTemplate`, `stripTracks`, `stripTracksLE`, `stripTracksBE`, `kindFromFormat`, `pidHex`. All were earlier-iteration helpers; the current test-itl generators use a different approach (build-from-scratch instead of strip-from-template).
- **`itl_convert_test.go:312`** — delete `const expectedUnix`. Test that referenced it was rewritten to compute the expected value inline.
- **`itl_le_remove_by_pid.go:25`** — delete `var logRemoveSkipped`. Logging is now done unconditionally at info level; the toggle is dead.
- **`sync_diagnostic_tests.go`** — delete `pidHexDeterministic` (line 675) and `_randPID` (line 685). Replaced by inline `ulid.Make()` in the diagnostic generators.
- **`xml_export_test.go:318`** — delete `func isValidXML`. Test that validated XML output was rewritten to use `encoding/xml.Decoder` directly.

### Style fix

- **`import.go:72`** — S1010: `parts[:len(parts)]` → `parts[:]` (redundant length expression).

## Verification
- [x] `staticcheck ./internal/itunes/...` → 0 warnings (was 12)
- [x] `go vet ./internal/itunes/...` → clean
- [x] `go build ./internal/itunes/...` → clean
- [x] `go test ./internal/itunes/...` short-mode → PASS (pre-existing `TestBackfillExternalIDsCollectsBookPIDs` timeout flake unrelated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)