### PR TITLE
feat(slog): W12 - operation context logging end-to-end

### DIFF
--- a/EXAMPLE_INTEGRATION.md
+++ b/EXAMPLE_INTEGRATION.md
@@ -1,0 +1,89 @@
+# Operation Context Logging Integration Example
+
+## Before (Current)
+```go
+func (s *Server) runBulkMetadataFetchAll(
+	ctx context.Context,
+	opID string,
+	params operations.BulkMetadataFetchParams,
+	store database.Store,
+	progress operations.ProgressReporter,
+) error {
+	// ... setup code ...
+	
+	totalBooks := len(existingResults) + len(work)
+	alreadyDone := len(existingResults)
+	slog.Info("bulk-metadata-fetch books total, already cached, to fetch", 
+		"opID", opID, "totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
+	
+	// ... more code with scattered opID logging ...
+	
+	for _, bw := range work {
+		slog.Info("fetching metadata", "opID", opID, "bookID", bw.book.ID)
+		// ... fetch logic ...
+	}
+	
+	slog.Info("bulk-metadata-fetch done books — cached not_found", 
+		"opID", opID, "finalCount", finalCount, "found", found, "notFound", notFound)
+}
+```
+
+## After (With Operation Context)
+```go
+func (s *Server) runBulkMetadataFetchAll(
+	ctx context.Context,
+	opID string,
+	params operations.BulkMetadataFetchParams,
+	store database.Store,
+	progress operations.ProgressReporter,
+) error {
+	// Create operation context at entry point
+	op := &logging.OpContext{
+		ID:     opID,
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	ctx = logging.WithOp(ctx, op)
+	
+	// ... setup code ...
+	
+	totalBooks := len(existingResults) + len(work)
+	alreadyDone := len(existingResults)
+	
+	// Log without repeating opID - it's automatically added from context
+	logging.Info(ctx, "bulk-metadata-fetch starting", 
+		"totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
+	
+	// Add books to operation context
+	for _, bw := range work {
+		op.AddEntity("books", bw.book.ID)
+	}
+	
+	// ... more code - all logs automatically tagged with opID/opType/opStatus ...
+	
+	for _, bw := range work {
+		logging.Info(ctx, "fetching metadata", "bookID", bw.book.ID)
+		// ... fetch logic ...
+	}
+	
+	// Update status at completion
+	op.SetStatus("success")
+	logging.Info(ctx, "bulk-metadata-fetch complete", 
+		"finalCount", finalCount, "found", found, "notFound", notFound)
+}
+```
+
+## Benefits
+
+1. **No repetition** — opID/opType/opStatus automatically on every log
+2. **Entity tracking** — track which books/genres/playlists were affected
+3. **Propagation** — context flows through all called functions automatically
+4. **UI integration** — UI can group all logs by opID
+
+## Rollout Steps
+
+1. Apply to metadata-fetch (largest operation)
+2. Apply to dedup operations
+3. Apply to organize operations
+4. Expand to remaining operations as needed
+

--- a/internal/ai/dedup_review.go
+++ b/internal/ai/dedup_review.go
@@ -215,7 +215,7 @@ func dedupReviewCallback(ctx context.Context, itemsJSON []byte, results []aijobs
 	}
 
 	applied := dedupVerdictApplier.ApplyVerdicts(allVerdicts, byIndex)
-	slog.Info("dedup_review callback applied verdicts (from successful rows, errors)", "value0", "applied", "applied", applied, "value2", "successCount", successCount, "errorCount", errorCount)
+	slog.Info("dedup_review callback applied verdicts (from successful rows, errors)", "applied", applied, "successCount", successCount, "errorCount", errorCount)
 
 	return successCount, errorCount, rowErrors, nil
 }

--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -152,7 +152,7 @@ func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]f
 	}
 
 	if c.cache != nil {
-		slog.Debug("embedding cache / hits, misses sent to API", "value0", "hits", "hits", hits, "value2", "value1", len(texts), "value2", len(missTexts))
+		slog.Debug("embedding cache / hits, misses sent to API", "hits", hits, "total", len(texts), "misses", len(missTexts))
 	}
 
 	apiResults, err := c.rawEmbed(ctx, missTexts)

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1657,7 +1657,7 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 				if err != nil || narrator == nil {
 					narrator, err = svc.store.CreateNarrator(nName)
 					if err != nil {
-						slog.Warn("failed to create narrator %q", "nName", nName, err)
+						slog.Warn("failed to create narrator", "nName", nName, "err", err)
 						continue
 					}
 				}
@@ -2064,13 +2064,13 @@ func (svc *AudiobookService) BatchUpdateUserTags(bookIDs []string, addTags []str
 	for _, bookID := range bookIDs {
 		for _, tag := range addTags {
 			if err := svc.store.AddBookTag(bookID, tag); err != nil {
-				slog.Warn("BatchUpdateUserTags failed to add tag %q to book", "tag", tag, "bookID", bookID, err)
+				slog.Warn("BatchUpdateUserTags failed to add tag to book", "tag", tag, "bookID", bookID, "err", err)
 				continue
 			}
 		}
 		for _, tag := range removeTags {
 			if err := svc.store.RemoveBookTag(bookID, tag); err != nil {
-				slog.Warn("BatchUpdateUserTags failed to remove tag %q from book", "tag", tag, "bookID", bookID, err)
+				slog.Warn("BatchUpdateUserTags failed to remove tag from book", "tag", tag, "bookID", bookID, "err", err)
 				continue
 			}
 		}

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -194,14 +194,14 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 		}
 		decrypted, err := database.DecryptValue(setting.Value)
 		if err != nil {
-			slog.Info("WARNING Failed to decrypt setting %q — will try config file fallback. (error )", "setting", setting.Key, err)
+			slog.Info("WARNING Failed to decrypt setting — will try config file fallback", "setting", setting.Key, "err", err)
 			corruptSecrets = append(corruptSecrets, setting.Key)
 			continue
 		}
 		if err := applySetting(setting.Key, decrypted, setting.Type); err != nil {
 			slog.Warn("Failed to apply secret setting", "setting", setting.Key, "err", err)
 		}
-		slog.Debug("LoadConfigFromDatabase found setting (isSecrettrue, valueLen)", "setting", setting.Key, "decrypted_count", len(decrypted))
+		slog.Debug("LoadConfigFromDatabase found setting", "setting", setting.Key, "decrypted_count", len(decrypted))
 	}
 
 	// --- Legacy path (existing installs without a blob) ---
@@ -242,15 +242,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			}
 			if plaintext != "" {
 				if err := store.SetSetting(key, plaintext, "string", true); err != nil {
-					slog.Warn("Failed to re-encrypt setting %q", "key", key, err)
+					slog.Warn("Failed to re-encrypt setting", "key", key, "err", err)
 				} else {
-					slog.Info("Re-encrypted setting %q successfully", key)
+					slog.Info("Re-encrypted setting successfully", "key", key)
 				}
 			} else {
 				if err := store.DeleteSetting(key); err != nil {
-					slog.Warn("Could not clear corrupt secret %q from DB", "key", key, err)
+					slog.Warn("Could not clear corrupt secret from DB", "key", key, "err", err)
 				} else {
-					slog.Info("Cleared corrupt secret %q — re-enter via Settings", key)
+					slog.Info("Cleared corrupt secret — re-enter via Settings", "key", key)
 				}
 			}
 		}

--- a/internal/itunes/import.go
+++ b/internal/itunes/import.go
@@ -278,7 +278,7 @@ func ValidateImport(opts ImportOptions) (*ValidationResult, error) {
 				tc := checks[idx]
 				if !tc.decodeOK {
 					if debugLog {
-						slog.Info("[] DECODE_ERR %q (raw )", "idx", idx, "tc", tc.name, tc.rawLoc)
+						slog.Info("DECODE_ERR", "idx", idx, "tc", tc.name, "rawLoc", tc.rawLoc)
 					}
 					results <- statResult{idx: idx, found: false}
 					continue
@@ -287,9 +287,9 @@ func ValidateImport(opts ImportOptions) (*ValidationResult, error) {
 				found := err == nil
 				if debugLog {
 					if found {
-						slog.Info("[] FOUND %q →", "idx", idx, "tc", tc.name, tc.path)
+						slog.Info("FOUND", "idx", idx, "tc", tc.name, "path", tc.path)
 					} else {
-						slog.Info("[] MISSING %q →", "idx", idx, "tc", tc.name, tc.path)
+						slog.Info("MISSING", "idx", idx, "tc", tc.name, "path", tc.path)
 					}
 				}
 				results <- statResult{idx: idx, found: found}
@@ -323,7 +323,7 @@ func ValidateImport(opts ImportOptions) (*ValidationResult, error) {
 		} else if sr.found {
 			result.FilesFound++
 			if firstFound {
-				slog.Info("iTunes validate first file found %q ()", "tc", tc.name, tc.path)
+				slog.Info("iTunes validate first file found", "name", tc.name, "path", tc.path)
 				firstFound = false
 			}
 		} else {

--- a/internal/itunes/service/playlist_sync.go
+++ b/internal/itunes/service/playlist_sync.go
@@ -72,7 +72,7 @@ func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, 
 
 		parsed, err := itunes.ParseSmartCriteria(pl.SmartCriteria)
 		if err != nil {
-			slog.Warn("parse smart criteria for %q (PID )", "pl", pl.Title, "pid", pid, err)
+			slog.Warn("parse smart criteria for playlist", "pl", pl.Title, "pid", pid, "err", err)
 			skipped++
 			continue
 		}
@@ -89,7 +89,7 @@ func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, 
 			Description:          fmt.Sprintf("Imported from iTunes smart playlist %q", pl.Title),
 		})
 		if err != nil {
-			slog.Warn("create playlist %q", "pl", pl.Title, err)
+			slog.Warn("create playlist", "pl", pl.Title, "err", err)
 			skipped++
 			continue
 		}

--- a/internal/itunes/service/validate.go
+++ b/internal/itunes/service/validate.go
@@ -98,12 +98,12 @@ func TestMapping(req TestMappingRequest) (TestMappingResponse, error) {
 		location := opts.RemapPath(track.Location)
 		path, err := itunes.DecodeLocation(location)
 		if err != nil {
-			slog.Info("[/20] decode error for %q", "response", response.Tested, "track", track.Name, err)
+			slog.Info("decode error", "tested", response.Tested, "track", track.Name, "err", err)
 			continue
 		}
 		if _, err := os.Stat(path); err == nil {
 			response.Found++
-			slog.Info("[/20] FOUND %q →", "response", response.Tested, "track", track.Name, path)
+			slog.Info("FOUND", "tested", response.Tested, "track", track.Name, "path", path)
 			if len(response.Examples) < 3 {
 				response.Examples = append(response.Examples, TestMappingItem{
 					Title: track.Name,
@@ -111,7 +111,7 @@ func TestMapping(req TestMappingRequest) (TestMappingResponse, error) {
 				})
 			}
 		} else {
-			slog.Info("[/20] MISSING %q →", "response", response.Tested, "track", track.Name, path)
+			slog.Info("MISSING", "tested", response.Tested, "track", track.Name, "path", path)
 		}
 	}
 

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -379,9 +379,8 @@ func (b *WriteBackBatcher) flush() {
 	slog.Info("iTunes write-back flushing location updates, metadata updates, adds, removes", "locationUpdates_count", len(locationUpdates), "metadataUpdates_count", len(metadataUpdates), "adds_count", len(adds), "removes_count", len(removes))
 
 	if dryRun {
-		slog.Info("iTunes write-back DRY-RUN active (ITUNES_WRITEBACK_DRYRUNtrue) — no file written."+
-			"Would have written %d location updates, %d metadata updates, %d adds, %d removes to %s",
-			len(locationUpdates), len(metadataUpdates), len(adds), len(removes), writePath)
+		slog.Info("iTunes write-back DRY-RUN active — no file written",
+			"locationUpdates", len(locationUpdates), "metadataUpdates", len(metadataUpdates), "adds", len(adds), "removes", len(removes), "path", writePath)
 		for pid := range removes {
 			slog.Info("iTunes write-back DRY-RUN would remove PID", "pid", pid)
 		}

--- a/internal/logging/integration_test.go
+++ b/internal/logging/integration_test.go
@@ -1,0 +1,98 @@
+// file: internal/logging/integration_test.go
+// version: 1.0.0
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestEndToEndLoggingFlow verifies the full flow: OpContext attached to ctx,
+// downstream logging.Info call emits an slog record carrying opID, opType,
+// opStatus, and entities attributes — the contract the UI relies on for
+// grouping logs by operation.
+func TestEndToEndLoggingFlow(t *testing.T) {
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	op := &OpContext{
+		ID:     "op-end-to-end-123",
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	op.AddEntity("books", "book-1", "book-2")
+
+	ctx := WithOp(context.Background(), op)
+	Info(ctx, "starting work", "totalBooks", 2)
+
+	op.SetStatus("success")
+	Info(ctx, "finished work", "found", 2)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d:\n%s", len(lines), buf.String())
+	}
+
+	// First line: pending status
+	var first map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("first line invalid JSON: %v\n%s", err, lines[0])
+	}
+	assertEqual(t, first, "opID", "op-end-to-end-123")
+	assertEqual(t, first, "opType", "metadata-fetch")
+	assertEqual(t, first, "opStatus", "pending")
+	assertEqual(t, first, "msg", "starting work")
+	assertEqual(t, first, "totalBooks", float64(2)) // JSON numbers decode as float64
+	if !strings.Contains(first["entities"].(string), "book-1") {
+		t.Errorf("entities attribute should mention book-1, got %v", first["entities"])
+	}
+
+	// Second line: success status (mutated through pointer)
+	var second map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatalf("second line invalid JSON: %v\n%s", err, lines[1])
+	}
+	assertEqual(t, second, "opStatus", "success")
+	assertEqual(t, second, "found", float64(2))
+}
+
+// TestLoggingWithoutOpContext verifies log calls work normally when no
+// operation context is attached — no panics, no spurious empty op attrs.
+func TestLoggingWithoutOpContext(t *testing.T) {
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	Info(context.Background(), "no op", "foo", "bar")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if _, ok := rec["opID"]; ok {
+		t.Errorf("opID should be absent when no OpContext, got %v", rec["opID"])
+	}
+	assertEqual(t, rec, "foo", "bar")
+}
+
+func assertEqual(t *testing.T, m map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := m[key]
+	if !ok {
+		t.Errorf("missing key %q in %v", key, m)
+		return
+	}
+	if got != want {
+		t.Errorf("key %q: got %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}

--- a/internal/logging/opcontext.go
+++ b/internal/logging/opcontext.go
@@ -1,0 +1,55 @@
+// file: internal/logging/opcontext.go
+// version: 1.0.0
+
+package logging
+
+import "context"
+
+type contextKey string
+
+const opContextKey contextKey = "opContext"
+
+// OpContext holds structured metadata for an operation.
+// It's passed through context.Context so all logs in the operation's
+// call stack automatically get tagged with operation ID, type, and status.
+type OpContext struct {
+	ID       string                 // Unique operation identifier (UUID or operation ID from DB)
+	Type     string                 // Operation type: metadata-fetch, dedup, organize, etc.
+	Status   string                 // pending, success, failed
+	Entities map[string][]string    // Entity refs: {"books": ["id1"], "genres": ["rock"], "playlists": ["main"]}
+}
+
+// WithOp returns a new context with the operation context attached.
+func WithOp(ctx context.Context, op *OpContext) context.Context {
+	return context.WithValue(ctx, opContextKey, op)
+}
+
+// OpFromContext extracts the operation context from ctx, or returns nil if not present.
+func OpFromContext(ctx context.Context) *OpContext {
+	op, ok := ctx.Value(opContextKey).(*OpContext)
+	if !ok {
+		return nil
+	}
+	return op
+}
+
+// AddEntity adds entity references to the operation context.
+// entityType: "books", "genres", "playlists", etc.
+// ids: list of entity identifiers to add
+func (oc *OpContext) AddEntity(entityType string, ids ...string) {
+	if oc == nil {
+		return
+	}
+	if oc.Entities == nil {
+		oc.Entities = make(map[string][]string)
+	}
+	oc.Entities[entityType] = append(oc.Entities[entityType], ids...)
+}
+
+// SetStatus updates the operation status and returns self for chaining.
+func (oc *OpContext) SetStatus(status string) *OpContext {
+	if oc != nil {
+		oc.Status = status
+	}
+	return oc
+}

--- a/internal/logging/structured.go
+++ b/internal/logging/structured.go
@@ -1,0 +1,57 @@
+// file: internal/logging/structured.go
+// version: 1.0.0
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"encoding/json"
+)
+
+// opAttrs builds a list of slog attributes from an OpContext.
+// Returns empty list if op is nil.
+func opAttrs(op *OpContext) []any {
+	if op == nil {
+		return []any{}
+	}
+	attrs := []any{
+		"opID", op.ID,
+		"opType", op.Type,
+		"opStatus", op.Status,
+	}
+	if len(op.Entities) > 0 {
+		entitiesJSON, _ := json.Marshal(op.Entities)
+		attrs = append(attrs, "entities", string(entitiesJSON))
+	}
+	return attrs
+}
+
+// Info logs a message with operation context from ctx automatically included.
+// Additional attrs are appended after operation attributes.
+func Info(ctx context.Context, msg string, attrs ...any) {
+	op := OpFromContext(ctx)
+	args := append(opAttrs(op), attrs...)
+	slog.Info(msg, args...)
+}
+
+// Warn logs a warning with operation context from ctx automatically included.
+func Warn(ctx context.Context, msg string, attrs ...any) {
+	op := OpFromContext(ctx)
+	args := append(opAttrs(op), attrs...)
+	slog.Warn(msg, args...)
+}
+
+// Error logs an error with operation context from ctx automatically included.
+func Error(ctx context.Context, msg string, attrs ...any) {
+	op := OpFromContext(ctx)
+	args := append(opAttrs(op), attrs...)
+	slog.Error(msg, args...)
+}
+
+// Debug logs a debug message with operation context from ctx automatically included.
+func Debug(ctx context.Context, msg string, attrs ...any) {
+	op := OpFromContext(ctx)
+	args := append(opAttrs(op), attrs...)
+	slog.Debug(msg, args...)
+}

--- a/internal/logging/structured_test.go
+++ b/internal/logging/structured_test.go
@@ -1,0 +1,115 @@
+// file: internal/logging/structured_test.go
+// version: 1.0.0
+
+package logging
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithOp(t *testing.T) {
+	op := &OpContext{
+		ID:     "op-123",
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	ctx := context.Background()
+	ctx = WithOp(ctx, op)
+
+	retrieved := OpFromContext(ctx)
+	if retrieved == nil {
+		t.Fatal("OpFromContext returned nil")
+	}
+	if retrieved.ID != op.ID {
+		t.Errorf("ID mismatch: got %q, want %q", retrieved.ID, op.ID)
+	}
+	if retrieved.Type != op.Type {
+		t.Errorf("Type mismatch: got %q, want %q", retrieved.Type, op.Type)
+	}
+	if retrieved.Status != op.Status {
+		t.Errorf("Status mismatch: got %q, want %q", retrieved.Status, op.Status)
+	}
+}
+
+func TestOpFromContextNil(t *testing.T) {
+	ctx := context.Background()
+	op := OpFromContext(ctx)
+	if op != nil {
+		t.Fatal("OpFromContext should return nil for context without operation")
+	}
+}
+
+func TestAddEntity(t *testing.T) {
+	op := &OpContext{
+		ID:     "op-123",
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	op.AddEntity("books", "book-1", "book-2")
+	op.AddEntity("genres", "rock")
+
+	if len(op.Entities) != 2 {
+		t.Errorf("Entities map size: got %d, want 2", len(op.Entities))
+	}
+	if len(op.Entities["books"]) != 2 {
+		t.Errorf("books entities: got %d, want 2", len(op.Entities["books"]))
+	}
+	if len(op.Entities["genres"]) != 1 {
+		t.Errorf("genres entities: got %d, want 1", len(op.Entities["genres"]))
+	}
+}
+
+func TestSetStatus(t *testing.T) {
+	op := &OpContext{
+		ID:     "op-123",
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	result := op.SetStatus("success")
+	if result != op {
+		t.Fatal("SetStatus should return self for chaining")
+	}
+	if op.Status != "success" {
+		t.Errorf("Status: got %q, want %q", op.Status, "success")
+	}
+}
+
+func TestOpAttrsNil(t *testing.T) {
+	attrs := opAttrs(nil)
+	if len(attrs) != 0 {
+		t.Errorf("opAttrs(nil) should return empty list, got %d attrs", len(attrs))
+	}
+}
+
+func TestOpAttrs(t *testing.T) {
+	op := &OpContext{
+		ID:     "op-123",
+		Type:   "metadata-fetch",
+		Status: "success",
+		Entities: map[string][]string{
+			"books":  {"book-1"},
+			"genres": {"rock"},
+		},
+	}
+	attrs := opAttrs(op)
+
+	// Should have 8 attrs: opID (2), opType (2), opStatus (2), entities (2)
+	if len(attrs) != 8 {
+		t.Errorf("opAttrs length: got %d, want 8", len(attrs))
+	}
+
+	// Verify keys are present
+	keyFound := make(map[string]bool)
+	for i := 0; i < len(attrs); i += 2 {
+		key := attrs[i].(string)
+		keyFound[key] = true
+	}
+
+	expectedKeys := []string{"opID", "opType", "opStatus", "entities"}
+	for _, key := range expectedKeys {
+		if !keyFound[key] {
+			t.Errorf("Missing key: %q", key)
+		}
+	}
+}

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -60,12 +60,14 @@ func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, r
 		if herr != nil {
 			msg := herr.Error()
 			slog.Warn("backfill-file-hashes hash failed for"+bf.FilePath, "details", msg)
+			reporter.Log("warn", "Hash computation failed for "+bf.FilePath, &msg)
 			continue
 		}
 		if !dryRun {
 			if serr := store.SetBookFileHash(bf.ID, hash); serr != nil {
 				msg := serr.Error()
 				slog.Error("backfill-file-hashes SetBookFileHash failed", "details", msg)
+				reporter.Log("error", "Failed to save file hash for "+bf.FilePath, &msg)
 				continue
 			}
 		}

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -88,11 +88,15 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 		if reason := comIsGarbageDirectory(name); reason != "" {
 			garbageFound++
 			slog.Warn("Garbage dir found", "dir", dir, "reason", reason)
+			msg := fmt.Sprintf("Garbage directory: %s (%s)", dir, reason)
+			reporter.Log("warn", msg, nil)
 		}
 
 		empty, checkErr := comIsDirEmpty(dir)
 		if checkErr != nil {
+			msg := checkErr.Error()
 			slog.Error("Stat error", "dir", dir, "err", checkErr)
+			reporter.Log("error", "Failed to check directory: "+dir, &msg)
 			reporter.Increment()
 			continue
 		}
@@ -103,7 +107,9 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 
 		if !dryRun {
 			if removeErr := os.Remove(dir); removeErr != nil {
+				msg := removeErr.Error()
 				slog.Error("Failed to remove", "dir", dir, "err", removeErr)
+				reporter.Log("error", "Failed to remove empty directory: "+dir, &msg)
 			} else {
 				emptyRemoved++
 			}

--- a/internal/maintenance/jobs/cleanup_organize_mess.go
+++ b/internal/maintenance/jobs/cleanup_organize_mess.go
@@ -87,12 +87,12 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 		name := filepath.Base(dir)
 		if reason := comIsGarbageDirectory(name); reason != "" {
 			garbageFound++
-			slog.Warn("Garbage dir %q", "dir", dir, reason)
+			slog.Warn("Garbage dir found", "dir", dir, "reason", reason)
 		}
 
 		empty, checkErr := comIsDirEmpty(dir)
 		if checkErr != nil {
-			slog.Error("Stat error for %q", "dir", dir, checkErr)
+			slog.Error("Stat error", "dir", dir, "err", checkErr)
 			reporter.Increment()
 			continue
 		}
@@ -103,7 +103,7 @@ func (j *cleanupOrganizeMess) Run(ctx context.Context, _ database.Store, reporte
 
 		if !dryRun {
 			if removeErr := os.Remove(dir); removeErr != nil {
-				slog.Error("Failed to remove %q", "dir", dir, removeErr)
+				slog.Error("Failed to remove", "dir", dir, "err", removeErr)
 			} else {
 				emptyRemoved++
 			}

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -78,7 +78,7 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 		singleFound++
 		if !dryRun {
 			if applyErr := csUnlinkAndDeleteSeries(store, &book, ser.ID); applyErr != nil {
-				slog.Error("Failed to remove 1-book series (%q)", "ser", ser.ID, "ser", ser.Name, applyErr)
+				slog.Error("Failed to remove 1-book series", "seriesID", ser.ID, "seriesName", ser.Name, "err", applyErr)
 			} else {
 				deletedIDs[ser.ID] = true
 				singleApplied++
@@ -121,7 +121,7 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 
 		if !dryRun {
 			if mergeErr := csMergeSeriesGroup(store, keeper.ID, mergeIDs); mergeErr != nil {
-				slog.Error("Failed to merge series group %q", "normName", normName, mergeErr)
+				slog.Error("Failed to merge series group", "normName", normName, "err", mergeErr)
 			} else {
 				dupApplied++
 			}

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -73,14 +73,20 @@ func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store
 			}
 
 			found++
+			msg := fmt.Sprintf("Author/narrator swap detected: %s = %s", author.Name, *book.Narrator)
+			reporter.Log("warn", msg, nil)
 			if !dryRun {
 				current, getErr := store.GetBookByID(book.ID)
 				if getErr != nil || current == nil {
+					errMsg := fmt.Sprintf("%v", getErr)
 					slog.Error("Failed to fetch book", "book", book.ID, "getErr", getErr)
+					reporter.Log("error", "Failed to fetch book for swap fix: "+book.ID, &errMsg)
 				} else {
 					current.AuthorID = nil
 					if _, updateErr := store.UpdateBook(book.ID, current); updateErr != nil {
+						errMsg := updateErr.Error()
 						slog.Error("Failed to update book", "book", book.ID, "updateErr", updateErr)
+						reporter.Log("error", "Failed to update book after swap fix: "+book.ID, &errMsg)
 					} else {
 						applied++
 					}

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -147,7 +147,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		}
 
 		if dryRun {
-			slog.Info("[dry] would set author %q for book ()", "authorName", authorName, "b", b.ID, b.Title)
+			slog.Info("[dry] would set author for book", "authorName", authorName, "bookID", b.ID, "bookTitle", b.Title)
 			filled++
 			continue
 		}
@@ -157,11 +157,11 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		if err != nil || author == nil {
 			author, err = store.CreateAuthor(authorName)
 			if err != nil {
-				slog.Error("failed to create author %q for book", "authorName", authorName, "b", b.ID, err)
+				slog.Error("failed to create author for book", "authorName", authorName, "bookID", b.ID, "err", err)
 				errors++
 				continue
 			}
-			slog.Info("refetch-missing-authors created author %q (id)", "opID", opID, "authorName", authorName, author.ID)
+			slog.Info("refetch-missing-authors created author", "opID", opID, "authorName", authorName, "authorID", author.ID)
 		}
 
 		b.AuthorID = &author.ID
@@ -171,7 +171,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 			continue
 		}
 
-		slog.Info("refetch-missing-authors set author %q on book ()", "opID", opID, "authorName", authorName, "b", b.ID, b.Title)
+		slog.Info("refetch-missing-authors set author on book", "opID", opID, "authorName", authorName, "bookID", b.ID, "bookTitle", b.Title)
 		filled++
 	}
 

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -108,7 +108,7 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		case 1:
 			newFP := filepath.Clean(matches[0])
 			if !util.WithinRoot(newFP, iTunesRoot) {
-				slog.Warn("relink-missing-to-itunes match %q outside iTunesRoot, skipping", newFP)
+				slog.Warn("relink-missing-to-itunes match outside iTunesRoot, skipping", "match", newFP)
 				unresolved++
 				break
 			}
@@ -132,7 +132,7 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 			if best != "" {
 				best = filepath.Clean(best)
 				if !util.WithinRoot(best, iTunesRoot) {
-					slog.Warn("relink-missing-to-itunes best match %q outside iTunesRoot, skipping", best)
+					slog.Warn("relink-missing-to-itunes best match outside iTunesRoot, skipping", "match", best)
 					unresolved++
 					break
 				}

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -91,7 +91,7 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 			}
 		}
 		if authorName == "" {
-			slog.Warn("No author for missing book (%q)", "book", book.ID, book.Title)
+			slog.Warn("No author for missing book", "bookID", book.ID, "bookTitle", book.Title)
 			unresolved++
 			reporter.Increment()
 			continue
@@ -104,11 +104,11 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 			unresolved++
 		case 1:
 			resolved++
-			slog.Info("Relinkable book title%q ->", "book", book.ID, "book", book.Title, matches[0])
+			slog.Info("Relinkable book found", "bookID", book.ID, "bookTitle", book.Title, "match", matches[0])
 		default:
 			if best := rrDisambiguate(matches, authorName, book.Title); best != "" {
 				resolved++
-				slog.Info("Relinkable book title%q ->", "book", book.ID, "book", book.Title, best)
+				slog.Info("Relinkable book found", "bookID", book.ID, "bookTitle", book.Title, "match", best)
 			} else {
 				unresolved++
 			}

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -516,7 +516,7 @@ func rmfr_repairOne(
 		}
 	}
 	if !withinARoot {
-		slog.Warn("repair-missing-files candidate %q outside all search roots, skipping", "opID", opID, candidate)
+		slog.Warn("repair-missing-files candidate outside all search roots, skipping", "opID", opID, "candidate", candidate)
 		res.Method = "unresolved"
 		return res
 	}

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -179,7 +179,7 @@ func (c *AudnexusClient) LookupByASIN(asin string) (*BookMetadata, error) {
 				continue
 			}
 			resp.Body.Close()
-			slog.Debug("Audnexus found ASIN in region %q", "asin", asin, region)
+			slog.Debug("Audnexus found ASIN in region", "asin", asin, "region", region)
 			return c.bookToMetadata(&book), nil
 		}
 		resp.Body.Close()

--- a/internal/metadata/folder_parser.go
+++ b/internal/metadata/folder_parser.go
@@ -122,7 +122,7 @@ func ExtractMetadataFromFolder(dirPath string) (*FolderMetadata, error) {
 		tryExtractAuthorFromDashSplit(innermost, fm)
 	}
 
-	slog.Debug("folder_parser result authors series%q pos title%q narrator%q", "fm", fm.Authors, "fm", fm.SeriesName, fm.SeriesPosition, fm.Title, fm.Narrator)
+	slog.Debug("folder_parser result", "authors", fm.Authors, "series", fm.SeriesName, "seriesPos", fm.SeriesPosition, "title", fm.Title, "narrator", fm.Narrator)
 	return fm, nil
 }
 

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -146,7 +146,7 @@ func (c *OpenLibraryClient) SearchByTitle(ctx context.Context, title string) ([]
 			for i := range editions {
 				results = append(results, editionToMetadata(&editions[i], c.olStore))
 			}
-			slog.Debug("SearchByTitle found results from local dump for %q", "results_count", len(results), title)
+			slog.Debug("SearchByTitle found results from local dump", "resultsCount", len(results), "title", title)
 			return results, nil
 		}
 	}

--- a/internal/openlibrary/downloader.go
+++ b/internal/openlibrary/downloader.go
@@ -99,7 +99,7 @@ func DownloadDump(dumpType string, targetDir string, tracker *DownloadTracker) e
 	var lastErr error
 	for _, baseURL := range DumpSources {
 		sourceURL := fmt.Sprintf("%s/%s", baseURL, filename)
-		slog.Info("Trying OL dump download from", "value0", "sourceURL", sourceURL)
+		slog.Info("Trying OL dump download from", "sourceURL", sourceURL)
 
 		err := downloadFromURL(dumpType, sourceURL, targetPath, tracker)
 		if err == nil {

--- a/internal/openlibrary/store.go
+++ b/internal/openlibrary/store.go
@@ -149,7 +149,7 @@ func (s *OLStore) ImportDump(dumpType, filePath string, progress func(int)) erro
 			lineNum++
 			if lineNum <= skipLines {
 				if lineNum%500000 == 0 {
-					slog.Info("Skipping lines for resume /", "value0", "dumpType", "dumpType", dumpType, "value2", "lineNum", lineNum, "skipLines", skipLines)
+					slog.Info("Skipping lines for resume", "dumpType", dumpType, "lineNum", lineNum, "skipLines", skipLines)
 				}
 				continue
 			}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -35,7 +35,7 @@ func Register(p Plugin) {
 		return
 	}
 	globalRegistry.plugins[p.ID()] = p
-	slog.Info("plugin registered () v", "value0", "value0", "p", p.Name(), "value2", "value1", p.ID(), "value2", p.Version())
+	slog.Info("plugin registered", "name", p.Name(), "id", p.ID(), "version", p.Version())
 }
 
 // Global returns the global registry.
@@ -118,7 +118,7 @@ func (r *Registry) InitAllScoped(ctx context.Context, baseDeps Deps, parentGroup
 	r.initOrder = nil
 	for id, p := range r.plugins {
 		if !r.enabled[id] {
-			slog.Info("plugin disabled, skipping init", "value0", "id", id)
+			slog.Info("plugin disabled, skipping init", "id", id)
 			continue
 		}
 
@@ -136,7 +136,7 @@ func (r *Registry) InitAllScoped(ctx context.Context, baseDeps Deps, parentGroup
 			return fmt.Errorf("plugin %s init failed: %w", id, err)
 		}
 		r.initOrder = append(r.initOrder, id)
-		slog.Info("plugin initialized", "value0", "id", id)
+		slog.Info("plugin initialized", "id", id)
 	}
 	return nil
 }
@@ -150,9 +150,9 @@ func (r *Registry) ShutdownAll(ctx context.Context) {
 		id := r.initOrder[i]
 		if p, ok := r.plugins[id]; ok {
 			if err := p.Shutdown(ctx); err != nil {
-				slog.Warn("plugin shutdown error", "value0", "id", "id", id, "err", err)
+				slog.Warn("plugin shutdown error", "id", id, "err", err)
 			} else {
-				slog.Info("plugin shut down", "value0", "id", id)
+				slog.Info("plugin shut down", "id", id)
 			}
 		}
 	}

--- a/internal/quarantine/service.go
+++ b/internal/quarantine/service.go
@@ -134,7 +134,7 @@ func (qs *QuarantineService) QuarantineBook(bookID, reason string) error {
 		ChangeType: "quarantine",
 	})
 
-	slog.Info("QuarantineBook → ()", "value0", "oldPath", "oldPath", oldPath, "value2", "dest", dest, "reason", reason)
+	slog.Info("QuarantineBook moved", "oldPath", oldPath, "dest", dest, "reason", reason)
 
 	qs.events.Publish(context.Background(), plugin.NewEvent(plugin.EventBookQuarantined, bookID, map[string]any{
 		"title":          book.Title,

--- a/internal/realtime/events.go
+++ b/internal/realtime/events.go
@@ -133,7 +133,7 @@ func (h *EventHub) Broadcast(event *Event) {
 			case client.Channel <- event:
 				count++
 			default:
-				slog.Info("Warning Client channel full, dropping event", "value0", "value0", client.ID)
+				slog.Info("Warning Client channel full, dropping event", "clientID", client.ID)
 			}
 		}
 	}
@@ -256,13 +256,13 @@ func (h *EventHub) HandleSSE(c *gin.Context) {
 	for {
 		select {
 		case <-c.Request.Context().Done():
-			slog.Info("Client connection closed", "value0", "clientID", clientID)
+			slog.Info("Client connection closed", "clientID", clientID)
 			return
 		case event := <-client.Channel:
 			// Marshal event to JSON
 			data, err := json.Marshal(event)
 			if err != nil {
-				slog.Info("Error marshaling event", "value0", "err", err)
+				slog.Info("Error marshaling event", "err", err)
 				continue
 			}
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -410,7 +410,7 @@ func FindUntrackedFiles(store Store, knownPaths map[string]bool) ([]string, erro
 	// Priority 2: Import paths
 	importPaths, err := store.GetAllImportPaths()
 	if err != nil {
-		slog.Warn("reconcile failed to get import paths", "value0", "err", err)
+		slog.Warn("reconcile failed to get import paths", "err", err)
 	} else {
 		for _, ip := range importPaths {
 			if ip.Enabled {
@@ -452,7 +452,7 @@ func FindUntrackedFiles(store Store, knownPaths map[string]bool) ([]string, erro
 
 	for _, dir := range dirs {
 		if _, err := os.Stat(dir); err != nil {
-			slog.Warn("reconcile directory does not exist", "value0", "dir", dir)
+			slog.Warn("reconcile directory does not exist", "dir", dir)
 			continue
 		}
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -641,7 +641,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 				continue
 			}
 
-			slog.Info("version-group cleanup removing duplicate () from group", "value0", "value0", "dup", dup.ID, "value2", "value1", dup.FilePath, "groupID", groupID)
+			slog.Info("version-group cleanup removing duplicate from group", "dupID", dup.ID, "dupPath", dup.FilePath, "groupID", groupID)
 
 			if !dryRun {
 				// Delete the file if it exists and is in the library

--- a/internal/remux/remux.go
+++ b/internal/remux/remux.go
@@ -62,7 +62,7 @@ func (r *Remuxer) RemuxMalformedFiles() {
 		return
 	}
 
-	slog.Info("Starting malformed M4B remux scan under …", "value0", "root", root)
+	slog.Info("Starting malformed M4B remux scan under", "root", root)
 	remuxed, clean, failed := 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
@@ -98,12 +98,12 @@ func (r *Remuxer) RemuxMalformedFiles() {
 			return nil
 		}
 
-		slog.Info("malformed M4B remuxed", "value0", "path", path)
+		slog.Info("malformed M4B remuxed", "path", path)
 		remuxed++
 		return nil
 	})
 
-	slog.Info("Malformed M4B remux remuxed, already readable, failed", "value0", "remuxed", "remuxed", remuxed, "value2", "clean", clean, "failed", failed)
+	slog.Info("Malformed M4B remux complete", "remuxed", remuxed, "clean", clean, "failed", failed)
 	_ = r.store.SetSetting(RemuxKey, "true", "bool", false)
 }
 

--- a/internal/remux/transcode.go
+++ b/internal/remux/transcode.go
@@ -72,11 +72,11 @@ func (t *Transcoder) TranscodeMalformedFiles() {
 		k := TranscodeSkipKey(p)
 		if skip, _ := t.store.GetSetting(k); skip == nil {
 			_ = t.store.SetSetting(k, "true", "bool", false)
-			slog.Info("malformed M4B transcode pre-marked permanently unfixable", "value0", "p", p)
+			slog.Info("malformed M4B transcode pre-marked permanently unfixable", "path", p)
 		}
 	}
 
-	slog.Info("Starting malformed M4B transcode scan under …", "value0", "root", root)
+	slog.Info("Starting malformed M4B transcode scan under", "root", root)
 	transcoded, clean, failed, skipped := 0, 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
@@ -99,7 +99,7 @@ func (t *Transcoder) TranscodeMalformedFiles() {
 
 		// Skip files that have already been confirmed permanently unfixable.
 		if skip, err := t.store.GetSetting(TranscodeSkipKey(path)); err == nil && skip != nil && skip.Value == "true" {
-			slog.Info("malformed M4B transcode skipping known-unfixable", "value0", "path", path)
+			slog.Info("malformed M4B transcode skipping known-unfixable", "path", path)
 			skipped++
 			failed++
 			return nil
@@ -121,7 +121,7 @@ func (t *Transcoder) TranscodeMalformedFiles() {
 			return nil
 		}
 
-		slog.Info("malformed M4B transcoded", "value0", "path", path)
+		slog.Info("malformed M4B transcoded", "path", path)
 		transcoded++
 		return nil
 	})

--- a/internal/server/activity_handlers.go
+++ b/internal/server/activity_handlers.go
@@ -1,11 +1,12 @@
 // file: internal/server/activity_handlers.go
-// version: 2.2.1
+// version: 2.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-10
+// last-edited: 2026-05-19
 
 package server
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -164,6 +165,58 @@ func (s *Server) listActivitySources(c *gin.Context) {
 	httputil.RespondWithOK(c, struct {
 		Sources []database.SourceCount `json:"sources"`
 	}{Sources: sources})
+}
+
+// listOperationActivity handles GET /api/v1/operations/:id/activity.
+//
+// Returns all activity log entries for the given operation ID, ordered by
+// timestamp ASC (oldest first) so the response reads as a chronological
+// transcript of the operation. Supports an optional `limit` query parameter
+// (default 1000, max 10000).
+func (s *Server) listOperationActivity(c *gin.Context) {
+	if s.activityService == nil {
+		httputil.RespondWithInternalError(c, "activity log not available")
+		return
+	}
+	opID := strings.TrimSpace(c.Param("id"))
+	if opID == "" {
+		httputil.RespondWithBadRequest(c, "operation id required")
+		return
+	}
+
+	limit := 1000
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 10000 {
+				n = 10000
+			}
+			limit = n
+		}
+	}
+
+	filter := database.ActivityFilter{
+		OperationID: opID,
+		Limit:       limit,
+	}
+	entries, total, err := s.activityService.Query(filter)
+	if err != nil {
+		httputil.InternalError(c, "failed to query activity log", err)
+		return
+	}
+
+	// Query returns entries newest-first; reverse for ASC chronological order.
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	if entries == nil {
+		entries = []database.ActivityEntry{}
+	}
+	httputil.RespondWithOK(c, struct {
+		OperationID string                   `json:"operation_id"`
+		Entries     []database.ActivityEntry `json:"entries"`
+		Total       int                      `json:"total"`
+	}{OperationID: opID, Entries: entries, Total: total})
 }
 
 // compactActivity handles POST /api/v1/activity/compact.

--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -74,7 +74,7 @@ func (bp *BatchPoller) Poll(ctx context.Context) (int, error) {
 
 		handler, ok := bp.handlers[b.Type]
 		if !ok {
-			slog.Warn("batch_poller no handler for type %q (batch )", "b", b.Type, b.ID)
+			slog.Warn("batch_poller no handler for type %q (batch )", "type", b.Type, "id", b.ID)
 			// Mark as processed so we don't warn repeatedly
 			bp.mu.Lock()
 			bp.processedBatches[b.ID] = true

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/dedup"
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 )
 
@@ -63,11 +65,24 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.book-scan: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.book-scan",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
 			dismissed := loadDismissedDedupGroups(store)
 
+			logging.Info(ctx, "book duplicate scan starting")
+
 			result, err := dedup.ScanBookDuplicates(ctx, store, dismissed, progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "book duplicate scan failed", "err", err)
 				return err
 			}
 
@@ -77,6 +92,10 @@ func (s *Server) RegisterBookDedupScanOp(reg *opsregistry.Registry) error {
 				"duplicate_count": result.TotalDuplicates,
 			}
 			s.dedupCache.SetWithTTL("book-dedup-scan", cacheVal, 30*time.Minute)
+
+			op.SetStatus("success")
+			logging.Info(ctx, "book duplicate scan complete", "groups", len(result.Groups), "duplicates", result.TotalDuplicates)
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.book-scan", "dedup",
@@ -112,13 +131,32 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.book-merge: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.book-merge",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
+
+			op.AddEntity("books", p.KeepID)
+			op.AddEntity("books", p.MergeIDs...)
+			logging.Info(ctx, "book merge starting", "keep_id", p.KeepID, "merge_count", len(p.MergeIDs))
 
 			_, err := dedup.MergeBooks(ctx, store, p.LegacyOpID, p.KeepID, p.MergeIDs, progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "book merge failed", "err", err)
 				return err
 			}
+
 			s.dedupCache.InvalidateAll()
+			op.SetStatus("success")
+			logging.Info(ctx, "book merge complete", "kept_id", p.KeepID, "merged_count", len(p.MergeIDs))
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.book-merge", "dedup",
@@ -157,18 +195,33 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.author-scan: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.author-scan",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
 
+			logging.Info(ctx, "author duplicate scan starting")
 			_ = progress.UpdateProgress(0, 100, "Fetching authors...")
 
 			authors, err := store.GetAllAuthors()
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "author scan failed to fetch authors", "err", err)
 				return err
 			}
+			logging.Info(ctx, "authors loaded", "count", len(authors))
 			_ = progress.UpdateProgress(10, 100, fmt.Sprintf("Loaded %d authors, fetching book counts...", len(authors)))
 
 			bookCounts, err := store.GetAllAuthorBookCounts()
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "author scan failed to fetch book counts", "err", err)
 				return err
 			}
 			bookCountFn := func(authorID int) int { return bookCounts[authorID] }
@@ -184,10 +237,20 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			// Filter out groups already reviewed by AI scans (server-owned state).
 			groups = s.filterReviewedAuthorGroups(groups)
 
+			for _, g := range groups {
+				op.AddEntity("authors", strconv.Itoa(g.Canonical.ID))
+				for _, v := range g.Variants {
+					op.AddEntity("authors", strconv.Itoa(v.ID))
+				}
+			}
+
 			result := gin.H{"groups": groups, "count": len(groups)}
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 
+			op.SetStatus("success")
 			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
+			logging.Info(ctx, "author duplicate scan complete", "groups", len(groups))
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.author-scan", "dedup",
@@ -223,11 +286,30 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.series-scan: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.series-scan",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
+
+			logging.Info(ctx, "series duplicate scan starting")
 
 			result, err := dedup.ScanSeriesDuplicates(ctx, store, progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "series duplicate scan failed", "err", err)
 				return err
+			}
+
+			for _, g := range result.Groups {
+				for _, sw := range g.Series {
+					op.AddEntity("series", strconv.Itoa(sw.ID))
+				}
 			}
 
 			resp := gin.H{
@@ -236,6 +318,10 @@ func (s *Server) RegisterSeriesDedupScanOp(reg *opsregistry.Registry) error {
 				"total_series": result.TotalSeries,
 			}
 			s.dedupCache.Set("series-duplicates", resp)
+
+			op.SetStatus("success")
+			logging.Info(ctx, "series duplicate scan complete", "groups", len(result.Groups), "total_series", result.TotalSeries)
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-scan", "dedup",
@@ -271,13 +357,30 @@ func (s *Server) RegisterSeriesDedupOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.series-dedup: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.series-dedup",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
+
+			logging.Info(ctx, "series deduplication starting")
 
 			_, err := dedup.DedupSeries(ctx, store, progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "series deduplication failed", "err", err)
 				return err
 			}
+
 			s.dedupCache.InvalidateAll()
+			op.SetStatus("success")
+			logging.Info(ctx, "series deduplication complete")
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-dedup", "dedup",
@@ -314,8 +417,28 @@ func (s *Server) RegisterSeriesPruneOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.series-prune: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.series-prune",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
+
+			logging.Info(ctx, "series prune starting")
 			runErr := s.executeSeriesPrune(ctx, store, progress, p.LegacyOpID)
+
+			if runErr != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "series prune failed", "err", runErr)
+			} else {
+				op.SetStatus("success")
+				logging.Info(ctx, "series prune complete")
+			}
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				summary := "Series prune completed"
@@ -353,13 +476,34 @@ func (s *Server) RegisterSeriesMergeOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.series-merge: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.series-merge",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
+
+			op.AddEntity("series", strconv.Itoa(p.KeepID))
+			for _, mid := range p.MergeIDs {
+				op.AddEntity("series", strconv.Itoa(mid))
+			}
+			logging.Info(ctx, "series merge starting", "keep_id", p.KeepID, "merge_count", len(p.MergeIDs))
 
 			_, err := dedup.MergeSeries(ctx, store, p.LegacyOpID, p.KeepID, p.MergeIDs, p.CustomName, progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "series merge failed", "err", err)
 				return err
 			}
+
 			s.dedupCache.InvalidateAll()
+			op.SetStatus("success")
+			logging.Info(ctx, "series merge complete", "kept_id", p.KeepID, "merged_count", len(p.MergeIDs))
+
 			if s.activityWriter != nil && p.LegacyOpID != "" {
 				activity.FlushOperation(s.activityWriter, p.LegacyOpID)
 				activity.EmitInfo(s.activityWriter, p.LegacyOpID, "dedup.series-merge", "dedup",
@@ -397,9 +541,19 @@ func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 			if store == nil {
 				return fmt.Errorf("dedup.series-normalize: database not initialized")
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     p.LegacyOpID,
+				Type:   "dedup.series-normalize",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
 			progress := registryProgressAdapter{r: reporter}
 			opID := p.LegacyOpID
 
+			logging.Info(ctx, "series normalization starting")
 			_ = progress.Log("info", "Starting series name normalization...", nil)
 
 			enqueueWB := func(bookID string) {
@@ -410,14 +564,23 @@ func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 
 			affectedBookIDs, opErr := executeSeriesNormalizeCore(ctx, store, enqueueWB)
 			if opErr != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "series normalization failed", "err", opErr)
 				return opErr
 			}
 
+			for _, bookID := range affectedBookIDs {
+				op.AddEntity("books", bookID)
+			}
+
+			logging.Info(ctx, "series normalization normalize complete, now organizing", "affected_books", len(affectedBookIDs))
 			_ = progress.Log("info", fmt.Sprintf("Renamed/merged series; organizing %d affected books...", len(affectedBookIDs)), nil)
 
 			log2 := logger.NewWithActivityLog("series-normalize", store)
 			for _, bookID := range affectedBookIDs {
 				if ctx.Err() != nil {
+					op.SetStatus("failed")
+					logging.Error(ctx, "series normalization cancelled", "err", ctx.Err())
 					return ctx.Err()
 				}
 				book, bErr := store.GetBookByID(bookID)
@@ -430,13 +593,18 @@ func (s *Server) RegisterSeriesNormalizeOp(reg *opsregistry.Registry) error {
 			}
 
 			if len(affectedBookIDs) > 0 {
+				logging.Info(ctx, "writing tags for affected books", "count", len(affectedBookIDs))
 				_ = progress.Log("info", fmt.Sprintf("Writing tags for %d affected books...", len(affectedBookIDs)), nil)
 				if wbErr := s.runBulkWriteBack(ctx, opID, affectedBookIDs, false, 0, progress); wbErr != nil {
+					logging.Warn(ctx, "tag write-back incomplete", "err", wbErr)
 					_ = progress.Log("warn", fmt.Sprintf("tag write-back incomplete: %v", wbErr), nil)
 				}
 			}
 
+			op.SetStatus("success")
+			logging.Info(ctx, "series normalization complete", "affected_books", len(affectedBookIDs))
 			_ = progress.Log("info", "Series normalization complete.", nil)
+
 			if s.activityWriter != nil && opID != "" {
 				activity.FlushOperation(s.activityWriter, opID)
 				activity.EmitInfo(s.activityWriter, opID, "dedup.series-normalize", "dedup",

--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -335,7 +335,7 @@ func recoverInterruptedFileOps(pool *FileIOPool) {
 
 		fn, ok := lookupFileOpRecovery(job.OpType)
 		if !ok {
-			slog.Warn("no recovery handler for op type %q (book ), removing stale key", "job", job.OpType, job.BookID)
+			slog.Warn("no recovery handler for op type %q (book ), removing stale key", "opType", job.OpType, "bookID", job.BookID)
 			_ = store.DeleteRaw(kv.Key)
 			continue
 		}

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -374,18 +374,18 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	itlPath := config.AppConfig.ITunesLibraryWritePath
 	itlResult, itlErr := itunes.UpdateITLLocations(itlPath, itlPath+".tmp", itlUpdates)
 	if itlErr != nil {
-		stdlog.Warn("ITL write-back failed: %v", itlErr)
+		stdlog.Warn("ITL write-back failed", "err", itlErr)
 		httputil.RespondWithInternalError(c, fmt.Sprintf("ITL write-back failed: %v", itlErr))
 		return
 	}
 
 	if renameErr := itunes.RenameITLFile(itlPath+".tmp", itlPath); renameErr != nil {
-		stdlog.Warn("ITL rename failed: %v", renameErr)
+		stdlog.Warn("ITL rename failed", "err", renameErr)
 		httputil.RespondWithInternalError(c, fmt.Sprintf("ITL rename failed: %v", renameErr))
 		return
 	}
 
-	stdlog.Info("ITL write-back: updated %d tracks", itlResult.UpdatedCount)
+	stdlog.Info("ITL write-back: updated tracks", "count", itlResult.UpdatedCount)
 	httputil.RespondWithOK(c, ITunesWriteBackResponse{
 		Success:      true,
 		UpdatedCount: itlResult.UpdatedCount,
@@ -447,10 +447,10 @@ func (s *Server) handleITunesWriteBackAll(c *gin.Context) {
 	}
 
 	itunesservice.RecordITLReadTime()
-	stdlog.Info("Bulk ITL write-back: updated %d tracks out of %d candidates", itlResult.UpdatedCount, len(itlUpdates))
+	stdlog.Info("Bulk ITL write-back: updated tracks out of candidates", "updated", itlResult.UpdatedCount, "candidates", len(itlUpdates))
 
 	if n, markErr := s.Store().MarkITunesSynced(writtenBookIDs); markErr == nil && n > 0 {
-		stdlog.Info("Marked %d books as iTunes-synced after write-back", n)
+		stdlog.Info("Marked books as iTunes-synced after write-back", "count", n)
 	}
 
 	httputil.RespondWithOK(c, gin.H{

--- a/internal/server/library_core_ops.go
+++ b/internal/server/library_core_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_core_ops.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 
 // library_core_ops registers the scan, organize, and transcode OperationDefs
@@ -16,6 +16,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/scanner"
@@ -62,12 +63,35 @@ func (s *Server) RegisterLibraryScanOp(reg *opsregistry.Registry) error {
 			if len(rawParams) > 0 {
 				_ = json.Unmarshal(rawParams, &p)
 			}
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     ulid.Make().String(),
+				Type:   "library.scan",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
+			folderPath := ""
+			if p.FolderPath != nil {
+				folderPath = *p.FolderPath
+			}
+			logging.Info(ctx, "library scan starting", "folder_path", folderPath)
+
 			scanReq := &scanner.ScanRequest{
 				FolderPath:  p.FolderPath,
 				ForceUpdate: p.ForceUpdate,
 			}
 			progress := registryProgressAdapter{r: reporter}
-			return s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
+			err := s.scanService.PerformScan(ctx, scanReq, operations.LoggerFromReporter(progress))
+			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "library scan failed", "err", err)
+				return err
+			}
+			op.SetStatus("success")
+			logging.Info(ctx, "library scan complete")
+			return nil
 		},
 	})
 }
@@ -93,6 +117,26 @@ func (s *Server) RegisterLibraryOrganizeOp(reg *opsregistry.Registry) error {
 				_ = json.Unmarshal(rawParams, &p)
 			}
 			opID := ulid.Make().String()
+
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     opID,
+				Type:   "library.organize",
+				Status: "pending",
+			}
+			ctx = logging.WithOp(ctx, op)
+
+			op.AddEntity("books", p.BookIDs...)
+			folderPath := ""
+			if p.FolderPath != nil {
+				folderPath = *p.FolderPath
+			}
+			logging.Info(ctx, "library organize starting",
+				"book_count", len(p.BookIDs),
+				"folder_path", folderPath,
+				"fetch_metadata_first", p.FetchMetadataFirst,
+				"sync_itunes_first", p.SyncITunesFirst)
+
 			progress := registryProgressAdapter{r: reporter}
 			organizeReq := &OrganizeRequest{
 				FolderPath:         p.FolderPath,
@@ -101,7 +145,15 @@ func (s *Server) RegisterLibraryOrganizeOp(reg *opsregistry.Registry) error {
 				SyncITunesFirst:    p.SyncITunesFirst,
 				OperationID:        opID,
 			}
-			return s.organizeService.PerformOrganize(ctx, organizeReq, operations.LoggerFromReporter(progress))
+			err := s.organizeService.PerformOrganize(ctx, organizeReq, operations.LoggerFromReporter(progress))
+			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "library organize failed", "err", err)
+				return err
+			}
+			op.SetStatus("success")
+			logging.Info(ctx, "library organize complete", "book_count", len(p.BookIDs))
+			return nil
 		},
 	})
 }
@@ -132,6 +184,20 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 				return fmt.Errorf("transcode: book_id is required")
 			}
 
+			// Create operation context for structured logging
+			op := &logging.OpContext{
+				ID:     ulid.Make().String(),
+				Type:   "library.transcode",
+				Status: "pending",
+			}
+			op.AddEntity("books", p.BookID)
+			ctx = logging.WithOp(ctx, op)
+			logging.Info(ctx, "transcode starting",
+				"book_id", p.BookID,
+				"output_format", p.OutputFormat,
+				"bitrate", p.Bitrate,
+				"keep_original", p.KeepOriginal)
+
 			progress := registryProgressAdapter{r: reporter}
 
 			opts := transcode.TranscodeOpts{
@@ -143,11 +209,15 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 
 			outputPath, err := transcode.Transcode(ctx, opts, s.Store(), progress)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "transcode failed", "book_id", p.BookID, "err", err)
 				return err
 			}
 
 			originalBook, err := s.Store().GetBookByID(p.BookID)
 			if err != nil {
+				op.SetStatus("failed")
+				logging.Error(ctx, "transcode: failed to get original book", "book_id", p.BookID, "err", err)
 				return fmt.Errorf("failed to get original book: %w", err)
 			}
 
@@ -217,6 +287,7 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 				return nil
 			}
 
+			op.AddEntity("books", newBook.ID)
 			progress.Log("info", fmt.Sprintf("Created M4B version %s (group %s), original %s demoted to non-primary", newBook.ID, groupID, p.BookID), nil)
 
 			if !config.AppConfig.ITLWriteBackEnabled &&
@@ -235,6 +306,8 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 				}
 			}
 
+			op.SetStatus("success")
+			logging.Info(ctx, "transcode complete", "book_id", p.BookID, "new_book_id", newBook.ID, "output_path", outputPath)
 			return nil
 		},
 	})

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.7.3
+// version: 3.7.4
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
 // last-edited: 2026-05-19
 //
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
@@ -898,10 +900,20 @@ func (s *Server) runBulkMetadataFetchAll(
 	store database.Store,
 	progress operations.ProgressReporter,
 ) error {
+	// Create operation context for structured logging
+	op := &logging.OpContext{
+		ID:     opID,
+		Type:   "metadata-fetch",
+		Status: "pending",
+	}
+	ctx = logging.WithOp(ctx, op)
+
 	_ = progress.UpdateProgress(0, 0, "loading books")
 
 	allBooks, err := store.GetAllBooks(0, 0)
 	if err != nil {
+		op.SetStatus("failed")
+		logging.Error(ctx, "failed to load all books", "err", err)
 		return fmt.Errorf("GetAllBooks: %w", err)
 	}
 
@@ -955,7 +967,12 @@ func (s *Server) runBulkMetadataFetchAll(
 
 	totalBooks := len(existingResults) + len(work)
 	alreadyDone := len(existingResults)
-	slog.Info("bulk-metadata-fetch books total, already cached, to fetch", "opID", opID, "totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
+	logging.Info(ctx, "bulk-metadata-fetch books total, already cached, to fetch", "totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
+
+	// Track affected books in operation context
+	for i := range work {
+		op.AddEntity("books", work[i].book.ID)
+	}
 	_ = progress.UpdateProgress(alreadyDone, totalBooks,
 		fmt.Sprintf("resuming: %d/%d already cached", alreadyDone, totalBooks))
 
@@ -1075,7 +1092,8 @@ func (s *Server) runBulkMetadataFetchAll(
 	finalCount := atomic.LoadInt64(&completed)
 	_ = progress.UpdateProgress(int(finalCount), totalBooks,
 		fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound))
-	slog.Info("bulk-metadata-fetch done books — cached not_found", "opID", opID, "finalCount", finalCount, "found", found, "notFound", notFound)
+	op.SetStatus("success")
+	logging.Info(ctx, "bulk-metadata-fetch complete", "finalCount", finalCount, "found", found, "notFound", notFound)
 	return nil
 }
 
@@ -1242,6 +1260,16 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 	store database.Store,
 	progress operations.ProgressReporter,
 ) error {
+	// Create operation context for structured logging
+	op := &logging.OpContext{
+		ID:     opID,
+		Type:   "metadata-fetch-ids",
+		Status: "pending",
+	}
+	ctx = logging.WithOp(ctx, op)
+	// Track requested books in operation context
+	op.AddEntity("books", bookIDs...)
+
 	_ = progress.UpdateProgress(0, len(bookIDs), "loading books")
 
 	maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
@@ -1292,7 +1320,7 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 
 	alreadyDone := len(existingResults)
 	totalBooks := alreadyDone + len(work)
-	slog.Info("bulk-metadata-fetch-ids total, done, to fetch", "opID", opID, "totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
+	logging.Info(ctx, "bulk-metadata-fetch-ids total, done, to fetch", "totalBooks", totalBooks, "alreadyDone", alreadyDone, "work_count", len(work))
 	_ = progress.UpdateProgress(alreadyDone, totalBooks,
 		fmt.Sprintf("resuming: %d/%d already done", alreadyDone, totalBooks))
 
@@ -1379,7 +1407,8 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 	finalCount := atomic.LoadInt64(&completed)
 	_ = progress.UpdateProgress(int(finalCount), totalBooks,
 		fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound))
-	slog.Info("bulk-metadata-fetch-ids done books — cached not_found", "opID", opID, "finalCount", finalCount, "found", found, "notFound", notFound)
+	op.SetStatus("success")
+	logging.Info(ctx, "bulk-metadata-fetch-ids complete", "finalCount", finalCount, "found", found, "notFound", notFound)
 	return nil
 }
 

--- a/internal/server/openlibrary_service.go
+++ b/internal/server/openlibrary_service.go
@@ -146,9 +146,9 @@ func (s *Server) startOLImport(c *gin.Context) {
 }
 
 func (s *Server) uploadOLDump(c *gin.Context) {
-	slog.Debug("uploadOLDump Content-Type, ContentLength", "c", c.ContentType(), "value1", c.Request.ContentLength)
+	slog.Debug("uploadOLDump Content-Type, ContentLength", "contentType", c.ContentType(), "contentLength", c.Request.ContentLength)
 	dumpType := c.PostForm("type")
-	slog.Debug("uploadOLDump dumpType%q", dumpType)
+	slog.Debug("uploadOLDump dumpType", "dumpType", dumpType)
 	if !metafetch.ValidDumpTypes[dumpType] {
 		httputil.RespondWithBadRequest(c, "type must be one of: editions, authors, works")
 		return

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -327,7 +327,7 @@ func (s *Server) setInternalFlag(c *gin.Context) {
 		httputil.InternalError(c, "failed to set flag", err)
 		return
 	}
-	slog.Info("setInternalFlag %q", "req", req.Key, req.Value)
+	slog.Info("setInternalFlag", "key", req.Key, "value", req.Value)
 	httputil.RespondWithOK(c, gin.H{"key": req.Key, "value": req.Value})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -353,15 +353,15 @@ func NewServer(store database.Store) *Server {
 		regContainer.IncludeGroup("activity")
 	}
 	if err := regContainer.Resolve(); err != nil {
-		slog.Error("serviceregistry resolve", "value0", "err", err)
+		slog.Error("serviceregistry resolve", "err", err)
 		os.Exit(1)
 	}
 	if err := regContainer.Build(regCtx); err != nil {
-		slog.Error("serviceregistry build", "value0", "err", err)
+		slog.Error("serviceregistry build", "err", err)
 		os.Exit(1)
 	}
 	if err := regContainer.PostInit(regCtx); err != nil {
-		slog.Error("serviceregistry postinit", "value0", "err", err)
+		slog.Error("serviceregistry postinit", "err", err)
 		os.Exit(1)
 	}
 	wireServerFromContainer(server, regContainer)
@@ -408,13 +408,13 @@ func NewServer(store database.Store) *Server {
 	// and the mock store has no UpsertOpDefinitionV2 expectations.
 	if config.AppConfig.RootDir != "" {
 		if err := maintenanceplugin.New(server).Register(server.opRegistry); err != nil {
-			slog.Warn("maintenance plugin register", "value0", "err", err)
+			slog.Warn("maintenance plugin register", "err", err)
 		}
 		// Iterate all op registrars. Each file calls addOpRegistrar in its init()
 		// so new ops never require touching this block.
 		for _, reg := range opRegistrars {
 			if err := reg(server, server.opRegistry); err != nil {
-				slog.Warn("op registrar", "value0", "err", err)
+				slog.Warn("op registrar", "err", err)
 			}
 		}
 	}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -278,9 +278,9 @@ func (s *Server) Start(cfg ServerConfig) error {
 			if cfg.HTTP3Port != "" {
 				protocols = "HTTPS/HTTP2 (HTTP/3 on UDP port " + cfg.HTTP3Port + ")"
 			}
-			slog.Info("Starting server on", "protocols", protocols, "value1", s.httpServer.Addr)
+			slog.Info("Starting server on", "protocols", protocols, "addr", s.httpServer.Addr)
 			if err := s.httpServer.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile); err != nil && err != http.ErrServerClosed {
-				slog.Error("Failed to start HTTPS server", "value0", "err", err)
+				slog.Error("Failed to start HTTPS server", "err", err)
 			}
 		}()
 
@@ -292,9 +292,9 @@ func (s *Server) Start(cfg ServerConfig) error {
 				TLSConfig: tlsConfig,
 			}
 			go func() {
-				slog.Info("Starting HTTP/3 (QUIC) server on UDP", "cfg", cfg.Host, "cfg", cfg.HTTP3Port)
+				slog.Info("Starting HTTP/3 (QUIC) server on UDP", "host", cfg.Host, "port", cfg.HTTP3Port)
 				if err := s.http3Server.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile); err != nil {
-					slog.Error("Failed to start HTTP/3 server", "value0", "err", err)
+					slog.Error("Failed to start HTTP/3 server", "err", err)
 				}
 			}()
 		}
@@ -316,7 +316,7 @@ func (s *Server) Start(cfg ServerConfig) error {
 				}
 				target += r.URL.RequestURI()
 
-				slog.Debug("HTTP->HTTPS redirect ->", "value0", r.URL.String(), "target", target)
+				slog.Debug("HTTP->HTTPS redirect", "url", r.URL.String(), "target", target)
 				http.Redirect(w, r, target, http.StatusMovedPermanently)
 			})
 
@@ -333,9 +333,9 @@ func (s *Server) Start(cfg ServerConfig) error {
 	} else {
 		// Start HTTP/1.1 server without TLS
 		go func() {
-			slog.Info("Starting HTTP/1.1 server on (use --tls-cert and --tls-key for HTTP/2, add --http3-port for HTTP/3)", "value0", s.httpServer.Addr)
+			slog.Info("Starting HTTP/1.1 server on (use --tls-cert and --tls-key for HTTP/2, add --http3-port for HTTP/3)", "addr", s.httpServer.Addr)
 			if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				slog.Error("Failed to start server", "value0", "err", err)
+				slog.Error("Failed to start server", "err", err)
 			}
 		}()
 	}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1058,6 +1058,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/operations/:id/results", s.perm(auth.PermLibraryView), s.handleGetOperationResults)
 			protected.GET("/operations/:id/status", s.perm(auth.PermLibraryView), s.getOperationStatus)
 			protected.GET("/operations/:id/logs", s.perm(auth.PermLibraryView), s.getOperationLogs)
+			protected.GET("/operations/:id/activity", s.perm(auth.PermLibraryView), s.listOperationActivity)
 			protected.GET("/operations/:id/result", s.perm(auth.PermLibraryView), s.getOperationResult)
 			protected.DELETE("/operations/:id", s.perm(auth.PermSettingsManage), s.cancelOperation)
 			protected.POST("/operations/clear-stale", s.perm(auth.PermSettingsManage), s.clearStaleOperations)

--- a/internal/sweep/archive_sweep.go
+++ b/internal/sweep/archive_sweep.go
@@ -29,7 +29,7 @@ func SweepArchivedBooks(store interface {
 }) int {
 	books, err := store.GetAllBooks(0, 0)
 	if err != nil {
-		slog.Warn("archive sweep list books", "value0", "err", err)
+		slog.Warn("archive sweep list books", "err", err)
 		return 0
 	}
 

--- a/internal/sweep/sweeper.go
+++ b/internal/sweep/sweeper.go
@@ -43,7 +43,7 @@ func SweepTombstones(store database.BookStore) (*SweeperResult, error) {
 
 		if existing != nil {
 			// Book still exists — purge didn't complete. Delete the orphan tombstone.
-			slog.Info("sweeper tombstone has live book record, removing tombstone", "value0", "value0", tomb.ID)
+			slog.Info("sweeper tombstone has live book record, removing tombstone", "tombID", tomb.ID)
 			_ = store.DeleteBookTombstone(tomb.ID)
 			result.TombstonesCleaned++
 			continue

--- a/internal/transcode/transcode.go
+++ b/internal/transcode/transcode.go
@@ -248,7 +248,7 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 		if !success {
 			for _, f := range tempFiles {
 				if err := os.Remove(f); err == nil {
-					slog.Info("transcode cleaned up temp file", "value0", "f", f)
+					slog.Info("transcode cleaned up temp file", "file", f)
 				}
 			}
 		}
@@ -362,7 +362,7 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 
 		chapterFile, err := BuildChapterMetadata(inputFiles)
 		if err != nil {
-			slog.Warn("transcode failed to build chapter metadata, skipping", "value0", "err", err)
+			slog.Warn("transcode failed to build chapter metadata, skipping", "err", err)
 		} else {
 			defer os.Remove(chapterFile)
 
@@ -480,13 +480,13 @@ func StartCleanupTicker(rootDir string, interval, maxAge time.Duration) func() {
 	go func() {
 		// Run once immediately on start
 		if n := CleanupStaleTempFiles(rootDir, maxAge); n > 0 {
-			slog.Info("transcode startup cleanup removed stale temp files", "value0", "n", n)
+			slog.Info("transcode startup cleanup removed stale temp files", "count", n)
 		}
 		for {
 			select {
 			case <-ticker.C:
 				if n := CleanupStaleTempFiles(rootDir, maxAge); n > 0 {
-					slog.Info("transcode periodic cleanup removed stale temp files", "value0", "n", n)
+					slog.Info("transcode periodic cleanup removed stale temp files", "count", n)
 				}
 			case <-done:
 				ticker.Stop()

--- a/internal/updater/scheduler.go
+++ b/internal/updater/scheduler.go
@@ -49,7 +49,7 @@ func (s *Scheduler) Start() {
 	}
 	s.ticker = time.NewTicker(interval)
 
-	slog.Info("Auto-update scheduler started checking every minutes on %q channel, window %02d:00-%02d:00", "value0", "value0", cfg.CheckMins)
+	slog.Info("Auto-update scheduler started checking every minutes", "checkMins", cfg.CheckMins)
 
 	go s.loop()
 }
@@ -82,7 +82,7 @@ func (s *Scheduler) tick() {
 
 	info, err := s.updater.CheckForUpdate(cfg.Channel)
 	if err != nil {
-		slog.Warn("Auto-update check failed", "value0", "err", err)
+		slog.Warn("Auto-update check failed", "err", err)
 		return
 	}
 
@@ -91,7 +91,7 @@ func (s *Scheduler) tick() {
 		return
 	}
 
-	slog.Info("Update available -> ()", "value0", "value0", "info", info.CurrentVersion, "value2", "value1", info.LatestVersion, "value2", info.Channel)
+	slog.Info("Update available", "currentVersion", info.CurrentVersion, "latestVersion", info.LatestVersion, "channel", info.Channel)
 
 	// Check if current hour is within the update window
 	hour := time.Now().Hour()
@@ -102,7 +102,7 @@ func (s *Scheduler) tick() {
 
 	slog.Info("Applying update within window...")
 	if err := s.updater.DownloadAndReplace(info); err != nil {
-		slog.Error("Failed to apply update", "value0", "err", err)
+		slog.Error("Failed to apply update", "err", err)
 		return
 	}
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -221,7 +221,7 @@ func (u *Updater) DownloadAndReplace(info *UpdateInfo) error {
 		return err
 	}
 
-	slog.Info("Downloading update from", "value0", "assetURL", assetURL)
+	slog.Info("Downloading update from", "assetURL", assetURL)
 
 	// Get current executable path
 	execPath, err := os.Executable()

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -143,7 +143,7 @@ func (w *Watcher) eventLoop() {
 			if !ok {
 				return
 			}
-			slog.Error("watcher", "value0", "err", err)
+			slog.Error("watcher error", "err", err)
 		}
 	}
 }
@@ -189,7 +189,7 @@ func (w *Watcher) scheduleScan() {
 		w.timer = nil
 		w.mu.Unlock()
 
-		slog.Info("watcher triggering callback for", "value0", "value0", w.rootDir)
+		slog.Info("watcher triggering callback", "rootDir", w.rootDir)
 		if w.callback != nil {
 			w.callback(w.rootDir)
 		}


### PR DESCRIPTION
## Summary

Completes the W12 phase of the slog migration by introducing **operation context logging**. Every log emitted during a long-running operation (metadata-fetch, dedup, organize, transcode, scan) now automatically carries the operation's identity, type, status, and affected entities — without each call site needing to pass the opID by hand.

This unlocks an activity-by-operation view in the UI via a new HTTP endpoint.

### Architecture

- **\`internal/logging.OpContext\`** — a struct that holds \`ID\`, \`Type\`, \`Status\`, \`Entities map[string][]string\` and is propagated through \`context.Context\`.
- **\`logging.Info/Warn/Error/Debug(ctx, msg, ...attrs)\`** — wrappers around the equivalent \`slog\` calls that pull the OpContext out of ctx and prepend \`opID\`, \`opType\`, \`opStatus\`, \`entities\` attrs to every record.
- All log lines in an operation's call stack are auto-tagged. No more manual \`"opID", opID\` threading.

### Operations wired with OpContext (12 total)

| Operation | Type tag |
|---|---|
| Bulk metadata fetch (all) | \`metadata-fetch\` |
| Bulk metadata fetch (by IDs) | \`metadata-fetch-ids\` |
| Book duplicate scan | \`dedup.book-scan\` |
| Book merge | \`dedup.book-merge\` |
| Author duplicate scan | \`dedup.author-scan\` |
| Series duplicate scan | \`dedup.series-scan\` |
| Series deduplication | \`dedup.series-dedup\` |
| Series prune | \`dedup.series-prune\` |
| Series merge | \`dedup.series-merge\` |
| Series normalize | \`dedup.series-normalize\` |
| Library scan | \`library.scan\` |
| Library organize | \`library.organize\` |
| Library transcode | \`library.transcode\` |

### New endpoint

\`GET /api/v1/operations/:id/activity\` — returns the activity-feed entries scoped to a single operation, ordered ASC. Backed by the existing \`ActivityFilter.OperationID\` filter (no schema migration needed).

### Cleanup

- Restored \`reporter.Log()\` calls in three maintenance jobs that W11 inadvertently dropped (\`backfill_file_hashes\`, \`cleanup_organize_mess\`, \`fix_author_narrator_swap\`).
- Fixed \~30 leftover \`slog\` calls across server, audiobooks, metadata, and itunes packages where W11 left orphan key args without values. \`go vet ./...\` is now clean across the whole module.

## Test plan

- [x] \`go test ./internal/logging/...\` — 8 tests pass, including new \`TestEndToEndLoggingFlow\` that captures real slog JSON output and asserts \`opID\`/\`opType\`/\`opStatus\`/\`entities\` propagation.
- [x] \`go test ./...\` — full suite passes.
- [x] \`go vet ./...\` — clean.
- [x] \`make build-api\` — clean.
- [ ] Smoke test in prod: trigger metadata-fetch, verify logs carry \`opID\` and \`/api/v1/operations/:id/activity\` returns the entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)