### PR TITLE
fix(web/login): make password managers detect username + password fields

### DIFF
--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Login.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9a3f2c1d-4b5e-6f70-8a9b-0c1d2e3f4a5b
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
@@ -76,7 +76,15 @@ export function Login() {
         p: 3,
       }}
     >
-      <Paper component="form" onSubmit={submit} sx={{ p: 4, maxWidth: 480, width: '100%' }}>
+      <Paper
+        component="form"
+        id="login-form"
+        name="login-form"
+        method="post"
+        action="#"
+        onSubmit={submit}
+        sx={{ p: 4, maxWidth: 480, width: '100%' }}
+      >
         <Stack spacing={2}>
           <Typography variant="h4" gutterBottom>
             {mode === 'setup' ? 'Create Admin Account' : 'Login'}
@@ -93,7 +101,15 @@ export function Login() {
             label="Username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
+            name="username"
+            id="username"
+            type="text"
             autoComplete="username"
+            inputProps={{
+              autoCapitalize: 'none',
+              autoCorrect: 'off',
+              spellCheck: false,
+            }}
             required
             fullWidth
           />
@@ -103,7 +119,15 @@ export function Login() {
               label="Email (optional)"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+              name="email"
+              id="email"
+              type="email"
               autoComplete="email"
+              inputProps={{
+                autoCapitalize: 'none',
+                autoCorrect: 'off',
+                spellCheck: false,
+              }}
               fullWidth
             />
           )}
@@ -113,6 +137,8 @@ export function Login() {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            name="password"
+            id="password"
             autoComplete={
               mode === 'setup' ? 'new-password' : 'current-password'
             }

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Setup.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0f8a9b4c-1d2e-4a70-b8c5-3d7e0f1b9a99
 
 import React, { useState } from 'react';
@@ -75,13 +75,29 @@ export default function Setup() {
             </Alert>
           )}
 
-          <Box component="form" onSubmit={handleSubmit}>
+          <Box
+            component="form"
+            id="setup-form"
+            name="setup-form"
+            method="post"
+            action="#"
+            onSubmit={handleSubmit}
+          >
             <TextField
               fullWidth
               label="Username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               margin="normal"
+              name="username"
+              id="username"
+              type="text"
+              autoComplete="username"
+              inputProps={{
+                autoCapitalize: 'none',
+                autoCorrect: 'off',
+                spellCheck: false,
+              }}
               required
               autoFocus
             />
@@ -91,7 +107,15 @@ export default function Setup() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               margin="normal"
+              name="email"
+              id="email"
               type="email"
+              autoComplete="email"
+              inputProps={{
+                autoCapitalize: 'none',
+                autoCorrect: 'off',
+                spellCheck: false,
+              }}
             />
             <TextField
               fullWidth
@@ -99,7 +123,10 @@ export default function Setup() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               margin="normal"
+              name="password"
+              id="password"
               type="password"
+              autoComplete="new-password"
               required
               helperText="Minimum 8 characters"
             />
@@ -109,7 +136,10 @@ export default function Setup() {
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               margin="normal"
+              name="confirm-password"
+              id="confirm-password"
               type="password"
+              autoComplete="new-password"
               required
             />
             <Button


### PR DESCRIPTION
## Summary

Safari / Chrome / Firefox all use heuristic detectors (in addition to \`autocomplete=\"...\"\`) to identify login forms for autofill + offer-to-save. Login.tsx and Setup.tsx had only the autocomplete hints — missing \`name\`/\`id\`/\`type\` made the form ambiguous enough that at least Safari + Chrome were not prompting password managers to save credentials.

## Changes

\`web/src/pages/Login.tsx\` + \`web/src/pages/Setup.tsx\`:
- Each field now has \`name\`, \`id\`, explicit \`type\` (\`text\` / \`email\` / \`password\`), and the appropriate \`autoComplete\` (\`username\` / \`email\` / \`current-password\` / \`new-password\`).
- Username + email get \`inputProps: { autoCapitalize: \"none\", autoCorrect: \"off\", spellCheck: false }\` so iOS doesn't mangle them.
- Forms get \`id=\"<form>-form\"\`, \`name=\"<form>-form\"\`, \`method=\"post\"\`, \`action=\"#\"\` — older detectors (LastPass, 1Password legacy) need these. Submit handlers \`preventDefault\` so nothing actually POSTs to \`#\`; the network call is still the existing \`auth.login\` / \`fetch(/api/v1/auth/setup)\`.

## Verification

\`\`\`
npx tsc --noEmit       # clean
make build             # clean
\`\`\`

Manual test plan after deploy: open \`/login\`, log in, browser should now offer to save credentials. Test on Safari, Chrome, Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)