### PR TITLE
feat(ai): register embedding/AI cluster services (W4)

### DIFF
--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -1,0 +1,89 @@
+// file: internal/ai/register.go
+// version: 1.0.0
+
+// Service registry registrations for the AI cluster (W4).
+//
+// These services are all optional and conditional on config. Each Build
+// returns (nil, nil) when its preconditions aren't met so the container
+// can complete Build without error, and downstream consumers TryGet
+// instead of Get.
+//
+// For consumers to be safe, they MUST nil-check the value returned
+// from TryGet. Wiring in NewServer remains inline for now; W7 cleanup
+// flips construction over to the container.
+
+package ai
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	// embedclient — OpenAI embedding client with optional cache.
+	// Conditional on: OpenAIAPIKey set AND EmbeddingEnabled true.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "embedclient",
+		Needs: []string{"config", "embeddingstore"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if cfg.OpenAIAPIKey == "" || !cfg.EmbeddingEnabled {
+				return (*EmbeddingClient)(nil), nil
+			}
+			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
+			client := NewEmbeddingClient(cfg.OpenAIAPIKey)
+			if embStore != nil {
+				client = client.WithCache(embStore)
+			}
+			return client, nil
+		},
+	})
+
+	// llmparser — OpenAIParser used by dedup Layer 3 review + metadata
+	// LLM reranker. Conditional on OpenAIAPIKey set.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "llmparser",
+		Needs: []string{"config"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if cfg.OpenAIAPIKey == "" {
+				return (*OpenAIParser)(nil), nil
+			}
+			return NewOpenAIParser(cfg, cfg.OpenAIAPIKey, cfg.EnableAIParsing), nil
+		},
+	})
+
+	// metadatascorer — embedding-based metadata candidate scorer.
+	// Conditional on embedclient + embeddingstore both being available.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "metadatascorer",
+		Needs: []string{"config", "embedclient", "embeddingstore"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if !cfg.MetadataEmbeddingScoringEnabled {
+				return (*EmbeddingScorer)(nil), nil
+			}
+			client, _ := serviceregistry.TryGet[*EmbeddingClient](c, "embedclient")
+			store, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
+			if client == nil || store == nil {
+				return (*EmbeddingScorer)(nil), nil
+			}
+			return NewEmbeddingScorer(client, store), nil
+		},
+	})
+
+	// metadatallmscorer — LLM-based metadata candidate rerank scorer.
+	// Conditional on llmparser being available.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "metadatallmscorer",
+		Needs: []string{"llmparser"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			parser, _ := serviceregistry.TryGet[*OpenAIParser](c, "llmparser")
+			if parser == nil {
+				return (*LLMScorer)(nil), nil
+			}
+			return NewLLMScorer(parser), nil
+		},
+	})
+}

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,14 +1,18 @@
 // file: internal/server/registry_wire.go
-// version: 1.2.0
+// version: 1.3.0
 
 package server
 
 import (
+	"path/filepath"
+
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
 	"github.com/jdfalk/audiobook-organizer/internal/batch"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
@@ -21,11 +25,16 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/work"
 )
 
-// init registers the `system` service. It lives here (not in
-// internal/sysinfo) because NewSystemService needs appVersion (a
-// package-level var in this package) and calculateLibrarySizes (a
-// function in this package). Both stay where they are; the registry
-// closure just captures them.
+// init registers services that can't live in their domain packages due
+// to import cycles or because they need package-private symbols from
+// internal/server.
+//
+//   - `system` — needs appVersion + calculateLibrarySizes from this pkg.
+//   - `embeddingstore`, `chromemstore`, `aijobsstore` — live in
+//     internal/database which can't import internal/config (cycle).
+//   - `dedup` (the engine) — needs *config.Config to read thresholds;
+//     internal/dedup doesn't already import internal/config, so registering
+//     here avoids forcing a new dependency on that pkg.
 func init() {
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:  "system",
@@ -33,6 +42,84 @@ func init() {
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
 			return sysinfo.NewSystemService(store, appVersion, calculateLibrarySizes), nil
+		},
+	})
+
+	// embeddingstore — Pebble-backed key namespace for dedup embeddings.
+	// Returns nil if the underlying store isn't *PebbleStore (e.g. tests).
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "embeddingstore",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			ps, ok := store.(*database.PebbleStore)
+			if !ok {
+				return (*database.EmbeddingStore)(nil), nil
+			}
+			return database.NewEmbeddingStore(ps.DB()), nil
+		},
+	})
+
+	// chromemstore — chromem-go ANN vector store for dedup Layer 2.
+	// Optional; failure logs a warning + returns nil so dedup falls back
+	// to the Pebble linear scan.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "chromemstore",
+		Needs: []string{"config"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if cfg.DatabasePath == "" {
+				return (*database.ChromemEmbeddingStore)(nil), nil
+			}
+			dir := filepath.Dir(cfg.DatabasePath)
+			store, err := database.NewChromemEmbeddingStore(dir, 3072)
+			if err != nil {
+				return (*database.ChromemEmbeddingStore)(nil), nil
+			}
+			return store, nil
+		},
+	})
+
+	// aijobsstore — interface assertion on the main store.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "aijobsstore",
+		Needs: []string{"store"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			if s, ok := store.(database.AIJobsStore); ok {
+				return s, nil
+			}
+			return database.AIJobsStore(nil), nil
+		},
+	})
+
+	// dedup — the duplicate detection engine.
+	// Returns nil if any required dep is missing (no API key, no embed
+	// client, etc.) — matches the existing inline conditional construction
+	// in NewServer.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "dedup",
+		Needs: []string{"store", "config", "embeddingstore", "embedclient", "llmparser", "merge"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if cfg.OpenAIAPIKey == "" || !cfg.EmbeddingEnabled {
+				return (*dedup.Engine)(nil), nil
+			}
+			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
+			embClient, _ := serviceregistry.TryGet[*ai.EmbeddingClient](c, "embedclient")
+			llmParser, _ := serviceregistry.TryGet[*ai.OpenAIParser](c, "llmparser")
+			if embStore == nil || embClient == nil || llmParser == nil {
+				return (*dedup.Engine)(nil), nil
+			}
+			store := serviceregistry.Get[database.Store](c, "store")
+			mergeSvc := serviceregistry.Get[*merge.Service](c, "merge")
+			engine := dedup.NewEngine(embStore, store, embClient, llmParser, mergeSvc)
+			engine.BookHighThreshold = cfg.DedupBookHighThreshold
+			engine.BookLowThreshold = cfg.DedupBookLowThreshold
+			engine.AuthorHighThreshold = cfg.DedupAuthorHighThreshold
+			engine.AuthorLowThreshold = cfg.DedupAuthorLowThreshold
+			engine.AutoMergeEnabled = cfg.DedupAutoMergeEnabled
+			return engine, nil
 		},
 	})
 }


### PR DESCRIPTION
## Summary

SERVER-PLUGIN-REG Wave 4 — registers 8 services backing the embedding/dedup pipeline. All optional and conditional on config; each Build returns a typed nil when its preconditions aren't met. Consumers TryGet and nil-check.

### Where each service lives

**`internal/ai/register.go` (new):**
- `embedclient` — Needs `[config, embeddingstore]`; OpenAIAPIKey + EmbeddingEnabled gate; wires the embed cache via `.WithCache(embeddingstore)` when available
- `llmparser` — Needs `[config]`; OpenAIAPIKey gate
- `metadatascorer` — Needs `[config, embedclient, embeddingstore]`; `MetadataEmbeddingScoringEnabled` gate
- `metadatallmscorer` — Needs `[llmparser]`

**`internal/server/registry_wire.go` (extended; lives here to dodge the `internal/database → internal/config → internal/database` import cycle):**
- `embeddingstore` — Pebble-backed; nil when store isn't `*PebbleStore`
- `chromemstore` — Optional; nil on open failure (dedup degrades to Pebble linear scan, matching current inline behavior)
- `aijobsstore` — Interface assertion on the main store
- `dedup` — Engine with all 5 thresholds wired from config; returns nil if any soft-dep (embedclient/llmparser/embeddingstore) is unavailable

### What stays inline
NewServer's existing inline construction of these services remains untouched. The container builds parallel copies, but the server still uses the inline instances. **W7 cleanup** flips construction from inline → container once all wiring has migrated.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/ai/... ./internal/dedup/... ./internal/database/... -short -race` PASS
- [x] `staticcheck` 0 warnings on touched packages
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)