### PR TITLE
fix(pathvalidation): SecureJoinResolved mishandled symlinked tmpdirs

### DIFF
--- a/internal/maintenance/registry.go
+++ b/internal/maintenance/registry.go
@@ -26,14 +26,11 @@ func Register(j MaintenanceJob) {
 	byID[j.ID()] = j
 }
 
-var enqueuer WriteBackEnqueuer
-
 // InjectEnqueuer injects the write-back enqueuer into all registered jobs
 // that implement EnqueuerInjectable.
 func InjectEnqueuer(e WriteBackEnqueuer) {
 	mu.Lock()
 	defer mu.Unlock()
-	enqueuer = e
 	for _, j := range registry {
 		if ei, ok := j.(EnqueuerInjectable); ok {
 			ei.InjectEnqueuer(e)

--- a/internal/openlibrary/store_test.go
+++ b/internal/openlibrary/store_test.go
@@ -6,7 +6,6 @@ package openlibrary
 
 import (
 	"compress/gzip"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -146,7 +145,7 @@ func TestImportInvalidDumpType(t *testing.T) {
 	defer store.Close()
 
 	dumpPath := writeTSVGz(t, dir, "bad.txt.gz", []string{
-		fmt.Sprintf("/type/bad\tkey\t1\t2024-01-01\t{}"),
+		"/type/bad\tkey\t1\t2024-01-01\t{}",
 	})
 	err = store.ImportDump("invalid", dumpPath, nil)
 	assert.Error(t, err)

--- a/internal/security/pathvalidation/pathvalidation.go
+++ b/internal/security/pathvalidation/pathvalidation.go
@@ -179,15 +179,21 @@ func SecureJoinResolved(root string, parts ...string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("evaluating symlinks for root %q: %w", root, err)
 	}
+	realRoot = filepath.Clean(realRoot)
 
 	// Resolve symlinks in the joined path.
 	realJoined, err := filepath.EvalSymlinks(joined)
 	if err != nil {
-		// Path doesn't exist yet — fall back to a clean static check.
-		realJoined = joined
-		realRoot = filepath.Clean(realRoot)
-	} else {
-		realRoot = filepath.Clean(realRoot)
+		// Path doesn't exist yet — both sides of the comparison must
+		// use the SAME root form, otherwise a symlinked tmpdir like
+		// macOS's /var/folders → /private/var/folders falsely fails:
+		// realRoot resolves to /private/var/folders/... but realJoined
+		// stays at /var/folders/... so isWithinRoot returns false.
+		//
+		// Walk the joined path upward to the first existing ancestor,
+		// EvalSymlinks that, then append the non-existent suffix. The
+		// resulting realJoined now lives under the same realRoot tree.
+		realJoined = resolveExistingPrefix(joined)
 	}
 
 	if !isWithinRoot(realJoined, realRoot) {
@@ -195,6 +201,34 @@ func SecureJoinResolved(root string, parts ...string) (string, error) {
 	}
 
 	return realJoined, nil
+}
+
+// resolveExistingPrefix walks a path upward to the first existing ancestor,
+// resolves symlinks on that ancestor, then re-appends the non-existent
+// suffix. This makes traversal checks consistent across paths that will
+// soon exist but currently don't (e.g. the file the caller is about to
+// create).
+func resolveExistingPrefix(path string) string {
+	clean := filepath.Clean(path)
+	suffix := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(clean)
+		if err == nil {
+			if suffix == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, suffix)
+		}
+		parent := filepath.Dir(clean)
+		if parent == clean {
+			// Reached the root and still couldn't resolve — fall back
+			// to the cleaned path so the static prefix check at least
+			// sees a normalized form.
+			return filepath.Clean(path)
+		}
+		suffix = filepath.Join(filepath.Base(clean), suffix)
+		clean = parent
+	}
 }
 
 // isWithinRoot reports whether path is equal to root or is directly contained

--- a/internal/security/pathvalidation/pathvalidation_test.go
+++ b/internal/security/pathvalidation/pathvalidation_test.go
@@ -330,9 +330,15 @@ func TestSecureJoinResolved_Normal(t *testing.T) {
 		// Other errors (e.g. EvalSymlinks failure on missing path) are acceptable.
 	}
 	if err == nil {
-		// The returned path must be within dir.
-		if !strings.HasPrefix(got, filepath.Clean(dir)) {
-			t.Errorf("resolved path %q is not within root %q", got, dir)
+		// The returned path must be within dir. Use EvalSymlinks on dir
+		// because SecureJoinResolved returns the symlink-resolved form
+		// (e.g. macOS resolves /var/folders → /private/var/folders).
+		realDir, evalErr := filepath.EvalSymlinks(dir)
+		if evalErr != nil {
+			realDir = filepath.Clean(dir)
+		}
+		if !strings.HasPrefix(got, realDir) {
+			t.Errorf("resolved path %q is not within root %q (real=%q)", got, dir, realDir)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`TestSecureJoinResolved_Normal` failed on macOS because `t.TempDir()` returns a path under `/var/folders/...` which is a symlink to `/private/var/folders/...`. `SecureJoinResolved` was inconsistently mixing the two forms when the joined path didn't yet exist:

```
realRoot   = EvalSymlinks(root)    → /private/var/folders/.../001
realJoined = joined (fallback when EvalSymlinks(joined) fails because path
                     doesn't exist yet)
           → /var/folders/.../001/sub/file.txt
```

`isWithinRoot` then incorrectly returned false because the prefix didn't match.

The bug is broader than the test: any caller resolving a path before creating it on a system with symlinked parent directories would hit this.

## Fix

When `EvalSymlinks(joined)` fails (path doesn't exist), walk the path upward to the first existing ancestor, `EvalSymlinks` THAT, then re-append the non-existent suffix. `resolveExistingPrefix()` handles this. Now `realJoined` always uses the same symlink-resolved root form as `realRoot`, so `isWithinRoot` gives the correct answer.

Also fixed the test itself: it was asserting that the returned path has `dir` as a prefix, but `SecureJoinResolved` correctly returns the symlink-resolved form. The test now `EvalSymlinks(dir)` before comparing.

## Test plan
- [x] `go test ./internal/security/pathvalidation/... -count=1 -race` → PASS
- [x] `TestSecureJoinResolved_SymlinkEscape` still catches actual symlink-escape attempts (unchanged behavior path)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)