### PR TITLE
refactor(arch): ISP narrow store interfaces — 4.12

### DIFF
--- a/internal/organizer/rename.go
+++ b/internal/organizer/rename.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/rename.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 
 package organizer
@@ -20,7 +20,7 @@ import (
 
 // RenameService handles preview and execution of file rename + tag write operations.
 type RenameService struct {
-	db database.Store
+	db Store
 
 	// IsProtectedPath checks whether a file path is protected (e.g. import/iTunes).
 	// Set by the server package after construction.
@@ -41,7 +41,7 @@ type RenameService struct {
 }
 
 // NewRenameService creates a new RenameService.
-func NewRenameService(db database.Store) *RenameService {
+func NewRenameService(db Store) *RenameService {
 	return &RenameService{
 		db: db,
 		// Defaults that can be overridden by server package

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package organizer
@@ -23,6 +23,20 @@ import (
 	ulid "github.com/oklog/ulid/v2"
 )
 
+// Store is the narrow slice of database.Store required by this package.
+// Using sub-interfaces reduces coupling and makes the service testable with a mock.
+type Store interface {
+	database.BookStore
+	database.BookFileStore
+	database.OperationStore
+	database.AuthorStore
+	database.NarratorStore
+	database.MaintenanceStore
+}
+
+// Compile-time proof that PebbleStore satisfies organizer.Store.
+var _ Store = (*database.PebbleStore)(nil)
+
 // WriteBackEnqueuer is the interface for enqueuing iTunes write-back requests.
 // Implemented by the server's WriteBackBatcher.
 type WriteBackEnqueuer interface {
@@ -31,7 +45,7 @@ type WriteBackEnqueuer interface {
 
 // Service orchestrates the library organization operation.
 type Service struct {
-	db               database.Store
+	db               Store
 	organizeHooks    OrganizeHooks
 	writeBackBatcher WriteBackEnqueuer
 	// ScanEnqueuer enqueues a background library scan. Wired by the server
@@ -40,11 +54,11 @@ type Service struct {
 
 	// DiscoverITunesLibraryPath discovers the iTunes library path.
 	// Set by the server package after construction.
-	DiscoverITunesLibraryPath func(database.Store) string
+	DiscoverITunesLibraryPath func() string
 
 	// ExecuteITunesSync executes an iTunes library sync.
 	// Set by the server package after construction.
-	ExecuteITunesSync func(ctx context.Context, store database.Store, log logger.Logger, libraryPath string) error
+	ExecuteITunesSync func(ctx context.Context, log logger.Logger, libraryPath string) error
 
 	// ApplyOrganizedFileMetadata applies metadata from an organized file to a Book.
 	// Set by the server package after construction.
@@ -80,12 +94,12 @@ func (orgSvc *Service) newOrganizer() *Organizer {
 }
 
 // NewService creates a new Service.
-func NewService(db database.Store) *Service {
+func NewService(db Store) *Service {
 	return &Service{
 		db: db,
 		// Default no-ops for optional callbacks
-		DiscoverITunesLibraryPath: func(database.Store) string { return "" },
-		ExecuteITunesSync: func(ctx context.Context, store database.Store, log logger.Logger, libraryPath string) error {
+		DiscoverITunesLibraryPath: func() string { return "" },
+		ExecuteITunesSync: func(ctx context.Context, log logger.Logger, libraryPath string) error {
 			return nil
 		},
 		ApplyOrganizedFileMetadata: func(book *database.Book, newPath string) {},
@@ -235,7 +249,7 @@ func (orgSvc *Service) autoBackup(log logger.Logger) {
 }
 
 func (orgSvc *Service) syncITunesBeforeOrganize(ctx context.Context, log logger.Logger) {
-	libraryPath := orgSvc.DiscoverITunesLibraryPath(orgSvc.db)
+	libraryPath := orgSvc.DiscoverITunesLibraryPath()
 	if libraryPath == "" {
 		log.Info("Skipping iTunes sync: no library found")
 		return
@@ -243,7 +257,7 @@ func (orgSvc *Service) syncITunesBeforeOrganize(ctx context.Context, log logger.
 
 	log.Info("Running iTunes sync before organize: %s", libraryPath)
 
-	if err := orgSvc.ExecuteITunesSync(ctx, orgSvc.db, log, libraryPath); err != nil {
+	if err := orgSvc.ExecuteITunesSync(ctx, log, libraryPath); err != nil {
 		log.Warn("iTunes pre-sync failed (continuing with organize): %s", err.Error())
 		return
 	}

--- a/internal/organizer/unit_test.go
+++ b/internal/organizer/unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/unit_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package organizer
@@ -1168,7 +1168,7 @@ func TestNewService(t *testing.T) {
 		t.Fatal("NewService returned nil")
 	}
 	// Verify defaults
-	if p := svc.DiscoverITunesLibraryPath(mockStore); p != "" {
+	if p := svc.DiscoverITunesLibraryPath(); p != "" {
 		t.Errorf("default DiscoverITunesLibraryPath should return empty, got %q", p)
 	}
 	if p := svc.ComputeITunesPath("/file"); p != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.19.1
+// version: 2.19.2
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-05-16
 
@@ -516,10 +516,10 @@ func NewServer(store database.Store) *Server {
 
 	// Wire iTunes-specific organizer callbacks now that itunesSvc is ready.
 	if server.itunesSvc.Enabled() {
-		server.organizeService.DiscoverITunesLibraryPath = func(_ database.Store) string {
+		server.organizeService.DiscoverITunesLibraryPath = func() string {
 			return server.itunesSvc.Importer.DiscoverLibraryPath()
 		}
-		server.organizeService.ExecuteITunesSync = func(ctx context.Context, _ database.Store, log logger.Logger, libraryPath string) error {
+		server.organizeService.ExecuteITunesSync = func(ctx context.Context, log logger.Logger, libraryPath string) error {
 			return server.itunesSvc.Importer.Sync(ctx, libraryPath, nil, server.itunesActivityFn, log)
 		}
 	}


### PR DESCRIPTION
## Summary
- Defines `organizer.Store` narrow interface combining 6 sub-interfaces (BookStore, BookFileStore, OperationStore, AuthorStore, NarratorStore, MaintenanceStore)
- Compile-time assertion ensures PebbleStore satisfies the interface
- Removes unused `database.Store` parameter from the `DiscoverITunesLibraryPath` and `ExecuteITunesSync` callbacks (all callers already ignored it with `_`)
- scanner, quarantine, fileops, sysinfo already had narrow interfaces — no changes needed
- importer.Store remains a `database.Store` alias pending ISP pass on the `versions` package

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/organizer/... -count=1` passes
- [ ] `make ci` full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)