### PR TITLE
feat(logging): convert Wave 5 iTunes service to slog

### DIFF
--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.0.3
+// version: 1.0.4
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 
 package itunesservice
@@ -7,7 +7,7 @@ package itunesservice
 import (
 	"context"
 	"fmt"
-	stdlog "log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -993,7 +993,7 @@ func (imp *Importer) organizeOneBook(book *database.Book, log logger.Logger) err
 func (imp *Importer) applyOrganizedFileMetadata(book *database.Book, newPath string) {
 	hash, err := scanner.ComputeFileHash(newPath)
 	if err != nil {
-		stdlog.Printf("[WARN] failed to compute organized hash for %s: %v", newPath, err)
+		slog.Warn("failed to compute organized hash", "path", newPath, "error", err)
 	} else if hash != "" {
 		book.FileHash = strPtr(hash)
 		book.OrganizedFileHash = strPtr(hash)
@@ -1157,7 +1157,7 @@ func (imp *Importer) buildBookFromAlbumGroup(group albumGroup, libraryPath strin
 	}
 
 	if len(group.tracks) > 1 {
-		stdlog.Printf("iTunes import: grouped %d tracks into album %q", len(group.tracks), title)
+		slog.Info("iTunes import: grouped tracks", "count", len(group.tracks), "album", title)
 	}
 	return book, nil
 }


### PR DESCRIPTION
## Wave 5: iTunes Service Logging Conversion

Converts the only stdlib `log` usage in `internal/itunes/service/` from `stdlog` (aliased import of the standard library) to `log/slog`.

### Changes

- **internal/itunes/service/importer.go**: 
  - Replaced `stdlog "log"` import with `"log/slog"`
  - Converted 2 `stdlog.Printf()` calls to structured slog calls:
    - `[WARN]` message → `slog.Warn()` with key-value attributes
    - Album grouping message → `slog.Info()` with key-value attributes
  - Version bumped from 1.0.3 to 1.0.4

### Test Results

✅ All tests pass (`make test`)
✅ No remaining stdlib `log` imports in `internal/itunes/service/`

### Wave Status

Wave 5 complete — only 1 file required conversion (other service files use the `logger.Logger` interface parameter, not stdlib log).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>