### PR TITLE
feat(logging): convert Wave 4 packages to slog

### DIFF
--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/helpers.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234560010
 // last-edited: 2026-05-05
 //
@@ -10,9 +10,9 @@
 package audiobooks
 
 import (
+	"log/slog"
 	"encoding/json"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -137,7 +137,7 @@ func (svc *AudiobookService) loadMetadataState(bookID string) (map[string]metada
 		return state, nil
 	}
 	if err := svc.saveMetadataState(bookID, legacy); err != nil {
-		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
+		slog.Warn("failed to migrate legacy metadata state for %s: %v", bookID, err)
 	}
 	return legacy, nil
 }
@@ -222,7 +222,7 @@ func (mss *metadataStateSvc) recordChange(bookID, field, changeType, source stri
 		ChangedAt:     time.Now(),
 	}
 	if err := mss.db.RecordMetadataChange(record); err != nil {
-		log.Printf("[WARN] failed to record metadata change for %s/%s: %v", bookID, field, err)
+		slog.Warn("failed to record metadata change for %s/%s: %v", bookID, field, err)
 	}
 }
 

--- a/internal/audiobooks/revert.go
+++ b/internal/audiobooks/revert.go
@@ -1,12 +1,12 @@
 // file: internal/audiobooks/revert.go
-// version: 1.2.1
+// version: 1.2.2
 // guid: d4e5f6a7-b8c9-d0e1-f2a3-b4c5d6e7f8a9
 
 package audiobooks
 
 import (
+	"log/slog"
 	"fmt"
-	"log"
 	"os"
 	"reflect"
 
@@ -61,7 +61,7 @@ func (rs *RevertService) RevertOperation(operationID string) error {
 		c := changes[i]
 		if err := rs.revertChange(c); err != nil {
 			errors = append(errors, fmt.Sprintf("change %s: %v", c.ID, err))
-			log.Printf("[WARN] revert failed for change %s: %v", c.ID, err)
+			slog.Warn("revert failed for change %s: %v", c.ID, err)
 		}
 	}
 
@@ -99,7 +99,7 @@ func (rs *RevertService) revertChange(c *database.OperationChange) error {
 func (rs *RevertService) revertFileMove(c *database.OperationChange) error {
 	// Check file exists at new location
 	if _, err := os.Stat(c.NewValue); os.IsNotExist(err) {
-		log.Printf("[WARN] file no longer at %s, skipping revert", c.NewValue)
+		slog.Warn("file no longer at %s, skipping revert", c.NewValue)
 		return nil
 	}
 
@@ -187,12 +187,12 @@ func (rs *RevertService) revertTagWrite(c *database.OperationChange) error {
 	}
 
 	if _, statErr := os.Stat(book.FilePath); os.IsNotExist(statErr) {
-		log.Printf("[WARN] file %s not found, skipping tag revert", book.FilePath)
+		slog.Warn("file %s not found, skipping tag revert", book.FilePath)
 		return nil
 	}
 
 	if isProtectedPath(rs.db, book.FilePath) {
-		log.Printf("[INFO] skipping tag revert for protected path: %s", book.FilePath)
+		slog.Info("skipping tag revert for protected path: %s", book.FilePath)
 		return nil
 	}
 

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,15 +1,15 @@
 // file: internal/audiobooks/service.go
-// version: 1.25.1
+// version: 1.25.2
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-05-16
 
 package audiobooks
 
 import (
+	"log/slog"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -993,7 +993,7 @@ func (svc *AudiobookService) GetAudiobook(ctx context.Context, id string) (*data
 	// Load metadata state and extract file metadata
 	state, err := svc.loadMetadataState(book.ID)
 	if err != nil {
-		log.Printf("[ERROR] GetAudiobook: failed to load metadata state for %s: %v", book.ID, err)
+		slog.Info("[ERROR] GetAudiobook: failed to load metadata state for %s: %v", book.ID, err)
 		// Don't fail the entire request, just use empty state
 		state = map[string]metadataFieldState{}
 	}
@@ -1007,7 +1007,7 @@ func (svc *AudiobookService) GetAudiobook(ctx context.Context, id string) (*data
 		if mi, miErr := mediainfo.Extract(book.FilePath); miErr == nil && mi.Duration > 0 {
 			book.Duration = &mi.Duration
 			if _, updErr := svc.store.UpdateBook(book.ID, book); updErr != nil {
-				log.Printf("[WARN] GetAudiobook: failed to backfill duration for %s: %v", book.ID, updErr)
+				slog.Warn("GetAudiobook: failed to backfill duration for %s: %v", book.ID, updErr)
 			}
 		}
 	}
@@ -1037,7 +1037,7 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 
 	state, err := svc.loadMetadataState(book.ID)
 	if err != nil {
-		log.Printf("[ERROR] GetAudiobookTags: failed to load metadata state for %s: %v", book.ID, err)
+		slog.Info("[ERROR] GetAudiobookTags: failed to load metadata state for %s: %v", book.ID, err)
 		state = map[string]metadataFieldState{}
 	}
 
@@ -1084,7 +1084,7 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 			}
 			if needsUpdate {
 				if _, err := svc.store.UpdateBook(book.ID, book); err != nil {
-					log.Printf("[WARN] GetAudiobookTags: failed to backfill media info for %s: %v", book.ID, err)
+					slog.Warn("GetAudiobookTags: failed to backfill media info for %s: %v", book.ID, err)
 				}
 				response["media_info"] = map[string]any{
 					"codec":       stringVal(book.Codec),
@@ -1112,7 +1112,7 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 			comparisonValues = buildComparisonValuesFromBook(snapshotBook, snapshotAuthorName, snapshotSeriesName)
 		} else {
 			// Fallback: reconstruct "before" state from activity log old_values
-			log.Printf("[DEBUG] GetAudiobookTags: GetBookAtVersion failed (%v), falling back to activity log for snapshot at %s", verErr, snapshotTS)
+			slog.Debug("GetAudiobookTags: GetBookAtVersion failed (%v), falling back to activity log for snapshot at %s", verErr, snapshotTS)
 			if svc.activityService != nil {
 				comparisonValues = buildComparisonValuesFromActivityLog(svc.activityService, id, ts)
 			}
@@ -1120,12 +1120,12 @@ func (svc *AudiobookService) GetAudiobookTags(ctx context.Context, id string, co
 	} else if compareID != "" {
 		compBook, err := svc.store.GetBookByID(compareID)
 		if err != nil {
-			log.Printf("[WARN] GetAudiobookTags: failed to load comparison book %s: %v", compareID, err)
+			slog.Warn("GetAudiobookTags: failed to load comparison book %s: %v", compareID, err)
 		} else if compBook != nil && compBook.FilePath != "" {
 			if cm, err := metadata.ExtractMetadata(compBook.FilePath, nil); err == nil {
 				comparisonValues = buildComparisonValuesFromMetadata(&cm)
 			} else {
-				log.Printf("[WARN] GetAudiobookTags: failed to extract comparison metadata for %s: %v", compBook.FilePath, err)
+				slog.Warn("GetAudiobookTags: failed to extract comparison metadata for %s: %v", compBook.FilePath, err)
 			}
 		}
 	}
@@ -1144,7 +1144,7 @@ func (svc *AudiobookService) extractBookFileMetadata(book *database.Book, author
 
 	m, err := metadata.ExtractMetadata(book.FilePath, nil)
 	if err != nil {
-		log.Printf("[WARN] audiobook_service: failed to extract metadata for %s: %v", book.FilePath, err)
+		slog.Warn("audiobook_service: failed to extract metadata for %s: %v", book.FilePath, err)
 		return meta
 	}
 
@@ -1177,7 +1177,7 @@ func (svc *AudiobookService) GetDuplicateBooks(ctx context.Context) (*Duplicates
 	// Get folder-based duplicates (same title in same folder, e.g. M4B + MP3)
 	folderGroups, err := svc.store.GetFolderDuplicates()
 	if err != nil {
-		log.Printf("[WARN] folder duplicate detection failed: %v", err)
+		slog.Warn("folder duplicate detection failed: %v", err)
 	} else {
 		// Merge folder groups, avoiding duplicate groups already found by hash
 		seenBookIDs := map[string]bool{}
@@ -1303,7 +1303,7 @@ func (svc *AudiobookService) PurgeSoftDeletedBooks(ctx context.Context, deleteFi
 		// Step 3: Delete file if requested (only from organizer root, never from protected/import paths)
 		if deleteFiles && book.FilePath != "" {
 			if isProtectedPath(svc.store, book.FilePath) {
-				log.Printf("[DEBUG] purge: skipping file deletion for %s — protected path: %s", book.ID, book.FilePath)
+				slog.Debug("purge: skipping file deletion for %s — protected path: %s", book.ID, book.FilePath)
 			} else {
 				info, statErr := os.Stat(book.FilePath)
 				if statErr == nil && info.IsDir() {
@@ -1458,7 +1458,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 		if _, err := os.Stat(req.Updates.FilePath); err != nil {
 			return nil, fmt.Errorf("file does not exist at new path: %s", req.Updates.FilePath)
 		}
-		log.Printf("[INFO] audiobook_service: FilePath changed for %s: %s → %s", id, currentBook.FilePath, req.Updates.FilePath)
+		slog.Info("audiobook_service: FilePath changed for %s: %s → %s", id, currentBook.FilePath, req.Updates.FilePath)
 		currentBook.FilePath = req.Updates.FilePath
 	}
 	if req.Updates.Narrator != nil {
@@ -1493,7 +1493,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 	// Load and process metadata state
 	state, err := svc.loadMetadataState(id)
 	if err != nil {
-		log.Printf("[ERROR] UpdateAudiobook: failed to load metadata state: %v", err)
+		slog.Info("[ERROR] UpdateAudiobook: failed to load metadata state: %v", err)
 		return nil, fmt.Errorf("failed to load metadata state")
 	}
 	if state == nil {
@@ -1582,7 +1582,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 			// Save multiple authors to join table
 			if len(bookAuthors) > 0 {
 				if err := svc.store.SetBookAuthors(id, bookAuthors); err != nil {
-					log.Printf("[WARN] failed to set book authors: %v", err)
+					slog.Warn("failed to set book authors: %v", err)
 				}
 			}
 		} else {
@@ -1609,7 +1609,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 				if err != nil || narrator == nil {
 					narrator, err = svc.store.CreateNarrator(nName)
 					if err != nil {
-						log.Printf("[WARN] failed to create narrator %q: %v", nName, err)
+						slog.Warn("failed to create narrator %q: %v", nName, err)
 						continue
 					}
 				}
@@ -1623,7 +1623,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 			}
 			if len(bookNarrators) > 0 {
 				if err := svc.store.SetBookNarrators(id, bookNarrators); err != nil {
-					log.Printf("[WARN] failed to set book narrators: %v", err)
+					slog.Warn("failed to set book narrators: %v", err)
 				}
 			}
 		}
@@ -1712,15 +1712,15 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 
 	for field, extractor := range fieldExtractors {
 		if _, ok := req.RawPayload[field]; !ok {
-			log.Printf("[DEBUG] UpdateAudiobook: field %s not in RawPayload", field)
+			slog.Debug("UpdateAudiobook: field %s not in RawPayload", field)
 			continue
 		}
 		if _, hasOverride := req.Updates.Overrides[field]; hasOverride {
-			log.Printf("[DEBUG] UpdateAudiobook: field %s has explicit override", field)
+			slog.Debug("UpdateAudiobook: field %s has explicit override", field)
 			continue
 		}
 		if value, ok := extractor(); ok {
-			log.Printf("[DEBUG] UpdateAudiobook: creating state for field %s with value %v", field, value)
+			slog.Debug("UpdateAudiobook: creating state for field %s with value %v", field, value)
 			entry := state[field]
 			oldValue := entry.OverrideValue
 
@@ -1734,7 +1734,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 				mss.recordChange(id, field, "override", "user_edit", oldValue, value)
 			}
 		} else {
-			log.Printf("[DEBUG] UpdateAudiobook: extractor for field %s returned false/nil", field)
+			slog.Debug("UpdateAudiobook: extractor for field %s returned false/nil", field)
 		}
 	}
 
@@ -1754,7 +1754,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 
 	// Save metadata state
 	if err := svc.saveMetadataState(id, state); err != nil {
-		log.Printf("[ERROR] UpdateAudiobook: failed to save metadata state: %v", err)
+		slog.Info("[ERROR] UpdateAudiobook: failed to save metadata state: %v", err)
 		return nil, fmt.Errorf("failed to persist metadata state")
 	}
 
@@ -1813,7 +1813,7 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 		blocked := false
 		if opts.BlockHash && book.FileHash != nil && *book.FileHash != "" {
 			if err := svc.store.AddBlockedHash(*book.FileHash, "User deleted - soft delete"); err != nil {
-				log.Printf("Warning: failed to block hash during soft delete: %v", err)
+				slog.Warn("failed to block hash during soft delete: %v", err)
 			} else {
 				blocked = true
 			}
@@ -1837,7 +1837,7 @@ func (svc *AudiobookService) DeleteAudiobook(ctx context.Context, id string, opt
 	blocked := false
 	if opts.BlockHash && book.FileHash != nil && *book.FileHash != "" {
 		if err := svc.store.AddBlockedHash(*book.FileHash, "User deleted - prevent reimport"); err != nil {
-			log.Printf("Warning: failed to block hash before delete: %v", err)
+			slog.Warn("failed to block hash before delete: %v", err)
 			// Continue with delete even if blocking fails
 		} else {
 			blocked = true
@@ -2016,13 +2016,13 @@ func (svc *AudiobookService) BatchUpdateUserTags(bookIDs []string, addTags []str
 	for _, bookID := range bookIDs {
 		for _, tag := range addTags {
 			if err := svc.store.AddBookTag(bookID, tag); err != nil {
-				log.Printf("[WARN] BatchUpdateUserTags: failed to add tag %q to book %s: %v", tag, bookID, err)
+				slog.Warn("BatchUpdateUserTags: failed to add tag %q to book %s: %v", tag, bookID, err)
 				continue
 			}
 		}
 		for _, tag := range removeTags {
 			if err := svc.store.RemoveBookTag(bookID, tag); err != nil {
-				log.Printf("[WARN] BatchUpdateUserTags: failed to remove tag %q from book %s: %v", tag, bookID, err)
+				slog.Warn("BatchUpdateUserTags: failed to remove tag %q from book %s: %v", tag, bookID, err)
 				continue
 			}
 		}

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,13 +1,13 @@
 // file: internal/config/persistence.go
-// version: 1.18.0
+// version: 1.18.1
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 
 package config
 
 import (
+	"log/slog"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -46,7 +46,7 @@ func LoadConfigFromFile() error {
 
 	var fileConfig map[string]any
 	if err := yaml.Unmarshal(data, &fileConfig); err != nil {
-		log.Printf("Warning: Failed to parse config file %s: %v", path, err)
+		slog.Warn("Failed to parse config file %s: %v", path, err)
 		return nil
 	}
 
@@ -66,7 +66,7 @@ func LoadConfigFromFile() error {
 			if val, ok := fileConfig[key].(string); ok && val != "" {
 				*ptr = val
 				applied++
-				log.Printf("[INFO] Loaded %s from config file", key)
+				slog.Info("Loaded %s from config file", key)
 			}
 		}
 	}
@@ -75,12 +75,12 @@ func LoadConfigFromFile() error {
 		if val, ok := fileConfig["enable_ai_parsing"].(bool); ok && val {
 			AppConfig.EnableAIParsing = true
 			applied++
-			log.Printf("[INFO] Loaded enable_ai_parsing from config file")
+			slog.Info("Loaded enable_ai_parsing from config file")
 		}
 	}
 
 	if applied > 0 {
-		log.Printf("Applied %d settings from config file %s", applied, path)
+		slog.Info("Applied %d settings from config file %s", applied, path)
 	}
 	return nil
 }
@@ -135,7 +135,7 @@ func SaveConfigToFile() error {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
-	log.Printf("Configuration saved to file: %s", path)
+	slog.Info("Configuration saved to file: %s", path)
 	return nil
 }
 
@@ -152,11 +152,11 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 		return fmt.Errorf("store is nil")
 	}
 
-	log.Println("Loading configuration from database...")
+	slog.Info("Loading configuration from database...")
 
 	settings, err := store.GetAllSettings()
 	if err != nil {
-		log.Printf("Note: Could not load settings from database: %v", err)
+		slog.Info("Note: Could not load settings from database: %v", err)
 		return nil
 	}
 
@@ -180,9 +180,9 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			AppConfig = loaded
 			AppConfig.DatabaseType = savedDBType
 			blobFound = true
-			log.Printf("[INFO] Loaded config from blob (%d bytes)", len(blob.Value))
+			slog.Info("Loaded config from blob (%d bytes)", len(blob.Value))
 		} else {
-			log.Printf("[WARN] Failed to parse config_blob: %v — falling back to individual keys", err)
+			slog.Warn("Failed to parse config_blob: %v — falling back to individual keys", err)
 		}
 	}
 
@@ -194,15 +194,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 		}
 		decrypted, err := database.DecryptValue(setting.Value)
 		if err != nil {
-			log.Printf("WARNING: Failed to decrypt setting %q — will try config file fallback. (error: %v)",
+			slog.Info("WARNING: Failed to decrypt setting %q — will try config file fallback. (error: %v)",
 				setting.Key, err)
 			corruptSecrets = append(corruptSecrets, setting.Key)
 			continue
 		}
 		if err := applySetting(setting.Key, decrypted, setting.Type); err != nil {
-			log.Printf("Warning: Failed to apply secret setting %s: %v", setting.Key, err)
+			slog.Warn("Failed to apply secret setting %s: %v", setting.Key, err)
 		}
-		log.Printf("[DEBUG] LoadConfigFromDatabase: found setting %s (isSecret=true, valueLen=%d)",
+		slog.Debug("LoadConfigFromDatabase: found setting %s (isSecret=true, valueLen=%d)",
 			setting.Key, len(decrypted))
 	}
 
@@ -214,22 +214,22 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 				continue // blob already handled; secrets handled above
 			}
 			if err := applySetting(setting.Key, setting.Value, setting.Type); err != nil {
-				log.Printf("Warning: Failed to apply setting %s: %v", setting.Key, err)
+				slog.Warn("Failed to apply setting %s: %v", setting.Key, err)
 				continue
 			}
 			applied++
 		}
-		log.Printf("Applied %d settings from database (legacy individual keys)", applied)
+		slog.Info("Applied %d settings from database (legacy individual keys)", applied)
 	}
 
 	// Fall back to config file for anything not yet loaded (e.g. corrupted secrets)
 	if err := LoadConfigFromFile(); err != nil {
-		log.Printf("Warning: Config file fallback failed: %v", err)
+		slog.Warn("Config file fallback failed: %v", err)
 	}
 
 	// Re-encrypt secrets that failed to decrypt but were recovered from the config file
 	if len(corruptSecrets) > 0 {
-		log.Printf("[INFO] Re-encrypting %d corrupt secret(s) recovered from config file...", len(corruptSecrets))
+		slog.Info("Re-encrypting %d corrupt secret(s) recovered from config file...", len(corruptSecrets))
 		for _, key := range corruptSecrets {
 			var plaintext string
 			switch key {
@@ -244,21 +244,21 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			}
 			if plaintext != "" {
 				if err := store.SetSetting(key, plaintext, "string", true); err != nil {
-					log.Printf("[WARN] Failed to re-encrypt setting %q: %v", key, err)
+					slog.Warn("Failed to re-encrypt setting %q: %v", key, err)
 				} else {
-					log.Printf("[INFO] Re-encrypted setting %q successfully", key)
+					slog.Info("Re-encrypted setting %q successfully", key)
 				}
 			} else {
 				if err := store.DeleteSetting(key); err != nil {
-					log.Printf("[WARN] Could not clear corrupt secret %q from DB: %v", key, err)
+					slog.Warn("Could not clear corrupt secret %q from DB: %v", key, err)
 				} else {
-					log.Printf("[INFO] Cleared corrupt secret %q — re-enter via Settings", key)
+					slog.Info("Cleared corrupt secret %q — re-enter via Settings", key)
 				}
 			}
 		}
 	}
 
-	log.Printf("[DEBUG] After config load: EnableAIParsing=%v, OpenAIAPIKey length=%d",
+	slog.Debug("After config load: EnableAIParsing=%v, OpenAIAPIKey length=%d",
 		AppConfig.EnableAIParsing, len(AppConfig.OpenAIAPIKey))
 
 	// Migrate auto-update window → maintenance window (idempotent)
@@ -294,7 +294,7 @@ func MigrateMaintenanceWindow(store database.SettingsStore) {
 	}
 
 	_ = store.SetSetting("maintenance_window_migrated", "true", "bool", false)
-	log.Printf("[INFO] Maintenance window migration complete (start=%d, end=%d)",
+	slog.Info("Maintenance window migration complete (start=%d, end=%d)",
 		AppConfig.MaintenanceWindowStart, AppConfig.MaintenanceWindowEnd)
 }
 
@@ -708,7 +708,7 @@ func SaveConfigToDatabase(store database.SettingsStore) error {
 		return fmt.Errorf("store is nil")
 	}
 
-	log.Println("Saving configuration to database...")
+	slog.Info("Saving configuration to database...")
 
 	// Build a safe copy with secrets zeroed — they are saved separately (encrypted).
 	safeConfig := AppConfig
@@ -742,20 +742,20 @@ func SaveConfigToDatabase(store database.SettingsStore) error {
 		if s.value == "" {
 			existing, err := store.GetSetting(s.key)
 			if err == nil && existing != nil && existing.Value != "" {
-				log.Printf("[DEBUG] Preserving existing secret %s (current value empty)", s.key)
+				slog.Debug("Preserving existing secret %s (current value empty)", s.key)
 				continue
 			}
 		}
 		if err := store.SetSetting(s.key, s.value, "string", true); err != nil {
-			log.Printf("Warning: Failed to save secret %s: %v", s.key, err)
+			slog.Warn("Failed to save secret %s: %v", s.key, err)
 		}
 	}
 
-	log.Printf("Configuration saved to database (blob + %d secrets)", len(secrets))
+	slog.Info("Configuration saved to database (blob + %d secrets)", len(secrets))
 
 	// Also save to config file as a reliable fallback
 	if err := SaveConfigToFile(); err != nil {
-		log.Printf("Warning: Failed to save config file: %v", err)
+		slog.Warn("Failed to save config file: %v", err)
 	}
 
 	return nil
@@ -773,7 +773,7 @@ func SyncConfigFromEnv() {
 	if viper.IsSet("openai_api_key") {
 		if val := viper.GetString("openai_api_key"); val != "" {
 			AppConfig.OpenAIAPIKey = val
-			log.Printf("[DEBUG] SyncConfigFromEnv: overriding OpenAI API key from env/config (length: %d)", len(val))
+			slog.Debug("SyncConfigFromEnv: overriding OpenAI API key from env/config (length: %d)", len(val))
 		}
 	}
 	if viper.IsSet("google_books_api_key") {

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,13 +1,13 @@
 // file: internal/config/update_service.go
-// version: 3.0.0
+// version: 3.0.1
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 
 package config
 
 import (
+	"log/slog"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -86,7 +86,7 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	// Apply secrets explicitly — they need masking/debug logging and must not
 	// flow through the JSON round-trip to avoid plaintext exposure.
 	if val, ok := payloadString(payload, "openai_api_key"); ok {
-		log.Printf("[DEBUG] UpdateConfig: updating OpenAI API key (len=%d)", len(val))
+		slog.Debug("UpdateConfig: updating OpenAI API key (len=%d)", len(val))
 		AppConfig.OpenAIAPIKey = val
 	}
 	if val, ok := payloadString(payload, "google_books_api_key"); ok {
@@ -123,14 +123,14 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	AppConfig.SetupComplete = AppConfig.RootDir != ""
 
 	if err := SaveConfigToDatabase(us.DB); err != nil {
-		log.Printf("ERROR: failed to persist config: %v", err)
+		slog.Error("failed to persist config: %v", err)
 		return http.StatusInternalServerError, map[string]any{
 			"error":   "failed to save configuration",
 			"details": err.Error(),
 		}
 	}
 
-	log.Printf("Configuration saved successfully")
+	slog.Info("Configuration saved successfully")
 
 	return http.StatusOK, map[string]any{
 		"message": "configuration updated and saved to database",

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,15 +1,15 @@
 // file: internal/database/activity_store.go
-// version: 1.9.2
+// version: 1.9.3
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
 
 import (
+	"log/slog"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -175,7 +175,7 @@ func (s *ActivityStore) MigrateSystemActivityLogs() (int, error) {
 	}
 	if count > 0 {
 		// Already migrated
-		log.Printf("[activity] system_activity_log migration already complete")
+		slog.Info("[activity] system_activity_log migration already complete")
 		return 0, nil
 	}
 
@@ -185,7 +185,7 @@ func (s *ActivityStore) MigrateSystemActivityLogs() (int, error) {
 	if err != nil {
 		// Table might not exist — that's OK, migration is a no-op
 		if strings.Contains(err.Error(), "no such table") {
-			log.Printf("[activity] system_activity_log table not found (no legacy logs)")
+			slog.Info("[activity] system_activity_log table not found (no legacy logs)")
 			return 0, nil
 		}
 		return 0, fmt.Errorf("activity_store: query system_activity_log: %w", err)
@@ -217,7 +217,7 @@ func (s *ActivityStore) MigrateSystemActivityLogs() (int, error) {
 	}
 
 	if len(oldLogs) == 0 {
-		log.Printf("[activity] no old system_activity_log rows found")
+		slog.Info("[activity] no old system_activity_log rows found")
 		// Write marker anyway so we don't check again
 		_, _ = s.Record(ActivityEntry{
 			Tier:    "system",
@@ -297,7 +297,7 @@ func (s *ActivityStore) MigrateSystemActivityLogs() (int, error) {
 		return 0, fmt.Errorf("activity_store: commit migration: %w", err)
 	}
 
-	log.Printf("[activity] migrated %d system_activity_log rows", insertedCount)
+	slog.Info("[activity] migrated %d system_activity_log rows", insertedCount)
 	return insertedCount, nil
 }
 
@@ -483,7 +483,7 @@ func (s *ActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier
 		)
 		if txErr != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("Summarize rollback on insert: %v", rbErr)
+				slog.Info("Summarize rollback on insert: %v", rbErr)
 			}
 			return totalDeleted, fmt.Errorf("activity_store: summarize insert: %w", txErr)
 		}
@@ -507,7 +507,7 @@ func (s *ActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier
 		}
 		if txErr != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("Summarize rollback on delete: %v", rbErr)
+				slog.Info("Summarize rollback on delete: %v", rbErr)
 			}
 			return totalDeleted, fmt.Errorf("activity_store: summarize delete: %w", txErr)
 		}
@@ -849,7 +849,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			LIMIT 1`, dateKey).Scan(&existingID, &existingDetailsJSON)
 		if err != nil && err != sql.ErrNoRows {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("CompactByDay rollback on check digest: %v", rbErr)
+				slog.Info("CompactByDay rollback on check digest: %v", rbErr)
 			}
 			return result, fmt.Errorf("activity_store: compact check digest: %w", err)
 		}
@@ -886,7 +886,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			merged, mErr := json.Marshal(dd)
 			if mErr != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
-					log.Printf("CompactByDay rollback on remarshal: %v", rbErr)
+					slog.Info("CompactByDay rollback on remarshal: %v", rbErr)
 				}
 				return result, fmt.Errorf("activity_store: compact remarshal merged digest: %w", mErr)
 			}
@@ -895,7 +895,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			// Delete the old digest row — we'll insert the combined one below.
 			if _, delErr := tx.ExecContext(ctx, `DELETE FROM activity_log WHERE id = ?`, existingID); delErr != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
-					log.Printf("CompactByDay rollback on delete old digest: %v", rbErr)
+					slog.Info("CompactByDay rollback on delete old digest: %v", rbErr)
 				}
 				return result, fmt.Errorf("activity_store: compact delete old digest: %w", delErr)
 			}
@@ -910,7 +910,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 		)
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("CompactByDay rollback on insert digest: %v", rbErr)
+				slog.Info("CompactByDay rollback on insert digest: %v", rbErr)
 			}
 			return result, fmt.Errorf("activity_store: compact insert digest: %w", err)
 		}
@@ -932,7 +932,7 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			delRes, delErr := tx.ExecContext(ctx, "DELETE FROM activity_log WHERE id IN ("+placeholders+")", args...)
 			if delErr != nil {
 				if rbErr := tx.Rollback(); rbErr != nil {
-					log.Printf("CompactByDay rollback on delete originals: %v", rbErr)
+					slog.Info("CompactByDay rollback on delete originals: %v", rbErr)
 				}
 				return result, fmt.Errorf("activity_store: compact delete: %w", delErr)
 			}

--- a/internal/database/ai_scan_store.go
+++ b/internal/database/ai_scan_store.go
@@ -1,15 +1,15 @@
 // file: internal/database/ai_scan_store.go
-// version: 2.0.0
+// version: 2.0.1
 // last-edited: 2026-05-11
 // guid: a7b3c9d1-4e5f-6a7b-8c9d-0e1f2a3b4c5d
 
 package database
 
 import (
+	"log/slog"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -102,7 +102,7 @@ func NewAIScanStore(path string) (*AIScanStore, error) {
 		return nil, err
 	}
 
-	log.Printf("[INFO] AI Scan DB opened at %s", path)
+	slog.Info("AI Scan DB opened at %s", path)
 	return store, nil
 }
 

--- a/internal/database/embedding_store_migrate.go
+++ b/internal/database/embedding_store_migrate.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store_migrate.go
-// version: 1.0.0
+// version: 1.0.1
 // last-edited: 2026-05-11
 // guid: a3c1f2e8-b947-4d6a-9e5c-0f1a8b7c3d2e
 //
@@ -16,9 +16,9 @@
 package database
 
 import (
+	"log/slog"
 	"database/sql"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -47,7 +47,7 @@ func MigrateEmbeddingsFromSQLite(db *pebble.DB, sqlitePath string) error {
 		return markMigrated(db)
 	}
 
-	log.Printf("[INFO] Migrating embeddings.db → PebbleDB from %s", sqlitePath)
+	slog.Info("Migrating embeddings.db → PebbleDB from %s", sqlitePath)
 	start := time.Now()
 
 	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=off&mode=ro", sqlitePath)
@@ -73,7 +73,7 @@ func MigrateEmbeddingsFromSQLite(db *pebble.DB, sqlitePath string) error {
 		return err
 	}
 
-	log.Printf("[INFO] Embeddings migration complete in %s: vectors=%d cache=%d candidates=%d",
+	slog.Info("Embeddings migration complete in %s: vectors=%d cache=%d candidates=%d",
 		time.Since(start).Round(time.Millisecond), vectors, cache, candidates)
 	return nil
 }
@@ -98,7 +98,7 @@ FROM embeddings ORDER BY created_at`)
 			updatedAtS string
 		)
 		if err := rows.Scan(&entityType, &entityID, &textHash, &vectorBlob, &model, &createdAtS, &updatedAtS); err != nil {
-			log.Printf("[WARN] migrate embeddings: scan row: %v", err)
+			slog.Warn("migrate embeddings: scan row: %v", err)
 			continue
 		}
 
@@ -115,7 +115,7 @@ FROM embeddings ORDER BY created_at`)
 				h = textHash
 			}
 			if err := store.PutCachedEmbedding(h, m, vec); err != nil {
-				log.Printf("[WARN] migrate embeddings: put cache %s: %v", entityID, err)
+				slog.Warn("migrate embeddings: put cache %s: %v", entityID, err)
 				continue
 			}
 			cache++
@@ -129,7 +129,7 @@ FROM embeddings ORDER BY created_at`)
 				UpdatedAt: updatedAt.UnixNano(),
 			}
 			if err := store.setJSON(key, rec); err != nil {
-				log.Printf("[WARN] migrate embeddings: write vector %s:%s: %v", entityType, entityID, err)
+				slog.Warn("migrate embeddings: write vector %s:%s: %v", entityType, entityID, err)
 				continue
 			}
 			vectors++
@@ -164,7 +164,7 @@ FROM dedup_candidates ORDER BY id`)
 		)
 		if err := rows.Scan(&entityType, &entityAID, &entityBID, &layer,
 			&sim, &verdict, &reason, &status, &createdAtS, &updatedAtS); err != nil {
-			log.Printf("[WARN] migrate dedup_candidates: scan row: %v", err)
+			slog.Warn("migrate dedup_candidates: scan row: %v", err)
 			continue
 		}
 
@@ -189,7 +189,7 @@ FROM dedup_candidates ORDER BY id`)
 		}
 
 		if err := store.UpsertCandidate(c); err != nil {
-			log.Printf("[WARN] migrate dedup_candidates: upsert %s %s/%s: %v", entityType, entityAID, entityBID, err)
+			slog.Warn("migrate dedup_candidates: upsert %s %s/%s: %v", entityType, entityAID, entityBID, err)
 			continue
 		}
 		n++

--- a/internal/database/pebble_store_versiongroup_backfill.go
+++ b/internal/database/pebble_store_versiongroup_backfill.go
@@ -1,4 +1,5 @@
 // file: internal/database/pebble_store_versiongroup_backfill.go
+// version: 1.0.1
 // PERF-VERSIONS: one-time backfill that writes the
 // book:versiongroup:<gid>:<id> secondary index for every existing book
 // that has a VersionGroupID. Without this, /audiobooks/:id/versions
@@ -8,9 +9,9 @@
 package database
 
 import (
+	"log/slog"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -75,6 +76,6 @@ func (p *PebbleStore) BackfillVersionGroupIndex() error {
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return err
 	}
-	log.Printf("[INFO] versiongroup-backfill: scanned=%d indexed=%d", scanned, indexed)
+	slog.Info("versiongroup-backfill: scanned=%d indexed=%d", scanned, indexed)
 	return nil
 }

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -1,10 +1,11 @@
 // file: internal/database/settings.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: 8a7b6c5d-4e3f-2a1b-0c9d-8e7f6a5b4c3d
 
 package database
 
 import (
+	"log/slog"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -12,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -327,7 +327,7 @@ func (s *SQLiteStore) GetAllSettings() ([]Setting, error) {
 		var isSecret any
 
 		if err := rows.Scan(&setting.Key, &setting.Value, &setting.Type, &isSecret); err != nil {
-			log.Printf("Warning: Failed to scan setting row: %v", err)
+			slog.Warn("Failed to scan setting row: %v", err)
 			continue
 		}
 

--- a/internal/database/sqlite_store_books.go
+++ b/internal/database/sqlite_store_books.go
@@ -1,15 +1,15 @@
 // file: internal/database/sqlite_store_books.go
-// version: 1.0.4
+// version: 1.0.5
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-16
 
 package database
 
 import (
+	"log/slog"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -1386,7 +1386,7 @@ func (s *SQLiteStore) CreateBook(book *Book) (*Book, error) {
 	defer func() {
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("CreateBook rollback: %v", rbErr)
+				slog.Info("CreateBook rollback: %v", rbErr)
 			}
 		}
 	}()
@@ -1737,7 +1737,7 @@ func (s *SQLiteStore) DeleteBook(id string) error {
 	defer func() {
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("DeleteBook rollback: %v", rbErr)
+				slog.Info("DeleteBook rollback: %v", rbErr)
 			}
 		}
 	}()


### PR DESCRIPTION
Convert 11 files in internal/config, internal/database, and internal/audiobooks packages from log.Printf/log.Println to slog.Debug/Info/Warn/Error.

## Changes
- internal/config: update_service.go, persistence.go
- internal/database: activity_store.go, ai_scan_store.go, embedding_store_migrate.go, pebble_store_versiongroup_backfill.go, settings.go, sqlite_store_books.go
- internal/audiobooks: service.go, revert.go, helpers.go

## Test plan
- [ ] `make test` passes
- [ ] `make ci` passes (80% coverage gate)
- [ ] Verify slog calls have proper structure for Wave 5+

🤖 Generated with [Claude Code](https://claude.com/claude-code)