### PR TITLE
feat(activity): chip colors, click-filter, per-item timestamps+tags

### DIFF
--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_compact_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package database
@@ -341,4 +341,58 @@ func TestCompactByDay_MergesIntoExistingDigest(t *testing.T) {
 	assert.Equal(t, 3, dd.Counts["metadata_applied"], "old counts preserved")
 	assert.Equal(t, 5, dd.Counts["tag_written"], "new counts added")
 	assert.Len(t, dd.Items, 8, "all 8 items present")
+}
+
+// TestCompactByDay_DigestItemTimestampAndTags verifies that each DigestItem
+// carries the source row's timestamp (non-zero) and any tags from that row.
+// This regression test covers the 2026-05-20 addition of these fields.
+func TestCompactByDay_DigestItemTimestampAndTags(t *testing.T) {
+	s := newTestActivityStore(t)
+
+	base := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	olderThan := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	// Insert 3 entries with explicit timestamps and tags, 1 minute apart.
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "change",
+			Type:      "metadata_applied",
+			Level:     "info",
+			Source:    "pipeline",
+			Summary:   "applied metadata",
+			Timestamp: base.Add(time.Duration(i) * time.Minute),
+			Tags:      []string{"action:metadata-apply", "outcome:ok", "source:pipeline"},
+		})
+		require.NoError(t, err)
+	}
+
+	result, err := s.CompactByDay(context.Background(), olderThan)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.DaysCompacted)
+	assert.Equal(t, 3, result.EntriesDeleted)
+
+	all, _, err := s.Query(ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+
+	detailsJSON, err := json.Marshal(all[0].Details)
+	require.NoError(t, err)
+	var dd DigestDetails
+	require.NoError(t, json.Unmarshal(detailsJSON, &dd))
+	require.Len(t, dd.Items, 3)
+
+	// Items are sorted audit→error→normal; all 3 here are normal.
+	// Verify timestamps are ascending (as inserted) and non-zero.
+	for i, item := range dd.Items {
+		assert.False(t, item.Timestamp.IsZero(), "item %d: Timestamp must be non-zero", i)
+		assert.NotEmpty(t, item.Tags, "item %d: Tags must be populated", i)
+		assert.Contains(t, item.Tags, "action:metadata-apply", "item %d: action tag preserved", i)
+		assert.Contains(t, item.Tags, "outcome:ok", "item %d: outcome tag preserved", i)
+	}
+
+	// Items should be in ascending timestamp order (all are "normal" tier).
+	for i := 1; i < len(dd.Items); i++ {
+		assert.True(t, !dd.Items[i].Timestamp.Before(dd.Items[i-1].Timestamp),
+			"items should be in non-decreasing timestamp order")
+	}
 }

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -59,13 +59,19 @@ type CompactResult struct {
 
 // DigestItem represents a single compacted entry within a daily digest.
 type DigestItem struct {
-	Type        string `json:"type"`
-	Tier        string `json:"tier,omitempty"`
-	Book        string `json:"book,omitempty"`
-	BookID      string `json:"book_id,omitempty"`
-	OperationID string `json:"operation_id,omitempty"`
-	Summary     string `json:"summary"`
-	Details     string `json:"details,omitempty"`
+	Type        string    `json:"type"`
+	Tier        string    `json:"tier,omitempty"`
+	Book        string    `json:"book,omitempty"`
+	BookID      string    `json:"book_id,omitempty"`
+	OperationID string    `json:"operation_id,omitempty"`
+	Summary     string    `json:"summary"`
+	Details     string    `json:"details,omitempty"`
+	// Timestamp is the original event time. Zero for digests compacted before
+	// 2026-05-20 (when this field was added); omitempty hides it from old JSON.
+	Timestamp   time.Time `json:"timestamp,omitempty"`
+	// Tags carries the enriched tag set from the source row.
+	// Empty for digests compacted before 2026-05-20.
+	Tags        []string  `json:"tags,omitempty"`
 }
 
 // DigestDetails is the JSON structure stored in a daily digest row's details column.
@@ -803,6 +809,8 @@ func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (
 				BookID:      e.BookID,
 				OperationID: e.OperationID,
 				Summary:     extractItemSummary(e),
+				Timestamp:   e.Timestamp,
+				Tags:        e.Tags,
 			}
 			switch {
 			case e.Tier == "audit":

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.14.0
+// version: 2.15.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -47,6 +47,7 @@ import { PendingFileOpsBanner } from '../components/PendingFileOpsBanner';
 import { usePendingFileOps } from '../hooks/usePendingFileOps';
 import { useOperationsStore } from '../stores/useOperationsStore';
 import { STORAGE_KEYS } from '../lib/storageKeys';
+import { tagChipProps } from '../utils/activityTagColors';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 250];
 
@@ -112,6 +113,14 @@ const formatTimestampCompact = (ts: string): string => {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 };
 
+/** Format an ISO timestamp string as HH:MM:SS time-of-day, or '' if missing/zero. */
+const formatItemTime = (ts?: string): string => {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (isNaN(d.getTime()) || d.getFullYear() < 2000) return '';
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+};
+
 export default function ActivityLog() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -132,6 +141,13 @@ export default function ActivityLog() {
   });
   const [hideNoOp, setHideNoOp] = useState(true);
   const [tagFilter, setTagFilter] = useState<string[]>([]);
+
+  /** Toggle a single tag in the tag filter. Adds if absent, removes if present. */
+  const toggleTagFilter = useCallback((tag: string) => {
+    setTagFilter((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  }, []);
 
   // Mobile filter collapse
   const [filtersExpanded, setFiltersExpanded] = useState(false);
@@ -1041,19 +1057,21 @@ export default function ActivityLog() {
                     Outcome
                   </Typography>
                   <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                    {['outcome:ok', 'outcome:warn', 'outcome:error', 'outcome:skip'].map((tag) => (
-                      <Chip
-                        key={tag}
-                        label={tag.split(':')[1]}
-                        size="small"
-                        variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
-                        onClick={() => {
-                          setTagFilter((prev) =>
-                            prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-                          );
-                        }}
-                      />
-                    ))}
+                    {['outcome:ok', 'outcome:warn', 'outcome:error', 'outcome:skip'].map((tag) => {
+                      const { color, sx, label } = tagChipProps(tag);
+                      return (
+                        <Chip
+                          key={tag}
+                          label={label}
+                          size="small"
+                          color={color}
+                          sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                          variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
+                          clickable
+                          onClick={() => toggleTagFilter(tag)}
+                        />
+                      );
+                    })}
                   </Stack>
                 </Box>
 
@@ -1062,19 +1080,21 @@ export default function ActivityLog() {
                     Action
                   </Typography>
                   <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                    {['action:metadata-apply', 'action:tag-write', 'action:import', 'action:scan', 'action:dedup', 'action:organizer', 'action:purge'].map((tag) => (
-                      <Chip
-                        key={tag}
-                        label={tag.split(':')[1]}
-                        size="small"
-                        variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
-                        onClick={() => {
-                          setTagFilter((prev) =>
-                            prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-                          );
-                        }}
-                      />
-                    ))}
+                    {['action:metadata-apply', 'action:tag-write', 'action:import', 'action:scan', 'action:dedup', 'action:organizer', 'action:purge'].map((tag) => {
+                      const { color, sx, label } = tagChipProps(tag);
+                      return (
+                        <Chip
+                          key={tag}
+                          label={label}
+                          size="small"
+                          color={color}
+                          sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                          variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
+                          clickable
+                          onClick={() => toggleTagFilter(tag)}
+                        />
+                      );
+                    })}
                   </Stack>
                 </Box>
 
@@ -1338,10 +1358,29 @@ export default function ActivityLog() {
                     original_count?: number;
                     counts?: Record<string, number>;
                     tag_counts?: Record<string, Record<string, number>>;
-                    items?: Array<{ type: string; tier?: string; book?: string; book_id?: string; operation_id?: string; summary: string; details?: string }>;
+                    items?: Array<{
+                      type: string;
+                      tier?: string;
+                      book?: string;
+                      book_id?: string;
+                      operation_id?: string;
+                      summary: string;
+                      details?: string;
+                      timestamp?: string;
+                      tags?: string[];
+                    }>;
                     truncated?: boolean;
                     truncated_count?: number;
                   } | undefined;
+                  // Pre-2026-05-20 digests won't have per-item timestamps or tags
+                  // because the source rows were already destroyed before this
+                  // field was added. Detect by checking the first item's timestamp.
+                  const isLegacyDigest = (() => {
+                    if (!details?.date) return false;
+                    const cutoff = new Date('2026-05-20');
+                    const digestDate = new Date(details.date);
+                    return digestDate < cutoff && !(details?.items?.[0]?.timestamp);
+                  })();
                   const rawCounts = details?.counts || {};
                   // Fall back to tag_counts.action when Counts is sparse (only
                   // the single legacy "system_log" key) so old digests show a
@@ -1394,12 +1433,22 @@ export default function ActivityLog() {
                         <TableRow>
                           <TableCell colSpan={isMobile ? 5 : 7} sx={{ py: 0, px: 2 }}>
                             <Box sx={{ maxHeight: 400, overflow: 'auto', py: 1 }}>
+                              {isLegacyDigest && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ display: 'block', mb: 1, fontStyle: 'italic' }}
+                                >
+                                  Pre-2026-05-20 digest — per-item timestamps and tags unavailable (source rows already compacted away)
+                                </Typography>
+                              )}
                               {items.map((item, idx) => (
                                 <Stack
                                   key={idx}
                                   direction="row"
                                   spacing={1}
                                   alignItems="center"
+                                  flexWrap="wrap"
                                   sx={{
                                     py: 0.5,
                                     borderBottom: '1px solid',
@@ -1407,6 +1456,11 @@ export default function ActivityLog() {
                                     color: item.type === 'error' ? 'error.main' : 'text.primary',
                                   }}
                                 >
+                                  {item.timestamp && (
+                                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', minWidth: 70 }}>
+                                      {formatItemTime(item.timestamp)}
+                                    </Typography>
+                                  )}
                                   <Chip size="small" label={item.type.replace(/_/g, ' ')} sx={{ minWidth: 100 }} />
                                   {item.tier === 'audit' && (
                                     <Chip size="small" label="audit" sx={{ bgcolor: '#7c4dff', color: 'white', fontSize: '0.65rem' }} />
@@ -1429,14 +1483,46 @@ export default function ActivityLog() {
                                     {item.summary}
                                   </Typography>
                                   {item.operation_id && (
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', fontSize: '0.65rem' }}>
-                                      {item.operation_id}
-                                    </Typography>
+                                    <Chip
+                                      size="small"
+                                      label={item.operation_id.slice(0, 12)}
+                                      title={`op:${item.operation_id} — click to filter`}
+                                      color="info"
+                                      variant="outlined"
+                                      sx={{ cursor: 'pointer', fontFamily: 'monospace', fontSize: '0.65rem' }}
+                                      clickable
+                                      onClick={(e: React.MouseEvent) => {
+                                        e.stopPropagation();
+                                        toggleTagFilter(`op:${item.operation_id}`);
+                                      }}
+                                    />
                                   )}
                                   {item.details && (
                                     <Typography variant="caption" color="error.main">
                                       {item.details}
                                     </Typography>
+                                  )}
+                                  {item.tags && item.tags.length > 0 && (
+                                    <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                                      {item.tags.map((tag) => {
+                                        const { color, sx: tagSx, label } = tagChipProps(tag);
+                                        return (
+                                          <Chip
+                                            key={tag}
+                                            size="small"
+                                            label={label}
+                                            color={color}
+                                            sx={{ cursor: 'pointer', fontSize: '0.65rem', ...(tagSx ?? {}) }}
+                                            variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
+                                            clickable
+                                            onClick={(e: React.MouseEvent) => {
+                                              e.stopPropagation();
+                                              toggleTagFilter(tag);
+                                            }}
+                                          />
+                                        );
+                                      })}
+                                    </Stack>
                                   )}
                                 </Stack>
                               ))}
@@ -1504,9 +1590,21 @@ export default function ActivityLog() {
                       <TableCell>
                         {entry.tags && entry.tags.length > 0 ? (
                           <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                            {entry.tags.map((tag) => (
-                              <Chip key={tag} size="small" label={tag} variant="outlined" />
-                            ))}
+                            {entry.tags.map((tag) => {
+                              const { color, sx, label } = tagChipProps(tag);
+                              return (
+                                <Chip
+                                  key={tag}
+                                  size="small"
+                                  label={label}
+                                  color={color}
+                                  sx={{ cursor: 'pointer', ...(sx ?? {}) }}
+                                  variant={tagFilter.includes(tag) ? 'filled' : 'outlined'}
+                                  clickable
+                                  onClick={(e) => { e.stopPropagation(); toggleTagFilter(tag); }}
+                                />
+                              );
+                            })}
                           </Stack>
                         ) : null}
                       </TableCell>

--- a/web/src/utils/__tests__/activityTagColors.test.ts
+++ b/web/src/utils/__tests__/activityTagColors.test.ts
@@ -1,0 +1,70 @@
+// file: web/src/utils/__tests__/activityTagColors.test.ts
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-cdef-1234567890ab
+
+import { describe, it, expect } from 'vitest';
+import { tagChipProps } from '../activityTagColors';
+
+describe('tagChipProps', () => {
+  it('action: prefix → primary color, stripped label', () => {
+    const p = tagChipProps('action:metadata-apply');
+    expect(p.color).toBe('primary');
+    expect(p.label).toBe('metadata-apply');
+  });
+
+  it('source: prefix → secondary color', () => {
+    const p = tagChipProps('source:pipeline');
+    expect(p.color).toBe('secondary');
+    expect(p.label).toBe('pipeline');
+  });
+
+  it('outcome:ok → success', () => {
+    expect(tagChipProps('outcome:ok').color).toBe('success');
+  });
+
+  it('outcome:warn → warning', () => {
+    expect(tagChipProps('outcome:warn').color).toBe('warning');
+  });
+
+  it('outcome:error → error', () => {
+    expect(tagChipProps('outcome:error').color).toBe('error');
+  });
+
+  it('outcome:skip → default', () => {
+    expect(tagChipProps('outcome:skip').color).toBe('default');
+  });
+
+  it('op: prefix → info color', () => {
+    const p = tagChipProps('op:01J123ABC');
+    expect(p.color).toBe('info');
+    expect(p.label).toBe('01J123ABC');
+  });
+
+  it('book: prefix → default color + orange sx', () => {
+    const p = tagChipProps('book:abc123');
+    expect(p.color).toBe('default');
+    expect(p.sx).toBeDefined();
+    expect(p.label).toBe('abc123');
+  });
+
+  it('scope: prefix → default', () => {
+    expect(tagChipProps('scope:book').color).toBe('default');
+    expect(tagChipProps('scope:book').label).toBe('book');
+  });
+
+  it('lifecycle: prefix → default', () => {
+    expect(tagChipProps('lifecycle:startup').color).toBe('default');
+  });
+
+  it('unknown namespace → default, full tag as label', () => {
+    const p = tagChipProps('no-op');
+    expect(p.color).toBe('default');
+    expect(p.label).toBe('no-op');
+  });
+
+  it('unknown namespace with colon → default', () => {
+    const p = tagChipProps('foo:bar');
+    expect(p.color).toBe('default');
+    expect(p.label).toBe('bar');
+  });
+});

--- a/web/src/utils/activityTagColors.ts
+++ b/web/src/utils/activityTagColors.ts
@@ -1,0 +1,78 @@
+// file: web/src/utils/activityTagColors.ts
+// version: 1.0.0
+// guid: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
+
+/**
+ * tagChipProps returns MUI Chip color+sx props for a given activity tag.
+ * Namespace prefixes set the chip color; the label strips the namespace so
+ * "action:metadata-apply" renders as "metadata-apply" in a blue chip.
+ *
+ * Namespaces:
+ *   action:*     → primary (blue)
+ *   source:*     → secondary (purple)
+ *   outcome:ok   → success (green)
+ *   outcome:warn → warning (amber)
+ *   outcome:error→ error (red)
+ *   outcome:skip → default (gray)
+ *   op:*         → info (teal)
+ *   book:*       → orange (custom sx)
+ *   scope:*      → default (gray)
+ *   lifecycle:*  → default (gray)
+ *   anything else→ default (gray)
+ */
+export type ChipColor =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'error'
+  | 'info'
+  | 'success'
+  | 'warning';
+
+export interface TagChipProps {
+  color: ChipColor;
+  sx?: Record<string, unknown>;
+  label: string;
+}
+
+export function tagChipProps(tag: string): TagChipProps {
+  const colonIdx = tag.indexOf(':');
+  const ns = colonIdx > 0 ? tag.slice(0, colonIdx) : '';
+  const val = colonIdx > 0 ? tag.slice(colonIdx + 1) : tag;
+
+  switch (ns) {
+    case 'action':
+      return { color: 'primary', label: val };
+    case 'source':
+      return { color: 'secondary', label: val };
+    case 'outcome':
+      switch (val) {
+        case 'ok':
+          return { color: 'success', label: val };
+        case 'warn':
+          return { color: 'warning', label: val };
+        case 'error':
+          return { color: 'error', label: val };
+        case 'skip':
+          return { color: 'default', label: val };
+        default:
+          return { color: 'default', label: val };
+      }
+    case 'op':
+      return { color: 'info', label: val };
+    case 'book':
+      return {
+        color: 'default',
+        sx: { bgcolor: '#ffb74d', color: '#000' },
+        label: val,
+      };
+    case 'scope':
+    case 'lifecycle':
+      return { color: 'default', label: val };
+    default:
+      // For any other namespace:value tag, strip the namespace so the chip
+      // shows the meaningful value (e.g. "no-op" stays as-is since there's
+      // no colon, but "foo:bar" shows "bar").
+      return { color: 'default', label: ns ? val : tag };
+  }
+}


### PR DESCRIPTION
## Summary

Five UX gaps the user flagged on the digest system, all addressed in one PR:

- **Tag chip colors by namespace:** `tagChipProps()` in `web/src/utils/activityTagColors.ts` is the single source of truth. `action:*` = primary blue, `source:*` = secondary purple, `outcome:ok/warn/error` = semantic colors, `op:*` = info teal, `book:*` = orange, `scope/lifecycle/other` = gray. Applied to filter UI, regular-row tag column, and digest expansion.
- **Click-to-filter on tag chips:** `toggleTagFilter(tag)` + `stopPropagation` on every chip. `clickable` prop and `cursor:pointer` make it visually obvious.
- **Op click-through:** `op:<id>` chips in digest expansion items are clickable and add the op tag to the filter. Regular rows get this for free via enriched `op:` tags already in the tag column.
- **Per-item timestamps:** `DigestItem.Timestamp time.Time` (omitempty) added to backend struct, populated from source row in `CompactByDay()`. Frontend renders as HH:MM:SS alongside each digest sub-item.
- **Per-item tags:** `DigestItem.Tags []string` (omitempty) added, populated from source row tags. Renders as colored clickable chips on each expanded digest item.

Old digests pre-2026-05-20 show an italic hint: "Pre-2026-05-20 digest — per-item timestamps and tags unavailable (source rows already compacted away)". Recompaction endpoint skipped per scope guidance.

## Test plan

- [x] `TestCompactByDay_DigestItemTimestampAndTags` — new backend test verifying non-zero Timestamp and Tags round-trip through compaction
- [x] All existing `TestCompactByDay_*` tests still pass (no regressions)
- [x] 12 frontend unit tests for `tagChipProps` cover all namespaces
- [x] `make build` succeeds (npm install + vite build + go build with embedded frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)