### PR TITLE
feat(library): cached quick-query presets in header kebab

### DIFF
--- a/internal/database/pebble_quick_queries.go
+++ b/internal/database/pebble_quick_queries.go
@@ -1,0 +1,335 @@
+// file: internal/database/pebble_quick_queries.go
+// version: 1.0.0
+// guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+// last-edited: 2026-05-20
+
+package database
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// quickQueryCacheKeyPrefix is the PebbleDB key prefix for per-query count caches.
+const quickQueryCacheKeyPrefix = "quick_query_cache:"
+
+// quickQueryCacheTTL is the maximum age of a cached quick-query count before it is
+// recomputed unconditionally (even without a dirty flag). Set to 1 hour so stale
+// data never lingers past the next maintenance window.
+const quickQueryCacheTTL = 1 * time.Hour
+
+// QuickQueryEntry is the JSON value stored under quick_query_cache:<id>.
+type QuickQueryEntry struct {
+	Count      int       `json:"count"`
+	ComputedAt time.Time `json:"computed_at"`
+	Dirty      bool      `json:"dirty"`
+}
+
+// QuickQueryResult is one item in the GET /api/v1/library/quick-queries response.
+type QuickQueryResult struct {
+	ID     string                 `json:"id"`
+	Label  string                 `json:"label"`
+	Count  int                    `json:"count"`
+	Filter map[string]interface{} `json:"filter"`
+}
+
+// quickQueryDefs defines the six preset quick queries: id, human label, and the
+// filter object expressed in the same shape the frontend FilterOptions/URL-params
+// system already understands.
+var quickQueryDefs = []struct {
+	id     string
+	label  string
+	filter map[string]interface{}
+}{
+	{
+		id:    "missing_covers",
+		label: "Missing covers",
+		filter: map[string]interface{}{
+			"missingCovers": true,
+		},
+	},
+	{
+		id:    "broken_files",
+		label: "Broken files",
+		filter: map[string]interface{}{
+			"hasFileErrors": true,
+		},
+	},
+	{
+		id:    "no_fingerprints",
+		label: "No fingerprints",
+		filter: map[string]interface{}{
+			"fingerprintStatus": "none",
+		},
+	},
+	{
+		id:    "in_import_path",
+		label: "In import path",
+		filter: map[string]interface{}{
+			"inImportPath": true,
+		},
+	},
+	{
+		id:    "no_isbn",
+		label: "No ISBN",
+		filter: map[string]interface{}{
+			"noIsbn": true,
+		},
+	},
+	{
+		id:    "duplicates_flagged",
+		label: "Duplicates flagged",
+		filter: map[string]interface{}{
+			"duplicatesFlagged": true,
+		},
+	},
+}
+
+// MarkQuickQueryDirty marks a single quick-query cache entry dirty without
+// recomputing. The next call to GetQuickQueryCounts will recompute it.
+// NoSync is intentional: a crash before flush leaves a dirty=false entry that
+// will be recomputed when TTL expires — same as missing-key behaviour.
+func (p *PebbleStore) MarkQuickQueryDirty(id, reason string) {
+	key := []byte(quickQueryCacheKeyPrefix + id)
+	val, closer, err := p.db.Get(key)
+	if err != nil {
+		// Cache miss — nothing to mark dirty; recompute will happen on next read.
+		slog.Debug("quick_query marked dirty (cache miss)", "id", id, "reason", reason)
+		return
+	}
+	var entry QuickQueryEntry
+	_ = json.Unmarshal(val, &entry)
+	closer.Close()
+
+	entry.Dirty = true
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	if err := p.db.Set(key, data, pebble.NoSync); err != nil {
+		slog.Warn("quick_query mark dirty failed", "id", id, "error", err)
+		return
+	}
+	slog.Debug("quick_query marked dirty", "id", id, "reason", reason)
+}
+
+// MarkAllQuickQueriesDirty marks all quick-query cache entries dirty.
+// Used on wide mutations (CreateBook, DeleteBook) where all six queries may change.
+func (p *PebbleStore) MarkAllQuickQueriesDirty(reason string) {
+	for _, def := range quickQueryDefs {
+		if def.id == "broken_files" {
+			// broken_files is served from LibraryStats; no separate cache entry to dirty.
+			continue
+		}
+		p.MarkQuickQueryDirty(def.id, reason)
+	}
+}
+
+// readCachedQuickQuery loads the cached entry for id. Returns nil when the
+// entry is missing, dirty, or older than quickQueryCacheTTL.
+func (p *PebbleStore) readCachedQuickQuery(id string) *QuickQueryEntry {
+	key := []byte(quickQueryCacheKeyPrefix + id)
+	val, closer, err := p.db.Get(key)
+	if err != nil {
+		return nil
+	}
+	defer closer.Close()
+	var entry QuickQueryEntry
+	if err := json.Unmarshal(val, &entry); err != nil {
+		return nil
+	}
+	if entry.Dirty {
+		return nil
+	}
+	if time.Since(entry.ComputedAt) > quickQueryCacheTTL {
+		return nil
+	}
+	return &entry
+}
+
+// writeCachedQuickQuery persists a fresh entry for id.
+func (p *PebbleStore) writeCachedQuickQuery(id string, count int) {
+	entry := QuickQueryEntry{
+		Count:      count,
+		ComputedAt: time.Now(),
+		Dirty:      false,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	if err := p.db.Set([]byte(quickQueryCacheKeyPrefix+id), data, pebble.Sync); err != nil {
+		slog.Error("quick_query cache write failed", "id", id, "error", err)
+	}
+}
+
+// computeQuickQueryCount runs the appropriate book scan for a single query id
+// and returns the matching book count.
+func (p *PebbleStore) computeQuickQueryCount(id string) (int, error) {
+	start := time.Now()
+
+	// Load import paths once for in_import_path query.
+	var importPaths []ImportPath
+	if id == "in_import_path" {
+		importPaths, _ = p.GetAllImportPaths()
+	}
+
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer iter.Close()
+
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") {
+			continue
+		}
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		// Primary versions only (consistent with LibraryStats).
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+
+		switch id {
+		case "missing_covers":
+			if b.CoverURL == nil || *b.CoverURL == "" {
+				count++
+			}
+		case "no_fingerprints":
+			if b.FingerprintStatus == "" || b.FingerprintStatus == "none" {
+				count++
+			}
+		case "in_import_path":
+			matched := false
+			for _, ip := range importPaths {
+				if strings.HasPrefix(b.FilePath, ip.Path) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				count++
+			}
+		case "no_isbn":
+			isbn10 := b.ISBN10 == nil || *b.ISBN10 == ""
+			isbn13 := b.ISBN13 == nil || *b.ISBN13 == ""
+			if isbn10 && isbn13 {
+				count++
+			}
+		}
+	}
+
+	elapsed := time.Since(start).Milliseconds()
+	slog.Info("quick_query cache recomputed", "id", id, "count", count, "duration_ms", elapsed)
+	return count, nil
+}
+
+// computeDuplicatesFlaggedCount counts books that appear in at least one
+// EmbeddingStore dedup candidate with status "pending".
+// Uses a key-only scan of the dedup_candidate: prefix with full JSON decode
+// only for entity_type=book entries. O(candidates) — typically in the hundreds.
+func (p *PebbleStore) computeDuplicatesFlaggedCount() (int, error) {
+	start := time.Now()
+
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("dedup_candidate:"),
+		UpperBound: []byte("dedup_candidate;"),
+	})
+	if err != nil {
+		// No candidates table yet — not an error.
+		slog.Info("quick_query cache recomputed", "id", "duplicates_flagged", "count", 0, "duration_ms", 0)
+		return 0, nil
+	}
+	defer iter.Close()
+
+	type candRec struct {
+		EntityType string `json:"entity_type"`
+		EntityAID  string `json:"entity_a_id"`
+		EntityBID  string `json:"entity_b_id"`
+		Status     string `json:"status"`
+	}
+
+	flagged := make(map[string]struct{})
+	for iter.First(); iter.Valid(); iter.Next() {
+		var rec candRec
+		if err := json.Unmarshal(iter.Value(), &rec); err != nil {
+			continue
+		}
+		if rec.EntityType != "book" || rec.Status != "pending" {
+			continue
+		}
+		flagged[rec.EntityAID] = struct{}{}
+		flagged[rec.EntityBID] = struct{}{}
+	}
+
+	elapsed := time.Since(start).Milliseconds()
+	slog.Info("quick_query cache recomputed", "id", "duplicates_flagged", "count", len(flagged), "duration_ms", elapsed)
+	return len(flagged), nil
+}
+
+// GetQuickQueryCounts returns the six preset quick-query results. Each entry's count
+// is served from the per-query PebbleDB cache when fresh; stale or dirty entries are
+// recomputed inline. broken_files is sourced from the existing LibraryStats cache so
+// there is no separate cache entry for it.
+func (p *PebbleStore) GetQuickQueryCounts() ([]QuickQueryResult, error) {
+	// Load LibraryStats once for broken_files (already cached).
+	var brokenFiles int
+	if stats, err := p.GetDashboardStats(); err == nil {
+		brokenFiles = stats.BrokenFiles
+	}
+
+	results := make([]QuickQueryResult, 0, len(quickQueryDefs))
+	for _, def := range quickQueryDefs {
+		var count int
+
+		if def.id == "broken_files" {
+			// Reuse LibraryStats; no per-query cache entry.
+			count = brokenFiles
+			slog.Info("quick_query cache hit (from stats:library)", "id", def.id, "count", count)
+		} else if cached := p.readCachedQuickQuery(def.id); cached != nil {
+			count = cached.Count
+			slog.Info("quick_query cache hit",
+				"id", def.id,
+				"count", cached.Count,
+				"age_seconds", time.Since(cached.ComputedAt).Seconds(),
+			)
+		} else {
+			// Cache miss or dirty — recompute.
+			var err error
+			if def.id == "duplicates_flagged" {
+				count, err = p.computeDuplicatesFlaggedCount()
+			} else {
+				count, err = p.computeQuickQueryCount(def.id)
+			}
+			if err != nil {
+				slog.Warn("quick_query recompute failed", "id", def.id, "error", err)
+				count = 0
+			}
+			p.writeCachedQuickQuery(def.id, count)
+		}
+
+		results = append(results, QuickQueryResult{
+			ID:     def.id,
+			Label:  def.label,
+			Count:  count,
+			Filter: def.filter,
+		})
+	}
+	return results, nil
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.75.0
+// version: 1.76.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-20
 
@@ -1789,6 +1789,7 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 	}
 
 	p.InvalidateLibraryStats()
+	p.MarkAllQuickQueriesDirty("create_book")
 	return book, nil
 }
 
@@ -1984,6 +1985,10 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	}
 
 	p.InvalidateLibraryStats()
+	// UpdateBook may change cover, isbn, or path; mark targeted queries dirty.
+	p.MarkQuickQueryDirty("missing_covers", "update_book")
+	p.MarkQuickQueryDirty("no_isbn", "update_book")
+	p.MarkQuickQueryDirty("in_import_path", "update_book")
 	return book, nil
 }
 
@@ -2308,6 +2313,7 @@ func (p *PebbleStore) DeleteBook(id string) error {
 		return err
 	}
 	p.InvalidateLibraryStats()
+	p.MarkAllQuickQueriesDirty("delete_book")
 	return nil
 }
 
@@ -7754,6 +7760,7 @@ func (s *PebbleStore) CreateBookFile(file *BookFile) error {
 		return err
 	}
 	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "create_book_file")
 	return nil
 }
 
@@ -7801,6 +7808,7 @@ func (s *PebbleStore) UpdateBookFile(id string, file *BookFile) error {
 		return err
 	}
 	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "update_book_file")
 	return nil
 }
 
@@ -8081,6 +8089,7 @@ func (s *PebbleStore) DeleteBookFile(id string) error {
 		return err
 	}
 	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "delete_book_file")
 	return nil
 }
 
@@ -8232,6 +8241,7 @@ func (s *PebbleStore) BatchUpsertBookFiles(files []*BookFile) error {
 		return err
 	}
 	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "batch_upsert_book_files")
 	return nil
 }
 

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.14.0
+// version: 2.15.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 // last-edited: 2026-05-20
 //
@@ -220,6 +220,10 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		enriched[i].CoveragePercent = coverage
 		enriched[i].LastFingerprintedAt = lastFp
 	}
+
+	// Apply quick-query preset filters (missing_covers, in_import_path, no_isbn, duplicates_flagged).
+	// These are post-fetch because they require enriched book fields (e.g. FingerprintStatus).
+	enriched = s.applyQuickQueryFiltersDetail(c, enriched)
 
 	// Get total count for proper pagination
 	totalCount := len(enriched)
@@ -1615,4 +1619,86 @@ func (s *Server) getBookChanges(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithOK(c, gin.H{"changes": changes})
+}
+
+// applyQuickQueryFiltersDetail applies the four "quick query" preset filters that are
+// expressed as boolean URL params: missing_covers, in_import_path, no_isbn, and
+// duplicates_flagged. Returns the filtered slice (unmodified if no params are set).
+// Called after fingerprinting enrichment so all book fields are populated.
+func (s *Server) applyQuickQueryFiltersDetail(c *gin.Context, books []AudiobookDetail) []AudiobookDetail {
+	missingCovers := c.Query("missing_covers") == "true"
+	inImportPath := c.Query("in_import_path") == "true"
+	noIsbn := c.Query("no_isbn") == "true"
+	duplicatesFlagged := c.Query("duplicates_flagged") == "true"
+
+	if !missingCovers && !inImportPath && !noIsbn && !duplicatesFlagged {
+		return books
+	}
+
+	// Load import paths once if needed.
+	var importPaths []database.ImportPath
+	if inImportPath {
+		importPaths, _ = s.Store().GetAllImportPaths()
+	}
+
+	// Build flagged-book set once if needed.
+	flaggedBookIDs := map[string]struct{}{}
+	if duplicatesFlagged && s.embeddingStore != nil {
+		candidates, _, _ := s.embeddingStore.ListCandidates(database.CandidateFilter{
+			EntityType: "book",
+			Status:     "pending",
+			Limit:      100000,
+		})
+		for _, cand := range candidates {
+			flaggedBookIDs[cand.EntityAID] = struct{}{}
+			flaggedBookIDs[cand.EntityBID] = struct{}{}
+		}
+	}
+
+	result := books[:0]
+	for _, detail := range books {
+		if detail.Book == nil {
+			continue
+		}
+		b := detail.Book
+		keep := true
+
+		if missingCovers && keep {
+			if b.CoverURL != nil && *b.CoverURL != "" {
+				keep = false
+			}
+		}
+
+		if inImportPath && keep {
+			matched := false
+			for _, ip := range importPaths {
+				if strings.HasPrefix(b.FilePath, ip.Path) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				keep = false
+			}
+		}
+
+		if noIsbn && keep {
+			isbn10Empty := b.ISBN10 == nil || *b.ISBN10 == ""
+			isbn13Empty := b.ISBN13 == nil || *b.ISBN13 == ""
+			if !isbn10Empty || !isbn13Empty {
+				keep = false
+			}
+		}
+
+		if duplicatesFlagged && keep {
+			if _, ok := flaggedBookIDs[b.ID]; !ok {
+				keep = false
+			}
+		}
+
+		if keep {
+			result = append(result, detail)
+		}
+	}
+	return result
 }

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.7.1
+// version: 2.8.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 package server
 
@@ -770,6 +770,7 @@ func (s *Server) dismissDedupCluster(c *gin.Context) {
 		dismissed++
 	}
 	slog.Info("dedup cluster dismiss dismissed candidate row(s) across books", "dismissed", dismissed, "count", len(body.BookIDs))
+	s.markDuplicatesFlaggedDirty("dismiss_cluster")
 
 	httputil.RespondWithOK(c, gin.H{
 		"status":    "dismissed",
@@ -965,6 +966,7 @@ func (s *Server) dismissDedupCandidate(c *gin.Context) {
 		httputil.InternalError(c, "failed to dismiss candidate", err)
 		return
 	}
+	s.markDuplicatesFlaggedDirty("dismiss_candidate")
 
 	httputil.RespondWithOK(c, gin.H{"status": "dismissed"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.19.4
+// version: 2.20.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 package server
 
@@ -851,3 +851,28 @@ type bulkFetchMetadataResult struct {
 // --- Preview Rename & Metadata Writeback Handlers ---
 
 // --- Preview Organize & Single-Book Organize Handlers ---
+
+// markDuplicatesFlaggedDirty marks the duplicates_flagged quick-query cache
+// entry dirty. Called from dedup handlers (dismiss, scan upsert) so the count
+// is recomputed on the next menu open rather than staying stale.
+func (s *Server) markDuplicatesFlaggedDirty(reason string) {
+	if s.Store() == nil {
+		return
+	}
+	type quickQueryDirtier interface {
+		MarkQuickQueryDirty(id, reason string)
+	}
+	if qd, ok := s.Store().(quickQueryDirtier); ok {
+		qd.MarkQuickQueryDirty("duplicates_flagged", reason)
+		return
+	}
+	// Unwrap if decorated (IndexedStore, etc.)
+	type unwrapper interface {
+		Unwrap() database.Store
+	}
+	if uw, ok := s.Store().(unwrapper); ok {
+		if qd, ok2 := uw.Unwrap().(quickQueryDirtier); ok2 {
+			qd.MarkQuickQueryDirty("duplicates_flagged", reason)
+		}
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.20.0
+// version: 1.21.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 package server
 
@@ -1201,6 +1201,7 @@ func (s *Server) setupRoutes() {
 			// Returns books with their latest fetch status + by_status counts; supports
 			// repeatable ?status= filtering for the Library page toggles + Resume Review.
 			protected.GET("/library/metadata-results", s.perm(auth.PermLibraryView), s.handleListMetadataResults)
+			protected.GET("/library/quick-queries", s.perm(auth.PermLibraryView), s.getQuickQueries)
 			protected.POST("/metadata/batch-apply-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleBatchApplyCandidates)
 			protected.POST("/metadata/batch-reject-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleRejectCandidates)
 			protected.POST("/metadata/batch-unreject-candidates", s.perm(auth.PermLibraryEditMetadata), s.handleUnrejectCandidates)

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_search.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
-// last-edited: 2026-05-11
+// last-edited: 2026-05-20
 
 package server
 
@@ -172,6 +172,7 @@ func (h *serverOrganizeHooks) OnCollision(currentBookID, occupantPath string) {
 			return
 		}
 		slog.Info("organize-collision created dedup candidate between and (occupant of )", "currentBookID", currentBookID, "occupant", occupant.ID, "occupantPath", occupantPath)
+		h.server.markDuplicatesFlaggedDirty("upsert_candidate")
 	}()
 }
 

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/system_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // last-edited: 2026-05-20
 // guid: 0c5a18be-5744-4e41-a35a-e7e96630833b
 //
@@ -690,4 +690,43 @@ func (s *Server) deleteUserPreference(c *gin.Context) {
 // GET /api/v1/policy/tags
 func (s *Server) handlePolicyTags(c *gin.Context) {
 	httputil.RespondWithOK(c, policy.KnownPolicyTags())
+}
+
+// getQuickQueries returns the six preset quick-filter counts for the Library
+// header kebab menu. Counts are served from the per-query PebbleDB cache when
+// fresh; stale or dirty entries are recomputed inline. broken_files reuses the
+// existing stats:library cache so it never incurs an extra scan.
+// GET /api/v1/library/quick-queries
+func (s *Server) getQuickQueries(c *gin.Context) {
+	if s.Store() == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+
+	type quickQueryGetter interface {
+		GetQuickQueryCounts() ([]database.QuickQueryResult, error)
+	}
+
+	var getter quickQueryGetter
+	if g, ok := s.Store().(quickQueryGetter); ok {
+		getter = g
+	} else if uw, ok := s.Store().(interface{ Unwrap() database.Store }); ok {
+		if g, ok2 := uw.Unwrap().(quickQueryGetter); ok2 {
+			getter = g
+		}
+	}
+
+	if getter == nil {
+		// Store implementation does not support quick queries (e.g. SQLite in tests).
+		httputil.RespondWithOK(c, gin.H{"queries": []interface{}{}})
+		return
+	}
+
+	results, err := getter.GetQuickQueryCounts()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "failed to compute quick-query counts")
+		return
+	}
+
+	httputil.RespondWithOK(c, gin.H{"queries": results})
 }

--- a/web/src/components/BookGrid.tsx
+++ b/web/src/components/BookGrid.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/BookGrid.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6e7f8a9b-0c1d-2e3f-4a5b-6c7d8e9f0a1b
 // last-edited: 2026-05-20
 
@@ -11,7 +11,7 @@ import {
 import { AudiobookGrid } from './audiobooks/AudiobookGrid';
 import { AudiobookList } from './audiobooks/AudiobookList';
 import { ViewMode } from './audiobooks/SearchBar';
-import type { Audiobook, SortOrder as SortOrderType } from '../types';
+import type { Audiobook, FilterOptions, SortOrder as SortOrderType } from '../types';
 import { SortOrder } from '../types';
 import type { ColumnDefinition } from '../config/columnDefinitions';
 
@@ -40,6 +40,7 @@ interface BookGridProps {
   onSelectAll?: () => void;
   visibleColumnIds?: string[];
   onToggleColumn?: (columnId: string) => void;
+  onFiltersChange?: (filters: FilterOptions) => void;
 }
 
 export const BookGrid: React.FC<BookGridProps> = ({
@@ -67,6 +68,7 @@ export const BookGrid: React.FC<BookGridProps> = ({
   onSelectAll,
   visibleColumnIds,
   onToggleColumn,
+  onFiltersChange,
 }) => {
   return (
     <>
@@ -113,6 +115,7 @@ export const BookGrid: React.FC<BookGridProps> = ({
           onColumnResize={onColumnResize}
           visibleColumnIds={visibleColumnIds}
           onToggleColumn={onToggleColumn}
+          onFiltersChange={onFiltersChange}
         />
       )}
     </>

--- a/web/src/components/audiobooks/AudiobookList.tsx
+++ b/web/src/components/audiobooks/AudiobookList.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/AudiobookList.tsx
-// version: 2.5.0
+// version: 2.6.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-20
 
@@ -24,6 +24,7 @@ import {
   Switch,
   FormControlLabel,
   Button,
+  Divider,
 } from '@mui/material';
 import {
   MoreVert as MoreVertIcon,
@@ -36,9 +37,10 @@ import {
   CheckCircle as CheckCircleIcon,
   Cancel as CancelIcon,
 } from '@mui/icons-material';
-import type { Audiobook, BookFile } from '../../types';
+import type { Audiobook, BookFile, FilterOptions } from '../../types';
 import { type ColumnDefinition, getDefaultVisibleColumns } from '../../config/columnDefinitions';
 import * as api from '../../services/api';
+import type { QuickQueryItem } from '../../services/api';
 
 interface AudiobookListProps {
   audiobooks: Audiobook[];
@@ -57,6 +59,8 @@ interface AudiobookListProps {
   onColumnResize?: (columnId: string, width: number) => void;
   visibleColumnIds?: string[];
   onToggleColumn?: (columnId: string) => void;
+  /** Called when a quick filter preset is clicked — applies the preset's filter. */
+  onFiltersChange?: (filters: FilterOptions) => void;
 }
 
 const fallbackColumns = getDefaultVisibleColumns();
@@ -78,11 +82,15 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
   onColumnResize,
   visibleColumnIds,
   onToggleColumn,
+  onFiltersChange,
 }) => {
   const activeColumns = columns ?? fallbackColumns;
 
   const [anchorEls, setAnchorEls] = React.useState<Record<string, HTMLElement | null>>({});
   const [headerMenuAnchor, setHeaderMenuAnchor] = React.useState<HTMLElement | null>(null);
+  // Quick-query preset counts, loaded lazily when the header menu opens.
+  const [quickQueries, setQuickQueries] = useState<QuickQueryItem[]>([]);
+  const [quickQueriesLoaded, setQuickQueriesLoaded] = useState(false);
   // Fix #1: use Record instead of Set for proper React equality comparisons
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
   const [filesCache, setFilesCache] = useState<Record<string, BookFile[]>>({});
@@ -120,6 +128,18 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
   const handleHeaderMenuClick = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     setHeaderMenuAnchor(event.currentTarget);
+    // Lazy-load quick-query counts on first open (or re-open after close).
+    // Session-level cache: once loaded, counts stay until the component unmounts.
+    if (!quickQueriesLoaded) {
+      api.getQuickQueries()
+        .then((items) => {
+          setQuickQueries(items);
+          setQuickQueriesLoaded(true);
+        })
+        .catch(() => {
+          // Non-fatal: quick filters just won't show counts.
+        });
+    }
   };
 
   const handleHeaderMenuClose = () => {
@@ -416,6 +436,45 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
                 open={Boolean(headerMenuAnchor)}
                 onClose={handleHeaderMenuClose}
               >
+                {/* Quick Filters section */}
+                {onFiltersChange && (
+                  <>
+                    <MenuItem disabled sx={{ py: 0.5 }}>
+                      <Typography variant="overline" color="text.secondary" sx={{ lineHeight: 1.5 }}>
+                        Quick Filters
+                      </Typography>
+                    </MenuItem>
+                    {quickQueries.length === 0 && !quickQueriesLoaded && (
+                      <MenuItem disabled>
+                        <Typography variant="body2" color="text.disabled">Loading...</Typography>
+                      </MenuItem>
+                    )}
+                    {quickQueries.map((q) => (
+                      q.count > 0 ? (
+                        <MenuItem
+                          key={q.id}
+                          onClick={() => {
+                            onFiltersChange(q.filter as FilterOptions);
+                            handleHeaderMenuClose();
+                          }}
+                          sx={{ pl: 3 }}
+                        >
+                          <Typography variant="body2">
+                            {q.label} ({q.count.toLocaleString()})
+                          </Typography>
+                        </MenuItem>
+                      ) : (
+                        <MenuItem key={q.id} disabled sx={{ pl: 3 }}>
+                          <Typography variant="body2" color="text.disabled">
+                            {q.label} (0)
+                          </Typography>
+                        </MenuItem>
+                      )
+                    ))}
+                    <Divider />
+                  </>
+                )}
+
                 {/* Column visibility toggle */}
                 {onToggleColumn && visibleColumnIds && (
                   <>

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-05-20
 
@@ -361,6 +361,7 @@ export const LibraryBookGrid = ({
             onSelectAll={handleToggleSelectAllOnPage}
             visibleColumnIds={visibleColumnIds}
             onToggleColumn={onToggleColumn}
+            onFiltersChange={handleFiltersChange}
           />
         )}
 

--- a/web/src/hooks/useLibraryFilters.ts
+++ b/web/src/hooks/useLibraryFilters.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryFilters.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 import { useState, useEffect, useCallback } from 'react';
 import type { FilterOptions } from '../types';
@@ -46,6 +46,11 @@ export function useLibraryFilters({
     fingerprintStatus: (searchParams.get('fingerprint_status') as "complete" | "partial" | "none" | null) || undefined,
     coveragePercentMin: searchParams.get('coverage_percent_min') ? parseInt(searchParams.get('coverage_percent_min')!, 10) : undefined,
     coveragePercentMax: searchParams.get('coverage_percent_max') ? parseInt(searchParams.get('coverage_percent_max')!, 10) : undefined,
+    // Quick-filter preset params
+    missingCovers: (searchParams.get('missing_covers') === 'true') || undefined,
+    inImportPath: (searchParams.get('in_import_path') === 'true') || undefined,
+    noIsbn: (searchParams.get('no_isbn') === 'true') || undefined,
+    duplicatesFlagged: (searchParams.get('duplicates_flagged') === 'true') || undefined,
   }));
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [availableAuthors, setAvailableAuthors] = useState<string[]>([]);

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.32.1
+// version: 2.33.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-20
 
@@ -5048,4 +5048,22 @@ export async function startOptimize(): Promise<{ operation_id: string }> {
     throw await buildApiError(response, 'Failed to start optimize operation');
   }
   return response.json();
+}
+
+// QuickQuery matches the QuickQuery interface defined in web/src/types/index.ts.
+export interface QuickQueryItem {
+  id: string;
+  label: string;
+  count: number;
+  filter: Record<string, unknown>;
+}
+
+/** Fetches the six preset quick-filter counts for the Library header kebab menu. */
+export async function getQuickQueries(): Promise<QuickQueryItem[]> {
+  const response = await fetch(`${API_BASE}/library/quick-queries`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to load quick queries');
+  }
+  const data = await response.json() as { queries: QuickQueryItem[] };
+  return data.queries ?? [];
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,7 +1,7 @@
 // file: web/src/types/index.ts
-// version: 1.16.0
+// version: 1.17.0
 // guid: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 // Audiobook (Book) type
 export interface Audiobook {
@@ -174,6 +174,19 @@ export interface FilterOptions {
   fingerprintStatus?: "complete" | "partial" | "none";
   coveragePercentMin?: number;
   coveragePercentMax?: number;
+  // Quick-filter presets (from header kebab menu)
+  missingCovers?: boolean;
+  inImportPath?: boolean;
+  noIsbn?: boolean;
+  duplicatesFlagged?: boolean;
+}
+
+// QuickQuery is one entry returned by GET /api/v1/library/quick-queries.
+export interface QuickQuery {
+  id: string;
+  label: string;
+  count: number;
+  filter: Partial<FilterOptions>;
 }
 
 // Pagination parameters


### PR DESCRIPTION
## Summary

- Adds 6 preset quick filters ("Missing covers", "Broken files", "No fingerprints", "In import path", "No ISBN", "Duplicates flagged") to the Library header kebab menu, each showing its result count inline
- Backend: new `GET /api/v1/library/quick-queries` endpoint backed by a per-query PebbleDB dirty-flag cache; `broken_files` reuses the existing `stats:library` cache entry from PR #1053
- Frontend: Quick Filters section appears above column toggles with a `<Divider>` separator; lazy-fetched on menu open, session-level cache; zero-count items are dimmed; clicking applies the preset filter via the existing `handleFiltersChange` path

## Cache keys / invalidation

| Cache key | Invalidated by |
|-----------|----------------|
| `quick_query_cache:missing_covers` | `UpdateBook`, `CreateBook`, `DeleteBook` |
| `broken_files` | existing `stats:library` invalidation (no new entry) |
| `quick_query_cache:no_fingerprints` | `CreateBookFile`, `UpdateBookFile`, `BatchUpsertBookFiles`, `DeleteBookFile`, `CreateBook`, `DeleteBook` |
| `quick_query_cache:in_import_path` | `UpdateBook`, `CreateBook`, `DeleteBook` |
| `quick_query_cache:no_isbn` | `UpdateBook`, `CreateBook`, `DeleteBook` |
| `quick_query_cache:duplicates_flagged` | `dismissDedupCandidate`, `dismissDedupCluster`, organize-collision upsert in `server_search.go` |

## Complexity note: `duplicates_flagged`

The count is computed by scanning all `dedup_candidate:` keys in PebbleDB for `entity_type=book` + `status=pending` pairs, then deduplicating entity IDs. This is O(candidates) — currently in the hundreds on prod. The dirty-flag cache means this scan only runs when the count is stale.

New `FilterOptions` fields (`missingCovers`, `inImportPath`, `noIsbn`, `duplicatesFlagged`) are applied as a post-fetch pass in `listAudiobooks` after fingerprinting enrichment.

## Test plan

- [ ] `go test ./internal/database/... ./internal/server/...` passes
- [ ] `npm run build` in `web/` succeeds
- [ ] Open Library kebab menu → Quick Filters section appears above column toggles
- [ ] Counts load lazily; clicking a non-zero preset applies the filter and closes the menu
- [ ] Zero-count items are visually dimmed (disabled)

Follow-up to PR #1056 (header kebab) and PR #1053 (cached aggregates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)