### PR TITLE
fix(dedup): sync legacy operation status on scan completion (BUG-SERIES-COUNT)

### DIFF
--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_ops.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
 
 // duplicates_ops registers v2 OperationDefs for the 8 async dedup operations
@@ -76,6 +76,10 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 				"duplicate_count": result.TotalDuplicates,
 			}
 			s.dedupCache.SetWithTTL("book-dedup-scan", cacheVal, 30*time.Minute)
+			if p.LegacyOpID != "" && s.Store() != nil {
+				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(result.Groups), len(result.Groups),
+					fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(result.Groups), result.TotalDuplicates))
+			}
 			return nil
 		},
 	})
@@ -175,6 +179,10 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 
 			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
+			if p.LegacyOpID != "" && s.Store() != nil {
+				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(groups), len(groups),
+					fmt.Sprintf("Found %d duplicate author groups", len(groups)))
+			}
 			return nil
 		},
 	})
@@ -217,6 +225,10 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 				"total_series": result.TotalSeries,
 			}
 			s.dedupCache.Set("series-duplicates", resp)
+			if p.LegacyOpID != "" && s.Store() != nil {
+				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", result.TotalSeries, result.TotalSeries,
+					fmt.Sprintf("Found %d duplicate groups (%d total series)", len(result.Groups), result.TotalSeries))
+			}
 			return nil
 		},
 	})


### PR DESCRIPTION
## Summary
- **Root cause**: Book/author/series dedup scan ops created a legacy `Operation` record for the frontend to poll, then enqueued a registry operation—but the `Run` functions never called `UpdateOperationStatus`. The legacy record stayed in `"running"` state forever, so `pollOperation` looped indefinitely and `onComplete` was never invoked.
- **Symptom**: `DedupSeriesTab` showed `Total series: 0` even after the scan completed, because `populateFromData(fresh)` was never called.
- **Fix**: Add `store.UpdateOperationStatus(p.LegacyOpID, "completed", ...)` after setting the dedup cache in all three scan ops (`book-scan`, `author-scan`, `series-scan`), matching the pattern already used in `folder_autoscan_op.go`.

## Test plan
- [ ] Open Series Dedup tab; confirm scan runs and `Total series: N` shows the real count after completion
- [ ] Open Book Dedup tab; confirm scan completes and groups appear
- [ ] Open Author Dedup tab; confirm scan completes and groups appear
- [ ] `make build-api` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)