### PR TITLE
refactor: SERVER-GLOBAL-STORE-AUDIT phase 2 — itunes/rebuild + backup

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -423,15 +423,20 @@ func ScheduleBackup(interval time.Duration, config BackupConfig) error {
 	return fmt.Errorf("scheduled backups not yet implemented")
 }
 
-// BackupDatabase is a convenience function that backs up the global database
-func BackupDatabase(config BackupConfig) (*BackupInfo, error) {
-	if database.GetGlobalStore() == nil {
+// BackupDatabase is a convenience function that backs up the database
+// referenced by the supplied store. Currently a stub — kept around because
+// tests exercise the nil-store error path, and a future implementation
+// will add Path()/Type() accessors to the Store interface.
+//
+// Signature takes an explicit database.Store (SERVER-GLOBAL-STORE-AUDIT
+// phase 2). Pass nil to exercise the "database not initialized" path.
+func BackupDatabase(store database.Store, config BackupConfig) (*BackupInfo, error) {
+	if store == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
 
-	// Get database path and type from config
-	// TODO: Add methods to Store interface to get database path and type
-	// For now, we'll need to pass these as parameters
+	// TODO: Add methods to Store interface to get database path and type.
+	// For now, we'll need to pass these as parameters via BackupConfig.
 
 	return nil, fmt.Errorf("backup requires database path and type information")
 }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1129,7 +1129,7 @@ func TestBackupDatabaseNilStore(t *testing.T) {
 	config := DefaultBackupConfig()
 
 	// Act
-	info, err := BackupDatabase(config)
+	info, err := BackupDatabase(nil, config)
 
 	// Assert
 	if err == nil {
@@ -1705,7 +1705,7 @@ func TestBackupDatabaseNotInitialized(t *testing.T) {
 	}
 
 	// Act
-	info, err := BackupDatabase(config)
+	info, err := BackupDatabase(nil, config)
 
 	// Assert
 	if err == nil {
@@ -1734,7 +1734,7 @@ func TestBackupDatabaseMissingInfo(t *testing.T) {
 	}
 
 	// Act
-	info, err := BackupDatabase(config)
+	info, err := BackupDatabase(nil, config)
 
 	// Assert - Should get an error (either "not initialized" or "requires path/type")
 	if err == nil {

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -17,6 +17,10 @@ import (
 type RebuildStore interface {
 	database.BookReader
 	GetBookFiles(bookID string) ([]database.BookFile, error)
+	// GetAuthorByID resolves an author by id for the
+	// resolveAuthorName helper. Added in SERVER-GLOBAL-STORE-AUDIT
+	// phase 2 to replace the prior database.GetGlobalStore() call.
+	GetAuthorByID(id int) (*database.Author, error)
 }
 
 // ComputeITLDiff reads the current ITL and the current DB state,
@@ -95,7 +99,7 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 		}
 
 		// Both exist — check if metadata or location need updating.
-		authorName := resolveAuthorName(book)
+		authorName := resolveAuthorName(store, book)
 		narrator := ""
 		if book.Narrator != nil {
 			narrator = *book.Narrator
@@ -162,7 +166,7 @@ func BuildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack 
 // Book for insertion into the ITL. Fills as many fields as
 // possible from the book's metadata.
 func buildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack {
-	authorName := resolveAuthorName(book)
+	authorName := resolveAuthorName(store, book)
 	genre := "Audiobook"
 	if book.Genre != nil && *book.Genre != "" {
 		genre = *book.Genre
@@ -198,14 +202,17 @@ func buildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack 
 	}
 }
 
-// resolveAuthorName returns the author name for a book.
-// This is a simplified version that works with the database store.
-func resolveAuthorName(book *database.Book) string {
+// resolveAuthorName returns the author name for a book. Takes the
+// caller's RebuildStore so we no longer depend on the package-level
+// database.GetGlobalStore (SERVER-GLOBAL-STORE-AUDIT phase 2). A nil
+// store falls back to the inline Author field — keeps tests that build
+// a Book{Author: &Author{Name: "..."}} working without wiring a store.
+func resolveAuthorName(store RebuildStore, book *database.Book) string {
 	if book.Author != nil {
 		return book.Author.Name
 	}
-	if book.AuthorID != nil {
-		if author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+	if book.AuthorID != nil && store != nil {
+		if author, err := store.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
 			return author.Name
 		}
 	}

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -151,6 +151,14 @@ func (m *mockRebuildStore) GetBookFiles(bookID string) ([]database.BookFile, err
 	return []database.BookFile{}, nil
 }
 
+// GetAuthorByID is a no-op for the mock — tests build books with an
+// inline Author pointer, so the AuthorID lookup path isn't exercised.
+// Returning (nil, nil) trips the helper's "nothing found" branch
+// safely (resolveAuthorName already handles a nil store gracefully).
+func (m *mockRebuildStore) GetAuthorByID(id int) (*database.Author, error) {
+	return nil, nil
+}
+
 func TestBuildNewTrackFromBook(t *testing.T) {
 	// Create a mock book
 	bookID := "book-1"
@@ -230,7 +238,7 @@ func TestResolveAuthorName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resolveAuthorName(tt.book)
+			result := resolveAuthorName(nil, tt.book)
 			if result != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}


### PR DESCRIPTION
Continues the global-store audit. resolveAuthorName takes a RebuildStore; BackupDatabase takes an explicit Store. ~108 → ~106 callers remaining.