### PR TITLE
feat(security): SafePath typed path boundary — SEC-AUDIT-1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -175,7 +175,7 @@ incrementally:
 
 ### Phase 1-6: Path Injection (217 alerts)
 
-- [ ] **SEC-AUDIT-1** Create `internal/security/pathvalidation` package (foundation)
+- [x] **SEC-AUDIT-1** Create `internal/security/pathvalidation` package (foundation)
   - **Priority:** P0
   - **Effort:** 4 hours
   - **Alerts:** Foundation for 217 path injection alerts

--- a/internal/security/safepath/safepath.go
+++ b/internal/security/safepath/safepath.go
@@ -1,0 +1,62 @@
+// file: internal/security/safepath/safepath.go
+// version: 1.0.0
+// guid: 2f8e4b29-9c1f-4f8b-8b6a-2c3f4e5a6b7c
+// last-edited: 2026-05-15
+package safepath
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SafePath is an opaque type representing a path that has been validated to
+// lie within a known-safe root directory. Obtain one via Join or Validate;
+// never construct directly from a string.
+//
+type SafePath struct{ s string }
+
+// String returns the validated absolute path.
+func (p SafePath) String() string { return p.s }
+
+// Join validates that joining root with parts does not escape root, then
+// returns a SafePath. Returns an error if any part would escape root.
+func Join(root string, parts ...string) (SafePath, error) {
+	// Reject absolute path components in parts for security and clarity.
+	for _, part := range parts {
+		if filepath.IsAbs(part) {
+			return SafePath{}, fmt.Errorf("safepath: absolute path component %q not allowed", part)
+		}
+	}
+
+	elems := append([]string{root}, parts...)
+	joined := filepath.Join(elems...)
+	cleaned := filepath.Clean(joined)
+	cleanRoot := filepath.Clean(root)
+	if cleaned != cleanRoot && !strings.HasPrefix(cleaned, cleanRoot+string(filepath.Separator)) {
+		return SafePath{}, fmt.Errorf("safepath: %q escapes root %q", cleaned, cleanRoot)
+	}
+	return SafePath{s: cleaned}, nil
+}
+
+// Validate asserts that an already-resolved path lies within root and wraps
+// it as a SafePath. Use when the path was resolved by an external mechanism
+// (e.g., os.Readlink) and needs validation.
+func Validate(root, path string) (SafePath, error) {
+	cleanRoot := filepath.Clean(root)
+	cleaned := filepath.Clean(path)
+	if cleaned != cleanRoot && !strings.HasPrefix(cleaned, cleanRoot+string(filepath.Separator)) {
+		return SafePath{}, fmt.Errorf("safepath: %q escapes root %q", cleaned, cleanRoot)
+	}
+	return SafePath{s: cleaned}, nil
+}
+
+// MustJoin is like Join but panics on error. Only use in tests or where the
+// inputs are compile-time constants.
+func MustJoin(root string, parts ...string) SafePath {
+	p, err := Join(root, parts...)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}

--- a/internal/security/safepath/safepath_test.go
+++ b/internal/security/safepath/safepath_test.go
@@ -1,0 +1,79 @@
+// file: internal/security/safepath/safepath_test.go
+// version: 1.0.0
+// guid: 8a7b6c5d-4e3f-2a1b-9c0d-123456789abc
+// last-edited: 2026-05-15
+package safepath
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestJoinNormal(t *testing.T) {
+	root := "/tmp/safepath-root"
+	p, err := Join(root, "sub", "file.txt")
+	if err != nil {
+		t.Fatalf("Join unexpected error: %v", err)
+	}
+	want := filepath.Clean(filepath.Join(root, "sub", "file.txt"))
+	if p.String() != want {
+		t.Fatalf("String() = %q; want %q", p.String(), want)
+	}
+}
+
+func TestJoinTraversalReturnsError(t *testing.T) {
+	root := "/tmp/safepath-root"
+	_, err := Join(root, "..")
+	if err == nil {
+		t.Fatalf("expected error for traversal, got nil")
+	}
+}
+
+func TestJoinAbsolutePartReturnsError(t *testing.T) {
+	root := "/tmp/safepath-root"
+	p, err := Join(root, "/etc/passwd")
+	if err == nil {
+		t.Fatalf("expected error for absolute part, got nil; result=%q", p.String())
+	}
+}
+
+func TestValidateInside(t *testing.T) {
+	root := "/tmp/safepath-root"
+	path := filepath.Clean(filepath.Join(root, "sub", "file.txt"))
+	p, err := Validate(root, path)
+	if err != nil {
+		t.Fatalf("Validate unexpected error: %v", err)
+	}
+	if p.String() != path {
+		t.Fatalf("Validate returned %q; want %q", p.String(), path)
+	}
+}
+
+func TestValidateOutsideReturnsError(t *testing.T) {
+	root := "/tmp/safepath-root"
+	_, err := Validate(root, "/etc/passwd")
+	if err == nil {
+		t.Fatalf("expected error for Validate outside root, got nil")
+	}
+}
+
+func TestMustJoinPanicsOnEscape(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("MustJoin did not panic on escape attempt")
+		}
+	}()
+	MustJoin("/tmp/safepath-root", "..")
+}
+
+func TestStringReturnsCleanedPath(t *testing.T) {
+	root := "/tmp/safepath-root"
+	p, err := Join(root, "sub", ".", "file.txt")
+	if err != nil {
+		t.Fatalf("Join unexpected error: %v", err)
+	}
+	want := filepath.Clean(filepath.Join(root, "sub", "file.txt"))
+	if p.String() != want {
+		t.Fatalf("String() = %q; want %q", p.String(), want)
+	}
+}


### PR DESCRIPTION
Adds SafePath typed newtype for validated filesystem paths (SEC-AUDIT-1). Includes implementation and unit tests.