### PR TITLE
fix(review): sort matched-first + client-side paginate Review dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.85.0 -->
+<!-- version: 2.86.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-20 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixes
+
+#### May 20, 2026 — Review Metadata Matches: fetch-all + client-side sort/page
+
+- `GET /api/v1/audiobooks/metadata/cache/review` now sorts results matched-first (pending → no_match → applied) and accepts `limit=0` to return the full cached set in one call. The shared `ParsePaginationParams` clamps to ≤500, so the handler parses `limit`/`offset` directly to allow uncapped responses for this endpoint.
+- `matched` / `no_match` / `total_applied` counts in the response are now computed over the full prepared set, not just the returned page — so the dialog's totals match the reality across all 5851 cached candidates.
+- `MetadataReviewDialog` fetches once on open with `limit=0` and paginates client-side via `filteredResults.slice(...)`. Hide / confidence / language filters no longer require a server round-trip and matched rows reliably surface on page 1.
+- Dropped the auto-advance-empty-page effect (no longer needed) and replaced it with a page-clamp effect so shrinking filters don't strand the paginator past the last page.
 
 ### Features
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,131 +1,31 @@
-# Structured Logging Migration – Wave 11 (Format String Fix)
+# Plan: Review Metadata Matches — fetch-all + client-side filter/sort
 
-**Branch:** `feat/slog-w11`
-**Scope:** Fix all format string issues in slog calls (674 calls across 119 files)
-**Status:** Planning (awaiting approval)
+## Problem
+Endpoint paginates server-side over all 5851 cached results in insertion order;
+filters (Hide Applied/Rejected/No Match, Min Confidence, Match Language) run
+client-side per page. Matched rows are scattered across 24 pages and never
+auto-float to page 1.
 
 ## Goal
+Server returns the full cached set in one call; client owns sort/filter/page.
 
-Fix the format string corruption introduced in W10. The W10 conversion was mechanical (just swapping `log.Printf` → `slog.Info`), but didn't account for slog's requirement for structured key-value pairs instead of printf-style format strings.
+## Changes
+1. `internal/server/metadata_cached_handlers.go` — `getCacheReviewResults`:
+   - `limit=0` (or omitted) returns all rows.
+   - Sort by status (matched first, then no_match, then applied), stable
+     within group.
+2. `web/src/services/api.ts` — allow `limit=0`.
+3. `web/src/components/audiobooks/MetadataReviewDialog.tsx`:
+   - Fetch once on open with limit=0.
+   - Compute `totalPages` from filtered length.
+   - Paginate `filteredResults` client-side via slice.
+   - Update chip labels to drop "(page)" suffix where counts are global.
+   - Drop the auto-advance-when-page-empty effect.
 
-Production logs now show: `msg="Startup task %s started: operation %s" !BADKEY=taskID !BADKEY=opID`
+## Test
+- `make build` (Go + TS).
+- Manual: open Review dialog → matched rows fill page 1; toggling hide filters
+  no longer refetches.
 
-This wave converts all format strings to proper key-value format.
-
-## Problem Statement
-
-**Current State (W10 output):**
-```go
-slog.Info("Startup task %s started: operation %s", taskID, opID)
-// Produces: msg="Startup task %s started: operation %s" !BADKEY=taskID !BADKEY=opID
-```
-
-**Desired State (W11 output):**
-```go
-slog.Info("Startup task started", "task", taskID, "op", opID)
-// Produces: msg="Startup task started" task=taskID op=opID
-```
-
-## Scope
-
-- **674 slog calls** across 119 files with format strings (`%s`, `%d`, `%v`, `%f`)
-- Affects: internal/, cmd/ packages
-- Pattern categories:
-  1. Single format string arg: `slog.Info("msg: %s", val)` → `slog.Info("msg", "key", val)`
-  2. Multiple format string args: `slog.Info("msg %s %d", val1, val2)` → `slog.Info("msg", "key1", val1, "key2", val2)`
-  3. Mixed (format string + KV): `slog.Error("msg %v", val, "existing", "kv")` → needs careful parsing
-
-## Conversion Strategy
-
-### Approach
-
-Build a Go program (`w11-fix-format-strings.go`) that:
-
-1. **Identifies problematic patterns** via regex matching `slog\.(Info|Warn|Error|Debug)\([^)]*%[sdvf]`
-2. **Extracts components**:
-   - Method name (Info, Warn, Error, Debug)
-   - Message string with format specifiers
-   - Format args (the positional values after the message)
-   - Any trailing key-value pairs
-3. **Generates key names** automatically (auto-increment: key0, key1, key2 or smarter naming based on context)
-4. **Reconstructs the call** with structured format
-
-### Rules for Key Naming
-
-When format string has positional args, generate keys intelligently:
-- If a variable name is available (e.g., `taskID`), use it: `"task", taskID`
-- If a function call (e.g., `len(items)`), use generic: `"count", len(items)`
-- If a complex expression, use generic: `"value0"`, `"value1"`, etc.
-
-Examples:
-```go
-// Input: slog.Info("file %s processed", filepath)
-// Output: slog.Info("file processed", "filepath", filepath)
-
-// Input: slog.Info("total: %d bytes, %d items", totalBytes, itemCount)
-// Output: slog.Info("total", "totalBytes", totalBytes, "itemCount", itemCount)
-
-// Input: slog.Error("error: %v", err)
-// Output: slog.Error("error", "err", err)
-```
-
-## Execution Steps
-
-1. **Build converter** — write `w11-fix-format-strings.go`
-   - Parse slog calls with format strings
-   - Extract method, message, args
-   - Generate key names
-   - Output fixed calls
-
-2. **Test converter** on a single file first (e.g., `settings.go`)
-
-3. **Apply to all 119 files**
-   - Run converter on all internal/cmd files
-   - Manual review of high-risk files (database, itunes, metadata)
-
-4. **Verify** 
-   ```bash
-   grep -rn 'slog\.\(Info\|Warn\|Error\|Debug\).*%[sdvf]' internal cmd
-   # Should return 0 results
-   ```
-
-5. **Run tests**
-   ```bash
-   make ci
-   ```
-
-6. **Commit**
-   ```bash
-   git commit -m "fix(slog): W11 format string to key-value conversion (674 calls)"
-   ```
-
-7. **Ship**
-   ```bash
-   /ship
-   ```
-
-## Risk Assessment
-
-**Low Risk**
-- All changes are mechanical (format string → KV transformation)
-- No behavioral changes (just log output format)
-- Easy to verify: grep for `%[sdvf]` patterns post-conversion
-
-## Timeline Estimate
-
-- **Converter development:** ~30 min
-- **Single file test:** ~5 min
-- **Batch apply:** ~10 min (automated)
-- **Testing:** ~15 min (make ci)
-- **Ship:** ~5 min (/ship)
-- **Total:** ~1.5 hours
-
-## Rollback Plan
-
-If issues arise post-commit:
-- Revert commit: `git revert <commit-hash>`
-- Rollback via `/ship` (auto-merge revert)
-
----
-
-**Approval Required:** Proceed with W11 conversion? [y/n]
+## Rollback
+Single PR.

--- a/internal/server/metadata_cached_handlers.go
+++ b/internal/server/metadata_cached_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_cached_handlers.go
-// version: 1.1.0
+// version: 1.2.0
 //
 // METADATA-CACHED-MATCHER: handlers for the persistent metadata-cache
 // query surface (Task 8). Adds GET /audiobooks/metadata/cached, the
@@ -15,6 +15,7 @@ package server
 import (
 	"encoding/json"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -98,7 +99,17 @@ func (s *Server) getCacheReviewResults(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "metadata service not initialized")
 		return
 	}
-	pp := httputil.ParsePaginationParams(c)
+	// Parse limit/offset directly rather than via ParsePaginationParams —
+	// the review dialog needs to request the full set in one call
+	// (limit=0 means "no cap"), which the shared parser clamps to ≤500.
+	limit := httputil.ParseQueryInt(c, "limit", 0)
+	offset := httputil.ParseQueryInt(c, "offset", 0)
+	if limit < 0 {
+		limit = 0
+	}
+	if offset < 0 {
+		offset = 0
+	}
 
 	summaries, err := s.metadataFetchService.ListCachedSummaries(c.Request.Context())
 	if err != nil {
@@ -107,23 +118,68 @@ func (s *Server) getCacheReviewResults(c *gin.Context) {
 	}
 
 	total := len(summaries)
-	start := pp.Offset
-	if start > total {
-		start = total
+
+	// Pre-resolve each summary's reviewStatus so we can sort matched-first
+	// before slicing. Without this the client sees pending matched rows
+	// scattered across pages in cache-insertion order.
+	type entryWithStatus struct {
+		sum    metafetch.MetadataCacheSummary
+		status string // "matched" | "no_match" | "applied"
 	}
-	end := total
-	if pp.Limit > 0 {
-		end = start + pp.Limit
-		if end > total {
-			end = total
+	prepared := make([]entryWithStatus, 0, total)
+	for _, sum := range summaries {
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		st := "matched"
+		if book.MetadataReviewStatus != nil {
+			switch *book.MetadataReviewStatus {
+			case "no_match":
+				st = "no_match"
+			case "matched":
+				st = "applied"
+			}
+		}
+		prepared = append(prepared, entryWithStatus{sum: sum, status: st})
+	}
+	// Stable sort: matched (pending review) first, then no_match, then applied.
+	statusRank := map[string]int{"matched": 0, "no_match": 1, "applied": 2}
+	sort.SliceStable(prepared, func(i, j int) bool {
+		return statusRank[prepared[i].status] < statusRank[prepared[j].status]
+	})
+
+	// limit=0 means "return all rows" — the client now paginates locally.
+	start := offset
+	if start > len(prepared) {
+		start = len(prepared)
+	}
+	end := len(prepared)
+	if limit > 0 {
+		end = start + limit
+		if end > len(prepared) {
+			end = len(prepared)
 		}
 	}
-	page := summaries[start:end]
+	page := prepared[start:end]
+
+	// Global counts over the full prepared set so the UI can show accurate
+	// totals even when paginating a subset.
+	var matched, noMatch, applied int
+	for _, p := range prepared {
+		switch p.status {
+		case "no_match":
+			noMatch++
+		case "applied":
+			applied++
+		default:
+			matched++
+		}
+	}
 
 	results := make([]CandidateResult, 0, len(page))
-	var matched, noMatch, applied int
-
-	for _, sum := range page {
+	for _, p := range page {
+		sum := p.sum
 		book, err := s.Store().GetBookByID(sum.BookID)
 		if err != nil || book == nil {
 			continue
@@ -138,27 +194,10 @@ func (s *Server) getCacheReviewResults(c *gin.Context) {
 			continue
 		}
 
-		var reviewStatus string
-		if book.MetadataReviewStatus != nil {
-			reviewStatus = *book.MetadataReviewStatus
-		}
-
-		status := "matched"
-		switch reviewStatus {
-		case "no_match":
-			status = "no_match"
-			noMatch++
-		case "matched":
-			status = "applied"
-			applied++
-		default:
-			matched++
-		}
-
 		results = append(results, CandidateResult{
 			Book:      metabatch.BuildCandidateBookInfo(s.Store(), book),
 			Candidate: &cand,
-			Status:    status,
+			Status:    p.status,
 		})
 	}
 

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -194,40 +194,39 @@ export function MetadataReviewDialog({
   // exactly once when the dialog closes, rather than on every individual apply.
   const hasChangesRef = useRef(false);
 
-  // Fetch the current page from the persistent metadata cache.
+  // Fetch the entire cached review set once. The dialog now paginates,
+  // filters, and sorts purely client-side — refetching only on manual
+  // refresh or dialog reopen. limit=0 tells the server "return all rows."
   useEffect(() => {
     if (!open) return;
     setLoading(true);
     const fetchId = ++fetchIdRef.current;
-    const offset = (serverPage - 1) * reviewPageSize;
     api
-      .getCachedReviewResults(reviewPageSize, offset)
+      .getCachedReviewResults(0, 0)
       .then((data) => {
         if (fetchId !== fetchIdRef.current) return; // stale — a newer fetch is in flight
-        const pageResults = data.results || [];
+        const allResults = data.results || [];
 
-        const pageStates = new Map<string, 'pending' | 'applied' | 'rejected' | 'skipped'>();
-        for (const r of pageResults) {
-          // Pre-seed UI state from persisted server status so toggles
-          // (hideApplied, hideNoMatch) work correctly on first render.
+        const seedStates = new Map<string, 'pending' | 'applied' | 'rejected' | 'skipped'>();
+        for (const r of allResults) {
           if (r.status === 'applied') {
-            pageStates.set(r.book.id, 'applied');
+            seedStates.set(r.book.id, 'applied');
           } else if (r.status === 'no_match') {
-            pageStates.set(r.book.id, 'rejected');
+            seedStates.set(r.book.id, 'rejected');
           }
         }
         setRowStates((prev) => {
           const merged = new Map(prev);
-          pageStates.forEach((v, k) => { if (!merged.has(k)) merged.set(k, v); });
+          seedStates.forEach((v, k) => { if (!merged.has(k)) merged.set(k, v); });
           return merged;
         });
 
-        setResults(pageResults);
-        const tc = data.total_count ?? pageResults.length;
+        setResults(allResults);
+        const tc = data.total_count ?? allResults.length;
         setTotalCount(tc);
         setSummary({
-          matched: data.matched ?? pageResults.filter((r) => r.status === 'matched').length,
-          no_match: data.no_match ?? pageResults.filter((r) => r.status === 'no_match').length,
+          matched: data.matched ?? allResults.filter((r) => r.status === 'matched').length,
+          no_match: data.no_match ?? allResults.filter((r) => r.status === 'no_match').length,
           errors: data.errors ?? 0,
           total: tc,
         });
@@ -237,7 +236,7 @@ export function MetadataReviewDialog({
         if (fetchId !== fetchIdRef.current) return;
         setLoading(false);
       });
-  }, [open, serverPage, reviewPageSize, refreshKey]);
+  }, [open, refreshKey]);
 
   // Reset page and un-groupings when the dialog opens.
   useEffect(() => {
@@ -426,10 +425,12 @@ export function MetadataReviewDialog({
   const handleUngroup = (bookId: string) =>
     setUngroupedIds((prev) => new Set(prev).add(bookId));
 
-  // All filtered items from the current server page are rendered directly —
-  // no second display-page layer. The single paginator navigates server pages.
-  const pageResults = filteredResults;
-  const totalPages = Math.max(1, Math.ceil(totalCount / reviewPageSize));
+  // Paginate the filtered set client-side. Because the server returned every
+  // cached row and sorted pending-matched first, page 1 reliably fills with
+  // the most relevant rows without any auto-advance dance.
+  const totalPages = Math.max(1, Math.ceil(filteredResults.length / reviewPageSize));
+  const pageStart = (serverPage - 1) * reviewPageSize;
+  const pageResults = filteredResults.slice(pageStart, pageStart + reviewPageSize);
 
   // Group books that were assigned the same candidate metadata. Key priority:
   // asin (most specific) → isbn13/isbn → source+title+author (normalized fallback).
@@ -460,13 +461,13 @@ export function MetadataReviewDialog({
   const groupedBookIds = new Set<string>();
   for (const g of multiGroups.values()) g.results.forEach(r => groupedBookIds.add(r.book.id));
 
-  // Auto-advance: if every item on this page is filtered out (all applied/hidden)
-  // and there are more pages, silently move to the next one so the list stays full.
+  // Clamp the current page when filters shrink the result set below the
+  // current page index. Previously the dialog auto-advanced through empty
+  // server pages; with client-side pagination there is no empty page to
+  // skip — we just clamp instead.
   useEffect(() => {
-    if (!loading && filteredResults.length === 0 && results.length > 0 && serverPage < totalPages) {
-      setServerPage((p) => p + 1);
-    }
-  }, [filteredResults.length, results.length, loading, serverPage, totalPages]);
+    if (serverPage > totalPages) setServerPage(totalPages);
+  }, [serverPage, totalPages]);
 
   const titleFilteredPendingIds = filteredResults
     .filter(
@@ -1437,8 +1438,8 @@ export function MetadataReviewDialog({
                 <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
                   <Typography variant="caption" color="text.secondary">
                     {filteredResults.length < results.length
-                      ? `${filteredResults.length} visible of ${results.length} on page ${serverPage} · ${totalCount} total`
-                      : `${filteredResults.length} on page ${serverPage} · ${totalCount} total`}
+                      ? `${pageResults.length} on page ${serverPage} of ${totalPages} · ${filteredResults.length} visible of ${totalCount} total`
+                      : `${pageResults.length} on page ${serverPage} of ${totalPages} · ${totalCount} total`}
                   </Typography>
                   <Stack direction="row" spacing={1} alignItems="center">
                     <Pagination


### PR DESCRIPTION
## Summary

- Server returns the full review cache in one call (sorted matched → no_match → applied) and computes status counts over the full set, not just the page.
- Client fetches once with `limit=0`, paginates `filteredResults` locally — Hide/confidence/language filters no longer round-trip, matched rows land on page 1.
- Dropped the auto-advance-empty-page effect; replaced with a clamp so shrinking filters can't strand the paginator past the last page.

## Why

Before: server paginated 5851 rows in insertion order, client filtered each page. \"15 matched\" really meant \"15 survived the filters within page N's 250-row slice.\" Pending matched rows scattered across 24 pages and never floated to page 1.

After: server sorts + returns everything; client owns sort/filter/page entirely.

## Test plan

- [ ] Open Review Metadata Matches dialog — page 1 fills with up to 250 matched rows
- [ ] Toggle Hide Applied / Hide No Match — no network request, page rebuilds instantly
- [ ] Confidence slider changes paginate locally
- [ ] Last-page clamp behaves correctly when filters shrink the set