### PR TITLE
feat(database): Chai SQL write-through sync from PebbleDB

### DIFF
--- a/internal/database/chai_books_by_author_test.go
+++ b/internal/database/chai_books_by_author_test.go
@@ -342,4 +342,3 @@ func insertTestBookAuthor(db *sql.DB, bookID string, authorID int) error {
 	_, err := db.Exec(query)
 	return err
 }
-

--- a/internal/database/chai_sync.go
+++ b/internal/database/chai_sync.go
@@ -1,0 +1,427 @@
+// file: internal/database/chai_sync.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-4789-0abc-def012345678
+// last-edited: 2026-05-24
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// ── SQL null helpers ─────────────────────────────────────────────────────────
+// Chai does not support parameterized queries, so we build SQL strings manually.
+// All helpers return either NULL or a properly-quoted/formatted literal.
+
+func chaiNullableString(s *string) string {
+	if s == nil || *s == "" {
+		return "NULL"
+	}
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(*s, "'", "''"))
+}
+
+func chaiNullableInt(i *int) string {
+	if i == nil {
+		return "NULL"
+	}
+	return fmt.Sprintf("%d", *i)
+}
+
+func chaiNullableInt64(i *int64) string {
+	if i == nil {
+		return "NULL"
+	}
+	return fmt.Sprintf("%d", *i)
+}
+
+func chaiNullableBool(b *bool) string {
+	if b == nil {
+		return "NULL"
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}
+
+func chaiNullableFloat64(f *float64) string {
+	if f == nil {
+		return "NULL"
+	}
+	return fmt.Sprintf("%g", *f)
+}
+
+func chaiNullableTime(t *time.Time) string {
+	if t == nil {
+		return "NULL"
+	}
+	return fmt.Sprintf("'%s'", t.UTC().Format("2006-01-02T15:04:05"))
+}
+
+func chaiEscapeStr(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// ── UpsertBookToChaiDB ───────────────────────────────────────────────────────
+
+// UpsertBookToChaiDB inserts or replaces a book and its relationships in the Chai
+// SQL tables. It uses a DELETE-then-INSERT strategy within a single transaction
+// because Chai does not support ON CONFLICT.
+//
+// Called on every CreateBook / UpdateBook; never hard-fails (Pebble is source of truth).
+func (p *PebbleStore) UpsertBookToChaiDB(ctx context.Context, book *Book) error {
+	if p.chai == nil {
+		return nil
+	}
+
+	tx, err := p.chai.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("chai begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	bookID := chaiEscapeStr(book.ID)
+
+	// Delete existing rows for this book (book_authors and book_files first, then books).
+	for _, delSQL := range []string{
+		fmt.Sprintf("DELETE FROM book_authors WHERE book_id = '%s'", bookID),
+		fmt.Sprintf("DELETE FROM book_files WHERE book_id = '%s'", bookID),
+		fmt.Sprintf("DELETE FROM books WHERE id = '%s'", bookID),
+	} {
+		if _, execErr := tx.ExecContext(ctx, delSQL); execErr != nil {
+			return fmt.Errorf("chai delete books: %w", execErr)
+		}
+	}
+
+	// Insert book row.
+	insertBook := fmt.Sprintf(`INSERT INTO books (
+		id, title, author_id, series_id, series_sequence,
+		file_path, format, duration,
+		work_id, narrator, edition, description, language, publisher, genre,
+		print_year, audiobook_release_year, isbn10, isbn13, asin,
+		open_library_id, hardcover_id, google_books_id,
+		itunes_persistent_id, itunes_date_added, itunes_play_count,
+		itunes_last_played, itunes_rating, itunes_bookmark,
+		itunes_import_source, itunes_path, original_filename,
+		bitrate_kbps, codec, sample_rate_hz, channels, bit_depth, quality,
+		is_primary_version, version_group_id, version_notes,
+		file_hash, file_size, original_file_hash, organized_file_hash,
+		library_state, quantity, marked_for_deletion, marked_for_deletion_at,
+		quarantine_reason, quarantined_at,
+		created_at, updated_at, metadata_updated_at, last_written_at,
+		last_organize_operation_id, last_organized_at,
+		metadata_review_status, metadata_source,
+		book_sig_v1, book_sig_segments, book_sig_built_at,
+		book_sig_v1_mask, book_sig_coverage_pct,
+		itunes_sync_status, audible_runtime_min, metadata_source_hash,
+		merged_into_book_id,
+		audible_rating_overall, audible_rating_performance, audible_rating_story,
+		audible_rating_count, audible_num_reviews,
+		google_rating_average, google_rating_count,
+		user_rating_overall, user_rating_story, user_rating_performance,
+		user_rating_notes, cover_url, narrators_json, source_import_path,
+		last_scan_mtime, last_scan_size, needs_rescan
+	) VALUES (
+		'%s', '%s', %s, %s, %s,
+		'%s', '%s', %s,
+		%s, %s, %s, %s, %s, %s, %s,
+		%s, %s, %s, %s, %s,
+		%s, %s, %s,
+		%s, %s, %s,
+		%s, %s, %s,
+		%s, %s, %s,
+		%s, %s, %s, %s, %s, %s,
+		%s, %s, %s,
+		%s, %s, %s, %s,
+		%s, %s, %s, %s,
+		%s, %s,
+		%s, %s, %s, %s,
+		%s, %s,
+		%s, %s,
+		%s, %s, %s,
+		%s, %s,
+		%s, %s, %s,
+		%s,
+		%s, %s, %s,
+		%s, %s,
+		%s, %s,
+		%s, %s, %s,
+		%s, %s, %s, %s,
+		%s, %s, %s
+	)`,
+		// id, title, author_id, series_id, series_sequence
+		bookID,
+		chaiEscapeStr(book.Title),
+		chaiNullableInt(book.AuthorID),
+		chaiNullableInt(book.SeriesID),
+		chaiNullableInt(book.SeriesSequence),
+		// file_path, format, duration
+		chaiEscapeStr(book.FilePath),
+		chaiEscapeStr(book.Format),
+		chaiNullableInt(book.Duration),
+		// work_id, narrator, edition, description, language, publisher, genre
+		chaiNullableString(book.WorkID),
+		chaiNullableString(book.Narrator),
+		chaiNullableString(book.Edition),
+		chaiNullableString(book.Description),
+		chaiNullableString(book.Language),
+		chaiNullableString(book.Publisher),
+		chaiNullableString(book.Genre),
+		// print_year, audiobook_release_year, isbn10, isbn13, asin
+		chaiNullableInt(book.PrintYear),
+		chaiNullableInt(book.AudiobookReleaseYear),
+		chaiNullableString(book.ISBN10),
+		chaiNullableString(book.ISBN13),
+		chaiNullableString(book.ASIN),
+		// external provider IDs
+		chaiNullableString(book.OpenLibraryID),
+		chaiNullableString(book.HardcoverID),
+		chaiNullableString(book.GoogleBooksID),
+		// iTunes fields
+		chaiNullableString(book.ITunesPersistentID),
+		chaiNullableTime(book.ITunesDateAdded),
+		chaiNullableInt(book.ITunesPlayCount),
+		chaiNullableTime(book.ITunesLastPlayed),
+		chaiNullableInt(book.ITunesRating),
+		chaiNullableInt64(book.ITunesBookmark),
+		chaiNullableString(book.ITunesImportSource),
+		chaiNullableString(book.ITunesPath),
+		chaiNullableString(book.OriginalFilename),
+		// media info
+		chaiNullableInt(book.Bitrate),
+		chaiNullableString(book.Codec),
+		chaiNullableInt(book.SampleRate),
+		chaiNullableInt(book.Channels),
+		chaiNullableInt(book.BitDepth),
+		chaiNullableString(book.Quality),
+		// version management
+		chaiNullableBool(book.IsPrimaryVersion),
+		chaiNullableString(book.VersionGroupID),
+		chaiNullableString(book.VersionNotes),
+		// file hashes
+		chaiNullableString(book.FileHash),
+		chaiNullableInt64(book.FileSize),
+		chaiNullableString(book.OriginalFileHash),
+		chaiNullableString(book.OrganizedFileHash),
+		// lifecycle
+		chaiNullableString(book.LibraryState),
+		chaiNullableInt(book.Quantity),
+		chaiNullableBool(book.MarkedForDeletion),
+		chaiNullableTime(book.MarkedForDeletionAt),
+		chaiNullableString(book.QuarantineReason),
+		chaiNullableTime(book.QuarantinedAt),
+		// timestamps
+		chaiNullableTime(book.CreatedAt),
+		chaiNullableTime(book.UpdatedAt),
+		chaiNullableTime(book.MetadataUpdatedAt),
+		chaiNullableTime(book.LastWrittenAt),
+		// organize tracking
+		chaiNullableString(book.LastOrganizeOperationID),
+		chaiNullableTime(book.LastOrganizedAt),
+		// metadata review
+		chaiNullableString(book.MetadataReviewStatus),
+		chaiNullableString(book.MetadataSource),
+		// book sig
+		chaiNullableString(book.BookSigV1),
+		chaiNullableInt(book.BookSigSegments),
+		chaiNullableTime(book.BookSigBuiltAt),
+		chaiNullableString(book.BookSigV1Mask),
+		chaiNullableInt(book.BookSigCoveragePct),
+		// iTunes sync status + audible runtime + metadata source hash + merged
+		chaiNullableString(book.ITunesSyncStatus),
+		chaiNullableInt(book.AudibleRuntimeMin),
+		chaiNullableString(book.MetadataSourceHash),
+		chaiNullableString(book.MergedIntoBookID),
+		// Audible ratings
+		chaiNullableFloat64(book.AudibleRatingOverall),
+		chaiNullableFloat64(book.AudibleRatingPerformance),
+		chaiNullableFloat64(book.AudibleRatingStory),
+		chaiNullableInt(book.AudibleRatingCount),
+		chaiNullableInt(book.AudibleNumReviews),
+		// Google ratings
+		chaiNullableFloat64(book.GoogleRatingAverage),
+		chaiNullableInt(book.GoogleRatingCount),
+		// User ratings
+		chaiNullableFloat64(book.UserRatingOverall),
+		chaiNullableFloat64(book.UserRatingStory),
+		chaiNullableFloat64(book.UserRatingPerformance),
+		chaiNullableString(book.UserRatingNotes),
+		// cover/narrators
+		chaiNullableString(book.CoverURL),
+		chaiNullableString(book.NarratorsJSON),
+		chaiNullableString(book.SourceImportPath),
+		// scan cache
+		chaiNullableInt64(book.LastScanMtime),
+		chaiNullableInt64(book.LastScanSize),
+		chaiNullableBool(book.NeedsRescan),
+	)
+
+	if _, execErr := tx.ExecContext(ctx, insertBook); execErr != nil {
+		return fmt.Errorf("chai insert book: %w", execErr)
+	}
+
+	// Insert book_authors rows from the per-book JSON blob stored at book_authors:<bookID>.
+	bookAuthors, baErr := p.GetBookAuthors(book.ID)
+	if baErr != nil {
+		slog.Warn("chai_sync: failed to load book_authors for book", "book_id", book.ID, "error", baErr)
+	}
+
+	// Fall back to AuthorID if no book_authors record exists (legacy books).
+	if len(bookAuthors) == 0 && book.AuthorID != nil {
+		bookAuthors = []BookAuthor{{
+			BookID:   book.ID,
+			AuthorID: *book.AuthorID,
+			Role:     "author",
+			Position: 0,
+		}}
+	}
+
+	for i, ba := range bookAuthors {
+		baID := fmt.Sprintf("%s_a%d", bookID, i)
+		role := ba.Role
+		if role == "" {
+			role = "author"
+		}
+		insertBA := fmt.Sprintf(`INSERT INTO book_authors (id, book_id, author_id, role, position, marked_for_deletion) VALUES (
+			'%s', '%s', %d, '%s', %d, false
+		)`,
+			baID,
+			bookID,
+			ba.AuthorID,
+			chaiEscapeStr(role),
+			ba.Position,
+		)
+		if _, execErr := tx.ExecContext(ctx, insertBA); execErr != nil {
+			return fmt.Errorf("chai insert book_author: %w", execErr)
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("chai commit upsert: %w", commitErr)
+	}
+	committed = true
+	return nil
+}
+
+// ── DeleteBookFromChaiDB ─────────────────────────────────────────────────────
+
+// DeleteBookFromChaiDB removes a book and its relationships from Chai SQL tables.
+// Called on every DeleteBook. Never hard-fails (Pebble is source of truth).
+func (p *PebbleStore) DeleteBookFromChaiDB(ctx context.Context, bookID string) error {
+	if p.chai == nil {
+		return nil
+	}
+
+	tx, err := p.chai.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("chai begin tx for delete: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	escaped := chaiEscapeStr(bookID)
+	for _, delSQL := range []string{
+		fmt.Sprintf("DELETE FROM book_authors WHERE book_id = '%s'", escaped),
+		fmt.Sprintf("DELETE FROM book_files WHERE book_id = '%s'", escaped),
+		fmt.Sprintf("DELETE FROM books WHERE id = '%s'", escaped),
+	} {
+		if _, execErr := tx.ExecContext(ctx, delSQL); execErr != nil {
+			return fmt.Errorf("chai delete: %w", execErr)
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("chai commit delete: %w", commitErr)
+	}
+	committed = true
+	return nil
+}
+
+// ── BackfillChaiFromPebble ───────────────────────────────────────────────────
+
+// BackfillChaiFromPebble iterates all books in Pebble and upserts each to Chai.
+// Idempotent — safe to run multiple times. Logs progress every 1000 books.
+// Returns the number of books successfully synced and any terminal error.
+func (p *PebbleStore) BackfillChaiFromPebble(ctx context.Context) (synced int, err error) {
+	if p.chai == nil {
+		return 0, fmt.Errorf("chai database not initialized")
+	}
+
+	slog.Info("chai_sync: starting backfill from Pebble")
+
+	iter, iterErr := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:"),
+		UpperBound: []byte("book;"),
+	})
+	if iterErr != nil {
+		return 0, fmt.Errorf("chai_sync backfill: failed to create iterator: %w", iterErr)
+	}
+	defer iter.Close()
+
+	var failed int
+	for iter.First(); iter.Valid(); iter.Next() {
+		select {
+		case <-ctx.Done():
+			slog.Warn("chai_sync: backfill cancelled", "synced", synced, "failed", failed)
+			return synced, ctx.Err()
+		default:
+		}
+
+		key := string(iter.Key())
+
+		// Skip secondary index keys — only canonical "book:<ULID>" keys have exactly
+		// one colon in the suffix. Anything with an additional colon or slash is an index.
+		suffix := strings.TrimPrefix(key, "book:")
+		if strings.ContainsAny(suffix, ":/") {
+			continue
+		}
+
+		rawVal, valErr := iter.ValueAndErr()
+		if valErr != nil {
+			slog.Warn("chai_sync: failed to read value", "key", key, "error", valErr)
+			failed++
+			continue
+		}
+
+		// Clone bytes before the iterator moves.
+		val := make([]byte, len(rawVal))
+		copy(val, rawVal)
+
+		var book Book
+		if jsonErr := json.Unmarshal(val, &book); jsonErr != nil {
+			slog.Warn("chai_sync: failed to unmarshal book", "key", key, "error", jsonErr)
+			failed++
+			continue
+		}
+
+		if upsertErr := p.UpsertBookToChaiDB(ctx, &book); upsertErr != nil {
+			slog.Warn("chai_sync: upsert failed", "book_id", book.ID, "error", upsertErr)
+			failed++
+			continue
+		}
+
+		synced++
+		if synced%1000 == 0 {
+			slog.Info("chai_sync: backfill progress", "synced", synced, "failed", failed)
+		}
+	}
+
+	slog.Info("chai_sync: backfill complete", "synced", synced, "failed", failed)
+	return synced, nil
+}

--- a/internal/database/chai_sync.go
+++ b/internal/database/chai_sync.go
@@ -1,5 +1,5 @@
 // file: internal/database/chai_sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1e2d3c4-b5a6-4789-0abc-def012345678
 // last-edited: 2026-05-24
 
@@ -305,6 +305,90 @@ func (p *PebbleStore) UpsertBookToChaiDB(ctx context.Context, book *Book) error 
 		)
 		if _, execErr := tx.ExecContext(ctx, insertBA); execErr != nil {
 			return fmt.Errorf("chai insert book_author: %w", execErr)
+		}
+	}
+
+	// Insert book_files rows by iterating the Pebble key range for this book.
+	// Key format: book_file:<bookID>:<fileID>
+	// The Chai book_files table is intentionally slimmer — only columns needed
+	// for aggregation (file count, duration, size, hash coverage).
+	filePrefix := fmt.Sprintf("book_file:%s:", book.ID)
+	fileUpper := fmt.Sprintf("book_file:%s;", book.ID)
+	fileIter, fileIterErr := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(filePrefix),
+		UpperBound: []byte(fileUpper),
+	})
+	if fileIterErr != nil {
+		slog.Warn("chai_sync: failed to create book_files iterator", "book_id", book.ID, "error", fileIterErr)
+	} else {
+		defer fileIter.Close()
+		for fileIter.First(); fileIter.Valid(); fileIter.Next() {
+			rawFile, fileValErr := fileIter.ValueAndErr()
+			if fileValErr != nil {
+				slog.Warn("chai_sync: failed to read book_file value", "key", string(fileIter.Key()), "error", fileValErr)
+				continue
+			}
+			// Clone before iterator advances.
+			fileBytes := make([]byte, len(rawFile))
+			copy(fileBytes, rawFile)
+
+			var bf BookFile
+			if jsonErr := json.Unmarshal(fileBytes, &bf); jsonErr != nil {
+				slog.Warn("chai_sync: failed to unmarshal book_file", "key", string(fileIter.Key()), "error", jsonErr)
+				continue
+			}
+
+			// Build nullable helpers for BookFile fields.
+			var bfDuration *int
+			if bf.Duration != 0 {
+				bfDuration = &bf.Duration
+			}
+			var bfSize *int64
+			if bf.FileSize != 0 {
+				bfSize = &bf.FileSize
+			}
+			var bfHash *string
+			if bf.FileHash != "" {
+				bfHash = &bf.FileHash
+			}
+			var bfFormat *string
+			if bf.Format != "" {
+				bfFormat = &bf.Format
+			}
+			bfMissing := bf.Missing
+			var bfCreatedAt *time.Time
+			if !bf.CreatedAt.IsZero() {
+				bfCreatedAt = &bf.CreatedAt
+			}
+			var bfUpdatedAt *time.Time
+			if !bf.UpdatedAt.IsZero() {
+				bfUpdatedAt = &bf.UpdatedAt
+			}
+			markedDel := false // BookFile has no MarkedForDeletion field
+
+			insertBF := fmt.Sprintf(`INSERT INTO book_files (
+				id, book_id, file_path, format, duration_ms, file_size_bytes,
+				file_hash, missing, created_at, updated_at, marked_for_deletion
+			) VALUES (
+				'%s', '%s', '%s', %s, %s, %s,
+				%s, %s, %s, %s, %s
+			)`,
+				chaiEscapeStr(bf.ID),
+				chaiEscapeStr(bf.BookID),
+				chaiEscapeStr(bf.FilePath),
+				chaiNullableString(bfFormat),
+				chaiNullableInt(bfDuration),
+				chaiNullableInt64(bfSize),
+				chaiNullableString(bfHash),
+				chaiNullableBool(&bfMissing),
+				chaiNullableTime(bfCreatedAt),
+				chaiNullableTime(bfUpdatedAt),
+				chaiNullableBool(&markedDel),
+			)
+			if _, execErr := tx.ExecContext(ctx, insertBF); execErr != nil {
+				slog.Warn("chai_sync: failed to insert book_file", "file_id", bf.ID, "error", execErr)
+				// Non-fatal: continue with remaining files.
+			}
 		}
 	}
 

--- a/internal/database/chai_sync_test.go
+++ b/internal/database/chai_sync_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/chai_sync_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a9b8c7d6-e5f4-4321-9876-fedcba012345
 // last-edited: 2026-05-24
 
@@ -7,6 +7,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -221,6 +222,71 @@ func TestBackfillChaiFromPebble_SyncsAllBooks(t *testing.T) {
 	if count < len(bookIDs) {
 		t.Errorf("expected at least %d books in chai after backfill, got %d", len(bookIDs), count)
 	}
+}
+
+// TestUpsertBookToChaiDB_BookFiles verifies that book_files rows in Pebble are
+// synced into the Chai book_files table as part of UpsertBookToChaiDB.
+func TestUpsertBookToChaiDB_BookFiles(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	book := makeTestBook("01TESTBOOKID00000000000005", "Book With Files")
+
+	// Store the book in Pebble (UseChaiDB is true, so it writes through).
+	// We need it in Pebble for CreateBookFile to work.
+	store.UseChaiDB = false // temporarily disable write-through so we can test explicitly
+	if _, err := store.CreateBook(book); err != nil {
+		t.Fatalf("CreateBook failed: %v", err)
+	}
+	store.UseChaiDB = true
+
+	// Create three book files in Pebble.
+	for i := 1; i <= 3; i++ {
+		bf := &BookFile{
+			ID:       fmt.Sprintf("01TESTFILEID0000000000000%d", i),
+			BookID:   book.ID,
+			FilePath: fmt.Sprintf("/test/book/%d.m4b", i),
+			Format:   "m4b",
+			Duration: i * 1000,
+			FileSize: int64(i * 10_000_000),
+			FileHash: fmt.Sprintf("sha256hash%d", i),
+			Missing:  false,
+		}
+		if err := store.CreateBookFile(bf); err != nil {
+			t.Fatalf("CreateBookFile %d failed: %v", i, err)
+		}
+	}
+
+	// Now upsert the book to Chai — this should pull the files from Pebble.
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("UpsertBookToChaiDB failed: %v", err)
+	}
+
+	// Verify 3 book_files rows in Chai.
+	var count int
+	if err := store.chai.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM book_files WHERE book_id = '01TESTBOOKID00000000000005'",
+	).Scan(&count); err != nil {
+		t.Fatalf("query book_files failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 book_files rows in Chai, got %d", count)
+	}
+
+	// Verify idempotency: upsert again — should still be 3 (DELETE+INSERT, not duplicates).
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("second UpsertBookToChaiDB failed: %v", err)
+	}
+	if err := store.chai.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM book_files WHERE book_id = '01TESTBOOKID00000000000005'",
+	).Scan(&count); err != nil {
+		t.Fatalf("query book_files after second upsert failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 book_files after idempotent upsert, got %d", count)
+	}
+
+	t.Logf("✓ BookFiles sync tests passed")
 }
 
 // TestChaiSyncHelper_NullableHelpers verifies the SQL null-formatting helpers.

--- a/internal/database/chai_sync_test.go
+++ b/internal/database/chai_sync_test.go
@@ -1,0 +1,276 @@
+// file: internal/database/chai_sync_test.go
+// version: 1.0.0
+// guid: a9b8c7d6-e5f4-4321-9876-fedcba012345
+// last-edited: 2026-05-24
+
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestChaiDB opens an in-memory-like (temp dir) ChaiDB for use in sync tests.
+func newTestChaiDB(t *testing.T) *ChaiDB {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "chai_sync_test.db")
+
+	ctx := context.Background()
+	db, err := NewChaiDB(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("NewChaiDB failed: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// newTestPebbleStoreWithChai creates a PebbleStore with a Chai database attached
+// and UseChaiDB = true.
+func newTestPebbleStoreWithChai(t *testing.T) *PebbleStore {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	store, err := NewPebbleStore(filepath.Join(tmpDir, "pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore failed: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	chaiDB := newTestChaiDB(t)
+	store.chai = chaiDB
+	store.UseChaiDB = true
+	return store
+}
+
+// makeTestBook returns a minimal valid Book for use in tests.
+func makeTestBook(id, title string) *Book {
+	now := time.Now()
+	isPrimary := true
+	markedDel := false
+	return &Book{
+		ID:               id,
+		Title:            title,
+		FilePath:         "/test/" + id + ".m4b",
+		Format:           "m4b",
+		IsPrimaryVersion: &isPrimary,
+		MarkedForDeletion: &markedDel,
+		CreatedAt:        &now,
+		UpdatedAt:        &now,
+	}
+}
+
+// TestUpsertBookToChaiDB_InsertAndQuery verifies that a book inserted via
+// UpsertBookToChaiDB is queryable through the Chai SQL layer.
+func TestUpsertBookToChaiDB_InsertAndQuery(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	book := makeTestBook("01TESTBOOKID00000000000000", "Test Book One")
+	authorID := 42
+	book.AuthorID = &authorID
+
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("UpsertBookToChaiDB failed: %v", err)
+	}
+
+	// Verify the book is queryable via SQL.
+	var count int
+	err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM books WHERE id = '01TESTBOOKID00000000000000'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query after upsert failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 book in chai, got %d", count)
+	}
+}
+
+// TestUpsertBookToChaiDB_Idempotent verifies that upserting the same book twice
+// does not create duplicate rows.
+func TestUpsertBookToChaiDB_Idempotent(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	book := makeTestBook("01TESTBOOKID00000000000001", "Idempotent Book")
+
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("first UpsertBookToChaiDB failed: %v", err)
+	}
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("second UpsertBookToChaiDB failed: %v", err)
+	}
+
+	var count int
+	err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM books WHERE id = '01TESTBOOKID00000000000001'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query after double upsert failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 book after idempotent upsert, got %d", count)
+	}
+}
+
+// TestUpsertBookToChaiDB_BookAuthors verifies that book_authors rows are
+// populated when the book has author associations.
+func TestUpsertBookToChaiDB_BookAuthors(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	book := makeTestBook("01TESTBOOKID00000000000002", "Multi-Author Book")
+	authorID := 7
+	book.AuthorID = &authorID
+
+	// Store authors via SetBookAuthors (mirrors what CreateBook callers do).
+	authors := []BookAuthor{
+		{BookID: book.ID, AuthorID: 7, Role: "author", Position: 0},
+		{BookID: book.ID, AuthorID: 8, Role: "co-author", Position: 1},
+	}
+	if err := store.SetBookAuthors(book.ID, authors); err != nil {
+		t.Fatalf("SetBookAuthors failed: %v", err)
+	}
+
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("UpsertBookToChaiDB failed: %v", err)
+	}
+
+	var count int
+	err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM book_authors WHERE book_id = '01TESTBOOKID00000000000002'").Scan(&count)
+	if err != nil {
+		t.Fatalf("query book_authors failed: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 book_authors rows, got %d", count)
+	}
+}
+
+// TestDeleteBookFromChaiDB verifies that a book is removed from Chai after delete.
+func TestDeleteBookFromChaiDB_RemovesBook(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	book := makeTestBook("01TESTBOOKID00000000000003", "Book To Delete")
+
+	if err := store.UpsertBookToChaiDB(ctx, book); err != nil {
+		t.Fatalf("UpsertBookToChaiDB failed: %v", err)
+	}
+
+	// Confirm it's there.
+	var countBefore int
+	if err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM books WHERE id = '01TESTBOOKID00000000000003'").Scan(&countBefore); err != nil {
+		t.Fatalf("pre-delete query failed: %v", err)
+	}
+	if countBefore != 1 {
+		t.Fatalf("expected 1 book before delete, got %d", countBefore)
+	}
+
+	if err := store.DeleteBookFromChaiDB(ctx, book.ID); err != nil {
+		t.Fatalf("DeleteBookFromChaiDB failed: %v", err)
+	}
+
+	var countAfter int
+	if err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM books WHERE id = '01TESTBOOKID00000000000003'").Scan(&countAfter); err != nil {
+		t.Fatalf("post-delete query failed: %v", err)
+	}
+	if countAfter != 0 {
+		t.Errorf("expected 0 books after delete, got %d", countAfter)
+	}
+}
+
+// TestBackfillChaiFromPebble verifies that BackfillChaiFromPebble syncs all
+// existing books from Pebble into Chai.
+func TestBackfillChaiFromPebble_SyncsAllBooks(t *testing.T) {
+	store := newTestPebbleStoreWithChai(t)
+	ctx := context.Background()
+
+	// Temporarily disable write-through so we can test backfill independently.
+	store.UseChaiDB = false
+
+	// Create books via Pebble only (no Chai sync).
+	bookIDs := []string{
+		"01BACKFILLBOOK000000000001",
+		"01BACKFILLBOOK000000000002",
+		"01BACKFILLBOOK000000000003",
+	}
+	for i, id := range bookIDs {
+		b := makeTestBook(id, "Backfill Book")
+		b.ID = id
+		b.FilePath = "/test/backfill/" + id + ".m4b"
+		b.Title = "Backfill Book " + string(rune('A'+i))
+		if _, err := store.CreateBook(b); err != nil {
+			t.Fatalf("CreateBook %s failed: %v", id, err)
+		}
+	}
+
+	// Re-enable chai and run backfill.
+	store.UseChaiDB = true
+	synced, err := store.BackfillChaiFromPebble(ctx)
+	if err != nil {
+		t.Fatalf("BackfillChaiFromPebble failed: %v", err)
+	}
+	if synced < len(bookIDs) {
+		t.Errorf("expected at least %d synced, got %d", len(bookIDs), synced)
+	}
+
+	// Verify all 3 books appear in Chai.
+	var count int
+	if err := store.chai.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM books").Scan(&count); err != nil {
+		t.Fatalf("query after backfill failed: %v", err)
+	}
+	if count < len(bookIDs) {
+		t.Errorf("expected at least %d books in chai after backfill, got %d", len(bookIDs), count)
+	}
+}
+
+// TestChaiSyncHelper_NullableHelpers verifies the SQL null-formatting helpers.
+func TestChaiSyncHelper_NullableHelpers(t *testing.T) {
+	t.Run("chaiNullableString_nil", func(t *testing.T) {
+		if got := chaiNullableString(nil); got != "NULL" {
+			t.Errorf("expected NULL, got %q", got)
+		}
+	})
+	t.Run("chaiNullableString_value", func(t *testing.T) {
+		s := "it's a test"
+		got := chaiNullableString(&s)
+		want := "'it''s a test'"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("chaiNullableInt_nil", func(t *testing.T) {
+		if got := chaiNullableInt(nil); got != "NULL" {
+			t.Errorf("expected NULL, got %q", got)
+		}
+	})
+	t.Run("chaiNullableInt_value", func(t *testing.T) {
+		v := 42
+		if got := chaiNullableInt(&v); got != "42" {
+			t.Errorf("expected 42, got %q", got)
+		}
+	})
+	t.Run("chaiNullableBool_true", func(t *testing.T) {
+		v := true
+		if got := chaiNullableBool(&v); got != "true" {
+			t.Errorf("expected true, got %q", got)
+		}
+	})
+	t.Run("chaiNullableBool_nil", func(t *testing.T) {
+		if got := chaiNullableBool(nil); got != "NULL" {
+			t.Errorf("expected NULL, got %q", got)
+		}
+	})
+	t.Run("chaiNullableTime_nil", func(t *testing.T) {
+		if got := chaiNullableTime(nil); got != "NULL" {
+			t.Errorf("expected NULL, got %q", got)
+		}
+	})
+	t.Run("chaiNullableTime_value", func(t *testing.T) {
+		ts := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+		got := chaiNullableTime(&ts)
+		want := "'2026-05-24T12:00:00'"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -195,7 +195,7 @@ func NewPebbleStore(path string) (*PebbleStore, error) {
 
 	store := &PebbleStore{
 		db:        db,
-		UseChaiDB: false, // Chai DB not yet populated — needs data sync before enabling
+		UseChaiDB: true, // Chai DB sync is wired — backfill via POST /api/v1/admin/backfill-chai
 	}
 
 	slog.Info("PebbleDB opened", "path", path, "format_version", db.FormatMajorVersion())
@@ -2163,6 +2163,14 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 
 	p.InvalidateLibraryStats()
 	p.MarkAllQuickQueriesDirty("create_book")
+
+	// Chai write-through sync (best-effort; Pebble is source of truth).
+	if p.UseChaiDB && p.chai != nil {
+		if syncErr := p.UpsertBookToChaiDB(context.Background(), book); syncErr != nil {
+			slog.Warn("chai sync failed for CreateBook", "id", book.ID, "error", syncErr)
+		}
+	}
+
 	return book, nil
 }
 
@@ -2408,6 +2416,14 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	p.MarkQuickQueryDirty("missing_covers", "update_book")
 	p.MarkQuickQueryDirty("no_isbn", "update_book")
 	p.MarkQuickQueryDirty("in_import_path", "update_book")
+
+	// Chai write-through sync (best-effort; Pebble is source of truth).
+	if p.UseChaiDB && p.chai != nil {
+		if syncErr := p.UpsertBookToChaiDB(context.Background(), book); syncErr != nil {
+			slog.Warn("chai sync failed for UpdateBook", "id", id, "error", syncErr)
+		}
+	}
+
 	return book, nil
 }
 
@@ -2755,6 +2771,14 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	}
 	p.InvalidateLibraryStats()
 	p.MarkAllQuickQueriesDirty("delete_book")
+
+	// Chai write-through sync (best-effort; Pebble is source of truth).
+	if p.UseChaiDB && p.chai != nil {
+		if syncErr := p.DeleteBookFromChaiDB(context.Background(), id); syncErr != nil {
+			slog.Warn("chai sync failed for DeleteBook", "id", id, "error", syncErr)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_fixups.go
-// version: 2.3.1
+// version: 2.4.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-05-22
+// last-edited: 2026-05-24
 
 package server
 
@@ -592,4 +592,30 @@ func (s *Server) handleGetAcoustIDStats(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithOK(c, stats)
+}
+
+// backfillChaiDB handles POST /api/v1/admin/backfill-chai.
+//
+// Iterates all books in Pebble and upserts them into the Chai SQL index.
+// Idempotent — safe to run multiple times. Returns { synced, error }.
+func (s *Server) backfillChaiDB(c *gin.Context) {
+	store := s.Store()
+	if store == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+
+	pebbleStore, ok := store.(*database.PebbleStore)
+	if !ok {
+		httputil.RespondWithBadRequest(c, "chai backfill only supported with PebbleStore backend")
+		return
+	}
+
+	synced, err := pebbleStore.BackfillChaiFromPebble(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "chai backfill failed", err)
+		return
+	}
+
+	httputil.RespondWithOK(c, gin.H{"synced": synced})
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1165,6 +1165,7 @@ func (s *Server) setupRoutes() {
 				adminOnly.POST("/maintenance/wipe", s.handleWipe)
 				adminOnly.GET("/cache/stats/keys", s.handleCacheKeysIntrospection)
 				adminOnly.POST("/admin/recompact-digests", s.recompactDigests)
+				adminOnly.POST("/admin/backfill-chai", s.backfillChaiDB)
 			}
 
 			// Unified activity log


### PR DESCRIPTION
## Summary

- Implements `UpsertBookToChaiDB`, `DeleteBookFromChaiDB`, and `BackfillChaiFromPebble` in `internal/database/chai_sync.go`
- Wires write-through sync into `PebbleStore.CreateBook`, `UpdateBook`, and `DeleteBook` (warn-only — Pebble remains source of truth)
- Populates Chai `book_files` table by iterating the `book_file:<bookID>:` Pebble key range inside the same transaction
- Adds admin endpoint `POST /api/v1/admin/backfill-chai` to backfill all existing books from Pebble into Chai
- Fixes: `CountFiles_Chai`, `GetAllSeriesFileCounts_Chai`, `GetAllAuthorFileCounts_Chai` were returning 0 because `book_files` was deleted but never re-inserted

## Key design decisions

- **DELETE-then-INSERT** upsert (Chai has no `ON CONFLICT` support)
- **String-built SQL** with `chaiEscapeStr` single-quote escaping (Chai has no parameterized queries)
- **Warn-only** on Chai errors — a Chai failure never fails the Pebble write
- **Transaction batching**: all deletes + book row + book_authors + book_files in one tx
- `UseChaiDB = true` set in `NewPebbleStore` (backfill endpoint available immediately)

## Test plan

- [x] `TestUpsertBookToChaiDB_InsertAndQuery` — book visible in Chai after upsert
- [x] `TestUpsertBookToChaiDB_Idempotent` — double upsert produces exactly 1 row
- [x] `TestUpsertBookToChaiDB_BookAuthors` — multi-author rows synced to `book_authors`
- [x] `TestUpsertBookToChaiDB_BookFiles` — 3 BookFile rows synced; idempotent upsert keeps 3
- [x] `TestDeleteBookFromChaiDB_RemovesBook` — book absent from Chai after delete
- [x] `TestBackfillChaiFromPebble_SyncsAllBooks` — 3 Pebble-only books appear in Chai after backfill
- [x] `TestChaiSyncHelper_NullableHelpers` — 8 sub-tests for all nullable helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)