### PR TITLE
feat(fe): resizable + sortable columns on Works and TrashedVersions pages (FE-1-16)

### DIFF
--- a/web/src/pages/TrashedVersions.tsx
+++ b/web/src/pages/TrashedVersions.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/TrashedVersions.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6f4a5b3c-7d8e-4a70-b8c5-3d7e0f1b9a99
 
 import { useCallback, useEffect, useState } from 'react';
@@ -8,6 +8,7 @@ import {
   Button,
   Chip,
   Paper,
+  Stack,
   Tab,
   Table,
   TableBody,
@@ -24,13 +25,66 @@ import {
   purgeVersion,
   hardDeleteVersion,
 } from '../services/versionApi';
+import {
+  useConfigurableTable,
+  ResizableHeaderCell,
+  ColumnPicker,
+  type ColumnDef,
+} from '../components/common/ConfigurableTable';
 
 const API_BASE = '/api/v1';
+
+const COLUMNS: ColumnDef<BookVersion>[] = [
+  {
+    key: 'book_id', label: 'Book ID', defaultWidth: 140, sortable: true,
+    render: (v) => <Typography variant="caption" fontFamily="monospace">{v.book_id.slice(0, 12)}…</Typography>,
+    sortValue: (v) => v.book_id,
+  },
+  {
+    key: 'format', label: 'Format', defaultWidth: 90, sortable: true,
+    render: (v) => v.format?.toUpperCase() ?? '—',
+    sortValue: (v) => v.format ?? '',
+  },
+  {
+    key: 'source', label: 'Source', defaultWidth: 120, sortable: true,
+    render: (v) => v.source,
+    sortValue: (v) => v.source,
+  },
+  {
+    key: 'status', label: 'Status', defaultWidth: 120, sortable: true,
+    render: (v) => <Chip label={v.status} size="small" color={v.status === 'trash' ? 'warning' : 'error'} />,
+    sortValue: (v) => v.status,
+  },
+  {
+    key: 'date', label: 'Date', defaultWidth: 110, sortable: true,
+    render: (v) => new Date(v.purged_date || v.created_at).toLocaleDateString(),
+    sortValue: (v) => new Date(v.purged_date || v.created_at).getTime(),
+  },
+];
 
 export default function TrashedVersions() {
   const [tab, setTab] = useState<'trash' | 'purged'>('trash');
   const [versions, setVersions] = useState<BookVersion[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const {
+    visibleColumns,
+    allColumns,
+    sortField,
+    sortDir,
+    columnWidths,
+    handleSort,
+    toggleColumn,
+    isColumnVisible,
+    startResize,
+    sortRows,
+    resetColumns,
+  } = useConfigurableTable<BookVersion>({
+    storageKey: 'trashed-versions',
+    columns: COLUMNS,
+    defaultSortField: 'date',
+    defaultSortDir: 'desc',
+  });
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -67,9 +121,19 @@ export default function TrashedVersions() {
     load();
   }, [load]);
 
+  const sorted = sortRows(versions);
+
   return (
     <Box sx={{ p: 3 }}>
-      <Typography variant="h4" sx={{ mb: 2 }}>Version Management</Typography>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Typography variant="h4">Version Management</Typography>
+        <ColumnPicker
+          columns={allColumns}
+          isVisible={isColumnVisible}
+          onToggle={toggleColumn}
+          onReset={resetColumns}
+        />
+      </Stack>
 
       <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label="Trash" value="trash" />
@@ -84,33 +148,37 @@ export default function TrashedVersions() {
         </Typography>
       ) : (
         <TableContainer component={Paper}>
-          <Table size="small">
+          <Table size="small" sx={{ tableLayout: 'fixed' }}>
             <TableHead>
               <TableRow>
-                <TableCell>Book ID</TableCell>
-                <TableCell>Format</TableCell>
-                <TableCell>Source</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Date</TableCell>
-                <TableCell align="right">Actions</TableCell>
+                {visibleColumns.map((col) => (
+                  <ResizableHeaderCell
+                    key={col.key}
+                    columnKey={col.key}
+                    label={col.label}
+                    width={columnWidths[col.key] ?? col.defaultWidth ?? 150}
+                    sortable={col.sortable}
+                    sortActive={sortField === col.key}
+                    sortDirection={sortDir}
+                    onSort={() => handleSort(col.key)}
+                    onStartResize={startResize}
+                  />
+                ))}
+                <TableCell align="right" sx={{ width: 160 }}>Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {versions.map((v) => (
+              {sorted.map((v) => (
                 <TableRow key={v.id}>
-                  <TableCell>
-                    <Typography variant="caption" fontFamily="monospace">
-                      {v.book_id.slice(0, 12)}...
-                    </Typography>
-                  </TableCell>
-                  <TableCell>{v.format?.toUpperCase()}</TableCell>
-                  <TableCell>{v.source}</TableCell>
-                  <TableCell>
-                    <Chip label={v.status} size="small" color={v.status === 'trash' ? 'warning' : 'error'} />
-                  </TableCell>
-                  <TableCell>
-                    {new Date(v.purged_date || v.created_at).toLocaleDateString()}
-                  </TableCell>
+                  {visibleColumns.map((col) => (
+                    <TableCell
+                      key={col.key}
+                      align={col.align}
+                      sx={{ width: columnWidths[col.key], maxWidth: columnWidths[col.key], overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                      {col.render(v)}
+                    </TableCell>
+                  ))}
                   <TableCell align="right">
                     {v.status === 'trash' && (
                       <>

--- a/web/src/pages/Works.tsx
+++ b/web/src/pages/Works.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Works.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
 
 import { useCallback, useEffect, useState } from 'react';
@@ -19,11 +19,43 @@ import {
   Typography,
 } from '@mui/material';
 import * as api from '../services/api';
+import {
+  useConfigurableTable,
+  ResizableHeaderCell,
+  ColumnPicker,
+  type ColumnDef,
+} from '../components/common/ConfigurableTable';
+
+const COLUMNS: ColumnDef<api.Work>[] = [
+  { key: 'title', label: 'Title', defaultWidth: 300, sortable: true, render: (w) => w.title || 'Untitled', sortValue: (w) => w.title ?? '' },
+  { key: 'id', label: 'Work ID', defaultWidth: 230, sortable: true, render: (w) => w.id, sortValue: (w) => w.id },
+  { key: 'author_id', label: 'Author ID', defaultWidth: 100, sortable: true, render: (w) => w.author_id ?? '—', sortValue: (w) => w.author_id ?? 0 },
+  { key: 'series_id', label: 'Series ID', defaultWidth: 100, sortable: true, render: (w) => w.series_id ?? '—', sortValue: (w) => w.series_id ?? 0 },
+  { key: 'alt_titles', label: 'Alternate Titles', defaultWidth: 120, sortable: true, render: (w) => w.alt_titles?.length ?? 0, sortValue: (w) => w.alt_titles?.length ?? 0 },
+];
 
 export function Works() {
   const [works, setWorks] = useState<api.Work[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const {
+    visibleColumns,
+    allColumns,
+    sortField,
+    sortDir,
+    columnWidths,
+    handleSort,
+    toggleColumn,
+    isColumnVisible,
+    startResize,
+    sortRows,
+    resetColumns,
+  } = useConfigurableTable<api.Work>({
+    storageKey: 'works',
+    columns: COLUMNS,
+    defaultSortField: 'title',
+  });
 
   const loadWorks = useCallback(async () => {
     setLoading(true);
@@ -68,14 +100,26 @@ export function Works() {
     );
   }
 
+  const sorted = sortRows(works);
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Typography variant="h4" gutterBottom>
-        Works
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Logical title-level groupings across editions and narrations.
-      </Typography>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Box>
+          <Typography variant="h4" gutterBottom>
+            Works
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Logical title-level groupings across editions and narrations.
+          </Typography>
+        </Box>
+        <ColumnPicker
+          columns={allColumns}
+          isVisible={isColumnVisible}
+          onToggle={toggleColumn}
+          onReset={resetColumns}
+        />
+      </Stack>
 
       {works.length === 0 ? (
         <Alert severity="info">
@@ -83,24 +127,36 @@ export function Works() {
         </Alert>
       ) : (
         <TableContainer component={Paper}>
-          <Table size="small">
+          <Table size="small" sx={{ tableLayout: 'fixed' }}>
             <TableHead>
               <TableRow>
-                <TableCell>Title</TableCell>
-                <TableCell>Work ID</TableCell>
-                <TableCell>Author ID</TableCell>
-                <TableCell>Series ID</TableCell>
-                <TableCell>Alternate Titles</TableCell>
+                {visibleColumns.map((col) => (
+                  <ResizableHeaderCell
+                    key={col.key}
+                    columnKey={col.key}
+                    label={col.label}
+                    width={columnWidths[col.key] ?? col.defaultWidth ?? 150}
+                    sortable={col.sortable}
+                    sortActive={sortField === col.key}
+                    sortDirection={sortDir}
+                    onSort={() => handleSort(col.key)}
+                    onStartResize={startResize}
+                  />
+                ))}
               </TableRow>
             </TableHead>
             <TableBody>
-              {works.map((work) => (
+              {sorted.map((work) => (
                 <TableRow key={work.id} hover>
-                  <TableCell>{work.title || 'Untitled'}</TableCell>
-                  <TableCell>{work.id}</TableCell>
-                  <TableCell>{work.author_id ?? '—'}</TableCell>
-                  <TableCell>{work.series_id ?? '—'}</TableCell>
-                  <TableCell>{work.alt_titles?.length ?? 0}</TableCell>
+                  {visibleColumns.map((col) => (
+                    <TableCell
+                      key={col.key}
+                      align={col.align}
+                      sx={{ width: columnWidths[col.key], maxWidth: columnWidths[col.key], overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    >
+                      {col.render(work)}
+                    </TableCell>
+                  ))}
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- **Works** and **TrashedVersions** pages now have resizable columns, client-side sorting, and a ColumnPicker button (show/hide columns)
- Uses the existing `useConfigurableTable` hook + `ResizableHeaderCell` + `ColumnPicker` from `ConfigurableTable.tsx`
- Column widths and visibility persisted to `localStorage` per table
- Library, Authors, Series pages already had this — this covers the remaining static tables

## Test plan
- [ ] Works page: columns resize by drag on header edge
- [ ] Works page: click column header to sort asc/desc
- [ ] Works page: ColumnPicker icon shows/hides columns
- [ ] TrashedVersions: same for all 5 data columns; Actions column stays fixed at right
- [ ] Column widths survive page reload (localStorage)
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)