### PR TITLE
fix: clean up final 2 staticcheck stragglers after sweep

### DIFF
--- a/internal/maintenance/registry.go
+++ b/internal/maintenance/registry.go
@@ -26,14 +26,11 @@ func Register(j MaintenanceJob) {
 	byID[j.ID()] = j
 }
 
-var enqueuer WriteBackEnqueuer
-
 // InjectEnqueuer injects the write-back enqueuer into all registered jobs
 // that implement EnqueuerInjectable.
 func InjectEnqueuer(e WriteBackEnqueuer) {
 	mu.Lock()
 	defer mu.Unlock()
-	enqueuer = e
 	for _, j := range registry {
 		if ei, ok := j.(EnqueuerInjectable); ok {
 			ei.InjectEnqueuer(e)

--- a/internal/openlibrary/store_test.go
+++ b/internal/openlibrary/store_test.go
@@ -6,7 +6,6 @@ package openlibrary
 
 import (
 	"compress/gzip"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -146,7 +145,7 @@ func TestImportInvalidDumpType(t *testing.T) {
 	defer store.Close()
 
 	dumpPath := writeTSVGz(t, dir, "bad.txt.gz", []string{
-		fmt.Sprintf("/type/bad\tkey\t1\t2024-01-01\t{}"),
+		"/type/bad\tkey\t1\t2024-01-01\t{}",
 	})
 	err = store.ImportDump("invalid", dumpPath, nil)
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary

Two warnings that slipped through the 11-task staticcheck cleanup sweep (PRs #850, #852–#861). With these merged, `staticcheck ./...` exits 0 across the entire repo.

### `internal/maintenance/registry.go:29` — U1000 unused `enqueuer` package var
The variable was being assigned in `InjectEnqueuer` but never read elsewhere. `InjectEnqueuer`'s only meaningful consumer is the per-job loop on line 37 which passes the parameter `e` directly into `EnqueuerInjectable.InjectEnqueuer`.

**Fix:** delete the var declaration and the assignment line. The loop is the only consumer.

### `internal/openlibrary/store_test.go:149` — S1039 unnecessary fmt.Sprintf
`fmt.Sprintf("/type/bad\tkey\t1\t2024-01-01\t{}")` had no interpolation arguments.

**Fix:** replace with the bare string literal; drop now-unused `fmt` import.

## Test plan
- [x] `staticcheck ./...` → 0 warnings (exit 0)
- [x] `go build ./...` → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)