### PR TITLE
feat(ops): emit activity feed events on operation completion

### DIFF
--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/duplicates_handlers.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: 47a3e3fb-f5cf-4970-a2fc-d2ef481368c9
-// last-edited: 2026-05-02
+// last-edited: 2026-05-18
 //
 // SQL-backed duplicate detection handlers split out of server.go:
 // find, list, merge, skip, dismiss, pair-level actions, and series
@@ -65,13 +65,21 @@ func (s *Server) scanBookDuplicates(c *gin.Context) {
 		return
 	}
 
-	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.book-scan", bookDedupScanOpParams{})
+	store := s.Store()
+	legacyID := ulid.Make().String()
+	detail := "book-dedup-scan"
+	op, err := store.CreateOperation(legacyID, "book-dedup-scan", &detail)
 	if err != nil {
+		httputil.InternalError(c, "failed to create operation", err)
+		return
+	}
+
+	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.book-scan", bookDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "book-dedup-scan", "status": "queued"})
+	httputil.RespondWithSuccess(c, 202, op)
 }
 
 // mergeBookDuplicatesAsVersions merges a group of duplicate books into a version group.
@@ -204,13 +212,21 @@ func (s *Server) refreshDuplicateAuthors(c *gin.Context) {
 		return
 	}
 
-	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.author-scan", authorDedupScanOpParams{})
+	store := s.Store()
+	legacyID := ulid.Make().String()
+	detail := "author-dedup-scan"
+	op, err := store.CreateOperation(legacyID, "author-dedup-scan", &detail)
 	if err != nil {
+		httputil.InternalError(c, "failed to create operation", err)
+		return
+	}
+
+	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.author-scan", authorDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "author-dedup-scan", "status": "queued"})
+	httputil.RespondWithSuccess(c, 202, op)
 }
 
 // filterReviewedAuthorGroups removes author dedup groups where all author IDs
@@ -281,13 +297,21 @@ func (s *Server) refreshSeriesDuplicates(c *gin.Context) {
 		return
 	}
 
-	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.series-scan", seriesDedupScanOpParams{})
+	store := s.Store()
+	legacyID := ulid.Make().String()
+	detail := "series-dedup-scan"
+	op, err := store.CreateOperation(legacyID, "series-dedup-scan", &detail)
 	if err != nil {
+		httputil.InternalError(c, "failed to create operation", err)
+		return
+	}
+
+	if _, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.series-scan", seriesDedupScanOpParams{LegacyOpID: op.ID}); err != nil {
 		httputil.InternalError(c, "failed to enqueue operation", err)
 		return
 	}
 
-	httputil.RespondWithSuccess(c, 202, gin.H{"id": opID, "type": "series-dedup-scan", "status": "queued"})
+	httputil.RespondWithSuccess(c, 202, op)
 }
 
 // validateDedupEntry searches metadata sources (OpenLibrary, Audible, etc.) to validate

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_ops.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
 
 // duplicates_ops registers v2 OperationDefs for the 8 async dedup operations
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
@@ -76,6 +77,12 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 				"duplicate_count": result.TotalDuplicates,
 			}
 			s.dedupCache.SetWithTTL("book-dedup-scan", cacheVal, 30*time.Minute)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.book-scan", "dedup",
+					fmt.Sprintf("Book duplicate scan found %d groups (%d duplicates)", len(result.Groups), result.TotalDuplicates),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -112,6 +119,12 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 				return err
 			}
 			s.dedupCache.InvalidateAll()
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.book-merge", "dedup",
+					fmt.Sprintf("Book merge completed: merged %d books into %s", len(p.MergeIDs), p.KeepID),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -175,6 +188,12 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 
 			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.author-scan", "dedup",
+					fmt.Sprintf("Author duplicate scan found %d groups", len(groups)),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -217,6 +236,12 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 				"total_series": result.TotalSeries,
 			}
 			s.dedupCache.Set("series-duplicates", resp)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-scan", "dedup",
+					fmt.Sprintf("Series duplicate scan found %d groups (of %d total series)", len(result.Groups), result.TotalSeries),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -253,6 +278,11 @@ func (s *Server) RegisterSeriesDedupOp(reg *opsregistry.Registry) error {
 				return err
 			}
 			s.dedupCache.InvalidateAll()
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-dedup", "dedup",
+					"Series deduplication completed", activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -285,7 +315,16 @@ func (s *Server) RegisterSeriesPruneOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("dedup.series-prune: database not initialized")
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return s.executeSeriesPrune(ctx, store, progress, p.LegacyOpID)
+			runErr := s.executeSeriesPrune(ctx, store, progress, p.LegacyOpID)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				summary := "Series prune completed"
+				if runErr != nil {
+					summary = fmt.Sprintf("Series prune failed: %v", runErr)
+				}
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-prune", "dedup", summary, activity.AlwaysShow)
+			}
+			return runErr
 		},
 	})
 }
@@ -321,6 +360,12 @@ func (s *Server) RegisterSeriesMergeOp(reg *opsregistry.Registry) error {
 				return err
 			}
 			s.dedupCache.InvalidateAll()
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-merge", "dedup",
+					fmt.Sprintf("Series merge completed: merged %d series into series %d", len(p.MergeIDs), p.KeepID),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})
@@ -392,6 +437,12 @@ func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 			}
 
 			_ = progress.Log("info", "Series normalization complete.", nil)
+			if s.activityWriter != nil && opID != "" {
+				activity.FlushOperation(s.activityWriter, opID)
+				activity.EmitInfo(s.activityWriter, opID, "dedup.series-normalize", "dedup",
+					fmt.Sprintf("Series normalization completed for %d affected books", len(affectedBookIDs)),
+					activity.AlwaysShow)
+			}
 			return nil
 		},
 	})

--- a/internal/server/folder_autoscan_op.go
+++ b/internal/server/folder_autoscan_op.go
@@ -1,5 +1,5 @@
 // file: internal/server/folder_autoscan_op.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7b3e9f2a-4c1d-4e85-a6b8-2f0d5c8e1a93
 // last-edited: 2026-05-10
 //
@@ -18,6 +18,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
@@ -150,10 +151,15 @@ func (s *Server) RegisterFolderAutoScanOp(reg *opsregistry.Registry) error {
 			// completion via the v1 ops endpoint. Without this the
 			// v1 row sticks in "queued" forever even though the work
 			// is done.
+			summary := fmt.Sprintf("Auto-scan completed (%d books found)", len(books))
 			if p.LegacyOpID != "" && s.Store() != nil {
-				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(books), len(books), fmt.Sprintf("Auto-scan completed (%d books)", len(books)))
+				_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", len(books), len(books), summary)
 			}
 			_ = progress.Log("info", fmt.Sprintf("Auto-scan completed. Total books: %d", len(books)), nil)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "library.folder-auto-scan", "library", summary, activity.AlwaysShow)
+			}
 			return nil
 		},
 	})

--- a/internal/server/itunes_ops.go
+++ b/internal/server/itunes_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/itunes_ops.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4b7e9f2a-1c3d-4e5f-8a9b-0c1d2e3f4a5b
 
 // itunes_ops registers v2 OperationDefs for iTunes import and sync.
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
@@ -65,6 +66,14 @@ func (s *Server) RegisterITunesImportOp(reg *opsregistry.Registry) error {
 				} else {
 					_ = s.Store().UpdateOperationStatus(p.LegacyOpID, "completed", 0, 0, "iTunes import completed")
 				}
+				if s.activityWriter != nil {
+					activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+					summary := "iTunes import completed"
+					if runErr != nil {
+						summary = fmt.Sprintf("iTunes import failed: %v", runErr)
+					}
+					activity.EmitInfo(s.activityWriter, p.LegacyOpID, "itunes.import", "itunes", summary, activity.AlwaysShow)
+				}
 			}
 			return runErr
 		},
@@ -94,7 +103,16 @@ func (s *Server) RegisterITunesSyncOp(reg *opsregistry.Registry) error {
 				}
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return s.itunesSvc.Importer.Sync(ctx, p.LibraryPath, p.PathMappings, s.itunesActivityFn, operations.LoggerFromReporter(progress))
+			syncErr := s.itunesSvc.Importer.Sync(ctx, p.LibraryPath, p.PathMappings, s.itunesActivityFn, operations.LoggerFromReporter(progress))
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				summary := "iTunes sync completed"
+				if syncErr != nil {
+					summary = fmt.Sprintf("iTunes sync failed: %v", syncErr)
+				}
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "itunes.sync", "itunes", summary, activity.AlwaysShow)
+			}
+			return syncErr
 		},
 	})
 }

--- a/internal/server/library_writeback_op.go
+++ b/internal/server/library_writeback_op.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_writeback_op.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 package server
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	ulid "github.com/oklog/ulid/v2"
@@ -50,7 +52,16 @@ func (s *Server) RegisterBulkWriteBackOp(reg *opsregistry.Registry) error {
 			}
 			opID := ulid.Make().String()
 			progress := registryProgressAdapter{r: reporter}
-			return s.runBulkWriteBack(ctx, opID, p.BookIDs, p.Rename, 0, progress)
+			runErr := s.runBulkWriteBack(ctx, opID, p.BookIDs, p.Rename, 0, progress)
+			if s.activityWriter != nil {
+				activity.FlushOperation(s.activityWriter, opID)
+				summary := fmt.Sprintf("Bulk tag write-back completed for %d books", len(p.BookIDs))
+				if runErr != nil {
+					summary = fmt.Sprintf("Bulk tag write-back failed: %v", runErr)
+				}
+				activity.EmitInfo(s.activityWriter, opID, "library.bulk-write-back", "library", summary, activity.AlwaysShow)
+			}
+			return runErr
 		},
 	})
 }

--- a/internal/server/reconcile_ops.go
+++ b/internal/server/reconcile_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/reconcile_ops.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c2d8f41-a3e7-4b19-8d60-9f1e2c3a4b5d
 
 // reconcile_ops registers the v2 OperationDefs for the reconcile scan and
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
@@ -58,7 +59,16 @@ func (s *Server) RegisterReconcileScanOpV2(reg *opsregistry.Registry) error {
 				return fmt.Errorf("reconcile.scan: database not initialized")
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return reconcile.RunReconcileScan(store, ctx, p.LegacyOpID, progress)
+			runErr := reconcile.RunReconcileScan(store, ctx, p.LegacyOpID, progress)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				summary := "Reconcile scan completed"
+				if runErr != nil {
+					summary = fmt.Sprintf("Reconcile scan failed: %v", runErr)
+				}
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "reconcile.scan", "reconcile", summary, activity.AlwaysShow)
+			}
+			return runErr
 		},
 	})
 }
@@ -89,7 +99,16 @@ func (s *Server) RegisterReconcileApplyOp(reg *opsregistry.Registry) error {
 			}
 			progress := registryProgressAdapter{r: reporter}
 			log := operations.LoggerFromReporter(progress)
-			return reconcile.ExecuteReconcile(ctx, store, p.LegacyOpID, p.Matches, log)
+			runErr := reconcile.ExecuteReconcile(ctx, store, p.LegacyOpID, p.Matches, log)
+			if s.activityWriter != nil && p.LegacyOpID != "" {
+				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
+				summary := fmt.Sprintf("Reconcile apply completed: %d matches applied", len(p.Matches))
+				if runErr != nil {
+					summary = fmt.Sprintf("Reconcile apply failed: %v", runErr)
+				}
+				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "reconcile.apply", "reconcile", summary, activity.AlwaysShow)
+			}
+			return runErr
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Add `activity.EmitInfo` calls to 12 v2 operation Run handlers that previously only logged to the op card but never surfaced a summary in the main activity feed
- Update 3 dedup scan handlers to create a legacy v1 operation record and pass its ID via `LegacyOpID` so scan completions also appear in the activity feed
- Follow the established pattern from `maintenance_job_op.go`: `FlushOperation` then `EmitInfo` after run completes

**Affected operations:** `itunes.import`, `itunes.sync`, `reconcile.scan`, `reconcile.apply`, `library.folder-auto-scan`, `library.bulk-write-back`, `dedup.book-scan`, `dedup.book-merge`, `dedup.author-scan`, `dedup.series-scan`, `dedup.series-dedup`, `dedup.series-merge`, `dedup.series-prune`, `dedup.series-normalize`

## Test plan

- [ ] `go build ./internal/server/` passes (verified)
- [ ] `go test ./internal/server/...` passes (verified: 69s, 2 packages OK)
- [ ] Activity feed shows completion events for dedup scans, iTunes import/sync, reconcile, folder auto-scan, bulk write-back after they run

🤖 Generated with [Claude Code](https://claude.com/claude-code)