### PR TITLE
refactor(server): finish W5.INT + remove duplicate inline construction

### DIFF
--- a/internal/plugins/acoustid/register.go
+++ b/internal/plugins/acoustid/register.go
@@ -1,16 +1,21 @@
 // file: internal/plugins/acoustid/register.go
-// version: 1.0.0
+// version: 1.1.0
 
-// Service registry registration for the acoustid UOS plugin (W5).
+// Service registry registration for the acoustid UOS plugin (W5/W7).
 //
 // Mirrors the dedup plugin's registration shape — needs the dedup engine
 // + embedding store. Build returns nil when deps are unavailable.
+// PostInit self-registers the plugin's op-defs.
 
 package acoustid
 
 import (
+	"context"
+	"log"
+
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
@@ -28,4 +33,16 @@ func init() {
 			return New(engine, store, embStore), nil
 		},
 	})
+}
+
+func (p *Plugin) PostInit(ctx context.Context, c *serviceregistry.Container) error {
+	if p == nil {
+		return nil
+	}
+	wrapper, ok := serviceregistry.TryGet[*opsregistry.RegistryWrapper](c, "opregistry")
+	if !ok || wrapper == nil {
+		log.Printf("[plugins/acoustid] PostInit: opregistry not available, skipping op-def registration")
+		return nil
+	}
+	return p.Register(wrapper.Registry)
 }

--- a/internal/plugins/dedup/register.go
+++ b/internal/plugins/dedup/register.go
@@ -1,19 +1,25 @@
 // file: internal/plugins/dedup/register.go
-// version: 1.0.0
+// version: 1.1.0
 
-// Service registry registration for the dedup UOS plugin (W5).
+// Service registry registration for the dedup UOS plugin (W5/W7).
 //
 // Build returns the constructed *Plugin when all required services are
 // available, or nil when any dep is unavailable (no API key → no dedup
-// engine → no plugin). Inline NewServer construction continues to be
-// the production path that actually calls Plugin.Register(opRegistry);
-// W7 cleanup migrates that registration to PostInit.
+// engine → no plugin).
+//
+// PostInit (W7) self-registers the plugin's op-defs against the
+// container's opregistry, replacing the inline `Register(server.opRegistry)`
+// call that used to live in NewServer.
 
 package dedup
 
 import (
+	"context"
+	"log"
+
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
@@ -31,4 +37,20 @@ func init() {
 			return New(engine, store, embStore), nil
 		},
 	})
+}
+
+// PostInit self-registers this plugin's op-defs against the container's
+// opregistry. Called by Container.PostInit() after all services are built.
+//
+// Safe to call when the plugin is nil — early-returns without error.
+func (p *Plugin) PostInit(ctx context.Context, c *serviceregistry.Container) error {
+	if p == nil {
+		return nil
+	}
+	wrapper, ok := serviceregistry.TryGet[*opsregistry.RegistryWrapper](c, "opregistry")
+	if !ok || wrapper == nil {
+		log.Printf("[plugins/dedup] PostInit: opregistry not available, skipping op-def registration")
+		return nil
+	}
+	return p.Register(wrapper.Registry)
 }

--- a/internal/plugins/deluge/register.go
+++ b/internal/plugins/deluge/register.go
@@ -1,19 +1,22 @@
 // file: internal/plugins/deluge/register.go
-// version: 1.0.0
+// version: 1.1.0
 
-// Service registry registration for the deluge UOS plugin (W5).
+// Service registry registration for the deluge UOS plugin (W5/W7).
 //
 // Build returns nil when Deluge is not configured (no global client OR
-// no protected-path cache configured). Inline NewServer construction
-// continues to be the production path; W7 migrates registration to
-// PostInit.
+// no protected-path cache configured). PostInit self-registers the
+// plugin's op-defs.
 
 package deluge
 
 import (
+	"context"
+	"log"
+
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
@@ -32,4 +35,16 @@ func init() {
 			return New(client, cache, store), nil
 		},
 	})
+}
+
+func (p *Plugin) PostInit(ctx context.Context, c *serviceregistry.Container) error {
+	if p == nil {
+		return nil
+	}
+	wrapper, ok := serviceregistry.TryGet[*opsregistry.RegistryWrapper](c, "opregistry")
+	if !ok || wrapper == nil {
+		log.Printf("[plugins/deluge] PostInit: opregistry not available, skipping op-def registration")
+		return nil
+	}
+	return p.Register(wrapper.Registry)
 }

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/quarantine"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
@@ -163,5 +164,21 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	// batchpoller is conditional on OpenAI config — pull via TryGet.
 	if poller, ok := serviceregistry.TryGet[*BatchPoller](c, "batchpoller"); ok {
 		s.batchPoller = poller
+	}
+	// opRegistry — Get'd via the RegistryWrapper that exposes Start/Stop;
+	// callers use the embedded *opsregistry.Registry. Always present.
+	if wrapper, ok := serviceregistry.TryGet[*opsregistry.RegistryWrapper](c, "opregistry"); ok && wrapper != nil {
+		s.opRegistry = wrapper.Registry
+	}
+	if hub, ok := serviceregistry.TryGet[*opsregistry.EventHub](c, "ophub"); ok {
+		s.opHub = hub
+	}
+
+	// W4 services — embedding/AI cluster.
+	if embStore, ok := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore"); ok {
+		s.embeddingStore = embStore
+	}
+	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok {
+		s.dedupEngine = engine
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,7 +8,6 @@ package server
 import (
 	"context"
 	"log"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -39,9 +38,12 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/scheduler"
-	acoustidplugin "github.com/jdfalk/audiobook-organizer/internal/plugins/acoustid"
-	dedupplugin "github.com/jdfalk/audiobook-organizer/internal/plugins/dedup"
-	delugeplug "github.com/jdfalk/audiobook-organizer/internal/plugins/deluge"
+	// Blank-import the plugin packages so their init() functions run and
+	// the plugins register themselves with the serviceregistry. The
+	// container's PostInit calls Plugin.Register(opRegistry) for each.
+	_ "github.com/jdfalk/audiobook-organizer/internal/plugins/acoustid"
+	_ "github.com/jdfalk/audiobook-organizer/internal/plugins/dedup"
+	_ "github.com/jdfalk/audiobook-organizer/internal/plugins/deluge"
 	itunesplug "github.com/jdfalk/audiobook-organizer/internal/plugins/itunes"
 	maintenanceplugin "github.com/jdfalk/audiobook-organizer/internal/plugins/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
@@ -319,8 +321,8 @@ func NewServer(store database.Store) *Server {
 	}
 
 	// SERVER-PLUGIN-REG: build the service registry container.
-	// W1 + W2 services come from the container; W3-W5 still construct
-	// inline below. IncludeAll() comes once all services are registered (W7).
+	// W1-W4 services flow through the container; remaining inline
+	// construction is for things still being migrated (W5+).
 	regCtx := context.Background()
 	includeNames := []string{
 		// W1 — leaf services
@@ -328,8 +330,19 @@ func NewServer(store database.Store) *Server {
 		"scan", "dashboard", "system", "configupdate", "metadatastate",
 		// W2 — cross-wired services
 		"metafetch", "merge", "organize", "quarantine", "eventbus",
-		// W3 — backend orchestration
-		"batchpoller",
+		// W3 — backend orchestration (only those with no inline-conflict)
+		"batchpoller", "opregistry", "ophub",
+		// W4 — embedding/AI cluster. Each Build is config-gated and
+		// returns typed nil when preconditions aren't met. The dedup
+		// engine's chromem/aijobs/embedding wiring stays inline in
+		// NewServer for now.
+		"embeddingstore", "embedclient", "llmparser", "chromemstore",
+		"aijobsstore", "dedup", "metadatascorer", "metadatallmscorer",
+		// W5 — UOS plugins. PostInit self-registers their op-defs
+		// against the container's opregistry. maintenanceplugin and
+		// itunesplugin are stubs (server-bound closures); their inline
+		// Register calls remain in NewServer below.
+		"dedupplugin", "acoustidplugin", "delugeplugin",
 	}
 	// `activity` (+ `activitystore`) only registers when DatabasePath is
 	// set — the NutsDB sidecar can't open without a path. Match the
@@ -372,11 +385,10 @@ func NewServer(store database.Store) *Server {
 	// needs explicit construction here.
 	server.pluginRegistry = plugin.Global()
 
-	// Initialize the UOS-02 operations registry. The registry holds the
-	// OperationDef registration table, dispatcher, and worker pool.
-	// Plugins register their defs in their own bot-tasks (UOS-03+).
-	server.opHub = opsregistry.NewEventHub()
-	server.opRegistry = opsregistry.New(resolvedStore, slog.Default(), 8, server.opHub)
+	// server.opHub + server.opRegistry are populated by
+	// wireServerFromContainer above (W3.5 RegistryWrapper). The dispatcher
+	// is started in Server.Start (server_lifecycle.go) where the bgCtx is
+	// available — same lifecycle as before.
 
 	// SERVER-THIN-RESIDUAL: build the ExtraOpsRegistrar before the opRegistrars
 	// loop so the 13 scheduler ops (scheduler_extra_ops.go shim) can delegate
@@ -584,17 +596,9 @@ func NewServer(store database.Store) *Server {
 				log.Println("[INFO] Embedding store and dedup engine initialized")
 				server.metadataFetchService.SetDedupEngine(server.dedupEngine)
 
-				// Register UOS dedup plugin (UOS-07). Done here so the engine
-				// and embeddingStore are both available.
-				if err := dedupplugin.New(server.dedupEngine, resolvedStore, server.embeddingStore).Register(server.opRegistry); err != nil {
-					log.Printf("[server] dedup plugin register: %v", err)
-				}
-
-				// Register acoustid plugin so acoustid.fingerprint-rescan
-				// and acoustid.scan op-defs are available via the UOS registry.
-				if err := acoustidplugin.New(server.dedupEngine, resolvedStore, server.embeddingStore).Register(server.opRegistry); err != nil {
-					log.Printf("[server] acoustid plugin register: %v", err)
-				}
+				// dedupplugin + acoustidplugin op-def registration is now
+				// done in their PostInit methods (W7). Container.PostInit()
+				// runs them earlier in NewServer (before this block).
 
 				// Dedup-on-import is now wired via SetScanHooks below
 				// (together with the activity recorder).
@@ -837,12 +841,8 @@ func NewServer(store database.Store) *Server {
 		// Register the Deluge plugin (UOS-11).
 		// Guard on RootDir: tests don't configure AppConfig, so RootDir="" and the
 		// mock store has no UpsertOpDefinitionV2 expectations.
-		if config.AppConfig.RootDir != "" && dc != nil && server.protectedPathCache != nil {
-			delugePlugin := delugeplug.New(dc, server.protectedPathCache, resolvedStore)
-			if err := delugePlugin.Register(server.opRegistry); err != nil {
-				log.Printf("[server] deluge plugin register: %v", err)
-			}
-		}
+		// delugePlugin op-def registration is now done in its PostInit
+		// method (W7). Container.PostInit() runs it earlier in NewServer.
 	}
 
 	server.setupRoutes()


### PR DESCRIPTION
## Summary

Finishes the deferred W4.INT/W5.INT cleanup that was skipped during the initial 7-wave sweep. Three structural changes:

### 1. Plugin op-defs self-register via PostInit
- `internal/plugins/dedup/register.go`, `acoustid/register.go`, `deluge/register.go` each gain a `PostInit(ctx, c)` that pulls the opregistry from the container and calls `Plugin.Register(opRegistry)`.
- Inline `Plugin.Register(server.opRegistry)` calls for these 3 plugins are **deleted** from NewServer.
- Plugins are now `Include()`'d in NewServer; `Container.PostInit()` drives op-def registration. Plugins are blank-imported in server.go to ensure their `init()` runs.

### 2. opRegistry / opHub / embeddingStore / dedupEngine sourced from container
- `wireServerFromContainer` now pulls all four from the container.
- Inline `server.opRegistry = opsregistry.New(...)` + `server.opHub = opsregistry.NewEventHub()` deleted.
- The container's RegistryWrapper exposes `.Registry` to give callers the embedded `*opsregistry.Registry`.

### 3. Stubs remain (tracked separately)
- W3.1 `writebackbatcher` — still a typed-nil stub
- W5.1 `maintenanceplugin` — still stub  
- W5.2 `itunesplugin` — still stub
- All blocked on `PLUGIN-DECOUPLE-SERVER-CLOSURES` — `itunesservice.Service.Deps` carries server-bound closures (`OnBookCreated` → `server.fireDedupOnImport`, `OrganizerFactory`) and `maintenance.ServerDeps` holds `*Server`. Event-driven refactor needed.

The inline AI block at server.go:~511 still constructs a parallel dedupEngine/embeddingStore for the `SetChromemStore`/`SetAIJobsStore` wiring. Full deletion requires extracting `aiScanStore` + `pipelineManager` into the container — tracked under `SERVER-LIFECYCLE-FLIP`.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/serviceregistry/... -race` PASS
- [x] `go test ./internal/plugins/... -short -race` PASS
- [x] `go test ./internal/server/ -short -race -run 'TestHandler_|TestNewServer|TestRegister|TestServer'` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)