### PR TITLE
feat(audiobooks): register OrganizeService in serviceregistry (W2.5)

### DIFF
--- a/internal/audiobooks/register.go
+++ b/internal/audiobooks/register.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/register.go
-// version: 1.0.0
+// version: 1.1.0
 
 package audiobooks
 
@@ -15,6 +15,14 @@ func init() {
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
 			return NewAudiobookService(store), nil
+		},
+	})
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "organize",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			return NewOrganizeService(store), nil
 		},
 	})
 }


### PR DESCRIPTION
## Summary
Adds a second `serviceregistry.Register(...)` call in `internal/audiobooks/register.go` for the `OrganizeService` (constructor: `NewOrganizeService(db database.Store)`). The package already registered the `audiobook` service from W1.

`OrganizeService` is actually a type alias to `organizer.Service` — the registration returns `*organizer.Service` as `any`. No behavior change.

Cross-wiring (`SetWriteBackBatcher`, `SetOrganizeHooks`, `DiscoverITunesLibraryPath`, `ExecuteITunesSync`, `ScanEnqueuer` closure) stays inline in NewServer for now — W3/W4/W5 clean up the wiring as itunes/opregistry/writeBackBatcher get registered.

Part of SERVER-PLUGIN-REG Wave 2.

## Test plan
- [x] `go vet ./internal/audiobooks/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/audiobooks/... -short -race` PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)