### PR TITLE
refactor: clean up staticcheck warnings in organizer/realtime/pathvalidation/rapidgen

### DIFF
--- a/internal/organizer/reflink_unix.go
+++ b/internal/organizer/reflink_unix.go
@@ -40,7 +40,7 @@ func (o *Organizer) reflinkFilePlatform(sourcePath, targetPath string) error {
 
 	// Try Linux FICLONE first (most common)
 	const FICLONE = 0x40049409
-	ret, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), FICLONE, uintptr(srcFd))
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, uintptr(dstFd), FICLONE, uintptr(srcFd))
 	if errno == 0 {
 		return nil
 	}

--- a/internal/realtime/events_test.go
+++ b/internal/realtime/events_test.go
@@ -370,7 +370,7 @@ func TestEventHub_Broadcast_ChannelFull(t *testing.T) {
 	// Create client with buffer of 0 to make it immediately full
 	client := &Client{
 		ID:         "client-1",
-		Channel:    make(chan *Event, 0), // No buffer
+		Channel:    make(chan *Event), // No buffer
 		Operations: make(map[string]bool),
 	}
 	hub.RegisterClient(client)

--- a/internal/security/pathvalidation/pathvalidation.go
+++ b/internal/security/pathvalidation/pathvalidation.go
@@ -42,10 +42,6 @@ var ErrAbsolutePathNotAllowed = errors.New("absolute path not allowed in user-su
 // ErrEmptyPath is returned when a path is empty after sanitisation.
 var ErrEmptyPath = errors.New("empty path")
 
-// unsafeSeparatorsRE matches any forward- or back-slash that could be used to
-// inject directory separators into a filename component.
-var unsafeSeparatorsRE = regexp.MustCompile(`[/\\]`)
-
 // unsafeFilenameRE matches characters that are illegal or dangerous in
 // filenames on Windows, macOS, or Linux. The set is intentionally conservative:
 // only printable, non-control, non-reserved characters are allowed.

--- a/internal/testutil/rapidgen/rapidgen_test.go
+++ b/internal/testutil/rapidgen/rapidgen_test.go
@@ -22,6 +22,7 @@ func TestGen_Book(t *testing.T) {
 		b := Book(t)
 		if b == nil {
 			t.Fatal("Book returned nil")
+			return // Unreachable, but satisfies static analyzer
 		}
 		if b.Title == "" {
 			t.Errorf("Title must be non-empty, got %q", b.Title)


### PR DESCRIPTION
## Summary

Mechanical staticcheck cleanup across 4 small packages. **4 warnings → 0. No behavior change. 4 files, +3 / -6 lines.**

## What was fixed and why

### `internal/organizer/reflink_unix.go:43` — SA4006
- The syscall returned `ret, _, errno` but `ret` was never used afterwards (`errno` is what callers check).
- **Fix:** `ret, _, errno` → `_, _, errno`. Identical syscall behavior; just drops the unused return.

### `internal/realtime/events_test.go:373` — S1019
- `make(chan *Event, 0)` → `make(chan *Event)`. The explicit `0` buffer size is the default; staticcheck flags it as redundant.

### `internal/security/pathvalidation/pathvalidation.go:47` — U1000
- Delete `var unsafeSeparatorsRE`. Regex was compiled at init time but never referenced; path validation uses `filepath.Clean` + explicit checks instead.

### `internal/testutil/rapidgen/rapidgen_test.go:26` — SA5011
- `if x == nil { t.Fatal(...) }` was immediately followed by `x.Field` access without a `return`. Same defense-in-depth pattern as the remux tests in #858.
- **Fix:** add `return` after the `t.Fatal` call.

## Verification
- [x] `staticcheck` for the 4 packages → 0 warnings (was 4)
- [x] `go vet` → clean
- [x] `go build ./...` → clean
- [x] `go test` short for organizer/realtime/rapidgen → PASS (pathvalidation has a pre-existing unrelated test failure on `origin/main`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)