### PR TITLE
refactor: SERVER-GLOBAL-STORE-AUDIT phase 3a — file_io_pool, title_helpers, middleware

### DIFF
--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1311,7 +1311,7 @@ func (s *Server) updateAudiobook(c *gin.Context) {
 			}
 		}
 		if len(tagMap) > 0 {
-			if isProtectedPath(updatedBook.FilePath) {
+			if s.isProtectedPath(updatedBook.FilePath) {
 				log.Printf("[INFO] skipping write-back for protected path: %s", updatedBook.FilePath)
 			} else {
 				opConfig := fileops.OperationConfig{VerifyChecksums: true}

--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -39,7 +39,16 @@ type FileIOPool struct {
 	stopped  int32
 	pending  sync.Map      // "{bookID}:{opType}" -> FileIOJob, for in-memory tracking
 	overflow chan struct{} // semaphore to limit overflow goroutines
+	// store is the database backing the pending-op persistence layer.
+	// Set via SetStore after construction (SERVER-GLOBAL-STORE-AUDIT
+	// phase 3a). Nil-safe — the three persistence helpers all no-op
+	// when nil, matching the prior GetGlobalStore == nil branch.
+	store database.Store
 }
+
+// SetStore sets the store the pool uses to persist pending file ops.
+// Idempotent. Pass nil to disable persistence (no recovery on restart).
+func (p *FileIOPool) SetStore(s database.Store) { p.store = s }
 
 type fileIOJobEntry struct {
 	bookID string
@@ -116,7 +125,7 @@ func (p *FileIOPool) worker(id int) {
 			}()
 			job.fn()
 			p.pending.Delete(pendingKey(job.bookID, job.opType))
-			removePendingFileOp(job.bookID, job.opType)
+			p.removePendingFileOp(job.bookID, job.opType)
 		}()
 	}
 }
@@ -134,7 +143,7 @@ func (p *FileIOPool) SubmitTyped(bookID, opType string, fn func()) {
 	}
 	job := FileIOJob{BookID: bookID, OpType: opType, CreatedAt: time.Now()}
 	p.pending.Store(pendingKey(bookID, opType), job)
-	storePendingFileOp(job)
+	p.storePendingFileOp(job)
 
 	select {
 	case p.ch <- fileIOJobEntry{bookID: bookID, opType: opType, fn: fn}:
@@ -145,7 +154,7 @@ func (p *FileIOPool) SubmitTyped(bookID, opType string, fn func()) {
 			defer func() { <-p.overflow }()
 			fn()
 			p.pending.Delete(pendingKey(bookID, opType))
-			removePendingFileOp(bookID, opType)
+			p.removePendingFileOp(bookID, opType)
 		}()
 	}
 }
@@ -258,30 +267,36 @@ func parsePebbleKey(key string) (bookID, opType string, ok bool) {
 	return rest[:idx], rest[idx+1:], true
 }
 
-func storePendingFileOp(job FileIOJob) {
-	store := database.GetGlobalStore()
-	if store == nil {
+// storePendingFileOp is a method on FileIOPool so it uses the pool's
+// configured store (set via SetStore from NewServer) instead of
+// reaching for database.GetGlobalStore (SERVER-GLOBAL-STORE-AUDIT
+// phase 3a). Nil-safe — no-op if the pool has no store.
+func (p *FileIOPool) storePendingFileOp(job FileIOJob) {
+	if p == nil || p.store == nil {
 		return
 	}
 	data, _ := json.Marshal(job)
-	_ = store.SetRaw(pebbleKey(job.BookID, job.OpType), data)
+	_ = p.store.SetRaw(pebbleKey(job.BookID, job.OpType), data)
 }
 
-func removePendingFileOp(bookID, opType string) {
-	store := database.GetGlobalStore()
-	if store == nil {
+// removePendingFileOp clears the persisted record for a finished job.
+// See storePendingFileOp for the audit-phase rationale.
+func (p *FileIOPool) removePendingFileOp(bookID, opType string) {
+	if p == nil || p.store == nil {
 		return
 	}
-	_ = store.DeleteRaw(pebbleKey(bookID, opType))
+	_ = p.store.DeleteRaw(pebbleKey(bookID, opType))
 }
 
 // recoverInterruptedFileOps re-queues any file I/O jobs that were in-flight
-// when the server last shut down (or crashed).
+// when the server last shut down (or crashed). Uses the pool's
+// configured store rather than database.GetGlobalStore
+// (SERVER-GLOBAL-STORE-AUDIT phase 3a).
 func recoverInterruptedFileOps(pool *FileIOPool) {
-	store := database.GetGlobalStore()
-	if store == nil {
+	if pool == nil || pool.store == nil {
 		return
 	}
+	store := pool.store
 
 	keys, err := store.ScanPrefix(pendingFileOpPrefix)
 	if err != nil || len(keys) == 0 {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1374,7 +1374,7 @@ func (s *Server) handleBulkWriteBack(c *gin.Context) {
 			continue
 		}
 		// Skip protected paths
-		if isProtectedPath(book.FilePath) {
+		if s.isProtectedPath(book.FilePath) {
 			continue
 		}
 		// Filter by library state (only when not filtering by author/series exclusively)
@@ -1509,7 +1509,7 @@ func (s *Server) runBulkWriteBack(
 			mu.Unlock()
 			continue
 		}
-		if isProtectedPath(book.FilePath) {
+		if s.isProtectedPath(book.FilePath) {
 			mu.Lock()
 			_ = progress.Log("info", fmt.Sprintf("book %s: skipping protected path", bookID), nil)
 			mu.Unlock()

--- a/internal/server/protected_path_test.go
+++ b/internal/server/protected_path_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 func TestIsProtectedPath_FailedDir(t *testing.T) {
+	// isProtectedPath is now a method on *Server (SERVER-GLOBAL-STORE-AUDIT
+	// phase 3a). A zero-value Server is fine for this test — only the
+	// ".failed/" string-match branch is exercised; s.Store() returns nil
+	// so the import-path branch is skipped.
+	s := &Server{}
 	cases := []struct {
 		path     string
 		expected bool
@@ -20,6 +25,6 @@ func TestIsProtectedPath_FailedDir(t *testing.T) {
 		{"/library/.failedish/book.m4b", false},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.expected, isProtectedPath(tc.path), "path: %s", tc.path)
+		assert.Equal(t, tc.expected, s.isProtectedPath(tc.path), "path: %s", tc.path)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -490,6 +490,7 @@ func NewServer(store database.Store) *Server {
 	// `if batcher != nil` guards already in place.
 	server.writeBackBatcher = server.itunesSvc.Batcher
 	server.fileIOPool = NewFileIOPool(4)
+	server.fileIOPool.SetStore(resolvedStore)
 
 	// writeBackBatcher fan-out into metafetch / merge / quarantine /
 	// audiobook now happens in those services' PostInit hooks (they pull

--- a/internal/server/server_middleware.go
+++ b/internal/server/server_middleware.go
@@ -76,12 +76,17 @@ func filesCommonDir(files []database.BookFile) string {
 	return common
 }
 
-func isProtectedPath(filePath string) bool {
+// isProtectedPath is now a method on *Server so it uses the server's
+// resolved store rather than the package-level GetGlobalStore
+// (SERVER-GLOBAL-STORE-AUDIT phase 3a). Nil-safe — if s.Store() is
+// nil, the import-path check is skipped (matches prior behaviour
+// when GetGlobalStore returned nil).
+func (s *Server) isProtectedPath(filePath string) bool {
 	absPath, _ := filepath.Abs(filePath)
 
 	// Check import paths
-	if database.GetGlobalStore() != nil {
-		importPaths, err := database.GetGlobalStore().GetAllImportPaths()
+	if store := s.Store(); store != nil {
+		importPaths, err := store.GetAllImportPaths()
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)

--- a/internal/server/server_title_helpers.go
+++ b/internal/server/server_title_helpers.go
@@ -204,8 +204,15 @@ func extractTitleFromSegmentFilename(filename string) string {
 	return name
 }
 
-func reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []database.BookFile) {
-	eidStore := asExternalIDStore(database.GetGlobalStore())
+// reassignExternalIDsForFiles is now a method on *Server so it uses
+// the server's resolved store rather than the package-level
+// GetGlobalStore (SERVER-GLOBAL-STORE-AUDIT phase 3a).
+func (s *Server) reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []database.BookFile) {
+	store := s.Store()
+	if store == nil {
+		return
+	}
+	eidStore := asExternalIDStore(store)
 	if eidStore == nil {
 		return
 	}
@@ -242,7 +249,7 @@ func reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []data
 	// Reassign each mapping: delete old reverse key, update primary, add new reverse key
 	for _, m := range toMove {
 		oldReverseKey := fmt.Sprintf("ext_id:book:%s:%s:%s", sourceBookID, m.Source, m.ExternalID)
-		_ = database.GetGlobalStore().DeleteRaw(oldReverseKey)
+		_ = store.DeleteRaw(oldReverseKey)
 
 		m.BookID = targetBookID
 		if createErr := eidStore.CreateExternalIDMapping(&m); createErr != nil {

--- a/internal/server/versions_handlers.go
+++ b/internal/server/versions_handlers.go
@@ -366,7 +366,7 @@ func (s *Server) splitSegmentsToBooks(c *gin.Context) {
 		_ = s.Store().MoveBookFilesToBook([]string{fileID}, sourceBook.ID, created.ID)
 
 		// Reassign external ID mappings (iTunes PIDs) that belong to the moved file
-		reassignExternalIDsForFiles(sourceBook.ID, created.ID, []database.BookFile{f})
+		s.reassignExternalIDsForFiles(sourceBook.ID, created.ID, []database.BookFile{f})
 
 		createdBooks = append(createdBooks, created)
 	}
@@ -469,7 +469,7 @@ func (s *Server) moveSegments(c *gin.Context) {
 	}
 
 	// 6. Reassign external ID mappings (iTunes PIDs) for moved files
-	reassignExternalIDsForFiles(id, req.TargetBookID, movedFiles)
+	s.reassignExternalIDsForFiles(id, req.TargetBookID, movedFiles)
 
 	httputil.RespondWithOK(c, gin.H{
 		"segments_moved": len(req.SegmentIDs),


### PR DESCRIPTION
7 more callers eliminated. FileIOPool gains a store field + SetStore; reassignExternalIDsForFiles + isProtectedPath become *Server methods.