### PR TITLE
feat: library.optimize maintenance sweep (Spec 2 Task 4)

### DIFF
--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-05-12
+// last-edited: 2026-05-19
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -90,6 +90,17 @@ type ServerDeps interface {
 	ActivityLogRetentionChangeDays() int
 	ActivityLogRetentionDebugDays() int
 	BackupRetentionDays() int
+
+	// ----- operation orchestration (used by library.optimize) -----
+
+	// EnqueueOp enqueues a child operation by defID with optional params.
+	// Returns the operation ID of the newly enqueued (or deduped existing) run.
+	EnqueueOp(ctx context.Context, defID string, params any) (string, error)
+
+	// WaitForOp blocks until the operation with the given ID reaches a terminal
+	// state (completed, failed, canceled, dropped) or ctx is done.
+	// Returns nil on success, non-nil on failure or context cancellation.
+	WaitForOp(ctx context.Context, opID string) error
 }
 
 // ----- reporter adapter -----

--- a/internal/plugins/maintenance/optimize.go
+++ b/internal/plugins/maintenance/optimize.go
@@ -1,0 +1,185 @@
+// file: internal/plugins/maintenance/optimize.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-4567-890123456789
+// last-edited: 2026-05-19
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// optimizeDef returns the OperationDef for library.optimize.
+func (p *Plugin) optimizeDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "library.optimize",
+		Plugin:          "maintenance",
+		DisplayName:     "Library optimize sweep",
+		Description:     "Chains cleanup-stale → fingerprint-rescan(missing) → dedup-acoustid-scan → backfill into one user-triggered maintenance pass.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "library.optimize",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         36 * time.Hour,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+			sdk.CapFilesRead,
+			sdk.CapFilesWrite,
+			sdk.CapFilesExecute,
+			sdk.CapSubprocessSpawn,
+		},
+		Run: p.runOptimize,
+	}
+}
+
+// childOp describes a single child operation in the optimize sweep.
+type childOp struct {
+	name   string
+	defID  string
+	params any
+}
+
+func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	opID := ctxOpID(ctx)
+	start := time.Now()
+
+	slog.Info("library.optimize: sweep started",
+		"operation_id", opID,
+	)
+	_ = reporter.Log(slog.LevelInfo, "Library optimize sweep started")
+	_ = reporter.UpdateProgress(0, 100, "Starting optimize sweep...")
+
+	children := []childOp{
+		{
+			name:   "temp-file-cleanup",
+			defID:  "maintenance.temp-file-cleanup",
+			params: nil,
+		},
+		{
+			name:  "fingerprint-rescan-missing",
+			defID: "acoustid.fingerprint-rescan",
+			params: map[string]any{
+				"scope": "missing",
+			},
+		},
+		{
+			name:   "acoustid-scan",
+			defID:  "acoustid.scan",
+			params: nil,
+		},
+		{
+			name:   "acoustid-backfill",
+			defID:  "acoustid.backfill",
+			params: nil,
+		},
+	}
+
+	total := len(children)
+	completed := 0
+	failed := 0
+
+	for i, ch := range children {
+		if reporter.IsCanceled() {
+			slog.Info("library.optimize: sweep canceled",
+				"operation_id", opID,
+				"completed", completed,
+				"failed", failed,
+			)
+			_ = reporter.Log(slog.LevelInfo,
+				fmt.Sprintf("Optimize sweep canceled after %d/%d children", i, total))
+			return fmt.Errorf("canceled")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		pct := 5 + (90 * i / total)
+		_ = reporter.UpdateProgress(pct, 100, fmt.Sprintf("Running child op %d/%d: %s", i+1, total, ch.name))
+
+		childStart := time.Now()
+		slog.Info("library.optimize: child started",
+			"operation_id", opID,
+			"child", ch.name,
+			"def_id", ch.defID,
+			"child_index", i+1,
+			"child_total", total,
+		)
+		_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("Starting child %d/%d: %s", i+1, total, ch.name))
+
+		childID, err := p.deps.EnqueueOp(ctx, ch.defID, ch.params)
+		if err != nil {
+			elapsed := time.Since(childStart)
+			slog.Warn("library.optimize: child enqueue failed",
+				"operation_id", opID,
+				"child", ch.name,
+				"def_id", ch.defID,
+				"elapsed_ms", elapsed.Milliseconds(),
+				"error", err,
+			)
+			_ = reporter.Log(slog.LevelWarn,
+				fmt.Sprintf("Child %s enqueue failed (skipping): %v", ch.name, err))
+			failed++
+			continue
+		}
+
+		slog.Info("library.optimize: child enqueued",
+			"operation_id", opID,
+			"child", ch.name,
+			"child_id", childID,
+		)
+
+		// Wait for the child to reach a terminal state.
+		if waitErr := p.deps.WaitForOp(ctx, childID); waitErr != nil {
+			elapsed := time.Since(childStart)
+			slog.Warn("library.optimize: child failed or timed out",
+				"operation_id", opID,
+				"child", ch.name,
+				"child_id", childID,
+				"elapsed_ms", elapsed.Milliseconds(),
+				"error", waitErr,
+			)
+			_ = reporter.Log(slog.LevelWarn,
+				fmt.Sprintf("Child %s failed (continuing): %v", ch.name, waitErr))
+			failed++
+			continue
+		}
+
+		elapsed := time.Since(childStart)
+		slog.Info("library.optimize: child completed",
+			"operation_id", opID,
+			"child", ch.name,
+			"child_id", childID,
+			"elapsed_ms", elapsed.Milliseconds(),
+		)
+		_ = reporter.Log(slog.LevelInfo,
+			fmt.Sprintf("Child %s completed in %s", ch.name, elapsed.Round(time.Second)))
+		completed++
+	}
+
+	totalElapsed := time.Since(start)
+	slog.Info("library.optimize: sweep complete",
+		"operation_id", opID,
+		"children_completed", completed,
+		"children_failed", failed,
+		"children_total", total,
+		"elapsed_ms", totalElapsed.Milliseconds(),
+	)
+	_ = reporter.UpdateProgress(100, 100,
+		fmt.Sprintf("Optimize sweep complete in %s — %d/%d children succeeded",
+			totalElapsed.Round(time.Second), completed, total))
+	_ = reporter.Log(slog.LevelInfo,
+		fmt.Sprintf("Library optimize sweep complete: %d/%d children succeeded, %d failed (elapsed: %s)",
+			completed, total, failed, totalElapsed.Round(time.Second)))
+
+	return nil
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-05-12
+// last-edited: 2026-05-19
 
 package maintenance
 
@@ -28,7 +28,7 @@ func (p *Plugin) Name() string { return "Maintenance" }
 // Version implements sdk.Plugin.
 func (p *Plugin) Version() string { return "1.0.0" }
 
-// Register registers all 26 maintenance OperationDefs with the UOS registry.
+// Register registers all maintenance OperationDefs with the UOS registry.
 func (p *Plugin) Register(r sdk.Registry) error {
 	defs := []sdk.OperationDef{
 		// --- cleanup ---
@@ -74,6 +74,9 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.movementAtomCleanupDef(),
 		p.malformedM4BRemuxDef(),
 		p.malformedM4BTranscodeDef(),
+
+		// --- optimize sweep ---
+		p.optimizeDef(),
 	}
 	for _, d := range defs {
 		if err := r.RegisterOp(d); err != nil {

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_handlers.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
 //
 // Background-operation HTTP handlers split out of server.go: the
@@ -54,6 +54,19 @@ func (s *Server) startOrganize(c *gin.Context) {
 		body = []byte("{}")
 	}
 	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.organize", body)
+	if err != nil {
+		httputil.InternalError(c, "enqueue failed", err)
+		return
+	}
+	c.JSON(202, gin.H{"op_id": opID, "id": opID})
+}
+
+func (s *Server) startOptimize(c *gin.Context) {
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
+		return
+	}
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "library.optimize", nil)
 	if err != nil {
 		httputil.InternalError(c, "enqueue failed", err)
 		return

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1045,6 +1045,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/operations/scan", s.perm(auth.PermScanTrigger), s.startScan)
 			protected.POST("/operations/organize", s.perm(auth.PermScanTrigger), s.startOrganize)
 			protected.POST("/operations/transcode", s.perm(auth.PermScanTrigger), s.startTranscode)
+			protected.POST("/operations/optimize", s.perm(auth.PermScanTrigger), s.startOptimize)
 
 			// UOS-06: operations v2 SSE + timeline + introspection endpoints
 			protected.GET("/operations/timeline", s.perm(auth.PermLibraryView), s.handleGetOperationTimeline)

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-05-07
+// last-edited: 2026-05-19
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -235,4 +235,54 @@ func (s *Server) BackupRetentionDays() int {
 		days = 30
 	}
 	return days
+}
+
+// ---- operation orchestration (library.optimize) ----
+
+// EnqueueOp implements maintenance.ServerDeps. It delegates to the UOS registry.
+// Returns an error if the registry is not initialized or the operation enqueue fails.
+func (s *Server) EnqueueOp(ctx context.Context, defID string, params any) (string, error) {
+	if s.opRegistry == nil {
+		return "", fmt.Errorf("operations registry not initialized")
+	}
+	return s.opRegistry.EnqueueOp(ctx, defID, params)
+}
+
+// WaitForOp implements maintenance.ServerDeps. It polls the database at 5-second
+// intervals until the operation reaches a terminal state or ctx is canceled.
+// Terminal states: completed, failed, canceled, interrupted_dropped, interrupted_quiesced.
+func (s *Server) WaitForOp(ctx context.Context, opID string) error {
+	store := s.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			row, err := store.GetOperationV2(opID)
+			if err != nil {
+				// DB error — keep polling; the op may still be in-flight.
+				continue
+			}
+			if row == nil {
+				// Not found yet — op may not be visible yet; keep polling.
+				continue
+			}
+			switch row.Status {
+			case "completed":
+				return nil
+			case "failed":
+				return fmt.Errorf("child operation %s failed", opID)
+			case "canceled":
+				return fmt.Errorf("child operation %s was canceled", opID)
+			case "interrupted_dropped", "interrupted_quiesced":
+				return fmt.Errorf("child operation %s was interrupted (%s)", opID, row.Status)
+			}
+			// queued or running — continue polling.
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Creates `library.optimize` operation that chains 4 child operations sequentially: `maintenance.temp-file-cleanup` → `acoustid.fingerprint-rescan` (scope=missing) → `acoustid.scan` → `acoustid.backfill`
- Adds HTTP endpoint `POST /api/v1/operations/optimize` (requires `scan.trigger` permission)
- Adds `EnqueueOp` and `WaitForOp` to `maintenance.ServerDeps` interface

## Deviations from plan

**`reg.WaitForOperation` does not exist** on the registry. Used 5-second DB-polling via `store.GetOperationV2()` instead. The `WaitForOp` method on `ServerDeps` polls until a terminal status (`completed`, `failed`, `canceled`, `interrupted_*`) is reached or ctx is canceled.

**Child op IDs differ from plan**: `library.cleanup-stale` and `dedup.acoustid-scan` are not registered operations. Used existing IDs: `maintenance.temp-file-cleanup` and `acoustid.scan` respectively.

**Non-blocking failures**: if a child enqueue or wait fails, the error is logged at WARN level and the sweep continues to the next child.

## Test plan

- [x] `make build-api` passes cleanly
- [x] `go test ./internal/plugins/maintenance/... ./internal/operations/...` passes
- [ ] Smoke test: `POST /api/v1/operations/optimize` returns 202 with `op_id`
- [ ] Verify operation appears in `/api/v1/operations/timeline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)