### PR TITLE
feat(plugins): register UOS plugins in serviceregistry (W5)

### DIFF
--- a/internal/plugins/acoustid/register.go
+++ b/internal/plugins/acoustid/register.go
@@ -1,0 +1,31 @@
+// file: internal/plugins/acoustid/register.go
+// version: 1.0.0
+
+// Service registry registration for the acoustid UOS plugin (W5).
+//
+// Mirrors the dedup plugin's registration shape — needs the dedup engine
+// + embedding store. Build returns nil when deps are unavailable.
+
+package acoustid
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "acoustidplugin",
+		Needs: []string{"store", "dedup", "embeddingstore"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			engine, _ := serviceregistry.TryGet[*dedupengine.Engine](c, "dedup")
+			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
+			if engine == nil || embStore == nil {
+				return (*Plugin)(nil), nil
+			}
+			store := serviceregistry.Get[database.Store](c, "store")
+			return New(engine, store, embStore), nil
+		},
+	})
+}

--- a/internal/plugins/dedup/register.go
+++ b/internal/plugins/dedup/register.go
@@ -1,0 +1,34 @@
+// file: internal/plugins/dedup/register.go
+// version: 1.0.0
+
+// Service registry registration for the dedup UOS plugin (W5).
+//
+// Build returns the constructed *Plugin when all required services are
+// available, or nil when any dep is unavailable (no API key → no dedup
+// engine → no plugin). Inline NewServer construction continues to be
+// the production path that actually calls Plugin.Register(opRegistry);
+// W7 cleanup migrates that registration to PostInit.
+
+package dedup
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "dedupplugin",
+		Needs: []string{"store", "dedup", "embeddingstore"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			engine, _ := serviceregistry.TryGet[*dedupengine.Engine](c, "dedup")
+			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
+			if engine == nil || embStore == nil {
+				return (*Plugin)(nil), nil
+			}
+			store := serviceregistry.Get[database.Store](c, "store")
+			return New(engine, store, embStore), nil
+		},
+	})
+}

--- a/internal/plugins/deluge/register.go
+++ b/internal/plugins/deluge/register.go
@@ -1,0 +1,35 @@
+// file: internal/plugins/deluge/register.go
+// version: 1.0.0
+
+// Service registry registration for the deluge UOS plugin (W5).
+//
+// Build returns nil when Deluge is not configured (no global client OR
+// no protected-path cache configured). Inline NewServer construction
+// continues to be the production path; W7 migrates registration to
+// PostInit.
+
+package deluge
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "delugeplugin",
+		Needs: []string{"store", "config"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			client := delugeclient.GetClient()
+			if client == nil {
+				return (*Plugin)(nil), nil
+			}
+			cache := delugeclient.NewProtectedPathCache(client, cfg.ProtectedPaths)
+			store := serviceregistry.Get[database.Store](c, "store")
+			return New(client, cache, store), nil
+		},
+	})
+}

--- a/internal/plugins/itunes/register.go
+++ b/internal/plugins/itunes/register.go
@@ -1,0 +1,35 @@
+// file: internal/plugins/itunes/register.go
+// version: 1.0.0
+
+// Service registry registration for the iTunes UOS plugin (W5).
+//
+// **Stub registration.** Mirrors maintenance/register.go: the iTunes
+// plugin's constructor needs `*itunesservice.Service`, which carries
+// server-bound closures (OnBookCreated → server.fireDedupOnImport,
+// OrganizerFactory referencing config.AppConfig, etc.). That coupling
+// blocks clean container registration today; see internal/itunes/
+// service/register.go for the parallel writebackbatcher discussion.
+//
+// Build returns nil so the plugin slot exists in the container.
+// Production path stays inline in NewServer.
+//
+// W7 (or follow-up): decouple itunesservice.Service from server-bound
+// closures so this plugin (and W3.1's writebackbatcher stub) can build
+// for real.
+
+package itunes
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "itunesplugin",
+		Needs: []string{},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			// Stub — see file header.
+			return (*Plugin)(nil), nil
+		},
+	})
+}

--- a/internal/plugins/maintenance/register.go
+++ b/internal/plugins/maintenance/register.go
@@ -1,0 +1,38 @@
+// file: internal/plugins/maintenance/register.go
+// version: 1.0.0
+
+// Service registry registration for the maintenance UOS plugin (W5).
+//
+// **Stub registration.** The maintenance plugin's constructor takes a
+// `ServerDeps` struct populated with multiple typed references to
+// *server.Server fields (scheduler, dedup engine, ai scan store,
+// activity writer, openlibrary service, ...). That coupling makes the
+// plugin unbuildable from the registry at present — every dep would
+// need to be registered first and the ServerDeps struct populated by
+// pulling them all from the container.
+//
+// For now this Build returns nil so the plugin is "present" in the
+// container (consumers can TryGet) but inert. Inline NewServer
+// construction continues to be the production path.
+//
+// SERVER-PLUGIN-REG W7 (or a follow-up sweep) needs to decouple
+// ServerDeps from *Server and register its constituent services in the
+// container before this plugin can build for real.
+
+package maintenance
+
+import (
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+func init() {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:  "maintenanceplugin",
+		Needs: []string{},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			// Stub — see file header. Inline construction remains the
+			// production path until ServerDeps is decoupled from *Server.
+			return (*Plugin)(nil), nil
+		},
+	})
+}


### PR DESCRIPTION
## Summary
SERVER-PLUGIN-REG Wave 5 — 5 `register.go` files for the UOS plugins. Each plugin's Build returns the constructed plugin when its deps are available, or typed nil when not.

### Real registrations
- `dedupplugin` — Needs `[store, dedup, embeddingstore]`; nil if no OpenAI key
- `acoustidplugin` — same deps as dedup; nil if no API key
- `delugeplugin` — Needs `[store, config]`; nil if `deluge.GetClient()` is nil

### Stub registrations (documented)
- `maintenanceplugin` — coupled to `*Server` via `ServerDeps` struct; can't build from container until that's decoupled
- `itunesplugin` — coupled to `itunesservice.Service` which carries server-bound closures (W3.1 stub for the same reason)

### What stays
Inline NewServer plugin construction + `Plugin.Register(opRegistry)` calls remain the production path. **W7 cleanup** migrates the `Register()` call into the plugin's PostInit and removes the inline construction.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/plugins/... -short -race` PASS
- [x] `staticcheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)