### PR TITLE
feat(logging): convert Wave 7 cmd files to slog

### DIFF
--- a/cmd/dedup_bench.go
+++ b/cmd/dedup_bench.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 //go:build bench
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -94,17 +94,17 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	log.Printf("Dedup bench output: %s", runDir)
+	slog.Info("Dedup bench output", "directory", runDir)
 
 	// Extract author data
 	var authorData *AuthorData
 	var err error
 
 	if benchServerURL != "" {
-		log.Printf("Fetching authors from remote server: %s", benchServerURL)
+		slog.Info("Fetching authors from server", "server", benchServerURL)
 		authorData, err = fetchAuthorsFromServer(benchServerURL)
 	} else {
-		log.Println("Fetching authors from local database")
+		slog.Info("Fetching authors from local database")
 		store, initErr := initializeStore(
 			config.AppConfig.DatabaseType,
 			config.AppConfig.DatabasePath,
@@ -131,10 +131,10 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Printf("Extracted %d authors, %d heuristic groups", len(authorData.Authors), len(groups))
+	slog.Info("Extracted author data", "authors", len(authorData.Authors), "groups", len(groups))
 
 	if benchDryRun {
-		log.Println("Dry run — data extracted, skipping API calls")
+		slog.Info("Dry run — data extracted, skipping API calls")
 		return nil
 	}
 
@@ -153,8 +153,8 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		log.Printf("Submitted %d batch jobs. Check results later with:", len(jobs))
-		log.Printf("  ./audiobook-organizer dedup-bench check %s", runDir)
+		slog.Info("Submitted batch jobs", "count", len(jobs))
+		slog.Info("Check results", "command", "dedup-bench check " + runDir)
 		return nil
 	}
 
@@ -162,12 +162,11 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 	var allResults []BenchRunResult
 	for i, tc := range configs {
 		for _, mode := range modes {
-			log.Printf("[%d/%d] Running: model=%s prompt=%s temp=%.1f mode=%s",
-				i+1, len(configs), tc.Model, tc.PromptVariant, tc.Temperature, mode)
+			slog.Info("Running benchmark", "step", i+1, "total", len(configs), "model", tc.Model, "prompt", tc.PromptVariant, "temp", tc.Temperature, "mode", mode)
 
 			result, runErr := executeBenchRun(cmd.Context(), apiKey, tc, authorData, groups, mode, runDir, benchChunkSize)
 			if runErr != nil {
-				log.Printf("  ERROR: %v", runErr)
+				slog.Error("benchmark run failed", "error", runErr)
 				result = &BenchRunResult{
 					Config: tc,
 					Mode:   mode,
@@ -187,8 +186,8 @@ func runDedupBench(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Printf("Benchmark complete. Results in %s", runDir)
-	log.Printf("View report: cat %s/summary.md", runDir)
+	slog.Info("Benchmark complete", "directory", runDir)
+	slog.Info("View report", "command", "cat " + runDir + "/summary.md")
 	return nil
 }
 
@@ -230,27 +229,26 @@ func runDedupBenchCheck(cmd *cobra.Command, args []string) error {
 	for _, job := range jobs {
 		batch, err := client.Batches.Get(cmd.Context(), job.BatchID)
 		if err != nil {
-			log.Printf("ERROR checking batch %s: %v", job.BatchID, err)
+			slog.Error("Error checking batch", "batch_id", job.BatchID, "error", err)
 			failed++
 			continue
 		}
 
 		status := string(batch.Status)
-		log.Printf("Batch %s (%s %s %s): %s",
-			job.BatchID, job.Config.Model, job.Config.PromptVariant, job.Mode, status)
+		slog.Info("Batch status", "batch_id", job.BatchID, "model", job.Config.Model, "variant", job.Config.PromptVariant, "mode", job.Mode, "status", status)
 
 		if status == "completed" {
 			completed++
 
 			// Download results
 			if batch.OutputFileID == "" {
-				log.Printf("  No output file ID")
+				slog.Warn("No output file ID")
 				continue
 			}
 
 			result, err := downloadBatchResult(cmd.Context(), &client, batch.OutputFileID, job)
 			if err != nil {
-				log.Printf("  ERROR downloading results: %v", err)
+				slog.Error("Error downloading results", "error", err)
 				continue
 			}
 			allResults = append(allResults, *result)
@@ -260,7 +258,7 @@ func runDedupBenchCheck(cmd *cobra.Command, args []string) error {
 			if len(batch.Errors.Data) > 0 {
 				errMsg = batch.Errors.Data[0].Message
 			}
-			log.Printf("  Failed: %s", errMsg)
+			slog.Error("Batch failed", "reason", errMsg)
 			allResults = append(allResults, BenchRunResult{
 				Config: job.Config,
 				Mode:   job.Mode,
@@ -269,12 +267,12 @@ func runDedupBenchCheck(cmd *cobra.Command, args []string) error {
 		} else {
 			pending++
 			if batch.RequestCounts.Completed > 0 || batch.RequestCounts.Total > 0 {
-				log.Printf("  Progress: %d/%d completed", batch.RequestCounts.Completed, batch.RequestCounts.Total)
+				slog.Info("Batch progress", "completed", batch.RequestCounts.Completed, "total", batch.RequestCounts.Total)
 			}
 		}
 	}
 
-	log.Printf("Status: %d completed, %d failed, %d pending", completed, failed, pending)
+	slog.Info("Batch check summary", "completed", completed, "failed", failed, "pending", pending)
 
 	if completed > 0 {
 		// Load author/group counts from saved data
@@ -300,11 +298,11 @@ func runDedupBenchCheck(cmd *cobra.Command, args []string) error {
 		if err := writeSummaryMarkdown(filepath.Join(runDir, "summary.md"), summary); err != nil {
 			return err
 		}
-		log.Printf("Summary updated: %s/summary.md", runDir)
+		slog.Info("Summary updated", "file", runDir + "/summary.md")
 	}
 
 	if pending > 0 {
-		log.Printf("Run this command again later to check remaining jobs")
+		slog.Info("Run this command again later to check remaining jobs")
 	}
 
 	return nil
@@ -405,7 +403,7 @@ func downloadBatchResult(ctx context.Context, client *openai.Client, outputFileI
 
 	_ = writeJSON(filepath.Join(job.RunDir, "stats.json"), result)
 
-	log.Printf("  Downloaded: %d suggestions, ~$%.4f", numSuggestions, costEstimate)
+	slog.Info("Downloaded batch results", "suggestions", numSuggestions, "cost_usd", costEstimate)
 	return result, nil
 }
 
@@ -457,7 +455,7 @@ func fetchAuthorsFromServer(serverURL string) (*AuthorData, error) {
 		return nil, fmt.Errorf("decode authors: %w", err)
 	}
 
-	log.Printf("Fetched %d authors from server", authorList.Count)
+	slog.Info("Fetched authors", "count", authorList.Count)
 
 	// Fetch audiobooks with pagination
 	bookCounts := map[int]int{}
@@ -468,7 +466,7 @@ func fetchAuthorsFromServer(serverURL string) (*AuthorData, error) {
 		url := fmt.Sprintf("%s/api/v1/audiobooks?limit=%d&offset=%d", serverURL, pageSize, offset)
 		booksResp, err := httpClient.Get(url)
 		if err != nil {
-			log.Printf("Warning: couldn't fetch books (offset %d): %v", offset, err)
+			slog.Warn("Could not fetch books", "offset", offset, "error", err)
 			break
 		}
 
@@ -479,7 +477,7 @@ func fetchAuthorsFromServer(serverURL string) (*AuthorData, error) {
 		decErr := json.NewDecoder(booksResp.Body).Decode(&page)
 		booksResp.Body.Close()
 		if decErr != nil {
-			log.Printf("Warning: couldn't decode books (offset %d): %v", offset, decErr)
+			slog.Warn("Could not decode books", "offset", offset, "error", decErr)
 			break
 		}
 
@@ -497,14 +495,13 @@ func fetchAuthorsFromServer(serverURL string) (*AuthorData, error) {
 			}
 		}
 
-		log.Printf("Fetched %d books (offset %d)", len(page.Items), offset)
+		slog.Info("Fetched books page", "count", len(page.Items), "offset", offset)
 		if len(page.Items) < pageSize {
 			break
 		}
 		offset += pageSize
 	}
-	log.Printf("Total: %d author-book mappings, %d authors with sample titles",
-		len(bookCounts), len(sampleBooks))
+	slog.Info("Book fetch complete", "mappings", len(bookCounts), "authors_with_samples", len(sampleBooks))
 
 	return &AuthorData{
 		Authors:     authorList.Items,

--- a/cmd/dedup_bench_batch.go
+++ b/cmd/dedup_bench_batch.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_batch.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: f6a7b8c9-d0e1-2345-fabc-678901234567
 
 //go:build bench
@@ -11,7 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,8 +55,7 @@ func submitBatchJobs(
 
 	for _, tc := range configs {
 		for _, mode := range modes {
-			log.Printf("Submitting batch: model=%s prompt=%s temp=%.1f mode=%s",
-				tc.Model, tc.PromptVariant, tc.Temperature, mode)
+			slog.Info("Submitting batch", "model", tc.Model, "prompt", tc.PromptVariant, "temp", tc.Temperature, "mode", mode)
 
 			// Create run output directory
 			dirName := fmt.Sprintf("%s_%s_t%.1f_%s", tc.Model, tc.PromptVariant, tc.Temperature, mode)
@@ -152,7 +151,7 @@ func submitBatchJobs(
 				Purpose: openai.FilePurposeBatch,
 			})
 			if err != nil {
-				log.Printf("  ERROR uploading file: %v", err)
+				slog.Error("uploading file failed", "error", err)
 				_ = writeJSON(filepath.Join(outDir, "error.json"), map[string]string{"error": err.Error()})
 				continue
 			}
@@ -164,7 +163,7 @@ func submitBatchJobs(
 				CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
 			})
 			if err != nil {
-				log.Printf("  ERROR creating batch: %v", err)
+				slog.Error("creating batch failed", "error", err)
 				_ = writeJSON(filepath.Join(outDir, "error.json"), map[string]string{"error": err.Error()})
 				continue
 			}
@@ -182,7 +181,7 @@ func submitBatchJobs(
 
 			_ = writeJSON(filepath.Join(outDir, "batch_info.json"), job)
 
-			log.Printf("  Submitted batch %s (%d requests, file %s)", batch.ID, len(chunks), file.ID)
+			slog.Info("Submitted batch", "batch_id", batch.ID, "requests", len(chunks), "file_id", file.ID)
 		}
 	}
 

--- a/cmd/dedup_bench_crossval.go
+++ b/cmd/dedup_bench_crossval.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_crossval.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 3c4d5e6f-7a8b-9012-cdef-333333333333
 
 //go:build bench
@@ -9,7 +9,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,7 +101,7 @@ func runDedupBenchCrossval(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load results: %w", err)
 	}
-	log.Printf("Loaded %d suggestions from %s", len(suggestionsA), crossvalModelA)
+	slog.Info("Loaded suggestions", "count", len(suggestionsA), "model", crossvalModelA)
 
 	suggestionsText, _ := json.Marshal(suggestionsA)
 
@@ -113,7 +113,7 @@ func runDedupBenchCrossval(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("read input data: %w", err)
 		}
 		inputText = string(data)
-		log.Printf("Loaded original input data (%d bytes)", len(data))
+		slog.Info("Loaded original input data", "bytes", len(data))
 	}
 
 	// Fetch book evidence for uncertain items
@@ -196,16 +196,16 @@ func runDedupBenchCrossval(cmd *cobra.Command, args []string) error {
 			userPrompt = strings.Join(parts, "")
 		}
 
-		log.Printf("[%s] %s reviewing %s: ~%d input tokens", variant, crossvalModelB, crossvalModelA, len(userPrompt)/4)
+		slog.Info("Reviewing suggestions", "variant", variant, "model", crossvalModelB, "reviewed_model", crossvalModelA, "tokens", len(userPrompt)/4)
 
 		customID := fmt.Sprintf("crossval_%s_%s", label, ts)
 		if err := submitSingleBatch(cmd.Context(), apiKey, crossvalModelB, systemPrompt, userPrompt, customID, outDir); err != nil {
-			log.Printf("  ERROR: %v", err)
+			slog.Error("batch submission failed", "error", err)
 			continue
 		}
 	}
 
-	log.Printf("Check: ./audiobook-organizer dedup-bench check %s", runDir)
+	slog.Info("Check results later", "command", "dedup-bench check " + runDir)
 	return nil
 }
 

--- a/cmd/dedup_bench_pass2.go
+++ b/cmd/dedup_bench_pass2.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_pass2.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 2b3c4d5e-6f7a-8901-bcde-222222222222
 
 //go:build bench
@@ -12,7 +12,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -86,7 +86,7 @@ func runDedupBenchPass2(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("load results: %w", err)
 	}
-	log.Printf("Loaded %d first-pass suggestions", len(suggestions))
+	slog.Info("Loaded first-pass suggestions", "count", len(suggestions))
 
 	// Filter uncertain
 	thresholds := map[string]bool{"low": true}
@@ -100,10 +100,10 @@ func runDedupBenchPass2(cmd *cobra.Command, args []string) error {
 			uncertain = append(uncertain, s)
 		}
 	}
-	log.Printf("Found %d uncertain suggestions (%s and below)", len(uncertain), pass2Threshold)
+	slog.Info("Found uncertain suggestions", "count", len(uncertain), "threshold", pass2Threshold)
 
 	if len(uncertain) == 0 {
-		log.Println("No uncertain suggestions to enrich.")
+		slog.Info("No uncertain suggestions to enrich")
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func runDedupBenchPass2(cmd *cobra.Command, args []string) error {
 	authorIDs := collectAuthorIDsFromGroups(uncertain, groups)
 
 	// Fetch book data
-	log.Printf("Fetching books for %d authors from %s...", len(authorIDs), benchServerURL)
+	slog.Info("Fetching books for authors", "count", len(authorIDs), "server", benchServerURL)
 	booksByAuthor, err := fetchBooksForAuthorIDs(benchServerURL, authorIDs)
 	if err != nil {
 		return fmt.Errorf("fetch books: %w", err)
@@ -402,7 +402,7 @@ func submitSingleBatch(ctx context.Context, apiKey, model, systemPrompt, userPro
 	}}
 	_ = writeJSON(filepath.Join(runDir, "batch_jobs.json"), jobInfo)
 
-	log.Printf("Submitted batch %s", batch.ID)
-	log.Printf("Check: ./audiobook-organizer dedup-bench check %s", runDir)
+	slog.Info("Submitted batch", "batch_id", batch.ID)
+	slog.Info("Check results later", "command", "dedup-bench check " + runDir)
 	return nil
 }

--- a/cmd/dedup_bench_runner.go
+++ b/cmd/dedup_bench_runner.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_runner.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: d4e5f6a7-b8c9-0123-defa-456789012345
 
 //go:build bench
@@ -10,7 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,7 +76,7 @@ func executeBenchRun(
 
 	// For large datasets, chunk the input
 	chunks := chunkInput(inputJSON, chunkSize, mode)
-	log.Printf("  Input size: %d bytes, %d chunk(s)", len(inputJSON), len(chunks))
+	slog.Info("Input size", "bytes", len(inputJSON), "chunks", len(chunks))
 
 	// Save the full request data
 	request := map[string]interface{}{
@@ -112,7 +112,7 @@ func executeBenchRun(
 
 	for ci, chunk := range chunks {
 		if len(chunks) > 1 {
-			log.Printf("  Chunk %d/%d (%d bytes)", ci+1, len(chunks), len(chunk))
+			slog.Info("Processing chunk", "number", ci+1, "total", len(chunks), "bytes", len(chunk))
 		}
 
 		userPrompt := userPromptPrefix + string(chunk)
@@ -187,7 +187,7 @@ func executeBenchRun(
 				Suggestions []json.RawMessage `json:"suggestions"`
 			}
 			if err := json.Unmarshal([]byte(content), &parsed); err != nil {
-				log.Printf("  Warning: failed to parse suggestions from chunk %d: %v", ci, err)
+				slog.Warn("Failed to parse suggestions", "chunk", ci, "error", err)
 				_ = writeJSON(filepath.Join(outDir, fmt.Sprintf("chunk_%d_parse_error.json", ci)), map[string]string{
 					"error": err.Error(),
 					"raw":   content,
@@ -197,8 +197,7 @@ func executeBenchRun(
 			}
 		}
 
-		log.Printf("  Chunk %d: %dms, in=%d out=%d",
-			ci, elapsed.Milliseconds(), completion.Usage.PromptTokens, completion.Usage.CompletionTokens)
+		slog.Info("Chunk processed", "number", ci, "duration_ms", elapsed.Milliseconds(), "input_tokens", completion.Usage.PromptTokens, "output_tokens", completion.Usage.CompletionTokens)
 
 		// Brief pause between chunks
 		if ci < len(chunks)-1 {
@@ -248,8 +247,7 @@ func executeBenchRun(
 		return nil, err
 	}
 
-	log.Printf("  Done: %dms, %d suggestions, ~$%.4f",
-		totalElapsed.Milliseconds(), len(allSuggestionsRaw), costEstimate)
+	slog.Info("Run complete", "duration_ms", totalElapsed.Milliseconds(), "suggestions", len(allSuggestionsRaw), "cost_usd", costEstimate)
 
 	return result, nil
 }

--- a/cmd/dedup_bench_status.go
+++ b/cmd/dedup_bench_status.go
@@ -1,5 +1,5 @@
 // file: cmd/dedup_bench_status.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 1a2b3c4d-5e6f-7890-abcd-111111111111
 
 //go:build bench
@@ -8,7 +8,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/jdfalk/audiobook-organizer/internal/config"
@@ -70,6 +70,6 @@ func runDedupBenchStatus(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%-24s %-14s %6d %6d %6d\n", b.ID[:24], status, ok, fail, total)
 	}
 
-	log.Printf("\nSummary: %d completed, %d failed, %d pending", completed, failed, pending)
+	slog.Info("Status summary", "completed", completed, "failed", failed, "pending", pending)
 	return nil
 }

--- a/cmd/pebble-inject-skip/main.go
+++ b/cmd/pebble-inject-skip/main.go
@@ -1,5 +1,5 @@
 // file: cmd/pebble-inject-skip/main.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 //
 // One-shot tool: writes transcode skip flags directly into PebbleDB.
@@ -10,7 +10,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -25,13 +25,13 @@ type Setting struct {
 
 func main() {
 	if len(os.Args) < 2 {
-		log.Fatal("usage: pebble-inject-skip <pebble-db-path>")
+		slog.Error("usage: pebble-inject-skip <pebble-db-path>"); os.Exit(1)
 	}
 	dbPath := os.Args[1]
 
 	db, err := pebble.Open(dbPath, &pebble.Options{})
 	if err != nil {
-		log.Fatalf("open pebble: %v", err)
+		slog.Error("open pebble failed", "error", err); os.Exit(1)
 	}
 	defer db.Close()
 
@@ -44,11 +44,11 @@ func main() {
 		s := Setting{Key: k, Value: "true", Type: "bool", IsSecret: false}
 		val, err := json.Marshal(s)
 		if err != nil {
-			log.Fatalf("marshal %s: %v", k, err)
+			slog.Error("marshal failed", "key", k, "error", err); os.Exit(1)
 		}
 		dbKey := "setting:" + k
 		if err := db.Set([]byte(dbKey), val, pebble.Sync); err != nil {
-			log.Fatalf("set %s: %v", dbKey, err)
+			slog.Error("set failed", "key", dbKey, "error", err); os.Exit(1)
 		}
 		fmt.Printf("SET %s = %s\n", dbKey, val)
 	}


### PR DESCRIPTION
## Summary

Convert 7 cmd files from log to slog (51 log calls total):
- cmd/dedup_bench_batch.go (4 calls)
- cmd/dedup_bench_crossval.go (5 calls)
- cmd/dedup_bench_status.go (1 call)
- cmd/dedup_bench_runner.go (5 calls)
- cmd/dedup_bench_pass2.go (6 calls)
- cmd/dedup_bench.go (26 calls)
- cmd/pebble-inject-skip/main.go (4 log.Fatal → slog.Error + os.Exit(1))

All log imports replaced with log/slog, version headers updated, flat KV pairs used throughout.

## Test plan

- go build ./cmd/... passes
- go vet ./cmd/... passes
- All slog calls verified (51 total)
- No remaining log. calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)