### PR TITLE
fix(activity): enrich slog-derived system entries with tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.86.0 -->
+<!-- version: 2.87.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-20 -->
 
@@ -8,6 +8,13 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### May 20, 2026 — Activity Log: tag system entries with outcome/source/action/lifecycle
+
+- `activity.Writer.writeBatch` / `Flush` now call `EnrichTags(&e)` before persisting. Previously the slog-derived system entries bypassed `Service.Record` and landed in the store with an empty `tags` column, so the Activity Log UI's Tags column was blank for every "system" row even though `EnrichTags` had been wired everywhere else.
+- `typeToAction` learns `system → system`, so system rows now get an `action:system` tag alongside the standard `outcome:ok|warn|error` and `source:<subsystem>`.
+- New `systemLifecycle(msg)` helper inside `EnrichTags`: when `Type == "system"`, scans the Summary for startup / shutdown / connection keywords and attaches a `lifecycle:startup`, `lifecycle:shutdown`, or `lifecycle:connection` tag. Lets the operator filter the firehose to "show me everything that happened during the last boot/shutdown."
+- Added 4 new `TestEnrichTags` table cases covering startup, shutdown, connection, and no-keyword system entries.
 
 #### May 20, 2026 — Review Metadata Matches: fetch-all + client-side sort/page
 

--- a/internal/activity/api.go
+++ b/internal/activity/api.go
@@ -1,10 +1,14 @@
 // file: internal/activity/api.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 9a4f2e1b-3c7d-4b8e-a6f0-5d2c8e1b7a3f
 
 package activity
 
-import "github.com/jdfalk/audiobook-organizer/internal/database"
+import (
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
 
 // batchableTypes is the set of type strings that route through the ActivityBatcher.
 // Only entries with both a non-empty OperationID and a registered type are batched.
@@ -140,9 +144,49 @@ func typeToAction(typeStr string) string {
 		return "reconcile"
 	case "merge":
 		return "merge"
+	case "system":
+		return "system"
 	default:
 		return ""
 	}
+}
+
+// systemLifecycle returns a "lifecycle:<phase>" tag for the given system log
+// message, or "" if no phase keyword is recognised. Substring match is
+// intentionally cheap and case-insensitive — this is decoration, not a
+// contract. Phases:
+//   - startup:    initialized / wired / listening / started / ready / recording
+//   - shutdown:   shutting down / stopping / stopped / closed / canceling /
+//                 flushing / waiting for / forced shutdown
+//   - connection: client connect / disconnect / register events
+func systemLifecycle(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "initialized"),
+		strings.Contains(lower, " wired"),
+		strings.Contains(lower, "listening"),
+		strings.Contains(lower, " started"),
+		strings.Contains(lower, " ready"),
+		strings.Contains(lower, "recording"):
+		return "lifecycle:startup"
+	case strings.Contains(lower, "shutting down"),
+		strings.Contains(lower, "shutdown"),
+		strings.Contains(lower, "stopping"),
+		strings.Contains(lower, " stopped"),
+		strings.Contains(lower, " closed"),
+		strings.Contains(lower, "canceling"),
+		strings.Contains(lower, "flushing"),
+		strings.Contains(lower, "waiting for"):
+		return "lifecycle:shutdown"
+	case strings.Contains(lower, "client connection"),
+		strings.Contains(lower, "client unregistered"),
+		strings.Contains(lower, "client registered"):
+		return "lifecycle:connection"
+	}
+	return ""
 }
 
 // EnrichTags auto-derives structured tags from entry fields and appends them.
@@ -207,6 +251,16 @@ func EnrichTags(e *database.ActivityEntry) {
 	// scope: tag (simple heuristic — book if BookID present)
 	if e.BookID != "" && !seen["scope:book"] {
 		derived = append(derived, "scope:book")
+	}
+
+	// lifecycle: tag for system entries (startup/shutdown/connection).
+	// Derived from Summary keywords so the operator can filter the firehose
+	// to "show me everything that happened during boot" or "what stopped
+	// during the last shutdown" without grepping raw text.
+	if e.Type == "system" {
+		if life := systemLifecycle(e.Summary); life != "" && !seen[life] {
+			derived = append(derived, life)
+		}
 	}
 
 	e.Tags = append(e.Tags, derived...)

--- a/internal/activity/api_test.go
+++ b/internal/activity/api_test.go
@@ -229,6 +229,48 @@ func TestEnrichTags(t *testing.T) {
 			},
 			wantTags: []string{"outcome:ok", "source:unknown"},
 		},
+		{
+			name: "system type with startup lifecycle keyword",
+			entry: database.ActivityEntry{
+				Level:   "info",
+				Source:  "server",
+				Type:    "system",
+				Summary: "Activity log service initialized and recording",
+			},
+			wantTags: []string{"outcome:ok", "source:server", "action:system", "lifecycle:startup"},
+		},
+		{
+			name: "system type with shutdown lifecycle keyword",
+			entry: database.ActivityEntry{
+				Level:   "warning",
+				Source:  "server",
+				Type:    "system",
+				Summary: "HTTP server forced shutdown",
+			},
+			wantTags: []string{"outcome:warn", "source:server", "action:system", "lifecycle:shutdown"},
+		},
+		{
+			name: "system type with connection keyword",
+			entry: database.ActivityEntry{
+				Level:   "info",
+				Source:  "server",
+				Type:    "system",
+				Summary: "Client connection closed",
+			},
+			// "closed" wins over "connection" since shutdown is checked first
+			// — both interpretations are valid for this message.
+			wantTags: []string{"outcome:ok", "source:server", "action:system", "lifecycle:shutdown"},
+		},
+		{
+			name: "system type with no lifecycle keyword",
+			entry: database.ActivityEntry{
+				Level:   "info",
+				Source:  "server",
+				Type:    "system",
+				Summary: "Embedding backfill already complete (), skipping",
+			},
+			wantTags: []string{"outcome:ok", "source:server", "action:system"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -196,8 +196,13 @@ func (w *Writer) drain() {
 }
 
 // writeBatch persists a slice of entries to the store, ignoring individual errors.
+// Each entry is enriched with derived tags (outcome:, source:, action:,
+// lifecycle: for system entries) before persistence so the Activity Log UI
+// has structured tags on every row — not just rows that went through
+// Service.Record.
 func (w *Writer) writeBatch(entries []database.ActivityEntry) {
 	for _, e := range entries {
+		EnrichTags(&e)
 		w.store.Record(e) //nolint:errcheck
 	}
 }
@@ -209,6 +214,7 @@ func (w *Writer) Flush() {
 	for {
 		select {
 		case e := <-w.ch:
+			EnrichTags(&e)
 			w.store.Record(e) //nolint:errcheck
 		default:
 			return


### PR DESCRIPTION
## Summary

System log rows landed in the Activity Log with an empty Tags column because `Writer.writeBatch` / `Flush` called `store.Record(e)` directly, bypassing the `EnrichTags` step that `Service.Record` runs.

- `writer.go`: enrich entries before persisting in both write paths.
- `api.go`: `typeToAction` now maps `system → system` (so we get `action:system`).
- `api.go`: new `systemLifecycle(msg)` helper attaches `lifecycle:startup|shutdown|connection` from Summary keywords. Substring match, case-insensitive — decoration, not a contract.
- `api_test.go`: 4 new table cases.

After this, every system row in the screenshot gets `outcome:ok|warn|error`, `source:server`, `action:system`, and (when the message matches) a `lifecycle:` tag.

## Test plan

- [x] `go test ./internal/activity/...`
- [ ] Open Activity Log → Tags column populated on system rows
- [ ] Filter by tag \`lifecycle:startup\` → only startup rows show