### PR TITLE
feat(deluge): importToLibrary reflink + core.move_storage (DELUGE-3)

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.12.0
+// version: 1.12.1
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-04-30
+// last-edited: 2026-05-15
 
 package database
 
@@ -150,6 +150,12 @@ type BookFileStore interface {
 	// UpdateBookFileHashes is a surgical update that records pre-write and post-write
 	// SHA-256 hashes without touching any other BookFile fields.
 	UpdateBookFileHashes(id, originalHash, postMetadataHash string) error
+	// MarkFileImportedFromDeluge records that a file has been imported from a
+	// Deluge download directory. originalPath is the source (download) path,
+	// libraryPath is the destination inside the organized library, and
+	// torrentHash is the Deluge info-hash (optional). Implementations SHOULD
+	// match by originalPath first, then fall back to matching by torrentHash.
+	MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error
 	// GetDuplicateFilesByHash returns groups of book_files that share the same
 	// original_file_hash (non-empty). Each group has ≥2 entries and represents
 	// the same physical audio file in multiple locations.

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -329,6 +329,7 @@ type MockStore struct {
 	GetBookFileByPIDFunc           func(itunesPID string) (*BookFile, error)
 	ClearITunesPIDFunc             func(itunesPID string) (bool, error)
 	GetBookFileByPathFunc          func(filePath string) (*BookFile, error)
+	MarkFileImportedFromDelugeFunc func(ctx context.Context, originalPath, libraryPath, torrentHash string) error
 	GetBookFileByAcoustIDFunc      func(fingerprint string) (*BookFile, error)
 	GetBookFileByAcoustIDFuzzyFunc func(fingerprint string, minSimilarity float64) (*BookFile, error)
 	DeleteBookFileFunc             func(id string) error
@@ -2269,6 +2270,14 @@ func (m *MockStore) GetAllBookFiles() ([]BookFile, error) {
 	return nil, nil
 }
 func (m *MockStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) { return nil, nil }
+
+func (m *MockStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
+	if m.MarkFileImportedFromDelugeFunc != nil {
+		return m.MarkFileImportedFromDelugeFunc(ctx, originalPath, libraryPath, torrentHash)
+	}
+	return nil
+}
+
 func (m *MockStore) GetBookFileByID(bookID, fileID string) (*BookFile, error) {
 	if m.GetBookFileByIDFunc != nil {
 		return m.GetBookFileByIDFunc(bookID, fileID)

--- a/internal/database/mocks/mock_store_mark_import.go
+++ b/internal/database/mocks/mock_store_mark_import.go
@@ -1,0 +1,38 @@
+// Code generated - supplemental manual additions for new Store method
+// DO NOT EDIT (this file is intentionally hand-written to augment generated mocks)
+
+package mocks
+
+import (
+	"context"
+)
+
+// MarkFileImportedFromDeluge provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
+	ret := _mock.Called(ctx, originalPath, libraryPath, torrentHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkFileImportedFromDeluge")
+	}
+
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		return rf(ctx, originalPath, libraryPath, torrentHash)
+	}
+
+	return ret.Error(0)
+}
+
+// MarkFileImportedFromDeluge provides a mock function for the type MockStore
+func (_mock *MockStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
+	ret := _mock.Called(ctx, originalPath, libraryPath, torrentHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkFileImportedFromDeluge")
+	}
+
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		return rf(ctx, originalPath, libraryPath, torrentHash)
+	}
+
+	return ret.Error(0)
+}

--- a/internal/database/pebble_store_mark_import.go
+++ b/internal/database/pebble_store_mark_import.go
@@ -1,0 +1,77 @@
+// file: internal/database/pebble_store_mark_import.go
+// version: 1.0.0
+// guid: e9f1a2b3-c4d5-6789-0abc-def123456789
+// last-edited: 2026-05-15
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+// MarkFileImportedFromDeluge sets ImportedFromDelugeAt and DelugeOriginalPath on
+// the matching BookFile. Matching is attempted by originalPath first and then
+// by torrentHash (via BookVersion lookup). If no matching row is found, the
+// call is a no-op and returns nil.
+func (p *PebbleStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
+	if originalPath == "" && torrentHash == "" {
+		return fmt.Errorf("originalPath and torrentHash both empty")
+	}
+
+	// Attempt to find by original (download) path first.
+	if originalPath != "" {
+		bf, err := p.GetBookFileByPath(originalPath)
+		if err != nil {
+			return err
+		}
+		if bf != nil {
+			now := time.Now()
+			bf.DelugeOriginalPath = originalPath
+			bf.FilePath = libraryPath
+			bf.ImportedFromDelugeAt = &now
+			if torrentHash != "" {
+				bf.DelugeHash = torrentHash
+			}
+			return p.UpdateBookFile(bf.ID, bf)
+		}
+	}
+
+	// Fallback: match by torrent hash to locate the BookVersion, then update
+	// a file belonging to that book/version if we can find one.
+	if torrentHash != "" {
+		bv, err := p.GetBookVersionByTorrentHash(torrentHash)
+		if err != nil {
+			return err
+		}
+		if bv == nil {
+			// No matching version — nothing to do.
+			return nil
+		}
+
+		files, err := p.GetBookFiles(bv.BookID)
+		if err != nil {
+			return err
+		}
+
+		base := filepath.Base(libraryPath)
+		for i := range files {
+			f := &files[i]
+			if f.DelugeHash == torrentHash || f.VersionID == bv.ID || filepath.Base(f.FilePath) == base {
+				now := time.Now()
+				f.DelugeOriginalPath = originalPath
+				f.FilePath = libraryPath
+				f.ImportedFromDelugeAt = &now
+				if torrentHash != "" {
+					f.DelugeHash = torrentHash
+				}
+				return p.UpdateBookFile(f.ID, f)
+			}
+		}
+	}
+
+	// No match found — treat as non-fatal.
+	return nil
+}

--- a/internal/database/sqlite_store_mark_import.go
+++ b/internal/database/sqlite_store_mark_import.go
@@ -1,0 +1,75 @@
+// file: internal/database/sqlite_store_mark_import.go
+// version: 1.0.0
+// guid: a9b8c7d6-e5f4-3210-abcd-9876543210fe
+// last-edited: 2026-05-15
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+// MarkFileImportedFromDeluge sets ImportedFromDelugeAt and DelugeOriginalPath on
+// the matching BookFile. Matching is attempted by originalPath first and then
+// by torrentHash (via BookVersion lookup). If no matching row is found, the
+// call is a no-op and returns nil.
+func (s *SQLiteStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
+	if originalPath == "" && torrentHash == "" {
+		return fmt.Errorf("originalPath and torrentHash both empty")
+	}
+
+	// Try match by original download path first.
+	if originalPath != "" {
+		bf, err := s.GetBookFileByPath(originalPath)
+		if err != nil {
+			return err
+		}
+		if bf != nil {
+			now := time.Now()
+			bf.DelugeOriginalPath = originalPath
+			bf.FilePath = libraryPath
+			bf.ImportedFromDelugeAt = &now
+			if torrentHash != "" {
+				bf.DelugeHash = torrentHash
+			}
+			return s.UpdateBookFile(bf.ID, bf)
+		}
+	}
+
+	// Fallback: match by torrent hash to locate the BookVersion, then update
+	// a file belonging to that book/version if we can find one.
+	if torrentHash != "" {
+		bv, err := s.GetBookVersionByTorrentHash(torrentHash)
+		if err != nil {
+			return err
+		}
+		if bv == nil {
+			return nil
+		}
+
+		files, err := s.GetBookFiles(bv.BookID)
+		if err != nil {
+			return err
+		}
+
+		base := filepath.Base(libraryPath)
+		for i := range files {
+			f := &files[i]
+			if f.DelugeHash == torrentHash || f.VersionID == bv.ID || filepath.Base(f.FilePath) == base {
+				now := time.Now()
+				f.DelugeOriginalPath = originalPath
+				f.FilePath = libraryPath
+				f.ImportedFromDelugeAt = &now
+				if torrentHash != "" {
+					f.DelugeHash = torrentHash
+				}
+				return s.UpdateBookFile(f.ID, f)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/deluge/import.go
+++ b/internal/deluge/import.go
@@ -137,6 +137,20 @@ func reflinkCopy(src, dest string) error {
 	return reflinkCopyOS(src, dest)
 }
 
+// ReflinkOrCopy attempts a copy-on-write reflink then falls back to a
+// full io.Copy if the reflink path is unsupported. Exported so callers in
+// other packages (e.g., the deluge plugin) can reuse the same semantics.
+func ReflinkOrCopy(src, dest string) error {
+	if err := reflinkCopy(src, dest); err != nil {
+		// Attempt a plain io.Copy as a fallback. Return the copy error if that
+		// also fails.
+		if err2 := ioCopy(src, dest); err2 != nil {
+			return err2
+		}
+	}
+	return nil
+}
+
 // ioCopy copies src to dest using standard io.Copy (read all bytes, write all bytes).
 func ioCopy(src, dest string) error {
 	in, err := os.Open(src)

--- a/internal/plugins/deluge/import.go
+++ b/internal/plugins/deluge/import.go
@@ -1,0 +1,58 @@
+// file: internal/plugins/deluge/import.go
+// version: 1.0.1
+// guid: f1e2d3c4-b5a6-7890-cdef-0123456789ab
+// last-edited: 2026-05-15
+
+package deluge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"log/slog"
+
+	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
+)
+
+// importToLibrary reflinks src into dst (falls back to copy), updates the DB,
+// then calls core.move_storage so Deluge continues seeding from dst.
+func (p *Plugin) importToLibrary(ctx context.Context, torrentHash, srcPath, dstPath string) error {
+	if p == nil {
+		return fmt.Errorf("plugin not initialized")
+	}
+
+	// 1. Validate both paths
+	if p.cache != nil && p.cache.IsProtected(srcPath) {
+		return fmt.Errorf("source path %q is protected", srcPath)
+	}
+
+	// 2. Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return fmt.Errorf("create destination dir: %w", err)
+	}
+
+	// 3. Reflink (best-effort) or copy
+	if err := delugeclient.ReflinkOrCopy(srcPath, dstPath); err != nil {
+		return fmt.Errorf("reflink/copy: %w", err)
+	}
+
+	// 4. Update DB: set imported_from_deluge_at, deluge_original_path
+	if p.store != nil {
+		if err := p.store.MarkFileImportedFromDeluge(ctx, srcPath, dstPath, torrentHash); err != nil {
+			slog.Warn("failed to update deluge import record", "err", err)
+			// non-fatal: file is already copied
+		}
+	}
+
+	// 5. Call core.move_storage (best-effort)
+	if p.client != nil && torrentHash != "" {
+		if err := p.client.MoveStorage([]string{torrentHash}, filepath.Dir(dstPath)); err != nil {
+			slog.Warn("core.move_storage failed; Deluge will seed from original path", "err", err, "torrent", torrentHash)
+			// non-fatal: the import succeeded even if seeding location doesn't update
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds deluge.ReflinkOrCopy and plugin import flow that reflinks (fallback copy) downloaded files into the organized library, records import metadata in the DB (imported_from_deluge_at, deluge_original_path), and calls Deluge core.move_storage so Deluge continues seeding from the new location. Implements MARK API in Pebble and SQLite stores and updates test mocks.\n\nBuild: all packages compile. Please run CI and review.