### PR TITLE
fix(dashboard): include broken_file_count in /system/status response

### DIFF
--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_handlers.go
-// version: 2.2.2
+// version: 2.2.3
 // last-edited: 2026-05-16
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
@@ -104,6 +104,28 @@ func (s *Server) getSystemStatus(c *gin.Context) {
 			}
 		}
 		status.PluginHealth = pluginHealth
+	}
+
+	// Attach broken file count — PebbleStore implements GetBrokenFileCount but it
+	// is not part of SystemServiceStore, so we probe via interface assertion here.
+	if s.Store() != nil {
+		bfc := func() (int, bool) {
+			if gf, ok := s.Store().(interface{ GetBrokenFileCount() (int, error) }); ok {
+				if cnt, err := gf.GetBrokenFileCount(); err == nil {
+					return cnt, true
+				}
+			} else if uw, ok := s.Store().(interface{ Unwrap() database.Store }); ok {
+				if inner, ok2 := uw.Unwrap().(interface{ GetBrokenFileCount() (int, error) }); ok2 {
+					if cnt, err := inner.GetBrokenFileCount(); err == nil {
+						return cnt, true
+					}
+				}
+			}
+			return 0, false
+		}
+		if cnt, ok := bfc(); ok {
+			status.BrokenFileCount = &cnt
+		}
 	}
 
 	httputil.RespondWithOK(c, status)

--- a/internal/sysinfo/service.go
+++ b/internal/sysinfo/service.go
@@ -1,5 +1,5 @@
 // file: internal/sysinfo/service.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
 // last-edited: 2026-05-01
 
@@ -69,6 +69,7 @@ type SystemStatus struct {
 	PluginHealth        map[string]string    `json:"plugin_health,omitempty"`
 	AppUptimeSeconds    float64              `json:"app_uptime_seconds"`
 	SystemUptimeSeconds float64              `json:"system_uptime_seconds"`
+	BrokenFileCount     *int                 `json:"broken_file_count,omitempty"`
 }
 
 type SystemLibraryStatus struct {


### PR DESCRIPTION
## Summary
- `SystemStatus` struct was missing `BrokenFileCount` field
- Dashboard stat card stayed in loading state forever (never resolved to a number)
- Clicking it navigated to `/library?has_file_errors=true` which returned empty results since the count was never populated
- Wired the same `GetBrokenFileCount()` type-assertion probe from `healthCheck` into `getSystemStatus`

## Test plan
- [ ] `go test ./internal/sysinfo/... ./internal/server/...` passes (109s, all ok)
- [ ] `GET /api/v1/system/status` now returns `broken_file_count` field
- [ ] Dashboard "Broken Files" card shows a number instead of spinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)