### PR TITLE
feat(database): migrate GetAllWorks to SQL routing (stub)

### DIFF
--- a/internal/database/chai_store.go
+++ b/internal/database/chai_store.go
@@ -1312,6 +1312,13 @@ func (cs *ChaiStore) GetAllBookSummaries_Chai(ctx context.Context, limit, offset
 	return summaries, nil
 }
 
+// GetAllWorks_Chai returns all works via SQL (stub — works table not yet in schema).
+func (cs *ChaiStore) GetAllWorks_Chai(ctx context.Context) ([]Work, error) {
+	// TODO(phase4): works table not yet in chai_schema.go — return empty slice
+	// until the schema is extended and data is synced.
+	return []Work{}, nil
+}
+
 // Helper functions
 func escapeSQL(s string) string {
 	return strings.ReplaceAll(s, "'", "''")

--- a/internal/database/chai_works_test.go
+++ b/internal/database/chai_works_test.go
@@ -1,0 +1,87 @@
+// file: internal/database/chai_works_test.go
+// version: 1.0.0
+// guid: f1a2b3c4-d5e6-47f8-9a0b-c1d2e3f4a5b6
+// last-edited: 2026-05-24
+
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetAllWorks_Chai_StubReturnsEmpty verifies that GetAllWorks_Chai returns an
+// empty (non-nil) slice while the works table is not yet in chai_schema.go.
+func TestGetAllWorks_Chai_StubReturnsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	chaiStore, err := NewChaiStore(chaiDB.DB())
+	if err != nil {
+		t.Fatalf("NewChaiStore failed: %v", err)
+	}
+
+	works, err := chaiStore.GetAllWorks_Chai(ctx)
+	if err != nil {
+		t.Fatalf("GetAllWorks_Chai returned unexpected error: %v", err)
+	}
+	if works == nil {
+		t.Fatal("expected non-nil slice, got nil")
+	}
+	if len(works) != 0 {
+		t.Errorf("expected 0 works (schema not yet extended), got %d", len(works))
+	}
+}
+
+// TestGetAllWorks_PebbleRoutesViaChai confirms that when UseChaiDB=true the routing
+// delegates to the Chai path and returns successfully (stub path, empty result).
+func TestGetAllWorks_PebbleRoutesViaChai(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	pebbleStore := store.(*PebbleStore)
+
+	chaiPath := filepath.Join(tmpDir, "chai.db")
+	chaiDB, err := NewChaiDB(ctx, chaiPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	defer chaiDB.Close()
+
+	pebbleStore.chai = chaiDB
+	pebbleStore.UseChaiDB = true
+
+	works, err := pebbleStore.GetAllWorks()
+	if err != nil {
+		t.Fatalf("GetAllWorks (Chai routing) returned unexpected error: %v", err)
+	}
+	if works == nil {
+		t.Fatal("expected non-nil slice, got nil")
+	}
+}
+
+// TestGetAllWorks_PebbleRoutesViaPebble confirms that when UseChaiDB=false the Pebble
+// implementation is used and returns successfully with an empty store.
+func TestGetAllWorks_PebbleRoutesViaPebble(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	// Default: UseChaiDB = false
+	works, err := store.GetAllWorks()
+	if err != nil {
+		t.Fatalf("GetAllWorks (Pebble routing) returned unexpected error: %v", err)
+	}
+	// Empty store — nil or empty slice, both fine
+	_ = works
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1135,7 +1135,17 @@ func (p *PebbleStore) GetAllSeriesFileCounts() (map[int]int, error) {
 
 // ---- Work operations (logical title-level grouping) ----
 
+// GetAllWorks returns all works. When UseChaiDB is enabled it delegates to the
+// SQL implementation in ChaiStore; otherwise it falls back to the Pebble prefix scan.
 func (p *PebbleStore) GetAllWorks() ([]Work, error) {
+	if p.UseChaiDB && p.chai != nil {
+		return p.GetAllWorks_Chai(context.Background())
+	}
+	return p.GetAllWorks_Pebble()
+}
+
+// GetAllWorks_Pebble returns all works by iterating the Pebble "work:" prefix.
+func (p *PebbleStore) GetAllWorks_Pebble() ([]Work, error) {
 	var works []Work
 	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: []byte("work:0"), UpperBound: []byte("work:;")})
 	if err != nil {
@@ -1154,6 +1164,20 @@ func (p *PebbleStore) GetAllWorks() ([]Work, error) {
 		works = append(works, w)
 	}
 	return works, nil
+}
+
+// GetAllWorks_Chai delegates work retrieval to the SQL backend via ChaiStore.
+// NOTE: The works table is not yet defined in chai_schema.go; ChaiStore.GetAllWorks_Chai
+// returns an empty slice until the schema is extended.
+func (p *PebbleStore) GetAllWorks_Chai(ctx context.Context) ([]Work, error) {
+	if p.chai == nil {
+		return nil, fmt.Errorf("Chai database not initialized")
+	}
+	chaiStore, err := NewChaiStore(p.chai.DB())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ChaiStore: %w", err)
+	}
+	return chaiStore.GetAllWorks_Chai(ctx)
 }
 
 func (p *PebbleStore) GetWorkByID(id string) (*Work, error) {


### PR DESCRIPTION
## Summary
- Adds feature-flag routing in `GetAllWorks()` to delegate to Chai SQL stub
- Works table is a future-use table (exists in schema.sql) so this implements the routing pattern with a stub implementation
- Follows the same delegate/fallback pattern as all other Phase 4 migrations

## Test plan
- [ ] `go build ./...` succeeds
- [ ] Feature flag defaults to false (Pebble fallback active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)