### PR TITLE
feat(logging): convert maintenance/jobs Wave 6 to slog

### DIFF
--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_book_files.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000005-0000-0000-0000-000000000005
 // last-edited: 2026-05-01
 
@@ -13,7 +13,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	ulid "github.com/oklog/ulid/v2"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&backfillBookFilesJob{}) }
 
@@ -62,7 +62,7 @@ func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, re
 			if !dryRun {
 				if cerr := store.CreateBookFile(bf); cerr != nil {
 					msg := cerr.Error()
-					reporter.Log("error", "failed to create book file", &msg)
+					slog.Error("failed to create book file", "details", msg)
 					continue
 				}
 			}
@@ -70,6 +70,6 @@ func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, re
 		}
 	}
 	_ = created
-	reporter.Log("info", "backfill-book-files complete", nil)
+	slog.Info("backfill-book-files complete")
 	return nil
 }

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a1000014-0000-0000-0000-000000000014
 // last-edited: 2026-05-16
 
@@ -14,7 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&backfillFileHashesJob{}) }
 
@@ -59,13 +59,13 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 		hash, herr := scanner.ComputeFileHash(bf.FilePath)
 		if herr != nil {
 			msg := herr.Error()
-			reporter.Log("warn", "backfill-file-hashes: hash failed for "+bf.FilePath, &msg)
+			slog.Warn("backfill-file-hashes: hash failed for "+bf.FilePath, "details", msg)
 			continue
 		}
 		if !dryRun {
 			if serr := store.SetBookFileHash(bf.ID, hash); serr != nil {
 				msg := serr.Error()
-				reporter.Log("error", "backfill-file-hashes: SetBookFileHash failed", &msg)
+				slog.Error("backfill-file-hashes: SetBookFileHash failed", "details", msg)
 				continue
 			}
 		}
@@ -97,6 +97,6 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 	}
 	_ = store.SaveOperationSummaryLog(opLog)
 
-	reporter.Log("info", "backfill-file-hashes complete", nil)
+	slog.Info("backfill-file-hashes complete")
 	return nil
 }

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000015-0000-0000-0000-000000000015
 // last-edited: 2026-05-01
 
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&backfillMetadataSourceHashJob{}) }
 
@@ -58,14 +58,14 @@ func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.
 			updBook.MetadataSourceHash = &hash
 			if _, uerr := store.UpdateBook(book.ID, &updBook); uerr != nil {
 				msg := uerr.Error()
-				reporter.Log("error", "backfill-metadata-source-hash: UpdateBook failed", &msg)
+				slog.Error("backfill-metadata-source-hash: UpdateBook failed", "details", msg)
 				continue
 			}
 		}
 		updated++
 	}
 	_ = updated
-	reporter.Log("info", "backfill-metadata-source-hash complete", nil)
+	slog.Info("backfill-metadata-source-hash complete")
 	return nil
 }
 

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
 // last-edited: 2026-05-01
 
@@ -20,7 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/util"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&bulkDelugeImportJob{}) }
 
@@ -118,7 +118,7 @@ func (j *bulkDelugeImportJob) Run(ctx context.Context, store database.Store, rep
 	}
 
 	log.Printf("[INFO] bulk-deluge-import %s: done. imported=%d failed=%d", opID, imported, failed)
-	reporter.Log("info", fmt.Sprintf("imported=%d failed=%d total=%d", imported, failed, total), nil)
+	slog.Info(fmt.Sprintf("imported=%d failed=%d total=%d", imported, failed, total))
 	return nil
 }
 

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/bulk_fetch_metadata.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
 // last-edited: 2026-05-05
 
@@ -21,7 +21,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&bulkFetchMetadataJob{}) }
 
@@ -138,7 +138,7 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 	}
 
 	if len(work) == 0 {
-		reporter.Log("info", "all books already cached", nil)
+		slog.Info("all books already cached")
 		return nil
 	}
 
@@ -237,7 +237,7 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 	finalCount := atomic.LoadInt64(&completed)
 	log.Printf("[INFO] bulk-fetch-metadata %s: done %d books — cached:%d not_found:%d",
 		opID, finalCount, found, notFound)
-	reporter.Log("info", fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound), nil)
+	slog.Info(fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound))
 	return nil
 }
 

--- a/internal/maintenance/jobs/cleanup_backups.go
+++ b/internal/maintenance/jobs/cleanup_backups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_backups.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000021-0000-0000-0000-000000000021
 // last-edited: 2026-05-01
 
@@ -14,7 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&cleanupBackupsJob{}) }
 
@@ -37,7 +37,7 @@ func (j *cleanupBackupsJob) CanResume() bool { return false }
 func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
 	root := config.AppConfig.RootDir
 	if root == "" {
-		reporter.Log("warn", "cleanup-backups: RootDir not configured", nil)
+		slog.Warn("cleanup-backups: RootDir not configured")
 		return nil
 	}
 	removed := 0
@@ -57,11 +57,11 @@ func (j *cleanupBackupsJob) Run(ctx context.Context, _ database.Store, reporter 
 			}
 		} else {
 			removed++
-			reporter.Log("info", "would remove: "+path, nil)
+			slog.Info("would remove: "+path)
 		}
 		return nil
 	})
 	_ = removed
-	reporter.Log("info", "cleanup-backups complete", nil)
+	slog.Info("cleanup-backups complete")
 	return err
 }

--- a/internal/maintenance/jobs/cleanup_empty_folders.go
+++ b/internal/maintenance/jobs/cleanup_empty_folders.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_empty_folders.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a1000006-0000-0000-0000-000000000006
 // last-edited: 2026-05-05
 
@@ -15,7 +15,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&cleanupEmptyFoldersJob{}) }
 
@@ -37,7 +37,7 @@ func (j *cleanupEmptyFoldersJob) CanResume() bool { return true }
 func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
 	root := config.AppConfig.RootDir
 	if root == "" {
-		reporter.Log("warn", "cleanup-empty-folders: RootDir not configured", nil)
+		slog.Warn("cleanup-empty-folders: RootDir not configured")
 		return nil
 	}
 
@@ -58,7 +58,7 @@ func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, repo
 	sort.Slice(dirs, func(i, k int) bool { return len(dirs[i]) > len(dirs[k]) })
 
 	reporter.SetTotal(len(dirs))
-	reporter.Log("info", fmt.Sprintf("cleanup-empty-folders: found %d directories to check (dry_run=%v)", len(dirs), dryRun), nil)
+	slog.Info(fmt.Sprintf("cleanup-empty-folders: found %d directories to check (dry_run=%v)", len(dirs), dryRun))
 
 	removed := 0
 	for _, dir := range dirs {
@@ -68,7 +68,7 @@ func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, repo
 
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			reporter.Log("error", fmt.Sprintf("cleanup-empty-folders: failed to read %s: %v", dir, err), nil)
+			slog.Error(fmt.Sprintf("cleanup-empty-folders: failed to read %s: %v", dir, err))
 			reporter.Increment()
 			continue
 		}
@@ -79,18 +79,18 @@ func (j *cleanupEmptyFoldersJob) Run(ctx context.Context, _ database.Store, repo
 		}
 
 		if dryRun {
-			reporter.Log("info", fmt.Sprintf("[dry] would remove empty dir: %s", dir), nil)
+			slog.Info(fmt.Sprintf("[dry] would remove empty dir: %s", dir))
 		} else {
 			if err := os.Remove(dir); err != nil {
-				reporter.Log("error", fmt.Sprintf("cleanup-empty-folders: failed to remove %s: %v", dir, err), nil)
+				slog.Error(fmt.Sprintf("cleanup-empty-folders: failed to remove %s: %v", dir, err))
 			} else {
-				reporter.Log("info", fmt.Sprintf("removed empty dir: %s", dir), nil)
+				slog.Info(fmt.Sprintf("removed empty dir: %s", dir))
 				removed++
 			}
 		}
 		reporter.Increment()
 	}
 
-	reporter.Log("info", fmt.Sprintf("cleanup-empty-folders: complete — checked %d dirs, removed %d (dry_run=%v)", len(dirs), removed, dryRun), nil)
+	slog.Info(fmt.Sprintf("cleanup-empty-folders: complete — checked %d dirs, removed %d (dry_run=%v)", len(dirs), removed, dryRun))
 	return nil
 }

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_organize_mess.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000007-0000-0000-0000-000000000007
 // last-edited: 2026-05-01
 
@@ -18,7 +18,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&cleanupOrganizeMess{}) }
 
@@ -86,12 +86,12 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 		name := filepath.Base(dir)
 		if reason := comIsGarbageDirectory(name); reason != "" {
 			garbageFound++
-			reporter.Log("warn", fmt.Sprintf("Garbage dir %q: %s", dir, reason), nil)
+			slog.Warn(fmt.Sprintf("Garbage dir %q: %s", dir, reason))
 		}
 
 		empty, checkErr := comIsDirEmpty(dir)
 		if checkErr != nil {
-			reporter.Log("error", fmt.Sprintf("Stat error for %q: %v", dir, checkErr), nil)
+			slog.Error(fmt.Sprintf("Stat error for %q: %v", dir, checkErr))
 			reporter.Increment()
 			continue
 		}
@@ -102,7 +102,7 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 
 		if !dryRun {
 			if removeErr := os.Remove(dir); removeErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to remove %q: %v", dir, removeErr), nil)
+				slog.Error(fmt.Sprintf("Failed to remove %q: %v", dir, removeErr))
 			} else {
 				emptyRemoved++
 			}
@@ -112,7 +112,7 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 		reporter.Increment()
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: garbage_dirs=%d empty_removed=%d dryRun=%v", garbageFound, emptyRemoved, dryRun), nil)
+	slog.Info(fmt.Sprintf("Done: garbage_dirs=%d empty_removed=%d dryRun=%v", garbageFound, emptyRemoved, dryRun))
 	return nil
 }
 

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000002-0000-0000-0000-000000000002
 // last-edited: 2026-05-01
 
@@ -14,7 +14,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&cleanupSeriesJob{}) }
 
@@ -77,7 +77,7 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 		singleFound++
 		if !dryRun {
 			if applyErr := csUnlinkAndDeleteSeries(store, &book, ser.ID); applyErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to remove 1-book series %d (%q): %v", ser.ID, ser.Name, applyErr), nil)
+				slog.Error(fmt.Sprintf("Failed to remove 1-book series %d (%q): %v", ser.ID, ser.Name, applyErr))
 			} else {
 				deletedIDs[ser.ID] = true
 				singleApplied++
@@ -120,15 +120,14 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 
 		if !dryRun {
 			if mergeErr := csMergeSeriesGroup(store, keeper.ID, mergeIDs); mergeErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to merge series group %q: %v", normName, mergeErr), nil)
+				slog.Error(fmt.Sprintf("Failed to merge series group %q: %v", normName, mergeErr))
 			} else {
 				dupApplied++
 			}
 		}
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: single_found=%d single_applied=%d dup_groups_found=%d dup_applied=%d dryRun=%v",
-		singleFound, singleApplied, dupFound, dupApplied, dryRun), nil)
+	slog.Info(fmt.Sprintf("Done: single_found=%d single_applied=%d dup_groups_found=%d dup_applied=%d dryRun=%v", singleFound, singleApplied, dupFound, dupApplied, dryRun))
 	return nil
 }
 

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000010-0000-0000-0000-000000000010
 // last-edited: 2026-05-01
 
@@ -17,7 +17,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&dedupBooksJob{}) }
 
@@ -64,7 +64,7 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 		}
 		if !dryRun {
 			if delErr := ddSoftDeleteBook(store, book.ID); delErr != nil {
-				reporter.Log("error", fmt.Sprintf("phase1 delete %s: %v", book.ID, delErr), nil)
+				slog.Error(fmt.Sprintf("phase1 delete %s: %v", book.ID, delErr))
 				continue
 			}
 		}
@@ -104,7 +104,7 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 			}
 			dup := &live[i]
 			if mergeErr := ddMergeDuplicateBook(store, keeper, dup, dryRun, j.enqueuer); mergeErr != nil {
-				reporter.Log("error", fmt.Sprintf("phase2 merge %s->%s fp=%s: %v", dup.ID, keeper.ID, fp, mergeErr), nil)
+				slog.Error(fmt.Sprintf("phase2 merge %s->%s fp=%s: %v", dup.ID, keeper.ID, fp, mergeErr))
 				continue
 			}
 			deletedIDs[dup.ID] = true
@@ -171,7 +171,7 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 			}
 			dup := &live[i]
 			if mergeErr := ddMergeDuplicateBook(store, keeper, dup, dryRun, j.enqueuer); mergeErr != nil {
-				reporter.Log("error", fmt.Sprintf("phase3 merge %s->%s: %v", dup.ID, keeper.ID, mergeErr), nil)
+				slog.Error(fmt.Sprintf("phase3 merge %s->%s: %v", dup.ID, keeper.ID, mergeErr))
 				continue
 			}
 			deletedIDs[dup.ID] = true
@@ -216,7 +216,7 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 				current.VersionGroupID = nil
 				current.IsPrimaryVersion = nil
 				if _, upErr := store.UpdateBook(dupID, current); upErr != nil {
-					reporter.Log("error", fmt.Sprintf("phase4 unlink vg %s from book %s: %v", vgID, dupID, upErr), nil)
+					slog.Error(fmt.Sprintf("phase4 unlink vg %s from book %s: %v", vgID, dupID, upErr))
 					continue
 				}
 				phase4++
@@ -230,9 +230,9 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 		reporter.Increment()
 	}
 
-	reporter.Log("info", fmt.Sprintf(
+	slog.Info(fmt.Sprintf(
 		"Done: phase1_junk=%d phase2_path=%d phase3_title=%d phase4_vg=%d dryRun=%v",
-		phase1, phase2, phase3, phase4, dryRun), nil)
+		phase1, phase2, phase3, phase4, dryRun))
 	return nil
 }
 

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/enrich_book_files.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000009-0000-0000-0000-000000000009
 // last-edited: 2026-05-01
 
@@ -14,7 +14,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&enrichBookFilesJob{}) }
 
@@ -63,13 +63,13 @@ func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, repo
 			bf.TrackNumber = n
 			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
 				msg := uerr.Error()
-				reporter.Log("error", "enrich-book-files: UpdateBookFile failed", &msg)
+				slog.Error("enrich-book-files: UpdateBookFile failed", "details", msg)
 				continue
 			}
 		}
 		updated++
 	}
 	_ = updated
-	reporter.Log("info", "enrich-book-files complete", nil)
+	slog.Info("enrich-book-files complete")
 	return nil
 }

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000003-0000-0000-0000-000000000003
 // last-edited: 2026-05-01
 
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&fixAuthorNarratorSwapJob{}) }
 
@@ -75,11 +75,11 @@ func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store
 			if !dryRun {
 				current, getErr := store.GetBookByID(book.ID)
 				if getErr != nil || current == nil {
-					reporter.Log("error", fmt.Sprintf("Failed to fetch book %s: %v", book.ID, getErr), nil)
+					slog.Error(fmt.Sprintf("Failed to fetch book %s: %v", book.ID, getErr))
 				} else {
 					current.AuthorID = nil
 					if _, updateErr := store.UpdateBook(book.ID, current); updateErr != nil {
-						reporter.Log("error", fmt.Sprintf("Failed to update book %s: %v", book.ID, updateErr), nil)
+						slog.Error(fmt.Sprintf("Failed to update book %s: %v", book.ID, updateErr))
 					} else {
 						applied++
 					}
@@ -94,6 +94,6 @@ func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store
 		offset += batchSize
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun), nil)
+	slog.Info(fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun))
 	return nil
 }

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_book_file_paths.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000011-0000-0000-0000-000000000011
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&fixBookFilePathsJob{}) }
 
@@ -50,7 +50,7 @@ func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, rep
 				bf.Missing = true
 				if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
 					msg := uerr.Error()
-					reporter.Log("error", "fix-book-file-paths: UpdateBookFile failed", &msg)
+					slog.Error("fix-book-file-paths: UpdateBookFile failed", "details", msg)
 					continue
 				}
 			}
@@ -58,6 +58,6 @@ func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, rep
 		}
 	}
 	_ = marked
-	reporter.Log("info", "fix-book-file-paths complete", nil)
+	slog.Info("fix-book-file-paths complete")
 	return nil
 }

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_library_states.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000008-0000-0000-0000-000000000008
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&fixLibraryStatesJob{}) }
 
@@ -59,7 +59,7 @@ func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, rep
 			updated.LibraryState = &wantState
 			if _, uerr := store.UpdateBook(book.ID, &updated); uerr != nil {
 				msg := uerr.Error()
-				reporter.Log("error", "fix-library-states: UpdateBook failed", &msg)
+				slog.Error("fix-library-states: UpdateBook failed", "details", msg)
 			} else {
 				fixed++
 			}
@@ -68,6 +68,6 @@ func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, rep
 		}
 	}
 	_ = fixed
-	reporter.Log("info", "fix-library-states complete", nil)
+	slog.Info("fix-library-states complete")
 	return nil
 }

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000001-0000-0000-0000-000000000001
 // last-edited: 2026-05-01
 
@@ -13,7 +13,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&fixReadByNarratorJob{}) }
 
@@ -78,7 +78,7 @@ func (j *fixReadByNarratorJob) Run(ctx context.Context, store database.Store, re
 		found++
 		if !dryRun {
 			if applyErr := rbnrApplyFix(store, book, fix); applyErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to fix book %s: %v", book.ID, applyErr), nil)
+				slog.Error(fmt.Sprintf("Failed to fix book %s: %v", book.ID, applyErr))
 			} else {
 				applied++
 			}
@@ -86,7 +86,7 @@ func (j *fixReadByNarratorJob) Run(ctx context.Context, store database.Store, re
 		reporter.Increment()
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun), nil)
+	slog.Info(fmt.Sprintf("Done: found=%d applied=%d dryRun=%v", found, applied, dryRun))
 	return nil
 }
 

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a1000004-0000-0000-0000-000000000004
 // last-edited: 2026-05-01
 
@@ -17,7 +17,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
 	"github.com/oklog/ulid/v2"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&fixVersionGroupsJob{}) }
 
@@ -82,7 +82,7 @@ func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, rep
 
 		if !dryRun {
 			if applyErr := vgUnlinkOutliers(store, outliers); applyErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to unlink outliers in group %s: %v", groupID, applyErr), nil)
+				slog.Error(fmt.Sprintf("Failed to unlink outliers in group %s: %v", groupID, applyErr))
 				mismatchErrors++
 			} else {
 				mismatchFixed++
@@ -118,7 +118,7 @@ func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, rep
 		suggested := vgBestMatchSubdir(b.FilePath, b.Title)
 		if !dryRun && suggested != "" {
 			if fixErr := vgFixAuthorDirPath(store, b, suggested); fixErr != nil {
-				reporter.Log("error", fmt.Sprintf("Failed to fix author-dir path for book %s: %v", b.ID, fixErr), nil)
+				slog.Error(fmt.Sprintf("Failed to fix author-dir path for book %s: %v", b.ID, fixErr))
 				authorDirErrors++
 			} else {
 				authorDirFixed++
@@ -128,8 +128,7 @@ func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, rep
 		}
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: mismatch_fixed=%d mismatch_errors=%d author_dir_fixed=%d author_dir_errors=%d dryRun=%v",
-		mismatchFixed, mismatchErrors, authorDirFixed, authorDirErrors, dryRun), nil)
+	slog.Info(fmt.Sprintf("Done: mismatch_fixed=%d mismatch_errors=%d author_dir_fixed=%d author_dir_errors=%d dryRun=%v", mismatchFixed, mismatchErrors, authorDirFixed, authorDirErrors, dryRun))
 	return nil
 }
 

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
 // last-edited: 2026-05-01
 
@@ -16,7 +16,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/util"
-)
+
+	"log/slog")
 
 func init() { maintenance.Register(&generateITLTestsJob{}) }
 
@@ -55,11 +56,11 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 	}
 
 	msg := fmt.Sprintf("found %d books and %d book_files", len(allBooks), len(allBookFiles))
-	reporter.Log("info", msg, nil)
+	slog.Info(msg)
 
 	if dryRun {
 		dry := fmt.Sprintf("dry-run: would generate ITL test suite in %s", outputDir)
-		reporter.Log("info", dry, nil)
+		slog.Info(dry)
 		return nil
 	}
 
@@ -74,6 +75,6 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 
 	done := fmt.Sprintf("Generated ITL test suite in %s with %d books and %d book_files",
 		outputDir, len(allBooks), len(allBookFiles))
-	reporter.Log("info", done, nil)
+	slog.Info(done)
 	return nil
 }

--- a/internal/maintenance/jobs/merge_chapter_groups.go
+++ b/internal/maintenance/jobs/merge_chapter_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/merge_chapter_groups.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000020-0000-0000-0000-000000000020
 // last-edited: 2026-05-01
 
@@ -12,7 +12,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&mergeChapterGroupsJob{}) }
 
@@ -54,14 +54,14 @@ func (j *mergeChapterGroupsJob) Run(ctx context.Context, store database.Store, r
 		if !dryRun {
 			if merr := store.MergeChapterBooks(primaryID, srcIDs, g.CommonTitle, g.TotalDuration); merr != nil {
 				msg := merr.Error()
-				reporter.Log("error", "merge-chapter-groups: MergeChapterBooks failed", &msg)
+				slog.Error("merge-chapter-groups: MergeChapterBooks failed", "details", msg)
 				continue
 			}
 		}
 		merged++
 		detail := fmt.Sprintf("primary=%s srcs=%v title=%q", primaryID, srcIDs, g.CommonTitle)
-		reporter.Log("info", "merged chapter group", &detail)
+		slog.Info("merged chapter group", "details", detail)
 	}
-	reporter.Log("info", fmt.Sprintf("merge-chapter-groups complete: %d merged", merged), nil)
+	slog.Info(fmt.Sprintf("merge-chapter-groups complete: %d merged", merged))
 	return nil
 }

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000013-0000-0000-0000-000000000013
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metafetch"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&recomputeITunesPathsJob{}) }
 
@@ -50,13 +50,13 @@ func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store,
 			bf.ITunesPath = want
 			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
 				msg := uerr.Error()
-				reporter.Log("error", "recompute-itunes-paths: UpdateBookFile failed", &msg)
+				slog.Error("recompute-itunes-paths: UpdateBookFile failed", "details", msg)
 				continue
 			}
 		}
 		updated++
 	}
 	_ = updated
-	reporter.Log("info", "recompute-itunes-paths complete", nil)
+	slog.Info("recompute-itunes-paths complete")
 	return nil
 }

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.0.0
+// version: 2.0.1
 // guid: a1000012-0000-0000-0000-000000000012
 // last-edited: 2026-05-05
 
@@ -14,7 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&refetchMissingAuthorsJob{}) }
 
@@ -106,7 +106,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		}
 
 		if audioPath == "" {
-			reporter.Log("warn", fmt.Sprintf("no audio file for book %s (%s), skipping", b.ID, b.Title), nil)
+			slog.Warn(fmt.Sprintf("no audio file for book %s (%s), skipping", b.ID, b.Title))
 			skipped++
 			continue
 		}
@@ -115,7 +115,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		// Tag priority: ALBUMARTIST > ARTIST > COMPOSER (composer = narrator in audiobooks).
 		tags, readErr := metadata.ReadRawTags(audioPath)
 		if readErr != nil {
-			reporter.Log("error", fmt.Sprintf("failed to read tags for %s: %v", audioPath, readErr), nil)
+			slog.Error(fmt.Sprintf("failed to read tags for %s: %v", audioPath, readErr))
 			errors++
 			continue
 		}
@@ -143,13 +143,13 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		}
 
 		if authorName == "" {
-			reporter.Log("warn", fmt.Sprintf("no author found in tags for book %s (%s)", b.ID, b.Title), nil)
+			slog.Warn(fmt.Sprintf("no author found in tags for book %s (%s)", b.ID, b.Title))
 			skipped++
 			continue
 		}
 
 		if dryRun {
-			reporter.Log("info", fmt.Sprintf("[dry] would set author %q for book %s (%s)", authorName, b.ID, b.Title), nil)
+			slog.Info(fmt.Sprintf("[dry] would set author %q for book %s (%s)", authorName, b.ID, b.Title))
 			filled++
 			continue
 		}
@@ -159,7 +159,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		if err != nil || author == nil {
 			author, err = store.CreateAuthor(authorName)
 			if err != nil {
-				reporter.Log("error", fmt.Sprintf("failed to create author %q for book %s: %v", authorName, b.ID, err), nil)
+				slog.Error(fmt.Sprintf("failed to create author %q for book %s: %v", authorName, b.ID, err))
 				errors++
 				continue
 			}
@@ -168,7 +168,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 
 		b.AuthorID = &author.ID
 		if _, err := store.UpdateBook(b.ID, b); err != nil {
-			reporter.Log("error", fmt.Sprintf("failed to update book %s: %v", b.ID, err), nil)
+			slog.Error(fmt.Sprintf("failed to update book %s: %v", b.ID, err))
 			errors++
 			continue
 		}
@@ -179,7 +179,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 
 	summary := fmt.Sprintf("refetch-missing-authors complete: total=%d filled=%d skipped=%d errors=%d dryRun=%v",
 		len(books), filled, skipped, errors, dryRun)
-	reporter.Log("info", summary, nil)
+	slog.Info(summary)
 	log.Printf("[INFO] %s %s", opID, summary)
 	return nil
 }

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
 // last-edited: 2026-05-05
 
@@ -20,7 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/util"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&relinkMissingToITunesJob{}) }
 
@@ -159,9 +159,7 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 
 	log.Printf("[INFO] relink-missing-to-itunes: relinked=%d ambiguous=%d unresolved=%d skipped=%d",
 		relinked, ambiguous, unresolved, skipped)
-	reporter.Log("info",
-		fmt.Sprintf("relinked=%d ambiguous=%d unresolved=%d skipped=%d", relinked, ambiguous, unresolved, skipped),
-		nil)
+	slog.Info(fmt.Sprintf("relinked=%d ambiguous=%d unresolved=%d skipped=%d", relinked, ambiguous, unresolved, skipped))
 	return nil
 }
 

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.2.0
+// version: 2.2.1
 // guid: a1000022-0000-0000-0000-000000000022
 // last-edited: 2026-05-05
 
@@ -18,7 +18,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&relinkReportJob{}) }
 
@@ -90,7 +90,7 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 			}
 		}
 		if authorName == "" {
-			reporter.Log("warn", fmt.Sprintf("No author for missing book %s (%q)", book.ID, book.Title), nil)
+			slog.Warn(fmt.Sprintf("No author for missing book %s (%q)", book.ID, book.Title))
 			unresolved++
 			reporter.Increment()
 			continue
@@ -103,11 +103,11 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 			unresolved++
 		case 1:
 			resolved++
-			reporter.Log("info", fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, matches[0]), nil)
+			slog.Info(fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, matches[0]))
 		default:
 			if best := rrDisambiguate(matches, authorName, book.Title); best != "" {
 				resolved++
-				reporter.Log("info", fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, best), nil)
+				slog.Info(fmt.Sprintf("Relinkable: book=%s title=%q -> %s", book.ID, book.Title, best))
 			} else {
 				unresolved++
 			}
@@ -115,7 +115,7 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 		reporter.Increment()
 	}
 
-	reporter.Log("info", fmt.Sprintf("Done: resolved=%d unresolved=%d skipped=%d", resolved, unresolved, skipped), nil)
+	slog.Info(fmt.Sprintf("Done: resolved=%d unresolved=%d skipped=%d", resolved, unresolved, skipped))
 	return nil
 }
 

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
 // last-edited: 2026-05-01
 
@@ -21,7 +21,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/util"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&repairMissingFilesJob{}) }
 
@@ -111,7 +111,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	}
 
 	if len(work) == 0 {
-		reporter.Log("info", "all files already processed", nil)
+		slog.Info("all files already processed")
 		return nil
 	}
 
@@ -142,7 +142,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	var idxMu sync.Mutex
 	buildIdx := func() {
 		idxOnce.Do(func() {
-			reporter.Log("info", "building filename index…", nil)
+			slog.Info("building filename index…")
 			idx := make(map[string][]string, 200000)
 			for _, root := range searchRoots {
 				_ = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
@@ -210,7 +210,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 
 	finalCount := atomic.LoadInt64(&completed)
 	msg := fmt.Sprintf("Repaired %d of %d missing files", finalCount, totalFiles)
-	reporter.Log("info", msg, nil)
+	slog.Info(msg)
 	log.Printf("[INFO] repair-missing-files %s: finished %d/%d files", opID, finalCount, totalFiles)
 	return nil
 }

--- a/internal/maintenance/jobs/revert_metadata_fetch.go
+++ b/internal/maintenance/jobs/revert_metadata_fetch.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/revert_metadata_fetch.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: c8d4e2b3-5f6a-7b8c-9d0e-1f2a3b4c5d6e
 // last-edited: 2026-04-28
 
@@ -15,7 +15,8 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+
+	"log/slog")
 
 func init() { maintenance.Register(&revertMetadataFetchJob{}) }
 
@@ -208,6 +209,6 @@ func (j *revertMetadataFetchJob) Run(ctx context.Context, store database.Store, 
 
 	log.Printf("[INFO] revert-metadata-fetch: done — reverted:%d skipped:%d errors:%d", reverted, skipped, errors)
 	summary := fmt.Sprintf("Reverted %d books (skipped: %d, errors: %d)", reverted, skipped, errors)
-	reporter.Log("info", summary, nil)
+	slog.Info(summary)
 	return nil
 }

--- a/internal/maintenance/jobs/scan_chapter_groups.go
+++ b/internal/maintenance/jobs/scan_chapter_groups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_chapter_groups.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000019-0000-0000-0000-000000000019
 // last-edited: 2026-05-01
 
@@ -12,7 +12,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&scanChapterGroupsJob{}) }
 
@@ -43,8 +43,8 @@ func (j *scanChapterGroupsJob) Run(ctx context.Context, store database.Store, re
 	for _, g := range groups {
 		reporter.Increment()
 		detail := fmt.Sprintf("title=%q files=%d duration=%.0fs ids=%v", g.CommonTitle, g.FileCount, g.TotalDuration, g.BookIDs)
-		reporter.Log("info", "chapter group detected", &detail)
+		slog.Info("chapter group detected", "details", detail)
 	}
-	reporter.Log("info", fmt.Sprintf("scan-chapter-groups complete: %d groups", len(groups)), nil)
+	slog.Info(fmt.Sprintf("scan-chapter-groups complete: %d groups", len(groups)))
 	return nil
 }

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
 // last-edited: 2026-04-28
 
@@ -19,7 +19,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&scanComposerTagsJob{}) }
 
@@ -131,7 +131,7 @@ func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, rep
 	}
 
 	if len(workItems) == 0 {
-		reporter.Log("info", "all files already processed", nil)
+		slog.Info("all files already processed")
 		return nil
 	}
 
@@ -221,7 +221,7 @@ func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, rep
 
 	finalCount := atomic.LoadInt64(&completed)
 	log.Printf("[INFO] scan-composer-tags %s: finished %d/%d files", opID, finalCount, totalFiles)
-	reporter.Log("info", fmt.Sprintf("scan complete: processed %d/%d files", finalCount, totalFiles), nil)
+	slog.Info(fmt.Sprintf("scan complete: processed %d/%d files", finalCount, totalFiles))
 	return nil
 }
 

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_duplicate_files.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000016-0000-0000-0000-000000000016
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&scanDuplicateFilesJob{}) }
 
@@ -51,9 +51,9 @@ func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, r
 		if len(paths) > 1 {
 			dups++
 			detail := fmt.Sprintf("hash=%s paths=%v", hash, paths)
-			reporter.Log("warn", "duplicate files detected", &detail)
+			slog.Warn("duplicate files detected", "details", detail)
 		}
 	}
-	reporter.Log("info", fmt.Sprintf("scan-duplicate-files complete: %d duplicate groups", dups), nil)
+	slog.Info(fmt.Sprintf("scan-duplicate-files complete: %d duplicate groups", dups))
 	return nil
 }

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_duration_mismatch.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000018-0000-0000-0000-000000000018
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&scanDurationMismatchJob{}) }
 
@@ -53,9 +53,9 @@ func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store,
 		if delta > 120 {
 			mismatches++
 			detail := fmt.Sprintf("local=%ds audible=%ds delta=%ds", *b.Duration, audibleSec, delta)
-			reporter.Log("warn", "duration mismatch: "+b.Title, &detail)
+			slog.Warn("duration mismatch: "+b.Title, "details", detail)
 		}
 	}
-	reporter.Log("info", fmt.Sprintf("scan-duration-mismatch complete: %d mismatches", mismatches), nil)
+	slog.Info(fmt.Sprintf("scan-duration-mismatch complete: %d mismatches", mismatches))
 	return nil
 }

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/scan_metadata_hash_dups.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1000017-0000-0000-0000-000000000017
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/maintenance"
-)
+	"log/slog")
 
 func init() { maintenance.Register(&scanMetadataHashDupsJob{}) }
 
@@ -51,9 +51,9 @@ func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store,
 		if len(ids) > 1 {
 			dups++
 			detail := fmt.Sprintf("book_ids=%v", ids)
-			reporter.Log("warn", "metadata hash duplicate group", &detail)
+			slog.Warn("metadata hash duplicate group", "details", detail)
 		}
 	}
-	reporter.Log("info", fmt.Sprintf("scan-metadata-hash-dups complete: %d duplicate groups", dups), nil)
+	slog.Info(fmt.Sprintf("scan-metadata-hash-dups complete: %d duplicate groups", dups))
 	return nil
 }


### PR DESCRIPTION
## Summary

Convert all 29 job files in `internal/maintenance/jobs` to use bare `slog.*` calls instead of `reporter.Log()`. This completes the Wave 6 infrastructure migration for the maintenance/jobs packages.

- 80 reporter.Log() calls converted to slog.Info/Warn/Error/Debug
- All 29 files updated with version bumps (patch increment)
- All imports updated to include "log/slog"
- Build verified, core functionality tests passing
- slog output visible in test runs

## Test plan

- [x] `go build ./internal/maintenance/jobs` — succeeds
- [x] `go test ./internal/maintenance/jobs/... -run TestCleanupEmptyFoldersJob` — all pass
- [x] Core functionality tests passing (deletion, file operations, etc.)
- [x] slog output verified in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)