### PR TITLE
feat(metadata): decouple MetadataReviewDialog from operationId (Task 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.67.0 -->
+<!-- version: 2.68.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-14 -->
 
@@ -8,6 +8,26 @@
 ## [Unreleased]
 
 ### Features
+
+#### May 14, 2026 — METADATA-CACHED-MATCHER: MetadataReviewDialog decoupled from operationId (Task 12)
+
+`MetadataReviewDialog` now reads entirely from the persistent metadata cache
+(`GET /audiobooks/metadata/cache/review`) instead of an ephemeral operation ID.
+The `operationId` prop is gone — the dialog opens directly from the Library
+"Resume Review" button without first creating an aggregate operation.
+
+New server endpoints added:
+- `GET /audiobooks/metadata/cache/review` — paginated `CandidateResult[]` list
+  sourced from the cache, with status "matched" / "no_match" / "applied"
+- `POST /audiobooks/metadata/batch-apply-cached` — applies the top cached
+  candidate for each book_id, replaces `batch-apply-candidates`
+- `POST /audiobooks/:id/clear-no-match` — clears `MetadataReviewStatus` back
+  to null (unreject), replaces the operation-scoped unreject endpoint
+
+Legacy endpoint removed: `POST /metadata/pending-review` and the
+`handleGetPendingReview` handler (created ephemeral aggregate operations).
+The `operationId` wiring in `LibraryDialogs.tsx` and `Library.tsx` is
+removed; `handleResumeReview` now just opens the dialog if cache has entries.
 
 #### May 13, 2026 — PERF-VERSIONS: Pebble version-group secondary index (PR #921)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.30.0 -->
+<!-- version: 8.31.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-14 -->
 

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 // last-edited: 2026-05-11
 //
@@ -913,63 +913,3 @@ func (s *Server) handleListMetadataResults(c *gin.Context) {
 	})
 }
 
-// handleGetPendingReview implements POST /api/v1/metadata/pending-review.
-// Thin compatibility wrapper around latestMetadataResultsByBook that keeps
-// the MetadataReviewDialog working unchanged: it filters to status=matched,
-// creates an aggregate operation, copies the matched rows under the new
-// op ID, and returns the aggregate ID for the dialog to consume.
-func (s *Server) handleGetPendingReview(c *gin.Context) {
-	store := s.Store()
-
-	latest, counts, err := latestMetadataResultsByBook(store)
-	if err != nil {
-		httputil.InternalError(c, "failed to list operations", err)
-		return
-	}
-
-	var pending []database.OperationResult
-	for _, r := range latest {
-		if r.Status == "matched" {
-			pending = append(pending, r)
-		}
-	}
-
-	log.Printf("[INFO] pending-review: %d unique books fetched — status counts: %v, matched: %d",
-		len(latest), counts, len(pending))
-
-	if len(pending) == 0 {
-		httputil.RespondWithOK(c, gin.H{
-			"operation_id": "",
-			"total_books":  0,
-			"message":      "no books with pending metadata candidates",
-		})
-		return
-	}
-
-	// Create an aggregate operation record so MetadataReviewDialog can use its
-	// standard operationId-based flow (apply, reject, pagination).
-	newOpID := ulid.Make().String()
-	if _, err := store.CreateOperation(newOpID, "metadata_candidate_fetch", nil); err != nil {
-		httputil.InternalError(c, "failed to create aggregate operation", err)
-		return
-	}
-
-	// Copy the latest CandidateResult rows under the new operation ID.
-	for _, r := range pending {
-		_ = store.CreateOperationResult(&database.OperationResult{
-			OperationID: newOpID,
-			BookID:      r.BookID,
-			ResultJSON:  r.ResultJSON,
-			Status:      r.Status,
-		})
-	}
-
-	// Mark the aggregate op as completed immediately — all results are already loaded.
-	_ = store.UpdateOperationStatus(newOpID, "completed", len(pending), len(pending), "")
-
-	httputil.RespondWithOK(c, gin.H{
-		"operation_id": newOpID,
-		"total_books":  len(pending),
-		"message":      fmt.Sprintf("%d book(s) have pending metadata candidates", len(pending)),
-	})
-}

--- a/internal/server/metadata_cached_handlers.go
+++ b/internal/server/metadata_cached_handlers.go
@@ -1,20 +1,27 @@
 // file: internal/server/metadata_cached_handlers.go
-// version: 1.0.1
+// version: 1.1.0
 //
 // METADATA-CACHED-MATCHER: handlers for the persistent metadata-cache
 // query surface (Task 8). Adds GET /audiobooks/metadata/cached, the
 // list endpoint that powers the Review popup. Each entry is augmented
 // with the per-book review-status so the UI can split into
 // pending/matched without a second round-trip.
+//
+// Task 12 additions: cache/review (full CandidateResult list sourced
+// from cache), batch-apply-cached, and clear-no-match.
 
 package server
 
 import (
+	"encoding/json"
+	"log"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/metabatch"
+	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 )
 
 // listCachedCandidates handles GET /api/v1/audiobooks/metadata/cached.
@@ -74,4 +81,161 @@ func (s *Server) listCachedCandidates(c *gin.Context) {
 	}
 
 	httputil.RespondWithOK(c, gin.H{"entries": out, "total": len(out)})
+}
+
+// getCacheReviewResults handles GET /api/v1/audiobooks/metadata/cache/review.
+//
+// Returns a paginated list of CandidateResult items sourced entirely from the
+// persistent metadata cache. The shape matches getOperationResults so
+// MetadataReviewDialog can consume it without changing its render logic.
+//
+// Status semantics in the response:
+//   - "matched"  — candidate found, book is pending user review
+//   - "no_match" — user previously rejected (MetadataReviewStatus="no_match")
+//   - "applied"  — metadata was already applied (MetadataReviewStatus="matched")
+func (s *Server) getCacheReviewResults(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+	pp := httputil.ParsePaginationParams(c)
+
+	summaries, err := s.metadataFetchService.ListCachedSummaries(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "failed to list metadata cache", err)
+		return
+	}
+
+	total := len(summaries)
+	start := pp.Offset
+	if start > total {
+		start = total
+	}
+	end := total
+	if pp.Limit > 0 {
+		end = start + pp.Limit
+		if end > total {
+			end = total
+		}
+	}
+	page := summaries[start:end]
+
+	results := make([]CandidateResult, 0, len(page))
+	var matched, noMatch, applied int
+
+	for _, sum := range page {
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		entry, _, err := s.metadataFetchService.GetCachedCandidates(sum.BookID)
+		if err != nil || entry == nil || len(entry.Candidates) == 0 {
+			continue
+		}
+		var cand metafetch.MetadataCandidate
+		if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
+			log.Printf("[WARN] getCacheReviewResults: decode candidate for %s: %v", sum.BookID, err)
+			continue
+		}
+
+		var reviewStatus string
+		if book.MetadataReviewStatus != nil {
+			reviewStatus = *book.MetadataReviewStatus
+		}
+
+		status := "matched"
+		switch reviewStatus {
+		case "no_match":
+			status = "no_match"
+			noMatch++
+		case "matched":
+			status = "applied"
+			applied++
+		default:
+			matched++
+		}
+
+		results = append(results, CandidateResult{
+			Book:      metabatch.BuildCandidateBookInfo(s.Store(), book),
+			Candidate: &cand,
+			Status:    status,
+		})
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"results":       results,
+		"total_count":   total,
+		"matched":       matched,
+		"no_match":      noMatch,
+		"errors":        0,
+		"total_applied": applied,
+	})
+}
+
+// batchApplyFromCache handles POST /api/v1/audiobooks/metadata/batch-apply-cached.
+//
+// Applies the highest-scored cached candidate for each book_id in the request.
+// Equivalent to the legacy batchApplyCandidates but reads from the persistent
+// cache rather than an operation's result rows.
+func (s *Server) batchApplyFromCache(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+	var body struct {
+		BookIDs []string `json:"book_ids" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		httputil.RespondWithBadRequest(c, "invalid request body")
+		return
+	}
+
+	applied := 0
+	for _, bookID := range body.BookIDs {
+		entry, _, err := s.metadataFetchService.GetCachedCandidates(bookID)
+		if err != nil || entry == nil || len(entry.Candidates) == 0 {
+			log.Printf("[WARN] batchApplyFromCache: no cached candidates for %s", bookID)
+			continue
+		}
+		var cand metafetch.MetadataCandidate
+		if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
+			log.Printf("[WARN] batchApplyFromCache: decode candidate for %s: %v", bookID, err)
+			continue
+		}
+		if _, err := s.metadataFetchService.ApplyMetadataCandidate(bookID, cand, nil); err != nil {
+			log.Printf("[WARN] batchApplyFromCache: apply for %s: %v", bookID, err)
+			continue
+		}
+		_ = s.metadataFetchService.InvalidateCachedCandidates(bookID)
+		if s.writeBackBatcher != nil {
+			s.writeBackBatcher.Enqueue(bookID)
+		}
+		applied++
+	}
+
+	httputil.RespondWithOK(c, gin.H{"applied": applied})
+}
+
+// clearMetadataNoMatch handles POST /api/v1/audiobooks/:id/clear-no-match.
+//
+// Clears a book's MetadataReviewStatus back to null so it re-surfaces in the
+// Review dialog. Inverse of mark-no-match. Does not create a rejection record.
+func (s *Server) clearMetadataNoMatch(c *gin.Context) {
+	id := c.Param("id")
+	store := s.Store()
+	if store == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	book, err := store.GetBookByID(id)
+	if err != nil || book == nil {
+		httputil.RespondWithNotFound(c, "audiobook", id)
+		return
+	}
+	book.MetadataReviewStatus = nil
+	if _, err := store.UpdateBook(id, book); err != nil {
+		httputil.InternalError(c, "failed to clear review status", err)
+		return
+	}
+	httputil.RespondWithOK(c, gin.H{"message": "Review status cleared"})
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-11
 
@@ -1183,7 +1183,6 @@ func (s *Server) setupRoutes() {
 			protected.POST("/metadata/bulk-fetch", s.perm(auth.PermLibraryEditMetadata), s.bulkFetchMetadata)
 			protected.POST("/metadata/batch-fetch-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleBatchFetchCandidates)
 			protected.GET("/metadata/recent-fetches", s.perm(auth.PermLibraryView), s.handleGetLatestMetadataFetch)
-			protected.POST("/metadata/pending-review", s.perm(auth.PermLibraryView), s.handleGetPendingReview)
 			// Unified metadata-results listing — preferred over /metadata/pending-review.
 			// Returns books with their latest fetch status + by_status counts; supports
 			// repeatable ?status= filtering for the Library page toggles + Resume Review.
@@ -1197,8 +1196,12 @@ func (s *Server) setupRoutes() {
 			// candidate set. Powers the Review popup without enumerating
 			// the operation log.
 			protected.GET("/audiobooks/metadata/cached", s.perm(auth.PermLibraryView), s.listCachedCandidates)
+			// Task 12: cache-sourced review list, batch-apply, and unreject.
+			protected.GET("/audiobooks/metadata/cache/review", s.perm(auth.PermLibraryView), s.getCacheReviewResults)
+			protected.POST("/audiobooks/metadata/batch-apply-cached", s.perm(auth.PermLibraryEditMetadata), s.batchApplyFromCache)
 			protected.POST("/audiobooks/:id/apply-metadata", s.perm(auth.PermLibraryEditMetadata), s.applyAudiobookMetadata)
 			protected.POST("/audiobooks/:id/mark-no-match", s.perm(auth.PermLibraryEditMetadata), s.markAudiobookNoMatch)
+			protected.POST("/audiobooks/:id/clear-no-match", s.perm(auth.PermLibraryEditMetadata), s.clearMetadataNoMatch)
 			protected.POST("/audiobooks/:id/revert-metadata", s.perm(auth.PermLibraryEditMetadata), s.revertAudiobookMetadata)
 			protected.GET("/audiobooks/:id/metadata-rejections", s.perm(auth.PermLibraryView), s.handleGetMetadataRejections)
 			protected.GET("/audiobooks/:id/similar", s.perm(auth.PermLibraryView), s.handleSimilarBooks)

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.11.0
+// version: 1.12.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -35,7 +35,6 @@ import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 interface MetadataReviewDialogProps {
   open: boolean;
-  operationId: string;
   onClose: () => void;
   onComplete: () => void;
   toast: (
@@ -143,7 +142,6 @@ function formatFileSize(bytes: number): string {
 
 export function MetadataReviewDialog({
   open,
-  operationId,
   onClose,
   onComplete,
   toast,
@@ -161,7 +159,7 @@ export function MetadataReviewDialog({
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
   const [summary, setSummary] = useState({ matched: 0, no_match: 0, errors: 0, total: 0 });
-  const [totalSummary, setTotalSummary] = useState<{ matched: number; no_match: number; errors: number } | null>(null);
+  const [totalSummary] = useState<{ matched: number; no_match: number; errors: number } | null>(null);
   const [previewCover, setPreviewCover] = useState<string | null>(null);
   // serverPage: which page to fetch from the API. Unified with the display page —
   // one paginator, one concept of "page".
@@ -196,23 +194,25 @@ export function MetadataReviewDialog({
   // exactly once when the dialog closes, rather than on every individual apply.
   const hasChangesRef = useRef(false);
 
-  // Fetch the current page from the server. Each page fetches exactly
-  // reviewPageSize items; all that pass client filters are rendered (no
-  // second level of pagination). One paginator, one concept of "page".
+  // Fetch the current page from the persistent metadata cache.
   useEffect(() => {
-    if (!open || !operationId) return;
+    if (!open) return;
     setLoading(true);
     const fetchId = ++fetchIdRef.current;
     const offset = (serverPage - 1) * reviewPageSize;
     api
-      .getOperationResults(operationId, reviewPageSize, offset)
+      .getCachedReviewResults(reviewPageSize, offset)
       .then((data) => {
         if (fetchId !== fetchIdRef.current) return; // stale — a newer fetch is in flight
         const pageResults = data.results || [];
 
         const pageStates = new Map<string, 'pending' | 'applied' | 'rejected' | 'skipped'>();
         for (const r of pageResults) {
-          if (r.status === 'rejected') {
+          // Pre-seed UI state from persisted server status so toggles
+          // (hideApplied, hideNoMatch) work correctly on first render.
+          if (r.status === 'applied') {
+            pageStates.set(r.book.id, 'applied');
+          } else if (r.status === 'no_match') {
             pageStates.set(r.book.id, 'rejected');
           }
         }
@@ -223,66 +223,29 @@ export function MetadataReviewDialog({
         });
 
         setResults(pageResults);
-        const tc = data.total_count ?? data.total ?? pageResults.length;
+        const tc = data.total_count ?? pageResults.length;
         setTotalCount(tc);
         setSummary({
           matched: data.matched ?? pageResults.filter((r) => r.status === 'matched').length,
           no_match: data.no_match ?? pageResults.filter((r) => r.status === 'no_match').length,
-          errors: data.errors ?? pageResults.filter((r) => r.status === 'error').length,
+          errors: data.errors ?? 0,
           total: tc,
         });
-        if (data.total_matched !== undefined) {
-          setTotalSummary({
-            matched: data.total_matched,
-            no_match: data.total_no_match ?? 0,
-            errors: data.total_errors ?? 0,
-          });
-        }
         setLoading(false);
       })
       .catch(() => {
         if (fetchId !== fetchIdRef.current) return;
         setLoading(false);
       });
-  }, [open, operationId, serverPage, reviewPageSize, refreshKey]);
+  }, [open, serverPage, reviewPageSize, refreshKey]);
 
-  // Poll for new results while the operation is still running.
-  // Fetches only limit=1 to get the updated total_count without
-  // downloading the full page again.
-  const [operationDone, setOperationDone] = useState(false);
-  const prevTotalRef = useRef(0);
-
+  // Reset page and un-groupings when the dialog opens.
   useEffect(() => {
-    if (!open || !operationId || loading || operationDone) return;
-    const interval = setInterval(async () => {
-      try {
-        const data = await api.getOperationResults(operationId, 1, 0);
-        const newTotal = data.total_count ?? data.total ?? 0;
-
-        if (newTotal > 0 && newTotal === prevTotalRef.current) {
-          setOperationDone(true);
-          return;
-        }
-        prevTotalRef.current = newTotal;
-
-        if (newTotal > totalCount) {
-          setTotalCount(newTotal);
-          setSummary((prev) => ({ ...prev, total: newTotal }));
-        }
-      } catch {
-        // Silent — polling failure is not fatal
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [open, operationId, loading, operationDone, totalCount]);
-
-  // Reset polling state, page, and un-groupings when the operation changes.
-  useEffect(() => {
-    setOperationDone(false);
-    prevTotalRef.current = 0;
-    setServerPage(1);
-    setUngroupedIds(new Set());
-  }, [operationId]);
+    if (open) {
+      setServerPage(1);
+      setUngroupedIds(new Set());
+    }
+  }, [open]);
 
   // Reset un-groupings when navigating to a new page (groups are per-page).
   useEffect(() => {
@@ -348,7 +311,7 @@ export function MetadataReviewDialog({
     applyQueueRef.current = [];
     if (ids.length === 0) return;
     try {
-      await api.batchApplyCandidates(operationId, ids);
+      await api.batchApplyFromCache(ids);
       hasChangesRef.current = true;
       toast(`Applied metadata to ${ids.length} book${ids.length > 1 ? 's' : ''}`, 'success', {
         label: 'Undo',
@@ -377,7 +340,7 @@ export function MetadataReviewDialog({
       });
       toast('Failed to apply', 'error');
     }
-  }, [operationId, toast]);
+  }, [toast]);
 
   const handleApplyOne = (bookId: string) => {
     // Optimistic UI update
@@ -392,7 +355,7 @@ export function MetadataReviewDialog({
     if (bookIds.length === 0) return;
     setApplying(true);
     try {
-      const { applied } = await api.batchApplyCandidates(operationId, bookIds);
+      const { applied } = await api.batchApplyFromCache(bookIds);
       const newStates = new Map(rowStates);
       bookIds.forEach((id) => newStates.set(id, 'applied'));
       setRowStates(newStates);
@@ -431,13 +394,13 @@ export function MetadataReviewDialog({
 
   const handleReject = async (bookId: string) => {
     try {
-      await api.batchRejectCandidates(operationId, [bookId]);
+      await api.markNoMatch(bookId);
       setRowStates((prev) => new Map(prev).set(bookId, 'rejected'));
       toast('Candidate rejected — will be excluded from future fetches', 'info', {
         label: 'Undo',
         onClick: async () => {
           try {
-            await api.batchUnrejectCandidates(operationId, [bookId]);
+            await api.clearMetadataNoMatch(bookId);
             setRowStates((prev) => new Map(prev).set(bookId, 'pending'));
             toast('Rejection undone', 'success');
           } catch {
@@ -452,7 +415,7 @@ export function MetadataReviewDialog({
 
   const handleUnreject = async (bookId: string) => {
     try {
-      await api.batchUnrejectCandidates(operationId, [bookId]);
+      await api.clearMetadataNoMatch(bookId);
       setRowStates((prev) => new Map(prev).set(bookId, 'pending'));
       toast('Rejection undone', 'success');
     } catch {
@@ -579,7 +542,7 @@ export function MetadataReviewDialog({
 
     const handleRejectGroup = async () => {
       try {
-        await api.batchRejectCandidates(operationId, actionableIds);
+        await Promise.all(actionableIds.map((id) => api.markNoMatch(id)));
         setRowStates(prev => {
           const next = new Map(prev);
           actionableIds.forEach(id => next.set(id, 'rejected'));

--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
 // last-edited: 2026-05-11
 
@@ -166,7 +166,6 @@ interface LibraryDialogsProps {
   // Metadata review dialog
   metadataReviewOpen: boolean;
   setMetadataReviewOpen: (open: boolean) => void;
-  metadataReviewOpId: string | null;
 
   // Version management
   versionManagingAudiobook: Audiobook | null;
@@ -295,7 +294,6 @@ export const LibraryDialogs = ({
   setBulkSearchOpen,
   metadataReviewOpen,
   setMetadataReviewOpen,
-  metadataReviewOpId,
   versionManagingAudiobook,
   versionManagementOpen,
   handleVersionManagementClose,
@@ -798,23 +796,10 @@ export const LibraryDialogs = ({
         user must click the x button or Done to close, which
         prevents accidentally blowing away a long review
         session. Reopening is instant because the data is
-        already loaded.
-
-        When the user explicitly closes, we KEEP the opId
-        alive so clicking "Resume Review" with the same
-        operation reopens the same dialog state without a
-        re-query. Clearing the opId happens only when the
-        user picks a DIFFERENT operation from the picker. */}
+        already loaded. */}
     <MetadataReviewDialog
       open={metadataReviewOpen}
-      operationId={metadataReviewOpId || ''}
-      onClose={() => {
-        setMetadataReviewOpen(false);
-        // Intentionally NOT clearing metadataReviewOpId so
-        // the dialog's internal state survives and reopen is
-        // instant. The opId is cleared when the user picks a
-        // new operation from the Resume Review picker.
-      }}
+      onClose={() => setMetadataReviewOpen(false)}
       onComplete={() => {
         loadAudiobooks();
         setSelectedAudiobooks([]);

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.62.0
+// version: 1.63.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-05-11
 
@@ -221,9 +221,9 @@ export const Library = () => {
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [batchPlaylistOpen, setBatchPlaylistOpen] = useState(false);
   const [mergePrimaryId, setMergePrimaryId] = useState<string>('');
-  const [metadataReviewOpId, setMetadataReviewOpId] = useState<string | null>(
-    searchParams.get('reviewOp')
-  );
+  // pendingFetchOpId tracks the in-flight metadata fetch so we can
+  // auto-open the review dialog when it completes.
+  const [pendingFetchOpId, setPendingFetchOpId] = useState<string | null>(null);
   const [metadataReviewOpen, setMetadataReviewOpen] = useState(!!searchParams.get('reviewOp'));
   const [mergeInProgress, setMergeInProgress] = useState(false);
   const sseStatusRef = useRef<EventSourceStatus['state'] | null>(null);
@@ -827,8 +827,8 @@ export const Library = () => {
   // Watch the operations store: open the review dialog when a metadata fetch op completes.
   const activeOperations = useOperationsStore((state) => state.activeOperations);
   useEffect(() => {
-    if (!metadataReviewOpId) return;
-    const op = activeOperations.find((o) => o.id === metadataReviewOpId);
+    if (!pendingFetchOpId) return;
+    const op = activeOperations.find((o) => o.id === pendingFetchOpId);
     if (!op) return;
     if (op.status === 'completed') {
       setMetadataReviewOpen(true);
@@ -836,7 +836,7 @@ export const Library = () => {
     } else if (op.status === 'failed') {
       toast('Metadata fetch failed.', 'error');
     }
-  }, [activeOperations, metadataReviewOpId, toast]);
+  }, [activeOperations, pendingFetchOpId, toast]);
 
   const handleEdit = useCallback((audiobook: Audiobook) => {
     setEditingAudiobook(audiobook);
@@ -1617,7 +1617,7 @@ export const Library = () => {
         toast('All selected books are already being fetched.', 'info');
         return;
       }
-      setMetadataReviewOpId(opId);
+      setPendingFetchOpId(opId);
       startOperationPolling(opId, 'metadata_candidate_fetch');
       toast(
         `Metadata fetch started for ${ids.length} book${ids.length !== 1 ? 's' : ''}. Click Review when complete to open candidates.`,
@@ -1646,31 +1646,12 @@ export const Library = () => {
   };
 
   const handleResumeReview = async () => {
-    // METADATA-CACHED-MATCHER: the cached-candidates endpoint is the
-    // canonical source for "anything pending review?". The legacy
-    // /metadata/pending-review endpoint is still wired for back-compat
-    // but produces an operation-scoped view; the cache produces a
-    // book-scoped view that survives across operations.
     try {
       const cached = await api.listCachedCandidates('pending');
       if (!cached.entries.length) {
-        // Fall back to the legacy operation-scoped lookup so users with
-        // pre-cache fetches (no metadata_cache:<id> rows yet) can still
-        // resume their last review.
-        const legacy = await api.getPendingReview();
-        if (!legacy.operation_id || legacy.total_books === 0) {
-          toast('No books with pending metadata candidates found. Click Fetch Selected to populate the cache.', 'info');
-          return;
-        }
-        setMetadataReviewOpId(legacy.operation_id);
-        setMetadataReviewOpen(true);
+        toast('No books with pending metadata candidates found. Click Fetch Selected to populate the cache.', 'info');
         return;
       }
-      // Cache hit — surface the most recent fetch's operation id so the
-      // existing dialog can render. Future: dialog should accept a
-      // book-id list directly (Task 12).
-      const legacy = await api.getPendingReview();
-      setMetadataReviewOpId(legacy.operation_id || '');
       setMetadataReviewOpen(true);
       toast(`${cached.entries.length} book${cached.entries.length === 1 ? '' : 's'} ready for review.`, 'info');
     } catch {
@@ -1875,7 +1856,6 @@ export const Library = () => {
           setBulkSearchOpen={setBulkSearchOpen}
           metadataReviewOpen={metadataReviewOpen}
           setMetadataReviewOpen={setMetadataReviewOpen}
-          metadataReviewOpId={metadataReviewOpId}
 
           versionManagingAudiobook={versionManagingAudiobook}
           versionManagementOpen={versionManagementOpen}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.25.0
+// version: 2.26.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-11
 
@@ -3032,7 +3032,7 @@ export interface CandidateBookInfo {
 export interface CandidateResult {
   book: CandidateBookInfo;
   candidate?: MetadataCandidate;
-  status: 'matched' | 'no_match' | 'error' | 'rejected';
+  status: 'matched' | 'no_match' | 'error' | 'rejected' | 'applied';
   error_message?: string;
 }
 
@@ -3143,6 +3143,51 @@ export async function listCachedCandidates(
   if (!response.ok) throw await buildApiError(response, 'Failed to list cached candidates');
   const data = await response.json();
   return data.data ?? data;
+}
+
+// getCachedReviewResults returns a paginated CandidateResult list sourced
+// from the persistent metadata cache. Replaces getOperationResults for the
+// MetadataReviewDialog. Status values: "matched" (pending review),
+// "no_match" (user rejected), "applied" (already applied).
+export async function getCachedReviewResults(
+  limit: number,
+  offset: number,
+): Promise<{
+  results: CandidateResult[];
+  total_count: number;
+  matched: number;
+  no_match: number;
+  errors: number;
+  total_applied?: number;
+}> {
+  const response = await fetch(
+    `${API_BASE}/audiobooks/metadata/cache/review?limit=${limit}&offset=${offset}`,
+  );
+  if (!response.ok) throw await buildApiError(response, 'Failed to load cached review results');
+  const data = await response.json();
+  return data.data ?? data;
+}
+
+// batchApplyFromCache applies the highest-scored cached candidate for each
+// book in book_ids. Cache-mode replacement for batchApplyCandidates.
+export async function batchApplyFromCache(bookIds: string[]): Promise<{ applied: number }> {
+  const response = await fetch(`${API_BASE}/audiobooks/metadata/batch-apply-cached`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ book_ids: bookIds }),
+  });
+  if (!response.ok) throw await buildApiError(response, 'Failed to apply cached candidates');
+  const data = await response.json();
+  return data.data ?? data;
+}
+
+// clearMetadataNoMatch clears a book's MetadataReviewStatus back to null
+// so it re-surfaces in the Review dialog. Inverse of markNoMatch.
+export async function clearMetadataNoMatch(bookId: string): Promise<void> {
+  const response = await fetch(`${API_BASE}/audiobooks/${bookId}/clear-no-match`, {
+    method: 'POST',
+  });
+  if (!response.ok) throw await buildApiError(response, 'Failed to clear no-match status');
 }
 
 // MetadataResultItem is one row in the unified metadata-results listing.


### PR DESCRIPTION
## Summary

- **Removes the `operationId` prop** from `MetadataReviewDialog` — the dialog now opens with no coupling to an ephemeral operation
- **Three new server endpoints** backed by the persistent Pebble metadata cache: `cache/review` (paginated list), `batch-apply-cached` (apply top candidate), `clear-no-match` (unreject)
- **Deletes `handleGetPendingReview`** and the `POST /metadata/pending-review` route, which created short-lived aggregate operations just to feed the dialog
- **`handleResumeReview` simplified** in `Library.tsx`: if cache has entries, open the dialog directly; no `getPendingReview` fallback needed
- **Polling useEffect removed** from dialog — cache is populated before the dialog opens, so there is nothing to poll

## Files changed

| File | Change |
|------|--------|
| `internal/server/metadata_cached_handlers.go` | +3 new handlers |
| `internal/server/metadata_batch_candidates.go` | delete `handleGetPendingReview` |
| `internal/server/server_lifecycle.go` | add 3 routes, remove 1 route |
| `web/src/services/api.ts` | add `getCachedReviewResults`, `batchApplyFromCache`, `clearMetadataNoMatch`; extend `CandidateResult.status` with `"applied"` |
| `web/src/components/audiobooks/MetadataReviewDialog.tsx` | remove `operationId` prop, polling, swap API calls |
| `web/src/components/library/LibraryDialogs.tsx` | remove `metadataReviewOpId` prop |
| `web/src/pages/Library.tsx` | rename state, simplify `handleResumeReview` |

## Test plan

- [ ] Go backend compiles: `go build ./internal/server/...` ✓
- [ ] All server tests pass: `go test ./internal/server/...` ✓
- [ ] TypeScript type-checks clean (0 errors in changed files): `npx tsc --noEmit` ✓
- [ ] Manual: click "Resume Review" in Library — dialog opens showing cached pending books
- [ ] Manual: apply a candidate → row turns green; close and reopen → book gone from "pending" list
- [ ] Manual: reject a candidate → `mark-no-match` fires, book hidden by hideNoMatch toggle
- [ ] Manual: un-reject → `clear-no-match` fires, book re-surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)