### PR TITLE
refactor(updater): wire appversion via container; pull updater + scheduler from registry

### DIFF
--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 	"github.com/jdfalk/audiobook-organizer/internal/sysinfo"
+	"github.com/jdfalk/audiobook-organizer/internal/updater"
 	"github.com/jdfalk/audiobook-organizer/internal/work"
 )
 
@@ -246,4 +247,17 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	// (May 13, 2026). Replaces the prior inline itunesservice.New(...) call
 	// in NewServer. Always present (Build returns NewDisabled() on error).
 	s.itunesSvc = serviceregistry.Get[*itunesservice.Service](c, "itunes")
+
+	// updater + updateScheduler — container-built since the updater
+	// LIFECYCLE-FLIP prep (May 13, 2026). Real version flows in via the
+	// "appversion" Override that NewServer sets to appVersion. The
+	// SchedulerStarterAdapter wraps Scheduler.Start/Stop for the eventual
+	// Container.Start hand-off; until then NewServer calls .Start()
+	// inline against the embedded scheduler.
+	if upd, ok := serviceregistry.TryGet[*updater.Updater](c, "updater"); ok {
+		s.updater = upd
+	}
+	if adapter, ok := serviceregistry.TryGet[*updater.SchedulerStarterAdapter](c, "updatescheduler"); ok && adapter != nil {
+		s.updateScheduler = adapter.Scheduler()
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -315,7 +315,8 @@ func NewServer(store database.Store) *Server {
 		listCache:              cache.New[gin.H]("list", 24*time.Hour),
 		facetsCache:            cache.New[gin.H]("facets", 24*time.Hour),
 		olService:              metafetch.NewOpenLibraryService(),
-		updater:                updater.NewUpdater(appVersion),
+		// updater + updateScheduler are container-built (see
+		// internal/updater/register.go). wireServerFromContainer sets them.
 		diagnosticsService:     diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),
 		changelogService:       activity.NewChangelogService(resolvedStore),
 	}
@@ -330,6 +331,7 @@ func NewServer(store database.Store) *Server {
 	regContainer := serviceregistry.NewContainer().
 		Override("store", resolvedStore).
 		Override("config", &config.AppConfig).
+		Override("appversion", appVersion).
 		IncludeGroup("core", "ai", "scheduler", "plugins").
 		// W3.6 batchpoller is in scheduler group; opregistry/ophub are
 		// in scheduler group. No additional explicit names needed.
@@ -408,17 +410,12 @@ func NewServer(store database.Store) *Server {
 	// internal/plugins/itunes/register.go ("itunesplugin"). No inline
 	// wiring is needed here.
 
-	// Initialize update scheduler
-	server.updateScheduler = updater.NewScheduler(server.updater, func() updater.SchedulerConfig {
-		return updater.SchedulerConfig{
-			Enabled:     config.AppConfig.AutoUpdateEnabled,
-			Channel:     config.AppConfig.AutoUpdateChannel,
-			CheckMins:   config.AppConfig.AutoUpdateCheckMinutes,
-			WindowStart: config.AppConfig.AutoUpdateWindowStart,
-			WindowEnd:   config.AppConfig.AutoUpdateWindowEnd,
-		}
-	})
-	server.updateScheduler.Start()
+	// updater + updateScheduler are container-built (internal/updater/
+	// register.go) and wired in wireServerFromContainer. Start() stays
+	// inline until SERVER-LIFECYCLE-FLIP hands it off to Container.Start.
+	if server.updateScheduler != nil {
+		server.updateScheduler.Start()
+	}
 
 	// Wire OL dump store into metadata fetch service for local-first lookups
 	if server.olService != nil && server.olService.Store() != nil {

--- a/internal/updater/register.go
+++ b/internal/updater/register.go
@@ -1,6 +1,18 @@
 // file: internal/updater/register.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 8c9d0a1b-2c3d-4e5f-6a7b-8c9d0a1b2c3d
+//
+// Service registry registrations for the auto-updater + its scheduler.
+//
+// Two services:
+//   - "updater":         *Updater. Real version comes from the host via
+//                        Override("appversion", appVersion). Falls back to
+//                        "dev" when not overridden (matches the historical
+//                        inline default).
+//   - "updatescheduler": *SchedulerStarterAdapter wrapping *Scheduler.
+//                        Depends on "updater". Implements Starter/Stopper
+//                        for Container.Start / Container.Stop hand-off
+//                        once SERVER-LIFECYCLE-FLIP wires those.
 
 package updater
 
@@ -17,33 +29,56 @@ type SchedulerStarterAdapter struct {
 	scheduler *Scheduler
 }
 
+// Scheduler returns the wrapped *Scheduler. Nil-safe.
+func (a *SchedulerStarterAdapter) Scheduler() *Scheduler {
+	if a == nil {
+		return nil
+	}
+	return a.scheduler
+}
+
 // Start implements the serviceregistry.Starter interface.
-func (a *SchedulerStarterAdapter) Start(ctx context.Context) error {
+func (a *SchedulerStarterAdapter) Start(_ context.Context) error {
+	if a == nil || a.scheduler == nil {
+		return nil
+	}
 	a.scheduler.Start()
 	return nil
 }
 
 // Stop implements the serviceregistry.Stopper interface.
-func (a *SchedulerStarterAdapter) Stop(ctx context.Context) error {
+func (a *SchedulerStarterAdapter) Stop(_ context.Context) error {
+	if a == nil || a.scheduler == nil {
+		return nil
+	}
 	a.scheduler.Stop()
 	return nil
 }
 
 func init() {
 	serviceregistry.Register(serviceregistry.ServiceDef{
-		Name:  "updatescheduler",
-		Needs: []string{},
+		Name:   "updater",
+		Needs:  []string{},
 		Groups: []string{"scheduler"},
 		Build: func(c *serviceregistry.Container) (any, error) {
-			// Create the Updater with the default "dev" version.
-			// The actual version is set at build time via ldflags in main.go
-			// and propagated to the server package's appVersion var.
-			// For now, we use "dev" as the fallback; the existing server.updater
-			// path (which has the real version from appVersion) remains unchanged.
-			updaterInst := NewUpdater("dev")
+			// appversion is an Override the host (server) sets to the
+			// ldflags-baked version. TryGet falls back to "dev" so the
+			// container can build in isolation (tests, tooling).
+			version, ok := serviceregistry.TryGet[string](c, "appversion")
+			if !ok || version == "" {
+				version = "dev"
+			}
+			return NewUpdater(version), nil
+		},
+	})
 
-			// Create the Scheduler with a closure that captures config.AppConfig
-			scheduler := NewScheduler(updaterInst, func() SchedulerConfig {
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "updatescheduler",
+		Needs:  []string{"updater"},
+		Groups: []string{"scheduler"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			upd := serviceregistry.Get[*Updater](c, "updater")
+			scheduler := NewScheduler(upd, func() SchedulerConfig {
 				return SchedulerConfig{
 					Enabled:     config.AppConfig.AutoUpdateEnabled,
 					Channel:     config.AppConfig.AutoUpdateChannel,
@@ -52,8 +87,6 @@ func init() {
 					WindowEnd:   config.AppConfig.AutoUpdateWindowEnd,
 				}
 			})
-
-			// Wrap in adapter to implement Starter/Stopper interfaces
 			return &SchedulerStarterAdapter{scheduler: scheduler}, nil
 		},
 	})


### PR DESCRIPTION
## Summary

SERVER-LIFECYCLE-FLIP prep. \`updatescheduler\` register.go was hardcoding \`\"dev\"\` as the app version, so the container-built scheduler was unusable in production and \`NewServer\` was building a *second, parallel* scheduler. This bridges the two and lets the inline construction be deleted.

## Changes

- **\`internal/updater/register.go\`** (version 1.0 → 2.0):
  - New \`\"updater\"\` \`ServiceDef\` (Groups: [\"scheduler\"]). Build reads \`\"appversion\"\` via \`TryGet\` — falls back to \`\"dev\"\` when not overridden, so tests/tooling still build the container in isolation.
  - \`\"updatescheduler\"\` now depends on \`\"updater\"\`, pulls \`*Updater\` from the container. \`SchedulerStarterAdapter\` gains a \`Scheduler()\` accessor and nil-safe \`Start\`/\`Stop\`.
- **\`internal/server/server.go\`**:
  - \`NewServer\`: add \`.Override(\"appversion\", appVersion)\` on the container builder so the real ldflags-baked version flows in.
  - Delete inline \`updater.NewUpdater(appVersion)\` field initialiser.
  - Delete inline \`updater.NewScheduler(...)\` construction. Replace with \`if server.updateScheduler != nil { server.updateScheduler.Start() }\`. The inline \`Start()\` call stays until SERVER-LIFECYCLE-FLIP hands it off to \`Container.Start\`.
- **\`internal/server/registry_wire.go\`**: \`wireServerFromContainer\` pulls \`*Updater\` + \`*SchedulerStarterAdapter\` via \`TryGet\` and sets \`s.updater\` + \`s.updateScheduler = adapter.Scheduler()\`.

\`NewServer\`: 428 → 421 lines.

## Behavior

No change for production. Same \`Updater\` (now built with the real \`appVersion\` in *both* container path and \`s.updater\` field — previously the container kept its own \`\"dev\"\` instance which was never used); same Scheduler; same single \`Start()\` at the same point. \`s.updater\` consumers (\`update_handlers.go\`, \`scheduler_maintenance_window_op.go\`) read \`*Updater\` through the same field; nothing changes for them.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.5s
go test ./internal/updater ./internal/serviceregistry \\
  -short -race                                               # ok
\`\`\`

## Test plan

- [x] build / vet clean
- [x] server test subset green
- [x] updater + serviceregistry tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)