### PR TITLE
fix(metadata): rewrite Google Books cover URLs to HTTPS

### DIFF
--- a/internal/metadata/googlebooks.go
+++ b/internal/metadata/googlebooks.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/googlebooks.go
-// version: 1.3.1
+// version: 1.3.2
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-f2a3b4c5d6e7
 
 package metadata
@@ -147,7 +147,7 @@ func (c *GoogleBooksClient) search(ctx context.Context, escapedQuery string) ([]
 			}
 		}
 		if vi.ImageLinks != nil && vi.ImageLinks.Thumbnail != "" {
-			meta.CoverURL = vi.ImageLinks.Thumbnail
+			meta.CoverURL = strings.Replace(vi.ImageLinks.Thumbnail, "http://", "https://", 1)
 		}
 		if vi.AverageRating > 0 {
 			meta.GoogleRatingAverage = vi.AverageRating


### PR DESCRIPTION
## Summary
- Google Books API returns `http://` thumbnail URLs in its JSON responses
- The HTTPS-served app was logging mixed-content warnings in the browser console
- Rewrite the scheme to `https://` at fetch time (`strings.Replace`, count=1)

## Test plan
- [ ] Fetch metadata for a book via Google Books; confirm `cover_url` in response uses `https://`
- [ ] Browser console shows no mixed-content warnings for cover images on the library page

🤖 Generated with [Claude Code](https://claude.com/claude-code)