### PR TITLE
refactor(server): metricsstore via container

### DIFF
--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.5.0
+// version: 1.6.0
 
 package server
 
@@ -131,6 +131,29 @@ func init() {
 			engine.AuthorLowThreshold = cfg.DedupAuthorLowThreshold
 			engine.AutoMergeEnabled = cfg.DedupAutoMergeEnabled
 			return engine, nil
+		},
+	})
+
+	// metricsstore — NutsDB-backed cache-stats snapshot store. Lives at
+	// {dirname(DatabasePath)}/metrics.nutsdb. Returns nil + logs when
+	// DatabasePath is empty (test paths) or open fails — server code
+	// nil-checks before use.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "metricsstore",
+		Needs:  []string{"config"},
+		Groups: []string{"core"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, "config")
+			if cfg.DatabasePath == "" {
+				return (*database.NutsMetricsStore)(nil), nil
+			}
+			dir := filepath.Join(filepath.Dir(cfg.DatabasePath), "metrics.nutsdb")
+			store, err := database.NewNutsMetricsStore(dir)
+			if err != nil {
+				log.Printf("[WARN] Failed to open metrics store: %v", err)
+				return (*database.NutsMetricsStore)(nil), nil
+			}
+			return store, nil
 		},
 	})
 
@@ -288,6 +311,9 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	}
 	if scanStore, ok := serviceregistry.TryGet[*database.AIScanStore](c, "aiscanstore"); ok && scanStore != nil {
 		s.aiScanStore = scanStore
+	}
+	if ms, ok := serviceregistry.TryGet[*database.NutsMetricsStore](c, "metricsstore"); ok && ms != nil {
+		s.metricsStore = ms
 	}
 	if pm, ok := serviceregistry.TryGet[*aiscan.PipelineManager](c, "pipelinemanager"); ok && pm != nil {
 		s.pipelineManager = pm

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -431,16 +431,8 @@ func NewServer(store database.Store) *Server {
 	// server.activityService is now populated by wireServerFromContainer
 	// when config.DatabasePath is set (W2). Nothing to do here.
 
-	// Open metrics store alongside main DB (NutsDB, CGo-free).
-	if dbPath := config.AppConfig.DatabasePath; dbPath != "" {
-		metricsDir := filepath.Join(filepath.Dir(dbPath), "metrics.nutsdb")
-		metricsStore, err := database.NewNutsMetricsStore(metricsDir)
-		if err != nil {
-			log.Printf("[WARN] Failed to open metrics store: %v", err)
-		} else {
-			server.metricsStore = metricsStore
-		}
-	}
+	// metricsStore is container-built (registry_wire.go "metricsstore");
+	// wireServerFromContainer populates the field.
 
 	// One-shot migration from the legacy embeddings.db SQLite sidecar.
 	// Safe to call every startup: a flag key in PebbleDB prevents re-runs.


### PR DESCRIPTION
## Summary

NEWSERVER-TRIM. Replace the 10-line inline \`NewNutsMetricsStore\` block in \`NewServer\` with a \`\"metricsstore\"\` \`ServiceDef\` in \`registry_wire.go\`.

## Changes

- **\`internal/server/registry_wire.go\`** (v1.5 → 1.6): \`\"metricsstore\"\` (Needs: \`[\"config\"]\`; Groups: \`[\"core\"]\`). Build returns nil when \`DatabasePath\` is empty (test paths) or \`NewNutsMetricsStore\` errors — logs the warning in the latter case. \`wireServerFromContainer\` pulls \`*database.NutsMetricsStore\` into \`s.metricsStore\`.
- **\`internal/server/server.go\`**: delete the inline block.

\`NewServer\`: **398 → 390 lines**.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.5s
\`\`\`

## Test plan

- [x] build / vet clean
- [x] server test subset green

🤖 Generated with [Claude Code](https://claude.com/claude-code)