### PR TITLE
fix(ui): wrap Summary column on mobile in activity log

### DIFF
--- a/web/src/components/BatchActivityEntry.tsx
+++ b/web/src/components/BatchActivityEntry.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/BatchActivityEntry.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e3a1f9c-4b82-4d5e-a6c8-2f0d8e7b3a91
 
 import React, { useState } from 'react';
@@ -12,6 +12,8 @@ import {
   TableRow,
   Tooltip,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight.js';
@@ -64,6 +66,8 @@ function formatTimestamp(ts: string): string {
 
 export function BatchActivityEntry({ entry, tierColor }: BatchActivityEntryProps) {
   const [expanded, setExpanded] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const details = entry.details as unknown as BatchDetails;
 
   // Safely cap rendered items at 200
@@ -132,8 +136,8 @@ export function BatchActivityEntry({ entry, tierColor }: BatchActivityEntryProps
         </TableCell>
 
         {/* 4. Summary (spans wider column) */}
-        <TableCell>
-          <Typography variant="body2" noWrap title={entry.summary}>
+        <TableCell sx={isMobile ? { wordBreak: 'break-word', minWidth: 0 } : {}}>
+          <Typography variant="body2" noWrap={!isMobile} title={entry.summary}>
             {entry.summary}
           </Typography>
         </TableCell>

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.11.0
+// version: 2.12.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -1402,8 +1402,8 @@ export default function ActivityLog() {
                     <TableCell>
                       <Chip size="small" label={(entry.type || '').replace(/_/g, ' ')} />
                     </TableCell>
-                    <TableCell sx={{ maxWidth: isMobile ? 180 : 400 }}>
-                      <Typography variant="body2" noWrap title={entry.summary}>
+                    <TableCell sx={isMobile ? { wordBreak: 'break-word', minWidth: 0 } : { maxWidth: 400 }}>
+                      <Typography variant="body2" noWrap={!isMobile} title={entry.summary}>
                         {entry.summary}
                       </Typography>
                       {entry.operation_id && !operationId && (


### PR DESCRIPTION
## Summary

- **Problem:** Activity log Summary column on mobile was set to `noWrap` with `maxWidth: 180px`, causing text to disappear off the right edge of the screen
- **Fix:** On mobile (`breakpoints.down('sm')`), allow the text to wrap with `wordBreak: break-word`; keep `noWrap` + title tooltip on desktop where truncation is fine

Changes to `ActivityLog.tsx` and `BatchActivityEntry.tsx`.

## Test plan

- [ ] Open activity log on mobile — Summary text should wrap within its cell
- [ ] Open activity log on desktop — behavior unchanged (truncated with tooltip on hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)