### PR TITLE
fix(database): disable Chai flag until data sync is implemented

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -195,7 +195,7 @@ func NewPebbleStore(path string) (*PebbleStore, error) {
 
 	store := &PebbleStore{
 		db:        db,
-		UseChaiDB: true, // Enable Chai SQL for aggregation functions (Phase 1-2 migration)
+		UseChaiDB: false, // Chai DB not yet populated — needs data sync before enabling
 	}
 
 	slog.Info("PebbleDB opened", "path", path, "format_version", db.FormatMajorVersion())


### PR DESCRIPTION
Hotfix: Chai DB was empty — queries returned 0 causing dashboard to show all books as organized.

Root cause: UseChaiDB flag enabled before Pebble→Chai write-through sync was built.

Next step: implement sync mechanism before re-enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)