### PR TITLE
feat(activity): recompact pre-fix digests with derived tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ## [Unreleased]
 
+### Features
+
+#### May 20, 2026 — Recompact old digests with derived types and tags
+
+- Added `ActivityStore.RecompactDigests(ctx)` — walks every stored daily-digest row, re-derives `type`/`tier`/`tags` on items that were compacted before 2026-05-20 (when those fields were added), and rebuilds `Counts` + `TagCounts`. Idempotent: items already with non-system type and non-empty tags are skipped.
+- Added `NutsActivityStore.RecompactDigests` no-op stub and `InstrumentedActivityStorer.RecompactDigests` traced wrapper to satisfy the `ActivityStorer` interface.
+- Added `POST /api/v1/admin/recompact-digests` endpoint (admin-only) returning `{ touched, skipped }`.
+- Tests: `TestActivityStore_RecompactDigests` and `TestActivityStore_RecompactDigests_AlreadyProcessed` verify re-derivation and idempotency.
+
 ### Fixes
 
 #### May 20, 2026 — iTunes backfill streaming parser (PR #1061)

--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -1,5 +1,5 @@
 // file: internal/activity/service.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package activity
@@ -58,6 +58,13 @@ func (s *Service) CompactByDay(ctx context.Context, olderThan time.Time) (databa
 // narrowed by the given filter's tier/level/since/until/search fields.
 func (s *Service) GetDistinctSources(filter database.ActivityFilter) ([]database.SourceCount, error) {
 	return s.store.GetDistinctSources(filter)
+}
+
+// RecompactDigests re-derives type, tier, and tags on all stored daily-digest
+// entries that were compacted before tag enrichment was added (2026-05-20).
+// Returns the count of digests touched and skipped.
+func (s *Service) RecompactDigests(ctx context.Context) (database.RecompactResult, error) {
+	return s.store.RecompactDigests(ctx)
 }
 
 // Store returns the underlying ActivityStorer (e.g. for close or direct access).

--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -1077,4 +1077,162 @@ func detailNumber(details map[string]any, key string) int {
 	default:
 		return 0
 	}
+}
+
+// RecompactResult holds the outcome of a RecompactDigests operation.
+type RecompactResult struct {
+	Touched int `json:"touched"`
+	Skipped int `json:"skipped"`
+}
+
+// RecompactDigests re-derives type, tier, and tags on every stored daily-digest
+// entry whose items were compacted before 2026-05-20 (when CompactByDay started
+// preserving proper types/tags). For each digest row (tier='digest'):
+//
+//  1. Items that already have a non-system type AND non-empty tags are skipped
+//     (already processed — idempotent guard).
+//  2. For each remaining item: call deriveTypeFromMessage(summary, source) to
+//     get a proper type/tier, and enrichLegacyLogTags to get tags.
+//  3. Rebuild Counts and TagCounts from the updated items.
+//  4. Save the updated digest back in-place (UPDATE details + summary).
+//
+// Returns the number of digest rows touched and skipped.
+func (s *ActivityStore) RecompactDigests(ctx context.Context) (RecompactResult, error) {
+	var result RecompactResult
+
+	// 1. Fetch all digest rows.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, details FROM activity_log
+		WHERE tier = 'digest' AND type = 'daily_digest'
+		ORDER BY timestamp ASC`)
+	if err != nil {
+		return result, fmt.Errorf("activity_store: recompact query digests: %w", err)
+	}
+
+	type digestRow struct {
+		id      int64
+		details string
+	}
+	var digestRows []digestRow
+	for rows.Next() {
+		var dr digestRow
+		var detailsRaw sql.NullString
+		if err := rows.Scan(&dr.id, &detailsRaw); err != nil {
+			rows.Close()
+			return result, fmt.Errorf("activity_store: recompact scan digest: %w", err)
+		}
+		if detailsRaw.Valid {
+			dr.details = detailsRaw.String
+		}
+		digestRows = append(digestRows, dr)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return result, fmt.Errorf("activity_store: recompact rows: %w", err)
+	}
+
+	slog.Info("[activity] recompact: starting digest re-derivation",
+		"digest_count", len(digestRows))
+
+	// 2. Process each digest.
+	for _, dr := range digestRows {
+		if dr.details == "" {
+			result.Skipped++
+			continue
+		}
+
+		var dd DigestDetails
+		if err := json.Unmarshal([]byte(dr.details), &dd); err != nil {
+			slog.Warn("[activity] recompact: failed to parse digest details, skipping",
+				"id", dr.id, "err", err)
+			result.Skipped++
+			continue
+		}
+
+		// Check if any items need updating.
+		needsUpdate := false
+		for _, item := range dd.Items {
+			if isLegacyItem(item) {
+				needsUpdate = true
+				break
+			}
+		}
+		if !needsUpdate {
+			result.Skipped++
+			continue
+		}
+
+		// Re-derive type, tier, and tags on each legacy item.
+		for i, item := range dd.Items {
+			if !isLegacyItem(item) {
+				continue
+			}
+			// Source isn't stored on DigestItem directly; use empty string as fallback.
+			derivedType, derivedTier := deriveTypeFromMessage(item.Summary, "")
+			derivedTags := enrichLegacyLogTags(item.Summary, "", "info")
+			dd.Items[i].Type = derivedType
+			dd.Items[i].Tier = derivedTier
+			dd.Items[i].Tags = derivedTags
+		}
+
+		// Rebuild Counts from updated items.
+		newCounts := make(map[string]int)
+		for _, item := range dd.Items {
+			newCounts[item.Type]++
+		}
+		dd.Counts = newCounts
+
+		// Rebuild TagCounts from updated items.
+		newTagCounts := make(map[string]map[string]int)
+		for _, item := range dd.Items {
+			for _, tag := range item.Tags {
+				colonIdx := strings.Index(tag, ":")
+				if colonIdx < 1 {
+					continue
+				}
+				ns := tag[:colonIdx]
+				val := tag[colonIdx+1:]
+				if ns != "action" && ns != "source" {
+					continue
+				}
+				if newTagCounts[ns] == nil {
+					newTagCounts[ns] = make(map[string]int)
+				}
+				newTagCounts[ns][val]++
+			}
+		}
+		if len(newTagCounts) > 0 {
+			dd.TagCounts = newTagCounts
+		}
+
+		// Re-marshal and save.
+		updatedBytes, err := json.Marshal(dd)
+		if err != nil {
+			return result, fmt.Errorf("activity_store: recompact marshal digest id=%d: %w", dr.id, err)
+		}
+
+		newSummary := fmt.Sprintf("Daily digest for %s (%d entries)", dd.Date, dd.OriginalCount)
+		_, err = s.db.ExecContext(ctx, `
+			UPDATE activity_log SET details = ?, summary = ? WHERE id = ?`,
+			string(updatedBytes), newSummary, dr.id,
+		)
+		if err != nil {
+			return result, fmt.Errorf("activity_store: recompact update digest id=%d: %w", dr.id, err)
+		}
+
+		slog.Info("[activity] recompact: updated digest",
+			"id", dr.id, "date", dd.Date, "items", len(dd.Items))
+		result.Touched++
+	}
+
+	slog.Info("[activity] recompact: complete",
+		"touched", result.Touched, "skipped", result.Skipped)
+	return result, nil
+}
+
+// isLegacyItem returns true if a DigestItem needs re-derivation.
+// An item needs update if its type is the generic "system_log" or "system" fallback
+// OR if it has no tags (i.e. was compacted before tag enrichment was added).
+func isLegacyItem(item DigestItem) bool {
+	return (item.Type == "system_log" || item.Type == "system") || len(item.Tags) == 0
 }

--- a/internal/database/activity_store_instrumented.go
+++ b/internal/database/activity_store_instrumented.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store_instrumented.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: b2c3d4e5-f6a7-0002-bcde-000000000002
 
 package database
@@ -171,6 +171,23 @@ func (i *InstrumentedActivityStorer) MigrateSystemActivityLogs() (int, error) {
 	}
 	span.SetAttributes(attribute.Int("entries_migrated", count))
 	return count, nil
+}
+
+// RecompactDigests traces the RecompactDigests operation.
+func (i *InstrumentedActivityStorer) RecompactDigests(ctx context.Context) (RecompactResult, error) {
+	_, span := tracer.Start(ctx, "activity_store.recompact_digests")
+	defer span.End()
+
+	result, err := i.store.RecompactDigests(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetAttributes(attribute.Bool("error", true))
+		return RecompactResult{}, err
+	}
+	span.SetAttributes(
+		attribute.Int("touched", result.Touched),
+		attribute.Int("skipped", result.Skipped))
+	return result, nil
 }
 
 // Close traces the Close operation.

--- a/internal/database/activity_store_test.go
+++ b/internal/database/activity_store_test.go
@@ -1,11 +1,12 @@
 // file: internal/database/activity_store_test.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: f3a1b2c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 
 package database
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -486,4 +487,110 @@ func TestMigrateSystemActivityLogs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, total2, "still exactly 3 legacy entries")
 	assert.Len(t, entries2, 3)
+}
+
+// TestActivityStore_RecompactDigests verifies that legacy digest items (type=system_log,
+// empty tags) are re-derived on the first call, and subsequent calls return 0 touched.
+func TestActivityStore_RecompactDigests(t *testing.T) {
+	s := newTestActivityStore(t)
+	ctx := context.Background()
+
+	// Build a legacy-style DigestDetails with items that have system_log type and no tags.
+	legacyDigest := DigestDetails{
+		Date:          "2026-05-12",
+		OriginalCount: 3,
+		Counts:        map[string]int{"system_log": 3},
+		Items: []DigestItem{
+			{Type: "system_log", Summary: "Scan completed: 100 files scanned"},
+			{Type: "system_log", Summary: "Metadata applied to book XYZ"},
+			{Type: "system_log", Summary: "iTunes sync finished"},
+		},
+	}
+	detailsBytes, err := json.Marshal(legacyDigest)
+	require.NoError(t, err)
+
+	// Insert as a digest row directly (mimicking old CompactByDay output).
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO activity_log
+			(timestamp, tier, type, level, source, summary, details, compacted)
+		VALUES ('2026-05-12 00:00:00', 'digest', 'daily_digest', 'info', 'compaction', 'Daily digest for 2026-05-12 (3 entries)', ?, 1)`,
+		string(detailsBytes),
+	)
+	require.NoError(t, err)
+
+	// First call: should touch the one digest.
+	result, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Touched, "one legacy digest should be touched")
+	assert.Equal(t, 0, result.Skipped)
+
+	// Fetch the updated digest to verify re-derivation.
+	rows, err := s.db.QueryContext(ctx, `SELECT details FROM activity_log WHERE tier = 'digest' AND type = 'daily_digest'`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var updatedDetailsStr string
+	require.True(t, rows.Next(), "digest row should exist")
+	require.NoError(t, rows.Scan(&updatedDetailsStr))
+
+	var updated DigestDetails
+	require.NoError(t, json.Unmarshal([]byte(updatedDetailsStr), &updated))
+
+	// All items should now have non-system_log types.
+	for _, item := range updated.Items {
+		assert.NotEqual(t, "system_log", item.Type,
+			"item %q should have derived type, got %q", item.Summary, item.Type)
+		assert.NotEmpty(t, item.Tags, "item %q should have tags after recompact", item.Summary)
+	}
+
+	// Counts should have multiple keys (not just system_log).
+	assert.Greater(t, len(updated.Counts), 0, "counts should be non-empty")
+	_, hasSystemLogOnly := updated.Counts["system_log"]
+	if hasSystemLogOnly {
+		assert.Greater(t, len(updated.Counts), 1,
+			"counts should not be only system_log after recompact")
+	}
+
+	// TagCounts should now have action entries.
+	assert.NotEmpty(t, updated.TagCounts, "tag_counts should be populated after recompact")
+
+	// Second call: idempotent — 0 touched.
+	result2, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result2.Touched, "second recompact should be idempotent (0 touched)")
+	assert.Equal(t, 1, result2.Skipped, "second recompact should skip the already-processed digest")
+}
+
+// TestActivityStore_RecompactDigests_AlreadyProcessed verifies that a digest with
+// proper type and tags is not re-processed.
+func TestActivityStore_RecompactDigests_AlreadyProcessed(t *testing.T) {
+	s := newTestActivityStore(t)
+	ctx := context.Background()
+
+	// Build a "already-processed" digest (non-system_log type, non-empty tags).
+	goodDigest := DigestDetails{
+		Date:          "2026-05-18",
+		OriginalCount: 2,
+		Counts:        map[string]int{"scan_completed": 1, "metadata_apply": 1},
+		TagCounts:     map[string]map[string]int{"action": {"scan": 1, "metadata-apply": 1}},
+		Items: []DigestItem{
+			{Type: "scan_completed", Tags: []string{"legacy", "action:scan"}, Summary: "Scan completed: 50 files"},
+			{Type: "metadata_apply", Tags: []string{"legacy", "action:metadata-apply"}, Summary: "Metadata applied"},
+		},
+	}
+	detailsBytes, err := json.Marshal(goodDigest)
+	require.NoError(t, err)
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO activity_log
+			(timestamp, tier, type, level, source, summary, details, compacted)
+		VALUES ('2026-05-18 00:00:00', 'digest', 'daily_digest', 'info', 'compaction', 'Daily digest for 2026-05-18 (2 entries)', ?, 1)`,
+		string(detailsBytes),
+	)
+	require.NoError(t, err)
+
+	result, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Touched, "already-processed digest should be skipped")
+	assert.Equal(t, 1, result.Skipped)
 }

--- a/internal/database/activity_storer.go
+++ b/internal/database/activity_storer.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_storer.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: a1b2c3d4-e5f6-0001-abcd-000000000001
 
 package database
@@ -19,6 +19,7 @@ type ActivityStorer interface {
 	GetDistinctSources(ActivityFilter) ([]SourceCount, error)
 	WipeAllActivity() (int64, error)
 	CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error)
+	RecompactDigests(ctx context.Context) (RecompactResult, error)
 	MigrateSystemActivityLogs() (int, error)
 	Close() error
 }

--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.2.1
+// version: 1.2.2
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
 
 package database
@@ -600,6 +600,12 @@ func (s *NutsActivityStore) CompactByDay(ctx context.Context, olderThan time.Tim
 // It returns 0 entries migrated (they're already in the unified store).
 func (s *NutsActivityStore) MigrateSystemActivityLogs() (int, error) {
 	return 0, nil
+}
+
+// RecompactDigests is a no-op for NutsActivityStore — it stores digests with
+// full type/tag enrichment at compaction time, so legacy re-derivation is not needed.
+func (s *NutsActivityStore) RecompactDigests(_ context.Context) (RecompactResult, error) {
+	return RecompactResult{}, nil
 }
 
 // ── internal helpers ──────────────────────────────────────────────────────────

--- a/internal/server/activity_handlers.go
+++ b/internal/server/activity_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/activity_handlers.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-19
+// last-edited: 2026-05-20
 
 package server
 
@@ -217,6 +217,26 @@ func (s *Server) listOperationActivity(c *gin.Context) {
 		Entries     []database.ActivityEntry `json:"entries"`
 		Total       int                      `json:"total"`
 	}{OperationID: opID, Entries: entries, Total: total})
+}
+
+// recompactDigests handles POST /api/v1/admin/recompact-digests.
+//
+// One-shot endpoint that re-derives type, tier, and tags on every stored
+// daily-digest entry whose items were compacted before 2026-05-20.
+// Returns { touched, skipped }. Safe to call multiple times (idempotent).
+func (s *Server) recompactDigests(c *gin.Context) {
+	if s.activityService == nil {
+		httputil.RespondWithInternalError(c, "activity log not available")
+		return
+	}
+
+	result, err := s.activityService.RecompactDigests(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "recompact digests failed", err)
+		return
+	}
+
+	httputil.RespondWithOK(c, result)
 }
 
 // compactActivity handles POST /api/v1/activity/compact.

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-05-20
 
@@ -1159,6 +1159,7 @@ func (s *Server) setupRoutes() {
 			{
 				adminOnly.POST("/maintenance/wipe", s.handleWipe)
 				adminOnly.GET("/cache/stats/keys", s.handleCacheKeysIntrospection)
+				adminOnly.POST("/admin/recompact-digests", s.recompactDigests)
 			}
 
 			// Unified activity log


### PR DESCRIPTION
## Summary

- Adds `ActivityStore.RecompactDigests(ctx)` that walks every stored daily-digest row, re-derives `type`/`tier`/`tags` on items compacted before 2026-05-20 (when those fields were added), then rebuilds `Counts` and `TagCounts` from the updated items.
- Idempotent: items already carrying a non-system type and non-empty tags are skipped on re-runs.
- Exposes `POST /api/v1/admin/recompact-digests` (admin-only middleware) returning `{ touched, skipped }` for a one-shot manual fix of the 8 old digests on prod.
- Retry of a prior task that died on a socket error.

## Files touched

- `internal/database/activity_store.go` — `RecompactDigests` + `isLegacyItem` + `RecompactResult`
- `internal/database/activity_storer.go` — added `RecompactDigests` to interface
- `internal/database/activity_store_instrumented.go` — traced wrapper
- `internal/database/nuts_activity_store.go` — no-op stub
- `internal/database/activity_store_test.go` — two new tests
- `internal/activity/service.go` — `RecompactDigests` passthrough
- `internal/server/activity_handlers.go` — `recompactDigests` handler
- `internal/server/server_lifecycle.go` — route registration under `adminOnly`

## Test plan

- [x] `TestActivityStore_RecompactDigests` — legacy digest items get new types/tags; `Counts` has multiple keys; second call returns 0 touched.
- [x] `TestActivityStore_RecompactDigests_AlreadyProcessed` — already-processed digest is skipped.
- [x] `make build-api` passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)