### PR TITLE
refactor(server): move activity Set wiring into PostInit on each service

### DIFF
--- a/internal/audiobooks/lifecycle.go
+++ b/internal/audiobooks/lifecycle.go
@@ -1,0 +1,30 @@
+// file: internal/audiobooks/lifecycle.go
+// version: 1.0.0
+
+// PostInit method on *AudiobookService that the serviceregistry container
+// picks up via interface satisfaction. Wires the optional activity service
+// dependency by pulling it from the container — replaces the inline
+// SetActivityService call that used to live in NewServer's activity
+// fan-out block.
+
+package audiobooks
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+// PostInit wires the activity service (used for snapshot fallback in
+// GetAudiobookTags). Activity is DatabasePath-gated — when absent, the
+// fallback path simply returns the legacy tag map without snapshots.
+func (svc *AudiobookService) PostInit(_ context.Context, c *serviceregistry.Container) error {
+	if svc == nil {
+		return nil
+	}
+	if as, ok := serviceregistry.TryGet[*activity.Service](c, "activity"); ok && as != nil {
+		svc.SetActivityService(as)
+	}
+	return nil
+}

--- a/internal/itunes/service/lifecycle.go
+++ b/internal/itunes/service/lifecycle.go
@@ -1,0 +1,29 @@
+// file: internal/itunes/service/lifecycle.go
+// version: 1.0.0
+
+// PostInit method on *Service. Wires the activity writer into the
+// PathRepairer sub-component so repair runs can emit per-book activity
+// events. Replaces the inline SetActivityWriter call from NewServer's
+// activity fan-out block.
+
+package itunesservice
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+// PostInit wires the activity writer into the path-repair sub-component.
+// activitywriter is DatabasePath-gated; the disabled service path (Repair
+// nil) and missing-writer path are both no-ops.
+func (s *Service) PostInit(_ context.Context, c *serviceregistry.Container) error {
+	if s == nil || !s.Enabled() || s.Repair == nil {
+		return nil
+	}
+	if aw, ok := serviceregistry.TryGet[*activity.Writer](c, "activitywriter"); ok && aw != nil {
+		s.Repair.SetActivityWriter(aw)
+	}
+	return nil
+}

--- a/internal/scanner/lifecycle.go
+++ b/internal/scanner/lifecycle.go
@@ -1,0 +1,29 @@
+// file: internal/scanner/lifecycle.go
+// version: 1.0.0
+
+// PostInit method on *ScanService that the serviceregistry container
+// picks up via interface satisfaction. Wires the optional activity
+// writer dependency from the container — replaces the inline
+// SetActivityWriter call from NewServer's activity fan-out block.
+
+package scanner
+
+import (
+	"context"
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
+)
+
+// PostInit wires the activity writer used to batch per-book scan
+// events. Writer is DatabasePath-gated — when absent, scan events are
+// dropped (the legacy behavior before the dual-write tap landed).
+func (ss *ScanService) PostInit(_ context.Context, c *serviceregistry.Container) error {
+	if ss == nil {
+		return nil
+	}
+	if aw, ok := serviceregistry.TryGet[*activity.Writer](c, "activitywriter"); ok && aw != nil {
+		ss.SetActivityWriter(aw)
+	}
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -566,27 +566,19 @@ func NewServer(store database.Store) *Server {
 		}
 	})
 
-	// Wire activity log dual-write hooks
+	// Activity-service fan-out into metafetch / audiobook / scanner /
+	// itunesSvc.Repair now happens in those services' PostInit hooks.
+	// What's left in this block is genuinely server-internal: starting
+	// the writer, the global log.SetOutput, extraOpsRegistrar back-fill,
+	// the itunesActivityFn closure, scanner.SetScanHooks (process-global),
+	// and the startup-record entry.
 	if server.activityService != nil {
-		// Task 11/14: Metadata fetch service → activity log
-		server.metadataFetchService.SetActivityService(server.activityService)
-
-		// Wire activity service into audiobook service for snapshot comparison fallback
-		server.audiobookService.SetActivityService(server.activityService)
-
-		// Global log capture via teeWriter — replaces globalActivityRecorder.
-		// activityWriter is container-built (internal/activity/register.go);
-		// wireServerFromContainer set it above. The inline Start() call here
-		// will move to Container.Start() under SERVER-LIFECYCLE-FLIP.
+		// Start the writer + plumb the bits that aren't container services.
+		// aw.Start() moves into Container.Start under SERVER-LIFECYCLE-FLIP.
 		if aw := server.activityWriter; aw != nil {
 			aw.Start(context.Background()) //nolint:errcheck
-			// Back-fill activityWriter into extraOpsRegistrar now that it is available.
 			server.extraOpsRegistrar.Deps.ActivityWriter = aw
-			server.scanService.SetActivityWriter(aw)
 			log.SetOutput(aw)
-			if server.itunesSvc != nil && server.itunesSvc.Enabled() {
-				server.itunesSvc.Repair.SetActivityWriter(aw)
-			}
 		}
 
 		// Task 15: iTunes sync → activity log


### PR DESCRIPTION
## Summary

NEWSERVER-TRIM. Move four \`Set*\` calls out of \`NewServer\`'s activity fan-out block and into \`PostInit\` hooks on the receiving services. \`metafetch.PostInit\` was already doing \`SetActivityService\` — the inline call was redundant.

## Changes

- **new** \`internal/audiobooks/lifecycle.go\` — \`AudiobookService.PostInit\` pulls \`\"activity\"\` via \`TryGet\` (DatabasePath-gated).
- **new** \`internal/scanner/lifecycle.go\` — \`ScanService.PostInit\` pulls \`\"activitywriter\"\` via \`TryGet\`.
- **new** \`internal/itunes/service/lifecycle.go\` — \`Service.PostInit\` pulls \`\"activitywriter\"\` and wires it into \`Repair\` (no-op when disabled / \`Repair\` nil).
- **\`internal/server/server.go\`**: delete the four \`Set*\` calls. What stays is genuinely server-internal:
  - \`aw.Start()\` (moves to \`Container.Start\` under LIFECYCLE-FLIP),
  - \`log.SetOutput(aw)\` — global side effect,
  - \`server.extraOpsRegistrar.Deps.ActivityWriter = aw\` — back-fill into a non-container struct,
  - \`server.itunesActivityFn\` closure,
  - \`scanner.SetScanHooks(...)\` — process-global side effect,
  - the startup \`ActivityEntry\` record.

\`NewServer\`: **421 → 417 lines**.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.5s
go test ./internal/audiobooks ./internal/scanner \\
        ./internal/itunes/service ./internal/metafetch \\
        ./internal/serviceregistry -short -race              # ok
\`\`\`

## Test plan

- [x] build / vet clean
- [x] server test subset green
- [x] all four affected packages' tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)