### PR TITLE
fix(metadata): block SSRF in DownloadCoverArt via private-IP DialContext (SEC-AUDIT-7b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.74.0 -->
+<!-- version: 2.75.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-14 -->
 
@@ -8,6 +8,16 @@
 ## [Unreleased]
 
 ### Security
+
+#### May 15, 2026 — SEC-AUDIT-7b: Block SSRF in DownloadCoverArt
+
+Added `safeCoverDialContext` to `metadata/cover.go` — a custom `DialContext`
+hook that resolves the target hostname and rejects connections to RFC1918
+private ranges (10/8, 172.16/12, 192.168/16), loopback (127/8, ::1),
+and link-local (169.254/16, fe80::/10). Also added scheme validation
+(rejects `file://`, `ftp://`, etc.). Tests added for both the SSRF block
+and the scheme block. Production cover downloads from metadata APIs are
+unaffected since those resolve to public IPs.
 
 #### May 14, 2026 — SEC-AUDIT-7a/c/d/e: Structured logging + audit fixes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.36.0 -->
+<!-- version: 8.37.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-05-14 -->
 
@@ -223,12 +223,7 @@ incrementally:
 
 - [x] **SEC-AUDIT-7a** Fix clear-text logging — Converted all `log.Printf` in `maintenance_fixups.go` to structured `slog.Info`/`slog.Warn` with named key-value attrs (PR #957). `cmd/root.go` uses `fmt.Printf` for CLI output, not a logging sink — no change needed (false positive).
 
-- [ ] **SEC-AUDIT-7b** Fix SSRF via URL validation (4 alerts: #587, #467, #458, #232)
-  - **Priority:** P1
-  - **Effort:** 4 hours
-  - **Files:** `internal/server/covers.go`, `internal/deluge/client.go`, `internal/plugins/webhook/plugin.go`, `internal/metadata/cover.go`
-  - **Action:** Whitelist allowed domains, block private IPs
-  - **Plan:** [`implementation-plan.md#task-72`](docs/security/audit-2026-05-03/implementation-plan.md#task-72-fix-request-forgery-4-alerts)
+- [x] **SEC-AUDIT-7b** Fix SSRF in `DownloadCoverArt` — Added `safeCoverDialContext` with RFC1918/loopback/link-local IP blocking and scheme validation (`http`/`https` only) to `metadata/cover.go` (PR #958). `server/covers.go` already had `IsAllowedCoverSource` domain allowlist. `deluge/client.go` + `plugins/webhook/plugin.go` connect to admin-configured endpoints (not SSRF-relevant).
 
 - [x] **SEC-AUDIT-7c** Fix uncontrolled allocation — `MaxScanBufferBytes` cap added to `scanner.go` in PR #768; buffer capped at `hashChunkSize` (1 MiB).
 

--- a/internal/metadata/cover.go
+++ b/internal/metadata/cover.go
@@ -1,28 +1,119 @@
 // file: internal/metadata/cover.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4efaa7b8-e29a-47f3-84f7-39b46bfc9a01
 
 package metadata
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 )
 
+// ErrSSRFBlocked is returned when a cover URL resolves to a private/reserved address.
+var ErrSSRFBlocked = fmt.Errorf("cover URL resolves to a blocked (private/reserved) address")
+
+// privateCIDRs lists address ranges that must not be reachable via cover downloads.
+var privateCIDRs = func() []*net.IPNet {
+	blocks := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",    // loopback
+		"169.254.0.0/16", // link-local (AWS IMDSv1)
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 unique-local
+		"fe80::/10",      // IPv6 link-local
+	}
+	nets := make([]*net.IPNet, 0, len(blocks))
+	for _, b := range blocks {
+		_, n, _ := net.ParseCIDR(b)
+		if n != nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// isPrivateIP returns true if ip falls within any reserved/private range.
+func isPrivateIP(ip net.IP) bool {
+	for _, cidr := range privateCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateCoverURL enforces scheme and rejects obviously-internal hostnames.
+// A full IP-block happens in the custom DialContext used by safeCoverClient.
+func validateCoverURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid cover URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("cover URL scheme %q not allowed (only http/https)", u.Scheme)
+	}
+	return nil
+}
+
+// safeCoverDialContext is a DialContext hook that blocks connections to
+// private/reserved IP ranges, preventing SSRF via cover-art downloads.
+func safeCoverDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range addrs {
+		ip := net.ParseIP(a)
+		if ip == nil {
+			continue
+		}
+		if isPrivateIP(ip) {
+			return nil, ErrSSRFBlocked
+		}
+	}
+	return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, net.JoinHostPort(host, port))
+}
+
 // DownloadCoverArt downloads a cover image from coverURL and saves it to
 // {destDir}/covers/{bookID}.{ext}. Returns the local file path on success.
 // Skips download if the file already exists. Only accepts image/* content types.
+// Rejects non-http(s) URLs and URLs that resolve to private/reserved IPs.
 func DownloadCoverArt(coverURL string, destDir string, bookID string) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext: safeCoverDialContext,
+		},
+	}
+	return downloadCoverArtWithClient(client, coverURL, destDir, bookID)
+}
+
+// downloadCoverArtWithClient is the internal implementation — accepts a custom
+// client so tests can substitute a plain http.Client pointing to localhost.
+func downloadCoverArtWithClient(client *http.Client, coverURL string, destDir string, bookID string) (string, error) {
 	if coverURL == "" {
 		return "", fmt.Errorf("empty cover URL")
 	}
 	if bookID == "" {
 		return "", fmt.Errorf("empty book ID")
+	}
+
+	if err := validateCoverURL(coverURL); err != nil {
+		return "", err
 	}
 
 	coversDir := filepath.Join(destDir, "covers")
@@ -41,11 +132,7 @@ func DownloadCoverArt(coverURL string, destDir string, bookID string) (string, e
 		return "", fmt.Errorf("failed to create covers directory: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Get(coverURL)
+	resp, err := client.Get(coverURL) //nolint:noctx // URL already validated above
 	if err != nil {
 		return "", fmt.Errorf("failed to download cover: %w", err)
 	}

--- a/internal/metadata/cover_test.go
+++ b/internal/metadata/cover_test.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/cover_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5fa1b8c9-d3e4-48f5-95a8-4ac57cde0b12
 
 package metadata
@@ -12,6 +12,8 @@ import (
 	"testing"
 )
 
+func testClient() *http.Client { return &http.Client{} }
+
 func TestDownloadCoverArt_Success(t *testing.T) {
 	// Serve a fake JPEG
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +23,7 @@ func TestDownloadCoverArt_Success(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	path, err := DownloadCoverArt(srv.URL+"/cover.jpg", dir, "book123")
+	path, err := downloadCoverArtWithClient(testClient(), srv.URL+"/cover.jpg", dir, "book123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +59,7 @@ func TestDownloadCoverArt_RejectsNonImage(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	_, err := DownloadCoverArt(srv.URL+"/notimage", dir, "book456")
+	_, err := downloadCoverArtWithClient(testClient(), srv.URL+"/notimage", dir, "book456")
 	if err == nil {
 		t.Fatal("expected error for non-image content type")
 	}
@@ -72,6 +74,34 @@ func TestDownloadCoverArt_EmptyInputs(t *testing.T) {
 	}
 }
 
+func TestDownloadCoverArt_BlocksPrivateIPs(t *testing.T) {
+	urls := []string{
+		"http://127.0.0.1/cover.jpg",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://192.168.1.1/cover.jpg",
+		"http://10.0.0.1/cover.jpg",
+	}
+	for _, u := range urls {
+		_, err := DownloadCoverArt(u, t.TempDir(), "book-ssrf")
+		if err == nil {
+			t.Errorf("expected SSRF block for %s, got nil", u)
+		}
+	}
+}
+
+func TestDownloadCoverArt_BlocksNonHTTP(t *testing.T) {
+	urls := []string{
+		"file:///etc/passwd",
+		"ftp://example.com/cover.jpg",
+	}
+	for _, u := range urls {
+		_, err := DownloadCoverArt(u, t.TempDir(), "book-scheme")
+		if err == nil {
+			t.Errorf("expected scheme block for %s, got nil", u)
+		}
+	}
+}
+
 func TestDownloadCoverArt_PNG(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
@@ -80,7 +110,7 @@ func TestDownloadCoverArt_PNG(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	path, err := DownloadCoverArt(srv.URL+"/cover.png", dir, "bookpng")
+	path, err := downloadCoverArtWithClient(testClient(), srv.URL+"/cover.png", dir, "bookpng")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Resolves CodeQL SSRF alerts #587, #458 in `metadata/cover.go` (`DownloadCoverArt`).

**What changed:**
- Added `safeCoverDialContext` — a custom `net.DialContext` hook that resolves the target hostname and **rejects connections** to:
  - RFC1918 private ranges: `10/8`, `172.16/12`, `192.168/16`
  - Loopback: `127/8`, `::1`
  - Link-local (AWS IMDSv1): `169.254/16`, `fe80::/10`
  - IPv6 unique-local: `fc00::/7`
- Added `validateCoverURL` that rejects non-`http`/`https` schemes (`file://`, `ftp://`, etc.)
- Extracted `downloadCoverArtWithClient(client, ...)` for testability — tests inject a plain `http.Client`; production uses the safe client

**Not changed:**
- `server/covers.go` already has `IsAllowedCoverSource` domain allowlist ✓
- `deluge/client.go` — connects to admin-configured Deluge daemon (not user-controlled URL) ✓
- `plugins/webhook/plugin.go` — posts to admin-configured webhook URL (not user-controlled) ✓

## Test plan

- [x] `go test ./internal/metadata/... -run TestDownloadCoverArt` — all 7 pass
- [x] `TestDownloadCoverArt_BlocksPrivateIPs` — blocks 127.0.0.1, 169.254.169.254, 192.168.x, 10.x
- [x] `TestDownloadCoverArt_BlocksNonHTTP` — blocks file://, ftp://
- [x] Existing tests (Success, PNG, SkipsExisting, RejectsNonImage, EmptyInputs) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)