### PR TITLE
refactor: SERVER-GLOBAL-STORE-AUDIT phase 6 — audiobooks/helpers

### DIFF
--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -85,12 +85,18 @@ func decodeRawValue(raw json.RawMessage) any {
 	return value
 }
 
-func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
+// loadLegacyMetadataState / loadMetadataState / saveMetadataState are now
+// methods on *AudiobookService so they read/write through svc.store
+// rather than the package-level GetGlobalStore (SERVER-GLOBAL-STORE-AUDIT
+// phase 6). Nil-safe: a zero-value AudiobookService falls back to
+// "database not initialized" same as the old GetGlobalStore == nil path.
+
+func (svc *AudiobookService) loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
-	if database.GetGlobalStore() == nil {
+	if svc == nil || svc.store == nil {
 		return state, nil
 	}
-	pref, err := database.GetGlobalStore().GetUserPreference(metadataStateKey(bookID))
+	pref, err := svc.store.GetUserPreference(metadataStateKey(bookID))
 	if err != nil {
 		return state, err
 	}
@@ -103,12 +109,12 @@ func loadLegacyMetadataState(bookID string) (map[string]metadataFieldState, erro
 	return state, nil
 }
 
-func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
+func (svc *AudiobookService) loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	state := map[string]metadataFieldState{}
-	if database.GetGlobalStore() == nil {
+	if svc == nil || svc.store == nil {
 		return state, fmt.Errorf("database not initialized")
 	}
-	stored, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	stored, err := svc.store.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return state, err
 	}
@@ -123,24 +129,24 @@ func loadMetadataState(bookID string) (map[string]metadataFieldState, error) {
 	if len(state) > 0 {
 		return state, nil
 	}
-	legacy, err := loadLegacyMetadataState(bookID)
+	legacy, err := svc.loadLegacyMetadataState(bookID)
 	if err != nil {
 		return state, err
 	}
 	if len(legacy) == 0 {
 		return state, nil
 	}
-	if err := saveMetadataState(bookID, legacy); err != nil {
+	if err := svc.saveMetadataState(bookID, legacy); err != nil {
 		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
 	}
 	return legacy, nil
 }
 
-func saveMetadataState(bookID string, state map[string]metadataFieldState) error {
-	if database.GetGlobalStore() == nil {
+func (svc *AudiobookService) saveMetadataState(bookID string, state map[string]metadataFieldState) error {
+	if svc == nil || svc.store == nil {
 		return fmt.Errorf("database not initialized")
 	}
-	existing, err := database.GetGlobalStore().GetMetadataFieldStates(bookID)
+	existing, err := svc.store.GetMetadataFieldStates(bookID)
 	if err != nil {
 		return err
 	}
@@ -169,13 +175,13 @@ func saveMetadataState(bookID string, state map[string]metadataFieldState) error
 			OverrideLocked: entry.OverrideLocked,
 			UpdatedAt:      entry.UpdatedAt,
 		}
-		if err := database.GetGlobalStore().UpsertMetadataFieldState(&dbState); err != nil {
+		if err := svc.store.UpsertMetadataFieldState(&dbState); err != nil {
 			return fmt.Errorf("failed to persist metadata state for %s: %w", field, err)
 		}
 		delete(existingFields, field)
 	}
 	for field := range existingFields {
-		if err := database.GetGlobalStore().DeleteMetadataFieldState(bookID, field); err != nil {
+		if err := svc.store.DeleteMetadataFieldState(bookID, field); err != nil {
 			return fmt.Errorf("failed to clean up metadata state for %s: %w", field, err)
 		}
 	}
@@ -222,13 +228,24 @@ func (mss *metadataStateSvc) recordChange(bookID, field, changeType, source stri
 
 // --- path helpers -----------------------------------------------------------
 
-// isProtectedPath returns true if filePath is under a configured import path,
-// an iTunes library path, or another protected location.
-func isProtectedPath(filePath string) bool {
+// importPathLister is the narrow slice isProtectedPath needs from any
+// store: just GetAllImportPaths. Both database.Store and the audiobook
+// service's narrower audiobookStore satisfy it.
+type importPathLister interface {
+	GetAllImportPaths() ([]database.ImportPath, error)
+}
+
+// isProtectedPath returns true if filePath is under a configured import
+// path, an iTunes library path, or another protected location. Takes an
+// explicit importPathLister so callers thread their own database
+// reference rather than reaching for the package global
+// (SERVER-GLOBAL-STORE-AUDIT phase 6). Pass nil to skip the import-path
+// check; the iTunes / .failed checks still apply.
+func isProtectedPath(store importPathLister, filePath string) bool {
 	absPath, _ := filepath.Abs(filePath)
 
-	if database.GetGlobalStore() != nil {
-		importPaths, err := database.GetGlobalStore().GetAllImportPaths()
+	if store != nil {
+		importPaths, err := store.GetAllImportPaths()
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)
@@ -265,27 +282,26 @@ func isProtectedPath(filePath string) bool {
 	return false
 }
 
-// resolveAuthorAndSeriesNames returns the author name and series name for book,
-// falling back to a database lookup when the join is not pre-loaded.
-func resolveAuthorAndSeriesNames(book *database.Book) (string, string) {
+// resolveAuthorAndSeriesNames returns the author name and series name
+// for book, falling back to a database lookup when the join is not
+// pre-loaded. Takes an explicit store (SERVER-GLOBAL-STORE-AUDIT phase 6).
+// Nil store skips the lookups; inline Book.Author / Book.Series still
+// resolve.
+func resolveAuthorAndSeriesNames(store authorSeriesStore, book *database.Book) (string, string) {
 	authorName := ""
 	if book.Author != nil {
 		authorName = book.Author.Name
-	} else if book.AuthorID != nil {
-		if database.GetGlobalStore() != nil {
-			if author, err := database.GetGlobalStore().GetAuthorByID(*book.AuthorID); err == nil && author != nil {
-				authorName = author.Name
-			}
+	} else if book.AuthorID != nil && store != nil {
+		if author, err := store.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+			authorName = author.Name
 		}
 	}
 	seriesName := ""
 	if book.Series != nil {
 		seriesName = book.Series.Name
-	} else if book.SeriesID != nil {
-		if database.GetGlobalStore() != nil {
-			if series, err := database.GetGlobalStore().GetSeriesByID(*book.SeriesID); err == nil && series != nil {
-				seriesName = series.Name
-			}
+	} else if book.SeriesID != nil && store != nil {
+		if series, err := store.GetSeriesByID(*book.SeriesID); err == nil && series != nil {
+			seriesName = series.Name
 		}
 	}
 	return authorName, seriesName

--- a/internal/audiobooks/organize_preview.go
+++ b/internal/audiobooks/organize_preview.go
@@ -19,11 +19,17 @@ type OrganizePreviewStep = organizer.PreviewStep
 type OrganizePreviewResponse = organizer.PreviewResponse
 type OrganizePreviewService = organizer.PreviewService
 
-// NewOrganizePreviewService creates a new organizer.PreviewService and wires up
-// server-specific callbacks.
+// NewOrganizePreviewService creates a new organizer.PreviewService and
+// wires up server-specific callbacks. IsProtectedPath /
+// ResolveAuthorAndSeriesNames bound to db via closures (see rename.go
+// for the rationale — SERVER-GLOBAL-STORE-AUDIT phase 6).
 func NewOrganizePreviewService(db database.Store) *OrganizePreviewService {
 	svc := organizer.NewPreviewService(db)
-	svc.IsProtectedPath = isProtectedPath
-	svc.ResolveAuthorAndSeriesNames = resolveAuthorAndSeriesNames
+	svc.IsProtectedPath = func(filePath string) bool {
+		return isProtectedPath(db, filePath)
+	}
+	svc.ResolveAuthorAndSeriesNames = func(book *database.Book) (string, string) {
+		return resolveAuthorAndSeriesNames(db, book)
+	}
 	return svc
 }

--- a/internal/audiobooks/rename.go
+++ b/internal/audiobooks/rename.go
@@ -23,10 +23,19 @@ type RenameApplyResult = organizer.RenameApplyResult
 
 // NewRenameService creates a new organizer.RenameService and wires up
 // server-specific callbacks.
+//
+// IsProtectedPath / ResolveAuthorAndSeriesNames are bound to db via
+// closures so the helpers can be free functions that take a store
+// explicitly (SERVER-GLOBAL-STORE-AUDIT phase 6) without changing the
+// function-value signatures organizer.RenameService exposes.
 func NewRenameService(db database.Store) *RenameService {
 	svc := organizer.NewRenameService(db)
-	svc.IsProtectedPath = isProtectedPath
-	svc.ResolveAuthorAndSeriesNames = resolveAuthorAndSeriesNames
+	svc.IsProtectedPath = func(filePath string) bool {
+		return isProtectedPath(db, filePath)
+	}
+	svc.ResolveAuthorAndSeriesNames = func(book *database.Book) (string, string) {
+		return resolveAuthorAndSeriesNames(db, book)
+	}
 	svc.FilterUnchangedTags = metafetch.FilterUnchangedTags
 	svc.ComputeITunesPath = metafetch.ComputeITunesPath
 	return svc

--- a/internal/audiobooks/revert.go
+++ b/internal/audiobooks/revert.go
@@ -20,6 +20,11 @@ type revertServiceStore interface {
 	database.BookReader
 	database.BookWriter
 	database.OperationStore
+	// Needed by the embedded isProtectedPath call in revertTagWrite
+	// (SERVER-GLOBAL-STORE-AUDIT phase 6). Inline single-method
+	// rather than database.ImportPathStore so this adapter doesn't
+	// have to expose ImportPath CRUD it never calls.
+	GetAllImportPaths() ([]database.ImportPath, error)
 }
 
 
@@ -187,7 +192,7 @@ func (rs *RevertService) revertTagWrite(c *database.OperationChange) error {
 		return nil
 	}
 
-	if isProtectedPath(book.FilePath) {
+	if isProtectedPath(rs.db, book.FilePath) {
 		log.Printf("[INFO] skipping tag revert for protected path: %s", book.FilePath)
 		return nil
 	}

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -47,6 +47,12 @@ type audiobookStore interface {
 	// Per-user filter pass on the listing endpoint reads UserBookState
 	// to evaluate read_status / progress_pct / last_played.
 	database.UserPositionStore
+	// Needed by isProtectedPath to compare absolute paths against
+	// configured import roots (SERVER-GLOBAL-STORE-AUDIT phase 6).
+	// Single method inline rather than database.ImportPathStore so
+	// the narrower audiobookUpdateStore adapter doesn't have to
+	// implement the full ImportPath CRUD surface.
+	GetAllImportPaths() ([]database.ImportPath, error)
 }
 
 // ITunesEnqueuer is the narrow surface AudiobookService uses to push
@@ -843,7 +849,7 @@ func splitMultipleNames(name string) []string {
 func (svc *AudiobookService) EnrichAudiobooksWithNames(books []database.Book) []AudiobookDetail {
 	enrichedBooks := make([]AudiobookDetail, 0, len(books))
 	for _, book := range books {
-		authorName, seriesName := resolveAuthorAndSeriesNames(&book)
+		authorName, seriesName := resolveAuthorAndSeriesNames(svc.store, &book)
 		detail := AudiobookDetail{Book: &book}
 		if authorName != "" {
 			detail.AuthorName = &authorName
@@ -875,14 +881,14 @@ func (svc *AudiobookService) GetAudiobook(ctx context.Context, id string) (*data
 	}
 
 	// Load metadata state and extract file metadata
-	state, err := loadMetadataState(book.ID)
+	state, err := svc.loadMetadataState(book.ID)
 	if err != nil {
 		log.Printf("[ERROR] GetAudiobook: failed to load metadata state for %s: %v", book.ID, err)
 		// Don't fail the entire request, just use empty state
 		state = map[string]metadataFieldState{}
 	}
 
-	authorName, seriesName := resolveAuthorAndSeriesNames(book)
+	authorName, seriesName := resolveAuthorAndSeriesNames(svc.store, book)
 
 	meta := svc.extractBookFileMetadata(book, authorName)
 
@@ -919,13 +925,13 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 		return nil, fmt.Errorf("audiobook not found")
 	}
 
-	state, err := loadMetadataState(book.ID)
+	state, err := svc.loadMetadataState(book.ID)
 	if err != nil {
 		log.Printf("[ERROR] GetAudiobookTags: failed to load metadata state for %s: %v", book.ID, err)
 		state = map[string]metadataFieldState{}
 	}
 
-	authorName, seriesName := resolveAuthorAndSeriesNames(book)
+	authorName, seriesName := resolveAuthorAndSeriesNames(svc.store, book)
 
 	response := map[string]any{
 		"media_info": map[string]any{
@@ -992,7 +998,7 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 		}
 		snapshotBook, verErr := svc.store.GetBookAtVersion(id, ts)
 		if verErr == nil && snapshotBook != nil {
-			snapshotAuthorName, snapshotSeriesName := resolveAuthorAndSeriesNames(snapshotBook)
+			snapshotAuthorName, snapshotSeriesName := resolveAuthorAndSeriesNames(svc.store, snapshotBook)
 			comparisonValues = buildComparisonValuesFromBook(snapshotBook, snapshotAuthorName, snapshotSeriesName)
 		} else {
 			// Fallback: reconstruct "before" state from activity log old_values
@@ -1186,7 +1192,7 @@ func (svc *AudiobookService) PurgeSoftDeletedBooks(ctx context.Context, deleteFi
 
 		// Step 3: Delete file if requested (only from organizer root, never from protected/import paths)
 		if deleteFiles && book.FilePath != "" {
-			if isProtectedPath(book.FilePath) {
+			if isProtectedPath(svc.store, book.FilePath) {
 				log.Printf("[DEBUG] purge: skipping file deletion for %s — protected path: %s", book.ID, book.FilePath)
 			} else {
 				info, statErr := os.Stat(book.FilePath)
@@ -1194,7 +1200,7 @@ func (svc *AudiobookService) PurgeSoftDeletedBooks(ctx context.Context, deleteFi
 					// Directory-based book: remove all book files then the directory
 					if bookFiles, bfErr := svc.store.GetBookFiles(book.ID); bfErr == nil {
 						for _, bf := range bookFiles {
-							if bf.FilePath != "" && !isProtectedPath(bf.FilePath) {
+							if bf.FilePath != "" && !isProtectedPath(svc.store, bf.FilePath) {
 								if rmErr := os.Remove(bf.FilePath); rmErr != nil && !os.IsNotExist(rmErr) {
 									result.Errors = append(result.Errors, fmt.Sprintf("%s: failed to delete book file %s: %v", book.ID, bf.FilePath, rmErr))
 								}
@@ -1375,7 +1381,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 	}
 
 	// Load and process metadata state
-	state, err := loadMetadataState(id)
+	state, err := svc.loadMetadataState(id)
 	if err != nil {
 		log.Printf("[ERROR] UpdateAudiobook: failed to load metadata state: %v", err)
 		return nil, fmt.Errorf("failed to load metadata state")
@@ -1637,7 +1643,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 	}
 
 	// Save metadata state
-	if err := saveMetadataState(id, state); err != nil {
+	if err := svc.saveMetadataState(id, state); err != nil {
 		log.Printf("[ERROR] UpdateAudiobook: failed to save metadata state: %v", err)
 		return nil, fmt.Errorf("failed to persist metadata state")
 	}

--- a/internal/audiobooks/update_service.go
+++ b/internal/audiobooks/update_service.go
@@ -25,6 +25,11 @@ type audiobookUpdateStore interface {
 	database.MetadataStore
 	database.UserPreferenceStore
 	database.UserPositionStore
+	// Required by audiobookStore (which we pass to NewAudiobookService
+	// below) — used by helpers.isProtectedPath. Inline single method
+	// rather than database.ImportPathStore so this adapter doesn't have
+	// to expose ImportPath CRUD it never calls.
+	GetAllImportPaths() ([]database.ImportPath, error)
 }
 
 


### PR DESCRIPTION
14 callers eliminated. Free helpers take explicit store; svc methods delegate; rename/preview services use closures to preserve field signatures.