### PR TITLE
fix(memory): clean up untracked setTimeout/setInterval calls

### DIFF
--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.15.0
+// version: 2.15.1
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -249,13 +249,14 @@ export default function ActivityLog() {
     }
     setOpLogsLoaded(false);
     let cancelled = false;
+    let scrollTimeoutId: ReturnType<typeof setTimeout> | null = null;
     const fetchLogs = async () => {
       try {
         const logs = await api.getOperationLogs(expandedOpId);
         if (!cancelled) {
           setOpLogs(logs.map((l: { message?: string }) => l.message || String(l)));
           setOpLogsLoaded(true);
-          setTimeout(() => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }), 50);
+          scrollTimeoutId = setTimeout(() => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }), 50);
         }
       } catch {
         if (!cancelled) {
@@ -270,10 +271,17 @@ export default function ActivityLog() {
     const op = activeOps.find((o) => o.id === expandedOpId);
     const terminal = op && ['completed', 'failed', 'canceled', 'interrupted_dropped', 'interrupted_restart'].includes(op.status);
     if (terminal) {
-      return () => { cancelled = true; };
+      return () => {
+        cancelled = true;
+        if (scrollTimeoutId) clearTimeout(scrollTimeoutId);
+      };
     }
     const interval = setInterval(fetchLogs, 3000);
-    return () => { cancelled = true; clearInterval(interval); };
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      if (scrollTimeoutId) clearTimeout(scrollTimeoutId);
+    };
   }, [expandedOpId, activeOps]);
 
   // Load sources

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -908,7 +908,13 @@ function EmbeddingDedupTab() {
     try {
       const op = await api.triggerDedupAcoustID();
       setScanMsg(trackOp(op, 'AcoustID scan'));
-      setTimeout(() => { loadCandidates(); loadStats(); }, 3000);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        if (!isUnmountedRef.current) {
+          loadCandidates();
+          loadStats();
+        }
+      }, 3000);
     } catch (err) {
       setScanMsg(err instanceof Error ? err.message : 'AcoustID scan failed');
     } finally {
@@ -2191,6 +2197,8 @@ function AcousticDedupTab() {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
   const [showComparePanel, setShowComparePanel] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isUnmountedRef = useRef(false);
 
   const loadCandidates = useCallback(async () => {
     setLoading(true);
@@ -2223,6 +2231,17 @@ function AcousticDedupTab() {
 
   useEffect(() => { loadCandidates(); }, [loadCandidates]);
 
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      isUnmountedRef.current = true;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
+
   const handleFingerprint = async () => {
     setFingerprinting(true);
     setStatusMsg(null);
@@ -2242,7 +2261,12 @@ function AcousticDedupTab() {
     try {
       const op = await api.triggerDedupAcoustID();
       setStatusMsg(`Duplicate scan queued — see bell icon for progress (op ${op.id.slice(-6)})`);
-      setTimeout(() => loadCandidates(), 5000);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        if (!isUnmountedRef.current) {
+          loadCandidates();
+        }
+      }, 5000);
     } catch (err) {
       setStatusMsg(err instanceof Error ? err.message : 'Scan failed to start');
     } finally {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.45.3
+// version: 1.45.4
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
 // last-edited: 2026-05-20
 
@@ -1103,7 +1103,7 @@ export function Settings() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [hasUnsavedChanges]);
 
-  // Cleanup save timeout on unmount
+  // Cleanup save timeout + scan intervals on unmount
   useEffect(() => {
     return () => {
       isUnmountedRef.current = true;
@@ -1111,6 +1111,11 @@ export function Settings() {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
       }
+      // Clear all active scan intervals
+      Object.values(scanIntervalsRef.current).forEach((interval) => {
+        window.clearInterval(interval);
+      });
+      scanIntervalsRef.current = {};
     };
   }, []);
 


### PR DESCRIPTION
Fixes memory leaks where async timers would fire after component unmount:

- **BookDedup.tsx**: Track setTimeout in scan/acoustID handlers, add cleanup useEffect to AcousticDedupTab
- **ActivityLog.tsx**: Track scroll setTimeout in operation logs fetch, clear in cleanup handlers
- **Settings.tsx**: Extend cleanup to clear all scan progress intervals on component unmount

These untracked timeouts would fire code after component unmount, causing silent state update attempts on destroyed components.