### PR TITLE
refactor: SERVER-GLOBAL-STORE-AUDIT phase 4 — metafetch helpers → *Service methods

### DIFF
--- a/internal/metafetch/helpers.go
+++ b/internal/metafetch/helpers.go
@@ -100,12 +100,14 @@ func stripSubtitle(title string) string {
 }
 
 // isProtectedPath returns true if the file path is within import or iTunes paths.
-func isProtectedPath(filePath string) bool {
+// Method on *Service so it uses mfs.db rather than database.GetGlobalStore
+// (SERVER-GLOBAL-STORE-AUDIT phase 4).
+func (mfs *Service) isProtectedPath(filePath string) bool {
 	absPath, _ := filepath.Abs(filePath)
 
 	// Check import paths
-	if database.GetGlobalStore() != nil {
-		importPaths, err := database.GetGlobalStore().GetAllImportPaths()
+	if mfs != nil && mfs.db != nil {
+		importPaths, err := mfs.db.GetAllImportPaths()
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)
@@ -190,10 +192,15 @@ func encodeMetadataValue(value any) (*string, error) {
 	return &encoded, nil
 }
 
-func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
+// These four helpers are *Service methods so they use mfs.db rather than
+// the package global (SERVER-GLOBAL-STORE-AUDIT phase 4).
+func (mfs *Service) loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
+	if mfs == nil || mfs.db == nil {
+		return state, fmt.Errorf("database not initialized")
+	}
 
-	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
+	pref, err := mfs.db.GetUserPreference(metadataStateKey(bookID))
 	if err != nil {
 		return state, err
 	}
@@ -207,13 +214,13 @@ func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, erro
 	return state, nil
 }
 
-func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
+func (mfs *Service) loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
-	if database.GetGlobalStore() == nil {
+	if mfs == nil || mfs.db == nil {
 		return state, fmt.Errorf("database not initialized")
 	}
 
-	stored, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	stored, err := mfs.db.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -229,7 +236,7 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 		return state, nil
 	}
 
-	legacy, err := loadLegacyMetadataState(bookID)
+	legacy, err := mfs.loadLegacyMetadataState(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -237,18 +244,18 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 		return state, nil
 	}
 
-	if err := saveMetadataState(bookID, legacy); err != nil {
+	if err := mfs.saveMetadataState(bookID, legacy); err != nil {
 		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
 	}
 	return legacy, nil
 }
 
-func saveMetadataState(bookID string, state map[string]metadataFieldState) error {
-	if database.GetGlobalStore() == nil {
+func (mfs *Service) saveMetadataState(bookID string, state map[string]metadataFieldState) error {
+	if mfs == nil || mfs.db == nil {
 		return fmt.Errorf("database not initialized")
 	}
 
-	existing, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	existing, err := mfs.db.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return err
 	}
@@ -280,14 +287,14 @@ func saveMetadataState(bookID string, state map[string]metadataFieldState) error
 			UpdatedAt:      entry.UpdatedAt,
 		}
 
-		if err := database.GetGlobalStore().UpsertMetadataFieldState(&dbState); err != nil {
+		if err := mfs.db.UpsertMetadataFieldState(&dbState); err != nil {
 			return fmt.Errorf("failed to persist metadata state for %s: %w", field, err)
 		}
 		delete(existingFields, field)
 	}
 
 	for field := range existingFields {
-		if err := database.GetGlobalStore().DeleteMetadataFieldState(bookID, field); err != nil {
+		if err := mfs.db.DeleteMetadataFieldState(bookID, field); err != nil {
 			return fmt.Errorf("failed to clean up metadata state for %s: %w", field, err)
 		}
 	}
@@ -295,8 +302,8 @@ func saveMetadataState(bookID string, state map[string]metadataFieldState) error
 	return nil
 }
 
-func updateFetchedMetadataState(bookID string, values map[string]any) error {
-	state, err := loadMetadataState(bookID)
+func (mfs *Service) updateFetchedMetadataState(bookID string, values map[string]any) error {
+	state, err := mfs.loadMetadataState(bookID)
 	if err != nil {
 		return err
 	}
@@ -309,7 +316,7 @@ func updateFetchedMetadataState(bookID string, values map[string]any) error {
 		entry.UpdatedAt = time.Now()
 		state[field] = entry
 	}
-	return saveMetadataState(bookID, state)
+	return mfs.saveMetadataState(bookID, state)
 }
 
 func stringVal(p *string) any {

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -137,7 +137,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	}
 
 	// If book is in a protected path, get or create a library copy
-	if isProtectedPath(book.FilePath) {
+	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
 			log.Printf("[WARN] cannot embed cover: no library copy for protected book %s", book.ID)
@@ -162,7 +162,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 			if bf.Missing {
 				continue
 			}
-			if isProtectedPath(bf.FilePath) {
+			if mfs.isProtectedPath(bf.FilePath) {
 				continue
 			}
 			bfExt := strings.ToLower(filepath.Ext(bf.FilePath))
@@ -348,7 +348,7 @@ func metadataCanonicalID(c MetadataCandidate) string {
 // Used by the "Save to Files" button to rename files without re-writing tags (tags are written separately).
 func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) error {
 	// If the book is in a protected path, run on library copy
-	if isProtectedPath(book.FilePath) {
+	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
 			return fmt.Errorf("no library copy for protected book %s", id)

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -267,7 +267,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 	if strings.HasPrefix(book.FilePath, config.AppConfig.RootDir) {
 		return book // already in library
 	}
-	if !isProtectedPath(book.FilePath) {
+	if !mfs.isProtectedPath(book.FilePath) {
 		return book // not protected, safe to modify
 	}
 
@@ -421,7 +421,7 @@ func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMeta
 		fetchedValues["asin"] = meta.ASIN
 	}
 	if len(fetchedValues) > 0 {
-		if err := updateFetchedMetadataState(bookID, fetchedValues); err != nil {
+		if err := mfs.updateFetchedMetadataState(bookID, fetchedValues); err != nil {
 			log.Printf("[ERROR] FetchMetadataForBook: failed to persist fetched metadata state: %v", err)
 		}
 	}

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -107,7 +107,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			// search. Sources that don't implement the interface just
 			// fall through to the title/author path below.
 			if ctxSearch, ok := src.(metadata.ContextualSearch); ok {
-				ctx := buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
+				ctx := mfs.buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
 				results, searchErr = ctxSearch.SearchByContext(ctx)
 				if searchErr != nil {
 					log.Printf("[WARN] %s context search failed for %q: %v", src.Name(), book.Title, searchErr)

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1078,7 +1078,7 @@ func TestApplyMetadataToBook(t *testing.T) {
 
 func TestBuildSearchContext(t *testing.T) {
 	t.Run("nil_book", func(t *testing.T) {
-		ctx := buildSearchContext(nil, "Title", "Author", "Narrator")
+		ctx := (&Service{}).buildSearchContext(nil, "Title", "Author", "Narrator")
 		assert.Equal(t, "Title", ctx.Title)
 		assert.Equal(t, "Author", ctx.Author)
 		assert.Equal(t, "Narrator", ctx.Narrator)
@@ -1094,7 +1094,7 @@ func TestBuildSearchContext(t *testing.T) {
 			ISBN13: &isbn13,
 			ASIN:   &asin,
 		}
-		ctx := buildSearchContext(book, "Title", "Author", "Narrator")
+		ctx := (&Service{}).buildSearchContext(book, "Title", "Author", "Narrator")
 		assert.Equal(t, "1234567890", ctx.ISBN10)
 		assert.Equal(t, "9781234567890", ctx.ISBN13)
 		assert.Equal(t, "B01N5AZR76", ctx.ASIN)
@@ -1102,7 +1102,7 @@ func TestBuildSearchContext(t *testing.T) {
 
 	t.Run("book_without_identifiers", func(t *testing.T) {
 		book := &database.Book{}
-		ctx := buildSearchContext(book, "T", "A", "N")
+		ctx := (&Service{}).buildSearchContext(book, "T", "A", "N")
 		assert.Empty(t, ctx.ISBN10)
 		assert.Empty(t, ctx.ISBN13)
 		assert.Empty(t, ctx.ASIN)

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -25,7 +25,10 @@ import (
 // that metadata.ContextualSearch implementations can use to do better
 // than plain title+author lookups. Empty fields are left empty so
 // sources see "" instead of a garbage placeholder.
-func buildSearchContext(book *database.Book, searchTitle, author, narrator string) *metadata.SearchContext {
+//
+// Method on *Service so the series lookup uses mfs.db rather than the
+// package global (SERVER-GLOBAL-STORE-AUDIT phase 4).
+func (mfs *Service) buildSearchContext(book *database.Book, searchTitle, author, narrator string) *metadata.SearchContext {
 	ctx := &metadata.SearchContext{
 		Title:    searchTitle,
 		Author:   author,
@@ -41,10 +44,8 @@ func buildSearchContext(book *database.Book, searchTitle, author, narrator strin
 		if book.ASIN != nil {
 			ctx.ASIN = *book.ASIN
 		}
-		// buildSearchContext is a top-level helper; use the package
-		// global here until the function is refactored into a method.
-		if book.SeriesID != nil && database.GetGlobalStore() != nil {
-			if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+		if book.SeriesID != nil && mfs != nil && mfs.db != nil {
+			if series, err := mfs.db.GetSeriesByID(*book.SeriesID); err == nil && series != nil {
 				ctx.Series = series.Name
 			}
 		}

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -71,7 +71,7 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 
 	// CRITICAL: Never write metadata to files in protected paths (import paths,
 	// iTunes Media folders). Only write to files in our organized library.
-	if isProtectedPath(book.FilePath) {
+	if mfs.isProtectedPath(book.FilePath) {
 		log.Printf("[INFO] skipping write-back for protected path: %s", book.FilePath)
 		return
 	}
@@ -102,7 +102,7 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 			if len(tagMap) == 0 {
 				continue
 			}
-			if isProtectedPath(bf.FilePath) {
+			if mfs.isProtectedPath(bf.FilePath) {
 				log.Printf("[INFO] skipping write-back for protected file: %s", bf.FilePath)
 				continue
 			}
@@ -473,7 +473,7 @@ func (mfs *Service) generateSegmentTitles(bookID string, bookTitle string) error
 // instead of the original to avoid moving source files.
 func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	// If the book is in a protected path, run the pipeline on the library copy instead
-	if isProtectedPath(book.FilePath) {
+	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
 			log.Printf("[WARN] runApplyPipeline: no library copy for protected book %s, skipping", id)
@@ -647,7 +647,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 	// metadata for building the tag map, rather than the library copy's stale data.
 	originalBook := book
 	originalID := id
-	if isProtectedPath(book.FilePath) {
+	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
 			return 0, fmt.Errorf("cannot write back: no library copy for protected book %s", id)
@@ -754,7 +754,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				log.Printf("[DEBUG] write-back: file %s tags already match, skipping", bf.FilePath)
 				continue
 			}
-			if isProtectedPath(bf.FilePath) {
+			if mfs.isProtectedPath(bf.FilePath) {
 				log.Printf("[DEBUG] skipping write-back for protected file: %s", bf.FilePath)
 				skippedProtected++
 				continue
@@ -772,7 +772,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		// Single-file or no files: write to book.FilePath.
 		// If book.FilePath is a directory (multi-file book with no file records),
 		// glob for audio files inside and write to each one individually.
-		if isProtectedPath(book.FilePath) {
+		if mfs.isProtectedPath(book.FilePath) {
 			log.Printf("[DEBUG] skipping write-back for protected path: %s", book.FilePath)
 			skippedProtected++
 		} else {
@@ -789,7 +789,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				// book.FilePath is a directory — write to each audio file found inside.
 				log.Printf("[INFO] write-back: %s is a directory; writing to %d audio file(s) inside", book.FilePath, len(dirFiles))
 				for _, f := range dirFiles {
-					if isProtectedPath(f) {
+					if mfs.isProtectedPath(f) {
 						log.Printf("[DEBUG] skipping write-back for protected file: %s", f)
 						skippedProtected++
 						continue
@@ -846,7 +846,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				if !strings.HasPrefix(sib.FilePath, config.AppConfig.RootDir) {
 					continue // only write to library copies, leave import copies alone
 				}
-				if isProtectedPath(sib.FilePath) {
+				if mfs.isProtectedPath(sib.FilePath) {
 					continue
 				}
 				tagMap := mfs.BuildTagMap(bookTitle, bookTitle, artistStr, narratorStr, year, "")


### PR DESCRIPTION
11 callers eliminated. isProtectedPath, loadMetadataState, saveMetadataState, updateFetchedMetadataState, buildSearchContext, loadLegacyMetadataState all become methods on *Service using mfs.db.