### PR TITLE
feat(server): metadata cache-first fetch + list endpoint [MATCHER 2/N]

### DIFF
--- a/internal/metafetch/cache.go
+++ b/internal/metafetch/cache.go
@@ -1,0 +1,125 @@
+// file: internal/metafetch/cache.go
+// version: 1.0.0
+//
+// Cache-layer on top of metafetch.Service. The persisted record type
+// lives in internal/database (MetadataCandidateCache) — re-exported
+// here via a type alias so existing metafetch callers keep their
+// import path. The forbidden direction (database → metafetch) is
+// preserved: metafetch imports database, never the other way.
+
+package metafetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// MetadataCandidateCache is a re-export of the persistence type so
+// metafetch callers don't need to know about internal/database.
+type MetadataCandidateCache = database.MetadataCandidateCache
+
+// MetadataCacheSummary is the lightweight enumeration record.
+type MetadataCacheSummary = database.MetadataCacheSummary
+
+// metadataCacheTopN caps how many candidates we persist per book.
+// Matches the existing default response size.
+const metadataCacheTopN = 10
+
+// nowUTC is overridable for tests.
+var nowUTC = func() time.Time { return time.Now().UTC() }
+
+// GetCachedCandidates returns the cached entry for bookID plus a
+// freshness flag (entry.IsFresh()). Returns (nil, false, nil) for
+// cache-miss. Errors are real I/O failures.
+func (mfs *Service) GetCachedCandidates(bookID string) (*MetadataCandidateCache, bool, error) {
+	if mfs == nil || mfs.db == nil {
+		return nil, false, nil
+	}
+	entry, err := mfs.db.GetMetadataCache(bookID)
+	if err != nil {
+		return nil, false, err
+	}
+	if entry == nil {
+		return nil, false, nil
+	}
+	return entry, entry.IsFresh(), nil
+}
+
+// FetchAndCache runs the existing search pipeline, writes top-N to
+// the cache (always replaces), and returns the resulting entry.
+//
+// This is the "manual = invalidate" path — every call overwrites
+// whatever was there. Use GetCachedCandidates for cache-respecting
+// reads.
+func (mfs *Service) FetchAndCache(ctx context.Context, bookID, query, author, narrator, series string, opts SearchOptions) (*MetadataCandidateCache, error) {
+	if mfs == nil {
+		return nil, fmt.Errorf("FetchAndCache: nil Service")
+	}
+	resp, err := mfs.SearchMetadataForBookWithOptions(bookID, query, author, narrator, series, opts)
+	if err != nil {
+		return nil, err
+	}
+	candidates := resp.Results
+	if len(candidates) > metadataCacheTopN {
+		candidates = candidates[:metadataCacheTopN]
+	}
+	raw := make([]json.RawMessage, 0, len(candidates))
+	for _, c := range candidates {
+		b, jerr := json.Marshal(c)
+		if jerr != nil {
+			// Skip a single corrupt candidate rather than fail.
+			continue
+		}
+		raw = append(raw, b)
+	}
+
+	entry := &MetadataCandidateCache{
+		BookID:     bookID,
+		Candidates: raw,
+		FetchedAt:  nowUTC(),
+		SourceHash: hashSearchInputs(bookID, query, author, narrator, series),
+	}
+	if mfs.db != nil {
+		if err := mfs.db.PutMetadataCache(entry); err != nil {
+			// Cache failure should not break the user's fetch; log and
+			// continue (callers can still consume the in-memory entry).
+			log.Printf("[WARN] metafetch: FetchAndCache write %s: %v", bookID, err)
+			return entry, nil
+		}
+	}
+	return entry, nil
+}
+
+// ListCachedSummaries returns one summary per cached entry, ordered
+// by FetchedAt descending.
+func (mfs *Service) ListCachedSummaries(_ context.Context) ([]MetadataCacheSummary, error) {
+	if mfs == nil || mfs.db == nil {
+		return nil, nil
+	}
+	return mfs.db.ListMetadataCacheKeys()
+}
+
+// InvalidateCachedCandidates removes the cache entry for bookID. Used
+// when book metadata changes underneath us (manual edit, metadata
+// apply, organize rename) so the next read fetches fresh.
+func (mfs *Service) InvalidateCachedCandidates(bookID string) error {
+	if mfs == nil || mfs.db == nil {
+		return nil
+	}
+	return mfs.db.DeleteMetadataCache(bookID)
+}
+
+// hashSearchInputs builds a short stable digest of the search inputs
+// so v2 can compare against the inputs the cached entry came from.
+func hashSearchInputs(bookID, query, author, narrator, series string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s", bookID, query, author, narrator, series)
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/internal/server/metadata_cached_handlers.go
+++ b/internal/server/metadata_cached_handlers.go
@@ -1,0 +1,77 @@
+// file: internal/server/metadata_cached_handlers.go
+// version: 1.0.1
+//
+// METADATA-CACHED-MATCHER: handlers for the persistent metadata-cache
+// query surface (Task 8). Adds GET /audiobooks/metadata/cached, the
+// list endpoint that powers the Review popup. Each entry is augmented
+// with the per-book review-status so the UI can split into
+// pending/matched without a second round-trip.
+
+package server
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+)
+
+// listCachedCandidates handles GET /api/v1/audiobooks/metadata/cached.
+//
+// Query params:
+//   - status=pending  → only books whose MetadataReviewStatus is empty/null
+//   - status=matched  → only books with status == "matched"
+//   - (omitted)       → all cached entries
+//
+// Response is { entries: [...], total: N }. Each entry carries the
+// book_id, fetched_at, candidate_count, fresh flag, plus title +
+// review_status pulled from the book row so the UI can render without
+// a second fetch.
+func (s *Server) listCachedCandidates(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+
+	summaries, err := s.metadataFetchService.ListCachedSummaries(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "failed to list metadata cache", err)
+		return
+	}
+
+	statusFilter := c.Query("status")
+	freshCutoff := time.Now().Add(-database.MetadataCacheTTL)
+
+	out := make([]gin.H, 0, len(summaries))
+	for _, sum := range summaries {
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		var reviewStatus string
+		if book.MetadataReviewStatus != nil {
+			reviewStatus = *book.MetadataReviewStatus
+		}
+		switch statusFilter {
+		case "pending":
+			if reviewStatus != "" && reviewStatus != "pending" {
+				continue
+			}
+		case "matched":
+			if reviewStatus != "matched" {
+				continue
+			}
+		}
+		out = append(out, gin.H{
+			"book_id":         sum.BookID,
+			"fetched_at":      sum.FetchedAt,
+			"candidate_count": sum.CandidateCount,
+			"is_fresh":        sum.FetchedAt.After(freshCutoff),
+			"title":           book.Title,
+			"review_status":   reviewStatus,
+		})
+	}
+
+	httputil.RespondWithOK(c, gin.H{"entries": out, "total": len(out)})
+}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -230,6 +230,12 @@ func (s *Server) fetchAudiobookMetadata(c *gin.Context) {
 }
 
 // searchAudiobookMetadata handles POST /api/v1/audiobooks/:id/search-metadata.
+//
+// METADATA-CACHED-MATCHER: when the caller doesn't override the search
+// inputs, we consult the persistent per-book cache first. `?refresh=true`
+// forces a fresh fetch + cache replace. Explicit query/author/narrator/
+// series in the body always bypass the cache because they're an
+// alternative-search, not a re-read of the same query.
 func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 	id := c.Param("id")
 	if s.Store() == nil {
@@ -244,14 +250,51 @@ func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 		UseRerank bool   `json:"use_rerank"`
 	}
 	_ = c.ShouldBindJSON(&body)
+	refresh := c.Query("refresh") == "true"
 
-	// Cache metadata search results for 60s — external API calls are expensive.
-	// use_rerank is part of the cache key so a rerank result and a non-rerank
-	// result for the same search don't clobber each other.
+	// Persistent cache read: only when the caller is doing a plain
+	// per-book fetch (no alt-query) and didn't force refresh.
 	cacheKey := fmt.Sprintf("meta_search:%s:%s:%s:%s:%s:%t",
 		id, body.Query, body.Author, body.Narrator, body.Series, body.UseRerank)
-	if cached, ok := s.listCache.Get(cacheKey); ok {
-		httputil.RespondWithOK(c, cached)
+	plainFetch := body.Query == "" && body.Author == "" && body.Narrator == "" && body.Series == ""
+	if !refresh && plainFetch && s.metadataFetchService != nil {
+		if entry, fresh, err := s.metadataFetchService.GetCachedCandidates(id); err == nil && entry != nil {
+			results := decodeCachedCandidates(entry)
+			respH := gin.H{
+				"results":      results,
+				"query":        body.Query,
+				"from_cache":   true,
+				"is_fresh":     fresh,
+				"fetched_at":   entry.FetchedAt,
+			}
+			s.listCache.Set(cacheKey, respH)
+			httputil.RespondWithOK(c, respH)
+			return
+		}
+	}
+
+	// 60-second in-memory cache: still useful for back-to-back UI re-renders
+	// even after the persistent cache lands. Keyed identically.
+	if !refresh {
+		if cached, ok := s.listCache.Get(cacheKey); ok {
+			httputil.RespondWithOK(c, cached)
+			return
+		}
+	}
+
+	// Plain per-book fetches go through FetchAndCache so the persistent
+	// cache stays warm. Alt-query searches use the bare search path
+	// because they're exploring outside the canonical fetch.
+	if plainFetch && s.metadataFetchService != nil {
+		entry, err := s.metadataFetchService.FetchAndCache(c.Request.Context(), id, body.Query, body.Author, body.Narrator, body.Series, metafetch.SearchOptions{UseRerank: body.UseRerank})
+		if err != nil {
+			httputil.RespondWithError(c, 404, err.Error(), "NOT_FOUND")
+			return
+		}
+		results := decodeCachedCandidates(entry)
+		respH := gin.H{"results": results, "query": body.Query, "from_cache": false, "is_fresh": true, "fetched_at": entry.FetchedAt}
+		s.listCache.Set(cacheKey, respH)
+		httputil.RespondWithOK(c, respH)
 		return
 	}
 
@@ -263,10 +306,23 @@ func (s *Server) searchAudiobookMetadata(c *gin.Context) {
 		httputil.RespondWithError(c, 404, err.Error(), "NOT_FOUND")
 		return
 	}
-	// Cache as gin.H wrapper
 	respH := gin.H{"results": resp.Results, "query": resp.Query, "sources_tried": resp.SourcesTried, "sources_failed": resp.SourcesFailed}
 	s.listCache.Set(cacheKey, respH)
 	httputil.RespondWithOK(c, resp)
+}
+
+// decodeCachedCandidates unwraps the persisted []json.RawMessage into
+// []metafetch.MetadataCandidate. Drops candidates that don't parse so
+// a single corrupt cache entry doesn't poison the whole response.
+func decodeCachedCandidates(entry *metafetch.MetadataCandidateCache) []metafetch.MetadataCandidate {
+	out := make([]metafetch.MetadataCandidate, 0, len(entry.Candidates))
+	for _, raw := range entry.Candidates {
+		var c metafetch.MetadataCandidate
+		if err := json.Unmarshal(raw, &c); err == nil {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // applyAudiobookMetadata handles POST /api/v1/audiobooks/:id/apply-metadata.
@@ -289,6 +345,13 @@ func (s *Server) applyAudiobookMetadata(c *gin.Context) {
 	if err != nil {
 		httputil.InternalError(c, "failed to apply metadata", err)
 		return
+	}
+
+	// METADATA-CACHED-MATCHER: applying invalidates the cache so the
+	// next read goes through a fresh fetch chain that reflects the
+	// new title/author/etc.
+	if s.metadataFetchService != nil {
+		_ = s.metadataFetchService.InvalidateCachedCandidates(id)
 	}
 
 	// Kick off slow file I/O (cover embed, tags, rename) in background.

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1193,6 +1193,10 @@ func (s *Server) setupRoutes() {
 			protected.POST("/metadata/batch-unreject-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleUnrejectCandidates)
 			protected.POST("/audiobooks/:id/fetch-metadata", s.perm(auth.PermLibraryEditMetadata), s.fetchAudiobookMetadata)
 			protected.POST("/audiobooks/:id/search-metadata", s.perm(auth.PermLibraryEditMetadata), s.searchAudiobookMetadata)
+			// METADATA-CACHED-MATCHER: list every book that has a cached
+			// candidate set. Powers the Review popup without enumerating
+			// the operation log.
+			protected.GET("/audiobooks/metadata/cached", s.perm(auth.PermLibraryView), s.listCachedCandidates)
 			protected.POST("/audiobooks/:id/apply-metadata", s.perm(auth.PermLibraryEditMetadata), s.applyAudiobookMetadata)
 			protected.POST("/audiobooks/:id/mark-no-match", s.perm(auth.PermLibraryEditMetadata), s.markAudiobookNoMatch)
 			protected.POST("/audiobooks/:id/revert-metadata", s.perm(auth.PermLibraryEditMetadata), s.revertAudiobookMetadata)


### PR DESCRIPTION
Handler-level wiring for the matcher consolidation. Cache-first search-metadata, new list endpoint, apply invalidation. Frontend wiring follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)