### PR TITLE
docs: record W12 op-context logging + UI panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.84.0 -->
+<!-- version: 2.85.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-18 -->
+<!-- last-edited: 2026-05-20 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Features
+
+#### May 20, 2026 — Per-operation activity panel (PR #1049)
+
+- New `OperationActivityPanel` React component fetches `/api/v1/operations/:id/activity` and renders the entries for a single operation: status banner, level-colored rows, collapsible details, 3s polling for non-terminal ops.
+- Mounted in `OperationsIndicator` (notifications bell): in-flight ops gain an article-icon button; terminal ops open the panel on click. Reusable anywhere — drop into BookDetail, Diagnostics, etc.
+- `web/src/services/activityApi.ts`: `fetchOperationActivity(opID, limit?)` + types.
+- Vitest coverage: empty / loaded / error states (3 new tests).
+
+#### May 20, 2026 — Operation context logging end-to-end (W12, PR #1047)
+
+- `internal/logging.OpContext`: struct holding operation ID, type, status, and entity refs, propagated via `context.Context`. `logging.Info/Warn/Error/Debug(ctx, msg, ...attrs)` auto-prepend `opID`, `opType`, `opStatus`, `entities` to every slog record.
+- Wired into 12 operations: bulk metadata-fetch (all + by-IDs), 8 dedup ops (book-scan/merge, author-scan, series-scan/dedup/prune/merge/normalize), library scan, library organize, library transcode.
+- New endpoint: `GET /api/v1/operations/:id/activity` (PermLibraryView) returns activity entries scoped to one opID, ASC order, default 1000 limit. Backed by existing `ActivityFilter.OperationID` — no schema migration.
+- New test: `TestEndToEndLoggingFlow` captures real slog JSON output and asserts attribute propagation.
+- Cleanup: restored `reporter.Log()` calls in 3 maintenance jobs that W11 inadvertently dropped (`backfill-file-hashes`, `cleanup-organize-mess`, `fix-author-narrator-swap`). Fixed ~30 leftover slog KV-pair errors across 8+ files. `go vet ./...` now clean across the whole module.
 
 ### Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -74,6 +74,20 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
+## ✅ Completed — May 20, 2026
+
+- [x] **SLOG-W12** Operation context logging end-to-end (PR #1047). New `internal/logging.OpContext` propagated via `context.Context`; `logging.Info/Warn/Error/Debug(ctx, ...)` auto-tag every record with `opID`/`opType`/`opStatus`/`entities`. Wired into 12 ops (metadata-fetch ×2, dedup ×8, library scan/organize/transcode). New endpoint `GET /api/v1/operations/:id/activity`. End-to-end test `TestEndToEndLoggingFlow` captures real slog JSON output and asserts attr propagation. Cleanup: restored 3 maintenance jobs' `reporter.Log` calls W11 dropped; fixed ~30 leftover slog KV-pair vet errors across 8+ files; `go vet ./...` now clean across the whole module.
+- [x] **SLOG-W12-UI** Per-operation activity panel (PR #1049). React component consumes `/api/v1/operations/:id/activity`, mounted in `OperationsIndicator` notifications bell. Reusable anywhere.
+- [x] **SLOG-W11** Repair W10's incomplete printf → kv conversion: 674 format-string fixes + 134 malformed-message cleanups (PRs #1036, #1037).
+- [x] **SLOG-W10** Wave 10 — migrated 265 log.Printf calls across 38 files to slog (PR #1036).
+
+### Remaining slog work (low priority)
+
+- [ ] Wire OpContext into long-tail async ops: `runBulkWriteBack`, ISBN enrichment goroutine, iTunes sync ops, batch poller, scanner deep paths.
+- [ ] Smoke-test metadata-fetch on prod to verify the full chain (opID in logs, /activity returns rows).
+
+---
+
 ## ✅ Completed — May 11, 2026
 
 - [x] **SERVER-THIN-1** Extract `DashboardService` → `internal/sysinfo` (PR #803)


### PR DESCRIPTION
## Summary
- CHANGELOG entries for #1047 (W12 op-context logging) and #1049 (per-op activity UI panel) under Features.
- TODO.md gains a Completed — May 20 section listing SLOG-W12 / SLOG-W12-UI plus the remaining low-priority items (long-tail op wiring, prod smoke test).

## Test plan
- [x] CHANGELOG renders cleanly
- [x] TODO entries link to PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)