### PR TITLE
fix(ui): make all page-level tab bars scrollable on mobile

### DIFF
--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.23.0
+// version: 3.24.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
 // last-edited: 2026-05-17
 
@@ -2274,7 +2274,7 @@ export function BookDedup() {
     <Box sx={{ p: 3 }}>
       <Typography variant="h5" sx={{ mb: 2 }}>Deduplication</Typography>
 
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
         <Tab icon={<Badge color="default"><MenuBookIcon /></Badge>} label="Version Groups" iconPosition="start" />
         <Tab icon={<Badge color="default"><ContentCopyIcon /></Badge>} label="Duplicate Scan" iconPosition="start" />
         <Tab icon={<Badge color="default"><PersonIcon /></Badge>} label="Authors" iconPosition="start" />

--- a/web/src/pages/Playlists.tsx
+++ b/web/src/pages/Playlists.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Playlists.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: 2b0c1d6e-3f4a-4a70-b8c5-3d7e0f1b9a99
 
 import { useCallback, useEffect, useState } from 'react';
@@ -73,7 +73,7 @@ export default function Playlists() {
         </Button>
       </Box>
 
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile sx={{ mb: 2 }}>
         <Tab label="All" value="all" />
         <Tab label="Static" value="static" />
         <Tab label="Smart" value="smart" />

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.45.1
+// version: 1.45.2
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 // last-edited: 2026-05-15
 
@@ -2122,6 +2122,9 @@ export function Settings() {
               window.history.replaceState(null, '', `#${TAB_KEYS[newValue]}`);
             }}
             aria-label="settings tabs"
+            variant="scrollable"
+            scrollButtons="auto"
+            allowScrollButtonsMobile
           >
             <Tab label="Library" />
             <Tab label="iTunes Import" />

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/System.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
 // last-edited: 2026-04-30
 
@@ -49,6 +49,9 @@ export function System() {
           value={tabValue}
           onChange={(_, newValue) => setTabValue(newValue)}
           aria-label="system tabs"
+          variant="scrollable"
+          scrollButtons="auto"
+          allowScrollButtonsMobile
         >
           <Tab label="System Info" />
           <Tab label="Storage" />

--- a/web/src/pages/TrashedVersions.tsx
+++ b/web/src/pages/TrashedVersions.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/TrashedVersions.tsx
-// version: 1.1.0
+// version: 1.1.1
 // guid: 6f4a5b3c-7d8e-4a70-b8c5-3d7e0f1b9a99
 
 import { useCallback, useEffect, useState } from 'react';
@@ -135,7 +135,7 @@ export default function TrashedVersions() {
         />
       </Stack>
 
-      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile sx={{ mb: 2 }}>
         <Tab label="Trash" value="trash" />
         <Tab label="Purged" value="purged" />
       </Tabs>


### PR DESCRIPTION
## Summary
- Deduplication page only showed 2 of 8 tabs on mobile — rest were clipped off-screen with no way to reach them
- Root cause: MUI `<Tabs>` defaults to non-scrollable; `allowScrollButtonsMobile` must be set explicitly for touch devices
- Fixed all 5 page-level tab bars: Deduplication (8), Settings (9), System (4), Playlists (3), Trashed Versions (2)

## Changes
Added `variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile` to:
- `web/src/pages/BookDedup.tsx` — 8-tab Deduplication page (reported in screenshot)
- `web/src/pages/Settings.tsx` — 9-tab Settings page
- `web/src/pages/System.tsx` — 4-tab System page
- `web/src/pages/Playlists.tsx` — 3-tab Playlists page
- `web/src/pages/TrashedVersions.tsx` — 2-tab Trashed Versions page

## Test plan
- [ ] Open Deduplication page on mobile — all 8 tabs reachable by scrolling
- [ ] Open Settings on mobile — all 9 tabs reachable
- [ ] `npm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)