### PR TITLE
fix(activity): three digest/ops-log bugs

### DIFF
--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
 
 package database
@@ -540,6 +540,14 @@ func (s *NutsActivityStore) CompactByDay(ctx context.Context, olderThan time.Tim
 			return result, fmt.Errorf("compact parse date: %w", err)
 		}
 
+		// Populate Details directly so it survives the ActivityEntry round-trip.
+		// The digestWithDetails workaround stored details under "digest_details"
+		// at the top level, which json.Unmarshal into ActivityEntry silently
+		// dropped — leaving details nil on every query.
+		var ddMap map[string]any
+		if mapErr := json.Unmarshal(detailsBytes, &ddMap); mapErr != nil {
+			return result, fmt.Errorf("compact unmarshal dd map: %w", mapErr)
+		}
 		digest := ActivityEntry{
 			ID:        s.counter.Add(1),
 			Timestamp: startOfDay,
@@ -548,24 +556,12 @@ func (s *NutsActivityStore) CompactByDay(ctx context.Context, olderThan time.Tim
 			Level:     "info",
 			Source:    "compaction",
 			Summary:   fmt.Sprintf("Daily digest for %s (%d entries)", dateKey, dd.OriginalCount),
-			Details:   map[string]any{"_raw": string(detailsBytes)},
+			Details:   ddMap,
 		}
-		// Store DigestDetails separately in details for proper JSON retrieval.
-		digest.Details = nil
 		digestKey := actTimeKey(startOfDay, ulid.Make().String())
 		digestBytes, err := json.Marshal(digest)
 		if err != nil {
 			return result, fmt.Errorf("compact marshal digest: %w", err)
-		}
-		// Re-inject details JSON inline.
-		type digestWithDetails struct {
-			ActivityEntry
-			DigestDetails json.RawMessage `json:"digest_details,omitempty"`
-		}
-		dwd := digestWithDetails{ActivityEntry: digest, DigestDetails: detailsBytes}
-		digestBytes, err = json.Marshal(dwd)
-		if err != nil {
-			return result, fmt.Errorf("compact marshal digest+details: %w", err)
 		}
 
 		var deletedCount int
@@ -741,6 +737,7 @@ func (s *NutsActivityStore) findExistingDigest(dateKey string) (DigestDetails, [
 		for i, v := range vals {
 			var row struct {
 				ActivityEntry
+				// Legacy field: digest details were stored here before the fix.
 				DigestDetails json.RawMessage `json:"digest_details,omitempty"`
 			}
 			if jsonErr := json.Unmarshal(v, &row); jsonErr != nil {
@@ -748,7 +745,13 @@ func (s *NutsActivityStore) findExistingDigest(dateKey string) (DigestDetails, [
 			}
 			if row.ActivityEntry.Type == "daily_digest" {
 				if row.DigestDetails != nil {
+					// Old format: digest_details at top level.
 					_ = json.Unmarshal(row.DigestDetails, &foundDD)
+				} else if row.ActivityEntry.Details != nil {
+					// New format: stored in the ActivityEntry.Details map.
+					if b, merr := json.Marshal(row.ActivityEntry.Details); merr == nil {
+						_ = json.Unmarshal(b, &foundDD)
+					}
 				}
 				foundKey = keys[i]
 				return nil // take the first one

--- a/internal/server/acoustid_backfill.go
+++ b/internal/server/acoustid_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/server/acoustid_backfill.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-05-15
 
@@ -107,7 +107,7 @@ const fingerprintThrottle = 10 * time.Millisecond
 // 7-segment fingerprints. Runs as a background goroutine after startup.
 // Safe to run repeatedly — skips files that already have seg0 set.
 // No-ops silently if neither fpcalc nor ffmpeg is installed.
-func (s *Server) backfillAcoustIDs() {
+func (s *Server) backfillAcoustIDs(ctx context.Context) {
 	if !fingerprint.Available() {
 		log.Println("[INFO] acoustid backfill: no fingerprint backend found, skipping")
 		return
@@ -125,7 +125,6 @@ func (s *Server) backfillAcoustIDs() {
 	}
 
 	var fingerprinted, alreadyImported, failed int
-	ctx := context.Background()
 	for _, b := range books {
 		select {
 		case <-ctx.Done():

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-11
+// last-edited: 2026-05-15
 
 package server
 
@@ -380,7 +380,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 	s.bgWG.Add(1)
 	go func() {
 		defer s.bgWG.Done()
-		s.backfillAcoustIDs()
+		s.backfillAcoustIDs(s.bgCtx)
 	}()
 
 	// PERF-VERSIONS: write the book:versiongroup:<gid>:<id> secondary

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.10.0
+// version: 2.11.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -176,7 +176,7 @@ export default function ActivityLog() {
   const [compactAnchor, setCompactAnchor] = useState<null | HTMLElement>(null);
   const [compacting, setCompacting] = useState(false);
   const [customCompactDays, setCustomCompactDays] = useState('');
-  const [expandedDigests, setExpandedDigests] = useState<Set<number>>(new Set());
+  const [expandedDigests, setExpandedDigests] = useState<Set<string>>(new Set());
 
   // Revert dialog
   const [revertEntry, setRevertEntry] = useState<ActivityEntry | null>(null);
@@ -1274,7 +1274,7 @@ export default function ActivityLog() {
                   );
                 }
                 if (entry.tier === 'digest') {
-                  const isExpanded = expandedDigests.has(Number(entry.id));
+                  const isExpanded = expandedDigests.has(String(entry.id));
                   const details = entry.details as {
                     date?: string;
                     original_count?: number;
@@ -1294,8 +1294,9 @@ export default function ActivityLog() {
                         onClick={() => {
                           setExpandedDigests((prev) => {
                             const next = new Set(prev);
-                            if (next.has(Number(entry.id))) next.delete(Number(entry.id));
-                            else next.add(Number(entry.id));
+                            const key = String(entry.id);
+                            if (next.has(key)) next.delete(key);
+                            else next.add(key);
                             return next;
                           });
                         }}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.26.0
+// version: 2.27.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-11
 
@@ -1606,7 +1606,8 @@ export async function getOperationLogs(id: string): Promise<OperationLog[]> {
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch operation logs');
   }
-  const data = await response.json();
+  const body = await response.json();
+  const data = body.data ?? body;
   return data.items || data.logs || [];
 }
 


### PR DESCRIPTION
## Summary

- **Bug 1 – all digest rows expand together**: ID counter is seeded from `time.Now().UnixNano()` (≈1.747×10¹⁸), exceeding JS `Number.MAX_SAFE_INTEGER`. Adjacent IDs round to the same float64 in a `Set<number>`, so every `Set.has()` matches after any click. Fix: `Set<string>` + `String(entry.id)`.

- **Bug 2 – no items in expanded digest**: NutsDB stored digest details in a top-level `digest_details` key (via a local `digestWithDetails` wrapper). `json.Unmarshal` into `ActivityEntry` silently drops unknown keys, leaving `Details: nil` on every query. Fix: unmarshal `DigestDetails` into `map[string]any` and put it directly in `ActivityEntry.Details` — matching the SQLite store. `findExistingDigest` updated to handle both old (`digest_details`) and new (`details`) formats for existing rows.

- **Bug 3 – op logs always empty**: `getOperationLogs` read `data.items` but the API wraps all responses in `{"data": {...}}`. Fix: unwrap `body.data` first.

## Test plan

- [ ] Click one digest row — only that row should expand; the others stay collapsed
- [ ] Expanded digest shows event items (up to 500) and a truncation notice for large days
- [ ] Expanded operation in the Active Ops panel now shows log lines for ops that have logged (e.g. Fetch Metadata Candidates)
- [ ] Old digest rows (written with `digest_details` format) still merge correctly when compaction runs again

🤖 Generated with [Claude Code](https://claude.com/claude-code)