### PR TITLE
feat(ops): async file-hash backfill — BACKFILL-ASYNC-1

### DIFF
--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,15 +1,18 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1000014-0000-0000-0000-000000000014
-// last-edited: 2026-05-01
+// last-edited: 2026-05-16
 
 package jobs
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
 )
 
@@ -18,11 +21,13 @@ func init() { maintenance.Register(&backfillFileHashesJob{}) }
 type backfillFileHashesJob struct{}
 
 func (j *backfillFileHashesJob) ID() string          { return "backfill-file-hashes" }
-func (j *backfillFileHashesJob) Name() string     { return "Backfill File Hashes" }
-func (j *backfillFileHashesJob) Category() string { return "files" }
-func (j *backfillFileHashesJob) DefaultParams() any { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
+func (j *backfillFileHashesJob) Name() string        { return "Backfill File Hashes" }
+func (j *backfillFileHashesJob) Category() string    { return "files" }
+func (j *backfillFileHashesJob) DefaultParams() any  { return struct{ DryRun bool `json:"dry_run"` }{DryRun: false} }
 func (j *backfillFileHashesJob) Description() string { return "Compute and store file hashes for book_files missing them" }
-func (j *backfillFileHashesJob) CanResume() bool     { return false }
+// Job now supports checkpoint-based resume after restart.
+func (j *backfillFileHashesJob) CanResume() bool { return true }
+
 func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
 	files, err := store.GetAllBookFiles()
 	if err != nil {
@@ -30,7 +35,20 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 	}
 	reporter.SetTotal(len(files))
 	hashed := 0
-	for i := range files {
+
+	// Resume support: load checkpoint if present.
+	opID := maintenance.OperationIDFromCtx(ctx)
+	resumeIndex := 0
+	if opID != "" {
+		if cp, _ := operations.LoadCheckpoint(store, opID); cp != nil {
+			// resume phase 'scanning'
+			if cp.Phase == "scanning" {
+				resumeIndex = cp.PhaseIndex
+			}
+		}
+	}
+
+	for i := resumeIndex; i < len(files); i++ {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -53,8 +71,33 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 			}
 		}
 		hashed++
+
+		// Periodic checkpoint so long runs can resume after restart.
+		if opID != "" && i%50 == 0 {
+			_ = operations.SaveCheckpoint(store, opID, "maintenance:backfill-file-hashes", "scanning", i, len(files))
+		}
 	}
-	_ = hashed
+
+	// Clear any saved state on clean completion.
+	if opID != "" {
+		_ = operations.ClearState(store, opID)
+	}
+
+	// Save a lightweight operation summary for the UI and activity feed.
+	res := fmt.Sprintf("Backfilled hashes for %d files", hashed)
+	now := time.Now()
+	opLog := &database.OperationSummaryLog{
+		ID:          opID,
+		Type:        "backfill-file-hashes",
+		Status:      "completed",
+		Progress:    1.0,
+		Result:      &res,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		CompletedAt: &now,
+	}
+	_ = store.SaveOperationSummaryLog(opLog)
+
 	reporter.Log("info", "backfill-file-hashes complete", nil)
 	return nil
 }

--- a/internal/operations/state.go
+++ b/internal/operations/state.go
@@ -70,6 +70,12 @@ type ComposerScanParams struct {
 	FixMode string `json:"fix_mode"` // "set_narrator" or "clear"
 }
 
+// BackfillFileHashesParams stores the immutable parameters for the backfill-file-hashes operation.
+// DryRun=true reports what would be written without updating DB rows.
+type BackfillFileHashesParams struct {
+	DryRun bool `json:"dry_run"`
+}
+
 // BulkMetadataFetchParams stores the immutable parameters for a bulk metadata fetch operation.
 // PreferAudible=true moves Audible to the front of the source chain.
 // SkipCached=true skips books that already have a valid (non-expired) cache entry.

--- a/internal/server/maintenance_job_op.go
+++ b/internal/server/maintenance_job_op.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_job_op.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7f3a9c21-4b8e-4d56-a123-0e5f6c7d8e9f
-// last-edited: 2026-05-11
+// last-edited: 2026-05-16
 
 package server
 
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
@@ -51,7 +52,27 @@ func (s *Server) RegisterMaintenanceJobOp(reg *opsregistry.Registry) error {
 			ctx = maintenance.WithOperationID(ctx, p.LegacyOpID)
 			progress := registryProgressAdapter{r: reporter}
 			adapter := &maintenance.ProgressAdapter{Ops: progress}
-			return job.Run(ctx, store, adapter, p.DryRun)
+
+			// Execute the job synchronously in this Run closure.
+			runErr := job.Run(ctx, store, adapter, p.DryRun)
+
+			// Emit an activity summary if an activity writer is available and a legacy
+			// operation ID was provided. Prefer any saved OperationSummaryLog created
+			// by the job; fall back to the job name.
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				if sum, serr := store.GetOperationSummaryLog(p.LegacyOpID); serr == nil && sum != nil {
+					if sum.Result != nil {
+						activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), *sum.Result, activity.AlwaysShow)
+					} else {
+						activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), job.Name(), activity.AlwaysShow)
+					}
+				} else {
+					activity.EmitInfo(s.activityWriter, p.LegacyOpID, job.ID(), job.ID(), job.Name(), activity.AlwaysShow)
+				}
+			}
+
+			return runErr
 		},
 	})
 }


### PR DESCRIPTION
Implements BACKFILL-ASYNC-1: convert backfill-file-hashes into a resumable async maintenance operation (checkpointing, summary logging). See docs/superpowers/fleet-tasks/018-backfill-async-1-file-hash.md