### PR TITLE
refactor(server): container-build itunesservice; delete inline block

### DIFF
--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,9 +1,10 @@
 // file: internal/server/registry_wire.go
-// version: 1.3.0
+// version: 1.4.0
 
 package server
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
@@ -15,9 +16,11 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"github.com/jdfalk/audiobook-organizer/internal/merge"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/quarantine"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
@@ -128,6 +131,51 @@ func init() {
 			return engine, nil
 		},
 	})
+
+	// itunes — the iTunes integration service. Registered here (rather
+	// than in internal/itunes/service/register.go) because the
+	// OrganizerFactory closure needs internal/organizer + internal/config,
+	// and itunesservice deliberately avoids importing internal/organizer
+	// (see internal/itunes/service/types.go BookOrganizer comment).
+	//
+	// Construction never returns an error in practice: itunesservice.New
+	// returns NewDisabled() when cfg.Enabled is false. The "Enabled: true"
+	// flag here mirrors the pre-container inline construction in NewServer
+	// — the per-feature toggles (AutoWriteBack, ITLWriteBackEnabled) come
+	// from AppConfig.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "itunes",
+		Needs:  []string{"store", "config", "eventbus", "metafetch"},
+		Groups: []string{"core"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			bus := serviceregistry.Get[*plugin.EventBus](c, "eventbus")
+			mf := serviceregistry.Get[*metafetch.Service](c, "metafetch")
+			svc, err := itunesservice.New(itunesservice.Deps{
+				Store: store,
+				Config: itunesservice.Config{
+					Enabled:             true,
+					LibraryReadPath:     cfg.ITunesLibraryReadPath,
+					LibraryWritePath:    cfg.ITunesLibraryWritePath,
+					AutoWriteBack:       cfg.ITunesAutoWriteBack,
+					ITLWriteBackEnabled: cfg.ITLWriteBackEnabled,
+				},
+				AudiobookRoot: cfg.RootDir,
+				ReportDir:     filepath.Join(cfg.RootDir, "reports"),
+				EventBus:      bus,
+				Metafetch:     mf,
+				OrganizerFactory: func() itunesservice.BookOrganizer {
+					return organizer.NewOrganizer(cfg)
+				},
+			})
+			if err != nil {
+				log.Printf("[WARN] iTunes service construction failed, falling back to disabled: %v", err)
+				return itunesservice.NewDisabled(), nil
+			}
+			return svc, nil
+		},
+	})
 }
 
 // wireServerFromContainer populates the typed service fields on *Server
@@ -186,4 +234,9 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok {
 		s.dedupEngine = engine
 	}
+
+	// itunesservice.Service — container-built since PLUGIN-DECOUPLE-CLOSURES
+	// (May 13, 2026). Replaces the prior inline itunesservice.New(...) call
+	// in NewServer. Always present (Build returns NewDisabled() on error).
+	s.itunesSvc = serviceregistry.Get[*itunesservice.Service](c, "itunes")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -403,43 +403,13 @@ func NewServer(store database.Store) *Server {
 		}
 	}
 
-	// Construct the iTunes service. Phase 2 M1 step 1 enables it via New()
-	// so the real TrackProvisioner gets wired into the import pipeline;
-	// remaining sub-components stay as empty-struct placeholders until
-	// they move in later M1 steps. Disabled fallback is preserved for
-	// construction failures or (future) test paths that explicitly opt out.
-	itunesCfg := itunesservice.Config{
-		Enabled:             true,
-		LibraryReadPath:     config.AppConfig.ITunesLibraryReadPath,
-		LibraryWritePath:    config.AppConfig.ITunesLibraryWritePath,
-		AutoWriteBack:       config.AppConfig.ITunesAutoWriteBack,
-		ITLWriteBackEnabled: config.AppConfig.ITLWriteBackEnabled,
-	}
-	itunesSvc, err := itunesservice.New(itunesservice.Deps{
-		Store:         resolvedStore,
-		Config:        itunesCfg,
-		AudiobookRoot: config.AppConfig.RootDir,
-		ReportDir:     filepath.Join(config.AppConfig.RootDir, "reports"),
-		// PLUGIN-DECOUPLE: publish BookImported via event bus instead of
-		// the pre-decouple OnBookCreated closure that captured *Server.
-		// dedup.Engine.PostInit subscribes to EventBookImported.
-		EventBus:  server.eventBus,
-		Metafetch: server.metadataFetchService,
-		OrganizerFactory: func() itunesservice.BookOrganizer {
-			return organizer.NewOrganizer(&config.AppConfig)
-		},
-	})
-	if err != nil {
-		log.Printf("[WARN] iTunes service construction failed, falling back to disabled: %v", err)
-		itunesSvc = itunesservice.NewDisabled()
-	}
-	server.itunesSvc = itunesSvc
-
-	// Register iTunes plugin (UOS-10)
-	// Guard on RootDir: tests don't configure AppConfig, so RootDir="" and the
-	// mock store has no UpsertOpDefinitionV2 expectations.
-	if config.AppConfig.RootDir != "" && itunesSvc != nil && itunesSvc.Enabled() {
-		itunesPlugin := itunesplug.New(itunesSvc, resolvedStore)
+	// iTunes service is container-built in registry_wire.go and wired into
+	// server.itunesSvc by wireServerFromContainer above. The plugin
+	// registration stays inline here because it depends on server.opRegistry
+	// (which is itself container-wired) and the RootDir guard mirrors the
+	// other plugin-registration guards in this block.
+	if config.AppConfig.RootDir != "" && server.itunesSvc != nil && server.itunesSvc.Enabled() {
+		itunesPlugin := itunesplug.New(server.itunesSvc, resolvedStore)
 		if err := itunesPlugin.Register(server.opRegistry); err != nil {
 			log.Printf("[server] iTunes plugin register: %v", err)
 		}


### PR DESCRIPTION
## Summary

Continues PLUGIN-DECOUPLE-SERVER-CLOSURES by moving `itunesservice.New(...)` out of `NewServer` and into the service registry, mirroring the pattern used for dedup/embeddingstore.

## Changes

- **`internal/server/registry_wire.go`** — new `"itunes"` `ServiceDef` (`Needs: store, config, eventbus, metafetch`; `Groups: ["core"]`). Build pulls deps from the container and constructs the same `Deps{}` value the inline code did. Falls back to `NewDisabled()` on error, identical to prior behavior. Registered here (not in `internal/itunes/service/register.go`) because `OrganizerFactory` needs `internal/organizer` + `internal/config`, and the itunesservice package deliberately doesn't import them (see `internal/itunes/service/types.go` `BookOrganizer` comment — the factory exists *because* of this constraint).
- **`internal/server/registry_wire.go` `wireServerFromContainer`** — one `Get` call sets `s.itunesSvc`.
- **`internal/server/server.go`** — deletes the inline `itunesCfg := itunesservice.Config{...}` + `itunesservice.New(...)` block (~30 lines). The downstream iTunes plugin registration block (lines reading `server.itunesSvc.Enabled()`) stays inline — it depends on `server.opRegistry` and the `RootDir` guard, both of which already live in `NewServer`.

`NewServer` line count: **462 → 432** (target ≤50).

## Why no writebackbatcher de-stub

The `"writebackbatcher"` stub in `internal/itunes/service/register.go` *can* now depend on `"itunes"` and return the real `svc.Batcher`. Deliberately left for a follow-up PR (PROMOTE-STUB-REGISTRATIONS) so this PR stays scoped to "move itunes into the container".

## Verification

```bash
go build ./...                # clean
go vet ./...                  # clean
go test ./internal/server -short -race -timeout=180s \
  -run "TestHandler_|TestNewServer|TestRegister|TestServer"   # ok 9.4s
go test ./internal/itunes/service ./internal/serviceregistry \
  -short -race                                                # ok
```

`internal/itunes TestBackfillExternalIDsCollectsBookPIDs` times out on `main` too (pre-existing SERVER-THIN-8 class); not introduced here.

## Test plan

- [x] go build clean
- [x] go vet clean
- [x] Server test subset green
- [x] itunes/service + serviceregistry tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)