### PR TITLE
fix(acoustid): pass bgCtx to backfillAcoustIDs so shutdown cancels it

### DIFF
--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/acoustid_backfill.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-05-15
 
@@ -107,7 +107,7 @@ const fingerprintThrottle = 10 * time.Millisecond
 // 7-segment fingerprints. Runs as a background goroutine after startup.
 // Safe to run repeatedly — skips files that already have seg0 set.
 // No-ops silently if neither fpcalc nor ffmpeg is installed.
-func (s *Server) backfillAcoustIDs() {
+func (s *Server) backfillAcoustIDs(ctx context.Context) {
 	if !fingerprint.Available() {
 		log.Println("[INFO] acoustid backfill: no fingerprint backend found, skipping")
 		return
@@ -125,7 +125,6 @@ func (s *Server) backfillAcoustIDs() {
 	}
 
 	var fingerprinted, alreadyImported, failed int
-	ctx := context.Background()
 	for _, b := range books {
 		select {
 		case <-ctx.Done():

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-11
+// last-edited: 2026-05-15
 
 package server
 
@@ -380,7 +380,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 	s.bgWG.Add(1)
 	go func() {
 		defer s.bgWG.Done()
-		s.backfillAcoustIDs()
+		s.backfillAcoustIDs(s.bgCtx)
 	}()
 
 	// PERF-VERSIONS: write the book:versiongroup:<gid>:<id> secondary


### PR DESCRIPTION
## Summary

- `backfillAcoustIDs` was creating its own `context.Background()` instead of using the server's `s.bgCtx`
- Shutdown cancels `bgCtx` and waits 30s for `bgWG`; if the backfill loop was still running past that window, it would call `store.GetBookFiles()` on an already-closed PebbleDB and panic
- Fix: pass `s.bgCtx` as a parameter so the per-book `select { case <-ctx.Done() }` guard actually fires on shutdown

## Test plan

- [ ] Deploy and restart service — confirm no `panic: pebble: closed` in journald on shutdown
- [ ] Verify backfill completes normally on a fresh start (log line `acoustid backfill complete: fingerprinted=N`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)