### PR TITLE
refactor: SERVER-GLOBAL-STORE-AUDIT phase 3b — server_metadata helpers → *Server methods

### DIFF
--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -210,7 +210,7 @@ func (s *Server) parseAudiobookWithAI(c *gin.Context) {
 
 	httputil.RespondWithOK(c, gin.H{
 		"message":    "audiobook updated with AI-parsed metadata",
-		"book":       enrichBookForResponseSingle(updatedBook),
+		"book":       s.enrichBookForResponseSingle(updatedBook),
 		"confidence": metadata.Confidence,
 	})
 }

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -320,7 +320,7 @@ func (s *Server) getAudiobook(c *gin.Context) {
 		return
 	}
 
-	httputil.RespondWithOK(c, enrichBookForResponseSingle(book))
+	httputil.RespondWithOK(c, s.enrichBookForResponseSingle(book))
 }
 
 // listAudiobookSegments returns file segments for a multi-file audiobook.
@@ -1332,7 +1332,7 @@ func (s *Server) updateAudiobook(c *gin.Context) {
 		s.writeBackBatcher.Enqueue(id)
 	}
 
-	httputil.RespondWithOK(c, enrichBookForResponseSingle(updatedBook))
+	httputil.RespondWithOK(c, s.enrichBookForResponseSingle(updatedBook))
 }
 
 func (s *Server) deleteAudiobook(c *gin.Context) {

--- a/internal/server/entities_handlers.go
+++ b/internal/server/entities_handlers.go
@@ -471,11 +471,11 @@ func (s *Server) getAuthorBooks(c *gin.Context) {
 	for i, b := range books {
 		bookIDs[i] = b.ID
 	}
-	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := batchFetchBookAuthorsAndNarrators(bookIDs)
+	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := s.batchFetchBookAuthorsAndNarrators(bookIDs)
 	
 	enriched := make([]enrichedBookResponse, len(books))
 	for i := range books {
-		enriched[i] = enrichBookForResponse(&books[i], bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
+		enriched[i] = s.enrichBookForResponse(&books[i], bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
 	}
 	httputil.RespondWithOK(c, gin.H{"items": enriched, "count": len(enriched)})
 }
@@ -697,11 +697,11 @@ func (s *Server) getSeriesBooks(c *gin.Context) {
 	for i, b := range books {
 		bookIDs[i] = b.ID
 	}
-	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := batchFetchBookAuthorsAndNarrators(bookIDs)
+	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := s.batchFetchBookAuthorsAndNarrators(bookIDs)
 	
 	enriched := make([]enrichedBookResponse, len(books))
 	for i := range books {
-		enriched[i] = enrichBookForResponse(&books[i], bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
+		enriched[i] = s.enrichBookForResponse(&books[i], bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
 	}
 	httputil.RespondWithOK(c, gin.H{"items": enriched, "count": len(enriched)})
 }

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -224,7 +224,7 @@ func (s *Server) fetchAudiobookMetadata(c *gin.Context) {
 	}
 	httputil.RespondWithOK(c, gin.H{
 		"message": resp.Message,
-		"book":    enrichBookForResponseSingle(enrichedBook),
+		"book":    s.enrichBookForResponseSingle(enrichedBook),
 		"source":  resp.Source,
 	})
 }
@@ -328,7 +328,7 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 	}
 	httputil.RespondWithOK(c, gin.H{
 		"message": resp.Message,
-		"book":    enrichBookForResponseSingle(enrichedBook),
+		"book":    s.enrichBookForResponseSingle(enrichedBook),
 		"source":  resp.Source,
 	})
 }
@@ -550,7 +550,7 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 			continue
 		}
 
-		state, err := loadMetadataState(bookID)
+		state, err := s.loadMetadataState(bookID)
 		if err != nil {
 			result.Status = "error"
 			result.Message = "failed to load metadata state"
@@ -777,7 +777,7 @@ func (s *Server) bulkFetchMetadata(c *gin.Context) {
 		}
 
 		if len(fetchedValues) > 0 {
-			if err := updateFetchedMetadataState(bookID, fetchedValues); err != nil {
+			if err := s.updateFetchedMetadataState(bookID, fetchedValues); err != nil {
 				log.Printf("[WARN] bulkFetchMetadata: failed to persist fetched metadata state for %s: %v", bookID, err)
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -437,7 +437,10 @@ func NewServer(store database.Store) *Server {
 	// not a runtime dependency.
 	if dbPath := config.AppConfig.DatabasePath; dbPath != "" {
 		dbDir := filepath.Dir(dbPath)
-		if ps, ok := database.GetGlobalStore().(*database.PebbleStore); ok {
+		// resolvedStore captured above from NewServer's caller (or the
+		// global as fallback in test paths) — avoids a second
+		// GetGlobalStore() lookup here (SERVER-GLOBAL-STORE-AUDIT).
+		if ps, ok := resolvedStore.(*database.PebbleStore); ok {
 			if migrateErr := database.MigrateEmbeddingsFromSQLite(ps.DB(), filepath.Join(dbDir, "embeddings.db")); migrateErr != nil {
 				log.Printf("[WARN] embeddings.db migration error (continuing): %v", migrateErr)
 			}

--- a/internal/server/server_metadata.go
+++ b/internal/server/server_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_metadata.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 588350bc-83db-47ed-9590-2b6513aadcda
-// last-edited: 2026-05-05
+// last-edited: 2026-05-13
 
 package server
 
@@ -45,10 +45,18 @@ func encodeMetadataValue(value any) (*string, error) {
 	return &encoded, nil
 }
 
-func loadLegacyMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
-	state := map[string]metafetch.MetadataFieldState{}
+// These helpers are now methods on *Server so they use the server's
+// resolved store (SERVER-GLOBAL-STORE-AUDIT phase 3b). Callers in this
+// package update to s.loadMetadataState(...) / s.saveMetadataState(...).
 
-	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
+func (s *Server) loadLegacyMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
+	state := map[string]metafetch.MetadataFieldState{}
+	store := s.Store()
+	if store == nil {
+		return state, fmt.Errorf("database not initialized")
+	}
+
+	pref, err := store.GetUserPreference(metadataStateKey(bookID))
 	if err != nil {
 		return state, err
 	}
@@ -62,13 +70,14 @@ func loadLegacyMetadataState(bookID string) (map[string]metafetch.MetadataFieldS
 	return state, nil
 }
 
-func loadMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
+func (s *Server) loadMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, error) {
 	state := map[string]metafetch.MetadataFieldState{}
-	if database.GetGlobalStore() == nil {
+	store := s.Store()
+	if store == nil {
 		return state, fmt.Errorf("database not initialized")
 	}
 
-	stored, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	stored, err := store.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -84,7 +93,7 @@ func loadMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, 
 		return state, nil
 	}
 
-	legacy, err := loadLegacyMetadataState(bookID)
+	legacy, err := s.loadLegacyMetadataState(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -92,18 +101,19 @@ func loadMetadataState(bookID string) (map[string]metafetch.MetadataFieldState, 
 		return state, nil
 	}
 
-	if err := saveMetadataState(bookID, legacy); err != nil {
+	if err := s.saveMetadataState(bookID, legacy); err != nil {
 		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
 	}
 	return legacy, nil
 }
 
-func saveMetadataState(bookID string, state map[string]metafetch.MetadataFieldState) error {
-	if database.GetGlobalStore() == nil {
+func (s *Server) saveMetadataState(bookID string, state map[string]metafetch.MetadataFieldState) error {
+	store := s.Store()
+	if store == nil {
 		return fmt.Errorf("database not initialized")
 	}
 
-	existing, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	existing, err := store.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return err
 	}
@@ -135,14 +145,14 @@ func saveMetadataState(bookID string, state map[string]metafetch.MetadataFieldSt
 			UpdatedAt:      entry.UpdatedAt,
 		}
 
-		if err := database.GetGlobalStore().UpsertMetadataFieldState(&dbState); err != nil {
+		if err := store.UpsertMetadataFieldState(&dbState); err != nil {
 			return fmt.Errorf("failed to persist metadata state for %s: %w", field, err)
 		}
 		delete(existingFields, field)
 	}
 
 	for field := range existingFields {
-		if err := database.GetGlobalStore().DeleteMetadataFieldState(bookID, field); err != nil {
+		if err := store.DeleteMetadataFieldState(bookID, field); err != nil {
 			return fmt.Errorf("failed to clean up metadata state for %s: %w", field, err)
 		}
 	}
@@ -161,8 +171,8 @@ func decodeRawValue(raw json.RawMessage) any {
 	return value
 }
 
-func updateFetchedMetadataState(bookID string, values map[string]any) error {
-	state, err := loadMetadataState(bookID)
+func (s *Server) updateFetchedMetadataState(bookID string, values map[string]any) error {
+	state, err := s.loadMetadataState(bookID)
 	if err != nil {
 		return err
 	}
@@ -175,15 +185,16 @@ func updateFetchedMetadataState(bookID string, values map[string]any) error {
 		entry.UpdatedAt = time.Now()
 		state[field] = entry
 	}
-	return saveMetadataState(bookID, state)
+	return s.saveMetadataState(bookID, state)
 }
 
-func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
+func (s *Server) resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 	authorName := ""
+	store := s.Store()
 	if book.Author != nil {
 		authorName = book.Author.Name
-	} else if book.AuthorID != nil {
-		if author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+	} else if book.AuthorID != nil && store != nil {
+		if author, err := store.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
 			authorName = author.Name
 		}
 	}
@@ -191,8 +202,8 @@ func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 	seriesName := ""
 	if book.Series != nil {
 		seriesName = book.Series.Name
-	} else if book.SeriesID != nil {
-		if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+	} else if book.SeriesID != nil && store != nil {
+		if series, err := store.GetSeriesByID(*book.SeriesID); err == nil && series != nil {
 			seriesName = series.Name
 		}
 	}
@@ -203,13 +214,12 @@ func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
 // batchFetchBookAuthorsAndNarrators pre-fetches author and narrator join table
 // entries plus their full details for all given books. Returns maps keyed by
 // book ID for join entries, plus maps keyed by author/narrator ID for details.
-// Nil maps are returned if the global store is not available.
-func batchFetchBookAuthorsAndNarrators(bookIDs []string) (map[string][]database.BookAuthor, map[int]*database.Author, map[string][]database.BookNarrator, map[int]*database.Narrator) {
-	if len(bookIDs) == 0 || database.GetGlobalStore() == nil {
+// Nil maps are returned if the server's store is not available.
+func (s *Server) batchFetchBookAuthorsAndNarrators(bookIDs []string) (map[string][]database.BookAuthor, map[int]*database.Author, map[string][]database.BookNarrator, map[int]*database.Narrator) {
+	store := s.Store()
+	if len(bookIDs) == 0 || store == nil {
 		return nil, nil, nil, nil
 	}
-
-	store := database.GetGlobalStore()
 
 	// Collect all book authors and extract author IDs
 	bookAuthorsMap := make(map[string][]database.BookAuthor)
@@ -256,17 +266,17 @@ func batchFetchBookAuthorsAndNarrators(bookIDs []string) (map[string][]database.
 
 // enrichBookForResponseSingle enriches a single book by pre-fetching its
 // author and narrator data. Convenience wrapper for single-book endpoints.
-func enrichBookForResponseSingle(book *database.Book) enrichedBookResponse {
-	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := batchFetchBookAuthorsAndNarrators([]string{book.ID})
-	return enrichBookForResponse(book, bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
+func (s *Server) enrichBookForResponseSingle(book *database.Book) enrichedBookResponse {
+	bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID := s.batchFetchBookAuthorsAndNarrators([]string{book.ID})
+	return s.enrichBookForResponse(book, bookAuthorsMap, authorsByID, bookNarratorsMap, narratorsByID)
 }
 
 // enrichBookForResponse resolves author, series, and narrator names from join
 // tables so the JSON response contains all the fields the frontend expects.
 // Pre-fetched maps of authors and narrators (by book ID) are used instead of
 // per-book DB calls to eliminate N+1 queries.
-func enrichBookForResponse(book *database.Book, bookAuthorsMap map[string][]database.BookAuthor, authorsByID map[int]*database.Author, bookNarratorsMap map[string][]database.BookNarrator, narratorsByID map[int]*database.Narrator) enrichedBookResponse {
-	authorName, seriesName := resolveAuthorAndSeriesNames(book)
+func (s *Server) enrichBookForResponse(book *database.Book, bookAuthorsMap map[string][]database.BookAuthor, authorsByID map[int]*database.Author, bookNarratorsMap map[string][]database.BookNarrator, narratorsByID map[int]*database.Narrator) enrichedBookResponse {
+	authorName, seriesName := s.resolveAuthorAndSeriesNames(book)
 	resp := enrichedBookResponse{Book: book}
 	if authorName != "" {
 		resp.AuthorName = &authorName
@@ -325,8 +335,8 @@ func enrichBookForResponse(book *database.Book, bookAuthorsMap map[string][]data
 	// Populate metadata_source_hash_duplicate_count if this book has a hash.
 	// This lets the BookDetail UI warn about possible duplicates without an
 	// extra round-trip.
-	if book.MetadataSourceHash != nil && *book.MetadataSourceHash != "" && database.GetGlobalStore() != nil {
-		if matches, err := database.GetGlobalStore().GetBooksByMetadataSourceHash(*book.MetadataSourceHash); err == nil {
+	if hashStore := s.Store(); book.MetadataSourceHash != nil && *book.MetadataSourceHash != "" && hashStore != nil {
+		if matches, err := hashStore.GetBooksByMetadataSourceHash(*book.MetadataSourceHash); err == nil {
 			count := 0
 			for _, m := range matches {
 				if m.ID != book.ID {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -244,7 +244,7 @@ func TestGetAudiobookTagsReportsEffectiveSourceSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	err = saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
+	err = server.saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
 		"title": {
 			FetchedValue:   "Fetched Title",
 			OverrideValue:  "Override Title",
@@ -680,7 +680,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
+	err = server.saveMetadataState(created.ID, map[string]metafetch.MetadataFieldState{
 		"publisher": {
 			OverrideValue:  "Manual Publisher",
 			OverrideLocked: true,
@@ -782,7 +782,7 @@ func TestBulkFetchMetadataRespectsOverridesAndMissingFields(t *testing.T) {
 	assert.Equal(t, "eng", *updatedBook.Language)
 	assert.NotNil(t, updatedBook.AuthorID)
 
-	state, err := loadMetadataState(created.ID)
+	state, err := server.loadMetadataState(created.ID)
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	entry := state["publisher"]
@@ -1328,7 +1328,7 @@ func TestGetAudiobookTagsReportsEffectiveSource(t *testing.T) {
 			OverrideLocked: false,
 		},
 	}
-	require.NoError(t, saveMetadataState(book.ID, state))
+	require.NoError(t, server.saveMetadataState(book.ID, state))
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/audiobooks/%s/tags", book.ID), nil)
 	w := httptest.NewRecorder()
@@ -1401,7 +1401,7 @@ func TestUpdateAudiobookPersistsOverrides(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	state, err := loadMetadataState(book.ID)
+	state, err := server.loadMetadataState(book.ID)
 	require.NoError(t, err)
 
 	if assert.Contains(t, state, "title") {


### PR DESCRIPTION
14 callers eliminated. 8 package-level helpers in server_metadata.go converted to methods on *Server. Inline embeddings.db migration in server.go uses captured resolvedStore.