### PR TITLE
feat(logging): convert Wave 8 metafetch packages to slog

### DIFF
--- a/internal/metafetch/cache.go
+++ b/internal/metafetch/cache.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/cache.go
-// version: 1.0.0
+// version: 1.1.0
 //
 // Cache-layer on top of metafetch.Service. The persisted record type
 // lives in internal/database (MetadataCandidateCache) — re-exported
@@ -15,7 +15,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -90,7 +90,7 @@ func (mfs *Service) FetchAndCache(ctx context.Context, bookID, query, author, na
 		if err := mfs.db.PutMetadataCache(entry); err != nil {
 			// Cache failure should not break the user's fetch; log and
 			// continue (callers can still consume the in-memory entry).
-			log.Printf("[WARN] metafetch: FetchAndCache write %s: %v", bookID, err)
+						slog.Warn("metafetch: FetchAndCache write :", "id", bookID, "error", err)
 			return entry, nil
 		}
 	}

--- a/internal/metafetch/helpers.go
+++ b/internal/metafetch/helpers.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/helpers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
 
 package metafetch
@@ -7,7 +7,7 @@ package metafetch
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -245,7 +245,7 @@ func (mfs *Service) loadMetadataState(bookID string) (map[string]metadataFieldSt
 	}
 
 	if err := mfs.saveMetadataState(bookID, legacy); err != nil {
-		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
+				slog.Warn("failed to migrate legacy metadata state for :", "id", bookID, "error", err)
 	}
 	return legacy, nil
 }

--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -1,12 +1,12 @@
 // file: internal/metafetch/isbn.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
 
 package metafetch
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
@@ -65,7 +65,7 @@ func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return false, err
 			}
-			log.Printf("[INFO] ISBN enrichment: found %s for %q (%s)", isbn, title, src.Name())
+						slog.Info("ISBN enrichment: found  for  ()", "value", isbn, "value", title, "name", src.Name())
 			updated = true
 			break
 		}
@@ -85,7 +85,7 @@ func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return updated, err
 			}
-			log.Printf("[INFO] ASIN enrichment: found %s for %q", asin, title)
+						slog.Info("ASIN enrichment: found  for", "value", asin, "value", title)
 			updated = true
 			break
 		}
@@ -131,7 +131,7 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *acti
 			checked++
 			found, err := s.EnrichBookISBN(books[i].ID)
 			if err != nil {
-				log.Printf("[WARN] ISBN enrichment failed for %s during batch scan: %v", books[i].ID, err)
+								slog.Warn("ISBN enrichment failed for  during batch scan:", "id", books[i].ID, "error", err)
 			} else if found {
 				updated++
 				activity.LogBatch(w, opID, "isbn-enrich", "isbn-enrichment",

--- a/internal/metafetch/lifecycle.go
+++ b/internal/metafetch/lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/lifecycle.go
-// version: 1.2.0
+// version: 1.3.0
 
 // Lifecycle methods on *metafetch.Service that the serviceregistry
 // container picks up via interface satisfaction. PostInit wires the
@@ -11,7 +11,7 @@ package metafetch
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
@@ -45,13 +45,13 @@ func (mfs *Service) PostInit(ctx context.Context, c *serviceregistry.Container) 
 	// Dedup engine wiring — engine is config-gated, may be nil
 	if engine, ok := serviceregistry.TryGet[*dedup.Engine](c, "dedup"); ok && engine != nil {
 		mfs.SetDedupEngine(engine)
-		log.Printf("[metafetch] PostInit: SetDedupEngine wired")
+		slog.Info("PostInit: SetDedupEngine wired")
 	}
 
 	// Embedding scorer — config-gated on MetadataEmbeddingScoringEnabled
 	if scorer, ok := serviceregistry.TryGet[*ai.EmbeddingScorer](c, "metadatascorer"); ok && scorer != nil {
 		mfs.SetMetadataScorer(scorer)
-		log.Println("[INFO] Metadata candidate scoring: embedding tier enabled")
+		slog.Info("Metadata candidate scoring: embedding tier enabled")
 	}
 
 	// LLM rerank scorer — wired unconditionally when llmparser is

--- a/internal/metafetch/metadata_state_service.go
+++ b/internal/metafetch/metadata_state_service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/metadata_state_service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 
 package metafetch
@@ -7,7 +7,7 @@ package metafetch
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -68,7 +68,7 @@ func (mss *MetadataStateService) LoadMetadataState(bookID string) (map[string]me
 
 	// Migrate legacy state
 	if err := mss.SaveMetadataState(bookID, legacy); err != nil {
-		log.Printf("[WARN] failed to migrate legacy metadata state for %s: %v", bookID, err)
+				slog.Warn("failed to migrate legacy metadata state for :", "id", bookID, "error", err)
 	}
 
 	return legacy, nil
@@ -147,7 +147,7 @@ func (mss *MetadataStateService) recordChange(bookID, field, changeType, source 
 		ChangedAt:     time.Now(),
 	}
 	if err := mss.db.RecordMetadataChange(record); err != nil {
-		log.Printf("[WARN] failed to record metadata change for %s/%s: %v", bookID, field, err)
+				slog.Warn("failed to record metadata change for /:", "id", bookID, "field", field, "error", err)
 	}
 }
 

--- a/internal/metafetch/openlibrary.go
+++ b/internal/metafetch/openlibrary.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/openlibrary.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package metafetch
@@ -7,7 +7,7 @@ package metafetch
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -48,12 +48,12 @@ func NewOpenLibraryService() *OpenLibraryService {
 	if info, err := os.Stat(storePath); err == nil && info.IsDir() {
 		// Auto-enable if store directory exists on disk
 		if !config.AppConfig.OpenLibraryDumpEnabled {
-			log.Printf("[INFO] Found existing OL dump store at %s, auto-enabling OpenLibraryDumpEnabled", storePath)
+						slog.Info("Found existing OL dump store at , auto-enabling OpenLibraryDumpEnabled", "path", storePath)
 			config.AppConfig.OpenLibraryDumpEnabled = true
 		}
 		store, err := openlibrary.NewOLStore(storePath)
 		if err != nil {
-			log.Printf("[WARN] Failed to open OL dump store: %v", err)
+						slog.Warn("Failed to open OL dump store:", "error", err)
 		} else {
 			svc.OLStore = store
 		}
@@ -116,7 +116,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 		svc.Mu.Lock()
 		if svc.Importing[dumpType] {
 			svc.Mu.Unlock()
-			log.Printf("[WARN] OL import already in progress for %s", dumpType)
+						slog.Warn("OL import already in progress for", "value", dumpType)
 			continue
 		}
 		svc.Importing[dumpType] = true
@@ -136,7 +136,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 			}()
 
 			filePath := filepath.Join(targetDir, openlibrary.DumpFilename(dt))
-			log.Printf("[INFO] Starting OL dump import: %s from %s", dt, filePath)
+						slog.Info("Starting OL dump import:  from", "value", dt, "path", filePath)
 
 			lastReported := 0
 			err := svc.OLStore.ImportDump(dt, filePath, func(count int) {
@@ -146,12 +146,12 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 						msg := fmt.Sprintf("Importing %s: %dk records", dt, count/1000)
 						_ = progress.UpdateProgress(idx, len(types), msg)
 					}
-					log.Printf("[INFO] OL %s import progress: %d records", dt, count)
+										slog.Info("OL  import progress:  records", "value", dt, "count", count)
 				}
 			})
 
 			if err != nil {
-				log.Printf("[ERROR] OL dump import failed for %s: %v", dt, err)
+								slog.Error("OL dump import failed for :", "value", dt, "error", err)
 				if progress != nil {
 					_ = progress.Log("error", fmt.Sprintf("%s import failed: %v", dt, err), nil)
 				}
@@ -159,7 +159,7 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 				importErr = err
 				mu.Unlock()
 			} else {
-				log.Printf("[INFO] OL dump import complete: %s", dt)
+								slog.Info("OL dump import complete:", "value", dt)
 				if progress != nil {
 					_ = progress.Log("info", fmt.Sprintf("%s import complete", dt), nil)
 				}
@@ -175,6 +175,6 @@ func (svc *OpenLibraryService) Import(ctx context.Context, progress operations.P
 			_ = progress.UpdateProgress(len(types), len(types), "All Open Library dump imports complete")
 		}
 	}
-	log.Printf("[INFO] All OL dump imports complete")
+		slog.Info("All OL dump imports complete")
 	return importErr
 }

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service.go
-// version: 5.0.0
+// version: 5.1.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
 // last-edited: 2026-05-01
 
@@ -9,7 +9,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -140,7 +140,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-			log.Printf("[WARN] cannot embed cover: no library copy for protected book %s", book.ID)
+						slog.Warn("cannot embed cover: no library copy for protected book", "id", book.ID)
 			return
 		}
 		book = libCopy
@@ -155,7 +155,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		// Multi-file book
 		bookFiles, err := mfs.db.GetBookFiles(book.ID)
 		if err != nil {
-			log.Printf("[WARN] failed to list book files for cover embedding on book %s: %v", book.ID, err)
+						slog.Warn("failed to list book files for cover embedding on book :", "id", book.ID, "error", err)
 			return
 		}
 		for _, bf := range bookFiles {
@@ -185,7 +185,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		if len(existingData) > 0 {
 			existingHash := fmt.Sprintf("%x", sha256.Sum256(existingData))[:12]
 			if newHash == existingHash {
-				log.Printf("[DEBUG] cover art unchanged for book %s, skipping embed", book.ID)
+								slog.Debug("cover art unchanged for book , skipping embed", "id", book.ID)
 				return
 			}
 		}
@@ -200,13 +200,13 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	embedded := 0
 	for _, f := range files {
 		if err := tagger.EmbedCoverArtSafe(context.Background(), f, coverPath, mfs.safeWriteDeps); err != nil {
-			log.Printf("[WARN] cover art embedding failed for %s: %v", f, err)
+						slog.Warn("cover art embedding failed for :", "value", f, "error", err)
 		} else {
 			embedded++
 		}
 	}
 	if embedded > 0 {
-		log.Printf("[INFO] cover art embedded into %d file(s) for book %s", embedded, book.ID)
+				slog.Info("cover art embedded into  file(s) for book", "count", embedded, "id", book.ID)
 	}
 }
 
@@ -236,7 +236,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	// Check if we already have this exact image archived (by hash)
 	dedupDir := filepath.Join(config.AppConfig.RootDir, "covers", "dedup")
 	if err := os.MkdirAll(dedupDir, 0775); err != nil {
-		log.Printf("[WARN] failed to create cover dedup dir: %v", err)
+				slog.Warn("failed to create cover dedup dir:", "error", err)
 		return
 	}
 
@@ -244,7 +244,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	if _, err := os.Stat(dedupPath); err != nil {
 		// New unique image — save to dedup store
 		if err := os.WriteFile(dedupPath, data, 0664); err != nil {
-			log.Printf("[WARN] failed to write dedup cover for %s: %v", bookID, err)
+						slog.Warn("failed to write dedup cover for :", "id", bookID, "error", err)
 			return
 		}
 	}
@@ -252,7 +252,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	// Create a history entry that references the dedup hash instead of storing a copy
 	historyDir := filepath.Join(config.AppConfig.RootDir, "covers", "history", bookID)
 	if err := os.MkdirAll(historyDir, 0775); err != nil {
-		log.Printf("[WARN] failed to create cover history dir: %v", err)
+				slog.Warn("failed to create cover history dir:", "error", err)
 		return
 	}
 
@@ -264,12 +264,12 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 		if err := os.Link(dedupPath, archivePath); err != nil {
 			// Hardlink also failed — just copy
 			if err := os.WriteFile(archivePath, data, 0664); err != nil {
-				log.Printf("[WARN] failed to archive old cover for %s: %v", bookID, err)
+								slog.Warn("failed to archive old cover for :", "id", bookID, "error", err)
 				return
 			}
 		}
 	}
-	log.Printf("[INFO] archived old cover art: %s (hash=%s)", archivePath, coverHash[:12])
+		slog.Info("archived old cover art:  (hash=)", "path", archivePath, "hash", coverHash[:12])
 
 	// Record in metadata change history so it appears in the changelog
 	now := time.Now()
@@ -283,7 +283,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 		ChangedAt:  now,
 	}
 	if err := mfs.db.RecordMetadataChange(record); err != nil {
-		log.Printf("[WARN] failed to record cover archive history for %s: %v", bookID, err)
+				slog.Warn("failed to record cover archive history for :", "id", bookID, "error", err)
 	}
 	// Dual-write to unified activity log
 	if mfs.activityService != nil {
@@ -439,15 +439,15 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 				bookFiles[0].FilePath = entry.TargetPath
 			}
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-				log.Printf("[WARN] failed to update book path for %s: %v", id, err)
+								slog.Warn("failed to update book path for :", "id", id, "error", err)
 			} else {
-				log.Printf("[INFO] renamed single-file book %s: %s", id, entry.TargetPath)
+								slog.Info("renamed single-file book :", "id", id, "path", entry.TargetPath)
 			}
 		} else if bf, ok := bfMap[entry.SegmentID]; ok {
 			bf.FilePath = entry.TargetPath
 			bf.ITunesPath = ComputeITunesPath(entry.TargetPath)
 			if err := mfs.db.UpdateBookFile(bf.ID, bf); err != nil {
-				log.Printf("[WARN] failed to update book_file path for %s: %v", bf.ID, err)
+								slog.Warn("failed to update book_file path for :", "id", bf.ID, "error", err)
 			}
 		}
 		// Record path change for each successful rename
@@ -479,9 +479,9 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		if newBookPath != book.FilePath {
 			book.FilePath = newBookPath
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-				log.Printf("[WARN] failed to update book path for %s: %v", id, err)
+								slog.Warn("failed to update book path for :", "id", id, "error", err)
 			} else {
-				log.Printf("[INFO] renamed book files for %s: %s", id, newBookPath)
+								slog.Info("renamed book files for :", "id", id, "path", newBookPath)
 			}
 		}
 	}
@@ -493,7 +493,7 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 				bookFiles[i].ITunesPath = itunesPath
 				if !strings.HasPrefix(bookFiles[i].ID, "virtual-") {
 					if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-						log.Printf("[WARN] failed to update itunes_path for book file %s: %v", bookFiles[i].ID, err)
+												slog.Warn("failed to update itunes_path for book file :", "id", bookFiles[i].ID, "error", err)
 					}
 				}
 			}
@@ -512,7 +512,7 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 	if mfs.dedupEngine != nil {
 		go func() {
 			if _, err := mfs.dedupEngine.CheckBook(context.Background(), id); err != nil {
-				log.Printf("[WARN] dedup re-check failed for book %s after metadata apply: %v", id, err)
+								slog.Warn("dedup re-check failed for book  after metadata apply:", "id", id, "error", err)
 			}
 		}()
 	}

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
 // last-edited: 2026-05-01
 
@@ -14,7 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/organizer"
 	"github.com/jdfalk/audiobook-organizer/internal/policy"
 	"github.com/oklog/ulid/v2"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -34,7 +34,7 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 	// Final safety: never leave title empty if it was set before
 	if book.Title == "" && originalTitle != "" {
 		book.Title = originalTitle
-		log.Printf("[WARN] applyMetadataToBook: prevented title from being cleared for book %s", book.ID)
+				slog.Warn("applyMetadataToBook: prevented title from being cleared for book", "id", book.ID)
 	}
 	if meta.Publisher != "" && IsBetterStringPtr(book.Publisher, meta.Publisher) {
 		book.Publisher = stringPtr(meta.Publisher)
@@ -61,13 +61,11 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 		if book.AuthorID != nil && book.Narrator != nil {
 			if existingAuthor, aErr := mfs.db.GetAuthorByID(*book.AuthorID); aErr == nil && existingAuthor != nil {
 				if strings.EqualFold(extractedAuthor, *book.Narrator) && !strings.EqualFold(extractedAuthor, existingAuthor.Name) {
-					log.Printf("[INFO] applyMetadataToBook: extracted artist %q matches narrator %q but not author %q for book %s — skipping author update",
-						extractedAuthor, *book.Narrator, existingAuthor.Name, book.ID)
+										slog.Info("applyMetadataToBook: extracted artist  matches narrator  but not author  for book — skipping author update", "value", extractedAuthor, "value", *book.Narrator, "name", existingAuthor.Name, "id", book.ID)
 					extractedAuthor = ""
 				} else if !strings.EqualFold(extractedAuthor, existingAuthor.Name) && !strings.EqualFold(extractedAuthor, *book.Narrator) {
 					// Extracted artist doesn't match either stored author or narrator — log mismatch for review
-					log.Printf("[WARN] applyMetadataToBook: extracted artist %q matches neither author %q nor narrator %q for book %s",
-						extractedAuthor, existingAuthor.Name, *book.Narrator, book.ID)
+										slog.Warn("applyMetadataToBook: extracted artist  matches neither author  nor narrator  for book", "value", extractedAuthor, "name", existingAuthor.Name, "value", *book.Narrator, "id", book.ID)
 				}
 			}
 		}
@@ -186,7 +184,7 @@ func (mfs *Service) RecordChangeHistory(book *database.Book, meta metadata.BookM
 			ChangedAt:     now,
 		}
 		if err := mfs.db.RecordMetadataChange(record); err != nil {
-			log.Printf("[WARN] failed to record metadata change for %s.%s: %v", book.ID, c.field, err)
+						slog.Warn("failed to record metadata change for .:", "id", book.ID, "field", c.field, "error", err)
 		}
 		// Dual-write to unified activity log
 		if mfs.activityService != nil {
@@ -231,9 +229,9 @@ func (mfs *Service) syncMetadataToLibraryCopy(original, libCopy *database.Book) 
 	libCopy.MetadataReviewStatus = original.MetadataReviewStatus
 
 	if _, err := mfs.db.UpdateBook(libCopy.ID, libCopy); err != nil {
-		log.Printf("[WARN] failed to sync metadata to library copy %s: %v", libCopy.ID, err)
+				slog.Warn("failed to sync metadata to library copy :", "id", libCopy.ID, "error", err)
 	} else {
-		log.Printf("[INFO] synced metadata from %s to library copy %s", original.ID, libCopy.ID)
+				slog.Info("synced metadata from  to library copy", "id", original.ID, "id", libCopy.ID)
 	}
 
 	// Also sync author associations
@@ -281,7 +279,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		if err == nil {
 			for i := range siblings {
 				if siblings[i].ID != book.ID && strings.HasPrefix(siblings[i].FilePath, config.AppConfig.RootDir) {
-					log.Printf("[INFO] using existing library copy %s for protected book %s", siblings[i].ID, book.ID)
+										slog.Info("using existing library copy  for protected book", "id", siblings[i].ID, "id", book.ID)
 					return &siblings[i]
 				}
 			}
@@ -311,7 +309,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		}
 		targetDir, pm, err := org.OrganizeBookDirectory(book, filePaths)
 		if err != nil {
-			log.Printf("[WARN] failed to create library copy for multi-file book %s: %v", book.ID, err)
+						slog.Warn("failed to create library copy for multi-file book :", "id", book.ID, "error", err)
 			return nil
 		}
 		pathMap = pm
@@ -321,7 +319,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		// Single-file: organize just the book file
 		p, _, err := org.OrganizeBook(book)
 		if err != nil {
-			log.Printf("[WARN] failed to create library copy for %s: %v", book.ID, err)
+						slog.Warn("failed to create library copy for :", "id", book.ID, "error", err)
 			return nil
 		}
 		newBookPath = p
@@ -347,7 +345,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 
 	created, err := mfs.db.CreateBook(&newBook)
 	if err != nil {
-		log.Printf("[WARN] failed to create library book record for %s: %v", book.ID, err)
+				slog.Warn("failed to create library book record for :", "id", book.ID, "error", err)
 		return nil
 	}
 
@@ -381,7 +379,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 				newBF.ITunesPath = ComputeITunesPath(newPath)
 			}
 			if err := mfs.db.CreateBookFile(&newBF); err != nil {
-				log.Printf("[WARN] failed to copy book_file %s for library book %s: %v", bf.ID, created.ID, err)
+								slog.Warn("failed to copy book_file  for library book :", "id", bf.ID, "id", created.ID, "error", err)
 			}
 		}
 	}
@@ -391,7 +389,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 	book.IsPrimaryVersion = &isNotPrimary
 	_, _ = mfs.db.UpdateBook(book.ID, book)
 
-	log.Printf("[INFO] created library copy %s -> %s for protected book %s (%d file(s))", newBookPath, created.ID, book.ID, len(activeFiles))
+		slog.Info("created library copy  ->  for protected book  ( file(s))", "path", newBookPath, "id", created.ID, "id", book.ID, "file", len(activeFiles))
 	return created
 }
 func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMetadata) {
@@ -426,7 +424,7 @@ func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMeta
 	}
 	if len(fetchedValues) > 0 {
 		if err := mfs.updateFetchedMetadataState(bookID, fetchedValues); err != nil {
-			log.Printf("[ERROR] FetchMetadataForBook: failed to persist fetched metadata state: %v", err)
+						slog.Error("FetchMetadataForBook: failed to persist fetched metadata state:", "error", err)
 		}
 	}
 }
@@ -454,9 +452,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		if book.Duration != nil {
 			bookDurSec = *book.Duration
 		}
-		log.Printf("[WARN] duration-mismatch apply book=%s title=%q candidate=%q delta=%ds (book=%ds audible=%ds): wrong match or abridged version",
-			id, book.Title, candidate.Title,
-			candidate.DurationDeltaSec, bookDurSec, candidate.DurationSec)
+				slog.Warn("duration-mismatch apply book= title= candidate= delta=s (book=s audible=s): wrong match or abridged version", "id", id, "value", book.Title, "id", candidate.Title, "id", candidate.DurationDeltaSec, "value", bookDurSec, "id", candidate.DurationSec)
 	}
 
 	meta := metadata.BookMetadata{
@@ -553,7 +549,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 
 	// Generate segment titles (fast, DB-only)
 	if err := mfs.generateSegmentTitles(id, updatedBook.Title); err != nil {
-		log.Printf("[WARN] generate segment titles failed for %s: %v", id, err)
+				slog.Warn("generate segment titles failed for :", "id", id, "error", err)
 	}
 
 	// Download cover art (fast network fetch + file write — keep inline so
@@ -561,9 +557,9 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	if meta.CoverURL != "" && config.AppConfig.RootDir != "" {
 		coverPath, coverErr := metadata.DownloadCoverArt(meta.CoverURL, config.AppConfig.RootDir, id)
 		if coverErr != nil {
-			log.Printf("[WARN] cover art download failed for %s: %v", id, coverErr)
+						slog.Warn("cover art download failed for :", "id", id, "error", coverErr)
 		} else {
-			log.Printf("[INFO] cover art saved to %s", coverPath)
+						slog.Info("cover art saved to", "path", coverPath)
 			localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
 			if updatedBook != nil {
 				updatedBook.CoverURL = &localCoverURL
@@ -589,7 +585,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// a tag write errors.
 	for _, tag := range candidate.CategoryTags {
 		if err := mfs.db.AddBookTagWithSource(id, tag, "audible_category"); err != nil {
-			log.Printf("[WARN] failed to apply category tag %q to book %s: %v", tag, id, err)
+						slog.Warn("failed to apply category tag  to book :", "value", tag, "id", id, "error", err)
 		}
 	}
 
@@ -612,7 +608,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 	matches, err := mfs.db.GetBooksByMetadataSourceHash(hash)
 	if err != nil {
-		log.Printf("[WARN] MATCH-4: metadata-source-hash dedup query failed for book %s: %v", bookID, err)
+				slog.Warn("MATCH-4: metadata-source-hash dedup query failed for book :", "id", bookID, "error", err)
 		return
 	}
 
@@ -657,9 +653,9 @@ func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 			continue
 		}
 		if err := mfs.db.FlagMetadataHashDuplicate(primaryID, id); err != nil {
-			log.Printf("[WARN] MATCH-4: failed to flag book %s as duplicate of %s: %v", id, primaryID, err)
+						slog.Warn("MATCH-4: failed to flag book  as duplicate of :", "id", id, "id", primaryID, "error", err)
 		} else {
-			log.Printf("[INFO] MATCH-4: auto-flagged book %s as merged into primary %s (hash %s)", id, primaryID, hash)
+						slog.Info("MATCH-4: auto-flagged book  as merged into primary  (hash )", "id", id, "id", primaryID, "hash", hash)
 		}
 	}
 }
@@ -675,7 +671,7 @@ func (mfs *Service) ApplyMetadataSystemTags(bookID, sourceName, language string)
 		if err := database.EnsureSingletonBookTag(
 			mfs.db, bookID, "metadata:source:", sourceTag, "system",
 		); err != nil {
-			log.Printf("[WARN] failed to tag book %s with %s: %v", bookID, sourceTag, err)
+						slog.Warn("failed to tag book  with :", "id", bookID, "value", sourceTag, "error", err)
 		}
 	}
 	langTag := MetadataLanguageTag(language)
@@ -683,7 +679,7 @@ func (mfs *Service) ApplyMetadataSystemTags(bookID, sourceName, language string)
 		if err := database.EnsureSingletonBookTag(
 			mfs.db, bookID, "metadata:language:", langTag, "system",
 		); err != nil {
-			log.Printf("[WARN] failed to tag book %s with %s: %v", bookID, langTag, err)
+						slog.Warn("failed to tag book  with :", "id", bookID, "value", langTag, "error", err)
 		}
 	}
 }

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
 // last-edited: 2026-05-05
 
@@ -12,7 +12,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,9 +32,9 @@ func (mfs *Service) queueISBNEnrichment(id string, book *database.Book) {
 	go func(bid string) {
 		found, err := mfs.isbnEnrichment.EnrichBookISBN(bid)
 		if err != nil {
-			log.Printf("[WARN] ISBN enrichment failed for %s: %v", bid, err)
+						slog.Warn("ISBN enrichment failed for :", "id", bid, "error", err)
 		} else if found {
-			log.Printf("[INFO] ISBN enrichment succeeded for %s", bid)
+						slog.Info("ISBN enrichment succeeded for", "id", bid)
 		}
 	}(id)
 }
@@ -94,8 +94,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			var cachedResults []metadata.BookMetadata
 			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
 				results = cachedResults
-				log.Printf("[DEBUG] metadata-fetch: cache HIT for (%s, %s) — %d results, age=%s",
-					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+								slog.Debug("metadata-fetch: cache HIT for ( ) —  results, age=", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 
@@ -111,7 +110,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 				ctx := mfs.buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
 				results, searchErr = ctxSearch.SearchByContext(ctx)
 				if searchErr != nil {
-					log.Printf("[WARN] %s context search failed for %q: %v", src.Name(), book.Title, searchErr)
+										slog.Warn("context search failed for :", "name", src.Name(), "value", book.Title, "error", searchErr)
 					// Context search failure is non-fatal — fall through
 					// to the regular title/author path in case that works.
 				}
@@ -121,7 +120,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) == 0 && currentAuthor != "" {
 				results, searchErr = src.SearchByTitleAndAuthor(context.Background(), searchTitle, currentAuthor)
 				if searchErr != nil {
-					log.Printf("[WARN] %s title+author search failed for %q by %q: %v", src.Name(), searchTitle, currentAuthor, searchErr)
+										slog.Warn("title+author search failed for  by :", "name", src.Name(), "value", searchTitle, "value", currentAuthor, "error", searchErr)
 				}
 			}
 
@@ -129,7 +128,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) == 0 {
 				results, searchErr = src.SearchByTitle(context.Background(), searchTitle)
 				if searchErr != nil {
-					log.Printf("[WARN] %s failed for %q: %v", src.Name(), searchTitle, searchErr)
+										slog.Warn("failed for :", "name", src.Name(), "value", searchTitle, "error", searchErr)
 					lastErr = searchErr
 				}
 			}
@@ -160,29 +159,27 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) > 0 {
 				if blob, merr := json.Marshal(results); merr == nil {
 					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
-						log.Printf("[WARN] metadata-fetch: cache put failed for (%s, %s): %v", id, src.Name(), perr)
+												slog.Warn("metadata-fetch: cache put failed for ( ):", "id", id, "name", src.Name(), "error", perr)
 					}
 				}
 			}
 		}
 
 		if len(results) == 0 {
-			log.Printf("[DEBUG] %s returned 0 results for %q", src.Name(), searchTitle)
+						slog.Debug("returned 0 results for", "name", src.Name(), "value", searchTitle)
 		}
 		if len(results) > 0 {
 			// Score all results and pick the best; reject if below quality threshold.
 			scored := mfs.bestTitleMatchForBook(book, results, currentAuthor, currentNarrator, searchTitle, book.Title)
 			if len(scored) == 0 {
-				log.Printf("[DEBUG] %s: all %d results rejected by quality scorer for %q",
-					src.Name(), len(results), searchTitle)
+								slog.Debug(": all  results rejected by quality scorer for", "name", src.Name(), "count", len(results), "value", searchTitle)
 				continue // try next source
 			}
 			// Apply series position filter if the book's position is already known.
 			if book.SeriesSequence != nil {
 				scored = ApplySeriesPositionFilter(scored, *book.SeriesSequence)
 				if len(scored) == 0 {
-					log.Printf("[DEBUG] %s: best result rejected by series position filter for %q",
-						src.Name(), searchTitle)
+										slog.Debug(": best result rejected by series position filter for", "name", src.Name(), "value", searchTitle)
 					continue
 				}
 			}
@@ -211,9 +208,9 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if meta.CoverURL != "" && config.AppConfig.RootDir != "" {
 				coverPath, coverErr := metadata.DownloadCoverArt(meta.CoverURL, config.AppConfig.RootDir, id)
 				if coverErr != nil {
-					log.Printf("[WARN] cover art download failed for %s: %v", id, coverErr)
+										slog.Warn("cover art download failed for :", "id", id, "error", coverErr)
 				} else {
-					log.Printf("[INFO] cover art saved to %s", coverPath)
+										slog.Info("cover art saved to", "path", coverPath)
 					// Update book's cover_url to the local path for serving
 					localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
 					if updatedBook != nil {

--- a/internal/metafetch/service_files.go
+++ b/internal/metafetch/service_files.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 969b284a-5657-442b-beba-275e325e000b
 // last-edited: 2026-05-01
 
@@ -9,7 +9,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"log"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -66,11 +66,11 @@ func backupFileBeforeWrite(filePath string) {
 	if err := os.Link(filePath, backupPath); err != nil {
 		// Hardlink failed — fall back to copy
 		if err := fileops.SafeCopy(filePath, backupPath, fileops.OperationConfig{}); err != nil {
-			log.Printf("[WARN] backup before tag write failed: %s: %v", filePath, err)
+						slog.Warn("backup before tag write failed: :", "path", filePath, "error", err)
 			return
 		}
 	}
-	log.Printf("[DEBUG] backup before tag write: %s", backupPath)
+		slog.Debug("backup before tag write:", "path", backupPath)
 }
 
 // ApplyMetadataFileIO runs the slow file operations after metadata is applied:
@@ -91,7 +91,7 @@ func (mfs *Service) ApplyMetadataFileIO(id string) {
 	// Run file rename + tag write pipeline
 	if config.AppConfig.AutoRenameOnApply || config.AppConfig.AutoWriteTagsOnApply {
 		if err := mfs.runApplyPipeline(id, book); err != nil {
-			log.Printf("[WARN] apply pipeline failed for %s: %v", id, err)
+						slog.Warn("apply pipeline failed for :", "id", id, "error", err)
 		}
 	}
 }
@@ -123,7 +123,7 @@ func removeEmptyDirs(dir, stopAt string) {
 		if err := os.Remove(dir); err != nil {
 			break
 		}
-		log.Printf("[INFO] removed empty directory: %s", dir)
+				slog.Info("removed empty directory:", "value", dir)
 		dir = filepath.Dir(dir)
 	}
 }

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"log"
+	"log/slog"
 	"regexp"
 	"sort"
 	"strconv"
@@ -396,11 +396,9 @@ func (mfs *Service) ScoreBaseCandidates(
 			return scores, mfs.metadataScorer.Name()
 		}
 		if err != nil {
-			log.Printf("[WARN] metadata-scorer %s failed, falling back to F1: %v",
-				mfs.metadataScorer.Name(), err)
+						slog.Warn("metadata-scorer  failed, falling back to F1:", "name", mfs.metadataScorer.Name(), "error", err)
 		} else {
-			log.Printf("[WARN] metadata-scorer %s returned %d scores for %d results, falling back to F1",
-				mfs.metadataScorer.Name(), len(scores), len(results))
+						slog.Warn("metadata-scorer  returned  scores for  results, falling back to F1", "name", mfs.metadataScorer.Name(), "count", len(scores), "count", len(results))
 		}
 	}
 
@@ -488,14 +486,12 @@ func (mfs *Service) RerankTopK(
 	}
 	if ambiguousEnd < 2 {
 		// Only one candidate within epsilon — nothing to resolve.
-		log.Printf("[DEBUG] metadata-search: rerank skipped — only 1 candidate within %.3f of best (%.3f)",
-			epsilon, bestScore)
+				slog.Debug("metadata-search: rerank skipped — only 1 candidate within %.3f of best (%.3f)", "value", epsilon, "value", bestScore)
 		return candidates
 	}
 
 	topCands := candidates[:ambiguousEnd]
-	log.Printf("[DEBUG] metadata-search: rerank firing on top %d candidates (epsilon=%.3f, bestScore=%.3f)",
-		len(topCands), epsilon, bestScore)
+		slog.Debug("metadata-search: rerank firing on top  candidates (epsilon=%.3f, bestScore=%.3f)", "count", len(topCands), "value", epsilon, "value", bestScore)
 
 	// Resolve the book's author name for the query payload.
 	authorName := ""
@@ -523,10 +519,9 @@ func (mfs *Service) RerankTopK(
 	llmScores, err := mfs.llmScorer.Score(ctx, query, llmCands)
 	if err != nil || len(llmScores) != len(topCands) {
 		if err != nil {
-			log.Printf("[WARN] metadata-search: rerank LLM call failed, keeping base scores: %v", err)
+						slog.Warn("metadata-search: rerank LLM call failed, keeping base scores:", "error", err)
 		} else {
-			log.Printf("[WARN] metadata-search: rerank returned %d scores for %d candidates, keeping base scores",
-				len(llmScores), len(topCands))
+						slog.Warn("metadata-search: rerank returned  scores for  candidates, keeping base scores", "count", len(llmScores), "count", len(topCands))
 		}
 		return candidates
 	}
@@ -561,8 +556,7 @@ func ApplySeriesPositionFilter(
 	wantPos := strconv.Itoa(knownPosition)
 	best := results[0]
 	if best.SeriesPosition != "" && best.SeriesPosition != wantPos {
-		log.Printf("[DEBUG] scorer: rejecting result %q (series position %q != expected %q)",
-			best.Title, best.SeriesPosition, wantPos)
+				slog.Debug("scorer: rejecting result  (series position  != expected )", "value", best.Title, "value", best.SeriesPosition, "value", wantPos)
 		return nil
 	}
 	return results

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_search.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
 // last-edited: 2026-05-05
 
@@ -12,7 +12,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"log"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -98,12 +98,12 @@ func (mfs *Service) BuildSourceChain() []metadata.MetadataSource {
 			if token != "" {
 				rawSource = metadata.NewHardcoverClient(token)
 			} else {
-				log.Printf("[WARN] Hardcover source enabled but no API token configured")
+								slog.Warn("Hardcover source enabled but no API token configured")
 			}
 		case "wikipedia":
 			rawSource = metadata.NewWikipediaClient()
 		default:
-			log.Printf("[WARN] Unknown metadata source: %s", src.ID)
+						slog.Warn("Unknown metadata source:", "id", src.ID)
 		}
 		if rawSource != nil {
 			chain = append(chain, metadata.NewProtectedSource(rawSource, 5, 30*time.Second))
@@ -239,8 +239,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
 				allResults = cachedResults
 				cacheHit = true
-				log.Printf("[DEBUG] metadata-search: cache HIT for (%s, %s) — %d results, age=%s",
-					id, src.Name(), len(cachedResults), time.Since(cached.CachedAt).Round(time.Second))
+								slog.Debug("metadata-search: cache HIT for ( ) —  results, age=", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 
@@ -251,7 +250,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					allResults = append(allResults, results...)
 				} else {
 					lastErr = serr
-					log.Printf("[DEBUG] metadata-search: %s SearchByTitleAndAuthor(%q, %q) error: %v", src.Name(), searchTitle, searchAuthor, serr)
+										slog.Debug("metadata-search:  SearchByTitleAndAuthor( ) error:", "name", src.Name(), "value", searchTitle, "value", searchAuthor, "error", serr)
 				}
 			}
 
@@ -262,7 +261,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				if results, serr := src.SearchByTitleAndAuthor(context.Background(), searchTitle, bookNarrator); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
-					log.Printf("[DEBUG] metadata-search: %s narrator-as-author fallback(%q, %q) error: %v", src.Name(), searchTitle, bookNarrator, serr)
+										slog.Debug("metadata-search:  narrator-as-author fallback( ) error:", "name", src.Name(), "value", searchTitle, "value", bookNarrator, "error", serr)
 				}
 			}
 
@@ -271,7 +270,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				allResults = append(allResults, results...)
 			} else {
 				lastErr = serr
-				log.Printf("[DEBUG] metadata-search: %s SearchByTitle(%q) error: %v", src.Name(), searchTitle, serr)
+								slog.Debug("metadata-search:  SearchByTitle() error:", "name", src.Name(), "value", searchTitle, "error", serr)
 			}
 			// SearchByTitle with original title if different
 			if searchTitle != book.Title {
@@ -287,7 +286,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				sourcesFailed[src.Name()] = lastErr.Error()
 			}
 
-			log.Printf("[DEBUG] metadata-search: %s returned %d raw results for %q", src.Name(), len(allResults), searchTitle)
+						slog.Debug("metadata-search:  returned  raw results for", "name", src.Name(), "count", len(allResults), "value", searchTitle)
 
 			// Write to cache on a successful non-empty fetch.
 			// Empty and error cases are not cached so they can
@@ -296,14 +295,14 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			if len(allResults) > 0 {
 				if blob, merr := json.Marshal(allResults); merr == nil {
 					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
-						log.Printf("[WARN] metadata-search: cache put failed for (%s, %s): %v", id, src.Name(), perr)
+												slog.Warn("metadata-search: cache put failed for ( ):", "id", id, "name", src.Name(), "error", perr)
 					}
 				}
 			}
 		}
 
 		baseScores, baseTier := mfs.ScoreBaseCandidates(context.Background(), book, allResults, searchWords)
-		log.Printf("[DEBUG] metadata-search: scored %d results from %s with tier %s", len(allResults), src.Name(), baseTier)
+				slog.Debug("metadata-search: scored  results from  with tier", "count", len(allResults), "name", src.Name(), "value", baseTier)
 
 		for i, r := range allResults {
 			key := strings.ToLower(r.Title + "|" + r.Author)
@@ -332,8 +331,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				minScore = config.AppConfig.MetadataEmbeddingMinScore
 			}
 			if score <= minScore {
-				log.Printf("[DEBUG] metadata-search: adjusted score=%.3f (tier=%s) below threshold for %q by %q from %s",
-					score, baseTier, r.Title, r.Author, src.Name())
+								slog.Debug("metadata-search: adjusted score=%.3f (tier=) below threshold for  by  from", "value", score, "value", baseTier, "value", r.Title, "value", r.Author, "name", src.Name())
 				continue
 			}
 
@@ -429,7 +427,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		audibleClient := metadata.NewAudibleClient()
 		result, err := audibleClient.LookupByASIN(asinToLookup)
 		if err != nil || result == nil {
-			log.Printf("[DEBUG] metadata-search: Audible API lookup for %q failed, trying Audnexus: %v", asinToLookup, err)
+						slog.Debug("metadata-search: Audible API lookup for  failed, trying Audnexus:", "value", asinToLookup, "error", err)
 			audnexus := metadata.NewAudnexusClient()
 			result, err = audnexus.LookupByASIN(asinToLookup)
 		}
@@ -475,7 +473,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				})
 			}
 		} else {
-			log.Printf("[DEBUG] metadata-search: ASIN lookup for %q failed: %v", asinToLookup, err)
+						slog.Debug("metadata-search: ASIN lookup for  failed:", "value", asinToLookup, "error", err)
 		}
 	}
 
@@ -533,7 +531,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		candidates = mfs.RerankTopK(context.Background(), book, candidates)
 	}
 
-	log.Printf("[DEBUG] metadata-search: returning %d candidates for %q (search words: %v)", len(candidates), searchTitle, searchWords)
+		slog.Debug("metadata-search: returning  candidates for  (search words: )", "id", len(candidates), "value", searchTitle, "value", searchWords)
 
 	return &SearchMetadataResponse{
 		Results:       candidates,

--- a/internal/metafetch/service_wiring.go
+++ b/internal/metafetch/service_wiring.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_wiring.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 571bfbf4-238b-49cb-a6d8-b302921dd1c4
 // last-edited: 2026-05-01
 

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_writeback.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: fad73c11-30c2-4fdc-addd-45afef25d792
 // last-edited: 2026-05-01
 
@@ -11,7 +11,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/fileops"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -72,7 +72,7 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 	// CRITICAL: Never write metadata to files in protected paths (import paths,
 	// iTunes Media folders). Only write to files in our organized library.
 	if mfs.isProtectedPath(book.FilePath) {
-		log.Printf("[INFO] skipping write-back for protected path: %s", book.FilePath)
+				slog.Info("skipping write-back for protected path:", "path", book.FilePath)
 		return
 	}
 
@@ -103,14 +103,14 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 				continue
 			}
 			if mfs.isProtectedPath(bf.FilePath) {
-				log.Printf("[INFO] skipping write-back for protected file: %s", bf.FilePath)
+								slog.Info("skipping write-back for protected file:", "path", bf.FilePath)
 				continue
 			}
 			backupFileBeforeWrite(bf.FilePath)
 			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
 				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
-				log.Printf("[WARN] write-back failed for file %s: %v", bf.FilePath, err)
+								slog.Warn("write-back failed for file :", "path", bf.FilePath, "error", err)
 			}
 		}
 	} else {
@@ -118,43 +118,43 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 		// If book.FilePath is a directory (multi-file book with no segment records),
 		// glob for audio files inside and write to each one individually.
 		tagMap := mfs.BuildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
-		log.Printf("[DEBUG] write-back: full tag map has %d entries for %s", len(tagMap), book.FilePath)
+				slog.Debug("write-back: full tag map has  entries for", "count", len(tagMap), "path", book.FilePath)
 		for k, v := range tagMap {
-			log.Printf("[DEBUG] write-back:   %s = %v", k, v)
+						slog.Debug("write-back:    =", "value", k, "value", v)
 		}
 
 		dirFiles := AudioFilesInDir(book.FilePath)
 		if len(dirFiles) > 0 {
 			// book.FilePath is a directory — write to each audio file found inside.
-			log.Printf("[INFO] write-back: %s is a directory; writing to %d audio file(s) inside", book.FilePath, len(dirFiles))
+						slog.Info("write-back:  is a directory; writing to  audio file(s) inside", "path", book.FilePath, "file", len(dirFiles))
 			wroteAny := false
 			for _, f := range dirFiles {
 				fm := FilterUnchangedTags(f, tagMap)
 				if len(fm) == 0 {
-					log.Printf("[DEBUG] write-back: all tags match, skipping %s", f)
+										slog.Debug("write-back: all tags match, skipping", "value", f)
 					continue
 				}
 				backupFileBeforeWrite(f)
 				if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
 					return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
 				}, fileops.WriteTagsSafeOptions{}); err != nil {
-					log.Printf("[WARN] write-back failed for %s: %v", f, err)
+										slog.Warn("write-back failed for :", "value", f, "error", err)
 				} else {
-					log.Printf("[INFO] wrote metadata back to %s", f)
+										slog.Info("wrote metadata back to", "value", f)
 					wroteAny = true
 				}
 			}
 			if wroteAny {
 				if err := mfs.db.SetLastWrittenAt(book.ID, time.Now()); err != nil {
-					log.Printf("[WARN] failed to stamp last_written_at for book %s: %v", book.ID, err)
+										slog.Warn("failed to stamp last_written_at for book :", "id", book.ID, "error", err)
 				}
 				_ = mfs.db.MarkNeedsRescan(book.ID)
 			}
 		} else {
 			tagMap = FilterUnchangedTags(book.FilePath, tagMap)
-			log.Printf("[DEBUG] write-back: after filter, %d entries remain", len(tagMap))
+						slog.Debug("write-back: after filter,  entries remain", "count", len(tagMap))
 			if len(tagMap) == 0 {
-				log.Printf("[DEBUG] write-back: all tags match, skipping write for %s", book.FilePath)
+								slog.Debug("write-back: all tags match, skipping write for", "path", book.FilePath)
 				return
 			}
 			backupFileBeforeWrite(book.FilePath)
@@ -165,12 +165,12 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 			if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
 				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 			}, wtsOptsPath); err != nil {
-				log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
+								slog.Warn("write-back failed for :", "path", book.FilePath, "error", err)
 			} else {
-				log.Printf("[INFO] wrote metadata back to %s", book.FilePath)
+								slog.Info("wrote metadata back to", "path", book.FilePath)
 				// Stamp last_written_at after successful write-back.
 				if err := mfs.db.SetLastWrittenAt(book.ID, time.Now()); err != nil {
-					log.Printf("[WARN] failed to stamp last_written_at for book %s: %v", book.ID, err)
+										slog.Warn("failed to stamp last_written_at for book :", "id", book.ID, "error", err)
 				}
 				// Flag for rescan so the next incremental scan re-reads the updated tags.
 				_ = mfs.db.MarkNeedsRescan(book.ID)
@@ -468,7 +468,7 @@ func (mfs *Service) generateSegmentTitles(bookID string, bookTitle string) error
 		bookFiles[i].Title = title
 
 		if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-			log.Printf("[WARN] failed to update book file title for %s: %v", bookFiles[i].ID, err)
+						slog.Warn("failed to update book file title for :", "id", bookFiles[i].ID, "error", err)
 		}
 	}
 
@@ -483,10 +483,10 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-			log.Printf("[WARN] runApplyPipeline: no library copy for protected book %s, skipping", id)
+						slog.Warn("runApplyPipeline: no library copy for protected book , skipping", "id", id)
 			return nil
 		}
-		log.Printf("[INFO] runApplyPipeline: using library copy %s for protected book %s", libCopy.ID, id)
+				slog.Info("runApplyPipeline: using library copy  for protected book", "id", libCopy.ID, "id", id)
 		id = libCopy.ID
 		book = libCopy
 	}
@@ -550,7 +550,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			return fmt.Errorf("rename files: %w", err)
 		}
 		if len(renameResult.Skipped) > 0 {
-			log.Printf("[WARN] %d files skipped (source missing) during rename", len(renameResult.Skipped))
+						slog.Warn("files skipped (source missing) during rename", "count", len(renameResult.Skipped))
 		}
 
 		// Update book file records with new paths (only for succeeded renames)
@@ -563,7 +563,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 				bf.FilePath = entry.TargetPath
 				bf.ITunesPath = ComputeITunesPath(entry.TargetPath)
 				if err := mfs.db.UpdateBookFile(bf.ID, bf); err != nil {
-					log.Printf("[WARN] failed to update book_file path for %s: %v", bf.ID, err)
+										slog.Warn("failed to update book_file path for :", "id", bf.ID, "error", err)
 				}
 			}
 			// Record path change for each successful rename
@@ -596,9 +596,9 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			if newBookPath != book.FilePath {
 				book.FilePath = newBookPath
 				if _, err := mfs.db.UpdateBook(id, book); err != nil {
-					log.Printf("[WARN] failed to update book path for %s: %v", id, err)
+										slog.Warn("failed to update book path for :", "id", id, "error", err)
 				} else {
-					log.Printf("[INFO] updated book path for %s: %s", id, newBookPath)
+										slog.Info("updated book path for :", "id", id, "path", newBookPath)
 				}
 			}
 		}
@@ -611,7 +611,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 			if itunesPath := ComputeITunesPath(bookFiles[i].FilePath); itunesPath != "" {
 				bookFiles[i].ITunesPath = itunesPath
 				if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-					log.Printf("[WARN] failed to update itunes_path for book file %s: %v", bookFiles[i].ID, err)
+										slog.Warn("failed to update itunes_path for book file :", "id", bookFiles[i].ID, "error", err)
 				}
 			}
 		}
@@ -620,9 +620,9 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	// Write metadata tags to audio files
 	if config.AppConfig.AutoWriteTagsOnApply && !hasCheckpoint(mfs.db, id, phaseTags) {
 		if written, err := mfs.WriteBackMetadataForBook(id); err != nil {
-			log.Printf("[WARN] tag writing failed for book %s: %v", id, err)
+						slog.Warn("tag writing failed for book :", "id", id, "error", err)
 		} else {
-			log.Printf("[INFO] wrote metadata tags to %d file(s) for book %s", written, id)
+						slog.Info("wrote metadata tags to  file(s) for book", "value", written, "id", id)
 			setCheckpoint(mfs.db, id, phaseTags)
 		}
 	}
@@ -759,11 +759,11 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			tagMap := mfs.BuildFullTagMap(book, bookTitle, segTitle, artistStr, narratorStr, year, trackStr)
 			tagMap = FilterUnchangedTags(bf.FilePath, tagMap)
 			if len(tagMap) == 0 {
-				log.Printf("[DEBUG] write-back: file %s tags already match, skipping", bf.FilePath)
+								slog.Debug("write-back: file  tags already match, skipping", "path", bf.FilePath)
 				continue
 			}
 			if mfs.isProtectedPath(bf.FilePath) {
-				log.Printf("[DEBUG] skipping write-back for protected file: %s", bf.FilePath)
+								slog.Debug("skipping write-back for protected file:", "path", bf.FilePath)
 				skippedProtected++
 				continue
 			}
@@ -771,7 +771,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			if _, _, err := fileops.WriteTagsSafe(bf.FilePath, func(tmpPath string) error {
 				return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 			}, fileops.WriteTagsSafeOptions{BookFileID: bf.ID, Store: mfs.db}); err != nil {
-				log.Printf("[WARN] write-back failed for file %s: %v", bf.FilePath, err)
+								slog.Warn("write-back failed for file :", "path", bf.FilePath, "error", err)
 			} else {
 				writtenCount++
 			}
@@ -781,7 +781,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		// If book.FilePath is a directory (multi-file book with no file records),
 		// glob for audio files inside and write to each one individually.
 		if mfs.isProtectedPath(book.FilePath) {
-			log.Printf("[DEBUG] skipping write-back for protected path: %s", book.FilePath)
+						slog.Debug("skipping write-back for protected path:", "path", book.FilePath)
 			skippedProtected++
 		} else {
 			fullTagMap := mfs.BuildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
@@ -795,16 +795,16 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 			dirFiles := AudioFilesInDir(book.FilePath)
 			if len(dirFiles) > 0 {
 				// book.FilePath is a directory — write to each audio file found inside.
-				log.Printf("[INFO] write-back: %s is a directory; writing to %d audio file(s) inside", book.FilePath, len(dirFiles))
+								slog.Info("write-back:  is a directory; writing to  audio file(s) inside", "path", book.FilePath, "file", len(dirFiles))
 				for _, f := range dirFiles {
 					if mfs.isProtectedPath(f) {
-						log.Printf("[DEBUG] skipping write-back for protected file: %s", f)
+												slog.Debug("skipping write-back for protected file:", "value", f)
 						skippedProtected++
 						continue
 					}
 					fm := FilterUnchangedTags(f, fullTagMap)
 					if len(fm) == 0 {
-						log.Printf("[DEBUG] write-back: all tags match, skipping %s", f)
+												slog.Debug("write-back: all tags match, skipping", "value", f)
 						continue
 					}
 					backupFileBeforeWrite(f)
@@ -815,16 +815,16 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					if _, _, err := fileops.WriteTagsSafe(f, func(tmpPath string) error {
 						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-						log.Printf("[WARN] write-back failed for %s: %v", f, err)
+												slog.Warn("write-back failed for :", "value", f, "error", err)
 					} else {
-						log.Printf("[INFO] wrote metadata back to %s", f)
+												slog.Info("wrote metadata back to", "value", f)
 						writtenCount++
 					}
 				}
 			} else {
 				fm := FilterUnchangedTags(book.FilePath, fullTagMap)
 				if len(fm) == 0 {
-					log.Printf("[DEBUG] write-back: all tags match, skipping %s", book.FilePath)
+										slog.Debug("write-back: all tags match, skipping", "path", book.FilePath)
 				} else {
 					backupFileBeforeWrite(book.FilePath)
 					var wtsOpts fileops.WriteTagsSafeOptions
@@ -834,7 +834,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 					if _, _, err := fileops.WriteTagsSafe(book.FilePath, func(tmpPath string) error {
 						return metadata.WriteMetadataToFile(tmpPath, fm, opConfig)
 					}, wtsOpts); err != nil {
-						log.Printf("[WARN] write-back failed for %s: %v", book.FilePath, err)
+												slog.Warn("write-back failed for :", "path", book.FilePath, "error", err)
 					} else {
 						writtenCount++
 					}
@@ -866,10 +866,10 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 				if _, _, err := fileops.WriteTagsSafe(sib.FilePath, func(tmpPath string) error {
 					return metadata.WriteMetadataToFile(tmpPath, tagMap, opConfig)
 				}, fileops.WriteTagsSafeOptions{}); err != nil {
-					log.Printf("[WARN] write-back failed for version-linked %s: %v", sib.FilePath, err)
+										slog.Warn("write-back failed for version-linked :", "path", sib.FilePath, "error", err)
 				} else {
 					writtenCount++
-					log.Printf("[INFO] wrote metadata to version-linked copy: %s", sib.FilePath)
+										slog.Info("wrote metadata to version-linked copy:", "path", sib.FilePath)
 				}
 			}
 		}
@@ -888,7 +888,7 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 		ChangedAt:  now,
 	}
 	if err := mfs.db.RecordMetadataChange(record); err != nil {
-		log.Printf("[WARN] failed to record write-back history for %s: %v", book.ID, err)
+				slog.Warn("failed to record write-back history for :", "id", book.ID, "error", err)
 	}
 	// Dual-write to unified activity log (Task 16: tag_write)
 	if mfs.activityService != nil && writtenCount > 0 {
@@ -905,14 +905,14 @@ func (mfs *Service) WriteBackMetadataForBook(id string, segmentFilter ...[]strin
 	// Stamp last_written_at
 	if writtenCount > 0 {
 		if err := mfs.db.SetLastWrittenAt(book.ID, now); err != nil {
-			log.Printf("[WARN] failed to stamp last_written_at for book %s: %v", book.ID, err)
+						slog.Warn("failed to stamp last_written_at for book :", "id", book.ID, "error", err)
 		}
 		// Flag for rescan so the next incremental scan re-reads the updated tags.
 		_ = mfs.db.MarkNeedsRescan(book.ID)
 	}
 
 	if skippedProtected > 0 {
-		log.Printf("[INFO] write-back for book %s: wrote %d file(s), skipped %d protected path(s)", book.ID, writtenCount-skippedProtected, skippedProtected)
+				slog.Info("write-back for book : wrote  file(s), skipped  protected path(s)", "id", book.ID, "count", writtenCount-skippedProtected, "value", skippedProtected)
 	}
 
 	return writtenCount, nil


### PR DESCRIPTION
## Summary
- Convert all internal/metafetch packages (~135 log calls across 13 files)
- Replace log.Printf with slog.Info/Warn/Error/Debug (flat key-value pairs)
- Replace log.Fatal with slog.Error + os.Exit(1)
- Update log imports to log/slog and bump all version headers

## Test plan
- ✅ go vet ./internal/metafetch/... passes
- ✅ go test ./internal/metafetch/... passes (all tests)
- ✅ make build-api succeeds
- ✅ 135 slog calls confirmed across 13 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)