### PR TITLE
feat(database): migrate GetAllSeries to SQL + fix test helper duplication

### DIFF
--- a/internal/database/chai_all_series_test.go
+++ b/internal/database/chai_all_series_test.go
@@ -1,0 +1,265 @@
+// file: internal/database/chai_all_series_test.go
+// version: 1.0.0
+// guid: 4a1b2c3d-e4f5-6a7b-8c9d-0e1f2a3b4c5d
+// last-edited: 2026-05-24
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetAllSeries_Chai_Basic validates SQL version returns all series ordered by name
+func TestGetAllSeries_Chai_Basic(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		t.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	// Insert 3 series in non-alphabetical order to verify ORDER BY name
+	_, err = chaiDB.ExecContext(ctx, `
+		INSERT INTO series (id, name, author_id, marked_for_deletion)
+		VALUES
+			(3, 'Zebra Chronicles', NULL, false),
+			(1, 'Apex Legends', NULL, false),
+			(2, 'Middle Earth', NULL, false)
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert series: %v", err)
+	}
+
+	series, err := chaiStore.GetAllSeries_Chai(ctx)
+	if err != nil {
+		t.Fatalf("GetAllSeries_Chai failed: %v", err)
+	}
+
+	if len(series) != 3 {
+		t.Fatalf("expected 3 series, got %d", len(series))
+	}
+
+	// Verify alphabetical order
+	expectedOrder := []string{"Apex Legends", "Middle Earth", "Zebra Chronicles"}
+	for i, name := range expectedOrder {
+		if series[i].Name != name {
+			t.Errorf("series[%d]: expected name %q, got %q", i, name, series[i].Name)
+		}
+	}
+}
+
+// TestGetAllSeries_Chai_EmptyDatabase validates behavior on empty DB
+func TestGetAllSeries_Chai_EmptyDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		t.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	series, err := chaiStore.GetAllSeries_Chai(ctx)
+	if err != nil {
+		t.Fatalf("GetAllSeries_Chai failed on empty DB: %v", err)
+	}
+
+	if len(series) != 0 {
+		t.Errorf("expected empty result, got %v", series)
+	}
+}
+
+// TestGetAllSeries_Chai_WithAuthorID validates that author_id is populated correctly
+func TestGetAllSeries_Chai_WithAuthorID(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		t.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	// Insert authors first (FK may not be enforced, but good practice)
+	_, err = chaiDB.ExecContext(ctx, `
+		INSERT INTO authors (id, name, marked_for_deletion)
+		VALUES (42, 'Brandon Sanderson', false)
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert author: %v", err)
+	}
+
+	// Insert series: one with author_id, one without
+	_, err = chaiDB.ExecContext(ctx, `
+		INSERT INTO series (id, name, author_id, marked_for_deletion)
+		VALUES
+			(1, 'Mistborn', 42, false),
+			(2, 'Standalone', NULL, false)
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert series: %v", err)
+	}
+
+	series, err := chaiStore.GetAllSeries_Chai(ctx)
+	if err != nil {
+		t.Fatalf("GetAllSeries_Chai failed: %v", err)
+	}
+
+	if len(series) != 2 {
+		t.Fatalf("expected 2 series, got %d", len(series))
+	}
+
+	// Find Mistborn (should be first alphabetically)
+	mistborn := series[0]
+	if mistborn.Name != "Mistborn" {
+		t.Fatalf("expected Mistborn first, got %q", mistborn.Name)
+	}
+	if mistborn.AuthorID == nil || *mistborn.AuthorID != 42 {
+		t.Errorf("Mistborn: expected author_id=42, got %v", mistborn.AuthorID)
+	}
+
+	// Standalone should have nil author_id
+	standalone := series[1]
+	if standalone.Name != "Standalone" {
+		t.Fatalf("expected Standalone second, got %q", standalone.Name)
+	}
+	if standalone.AuthorID != nil {
+		t.Errorf("Standalone: expected nil author_id, got %v", standalone.AuthorID)
+	}
+}
+
+// TestGetAllSeries_ChaiVsPebble compares Pebble and Chai implementations return equivalent results.
+// Both stores are seeded with the same series names; we compare by name set (order may differ).
+func TestGetAllSeries_ChaiVsPebble(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	// Build Pebble store with some series
+	pstore, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	seriesNames := []string{"Fantasy Series", "Mystery Series", "Sci-Fi Series"}
+	for _, name := range seriesNames {
+		if _, err := pstore.CreateSeries(name, nil); err != nil {
+			t.Fatalf("CreateSeries(%q) failed: %v", name, err)
+		}
+	}
+
+	// Pebble result
+	pebbleStore, ok := pstore.(*PebbleStore)
+	if !ok {
+		t.Fatal("expected *PebbleStore from setupPebbleTestDB")
+	}
+	pebbleSeries, err := pebbleStore.GetAllSeries_Pebble()
+	if err != nil {
+		t.Fatalf("GetAllSeries_Pebble failed: %v", err)
+	}
+
+	// Build Chai store with same series
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		t.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	for i, name := range seriesNames {
+		_, err = chaiDB.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO series (id, name, author_id, marked_for_deletion)
+			VALUES (%d, '%s', NULL, false)
+		`, i+1, name))
+		if err != nil {
+			t.Fatalf("failed to insert series %q into Chai: %v", name, err)
+		}
+	}
+
+	// Chai result
+	chaiSeries, err := chaiStore.GetAllSeries_Chai(ctx)
+	if err != nil {
+		t.Fatalf("GetAllSeries_Chai failed: %v", err)
+	}
+
+	// Compare counts
+	if len(pebbleSeries) != len(chaiSeries) {
+		t.Fatalf("result count mismatch: Pebble=%d, Chai=%d", len(pebbleSeries), len(chaiSeries))
+	}
+
+	// Build name sets for comparison (order may differ between implementations)
+	pebbleNames := make(map[string]bool, len(pebbleSeries))
+	for _, s := range pebbleSeries {
+		pebbleNames[s.Name] = true
+	}
+
+	for _, s := range chaiSeries {
+		if !pebbleNames[s.Name] {
+			t.Errorf("Chai series %q not found in Pebble results", s.Name)
+		}
+	}
+}
+
+// BenchmarkGetAllSeries_Chai benchmarks the SQL implementation
+func BenchmarkGetAllSeries_Chai(b *testing.B) {
+	tmpDir := b.TempDir()
+	ctx := context.Background()
+
+	chaiPath := filepath.Join(tmpDir, "bench.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		b.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		b.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	// Insert 100 series for a meaningful benchmark
+	seriesInsert := "INSERT INTO series (id, name, author_id, marked_for_deletion) VALUES"
+	values := []string{}
+	for i := 1; i <= 100; i++ {
+		values = append(values, fmt.Sprintf("(%d, 'Series %04d', NULL, false)", i, i))
+	}
+	query := seriesInsert + "\n" + values[0]
+	for _, v := range values[1:] {
+		query += ",\n" + v
+	}
+	if _, err := chaiDB.ExecContext(ctx, query); err != nil {
+		b.Fatalf("failed to insert benchmark series: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := chaiStore.GetAllSeries_Chai(ctx); err != nil {
+			b.Fatalf("GetAllSeries_Chai failed: %v", err)
+		}
+	}
+}

--- a/internal/database/chai_books_by_author_test.go
+++ b/internal/database/chai_books_by_author_test.go
@@ -7,11 +7,9 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // TestGetBooksByAuthorID_Chai_BasicFiltering tests basic author filtering
@@ -42,7 +40,7 @@ func TestGetBooksByAuthorID_Chai_BasicFiltering(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert test book %d: %v", i, err)
 		}
 
@@ -115,7 +113,7 @@ func TestGetBooksByAuthorID_Chai_Pagination(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert test book %d: %v", i, err)
 		}
 		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
@@ -189,7 +187,7 @@ func TestGetBooksByAuthorID_Chai_DeletedBookExclusion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert active book: %v", err)
 		}
 		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
@@ -204,7 +202,7 @@ func TestGetBooksByAuthorID_Chai_DeletedBookExclusion(t *testing.T) {
 			IsPrimaryVersion:  boolPtr(true),
 			MarkedForDeletion: boolPtr(true),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert deleted book: %v", err)
 		}
 		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
@@ -251,7 +249,7 @@ func TestGetBooksByAuthorID_Chai_NonPrimaryVersionExclusion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert primary book: %v", err)
 		}
 		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
@@ -267,7 +265,7 @@ func TestGetBooksByAuthorID_Chai_NonPrimaryVersionExclusion(t *testing.T) {
 			IsPrimaryVersion:  boolPtr(false),
 			MarkedForDeletion: boolPtr(false),
 		}
-		if err := insertTestBook(db.DB(), book); err != nil {
+		if _, err := insertTestBook(db.DB(), book); err != nil {
 			t.Fatalf("failed to insert non-primary book: %v", err)
 		}
 		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
@@ -315,11 +313,15 @@ func BenchmarkGetBooksByAuthorID_Chai(b *testing.B) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		insertTestBook(db.DB(), book)
+		if _, err := insertTestBook(db.DB(), book); err != nil {
+			b.Fatalf("insertTestBook failed: %v", err)
+		}
 
 		// Assign to author (round-robin across 100 authors)
 		authorID := (bookNum % totalAuthors) + 1
-		insertTestBookAuthor(db.DB(), book.ID, authorID)
+		if err := insertTestBookAuthor(db.DB(), book.ID, authorID); err != nil {
+			b.Fatalf("insertTestBookAuthor failed: %v", err)
+		}
 	}
 
 	// Benchmark: lookup all books for a single author (should be ~500 books)
@@ -333,45 +335,5 @@ func BenchmarkGetBooksByAuthorID_Chai(b *testing.B) {
 	}
 }
 
-// Helper function to insert a book into the test database
-func insertTestBook(db *sql.DB, book *Book) error {
-	now := time.Now().Format("2006-01-02T15:04:05")
-	query := fmt.Sprintf(`
-		INSERT INTO books (id, title, is_primary_version, marked_for_deletion, created_at, updated_at)
-		VALUES ('%s', '%s', %v, %v, '%s', '%s')
-	`,
-		book.ID,
-		escapeSQL(book.Title),
-		boolToSQL(*book.IsPrimaryVersion),
-		boolToSQL(*book.MarkedForDeletion),
-		now,
-		now,
-	)
-
-	_, err := db.Exec(query)
-	return err
-}
-
-// Helper function to insert a book-author relationship
-func insertTestBookAuthor(db *sql.DB, bookID string, authorID int) error {
-	query := fmt.Sprintf(`
-		INSERT INTO book_authors (id, book_id, author_id, marked_for_deletion)
-		VALUES ('BA_%s_%d', '%s', %d, false)
-	`, bookID, authorID, bookID, authorID)
-
-	_, err := db.Exec(query)
-	return err
-}
-
-// Helper function to convert bool to SQL value string
-func boolToSQL(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
-// Helper function to convert bool to *bool
-func boolPtr(b bool) *bool {
-	return &b
-}
+// insertTestBook, insertTestBookAuthor, boolToSQL, and boolPtr
+// are defined in chai_books_list_test_helper.go

--- a/internal/database/chai_books_list_test.go
+++ b/internal/database/chai_books_list_test.go
@@ -7,11 +7,9 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // TestGetAllBooks_Chai_BasicPagination tests pagination with default filters
@@ -221,38 +219,4 @@ func TestGetAllBooks_Chai_IsPrimaryVersion(t *testing.T) {
 	t.Logf("✓ Primary version filtering tests passed")
 }
 
-// Helper function to insert a test book (uses minimal columns)
-func insertTestBook(db *sql.DB, book *Book) (*Book, error) {
-	now := time.Now()
-	if book.CreatedAt == nil {
-		book.CreatedAt = &now
-	}
-	if book.UpdatedAt == nil {
-		book.UpdatedAt = &now
-	}
-	if book.IsPrimaryVersion == nil {
-		book.IsPrimaryVersion = boolPtr(true)
-	}
-	if book.MarkedForDeletion == nil {
-		book.MarkedForDeletion = boolPtr(false)
-	}
-
-	query := fmt.Sprintf(`
-		INSERT INTO books (id, title, file_path, is_primary_version, marked_for_deletion, created_at, updated_at)
-		VALUES ('%s', '%s', '%s', %v, %v, '%s', '%s')
-	`,
-		book.ID,
-		escapeSQL(book.Title),
-		escapeSQL(book.FilePath),
-		boolToSQL(*book.IsPrimaryVersion),
-		boolToSQL(*book.MarkedForDeletion),
-		now.Format("2006-01-02T15:04:05"),
-		now.Format("2006-01-02T15:04:05"),
-	)
-
-	_, err := db.Exec(query)
-	if err != nil {
-		return nil, err
-	}
-	return book, nil
-}
+// insertTestBook is defined in chai_books_list_test_helper.go

--- a/internal/database/chai_books_list_test_helper.go
+++ b/internal/database/chai_books_list_test_helper.go
@@ -1,5 +1,5 @@
 // file: internal/database/chai_books_list_test_helper.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c2d3e4f5-g6h7-48i9-j0k1-l2m3n4o5p6q7
 // last-edited: 2026-05-24
 
@@ -76,4 +76,51 @@ func boolToSQL(b bool) int {
 
 func intPtr(i int) *int {
 	return &i
+}
+
+// insertTestBook inserts a minimal book row for use in Chai SQL tests.
+// Returns the book (with defaults filled in) and any insert error.
+func insertTestBook(db *sql.DB, book *Book) (*Book, error) {
+	now := time.Now()
+	if book.CreatedAt == nil {
+		book.CreatedAt = &now
+	}
+	if book.UpdatedAt == nil {
+		book.UpdatedAt = &now
+	}
+	if book.IsPrimaryVersion == nil {
+		book.IsPrimaryVersion = boolPtr(true)
+	}
+	if book.MarkedForDeletion == nil {
+		book.MarkedForDeletion = boolPtr(false)
+	}
+
+	query := fmt.Sprintf(`
+		INSERT INTO books (id, title, is_primary_version, marked_for_deletion, created_at, updated_at)
+		VALUES ('%s', '%s', %v, %v, '%s', '%s')
+	`,
+		book.ID,
+		escapeSQL(book.Title),
+		boolToSQL(*book.IsPrimaryVersion),
+		boolToSQL(*book.MarkedForDeletion),
+		now.Format("2006-01-02T15:04:05"),
+		now.Format("2006-01-02T15:04:05"),
+	)
+
+	_, err := db.Exec(query)
+	if err != nil {
+		return nil, err
+	}
+	return book, nil
+}
+
+// insertTestBookAuthor inserts a book-author relationship row for use in Chai SQL tests.
+func insertTestBookAuthor(db *sql.DB, bookID string, authorID int) error {
+	query := fmt.Sprintf(`
+		INSERT INTO book_authors (id, book_id, author_id, marked_for_deletion)
+		VALUES ('BA_%s_%d', '%s', %d, false)
+	`, bookID, authorID, bookID, authorID)
+
+	_, err := db.Exec(query)
+	return err
 }

--- a/internal/database/chai_store.go
+++ b/internal/database/chai_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/chai_store.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: e5f6a7b8-c9d0-4e1f-2a3b-c4d5e6f7a8b9
 // last-edited: 2026-05-24
 
@@ -67,6 +67,49 @@ func (cs *ChaiStore) GetAllSeriesBookCounts_SQL(ctx context.Context) (map[int]in
 	}
 
 	return counts, nil
+}
+
+// GetAllSeries_Chai returns all series ordered by name via SQL.
+// Replaces manual Pebble key-range iteration (series:0 to series:;) + JSON
+// unmarshaling + index-key skipping with a single ORDER BY query.
+// SQL pattern:
+//
+//	SELECT id, name, author_id FROM series ORDER BY name
+func (cs *ChaiStore) GetAllSeries_Chai(ctx context.Context) ([]Series, error) {
+	if cs.db == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+
+	// Single SQL query replaces:
+	// 1. Create iterator over "series:0" to "series:;"
+	// 2. Skip keys containing ":name:" (index keys)
+	// 3. Unmarshal JSON per record
+	// 4. Append to slice
+	rows, err := cs.db.QueryContext(ctx, `SELECT id, name, author_id FROM series ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query series: %w", err)
+	}
+	defer rows.Close()
+
+	var series []Series
+	for rows.Next() {
+		var s Series
+		var authorID sql.NullInt64
+		if err := rows.Scan(&s.ID, &s.Name, &authorID); err != nil {
+			continue
+		}
+		if authorID.Valid {
+			v := int(authorID.Int64)
+			s.AuthorID = &v
+		}
+		series = append(series, s)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error reading series: %w", err)
+	}
+
+	return series, nil
 }
 
 // GetAllAuthorBookCounts_Chai migrates author book count aggregation to SQL.

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.80.0
+// version: 1.81.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-24
 
@@ -754,6 +754,15 @@ func (p *PebbleStore) deleteAuthorAliases(batch *pebble.Batch, authorID int) err
 // Series operations
 
 func (p *PebbleStore) GetAllSeries() ([]Series, error) {
+	// Use feature flag to switch between Pebble and Chai implementations
+	if p.UseChaiDB && p.chai != nil {
+		return p.GetAllSeries_Chai(context.Background())
+	}
+	return p.GetAllSeries_Pebble()
+}
+
+// GetAllSeries_Pebble returns all series using Pebble key-range iteration.
+func (p *PebbleStore) GetAllSeries_Pebble() ([]Series, error) {
 	var series []Series
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("series:0"),
@@ -778,6 +787,21 @@ func (p *PebbleStore) GetAllSeries() ([]Series, error) {
 	}
 
 	return series, nil
+}
+
+// GetAllSeries_Chai returns all series via Chai SQL (SELECT id, name FROM series ORDER BY name).
+// This is the production entry point when UseChaiDB feature flag is enabled.
+func (p *PebbleStore) GetAllSeries_Chai(ctx context.Context) ([]Series, error) {
+	if p.chai == nil {
+		return nil, fmt.Errorf("Chai database not initialized")
+	}
+
+	chaiStore, err := NewChaiStore(p.chai.DB())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ChaiStore: %w", err)
+	}
+
+	return chaiStore.GetAllSeries_Chai(ctx)
 }
 
 func (p *PebbleStore) GetSeriesByID(id int) (*Series, error) {


### PR DESCRIPTION
## Summary
- Adds `GetAllSeries_Chai()` using a single indexed SQL query vs Pebble key-range iteration
- Feature flag routing in `GetAllSeries()` (`UseChaiDB && chai != nil`)
- 4 new tests: ordering, empty DB, nullable author_id hydration, Pebble-vs-Chai comparison
- **Fixes pre-existing test compilation errors**: extracted shared helpers (`insertTestBook`, `boolPtr`, `boolToSQL`, `insertTestBookAuthor`) into `chai_books_list_test_helper.go`, removed duplicate declarations from `chai_books_by_author_test.go` and `chai_books_list_test.go`

## Test plan
- [ ] All 4 new Chai series tests pass
- [ ] `go build ./...` succeeds (already verified)
- [ ] `go test ./internal/database/...` no longer fails on duplicate symbol declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)