### PR TITLE
refactor(operations/registry): remove unused UOS-02 stubs and dead test helpers

### DIFF
--- a/internal/operations/registry/reporter.go
+++ b/internal/operations/registry/reporter.go
@@ -1,23 +1,22 @@
 // file: internal/operations/registry/reporter.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-05-08
+// last-edited: 2026-05-12
 
 package registry
 
 // Reporter is the per-run handle a plugin's Run function uses to emit
-// progress, logs, and checkpoints. The full DB-write implementation
-// lands in UOS-03/04. This file defines only the interface and a
-// minimal stub sufficient for the worker loop.
+// progress, logs, and checkpoints. The real implementation is reporterDB
+// in reporter_db.go (UOS-03+). This file is interface-only — the
+// transitional UOS-02 stub (stubReporter / newStubReporter) was removed
+// after UOS-03 made it unused.
 
 import (
 	"context"
 	"log/slog"
-	"sync"
 )
 
 // Reporter is the per-run API surface for an in-flight operation.
-// Real DB writes are implemented in UOS-03; this stub buffers to memory.
 type Reporter interface {
 	UpdateProgress(current, total int, message string) error
 	Log(level slog.Level, message string, attrs ...slog.Attr) error
@@ -32,68 +31,3 @@ type Reporter interface {
 	// iteration without measurable cost.
 	SetCurrentItem(label string)
 }
-
-// stubReporter is the UOS-02 stand-in. It buffers log lines in memory
-// and does nothing with checkpoints. Real persistence is UOS-03/04.
-type stubReporter struct {
-	opID   string
-	logs   []string
-	mu     sync.Mutex
-	logger *slog.Logger
-	ctx    context.Context
-}
-
-// newStubReporter creates a stub Reporter bound to the given operation id.
-func newStubReporter(ctx context.Context, opID string) Reporter {
-	return &stubReporter{
-		opID:   opID,
-		logger: slog.Default().With("op_id", opID),
-		ctx:    ctx,
-	}
-}
-
-func (r *stubReporter) UpdateProgress(current, total int, message string) error {
-	r.mu.Lock()
-	r.logs = append(r.logs, message)
-	r.mu.Unlock()
-	return nil
-}
-
-func (r *stubReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
-	r.mu.Lock()
-	r.logs = append(r.logs, message)
-	r.mu.Unlock()
-	return nil
-}
-
-func (r *stubReporter) Logger() *slog.Logger {
-	return r.logger
-}
-
-func (r *stubReporter) Checkpoint(_ any) error {
-	// No-op in stub; real implementation persists to op_state_v2 (UOS-03).
-	return nil
-}
-
-func (r *stubReporter) IsCanceled() bool {
-	select {
-	case <-r.ctx.Done():
-		return true
-	default:
-		return false
-	}
-}
-
-func (r *stubReporter) RunPhase(ctx context.Context, name string, fn func(context.Context, Reporter) error) error {
-	// Phase tracking (skip completed phases on resume) lands in UOS-03.
-	_ = name
-	return fn(ctx, r)
-}
-
-func (r *stubReporter) Trigger(_ context.Context, _ string, _ any) error {
-	// Event bus wiring lands in UOS-05.
-	return nil
-}
-
-func (r *stubReporter) SetCurrentItem(_ string) {}
-

--- a/internal/operations/registry/teststore_test.go
+++ b/internal/operations/registry/teststore_test.go
@@ -196,19 +196,6 @@ func (f *fakeStore) DeleteOpStateV2(opID string) error {
 	return nil
 }
 
-// strikeCount returns the number of strikes recorded for a given op id.
-func (f *fakeStore) strikeCount(opID string) int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	n := 0
-	for _, s := range f.strikes {
-		if s.OperationID == opID {
-			n++
-		}
-	}
-	return n
-}
-
 // strikesOfKind returns strikes of a given kind for an op.
 func (f *fakeStore) strikesOfKind(opID, kind string) []database.OpStrikeV2Row {
 	f.mu.Lock()
@@ -231,18 +218,6 @@ func (f *fakeStore) setLastProgressAt(opID string, t *time.Time) {
 		return
 	}
 	op.LastProgressAt = t
-	f.ops[opID] = op
-}
-
-// setLastCheckpointAt allows tests to simulate stale checkpoint timestamps.
-func (f *fakeStore) setLastCheckpointAt(opID string, t *time.Time) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	op, ok := f.ops[opID]
-	if !ok {
-		return
-	}
-	op.LastCheckpointAt = t
 	f.ops[opID] = op
 }
 

--- a/internal/operations/registry/watchdog_test.go
+++ b/internal/operations/registry/watchdog_test.go
@@ -15,17 +15,6 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 )
 
-// newTestRegistryWithWatchdog creates a registry with a very short watchdog
-// interval for testing. The progress/checkpoint timeouts are also shortened.
-func newRegistryFast(t *testing.T, watchdogInterval time.Duration) (*registry.Registry, *fakeStore) {
-	t.Helper()
-	store := newFakeStore()
-	r := registry.NewWithOptions(store, slog.Default(), 4, registry.Options{
-		WatchdogInterval: watchdogInterval,
-	})
-	return r, store
-}
-
 // TestWatchdog_StuckOpGetStrike verifies that an op with stale last_progress_at
 // gets a "stuck" strike and its context is canceled.
 func TestWatchdog_StuckOpGetsStrike(t *testing.T) {

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -56,8 +56,6 @@ type queuedRun struct {
 	concurrKey   string
 	plugin       string
 	resumePolicy ResumePolicy
-	// initialState is the op_state_v2 blob passed on ResumeRestart. May be nil.
-	initialState []byte
 }
 
 // startWorker is a long-running goroutine that reads from r.nextRun and


### PR DESCRIPTION
## Summary

Mechanical staticcheck cleanup in `internal/operations/registry/`. **14 U1000 warnings → 0. No behavior change. 4 files, +6 / -110 lines.**

**Replaces #851**, which was corrupted (260 files / -240k lines) by a stray `git add -A` in the subagent's worktree. This revision is a clean 4-file diff with only the intended removals.

## What was removed and why

### `reporter.go` — UOS-02 stub Reporter implementation
- Delete `stubReporter` type + `newStubReporter` constructor + 7 method implementations (`UpdateProgress`, `Log`, `Logger`, `Checkpoint`, `IsCanceled`, `RunPhase`, `Trigger`, `SetCurrentItem`)
- **Why safe:** these were the UOS-02 in-memory stand-in for the Reporter interface; the real implementation `reporterDB` in `reporter_db.go` (UOS-03+) supplanted them and is the only `Reporter` constructed anywhere in production today. `grep -rn 'stubReporter\|newStubReporter'` → 0 hits outside the file.
- Drop now-unused `sync` import (only used by stubReporter's mutex).
- Bump version 1.1.0 → 1.2.0.

### `worker.go:59-60` — unused `initialState` field on `queuedRun`
- Delete `initialState []byte` field.
- **Why safe:** field was added for ResumeRestart state hand-off in an earlier draft, but the live resume path (`resume.go::ResumeQueuedRun`) re-reads state from `op_state_v2` instead of receiving it via the queue. No producer or consumer left.

### `teststore_test.go:199-210, 237-247` — unused fakeStore helpers
- Delete `(*fakeStore).strikeCount()` — no test calls it; `strikesOfKind()` covers the same need with finer granularity and IS called by tests.
- Delete `(*fakeStore).setLastCheckpointAt()` — no test calls it; `setLastProgressAt` is the one tests actually use. The checkpoint variant was never wired up.

### `watchdog_test.go:18-27` — unused `newRegistryFast()` helper
- Delete the helper.
- **Why safe:** no test calls it. The two watchdog tests that DO need a registry build one inline with `registry.NewWithOptions(...)` directly. The helper duplicated that pattern but only its outline was committed; nothing imported it.

## Test plan
- [x] `staticcheck ./internal/operations/registry/...` → 0 warnings (was 14)
- [x] `go vet ./internal/operations/registry/...` → clean
- [x] `go build ./...` → clean
- [x] `go test ./internal/operations/registry/... -short -race -timeout=60s` → PASS (18.7s)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)