### PR TITLE
fix(fingerprint): skip re-attempts on known-bad files

### DIFF
--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -673,6 +673,12 @@ type BookFile struct {
 	AcoustIDSeg4 string `json:"acoustid_seg4,omitempty"`
 	AcoustIDSeg5 string `json:"acoustid_seg5,omitempty"`
 	AcoustIDSeg6 string `json:"acoustid_seg6,omitempty"`
+	// FingerprintFailedAt records when the last ffmpeg/fpcalc attempt
+	// failed (corrupt file, unsupported codec, etc.). Set by the
+	// fingerprint backfill so we don't loop forever retrying the same
+	// unreadable files. Force-rescan clears it. nil = never attempted
+	// or last attempt succeeded.
+	FingerprintFailedAt   *time.Time `json:"fingerprint_failed_at,omitempty"`
 	OrganizeMethod        string    `json:"organize_method,omitempty"` // "reflink", "hardlink", "copy", "symlink"
 	Missing            bool      `json:"missing"`
 	CreatedAt          time.Time `json:"created_at"`

--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -37,6 +37,16 @@ func fingerprintBookFile(store database.Store, f database.BookFile, force bool) 
 	if f.AcoustIDSeg0 != "" && !force {
 		return fingerprintOutcomeSkipped
 	}
+	// Skip files that already failed recently. Without this we re-run
+	// ffmpeg on every unreadable MP3 in the library on every backfill
+	// pass — the log gets flooded with the same "Failed to find two
+	// consecutive MPEG audio frames" error per startup. Reattempt after
+	// 7 days in case the file was replaced. Force=true overrides.
+	if f.FingerprintFailedAt != nil && !force {
+		if time.Since(*f.FingerprintFailedAt) < 7*24*time.Hour {
+			return fingerprintOutcomeSkipped
+		}
+	}
 	if f.FilePath == "" || f.Missing {
 		return fingerprintOutcomeIneligible
 	}
@@ -50,6 +60,12 @@ func fingerprintBookFile(store database.Store, f database.BookFile, force bool) 
 	segs, err := fingerprint.FileSegments(f.FilePath, f.Duration)
 	if err != nil {
 		log.Printf("[WARN] fingerprint: %s: %v", f.FilePath, err)
+		// Stamp the failure so the next backfill pass skips this file
+		// instead of re-running ffmpeg on a known-bad input.
+		failedAt := time.Now()
+		marked := f
+		marked.FingerprintFailedAt = &failedAt
+		_ = store.UpdateBookFile(f.ID, &marked)
 		return fingerprintOutcomeFailed
 	}
 


### PR DESCRIPTION
Stamp FingerprintFailedAt on ffmpeg failures so backfill doesn't re-run on the same corrupt MP3s every startup. 7-day reattempt window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)