### PR TITLE
ui(library): header-row kebab menu with column toggle

### DIFF
--- a/web/src/components/BookGrid.tsx
+++ b/web/src/components/BookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/BookGrid.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e7f8a9b-0c1d-2e3f-4a5b-6c7d8e9f0a1b
-// last-edited: 2026-04-30
+// last-edited: 2026-05-20
 
 import React from 'react';
 import {
@@ -38,6 +38,8 @@ interface BookGridProps {
   onSortChange?: (sortKey: string, order: 'asc' | 'desc') => void;
   onColumnResize?: (columnId: string, width: number) => void;
   onSelectAll?: () => void;
+  visibleColumnIds?: string[];
+  onToggleColumn?: (columnId: string) => void;
 }
 
 export const BookGrid: React.FC<BookGridProps> = ({
@@ -63,6 +65,8 @@ export const BookGrid: React.FC<BookGridProps> = ({
   onSortChange,
   onColumnResize,
   onSelectAll,
+  visibleColumnIds,
+  onToggleColumn,
 }) => {
   return (
     <>
@@ -107,6 +111,8 @@ export const BookGrid: React.FC<BookGridProps> = ({
           sortOrder={sortOrder === SortOrder.Ascending ? 'asc' : 'desc'}
           onSortChange={onSortChange}
           onColumnResize={onColumnResize}
+          visibleColumnIds={visibleColumnIds}
+          onToggleColumn={onToggleColumn}
         />
       )}
     </>

--- a/web/src/components/audiobooks/AudiobookList.tsx
+++ b/web/src/components/audiobooks/AudiobookList.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/AudiobookList.tsx
-// version: 2.4.0
+// version: 2.5.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-20
 
@@ -55,6 +55,8 @@ interface AudiobookListProps {
   sortOrder?: 'asc' | 'desc';
   onSortChange?: (sortKey: string, order: 'asc' | 'desc') => void;
   onColumnResize?: (columnId: string, width: number) => void;
+  visibleColumnIds?: string[];
+  onToggleColumn?: (columnId: string) => void;
 }
 
 const fallbackColumns = getDefaultVisibleColumns();
@@ -74,10 +76,13 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
   sortOrder = 'asc',
   onSortChange,
   onColumnResize,
+  visibleColumnIds,
+  onToggleColumn,
 }) => {
   const activeColumns = columns ?? fallbackColumns;
 
   const [anchorEls, setAnchorEls] = React.useState<Record<string, HTMLElement | null>>({});
+  const [headerMenuAnchor, setHeaderMenuAnchor] = React.useState<HTMLElement | null>(null);
   // Fix #1: use Record instead of Set for proper React equality comparisons
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
   const [filesCache, setFilesCache] = useState<Record<string, BookFile[]>>({});
@@ -110,6 +115,15 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
 
   const handleClose = (id: string) => {
     setAnchorEls((prev) => ({ ...prev, [id]: null }));
+  };
+
+  const handleHeaderMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    setHeaderMenuAnchor(event.currentTarget);
+  };
+
+  const handleHeaderMenuClose = () => {
+    setHeaderMenuAnchor(null);
   };
 
   const handleEdit = (audiobook: Audiobook) => {
@@ -388,8 +402,54 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
               );
             })}
 
-            {/* Actions column */}
-            {hasActions && <TableCell width={50} />}
+            {/* Header actions column (kebab menu) */}
+            <TableCell width={50} sx={{ textAlign: 'center' }}>
+              <IconButton
+                size="small"
+                onClick={handleHeaderMenuClick}
+                aria-label="Header actions"
+              >
+                <MoreVertIcon />
+              </IconButton>
+              <Menu
+                anchorEl={headerMenuAnchor}
+                open={Boolean(headerMenuAnchor)}
+                onClose={handleHeaderMenuClose}
+              >
+                {/* Column visibility toggle */}
+                {onToggleColumn && visibleColumnIds && (
+                  <>
+                    <MenuItem disabled sx={{ py: 1 }}>
+                      <Typography variant="caption" fontWeight="bold" color="text.secondary">
+                        Show/Hide Columns
+                      </Typography>
+                    </MenuItem>
+                    {activeColumns.map((col) => (
+                      <MenuItem
+                        key={col.id}
+                        onClick={() => {
+                          onToggleColumn(col.id);
+                        }}
+                        sx={{ pl: 4 }}
+                      >
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              size="small"
+                              checked={visibleColumnIds.includes(col.id)}
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          }
+                          label={<Typography variant="body2">{col.label}</Typography>}
+                          sx={{ m: 0, flex: 1 }}
+                        />
+                      </MenuItem>
+                    ))}
+                    {/* Future menu items go here */}
+                  </>
+                )}
+              </Menu>
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -460,31 +520,33 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
               ))}
 
               {/* Actions cell */}
-              {hasActions && (
-                <TableCell>
-                  <IconButton size="small" onClick={(e) => handleMenuClick(e, audiobook.id)}>
-                    <MoreVertIcon />
-                  </IconButton>
-                  <Menu
-                    anchorEl={anchorEls[audiobook.id] || null}
-                    open={Boolean(anchorEls[audiobook.id])}
-                    onClose={() => handleClose(audiobook.id)}
-                  >
-                    {onEdit && (
-                      <MenuItem onClick={() => handleEdit(audiobook)}>
-                        <EditIcon sx={{ mr: 1 }} fontSize="small" />
-                        Edit
-                      </MenuItem>
-                    )}
-                    {onDelete && (
-                      <MenuItem onClick={() => handleDelete(audiobook)}>
-                        <DeleteIcon sx={{ mr: 1 }} fontSize="small" />
-                        Delete
-                      </MenuItem>
-                    )}
-                  </Menu>
-                </TableCell>
-              )}
+              <TableCell width={50} sx={{ textAlign: 'center' }}>
+                {hasActions && (
+                  <>
+                    <IconButton size="small" onClick={(e) => handleMenuClick(e, audiobook.id)}>
+                      <MoreVertIcon />
+                    </IconButton>
+                    <Menu
+                      anchorEl={anchorEls[audiobook.id] || null}
+                      open={Boolean(anchorEls[audiobook.id])}
+                      onClose={() => handleClose(audiobook.id)}
+                    >
+                      {onEdit && (
+                        <MenuItem onClick={() => handleEdit(audiobook)}>
+                          <EditIcon sx={{ mr: 1 }} fontSize="small" />
+                          Edit
+                        </MenuItem>
+                      )}
+                      {onDelete && (
+                        <MenuItem onClick={() => handleDelete(audiobook)}>
+                          <DeleteIcon sx={{ mr: 1 }} fontSize="small" />
+                          Delete
+                        </MenuItem>
+                      )}
+                    </Menu>
+                  </>
+                )}
+              </TableCell>
             </TableRow>
 
             {/* Expanded files rows */}

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-11
+// last-edited: 2026-05-20
 
 import {
   Typography,
@@ -81,6 +81,8 @@ interface LibraryBookGridProps {
   columnWidths: Record<string, number>;
   handleColumnSortChange: (key: string, order: 'asc' | 'desc') => void;
   resizeColumn: (id: string, width: number) => void;
+  visibleColumnIds?: string[];
+  onToggleColumn?: (columnId: string) => void;
   softDeletedCount: number;
   softDeletedBooks: Audiobook[];
   softDeletedLoading: boolean;
@@ -149,6 +151,8 @@ export const LibraryBookGrid = ({
   columnWidths,
   handleColumnSortChange,
   resizeColumn,
+  visibleColumnIds,
+  onToggleColumn,
   softDeletedCount,
   softDeletedBooks,
   softDeletedLoading,
@@ -359,6 +363,8 @@ export const LibraryBookGrid = ({
             onSortChange={handleColumnSortChange}
             onColumnResize={resizeColumn}
             onSelectAll={handleToggleSelectAllOnPage}
+            visibleColumnIds={visibleColumnIds}
+            onToggleColumn={onToggleColumn}
           />
         )}
 

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1781,6 +1781,8 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           columnWidths={columnWidths}
           handleColumnSortChange={handleColumnSortChange}
           resizeColumn={resizeColumn}
+          visibleColumnIds={visibleColumnIds}
+          onToggleColumn={toggleColumn}
           softDeletedCount={softDeletedCount}
           softDeletedBooks={softDeletedBooks}
           softDeletedLoading={softDeletedLoading}


### PR DESCRIPTION
Adds a 3-dot menu to the end of the Library table header row, mirroring the existing per-row kebabs. Currently exposes column show/hide using the existing visibility plumbing. Structured for future menu additions.

## Changes
- AudiobookList: Added header kebab menu with inline column visibility toggles
- BookGrid: Passed through visibleColumnIds and onToggleColumn props
- LibraryBookGrid: Accepted and forwarded column visibility props
- Library.tsx: Passed visibleColumnIds and toggleColumn to LibraryBookGrid

## Implementation
- Header menu styled identically to per-row kebabs (MoreVertIcon, IconButton, Menu)
- Column toggles render as CheckboxMenuItem with FormControlLabel (reuses existing pattern)
- Future menu items can be added in header Menu component (TODO comment)
- Data row actions cell width (50px) matches header kebab width