### PR TITLE
refactor(server): aiscanstore + pipelinemanager via container

### DIFF
--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.4.0
+// version: 1.5.0
 
 package server
 
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
+	"github.com/jdfalk/audiobook-organizer/internal/aiscan"
 	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
 	"github.com/jdfalk/audiobook-organizer/internal/batch"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
@@ -133,6 +134,46 @@ func init() {
 		},
 	})
 
+	// aiscanstore — AI scan history/phases/results, sharing the main
+	// PebbleDB under the "aiscan:" key prefix. Returns nil when the
+	// store isn't a PebbleStore (test paths).
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "aiscanstore",
+		Needs:  []string{"store"},
+		Groups: []string{"ai"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			ps, ok := store.(*database.PebbleStore)
+			if !ok {
+				return (*database.AIScanStore)(nil), nil
+			}
+			s, err := database.NewAIScanStoreFromDB(ps.DB())
+			if err != nil {
+				log.Printf("[WARN] Failed to init AI scan store: %v", err)
+				return (*database.AIScanStore)(nil), nil
+			}
+			return s, nil
+		},
+	})
+
+	// pipelinemanager — AI scan pipeline coordinator. Needs aiscanstore +
+	// the main store + an *ai.OpenAIParser (llmparser). When the parser
+	// is nil (no OpenAI key) or aiscanstore is nil, returns nil.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "pipelinemanager",
+		Needs:  []string{"store", "aiscanstore", "llmparser"},
+		Groups: []string{"ai"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			scanStore, _ := serviceregistry.TryGet[*database.AIScanStore](c, "aiscanstore")
+			parser, _ := serviceregistry.TryGet[*ai.OpenAIParser](c, "llmparser")
+			if scanStore == nil || parser == nil {
+				return (*aiscan.PipelineManager)(nil), nil
+			}
+			store := serviceregistry.Get[database.Store](c, "store")
+			return aiscan.NewPipelineManager(scanStore, store, parser), nil
+		},
+	})
+
 	// itunes — the iTunes integration service. Registered here (rather
 	// than in internal/itunes/service/register.go) because the
 	// OrganizerFactory closure needs internal/organizer + internal/config,
@@ -244,6 +285,12 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	}
 	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok {
 		s.dedupEngine = engine
+	}
+	if scanStore, ok := serviceregistry.TryGet[*database.AIScanStore](c, "aiscanstore"); ok && scanStore != nil {
+		s.aiScanStore = scanStore
+	}
+	if pm, ok := serviceregistry.TryGet[*aiscan.PipelineManager](c, "pipelinemanager"); ok && pm != nil {
+		s.pipelineManager = pm
 	}
 
 	// itunesservice.Service — container-built since PLUGIN-DECOUPLE-CLOSURES

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -420,20 +420,12 @@ func NewServer(store database.Store) *Server {
 	// PostInit (internal/metafetch/lifecycle.go). The container drives
 	// these now; no inline server-side wiring needed.
 
-	// Wire AI scan store into main PebbleDB (aiscan: key namespace, no separate file).
-	// BatchPoller is now registered via serviceregistry (W3).
-	if ps, ok := database.GetGlobalStore().(*database.PebbleStore); ok {
-		aiScanStore, err := database.NewAIScanStoreFromDB(ps.DB())
-		if err != nil {
-			log.Printf("[WARN] Failed to init AI scan store: %v", err)
-		} else {
-			server.aiScanStore = aiScanStore
-			server.extraOpsRegistrar.Deps.AIScanStore = aiScanStore
-			aiParserInst := newAIParser(config.AppConfig.OpenAIAPIKey, config.AppConfig.EnableAIParsing)
-			if p, ok := aiParserInst.(*ai.OpenAIParser); ok {
-				server.pipelineManager = aiscan.NewPipelineManager(aiScanStore, database.GetGlobalStore(), p)
-			}
-		}
+	// aiScanStore + pipelineManager are container-built (registry_wire.go
+	// "aiscanstore" + "pipelinemanager"). Back-fill extraOpsRegistrar's
+	// AIScanStore dep — the registrar was constructed before
+	// wireServerFromContainer populated the field.
+	if server.aiScanStore != nil {
+		server.extraOpsRegistrar.Deps.AIScanStore = server.aiScanStore
 	}
 
 	// server.activityService is now populated by wireServerFromContainer


### PR DESCRIPTION
## Summary

NEWSERVER-TRIM. Two new services in \`registry_wire.go\` replace the 14-line inline AI scan store + pipeline manager block in \`NewServer\`.

## Changes

- **\`internal/server/registry_wire.go\`** (v1.4 → 1.5):
  - \`\"aiscanstore\"\` (Needs: \`[\"store\"]\`; Groups: \`[\"ai\"]\`). Type-asserts \`\"store\"\` to \`*PebbleStore\`; calls \`NewAIScanStoreFromDB\`. Returns nil on mismatch (test paths) or open error.
  - \`\"pipelinemanager\"\` (Needs: \`[\"store\", \"aiscanstore\", \"llmparser\"]\`; Groups: \`[\"ai\"]\`). Returns nil when \`aiscanstore\` or \`llmparser\` is nil. Otherwise: \`aiscan.NewPipelineManager(scanStore, store, parser)\`.
  - \`wireServerFromContainer\` pulls both via \`TryGet\` into \`s.aiScanStore\` / \`s.pipelineManager\`.
- **\`internal/server/server.go\`**: replace the inline block with a 3-line \`extraOpsRegistrar.Deps.AIScanStore\` back-fill. The back-fill stays inline because \`extraOpsRegistrar\` is constructed earlier in \`NewServer\` and isn't a container service.

\`NewServer\`: **406 → 398 lines**.

## Behavior

Production path identical. The previous \`newAIParser(...)\` package-var indirection (a test mock hook) is bypassed for the pipeline-manager construction, but \`newAIParser\` itself is unchanged and still wraps the same \`ai.NewOpenAIParser(cfg, OpenAIAPIKey, EnableAIParsing)\` call the container's \`llmparser\` makes — so the produced \`*OpenAIParser\` is equivalent. \`newAIParser\` remains usable elsewhere (\`ai_handlers.go\`, \`ai_ops.go\`, etc.) for those mock paths.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.5s
go test ./internal/aiscan ./internal/serviceregistry \\
  -short -race                                               # ok
\`\`\`

## Test plan

- [x] build / vet clean
- [x] server test subset green
- [x] aiscan + serviceregistry tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)