### PR TITLE
fix(metadata): handle string-encoded Audible ratings + rename acoustid log key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.76.0 -->
+<!-- version: 2.77.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-15 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### May 15, 2026 — Fix Audible JSON decode error + acoustid log label
+
+- `internal/metadata/audible.go`: Added `flexFloat64` type that implements
+  `UnmarshalJSON([]byte) error` to handle Audible API responses where
+  `display_average_rating` arrives as a JSON string (`"4.5"`) instead of a
+  number. `encoding/json/v2` is strict about types; the mismatch caused the
+  entire catalog response to fail to decode, returning 0 candidates for every
+  Audible search. Audible is the primary metadata source so this was a
+  near-total metadata-fetch outage.
+- `internal/server/acoustid_backfill.go`: Renamed `skipped` counter to
+  `alreadyImported` and updated the completion log key from `skipped=` to
+  `already_imported=` for clarity.
 
 #### May 15, 2026 — TEST-1: Fix test build failures from CTX-3 context threading
 

--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible.go
-// version: 1.5.1
+// version: 1.5.2
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
 
 package metadata
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -87,9 +88,40 @@ type audibleRating struct {
 	StoryDistribution   audibleRatingDistribution `json:"story_distribution"`
 }
 
+// flexFloat64 handles Audible API responses where numeric fields arrive as
+// either a JSON number (4.5) or a quoted string ("4.5"). encoding/json/v2
+// is strict about type mismatches so we implement the v1-compatible interface
+// (UnmarshalJSON([]byte)) which v2 also recognizes.
+type flexFloat64 float64
+
+func (f *flexFloat64) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		// Quoted string — strip quotes and parse the number inside
+		s := string(data[1 : len(data)-1])
+		if s == "" {
+			return nil
+		}
+		n, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("flexFloat64: cannot parse %q: %w", s, err)
+		}
+		*f = flexFloat64(n)
+		return nil
+	}
+	n, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return fmt.Errorf("flexFloat64: cannot parse number %q: %w", data, err)
+	}
+	*f = flexFloat64(n)
+	return nil
+}
+
 type audibleRatingDistribution struct {
-	DisplayAverageRating float64 `json:"display_average_rating"`
-	NumRatings           int     `json:"num_ratings"`
+	DisplayAverageRating flexFloat64 `json:"display_average_rating"`
+	NumRatings           int         `json:"num_ratings"`
 }
 
 type audiblePerson struct {
@@ -278,9 +310,9 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 
 	// Ratings: overall, narrator performance, story quality.
 	if p.Rating != nil {
-		meta.AudibleRatingOverall = p.Rating.OverallDistribution.DisplayAverageRating
-		meta.AudibleRatingPerformance = p.Rating.PerformanceDistribution.DisplayAverageRating
-		meta.AudibleRatingStory = p.Rating.StoryDistribution.DisplayAverageRating
+		meta.AudibleRatingOverall = float64(p.Rating.OverallDistribution.DisplayAverageRating)
+		meta.AudibleRatingPerformance = float64(p.Rating.PerformanceDistribution.DisplayAverageRating)
+		meta.AudibleRatingStory = float64(p.Rating.StoryDistribution.DisplayAverageRating)
 		meta.AudibleRatingCount = p.Rating.OverallDistribution.NumRatings
 		meta.AudibleNumReviews = p.Rating.NumReviews
 	}

--- a/internal/metadata/audible_test.go
+++ b/internal/metadata/audible_test.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audible_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b8c7d6e5-f4a3-2b1c-0d9e-8f7a6b5c4d3e
 
 package metadata
@@ -7,6 +7,7 @@ package metadata
 import (
 	json "encoding/json/v2"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -152,6 +153,60 @@ func TestAudibleClient_HTMLStripping(t *testing.T) {
 	}
 	if results[0].Description != "Hello world" {
 		t.Errorf("description: got %q, want 'Hello world'", results[0].Description)
+	}
+}
+
+// TestAudibleClient_StringRating covers the Audible API quirk where
+// display_average_rating is returned as a JSON string ("4.5") rather than a
+// JSON number. encoding/json/v2 is strict about types, so flexFloat64 is needed.
+func TestAudibleClient_StringRating(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate real Audible response with string-encoded rating
+		fmt.Fprint(w, `{
+			"products": [{
+				"asin": "B001",
+				"title": "Test Book",
+				"rating": {
+					"num_reviews": 500,
+					"overall_distribution": {
+						"display_average_rating": "4.5",
+						"num_ratings": 1200
+					},
+					"performance_distribution": {
+						"display_average_rating": "4.7",
+						"num_ratings": 1100
+					},
+					"story_distribution": {
+						"display_average_rating": "4.3",
+						"num_ratings": 1050
+					}
+				}
+			}],
+			"total_results": 1
+		}`)
+	}))
+	defer server.Close()
+
+	client := NewAudibleClientWithBaseURL(server.URL)
+	results, err := client.SearchByTitle(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("unexpected error with string-encoded rating: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.AudibleRatingOverall != 4.5 {
+		t.Errorf("overall rating: got %v, want 4.5", r.AudibleRatingOverall)
+	}
+	if r.AudibleRatingPerformance != 4.7 {
+		t.Errorf("performance rating: got %v, want 4.7", r.AudibleRatingPerformance)
+	}
+	if r.AudibleRatingStory != 4.3 {
+		t.Errorf("story rating: got %v, want 4.3", r.AudibleRatingStory)
+	}
+	if r.AudibleRatingCount != 1200 {
+		t.Errorf("rating count: got %d, want 1200", r.AudibleRatingCount)
 	}
 }
 

--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/server/acoustid_backfill.go
-// version: 2.5.1
+// version: 2.5.2
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-12
+// last-edited: 2026-05-15
 
 package server
 
@@ -114,7 +114,7 @@ func (s *Server) backfillAcoustIDs() {
 		return
 	}
 
-	var fingerprinted, skipped, failed int
+	var fingerprinted, alreadyImported, failed int
 	ctx := context.Background()
 	for _, b := range books {
 		select {
@@ -134,7 +134,7 @@ func (s *Server) backfillAcoustIDs() {
 				bookModified = true
 				time.Sleep(fingerprintThrottle)
 			case fingerprintOutcomeSkipped:
-				skipped++
+				alreadyImported++
 			case fingerprintOutcomeFailed:
 				failed++
 			}
@@ -148,8 +148,8 @@ func (s *Server) backfillAcoustIDs() {
 		}
 	}
 
-	log.Printf("[INFO] acoustid backfill complete: fingerprinted=%d skipped=%d failed=%d",
-		fingerprinted, skipped, failed)
+	log.Printf("[INFO] acoustid backfill complete: fingerprinted=%d already_imported=%d failed=%d",
+		fingerprinted, alreadyImported, failed)
 }
 
 // AcoustIDLookupStore is the subset of the store needed for fingerprint lookups.


### PR DESCRIPTION
## Summary

- **Audible decode fix**: Audible API sometimes returns `display_average_rating` as a JSON string (`"4.5"`) instead of a number. `encoding/json/v2` is strict about type mismatches — the decode error caused the entire catalog response to fail, returning 0 candidates for every Audible search (near-total metadata outage since Audible is the primary source). Added `flexFloat64` type with `UnmarshalJSON([]byte)` that handles both string and number JSON input.
- **Acoustid log**: Renamed `skipped` counter to `alreadyImported`; log key changes from `skipped=` to `already_imported=`.

## Test plan

- [ ] `go test ./internal/metadata/... -run TestAudible` — all pass including new `TestAudibleClient_StringRating`
- [ ] `go build ./...` — clean compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)