### PR TITLE
refactor(fe): extract useLibraryFilters hook from Library.tsx (FE-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 2.75.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-14 -->
+<!-- last-edited: 2026-05-15 -->
 
 # Changelog
 
@@ -27,6 +27,23 @@ unaffected since those resolve to public IPs.
 - Confirmed SEC-AUDIT-7c done (scanner `MaxScanBufferBytes` cap, PR #768)
 - Confirmed SEC-AUDIT-7d done (`isPathWithinTarget` zipslip guard in `backup.go`)
 - Confirmed SEC-AUDIT-7e done (`argon2.IDKey` KDF already in `settings.go`)
+
+### Refactors
+
+#### May 15, 2026 — FE-1: Extract useLibraryFilters hook from Library.tsx
+
+Created `web/src/hooks/useLibraryFilters.ts` to own all filter-related state
+that previously lived inline in `Library.tsx`: `filterOpen`, `filters`,
+`selectedTags`, five `available*` arrays, two data-loading effects (facets +
+tags), and `handleFiltersChange` / `handleTagFilterChange` / `refreshTags` /
+`getActiveFilterCount`. `Library.tsx` now calls the hook and destructures the
+result, removing ~20 state declarations and 2 `useEffect` blocks.
+
+PROJ-1 and PROJ-2 were verified already done: `BookSummary` struct is defined
+in `internal/database/store.go`; `GetAllBookSummaries` is implemented in both
+`PebbleStore` and `SQLiteStore` (with a proper projected SQL query in SQLite),
+and the audiobooks service uses it for the default library-list path. Marked
+done in TODO.
 
 ### Chores
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,82 +1,53 @@
 <!-- file: PLAN.md -->
-<!-- version: 3.0.0 -->
+<!-- version: 3.1.0 -->
 <!-- guid: 7d8e9f10-2345-4abc-9def-0123456789ab -->
-<!-- last-edited: 2026-05-10 -->
+<!-- last-edited: 2026-05-15 -->
 
-# Plan: UOS Bell + Select-All + iTunes Dialog + Bulk Metadata Fix
+# FE-1 / PROJ-1 / PROJ-2: FilterPanel extraction + BookSummary mark-done
 
 ## Goal
 
-Fix four regressions after UOS-13/14 cleanup:
-1. Bell shows no operations (SSE never opened, no initial load on mount)
-2. Select-all across pages silently capped at 500
-3. iTunes sync dialog lacks select-all
-4. Library bulk metadata fetch not resumable
+PROJ-1 and PROJ-2 are already fully implemented (`BookSummary` struct in `store.go`,
+`GetAllBookSummaries` in both PebbleStore and SQLiteStore, wired into the audiobooks
+service). Mark them done and log them.
 
-## Root Causes
+FE-1 requires real work: Library.tsx still owns all filter state
+(`filterOpen`, `filters`, `selectedTags`, 5×available* arrays, 2×useEffects that
+load filter data, 3 handlers). The filter UI components (`FilterPanel.tsx`,
+`FilterSidebar.tsx`) were already extracted, but the state was not. Extract it into
+`web/src/hooks/useLibraryFilters.ts` to reduce Library.tsx's bulk and make filter
+logic reusable.
 
-1. `openSSE()` never called — entire SSE path is dead; page reload loses all op state
-2. `BridgeQueue` writes `Plugin: "legacy"` — ops shown as wrong type; also no progress updates
-3. `ParsePaginationParams` hard-cap at 500 — select-all endpoint returns at most 500 IDs
-4. Library bulk fetch does `Promise.all(N × fetchBookMetadata)` in-browser — not an op
+## Affected files
 
-## Files To Change
+- `web/src/hooks/useLibraryFilters.ts` — new hook; moves all filter state + loading
+- `web/src/pages/Library.tsx` — replace ~15 state vars + 2 useEffects with the hook
+- `TODO.md` — mark PROJ-1, PROJ-2, FE-1 done
+- `CHANGELOG.md` — add entries
 
-### Backend
-- `internal/operations/bridge.go` — fix Plugin/DefID fields; forward progress to v2 store
-- `internal/server/server_lifecycle.go` — register `GET /api/v1/audiobooks/ids` + bulk_metadata_fetch def
-- `internal/server/handlers_audiobooks.go` (or nearby) — new IDs-only handler
-- `internal/server/metadata_batch_candidates.go` — add `bulk_metadata_fetch` op func registered via opRegistry
-- `internal/operations/registry/` — register the new op def
+## Steps
 
-### Frontend
-- `web/src/App.tsx` — call `openSSE()` + `loadFromServer()` after auth confirmed; cleanup with `closeSSE()`
-- `web/src/services/api.ts` — add `getAudiobookIds()` and `startBulkMetadataFetch()`
-- `web/src/pages/Library.tsx` — use IDs endpoint for select-all; convert bulk fetch to v2 op
-- `web/src/components/settings/ITunesImport.tsx` — add "Select All (N)" button with filtered IDs
+1. Create `useLibraryFilters` hook:
+   - Accepts `{ searchParams }` for URL-seeded initial state
+   - Returns `{ filterOpen, setFilterOpen, filters, setFilters, selectedTags, handleTagFilterChange, handleFiltersChange, refreshTags, availableAuthors, availableSeries, availableGenres, availableLanguages, availableTags, getActiveFilterCount }`
+   - Moves the 2 useEffects that load facets + tags
 
-## Ordered Steps
+2. Update Library.tsx:
+   - Replace the ~15 filter state declarations + useEffects with `const { ... } = useLibraryFilters({ searchParams })`
+   - Remove now-dead `getActiveFilterCount` local function (moved into hook)
 
-### Step 1 — Wire SSE + initial load in App.tsx
-Add useEffect after auth check:
-- `useOperationsStore.getState().openSSE()` — opens SSE connection
-- `useOperationsStore.getState().loadFromServer()` — loads recent ops on mount
-- Return `() => useOperationsStore.getState().closeSSE()` for cleanup
+3. Mark PROJ-1, PROJ-2, FE-1 done in TODO.md
 
-### Step 2 — Fix BridgeQueue plugin field + progress forwarding
-- `Plugin: opType` (was "legacy")
-- `DefID: "bridge." + opType` (was "legacy." + opType)
-- Wrap ProgressReporter to call `b.v2Store.UpdateOpProgressV2(id, current, total, message)` on
-  each progress update so the timeline shows real progress
+4. Append CHANGELOG entries
 
-### Step 3 — New `/api/v1/audiobooks/ids` endpoint
-`GET /api/v1/audiobooks/ids` — accepts same filter/sort params as getBooks but returns only:
-`{"data": {"ids": [...string], "total": N}}`
-No pagination cap — IDs only so result set is cheap. Register in server_lifecycle.go.
+5. Commit: `refactor(fe): extract useLibraryFilters hook from Library.tsx (FE-1)` and
+   `chore(todo): mark PROJ-1/2 and FE-1 done`
 
-### Step 4 — Library select-all uses IDs endpoint
-`handleSelectAllItems` → calls `api.getAudiobookIds(filters)`, stores returned IDs in
-`selectedAudiobookIds: string[]`. Existing `selectedAudiobooks` used only for display;
-batch op calls use `selectedAudiobookIds`.
+## Test strategy
 
-### Step 5 — iTunes dialog "Select All"
-Add "Select All (N)" button that calls `getAudiobookIds({ hasItunesId: true })` and
-merges all returned IDs into `browseSelected`.
-
-### Step 6 — Bulk metadata fetch as v2 op
-Register op def `bulk_metadata_fetch` with opRegistry (plugin "builtin"):
-- Params: `{"book_ids": [...]}` 
-- Resumable via `high_water_progress` (index of last processed book)
-- Op func reuses existing per-book metadata fetch logic
-Frontend: replace Library's `Promise.all` bulk fetch with `POST /api/v1/operations/v2`
-
-## Test Strategy
-- `go test ./internal/operations/...` and `go test ./internal/server/...`
-- `make test`
-- Manual verification: scan → bell shows "Library Scan"; reload → bell still shows running op
+- `make test-all` (Vitest + Go)
+- `cd web && npx tsc --noEmit` to verify no type regressions
 
 ## Rollback
-- Bridge change: non-breaking (type label improvement only)
-- New endpoint: additive
-- App.tsx change: openSSE guarded by null-check — calling twice is a no-op
-- Frontend bulk fetch: old in-browser path removed; if v2 op fails, users can't fetch in bulk
+
+- `git reset HEAD~2` in the worktree

--- a/TODO.md
+++ b/TODO.md
@@ -326,9 +326,9 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 
 ### PROJ — Query Projection (2 tasks)
 
-- [ ] **PROJ-1** `perf/book-summary-columns` — Define BookSummary DB struct
+- [x] **PROJ-1** `perf/book-summary-columns` — Done: `BookSummary` struct defined in `internal/database/store.go:269`; SQLite projected query uses `bookSummarySelectColumns` (excludes description, embeddings, heavy fields).
   → [`2026-04-30-proj-1-summary-columns.md`](docs/superpowers/bot-tasks/2026-04-30-proj-1-summary-columns.md)
-- [ ] **PROJ-2** `perf/book-list-summary-query` — Implement GetBookSummaries projected query
+- [x] **PROJ-2** `perf/book-list-summary-query` — Done: `GetAllBookSummaries` implemented in both `PebbleStore` and `SQLiteStore`; audiobooks service uses it for the default library list path.
   → [`2026-04-30-proj-2-list-query.md`](docs/superpowers/bot-tasks/2026-04-30-proj-2-list-query.md)
 
 ### SCAN — Scanner Efficiency (1 task)
@@ -343,7 +343,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 
 ### FE — Frontend Cleanup (10 tasks)
 
-- [ ] **FE-1** `refactor/library-filter-panel` — Extract FilterPanel from Library.tsx
+- [x] **FE-1** `refactor/library-filter-panel` — Done: `useLibraryFilters` hook created (`web/src/hooks/useLibraryFilters.ts`); moves filter state, available-data loading, and handlers out of `Library.tsx`.
   → [`2026-04-30-fe-1-filter-panel.md`](docs/superpowers/bot-tasks/2026-04-30-fe-1-filter-panel.md)
 - [x] **FE-2** `refactor/library-book-grid` — Done: `LibraryBookGrid.tsx` extracted.
 - [x] **FE-3** `refactor/library-batch-toolbar` — Done: `LibraryToolbar.tsx` extracted.

--- a/web/src/hooks/useLibraryFilters.ts
+++ b/web/src/hooks/useLibraryFilters.ts
@@ -1,0 +1,124 @@
+// file: web/src/hooks/useLibraryFilters.ts
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-05-15
+
+import { useState, useEffect, useCallback } from 'react';
+import type { FilterOptions } from '../types';
+import * as api from '../services/api';
+
+interface UseLibraryFiltersOptions {
+  searchParams: URLSearchParams;
+  /** Called when filters change so the caller can reset pagination to page 1. */
+  onFiltersChange?: () => void;
+}
+
+export interface LibraryFiltersResult {
+  filterOpen: boolean;
+  setFilterOpen: (open: boolean) => void;
+  filters: FilterOptions;
+  setFilters: React.Dispatch<React.SetStateAction<FilterOptions>>;
+  handleFiltersChange: (newFilters: FilterOptions) => void;
+  selectedTags: string[];
+  setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>;
+  handleTagFilterChange: (tags: string[]) => void;
+  refreshTags: () => void;
+  availableAuthors: string[];
+  availableSeries: string[];
+  availableGenres: string[];
+  availableLanguages: string[];
+  availableTags: Array<{ tag: string; count: number }>;
+  getActiveFilterCount: () => number;
+}
+
+export function useLibraryFilters({
+  searchParams,
+  onFiltersChange,
+}: UseLibraryFiltersOptions): LibraryFiltersResult {
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [filters, setFilters] = useState<FilterOptions>(() => ({
+    author: searchParams.get('author') || undefined,
+    series: searchParams.get('series') || undefined,
+    genre: searchParams.get('genre') || undefined,
+    language: searchParams.get('language') || undefined,
+    libraryState: searchParams.get('state') || undefined,
+  }));
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [availableAuthors, setAvailableAuthors] = useState<string[]>([]);
+  const [availableSeries, setAvailableSeries] = useState<string[]>([]);
+  const [availableGenres, setAvailableGenres] = useState<string[]>([]);
+  const [availableLanguages, setAvailableLanguages] = useState<string[]>([]);
+  const [availableTags, setAvailableTags] = useState<Array<{ tag: string; count: number }>>([]);
+
+  useEffect(() => {
+    api
+      .listAllUserTags()
+      .then((tags) => setAvailableTags(tags ?? []))
+      .catch((_err) => {
+        console.error('Failed to load tags:', _err);
+      });
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [facets, authors, series] = await Promise.all([
+          api.getBookFacets(),
+          api.getAuthors(),
+          api.getSeries(),
+        ]);
+        setAvailableGenres(facets.genres);
+        setAvailableLanguages(facets.languages);
+        setAvailableAuthors(authors.map((a) => a.name).filter(Boolean).sort());
+        setAvailableSeries(series.map((s) => s.name).filter(Boolean).sort());
+      } catch (e) {
+        console.error('Failed to load filter facets', e);
+      }
+    })();
+  }, []);
+
+  const handleFiltersChange = useCallback(
+    (newFilters: FilterOptions) => {
+      setFilters(newFilters);
+      onFiltersChange?.();
+    },
+    [onFiltersChange]
+  );
+
+  const handleTagFilterChange = useCallback((tags: string[]) => {
+    setSelectedTags(tags);
+    setFilters((prev) => ({ ...prev, tags: tags.length > 0 ? tags : undefined }));
+  }, []);
+
+  const refreshTags = useCallback(() => {
+    api
+      .listAllUserTags()
+      .then((tags) => setAvailableTags(tags ?? []))
+      .catch((_err) => {
+        console.error('Failed to refresh tags:', _err);
+      });
+  }, []);
+
+  const getActiveFilterCount = useCallback(
+    () => Object.values(filters).filter((v) => v !== undefined && v !== '').length,
+    [filters]
+  );
+
+  return {
+    filterOpen,
+    setFilterOpen,
+    filters,
+    setFilters,
+    handleFiltersChange,
+    selectedTags,
+    setSelectedTags,
+    handleTagFilterChange,
+    refreshTags,
+    availableAuthors,
+    availableSeries,
+    availableGenres,
+    availableLanguages,
+    availableTags,
+    getActiveFilterCount,
+  };
+}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,15 +1,16 @@
 // file: web/src/pages/Library.tsx
-// version: 1.63.0
+// version: 1.64.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-05-11
+// last-edited: 2026-05-15
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Box } from '@mui/material';
 import { ViewMode } from '../components/audiobooks/SearchBar';
 import { useColumnConfig } from '../hooks/useColumnConfig';
+import { useLibraryFilters } from '../hooks/useLibraryFilters';
 import { useToast } from '../components/toast/ToastProvider';
-import type { Audiobook, FilterOptions } from '../types';
+import type { Audiobook } from '../types';
 import { SortField, SortOrder } from '../types';
 import { parseSearch, type ParsedSearch } from '../utils/searchParser';
 import * as api from '../services/api';
@@ -121,14 +122,6 @@ export const Library = () => {
       10
     )
   );
-  const initialFilters: FilterOptions = {
-    author: searchParams.get('author') || undefined,
-    series: searchParams.get('series') || undefined,
-    genre: searchParams.get('genre') || undefined,
-    language: searchParams.get('language') || undefined,
-    libraryState: searchParams.get('state') || undefined,
-  };
-
   const [audiobooks, setAudiobooks] = useState<Audiobook[]>([]);
   const [totalCount, setTotalCount] = useState(0); // Total matching books (server-reported, all pages)
   const [loading, setLoading] = useState(false);
@@ -137,8 +130,6 @@ export const Library = () => {
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   const [sortBy, setSortBy] = useState<SortField>(initialSortBy);
   const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder);
-  const [filterOpen, setFilterOpen] = useState(false);
-  const [filters, setFilters] = useState<FilterOptions>(initialFilters);
   const [page, setPage] = useState(initialPage);
   const [itemsPerPage, setItemsPerPage] = useState(initialItemsPerPage);
   const [totalPages, setTotalPages] = useState(1);
@@ -152,12 +143,23 @@ export const Library = () => {
   const [batchEditOpen, setBatchEditOpen] = useState(false);
   const [versionManagementOpen, setVersionManagementOpen] = useState(false);
   const [versionManagingAudiobook, setVersionManagingAudiobook] = useState<Audiobook | null>(null);
-  const [availableAuthors, setAvailableAuthors] = useState<string[]>([]);
-  const [availableSeries, setAvailableSeries] = useState<string[]>([]);
-  const [availableGenres, setAvailableGenres] = useState<string[]>([]);
-  const [availableLanguages, setAvailableLanguages] = useState<string[]>([]);
-  const [availableTags, setAvailableTags] = useState<Array<{ tag: string; count: number }>>([]);
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  const {
+    filterOpen,
+    setFilterOpen,
+    filters,
+    handleFiltersChange: baseHandleFiltersChange,
+    selectedTags,
+    setSelectedTags,
+    handleTagFilterChange,
+    refreshTags,
+    availableAuthors,
+    availableSeries,
+    availableGenres,
+    availableLanguages,
+    availableTags,
+    getActiveFilterCount,
+  } = useLibraryFilters({ searchParams, onFiltersChange: () => setPage(1) });
   const [parsedSearch, setParsedSearch] = useState<ParsedSearch>(() => parseSearch(initialSearch));
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
   const [bulkRatingDialogOpen, setBulkRatingDialogOpen] = useState(false);
@@ -262,24 +264,6 @@ export const Library = () => {
   const [bulkOrganizeError, setBulkOrganizeError] = useState<OrganizeErrorState | null>(null);
   const bulkOrganizeSnapshotRef = useRef<Map<string, Audiobook>>(new Map());
 
-
-  // Fetch all available tags on mount
-  useEffect(() => {
-    api.listAllUserTags().then((tags) => setAvailableTags(tags ?? [])).catch((_err) => {
-      console.error('Failed to load tags:', _err);
-    });
-  }, []);
-
-  const handleTagFilterChange = useCallback((tags: string[]) => {
-    setSelectedTags(tags);
-    setFilters((prev) => ({ ...prev, tags: tags.length > 0 ? tags : undefined }));
-  }, []);
-
-  const refreshTags = useCallback(() => {
-    api.listAllUserTags().then((tags) => setAvailableTags(tags ?? [])).catch((_err) => {
-      console.error('Failed to refresh tags:', _err);
-    });
-  }, []);
 
   // SSE subscription for live operation progress & logs + historical hydration
   useEffect(() => {
@@ -786,25 +770,6 @@ export const Library = () => {
       setImportFileInProgress(false);
     }
   };
-
-  // Load facets (genres, languages) + author/series names once on mount for filter sidebar.
-  useEffect(() => {
-    void (async () => {
-      try {
-        const [facets, authors, series] = await Promise.all([
-          api.getBookFacets(),
-          api.getAuthors(),
-          api.getSeries(),
-        ]);
-        setAvailableGenres(facets.genres);
-        setAvailableLanguages(facets.languages);
-        setAvailableAuthors(authors.map((a) => a.name).filter(Boolean).sort());
-        setAvailableSeries(series.map((s) => s.name).filter(Boolean).sort());
-      } catch (e) {
-        console.error('Failed to load filter facets', e);
-      }
-    })();
-  }, []);
 
   // Load audiobooks when filters change
   useEffect(() => {
@@ -1412,10 +1377,7 @@ export const Library = () => {
     }
   };
 
-  const handleFiltersChange = (newFilters: FilterOptions) => {
-    setFilters(newFilters);
-    setPage(1); // Reset to first page on filter change
-  };
+  const handleFiltersChange = baseHandleFiltersChange;
 
   const handleSortChange = (newSort: SortField) => {
     setSortBy(newSort);
@@ -1427,10 +1389,6 @@ export const Library = () => {
   const handleColumnSortChange = (sortKey: string, order: 'asc' | 'desc') => {
     setSortBy(sortKey as SortField);
     setSortOrder(order === 'asc' ? SortOrder.Ascending : SortOrder.Descending);
-  };
-
-  const getActiveFilterCount = () => {
-    return Object.values(filters).filter((v) => v !== undefined && v !== '').length;
   };
 
   const libraryBookCount =


### PR DESCRIPTION
## Summary

- Created `web/src/hooks/useLibraryFilters.ts` — owns all filter state (`filterOpen`, `filters`, `selectedTags`, 5× `available*` arrays), two data-loading effects (facets + tags), and all filter handlers (`handleFiltersChange`, `handleTagFilterChange`, `refreshTags`, `getActiveFilterCount`)
- `Library.tsx` now calls the hook via one destructure, removing ~20 state declarations and 2 `useEffect` blocks
- Marked PROJ-1 and PROJ-2 done in TODO — `BookSummary` struct and `GetAllBookSummaries` were already fully implemented and wired in the audiobooks service

## Test plan

- [x] 172 Vitest tests passing
- [x] TypeScript `tsc --noEmit` clean on changed files
- [ ] Go vet failures in `internal/fileops` and `internal/server` are pre-existing (CTX-3 test files not updated) — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)