### PR TITLE
fix(activity): implement RecompactDigests for NutsDB backend

### DIFF
--- a/internal/database/activity_compact_test.go
+++ b/internal/database/activity_compact_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_compact_test.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 
 package database
@@ -395,4 +395,65 @@ func TestCompactByDay_DigestItemTimestampAndTags(t *testing.T) {
 		assert.True(t, !dd.Items[i].Timestamp.Before(dd.Items[i-1].Timestamp),
 			"items should be in non-decreasing timestamp order")
 	}
+}
+
+// newTestNutsActivityStore creates a temp NutsActivityStore and registers cleanup.
+func newTestNutsActivityStore(t *testing.T) *NutsActivityStore {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewNutsActivityStore(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestNutsActivityStore_RecompactDigests verifies that RecompactDigests:
+//  1. Re-derives type+tags on legacy digest items (type=system_log, empty tags).
+//  2. Returns the correct touched count.
+//  3. Is idempotent: a second run returns 0 touched.
+func TestNutsActivityStore_RecompactDigests(t *testing.T) {
+	s := newTestNutsActivityStore(t)
+	ctx := context.Background()
+
+	day := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	// Insert 3 entries with legacy-style types that should be re-derived.
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "change",
+			Type:      "system_log",  // legacy type — should be re-derived
+			Level:     "info",
+			Source:    "compaction",
+			Summary:   "applied metadata to book",
+			Timestamp: day.Add(time.Duration(i) * time.Minute),
+			Tags:      []string{},    // empty tags — triggers isLegacyItem
+		})
+		require.NoError(t, err)
+	}
+
+	// Compact to create a digest.
+	olderThan := day.Add(24 * time.Hour)
+	_, err := s.CompactByDay(ctx, olderThan)
+	require.NoError(t, err)
+
+	// Run RecompactDigests — should touch exactly 1 digest.
+	res, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Touched, "first run: should touch the one digest")
+	assert.Equal(t, 0, res.Skipped, "first run: nothing should be skipped")
+
+	// Read back the digest and verify items got proper types and tags.
+	dd, _, err := s.findExistingDigest(day.Format("2006-01-02"))
+	require.NoError(t, err)
+	require.Len(t, dd.Items, 3, "digest should still have 3 items")
+	for i, item := range dd.Items {
+		assert.NotEqual(t, "system_log", item.Type, "item %d: type should be re-derived away from system_log", i)
+		assert.NotEmpty(t, item.Tags, "item %d: tags should be populated after recompact", i)
+	}
+
+	// Idempotency: second run should touch 0 (all items now have proper types/tags).
+	res2, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res2.Touched, "second run: should be idempotent (0 touched)")
+	assert.Equal(t, 1, res2.Skipped, "second run: digest should be skipped as already clean")
 }

--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.2.2
+// version: 1.2.3
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
 
 package database
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -602,10 +603,155 @@ func (s *NutsActivityStore) MigrateSystemActivityLogs() (int, error) {
 	return 0, nil
 }
 
-// RecompactDigests is a no-op for NutsActivityStore — it stores digests with
-// full type/tag enrichment at compaction time, so legacy re-derivation is not needed.
-func (s *NutsActivityStore) RecompactDigests(_ context.Context) (RecompactResult, error) {
-	return RecompactResult{}, nil
+// RecompactDigests re-derives type, tier, and tags on every stored daily-digest
+// entry in NutsDB whose items were compacted before enrichment was added.
+// It mirrors ActivityStore.RecompactDigests but uses NutsDB iteration instead of SQL.
+//
+// Algorithm:
+//  1. Range-scan the entire "act:digest" bucket (all keys).
+//  2. Decode each entry's Details map as DigestDetails.
+//  3. Skip entries where no items are legacy (idempotent guard).
+//  4. For each legacy item: call deriveTypeFromMessage + enrichLegacyLogTags.
+//  5. Rebuild Counts and TagCounts, marshal back, and write with the same key.
+func (s *NutsActivityStore) RecompactDigests(ctx context.Context) (RecompactResult, error) {
+	var result RecompactResult
+
+	// Collect all digest keys+values first so we can update outside the View tx.
+	type digestKV struct {
+		key   []byte
+		entry ActivityEntry
+		dd    DigestDetails
+	}
+
+	var candidates []digestKV
+
+	err := s.db.View(func(tx *nutsdb.Tx) error {
+		keys, vals, err := tx.RangeScanEntries(
+			actBucket("digest"),
+			[]byte("00000000000000000000:"),
+			[]byte("99999999999999999999:\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+			true, true,
+		)
+		if err != nil {
+			if isNutsEmptyScan(err) {
+				return nil
+			}
+			return err
+		}
+		for i, v := range vals {
+			var e ActivityEntry
+			if jsonErr := json.Unmarshal(v, &e); jsonErr != nil {
+				continue
+			}
+			if e.Type != "daily_digest" {
+				continue
+			}
+			// Decode Details map into DigestDetails.
+			var dd DigestDetails
+			if e.Details != nil {
+				if b, merr := json.Marshal(e.Details); merr == nil {
+					_ = json.Unmarshal(b, &dd)
+				}
+			}
+			candidates = append(candidates, digestKV{key: keys[i], entry: e, dd: dd})
+		}
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("nuts_activity_store: recompact scan digests: %w", err)
+	}
+
+	slog.Info("[activity] recompact: starting digest re-derivation (nuts)",
+		"digest_count", len(candidates))
+
+	for _, c := range candidates {
+		// Check if any items need updating.
+		needsUpdate := false
+		for _, item := range c.dd.Items {
+			if isLegacyItem(item) {
+				needsUpdate = true
+				break
+			}
+		}
+		if !needsUpdate {
+			result.Skipped++
+			continue
+		}
+
+		// Re-derive type, tier, and tags on each legacy item.
+		for i, item := range c.dd.Items {
+			if !isLegacyItem(item) {
+				continue
+			}
+			derivedType, derivedTier := deriveTypeFromMessage(item.Summary, "")
+			derivedTags := enrichLegacyLogTags(item.Summary, "", "info")
+			c.dd.Items[i].Type = derivedType
+			c.dd.Items[i].Tier = derivedTier
+			c.dd.Items[i].Tags = derivedTags
+		}
+
+		// Rebuild Counts from updated items.
+		newCounts := make(map[string]int)
+		for _, item := range c.dd.Items {
+			newCounts[item.Type]++
+		}
+		c.dd.Counts = newCounts
+
+		// Rebuild TagCounts from updated items.
+		newTagCounts := make(map[string]map[string]int)
+		for _, item := range c.dd.Items {
+			for _, tag := range item.Tags {
+				colonIdx := strings.Index(tag, ":")
+				if colonIdx < 1 {
+					continue
+				}
+				ns := tag[:colonIdx]
+				val := tag[colonIdx+1:]
+				if ns != "action" && ns != "source" {
+					continue
+				}
+				if newTagCounts[ns] == nil {
+					newTagCounts[ns] = make(map[string]int)
+				}
+				newTagCounts[ns][val]++
+			}
+		}
+		if len(newTagCounts) > 0 {
+			c.dd.TagCounts = newTagCounts
+		}
+
+		// Merge updated DigestDetails back into the entry's Details map.
+		ddBytes, merr := json.Marshal(c.dd)
+		if merr != nil {
+			return result, fmt.Errorf("nuts_activity_store: recompact marshal digest key=%s: %w", c.key, merr)
+		}
+		var detailsMap map[string]any
+		if err := json.Unmarshal(ddBytes, &detailsMap); err != nil {
+			return result, fmt.Errorf("nuts_activity_store: recompact unmarshal detailsMap key=%s: %w", c.key, err)
+		}
+		c.entry.Details = detailsMap
+		c.entry.Summary = fmt.Sprintf("Daily digest for %s (%d entries)", c.dd.Date, c.dd.OriginalCount)
+
+		entryBytes, merr := json.Marshal(c.entry)
+		if merr != nil {
+			return result, fmt.Errorf("nuts_activity_store: recompact marshal entry key=%s: %w", c.key, merr)
+		}
+
+		key := c.key // capture for closure
+		if uerr := s.db.Update(func(tx *nutsdb.Tx) error {
+			return tx.Put(actBucket("digest"), key, entryBytes, 0)
+		}); uerr != nil {
+			return result, fmt.Errorf("nuts_activity_store: recompact write key=%s: %w", key, uerr)
+		}
+
+		slog.Info("[activity] recompact: updated digest (nuts)",
+			"key", string(c.key), "date", c.dd.Date, "items", len(c.dd.Items))
+		result.Touched++
+	}
+
+	slog.Info("[activity] recompact: complete (nuts)",
+		"touched", result.Touched, "skipped", result.Skipped)
+	return result, nil
 }
 
 // ── internal helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Production uses `NutsActivityStore` but PR #1074's `RecompactDigests` left it as a no-op stub, so `POST /api/v1/admin/recompact-digests` was always returning `{touched:0, skipped:0}` without doing anything.
- Ports the SQL-backed implementation to NutsDB: range-scans the `act:digest` bucket, decodes each entry's `Details` map as `DigestDetails`, applies `deriveTypeFromMessage` + `enrichLegacyLogTags` on legacy items (empty tags or `system_log` type), rebuilds `Counts`/`TagCounts`, writes back with the same key.
- Adds `TestNutsActivityStore_RecompactDigests` covering: correct touched count, item re-enrichment, and idempotency (second run returns 0 touched).

## Test plan

- [x] `TestNutsActivityStore_RecompactDigests` passes (touched=1 first run, touched=0 second run)
- [x] All `./internal/database/...` tests pass (93s)
- [x] `make build-api` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)