### PR TITLE
fix(server): close the searchindex lifecycle holdout — move indexedStore wrap ahead of bg goroutines

### DIFF
--- a/internal/search/register.go
+++ b/internal/search/register.go
@@ -1,13 +1,13 @@
 // file: internal/search/register.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: 7b4e2c1a-9f3d-4a82-b6e5-1d0c8f5a3e72
 //
-// Registers the BleveIndex as the "searchindex" service in the
-// serviceregistry. IndexService satisfies Starter and Stopper so
-// the container manages its lifecycle once Container.Start/Stop
-// is wired (SERVER-LIFECYCLE-FLIP).
+// Registers the BleveIndex as the "searchindex" service. IndexService
+// satisfies Starter and Stopper — Container.Start opens the index,
+// Container.Stop closes it. server_lifecycle.go pulls Index() into
+// s.searchIndex right after Container.Start returns.
 //
-// Path convention mirrors server_lifecycle.go:
+// Path convention:
 //
 //	{dirname(config.DatabasePath)}/library.bleve
 
@@ -22,44 +22,27 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
 
-// IndexService wraps a *BleveIndex and defers the actual file-system
-// open to Start so that test code that never calls Start doesn't leak
-// Bleve file handles.
-//
-// Exported (renamed from bleveIndexService in v2.0.0) so server-package
-// code can fetch it from the container via TryGet[*search.IndexService]
-// and pull the underlying index via Index().
+// IndexService wraps a *BleveIndex with deferred-open semantics so
+// test code that never calls Start doesn't leak Bleve file handles.
 type IndexService struct {
 	cfg  *config.Config
 	idx  *BleveIndex
 	path string
 }
 
-// Start currently a no-op. Bleve open stays inline in
-// server_lifecycle.go because moving it here exposes a pre-existing
-// race between the stripMovementAtoms / remuxMalformedM4BFiles
-// goroutines (which read s.store) and the indexedStore decorator
-// install. Once that race is fixed independently, the OpenInline
-// helper below can move into this Start and Container.Start drives
-// the open.
+// Start opens the on-disk Bleve index. Idempotent — if already open,
+// Start is a no-op and returns nil.
 //
-// Until then, Stop is a no-op too — the inline path also drives Close.
+// Open failures are downgraded to warnings rather than errors so the
+// server can run without search. Returning an error here would abort
+// Container.Start and roll back already-started services. Callers
+// check Index() != nil before using the result.
 func (b *IndexService) Start(_ context.Context) error {
-	return nil
-}
-
-// OpenInline opens the on-disk Bleve index. Idempotent — if already
-// open, returns the existing handle. Called by server_lifecycle.go's
-// inline open path. Open failures are downgraded to nil + warning so
-// the server can run without search.
-func (b *IndexService) OpenInline() *BleveIndex {
-	if b == nil {
+	if b == nil || b.idx != nil {
 		return nil
 	}
-	if b.idx != nil {
-		return b.idx
-	}
 	if b.cfg == nil || b.cfg.DatabasePath == "" {
+		log.Printf("[INFO] searchindex: DatabasePath not configured, running without search")
 		return nil
 	}
 	indexPath := filepath.Join(filepath.Dir(b.cfg.DatabasePath), "library.bleve")
@@ -71,14 +54,24 @@ func (b *IndexService) OpenInline() *BleveIndex {
 	b.idx = idx
 	b.path = indexPath
 	log.Printf("[INFO] Search index opened at %s", indexPath)
-	return idx
+	return nil
 }
 
-// Stop currently a no-op. Bleve close stays inline in
-// server_lifecycle.go alongside the inline open. When the
-// store-install race is fixed and Start/Stop drive open/close, this
-// becomes b.idx.Close() + b.idx = nil.
+// Stop closes the underlying Bleve index. Safe to call multiple times
+// or before Start has been called. Idempotent: clears b.idx so a
+// follow-up Stop (e.g. from the inline s.searchIndex.Close() in
+// Server.Shutdown) is a no-op.
 func (b *IndexService) Stop(_ context.Context) error {
+	if b == nil || b.idx == nil {
+		return nil
+	}
+	err := b.idx.Close()
+	b.idx = nil
+	if err != nil {
+		log.Printf("[WARN] Failed to close search index: %v", err)
+		return err
+	}
+	log.Println("[INFO] Search index closed")
 	return nil
 }
 

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -177,22 +177,43 @@ func (s *Server) resumeInterruptedOperations() {
 
 func (s *Server) Start(cfg ServerConfig) error {
 	// SERVER-LIFECYCLE-FLIP: drive Starter services via the container.
-	// Replaces the inline s.itunesSvc.Start / s.opRegistry.Start /
-	// updateScheduler.Start / activityWriter.Start calls. Container.Start
-	// runs services in resolved dep order; failures abort startup and
-	// roll back already-started services.
-	//
-	// Note: "searchindex" is registered as a Starter but the Bleve open
-	// stays inline below for now. There is a pre-existing race between
-	// the stripMovementAtoms/remuxMalformedM4BFiles goroutines (which
-	// read s.store) and the indexedStore decorator install. Starting the
-	// Bleve service eagerly here changes timing enough that the race
-	// manifests reliably. Folding searchindex into the container's
-	// Start path is deferred until the underlying store-install race
-	// is fixed independently.
+	// Container.Start runs services in resolved dep order; failures
+	// abort startup and roll back already-started services.
 	if s.container != nil {
 		if err := s.container.Start(s.bgCtx); err != nil {
 			return fmt.Errorf("container start: %w", err)
+		}
+	}
+
+	// Pull the now-open Bleve index out of the searchindex service
+	// (opened above by Container.Start) and install the indexedStore
+	// decorator BEFORE any background goroutines or HTTP handlers
+	// start using s.store. Doing the wrap first eliminates the race
+	// between bg goroutines (stripMovementAtoms / remuxMalformedM4BFiles
+	// / backfills) reading s.store and the indexedStore install — pre-PR
+	// #903 this happened later and was timing-dependent.
+	//
+	// Bleve open failures are already logged inside IndexService.Start;
+	// when Index() returns nil the server runs without search.
+	if s.container != nil && s.searchIndex == nil {
+		if idx, ok := serviceregistry.TryGet[*search.IndexService](s.container, "searchindex"); ok && idx != nil {
+			s.searchIndex = idx.Index()
+		}
+	}
+	if s.searchIndex != nil {
+		s.indexQueue = make(chan indexRequest, 1024)
+		inner := s.Store()
+		wrapped := &indexedStore{Store: inner, server: s}
+		s.store = wrapped
+		database.SetGlobalStore(wrapped)
+		s.bgWG.Add(1)
+		go func() {
+			defer s.bgWG.Done()
+			s.runIndexWorker()
+		}()
+		// Route the /audiobooks?search= path through Bleve.
+		if s.audiobookService != nil {
+			s.audiobookService.SetSearchIndex(s.searchIndex)
 		}
 	}
 
@@ -377,42 +398,6 @@ func (s *Server) Start(cfg ServerConfig) error {
 		defer s.bgWG.Done()
 		s.remuxMalformedM4BFiles()
 	}()
-
-	// Open the library search index (Bleve, spec DES-1) via the
-	// container's IndexService.OpenInline helper. Same lazy-open
-	// semantics as before — kept inline (rather than in
-	// IndexService.Start driven by Container.Start) because folding
-	// it into Container.Start exposes a pre-existing race between
-	// stripMovementAtoms / remuxMalformedM4BFiles goroutines that
-	// read s.store and the indexedStore decorator install below.
-	if s.container != nil && s.searchIndex == nil {
-		if idx, ok := serviceregistry.TryGet[*search.IndexService](s.container, "searchindex"); ok && idx != nil {
-			if bi := idx.OpenInline(); bi != nil {
-				s.searchIndex = bi
-			}
-		}
-	}
-
-	// Install the indexing store decorator + worker once the index is
-	// open. Every downstream book mutation flows through s.Store()
-	// (or the package-level global) so wrapping both keeps the index
-	// in sync regardless of whether a caller has migrated to DI yet.
-	if s.searchIndex != nil {
-		s.indexQueue = make(chan indexRequest, 1024)
-		inner := s.Store()
-		wrapped := &indexedStore{Store: inner, server: s}
-		s.store = wrapped
-		database.SetGlobalStore(wrapped)
-		s.bgWG.Add(1)
-		go func() {
-			defer s.bgWG.Done()
-			s.runIndexWorker()
-		}()
-		// Route the /audiobooks?search= path through Bleve.
-		if s.audiobookService != nil {
-			s.audiobookService.SetSearchIndex(s.searchIndex)
-		}
-	}
 
 	// Build the search index on first startup (or if it got wiped).
 	// Tracked via bgWG so shutdown can wait for in-flight indexing
@@ -720,17 +705,9 @@ func (s *Server) Start(cfg ServerConfig) error {
 		s.pluginRegistry.ShutdownAll(ctx)
 	}
 
-	// Close the search index before the DB goes away — the index is
-	// independent storage but closing it here keeps shutdown order
-	// predictable and avoids Bleve holding file handles after the
-	// process starts tearing down.
-	if s.searchIndex != nil {
-		if err := s.searchIndex.Close(); err != nil {
-			log.Printf("[WARN] Failed to close search index: %v", err)
-		} else {
-			log.Println("[INFO] Search index closed")
-		}
-	}
+	// Search index is closed by Container.Stop below — IndexService.Stop
+	// runs in reverse-resolved order alongside the other registered
+	// Stoppers and clears its handle so a double-call is a no-op.
 
 	// SERVER-LIFECYCLE-FLIP: drive remaining Stoppers via the container.
 	// Runs in reverse resolved order; covers activityWriter (replaces


### PR DESCRIPTION
## Summary

Closes the documented \`searchindex\` holdout from PR #901. The race that pre-FLIP timing happened to hide:

\`Server.Start\` was launching \`stripMovementAtoms\` / \`remuxMalformedM4BFiles\` / external-ID + AcoustID backfill goroutines (plus HTTP handlers) that read \`s.store\` **before** the \`indexedStore\` decorator wrapped \`s.store\`. With PR #901's \`Container.Start\` shifting timing, the race manifested reliably in \`TestServerStartGracefulShutdown\`.

## Fix

Do the Bleve open + \`indexedStore\` wrap at the **top** of \`Server.Start\`, right after \`Container.Start\`. Every subsequent reader sees the wrapped store.

With ordering fixed, \`searchindex\` fully participates in the container lifecycle:

- **\`internal/search/register.go\`** (v2.0 → 3.0):
  - \`IndexService.Start\` now actually opens Bleve (no more \`OpenInline\` helper).
  - \`IndexService.Stop\` actually closes + clears the handle. Idempotent.
  - \`Container.Start\` drives open; \`Container.Stop\` drives close.
- **\`internal/server/server_lifecycle.go\`**:
  - Bleve-pull + \`indexedStore\` wrap move to immediately after \`Container.Start\`. \`s.searchIndex\` set from \`idx.Index()\`.
  - Delete the inline \`s.searchIndex.Close()\` block in \`Shutdown\` — \`Container.Stop\`'s \`IndexService.Stop\` handles it. Idempotent, so a future inline regression wouldn't panic.
  - Drop the duplicate \"Open search index\" block lower in \`Start\` (it was after the wrap was already installed above).

## Verification

\`\`\`
go build ./... ; go vet ./...                                  # clean
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestServerStartGracefulShutdown\" -count=3              # ok 21.6s
\`\`\`

**3 consecutive race-clean passes.** Pre-fix this test failed reliably once PR #901's \`Container.Start\` was wired (that's why PR #901 deferred this — it took a separate, focused fix).

\`\`\`
go test ./internal/server -short -race -timeout=180s \\
  -run \"TestHandler_|TestNewServer|TestRegister|TestServer\"   # ok 9.5s
go test ./internal/search ./internal/serviceregistry \\
  -short -race                                                 # ok
\`\`\`

\`NewServer\` line count unchanged (388) — this is a \`Server.Start\` restructure + \`internal/search\` refactor, not a \`NewServer\` trim. The structural win is that **searchindex is no longer a documented lifecycle holdout**: \`Container.Start\`/\`Stop\` fully drives the lifecycle now.

## Test plan

- [x] build / vet clean
- [x] graceful shutdown race-clean ×3
- [x] server test subset green
- [x] search + serviceregistry tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)