### PR TITLE
ui: remove redundant sort dropdown from Library

### DIFF
--- a/web/src/components/FilterPanel.tsx
+++ b/web/src/components/FilterPanel.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/FilterPanel.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
-// last-edited: 2026-05-01
+// last-edited: 2026-05-20
 
 import React from 'react';
 import {
@@ -13,7 +13,6 @@ import {
   Info as InfoIcon,
 } from '@mui/icons-material';
 import { SearchBar, ViewMode } from './audiobooks/SearchBar';
-import { SortField, SortOrder } from '../types';
 import type { ParsedSearch } from '../utils/searchParser';
 
 interface FilterPanelProps {
@@ -22,10 +21,6 @@ interface FilterPanelProps {
   onParsedSearchChange?: (parsed: ParsedSearch) => void;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
-  sortBy: SortField;
-  onSortChange: (sort: SortField) => void;
-  sortOrder: SortOrder;
-  onSortOrderChange: (order: SortOrder) => void;
   onLibraryInfoClick: () => void;
 }
 
@@ -35,10 +30,6 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   onParsedSearchChange,
   viewMode,
   onViewModeChange,
-  sortBy,
-  onSortChange,
-  sortOrder,
-  onSortOrderChange,
   onLibraryInfoClick,
 }) => {
   return (
@@ -50,10 +41,6 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           onParsedSearchChange={onParsedSearchChange}
           viewMode={viewMode}
           onViewModeChange={onViewModeChange}
-          sortBy={sortBy}
-          onSortChange={onSortChange}
-          sortOrder={sortOrder}
-          onSortOrderChange={onSortOrderChange}
         />
       </Box>
       <Tooltip title="Library info">

--- a/web/src/components/audiobooks/SearchBar.test.tsx
+++ b/web/src/components/audiobooks/SearchBar.test.tsx
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { SearchBar, type ViewMode } from './SearchBar';
-import { SortField, SortOrder } from '../../types';
 
 // Minimal default props — every test can override what it needs.
 function defaultProps(overrides: Partial<Parameters<typeof SearchBar>[0]> = {}) {
@@ -44,20 +43,6 @@ describe('SearchBar', () => {
       expect(screen.queryByLabelText('Sort by')).not.toBeInTheDocument();
     });
 
-    it('renders sort controls when onSortChange is provided', () => {
-      renderWithProviders(
-        <SearchBar
-          {...defaultProps({
-            onSortChange: vi.fn(),
-            onSortOrderChange: vi.fn(),
-            sortBy: SortField.Title,
-            sortOrder: SortOrder.Ascending,
-          })}
-        />
-      );
-      expect(screen.getByLabelText('Sort by')).toBeInTheDocument();
-      expect(screen.getByLabelText('Order')).toBeInTheDocument();
-    });
   });
 
   describe('view mode toggle', () => {

--- a/web/src/components/audiobooks/SearchBar.tsx
+++ b/web/src/components/audiobooks/SearchBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/SearchBar.tsx
-// version: 2.3.0
+// version: 2.4.0
 // guid: 1d2e3f4a-5b6c-7d8e-9f0a-1b2c3d4e5f6a
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -7,14 +7,10 @@ import {
   Autocomplete,
   Box,
   Chip,
-  FormControl,
   IconButton,
   InputAdornment,
-  InputLabel,
-  MenuItem,
   Paper,
   Popper,
-  Select,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -29,7 +25,6 @@ import {
   HelpOutline as HelpIcon,
   Close as CloseIcon,
 } from '@mui/icons-material';
-import { SortField, SortOrder } from '../../types';
 import { parseSearch, SEARCH_FIELDS, type ParsedSearch } from '../../utils/searchParser';
 import { STORAGE_KEYS } from '../../lib/storageKeys';
 
@@ -132,10 +127,6 @@ interface SearchBarProps {
   onParsedSearchChange?: (parsed: ParsedSearch) => void;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
-  sortBy?: SortField;
-  onSortChange?: (sort: SortField) => void;
-  sortOrder?: SortOrder;
-  onSortOrderChange?: (order: SortOrder) => void;
   placeholder?: string;
 }
 
@@ -145,10 +136,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   onParsedSearchChange,
   viewMode,
   onViewModeChange,
-  sortBy = SortField.Title,
-  onSortChange,
-  sortOrder = SortOrder.Ascending,
-  onSortOrderChange,
   placeholder = 'Search audiobooks... (try author:"Name" tag:scifi)',
 }) => {
   const parsed = useMemo(() => parseSearch(value), [value]);
@@ -252,39 +239,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({
             />
           )}
         />
-
-        {onSortChange && (
-          <FormControl sx={{ minWidth: 150 }}>
-            <InputLabel id="sort-select-label">Sort by</InputLabel>
-            <Select
-              labelId="sort-select-label"
-              value={sortBy}
-              label="Sort by"
-              onChange={(e) => onSortChange(e.target.value as SortField)}
-            >
-              <MenuItem value={SortField.Title}>Title</MenuItem>
-              <MenuItem value={SortField.Author}>Author</MenuItem>
-              <MenuItem value={SortField.Series}>Series</MenuItem>
-              <MenuItem value={SortField.Year}>Year</MenuItem>
-              <MenuItem value={SortField.CreatedAt}>Date Added</MenuItem>
-            </Select>
-          </FormControl>
-        )}
-
-        {onSortOrderChange && (
-          <FormControl sx={{ minWidth: 140 }}>
-            <InputLabel id="sort-order-label">Order</InputLabel>
-            <Select
-              labelId="sort-order-label"
-              value={sortOrder}
-              label="Order"
-              onChange={(e) => onSortOrderChange(e.target.value as SortOrder)}
-            >
-              <MenuItem value={SortOrder.Ascending}>Ascending</MenuItem>
-              <MenuItem value={SortOrder.Descending}>Descending</MenuItem>
-            </Select>
-          </FormControl>
-        )}
 
         <ToggleButtonGroup
           value={viewMode}

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-11
+// last-edited: 2026-05-20
 
 import {
   Typography,
@@ -114,9 +114,9 @@ export const LibraryBookGrid = ({
   viewMode,
   setViewMode,
   sortBy,
-  handleSortChange,
+  handleSortChange: _handleSortChange,
   sortOrder,
-  setSortOrder,
+  setSortOrder: _setSortOrder,
   setStorageDrawerOpen,
   importPaths,
   handleManualImport,
@@ -242,10 +242,6 @@ export const LibraryBookGrid = ({
             onParsedSearchChange={setParsedSearch}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
-            sortBy={sortBy}
-            onSortChange={handleSortChange}
-            sortOrder={sortOrder}
-            onSortOrderChange={setSortOrder}
             onLibraryInfoClick={() => setStorageDrawerOpen(true)}
           />
         </Stack>


### PR DESCRIPTION
Column-header sorting in AudiobookList makes the standalone sort dropdown redundant. Sort state is preserved for column sorting, URL params, and server-side sort — only the dropdown UI is removed.