### PR TITLE
refactor(metafetch): olservice + ISBN enrichment via container PostInit

### DIFF
--- a/internal/metafetch/lifecycle.go
+++ b/internal/metafetch/lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/lifecycle.go
-// version: 1.0.0
+// version: 1.2.0
 
 // Lifecycle methods on *metafetch.Service that the serviceregistry
 // container picks up via interface satisfaction. PostInit wires the
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
@@ -71,6 +72,24 @@ func (mfs *Service) PostInit(ctx context.Context, c *serviceregistry.Container) 
 	// metafetch).
 	if enq, ok := serviceregistry.TryGet[WriteBackEnqueuer](c, "writebackbatcher"); ok && enq != nil {
 		mfs.SetWriteBackBatcher(enq)
+	}
+
+	// OL dump store — local-first lookups. olservice opens the store
+	// lazily on first EnsureStore; if nothing has called that yet,
+	// Store() returns nil and we skip wiring (the chain reverts to
+	// network-only).
+	if ol, ok := serviceregistry.TryGet[*OpenLibraryService](c, "olservice"); ok && ol != nil {
+		if store := ol.Store(); store != nil {
+			mfs.SetOLStore(store)
+		}
+	}
+
+	// ISBN enrichment — needs a source chain. Empty chain (e.g. no
+	// AI key, no Audnexus) means no enrichment.
+	if store, ok := serviceregistry.TryGet[database.Store](c, "store"); ok && store != nil {
+		if sources := mfs.BuildSourceChain(); len(sources) > 0 {
+			mfs.SetISBNEnrichment(NewISBNService(store, sources))
+		}
 	}
 
 	return nil

--- a/internal/metafetch/register.go
+++ b/internal/metafetch/register.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/register.go
-// version: 1.1.0
+// version: 1.2.0
 
 package metafetch
 
@@ -26,6 +26,18 @@ func init() {
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
 			return NewService(store), nil
+		},
+	})
+
+	// olservice — Open Library data-dump lifecycle wrapper. No build-time
+	// deps; the underlying OL store is opened lazily on first EnsureStore.
+	// metafetch.Service.PostInit pulls this to wire SetOLStore.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "olservice",
+		Needs:  []string{},
+		Groups: []string{"core"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			return NewOpenLibraryService(), nil
 		},
 	})
 }

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -204,6 +204,9 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 
 	// W2 services
 	s.metadataFetchService = serviceregistry.Get[*metafetch.Service](c, "metafetch")
+	if ol, ok := serviceregistry.TryGet[*metafetch.OpenLibraryService](c, "olservice"); ok && ol != nil {
+		s.olService = ol
+	}
 	s.mergeService = serviceregistry.Get[*merge.Service](c, "merge")
 	s.organizeService = serviceregistry.Get[*OrganizeService](c, "organize")
 	s.quarantineSvc = serviceregistry.Get[*quarantine.QuarantineService](c, "quarantine")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -314,9 +314,8 @@ func NewServer(store database.Store) *Server {
 		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),
 		listCache:              cache.New[gin.H]("list", 24*time.Hour),
 		facetsCache:            cache.New[gin.H]("facets", 24*time.Hour),
-		olService:              metafetch.NewOpenLibraryService(),
-		// updater + updateScheduler are container-built (see
-		// internal/updater/register.go). wireServerFromContainer sets them.
+		// olService, updater, updateScheduler are container-built;
+		// wireServerFromContainer populates the fields.
 		diagnosticsService:     diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),
 		changelogService:       activity.NewChangelogService(resolvedStore),
 	}
@@ -417,18 +416,9 @@ func NewServer(store database.Store) *Server {
 		server.updateScheduler.Start()
 	}
 
-	// Wire OL dump store into metadata fetch service for local-first lookups
-	if server.olService != nil && server.olService.Store() != nil {
-		server.metadataFetchService.SetOLStore(server.olService.Store())
-	}
-
-	// Wire ISBN enrichment service into metadata fetch service
-	isbnSources := server.metadataFetchService.BuildSourceChain()
-	if len(isbnSources) > 0 {
-		server.metadataFetchService.SetISBNEnrichment(
-			metafetch.NewISBNService(database.GetGlobalStore(), isbnSources),
-		)
-	}
+	// OL dump store + ISBN enrichment wiring moved into metafetch.Service
+	// PostInit (internal/metafetch/lifecycle.go). The container drives
+	// these now; no inline server-side wiring needed.
 
 	// Wire AI scan store into main PebbleDB (aiscan: key namespace, no separate file).
 	// BatchPoller is now registered via serviceregistry (W3).


### PR DESCRIPTION
## Summary

NEWSERVER-TRIM. Move two more wires out of \`NewServer\` into \`metafetch.PostInit\`.

## Changes

- **\`internal/metafetch/register.go\`** (v1.1 → 1.2): new \`\"olservice\"\` \`ServiceDef\` (Groups: \`[\"core\"]\`). Build is \`NewOpenLibraryService()\` — no deps. Lazy-open semantics preserved (\`EnsureStore\` is what actually opens the dump).
- **\`internal/metafetch/lifecycle.go\`** (v1.0 → 1.2): \`PostInit\` now also:
  - TryGets \`*OpenLibraryService\` from \`\"olservice\"\`. Calls \`SetOLStore\` if the underlying store is open.
  - TryGets \`database.Store\` from \`\"store\"\`. Calls \`BuildSourceChain()\` + \`SetISBNEnrichment(NewISBNService(...))\` if the chain is non-empty.
- **\`internal/server/registry_wire.go\`**: \`wireServerFromContainer\` pulls \`*OpenLibraryService\` into \`s.olService\`.
- **\`internal/server/server.go\`**:
  - Delete the inline \`olService: metafetch.NewOpenLibraryService()\` field init.
  - Delete the 13-line \`SetOLStore\` + \`SetISBNEnrichment\` block.

\`NewServer\`: **416 → 405 lines**.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.5s
go test ./internal/metafetch ./internal/serviceregistry \\
  -short -race                                               # ok
\`\`\`

## Test plan

- [x] build / vet clean
- [x] server test subset green
- [x] metafetch + serviceregistry tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)