### PR TITLE
feat(scanner): detect metadata hash duplicates at import (MATCH-4)

### DIFF
--- a/internal/scanner/dedup.go
+++ b/internal/scanner/dedup.go
@@ -1,0 +1,54 @@
+// file: internal/scanner/dedup.go
+// version: 1.0.0
+// guid: match-4-dedup-001
+
+package scanner
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// computeMetadataSourceHash computes the metadata_source_hash for a book
+// based on its metadata source and ID. Returns empty string if not enough
+// metadata is available.
+func computeMetadataSourceHash(book *database.Book) string {
+	src, id := bookMetadataSourceAndID(book)
+	if src == "" || id == "" {
+		return ""
+	}
+	raw := fmt.Sprintf("%s:%s", src, id)
+	sum := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", sum)
+}
+
+// bookMetadataSourceAndID extracts the metadata source and ID from a book.
+// Returns (source, id) tuple where source is one of: "audible", "openlibrary",
+// "google_books", or "hardcover".
+func bookMetadataSourceAndID(book *database.Book) (string, string) {
+	if book.MetadataSource == nil || *book.MetadataSource == "" {
+		return "", ""
+	}
+	src := *book.MetadataSource
+	switch src {
+	case "audible":
+		if book.ASIN != nil && *book.ASIN != "" {
+			return src, *book.ASIN
+		}
+	case "openlibrary":
+		if book.OpenLibraryID != nil && *book.OpenLibraryID != "" {
+			return src, *book.OpenLibraryID
+		}
+	case "google_books":
+		if book.GoogleBooksID != nil && *book.GoogleBooksID != "" {
+			return src, *book.GoogleBooksID
+		}
+	case "hardcover":
+		if book.HardcoverID != nil && *book.HardcoverID != "" {
+			return src, *book.HardcoverID
+		}
+	}
+	return "", ""
+}

--- a/internal/scanner/register.go
+++ b/internal/scanner/register.go
@@ -11,11 +11,16 @@ import (
 func init() {
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "scan",
-		Needs:  []string{"store"},
+		Needs:  []string{"store", "embeddingstore"},
 		Groups: []string{"core"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
-			return NewScanService(store), nil
+			scanSvc := NewScanService(store)
+			// Wire in EmbeddingStore for metadata hash dedup detection
+			if es := serviceregistry.Get[*database.EmbeddingStore](c, "embeddingstore"); es != nil {
+				scanSvc.SetEmbeddingStore(es)
+			}
+			return scanSvc, nil
 		},
 	})
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -51,9 +51,66 @@ type Scanner interface {
 // activeScanner overrides the default implementation. Set by tests via SetScanner.
 var activeScanner Scanner
 
+// activeEmbeddingStore is used for dedup candidate creation during scanning.
+// Set by ScanService before starting a scan.
+var activeEmbeddingStore *database.EmbeddingStore
+
 // SetScanner overrides the default scanner implementation for testing.
 func SetScanner(s Scanner) {
 	activeScanner = s
+}
+
+// setActiveEmbeddingStore sets the embedding store for dedup detection.
+func setActiveEmbeddingStore(es *database.EmbeddingStore) {
+	activeEmbeddingStore = es
+}
+
+// detectMetadataHashDuplicate checks if a newly created/updated book matches an existing
+// book by metadata_source_hash and creates a dedup candidate if found.
+func detectMetadataHashDuplicate(book *database.Book, log logger.Logger) {
+	if activeEmbeddingStore == nil {
+		return
+	}
+	if getStore() == nil {
+		return
+	}
+
+	// Compute hash based on current metadata
+	hash := computeMetadataSourceHash(book)
+	if hash == "" {
+		return
+	}
+
+	// Check if another book has the same hash
+	existing, err := getStore().GetBooksByMetadataSourceHash(hash)
+	if err != nil {
+		if log != nil {
+			log.Warn("Failed to check for metadata hash duplicates for %s: %v", book.ID, err)
+		}
+		return
+	}
+
+	// Find a different book with the same hash
+	for _, candidate := range existing {
+		if candidate.ID != book.ID {
+			if log != nil {
+				log.Info("import: metadata hash duplicate detected book=%s existing=%s", book.ID, candidate.ID)
+			}
+			// Create dedup candidate with high confidence
+			dedupCandidate := database.DedupCandidate{
+				EntityType: "book",
+				EntityAID:  candidate.ID,
+				EntityBID:  book.ID,
+				Layer:      "metadata_hash_match",
+				Similarity: new(float64),
+			}
+			*dedupCandidate.Similarity = 1.0
+			if err := activeEmbeddingStore.UpsertCandidate(dedupCandidate); err != nil && log != nil {
+				log.Warn("Failed to create dedup candidate for %s and %s: %v", dedupCandidate.EntityAID, dedupCandidate.EntityBID, err)
+			}
+			break // Only create one candidate per scanned book
+		}
+	}
 }
 
 // pkgStore is the database the scanner's package-level helpers use.
@@ -1717,9 +1774,13 @@ func saveBookToDatabase(book *Book) error {
 			}
 
 			_, err = getStore().CreateBook(dbBook)
-			if err == nil && scanHooks != nil {
-				scanHooks.OnBookScanned(dbBook.ID, dbBook.Title)
-				scanHooks.OnImportDedup(dbBook.ID)
+			if err == nil {
+				// Check for metadata hash duplicates
+				detectMetadataHashDuplicate(dbBook, defaultLog)
+				if scanHooks != nil {
+					scanHooks.OnBookScanned(dbBook.ID, dbBook.Title)
+					scanHooks.OnImportDedup(dbBook.ID)
+				}
 			}
 			return err
 		}
@@ -1736,6 +1797,10 @@ func saveBookToDatabase(book *Book) error {
 		preserveExistingFields(dbBook, existing)
 
 		_, err = getStore().UpdateBook(existing.ID, dbBook)
+		if err == nil {
+			// Check for metadata hash duplicates after update
+			detectMetadataHashDuplicate(dbBook, defaultLog)
+		}
 		return err
 	}
 

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -32,6 +32,7 @@ type scanServiceStore interface {
 // ScanService orchestrates multi-folder audiobook scanning.
 type ScanService struct {
 	db             scanServiceStore
+	embedStore     *database.EmbeddingStore
 	PostScanFn     func() // optional hook called after each full scan completes
 	activityWriter *activity.Writer
 	// AutoOrganizeFn is an optional hook called after books are processed in a
@@ -40,9 +41,14 @@ type ScanService struct {
 	AutoOrganizeFn func(ctx context.Context, books []Book, log logger.Logger)
 }
 
-// NewScanService creates a new ScanService backed by the given store.
+// NewScanService creates a new ScanService backed by the given store and embedding store.
 func NewScanService(db scanServiceStore) *ScanService {
 	return &ScanService{db: db}
+}
+
+// SetEmbeddingStore sets the EmbeddingStore for dedup candidate creation.
+func (ss *ScanService) SetEmbeddingStore(es *database.EmbeddingStore) {
+	ss.embedStore = es
 }
 
 // SetActivityWriter sets the activity writer used to batch per-book scan events.
@@ -85,6 +91,9 @@ func (ss *ScanService) PerformScan(ctx context.Context, req *ScanRequest, log lo
 // performScanInternal is the shared implementation used by PerformScan and PerformScanWithID.
 // opID may be empty when called without a tracked operation (activity batching is skipped).
 func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req *ScanRequest, log logger.Logger) error {
+	// Set the active embedding store for dedup detection during this scan
+	setActiveEmbeddingStore(ss.embedStore)
+
 	if log == nil {
 		log = logger.New("scan")
 	}


### PR DESCRIPTION
## Summary

Implements MATCH-4: import-time metadata hash dedup detection. When a book is created or updated during a scan, computes its metadata_source_hash and checks if another book has the same hash. If found, creates a dedup candidate with high confidence to flag as potential duplicates.

## Changes

- Add embedStore field to ScanService for dedup candidate creation
- Add activeEmbeddingStore global variable for package-level functions
- Implement computeMetadataSourceHash helper (based on source + ID)
- Implement bookMetadataSourceAndID helper to extract external IDs
- Add detectMetadataHashDuplicate function called after CreateBook/UpdateBook
- Update scanner/register.go to wire in embeddingstore dependency
- Emit "import: metadata hash duplicate detected" log on match
- Create dedup candidates with layer "metadata_hash_match" and similarity 1.0

The hash is computed as sha256("{source}:{canonical_id}") where source is audible, openlibrary, google_books, or hardcover. This flags books sharing the same external record.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>