### PR TITLE
fix: activity 500s + Active Ops display + hide Cancel on completed

### DIFF
--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
 
 package database
@@ -7,6 +7,7 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -16,6 +17,33 @@ import (
 	"github.com/nutsdb/nutsdb"
 	"github.com/oklog/ulid/v2"
 )
+
+// isNutsEmptyScan returns true for the family of nutsdb errors that all
+// mean "no entries to scan" — none of which should be propagated as a
+// 500 error to the activity-log API. nutsdb v1.1.0 has THREE relevant
+// sentinels (note the two near-identical names):
+//
+//   - ErrBucketNotFound ("bucket not found")  — tx_bucket.go etc.
+//   - ErrNotFoundBucket ("bucket not found")  — tx_btree.go RangeScanEntries
+//   - ErrRangeScan      ("range scans not found") — RangeScanEntries when
+//     the bucket exists but yields zero results
+//   - ErrBucketEmpty    — the (older) empty-bucket sentinel.
+//
+// nutsdb.IsBucketNotFound only matches the first. Without this helper, a
+// fresh activity store (no buckets created yet) returns 500 on every
+// /api/v1/activity request — because Query() → scanTier() →
+// RangeScanEntries returns ErrNotFoundBucket which IsBucketNotFound
+// doesn't catch. Same applies on the first request to a freshly-deployed
+// server when a tier bucket has never had a write committed.
+func isNutsEmptyScan(err error) bool {
+	if err == nil {
+		return false
+	}
+	return nutsdb.IsBucketNotFound(err) ||
+		nutsdb.IsBucketEmpty(err) ||
+		errors.Is(err, nutsdb.ErrNotFoundBucket) ||
+		errors.Is(err, nutsdb.ErrRangeScan)
+}
 
 // NutsActivityStore persists activity log entries in a NutsDB directory.
 // It is a drop-in replacement for ActivityStore (SQLite).
@@ -611,7 +639,7 @@ func (s *NutsActivityStore) scanTierKeysAndValues(tier string, since, until *tim
 	err := s.db.View(func(tx *nutsdb.Tx) error {
 		keys, vals, err := tx.RangeScanEntries(bucket, start, end, true, true)
 		if err != nil {
-			if nutsdb.IsBucketNotFound(err) || nutsdb.IsBucketEmpty(err) {
+			if isNutsEmptyScan(err) {
 				return nil
 			}
 			return err
@@ -638,7 +666,7 @@ func (s *NutsActivityStore) queryByIndex(indexBucket string, f ActivityFilter) (
 			false, true,
 		)
 		if err != nil {
-			if nutsdb.IsBucketNotFound(err) || nutsdb.IsBucketEmpty(err) {
+			if isNutsEmptyScan(err) {
 				return nil
 			}
 			return err
@@ -705,7 +733,7 @@ func (s *NutsActivityStore) findExistingDigest(dateKey string) (DigestDetails, [
 			true, true,
 		)
 		if err != nil {
-			if nutsdb.IsBucketNotFound(err) || nutsdb.IsBucketEmpty(err) {
+			if isNutsEmptyScan(err) {
 				return nil
 			}
 			return err

--- a/internal/database/nuts_metrics_store.go
+++ b/internal/database/nuts_metrics_store.go
@@ -114,7 +114,7 @@ func (s *NutsMetricsStore) GetCacheStatsHistory(cacheName string, since time.Tim
 		err := s.db.View(func(tx *nutsdb.Tx) error {
 			_, vals, err := tx.RangeScanEntries(metsBucket(name), start, end, false, true)
 			if err != nil {
-				if nutsdb.IsBucketNotFound(err) || nutsdb.IsBucketEmpty(err) {
+				if isNutsEmptyScan(err) {
 					return nil
 				}
 				return err
@@ -160,7 +160,7 @@ func (s *NutsMetricsStore) cacheNames(cacheName string) ([]string, error) {
 	err := s.db.View(func(tx *nutsdb.Tx) error {
 		keys, _, err := tx.RangeScanEntries(metricsIdxBucket, []byte(""), []byte("\xff\xff\xff\xff"), true, false)
 		if err != nil {
-			if nutsdb.IsBucketNotFound(err) || nutsdb.IsBucketEmpty(err) {
+			if isNutsEmptyScan(err) {
 				return nil
 			}
 			return err

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -748,24 +748,32 @@ export default function ActivityLog() {
                             </Typography>
                           )}
                           <Typography variant="subtitle2" fontWeight="bold">
-                            {op.type.replace(/_/g, ' ')}
+                            {op.displayName || op.def_id || op.type.replace(/_/g, ' ')}
                           </Typography>
                           <Chip
                             size="small"
                             label={op.status === 'queued' ? 'pending' : op.status}
-                            color={op.status === 'queued' ? 'default' : 'info'}
+                            color={
+                              op.status === 'queued' ? 'default' :
+                              op.status === 'completed' ? 'success' :
+                              op.status === 'failed' ? 'error' :
+                              op.status === 'canceled' ? 'warning' :
+                              'info'
+                            }
                           />
                         </Stack>
-                        <Button
-                          size="small"
-                          color="error"
-                          variant="outlined"
-                          startIcon={<CancelIcon />}
-                          onClick={(e) => { e.stopPropagation(); handleCancelOp(op.id); }}
-                          disabled={cancelling.has(op.id)}
-                        >
-                          {cancelling.has(op.id) ? 'Cancelling...' : 'Cancel'}
-                        </Button>
+                        {!['completed', 'failed', 'canceled'].includes(op.status) && (
+                          <Button
+                            size="small"
+                            color="error"
+                            variant="outlined"
+                            startIcon={<CancelIcon />}
+                            onClick={(e) => { e.stopPropagation(); handleCancelOp(op.id); }}
+                            disabled={cancelling.has(op.id)}
+                          >
+                            {cancelling.has(op.id) ? 'Cancelling...' : 'Cancel'}
+                          </Button>
+                        )}
                       </Stack>
                       {op.status === 'queued' ? (
                         <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 3.2.0
+// version: 3.3.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
@@ -9,7 +9,22 @@ import { useAppStore } from './useAppStore';
 
 export interface ActiveOperation {
   id: string;
+  /** def_id is the canonical operation identifier, e.g.
+   *  "scheduler.purge-deleted". Use this for equality checks like
+   *  `op.def_id === 'scan'`. Kept separate from the legacy `type`
+   *  field so existing call sites that match on the old short name
+   *  ('scan', 'itunes_import', 'ol_dump_import') keep working. */
+  def_id?: string;
+  /** Plugin namespace, e.g. "scheduler", "maintenance", "itunes". */
+  plugin?: string;
+  /** Legacy short type code (e.g. 'scan', 'itunes_import'). Old call
+   *  sites filter on this; keep as-is. For NEW filters prefer def_id. */
   type: string;
+  /** Human-readable label for UI display ("Purge soft-deleted books",
+   *  "iTunes Path Repair", etc.). Sourced from the OperationDef
+   *  DisplayName on the backend. Use this in render code instead of
+   *  type. */
+  displayName?: string;
   status: string;
   progress: number;
   total: number;
@@ -45,11 +60,26 @@ interface OperationsState {
   closeSSE: () => void;
 }
 
-// Converts v2 operation to unified ActiveOperation
+// Converts v2 operation to unified ActiveOperation.
+//
+// The legacy `type` field used to be set from `op.plugin`, which made every
+// scheduler op render as "scheduler" (the plugin namespace) in the UI even
+// though the def_id and display_name carried the real identity. We now
+// derive `type` from the def_id's tail segment ("scheduler.purge-deleted"
+// → "purge-deleted") so existing equality checks like
+// `op.type === 'scan'` keep working when the def_id is just "scan", while
+// the bare-plugin display is fixed. The full def_id and the curated
+// display_name are also exposed for code that wants them.
 function fromV2(op: api.OperationV2): ActiveOperation {
+  const defID = op.def_id ?? '';
+  // Strip plugin prefix for back-compat with old `op.type === 'scan'` checks.
+  const shortType = defID.includes('.') ? defID.slice(defID.indexOf('.') + 1) : defID || op.plugin;
   return {
     id: op.id,
-    type: op.plugin, // In v2, the operation type is stored in 'plugin'
+    def_id: defID,
+    plugin: op.plugin,
+    type: shortType,
+    displayName: op.display_name,
     status: op.status,
     progress: op.progress_current ?? 0,
     total: op.progress_total ?? 0,


### PR DESCRIPTION
Three coupled dashboard bugs:

1. \`/api/v1/activity\` and \`/api/v1/activity/sources\` return 500 with \`bucket not found\` — nutsdb v1.1.0 has TWO error vars with the same message (\`ErrBucketNotFound\` vs \`ErrNotFoundBucket\`), and \`nutsdb.IsBucketNotFound\` only matches one of them. Add an \`isNutsEmptyScan\` helper matching both plus \`ErrRangeScan\` + \`ErrBucketEmpty\`.

2. Active Operations all rendered as \"scheduler\" — \`useOperationsStore.fromV2\` set \`type = op.plugin\`. Now split into \`type\` (short def-id tail, back-compat for old \`op.type === 'scan'\` filters), \`def_id\` (full), \`displayName\` (e.g. \"Purge soft-deleted books\"). ActivityLog renders \`displayName || def_id || type\`.

3. Cancel button shown on completed ops — wrap in \`{!['completed','failed','canceled'].includes(op.status) && ...}\`. Also color-code the status chip (success/error/warning).

Build clean; deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)