### PR TITLE
perf+activity follow-ups: version-group index + CHANGELOG/TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@
 
 ## [Unreleased]
 
+### Fixes
+
+#### May 13, 2026 — Activity Log UX + op log persistence (PRs #919, #920)
+
+- **Active Operations now partitioned** into Pending / Active / Completed
+  sections so finished jobs don't sit visually mixed with running ones
+  and queued ops are distinct from in-flight work.
+- **Operation logs read from `op_logs_v2`** (the canonical v2 store
+  populated by `dbReporter`) instead of the legacy `operation_logs`
+  table — completed UOS v2 ops were always showing "No logs recorded
+  for this operation." V1 fallback retained for pre-cutover rows.
+- **Plugin SDK stub `itunes.import` def removed from Register list**.
+  Earlier the stub (`Isolate=true`, `Run=no-op`) won the registry race
+  and routed every iTunes import through a no-op subprocess. The
+  canonical `Isolate=false` op in `internal/server/itunes_ops.go` now
+  wires `Importer.Execute` as designed.
+- **Tests start the opRegistry worker pool**. Several integration tests
+  (TestITunesImport_*, TestE2E_ITunesImportOrganizeWriteBack,
+  TestOrganizeService_ViaHTTP, TestStartScanOperation, etc.) called
+  `NewServer(nil)` without `Container.Start`, so enqueued ops sat in
+  the queue forever. `testutil.WaitForOp` and `waitForOperationStatus`
+  now check the v2 ops table before falling back to v1.
+- **V2→V1 op-status bridge**: `folder_autoscan_op` and `itunes_ops`
+  call `UpdateOperationStatus` on the legacy v1 row at terminal status
+  so HTTP callers polling the `LegacyOpID` see completion.
+
+#### May 13, 2026 — Activity entries + completed-op animation + duplicate ops (PRs #905-918)
+
+- Pebble: closed panic on shutdown eliminated by ctx-aware
+  `BackfillExternalIDs` + `Registry.shuttingDown` atomic flag; watchdog
+  no longer respawns workers during shutdown.
+- Operations registry `EnqueueOp` deduplicates against active rows when
+  `ConcurrencyKey != ""`, blocking the cron+maintenance.window double
+  enqueue that produced "Purge ×2 / Temp File ×2" rows.
+- Activity Log: completed ops show static colored bar instead of
+  indeterminate animation; "Loading logs..." now distinct from
+  "fetched, empty"; terminal-status ops stop log-polling and hide
+  Cancel; op cards display `op.displayName || def_id || type`.
+- `slog.Default` routed to `MultiWriter(os.Stderr, activityWriter)` so
+  registry log lines reach the activity feed. (Coverage of slog text
+  format in `ParseLogLine` still needs validation — see TODO.)
+- `nutsdb` activity bucket-not-found handled (`ErrBucketNotFound` *and*
+  `ErrNotFoundBucket` plus `ErrRangeScan`).
+
 ### Refactors
 
 #### May 13, 2026 — SERVER-PLUGIN-REG W4.INT/W5.INT partial cleanup (PR #882)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.28.0 -->
+<!-- version: 8.29.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-13 -->
 
@@ -109,9 +109,14 @@ incrementally:
   `internal/scheduler/extra_ops.go` as `*ExtraOpsRegistrar` (W6). All 13 ops moved;
   server shim delegates via `s.extraOpsRegistrar`.
 
-- [ ] **SERVER-THIN-8** Fix pre-existing iTunes/organize/scan timeout failures
-  (`TestITunesImport_*`, `TestOrganizeService_ViaHTTP`, `TestAddImportPathAutoScan`,
-  `TestStartScanOperation`, `TestStartOrganizeOperation` all timeout at 10–15s)
+- [x] **SERVER-THIN-8** Pre-existing iTunes/organize/scan timeout failures fixed
+  (PRs #919, #920 — 2026-05-13). Root causes: (a) test setup didn't start the
+  opRegistry worker pool so enqueued ops never ran; (b) plugin SDK's
+  `itunes.import` stub (Isolate=true, Run=no-op) won the registration race and
+  routed runs through a no-op subprocess; (c) handler returned legacy v1 op
+  id while v2 was the canonical record. Tests now Start the registry, the
+  stub is removed from the plugin Register list, and the v2→v1 status
+  bridge fires from `itunes_ops` and `folder_autoscan_op`.
 
 ---
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1722,6 +1722,17 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 		}
 	}
 
+	// Version-group index (PERF-VERSIONS): O(N) full-scan in
+	// GetBooksByVersionGroup was costing ~15s on a 10K-book library.
+	// Indexed by group_id so the read can iterate only matching keys.
+	if book.VersionGroupID != nil && *book.VersionGroupID != "" {
+		vgKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", *book.VersionGroupID, book.ID))
+		if err := batch.Set(vgKey, []byte(book.ID), nil); err != nil {
+			batch.Close()
+			return nil, err
+		}
+	}
+
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return nil, err
 	}
@@ -1882,6 +1893,32 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 		if newAuthorID != -1 {
 			newAuthorKey := []byte(fmt.Sprintf("book:author:%d:%s", newAuthorID, id))
 			if err := batch.Set(newAuthorKey, []byte(id), nil); err != nil {
+				batch.Close()
+				return nil, err
+			}
+		}
+	}
+
+	// Update version-group index if changed (PERF-VERSIONS).
+	oldVG := ""
+	if oldBook.VersionGroupID != nil {
+		oldVG = *oldBook.VersionGroupID
+	}
+	newVG := ""
+	if book.VersionGroupID != nil {
+		newVG = *book.VersionGroupID
+	}
+	if oldVG != newVG {
+		if oldVG != "" {
+			oldVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", oldVG, id))
+			if err := batch.Delete(oldVGKey, nil); err != nil {
+				batch.Close()
+				return nil, err
+			}
+		}
+		if newVG != "" {
+			newVGKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", newVG, id))
+			if err := batch.Set(newVGKey, []byte(id), nil); err != nil {
 				batch.Close()
 				return nil, err
 			}
@@ -2132,6 +2169,15 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	if book.AuthorID != nil {
 		authorKey := []byte(fmt.Sprintf("book:author:%d:%s", *book.AuthorID, id))
 		if err := batch.Delete(authorKey, nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+
+	// Delete version-group index (PERF-VERSIONS).
+	if book.VersionGroupID != nil && *book.VersionGroupID != "" {
+		vgKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", *book.VersionGroupID, id))
+		if err := batch.Delete(vgKey, nil); err != nil {
 			batch.Close()
 			return err
 		}
@@ -2611,6 +2657,41 @@ func (p *PebbleStore) ListSoftDeletedBooks(limit, offset int, olderThan *time.Ti
 
 // GetBooksByVersionGroup returns all books in a version group
 func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
+	// Fast path: use the book:versiongroup:<gid>:<id> index added in
+	// PERF-VERSIONS so we touch O(|group|) keys instead of full-scanning
+	// the entire books table (was ~15s on 10K books).
+	prefix := []byte(fmt.Sprintf("book:versiongroup:%s:", groupID))
+	upper := append([]byte(nil), prefix...)
+	upper[len(upper)-1] = ';' // ':' + 1
+	idxIter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for idxIter.First(); idxIter.Valid(); idxIter.Next() {
+		ids = append(ids, string(idxIter.Value()))
+	}
+	idxIter.Close()
+
+	if len(ids) > 0 {
+		books := make([]Book, 0, len(ids))
+		for _, id := range ids {
+			b, err := p.GetBookByID(id)
+			if err != nil || b == nil {
+				continue
+			}
+			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+				continue
+			}
+			books = append(books, *b)
+		}
+		sortVersions(books)
+		return books, nil
+	}
+
+	// Fallback: full scan for groups whose index hasn't been backfilled
+	// yet. The backfill goroutine writes index entries on startup; this
+	// path keeps the API correct in the meantime.
 	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
@@ -2622,10 +2703,10 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Skip index keys
 		key := string(iter.Key())
 		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
-			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") {
+			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") ||
+			strings.Contains(key, ":versiongroup:") {
 			continue
 		}
 
@@ -2643,7 +2724,12 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 		}
 	}
 
-	// Sort by primary version first, then by title
+	sortVersions(books)
+	return books, nil
+}
+
+// sortVersions orders books with the primary version first, then by title.
+func sortVersions(books []Book) {
 	sort.Slice(books, func(i, j int) bool {
 		if books[i].IsPrimaryVersion != nil && *books[i].IsPrimaryVersion {
 			return true
@@ -2653,8 +2739,6 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 		}
 		return books[i].Title < books[j].Title
 	})
-
-	return books, nil
 }
 
 // GetBooksByMetadataSourceHash returns all books with the given metadata source hash.

--- a/internal/database/pebble_store_versiongroup_backfill.go
+++ b/internal/database/pebble_store_versiongroup_backfill.go
@@ -1,0 +1,80 @@
+// file: internal/database/pebble_store_versiongroup_backfill.go
+// PERF-VERSIONS: one-time backfill that writes the
+// book:versiongroup:<gid>:<id> secondary index for every existing book
+// that has a VersionGroupID. Without this, /audiobooks/:id/versions
+// falls back to a 10K-row full scan (~15s in prod). After the backfill
+// runs once, the fast path in GetBooksByVersionGroup serves all reads.
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+const versionGroupBackfillKey = "system:backfill:versiongroup_index_v1_done"
+
+// BackfillVersionGroupIndex writes the secondary index for every book with
+// a non-empty VersionGroupID. Idempotent — gated by a sentinel key so
+// repeated calls after the first successful run are cheap no-ops.
+func (p *PebbleStore) BackfillVersionGroupIndex() error {
+	if _, closer, err := p.db.Get([]byte(versionGroupBackfillKey)); err == nil {
+		closer.Close()
+		return nil
+	}
+
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return err
+	}
+
+	batch := p.db.NewBatch()
+	indexed := 0
+	scanned := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		// Only the primary `book:<id>` rows carry full JSON payloads;
+		// skip every secondary index prefix.
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") || strings.Contains(key, ":version:") ||
+			strings.Contains(key, ":versiongroup:") || strings.Contains(key, ":hash:") ||
+			strings.Contains(key, ":originalhash:") || strings.Contains(key, ":organizedhash:") ||
+			strings.Contains(key, ":organizedhash:") {
+			continue
+		}
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			continue
+		}
+		scanned++
+		if book.VersionGroupID == nil || *book.VersionGroupID == "" {
+			continue
+		}
+		vgKey := []byte(fmt.Sprintf("book:versiongroup:%s:%s", *book.VersionGroupID, book.ID))
+		if err := batch.Set(vgKey, []byte(book.ID), nil); err != nil {
+			iter.Close()
+			batch.Close()
+			return err
+		}
+		indexed++
+	}
+	iter.Close()
+
+	if err := batch.Set([]byte(versionGroupBackfillKey), []byte("1"), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	log.Printf("[INFO] versiongroup-backfill: scanned=%d indexed=%d", scanned, indexed)
+	return nil
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -383,6 +383,23 @@ func (s *Server) Start(cfg ServerConfig) error {
 		s.backfillAcoustIDs()
 	}()
 
+	// PERF-VERSIONS: write the book:versiongroup:<gid>:<id> secondary
+	// index for every existing book once so /audiobooks/:id/versions
+	// stops full-scanning. Idempotent and gated by a sentinel key.
+	s.bgWG.Add(1)
+	go func() {
+		defer s.bgWG.Done()
+		if err := s.bgCtx.Err(); err != nil {
+			return
+		}
+		type vgBackfiller interface{ BackfillVersionGroupIndex() error }
+		if b, ok := s.Store().(vgBackfiller); ok {
+			if err := b.BackfillVersionGroupIndex(); err != nil {
+				log.Printf("[WARN] versiongroup-backfill: %v", err)
+			}
+		}
+	}()
+
 	// Strip shwm/©mvi/©mvn atoms from audiobook files (one-time). These
 	// classical-music atoms crash Apple Devices for Windows at sync.
 	s.bgWG.Add(1)


### PR DESCRIPTION
## Summary
- PERF-VERSIONS: Pebble `book:versiongroup:<gid>:<id>` secondary index; /audiobooks/:id/versions O(N) → O(|group|). One-shot backfill on startup, idempotent.
- CHANGELOG + TODO updates for the past 48 hours of work (UI/op-log fixes, SERVER-THIN-8 done, follow-up perf items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)