### PR TITLE
chore(web): opt into react-router v7 future flags in remaining test files

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -62,7 +62,7 @@ beforeEach(() => {
 describe('App', () => {
   it('renders without crashing', async () => {
     render(
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <ThemeProvider theme={theme}>
           <AuthProvider>
             <App />
@@ -76,7 +76,7 @@ describe('App', () => {
 
   it('renders navigation items', async () => {
     render(
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <ThemeProvider theme={theme}>
           <AuthProvider>
             <App />

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -71,7 +71,7 @@ vi.mock('../services/api', () => {
 describe('Library import dialog', () => {
   it('imports a selected file path', async () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Library />
       </MemoryRouter>
     );

--- a/web/src/test/renderWithProviders.tsx
+++ b/web/src/test/renderWithProviders.tsx
@@ -26,7 +26,7 @@ export function renderWithProviders(
 
   function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <MemoryRouter initialEntries={initialEntries}>
+      <MemoryRouter initialEntries={initialEntries} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <ThemeProvider theme={testTheme}>{children}</ThemeProvider>
       </MemoryRouter>
     );


### PR DESCRIPTION
\`main.tsx\` and several test files already carried the future flags; this finishes the sweep for the remaining three files that still used bare \`<BrowserRouter>\`/\`<MemoryRouter>\` without the \`future\` prop.

## Changes
- \`web/src/App.test.tsx\` — added \`future\` to both \`<BrowserRouter>\` instances
- \`web/src/test/renderWithProviders.tsx\` — added \`future\` to shared \`<MemoryRouter>\`
- \`web/src/pages/Library.importFile.test.tsx\` — added \`future\` to \`<MemoryRouter>\`

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`vitest run\` — 172/172 tests pass
- [x] No behavior change; eliminates React Router v7 future-flag warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)