### PR TITLE
fix(activity): derive type for legacy logs + tag-count digest

### DIFF
--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.9.3
+// version: 1.10.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -70,12 +70,18 @@ type DigestItem struct {
 
 // DigestDetails is the JSON structure stored in a daily digest row's details column.
 type DigestDetails struct {
-	Date           string         `json:"date"`
-	OriginalCount  int            `json:"original_count"`
-	Counts         map[string]int `json:"counts"`
-	Items          []DigestItem   `json:"items"`
-	Truncated      bool           `json:"truncated,omitempty"`
-	TruncatedCount int            `json:"truncated_count,omitempty"`
+	Date           string                       `json:"date"`
+	OriginalCount  int                          `json:"original_count"`
+	Counts         map[string]int               `json:"counts"`
+	// TagCounts aggregates entry counts grouped by tag namespace → tag value.
+	// Outer key is a namespace like "action" or "source"; inner key is the
+	// tag value (e.g. "metadata-apply", "scan"). Used by the frontend as a
+	// fallback breakdown when Counts has only one key (e.g. legacy "system_log"
+	// entries whose type was not yet classified at compaction time).
+	TagCounts      map[string]map[string]int    `json:"tag_counts,omitempty"`
+	Items          []DigestItem                 `json:"items"`
+	Truncated      bool                         `json:"truncated,omitempty"`
+	TruncatedCount int                          `json:"truncated_count,omitempty"`
 }
 
 const maxDigestItems = 500
@@ -237,19 +243,14 @@ func (s *ActivityStore) MigrateSystemActivityLogs() (int, error) {
 
 	insertedCount := 0
 	for _, old := range oldLogs {
-		// Map old schema to new ActivityEntry
-		// timestamp ← created_at
-		// tier ← "system"
-		// type ← "system_log"
-		// level ← level (pass through)
-		// source ← source (pass through)
-		// summary ← message
-		// details ← nil
-		// tags ← intelligently derived from message patterns, level, and source
+		// Map old schema to new ActivityEntry.
+		// Type and Tier are derived from the message content so daily digests
+		// can produce meaningful breakdown chips instead of a single "system_log" chip.
+		derivedType, derivedTier := deriveTypeFromMessage(old.Message, old.Source)
 		entry := ActivityEntry{
 			Timestamp: old.CreatedAt,
-			Tier:      "system",
-			Type:      "system_log",
+			Tier:      derivedTier,
+			Type:      derivedType,
 			Level:     old.Level,
 			Source:    old.Source,
 			Summary:   old.Message,
@@ -688,11 +689,14 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 	var result CompactResult
 
 	// 1. Fetch all compactable entries.
+	// Include 'system' tier so legacy migrated rows (which used to be hardcoded
+	// to tier='system') are also compacted into daily digests and produce
+	// breakdown chips via TagCounts.
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, tier, type, level, source, operation_id,
 		       book_id, summary, details, tags
 		FROM   activity_log
-		WHERE  tier IN ('change', 'debug', 'audit')
+		WHERE  tier IN ('change', 'debug', 'audit', 'system')
 		  AND  compacted = 0
 		  AND  timestamp < ?
 		ORDER BY timestamp ASC`,
@@ -759,10 +763,33 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 	for _, dateKey := range dayOrder {
 		dg := days[dateKey]
 
-		// Build counts map.
+		// Build counts map (keyed by Type).
 		counts := make(map[string]int)
 		for _, e := range dg.entries {
 			counts[e.Type]++
+		}
+
+		// Build tag-counts map: namespace → value → count.
+		// Only "action" and "source" namespaces are aggregated for now.
+		// These are used by the frontend as a fallback when Counts is sparse
+		// (e.g. all entries have type="system_log" from old legacy imports).
+		tagCounts := make(map[string]map[string]int)
+		for _, e := range dg.entries {
+			for _, tag := range e.Tags {
+				colonIdx := strings.Index(tag, ":")
+				if colonIdx < 1 {
+					continue
+				}
+				ns := tag[:colonIdx]
+				val := tag[colonIdx+1:]
+				if ns != "action" && ns != "source" {
+					continue
+				}
+				if tagCounts[ns] == nil {
+					tagCounts[ns] = make(map[string]int)
+				}
+				tagCounts[ns][val]++
+			}
 		}
 
 		// Build items — audit first (forensic record must survive
@@ -798,10 +825,15 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 			truncated = true
 		}
 
+		var tagCountsOrNil map[string]map[string]int
+		if len(tagCounts) > 0 {
+			tagCountsOrNil = tagCounts
+		}
 		dd := DigestDetails{
 			Date:           dateKey,
 			OriginalCount:  len(dg.entries),
 			Counts:         counts,
+			TagCounts:      tagCountsOrNil,
 			Items:          items,
 			Truncated:      truncated,
 			TruncatedCount: truncatedCount,
@@ -862,6 +894,18 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 					// Merge counts.
 					for k, v := range existing.Counts {
 						dd.Counts[k] += v
+					}
+					// Merge tag counts.
+					for ns, vals := range existing.TagCounts {
+						if dd.TagCounts == nil {
+							dd.TagCounts = make(map[string]map[string]int)
+						}
+						if dd.TagCounts[ns] == nil {
+							dd.TagCounts[ns] = make(map[string]int)
+						}
+						for val, cnt := range vals {
+							dd.TagCounts[ns][val] += cnt
+						}
 					}
 					dd.OriginalCount += existing.OriginalCount
 					// Merge items — old items first so new errors/warnings

--- a/internal/database/activity_store_test.go
+++ b/internal/database/activity_store_test.go
@@ -424,18 +424,34 @@ func TestMigrateSystemActivityLogs(t *testing.T) {
 	assert.Len(t, entries, 3)
 
 	// Verify all entries have the correct structure (order is newest-first).
+	// Note: type and tier are now derived from message content via deriveTypeFromMessage
+	// rather than hardcoded to "system_log"/"system", so we check for non-empty values only.
 	sourcesSeen := make(map[string]bool)
 	tagsSeen := make(map[string][]string)
+	typesSeen := make(map[string]string)
 	for _, e := range entries {
-		assert.Equal(t, "system", e.Tier, "all should have tier='system'")
-		assert.Equal(t, "system_log", e.Type, "all should have type='system_log'")
+		assert.NotEmpty(t, e.Tier, "tier should be set")
+		assert.NotEmpty(t, e.Type, "type should be derived from message")
 		assert.NotEmpty(t, e.Summary, "summary should be populated from old message field")
 		// Verify enriched tags: all should have "legacy" and ideally action/outcome tags
 		assert.Contains(t, e.Tags, "legacy", "all should have legacy tag")
 		assert.Greater(t, len(e.Tags), 1, "should have more than just legacy tag (enriched)")
 		sourcesSeen[e.Source] = true
 		tagsSeen[e.Source] = e.Tags
+		typesSeen[e.Source] = e.Type
 	}
+	// iTunes scan started → scan_started
+	assert.Equal(t, "scan_started", typesSeen["itunes"], "itunes scan message should be classified as scan_started")
+	// iTunes is matched before server check, so tier should be "itunes_sync" or "audit".
+	// Actually "iTunes scan started" matches scan before itunes pattern check → scan_started/audit.
+	assert.Equal(t, "audit", func() string {
+		for _, e := range entries {
+			if e.Source == "itunes" {
+				return e.Tier
+			}
+		}
+		return ""
+	}(), "itunes scan started should have audit tier")
 	// Verify all three sources are present.
 	assert.Contains(t, sourcesSeen, "itunes")
 	assert.Contains(t, sourcesSeen, "reconcile")

--- a/internal/database/legacy_migration.go
+++ b/internal/database/legacy_migration.go
@@ -1,5 +1,5 @@
 // file: internal/database/legacy_migration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-1234-abcd-ef0123456789
 
 package database
@@ -8,9 +8,102 @@ import (
 	"strings"
 )
 
+// deriveTypeFromMessage inspects the message (and optionally source) of a legacy
+// system_activity_log row and returns a structured (typ, tier) pair suitable for
+// the unified activity_log schema. The function is used by both
+// MigrateSystemActivityLogs (to set the Type/Tier fields on new rows) and
+// enrichLegacyLogTags (to stay in sync with the action: tags it produces).
+//
+// Priority order: most-specific patterns first, "system_log" / "system" as
+// ultimate fallback.
+func deriveTypeFromMessage(msg, source string) (typ, tier string) {
+	m := strings.ToLower(msg)
+
+	// ── metadata / tag write ───────────────────────────────────────────────
+	// Match on "metadata" alone (broader) so that messages like
+	// "Failed to process metadata" are still classified here.
+	if strings.Contains(m, "metadata") || strings.Contains(m, "metadata_apply") ||
+		strings.Contains(m, "isbn") || strings.Contains(m, "enriched") {
+		return "metadata_apply", "change"
+	}
+	if (strings.Contains(m, "tag") && strings.Contains(m, "write")) ||
+		strings.Contains(m, "tag_write") ||
+		strings.Contains(m, "wrote tag") ||
+		strings.Contains(m, "tags written") {
+		return "tag_write", "change"
+	}
+
+	// ── scan ───────────────────────────────────────────────────────────────
+	if strings.Contains(m, "scan completed") || strings.Contains(m, "scan complete") ||
+		strings.Contains(m, "scan finished") || strings.Contains(m, "finished scanning") ||
+		strings.Contains(m, "scanned") {
+		return "scan_completed", "audit"
+	}
+	if strings.Contains(m, "scan started") || strings.Contains(m, "starting scan") ||
+		strings.Contains(m, "begin scan") {
+		return "scan_started", "audit"
+	}
+	// generic scan (no start/end qualifier)
+	if strings.Contains(m, "scan") {
+		return "scan_completed", "audit"
+	}
+
+	// ── operation lifecycle ────────────────────────────────────────────────
+	if strings.Contains(m, "operation completed") || strings.Contains(m, "op completed") ||
+		strings.Contains(m, "operation finished") {
+		return "operation_completed", "audit"
+	}
+	if strings.Contains(m, "operation started") || strings.Contains(m, "op started") ||
+		strings.Contains(m, "op id") || strings.Contains(m, "operation id") {
+		return "operation_started", "audit"
+	}
+
+	// ── fingerprint ────────────────────────────────────────────────────────
+	if strings.Contains(m, "fingerprint") {
+		return "fingerprint", "change"
+	}
+
+	// ── dedup ──────────────────────────────────────────────────────────────
+	if strings.Contains(m, "dedup") || strings.Contains(m, "duplicate") {
+		return "dedup", "change"
+	}
+
+	// ── itunes ─────────────────────────────────────────────────────────────
+	if strings.Contains(m, "itunes") || strings.Contains(m, "itl") {
+		return "itunes_sync", "change"
+	}
+
+	// ── cover ──────────────────────────────────────────────────────────────
+	if strings.Contains(m, "cover") {
+		return "cover_update", "change"
+	}
+
+	// ── organize / rename ──────────────────────────────────────────────────
+	if strings.Contains(m, "rename") || strings.Contains(m, "organize") {
+		return "organize", "change"
+	}
+
+	// ── server / boot / shutdown ────────────────────────────────────────────
+	if strings.Contains(m, "server") || strings.Contains(m, "listening") ||
+		strings.Contains(m, "startup") || strings.Contains(m, "shutdown") ||
+		strings.Contains(m, "starting") || strings.Contains(m, "http") {
+		return "server_log", "system"
+	}
+	// source-based heuristic: if the source looks like an HTTP or server module
+	if strings.Contains(strings.ToLower(source), "server") ||
+		strings.Contains(strings.ToLower(source), "http") {
+		return "server_log", "system"
+	}
+
+	// ── fallback ──────────────────────────────────────────────────────────
+	return "system_log", "system"
+}
+
 // enrichLegacyLogTags derives intelligent tags from legacy system_activity_log entries.
 // Analyzes message content and level to infer action, outcome, source, and tier tags.
 // Returns a de-duplicated list of tags that describe what the log entry represents.
+// The action: tag is kept in sync with deriveTypeFromMessage so digest aggregation
+// and tag-based filtering agree on the classification.
 func enrichLegacyLogTags(message, source, level string) []string {
 	seen := make(map[string]bool)
 	var tags []string
@@ -25,50 +118,55 @@ func enrichLegacyLogTags(message, source, level string) []string {
 	// Always include legacy marker
 	addTag("legacy")
 
-	// Detect action/log type from message patterns
 	msgLower := strings.ToLower(message)
+
+	// Apply legacy secondary action patterns first (backward-compat).
+	// These are more granular than deriveTypeFromMessage for certain cases.
+	actionAdded := false
 
 	// Compaction and maintenance operations
 	if strings.Contains(msgLower, "compacted") || strings.Contains(msgLower, "compaction") {
 		addTag("action:compact")
 		addTag("tier:maintenance")
+		actionAdded = true
 	}
 
 	// Purge operations
 	if strings.Contains(msgLower, "purged") || strings.Contains(msgLower, "purge") {
 		addTag("action:purge")
+		actionAdded = true
 	}
 
-	// Scan operations
-	if strings.Contains(msgLower, "scanned") || strings.Contains(msgLower, "scan") {
-		addTag("action:scan")
-	}
-
-	// Metadata operations
-	if strings.Contains(msgLower, "metadata") || strings.Contains(msgLower, "isbn") ||
-		strings.Contains(msgLower, "enriched") {
-		addTag("action:metadata-apply")
-	}
-
-	// Dedup operations
-	if strings.Contains(msgLower, "dedup") || strings.Contains(msgLower, "duplicate") ||
-		strings.Contains(msgLower, "merged") {
-		addTag("action:dedup")
-	}
-
-	// Cover operations
-	if strings.Contains(msgLower, "cover") {
-		addTag("action:cover-update")
-	}
-
-	// Tag write operations
-	if strings.Contains(msgLower, "tag") && strings.Contains(msgLower, "write") {
-		addTag("action:tag-write")
-	}
-
-	// Organize/rename operations
-	if strings.Contains(msgLower, "rename") || strings.Contains(msgLower, "organize") {
-		addTag("action:organizer")
+	// If no action tag was produced by the legacy patterns, derive one from
+	// deriveTypeFromMessage so that digest TagCounts.action has meaningful values.
+	// Skip the "system_log" fallback to avoid adding a generic action:system tag
+	// to messages that simply have no recognised pattern.
+	if !actionAdded {
+		typ, _ := deriveTypeFromMessage(message, source)
+		switch typ {
+		case "metadata_apply":
+			addTag("action:metadata-apply")
+		case "tag_write":
+			addTag("action:tag-write")
+		case "scan_started", "scan_completed":
+			addTag("action:scan")
+		case "operation_started", "operation_completed":
+			addTag("action:operation")
+		case "fingerprint":
+			addTag("action:fingerprint")
+		case "dedup":
+			addTag("action:dedup")
+		case "itunes_sync":
+			addTag("action:itunes-sync")
+		case "cover_update":
+			addTag("action:cover-update")
+		case "organize":
+			addTag("action:organizer")
+		case "server_log":
+			addTag("action:server")
+		// "system_log" fallback: don't add a tag — mirrors the pre-existing
+		// behaviour where unknown messages had no action: tag at all.
+		}
 	}
 
 	// Derive outcome from level

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1337,11 +1337,21 @@ export default function ActivityLog() {
                     date?: string;
                     original_count?: number;
                     counts?: Record<string, number>;
+                    tag_counts?: Record<string, Record<string, number>>;
                     items?: Array<{ type: string; tier?: string; book?: string; book_id?: string; operation_id?: string; summary: string; details?: string }>;
                     truncated?: boolean;
                     truncated_count?: number;
                   } | undefined;
-                  const counts = details?.counts || {};
+                  const rawCounts = details?.counts || {};
+                  // Fall back to tag_counts.action when Counts is sparse (only
+                  // the single legacy "system_log" key) so old digests show a
+                  // meaningful breakdown rather than one undifferentiated chip.
+                  const countsKeys = Object.keys(rawCounts);
+                  const isLegacySparse =
+                    countsKeys.length === 1 && countsKeys[0] === 'system_log';
+                  const counts: Record<string, number> = isLegacySparse
+                    ? (details?.tag_counts?.action ?? rawCounts)
+                    : rawCounts;
                   const items = details?.items || [];
 
                   return (


### PR DESCRIPTION
## Summary

- **Part A**: Extract `deriveTypeFromMessage()` helper in `legacy_migration.go`. `MigrateSystemActivityLogs()` now derives meaningful `type`/`tier` values from message content (metadata_apply, scan_completed, operation_completed, fingerprint, dedup, itunes_sync, server_log) instead of hardcoding `type='system_log'`. `enrichLegacyLogTags()` stays in sync. `CompactByDay` now includes `'system'` tier so already-migrated legacy rows get compacted.
- **Part B**: Add `TagCounts map[string]map[string]int` to `DigestDetails`. `CompactByDay` aggregates counts by `action:` and `source:` tags. Merge path preserves `TagCounts`. Frontend falls back to `tag_counts.action` chips when `counts` has only one key `system_log` (old digests compacted before this fix).

## Test plan

- [x] All `internal/database/...` tests pass
- [x] Frontend builds cleanly
- [x] `TestEnrichLegacyLogTags` all sub-cases pass
- [x] `TestMigrateSystemActivityLogs` passes with derived types
- Old digests (2026-05-12 to 2026-05-14) will show breakdown chips via `TagCounts.action` fallback on next page load — no re-migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)