### PR TITLE
feat(ui): per-operation activity panel

### DIFF
--- a/web/src/components/OperationActivityPanel.test.tsx
+++ b/web/src/components/OperationActivityPanel.test.tsx
@@ -1,0 +1,87 @@
+// file: web/src/components/OperationActivityPanel.test.tsx
+// version: 1.0.0
+// guid: c2e4a7b9-5d1f-4823-9a06-7b3e8c1d4f2a
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OperationActivityPanel } from './OperationActivityPanel';
+import * as activityApi from '../services/activityApi';
+
+vi.mock('../services/activityApi', async () => {
+  const actual = await vi.importActual<typeof activityApi>('../services/activityApi');
+  return {
+    ...actual,
+    fetchOperationActivity: vi.fn(),
+  };
+});
+
+describe('OperationActivityPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('renders empty state when no entries', async () => {
+    vi.mocked(activityApi.fetchOperationActivity).mockResolvedValue({
+      operation_id: 'op-1',
+      entries: [],
+      total: 0,
+    });
+
+    render(<OperationActivityPanel operationId="op-1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No activity recorded for this operation yet/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders entries with level chips and message text', async () => {
+    vi.mocked(activityApi.fetchOperationActivity).mockResolvedValue({
+      operation_id: 'op-2',
+      entries: [
+        {
+          timestamp: '2026-05-20T10:00:00Z',
+          level: 'info',
+          operation_id: 'op-2',
+          operation_type: 'metadata-fetch',
+          message: 'Started fetch',
+        },
+        {
+          timestamp: '2026-05-20T10:00:05Z',
+          level: 'error',
+          operation_id: 'op-2',
+          operation_type: 'metadata-fetch',
+          message: 'Provider returned 503',
+          details: 'request_id=abc123',
+        },
+      ],
+      total: 2,
+    });
+
+    render(<OperationActivityPanel operationId="op-2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Started fetch')).toBeInTheDocument();
+      expect(screen.getByText('Provider returned 503')).toBeInTheDocument();
+      expect(screen.getByText('2 entries')).toBeInTheDocument();
+    });
+
+    // Level chips render
+    expect(screen.getByText('info')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
+  });
+
+  it('renders error state on fetch failure', async () => {
+    vi.mocked(activityApi.fetchOperationActivity).mockRejectedValue(
+      new Error('Network down'),
+    );
+
+    render(<OperationActivityPanel operationId="op-3" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Network down/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/OperationActivityPanel.tsx
+++ b/web/src/components/OperationActivityPanel.tsx
@@ -1,0 +1,286 @@
+// file: web/src/components/OperationActivityPanel.tsx
+// version: 1.0.0
+// guid: f7a1e2c3-9b4d-4e5a-8c6f-1d3b5a7e9c0f
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight.js';
+import RefreshIcon from '@mui/icons-material/Refresh.js';
+import {
+  fetchOperationActivity,
+  type OperationActivityEntry,
+} from '../services/activityApi';
+import { useOperationsStore } from '../stores/useOperationsStore';
+
+interface OperationActivityPanelProps {
+  /** Operation ID to fetch the per-op activity feed for. */
+  operationId: string;
+  /** Optional cap on entries returned by the server (default 1000 server-side). */
+  limit?: number;
+}
+
+const TERMINAL_STATUSES = new Set([
+  'completed',
+  'failed',
+  'canceled',
+  'interrupted_dropped',
+  'interrupted_restart',
+]);
+
+function levelChip(level: string) {
+  const colorMap: Record<string, 'error' | 'warning' | 'info' | 'default'> = {
+    error: 'error',
+    warn: 'warning',
+    warning: 'warning',
+    info: 'info',
+    debug: 'default',
+  };
+  return (
+    <Chip
+      size="small"
+      label={level}
+      color={colorMap[level] ?? 'default'}
+      variant="outlined"
+      sx={{ minWidth: 60 }}
+    />
+  );
+}
+
+function rowBgColor(level: string): string | undefined {
+  if (level === 'error') return 'rgba(211, 47, 47, 0.08)';
+  if (level === 'warn' || level === 'warning') return 'rgba(237, 108, 2, 0.08)';
+  return undefined;
+}
+
+function formatTimestamp(ts: string): string {
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function statusColor(
+  status: string,
+): 'success' | 'error' | 'warning' | 'info' | 'default' {
+  if (status === 'completed') return 'success';
+  if (status === 'failed') return 'error';
+  if (status === 'canceled') return 'warning';
+  if (status === 'queued') return 'default';
+  return 'info';
+}
+
+function inferStatusFromEntries(entries: OperationActivityEntry[]): string {
+  if (entries.length === 0) return 'unknown';
+  const last = entries[entries.length - 1];
+  if (last.level === 'error') return 'failed';
+  return 'completed';
+}
+
+interface EntryRowProps {
+  entry: OperationActivityEntry;
+}
+
+function EntryRow({ entry }: EntryRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = Boolean(entry.details && entry.details.trim().length > 0);
+
+  return (
+    <Box
+      sx={{
+        bgcolor: rowBgColor(entry.level),
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        px: 1.5,
+        py: 0.75,
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Typography
+          variant="caption"
+          sx={{
+            fontFamily: 'monospace',
+            color: 'text.secondary',
+            minWidth: 80,
+            flexShrink: 0,
+          }}
+        >
+          {formatTimestamp(entry.timestamp)}
+        </Typography>
+        {levelChip(entry.level)}
+        <Typography variant="body2" sx={{ flexGrow: 1, wordBreak: 'break-word' }}>
+          {entry.message}
+        </Typography>
+        {hasDetails && (
+          <IconButton
+            size="small"
+            onClick={() => setExpanded((v) => !v)}
+            aria-label={expanded ? 'Collapse details' : 'Expand details'}
+          >
+            {expanded ? (
+              <ExpandMoreIcon fontSize="small" />
+            ) : (
+              <ChevronRightIcon fontSize="small" />
+            )}
+          </IconButton>
+        )}
+      </Stack>
+      {hasDetails && (
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <Box
+            sx={{
+              mt: 0.5,
+              ml: 11,
+              p: 1,
+              bgcolor: 'grey.900',
+              color: 'grey.100',
+              borderRadius: 1,
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+            }}
+          >
+            {entry.details}
+          </Box>
+        </Collapse>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * OperationActivityPanel — scoped view of the activity-feed entries for a
+ * single operation, backed by GET /api/v1/operations/:id/activity. Shows a
+ * status banner (sourced from the operations store when available, else
+ * inferred from the last entry's level) plus a chronological list of entries
+ * with color-coded level badges and collapsible details.
+ */
+export function OperationActivityPanel({
+  operationId,
+  limit,
+}: OperationActivityPanelProps) {
+  const [entries, setEntries] = useState<OperationActivityEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [total, setTotal] = useState(0);
+
+  const op = useOperationsStore((state) =>
+    state.activeOperations.find((o) => o.id === operationId),
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchOperationActivity(operationId, limit);
+      setEntries(data.entries ?? []);
+      setTotal(data.total ?? (data.entries?.length ?? 0));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setEntries([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [operationId, limit]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll for non-terminal ops every 3s — terminal ops do not need refresh.
+  useEffect(() => {
+    if (op && TERMINAL_STATUSES.has(op.status)) return;
+    const id = window.setInterval(load, 3000);
+    return () => window.clearInterval(id);
+  }, [load, op]);
+
+  const status = op?.status ?? inferStatusFromEntries(entries);
+  const operationType =
+    op?.displayName ||
+    op?.def_id ||
+    entries[0]?.operation_type ||
+    'operation';
+
+  return (
+    <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+      {/* Status banner */}
+      <Box
+        sx={{
+          px: 2,
+          py: 1.25,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          bgcolor: 'action.hover',
+        }}
+      >
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+            {operationType}
+          </Typography>
+          <Chip
+            size="small"
+            label={status === 'queued' ? 'pending' : status}
+            color={statusColor(status)}
+          />
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontFamily: 'monospace' }}
+          >
+            {operationId.slice(0, 12)}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Typography variant="caption" color="text.secondary">
+            {total} {total === 1 ? 'entry' : 'entries'}
+          </Typography>
+          <IconButton size="small" onClick={load} aria-label="Refresh activity">
+            <RefreshIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      </Box>
+
+      {/* Body */}
+      {loading && entries.length === 0 ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : error ? (
+        <Box sx={{ py: 3, px: 2, textAlign: 'center' }}>
+          <Typography variant="body2" color="error">
+            {error}
+          </Typography>
+        </Box>
+      ) : entries.length === 0 ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ py: 4, textAlign: 'center' }}
+        >
+          No activity recorded for this operation yet.
+        </Typography>
+      ) : (
+        <Box sx={{ maxHeight: 480, overflowY: 'auto' }}>
+          {entries.map((entry, idx) => (
+            <EntryRow key={`${entry.timestamp}-${idx}`} entry={entry} />
+          ))}
+        </Box>
+      )}
+    </Paper>
+  );
+}
+
+export default OperationActivityPanel;

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.9.0
+// version: 3.10.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useState } from 'react';
@@ -10,6 +10,9 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   Divider,
   IconButton,
   LinearProgress,
@@ -21,6 +24,9 @@ import NotificationsIcon from '@mui/icons-material/Notifications.js';
 import CancelIcon from '@mui/icons-material/Cancel.js';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew.js';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty.js';
+import ArticleIcon from '@mui/icons-material/Article.js';
+import CloseIcon from '@mui/icons-material/Close.js';
+import { OperationActivityPanel } from '../OperationActivityPanel';
 import {
   useOperationsStore,
   type ActiveOperation,
@@ -110,6 +116,7 @@ export function OperationsIndicator() {
   const alertOperations = useOperationsStore((state) => state.alertOperations);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
+  const [activityOpId, setActivityOpId] = useState<string | null>(null);
   const navigate = useNavigate();
 
   // Active ops are now discovered exclusively via SSE (op.created) and
@@ -279,6 +286,18 @@ export function OperationsIndicator() {
                         {elapsed}
                       </Typography>
                     )}
+                    <Tooltip title="View activity">
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setActivityOpId(op.id);
+                        }}
+                        sx={{ p: 0.25 }}
+                      >
+                        <ArticleIcon sx={{ fontSize: 18 }} />
+                      </IconButton>
+                    </Tooltip>
                     <Tooltip title="Cancel">
                       <IconButton
                         size="small"
@@ -382,8 +401,7 @@ export function OperationsIndicator() {
             <Box
               key={`recent-${op.id}`}
               onClick={() => {
-                setAnchorEl(null);
-                navigate(`/activity?op=${op.id}`);
+                setActivityOpId(op.id);
               }}
               sx={{
                 px: 2,
@@ -468,6 +486,29 @@ export function OperationsIndicator() {
           ))}
         </Box>
       </Popover>
+
+      {/* Per-operation activity dialog — surfaces the focused
+          /api/v1/operations/:id/activity feed without navigating away. */}
+      <Dialog
+        open={activityOpId !== null}
+        onClose={() => setActivityOpId(null)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle sx={{ pr: 6 }}>
+          Operation Activity
+          <IconButton
+            aria-label="Close"
+            onClick={() => setActivityOpId(null)}
+            sx={{ position: 'absolute', right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          {activityOpId && <OperationActivityPanel operationId={activityOpId} />}
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/services/activityApi.ts
+++ b/web/src/services/activityApi.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/activityApi.ts
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
@@ -95,6 +95,46 @@ export async function fetchActivitySources(filter: Partial<ActivityFilter> = {})
 export interface CompactResult {
   days_compacted: number;
   entries_deleted: number;
+}
+
+/** Single entry in the per-operation activity stream emitted by
+ *  `GET /api/v1/operations/:id/activity`. Distinct from the global
+ *  `ActivityEntry` because the backend route shapes a leaner payload
+ *  scoped to one op. */
+export interface OperationActivityEntry {
+  timestamp: string;
+  level: 'info' | 'warn' | 'error' | string;
+  operation_id: string;
+  operation_type: string;
+  message: string;
+  details?: string;
+}
+
+export interface OperationActivityResponse {
+  operation_id: string;
+  entries: OperationActivityEntry[];
+  total: number;
+}
+
+export async function fetchOperationActivity(
+  opID: string,
+  limit?: number,
+): Promise<OperationActivityResponse> {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.set('limit', String(limit));
+  const query = params.toString();
+  const url = `${API_BASE}/operations/${encodeURIComponent(opID)}/activity${query ? `?${query}` : ''}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch operation activity: ${response.status}`);
+  }
+  const body = await response.json();
+  // The standard envelope wraps data in `data`; fall back to the raw body
+  // for robustness in case the envelope is dropped (matches the pattern in
+  // getOperationLogs).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data = (body as any).data ?? body;
+  return data as OperationActivityResponse;
 }
 
 export async function compactActivityLog(olderThanDays: number): Promise<CompactResult> {


### PR DESCRIPTION
## Summary
- Adds `OperationActivityPanel` — a focused, scrollable view of the activity-feed entries for a single operation, backed by the new `GET /api/v1/operations/:id/activity` endpoint.
- Surfaces it from `OperationsIndicator` (the notifications bell) via a Dialog: running ops gain an article-icon button next to Cancel; terminal ops now open the panel inline instead of navigating to the global activity log.
- Renders entries chronologically with color-coded level badges (info/warn/error), per-entry collapsible details, a status banner sourced from `useOperationsStore` (falling back to inference from the last entry), and 3s polling while the op is not yet terminal.

## Changes
- `web/src/services/activityApi.ts` — new `fetchOperationActivity(opID, limit?)` + types.
- `web/src/components/OperationActivityPanel.tsx` — new component.
- `web/src/components/OperationActivityPanel.test.tsx` — Vitest coverage: empty, loaded (2 entries), error.
- `web/src/components/layout/OperationsIndicator.tsx` — wires Dialog + article-icon trigger; terminal-op click now opens the dialog.

## Tradeoff
Picked the Dialog-from-OperationsIndicator path over a `?op=` query-param mode on ActivityLog: the existing ActivityLog already has its own per-op log viewer driven by `getOperationLogs`, so a second mode there would have crossed wires. A dedicated panel reusable elsewhere keeps the new endpoint's semantics distinct.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 207/207 pass (3 new)
- [ ] Manual: open the bell, click the article icon on a running op or click a completed op — dialog should show entries with level chips, expand details, refresh icon, and auto-refresh while running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)