### PR TITLE
feat(dedup): import-time metadata hash dedup — MATCH-4

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1,11 +1,12 @@
 // file: internal/importer/service.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
-// last-edited: 2026-05-01
+// last-edited: 2026-05-16
 
 package importer
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -29,12 +30,17 @@ type Store = database.Store
 type ImportService struct {
 	db          Store
 	provisioner *itunesservice.TrackProvisioner
+	dedupEngine *dedup.Engine
 }
 
 // SetTrackProvisioner wires the iTunes track provisioner for newly-imported
 // books. Pass nil to disable ITL track provisioning (e.g. in tests).
 func (is *ImportService) SetTrackProvisioner(p *itunesservice.TrackProvisioner) {
 	is.provisioner = p
+}
+
+func (is *ImportService) SetDedupEngine(e *dedup.Engine) {
+	is.dedupEngine = e
 }
 
 func NewImportService(db Store) *ImportService {
@@ -187,6 +193,16 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 		if err := is.provisioner.ProvisionAll(created); err != nil {
 			log.Printf("[WARN] ITL track provisioning failed for %s: %v", created.ID, err)
 		}
+	}
+
+	// Fire dedup check on import if dedup engine is wired. Run async so we don't
+	// block the import API; dedup engine will create pending candidates for review.
+	if is.dedupEngine != nil {
+		go func(id string) {
+			if _, err := is.dedupEngine.CheckBook(context.Background(), id); err != nil {
+				log.Printf("[WARN] dedup-on-import CheckBook(%s): %v", id, err)
+			}
+		}(created.ID)
 	}
 
 	return &ImportFileResponse{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.19.0
+// version: 2.19.1
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-12
+// last-edited: 2026-05-16
 
 package server
 
@@ -528,6 +528,7 @@ func NewServer(store database.Store) *Server {
 	// during Phase 2 M1 step 1). Nil provisioner → ITL track provisioning
 	// is skipped (service is disabled or construction failed above).
 	server.importService.SetTrackProvisioner(server.itunesSvc.Provisioner)
+	server.importService.SetDedupEngine(server.dedupEngine)
 	// After M1 step 2, the batcher is owned by itunesservice.Service and
 	// Provisioner was wired with the real Enqueuer at Service.New() time.
 	// No SetEnqueuer hop needed.


### PR DESCRIPTION
Implement MATCH-4: run dedup engine on import to flag metadata-based duplicates for manual review. No auto-merge.