### PR TITLE
feat(library): tag cloud filter — browse and filter by tags

### DIFF
--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,6 +1,7 @@
 // file: internal/audiobooks/service.go
-// version: 1.25.0
+// version: 1.25.1
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-05-16
 
 package audiobooks
 
@@ -193,6 +194,7 @@ type ListFilters struct {
 	IsPrimaryVersion *bool
 	LibraryState     string
 	Tag              string
+	Tags             []string
 	SortBy           string        // column sort key
 	SortOrder        string        // "asc" or "desc"
 	FieldFilters     []FieldFilter // advanced field-specific filters (book-global)
@@ -658,7 +660,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	}
 	hasSorting := f.SortBy != ""
 	hasPerUser := len(f.PerUserFilters) > 0 && f.UserID != ""
-	hasPostFilters := f.IsPrimaryVersion != nil || f.LibraryState != "" || f.Tag != "" || len(f.FieldFilters) > 0 || hasPerUser || hasSorting
+	hasPostFilters := f.IsPrimaryVersion != nil || f.LibraryState != "" || f.Tag != "" || len(f.Tags) > 0 || len(f.FieldFilters) > 0 || hasPerUser || hasSorting
 
 	// When post-filters are active, fetch all and filter in memory
 	// (PebbleStore doesn't support query-level boolean/string filtering)
@@ -712,22 +714,46 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 
 	// Apply post-filters
 	if hasPostFilters {
-		// If tag filter is set, build a set of matching book IDs
+		// If tag filter is set, build a set of matching book IDs (intersection of all tags)
 		var tagBookIDs map[string]struct{}
-		if f.Tag != "" {
-			ids, tagErr := svc.store.GetBooksByTag(f.Tag)
-			if tagErr != nil {
-				return nil, tagErr
-			}
-			tagBookIDs = make(map[string]struct{}, len(ids))
-			for _, id := range ids {
-				tagBookIDs[id] = struct{}{}
+		tagsToMatch := f.Tags
+		if len(tagsToMatch) == 0 && f.Tag != "" {
+			tagsToMatch = []string{f.Tag}
+		}
+		if len(tagsToMatch) > 0 {
+			for _, tag := range tagsToMatch {
+				if tag == "" {
+					continue
+				}
+				ids, tagErr := svc.store.GetBooksByTag(tag)
+				if tagErr != nil {
+					return nil, tagErr
+				}
+				curSet := make(map[string]struct{}, len(ids))
+				for _, id := range ids {
+					curSet[id] = struct{}{}
+				}
+				if tagBookIDs == nil {
+					tagBookIDs = curSet
+				} else {
+					for id := range tagBookIDs {
+						if _, ok := curSet[id]; !ok {
+							delete(tagBookIDs, id)
+						}
+					}
+				}
+				if len(tagBookIDs) == 0 {
+					break
+				}
 			}
 		}
 
 		filtered := make([]database.Book, 0, len(books))
 		for _, b := range books {
-			if f.Tag != "" {
+			if len(tagsToMatch) > 0 {
+				if tagBookIDs == nil {
+					continue
+				}
 				if _, ok := tagBookIDs[b.ID]; !ok {
 					continue
 				}
@@ -807,6 +833,40 @@ func (svc *AudiobookService) CountAudiobooksFiltered(ctx context.Context, filter
 	if err != nil {
 		return 0, err
 	}
+	// Build tag intersection if tags are provided
+	tagsToMatch := filters.Tags
+	if len(tagsToMatch) == 0 && filters.Tag != "" {
+		tagsToMatch = []string{filters.Tag}
+	}
+	var tagBookIDs map[string]struct{}
+	if len(tagsToMatch) > 0 {
+		for _, tag := range tagsToMatch {
+			if tag == "" {
+				continue
+			}
+			ids, tagErr := svc.store.GetBooksByTag(tag)
+			if tagErr != nil {
+				return 0, tagErr
+			}
+			curSet := make(map[string]struct{}, len(ids))
+			for _, id := range ids {
+				curSet[id] = struct{}{}
+			}
+			if tagBookIDs == nil {
+				tagBookIDs = curSet
+			} else {
+				for id := range tagBookIDs {
+					if _, ok := curSet[id]; !ok {
+						delete(tagBookIDs, id)
+					}
+				}
+			}
+			if len(tagBookIDs) == 0 {
+				break
+			}
+		}
+	}
+
 	count := 0
 	for _, b := range books {
 		if filters.IsPrimaryVersion != nil {
@@ -821,6 +881,14 @@ func (svc *AudiobookService) CountAudiobooksFiltered(ctx context.Context, filter
 				bState = *b.LibraryState
 			}
 			if bState != filters.LibraryState {
+				continue
+			}
+		}
+		if len(tagsToMatch) > 0 {
+			if tagBookIDs == nil {
+				continue
+			}
+			if _, ok := tagBookIDs[b.ID]; !ok {
 				continue
 			}
 		}

--- a/internal/database/mocks/mock_store_mark_import.go
+++ b/internal/database/mocks/mock_store_mark_import.go
@@ -5,6 +5,8 @@ package mocks
 
 import (
 	"context"
+
+	mock "github.com/stretchr/testify/mock"
 )
 
 // MarkFileImportedFromDeluge provides a mock function for the type MockBookFileStore
@@ -35,4 +37,108 @@ func (_mock *MockStore) MarkFileImportedFromDeluge(ctx context.Context, original
 	}
 
 	return ret.Error(0)
+}
+
+// MockBookFileStore_MarkFileImportedFromDeluge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkFileImportedFromDeluge'
+type MockBookFileStore_MarkFileImportedFromDeluge_Call struct {
+	*mock.Call
+}
+
+// MarkFileImportedFromDeluge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - originalPath string
+//   - libraryPath string
+//   - torrentHash string
+func (_e *MockBookFileStore_Expecter) MarkFileImportedFromDeluge(ctx interface{}, originalPath interface{}, libraryPath interface{}, torrentHash interface{}) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
+	return &MockBookFileStore_MarkFileImportedFromDeluge_Call{Call: _e.mock.On("MarkFileImportedFromDeluge", ctx, originalPath, libraryPath, torrentHash)}
+}
+
+func (_c *MockBookFileStore_MarkFileImportedFromDeluge_Call) Run(run func(ctx context.Context, originalPath string, libraryPath string, torrentHash string)) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookFileStore_MarkFileImportedFromDeluge_Call) Return(err error) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookFileStore_MarkFileImportedFromDeluge_Call) RunAndReturn(run func(ctx context.Context, originalPath string, libraryPath string, torrentHash string) error) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_MarkFileImportedFromDeluge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkFileImportedFromDeluge'
+type MockStore_MarkFileImportedFromDeluge_Call struct {
+	*mock.Call
+}
+
+// MarkFileImportedFromDeluge is a helper method to define mock.On call
+//   - ctx context.Context
+//   - originalPath string
+//   - libraryPath string
+//   - torrentHash string
+func (_e *MockStore_Expecter) MarkFileImportedFromDeluge(ctx interface{}, originalPath interface{}, libraryPath interface{}, torrentHash interface{}) *MockStore_MarkFileImportedFromDeluge_Call {
+	return &MockStore_MarkFileImportedFromDeluge_Call{Call: _e.mock.On("MarkFileImportedFromDeluge", ctx, originalPath, libraryPath, torrentHash)}
+}
+
+func (_c *MockStore_MarkFileImportedFromDeluge_Call) Run(run func(ctx context.Context, originalPath string, libraryPath string, torrentHash string)) *MockStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_MarkFileImportedFromDeluge_Call) Return(err error) *MockStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_MarkFileImportedFromDeluge_Call) RunAndReturn(run func(ctx context.Context, originalPath string, libraryPath string, torrentHash string) error) *MockStore_MarkFileImportedFromDeluge_Call {
+	_c.Call.Return(run)
+	return _c
 }

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -1,7 +1,7 @@
 // file: internal/operations/types.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
-// last-edited: 2026-05-11
+// last-edited: 2026-05-16
 //
 // SelectionSpec and related types for server-side bulk operation targeting.
 // A SelectionSpec describes which books an operation targets without requiring
@@ -25,6 +25,7 @@ type FilterSpec struct {
 	Search         string        `json:"search,omitempty"`
 	LibraryState   string        `json:"library_state,omitempty"`
 	Tag            string        `json:"tag,omitempty"`
+	Tags           []string      `json:"tags,omitempty"`
 	FieldFilters   []FieldFilter `json:"field_filters,omitempty"`
 	AuthorID       *int64        `json:"author_id,omitempty"`
 	SeriesID       *int64        `json:"series_id,omitempty"`

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,6 +1,7 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.9.0
+// version: 2.9.1
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
+// last-edited: 2026-05-16
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
 // operations, file/segment actions, tag read/write, cover art, path
@@ -44,13 +45,18 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 	if sortOrder != "" && sortOrder != "asc" && sortOrder != "desc" {
 		sortOrder = "asc"
 	}
-	filters := ListFilters{
-		IsPrimaryVersion: httputil.ParseQueryBoolPtr(c, "is_primary_version"),
-		LibraryState:     httputil.ParseQueryString(c, "library_state"),
-		Tag:              httputil.ParseQueryString(c, "tag"),
-		SortBy:           httputil.ParseQueryString(c, "sort_by"),
-		SortOrder:        sortOrder,
-	}
+	tags := c.QueryArray("tags")
+		if len(tags) == 0 {
+			tags = c.QueryArray("tags[]")
+		}
+		filters := ListFilters{
+			IsPrimaryVersion: httputil.ParseQueryBoolPtr(c, "is_primary_version"),
+			LibraryState:     httputil.ParseQueryString(c, "library_state"),
+			Tag:              httputil.ParseQueryString(c, "tag"),
+			Tags:             tags,
+			SortBy:           httputil.ParseQueryString(c, "sort_by"),
+			SortOrder:        sortOrder,
+		}
 
 	// Parse field filters from JSON query param. Per-user filters
 	// (read_status / progress_pct / last_played) are split off so the
@@ -114,7 +120,7 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 
 	// Get total count for proper pagination
 	totalCount := len(enriched)
-	hasFilters := filters.IsPrimaryVersion != nil || filters.LibraryState != "" || filters.Tag != ""
+	hasFilters := filters.IsPrimaryVersion != nil || filters.LibraryState != "" || filters.Tag != "" || len(filters.Tags) > 0
 	if params.Search == "" && authorID == nil && seriesID == nil {
 		if hasFilters {
 			if tc, err := s.audiobookService.CountAudiobooksFiltered(c.Request.Context(), filters); err == nil {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.7.0
+// version: 3.7.1
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
-// last-edited: 2026-05-10
+// last-edited: 2026-05-16
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
 // search/apply/revert/no-match, bulk fetch and bulk writeback, the
@@ -1129,6 +1129,7 @@ func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.Filter
 		IsPrimaryVersion: &trueVal,
 		LibraryState:     f.LibraryState,
 		Tag:              f.Tag,
+		Tags:             f.Tags,
 	}
 	for _, ff := range f.FieldFilters {
 		if IsPerUserField(ff.Field) {

--- a/web/src/components/audiobooks/FilterSidebar.tsx
+++ b/web/src/components/audiobooks/FilterSidebar.tsx
@@ -198,6 +198,24 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
               <Typography variant="subtitle2" gutterBottom>
                 Tags
               </Typography>
+
+              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', maxHeight: 140, overflowY: 'auto', mb: 1 }}>
+                {availableTags.map((t) => (
+                  <Chip
+                    key={t.tag}
+                    label={`${t.tag} (${t.count})`}
+                    size="small"
+                    onClick={() => {
+                      const exists = selectedTags.includes(t.tag);
+                      const newTags = exists ? selectedTags.filter((x) => x !== t.tag) : [...selectedTags, t.tag];
+                      onTagsChange(newTags);
+                    }}
+                    color={selectedTags.includes(t.tag) ? 'primary' : undefined}
+                    variant={selectedTags.includes(t.tag) ? 'filled' : 'outlined'}
+                  />
+                ))}
+              </Box>
+
               <Autocomplete
                 multiple
                 size="small"

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.64.0
+// version: 1.64.1
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-05-15
+// last-edited: 2026-05-16
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -589,14 +589,22 @@ export const Library = () => {
   const handleSelectAllItems = useCallback(() => {
     const fieldFilters = buildFieldFilters();
     const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
-    const tagFilter =
-      selectedTags?.[0] ||
-      parsedSearch?.fieldFilters.find((f) => f.field === 'tag' && !f.negated)?.value;
+    let tagsForFilter: string[] | undefined;
+    if (selectedTags && selectedTags.length > 0) {
+      tagsForFilter = selectedTags;
+    } else {
+      const parsedTag = parsedSearch?.fieldFilters.find((f) => f.field === 'tag' && !f.negated)?.value;
+      if (parsedTag) tagsForFilter = [parsedTag];
+    }
     const libraryState = filters.libraryState === 'deleted' ? undefined : filters.libraryState;
 
     const filterSpec: api.SelectionSpec['filter'] = {};
     if (searchText) filterSpec.search = searchText;
-    if (tagFilter) filterSpec.tag = tagFilter;
+    if (tagsForFilter && tagsForFilter.length > 0) {
+      filterSpec.tags = tagsForFilter;
+      // back-compat single-tag field
+      filterSpec.tag = tagsForFilter[0];
+    }
     if (libraryState) filterSpec.library_state = libraryState;
     if (fieldFilters.length > 0) filterSpec.field_filters = fieldFilters;
 
@@ -614,9 +622,13 @@ export const Library = () => {
       const offset = (page - 1) * itemsPerPage;
       const fieldFilters = buildFieldFilters();
       const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
-      const tagFilter =
-        selectedTags?.[0] ||
-        parsedSearch?.fieldFilters.find((f) => f.field === 'tag' && !f.negated)?.value;
+      let tagsParam: string[] | undefined;
+      if (selectedTags && selectedTags.length > 0) {
+        tagsParam = selectedTags;
+      } else {
+        const parsedTag = parsedSearch?.fieldFilters.find((f) => f.field === 'tag' && !f.negated)?.value;
+        if (parsedTag) tagsParam = [parsedTag];
+      }
 
       // 'deleted' is a client-side concept (marked_for_deletion flag); send no library_state to server
       const libraryState = filters.libraryState === 'deleted' ? undefined : filters.libraryState;
@@ -627,7 +639,7 @@ export const Library = () => {
           : api.getBooks(itemsPerPage, offset, {
               sortBy,
               sortOrder,
-              tag: tagFilter,
+              tags: tagsParam,
               libraryState,
               filters: fieldFilters.length > 0 ? JSON.stringify(fieldFilters) : undefined,
               showFailed: filters.showFailed,

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.27.0
+// version: 2.27.1
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-11
+// last-edited: 2026-05-16
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -692,6 +692,7 @@ export async function getBooks(
     sortBy?: string;
     sortOrder?: string;
     tag?: string;
+    tags?: string[];
     libraryState?: string;
     filters?: string;
     showFailed?: boolean;
@@ -702,7 +703,13 @@ export async function getBooks(
   params.set('offset', String(offset));
   if (options?.sortBy) params.set('sort_by', options.sortBy);
   if (options?.sortOrder) params.set('sort_order', options.sortOrder);
-  if (options?.tag) params.set('tag', options.tag);
+  if (options?.tags && options.tags.length > 0) {
+    for (const t of options.tags) {
+      params.append('tags[]', t);
+    }
+  } else if (options?.tag) {
+    params.set('tag', options.tag);
+  }
   if (options?.libraryState) params.set('library_state', options.libraryState);
   if (options?.filters) params.set('filters', options.filters);
   if (options?.showFailed) params.set('show_quarantined', 'true');
@@ -1489,6 +1496,7 @@ export interface SelectionSpec {
     search?: string;
     library_state?: string;
     tag?: string;
+    tags?: string[];
     field_filters?: Array<{ field: string; value: string; negated: boolean }>;
     author_id?: number;
     series_id?: number;


### PR DESCRIPTION
Implements Task 017: tag cloud and multi-tag filtering (intersection semantics).

Changes:
- Backend: parse repeated tags[] and intersect per-tag bookID sets in service
- Frontend: send repeated tags[]=..., add tag cloud UI
- Regenerated mocks for MockStore expecters

Tests: ran 'make test-short' (backend short tests passed)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
