### PR TITLE
fix: add missing key filters in GetDistinct* functions (HOTFIX)

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -2722,6 +2722,13 @@ func (p *PebbleStore) GetDistinctGenres() ([]string, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip index keys (same as GetAllBooks)
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") {
+			continue
+		}
+
 		var b Book
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
@@ -2753,6 +2760,13 @@ func (p *PebbleStore) GetDistinctLanguages() ([]string, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip index keys (same as GetAllBooks)
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
+			strings.Contains(key, ":author:") {
+			continue
+		}
+
 		var b Book
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue


### PR DESCRIPTION
Critical fix: GetDistinctGenres and GetDistinctLanguages were iterating index keys without filtering, causing startup cache warm-up to hang. Added key filtering to skip book:author:*, book:series:*, book:path:* index metadata keys. Deployed to production.