### PR TITLE
docs: mark DELUGE-3 implemented in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -492,7 +492,7 @@ Implementation steps (in order):
 
 - [x] **DELUGE-1** `deluge_hash`, `deluge_original_path`, `imported_from_deluge_at` columns on `book_files` — PR #540
 - [x] **DELUGE-2** `protectedPathCache` with TTL refresh + IsProtected() — PR #556
-- [ ] **DELUGE-3** `importToLibrary`: reflink `src → library_path`, update DB, call `core.move_storage` if enabled (best-effort) — bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md)
+- [x] **DELUGE-3** `importToLibrary`: reflink `src → library_path`, update DB, call `core.move_storage` if enabled (best-effort). Implemented in fleet branch `fleet/014-deluge-3-import-to-library` (PR #976). Bot-task: [`docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md`](docs/superpowers/bot-tasks/2026-04-29-deluge-3-import-to-library.md)
 - [ ] **`WriteTagsSafe`**: pre-flight guard wrapping all tag-write call sites; falls back to `os.Copy` on non-reflink FS
 - [ ] **Migrate all call sites** to `WriteTagsSafe` (bulk write-back, single-file write, cover embed)
 - [x] **Discovery → Import UI**: "Import" button on discovered torrent calls the import flow — PR #562


### PR DESCRIPTION
## Summary
- Marks DELUGE-3 (importToLibrary reflink + core.move_storage) as completed in TODO.md
- The implementation shipped in PR #976

## Test plan
- [ ] TODO.md shows DELUGE-3 checked off

🤖 Generated with [Claude Code](https://claude.com/claude-code)