### PR TITLE
feat(acoustid): manual fingerprint comparison tool — ACOUSTID-COMPARE-1 #029

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-08
 
@@ -1054,4 +1054,98 @@ func (s *Server) triggerBookSignatureScan(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
+}
+
+// AcoustIDSegmentComparison holds comparison data for one fingerprint segment.
+type AcoustIDSegmentComparison struct {
+	Segment string `json:"segment"` // "seg0" … "seg6"
+	HashA   string `json:"hash_a"`  // fingerprint hex or ""
+	HashB   string `json:"hash_b"`
+	Match   bool   `json:"match"`
+}
+
+// AcoustIDCompareResponse is the response body for the compare-acoustid endpoint.
+type AcoustIDCompareResponse struct {
+	BookA         database.Book               `json:"book_a"`
+	BookB         database.Book               `json:"book_b"`
+	OverallScore  float64                     `json:"overall_score"`  // 0.0–1.0
+	SegmentScores []AcoustIDSegmentComparison `json:"segment_scores"` // 7 entries
+}
+
+// handleCompareAcoustID handles POST /api/v1/books/:id/compare-acoustid?other=<bookID2>.
+// Computes per-segment fingerprint comparison between two books' primary files.
+func (s *Server) handleCompareAcoustID(c *gin.Context) {
+	idA := c.Param("id")
+	idB := c.Query("other")
+	if idB == "" {
+		httputil.RespondWithBadRequest(c, "missing ?other= query parameter")
+		return
+	}
+
+	bookA, err := s.Store().GetBookByID(idA)
+	if err != nil || bookA == nil {
+		httputil.RespondWithNotFound(c, "book", idA)
+		return
+	}
+	bookB, err := s.Store().GetBookByID(idB)
+	if err != nil || bookB == nil {
+		httputil.RespondWithNotFound(c, "book", idB)
+		return
+	}
+
+	filesA, _ := s.Store().GetBookFiles(idA)
+	filesB, _ := s.Store().GetBookFiles(idB)
+
+	primary := func(files []database.BookFile) *database.BookFile {
+		for i := range files {
+			if files[i].AcoustIDSeg0 != "" {
+				return &files[i]
+			}
+		}
+		if len(files) > 0 {
+			return &files[0]
+		}
+		return nil
+	}
+
+	fa := primary(filesA)
+	fb := primary(filesB)
+
+	segNames := []string{"seg0", "seg1", "seg2", "seg3", "seg4", "seg5", "seg6"}
+
+	segsA := []string{"", "", "", "", "", "", ""}
+	segsB := []string{"", "", "", "", "", "", ""}
+	if fa != nil {
+		segsA = []string{fa.AcoustIDSeg0, fa.AcoustIDSeg1, fa.AcoustIDSeg2, fa.AcoustIDSeg3, fa.AcoustIDSeg4, fa.AcoustIDSeg5, fa.AcoustIDSeg6}
+	}
+	if fb != nil {
+		segsB = []string{fb.AcoustIDSeg0, fb.AcoustIDSeg1, fb.AcoustIDSeg2, fb.AcoustIDSeg3, fb.AcoustIDSeg4, fb.AcoustIDSeg5, fb.AcoustIDSeg6}
+	}
+
+	var comparisons []AcoustIDSegmentComparison
+	var matching, total int
+	for i, name := range segNames {
+		a, b := segsA[i], segsB[i]
+		comp := AcoustIDSegmentComparison{Segment: name, HashA: a, HashB: b}
+		if a != "" && b != "" {
+			total++
+			comp.Match = a == b
+			if comp.Match {
+				matching++
+			}
+		}
+		comparisons = append(comparisons, comp)
+	}
+
+	overall := 0.0
+	if total > 0 {
+		overall = float64(matching) / float64(total)
+	}
+
+	httputil.RespondWithOK(c, AcoustIDCompareResponse{
+		BookA:         *bookA,
+		BookB:         *bookB,
+		OverallScore:  overall,
+		SegmentScores: comparisons,
+	})
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-16
 
@@ -1011,6 +1011,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/scan", s.perm(auth.PermScanTrigger), s.triggerDedupScan)
 			protected.POST("/dedup/scan-llm", s.perm(auth.PermScanTrigger), s.triggerDedupLLM)
 			protected.POST("/dedup/scan-acoustid", s.perm(auth.PermScanTrigger), s.triggerDedupAcoustID)
+			protected.POST("/audiobooks/:id/compare-acoustid", s.perm(auth.PermLibraryView), s.handleCompareAcoustID)
 			protected.POST("/dedup/scan-book-signature", s.perm(auth.PermScanTrigger), s.triggerBookSignatureScan)
 			protected.POST("/dedup/fingerprint-rescan", s.perm(auth.PermScanTrigger), s.triggerFingerprintRescan)
 			protected.POST("/dedup/refresh", s.perm(auth.PermScanTrigger), s.triggerDedupRefresh)

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1768,6 +1768,110 @@ function EmbeddingDedupTab() {
   );
 }
 
+// ---- Acoustic Compare Panel ----
+// Manual two-book fingerprint comparison tool.
+function AcousticComparePanel() {
+  const [bookAID, setBookAID] = useState('');
+  const [bookBID, setBookBID] = useState('');
+  const [result, setResult] = useState<api.AcoustIDCompareResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCompare = async () => {
+    if (!bookAID.trim() || !bookBID.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const resp = await api.compareAcoustID(bookAID.trim(), bookBID.trim());
+      setResult(resp);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Comparison failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const segLabels: Record<string, string> = {
+    seg0: 'Intro', seg1: 'Body 1', seg2: 'Body 2',
+    seg3: 'Body 3', seg4: 'Body 4', seg5: 'Body 5', seg6: 'Outro',
+  };
+
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>Compare Two Books</Typography>
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }} alignItems="center">
+        <TextField
+          label="Book A ID"
+          size="small"
+          value={bookAID}
+          onChange={(e) => setBookAID(e.target.value)}
+          sx={{ width: 280 }}
+        />
+        <TextField
+          label="Book B ID"
+          size="small"
+          value={bookBID}
+          onChange={(e) => setBookBID(e.target.value)}
+          sx={{ width: 280 }}
+        />
+        <Button variant="contained" onClick={handleCompare} disabled={loading || !bookAID || !bookBID}>
+          {loading ? 'Comparing…' : 'Compare'}
+        </Button>
+      </Stack>
+      {error && <Alert severity="error" sx={{ mb: 1 }}>{error}</Alert>}
+      {result && (
+        <Box>
+          <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+            <Chip
+              label={`${Math.round(result.overall_score * 100)}% similar`}
+              color={result.overall_score >= 0.85 ? 'error' : result.overall_score >= 0.6 ? 'warning' : 'default'}
+              icon={<GraphicEqIcon />}
+            />
+            <Typography variant="body2" color="text.secondary">
+              {result.book_a.title} vs {result.book_b.title}
+            </Typography>
+          </Stack>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Segment</TableCell>
+                <TableCell>Book A hash</TableCell>
+                <TableCell>Book B hash</TableCell>
+                <TableCell align="center">Match</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {result.segment_scores.map((seg) => (
+                <TableRow key={seg.segment}
+                  sx={{ bgcolor: seg.match ? 'success.light' : seg.hash_a && seg.hash_b ? 'error.light' : undefined, opacity: 0.9 }}
+                >
+                  <TableCell><strong>{segLabels[seg.segment] ?? seg.segment}</strong></TableCell>
+                  <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                    {seg.hash_a ? seg.hash_a.slice(0, 12) + '…' : <em>missing</em>}
+                  </TableCell>
+                  <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                    {seg.hash_b ? seg.hash_b.slice(0, 12) + '…' : <em>missing</em>}
+                  </TableCell>
+                  <TableCell align="center">
+                    {!seg.hash_a || !seg.hash_b ? (
+                      <Chip label="n/a" size="small" />
+                    ) : seg.match ? (
+                      <Chip label="✓" size="small" color="success" />
+                    ) : (
+                      <Chip label="✗" size="small" color="error" />
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      )}
+    </Paper>
+  );
+}
+
 // ---- Acoustic Dedup Tab ----
 // Shows AcoustID-layer duplicate candidates (stored by engine.AcoustIDScan).
 // Triggers a new scan or displays existing results filtered by layer=acoustid.
@@ -1902,6 +2006,10 @@ function AcousticDedupTab() {
           />
         </Paper>
       )}
+
+      <Box sx={{ mt: 3 }}>
+        <AcousticComparePanel />
+      </Box>
     </Box>
   );
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.28.0
+// version: 2.29.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-16
 
@@ -4558,6 +4558,32 @@ export async function triggerDedupAcoustID(): Promise<Operation> {
   }
   const responseData = await response.json();
   return responseData.data;
+}
+
+export interface AcoustIDSegmentComparison {
+  segment: string;
+  hash_a: string;
+  hash_b: string;
+  match: boolean;
+}
+
+export interface AcoustIDCompareResponse {
+  book_a: Book;
+  book_b: Book;
+  overall_score: number;
+  segment_scores: AcoustIDSegmentComparison[];
+}
+
+export async function compareAcoustID(bookAID: string, bookBID: string): Promise<AcoustIDCompareResponse> {
+  const response = await fetch(
+    `${API_BASE}/audiobooks/${encodeURIComponent(bookAID)}/compare-acoustid?other=${encodeURIComponent(bookBID)}`,
+    { method: 'POST' },
+  );
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to compare AcoustID fingerprints');
+  }
+  const responseData = await response.json();
+  return responseData.data ?? responseData;
 }
 
 export async function triggerDedupRefresh(): Promise<Operation> {


### PR DESCRIPTION
## Summary
- **Backend**: `POST /api/v1/audiobooks/:id/compare-acoustid?other=<id2>` returns `overall_score` (0.0–1.0) and 7 per-segment comparisons (Intro, Body 1–5, Outro)
- **API client**: `compareAcoustID(bookAID, bookBID)` added to `api.ts`
- **Frontend**: `AcousticComparePanel` added to the Acoustic tab in BookDedup — two ID inputs, Compare button, color-coded segment table, similarity score chip

## Test plan
- [x] `go build ./internal/server/...` — clean
- [x] Server tests pass (70s)
- [x] TypeScript compiles clean

Fleet task 029 (ACOUSTID-COMPARE-1: acoustic fingerprint comparison tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)