### PR TITLE
feat(policy): tag-based book processing policies — 7.1 #034

### DIFF
--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
 // last-edited: 2026-05-01
 
@@ -12,6 +12,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
+	"github.com/jdfalk/audiobook-organizer/internal/policy"
 	"github.com/oklog/ulid/v2"
 	"log"
 	"path/filepath"
@@ -436,6 +437,13 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	book, err := mfs.db.GetBookByID(id)
 	if err != nil || book == nil {
 		return nil, fmt.Errorf("audiobook not found")
+	}
+
+	// Policy check: policy:no-metadata tag skips automated metadata application.
+	if tags, tagErr := mfs.db.GetBookTags(id); tagErr == nil {
+		if policy.EvaluatePolicy(tags).NoMetadataFetch {
+			return nil, fmt.Errorf("metadata application disabled by policy:no-metadata tag")
+		}
 	}
 
 	// Warn when the candidate runtime diverges significantly from the local

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 
 package organizer
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
+	"github.com/jdfalk/audiobook-organizer/internal/policy"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -32,6 +33,7 @@ type Store interface {
 	database.AuthorStore
 	database.NarratorStore
 	database.MaintenanceStore
+	database.TagStore
 }
 
 // Compile-time proof that PebbleStore satisfies organizer.Store.
@@ -501,6 +503,19 @@ func (orgSvc *Service) organizeBooks(ctx context.Context, booksToOrganize []data
 
 			for i := range jobs {
 				book := booksToOrganize[i]
+
+				// Policy check: skip books tagged policy:no-organize.
+				if tags, err := orgSvc.db.GetBookTags(book.ID); err == nil {
+					if policy.EvaluatePolicy(tags).NoOrganize {
+						log.Debug("organize: skipping book %s — policy:no-organize tag", book.ID)
+						statsMu.Lock()
+						stats.Skipped++
+						statsMu.Unlock()
+						atomic.AddInt64(&progressCounter, 1)
+						continue
+					}
+				}
+
 				oldPath := book.FilePath
 				isDir := false
 				if info, err := os.Stat(oldPath); err == nil && info.IsDir() {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,90 @@
+// file: internal/policy/policy.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+// Package policy evaluates per-book processing policy tags.
+//
+// Policy tags are user-applied strings on the book_tags table with the
+// "policy:" prefix.  EvaluatePolicy converts a tag list into a typed
+// BookPolicy struct so every consumer can branch on named booleans
+// rather than repeated string comparisons.
+package policy
+
+import "github.com/jdfalk/audiobook-organizer/internal/database"
+
+// Known policy tag strings.
+const (
+	TagNoOrganize      = "policy:no-organize"
+	TagNoWriteback     = "policy:no-writeback"
+	TagNoMetadata      = "policy:no-metadata"
+	TagSourceAudible   = "policy:source:audible"
+	TagSourceGoogle    = "policy:source:google"
+	TagSourceISBN      = "policy:source:isbn"
+	TagPriorityHigh    = "policy:priority:high"
+	TagPriorityLow     = "policy:priority:low"
+)
+
+// BookPolicy holds the processing flags derived from a book's tags.
+type BookPolicy struct {
+	NoOrganize      bool   // skip filesystem renaming/moving
+	NoWriteback     bool   // skip tag write-back to audio files
+	NoMetadataFetch bool   // skip automated metadata enrichment
+	PreferredSource string // "audible", "google", "isbn", or ""
+	Priority        int    // 10=high, -10=low, 0=normal
+}
+
+// KnownPolicyTags returns the full catalogue of recognised policy tags
+// with human-readable descriptions, for use by the API endpoint.
+func KnownPolicyTags() []PolicyTagInfo {
+	return []PolicyTagInfo{
+		{Tag: TagNoOrganize, Description: "Skip filesystem renaming/moving for this book."},
+		{Tag: TagNoWriteback, Description: "Skip writing metadata tags back to audio files."},
+		{Tag: TagNoMetadata, Description: "Skip automated metadata enrichment from external sources."},
+		{Tag: TagSourceAudible, Description: "Prefer Audible as the metadata source for this book."},
+		{Tag: TagSourceGoogle, Description: "Prefer Google Books as the metadata source."},
+		{Tag: TagSourceISBN, Description: "Prefer ISBN-based lookup (Open Library) as the metadata source."},
+		{Tag: TagPriorityHigh, Description: "Process this book at high priority in async queues."},
+		{Tag: TagPriorityLow, Description: "Process this book at low priority in async queues."},
+	}
+}
+
+// PolicyTagInfo describes one known policy tag.
+type PolicyTagInfo struct {
+	Tag         string `json:"tag"`
+	Description string `json:"description"`
+}
+
+// EvaluatePolicy derives a BookPolicy from the book's tag strings.
+func EvaluatePolicy(tags []string) BookPolicy {
+	var p BookPolicy
+	for _, t := range tags {
+		switch t {
+		case TagNoOrganize:
+			p.NoOrganize = true
+		case TagNoWriteback:
+			p.NoWriteback = true
+		case TagNoMetadata:
+			p.NoMetadataFetch = true
+		case TagSourceAudible:
+			p.PreferredSource = "audible"
+		case TagSourceGoogle:
+			p.PreferredSource = "google"
+		case TagSourceISBN:
+			p.PreferredSource = "isbn"
+		case TagPriorityHigh:
+			p.Priority = 10
+		case TagPriorityLow:
+			p.Priority = -10
+		}
+	}
+	return p
+}
+
+// EvaluatePolicyDetailed derives a BookPolicy from detailed BookTag entries.
+func EvaluatePolicyDetailed(tags []database.BookTag) BookPolicy {
+	names := make([]string, len(tags))
+	for i, t := range tags {
+		names[i] = t.Tag
+	}
+	return EvaluatePolicy(names)
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,77 @@
+// file: internal/policy/policy_test.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluatePolicy_Empty(t *testing.T) {
+	p := EvaluatePolicy(nil)
+	assert.False(t, p.NoOrganize)
+	assert.False(t, p.NoWriteback)
+	assert.False(t, p.NoMetadataFetch)
+	assert.Empty(t, p.PreferredSource)
+	assert.Zero(t, p.Priority)
+}
+
+func TestEvaluatePolicy_NoOrganize(t *testing.T) {
+	p := EvaluatePolicy([]string{TagNoOrganize})
+	assert.True(t, p.NoOrganize)
+	assert.False(t, p.NoWriteback)
+}
+
+func TestEvaluatePolicy_NoWriteback(t *testing.T) {
+	p := EvaluatePolicy([]string{TagNoWriteback})
+	assert.True(t, p.NoWriteback)
+}
+
+func TestEvaluatePolicy_NoMetadata(t *testing.T) {
+	p := EvaluatePolicy([]string{TagNoMetadata})
+	assert.True(t, p.NoMetadataFetch)
+}
+
+func TestEvaluatePolicy_PreferredSource(t *testing.T) {
+	p := EvaluatePolicy([]string{TagSourceAudible})
+	assert.Equal(t, "audible", p.PreferredSource)
+
+	p = EvaluatePolicy([]string{TagSourceGoogle})
+	assert.Equal(t, "google", p.PreferredSource)
+}
+
+func TestEvaluatePolicy_Priority(t *testing.T) {
+	p := EvaluatePolicy([]string{TagPriorityHigh})
+	assert.Equal(t, 10, p.Priority)
+
+	p = EvaluatePolicy([]string{TagPriorityLow})
+	assert.Equal(t, -10, p.Priority)
+}
+
+func TestEvaluatePolicy_MultipleFlags(t *testing.T) {
+	p := EvaluatePolicy([]string{TagNoOrganize, TagNoWriteback, TagSourceAudible, TagPriorityHigh})
+	assert.True(t, p.NoOrganize)
+	assert.True(t, p.NoWriteback)
+	assert.False(t, p.NoMetadataFetch)
+	assert.Equal(t, "audible", p.PreferredSource)
+	assert.Equal(t, 10, p.Priority)
+}
+
+func TestEvaluatePolicy_UnknownTagsIgnored(t *testing.T) {
+	p := EvaluatePolicy([]string{"unknown-tag", "dedup:merge-survivor"})
+	assert.False(t, p.NoOrganize)
+	assert.False(t, p.NoWriteback)
+	assert.Empty(t, p.PreferredSource)
+}
+
+func TestKnownPolicyTags_NotEmpty(t *testing.T) {
+	tags := KnownPolicyTags()
+	assert.NotEmpty(t, tags)
+	for _, ti := range tags {
+		assert.NotEmpty(t, ti.Tag)
+		assert.NotEmpty(t, ti.Description)
+	}
+}

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.7.1
+// version: 3.7.2
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 // last-edited: 2026-05-16
 //
@@ -37,6 +37,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
+	"github.com/jdfalk/audiobook-organizer/internal/policy"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -1588,6 +1589,14 @@ func (s *Server) runBulkWriteBack(
 			_ = progress.Log("info", fmt.Sprintf("book %s: skipping protected path", bookID), nil)
 			mu.Unlock()
 			continue
+		}
+		if tags, tagErr := store.GetBookTags(bookID); tagErr == nil {
+			if policy.EvaluatePolicy(tags).NoWriteback {
+				mu.Lock()
+				_ = progress.Log("info", fmt.Sprintf("book %s: skipping write-back (policy:no-writeback tag)", bookID), nil)
+				mu.Unlock()
+				continue
+			}
 		}
 		if doRename {
 			if renameErr := mfs.RunApplyPipelineRenameOnly(bookID, book); renameErr != nil {

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1156,6 +1156,9 @@ func (s *Server) setupRoutes() {
 			protected.GET("/activity/sources", s.perm(auth.PermLibraryView), s.listActivitySources)
 			protected.POST("/activity/compact", s.perm(auth.PermSettingsManage), s.compactActivity)
 
+			// Policy routes
+			protected.GET("/policy/tags", s.perm(auth.PermLibraryView), s.handlePolicyTags)
+
 			// System routes
 			protected.GET("/system/status", s.perm(auth.PermSettingsManage), s.getSystemStatus)
 			protected.GET("/system/announcements", s.perm(auth.PermSettingsManage), s.getSystemAnnouncements)

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_handlers.go
-// version: 2.2.3
+// version: 2.2.4
 // last-edited: 2026-05-16
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
@@ -27,6 +27,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
+	"github.com/jdfalk/audiobook-organizer/internal/policy"
 )
 
 // Handler functions (stubs for now)
@@ -694,4 +695,10 @@ func (s *Server) deleteUserPreference(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithOK(c, gin.H{"message": "preference deleted"})
+}
+
+// handlePolicyTags returns the catalogue of recognised policy tags.
+// GET /api/v1/policy/tags
+func (s *Server) handlePolicyTags(c *gin.Context) {
+	httputil.RespondWithOK(c, policy.KnownPolicyTags())
 }


### PR DESCRIPTION
## Summary
- New `internal/policy` package: `EvaluatePolicy(tags []string) BookPolicy` converts book tags to typed policy struct
- `policy:no-organize` → skips organizer (organizer/service.go)
- `policy:no-writeback` → skips write-back (server/metadata_handlers.go)
- `policy:no-metadata` → rejects ApplyMetadataCandidate (metafetch/service_apply.go)
- `policy:source:audible/google/isbn`, `policy:priority:high/low` recognized
- New endpoint: `GET /api/v1/policy/tags` returns catalog of all recognized policy tags

## Test plan
- [x] 9 unit tests for `EvaluatePolicy` — all pass
- [x] Organizer, metafetch tests pass without regressions
- [x] Build clean across entire project

Fleet task 034 (ARCH-7-1: tag-based processing policies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)