### PR TITLE
refactor(itunes): replace OnBookCreated closure with event-bus dispatch (PLUGIN-DECOUPLE pt.1)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/ai/aijobs"
@@ -51,6 +52,15 @@ type Engine struct {
 	// LLMMaxPairsPerRun caps how many pairs a single RunLLMReview invocation will
 	// send to the LLM. Zero means "all pending ambiguous candidates".
 	LLMMaxPairsPerRun int
+
+	// Background-context fields used by event-driven flows (e.g. dedup-on-import
+	// subscriber, chromem hydrate). Initialised lazily in PostInit so the
+	// engine doesn't need a New-time ctx and Stop can cleanly cancel
+	// outstanding work. Guarded by bgMu (RWMutex — readers are subscriber
+	// goroutines that snapshot the ctx; writers are PostInit and Stop).
+	bgCtx    context.Context
+	bgCancel context.CancelFunc
+	bgMu     sync.RWMutex
 }
 
 // NewEngine creates a Engine with sensible defaults.

--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -1,0 +1,93 @@
+// file: internal/dedup/lifecycle.go
+// version: 1.0.0
+
+// Lifecycle methods on *dedup.Engine that the serviceregistry container
+// picks up via interface satisfaction. PostInit subscribes to lifecycle
+// events on the plugin event bus so the engine reacts to book imports
+// from any source (filesystem watcher, iTunes importer, manual upload)
+// without a server-bound closure callback.
+//
+// Replaces server.fireDedupOnImport, which was wired via a closure in
+// itunesservice.Deps.OnBookCreated (removed in PLUGIN-DECOUPLE).
+
+package dedup
+
+import (
+	"context"
+	"log"
+
+	"github.com/jdfalk/audiobook-organizer/internal/plugin"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+// PostInit wires the dedup engine into the plugin event bus. Called by
+// Container.PostInit after Build completes. The engine subscribes to
+// EventBookImported and runs CheckBook in its own goroutine with the
+// engine's bg-context (NOT the event publisher's ctx — see Q1 brainstorm
+// decision in deferred-work doc).
+//
+// Safe to call when the engine is nil (Build returns nil when API key
+// isn't configured — typed-nil receiver allowed by Go method dispatch on
+// pointer types only when method has a nil-check, which we do).
+func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) error {
+	if de == nil {
+		return nil
+	}
+	bus, ok := serviceregistry.TryGet[*plugin.EventBus](c, "eventbus")
+	if !ok || bus == nil {
+		log.Printf("[dedup] PostInit: eventbus not available, skipping dedup-on-import subscription")
+		return nil
+	}
+	// Initialise the engine's own bg-context for subscriber goroutines.
+	// The event bus's Publish runs each handler in its own goroutine with
+	// the publisher's ctx; we ignore that ctx in favor of our own so a
+	// canceled publisher (e.g. test-only request ctx) doesn't kill our
+	// dedup check mid-flight.
+	de.bgMu.Lock()
+	if de.bgCtx == nil {
+		de.bgCtx, de.bgCancel = context.WithCancel(context.Background())
+	}
+	de.bgMu.Unlock()
+
+	bus.Subscribe(plugin.EventBookImported, de.onBookImported)
+	log.Printf("[dedup] PostInit: subscribed to EventBookImported")
+	return nil
+}
+
+// onBookImported is the EventHandler bound to EventBookImported. It runs
+// in a goroutine spawned by EventBus.Publish; we ignore the publisher's
+// ctx in favor of the engine's bg-context so external cancellation
+// (e.g. an HTTP request that just finished) doesn't cut the dedup check
+// off mid-stream.
+func (de *Engine) onBookImported(_ context.Context, evt plugin.Event) error {
+	if evt.BookID == "" {
+		return nil
+	}
+	de.bgMu.RLock()
+	bgCtx := de.bgCtx
+	de.bgMu.RUnlock()
+	if bgCtx == nil {
+		bgCtx = context.Background()
+	}
+	if _, err := de.CheckBook(bgCtx, evt.BookID); err != nil {
+		log.Printf("[WARN] dedup-on-import CheckBook(%s): %v", evt.BookID, err)
+	}
+	return nil
+}
+
+// Stop releases the engine's background-context resources. Called by
+// Container.Stop. Safe to call multiple times.
+func (de *Engine) Stop(ctx context.Context) error {
+	if de == nil {
+		return nil
+	}
+	de.bgMu.Lock()
+	defer de.bgMu.Unlock()
+	if de.bgCancel != nil {
+		de.bgCancel()
+		de.bgCancel = nil
+		de.bgCtx = nil
+	}
+	return nil
+}
+

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/oklog/ulid/v2"
 )
@@ -70,7 +71,7 @@ type albumGroup struct {
 type Importer struct {
 	store            Store
 	activityFn       func(database.ActivityEntry)
-	onBookCreated    func(bookID string)
+	eventBus         plugin.EventPublisher // may be nil; replaces OnBookCreated
 	cfg              Config
 	log              logger.Logger
 	mfs              *metafetch.Service
@@ -82,12 +83,25 @@ func newImporter(deps Deps) *Importer {
 	return &Importer{
 		store:            deps.Store,
 		activityFn:       deps.ActivityFn,
-		onBookCreated:    deps.OnBookCreated,
+		eventBus:         deps.EventBus,
 		cfg:              deps.Config,
 		log:              deps.Logger,
 		mfs:              deps.Metafetch,
 		organizerFactory: deps.OrganizerFactory,
 	}
+}
+
+// publishBookCreated emits a plugin.EventBookImported for bookID via the
+// event bus, if configured. Replaces the pre-PLUGIN-DECOUPLE OnBookCreated
+// callback. Subscribers (dedup engine, webhook plugin, etc.) receive the
+// event asynchronously and handle it with their own background contexts.
+func (imp *Importer) publishBookCreated(ctx context.Context, bookID string) {
+	if imp.eventBus == nil || bookID == "" {
+		return
+	}
+	imp.eventBus.Publish(ctx, plugin.NewEvent(plugin.EventBookImported, bookID, map[string]any{
+		"source": "itunes",
+	}))
 }
 
 // GetStatus returns an exported counter snapshot for opID.
@@ -248,9 +262,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 			continue
 		}
 
-		if imp.onBookCreated != nil {
-			imp.onBookCreated(created.ID)
-		}
+		imp.publishBookCreated(ctx, created.ID)
 
 		incImportImported(status)
 		newBookIDs = append(newBookIDs, created.ID)
@@ -644,9 +656,7 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 				log.Error("Failed to create '%s': %v", book.Title, err)
 			} else {
 				newBooks++
-				if imp.onBookCreated != nil {
-					imp.onBookCreated(created.ID)
-				}
+				imp.publishBookCreated(ctx, created.ID)
 				if created.AuthorID != nil && len(book.Authors) > 0 {
 					for i := range book.Authors {
 						book.Authors[i].BookID = created.ID

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/service.go
-// version: 1.6.0
+// version: 2.0.0
 // guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
 
 package itunesservice
@@ -11,17 +11,22 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/realtime"
 )
 
 // Deps is the explicit dependency set for Service. No globals, no Server,
-// no config.AppConfig — everything the service needs is passed in.
+// no closure captures of server-owned state.
+//
+// PLUGIN-DECOUPLE (May 13, 2026): replaced two server-bound closure fields
+// with event-bus + organizer-factory deps that don't capture *Server.
+// This unblocks the container's ability to construct itunesservice.
 type Deps struct {
 	Store      Store
 	ActivityFn func(database.ActivityEntry)
-	Realtime         *realtime.EventHub // may be nil; means no SSE push
-	Config           Config
-	Logger           logger.Logger
+	Realtime   *realtime.EventHub // may be nil; means no SSE push
+	Config     Config
+	Logger     logger.Logger
 	// AudiobookRoot is the on-disk audiobook tree the path-repair
 	// operation walks for tier B (embedded tag scan) and tier C
 	// (fuzzy match). Empty disables those tiers.
@@ -29,14 +34,26 @@ type Deps struct {
 	// ReportDir is where the path-repair operation drops its JSON
 	// report file. Empty means inline-only (no file).
 	ReportDir string
-	// OnBookCreated fires after CreateBook so the dedup engine can check
-	// new iTunes imports against the organized library. May be nil.
-	OnBookCreated    func(bookID string)
+	// EventBus is where the service publishes lifecycle events. The
+	// dedup engine subscribes to plugin.EventBookImported and runs its
+	// dedup-on-import check there. May be nil (no events published).
+	//
+	// Replaces the pre-PLUGIN-DECOUPLE `OnBookCreated func(bookID string)`
+	// callback, which captured server.fireDedupOnImport and prevented
+	// container-based construction.
+	EventBus plugin.EventPublisher
 	// Metafetch is a pre-constructed metafetch service used during
 	// metadata enrichment. May be nil (enrichment becomes a no-op).
-	Metafetch        *metafetch.Service
+	Metafetch *metafetch.Service
 	// OrganizerFactory builds a BookOrganizer on demand. Required when
 	// ImportMode is organize/organized. May be nil (organize phase skipped).
+	//
+	// Post PLUGIN-DECOUPLE the factory must be a pure-data closure (no
+	// server captures); callers pass e.g.
+	//   OrganizerFactory: func() BookOrganizer {
+	//       return organizer.NewOrganizer(&config.AppConfig)
+	//   }
+	// which only captures the package-level config pointer.
 	OrganizerFactory func() BookOrganizer
 }
 

--- a/internal/plugin/events.go
+++ b/internal/plugin/events.go
@@ -75,8 +75,11 @@ func (b *EventBus) Subscribe(eventType EventType, handler EventHandler) {
 	b.subscribers[eventType] = append(b.subscribers[eventType], handler)
 }
 
-// Publish sends an event to all subscribers. Handlers run in goroutines.
-// Errors are logged but do not propagate to the publisher.
+// Publish sends an event to all subscribers. Handlers run in goroutines
+// with panic recovery so a buggy subscriber can't crash the publisher
+// (per the May 13 Q1 brainstorm — async dispatch, panic-isolated).
+//
+// Errors and recovered panics are logged but do not propagate.
 func (b *EventBus) Publish(ctx context.Context, event Event) {
 	b.mu.RLock()
 	handlers := b.subscribers[event.Type]
@@ -85,6 +88,11 @@ func (b *EventBus) Publish(ctx context.Context, event Event) {
 	for _, handler := range handlers {
 		h := handler // capture
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[ERROR] plugin event handler panicked for %s: %v", event.Type, r)
+				}
+			}()
 			if err := h(ctx, event); err != nil {
 				log.Printf("[WARN] plugin event handler error for %s: %v", event.Type, err)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -420,10 +420,10 @@ func NewServer(store database.Store) *Server {
 		Config:        itunesCfg,
 		AudiobookRoot: config.AppConfig.RootDir,
 		ReportDir:     filepath.Join(config.AppConfig.RootDir, "reports"),
-		OnBookCreated: func(bookID string) {
-			// Resolved lazily via closure so server.fireDedupOnImport is available.
-			server.fireDedupOnImport(bookID)
-		},
+		// PLUGIN-DECOUPLE: publish BookImported via event bus instead of
+		// the pre-decouple OnBookCreated closure that captured *Server.
+		// dedup.Engine.PostInit subscribes to EventBookImported.
+		EventBus:  server.eventBus,
 		Metafetch: server.metadataFetchService,
 		OrganizerFactory: func() itunesservice.BookOrganizer {
 			return organizer.NewOrganizer(&config.AppConfig)


### PR DESCRIPTION
## Summary
PLUGIN-DECOUPLE-SERVER-CLOSURES, part 1 — itunesservice decoupled from `*Server` via event bus.

Replaces `itunesservice.Deps.OnBookCreated` (closure capturing `server.fireDedupOnImport`, blocked container-based construction) with `plugin.EventBookImported` dispatch via the container's eventbus.

## Changes

- `internal/plugin/events.go`: `EventBus.Publish` gains panic recovery (Q1 brainstorm).
- `internal/itunes/service/service.go`: Deps drops `OnBookCreated`, gains `EventBus plugin.EventPublisher`.
- `internal/itunes/service/importer.go`: Importer publishes `EventBookImported` (`source: itunes`) after CreateBook.
- `internal/dedup/engine.go` + new `internal/dedup/lifecycle.go`: Engine gains bgCtx/bgCancel/bgMu + `PostInit` that subscribes to `EventBookImported` via the container's eventbus. Handler ignores publisher's ctx (Q1 decoupled-contexts decision).
- `internal/server/server.go`: itunesservice construction passes `server.eventBus` instead of the closure.

## What's NOT in this PR (follow-ups)

- `OrganizerFactory` closure still uses `&config.AppConfig` — that's a pure-data capture and acceptable. Kept inline.
- `server.fireDedupOnImport` function still exists (1 inline caller remains); removed by SERVER-LIFECYCLE-FLIP.
- itunesservice still constructed inline in NewServer — un-stubbing W3.1 writebackbatcher / W5.2 itunesplugin needs the full container registration of itunes, which is a follow-up.
- maintenance plugin (W5.1 stub) still blocked on `ServerDeps` — separate ticket.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/dedup/... -race` PASS
- [x] `go test ./internal/plugin/... -race` PASS  
- [x] `go test ./internal/itunes/service/... -race` PASS
- [x] `go test ./internal/server/ -short -race -run 'TestHandler_|TestNewServer|TestRegister|TestServer'` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)