### PR TITLE
feat(dedup): async embedding via OpenAI Batch API (Task 024 / OPS-1-11)

### DIFF
--- a/internal/ai/embedding_batch.go
+++ b/internal/ai/embedding_batch.go
@@ -1,0 +1,154 @@
+// file: internal/ai/embedding_batch.go
+// version: 1.0.0
+// guid: a7b8c9d0-e1f2-3456-7890-abcdef012345
+// last-edited: 2026-05-17
+
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openai/openai-go"
+)
+
+// EmbedBatchItem is one book→text pair submitted for async embedding.
+type EmbedBatchItem struct {
+	BookID string
+	Text   string
+}
+
+// EmbedBatchResult holds a single result returned from a completed embedding batch.
+type EmbedBatchResult struct {
+	BookID string
+	Vector []float32
+}
+
+// CreateEmbeddingBatch submits a list of book texts to the OpenAI Batch API
+// using the /v1/embeddings endpoint. Returns the batch ID for polling.
+func (c *EmbeddingClient) CreateEmbeddingBatch(ctx context.Context, items []EmbedBatchItem) (string, error) {
+	if c.client == nil {
+		return "", fmt.Errorf("embedding client not initialised")
+	}
+	if len(items) == 0 {
+		return "", fmt.Errorf("no items to embed")
+	}
+
+	// Build JSONL — one request per item.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, it := range items {
+		req := map[string]any{
+			"custom_id": "book-" + it.BookID,
+			"method":    "POST",
+			"url":       "/v1/embeddings",
+			"body": map[string]any{
+				"model":           c.model,
+				"input":           it.Text,
+				"encoding_format": "float",
+			},
+		}
+		if err := enc.Encode(req); err != nil {
+			return "", fmt.Errorf("encode batch request: %w", err)
+		}
+	}
+
+	// Upload the JSONL file.
+	file, err := c.client.Files.New(ctx, openai.FileNewParams{
+		File:    bytes.NewReader(buf.Bytes()),
+		Purpose: openai.FilePurposeBatch,
+	})
+	if err != nil {
+		return "", fmt.Errorf("upload embedding batch file: %w", err)
+	}
+
+	// Create the batch job.
+	batch, err := c.client.Batches.New(ctx, openai.BatchNewParams{
+		InputFileID:      file.ID,
+		Endpoint:         openai.BatchNewParamsEndpointV1Embeddings,
+		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+		Metadata: map[string]string{
+			"project": "audiobook-organizer",
+			"type":    "embed_async",
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("create embedding batch: %w", err)
+	}
+	return batch.ID, nil
+}
+
+// DownloadEmbeddingBatchResults downloads the output file for a completed
+// embedding batch and returns the parsed vectors keyed by book ID.
+func (c *EmbeddingClient) DownloadEmbeddingBatchResults(ctx context.Context, outputFileID string) ([]EmbedBatchResult, error) {
+	if c.client == nil {
+		return nil, fmt.Errorf("embedding client not initialised")
+	}
+
+	resp, err := c.client.Files.Content(ctx, outputFileID)
+	if err != nil {
+		return nil, fmt.Errorf("download embedding batch output: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read embedding batch output: %w", err)
+	}
+
+	return parseEmbeddingBatchOutput(data)
+}
+
+// parseEmbeddingBatchOutput parses JSONL output from an embedding batch.
+// Each line has custom_id "book-<ID>" and a response body with data[0].embedding.
+func parseEmbeddingBatchOutput(data []byte) ([]EmbedBatchResult, error) {
+	var results []EmbedBatchResult
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry struct {
+			CustomID string `json:"custom_id"`
+			Response struct {
+				StatusCode int `json:"status_code"`
+				Body       struct {
+					Data []struct {
+						Embedding []float64 `json:"embedding"`
+					} `json:"data"`
+				} `json:"body"`
+			} `json:"response"`
+			Error *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry.Error != nil || entry.Response.StatusCode != 200 {
+			continue
+		}
+		if len(entry.Response.Body.Data) == 0 || len(entry.Response.Body.Data[0].Embedding) == 0 {
+			continue
+		}
+
+		bookID := strings.TrimPrefix(entry.CustomID, "book-")
+		vec64 := entry.Response.Body.Data[0].Embedding
+		vec := make([]float32, len(vec64))
+		for i, v := range vec64 {
+			vec[i] = float32(v)
+		}
+		results = append(results, EmbedBatchResult{BookID: bookID, Vector: vec})
+	}
+	return results, scanner.Err()
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1230,6 +1230,63 @@ func (de *Engine) EmbedAuthor(ctx context.Context, authorID int) error {
 	return nil
 }
 
+// EmbedBooksAsync submits all primary books that lack a current embedding to
+// the OpenAI Batch API (/v1/embeddings) for offline processing. The batch
+// completes within 24 hours; results are ingested by BatchPoller when the
+// "embed_async" batch type completes.
+//
+// Returns the OpenAI batch ID and the number of books submitted. Returns an
+// empty batchID (and count=0, err=nil) when all books are already embedded.
+func (de *Engine) EmbedBooksAsync(ctx context.Context) (batchID string, count int, err error) {
+	if de.embedClient == nil {
+		return "", 0, fmt.Errorf("no embedding client configured")
+	}
+
+	books, err := de.getAllBooks()
+	if err != nil {
+		return "", 0, fmt.Errorf("load books: %w", err)
+	}
+
+	var items []ai.EmbedBatchItem
+	for _, book := range books {
+		if !hasUsableTitle(book.Title) {
+			continue
+		}
+		authorName := ""
+		if book.AuthorID != nil {
+			if a, lookupErr := de.bookStore.GetAuthorByID(*book.AuthorID); lookupErr == nil && a != nil {
+				authorName = a.Name
+			}
+		}
+		seriesName := ""
+		if book.SeriesID != nil {
+			if s, lookupErr := de.bookStore.GetSeriesByID(*book.SeriesID); lookupErr == nil && s != nil {
+				seriesName = s.Name
+			}
+		}
+		text := ai.BuildBookEmbeddingText(book.Title, authorName, derefStr(book.Narrator), seriesName, seriesNumberOf(&book))
+		hash := ai.TextHash(text)
+
+		// Skip books that already have a current embedding.
+		existing, getErr := de.embedStore.Get("book", book.ID)
+		if getErr == nil && existing != nil && existing.TextHash == hash {
+			continue
+		}
+		items = append(items, ai.EmbedBatchItem{BookID: book.ID, Text: text})
+	}
+
+	if len(items) == 0 {
+		return "", 0, nil
+	}
+
+	id, err := de.embedClient.CreateEmbeddingBatch(ctx, items)
+	if err != nil {
+		return "", 0, fmt.Errorf("submit embedding batch: %w", err)
+	}
+	log.Printf("[INFO] dedup: submitted async embedding batch %s for %d books", id, len(items))
+	return id, len(items), nil
+}
+
 // mirrorAuthorToChromem writes an author embedding to the chromem index.
 // Best-effort; see mirrorBookToChromem for rationale.
 func (de *Engine) mirrorAuthorToChromem(ctx context.Context, authorID string, vec []float32) {

--- a/internal/plugins/dedup/embed_async.go
+++ b/internal/plugins/dedup/embed_async.go
@@ -1,0 +1,55 @@
+// file: internal/plugins/dedup/embed_async.go
+// version: 1.0.0
+// guid: b1c2d3e4-f5a6-7890-bcde-f01234567890
+// last-edited: 2026-05-17
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+func (p *Plugin) embedAsyncDef() sdk.OperationDef {
+	sched := "0 3 * * *"
+	return sdk.OperationDef{
+		ID:              "dedup.embed-async",
+		Plugin:          "dedup",
+		DisplayName:     "Embed books async (batch API)",
+		Description:     "Submits all un-embedded books to the OpenAI Batch API. Results arrive within 24 hours and are ingested automatically.",
+		ResumePolicy:    sdk.ResumeRequeue,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "dedup.embed-async",
+		Cancellable:     false,
+		Isolate:         false,
+		Timeout:         10 * time.Minute,
+		Schedule:        &sched, // nightly at 03:00 server time
+		Run:             p.runEmbedAsync,
+	}
+}
+
+func (p *Plugin) runEmbedAsync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return errors.New("dedup engine not available (embedding may be disabled or API key not configured)")
+	}
+
+	_ = reporter.UpdateProgress(0, 100, "Collecting un-embedded books...")
+
+	batchID, count, err := p.engine.EmbedBooksAsync(ctx)
+	if err != nil {
+		return fmt.Errorf("submit embedding batch: %w", err)
+	}
+	if count == 0 {
+		_ = reporter.UpdateProgress(100, 100, "All books already embedded — nothing to submit")
+		return nil
+	}
+
+	_ = reporter.UpdateProgress(100, 100,
+		fmt.Sprintf("Submitted %d books to OpenAI Batch API (batch_id=%s). Results will be ingested automatically within 24h.", count, batchID))
+	return nil
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -46,6 +46,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 	ops := []sdk.OperationDef{
 		p.embedScanDef(),
+		p.embedAsyncDef(),
 		p.fullScanDef(),
 		p.llmReviewDef(),
 		p.bookSignatureScanDef(),

--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -1,5 +1,5 @@
 // file: internal/server/batch_poller.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f8a1b2c3-d4e5-6789-abcd-0123456789ab
 
 package server
@@ -204,6 +204,34 @@ func (s *Server) registerBatchPollerHandlers() {
 			return fmt.Errorf("aijobs: store does not implement AIJobsStore")
 		}
 		return aijobs.Dispatch(ctx, store, batchID, results)
+	})
+
+	s.batchPoller.RegisterHandler("embed_async", func(ctx context.Context, batchID, outputFileID string) error {
+		if outputFileID == "" {
+			return fmt.Errorf("embed_async: no output file for batch %s", batchID)
+		}
+		if s.embedClient == nil || s.embeddingStore == nil {
+			return fmt.Errorf("embed_async: embedding client or store not available")
+		}
+		results, err := s.embedClient.DownloadEmbeddingBatchResults(ctx, outputFileID)
+		if err != nil {
+			return fmt.Errorf("embed_async: download results for batch %s: %w", batchID, err)
+		}
+		stored := 0
+		for _, r := range results {
+			if err := s.embeddingStore.Upsert(database.Embedding{
+				EntityType: "book",
+				EntityID:   r.BookID,
+				Vector:     r.Vector,
+				Model:      "text-embedding-3-large",
+			}); err != nil {
+				log.Printf("[WARN] embed_async: upsert book %s: %v", r.BookID, err)
+			} else {
+				stored++
+			}
+		}
+		log.Printf("[INFO] embed_async: stored %d/%d embeddings from batch %s", stored, len(results), batchID)
+		return nil
 	})
 }
 

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-08
 
@@ -1036,6 +1036,21 @@ func (s *Server) triggerEmbedScan(c *gin.Context) {
 	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.embed-scan", nil)
 	if err != nil {
 		httputil.InternalError(c, "failed to enqueue embed scan", err)
+		return
+	}
+	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
+}
+
+// triggerEmbedAsync handles POST /api/v1/dedup/embed-async.
+// Enqueues the nightly embed-async UOS op on demand.
+func (s *Server) triggerEmbedAsync(c *gin.Context) {
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
+		return
+	}
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.embed-async", nil)
+	if err != nil {
+		httputil.InternalError(c, "failed to enqueue embed-async", err)
 		return
 	}
 	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -308,6 +308,9 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	if embStore, ok := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore"); ok {
 		s.embeddingStore = embStore
 	}
+	if ec, ok := serviceregistry.TryGet[*ai.EmbeddingClient](c, "embedclient"); ok {
+		s.embedClient = ec
+	}
 	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok {
 		s.dedupEngine = engine
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -180,6 +180,7 @@ type Server struct {
 	changelogService       *activity.ChangelogService
 	activityService        *activity.Service
 	embeddingStore         *database.EmbeddingStore
+	embedClient            *ai.EmbeddingClient
 	metricsStore           database.MetricsStorer
 	dedupEngine            *dedup.Engine
 	activityWriter         *activity.Writer

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-16
 
@@ -1016,6 +1016,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/fingerprint-rescan", s.perm(auth.PermScanTrigger), s.triggerFingerprintRescan)
 			protected.POST("/dedup/refresh", s.perm(auth.PermScanTrigger), s.triggerDedupRefresh)
 			protected.POST("/dedup/embed", s.perm(auth.PermScanTrigger), s.triggerEmbedScan)
+			protected.POST("/dedup/embed-async", s.perm(auth.PermScanTrigger), s.triggerEmbedAsync)
 
 			// File system routes
 			protected.GET("/filesystem/home", s.perm(auth.PermSettingsManage), s.getHomeDirectory)


### PR DESCRIPTION
## Summary

- Adds `dedup.embed-async` UOS operation that submits all un-embedded books to the OpenAI Batch API nightly (cron `0 3 * * *`). Results arrive within 24 h and are ingested automatically when the BatchPoller detects the completed batch.
- New `POST /api/v1/dedup/embed-async` route lets operators trigger the batch submission on demand (requires `PermScanTrigger`).
- Same-directory chapter-file false positives are already fixed (PR #1001); this PR adds the async path that feeds those embeddings.

## Key files

| File | Change |
|---|---|
| `internal/ai/embedding_batch.go` | `CreateEmbeddingBatch` + `DownloadEmbeddingBatchResults` on `EmbeddingClient` |
| `internal/dedup/engine.go` | `EmbedBooksAsync` — collects un-embedded primary books, submits batch |
| `internal/plugins/dedup/embed_async.go` | UOS `OperationDef` (nightly schedule + on-demand handler) |
| `internal/plugins/dedup/plugin.go` | Registers embed-async alongside embed-scan, full-scan, etc. |
| `internal/server/batch_poller.go` | `embed_async` completion handler — downloads results, upserts vectors |
| `internal/server/dedup_handlers.go` | `triggerEmbedAsync` HTTP handler |
| `internal/server/server_lifecycle.go` | Route wired under `PermScanTrigger` |
| `internal/server/{server,registry_wire}.go` | `embedClient` field wired from service registry |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/ai/... ./internal/dedup/... ./internal/plugins/dedup/...` — all pass
- [ ] Nightly schedule fires at 03:00 in production (verify via UOS job history)
- [ ] Manual trigger via `POST /api/v1/dedup/embed-async` returns `202 Accepted` with `op_id`
- [ ] Batch poller ingests results and `embedding_store` row count increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)