### PR TITLE
feat(metafetch): register Service in serviceregistry (W2.1)

### DIFF
--- a/internal/metafetch/register.go
+++ b/internal/metafetch/register.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/register.go
-// version: 1.0.0
+// version: 1.1.0
 
 package metafetch
 
@@ -15,6 +15,15 @@ func init() {
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
 			return NewMetadataStateService(store), nil
+		},
+	})
+
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "metafetch",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewService(store), nil
 		},
 	})
 }


### PR DESCRIPTION
## Summary
Adds a second `serviceregistry.Register(...)` call in `internal/metafetch/register.go` for the main `metafetch.Service` (constructor: `NewService(db database.Store)`). The package already registered `metadatastate` from W1; this brings the main service into the registry too.

Cross-wiring (`SetOLStore`, `SetWriteBackBatcher`, `SetDedupEngine`, `SetMetadataScorer`, `SetMetadataLLMScorer`, `SetSafeWriteDeps`, `SetActivityService`, `SetISBNEnrichment`) **stays inline in NewServer for now** — later waves clean up that wiring as the dependent services (dedupEngine in W4, writeBackBatcher in W3, etc.) get registered.

Part of SERVER-PLUGIN-REG Wave 2.

## Test plan
- [x] `go vet ./internal/metafetch/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/metafetch/... -short -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)