### PR TITLE
feat(merge): register Service in serviceregistry (W2.3)

### DIFF
--- a/internal/merge/register.go
+++ b/internal/merge/register.go
@@ -1,0 +1,20 @@
+// file: internal/merge/register.go
+// version: 1.0.0
+
+package merge
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "merge",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewService(store), nil
+		},
+	})
+}


### PR DESCRIPTION
## Summary
Creates `internal/merge/register.go`. One ServiceDef: `merge`, Needs=`[store]`, Build calls `NewService(store)`.

Cross-wiring (`SetWriteBackBatcher`) stays inline in NewServer for now — W3 covers writeBackBatcher as a Start/Stop service and will clean up the wiring then.

Part of SERVER-PLUGIN-REG Wave 2.

## Test plan
- [x] `go vet ./internal/merge/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/merge/... -short -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)