### PR TITLE
fix(server): server tests start opRegistry; bridge v2→v1 itunes.import

### DIFF
--- a/internal/plugins/itunes/plugin.go
+++ b/internal/plugins/itunes/plugin.go
@@ -48,7 +48,10 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 	defs := []sdk.OperationDef{
 		p.syncDef(),
-		p.importDef(),
+		// importDef is a stub — the canonical itunes.import op is
+		// registered by server.RegisterITunesImportOp (itunes_ops.go),
+		// which wires Importer.Execute. Registering the stub here would
+		// collide with the real one and route through a no-op subprocess.
 		p.pathReconciledDef(),
 		p.pathRepairDef(),
 		p.positionSyncDef(),

--- a/internal/server/e2e_workflow_test.go
+++ b/internal/server/e2e_workflow_test.go
@@ -46,6 +46,10 @@ func TestE2E_ITunesImportOrganizeWriteBack(t *testing.T) {
 	}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 
 	// Step 3: Import (non-organize mode)
 	importBody := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
@@ -81,11 +85,18 @@ func TestE2E_ITunesImportOrganizeWriteBack(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 	var orgResp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &orgResp))
-	orgData := orgResp["data"].(map[string]any)
+	// Organize endpoint returns flat {id, op_id, ...}; tolerate {data: {...}}
+	// in case the envelope changes again.
+	orgData := orgResp
+	if d, ok := orgResp["data"].(map[string]any); ok {
+		orgData = d
+	}
 	opID = ""
 	if id, ok := orgData["id"].(string); ok {
 		opID = id
 	} else if id, ok := orgData["operation_id"].(string); ok {
+		opID = id
+	} else if id, ok := orgData["op_id"].(string); ok {
 		opID = id
 	}
 	require.NotEmpty(t, opID, "organize response should contain id")

--- a/internal/server/folder_autoscan_op.go
+++ b/internal/server/folder_autoscan_op.go
@@ -144,6 +144,15 @@ func (s *Server) RegisterFolderAutoScanOp(reg *opsregistry.Registry) error {
 				}
 			}
 
+			// Bridge the v2 run completion back to the legacy v1
+			// Operation row so callers (e.g. POST /import-paths) that
+			// returned scan_operation_id = LegacyOpID can poll
+			// completion via the v1 ops endpoint. Without this the
+			// v1 row sticks in "queued" forever even though the work
+			// is done.
+			if p.LegacyOpID != "" && s.Store() != nil {
+				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(books), len(books), fmt.Sprintf("Auto-scan completed (%d books)", len(books)))
+			}
 			_ = progress.Log("info", fmt.Sprintf("Auto-scan completed. Total books: %d", len(books)), nil)
 			return nil
 		},

--- a/internal/server/itunes_error_test.go
+++ b/internal/server/itunes_error_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -29,6 +30,10 @@ func TestITunesImport_CorruptXML(t *testing.T) {
 	require.NoError(t, os.WriteFile(xmlPath, []byte("this is not valid XML at all <broken"), 0644))
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -72,6 +77,10 @@ func TestITunesImport_EmptyXML(t *testing.T) {
 	testutil.GenerateITunesXML(t, []testutil.ITunesTestTrack{}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -113,6 +122,10 @@ func TestITunesImport_MissingFilesPartial(t *testing.T) {
 	}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -260,6 +273,10 @@ func TestITunesImport_RealTestLibrary(t *testing.T) {
 	// These won't exist, so books with missing files will be skipped during import
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/itunes_integration_test.go
+++ b/internal/server/itunes_integration_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -51,6 +52,10 @@ func TestITunesImport_FullWorkflow(t *testing.T) {
 
 	// Import via HTTP handler
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":true}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -114,6 +119,10 @@ func TestITunesImport_OrganizeMode(t *testing.T) {
 	}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s","import_mode":"organize","skip_duplicates":false}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -157,6 +166,10 @@ func TestITunesImport_SkipDuplicates(t *testing.T) {
 	}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	importOnce := func() int {
 		body := fmt.Sprintf(`{"library_path":"%s","import_mode":"import","skip_duplicates":true}`, xmlPath)
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/import", strings.NewReader(body))
@@ -202,6 +215,10 @@ func TestITunesWriteBack(t *testing.T) {
 
 	// Execute write-back via HTTP — ITL is not configured in test, so should return 400
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"audiobook_ids":["%s"]}`, created.ID)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/write-back", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -231,6 +248,10 @@ func TestITunesValidate_Endpoint(t *testing.T) {
 	}, xmlPath)
 
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	body := fmt.Sprintf(`{"library_path":"%s"}`, xmlPath)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/itunes/validate", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/itunes_ops.go
+++ b/internal/server/itunes_ops.go
@@ -56,7 +56,17 @@ func (s *Server) RegisterITunesImportOp(reg *opsregistry.Registry) error {
 				}
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return s.itunesSvc.Importer.Execute(ctx, p.LegacyOpID, p.Request, operations.LoggerFromReporter(progress))
+			runErr := s.itunesSvc.Importer.Execute(ctx, p.LegacyOpID, p.Request, operations.LoggerFromReporter(progress))
+			// Bridge v2 run completion back to the legacy v1 row so HTTP
+			// callers that received legacy_op_id can poll completion.
+			if p.LegacyOpID != "" && s.Store() != nil {
+				if runErr != nil {
+					_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "failed", 0, 0, runErr.Error())
+				} else {
+					_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", 0, 0, "iTunes import completed")
+				}
+			}
+			return runErr
 		},
 	})
 }

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -950,6 +950,9 @@ func TestWriteBackMetadataForBook_SingleFile(t *testing.T) {
 	mockStore.On("GetBookFiles", book.ID).Return([]database.BookFile{}, nil)
 	mockStore.On("GetBookFileByPath", book.FilePath).Return((*database.BookFile)(nil), nil)
 	mockStore.On("RecordMetadataChange", mock.AnythingOfType("*database.MetadataChangeRecord")).Return(nil)
+	// isProtectedPath (SERVER-GLOBAL-STORE-AUDIT phase 4) consults
+	// GetAllImportPaths via mfs.db before any write.
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil).Maybe()
 
 	svc := metafetch.NewService(mockStore)
 	// WriteMetadataToFile will fail because the file doesn't exist, but the

--- a/internal/server/organize_integration_test.go
+++ b/internal/server/organize_integration_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -44,8 +45,15 @@ func TestOrganizeService_ViaHTTP(t *testing.T) {
 		Format:   "m4b",
 	}))
 
-	// Trigger organize via HTTP
+	// Trigger organize via HTTP. NewServer constructs the registry but
+	// doesn't Start its worker pool (Container.Start does that during
+	// Server.Start, which we don't call here). Start it explicitly so
+	// the enqueued op actually runs.
 	server := NewServer(nil)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+		t.Cleanup(func() { _ = server.opRegistry.Shutdown(context.Background()) })
+	}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/operations/organize", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -55,11 +55,22 @@ func copyFixtureToDir(t *testing.T, name, dir string) string {
 
 func waitForOperationStatus(t *testing.T, id string, timeout time.Duration) *database.Operation {
 	t.Helper()
+	if id == "" {
+		t.Fatal("waitForOperationStatus: empty op id (handler likely returned the v2 envelope this helper used to ignore)")
+	}
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		op, err := database.GetGlobalStore().GetOperationByID(id)
-		if err == nil && op != nil {
+		// v2 path first — ops enqueued via opRegistry.EnqueueOp land in
+		// operation_v2 (and never in the legacy ops table). Fall back
+		// to the legacy ops table for endpoints that still use v1 storage.
+		if row, err := database.GetGlobalStore().GetOperationV2(id); err == nil && row != nil {
+			switch row.Status {
+			case "completed", "failed", "canceled":
+				return &database.Operation{ID: row.ID, Status: row.Status}
+			}
+		}
+		if op, err := database.GetGlobalStore().GetOperationByID(id); err == nil && op != nil {
 			switch op.Status {
 			case "completed", "failed", "canceled":
 				return op
@@ -606,11 +617,20 @@ func TestStartScanOperation(t *testing.T) {
 	server.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusAccepted, w.Code)
 
+	// startScan returns {"op_id": "...", "id": "..."} (no `data` envelope).
+	// Read the flat field; the old `Data database.Operation` shape was a
+	// vestige of an earlier handler version and produced an empty ID,
+	// which is why this test was on the SERVER-THIN-8 baseline list.
 	var resp struct {
-		Data database.Operation `json:"data"`
+		OpID string `json:"op_id"`
+		ID   string `json:"id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	waitForOperationStatus(t, resp.Data.ID, 10*time.Second)
+	opID := resp.OpID
+	if opID == "" {
+		opID = resp.ID
+	}
+	waitForOperationStatus(t, opID, 10*time.Second)
 }
 
 func TestStartOrganizeOperation(t *testing.T) {
@@ -640,10 +660,15 @@ func TestStartOrganizeOperation(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 
 	var resp struct {
-		Data database.Operation `json:"data"`
+		OpID string `json:"op_id"`
+		ID   string `json:"id"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	waitForOperationStatus(t, resp.Data.ID, 10*time.Second)
+	opID := resp.OpID
+	if opID == "" {
+		opID = resp.ID
+	}
+	waitForOperationStatus(t, opID, 10*time.Second)
 	waitForQueueIdle(t, server, 10*time.Second)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -58,8 +58,22 @@ func setupTestServer(t *testing.T) (*Server, func()) {
 	// Create server (NewServer creates hub, queue, batcher, fileIOPool internally)
 	server := NewServer(store)
 
+	// Start the operations registry's dispatcher + worker pool. Without
+	// this, ops enqueued by the test never execute (enqueued in the v2
+	// table but no worker is reading from r.nextRun). Tests previously
+	// timing out at 10s with "timeout waiting for operation" were
+	// hitting this — the registry's Start lives in Container.Start
+	// (lifecycle-flip) which setupTestServer doesn't call. Start it
+	// explicitly here so the registry processes queued runs.
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+	}
+
 	// Cleanup function
 	cleanup := func() {
+		if server.opRegistry != nil {
+			_ = server.opRegistry.Shutdown(context.Background())
+		}
 		if server.fileIOPool != nil {
 			server.fileIOPool.Stop()
 		}

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -131,9 +131,22 @@ func FindRepoRoot(t *testing.T) string {
 }
 
 // WaitForOp polls until an operation completes or times out.
+//
+// Checks v2 first (operations enqueued via opRegistry.EnqueueOp land
+// in the operations_v2 table) and falls back to v1 for legacy paths.
+// Pass a database.Store (which embeds OpsV2Store) so v2 lookups work;
+// the parameter type stays OperationStore for source-compat.
 func WaitForOp(t *testing.T, store database.OperationStore, opID string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
+		if v2, ok := store.(database.OpsV2Store); ok {
+			if row, err := v2.GetOperationV2(opID); err == nil && row != nil {
+				switch row.Status {
+				case "completed", "failed", "canceled":
+					return true
+				}
+			}
+		}
 		op, err := store.GetOperationByID(opID)
 		return err == nil && op != nil && (op.Status == "completed" || op.Status == "failed")
 	}, timeout, 100*time.Millisecond)


### PR DESCRIPTION
## Summary
- Start opRegistry worker pool in tests that call NewServer directly (itunes/e2e/organize integration suites)
- testutil.WaitForOp + server_more_test.waitForOperationStatus check v2 ops before v1
- Bridge v2→v1 op status in folder_autoscan_op and itunes_ops so HTTP callers polling the legacy id see completion
- Drop stub itunes.import from plugin SDK Register list — canonical Isolate=false op lives in server/itunes_ops.go
- e2e test tolerates flat {id|op_id} response shape from organize endpoint
- metadata_fetch_service_test stubs GetAllImportPaths for new isProtectedPath path

## Test plan
- [x] iTunes tests pass: TestITunesImport_{CorruptXML,EmptyXML,MissingFilesPartial,FullWorkflow,OrganizeMode,SkipDuplicates,RealTestLibrary}
- [x] TestE2E_ITunesImportOrganizeWriteBack
- [x] TestOrganizeService_ViaHTTP, TestStartScanOperation, TestStartOrganizeOperation, TestAddImportPathAutoScan
- [x] TestWriteBackMetadataForBook_SingleFile

🤖 Generated with [Claude Code](https://claude.com/claude-code)