### PR TITLE
fix(tests): add missing context args to fileops/server tests (TEST-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.75.0 -->
+<!-- version: 2.76.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-15 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixes
+
+#### May 15, 2026 — TEST-1: Fix test build failures from CTX-3 context threading
+
+Added missing `context.Context` args to `BrowseDirectory`, `CreateExclusion`,
+and `RemoveExclusion` calls in `internal/fileops/service_test.go` and
+`internal/server/service_layer_test.go`. Both packages now compile and pass.
+The original TEST-1 description blamed PROJ-1/2; the real cause was the CTX-3
+context threading (PR #956).
 
 ### Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -1043,7 +1043,7 @@ Findings from the 2026-05-01 re-audit. See `docs/codebase-evaluation.md` §Re-Au
 
 ### High Priority
 
-- **TEST-1** Fix 11+ failing unit tests in `internal/server` after PROJ-1/PROJ-2 changed `GetAllBooks` → `GetAllBookSummaries`  
+- [x] **TEST-1** Done: actual failures were missing `context.Context` args from CTX-3 (not PROJ-1/2); fixed `internal/fileops/service_test.go` and `internal/server/service_layer_test.go` — both packages now pass.
   Spec: `docs/superpowers/bot-tasks/2026-05-01-test-1-fix-audiobook-service-tests.md`
 
 - **TEST-2** Fix `TestStoreAdditionalCoverageSQLite` failure in `internal/database` package  

--- a/internal/fileops/service_test.go
+++ b/internal/fileops/service_test.go
@@ -1,11 +1,12 @@
 // file: internal/fileops/service_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
-// last-edited: 2026-05-01
+// last-edited: 2026-05-15
 
 package fileops
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func TestFilesystemService_BrowseDirectory_Empty(t *testing.T) {
 	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil)
 	fs := NewFilesystemService(mockStore)
 
-	_, err := fs.BrowseDirectory("")
+	_, err := fs.BrowseDirectory(context.Background(), "")
 
 	if err == nil {
 		t.Error("expected error for empty path")
@@ -31,7 +32,7 @@ func TestFilesystemService_BrowseDirectory_InvalidPath(t *testing.T) {
 	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil)
 	fs := NewFilesystemService(mockStore)
 
-	_, err := fs.BrowseDirectory("/nonexistent/path/that/does/not/exist")
+	_, err := fs.BrowseDirectory(context.Background(), "/nonexistent/path/that/does/not/exist")
 
 	if err == nil {
 		t.Error("expected error for nonexistent path")
@@ -48,7 +49,7 @@ func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	err = fs.CreateExclusion(tmpDir)
+	err = fs.CreateExclusion(context.Background(), tmpDir)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -69,7 +70,7 @@ func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	err = fs.RemoveExclusion(tmpDir)
+	err = fs.RemoveExclusion(context.Background(), tmpDir)
 	if err == nil {
 		t.Error("expected error for nonexistent exclusion")
 	}

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/service_layer_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-05-11
+// last-edited: 2026-05-15
 
 package server
 
@@ -1509,7 +1509,7 @@ func TestServerHelpers_IntVal(t *testing.T) {
 func TestFilesystemService_CreateExclusion_EmptyPath(t *testing.T) {
 	svc := fileops.NewFilesystemService(nil)
 
-	err := svc.CreateExclusion("")
+	err := svc.CreateExclusion(context.Background(), "")
 	if err == nil {
 		t.Error("expected error, got nil")
 	}
@@ -1526,7 +1526,7 @@ func TestFilesystemService_CreateExclusion_NotDirectory(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "not_a_dir.txt")
 	os.WriteFile(tmpFile, []byte("test"), 0644)
 
-	err := svc.CreateExclusion(tmpFile)
+	err := svc.CreateExclusion(context.Background(), tmpFile)
 	if err == nil {
 		t.Error("expected error, got nil")
 	}
@@ -1539,7 +1539,7 @@ func TestFilesystemService_CreateExclusion_NotDirectory(t *testing.T) {
 func TestFilesystemService_RemoveExclusion_EmptyPath(t *testing.T) {
 	svc := fileops.NewFilesystemService(nil)
 
-	err := svc.RemoveExclusion("")
+	err := svc.RemoveExclusion(context.Background(), "")
 	if err == nil {
 		t.Error("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary

- Added `context.Background()` to 7 call sites in `internal/fileops/service_test.go` and `internal/server/service_layer_test.go` where `BrowseDirectory`, `CreateExclusion`, and `RemoveExclusion` gained a `context.Context` parameter in CTX-3 (PR #956) but the test files were not updated
- Both packages now compile and all tests pass
- Marks TEST-1 done in TODO (original description blamed PROJ-1/2; real cause was CTX-3)

## Test plan

- [x] `go test ./internal/fileops/... ./internal/server/...` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)