### PR TITLE
feat(web): rename Fetch & Review → Fetch Selected + Review [MATCHER 6/N]

### DIFF
--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -210,7 +210,15 @@ func (s *Server) fetchCandidateForBook(
 		authorHint = append(authorHint, book.Author.Name)
 	}
 
-	resp, err := mfs.SearchMetadataForBook(bookID, book.Title, authorHint...)
+	// METADATA-CACHED-MATCHER: batch fetch always invalidates + writes
+	// the persistent cache for each book. FetchAndCache runs the same
+	// search chain and replaces the cache row in one call, so the
+	// per-book Review UI hits a fresh top-10 next render.
+	authorForHash := ""
+	if len(authorHint) > 0 {
+		authorForHash = authorHint[0]
+	}
+	entry, err := mfs.FetchAndCache(ctx, bookID, book.Title, authorForHash, "", "", metafetch.SearchOptions{})
 	if err != nil {
 		return CandidateResult{
 			Book:   bookInfo,
@@ -218,6 +226,16 @@ func (s *Server) fetchCandidateForBook(
 			Error:  fmt.Sprintf("search failed: %v", err),
 		}
 	}
+	// Decode cached []json.RawMessage back into MetadataCandidate
+	// for the OperationResult payload (back-compat with the progress UI).
+	results := make([]metafetch.MetadataCandidate, 0, len(entry.Candidates))
+	for _, raw := range entry.Candidates {
+		var c metafetch.MetadataCandidate
+		if jerr := json.Unmarshal(raw, &c); jerr == nil {
+			results = append(results, c)
+		}
+	}
+	resp := &metafetch.SearchMetadataResponse{Results: results, Query: book.Title}
 
 	if len(resp.Results) == 0 {
 		return CandidateResult{

--- a/web/src/components/BatchToolbar.tsx
+++ b/web/src/components/BatchToolbar.tsx
@@ -60,16 +60,17 @@ export const BatchToolbar = ({
         color="primary"
         onClick={onFetchReviewClick}
         disabled={selectedAudiobooksLength < 2}
+        title="Fetch metadata candidates for selected books into the persistent cache. The Review button opens the dialog when results are ready."
       >
-        Fetch & Review
+        Fetch Selected
       </Button>
       <Button
         size="small"
         variant="outlined"
         onClick={onResumeReviewClick}
-        title="Pick a recent fetch operation to review — useful when multiple fetches completed without review or after a page reload"
+        title="Open the review dialog for books with cached candidates pending review"
       >
-        Resume Review
+        Review
       </Button>
       <Button size="small" variant="outlined" onClick={onSearchMetadataClick} disabled={!selectedCount}>
         Search Metadata

--- a/web/src/components/audiobooks/MetadataSearchDialog.tsx
+++ b/web/src/components/audiobooks/MetadataSearchDialog.tsx
@@ -25,6 +25,7 @@ import {
   Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search.js';
+import RefreshIcon from '@mui/icons-material/Refresh.js';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess.js';
 import HeadphonesIcon from '@mui/icons-material/Headphones.js';
@@ -127,7 +128,7 @@ export function MetadataSearchDialog({
   }, [open, book?.id]);
 
   const doSearch = useCallback(
-    async (searchQuery: string, author?: string, narrator?: string, series?: string) => {
+    async (searchQuery: string, author?: string, narrator?: string, series?: string, refresh?: boolean) => {
       if (!book?.id) return;
       setLoading(true);
       try {
@@ -137,7 +138,8 @@ export function MetadataSearchDialog({
           author || undefined,
           narrator || undefined,
           series || undefined,
-          useRerank || undefined
+          useRerank || undefined,
+          refresh
         );
         setResults(resp.results || []);
         setSourcesTried(resp.sources_tried || []);
@@ -157,6 +159,11 @@ export function MetadataSearchDialog({
 
   const handleSearch = () => {
     doSearch(query, authorQuery, narratorQuery, seriesQuery);
+  };
+  // METADATA-CACHED-MATCHER: bypass the persistent cache so a user
+  // explicitly asking for fresh metadata re-runs every source.
+  const handleRefresh = () => {
+    doSearch(query, authorQuery, narratorQuery, seriesQuery, true);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -332,6 +339,13 @@ export function MetadataSearchDialog({
             ),
             endAdornment: (
               <InputAdornment position="end">
+                <IconButton
+                  onClick={handleRefresh}
+                  disabled={loading}
+                  title="Bypass cache — re-fetch from all metadata sources"
+                >
+                  <RefreshIcon />
+                </IconButton>
                 <IconButton onClick={handleSearch} disabled={loading}>
                   <SearchIcon />
                 </IconButton>

--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -91,7 +91,7 @@ describe('Library bulk metadata fetch', () => {
       </MemoryRouter>
     );
 
-    // Select both books so "Fetch & Review" becomes enabled (requires 2+)
+    // Select both books so "Fetch Selected" becomes enabled (requires 2+)
     const selectBoxes = await screen.findAllByRole('checkbox', {
       name: /select /i,
     });
@@ -105,7 +105,7 @@ describe('Library bulk metadata fetch', () => {
     });
 
     const fetchButton = await screen.findByRole('button', {
-      name: /fetch & review/i,
+      name: /fetch selected/i,
     });
     await waitFor(() => {
       expect(fetchButton).toBeEnabled();

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1620,7 +1620,7 @@ export const Library = () => {
       setMetadataReviewOpId(opId);
       startOperationPolling(opId, 'metadata_candidate_fetch');
       toast(
-        `Metadata fetch started for ${ids.length} book${ids.length !== 1 ? 's' : ''} — watch the bell for progress.`,
+        `Metadata fetch started for ${ids.length} book${ids.length !== 1 ? 's' : ''}. Click Review when complete to open candidates.`,
         'info',
       );
     } catch { toast('Failed to start metadata fetch', 'error'); }
@@ -1659,7 +1659,7 @@ export const Library = () => {
         // resume their last review.
         const legacy = await api.getPendingReview();
         if (!legacy.operation_id || legacy.total_books === 0) {
-          toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
+          toast('No books with pending metadata candidates found. Click Fetch Selected to populate the cache.', 'info');
           return;
         }
         setMetadataReviewOpId(legacy.operation_id);

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1646,14 +1646,33 @@ export const Library = () => {
   };
 
   const handleResumeReview = async () => {
+    // METADATA-CACHED-MATCHER: the cached-candidates endpoint is the
+    // canonical source for "anything pending review?". The legacy
+    // /metadata/pending-review endpoint is still wired for back-compat
+    // but produces an operation-scoped view; the cache produces a
+    // book-scoped view that survives across operations.
     try {
-      const result = await api.getPendingReview();
-      if (!result.operation_id || result.total_books === 0) {
-        toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
+      const cached = await api.listCachedCandidates('pending');
+      if (!cached.entries.length) {
+        // Fall back to the legacy operation-scoped lookup so users with
+        // pre-cache fetches (no metadata_cache:<id> rows yet) can still
+        // resume their last review.
+        const legacy = await api.getPendingReview();
+        if (!legacy.operation_id || legacy.total_books === 0) {
+          toast('No books with pending metadata candidates found. Start a Fetch & Review first.', 'info');
+          return;
+        }
+        setMetadataReviewOpId(legacy.operation_id);
+        setMetadataReviewOpen(true);
         return;
       }
-      setMetadataReviewOpId(result.operation_id);
+      // Cache hit — surface the most recent fetch's operation id so the
+      // existing dialog can render. Future: dialog should accept a
+      // book-id list directly (Task 12).
+      const legacy = await api.getPendingReview();
+      setMetadataReviewOpId(legacy.operation_id || '');
       setMetadataReviewOpen(true);
+      toast(`${cached.entries.length} book${cached.entries.length === 1 ? '' : 's'} ready for review.`, 'info');
     } catch {
       toast('Failed to load pending review', 'error');
     }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -2448,7 +2448,10 @@ export async function searchMetadataForBook(
   author?: string,
   narrator?: string,
   series?: string,
-  useRerank?: boolean
+  useRerank?: boolean,
+  // METADATA-CACHED-MATCHER: pass refresh=true to bypass the persistent
+  // cache and force a fresh fetch chain. Default false (use cache).
+  refresh?: boolean,
 ): Promise<SearchMetadataResponse> {
   const body: {
     query: string;
@@ -2461,14 +2464,14 @@ export async function searchMetadataForBook(
   if (narrator) body.narrator = narrator;
   if (series) body.series = series;
   if (useRerank) body.use_rerank = true;
-  const response = await fetch(
-    `${API_BASE}/audiobooks/${bookId}/search-metadata`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }
-  );
+  const url = refresh
+    ? `${API_BASE}/audiobooks/${bookId}/search-metadata?refresh=true`
+    : `${API_BASE}/audiobooks/${bookId}/search-metadata`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to search metadata');
   }


### PR DESCRIPTION
UI rename to match the matcher design. Fetch Selected populates the cache; Review opens the dialog over cached candidates.