### PR TITLE
fix(sec): path injection in cover handlers (SEC-AUDIT-3)

### DIFF
--- a/internal/covers/covers.go
+++ b/internal/covers/covers.go
@@ -1,7 +1,7 @@
 // file: internal/covers/covers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-7890-abcd-ef12-34567890abcd
-// last-edited: 2026-05-11
+// last-edited: 2026-05-18
 //
 // Cover service logic for proxy caching and validation.
 // Business logic extracted from internal/server/covers.go.
@@ -16,6 +16,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/security/safepath"
 )
 
 // ProxyCoverRequest holds parameters for proxying a cover image.
@@ -105,14 +107,14 @@ func FetchAndCacheCover(coverURL, cacheDir string) (string, string) {
 
 // FindCoverFile searches for a cover file in standard directories.
 func FindCoverFile(filename string, rootDir string) (string, error) {
-	dirs := []string{
-		filepath.Join(rootDir, ".covers"),
-		filepath.Join(rootDir, "covers"),
-	}
-	for _, dir := range dirs {
-		coverPath := filepath.Join(dir, filename)
-		if _, err := os.Stat(coverPath); err == nil {
-			return coverPath, nil
+	roots := []string{".covers", "covers"}
+	for _, sub := range roots {
+		sp, err := safepath.Join(rootDir, sub, filename)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(sp.String()); err == nil {
+			return sp.String(), nil
 		}
 	}
 	return "", os.ErrNotExist

--- a/internal/covers/history.go
+++ b/internal/covers/history.go
@@ -1,7 +1,7 @@
 // file: internal/covers/history.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-8901-bcde-f123-4567890abcde
-// last-edited: 2026-05-11
+// last-edited: 2026-05-18
 //
 // Cover history management for browsing and restoring previous cover versions.
 // Business logic extracted from internal/server/cover_history.go.
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/security/safepath"
 )
 
 // CoverHistoryEntry represents one saved cover version.
@@ -25,9 +27,12 @@ type CoverHistoryEntry struct {
 
 // ListCoverHistory returns all cover versions for a book, sorted by modification time (newest first).
 func ListCoverHistory(bookID, rootDir string) ([]CoverHistoryEntry, error) {
-	histDir := filepath.Join(rootDir, "covers", "history", bookID)
+	histDirSP, err := safepath.Join(rootDir, "covers", "history", bookID)
+	if err != nil {
+		return []CoverHistoryEntry{}, nil
+	}
 
-	entries, err := os.ReadDir(histDir)
+	entries, err := os.ReadDir(histDirSP.String())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return []CoverHistoryEntry{}, nil
@@ -35,7 +40,7 @@ func ListCoverHistory(bookID, rootDir string) ([]CoverHistoryEntry, error) {
 		return nil, err
 	}
 
-	var covers []CoverHistoryEntry
+	var result []CoverHistoryEntry
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -49,7 +54,7 @@ func ListCoverHistory(bookID, rootDir string) ([]CoverHistoryEntry, error) {
 		if err != nil {
 			continue
 		}
-		covers = append(covers, CoverHistoryEntry{
+		result = append(result, CoverHistoryEntry{
 			Filename:  name,
 			URL:       "/api/v1/covers/local/" + name,
 			SizeBytes: info.Size(),
@@ -57,37 +62,40 @@ func ListCoverHistory(bookID, rootDir string) ([]CoverHistoryEntry, error) {
 		})
 	}
 
-	sort.Slice(covers, func(i, j int) bool {
-		return covers[i].ModTime > covers[j].ModTime
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ModTime > result[j].ModTime
 	})
 
-	return covers, nil
+	return result, nil
 }
 
 // RestoreCoverFile copies a historical cover to the current cover location.
 func RestoreCoverFile(bookID, filename, rootDir string) (string, error) {
-	// Prevent path traversal
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+	// Reject filenames that cross directory boundaries before path construction.
+	if strings.ContainsAny(filename, "/\\") || strings.Contains(filename, "..") {
 		return "", os.ErrInvalid
 	}
-
-	srcPath := filepath.Join(rootDir, "covers", "history", bookID, filename)
-	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+	srcSP, err := safepath.Join(rootDir, "covers", "history", bookID, filename)
+	if err != nil {
+		return "", os.ErrInvalid
+	}
+	if _, err := os.Stat(srcSP.String()); os.IsNotExist(err) {
 		return "", os.ErrNotExist
 	}
 
-	// Copy the history file to the current cover location
-	dstDir := filepath.Join(rootDir, "covers")
 	ext := filepath.Ext(filename)
-	dstPath := filepath.Join(dstDir, bookID+ext)
+	dstSP, err := safepath.Join(rootDir, "covers", bookID+ext)
+	if err != nil {
+		return "", os.ErrInvalid
+	}
 
-	src, err := os.ReadFile(srcPath)
+	src, err := os.ReadFile(srcSP.String())
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(dstPath, src, 0o644); err != nil {
+	if err := os.WriteFile(dstSP.String(), src, 0o644); err != nil {
 		return "", err
 	}
 
-	return dstPath, nil
+	return dstSP.String(), nil
 }

--- a/internal/metadata/cover.go
+++ b/internal/metadata/cover.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/cover.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4efaa7b8-e29a-47f3-84f7-39b46bfc9a01
 
 package metadata
@@ -169,8 +169,13 @@ func downloadCoverArtWithClient(client *http.Client, coverURL string, destDir st
 
 // CoverPathForBook returns the local cover file path if it exists, empty string otherwise.
 func CoverPathForBook(destDir string, bookID string) string {
+	// filepath.Base strips any directory traversal from the bookID segment.
+	safeID := filepath.Base(bookID)
+	if safeID == "." || safeID == "/" {
+		return ""
+	}
 	coversDir := filepath.Join(destDir, "covers")
-	matches, _ := filepath.Glob(filepath.Join(coversDir, bookID+".*"))
+	matches, _ := filepath.Glob(filepath.Join(coversDir, safeID+".*"))
 	for _, m := range matches {
 		ext := strings.ToLower(filepath.Ext(m))
 		if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".webp" || ext == ".gif" {

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.9.3
+// version: 2.9.4
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
-// last-edited: 2026-05-16
+// last-edited: 2026-05-18
 //
 // Audiobook HTTP handlers split out of server.go: book CRUD, batch
 // operations, file/segment actions, tag read/write, cover art, path
@@ -31,6 +31,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
+	"github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 )
 
@@ -357,7 +358,11 @@ func (s *Server) audiobookFacets(c *gin.Context) {
 }
 
 func (s *Server) serveAudiobookCover(c *gin.Context) {
-	id := c.Param("id")
+	id := pathvalidation.SanitizeFilename(c.Param("id"))
+	if id == "" {
+		httputil.RespondWithBadRequest(c, "invalid book id")
+		return
+	}
 	if config.AppConfig.RootDir == "" {
 		httputil.RespondWithInternalError(c, "root_dir not configured")
 		return


### PR DESCRIPTION
## Summary

- Replace unguarded `filepath.Join` calls with `safepath.Join` in `internal/covers/` and `internal/metadata/` so user-controlled `bookID`/`filename` URL params cannot traverse outside their expected root directories (CodeQL alerts #602–#594)
- `covers/history.go`: `ListCoverHistory` and `RestoreCoverFile` use `safepath.Join` for all path construction; `RestoreCoverFile` also retains explicit `/`, `\`, `..` filename check for lateral traversal
- `covers/covers.go`: `FindCoverFile` uses `safepath.Join` instead of `filepath.Join`
- `metadata/cover.go`: `CoverPathForBook` sanitizes `bookID` via `filepath.Base` before the glob
- `server/audiobooks_handlers.go`: `serveAudiobookCover` sanitizes the id URL param with `pathvalidation.SanitizeFilename`

## Test plan

- [x] `go build ./internal/covers/... ./internal/metadata/... ./internal/server/...` passes
- [x] `go test ./internal/covers/...` passes (including `TestRestoreCoverFilePathTraversal`)
- [x] `go test ./internal/server/...` passes (63s, 2 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)