### PR TITLE
refactor(plugins/itunes): remove unused progressAdapter

### DIFF
--- a/internal/plugins/itunes/adapter.go
+++ b/internal/plugins/itunes/adapter.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/itunes/adapter.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-05-07
+// last-edited: 2026-05-12
 
 package itunes
 
@@ -12,37 +12,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
-
-// progressAdapter converts sdk.Reporter to operations.ProgressReporter.
-// It wraps the SDK reporter and implements the operations.ProgressReporter interface
-// so that service methods that expect ProgressReporter can work with SDK reporters.
-type progressAdapter struct {
-	reporter sdk.Reporter
-}
-
-func (pa *progressAdapter) UpdateProgress(current, total int, message string) error {
-	return pa.reporter.UpdateProgress(current, total, message)
-}
-
-func (pa *progressAdapter) Log(level, message string, details *string) error {
-	switch level {
-	case "error":
-		pa.reporter.Logger().Error(message)
-	case "warn":
-		pa.reporter.Logger().Warn(message)
-	case "info":
-		pa.reporter.Logger().Info(message)
-	case "debug":
-		pa.reporter.Logger().Debug(message)
-	default:
-		pa.reporter.Logger().Info(message)
-	}
-	return nil
-}
-
-func (pa *progressAdapter) IsCanceled() bool {
-	return pa.reporter.IsCanceled()
-}
 
 // loggerWrapper wraps an SDK reporter and implements logger.Logger.
 // It delegates logging to the SDK reporter's slog.Logger and forwards progress updates


### PR DESCRIPTION
## Summary

Mechanical staticcheck cleanup in `internal/plugins/itunes/`. **4 U1000 warnings → 0. No behavior change. 1 file, +2 / -33 lines.**

## What was removed and why

All four warnings are in `adapter.go` (lines 19, 23, 27, 43) and form a single dead block: the `progressAdapter` type plus its three method implementations (`UpdateProgress`, `Log`, `IsCanceled`).

- **Delete:** the entire `progressAdapter` type + the 3 methods (lines 19–45).
- **Why safe:** `grep -rn 'progressAdapter\b' internal/` → 0 hits outside the file. The iTunes plugin uses `registry.Reporter` directly via closure at registration time; the adapter was an earlier-iteration bridge type that was never wired.
- **Kept:** `loggerWrapper` type + `NewLoggerWrapper` export — those have active callers.

Bumped version 1.0.0 → 1.1.0.

## Verification
- [x] `staticcheck ./internal/plugins/itunes/...` → 0 warnings (was 4)
- [x] `go vet ./internal/plugins/itunes/...` → clean
- [x] `go build ./...` → clean
- [x] `go test ./internal/plugins/itunes/... -race -timeout=60s` → PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)