### PR TITLE
fix(organizer): collapse redundant Title-Title folder names

### DIFF
--- a/internal/organizer/path_format.go
+++ b/internal/organizer/path_format.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/path_format.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b3c1d2-e4f5-6789-abcd-ef0123456789
 
 package organizer
@@ -123,6 +123,14 @@ func FormatPath(format string, vars FormatVars) string {
 	}
 	result = strings.Trim(result, "/")
 
+	// Collapse redundant "X - X" duplication in the final segment only.
+	// This catches cases where series name equals title (e.g., "Cobra Outlaw - Cobra Outlaw").
+	pathParts := strings.Split(result, "/")
+	if len(pathParts) > 0 {
+		pathParts[len(pathParts)-1] = collapseRedundantDup(pathParts[len(pathParts)-1])
+		result = strings.Join(pathParts, "/")
+	}
+
 	return result
 }
 
@@ -160,4 +168,21 @@ func SanitizePathComponent(s string) string {
 		s = strings.ReplaceAll(s, "  ", " ")
 	}
 	return strings.TrimSpace(s)
+}
+
+// collapseRedundantDup strips "X - X" → "X" in a single path segment,
+// case-insensitive, whitespace-normalized. Handles only 2-part duplicates.
+// Idempotent.
+func collapseRedundantDup(segment string) string {
+	parts := strings.Split(segment, " - ")
+	if len(parts) != 2 {
+		return segment
+	}
+	norm := func(s string) string {
+		return strings.ToLower(strings.Join(strings.Fields(s), " "))
+	}
+	if norm(parts[0]) == norm(parts[1]) {
+		return strings.TrimSpace(parts[0])
+	}
+	return segment
 }

--- a/internal/organizer/pattern_test.go
+++ b/internal/organizer/pattern_test.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/pattern_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
 
 package organizer
@@ -503,5 +503,54 @@ func TestPatternRejectsUnknownPlaceholder(t *testing.T) {
 	_, err := org.expandPattern("{title}/{unsupported}", book)
 	if err == nil {
 		t.Fatalf("expected error for unresolved placeholder")
+	}
+}
+
+// TestCollapseRedundantDup tests the collapse logic for "X - X" duplications.
+func TestCollapseRedundantDup(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "exact duplicate with case difference",
+			input:    "Cobra Outlaw - Cobra Outlaw",
+			expected: "Cobra Outlaw",
+		},
+		{
+			name:     "duplicate with whitespace difference",
+			input:    "The Moon is a Harsh Mistress - The Moon Is a Harsh Mistress",
+			expected: "The Moon is a Harsh Mistress",
+		},
+		{
+			name:     "duplicate with extra spaces",
+			input:    "Series Name  -  Series Name",
+			expected: "Series Name",
+		},
+		{
+			name:     "different segments no collapse",
+			input:    "Series Name - Book Title",
+			expected: "Series Name - Book Title",
+		},
+		{
+			name:     "no separator no collapse",
+			input:    "Cobra Outlaw",
+			expected: "Cobra Outlaw",
+		},
+		{
+			name:     "three parts no collapse (handles 2-part only)",
+			input:    "Part A - Part B - Part C",
+			expected: "Part A - Part B - Part C",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collapseRedundantDup(tt.input)
+			if result != tt.expected {
+				t.Errorf("collapseRedundantDup(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Patches the path-template expansion to detect when Series falls back to Title (producing 'X - X' folders) and collapse to 'X'. Prevents new entries from joining the 728 doubled-folder entries already on disk. Reconciler tool (separate PR) handles the existing data.