### PR TITLE
feat: per-file skip_scan toggle

### DIFF
--- a/web/src/components/audiobooks/AudiobookList.tsx
+++ b/web/src/components/audiobooks/AudiobookList.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/AudiobookList.tsx
-// version: 2.2.0
+// version: 2.3.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-19
 
@@ -21,6 +21,8 @@ import {
   Checkbox,
   Chip,
   Collapse,
+  Switch,
+  FormControlLabel,
 } from '@mui/material';
 import {
   MoreVert as MoreVertIcon,
@@ -116,6 +118,15 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
 
   const handleRowClick = (audiobook: Audiobook) => {
     onClick?.(audiobook);
+  };
+
+  const handleFileUpdate = (bookId: string, updatedFile: BookFile) => {
+    setFilesCache((prev) => ({
+      ...prev,
+      [bookId]: (prev[bookId] || []).map((f) =>
+        f.id === updatedFile.id ? updatedFile : f
+      ),
+    }));
   };
 
   const handleSortClick = useCallback(
@@ -500,6 +511,27 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
                                   color={getFingerprinterStatusColor(file)}
                                   variant="outlined"
                                   size="small"
+                                />
+                                <FormControlLabel
+                                  control={
+                                    <Switch
+                                      size="small"
+                                      checked={!!file.skip_scan}
+                                      onChange={async (e) => {
+                                        const newValue = e.target.checked;
+                                        try {
+                                          const updated = await api.patchBookFile(audiobook.id, file.id, {
+                                            skip_scan: newValue,
+                                          });
+                                          handleFileUpdate(audiobook.id, updated);
+                                        } catch (err) {
+                                          console.error('Failed to update skip_scan:', err);
+                                        }
+                                      }}
+                                    />
+                                  }
+                                  label="Skip"
+                                  sx={{ ml: 0.5 }}
                                 />
                                 <Typography variant="caption" color="text.secondary" sx={{ minWidth: 80, textAlign: 'right' }}>
                                   {formatFileSize(file.file_size)}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.30.0
+// version: 2.31.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-19
 
@@ -1049,6 +1049,22 @@ export async function getBookFiles(
     throw new Error(`Failed to fetch book files: ${response.status}`);
   const body = await response.json();
   return body.data;
+}
+
+export async function patchBookFile(
+  bookId: string,
+  fileId: string,
+  patch: { skip_scan?: boolean }
+): Promise<BookFile> {
+  const response = await fetch(`${API_BASE}/audiobooks/${bookId}/files/${fileId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to update file');
+  }
+  return response.json();
 }
 
 export async function getSegmentTags(

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,5 +1,5 @@
 // file: web/src/types/index.ts
-// version: 1.15.0
+// version: 1.16.0
 // guid: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a
 // last-edited: 2026-05-19
 
@@ -228,6 +228,7 @@ export interface BookFile {
   fingerprint_failure_detail?: string | null;
   fingerprint_diagnostic_json?: string | null;
   organize_method?: string;
+  skip_scan?: boolean;
   missing: boolean;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
Spec 2 Task 7. Adds a 'Skip' switch on each file row in the book expansion view. Calls PATCH endpoint (PR #1042) and updates local cache on success.