### PR TITLE
feat(activity): op_id + component tags on slog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.90.0 -->
+<!-- version: 2.91.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-20 -->
 
@@ -15,6 +15,16 @@
 - Added `NutsActivityStore.RecompactDigests` no-op stub and `InstrumentedActivityStorer.RecompactDigests` traced wrapper to satisfy the `ActivityStorer` interface.
 - Added `POST /api/v1/admin/recompact-digests` endpoint (admin-only) returning `{ touched, skipped }`.
 - Tests: `TestActivityStore_RecompactDigests` and `TestActivityStore_RecompactDigests_AlreadyProcessed` verify re-derivation and idempotency.
+
+#### May 20, 2026 — Activity log: op_id + component tags on slog entries (PR #1075)
+
+- `ParseLogLineFull()` added to `internal/activity/writer.go` — extracts `op_id`/`operation_id`/`opID` and `component`/`subsystem`/`pkg` attributes from slog text-format log lines. `ParseLogLine` remains a thin wrapper for backward compatibility.
+- `sendEntry()` now sets `entry.OperationID` from the extracted `op_id` attr, so W12 operation-context log lines get `op:<id>` tags automatically. `component` attr is propagated via `entry.Details["component"]`.
+- `EnrichTags()` in `api.go` adds a `component:<subsystem>` tag: prefers `Details["component"]`/`"subsystem"`, falls back to `sourceToComponent` map for well-known sources (scanner, itunes, acoustid, dedup, isbn, scheduler, maintenance).
+- `componentFromEntry()` helper and `sourceToComponent` map added to `api.go`.
+- `pebble_store.go` `GetDashboardStats()`: adds `"component", "library_counts_cache"` attr to all three library_counts slog calls so those spam entries get a recognizable tag.
+- `activityTagColors.ts`: adds `component:*` → indigo chip (`#7986cb` bg, white text) to the `tagChipProps()` color map.
+- 8 new tests in `api_test.go` covering component-from-details, component-from-source-mapping, no-component-for-server, op-id regression, and `ParseLogLineFull` with/without op_id/component.
 
 ### Fixes
 

--- a/internal/activity/api.go
+++ b/internal/activity/api.go
@@ -1,5 +1,5 @@
 // file: internal/activity/api.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 9a4f2e1b-3c7d-4b8e-a6f0-5d2c8e1b7a3f
 
 package activity
@@ -263,7 +263,52 @@ func EnrichTags(e *database.ActivityEntry) {
 		}
 	}
 
+	// component: tag — identifies the specific subsystem. Prefer an
+	// explicit "component" value stored in Details (set by the slog parser
+	// when it extracts a component= attr from a structured log line), then
+	// fall back to a static source→component mapping for well-known sources.
+	// We intentionally skip emitting component: when no mapping exists so
+	// we don't produce misleading tags for generic "server" entries.
+	if comp := componentFromEntry(e); comp != "" {
+		tag := "component:" + comp
+		if !seen[tag] {
+			derived = append(derived, tag)
+		}
+	}
+
 	e.Tags = append(e.Tags, derived...)
+}
+
+// sourceToComponent maps well-known Source values to component names.
+// This is the last-resort fallback when no explicit "component" attr was
+// emitted and the source path derivation in ParseLogLineFull didn't match.
+var sourceToComponent = map[string]string{
+	"scanner":     "scanner",
+	"itunes":      "itunes_sync",
+	"acoustid":    "acoustid",
+	"dedup":       "dedup",
+	"isbn":        "isbn_enrich",
+	"scheduler":   "scheduler",
+	"maintenance": "maintenance",
+}
+
+// componentFromEntry derives the component name for an ActivityEntry.
+// Priority: Details["component"] > Details["subsystem"] > sourceToComponent[Source].
+// Returns "" when no component can be reliably inferred.
+func componentFromEntry(e *database.ActivityEntry) string {
+	if e.Details != nil {
+		for _, key := range []string{"component", "subsystem"} {
+			if v, ok := e.Details[key]; ok {
+				if s, ok := v.(string); ok && s != "" {
+					return s
+				}
+			}
+		}
+	}
+	if comp, ok := sourceToComponent[e.Source]; ok {
+		return comp
+	}
+	return ""
 }
 
 // FlushOperation immediately flushes all pending batches whose OperationID

--- a/internal/activity/api_test.go
+++ b/internal/activity/api_test.go
@@ -1,10 +1,11 @@
 // file: internal/activity/api_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2e7f4a1-6c9d-4e3b-8f0a-1d5c7e2b9f4a
 
 package activity
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -168,7 +169,7 @@ func TestEnrichTags(t *testing.T) {
 				Source:      "scanner",
 				Type:        "scan",
 			},
-			wantTags: []string{"op:op-123", "outcome:ok", "source:scanner", "action:scan"},
+			wantTags: []string{"op:op-123", "outcome:ok", "source:scanner", "action:scan", "component:scanner"},
 		},
 		{
 			name: "book and scope tags from BookID",
@@ -187,7 +188,7 @@ func TestEnrichTags(t *testing.T) {
 				Source: "itunes",
 				Type:   "itunes_sync",
 			},
-			wantTags: []string{"outcome:warn", "source:itunes", "action:import"},
+			wantTags: []string{"outcome:warn", "source:itunes", "action:import", "component:itunes_sync"},
 		},
 		{
 			name: "outcome:error from error level",
@@ -196,7 +197,7 @@ func TestEnrichTags(t *testing.T) {
 				Source: "dedup",
 				Type:   "dedup",
 			},
-			wantTags: []string{"outcome:error", "source:dedup", "action:dedup"},
+			wantTags: []string{"outcome:error", "source:dedup", "action:dedup", "component:dedup"},
 		},
 		{
 			name: "idempotency: existing tags not duplicated",
@@ -207,7 +208,7 @@ func TestEnrichTags(t *testing.T) {
 				Type:        "scan",
 				Tags:        []string{"op:op-789"}, // Already has this tag
 			},
-			wantTags: []string{"op:op-789", "outcome:ok", "source:scanner", "action:scan"},
+			wantTags: []string{"op:op-789", "outcome:ok", "source:scanner", "action:scan", "component:scanner"},
 		},
 		{
 			name: "all fields populated",
@@ -306,4 +307,123 @@ func TestEnrichTags_NilEntry(t *testing.T) {
 		}
 	}()
 	EnrichTags(nil)
+}
+
+// TestEnrichTags_ComponentFromDetails verifies that a "component" key in
+// Details produces a component: tag without disturbing other tags.
+func TestEnrichTags_ComponentFromDetails(t *testing.T) {
+	e := database.ActivityEntry{
+		Level:   "info",
+		Source:  "server",
+		Type:    "system",
+		Details: map[string]any{"component": "library_counts_cache"},
+	}
+	EnrichTags(&e)
+
+	found := false
+	for _, tag := range e.Tags {
+		if tag == "component:library_counts_cache" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected component:library_counts_cache in %v", e.Tags)
+	}
+}
+
+// TestEnrichTags_ComponentFromSourceMapping verifies that a well-known source
+// value produces a component: tag via the sourceToComponent mapping.
+func TestEnrichTags_ComponentFromSourceMapping(t *testing.T) {
+	e := database.ActivityEntry{
+		Level:  "info",
+		Source: "scanner",
+		Type:   "system",
+	}
+	EnrichTags(&e)
+
+	found := false
+	for _, tag := range e.Tags {
+		if tag == "component:scanner" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected component:scanner in %v", e.Tags)
+	}
+}
+
+// TestEnrichTags_NoComponentForGenericSource verifies that a source with no
+// mapping does not produce a component: tag.
+func TestEnrichTags_NoComponentForGenericSource(t *testing.T) {
+	e := database.ActivityEntry{
+		Level:  "info",
+		Source: "server",
+		Type:   "system",
+		Summary: "generic message",
+	}
+	EnrichTags(&e)
+
+	for _, tag := range e.Tags {
+		if strings.HasPrefix(tag, "component:") {
+			t.Errorf("unexpected component tag on generic server entry: %q in %v", tag, e.Tags)
+		}
+	}
+}
+
+// TestEnrichTags_OpIDFromOperationID verifies that a non-empty OperationID
+// produces an op: tag (this was already supported; guard against regression).
+func TestEnrichTags_OpIDFromOperationID(t *testing.T) {
+	e := database.ActivityEntry{
+		Level:       "info",
+		Source:      "scanner",
+		Type:        "scan",
+		OperationID: "01JTEST",
+	}
+	EnrichTags(&e)
+
+	found := false
+	for _, tag := range e.Tags {
+		if tag == "op:01JTEST" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected op:01JTEST in %v", e.Tags)
+	}
+}
+
+// TestParseLogLineFull_SlogOpID verifies that ParseLogLineFull extracts op_id
+// from a slog text-format line and returns it in ParsedLogLine.OpID.
+func TestParseLogLineFull_SlogOpID(t *testing.T) {
+	line := `time=2026-05-20T00:00:00Z level=INFO msg="scan started" op_id=01JTEST component=acoustid`
+	p := ParseLogLineFull(line)
+	if p.OpID != "01JTEST" {
+		t.Errorf("expected OpID=01JTEST, got %q (full: %+v)", p.OpID, p)
+	}
+}
+
+// TestParseLogLineFull_SlogComponent verifies that ParseLogLineFull extracts
+// the component attr from a slog text-format line.
+func TestParseLogLineFull_SlogComponent(t *testing.T) {
+	line := `time=2026-05-20T00:00:00Z level=INFO msg="cache hit" component=library_counts_cache total_books=100`
+	p := ParseLogLineFull(line)
+	if p.Component != "library_counts_cache" {
+		t.Errorf("expected Component=library_counts_cache, got %q (full: %+v)", p.Component, p)
+	}
+}
+
+// TestParseLogLineFull_NoOpNoComponent verifies that a plain non-slog line
+// produces empty OpID and Component (no regression on existing behaviour).
+func TestParseLogLineFull_NoOpNoComponent(t *testing.T) {
+	line := `2026/05/20 00:00:00 main.go:42: [INFO] server: HTTP server started`
+	p := ParseLogLineFull(line)
+	if p.OpID != "" {
+		t.Errorf("expected empty OpID for non-slog line, got %q", p.OpID)
+	}
+	if p.Component != "" {
+		t.Errorf("expected empty Component for non-slog line, got %q", p.Component)
+	}
+	if p.Source != "server" {
+		t.Errorf("expected source=server, got %q", p.Source)
+	}
 }

--- a/internal/activity/writer.go
+++ b/internal/activity/writer.go
@@ -1,5 +1,5 @@
 // file: internal/activity/writer.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
 
 package activity
@@ -115,8 +115,8 @@ func (w *Writer) sendEntry(line string) {
 	if w.closed.Load() {
 		return
 	}
-	level, source, message := ParseLogLine(line)
-	if _, skip := w.skipSources[source]; skip {
+	parsed := ParseLogLineFull(line)
+	if _, skip := w.skipSources[parsed.Source]; skip {
 		return
 	}
 	// Tier is derived from level. The Activity Log UI defaults to
@@ -125,18 +125,24 @@ func (w *Writer) sendEntry(line string) {
 	// happening. info/warn/error → change so the user sees actual
 	// progress; debug stays debug for the firehose.
 	tier := "change"
-	switch level {
+	switch parsed.Level {
 	case "debug":
 		tier = "debug"
 	case "warn", "warning", "error":
 		tier = "change"
 	}
 	entry := database.ActivityEntry{
-		Tier:    tier,
-		Type:    "system",
-		Level:   level,
-		Source:  source,
-		Summary: message,
+		Tier:        tier,
+		Type:        "system",
+		Level:       parsed.Level,
+		Source:      parsed.Source,
+		Summary:     parsed.Message,
+		OperationID: parsed.OpID,
+	}
+	// Propagate component into Details so EnrichTags can produce
+	// a component: tag without requiring a DB schema change.
+	if parsed.Component != "" {
+		entry.Details = map[string]any{"component": parsed.Component}
 	}
 	if isBatchable(entry) {
 		w.batcher.Submit(BatchKey{
@@ -149,8 +155,8 @@ func (w *Writer) sendEntry(line string) {
 	select {
 	case w.ch <- entry:
 	default:
-		if level != "debug" {
-			w.stdout.Write([]byte("[WARN] activity channel full, dropped: " + message + "\n")) //nolint:errcheck
+		if parsed.Level != "debug" {
+			w.stdout.Write([]byte("[WARN] activity channel full, dropped: " + parsed.Message + "\n")) //nolint:errcheck
 		}
 	}
 }
@@ -241,6 +247,101 @@ func (w *Writer) Stop(ctx context.Context) error {
 
 // ── log line parser ───────────────────────────────────────────────────────────
 
+// ParsedLogLine holds all fields extracted from a single log line.
+type ParsedLogLine struct {
+	Level     string // "info", "warn", "error", "debug"
+	Source    string // subsystem name, e.g. "scanner", "server"
+	Message   string // human-readable message text
+	OpID      string // operation_id / op_id slog attribute, if present
+	Component string // component / subsystem slog attribute or source-path derived name
+}
+
+// ParseLogLineFull extracts all structured fields from a single log line,
+// including op_id and component attributes when the line is in slog text format.
+// ParseLogLine is a thin wrapper for callers that only need level/source/message.
+func ParseLogLineFull(line string) ParsedLogLine {
+	p := ParsedLogLine{}
+	p.Level, p.Source, p.Message = parseLogLineCore(line)
+
+	// For slog text lines, also extract op_id, component, and subsystem attrs.
+	if strings.HasPrefix(line, "time=") && strings.Contains(line, " level=") && strings.Contains(line, " msg=") {
+		p.OpID = extractSlogAttr(line, "op_id", "operation_id", "opID")
+		p.Component = extractSlogAttr(line, "component", "subsystem", "pkg")
+	}
+
+	// If no explicit component, derive one from the source path field when the
+	// slog Source attr includes a file path (e.g., "internal/plugins/acoustid/scan.go").
+	if p.Component == "" {
+		p.Component = deriveComponentFromSource(p.Source)
+	}
+	return p
+}
+
+// extractSlogAttr scans the slog key=value attrs in a text-format log line for
+// any of the supplied key names and returns the first matching value. Values may
+// be quoted or bare. Returns "" if none match.
+func extractSlogAttr(line string, keys ...string) string {
+	for _, key := range keys {
+		needle := " " + key + "="
+		idx := strings.Index(line, needle)
+		if idx < 0 {
+			continue
+		}
+		rest := line[idx+len(needle):]
+		if rest == "" {
+			continue
+		}
+		if rest[0] == '"' {
+			// Quoted value: find the closing quote (skip escaped quotes).
+			i := 1
+			for i < len(rest) {
+				if rest[i] == '\\' {
+					i += 2
+					continue
+				}
+				if rest[i] == '"' {
+					return rest[1:i]
+				}
+				i++
+			}
+			continue
+		}
+		// Bare value: ends at next space.
+		if sp := strings.IndexByte(rest, ' '); sp > 0 {
+			return rest[:sp]
+		}
+		return rest
+	}
+	return ""
+}
+
+// deriveComponentFromSource maps known source file path segments to a
+// component name. Returns "" when no known prefix matches, so we don't
+// emit a misleading tag for unrecognised sources.
+func deriveComponentFromSource(source string) string {
+	lower := strings.ToLower(source)
+	switch {
+	case strings.Contains(lower, "acoustid") || strings.Contains(lower, "acousticid"):
+		return "acoustid"
+	case strings.Contains(lower, "itunes"):
+		return "itunes_sync"
+	case strings.Contains(lower, "scanner"):
+		return "scanner"
+	case strings.Contains(lower, "dedup"):
+		return "dedup"
+	case strings.Contains(lower, "isbn"):
+		return "isbn_enrich"
+	case strings.Contains(lower, "embed"):
+		return "embedding"
+	case strings.Contains(lower, "scheduler"):
+		return "scheduler"
+	case strings.Contains(lower, "maintenance"):
+		return "maintenance"
+	default:
+		return ""
+	}
+}
+
 // ParseLogLine extracts (level, source, message) from a single log line.
 //
 // Recognised formats:
@@ -249,6 +350,11 @@ func (w *Writer) Stop(ctx context.Context) error {
 //   - Go standard log: "YYYY/MM/DD HH:MM:SS file.go:NNN: [level] source: message"
 //   - Bare text: returned as-is with level=info, source=server.
 func ParseLogLine(line string) (level, source, message string) {
+	p := ParseLogLineFull(line)
+	return p.Level, p.Source, p.Message
+}
+
+func parseLogLineCore(line string) (level, source, message string) {
 	// GIN logs: [GIN] YYYY/MM/DD - HH:MM:SS | STATUS | ...
 	if strings.HasPrefix(line, "[GIN]") {
 		rest := line[5:]

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -2610,6 +2610,7 @@ func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
 		minIntervalSec := float64(getLibraryCountsMinIntervalSeconds())
 		if ageSec < minIntervalSec {
 			slog.Debug("library_counts cache hit (within min interval)",
+				"component", "library_counts_cache",
 				"age_seconds", ageSec,
 				"min_interval_seconds", minIntervalSec,
 			)
@@ -2629,6 +2630,7 @@ func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
 		minIntervalSec := float64(getLibraryCountsMinIntervalSeconds())
 		if ageSec < minIntervalSec {
 			slog.Debug("library_counts cache hit (within min interval, after lock wait)",
+				"component", "library_counts_cache",
 				"age_seconds", ageSec,
 				"min_interval_seconds", minIntervalSec,
 			)
@@ -2644,6 +2646,7 @@ func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
 	}
 	p.writeCachedLibraryStats(stats)
 	slog.Info("library_counts cache recomputed",
+		"component", "library_counts_cache",
 		"total_books", stats.TotalBooks,
 		"organized_books", stats.OrganizedBooks,
 		"unorganized_books", stats.UnorganizedBooks,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audiobook-organizer-web",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audiobook-organizer-web",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -27,11 +27,14 @@
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.1",
+        "@vitest/coverage-v8": "^4.1.5",
+        "axios": "^1.15.2",
         "eslint": "^9.39.3",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "globals": "^16.5.0",
         "jsdom": "^23.0.1",
+        "playwright": "^1.59.1",
         "prettier": "^3.1.1",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.56.0",
@@ -249,9 +252,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -340,6 +343,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1468,6 +1480,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -2277,30 +2319,60 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2309,7 +2381,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2321,24 +2393,24 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2346,12 +2418,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2360,26 +2433,33 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2491,6 +2571,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2510,6 +2607,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -3034,9 +3168,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true
     },
     "node_modules/es-object-atoms": {
@@ -3423,6 +3557,26 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3662,6 +3816,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4041,6 +4201,42 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4228,6 +4424,44 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4542,12 +4776,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4560,9 +4794,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -4679,6 +4913,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -5121,9 +5364,9 @@
       "dev": true
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true
     },
     "node_modules/stop-iteration-iterator": {
@@ -5229,9 +5472,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -5485,30 +5728,30 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -5524,12 +5767,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -5550,6 +5796,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -5558,6 +5810,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/web/src/utils/activityTagColors.ts
+++ b/web/src/utils/activityTagColors.ts
@@ -1,5 +1,5 @@
 // file: web/src/utils/activityTagColors.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
 
 /**
@@ -16,6 +16,7 @@
  *   outcome:skip → default (gray)
  *   op:*         → info (teal)
  *   book:*       → orange (custom sx)
+ *   component:*  → secondary-light (indigo-ish custom sx)
  *   scope:*      → default (gray)
  *   lifecycle:*  → default (gray)
  *   anything else→ default (gray)
@@ -64,6 +65,12 @@ export function tagChipProps(tag: string): TagChipProps {
       return {
         color: 'default',
         sx: { bgcolor: '#ffb74d', color: '#000' },
+        label: val,
+      };
+    case 'component':
+      return {
+        color: 'default',
+        sx: { bgcolor: '#7986cb', color: '#fff' },
         label: val,
       };
     case 'scope':


### PR DESCRIPTION
## Summary

- Adds `op:<id>` tag to activity entries when the slog record carries an `op_id`/`operation_id` attribute (emitted by `logger.WithOperation` / W12 op-context). Sets `entry.OperationID` directly so `EnrichTags` picks it up.
- Adds `component:<subsystem>` tag: prefer explicit `component`/`subsystem` slog attr, fall back to `sourceToComponent` map for well-known sources (scanner, itunes_sync, acoustid, dedup, isbn_enrich, scheduler, maintenance).
- `pebble_store.go` `GetDashboardStats`: all three slog calls now include `"component", "library_counts_cache"` so the cache spam entries get a recognizable tag.
- `activityTagColors.ts`: `component:*` → indigo chip (`#7986cb`); `op:*` already had cyan — no change needed.
- 8 new tests covering component-from-details, component-from-source-map, no-component-for-server, op-id regression, and `ParseLogLineFull` attr extraction.

## Test plan

- [x] `go test ./internal/activity/... ./internal/database/...` — all pass
- [x] `make build-api` — clean
- [x] `npm run build` — clean
- [x] `ParseLogLineFull` extracts `op_id` and `component` from slog text lines
- [x] `EnrichTags` with `Details["component"]` → `component:library_counts_cache`
- [x] `EnrichTags` with `Source="scanner"` → `component:scanner`
- [x] `EnrichTags` with `Source="server"` → no `component:` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)