### PR TITLE
feat(quarantine): register Service + eventbus in serviceregistry (W2.4)

### DIFF
--- a/internal/plugin/register.go
+++ b/internal/plugin/register.go
@@ -1,0 +1,20 @@
+// file: internal/plugin/register.go
+// version: 1.0.0
+
+package plugin
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	// eventbus: shared plugin event bus. Plugins and services publish here;
+	// the bus has no external dependencies, so it's a leaf.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "eventbus",
+		Needs: []string{},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			return NewEventBus(), nil
+		},
+	})
+}

--- a/internal/quarantine/register.go
+++ b/internal/quarantine/register.go
@@ -1,0 +1,24 @@
+// file: internal/quarantine/register.go
+// version: 1.0.0
+
+package quarantine
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/plugin"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "quarantine",
+		Needs: []string{"store", "config", "eventbus"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			bus := serviceregistry.Get[*plugin.EventBus](c, "eventbus")
+			return NewQuarantineService(store, cfg, bus), nil
+		},
+	})
+}


### PR DESCRIPTION
## Summary
Two new files:

- **`internal/plugin/register.go`** — registers `eventbus` (the shared `*plugin.EventBus` from `plugin.NewEventBus()`). Leaf service, no deps.
- **`internal/quarantine/register.go`** — registers `quarantine`. Needs=`[store, config, eventbus]`. Build calls `NewQuarantineService(store, cfg, bus)`.

The plugin event bus had to be registered too because quarantine constructor requires it. Other plugins/services that publish events can now pull `eventbus` via Needs in later waves.

Cross-wiring (`SetWriteBackBatcher`, `AutoQuarantineFailedScans` post-scan hook) stays inline in NewServer.

Part of SERVER-PLUGIN-REG Wave 2.

## Test plan
- [x] `go vet ./internal/plugin/... ./internal/quarantine/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/quarantine/... -short -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)