### PR TITLE
docs(fleet): add fleet-status tracking files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,8 @@ docs/reports/
 docs/superpowers/
 !docs/superpowers/fleet-tasks/
 !docs/superpowers/fleet-tasks/*
+!docs/superpowers/fleet-status/
+!docs/superpowers/fleet-status/*
 
 .copilot/
 .aider*

--- a/docs/superpowers/fleet-status/001-sec-0-govulncheck-binary-mode-status.md
+++ b/docs/superpowers/fleet-status/001-sec-0-govulncheck-binary-mode-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 001-sec-0-govulncheck-binary-mode
+
+Status: DONE
+Commit: 22b96be0
+Notes: ci: switch govulncheck to binary mode for GOEXPERIMENT=jsonv2 builds

--- a/docs/superpowers/fleet-status/002-sec-9-npm-follow-redirects-status.md
+++ b/docs/superpowers/fleet-status/002-sec-9-npm-follow-redirects-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 002-sec-9-npm-follow-redirects
+
+Status: DONE
+Commit: 709099b1
+Notes: fix(deps): bump follow-redirects to >=1.16.0 (GHSA-r4q5-vmmm-2653)

--- a/docs/superpowers/fleet-status/003-sec-8-four-warning-alerts-status.md
+++ b/docs/superpowers/fleet-status/003-sec-8-four-warning-alerts-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 003-sec-8-four-warning-alerts
+
+Status: DONE
+Commit: ec2fa3b3 b705924d 5fd031fe 8c7269af 7ae7bce2 b87fb402
+Notes: Multiple commits: InsecureSkipVerify comment, sanitizeImportPayload, TLS bypass script, ITL size cap, staticcheck suppressions

--- a/docs/superpowers/fleet-status/004-sec-codeql-mad-pack-status.md
+++ b/docs/superpowers/fleet-status/004-sec-codeql-mad-pack-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 004-sec-codeql-mad-pack
+
+Status: DONE
+Commit: 6db374c0 d083c149 81090fcd
+Notes: CodeQL MaD pack + sanitizer model registration

--- a/docs/superpowers/fleet-status/005-sec-1-safepath-package-status.md
+++ b/docs/superpowers/fleet-status/005-sec-1-safepath-package-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 005-sec-1-safepath-package
+
+Status: DONE
+Commit: eaab4fa2
+Notes: feat(security): add SafePath typed newtype for validated filesystem paths

--- a/docs/superpowers/fleet-status/006-sec-2-path-injection-fileops-status.md
+++ b/docs/superpowers/fleet-status/006-sec-2-path-injection-fileops-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 006-sec-2-path-injection-fileops
+
+Status: DONE
+Commit: 5f74b70b c33da795
+Notes: fix(fileops): replace filepath.Join with safepath.Join

--- a/docs/superpowers/fleet-status/007-sec-3-path-injection-covers-status.md
+++ b/docs/superpowers/fleet-status/007-sec-3-path-injection-covers-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 007-sec-3-path-injection-covers
+
+Status: DONE
+Commit: 83a68ee7
+Notes: fix(covers): replace filepath.Join with safepath.Join in cover handlers

--- a/docs/superpowers/fleet-status/008-sec-4-path-injection-itunes-status.md
+++ b/docs/superpowers/fleet-status/008-sec-4-path-injection-itunes-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 008-sec-4-path-injection-itunes
+
+Status: DONE
+Agent: subagent a249b865f2a4fd313
+Notes: validateAbsolutePath() added to server_helpers.go; applied to handleITunesImport, handleITunesWriteBackPreview, handleITunesLibraryStatus, handleITunesSync, and audiobooks relocate handlers. Tests in validate_path_test.go. Shipped via PR #991.

--- a/docs/superpowers/fleet-status/009-sec-5-path-injection-scanner-status.md
+++ b/docs/superpowers/fleet-status/009-sec-5-path-injection-scanner-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 009-sec-5-path-injection-scanner
+
+Status: DONE
+Commit: 8fb247b2
+Notes: fix(scanner): replace unsafe filepath ops with safepath.Join

--- a/docs/superpowers/fleet-status/010-sec-6-path-injection-backup-status.md
+++ b/docs/superpowers/fleet-status/010-sec-6-path-injection-backup-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 010-sec-6-path-injection-backup
+
+Status: DONE
+Commit: cdaefb1e
+Notes: fix(backup): replace unsafe filepath ops with safepath.Join

--- a/docs/superpowers/fleet-status/011-sec-10-path-validation-docs-status.md
+++ b/docs/superpowers/fleet-status/011-sec-10-path-validation-docs-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 011-sec-10-path-validation-docs
+
+Status: DONE
+Agent: subagent a85c6a087b1840c30
+Notes: Path validation policy doc shipped via PR #989.

--- a/docs/superpowers/fleet-status/012-sec-11-final-verification-status.md
+++ b/docs/superpowers/fleet-status/012-sec-11-final-verification-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 012-sec-11-final-verification
+
+Status: DONE
+Commit: N/A
+Notes: Task file marked done; CodeQL alert counts verified

--- a/docs/superpowers/fleet-status/013-rate-5-bulk-rating-status.md
+++ b/docs/superpowers/fleet-status/013-rate-5-bulk-rating-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 013-rate-5-bulk-rating
+
+Status: DONE
+Commit: cd2b3eb8
+Notes: chore(todo): mark RATE-5 complete — BulkRatingDialog already ships bulk rating

--- a/docs/superpowers/fleet-status/014-deluge-3-import-to-library-status.md
+++ b/docs/superpowers/fleet-status/014-deluge-3-import-to-library-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 014-deluge-3-import-to-library
+
+Status: DONE
+Commit: 975d0d52
+Notes: feat(deluge): importToLibrary reflink + core.move_storage

--- a/docs/superpowers/fleet-status/015-write-tags-safe-status.md
+++ b/docs/superpowers/fleet-status/015-write-tags-safe-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 015-write-tags-safe
+
+Status: DONE
+Commit: f2db81d0 c515d9f4
+Notes: feat(fileops,database): WriteTagsSafe pre-flight hash + atomic tag write; migrate all 4 call sites

--- a/docs/superpowers/fleet-status/016-match-4-import-time-dedup-status.md
+++ b/docs/superpowers/fleet-status/016-match-4-import-time-dedup-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 016-match-4-import-time-dedup
+
+Status: DONE
+Commit: 2a3694a9
+Notes: feat(dedup): flag metadata-hash duplicates at import time (MATCH-4)

--- a/docs/superpowers/fleet-status/017-cat-tag-cloud-filter-status.md
+++ b/docs/superpowers/fleet-status/017-cat-tag-cloud-filter-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 017-cat-tag-cloud-filter
+
+Status: DONE
+Commit: 685f7deb
+Notes: feat(library): tag cloud filter — browse and filter by tags

--- a/docs/superpowers/fleet-status/018-backfill-async-1-file-hash-status.md
+++ b/docs/superpowers/fleet-status/018-backfill-async-1-file-hash-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 018-backfill-async-1-file-hash
+
+Status: DONE
+Commit: 11e9aad0
+Notes: feat(ops): async backfill-file-hashes operation with checkpoint resume (BACKFILL-ASYNC-1)

--- a/docs/superpowers/fleet-status/019-backfill-async-2-metadata-hash-status.md
+++ b/docs/superpowers/fleet-status/019-backfill-async-2-metadata-hash-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 019-backfill-async-2-metadata-hash
+
+Status: DONE
+Commit: 1dcf9473
+Notes: feat(ops): async backfill-metadata-source-hash operation (BACKFILL-ASYNC-2)

--- a/docs/superpowers/fleet-status/020-backfill-async-3-metadata-hash-ui-status.md
+++ b/docs/superpowers/fleet-status/020-backfill-async-3-metadata-hash-ui-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 020-backfill-async-3-metadata-hash-ui
+
+Status: DONE
+Commit: 0bc4de1f
+Notes: feat(maintenance): MetadataHashDuplicateCard UI + API client (BACKFILL-ASYNC-3) — PR #988

--- a/docs/superpowers/fleet-status/021-ops-1-12-op-log-lines-status.md
+++ b/docs/superpowers/fleet-status/021-ops-1-12-op-log-lines-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 021-ops-1-12-op-log-lines
+
+Status: DONE
+Commit: 13515059
+Notes: feat(ops): context-bound op logger routes log lines to operation_logs (1.12)

--- a/docs/superpowers/fleet-status/022-ops-1-13-broken-files-dashboard-status.md
+++ b/docs/superpowers/fleet-status/022-ops-1-13-broken-files-dashboard-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 022-ops-1-13-broken-files-dashboard
+
+Status: DONE
+Commit: 377b1050
+Notes: feat(maintenance): broken-files dashboard card + repair pipeline (1.13)

--- a/docs/superpowers/fleet-status/023-ops-1-15-current-item-ticker-status.md
+++ b/docs/superpowers/fleet-status/023-ops-1-15-current-item-ticker-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 023-ops-1-15-current-item-ticker
+
+Status: DONE
+Commit: 29187558
+Notes: feat(uos): Reporter.SetCurrentItem live ticker (1.15)

--- a/docs/superpowers/fleet-status/024-ops-1-11-async-embed-batch-api-status.md
+++ b/docs/superpowers/fleet-status/024-ops-1-11-async-embed-batch-api-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 024-ops-1-11-async-embed-batch-api
+
+Status: NOT_STARTED
+Notes: Complex L task — async OpenAI Batch API embedding path. Queued for next wave.

--- a/docs/superpowers/fleet-status/025-acoustid-stats-1-store-status.md
+++ b/docs/superpowers/fleet-status/025-acoustid-stats-1-store-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 025-acoustid-stats-1-store
+
+Status: DONE
+Agent: subagent a846c2c0fedc589aa
+Notes: GetAcoustIDStats() implemented in PebbleStore with per-library breakdown. PR #991.

--- a/docs/superpowers/fleet-status/026-acoustid-stats-2-endpoint-status.md
+++ b/docs/superpowers/fleet-status/026-acoustid-stats-2-endpoint-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 026-acoustid-stats-2-endpoint
+
+Status: DONE
+Agent: subagent a846c2c0fedc589aa
+Notes: GET /api/v1/maintenance/acoustid-stats registered in server_lifecycle.go. PR #991.

--- a/docs/superpowers/fleet-status/027-acoustid-stats-3-ui-card-status.md
+++ b/docs/superpowers/fleet-status/027-acoustid-stats-3-ui-card-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 027-acoustid-stats-3-ui-card
+
+Status: DONE
+Agent: subagent a846c2c0fedc589aa
+Notes: AcoustIDFingerprintCard added to MaintenanceTab.tsx; getAcoustIDStats() in api.ts. PR #991.

--- a/docs/superpowers/fleet-status/028-acoustid-dedup-1-status.md
+++ b/docs/superpowers/fleet-status/028-acoustid-dedup-1-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 028-acoustid-dedup-1
+
+Status: NOT_STARTED
+Notes: L task — acoustic fingerprint similarity dedup. Queued for next wave.

--- a/docs/superpowers/fleet-status/029-acoustid-compare-1-status.md
+++ b/docs/superpowers/fleet-status/029-acoustid-compare-1-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 029-acoustid-compare-1
+
+Status: NOT_STARTED
+Notes: L task — manual two-book acoustic comparison tool. Queued for next wave.

--- a/docs/superpowers/fleet-status/030-arch-4-10-service-tests-status.md
+++ b/docs/superpowers/fleet-status/030-arch-4-10-service-tests-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 030-arch-4-10-service-tests
+
+Status: NOT_STARTED
+Notes: L task — service-layer unit tests with MockStore. Queued for next wave.

--- a/docs/superpowers/fleet-status/031-arch-4-12-isp-interfaces-status.md
+++ b/docs/superpowers/fleet-status/031-arch-4-12-isp-interfaces-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 031-arch-4-12-isp-interfaces
+
+Status: NOT_STARTED
+Notes: M task — narrow service deps to ISP sub-interfaces. Queued for next wave.

--- a/docs/superpowers/fleet-status/032-arch-4-13-itunes-extract-status.md
+++ b/docs/superpowers/fleet-status/032-arch-4-13-itunes-extract-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 032-arch-4-13-itunes-extract
+
+Status: NOT_STARTED
+Notes: L task — decouple iTunes service from server-bound closures. High complexity.

--- a/docs/superpowers/fleet-status/033-arch-6-4-itl-partial-export-status.md
+++ b/docs/superpowers/fleet-status/033-arch-6-4-itl-partial-export-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 033-arch-6-4-itl-partial-export
+
+Status: NOT_STARTED
+Notes: M task — ITL partial export. Blocked on task 035 (full rebuild/ITL writer).

--- a/docs/superpowers/fleet-status/034-arch-7-1-tag-policies-status.md
+++ b/docs/superpowers/fleet-status/034-arch-7-1-tag-policies-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 034-arch-7-1-tag-policies
+
+Status: NOT_STARTED
+Notes: L task — tag-based processing policies. Queued for next wave.

--- a/docs/superpowers/fleet-status/035-arch-7-9-itunes-rebuild-status.md
+++ b/docs/superpowers/fleet-status/035-arch-7-9-itunes-rebuild-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 035-arch-7-9-itunes-rebuild
+
+Status: NOT_STARTED
+Notes: L task — full iTunes library rebuild / ITL binary writer. Very complex.

--- a/docs/superpowers/fleet-status/036-fe-1-16-resizable-columns-status.md
+++ b/docs/superpowers/fleet-status/036-fe-1-16-resizable-columns-status.md
@@ -1,0 +1,4 @@
+# Fleet Task Status: 036-fe-1-16-resizable-columns
+
+Status: NOT_STARTED
+Notes: L task — resizable + sortable columns on all table pages. Queued for next wave.

--- a/docs/superpowers/fleet-status/037-fe-10-coverage-thresholds-status.md
+++ b/docs/superpowers/fleet-status/037-fe-10-coverage-thresholds-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 037-fe-10-coverage-thresholds
+
+Status: DONE
+Commit: a9e92f50
+Notes: chore(web): set frontend coverage thresholds (FE-10)

--- a/docs/superpowers/fleet-status/038-techdebt-1-deprecated-sweep-status.md
+++ b/docs/superpowers/fleet-status/038-techdebt-1-deprecated-sweep-status.md
@@ -1,0 +1,5 @@
+# Fleet Task Status: 038-techdebt-1-deprecated-sweep
+
+Status: DONE
+Agent: subagent a85c6a087b1840c30
+Notes: ioutil deprecated sweep shipped via PR #990.

--- a/docs/superpowers/fleet-status/README.md
+++ b/docs/superpowers/fleet-status/README.md
@@ -1,0 +1,23 @@
+# Fleet Task Status
+
+Each file here tracks the status of one fleet task. Agents write to their own
+status file as they work. The orchestrator (main Claude session) reads all files
+to know what is in-flight, done, or failed.
+
+## File naming
+`<task-id>-status.md` — e.g. `008-sec-4-path-injection-itunes-status.md`
+
+## Status values
+- `DONE` — merged to main
+- `IN_PROGRESS` — agent is currently working on it
+- `FAILED` — agent errored; reason in file
+- `SKIPPED` — intentionally not done (see reason)
+
+## Format
+```
+Status: DONE
+PR: #<number>
+Commit: <sha>
+Merged: <date>
+Notes: <anything notable>
+```


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/fleet-status/` with 38 per-task status files
- Updates `.gitignore` to un-ignore `fleet-status/` directory
- Marks stale `IN_PROGRESS` tasks as `DONE` based on merged PRs (#988–991)

## Current fleet status

**28/38 tasks DONE, 10 NOT_STARTED**

Done this session: 008 (SEC-AUDIT-4 iTunes path injection), 011 (validation docs), 020 (metadata hash UI), 025–027 (AcoustID stats 1/2/3), 038 (techdebt sweep)

Remaining not-started: 024 (async embed batch API), 028–036 (AcoustID dedup/compare, arch, frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)