### PR TITLE
refactor(cmd): SERVER-GLOBAL-STORE-AUDIT phase 1 — Store passed explicitly

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -35,7 +35,7 @@ func stubCommandDeps(t *testing.T) {
 	origDefaultCfg := getDefaultServerConfig
 	origStart := startServer
 
-	initializeStore = func(dbType, path string, enableSQLite bool) error {
+	initializeStore = func(dbType, path string, enableSQLite bool) (database.Store, error) {
 		// Command tests only need GlobalStore to be non-nil for the
 		// startup sequence to proceed. The only store method the
 		// startup path actually touches is GetAllImportPaths (in
@@ -46,7 +46,7 @@ func stubCommandDeps(t *testing.T) {
 		ms := mocks.NewMockStore(t)
 		ms.EXPECT().GetAllImportPaths().Return(nil, nil).Maybe()
 		database.SetGlobalStore(ms)
-		return nil
+		return ms, nil
 	}
 	closeStore = func() error {
 		database.SetGlobalStore(nil)
@@ -273,8 +273,8 @@ func TestStoreInitializationError(t *testing.T) {
 	config.AppConfig.DatabasePath = filepath.Join(tempDir, "db.sqlite")
 	config.AppConfig.EnableSQLite = true
 
-	initializeStore = func(dbType, path string, enableSQLite bool) error {
-		return fmt.Errorf("store init failed")
+	initializeStore = func(dbType, path string, enableSQLite bool) (database.Store, error) {
+		return nil, fmt.Errorf("store init failed")
 	}
 
 	if err := scanCmd.RunE(scanCmd, nil); err == nil {

--- a/cmd/dedup_bench.go
+++ b/cmd/dedup_bench.go
@@ -105,15 +105,16 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 		authorData, err = fetchAuthorsFromServer(benchServerURL)
 	} else {
 		log.Println("Fetching authors from local database")
-		if initErr := initializeStore(
+		store, initErr := initializeStore(
 			config.AppConfig.DatabaseType,
 			config.AppConfig.DatabasePath,
 			config.AppConfig.EnableSQLite,
-		); initErr != nil {
+		)
+		if initErr != nil {
 			return fmt.Errorf("failed to initialize database: %w", initErr)
 		}
 		defer closeStore()
-		authorData, err = extractAuthorData(database.GetGlobalStore())
+		authorData, err = extractAuthorData(store)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to extract author data: %w", err)

--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -58,23 +58,24 @@ func init() {
 	diagnosticsCmd.AddCommand(queryCmd)
 }
 
-func ensureDiagnosticsStore() (func(), error) {
-	if err := database.InitializeStore(
+func ensureDiagnosticsStore() (database.Store, func(), error) {
+	store, err := database.InitializeStore(
 		config.AppConfig.DatabaseType,
 		config.AppConfig.DatabasePath,
 		config.AppConfig.EnableSQLite,
-	); err != nil {
-		return nil, fmt.Errorf("failed to initialize database: %w", err)
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize database: %w", err)
 	}
 
 	cleanup := func() {
 		database.CloseStore()
 	}
-	return cleanup, nil
+	return store, cleanup, nil
 }
 
 func runCleanupInvalidBooks(force, dryRun bool) error {
-	closer, err := ensureDiagnosticsStore()
+	store, closer, err := ensureDiagnosticsStore()
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func runCleanupInvalidBooks(force, dryRun bool) error {
 	placeholders := []string{"{series}", "{narrator}", "{author}", "{title}"}
 
 	for {
-		books, err := database.GetGlobalStore().GetAllBooks(batchSize, offset)
+		books, err := store.GetAllBooks(batchSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed to fetch books: %w", err)
 		}
@@ -136,7 +137,7 @@ func runCleanupInvalidBooks(force, dryRun bool) error {
 
 	deleted := 0
 	for _, book := range invalid {
-		if err := database.GetGlobalStore().DeleteBook(book.ID); err != nil {
+		if err := store.DeleteBook(book.ID); err != nil {
 			fmt.Printf("Failed to delete %s: %v\n", book.ID, err)
 			continue
 		}
@@ -159,13 +160,13 @@ func runDiagnosticsQuery(limit int, prefix string, raw bool) error {
 		return runRawPebbleQuery(limit, prefix)
 	}
 
-	closer, err := ensureDiagnosticsStore()
+	store, closer, err := ensureDiagnosticsStore()
 	if err != nil {
 		return err
 	}
 	defer closer()
 
-	books, err := database.GetGlobalStore().GetAllBooks(limit, 0)
+	books, err := store.GetAllBooks(limit, 0)
 	if err != nil {
 		return fmt.Errorf("failed to fetch books: %w", err)
 	}

--- a/cmd/diagnostics_test.go
+++ b/cmd/diagnostics_test.go
@@ -363,7 +363,7 @@ func TestEnsureDiagnosticsStoreError(t *testing.T) {
 	// Set invalid database type
 	config.AppConfig.DatabaseType = "invalid"
 
-	_, err := ensureDiagnosticsStore()
+	_, _, err := ensureDiagnosticsStore()
 	if err == nil {
 		t.Fatal("expected error for invalid database type")
 	}
@@ -379,7 +379,7 @@ func TestEnsureDiagnosticsStorePebble(t *testing.T) {
 	config.AppConfig.DatabaseType = "pebble"
 	config.AppConfig.DatabasePath = tempDir
 
-	cleanup, err := ensureDiagnosticsStore()
+	_, cleanup, err := ensureDiagnosticsStore()
 	if err != nil {
 		t.Fatalf("expected pebble store creation to succeed: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ var scanCmd = &cobra.Command{
 		}
 
 		// Initialize database
-		if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+		if _, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
 			return fmt.Errorf("failed to initialize database: %w", err)
 		}
 		defer closeStore()
@@ -112,7 +112,7 @@ var playlistCmd = &cobra.Command{
 	Long:  `Generate iTunes-compatible playlists for each audiobook series.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Initialize database
-		if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+		if _, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
 			return fmt.Errorf("failed to initialize database: %w", err)
 		}
 		defer closeStore()
@@ -137,7 +137,7 @@ var tagCmd = &cobra.Command{
 	Long:  `Update the metadata tags of audio files to include series information.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Initialize database
-		if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+		if _, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
 			return fmt.Errorf("failed to initialize database: %w", err)
 		}
 		defer closeStore()
@@ -173,7 +173,7 @@ var organizeCmd = &cobra.Command{
 		}
 
 		// Initialize database
-		if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+		if _, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
 			return fmt.Errorf("failed to initialize database: %w", err)
 		}
 		defer closeStore()
@@ -228,8 +228,10 @@ var serveCmd = &cobra.Command{
 			defer logFile.Close()
 		}
 
-		// Initialize database
-		if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+		// Initialize database. Capture the returned Store so we can pass
+		// it explicitly down the call chain (SERVER-GLOBAL-STORE-AUDIT).
+		store, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite)
+		if err != nil {
 			return fmt.Errorf("failed to initialize database: %w", err)
 		}
 		defer closeStore()
@@ -244,7 +246,7 @@ var serveCmd = &cobra.Command{
 		fmt.Println("Settings encryption initialized")
 
 		// Load configuration from database (overrides defaults with persisted values)
-		if err := loadConfigFromDB(database.GetGlobalStore()); err != nil {
+		if err := loadConfigFromDB(store); err != nil {
 			fmt.Printf("Warning: Could not load config from database: %v\n", err)
 		} else {
 			fmt.Println("Configuration loaded from database")
@@ -265,7 +267,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		// Log import path count
-		if folders, err := database.GetGlobalStore().GetAllImportPaths(); err == nil {
+		if folders, err := store.GetAllImportPaths(); err == nil {
 			fmt.Printf("  - Import paths (scan paths): %d configured\n", len(folders))
 			for _, folder := range folders {
 				fmt.Printf("    * %s (%s)\n", folder.Name, folder.Path)
@@ -277,7 +279,7 @@ var serveCmd = &cobra.Command{
 		// Create and start server. Store is passed explicitly per the 4.4 DI
 		// migration; database.GlobalStore remains assigned for call sites that
 		// haven't yet been migrated to use s.Store().
-		srv := newServer(database.GetGlobalStore())
+		srv := newServer(store)
 
 		fmt.Println("Server initialized (hub, batcher, file I/O pool)")
 		cfg := getDefaultServerConfig()

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -91,12 +91,12 @@ func runSeed(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--series must be > 0")
 	}
 
-	if err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite); err != nil {
+	store, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite)
+	if err != nil {
 		return fmt.Errorf("failed to initialize database: %w", err)
 	}
 	defer closeStore()
 
-	store := database.GetGlobalStore()
 	if store == nil {
 		return fmt.Errorf("database not initialized")
 	}

--- a/internal/database/coverage_test.go
+++ b/internal/database/coverage_test.go
@@ -20,11 +20,11 @@ func TestInitializeStoreAndClose(t *testing.T) {
 		DB = origDB
 	}()
 
-	if err := InitializeStore("sqlite", filepath.Join(tempDir, "db.sqlite"), false); err == nil {
+	if _, err := InitializeStore("sqlite", filepath.Join(tempDir, "db.sqlite"), false); err == nil {
 		t.Fatal("expected error when sqlite is not enabled")
 	}
 
-	if err := InitializeStore("sqlite", filepath.Join(tempDir, "db.sqlite"), true); err != nil {
+	if _, err := InitializeStore("sqlite", filepath.Join(tempDir, "db.sqlite"), true); err != nil {
 		t.Fatalf("unexpected sqlite init error: %v", err)
 	}
 	if globalStore == nil {
@@ -37,7 +37,7 @@ func TestInitializeStoreAndClose(t *testing.T) {
 	DB = nil
 
 	pebbleDir := filepath.Join(tempDir, "pebble")
-	if err := InitializeStore("pebble", pebbleDir, false); err != nil {
+	if _, err := InitializeStore("pebble", pebbleDir, false); err != nil {
 		t.Fatalf("unexpected pebble init error: %v", err)
 	}
 	if err := CloseStore(); err != nil {
@@ -45,7 +45,7 @@ func TestInitializeStoreAndClose(t *testing.T) {
 	}
 	globalStore = nil
 
-	if err := InitializeStore("unknown", filepath.Join(tempDir, "bad"), false); err == nil {
+	if _, err := InitializeStore("unknown", filepath.Join(tempDir, "bad"), false); err == nil {
 		t.Fatal("expected error for unsupported database type")
 	}
 }

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -990,39 +990,46 @@ func SetGlobalStore(s Store) {
 }
 
 // InitializeStore initializes the database store based on configuration
-func InitializeStore(dbType, path string, enableSQLite bool) error {
+// and returns it. The package-level globalStore is also set for back-compat
+// with code paths that still use GetGlobalStore(); new code should prefer
+// the returned Store and pass it explicitly down the call chain
+// (SERVER-GLOBAL-STORE-AUDIT, in flight).
+func InitializeStore(dbType, path string, enableSQLite bool) (Store, error) {
+	var s Store
 	var err error
 
 	switch dbType {
 	case "sqlite", "sqlite3":
 		if !enableSQLite {
-			return fmt.Errorf("SQLite3 is not enabled. To use SQLite3, you must explicitly enable it with --enable-sqlite3-i-know-the-risks or set 'enable_sqlite3_i_know_the_risks: true' in your config file. PebbleDB is the recommended database for production use")
+			return nil, fmt.Errorf("SQLite3 is not enabled. To use SQLite3, you must explicitly enable it with --enable-sqlite3-i-know-the-risks or set 'enable_sqlite3_i_know_the_risks: true' in your config file. PebbleDB is the recommended database for production use")
 		}
-		globalStore, err = NewSQLiteStore(path)
+		s, err = NewSQLiteStore(path)
 		if err != nil {
-			return fmt.Errorf("failed to initialize SQLite store: %w", err)
+			return nil, fmt.Errorf("failed to initialize SQLite store: %w", err)
 		}
 	case "pebble", "":
 		// PebbleDB is the default
-		globalStore, err = NewPebbleStore(path)
+		s, err = NewPebbleStore(path)
 		if err != nil {
-			return fmt.Errorf("failed to initialize PebbleDB store: %w", err)
+			return nil, fmt.Errorf("failed to initialize PebbleDB store: %w", err)
 		}
 	default:
-		return fmt.Errorf("unsupported database type: %s (supported: pebble, sqlite)", dbType)
+		return nil, fmt.Errorf("unsupported database type: %s (supported: pebble, sqlite)", dbType)
 	}
 
+	globalStore = s
+
 	// Maintain backwards compatibility with the global DB variable for SQLite
-	if sqliteStore, ok := globalStore.(*SQLiteStore); ok {
+	if sqliteStore, ok := s.(*SQLiteStore); ok {
 		DB = sqliteStore.db
 	}
 
 	// Run migrations to ensure schema is up to date
-	if err := RunMigrations(globalStore); err != nil {
-		return fmt.Errorf("failed to run migrations: %w", err)
+	if err := RunMigrations(s); err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 
-	return nil
+	return s, nil
 }
 
 // CloseStore closes the global store

--- a/internal/scanner/scanner_coverage_test.go
+++ b/internal/scanner/scanner_coverage_test.go
@@ -476,7 +476,7 @@ func TestSaveBookToDatabaseCodePaths(t *testing.T) {
 		}
 		defer database.Close()
 
-		if err := database.InitializeStore("sqlite", dbPath, true); err != nil {
+		if _, err := database.InitializeStore("sqlite", dbPath, true); err != nil {
 			t.Skip("cannot initialize store for this test")
 		}
 		defer database.CloseStore()


### PR DESCRIPTION
First slice of the global-store audit per the handoff plan. \`cmd/\` files are the smallest and most-isolated callers; doing them first lets the pattern be well-exercised before tackling the ~110 server-package callers.

## Changes

- **\`internal/database/store.go\`**: \`InitializeStore\` signature \`(...) error\` → \`(Store, error)\`. The package-level \`globalStore\` is still set inside so unmigrated callers keep working during the rest of the audit. New code should prefer the returned Store.
- **\`cmd/root.go\`**: capture the returned Store (named \`store\` in \`serve\`). Use it for \`loadConfigFromDB\`, \`GetAllImportPaths\`, and \`newServer\` instead of \`database.GetGlobalStore()\`. 5 \`InitializeStore\` call sites in this file updated.
- **\`cmd/seed.go\`**, **\`cmd/dedup_bench.go\`**, **\`cmd/diagnostics.go\`**: receive the Store from \`InitializeStore\`, pass to downstream funcs (\`extractAuthorData\`, mock checks) instead of \`GetGlobalStore\`. \`ensureDiagnosticsStore\` returns \`(Store, func(), error)\`.
- **\`cmd/commands_test.go\`**, **\`cmd/diagnostics_test.go\`**, **\`internal/database/coverage_test.go\`**, **\`internal/scanner/scanner_coverage_test.go\`**: mock signature + test callers updated.

After this PR, **\`cmd/\` has zero production callers of \`database.GetGlobalStore()\`**. ~108 callers remain (mostly \`internal/server\`, \`internal/scanner\`, \`internal/audiobooks\`, \`internal/metafetch\`) — subsequent phases.

## Verification

\`\`\`
go build ./... ; go vet ./...                          # clean
go test ./internal/database ./cmd -short -race         # ok 24s / 8.5s
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)