### PR TITLE
refactor(dedup): drop legacy op creation from scan handlers, v2 status fallthrough

### DIFF
--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_handlers.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: 47a3e3fb-f5cf-4970-a2fc-d2ef481368c9
 // last-edited: 2026-05-02
 //
@@ -65,20 +65,13 @@ func (s *Server) scanBookDuplicates(c *gin.Context) {
 		return
 	}
 
-	store := s.Store()
-	opID := ulid.Make().String()
-	op, err := store.CreateOperation(opID, "book-dedup-scan", nil)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.book-scan", bookDedupScanOpParams{})
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
-		return
-	}
-
-	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.book-scan", bookDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, op)
+	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "book-dedup-scan", "status": "queued"})
 }
 
 // mergeBookDuplicatesAsVersions merges a group of duplicate books into a version group.
@@ -211,20 +204,13 @@ func (s *Server) refreshDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	store := s.Store()
-	opID := ulid.Make().String()
-	op, err := store.CreateOperation(opID, "author-dedup-scan", nil)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.author-scan", authorDedupScanOpParams{})
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
-		return
-	}
-
-	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.author-scan", authorDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, op)
+	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "author-dedup-scan", "status": "queued"})
 }
 
 // filterReviewedAuthorGroups removes author dedup groups where all author IDs
@@ -295,20 +281,13 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 		return
 	}
 
-	store := s.Store()
-	opID := ulid.Make().String()
-	op, err := store.CreateOperation(opID, "series-dedup-scan", nil)
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.series-scan", seriesDedupScanOpParams{})
 	if err != nil {
-		httputil.InternalError(c, "failed to create operation", err)
-		return
-	}
-
-	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.series-scan", seriesDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, op)
+	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "series-dedup-scan", "status": "queued"})
 }
 
 // validateDedupEntry searches metadata sources (OpenLibrary, Audible, etc.) to validate

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_ops.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
 
 // duplicates_ops registers v2 OperationDefs for the 8 async dedup operations
@@ -76,10 +76,6 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 				"duplicate_count": result.TotalDuplicates,
 			}
 			s.dedupCache.SetWithTTL("book-dedup-scan", cacheVal, 30*time.Minute)
-			if p.LegacyOpID != "" && s.Store() != nil {
-				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(result.Groups), len(result.Groups),
-					fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(result.Groups), result.TotalDuplicates))
-			}
 			return nil
 		},
 	})
@@ -179,10 +175,6 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 
 			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
-			if p.LegacyOpID != "" && s.Store() != nil {
-				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(groups), len(groups),
-					fmt.Sprintf("Found %d duplicate author groups", len(groups)))
-			}
 			return nil
 		},
 	})
@@ -225,10 +217,6 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 				"total_series": result.TotalSeries,
 			}
 			s.dedupCache.Set("series-duplicates", resp)
-			if p.LegacyOpID != "" && s.Store() != nil {
-				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", result.TotalSeries, result.TotalSeries,
-					fmt.Sprintf("Found %d duplicate groups (%d total series)", len(result.Groups), result.TotalSeries))
-			}
 			return nil
 		},
 	})

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
@@ -96,6 +96,8 @@ func TestHandler_GetOperationStatus_Found(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
 	op := &database.Operation{ID: "op-123", Type: "scan", Status: "completed"}
+	// v2 check first (returns nil → falls through to legacy)
+	mockStore.EXPECT().GetOperationV2("op-123").Return(nil, errors.New("not found"))
 	mockStore.EXPECT().GetOperationByID("op-123").Return(op, nil)
 
 	router.GET("/operations/:id", srv.getOperationStatus)
@@ -111,9 +113,40 @@ func TestHandler_GetOperationStatus_Found(t *testing.T) {
 	assert.Equal(t, "op-123", data["id"])
 }
 
+func TestHandler_GetOperationStatus_FoundV2(t *testing.T) {
+	srv, mockStore, router := setupHandlerTest(t)
+
+	now := time.Now()
+	v2 := &database.OperationV2Row{
+		ID:              "v2-op-123",
+		DefID:           "dedup.series-scan",
+		Status:          "completed",
+		ProgressCurrent: 42,
+		ProgressTotal:   100,
+		ProgressMessage: "done",
+		QueuedAt:        now,
+		CompletedAt:     &now,
+	}
+	mockStore.EXPECT().GetOperationV2("v2-op-123").Return(v2, nil)
+
+	router.GET("/operations/:id", srv.getOperationStatus)
+
+	req := httptest.NewRequest("GET", "/operations/v2-op-123", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]any)
+	assert.Equal(t, "v2-op-123", data["id"])
+	assert.Equal(t, "completed", data["status"])
+}
+
 func TestHandler_GetOperationStatus_NotFound(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
+	mockStore.EXPECT().GetOperationV2("nope").Return(nil, errors.New("not found"))
 	mockStore.EXPECT().GetOperationByID("nope").Return(nil, errors.New("not found"))
 
 	router.GET("/operations/:id", srv.getOperationStatus)

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -88,12 +88,37 @@ func (s *Server) getOperationStatus(c *gin.Context) {
 		return
 	}
 	id := c.Param("id")
+
+	// Try v2 registry first; fall back to legacy table.
+	if v2, err := s.Store().GetOperationV2(id); err == nil && v2 != nil {
+		httputil.RespondWithOK(c, operationV2ToLegacy(v2))
+		return
+	}
+
 	op, err := s.Store().GetOperationByID(id)
 	if err != nil || op == nil {
 		httputil.RespondWithNotFound(c, "operation", id)
 		return
 	}
 	httputil.RespondWithOK(c, op)
+}
+
+// operationV2ToLegacy converts a v2 registry row to the legacy Operation shape
+// that the frontend's pollOperation helper expects (id, status, progress, etc.).
+func operationV2ToLegacy(v2 *database.OperationV2Row) database.Operation {
+	op := database.Operation{
+		ID:          v2.ID,
+		Type:        v2.DefID,
+		Status:      v2.Status,
+		Progress:    v2.ProgressCurrent,
+		Total:       v2.ProgressTotal,
+		Message:     v2.ProgressMessage,
+		CreatedAt:   v2.QueuedAt,
+		StartedAt:   v2.StartedAt,
+		CompletedAt: v2.CompletedAt,
+		ErrorMessage: v2.ErrorMessage,
+	}
+	return op
 }
 
 func (s *Server) cancelOperation(c *gin.Context) {


### PR DESCRIPTION
## Summary
- `getOperationStatus` now checks the v2 registry store first and falls through to the legacy table — any op ID (v2 or v1) can be polled via the same `/api/v1/operations/{id}/status` endpoint
- Three dedup scan handlers (`scanBookDuplicates`, `refreshDuplicateAuthors`, `refreshSeriesDuplicates`) no longer create a legacy `Operation` row; they enqueue the registry op and return its ID directly
- Removes the band-aid `UpdateOperationStatus` calls added in PR #1008, since the v2 fallthrough makes them unnecessary
- Adds `TestHandler_GetOperationStatus_FoundV2` to exercise the new code path

## Test plan
- [ ] `make build-api` passes
- [ ] `TestHandler_GetOperationStatus_*` all pass (verified locally)
- [ ] Series Dedup tab shows correct series count after scan
- [ ] Author/Book Dedup tabs complete scans without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)