### PR TITLE
fix(ci): switch govulncheck to binary mode for GOEXPERIMENT=jsonv2 builds

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/vulnerability-scan.yml
-# version: 1.7.0
+# version: 1.8.0
 # guid: vuln-scan-001
+# last-edited: 2026-05-15
 
 name: Nightly Vulnerability Scan
 
@@ -27,13 +28,13 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: Build binary
-        run: go build -o bin/audiobook-organizer ./...
-  env:
-    GOEXPERIMENT: jsonv2
+      - name: Build binary for scanning
+        run: go build -o /tmp/audiobook-organizer-bin .
+        env:
+          GOEXPERIMENT: jsonv2
 
-      - name: Run govulncheck (binary mode)
-        run: govulncheck -mode=binary ./bin/audiobook-organizer
+      - name: Run govulncheck
+        run: govulncheck -mode=binary /tmp/audiobook-organizer-bin
 
 
   scan-npm:


### PR DESCRIPTION
## Summary
- Fix YAML indentation: `env: GOEXPERIMENT: jsonv2` was misplaced at job level instead of step level
- Move env to the Build binary step so GOEXPERIMENT is set when compiling the binary
- Build output goes to `/tmp/` instead of `bin/` to avoid working-dir pollution
- Closes SEC-AUDIT-0

## Test plan
- [ ] Vulnerability scan workflow runs without GOEXPERIMENT env error
- [ ] govulncheck binary mode scan succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)