### PR TITLE
feat(itunes): full ITL rebuild-from-DB + partial export (Tasks 033+035)

### DIFF
--- a/internal/itunes/itl.go
+++ b/internal/itunes/itl.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl.go
-// version: 1.5.1
+// version: 1.6.0
 // guid: 7f2a8b3c-4d5e-6f01-a2b3-c4d5e6f7a8b9
 // last-edited: 2026-05-15
 
@@ -979,6 +979,25 @@ func InsertITLPlaylist(inputPath, outputPath string, playlist ITLNewPlaylist) (*
 // writeITLFile handles compression, encryption, and writing of an ITL file.
 // Uses 0664 permissions and runs setfacl to restore a permissive ACL mask
 // so the file remains accessible via SMB to iTunes.
+// encodeITLPayload compresses, encrypts, and wraps payload in a new hdfm header,
+// returning the final ITL file bytes without writing to disk.
+// Used by the in-memory export path (BuildExportITL / Task 033).
+func encodeITLPayload(hdr *hdfmHeader, payload []byte, compress bool) ([]byte, error) {
+	var finalPayload []byte
+	if compress {
+		finalPayload = itlDeflate(payload)
+	} else {
+		finalPayload = payload
+	}
+	encrypted := itlEncrypt(hdr, finalPayload)
+	newFileLen := uint32(len(encrypted)) + hdr.headerLen
+	newHeader := buildHdfmHeader(hdr.version, hdr.headerRemainder, newFileLen, hdr.unknown)
+	out := make([]byte, 0, len(newHeader)+len(encrypted))
+	out = append(out, newHeader...)
+	out = append(out, encrypted...)
+	return out, nil
+}
+
 func writeITLFile(outputPath string, hdr *hdfmHeader, payload []byte, compress bool, count int) (*ITLWriteBackResult, error) {
 	var finalPayload []byte
 	if compress {

--- a/internal/itunes/itl_combined_mutate.go
+++ b/internal/itunes/itl_combined_mutate.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_combined_mutate.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
 //
 // Combined ITL mutation: applies removes, adds, and location patches in a
@@ -112,4 +112,47 @@ func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet) (*ITL
 	}
 
 	return writeITLFile(outputPath, hdr, decompressed, wasCompressed, totalUpdated)
+}
+
+// ApplyITLOperationsInMemory applies the same mutations as ApplyITLOperations
+// but returns the resulting ITL bytes instead of writing to disk.
+// Used by the partial-export path (Task 033 / ARCH-6-4).
+func ApplyITLOperationsInMemory(inputPath string, ops ITLOperationSet) ([]byte, error) {
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading ITL: %w", err)
+	}
+
+	hdr, err := parseHdfmHeader(data)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := data[hdr.headerLen:]
+	decrypted := itlDecrypt(hdr, payload)
+	decompressed, wasCompressed := itlInflate(decrypted)
+	isLE := detectLE(decompressed)
+
+	if len(ops.Removes) > 0 && isLE {
+		decompressed, _ = RemoveTracksByPIDLE(decompressed, ops.Removes)
+	}
+	if len(ops.Adds) > 0 && isLE {
+		decompressed = AddTracksLE(decompressed, ops.Adds)
+	}
+	if len(ops.LocationUpdates) > 0 {
+		updateMap := make(map[string]string, len(ops.LocationUpdates))
+		for _, u := range ops.LocationUpdates {
+			updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
+		}
+		if isLE {
+			decompressed, _ = rewriteChunksLE(decompressed, updateMap)
+		} else {
+			decompressed, _ = rewriteChunksBE(decompressed, updateMap)
+		}
+	}
+	if len(ops.MetadataUpdates) > 0 && isLE {
+		decompressed, _ = UpdateMetadataLE(decompressed, ops.MetadataUpdates)
+	}
+
+	return encodeITLPayload(hdr, decompressed, wasCompressed)
 }

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/rebuild.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 3f2e1d0c-9b8a-7c6d-5e4f-3a2b1c0d9e8f
+// last-edited: 2026-05-17
 
 package itunes
 
@@ -237,4 +238,123 @@ type ITLRebuildResult struct {
 	Preview ITLRebuildPreview `json:"preview"`
 	Applied bool              `json:"applied"`
 	Error   string            `json:"error,omitempty"`
+}
+
+// RebuildITLFromDB removes ALL existing tracks from the ITL file and re-inserts
+// every primary-version, non-deleted book from the DB that has an iTunes PID.
+// This is the "nuclear" rebuild path for when incremental diff is impractical.
+// The existing ITL is used as a structural template so the container format,
+// compression, and encryption are preserved — only the track data is replaced.
+// The result is written to outputPath via ApplyITLOperations.
+func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string) (*ITLRebuildResult, error) {
+	lib, err := ParseITL(itlPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse ITL: %w", err)
+	}
+
+	// Collect ALL existing PIDs to remove.
+	removes := make(map[string]bool, len(lib.Tracks))
+	for i := range lib.Tracks {
+		pid := strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))
+		removes[pid] = true
+	}
+
+	// Collect all DB books to add back.
+	var adds []ITLNewTrack
+	const pageSize = 500
+	for offset := 0; ; offset += pageSize {
+		books, err := store.GetAllBooks(pageSize, offset)
+		if err != nil {
+			return nil, fmt.Errorf("get books page %d: %w", offset/pageSize, err)
+		}
+		if len(books) == 0 {
+			break
+		}
+		for i := range books {
+			b := &books[i]
+			if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+				continue
+			}
+			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+				continue
+			}
+			if b.ITunesPersistentID == nil || *b.ITunesPersistentID == "" {
+				continue
+			}
+			adds = append(adds, buildNewTrackFromBook(store, b))
+		}
+	}
+
+	preview := ITLRebuildPreview{
+		TracksInITL: len(lib.Tracks),
+		BooksInDB:   len(adds),
+		ToRemove:    len(removes),
+		ToAdd:       len(adds),
+	}
+
+	ops := ITLOperationSet{Removes: removes, Adds: adds}
+	if _, err := ApplyITLOperations(itlPath, outputPath, ops); err != nil {
+		return nil, fmt.Errorf("apply rebuild ops: %w", err)
+	}
+
+	return &ITLRebuildResult{Preview: preview, Applied: true}, nil
+}
+
+// BuildExportITL builds a partial ITL containing only the requested bookIDs.
+// It strips all tracks from the template ITL and inserts only the matching
+// DB books. The resulting bytes are returned (not written to disk); the caller
+// is responsible for sending them to the client.
+// If bookIDs is empty, all primary-version non-deleted books with PIDs are included.
+func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) ([]byte, error) {
+	// Collect the requested books from the store.
+	wantIDs := make(map[string]bool, len(bookIDs))
+	for _, id := range bookIDs {
+		wantIDs[id] = true
+	}
+
+	var adds []ITLNewTrack
+	const pageSize = 500
+	for offset := 0; ; offset += pageSize {
+		books, err := store.GetAllBooks(pageSize, offset)
+		if err != nil {
+			return nil, fmt.Errorf("get books page %d: %w", offset/pageSize, err)
+		}
+		if len(books) == 0 {
+			break
+		}
+		for i := range books {
+			b := &books[i]
+			if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+				continue
+			}
+			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+				continue
+			}
+			if b.ITunesPersistentID == nil || *b.ITunesPersistentID == "" {
+				continue
+			}
+			if len(wantIDs) > 0 && !wantIDs[b.ID] {
+				continue
+			}
+			adds = append(adds, buildNewTrackFromBook(store, b))
+		}
+	}
+
+	lib, err := ParseITL(templatePath)
+	if err != nil {
+		return nil, fmt.Errorf("parse template ITL: %w", err)
+	}
+
+	removes := make(map[string]bool, len(lib.Tracks))
+	for i := range lib.Tracks {
+		pid := strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))
+		removes[pid] = true
+	}
+
+	ops := ITLOperationSet{Removes: removes, Adds: adds}
+	result, err := ApplyITLOperationsInMemory(templatePath, ops)
+	if err != nil {
+		return nil, fmt.Errorf("build export ITL: %w", err)
+	}
+	return result, nil
 }

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,5 +1,5 @@
 // file: internal/server/itl_rebuild.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
 // last-edited: 2026-05-11
 //
@@ -18,14 +18,16 @@ package server
 
 import (
 	"fmt"
-	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"log"
 	"net/http"
+	"path/filepath"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
+	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 )
 
 // ITLRebuildPreview summarizes the diff between the DB and the
@@ -91,4 +93,73 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 		Preview: *preview,
 		Applied: true,
 	})
+}
+
+// rebuildITLFullHandler handles POST /api/v1/itunes/rebuild-full.
+// Strips ALL tracks from the ITL and re-inserts every DB book with an iTunes PID.
+// This is the "nuclear" reset path — use rebuildITLHandler (incremental diff) first.
+// Query param: dry_run=true returns a preview without applying.
+func (s *Server) rebuildITLFullHandler(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath not configured")
+		return
+	}
+
+	dryRun := c.Query("dry_run") == "true"
+	store := s.Store()
+
+	if dryRun {
+		// Parse just to count tracks and books — don't apply.
+		lib, err := itunes.ParseITL(itlPath)
+		if err != nil {
+			httputil.RespondWithInternalError(c, fmt.Sprintf("parse ITL: %v", err))
+			return
+		}
+		preview := itunes.ITLRebuildPreview{
+			TracksInITL: len(lib.Tracks),
+		}
+		httputil.RespondWithOK(c, struct {
+			DryRun  bool                      `json:"dry_run"`
+			Preview itunes.ITLRebuildPreview  `json:"preview"`
+		}{DryRun: true, Preview: preview})
+		return
+	}
+
+	result, err := itunes.RebuildITLFromDB(store, itlPath, itlPath)
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("full rebuild failed: %v", err))
+		return
+	}
+
+	log.Printf("[INFO] ITL full-rebuild: removed %d existing tracks, inserted %d DB books",
+		result.Preview.ToRemove, result.Preview.ToAdd)
+	httputil.RespondWithOK(c, result)
+}
+
+// exportITLPartialHandler handles POST /api/v1/itunes/export-partial.
+// Builds a partial ITL containing only the requested book IDs and returns
+// it as a downloadable file. Body: {"book_ids": ["id1", "id2", ...]}
+// If book_ids is empty or omitted, all primary-version books with PIDs are included.
+func (s *Server) exportITLPartialHandler(c *gin.Context) {
+	itlPath := config.AppConfig.ITunesLibraryWritePath
+	if itlPath == "" {
+		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath not configured")
+		return
+	}
+
+	var body struct {
+		BookIDs []string `json:"book_ids"`
+	}
+	_ = c.ShouldBindJSON(&body) // empty body = all books
+
+	data, err := itunes.BuildExportITL(s.Store(), itlPath, body.BookIDs)
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("build export ITL: %v", err))
+		return
+	}
+
+	filename := "iTunes Library Export " + time.Now().Format("2006-01-02") + filepath.Ext(itlPath)
+	c.Header("Content-Disposition", `attachment; filename="`+filename+`"`)
+	c.Data(http.StatusOK, "application/octet-stream", data)
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-16
 
@@ -1113,6 +1113,10 @@ func (s *Server) setupRoutes() {
 				// safeWriteITL call. Supports dry_run=true to
 				// preview without applying. Backlog 7.9.
 				itunesGroup.POST("/rebuild", s.perm(auth.PermLibraryEditMetadata), s.rebuildITLHandler)
+				// Full rebuild: strip all tracks, re-insert all DB books (7.9 nuclear path).
+				itunesGroup.POST("/rebuild-full", s.perm(auth.PermLibraryEditMetadata), s.rebuildITLFullHandler)
+				// Partial export: build ITL containing only specified book IDs (6.4 partial).
+				itunesGroup.POST("/export-partial", s.perm(auth.PermIntegrationsManage), s.exportITLPartialHandler)
 
 				// ITL file transfer (6.4)
 				itunesGroup.GET("/library/download", s.perm(auth.PermIntegrationsManage), s.itunesSvcGuard(func(c *gin.Context) { s.itunesSvc.Transfer.HandleDownload(c) }))


### PR DESCRIPTION
## Summary

Completes backlog items **7.9** (full rebuild-from-scratch) and **6.4** (partial ITL export). Both depend on the same infrastructure: strip the template ITL and re-insert books from DB.

## Task 035 — Full rebuild (nuclear path)

- `itunes.RebuildITLFromDB(store, itlPath, outputPath)` — removes ALL existing tracks, re-inserts every primary-version non-deleted DB book with a PID. Uses the real ITL as a structural template so iTunes doesn't reject the container format.
- `POST /api/v1/itunes/rebuild-full` — on-demand trigger with optional `dry_run=true`. Requires `PermLibraryEditMetadata`.

## Task 033 — Partial export

- `itunes.BuildExportITL(store, templatePath, bookIDs)` — builds an ITL with only the requested books (all books if `bookIDs` is empty). Returns bytes, never writes to disk.
- `itunes.ApplyITLOperationsInMemory(inputPath, ops)` — in-memory sibling of `ApplyITLOperations`.
- `itunes.encodeITLPayload(hdr, payload, compress)` — extracted compress+encrypt+wrap helper shared by both paths.
- `POST /api/v1/itunes/export-partial` — body `{"book_ids": [...]}`, returns the ITL as a file download. Requires `PermIntegrationsManage`.

## Test plan
- [x] `go build ./internal/itunes/...` and `./internal/server/...` pass
- [x] `go test ./internal/itunes/...` — all pass (1.1 s)
- [ ] `POST /api/v1/itunes/rebuild-full?dry_run=true` returns track count
- [ ] `POST /api/v1/itunes/export-partial` with `{}` body downloads a valid ITL
- [ ] Verify iTunes accepts the exported ITL (on Windows test machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)