### PR TITLE
refactor(server): SERVER-LIFECYCLE-FLIP — Container.Start/Stop drive Server lifecycle

### DIFF
--- a/internal/search/register.go
+++ b/internal/search/register.go
@@ -1,10 +1,11 @@
 // file: internal/search/register.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 7b4e2c1a-9f3d-4a82-b6e5-1d0c8f5a3e72
 //
 // Registers the BleveIndex as the "searchindex" service in the
-// serviceregistry. The wrapper type (bleveIndexService) satisfies
-// Starter and Stopper so the container can manage its lifecycle.
+// serviceregistry. IndexService satisfies Starter and Stopper so
+// the container manages its lifecycle once Container.Start/Stop
+// is wired (SERVER-LIFECYCLE-FLIP).
 //
 // Path convention mirrors server_lifecycle.go:
 //
@@ -14,68 +15,99 @@ package search
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
-// bleveIndexService wraps a *BleveIndex and defers the actual file-system
+// IndexService wraps a *BleveIndex and defers the actual file-system
 // open to Start so that test code that never calls Start doesn't leak
-// Bleve file handles (same discipline the server uses).
-type bleveIndexService struct {
+// Bleve file handles.
+//
+// Exported (renamed from bleveIndexService in v2.0.0) so server-package
+// code can fetch it from the container via TryGet[*search.IndexService]
+// and pull the underlying index via Index().
+type IndexService struct {
 	cfg  *config.Config
 	idx  *BleveIndex
 	path string
 }
 
-// Start opens the on-disk Bleve index. Idempotent — if the index is already
-// open, Start is a no-op and returns nil.
-func (b *bleveIndexService) Start(_ context.Context) error {
-	if b.idx != nil {
+// Start currently a no-op. Bleve open stays inline in
+// server_lifecycle.go because moving it here exposes a pre-existing
+// race between the stripMovementAtoms / remuxMalformedM4BFiles
+// goroutines (which read s.store) and the indexedStore decorator
+// install. Once that race is fixed independently, the OpenInline
+// helper below can move into this Start and Container.Start drives
+// the open.
+//
+// Until then, Stop is a no-op too — the inline path also drives Close.
+func (b *IndexService) Start(_ context.Context) error {
+	return nil
+}
+
+// OpenInline opens the on-disk Bleve index. Idempotent — if already
+// open, returns the existing handle. Called by server_lifecycle.go's
+// inline open path. Open failures are downgraded to nil + warning so
+// the server can run without search.
+func (b *IndexService) OpenInline() *BleveIndex {
+	if b == nil {
 		return nil
 	}
-	if b.cfg.DatabasePath == "" {
-		return fmt.Errorf("searchindex: DatabasePath not configured")
+	if b.idx != nil {
+		return b.idx
+	}
+	if b.cfg == nil || b.cfg.DatabasePath == "" {
+		return nil
 	}
 	indexPath := filepath.Join(filepath.Dir(b.cfg.DatabasePath), "library.bleve")
 	idx, err := Open(indexPath)
 	if err != nil {
-		return fmt.Errorf("searchindex Start: %w", err)
+		log.Printf("[WARN] Failed to open search index: %v", err)
+		return nil
 	}
 	b.idx = idx
 	b.path = indexPath
+	log.Printf("[INFO] Search index opened at %s", indexPath)
+	return idx
+}
+
+// Stop currently a no-op. Bleve close stays inline in
+// server_lifecycle.go alongside the inline open. When the
+// store-install race is fixed and Start/Stop drive open/close, this
+// becomes b.idx.Close() + b.idx = nil.
+func (b *IndexService) Stop(_ context.Context) error {
 	return nil
 }
 
-// Stop closes the underlying Bleve index. Safe to call multiple times or
-// before Start has been called.
-func (b *bleveIndexService) Stop(_ context.Context) error {
-	if b.idx == nil {
+// Index returns the live *BleveIndex, or nil if Start has not been
+// called or the service was stopped.
+func (b *IndexService) Index() *BleveIndex {
+	if b == nil {
 		return nil
 	}
-	err := b.idx.Close()
-	b.idx = nil
-	return err
+	return b.idx
 }
 
-// Index returns the live *BleveIndex, or nil if Start has not been called
-// or the service was stopped. Callers that need the raw index (e.g. a
-// PostInit wiring step) may type-assert the container value to
-// *bleveIndexService and call Index().
-func (b *bleveIndexService) Index() *BleveIndex {
-	return b.idx
+// Path returns the on-disk path the index was opened from, or "" if
+// not yet started.
+func (b *IndexService) Path() string {
+	if b == nil {
+		return ""
+	}
+	return b.path
 }
 
 func init() {
 	serviceregistry.Register(serviceregistry.ServiceDef{
-		Name:  "searchindex",
-		Needs: []string{"config"},
+		Name:   "searchindex",
+		Needs:  []string{"config"},
 		Groups: []string{"scheduler"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
-			return &bleveIndexService{cfg: cfg}, nil
+			return &IndexService{cfg: cfg}, nil
 		},
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -409,12 +409,9 @@ func NewServer(store database.Store) *Server {
 	// internal/plugins/itunes/register.go ("itunesplugin"). No inline
 	// wiring is needed here.
 
-	// updater + updateScheduler are container-built (internal/updater/
-	// register.go) and wired in wireServerFromContainer. Start() stays
-	// inline until SERVER-LIFECYCLE-FLIP hands it off to Container.Start.
-	if server.updateScheduler != nil {
-		server.updateScheduler.Start()
-	}
+	// updater + updateScheduler are container-built and started by
+	// Container.Start() during Server.Start (SERVER-LIFECYCLE-FLIP).
+	// No inline Start() needed.
 
 	// OL dump store + ISBN enrichment wiring moved into metafetch.Service
 	// PostInit (internal/metafetch/lifecycle.go). The container drives
@@ -546,10 +543,11 @@ func NewServer(store database.Store) *Server {
 	// the itunesActivityFn closure, scanner.SetScanHooks (process-global),
 	// and the startup-record entry.
 	if server.activityService != nil {
-		// Start the writer + plumb the bits that aren't container services.
-		// aw.Start() moves into Container.Start under SERVER-LIFECYCLE-FLIP.
+		// activityWriter is started by Container.Start in Server.Start
+		// (SERVER-LIFECYCLE-FLIP). What stays inline here is the
+		// extraOpsRegistrar back-fill + log.SetOutput global, both of
+		// which need the writer reference but not its Start.
 		if aw := server.activityWriter; aw != nil {
-			aw.Start(context.Background()) //nolint:errcheck
 			server.extraOpsRegistrar.Deps.ActivityWriter = aw
 			log.SetOutput(aw)
 		}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/realtime"
 	"github.com/jdfalk/audiobook-organizer/internal/scheduler"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
+	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 	"github.com/jdfalk/audiobook-organizer/internal/transcode"
 	"github.com/jdfalk/audiobook-organizer/internal/watcher"
@@ -175,13 +176,24 @@ func (s *Server) resumeInterruptedOperations() {
 }
 
 func (s *Server) Start(cfg ServerConfig) error {
-	if err := s.itunesSvc.Start(s.bgCtx); err != nil {
-		return fmt.Errorf("itunes service start: %w", err)
-	}
-
-	// Start the UOS-02 operations registry (dispatcher + worker pool).
-	if s.opRegistry != nil {
-		s.opRegistry.Start(s.bgCtx)
+	// SERVER-LIFECYCLE-FLIP: drive Starter services via the container.
+	// Replaces the inline s.itunesSvc.Start / s.opRegistry.Start /
+	// updateScheduler.Start / activityWriter.Start calls. Container.Start
+	// runs services in resolved dep order; failures abort startup and
+	// roll back already-started services.
+	//
+	// Note: "searchindex" is registered as a Starter but the Bleve open
+	// stays inline below for now. There is a pre-existing race between
+	// the stripMovementAtoms/remuxMalformedM4BFiles goroutines (which
+	// read s.store) and the indexedStore decorator install. Starting the
+	// Bleve service eagerly here changes timing enough that the race
+	// manifests reliably. Folding searchindex into the container's
+	// Start path is deferred until the underlying store-install race
+	// is fixed independently.
+	if s.container != nil {
+		if err := s.container.Start(s.bgCtx); err != nil {
+			return fmt.Errorf("container start: %w", err)
+		}
 	}
 
 	// Pre-warm the facets cache in the background so the first Library page
@@ -366,18 +378,18 @@ func (s *Server) Start(cfg ServerConfig) error {
 		s.remuxMalformedM4BFiles()
 	}()
 
-	// Open the library search index (Bleve, spec DES-1). Opened here
-	// rather than in NewServer so tests that skip Start don't leak
-	// Bleve handles. Failures are non-fatal — server runs without
-	// search until the index comes back.
-	if dbPath := config.AppConfig.DatabasePath; dbPath != "" && s.searchIndex == nil {
-		indexPath := filepath.Join(filepath.Dir(dbPath), "library.bleve")
-		idx, err := search.Open(indexPath)
-		if err != nil {
-			log.Printf("[WARN] Failed to open search index: %v", err)
-		} else {
-			s.searchIndex = idx
-			log.Printf("[INFO] Search index opened at %s", indexPath)
+	// Open the library search index (Bleve, spec DES-1) via the
+	// container's IndexService.OpenInline helper. Same lazy-open
+	// semantics as before — kept inline (rather than in
+	// IndexService.Start driven by Container.Start) because folding
+	// it into Container.Start exposes a pre-existing race between
+	// stripMovementAtoms / remuxMalformedM4BFiles goroutines that
+	// read s.store and the indexedStore decorator install below.
+	if s.container != nil && s.searchIndex == nil {
+		if idx, ok := serviceregistry.TryGet[*search.IndexService](s.container, "searchindex"); ok && idx != nil {
+			if bi := idx.OpenInline(); bi != nil {
+				s.searchIndex = bi
+			}
 		}
 	}
 
@@ -720,9 +732,18 @@ func (s *Server) Start(cfg ServerConfig) error {
 		}
 	}
 
-	// Stop activity writer before closing store
-	if s.activityWriter != nil {
-		s.activityWriter.Stop(context.Background()) //nolint:errcheck
+	// SERVER-LIFECYCLE-FLIP: drive remaining Stoppers via the container.
+	// Runs in reverse resolved order; covers activityWriter (replaces
+	// the inline Stop here pre-flip), updateScheduler (previously never
+	// stopped — a leak), and any future Stopper additions. Inline Stops
+	// above remain the source of truth for the carefully-sequenced
+	// teardown (opRegistry drain before bgCancel, writeBackBatcher flush
+	// before itunesSvc.Shutdown, etc.); Container.Stop is idempotent on
+	// already-stopped services for those.
+	if s.container != nil {
+		if err := s.container.Stop(context.Background()); err != nil {
+			log.Printf("[WARN] container stop: %v", err)
+		}
 	}
 
 	// Close activity log store


### PR DESCRIPTION
## Summary

Two coupled changes that together implement SERVER-LIFECYCLE-FLIP:

1. **\`search.IndexService\` exported** (renamed from \`bleveIndexService\`). New \`Index()\` / \`Path()\` / \`OpenInline()\` accessors let server code pull the \`*BleveIndex\` from the container.
2. **\`Container.Start(s.bgCtx)\` in \`Server.Start\`, \`Container.Stop(...)\` in \`Server.Shutdown\`.** Replaces 4 inline \`Start\` calls and 1 inline \`Stop\`, fixes a pre-existing \`updateScheduler.Stop\` goroutine leak.

## Inline calls removed

| Call | Location | Replacement |
|---|---|---|
| \`s.itunesSvc.Start(s.bgCtx)\` | server_lifecycle.go:178 | Container.Start |
| \`s.opRegistry.Start(s.bgCtx)\` | server_lifecycle.go:184 | Container.Start |
| \`server.updateScheduler.Start()\` | server.go:415-417 | Container.Start |
| \`aw.Start(context.Background())\` | server.go:568 | Container.Start |
| \`s.activityWriter.Stop(...)\` | server_lifecycle.go:737 | Container.Stop |
| *(never called)* \`updateScheduler.Stop\` | — | Container.Stop — **fixes leak** |

## What stays inline + why

\`searchindex\` is registered as a Starter but \`IndexService.Start\` is currently a no-op. The Bleve open stays inline (via the new \`IndexService.OpenInline()\` helper) because folding it into \`Container.Start\` exposes a **pre-existing race** between the \`stripMovementAtoms\` / \`remuxMalformedM4BFiles\` goroutines (which read \`s.store\` before the \`indexedStore\` decorator wraps it). Documented in the \`IndexService.Start\` docstring. Future PR can collapse this once the store-install race is fixed independently.

Other inline \`Stop\`s stay (\`writeBackBatcher\`, \`opRegistry.Shutdown\`, \`itunesSvc.Shutdown\`, \`searchIndex.Close\`, plugin teardown) because they need specific ordering relative to \`bgCancel\` / store close. Each is idempotent so the \`Container.Stop\` tail-call doesn't re-trigger work.

\`NewServer\`: **390 → 388 lines**. The structural value is that the container now drives both directions of the lifecycle — future Starter/Stopper additions auto-wire.

## Verification

\`\`\`
go build ./... ; go vet ./...                                # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"  # ok 9.4s
go test ./internal/search ./internal/serviceregistry \\
        ./internal/updater ./internal/activity \\
        ./internal/itunes/service ./internal/metafetch \\
        ./internal/audiobooks -short -race                   # ok
\`\`\`

\`TestServerStartGracefulShutdown\` now logs **\"Auto-update scheduler stopped\"** during teardown — proof that the previously-leaked \`updateScheduler.Stop\` fires.

## Test plan

- [x] build / vet clean
- [x] server test subset green (incl. graceful shutdown)
- [x] all affected leaf packages green
- [x] Container.Stop double-Stop on already-stopped services confirmed idempotent (writeBackBatcher, opRegistry.Shutdown observed twice in test logs, second pass is no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)