### PR TITLE
fix(library): correct pagination for quick-query filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.87.0 -->
+<!-- version: 2.88.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-20 -->
 
@@ -8,6 +8,13 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### May 20, 2026 — Quick-query filter pagination fix
+
+- Quick-query boolean params (`missing_covers`, `in_import_path`, `no_isbn`, `duplicates_flagged`) were previously applied post-pagination: `GetAudiobooks` fetched 20 books, then filtered in-place, resulting in at most 20 results per page and a wrong `totalCount`.
+- Replaced post-pagination filter with a fast-path that mirrors the existing `has_file_errors` pattern: `GetAllBookIDsForQuickQuery(id)` scans all matching book IDs upfront, slices the ID array for pagination, then fetches only those books. `totalCount` now reflects the true matching-book count.
+- `duplicates_flagged` fast-path uses `getAllBookIDsDuplicatesFlagged` (extracted from the duplicated dedup-candidate scan already in `computeDuplicatesFlaggedCount`).
+- Removed the now-unused `applyQuickQueryFiltersDetail` helper from `audiobooks_handlers.go`.
 
 #### May 20, 2026 — Activity Log: tag system entries with outcome/source/action/lifecycle
 

--- a/internal/database/pebble_quick_queries.go
+++ b/internal/database/pebble_quick_queries.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_quick_queries.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
 // last-edited: 2026-05-20
 
@@ -281,6 +281,124 @@ func (p *PebbleStore) computeDuplicatesFlaggedCount() (int, error) {
 	elapsed := time.Since(start).Milliseconds()
 	slog.Info("quick_query cache recomputed", "id", "duplicates_flagged", "count", len(flagged), "duration_ms", elapsed)
 	return len(flagged), nil
+}
+
+// GetAllBookIDsForQuickQuery returns the IDs of all non-deleted, primary-version
+// books that match the given quick-query id. Supported ids:
+// "missing_covers", "no_fingerprints", "in_import_path", "no_isbn", "duplicates_flagged".
+// "broken_files" is handled by a separate code-path (ListBooksWithFileErrors) and
+// is not supported here; an empty slice is returned for unknown ids.
+//
+// This is used by the listAudiobooks fast-path so that pagination operates on the
+// full matching-ID slice rather than a single page of books.
+func (p *PebbleStore) GetAllBookIDsForQuickQuery(id string) ([]string, error) {
+	start := time.Now()
+
+	if id == "duplicates_flagged" {
+		ids, err := p.getAllBookIDsDuplicatesFlagged()
+		slog.Info("quick_query id scan", "id", id, "count", len(ids), "duration_ms", time.Since(start).Milliseconds())
+		return ids, err
+	}
+
+	// Load import paths once for in_import_path query.
+	var importPaths []ImportPath
+	if id == "in_import_path" {
+		importPaths, _ = p.GetAllImportPaths()
+	}
+
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var ids []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") {
+			continue
+		}
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		// Primary versions only (consistent with LibraryStats and computeQuickQueryCount).
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+
+		switch id {
+		case "missing_covers":
+			if b.CoverURL == nil || *b.CoverURL == "" {
+				ids = append(ids, b.ID)
+			}
+		case "no_fingerprints":
+			if b.FingerprintStatus == "" || b.FingerprintStatus == "none" {
+				ids = append(ids, b.ID)
+			}
+		case "in_import_path":
+			for _, ip := range importPaths {
+				if strings.HasPrefix(b.FilePath, ip.Path) {
+					ids = append(ids, b.ID)
+					break
+				}
+			}
+		case "no_isbn":
+			isbn10 := b.ISBN10 == nil || *b.ISBN10 == ""
+			isbn13 := b.ISBN13 == nil || *b.ISBN13 == ""
+			if isbn10 && isbn13 {
+				ids = append(ids, b.ID)
+			}
+		}
+	}
+
+	slog.Info("quick_query id scan", "id", id, "count", len(ids), "duration_ms", time.Since(start).Milliseconds())
+	return ids, nil
+}
+
+// getAllBookIDsDuplicatesFlagged returns IDs of books in a "pending" dedup candidate.
+func (p *PebbleStore) getAllBookIDsDuplicatesFlagged() ([]string, error) {
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("dedup_candidate:"),
+		UpperBound: []byte("dedup_candidate;"),
+	})
+	if err != nil {
+		return nil, nil //nolint:nilerr // no candidates table yet
+	}
+	defer iter.Close()
+
+	type candRec struct {
+		EntityType string `json:"entity_type"`
+		EntityAID  string `json:"entity_a_id"`
+		EntityBID  string `json:"entity_b_id"`
+		Status     string `json:"status"`
+	}
+
+	flagged := make(map[string]struct{})
+	for iter.First(); iter.Valid(); iter.Next() {
+		var rec candRec
+		if err := json.Unmarshal(iter.Value(), &rec); err != nil {
+			continue
+		}
+		if rec.EntityType != "book" || rec.Status != "pending" {
+			continue
+		}
+		flagged[rec.EntityAID] = struct{}{}
+		flagged[rec.EntityBID] = struct{}{}
+	}
+
+	ids := make([]string, 0, len(flagged))
+	for id := range flagged {
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 // GetQuickQueryCounts returns the six preset quick-query results. Each entry's count

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.15.0
+// version: 2.16.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 // last-edited: 2026-05-20
 //
@@ -96,6 +96,96 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 			books = append(books, *b)
 		}
 		enriched := s.audiobookService.EnrichAudiobooksWithNames(books)
+		httputil.RespondWithOK(c, gin.H{"items": enriched, "count": total, "limit": params.Limit, "offset": params.Offset})
+		return
+	}
+
+	// Quick-query boolean params fast-path: missing_covers, in_import_path, no_isbn,
+	// duplicates_flagged. Replicates the has_file_errors pattern — scan ALL matching
+	// book IDs first, slice for pagination, then fetch each book individually.
+	// This ensures totalCount and page offsets are correct regardless of page size.
+	quickQueryID := ""
+	switch {
+	case c.Query("missing_covers") == "true":
+		quickQueryID = "missing_covers"
+	case c.Query("in_import_path") == "true":
+		quickQueryID = "in_import_path"
+	case c.Query("no_isbn") == "true":
+		quickQueryID = "no_isbn"
+	case c.Query("duplicates_flagged") == "true":
+		quickQueryID = "duplicates_flagged"
+	}
+	if quickQueryID != "" {
+		var bookIDs []string
+		if qqStore, ok := s.Store().(interface {
+			GetAllBookIDsForQuickQuery(id string) ([]string, error)
+		}); ok {
+			ids, err := qqStore.GetAllBookIDsForQuickQuery(quickQueryID)
+			if err != nil {
+				httputil.InternalError(c, "failed to list books for quick query", err)
+				return
+			}
+			bookIDs = ids
+		} else if uw, ok := s.Store().(interface{ Unwrap() database.Store }); ok {
+			if inner, ok2 := uw.Unwrap().(interface {
+				GetAllBookIDsForQuickQuery(id string) ([]string, error)
+			}); ok2 {
+				ids, err := inner.GetAllBookIDsForQuickQuery(quickQueryID)
+				if err != nil {
+					httputil.InternalError(c, "failed to list books for quick query", err)
+					return
+				}
+				bookIDs = ids
+			}
+		}
+
+		if bookIDs == nil {
+			// Store doesn't support this method — return empty set.
+			httputil.RespondWithOK(c, gin.H{"items": []AudiobookDetail{}, "count": 0, "limit": params.Limit, "offset": params.Offset})
+			return
+		}
+
+		total := len(bookIDs)
+		start := params.Offset
+		if start < 0 {
+			start = 0
+		}
+		end := start + params.Limit
+		if params.Limit <= 0 || end > len(bookIDs) {
+			end = len(bookIDs)
+		}
+		if start > len(bookIDs) {
+			start = len(bookIDs)
+		}
+		selected := bookIDs[start:end]
+		books := make([]database.Book, 0, len(selected))
+		for _, id := range selected {
+			b, err := s.Store().GetBookByID(id)
+			if err != nil || b == nil {
+				continue
+			}
+			books = append(books, *b)
+		}
+		enriched := s.audiobookService.EnrichAudiobooksWithNames(books)
+
+		// Compute fingerprinting fields for the selected books.
+		for i, book := range enriched {
+			files, err := s.Store().GetBookFiles(book.ID)
+			if err != nil {
+				continue
+			}
+			fpFiles := make([]fingerprint.FileWithFingerprint, len(files))
+			for j := range files {
+				fpFiles[j] = &files[j]
+			}
+			status, fpCount, coverage, lastFp := fingerprint.ComputeFingerprintFields(fpFiles)
+			enriched[i].FingerprintStatus = status
+			enriched[i].FingerprintedFileCount = fpCount
+			enriched[i].TotalFileCount = len(files)
+			enriched[i].CoveragePercent = coverage
+			enriched[i].LastFingerprintedAt = lastFp
+		}
+
 		httputil.RespondWithOK(c, gin.H{"items": enriched, "count": total, "limit": params.Limit, "offset": params.Offset})
 		return
 	}
@@ -220,10 +310,6 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		enriched[i].CoveragePercent = coverage
 		enriched[i].LastFingerprintedAt = lastFp
 	}
-
-	// Apply quick-query preset filters (missing_covers, in_import_path, no_isbn, duplicates_flagged).
-	// These are post-fetch because they require enriched book fields (e.g. FingerprintStatus).
-	enriched = s.applyQuickQueryFiltersDetail(c, enriched)
 
 	// Get total count for proper pagination
 	totalCount := len(enriched)
@@ -1621,84 +1707,3 @@ func (s *Server) getBookChanges(c *gin.Context) {
 	httputil.RespondWithOK(c, gin.H{"changes": changes})
 }
 
-// applyQuickQueryFiltersDetail applies the four "quick query" preset filters that are
-// expressed as boolean URL params: missing_covers, in_import_path, no_isbn, and
-// duplicates_flagged. Returns the filtered slice (unmodified if no params are set).
-// Called after fingerprinting enrichment so all book fields are populated.
-func (s *Server) applyQuickQueryFiltersDetail(c *gin.Context, books []AudiobookDetail) []AudiobookDetail {
-	missingCovers := c.Query("missing_covers") == "true"
-	inImportPath := c.Query("in_import_path") == "true"
-	noIsbn := c.Query("no_isbn") == "true"
-	duplicatesFlagged := c.Query("duplicates_flagged") == "true"
-
-	if !missingCovers && !inImportPath && !noIsbn && !duplicatesFlagged {
-		return books
-	}
-
-	// Load import paths once if needed.
-	var importPaths []database.ImportPath
-	if inImportPath {
-		importPaths, _ = s.Store().GetAllImportPaths()
-	}
-
-	// Build flagged-book set once if needed.
-	flaggedBookIDs := map[string]struct{}{}
-	if duplicatesFlagged && s.embeddingStore != nil {
-		candidates, _, _ := s.embeddingStore.ListCandidates(database.CandidateFilter{
-			EntityType: "book",
-			Status:     "pending",
-			Limit:      100000,
-		})
-		for _, cand := range candidates {
-			flaggedBookIDs[cand.EntityAID] = struct{}{}
-			flaggedBookIDs[cand.EntityBID] = struct{}{}
-		}
-	}
-
-	result := books[:0]
-	for _, detail := range books {
-		if detail.Book == nil {
-			continue
-		}
-		b := detail.Book
-		keep := true
-
-		if missingCovers && keep {
-			if b.CoverURL != nil && *b.CoverURL != "" {
-				keep = false
-			}
-		}
-
-		if inImportPath && keep {
-			matched := false
-			for _, ip := range importPaths {
-				if strings.HasPrefix(b.FilePath, ip.Path) {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				keep = false
-			}
-		}
-
-		if noIsbn && keep {
-			isbn10Empty := b.ISBN10 == nil || *b.ISBN10 == ""
-			isbn13Empty := b.ISBN13 == nil || *b.ISBN13 == ""
-			if !isbn10Empty || !isbn13Empty {
-				keep = false
-			}
-		}
-
-		if duplicatesFlagged && keep {
-			if _, ok := flaggedBookIDs[b.ID]; !ok {
-				keep = false
-			}
-		}
-
-		if keep {
-			result = append(result, detail)
-		}
-	}
-	return result
-}


### PR DESCRIPTION
## Summary

- Quick-query boolean params (`missing_covers`, `in_import_path`, `no_isbn`, `duplicates_flagged`) were applied *after* `GetAudiobooks` paginated, so clicking "Missing covers (47)" only checked the first 20 library books, returned at most 20 (often far fewer) results, and reported a wrong `totalCount`
- Replicates the existing `has_file_errors` fast-path: new `GetAllBookIDsForQuickQuery(id string)` method on `PebbleStore` scans all matching book IDs upfront, the handler slices the ID array for pagination, then fetches only those books. `totalCount` now equals the true matching-book count across the full library
- `duplicates_flagged` uses `getAllBookIDsDuplicatesFlagged` (extracted from the scan already in `computeDuplicatesFlaggedCount`)
- Removes the no-longer-needed `applyQuickQueryFiltersDetail` helper

## Test plan

- [ ] Navigate to Library, open kebab menu, click "Missing covers (N)" — verify page 2, 3 navigate correctly and total count in header matches N
- [ ] Same test for "No ISBN", "In import path", "Duplicates flagged"
- [ ] Verify normal library browsing (without quick-query params) is unaffected
- [ ] `go build ./internal/database/... ./internal/server/...` passes
- [ ] `go vet ./internal/database/... ./internal/server/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)