### PR TITLE
fix(ui): show bell + toast instantly when starting an operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.88.0 -->
+<!-- version: 2.89.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-20 -->
 
@@ -8,6 +8,13 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### May 20, 2026 — Bell + toast appear instantly when starting an operation
+
+- New store primitives `beginOptimistic(type)` and `reconcileOptimistic(tempId, realId|null)` on `useOperationsStore`. Click → bell shows a `queued` placeholder + "{Label} starting…" toast *before* the network round-trip, then reconcile renames the placeholder to the real operation id when the API responds (or removes it silently if the call fails / there's nothing to do).
+- New helper `web/src/utils/withOptimisticOperation.ts` wraps the begin/await/reconcile dance. Picks the real id from `operation_id ?? id` on the response by default.
+- Migrated the user-facing start-op handlers off the post-await `startPolling(opId, type)` pattern: Fetch Unmatched / Fetch Review / Scan / Scan All / Full Rescan / Organize / Fingerprint Rescan (all + missing) / Batch Save to Files on the Library page; Optimize Library + Manual Fixes (per-job) under System → Maintenance.
+- Previously the bell + toast only appeared *after* the start-endpoint returned, so slow start-endpoints (e.g. "fetch all unmatched" scanning 5851 books) gave the operator zero feedback for several seconds and looked broken. Now both fire on click; reconcile picks up the real op metadata when the server responds.
 
 #### May 20, 2026 — Quick-query filter pagination fix
 

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -28,7 +28,7 @@ import {
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow.js';
 import * as api from '../../services/api';
-import { useOperationsStore } from '../../stores/useOperationsStore';
+import { withOptimisticOperation } from '../../utils/withOptimisticOperation';
 
 // ─── OptimizeLibraryCard ────────────────────────────────────────────────────
 
@@ -36,16 +36,13 @@ function OptimizeLibraryCard() {
   const [optimizeRunning, setOptimizeRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
-  const startPolling = useOperationsStore((state) => state.startPolling);
-
   const handleOptimize = async () => {
     setOptimizeRunning(true);
     setError(null);
     setSuccessMsg(null);
     try {
-      const result = await api.startOptimize();
+      const result = await withOptimisticOperation('library.optimize', () => api.startOptimize());
       setSuccessMsg(`Optimize started (op ${result.operation_id})`);
-      startPolling(result.operation_id, 'library.optimize');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to start optimize');
     } finally {
@@ -858,8 +855,6 @@ function ManualFixesCard() {
   const [loading, setLoading] = useState(true);
   const [running, setRunning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const startPolling = useOperationsStore((state) => state.startPolling);
-
   useEffect(() => {
     api.listMaintenanceJobs()
       .then(setJobs)
@@ -871,9 +866,9 @@ function ManualFixesCard() {
     setRunning(jobId);
     setError(null);
     try {
-      const result = await api.runMaintenanceJob(jobId);
-      // Register with the operations store so the bell + activity page track it
-      startPolling(result.operation_id, `maintenance:${jobId}`);
+      // Bell + toast appear instantly; reconcile to the real op id once the
+      // dispatcher returns.
+      await withOptimisticOperation(`maintenance:${jobId}`, () => api.runMaintenanceJob(jobId));
     } catch (e) {
       setError(e instanceof Error ? e.message : `Failed to run ${jobId}`);
     } finally {

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -23,6 +23,7 @@ import {
 } from '../services/eventSourceManager';
 import { pollOperation } from '../utils/operationPolling';
 import { useOperationsStore } from '../stores/useOperationsStore';
+import { withOptimisticOperation } from '../utils/withOptimisticOperation';
 import { STORAGE_KEYS } from '../lib/storageKeys';
 import { LibraryToolbar } from '../components/library/LibraryToolbar';
 import { LibraryBookGrid } from '../components/library/LibraryBookGrid';
@@ -105,7 +106,6 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const startOperationPolling = useOperationsStore((state) => state.startPolling);
   const initialSearch = searchParams.get('search') ?? '';
   const initialViewMode = (searchParams.get('view') as ViewMode) || ('grid' as ViewMode);
   const initialSortBy = ((): SortField => {
@@ -1124,11 +1124,11 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
 
     setBulkWriteBackInProgress(true);
     try {
-      const result = await api.batchWriteBackMetadata(ids, bulkWriteBackRename, bulkWriteBackForce);
-      if (result.operation_id) {
-        startOperationPolling(result.operation_id, 'batch_save_to_files');
-      }
+      const result = await withOptimisticOperation('batch_save_to_files', () =>
+        api.batchWriteBackMetadata(ids, bulkWriteBackRename, bulkWriteBackForce),
+      );
       toast(`Saving ${ids.length} books to files…`, 'success');
+      void result;
       setBulkWriteBackDialogOpen(false);
       setCrossPageFilter(null);
       setSelectedAudiobooks([]);
@@ -1541,7 +1541,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       const path = pathEntry?.path;
       if (!path) return;
       setImportPaths((prev) => prev.map((p) => (p.id === id ? { ...p, status: 'scanning' } : p)));
-      const op = await api.startScan(path);
+      const op = await withOptimisticOperation('scan', () => api.startScan(path));
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to scan import path:', error);
@@ -1555,7 +1555,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       // Mark all paths scanning
       setImportPaths((prev) => prev.map((p) => ({ ...p, status: 'scanning' })));
-      const op = await api.startScan(); // no folder path -> scan all
+      const op = await withOptimisticOperation('scan', () => api.startScan()); // no folder path -> scan all
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to start full scan:', error);
@@ -1569,7 +1569,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       // Mark all paths scanning
       setImportPaths((prev) => prev.map((p) => ({ ...p, status: 'scanning' })));
       // Force full rescan with database path updates
-      const op = await api.startScan(undefined, undefined, true);
+      const op = await withOptimisticOperation('scan', () => api.startScan(undefined, undefined, true));
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to start full rescan:', error);
@@ -1582,9 +1582,10 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       return;
     }
     try {
-      const op = await api.triggerFingerprintBackfill('all');
+      const op = await withOptimisticOperation('fingerprint-rescan', () =>
+        api.triggerFingerprintBackfill('all'),
+      );
       toast(`Fingerprint rescan started. Operation ID: ${op.id}`, 'success');
-      startOperationPolling(op.id, 'fingerprint-rescan');
     } catch (error) {
       console.error('Failed to trigger fingerprint rescan:', error);
       toast('Failed to start fingerprint rescan', 'error');
@@ -1593,9 +1594,10 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
 
   const handleFingerprintRescanMissing = async () => {
     try {
-      const op = await api.triggerFingerprintBackfill('missing');
+      const op = await withOptimisticOperation('fingerprint-rescan', () =>
+        api.triggerFingerprintBackfill('missing'),
+      );
       toast(`Fingerprint rescan started. Operation ID: ${op.id}`, 'success');
-      startOperationPolling(op.id, 'fingerprint-rescan');
     } catch (error) {
       console.error('Failed to trigger fingerprint rescan:', error);
       toast('Failed to start fingerprint rescan', 'error');
@@ -1605,7 +1607,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const handleOrganizeLibrary = async () => {
     try {
       setOrganizeRunning(true);
-      const op = await api.startOrganize();
+      const op = await withOptimisticOperation('organize', () => api.startOrganize());
       startPolling(op.id, 'organize');
     } catch (e) {
       console.error('Failed to start organize', e);
@@ -1616,14 +1618,15 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const handleFetchReview = async () => {
     try {
       const ids = effectiveSelectedIds;
-      const resp = await api.batchFetchCandidates({ book_ids: ids });
+      const resp = await withOptimisticOperation('metadata_candidate_fetch', () =>
+        api.batchFetchCandidates({ book_ids: ids }),
+      );
       const opId = resp.operation_id;
       if (!opId) {
         toast('All selected books are already being fetched.', 'info');
         return;
       }
       setPendingFetchOpId(opId);
-      startOperationPolling(opId, 'metadata_candidate_fetch');
       toast(
         `Metadata fetch started for ${ids.length} book${ids.length !== 1 ? 's' : ''}. Click Review when complete to open candidates.`,
         'info',
@@ -1633,14 +1636,16 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
 
   const handleFetchAllUnmatched = async () => {
     try {
-      const resp = await api.batchFetchCandidates({
-        selection: { filter: { only_unmatched: true } },
-      });
+      // Insert the bell placeholder BEFORE the round-trip — server-side
+      // selection of "all unmatched" is slow on big libraries and the
+      // user previously got zero feedback while it ran.
+      const resp = await withOptimisticOperation('metadata_candidate_fetch', () =>
+        api.batchFetchCandidates({ selection: { filter: { only_unmatched: true } } }),
+      );
       if (!resp.operation_id) {
         toast(resp.message ?? 'All books already have matched candidates.', 'info');
         return;
       }
-      startOperationPolling(resp.operation_id, 'metadata_candidate_fetch');
       toast(
         `Fetching metadata for ${resp.book_count ?? 'unmatched'} books — check the operations list for progress.`,
         'info',

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 3.3.0
+// version: 3.4.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 
 import { create } from 'zustand';
@@ -50,6 +50,17 @@ interface OperationsState {
   _sseSource: EventSource | null;
 
   startPolling: (operationId: string, type: string, resumed?: boolean) => void;
+  /** beginOptimistic inserts a placeholder queued op IMMEDIATELY so the bell
+   *  reflects user intent before any network round-trip completes.
+   *  Returns a synthetic id ("optimistic-…") that callers must hand back to
+   *  reconcileOptimistic once the server returns the real operation id. */
+  beginOptimistic: (type: string) => string;
+  /** reconcileOptimistic finalises a placeholder. If realId is non-null the
+   *  placeholder is renamed in place (so SSE updates land on it) and the
+   *  normal startPolling side-effects (toast, server refresh) fire. If
+   *  realId is null the placeholder is removed silently — used when the
+   *  API call failed or returned no operation_id (e.g. nothing to do). */
+  reconcileOptimistic: (tempId: string, realId: string | null) => void;
   removeOperation: (operationId: string) => void;
   updateOperation: (op: ActiveOperation) => void;
   loadFromServer: () => Promise<void>;
@@ -188,6 +199,68 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
     });
 
     // Trigger a server load shortly after to catch any v2 op registration.
+    setTimeout(() => get().loadFromServer(), 1500);
+  },
+
+  beginOptimistic: (type: string) => {
+    // crypto.randomUUID is available in all modern browsers; fall back to a
+    // timestamp-based id in the unlikely test/SSR case where it is absent.
+    const rand =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tempId = `optimistic-${rand}`;
+    const op: ActiveOperation = {
+      id: tempId,
+      type,
+      status: 'queued',
+      progress: 0,
+      total: 0,
+      message: 'Starting…',
+      startedAt: Date.now(),
+    };
+    set((state) => {
+      const operations = { ...state.operations, [tempId]: op };
+      return {
+        operations,
+        ...deriveOperationArrays(operations),
+        polling: true,
+      };
+    });
+
+    // Fire the "started" toast IMMEDIATELY — the click should produce
+    // visible feedback before any network round-trip. The reconcile step
+    // does not emit a second toast; the catch path can show "Failed".
+    const label = formatOpLabel(type);
+    useAppStore.getState().addNotification(`${label} starting…`, 'info');
+
+    return tempId;
+  },
+
+  reconcileOptimistic: (tempId: string, realId: string | null) => {
+    const existing = get().operations[tempId];
+    if (!existing) return;
+
+    if (realId === null) {
+      // Failed or no-op — drop the placeholder silently.
+      get().removeOperation(tempId);
+      return;
+    }
+
+    // Rename the placeholder to the real id so SSE op.updated events land
+    // on the same entry rather than creating a duplicate.
+    set((state) => {
+      const { [tempId]: _, ...rest } = state.operations;
+      const operations = {
+        ...rest,
+        [realId]: { ...existing, id: realId },
+      };
+      return { operations, ...deriveOperationArrays(operations) };
+    });
+
+    // Server refresh to pick up the real v2 op metadata (display name,
+    // notify_level, progress totals). No additional toast — the "starting…"
+    // notification already fired from beginOptimistic.
     setTimeout(() => get().loadFromServer(), 1500);
   },
 

--- a/web/src/utils/withOptimisticOperation.ts
+++ b/web/src/utils/withOptimisticOperation.ts
@@ -1,0 +1,52 @@
+// file: web/src/utils/withOptimisticOperation.ts
+// version: 1.0.0
+//
+// Wraps an async API call that creates a server-side operation so the bell
+// reflects the user's intent IMMEDIATELY — before the network round-trip
+// completes — rather than after the start-endpoint returns. The placeholder
+// is reconciled to the real operation_id when the API responds, or removed
+// silently if the API failed or reported "nothing to do".
+
+import { useOperationsStore } from '../stores/useOperationsStore';
+
+interface MaybeOperationResult {
+  operation_id?: string | null;
+  id?: string | null;
+}
+
+/**
+ * Inserts a placeholder queued op into the bell BEFORE calling `fn`. When
+ * `fn` resolves, the placeholder is renamed to the real operation id
+ * (extracted via `pickId` or, by default, `result.operation_id ?? result.id`).
+ * If `fn` rejects or `pickId` yields no id, the placeholder is removed.
+ *
+ * Typical use:
+ *   const resp = await withOptimisticOperation('scan', () => api.startScan());
+ *   if (!resp.operation_id) toast('Nothing to do', 'info');
+ *
+ * Callers no longer need a separate `startPolling(opId, type)` — the
+ * reconcile step fires the same toast + loadFromServer side-effects.
+ */
+export async function withOptimisticOperation<T>(
+  type: string,
+  fn: () => Promise<T>,
+  pickId: (result: T) => string | null | undefined = defaultPickId,
+): Promise<T> {
+  const store = useOperationsStore.getState();
+  const tempId = store.beginOptimistic(type);
+  try {
+    const result = await fn();
+    const realId = pickId(result);
+    store.reconcileOptimistic(tempId, realId ?? null);
+    return result;
+  } catch (err) {
+    store.reconcileOptimistic(tempId, null);
+    throw err;
+  }
+}
+
+function defaultPickId(result: unknown): string | null {
+  if (!result || typeof result !== 'object') return null;
+  const r = result as MaybeOperationResult;
+  return r.operation_id ?? r.id ?? null;
+}


### PR DESCRIPTION
## Summary

Closes the click-to-bell-update gap. Previously the bell badge + \"X started\" toast only appeared *after* the start-endpoint returned. For slow endpoints (Fetch All Unmatched scanning 5851 books, Optimize chaining 4 maintenance ops) that meant several seconds of zero feedback — the user couldn't tell whether their click registered.

- New store primitives \`beginOptimistic(type)\` / \`reconcileOptimistic(tempId, realId|null)\` on \`useOperationsStore\`.
- New helper \`utils/withOptimisticOperation.ts\` wraps the begin/await/reconcile dance.
- Migrated handlers (click → bell + toast are now synchronous): Library Fetch Unmatched, Fetch Review, Scan / Scan All / Full Rescan, Organize, Fingerprint Rescan all/missing, Batch Save to Files; MaintenanceTab Optimize, Manual Fixes (per-job).

## Test plan

- [x] \`npm run build\` (tsc + vite) clean
- [x] \`vitest run useOperationsStore.test.ts\` passes (4/4)
- [ ] Click Fetch Unmatched → toast appears immediately, bell shows pending placeholder, placeholder gets reconciled to real op id when API responds
- [ ] Click Optimize → same flow
- [ ] Force the start-endpoint to error → placeholder removed silently, no orphan in bell