### PR TITLE
feat(matcher): batch fetch writes cache; Resume Review consults cache [MATCHER 4/N]

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -210,7 +210,15 @@ func (s *Server) fetchCandidateForBook(
 		authorHint = append(authorHint, book.Author.Name)
 	}
 
-	resp, err := mfs.SearchMetadataForBook(bookID, book.Title, authorHint...)
+	// METADATA-CACHED-MATCHER: batch fetch always invalidates + writes
+	// the persistent cache for each book. FetchAndCache runs the same
+	// search chain and replaces the cache row in one call, so the
+	// per-book Review UI hits a fresh top-10 next render.
+	authorForHash := ""
+	if len(authorHint) > 0 {
+		authorForHash = authorHint[0]
+	}
+	entry, err := mfs.FetchAndCache(ctx, bookID, book.Title, authorForHash, "", "", metafetch.SearchOptions{})
 	if err != nil {
 		return CandidateResult{
 			Book:   bookInfo,
@@ -218,6 +226,16 @@ func (s *Server) fetchCandidateForBook(
 			Error:  fmt.Sprintf("search failed: %v", err),
 		}
 	}
+	// Decode cached []json.RawMessage back into MetadataCandidate
+	// for the OperationResult payload (back-compat with the progress UI).
+	results := make([]metafetch.MetadataCandidate, 0, len(entry.Candidates))
+	for _, raw := range entry.Candidates {
+		var c metafetch.MetadataCandidate
+		if jerr := json.Unmarshal(raw, &c); jerr == nil {
+			results = append(results, c)
+		}
+	}
+	resp := &metafetch.SearchMetadataResponse{Results: results, Query: book.Title}
 
 	if len(resp.Results) == 0 {
 		return CandidateResult{

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1646,14 +1646,33 @@ export const Library = () => {
   };
 
   const handleResumeReview = async () => {
+    // METADATA-CACHED-MATCHER: the cached-candidates endpoint is the
+    // canonical source for "anything pending review?". The legacy
+    // /metadata/pending-review endpoint is still wired for back-compat
+    // but produces an operation-scoped view; the cache produces a
+    // book-scoped view that survives across operations.
     try {
-      const result = await api.getPendingReview();
-      if (!result.operation_id || result.total_books === 0) {
-        toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
+      const cached = await api.listCachedCandidates('pending');
+      if (!cached.entries.length) {
+        // Fall back to the legacy operation-scoped lookup so users with
+        // pre-cache fetches (no metadata_cache:<id> rows yet) can still
+        // resume their last review.
+        const legacy = await api.getPendingReview();
+        if (!legacy.operation_id || legacy.total_books === 0) {
+          toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
+          return;
+        }
+        setMetadataReviewOpId(legacy.operation_id);
+        setMetadataReviewOpen(true);
         return;
       }
-      setMetadataReviewOpId(result.operation_id);
+      // Cache hit — surface the most recent fetch's operation id so the
+      // existing dialog can render. Future: dialog should accept a
+      // book-id list directly (Task 12).
+      const legacy = await api.getPendingReview();
+      setMetadataReviewOpId(legacy.operation_id || '');
       setMetadataReviewOpen(true);
+      toast(`${cached.entries.length} book${cached.entries.length === 1 ? '' : 's'} ready for review.`, 'info');
     } catch {
       toast('Failed to load pending review', 'error');
     }


### PR DESCRIPTION
Batch fetch now populates the cache via FetchAndCache. Resume Review uses listCachedCandidates first for the modern view.