### PR TITLE
feat: cache library counts with dirty-flag invalidation

### DIFF
--- a/internal/database/pebble_book_file_errors.go
+++ b/internal/database/pebble_book_file_errors.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_book_file_errors.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-05-16
+// last-edited: 2026-05-20
 
 package database
 
@@ -68,6 +68,7 @@ func (p *PebbleStore) RecordFileError(filePath, bookID, errClass, message string
 	if err := p.db.Set(indexKey, []byte("1"), pebble.Sync); err != nil {
 		return fmt.Errorf("pebble Set index: %w", err)
 	}
+	p.InvalidateLibraryStats()
 	return nil
 }
 
@@ -98,6 +99,7 @@ func (p *PebbleStore) ClearFileError(filePath string) error {
 	if err := p.db.Delete(indexKey, pebble.Sync); err != nil && err != pebble.ErrNotFound {
 		return fmt.Errorf("pebble Delete index: %w", err)
 	}
+	p.InvalidateLibraryStats()
 	return nil
 }
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.74.0
+// version: 1.75.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-05-05
+// last-edited: 2026-05-20
 
 package database
 
@@ -90,10 +90,14 @@ func (p *PebbleStore) SetRootDir(rootDir string) {
 
 // InvalidateLibraryStats drops the cached stats:library key so the next
 // GetDashboardStats call triggers a fresh full recompute.
+// NoSync is intentional: a crash before the delete flushes leaves a stale
+// cache that expires within statsLibraryTTL — identical to the pre-cache
+// behaviour. The benefit is avoiding a sync flush on every book/file mutation.
 func (p *PebbleStore) InvalidateLibraryStats() {
-	if err := p.db.Delete([]byte(statsLibraryKey), pebble.Sync); err != nil {
-		slog.Error("pebble Delete stats:library", "error", err)
+	if err := p.db.Delete([]byte(statsLibraryKey), pebble.NoSync); err != nil {
+		slog.Warn("pebble Delete stats:library", "error", err)
 	}
+	slog.Debug("library_counts marked dirty", "reason", "invalidated")
 }
 
 func (p *PebbleStore) readCachedLibraryStats() *LibraryStats {
@@ -1784,6 +1788,7 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 		slog.Warn("pebble RecordPathChange on create", "book_id", book.ID, "error", err)
 	}
 
+	p.InvalidateLibraryStats()
 	return book, nil
 }
 
@@ -1978,6 +1983,7 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 		return nil, err
 	}
 
+	p.InvalidateLibraryStats()
 	return book, nil
 }
 
@@ -2298,7 +2304,11 @@ func (p *PebbleStore) DeleteBook(id string) error {
 		}
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	p.InvalidateLibraryStats()
+	return nil
 }
 
 func (p *PebbleStore) SearchBooks(query string, limit, offset int) ([]Book, error) {
@@ -2573,13 +2583,29 @@ func (p *PebbleStore) GetBookSizesByLocation(rootDir string) (librarySize, impor
 // computeLibraryStats which does two range scans and writes the result back.
 func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
 	if cached := p.readCachedLibraryStats(); cached != nil {
+		slog.Info("library_counts cache hit",
+			"total_books", cached.TotalBooks,
+			"organized_books", cached.OrganizedBooks,
+			"unorganized_books", cached.UnorganizedBooks,
+			"broken_files", cached.BrokenFiles,
+			"age_seconds", time.Since(cached.ComputedAt).Seconds(),
+		)
 		return cached, nil
 	}
+	start := time.Now()
 	stats, err := p.computeLibraryStats()
 	if err != nil {
 		return nil, err
 	}
 	p.writeCachedLibraryStats(stats)
+	slog.Info("library_counts cache recomputed",
+		"total_books", stats.TotalBooks,
+		"organized_books", stats.OrganizedBooks,
+		"unorganized_books", stats.UnorganizedBooks,
+		"broken_files", stats.BrokenFiles,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"reason", "missing_or_expired",
+	)
 	return stats, nil
 }
 
@@ -2701,6 +2727,12 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 	}
 	if sc, err := p.CountSeries(); err == nil {
 		stats.TotalSeries = sc
+	}
+
+	// Pass 3: book_file_errors_by_book: key-only scan — count distinct books with errors.
+	// Reuses the secondary index written by RecordFileError so no JSON deserialization needed.
+	if booksWithErrors, err := p.ListBooksWithFileErrors(); err == nil {
+		stats.BrokenFiles = len(booksWithErrors)
 	}
 
 	return stats, nil
@@ -7718,7 +7750,11 @@ func (s *PebbleStore) CreateBookFile(file *BookFile) error {
 		return err
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	s.InvalidateLibraryStats()
+	return nil
 }
 
 // UpdateBookFile replaces an existing BookFile, cleaning up stale secondary
@@ -7761,7 +7797,11 @@ func (s *PebbleStore) UpdateBookFile(id string, file *BookFile) error {
 		return err
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	s.InvalidateLibraryStats()
+	return nil
 }
 
 // GetBookFiles returns all BookFile records for the given bookID by iterating
@@ -8037,7 +8077,11 @@ func (s *PebbleStore) DeleteBookFile(id string) error {
 		return err
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	s.InvalidateLibraryStats()
+	return nil
 }
 
 // DeleteBookFilesForBook removes all BookFile records for a given bookID,
@@ -8066,7 +8110,11 @@ func (s *PebbleStore) DeleteBookFilesForBook(bookID string) error {
 		}
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	s.InvalidateLibraryStats()
+	return nil
 }
 
 // UpsertBookFile creates or updates a BookFile. Lookup order:
@@ -8180,7 +8228,11 @@ func (s *PebbleStore) BatchUpsertBookFiles(files []*BookFile) error {
 		}
 	}
 
-	return batch.Commit(pebble.Sync)
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	s.InvalidateLibraryStats()
+	return nil
 }
 
 // GetBookFileByID returns a single BookFile by bookID and fileID.

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.75.0
+// version: 2.76.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 package database
 
@@ -905,6 +905,11 @@ type LibraryStats struct {
 	SizeByImportPath   map[int]int64  `json:"size_by_import_path"`
 	StateDistribution  map[string]int `json:"state_distribution"`
 	FormatDistribution map[string]int `json:"format_distribution"`
+	// BrokenFiles is the number of distinct books that have at least one recorded
+	// file error (from the book_file_errors_by_book: index). Populated alongside
+	// TotalBooks/TotalFiles in computeLibraryStats so all three counts share a
+	// single cache entry and invalidation path.
+	BrokenFiles        int            `json:"broken_files"`
 	ComputedAt         time.Time      `json:"computed_at"`
 }
 

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/system_handlers.go
-// version: 2.2.5
-// last-edited: 2026-05-18
+// version: 2.3.0
+// last-edited: 2026-05-20
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
 // System-level HTTP handlers split out of server.go: health, status,
@@ -108,27 +108,8 @@ func (s *Server) getSystemStatus(c *gin.Context) {
 		status.PluginHealth = pluginHealth
 	}
 
-	// Attach broken file count — PebbleStore implements GetBrokenFileCount but it
-	// is not part of SystemServiceStore, so we probe via interface assertion here.
-	if s.Store() != nil {
-		bfc := func() (int, bool) {
-			if gf, ok := s.Store().(interface{ GetBrokenFileCount() (int, error) }); ok {
-				if cnt, err := gf.GetBrokenFileCount(); err == nil {
-					return cnt, true
-				}
-			} else if uw, ok := s.Store().(interface{ Unwrap() database.Store }); ok {
-				if inner, ok2 := uw.Unwrap().(interface{ GetBrokenFileCount() (int, error) }); ok2 {
-					if cnt, err := inner.GetBrokenFileCount(); err == nil {
-						return cnt, true
-					}
-				}
-			}
-			return 0, false
-		}
-		if cnt, ok := bfc(); ok {
-			status.BrokenFileCount = &cnt
-		}
-	}
+	// BrokenFileCount is now populated by CollectSystemStatus via LibraryStats.BrokenFiles
+	// (cached in the stats:library PebbleDB entry). No per-request scan needed.
 
 	httputil.RespondWithOK(c, status)
 }

--- a/internal/sysinfo/service.go
+++ b/internal/sysinfo/service.go
@@ -1,7 +1,7 @@
 // file: internal/sysinfo/service.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: h8i9j0k1-l2m3-n4o5-p6q7-r8s9t0u1v2w3
-// last-edited: 2026-05-01
+// last-edited: 2026-05-20
 
 package sysinfo
 
@@ -150,6 +150,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 	}
 	totalSize := librarySize + importSize
 
+	brokenFiles := dbStats.BrokenFiles
 	status := &SystemStatus{
 		Status:           "running",
 		Version:          ss.version,
@@ -159,6 +160,7 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 		TotalFileCount:   dbStats.TotalFiles,
 		AuthorCount:      dbStats.TotalAuthors,
 		SeriesCount:      dbStats.TotalSeries,
+		BrokenFileCount:  &brokenFiles,
 		LibrarySizeBytes: librarySize,
 		ImportSizeBytes:  importSize,
 		TotalSizeBytes:   totalSize,


### PR DESCRIPTION
## Summary

- Extends the existing `LibraryStats` cache (`stats:library` in PebbleDB) to include `broken_files` — no second parallel cache needed
- `GetBrokenFileCount()` was called on every `/api/v1/system/status` request via a per-request range scan; it now piggybacks on the cached `computeLibraryStats()` recompute
- `InvalidateLibraryStats()` now fires after all book/file/error mutations so the cache is always fresh on the next read (previously only TTL or `SetRootDir` triggered invalidation)

## Mutation methods now calling InvalidateLibraryStats

- `CreateBook`, `UpdateBook`, `DeleteBook`
- `CreateBookFile`, `UpdateBookFile`, `DeleteBookFile`, `DeleteBookFilesForBook`, `BatchUpsertBookFiles`
- `RecordFileError`, `ClearFileError`

## Cache key and design notes

- Cache key: `stats:library` (existing — reused as per existing pattern; spec's `library_counts_cache_v1` is superseded by the richer existing cache)
- Invalidation uses `pebble.NoSync` (was `pebble.Sync`): a crash before the delete flushes leaves a stale cache for at most 10 min TTL, which is identical to the pre-mutation behaviour
- Dirty marking is idempotent: deleting a missing key is a no-op in PebbleDB
- `BatchUpsertBookFiles` (called by iTunes sync for 10K+ files) now calls `InvalidateLibraryStats()` once after the batch commit, not per-file

## API endpoint

`GET /api/v1/system/status` → `getSystemStatus` → `CollectSystemStatus()` now reads `BrokenFileCount` from cached `LibraryStats.BrokenFiles` instead of issuing a separate uncached range scan. The interface-assertion dance has been removed from the handler.

## Test plan

- [x] `go test ./internal/database/... ./internal/server/... ./internal/sysinfo/...` — all pass
- [x] `make build-api` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)