### PR TITLE
refactor(server): delete inline AI block; PostInit drives all wiring (SERVER-LIFECYCLE-FLIP pt.1)

### DIFF
--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -15,27 +15,32 @@ package dedup
 import (
 	"context"
 	"log"
+	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
-// PostInit wires the dedup engine into the plugin event bus. Called by
-// Container.PostInit after Build completes. The engine subscribes to
-// EventBookImported and runs CheckBook in its own goroutine with the
-// engine's bg-context (NOT the event publisher's ctx — see Q1 brainstorm
-// decision in deferred-work doc).
+// PostInit wires the dedup engine into the rest of the container. Called
+// by Container.PostInit after Build completes. Three steps:
+//
+//  1. Subscribe to plugin.EventBookImported via the eventbus so any source
+//     (iTunes import, filesystem watcher, manual upload) triggers a dedup
+//     check on the new book.
+//  2. Pull chromem-go ANN store (optional, soft) and wire it via
+//     SetChromemStore. Launch the chromem hydration goroutine on the
+//     engine's bg-context.
+//  3. Pull AIJobsStore (interface assertion against the main store) and
+//     wire it for async dedup review batches. Register the engine as the
+//     dedup verdict applier for batch callbacks.
 //
 // Safe to call when the engine is nil (Build returns nil when API key
 // isn't configured — typed-nil receiver allowed by Go method dispatch on
 // pointer types only when method has a nil-check, which we do).
 func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) error {
 	if de == nil {
-		return nil
-	}
-	bus, ok := serviceregistry.TryGet[*plugin.EventBus](c, "eventbus")
-	if !ok || bus == nil {
-		log.Printf("[dedup] PostInit: eventbus not available, skipping dedup-on-import subscription")
 		return nil
 	}
 	// Initialise the engine's own bg-context for subscriber goroutines.
@@ -47,10 +52,41 @@ func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) er
 	if de.bgCtx == nil {
 		de.bgCtx, de.bgCancel = context.WithCancel(context.Background())
 	}
+	bgCtx := de.bgCtx
 	de.bgMu.Unlock()
 
-	bus.Subscribe(plugin.EventBookImported, de.onBookImported)
-	log.Printf("[dedup] PostInit: subscribed to EventBookImported")
+	// Step 1 — event bus subscription
+	if bus, ok := serviceregistry.TryGet[*plugin.EventBus](c, "eventbus"); ok && bus != nil {
+		bus.Subscribe(plugin.EventBookImported, de.onBookImported)
+		log.Printf("[dedup] PostInit: subscribed to EventBookImported")
+	} else {
+		log.Printf("[dedup] PostInit: eventbus not available, skipping dedup-on-import subscription")
+	}
+
+	// Step 2 — chromem store + hydrate
+	if chromemStore, ok := serviceregistry.TryGet[*database.ChromemEmbeddingStore](c, "chromemstore"); ok && chromemStore != nil {
+		de.SetChromemStore(chromemStore)
+		log.Println("[INFO] chromem-go ANN store active for dedup Layer 2")
+		// Hydrate asynchronously on the engine's bg-context.
+		go func() {
+			hCtx, cancel := context.WithTimeout(bgCtx, 30*time.Minute)
+			defer cancel()
+			books, authors, err := de.HydrateChromem(hCtx)
+			if err != nil {
+				log.Printf("[WARN] chromem hydrate finished with error: %v (books=%d authors=%d)", err, books, authors)
+				return
+			}
+			log.Printf("[INFO] chromem hydrate complete: books=%d authors=%d", books, authors)
+		}()
+	}
+
+	// Step 3 — aijobs store + verdict applier
+	if jobs, ok := serviceregistry.TryGet[database.AIJobsStore](c, "aijobsstore"); ok && jobs != nil {
+		de.SetAIJobsStore(jobs)
+		ai.SetDedupVerdictApplier(de)
+		log.Println("[INFO] Dedup async review (aijobs) wired")
+	}
+
 	return nil
 }
 

--- a/internal/metafetch/lifecycle.go
+++ b/internal/metafetch/lifecycle.go
@@ -1,0 +1,69 @@
+// file: internal/metafetch/lifecycle.go
+// version: 1.0.0
+
+// Lifecycle methods on *metafetch.Service that the serviceregistry
+// container picks up via interface satisfaction. PostInit wires the
+// service's dependencies (dedup engine, scorers, activity service) by
+// pulling them from the container. Replaces the inline SetX block that
+// lived in NewServer's AI cluster region.
+
+package metafetch
+
+import (
+	"context"
+	"log"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+// PostInit wires metafetch's optional dependencies into the service.
+// Each dep is TryGet'd — if absent (config-gated services that built to
+// nil), the corresponding Set call is skipped. The service degrades
+// gracefully: scoring tiers + dedup hooks just don't fire.
+//
+// Replaces inline SetX calls from NewServer's pre-W7 AI block.
+// Specifically:
+//
+//   - SetDedupEngine   (W4 dedup, config-gated)
+//   - SetMetadataScorer (W4 metadatascorer, config-gated)
+//   - SetMetadataLLMScorer (W4 metadatallmscorer, config-gated)
+//   - SetActivityService (W2 activity, DatabasePath-gated)
+//
+// Several other SetX calls (SetISBNEnrichment, SetOLStore, SetSafeWriteDeps,
+// SetWriteBackBatcher) still live inline in NewServer because they depend
+// on server-local state (olService, protectedPathCache) that isn't in
+// the container yet. Those move when their underlying services migrate.
+func (mfs *Service) PostInit(ctx context.Context, c *serviceregistry.Container) error {
+	if mfs == nil {
+		return nil
+	}
+
+	// Dedup engine wiring — engine is config-gated, may be nil
+	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok && engine != nil {
+		mfs.SetDedupEngine(engine)
+		log.Printf("[metafetch] PostInit: SetDedupEngine wired")
+	}
+
+	// Embedding scorer — config-gated on MetadataEmbeddingScoringEnabled
+	if scorer, ok := serviceregistry.TryGet[*ai.EmbeddingScorer](c, "metadatascorer"); ok && scorer != nil {
+		mfs.SetMetadataScorer(scorer)
+		log.Println("[INFO] Metadata candidate scoring: embedding tier enabled")
+	}
+
+	// LLM rerank scorer — wired unconditionally when llmparser is
+	// available; the per-search use_rerank flag + MetadataLLMScoringEnabled
+	// config gate whether it actually fires.
+	if scorer, ok := serviceregistry.TryGet[*ai.LLMScorer](c, "metadatallmscorer"); ok && scorer != nil {
+		mfs.SetMetadataLLMScorer(scorer)
+	}
+
+	// Activity service — DatabasePath-gated
+	if svc, ok := serviceregistry.TryGet[*activity.Service](c, "activity"); ok && svc != nil {
+		mfs.SetActivityService(svc)
+	}
+
+	return nil
+}

--- a/internal/plugins/deluge/register.go
+++ b/internal/plugins/deluge/register.go
@@ -27,6 +27,13 @@ func init() {
 		Groups: []string{"plugins"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
+			// Mirror the original inline guard: skip when library root
+			// isn't configured (test paths). Without this, MockStore-based
+			// tests blow up because PostInit's Plugin.Register triggers
+			// UpsertOpDefinitionV2 calls the mock doesn't expect.
+			if cfg.RootDir == "" {
+				return (*Plugin)(nil), nil
+			}
 			client := delugeclient.GetClient()
 			if client == nil {
 				return (*Plugin)(nil), nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -500,145 +500,45 @@ func NewServer(store database.Store) *Server {
 		}
 	}
 
-	// Open embedding store for dedup (PebbleDB-backed, shared with main DB).
+	// One-shot migration from the legacy embeddings.db SQLite sidecar.
+	// Safe to call every startup: a flag key in PebbleDB prevents re-runs.
+	// Stays inline (not a service) because it's a one-time migration step,
+	// not a runtime dependency.
 	if dbPath := config.AppConfig.DatabasePath; dbPath != "" {
 		dbDir := filepath.Dir(dbPath)
-		// One-shot migration from the legacy embeddings.db SQLite sidecar.
-		// Safe to call every startup: a flag key in PebbleDB prevents re-runs.
 		if ps, ok := database.GetGlobalStore().(*database.PebbleStore); ok {
 			if migrateErr := database.MigrateEmbeddingsFromSQLite(ps.DB(), filepath.Join(dbDir, "embeddings.db")); migrateErr != nil {
 				log.Printf("[WARN] embeddings.db migration error (continuing): %v", migrateErr)
 			}
-			embeddingStore := database.NewEmbeddingStore(ps.DB())
-			server.embeddingStore = embeddingStore
-			if config.AppConfig.OpenAIAPIKey != "" && config.AppConfig.EmbeddingEnabled {
-				// Wire the embedding store as a content-hash cache so
-				// repeated embeds of identical text (e.g. "Foundation
-				// by Isaac Asimov" appearing as a candidate across
-				// many metadata fetches) return instantly without
-				// re-hitting OpenAI. Added after the 2026-04-11 quota
-				// incident where a single bulk fetch burned the
-				// entire monthly budget by re-embedding every
-				// candidate on every fetch.
-				embedClient := ai.NewEmbeddingClient(config.AppConfig.OpenAIAPIKey).
-					WithCache(embeddingStore)
-				// Dedup Layer 3 uses a dedicated chat parser so it can call
-				// OpenAIParser.ReviewDedupPairs during maintenance runs.
-				llmParser := ai.NewOpenAIParser(&config.AppConfig, config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
-				server.dedupEngine = dedup.NewEngine(
-					embeddingStore,
-					database.GetGlobalStore(),
-					embedClient,
-					llmParser,
-					server.mergeService,
-				)
-				server.dedupEngine.BookHighThreshold = config.AppConfig.DedupBookHighThreshold
-				server.dedupEngine.BookLowThreshold = config.AppConfig.DedupBookLowThreshold
-				server.dedupEngine.AuthorHighThreshold = config.AppConfig.DedupAuthorHighThreshold
-				server.dedupEngine.AuthorLowThreshold = config.AppConfig.DedupAuthorLowThreshold
-				server.dedupEngine.AutoMergeEnabled = config.AppConfig.DedupAutoMergeEnabled
-				server.extraOpsRegistrar.Deps.DedupEngine = server.dedupEngine
-
-				// Wire chromem-go ANN store if available.
-				chromemDir := dbDir
-				chromemStore, chromemErr := database.NewChromemEmbeddingStore(chromemDir, 3072)
-				if chromemErr != nil {
-					log.Printf("[WARN] chromem-go init failed (falling back to PebbleDB linear scan): %v", chromemErr)
-				} else {
-					server.dedupEngine.SetChromemStore(chromemStore)
-					log.Println("[INFO] chromem-go ANN store active for dedup Layer 2")
-
-					// Hydrate chromem from the PebbleDB embeddings namespace in
-					// the background. Without this, an empty or stale
-					// chromem dir means Layer 2 returns zero matches even
-					// though tens of thousands of embeddings exist on disk.
-					// Run async so it doesn't block startup; the dedup
-					// engine works (slowly) before hydration completes
-					// because mirrorBookToChromem populates entries on
-					// demand whenever EmbedBook is called.
-					go func() {
-						hCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-						defer cancel()
-						books, authors, err := server.dedupEngine.HydrateChromem(hCtx)
-						if err != nil {
-							log.Printf("[WARN] chromem hydrate finished with error: %v (books=%d authors=%d)", err, books, authors)
-							return
-						}
-						log.Printf("[INFO] chromem hydrate complete: books=%d authors=%d", books, authors)
-					}()
-				}
-
-				// Wire aijobs store for async dedup review batches.
-				if aiJobsStore, ok := database.GetGlobalStore().(database.AIJobsStore); ok {
-					server.dedupEngine.SetAIJobsStore(aiJobsStore)
-					// Register the engine as the dedup verdict applier for batch callbacks.
-					ai.SetDedupVerdictApplier(server.dedupEngine)
-					log.Println("[INFO] Dedup async review (aijobs) wired")
-				} else {
-					log.Println("[WARN] Global store does not implement AIJobsStore; dedup async review disabled")
-				}
-
-				log.Println("[INFO] Embedding store and dedup engine initialized")
-				server.metadataFetchService.SetDedupEngine(server.dedupEngine)
-
-				// dedupplugin + acoustidplugin op-def registration is now
-				// done in their PostInit methods (W7). Container.PostInit()
-				// runs them earlier in NewServer (before this block).
-
-				// Dedup-on-import is now wired via SetScanHooks below
-				// (together with the activity recorder).
-				log.Println("[INFO] Dedup-on-import hook wired via SetScanHooks")
-
-				// Wire the organize collision hook. When OrganizeBook
-				// hits ErrTargetOccupied (two books with identical
-				// metadata producing the same target path, or a re-organize
-				// of a content-duplicate), this hook creates a pending
-				// "exact" dedup candidate between the current book and the
-				// book that already owns the target. Without it, the
-				// collision would surface only as an opaque error and the
-				// user would have no trail to follow.
-				//
-				// Runs inside a bgWG-tracked goroutine so it doesn't block
-				// the organize caller and shutdown drains it cleanly.
-				server.organizeService.SetOrganizeHooks(&serverOrganizeHooks{server: server})
-				log.Println("[INFO] Organize collision hook wired via OrganizeService")
-
-				// Wire the embedding-based metadata candidate scorer. The
-				// scorer reuses the same embedClient + embeddingStore as the
-				// dedup engine; it's a lightweight wrapper exposing the
-				// MetadataCandidateScorer interface. Any failure at search
-				// time falls back to the F1 path inside scoreBaseCandidates,
-				// so this is safe to leave wired up unconditionally once
-				// the embedding infra is available.
-				if config.AppConfig.MetadataEmbeddingScoringEnabled {
-					server.metadataFetchService.SetMetadataScorer(
-						ai.NewEmbeddingScorer(embedClient, embeddingStore),
-					)
-					log.Println("[INFO] Metadata candidate scoring: embedding tier enabled")
-				}
-
-				// Wire the LLM rerank scorer. It reuses the same llmParser
-				// the dedup engine uses for Layer 3 review. The scorer is
-				// injected unconditionally — the per-search use_rerank flag
-				// and the MetadataLLMScoringEnabled config key together gate
-				// whether it actually fires.
-				server.metadataFetchService.SetMetadataLLMScorer(ai.NewLLMScorer(llmParser))
-				if config.AppConfig.MetadataLLMScoringEnabled {
-					log.Println("[INFO] Metadata candidate scoring: LLM rerank tier enabled (opt-in per search)")
-				} else {
-					log.Println("[INFO] Metadata candidate scoring: LLM rerank tier wired but disabled in config")
-				}
-			} else {
-				log.Println("[INFO] Embedding store opened (dedup engine disabled — no API key or embedding_enabled=false)")
-			}
 		}
+	}
+
+	// AI cluster (embeddingstore / embedclient / llmparser / chromemstore /
+	// aijobsstore / dedup / metadatascorer / metadatallmscorer) is now
+	// fully container-driven. dedup.Engine.PostInit wires SetChromemStore,
+	// SetAIJobsStore, SetDedupVerdictApplier + launches the chromem hydrate
+	// goroutine. metafetch.Service.PostInit wires SetDedupEngine,
+	// SetMetadataScorer, SetMetadataLLMScorer, SetActivityService.
+	// extraOpsRegistrar's DedupEngine dep gets the container's engine.
+	if server.dedupEngine != nil {
+		server.extraOpsRegistrar.Deps.DedupEngine = server.dedupEngine
+	}
+
+	// Organize collision hook stays inline because it uses serverOrganizeHooks
+	// which captures *Server (bgCtx + bgWG + cross-service helpers). Moving
+	// it requires further decoupling — tracked under SERVER-LIFECYCLE-FLIP.
+	if server.dedupEngine != nil {
+		server.organizeService.SetOrganizeHooks(&serverOrganizeHooks{server: server})
+		log.Println("[INFO] Organize collision hook wired via OrganizeService")
 	}
 
 	// Start embedding backfill if dedup engine is ready. Tracked via
 	// bgWG so Shutdown() can wait for it to finish before the database
 	// closes — without this, a backfill still iterating Pebble when the
 	// server stops will leave iterators open and panic inside Pebble's
-	// FileCache.Unref during Close().
+	// FileCache.Unref during Close(). Could move into a Starter on
+	// dedup.Engine; deferred for now because the goroutine wants the
+	// server's bgWG for Shutdown coordination.
 	if server.dedupEngine != nil {
 		server.bgWG.Add(1)
 		go func() {


### PR DESCRIPTION
## Summary
NewServer shrinks **577 → 462 lines (-115)** by moving the 140-line AI cluster inline block into PostInit methods on `dedup.Engine` and `metafetch.Service`.

This finishes W4.INT and is the first chunk of SERVER-LIFECYCLE-FLIP.

## What moved into PostInit

**`dedup.Engine.PostInit`** (extended from PR #887):
- `SetChromemStore` from container's `chromemstore`
- Chromem hydrate goroutine launches on engine's bg-context
- `SetAIJobsStore` from container's `aijobsstore`  
- `ai.SetDedupVerdictApplier(de)` for batch callbacks

**`metafetch.Service.PostInit` (new):**
- `SetDedupEngine` from container's `dedup`
- `SetMetadataScorer` from container's `metadatascorer`
- `SetMetadataLLMScorer` from container's `metadatallmscorer`  
- `SetActivityService` from container's `activity`

## What stays inline (documented)

- Embeddings.db one-shot migration (migration step, not runtime dep)
- Organize collision hook (`serverOrganizeHooks` captures `*Server`)
- Embedding backfill goroutine (needs server's `bgWG` for Shutdown coordination)

## Fix included
deluge plugin Build now guards on `cfg.RootDir != ""` — without this, MockStore-based tests blew up because PostInit's `Plugin.Register` triggered `UpsertOpDefinitionV2` calls the mock didn't expect. Mirrors the original inline guard that PR #882 lost.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/serviceregistry/... ./internal/dedup/... ./internal/metafetch/... ./internal/ai/... -race` PASS
- [x] `go test ./internal/server/ -short -race` — only SERVER-THIN-8 pre-existing timeouts fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)