### PR TITLE
fix(fileops): thread context through FilesystemService handlers (CTX-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.72.0 -->
+<!-- version: 2.73.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-14 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Chores
+
+#### May 14, 2026 — CTX-3: Thread context into filesystem service handlers
+
+Added `ctx context.Context` to `FilesystemService.BrowseDirectory`,
+`CreateExclusion`, and `RemoveExclusion`; HTTP handlers now pass
+`c.Request.Context()` down. Also converted the stray `log.Printf` in
+`filesystem_handlers.go` to `slog.Warn`. CTX-1/2 were already done
+(verified). SEC-4 and FE-4 confirmed done via audit.
 
 ### Performance
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.34.0 -->
+<!-- version: 8.35.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-14 -->
 
@@ -323,8 +323,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 - [x] **SEC-1** `fix/browse-dir-allowlist` — Done: `isAllowedPath` check in `fileops/service.go:BrowseDirectory`; returns `ErrPathNotAllowed`.
 - [x] **SEC-2** `fix/auth-enabled-default` — Done: `[WARN] authentication is disabled` log in `server_lifecycle.go:851`.
 - [x] **SEC-3** `fix/rate-limit-default` — Done: `[WARN] rate limiting is disabled` log in `server_lifecycle.go:854`.
-- [ ] **SEC-4** `fix/ratelimit-o1-cleanup` — Remove duplicate o1 rate-limit middleware
-  → [`2026-04-30-sec-4-ratelimit-cleanup.md`](docs/superpowers/bot-tasks/2026-04-30-sec-4-ratelimit-cleanup.md)
+- [x] **SEC-4** `fix/ratelimit-o1-cleanup` — No duplicate found; single `IPRateLimiter` in `server/middleware/ratelimit.go`, applied once in `server_lifecycle.go:859`.
 
 ### DB — Database Hygiene (6 tasks)
 
@@ -339,12 +338,9 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 
 ### CTX — Context Propagation (3 tasks)
 
-- [ ] **CTX-1** `fix/ctx-audiobook-update-service` — Thread context through AudiobookUpdateService
-  → [`2026-04-30-ctx-1-audiobook-update.md`](docs/superpowers/bot-tasks/2026-04-30-ctx-1-audiobook-update.md)
-- [ ] **CTX-2** `fix/ctx-openlibrary-service` — Thread context through OpenLibrary client
-  → [`2026-04-30-ctx-2-openlibrary.md`](docs/superpowers/bot-tasks/2026-04-30-ctx-2-openlibrary.md)
-- [ ] **CTX-3** `fix/ctx-filesystem-handlers` — Thread context through filesystem handlers
-  → [`2026-04-30-ctx-3-filesystem-handlers.md`](docs/superpowers/bot-tasks/2026-04-30-ctx-3-filesystem-handlers.md)
+- [x] **CTX-1** `fix/ctx-audiobook-update-service` — Done: `AudiobookUpdateService.UpdateAudiobook` already accepts `ctx context.Context` and threads it to `audiobookService.UpdateAudiobook`.
+- [x] **CTX-2** `fix/ctx-openlibrary-service` — Done: all `OpenLibraryClient` methods (`SearchByTitle`, `SearchByTitleAndAuthor`, `GetBookByISBN`) already accept `ctx context.Context`.
+- [x] **CTX-3** `fix/ctx-filesystem-handlers` — Added `ctx context.Context` to `BrowseDirectory`, `CreateExclusion`, `RemoveExclusion`; handlers pass `c.Request.Context()` (PR #956).
 
 ### LOG — Structured Logging (4 tasks)
 
@@ -376,7 +372,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
   → [`2026-04-30-fe-1-filter-panel.md`](docs/superpowers/bot-tasks/2026-04-30-fe-1-filter-panel.md)
 - [x] **FE-2** `refactor/library-book-grid` — Done: `LibraryBookGrid.tsx` extracted.
 - [x] **FE-3** `refactor/library-batch-toolbar` — Done: `LibraryToolbar.tsx` extracted.
-- [ ] **FE-4** `refactor/settings-general-tab` — Extract GeneralSettingsTab from Settings.tsx
+- [x] **FE-4** `refactor/settings-general-tab` — Done: `web/src/components/SettingsGeneral.tsx` exists and is imported in `Settings.tsx`.
   → [`2026-04-30-fe-4-settings-general.md`](docs/superpowers/bot-tasks/2026-04-30-fe-4-settings-general.md)
 - [x] **FE-5** `refactor/settings-paths-tab` — Done: `PathsSettingsTab.tsx` extracted.
 - [x] **FE-6** `refactor/settings-metadata-tab` — Done: `MetadataSettingsTab.tsx` extracted.

--- a/internal/fileops/service.go
+++ b/internal/fileops/service.go
@@ -1,11 +1,12 @@
 // file: internal/fileops/service.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
 // last-edited: 2026-05-01
 
 package fileops
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -80,7 +81,7 @@ type BrowseResult struct {
 	DiskInfo map[string]any `json:"disk_info"`
 }
 
-func (fs *FilesystemService) BrowseDirectory(path string) (*BrowseResult, error) {
+func (fs *FilesystemService) BrowseDirectory(_ context.Context, path string) (*BrowseResult, error) {
 	if path == "" {
 		return nil, fmt.Errorf("path is required")
 	}
@@ -153,7 +154,7 @@ func (fs *FilesystemService) BrowseDirectory(path string) (*BrowseResult, error)
 	}, nil
 }
 
-func (fs *FilesystemService) CreateExclusion(path string) error {
+func (fs *FilesystemService) CreateExclusion(_ context.Context, path string) error {
 	if path == "" {
 		return fmt.Errorf("path is required")
 	}
@@ -176,7 +177,7 @@ func (fs *FilesystemService) CreateExclusion(path string) error {
 	return os.WriteFile(excludeFile, []byte(""), 0644)
 }
 
-func (fs *FilesystemService) RemoveExclusion(path string) error {
+func (fs *FilesystemService) RemoveExclusion(_ context.Context, path string) error {
 	if path == "" {
 		return fmt.Errorf("path is required")
 	}

--- a/internal/server/filesystem_handlers.go
+++ b/internal/server/filesystem_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/filesystem_handlers.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: 565db679-19ba-4518-b63e-6892663be41b
 // last-edited: 2026-05-10
 //
@@ -12,7 +12,7 @@ package server
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -58,7 +58,7 @@ func (s *Server) getHomeDirectory(c *gin.Context) {
 
 func (s *Server) browseFilesystem(c *gin.Context) {
 	path := c.Query("path")
-	result, err := s.filesystemService.BrowseDirectory(path)
+	result, err := s.filesystemService.BrowseDirectory(c.Request.Context(), path)
 	if err != nil {
 		if errors.Is(err, fileops.ErrPathNotAllowed) {
 			httputil.RespondWithForbidden(c, err.Error())
@@ -78,7 +78,7 @@ func (s *Server) createExclusion(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
 	}
-	if err := s.filesystemService.CreateExclusion(req.Path); err != nil {
+	if err := s.filesystemService.CreateExclusion(c.Request.Context(), req.Path); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
 	}
@@ -93,7 +93,7 @@ func (s *Server) removeExclusion(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
 	}
-	if err := s.filesystemService.RemoveExclusion(req.Path); err != nil {
+	if err := s.filesystemService.RemoveExclusion(c.Request.Context(), req.Path); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
 	}
@@ -206,7 +206,7 @@ func (s *Server) addImportPath(c *gin.Context) {
 							}
 						}
 					} else if config.AppConfig.AutoOrganize && config.AppConfig.RootDir == "" {
-						log.Printf("auto-organize enabled but root_dir not set")
+						slog.Warn("auto-organize enabled but root_dir not set")
 					}
 				}
 				folder.BookCount = len(books)


### PR DESCRIPTION
## Summary

- Added `ctx context.Context` parameter to `FilesystemService.BrowseDirectory`, `CreateExclusion`, and `RemoveExclusion`
- HTTP handlers now pass `c.Request.Context()` instead of discarding the request context
- Ctx is held (not used internally yet) — forwarded once `GetAllImportPaths` gains context support
- Converted the last `log.Printf` in `filesystem_handlers.go` to `slog.Warn`

**Audit findings (no code changes needed):**
- CTX-1: `AudiobookUpdateService.UpdateAudiobook` already accepts and threads `ctx`
- CTX-2: All `OpenLibraryClient` methods already accept `ctx`
- SEC-4: Only one `IPRateLimiter` exists; no duplicate found
- FE-4: `SettingsGeneral.tsx` already exists and is imported

## Test plan

- [x] `go build ./internal/fileops/... ./internal/server/...` — clean
- [ ] Smoke-test browse-filesystem endpoint returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)