### PR TITLE
fix(web): repair TS build errors from memory-leak cleanup

### DIFF
--- a/web/src/components/OperationActivityPanel.tsx
+++ b/web/src/components/OperationActivityPanel.tsx
@@ -221,9 +221,9 @@ export function OperationActivityPanel({
   useEffect(() => {
     if (op && TERMINAL_STATUSES.has(op.status)) return;
     if (intervalRef.current) clearInterval(intervalRef.current);
-    intervalRef.current = window.setInterval(load, 3000);
+    intervalRef.current = setInterval(load, 3000);
     return () => {
-      if (intervalRef.current) window.clearInterval(intervalRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, [load, op]);
 

--- a/web/src/components/audiobooks/VersionManagement.tsx
+++ b/web/src/components/audiobooks/VersionManagement.tsx
@@ -2,7 +2,7 @@
 // version: 1.1.3
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -58,11 +58,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
         if (attempt > 0) {
-          await new Promise((r) => {
-            const timeout = setTimeout(r, RETRY_DELAY_MS);
-            // No memory leak here since we return and the promise resolves.
-            // The timeout will complete before the component unmounts in normal flow.
-          });
+          await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
         }
         if (!isMountedRef.current) return;
         const status = await api.getAuthStatus();

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -194,7 +194,7 @@ export const BookDetail = () => {
     let cancelled = false;
     setLinkSearchLoading(true);
     let timer: ReturnType<typeof setTimeout> | null = null;
-    timer = window.setTimeout(async () => {
+    timer = setTimeout(async () => {
       try {
         const results = await api.searchBooks(q, 10);
         if (!cancelled) setLinkSearchResults(results.filter(r => r.id !== book?.id && !versions.some(v => v.id === r.id)));


### PR DESCRIPTION
Four trivial fixes — unused imports + window.setTimeout/setInterval return number not Timeout. Unblocks 'make deploy'.