### PR TITLE
feat(library): add 1-minute cache layer for instant page loads

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.66.1
+// version: 1.67.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-05-20
 
@@ -23,6 +23,7 @@ import {
 } from '../services/eventSourceManager';
 import { pollOperation } from '../utils/operationPolling';
 import { useOperationsStore } from '../stores/useOperationsStore';
+import { useLibraryCache, buildCacheKey } from '../stores/useLibraryCache';
 import { withOptimisticOperation } from '../utils/withOptimisticOperation';
 import { STORAGE_KEYS } from '../lib/storageKeys';
 import { LibraryToolbar } from '../components/library/LibraryToolbar';
@@ -649,6 +650,19 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       // 'deleted' is a client-side concept (marked_for_deletion flag); send no library_state to server
       const libraryState = filters.libraryState === 'deleted' ? undefined : filters.libraryState;
 
+      // Check cache before fetching
+      const filterStr = JSON.stringify({ fieldFilters, tagsParam, libraryState, showFailed: filters.showFailed, hasFileErrors: filters.hasFileErrors, fingerprintStatus: filters.fingerprintStatus, coveragePercentMin: filters.coveragePercentMin, coveragePercentMax: filters.coveragePercentMax });
+      const cacheKey = buildCacheKey(page, itemsPerPage, searchText, filterStr, sortBy, sortOrder);
+      const cached = useLibraryCache.getState().getCached(cacheKey);
+      if (cached) {
+        setAudiobooks(cached.audiobooks);
+        setTotalCount(cached.totalCount);
+        setTotalPages(cached.totalPages);
+        setImportPaths(cached.importPaths);
+        setLoading(false);
+        return;
+      }
+
       const [page_, folders] = await Promise.all([
         searchText
           ? api.searchBooksPage(searchText, itemsPerPage, offset, filters.showFailed)
@@ -678,16 +692,26 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       }
 
       const total = serverCount ?? convertedBooks.length;
-      setAudiobooks(convertedBooks);
-      setTotalCount(total);
-      setTotalPages(Math.max(1, Math.ceil(total / itemsPerPage)));
-
-      setImportPaths(folders.map((folder) => ({
+      const totalPages = Math.max(1, Math.ceil(total / itemsPerPage));
+      const importPathsData = folders.map((folder) => ({
         id: folder.id,
         path: folder.path,
         status: 'idle' as const,
         book_count: folder.book_count,
-      })));
+      }));
+
+      // Cache the results
+      useLibraryCache.getState().setCached(cacheKey, {
+        audiobooks: convertedBooks,
+        totalCount: total,
+        totalPages,
+        importPaths: importPathsData,
+      });
+
+      setAudiobooks(convertedBooks);
+      setTotalCount(total);
+      setTotalPages(totalPages);
+      setImportPaths(importPathsData);
     } catch (error) {
       if (error instanceof api.ApiError && error.status === 401) {
         navigate('/login');

--- a/web/src/stores/useLibraryCache.ts
+++ b/web/src/stores/useLibraryCache.ts
@@ -1,0 +1,64 @@
+// file: web/src/stores/useLibraryCache.ts
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+import { create } from 'zustand';
+import type { Audiobook } from '../types';
+import type { ImportPath } from '../pages/libraryTypes';
+
+interface LibraryCacheEntry {
+  audiobooks: Audiobook[];
+  totalCount: number;
+  totalPages: number;
+  importPaths: ImportPath[];
+  timestamp: number;
+}
+
+interface LibraryStore {
+  cache: Map<string, LibraryCacheEntry>;
+  getCached: (key: string, maxAgeMs?: number) => LibraryCacheEntry | null;
+  setCached: (key: string, entry: Omit<LibraryCacheEntry, 'timestamp'>) => void;
+  clear: () => void;
+}
+
+const CACHE_TTL_MS = 1 * 60 * 1000; // 1 minute cache
+
+export const useLibraryCache = create<LibraryStore>((set, get) => ({
+  cache: new Map(),
+
+  getCached: (key: string, maxAgeMs = CACHE_TTL_MS) => {
+    const entry = get().cache.get(key);
+    if (!entry) return null;
+
+    const age = Date.now() - entry.timestamp;
+    if (age > maxAgeMs) {
+      get().cache.delete(key);
+      return null;
+    }
+
+    return entry;
+  },
+
+  setCached: (key: string, entry) => {
+    set((state) => {
+      const newCache = new Map(state.cache);
+      newCache.set(key, { ...entry, timestamp: Date.now() });
+      return { cache: newCache };
+    });
+  },
+
+  clear: () => {
+    set({ cache: new Map() });
+  },
+}));
+
+export const buildCacheKey = (
+  page: number,
+  itemsPerPage: number,
+  searchQuery: string,
+  filters: string,
+  sortBy: string,
+  sortOrder: string
+): string => {
+  return `${page}:${itemsPerPage}:${searchQuery}:${filters}:${sortBy}:${sortOrder}`;
+};


### PR DESCRIPTION
## Summary

Implements a Zustand-based cache store to eliminate re-fetching when navigating back to the library or repeating the same search/filter.

- Cache key built from all filter parameters (page, itemsPerPage, searchQuery, filters, sortBy, sortOrder)
- 1-minute TTL ensures freshness while preventing redundant API calls
- Instant restore of audiobooks list, pagination, and import paths on cached hits
- Graceful stale cache expiration after TTL

Directly addresses library page performance: subsequent loads or back navigation now serve from cache instead of re-fetching.