### PR TITLE
fix(activity): split active ops sections + read v2 op logs

### DIFF
--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -361,25 +361,51 @@ func (s *Server) listStaleOperations(c *gin.Context) {
 	})
 }
 
-// getOperationLogs returns logs for a given operation
+// getOperationLogs returns logs for a given operation. UOS v2 ops persist
+// their log lines to op_logs_v2 via dbReporter; v1 ops used operation_logs.
+// We query v2 first (canonical for all currently-enqueued ops) and fall
+// back to v1 only if v2 has nothing — legacy rows from before the v2 cutover.
 func (s *Server) getOperationLogs(c *gin.Context) {
 	if s.Store() == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
 	id := c.Param("id")
-	logs, err := s.Store().GetOperationLogs(id)
-	if err != nil {
-		httputil.InternalError(c, "failed to get operation logs", err)
-		return
-	}
-	// Optional tail parameter for last N log lines
+	limit := 1000
 	if tailStr := c.Query("tail"); tailStr != "" {
-		if n, convErr := strconv.Atoi(tailStr); convErr == nil && n > 0 && n < len(logs) {
-			logs = logs[len(logs)-n:]
+		if n, convErr := strconv.Atoi(tailStr); convErr == nil && n > 0 {
+			limit = n
 		}
 	}
-	httputil.RespondWithOK(c, gin.H{"items": logs, "count": len(logs)})
+	type logItem struct {
+		Level     string    `json:"level"`
+		Message   string    `json:"message"`
+		Attrs     string    `json:"attrs,omitempty"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	var items []logItem
+	if v2, ok := s.Store().(database.OpsV2Store); ok {
+		v2Logs, err := v2.GetOpLogsV2(id, limit)
+		if err != nil {
+			httputil.InternalError(c, "failed to get operation logs", err)
+			return
+		}
+		for _, l := range v2Logs {
+			items = append(items, logItem{Level: l.Level, Message: l.Message, Attrs: l.Attrs, CreatedAt: l.CreatedAt})
+		}
+	}
+	if len(items) == 0 {
+		v1Logs, err := s.Store().GetOperationLogs(id)
+		if err == nil {
+			for _, l := range v1Logs {
+				items = append(items, logItem{Level: l.Level, Message: l.Message, CreatedAt: l.CreatedAt})
+			}
+			if len(items) > limit {
+				items = items[len(items)-limit:]
+			}
+		}
+	}
+	httputil.RespondWithOK(c, gin.H{"items": items, "count": len(items)})
 }
 
 func (s *Server) getOperationResult(c *gin.Context) {

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -718,9 +718,18 @@ export default function ActivityLog() {
                   return false;
                 };
 
-                return activeOps
-                  .filter((op) => !isHiddenByCollapse(op))
-                  .map((op) => {
+                // Partition by status so finished jobs aren't mixed with
+                // running ones. Within each section the existing
+                // parent-child hierarchy still works.
+                const TERMINAL_STATUSES = ['completed', 'failed', 'canceled', 'interrupted_dropped', 'interrupted_restart'];
+                const visibleOps = activeOps.filter((op) => !isHiddenByCollapse(op));
+                const sections: { key: string; title: string; ops: typeof activeOps }[] = [
+                  { key: 'pending',   title: 'Pending',   ops: visibleOps.filter((o) => o.status === 'queued') },
+                  { key: 'active',    title: 'Active',    ops: visibleOps.filter((o) => o.status !== 'queued' && !TERMINAL_STATUSES.includes(o.status)) },
+                  { key: 'completed', title: 'Completed', ops: visibleOps.filter((o) => TERMINAL_STATUSES.includes(o.status)) },
+                ];
+
+                const renderOp = (op: typeof activeOps[0]) => {
                   const pct = op.total > 0 ? Math.round((op.progress / op.total) * 100) : 0;
                   const depth = getDepth(op);
                   const indent = depth * 24; // 24px per level for indentation
@@ -875,7 +884,21 @@ export default function ActivityLog() {
                       </Collapse>
                     </Paper>
                   );
-                });
+                };
+
+                return sections
+                  .filter((s) => s.ops.length > 0)
+                  .map((section) => (
+                    <Box key={section.key} sx={{ mb: 1 }}>
+                      <Typography
+                        variant="overline"
+                        sx={{ color: 'text.secondary', fontWeight: 600, display: 'block', mb: 0.5 }}
+                      >
+                        {section.title} ({section.ops.length})
+                      </Typography>
+                      <Stack spacing={1}>{section.ops.map(renderOp)}</Stack>
+                    </Box>
+                  ));
               })()}
             </Stack>
           )}


### PR DESCRIPTION
## Summary
- Activity Log: partition Active Operations into Pending / Active / Completed sections
- Operations logs: query op_logs_v2 (current registry path) before falling back to v1 operation_logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)