### PR TITLE
perf: optimize GetAllBookSummaries pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.92.0 -->
+<!-- version: 2.93.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-24 -->
 
@@ -9,13 +9,14 @@
 
 ### Features
 
-#### May 24, 2026 — Optimize all memory-load pain points
+#### May 24, 2026 — Optimize all memory-load pain points (5 issues)
 
 - **SearchBooks:** Replaced `GetAllBooks(1000000, 0)` with direct `book:*` index scan; filters during iteration instead of loading entire dataset to memory.
 - **GetDistinctGenres/Languages:** Changed from `GetAllBooks(0, 0)` to single-pass `book:*` index scan, collecting distinct values during iteration.
 - **GetQuarantinedBooks/CountQuarantinedBooks:** Replaced `GetAllBooks(100000, 0)` with index scan; only deserializes books with non-nil `QuarantinedAt`.
 - **GetITunesPurgePendingBooks/GetITunesDirtyBooks:** iTunes sync status filtering now happens during index scan, not after loading 100K books.
-- **Result:** Critical operations that loaded full dataset into memory (500K–1M book deserializations) now use filtered index scans. Eliminates memory bloat and improves response times for search, distinct-value queries, and admin operations.
+- **GetAllBookSummaries pagination:** Changed from `GetAllBooks(limit+offset, 0)` with post-slicing to `GetAllBooks(limit, offset)` using built-in pagination; eliminates loading extra books just to discard them.
+- **Result:** Critical operations that loaded full dataset into memory (500K–1M book deserializations) now use filtered index scans with proper pagination. Eliminates memory bloat and improves response times for search, distinct-value queries, admin operations, and library browsing.
 
 #### May 23, 2026 — Authors/Series endpoint caching (MATCH-6)
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.78.0
+// version: 1.79.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-24
 
@@ -1259,16 +1259,12 @@ func (p *PebbleStore) GetAllBookSummaries(limit, offset int) ([]BookSummary, err
 	if offset < 0 {
 		offset = 0
 	}
-	books, err := p.GetAllBooks(limit+offset, 0)
+	books, err := p.GetAllBooks(limit, offset)
 	if err != nil {
 		return nil, err
 	}
-	if offset >= len(books) {
+	if len(books) == 0 {
 		return nil, nil
-	}
-	books = books[offset:]
-	if len(books) > limit {
-		books = books[:limit]
 	}
 	summaries := make([]BookSummary, 0, len(books))
 	for _, b := range books {


### PR DESCRIPTION
## Summary

Fixed pagination inefficiency in GetAllBookSummaries where the function was loading extra books just to discard them.

- **Old:** `GetAllBooks(limit+offset, 0)` then slice `books[offset:]`
- **New:** `GetAllBooks(limit, offset)` using built-in pagination with early termination

Eliminates unnecessary book deserializations for skipped pages during library browsing.

## Commits

- a789d0d0 perf: optimize GetAllBookSummaries pagination
- 9ae6cee0 chore(docs): add pagination optimization to CHANGELOG

## Test Plan

- [x] Backend tests pass (audiobooks and server packages)
- [x] No behavior changes (same results, faster execution)
- [x] Pagination correctness verified by existing GetAllBookSummaries tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)