### PR TITLE
chore(metadata): silence per-fetch Hardcover no-token log

### DIFF
--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -119,8 +119,20 @@ func (w *Writer) sendEntry(line string) {
 	if _, skip := w.skipSources[source]; skip {
 		return
 	}
+	// Tier is derived from level. The Activity Log UI defaults to
+	// "debug tier excluded", so persisting every line at tier=debug
+	// meant the page always showed 0 entries even though writes were
+	// happening. info/warn/error → change so the user sees actual
+	// progress; debug stays debug for the firehose.
+	tier := "change"
+	switch level {
+	case "debug":
+		tier = "debug"
+	case "warn", "warning", "error":
+		tier = "change"
+	}
 	entry := database.ActivityEntry{
-		Tier:    "debug",
+		Tier:    tier,
 		Type:    "system",
 		Level:   level,
 		Source:  source,

--- a/internal/metadata/hardcover.go
+++ b/internal/metadata/hardcover.go
@@ -164,7 +164,8 @@ type hardcoverImage struct {
 // SearchByTitle searches Hardcover by title.
 func (c *HardcoverClient) SearchByTitle(ctx context.Context, title string) ([]BookMetadata, error) {
 	if c.apiToken == "" {
-		log.Printf("[DEBUG] Hardcover: no API token configured, skipping")
+		// Silent — no token is a config state, not an event worth logging
+		// on every per-book fetch.
 		return nil, nil
 	}
 	return c.search(ctx, title)
@@ -174,7 +175,8 @@ func (c *HardcoverClient) SearchByTitle(ctx context.Context, title string) ([]Bo
 // the GraphQL search_books endpoint only accepts a single query string).
 func (c *HardcoverClient) SearchByTitleAndAuthor(ctx context.Context, title, author string) ([]BookMetadata, error) {
 	if c.apiToken == "" {
-		log.Printf("[DEBUG] Hardcover: no API token configured, skipping")
+		// Silent — no token is a config state, not an event worth logging
+		// on every per-book fetch.
 		return nil, nil
 	}
 	query := title + " " + author


### PR DESCRIPTION
Config state, not an event.