### PR TITLE
fix(shutdown): stop pebble:closed panic + watchdog respawn during shutdown

### DIFF
--- a/internal/itunes/backfill.go
+++ b/internal/itunes/backfill.go
@@ -1,10 +1,11 @@
 // file: internal/itunes/backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-b4c5-d6e7-f8a9b0c1d2e3
 
 package itunes
 
 import (
+	"context"
 	"log"
 	"strings"
 
@@ -24,9 +25,18 @@ type ExternalIDBackfillStore interface {
 // BackfillExternalIDs scans all books and creates external ID mappings for any
 // book that has an iTunes PersistentID set. This is idempotent — it checks the
 // setting "external_id_backfill_done" and only runs once.
-func BackfillExternalIDs(store ExternalIDBackfillStore) error {
+//
+// ctx is honored at every batch boundary AND between book entries so a
+// shutdown signal aborts the backfill quickly. Without ctx-awareness this
+// loop runs to completion (potentially minutes on a large library) and
+// crashes with "pebble: closed" if the store closes mid-iteration. The
+// caller (Server.Start's background goroutine) passes s.bgCtx.
+func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) error {
 	if store == nil {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	// Check if backfill has already been performed (v4 = includes BookFile-level PIDs)
@@ -36,11 +46,19 @@ func BackfillExternalIDs(store ExternalIDBackfillStore) error {
 	offset := 0
 	backfilled := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			log.Printf("[INFO] external ID backfill canceled at offset %d after %d mappings: %v", offset, backfilled, err)
+			return nil
+		}
 		books, err := store.GetAllBooks(10000, offset)
 		if err != nil || len(books) == 0 {
 			break
 		}
 		for _, book := range books {
+			if err := ctx.Err(); err != nil {
+				log.Printf("[INFO] external ID backfill canceled mid-batch after %d mappings: %v", backfilled, err)
+				return nil
+			}
 			// Book-level PID
 			if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
 				_ = store.CreateExternalIDMapping(&database.ExternalIDMapping{
@@ -72,24 +90,36 @@ func BackfillExternalIDs(store ExternalIDBackfillStore) error {
 		offset += 10000
 	}
 
+	if err := ctx.Err(); err != nil {
+		log.Printf("[INFO] external ID backfill canceled before track-PID pass: %v", err)
+		return nil
+	}
 	log.Printf("[INFO] Backfilled %d external ID mappings from book + file records", backfilled)
 
 	// Backfill ALL track-level PIDs from the iTunes XML
-	itunesBackfilled, _ := BackfillITunesTrackPIDs(store)
+	itunesBackfilled, _ := BackfillITunesTrackPIDs(ctx, store)
 	if itunesBackfilled > 0 {
 		log.Printf("[INFO] Backfilled %d track-level PIDs from iTunes XML", itunesBackfilled)
 	}
 
-	// Only mark as done AFTER everything completes successfully
-	_ = store.SetSetting("external_id_backfill_v4_done", "true", "bool", false)
-	log.Printf("[INFO] External ID backfill v4 complete")
+	// Only mark as done AFTER everything completes successfully (and not canceled)
+	if err := ctx.Err(); err == nil {
+		_ = store.SetSetting("external_id_backfill_v4_done", "true", "bool", false)
+		log.Printf("[INFO] External ID backfill v4 complete")
+	}
 	return nil
 }
 
 // BackfillITunesTrackPIDs reads the iTunes XML and registers ALL track PIDs
 // for existing books. This catches the multi-track albums where only the first
 // track's PID was stored on the book record.
-func BackfillITunesTrackPIDs(store ExternalIDBackfillStore) (int, error) {
+//
+// ctx aborts the inner book-scan + album-build loops; passing
+// context.Background is safe.
+func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore) (int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	xmlPath := config.AppConfig.ITunesLibraryReadPath
 	if xmlPath == "" {
 		log.Printf("[INFO] BackfillITunesTrackPIDs: no iTunes XML path configured, skipping")
@@ -136,6 +166,10 @@ func BackfillITunesTrackPIDs(store ExternalIDBackfillStore) (int, error) {
 	totalBooks := 0
 	offset := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			log.Printf("[INFO] BackfillITunesTrackPIDs canceled mid-index at offset %d", offset)
+			return 0, nil
+		}
 		books, err := store.GetAllBooks(10000, offset)
 		if err != nil || len(books) == 0 {
 			break
@@ -156,6 +190,10 @@ func BackfillITunesTrackPIDs(store ExternalIDBackfillStore) (int, error) {
 	var batch []database.ExternalIDMapping
 
 	for _, ag := range albums {
+		if err := ctx.Err(); err != nil {
+			log.Printf("[INFO] BackfillITunesTrackPIDs canceled mid-album pass after %d PIDs", registered)
+			return registered, nil
+		}
 		// Find our book: match by any track PID first, then by title
 		var bookID string
 		for _, t := range ag.tracks {

--- a/internal/itunes/backfill_test.go
+++ b/internal/itunes/backfill_test.go
@@ -5,6 +5,7 @@
 package itunes
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -71,7 +72,7 @@ func (m *MockBackfillStore) SetSetting(key, value, dataType string, internal boo
 }
 
 func TestBackfillExternalIDsWithNilStore(t *testing.T) {
-	err := BackfillExternalIDs(nil)
+	err := BackfillExternalIDs(context.Background(), nil)
 	if err != nil {
 		t.Errorf("expected nil error for nil store, got %v", err)
 	}
@@ -86,7 +87,7 @@ func TestBackfillExternalIDsCollectsBookPIDs(t *testing.T) {
 		ITunesPersistentID:   &pidValue,
 	}
 
-	err := BackfillExternalIDs(mockStore)
+	err := BackfillExternalIDs(context.Background(), mockStore)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -101,7 +102,7 @@ func TestBackfillITunesTrackPIDsWithNoConfiguredPath(t *testing.T) {
 	mockStore := NewMockBackfillStore()
 
 	// With no configured path, should return 0 gracefully
-	count, err := BackfillITunesTrackPIDs(mockStore)
+	count, err := BackfillITunesTrackPIDs(context.Background(), mockStore)
 	if count != 0 {
 		t.Errorf("expected 0 registered PIDs with no configured path, got %d", count)
 	}

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -34,6 +35,13 @@ type Registry struct {
 	logger          *slog.Logger
 	workers         int
 	abandoned       *abandonedTracker
+
+	// shuttingDown is flipped at the top of Shutdown so the abandoned-run
+	// watchdog in executeRun stops spawning replacement workers. Without
+	// this flag the watchdog respawns a worker right as bgCtx is being
+	// canceled — the new worker's runs then race against database.Close()
+	// and panic with "pebble: closed".
+	shuttingDown atomic.Bool
 
 	// Tunable intervals for testing. Zero means use defaults.
 	watchdogInterval time.Duration
@@ -324,6 +332,12 @@ func (r *Registry) ActiveDefs() []OperationDef {
 // as interrupted per their ResumePolicy and returns.
 func (r *Registry) Shutdown(ctx context.Context) error {
 	r.logger.Info("registry: shutting down")
+	// Flip the shutdown flag before canceling handles so the abandoned-run
+	// watchdog (in worker.go executeRun) refuses to spawn replacement
+	// workers. Without this, a replacement worker is born just as the
+	// embedded Pebble store is closing, and its next DB write panics
+	// with "pebble: closed".
+	r.shuttingDown.Store(true)
 
 	// Gather running ops.
 	r.mu.Lock()

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -193,6 +193,20 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 			// Goroutine is stuck. Classify as abandoned.
 			r.releaseRunHandle(qr.opID)
 			r.abandoned.increment(qr.plugin)
+			// During Shutdown, do NOT spawn a replacement worker — the
+			// pool is on its way out and a new worker would race against
+			// store close (pebble: closed panic). Just log and exit.
+			if r.shuttingDown.Load() {
+				r.logger.Info("registry: op goroutine abandoned during shutdown; not respawning",
+					"op_id", qr.opID, "plugin", qr.plugin)
+				// Still monitor the goroutine so the abandoned counter
+				// drains correctly if it eventually returns.
+				go func() {
+					<-done
+					r.abandoned.decrement(qr.plugin)
+				}()
+				return true
+			}
 			r.logger.Warn("registry: op goroutine abandoned; spawning replacement worker",
 				"op_id", qr.opID, "plugin", qr.plugin)
 			// Spawn a replacement so the pool doesn't shrink.

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -56,8 +56,10 @@ func (s *Server) backfillExternalIDs() {
 		return
 	}
 
-	// Delegate to the itunes domain package, passing an adapter for the store
-	if err := itunes.BackfillExternalIDs(&externalIDStoreAdapter{eidStore: eidStore, store: store}); err != nil {
+	// Delegate to the itunes domain package. s.bgCtx aborts the backfill
+	// on shutdown so it can't outlive the store and crash on
+	// "pebble: closed" in CreateExternalIDMapping.
+	if err := itunes.BackfillExternalIDs(s.bgCtx, &externalIDStoreAdapter{eidStore: eidStore, store: store}); err != nil {
 		log.Printf("[WARN] backfillExternalIDs: %v", err)
 	}
 }


### PR DESCRIPTION
EMERGENCY. Two coupled bugs caused prod to restart-loop after every shutdown:

1. **BackfillExternalIDs ignored ctx** → outlived Pebble close → `pebble: closed` panic in CreateExternalIDMapping → systemd restart.
2. **Registry watchdog respawned workers during Shutdown** → new worker raced store-close.

Fix: ctx-aware backfill (passes `s.bgCtx`), Registry.shuttingDown atomic.Bool flag flipped at the top of Shutdown(), executeRun skips respawn when shutting down.