### PR TITLE
fix(security): path injection in backup/Deluge — SEC-AUDIT-6

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,6 +1,7 @@
 // file: internal/backup/backup.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 8f9e0a1b-2c3d-4e5f-6a7b-8c9d0e1f2a3b
+// last-edited: 2026-05-15
 
 package backup
 
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/security/safepath"
 )
 
 // BackupInfo contains information about a backup
@@ -307,9 +309,16 @@ func addToArchive(tarWriter *tar.Writer, path, dbType string) error {
 
 	if info.IsDir() {
 		// PebbleDB - archive entire directory
-		return filepath.Walk(path, func(file string, fi os.FileInfo, err error) error {
+		root := path
+		return filepath.Walk(root, func(file string, fi os.FileInfo, err error) error {
 			if err != nil {
 				return err
+			}
+
+			// Validate that the file really lies within the root directory.
+			sp, err := safepath.Validate(root, file)
+			if err != nil {
+				return fmt.Errorf("safepath validation failed for %q: %w", file, err)
 			}
 
 			// Create tar header
@@ -318,12 +327,19 @@ func addToArchive(tarWriter *tar.Writer, path, dbType string) error {
 				return err
 			}
 
-			// Use relative path in archive
-			relPath, err := filepath.Rel(filepath.Dir(path), file)
+			// Use a sanitized, relative path in the archive that does not contain
+			// any parent-traversal components.
+			relPath, err := filepath.Rel(root, sp.String())
 			if err != nil {
 				return err
 			}
-			header.Name = relPath
+			relPath = filepath.Clean(relPath)
+			if relPath == "." {
+				header.Name = filepath.ToSlash(filepath.Base(root))
+			} else {
+				// header.Name must use forward slashes per TAR spec
+				header.Name = filepath.ToSlash(filepath.Join(filepath.Base(root), relPath))
+			}
 
 			// Write header
 			if err := tarWriter.WriteHeader(header); err != nil {

--- a/internal/deluge/import.go
+++ b/internal/deluge/import.go
@@ -1,7 +1,7 @@
 // file: internal/deluge/import.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-11
+// last-edited: 2026-05-15
 //
 // ImportToLibrary copies a Deluge-managed file into the library root,
 // updates the BookFile record, and optionally tells Deluge to move
@@ -19,6 +19,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/security/safepath"
 )
 
 // ImportToLibrary copies a file from a Deluge-managed path into the library root,
@@ -60,20 +61,27 @@ func ImportToLibrary(
 		return "", fmt.Errorf("ImportToLibrary: bookFile.FilePath is empty")
 	}
 
-	// Determine destination directory inside RootDir.
-	// If the source is already under RootDir, preserve relative structure.
-	// If it is outside, place it directly under RootDir using just the filename.
-	var destDir string
+	// Determine destination path inside RootDir, validating with safepath.
+	// If the source is under RootDir, preserve its relative structure. Otherwise
+	// place the file directly under RootDir.
 	rel, relErr := filepath.Rel(cfg.RootDir, filepath.Dir(src))
+
+	var destSP safepath.SafePath
 	if relErr == nil && !filepath.IsAbs(rel) && !isParentTraversal(rel) {
-		// Source is under RootDir (or a sub-path of it) — preserve structure.
-		destDir = filepath.Join(cfg.RootDir, rel)
+		// Source is under RootDir — preserve structure.
+		destSP, err = safepath.Join(cfg.RootDir, rel, filepath.Base(src))
+		if err != nil {
+			return "", fmt.Errorf("ImportToLibrary: invalid destination path: %w", err)
+		}
 	} else {
 		// Source is outside RootDir — place directly under RootDir.
-		destDir = cfg.RootDir
+		destSP, err = safepath.Join(cfg.RootDir, filepath.Base(src))
+		if err != nil {
+			return "", fmt.Errorf("ImportToLibrary: invalid destination path: %w", err)
+		}
 	}
 
-	dest := filepath.Join(destDir, filepath.Base(src))
+	dest := destSP.String()
 
 	// Do not copy if source and destination are the same path.
 	if src == dest {
@@ -82,6 +90,7 @@ func ImportToLibrary(
 	}
 
 	// Create destination directory if it does not exist.
+	destDir := filepath.Dir(dest)
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return "", fmt.Errorf("ImportToLibrary: create dest dir %s: %w", destDir, err)
 	}


### PR DESCRIPTION
Replaces unsafe filepath operations with internal/security/safepath and sanitizes tar archive member names to prevent path-injection. Files changed: internal/backup/backup.go, internal/deluge/import.go. See task 010-sec-6-path-injection-backup.