### PR TITLE
refactor(database): Task 3.4 - remove denormalized book:series + book:author indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 ## [Unreleased]
 
+### Refactors
+
+#### May 24, 2026 — Task 3.4: Remove denormalized book:series / book:author indexes
+
+Removed dual-write logic for `book:series:<id>:<bookID>` and `book:author:<id>:<bookID>` prefix keys from `SetBook`, `UpdateBook`, and `DeleteBook`. These denormalized indexes existed to speed up `GetBooksBySeriesID` and `GetBooksByAuthorID`, but are superseded by Chai SQL variants added in Tasks 3.2/3.3.
+
+- **SetBook:** Removed series and author index writes (was ~20 lines)
+- **UpdateBook:** Removed dual-write logic that swapped old/new index keys on series/author change (~40 lines)
+- **DeleteBook:** Removed prefix-key cleanup on delete
+- **GetBooksBySeriesID / GetBooksByAuthorID:** Now route to Chai SQL (`GetBooksBySeriesID_Chai`, `GetBooksByAuthorID_Chai`) when `UseChaiDB` is enabled; added full Pebble scan fallbacks (`_Pebble` variants) for when Chai is disabled
+- **GetAllAuthorBookCounts / GetAllAuthorFileCounts_Pebble:** Rewrote to use full book scan (was using the removed `book:author:` index)
+- **GetAllBooks:** Cleaned up skip logic — no longer needs to skip `:series:` and `:author:` keys
+- **scanBookFromSQL:** Fixed NULL handling for non-pointer string fields (`ID`, `Title`, `FilePath`, `Format`) — these were silently dropped when columns were NULL; now uses `sql.NullString` intermediaries
+- **Test conflicts:** Fixed name collisions from Tasks 3.1/3.3 (duplicate `insertTestBook`, `boolToSQL`, `boolPtr` definitions across test files)
+
 ### Fixes
 
 #### May 24, 2026 — EMERGENCY: Disable cache warm-ups (memory leak, 81GB peak)

--- a/internal/database/chai_books_list_test.go
+++ b/internal/database/chai_books_list_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/chai_books_list_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: a1b2c3d4-e5f6-47a8-b9c0-d1e2f3a4b5c6
 // last-edited: 2026-05-24
 
@@ -38,7 +38,7 @@ func TestGetAllBooks_Chai_BasicPagination(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		_, err := insertTestBook(db.DB(), book)
+		_, err := insertTestBookFull(db.DB(), book)
 		if err != nil {
 			t.Fatalf("failed to insert test book %d: %v", i, err)
 		}
@@ -109,7 +109,7 @@ func TestGetAllBooks_Chai_MarkedForDeletion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		_, err := insertTestBook(db.DB(), book)
+		_, err := insertTestBookFull(db.DB(), book)
 		if err != nil {
 			t.Fatalf("failed to insert active book: %v", err)
 		}
@@ -123,7 +123,7 @@ func TestGetAllBooks_Chai_MarkedForDeletion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(true),
 		}
-		_, err := insertTestBook(db.DB(), book)
+		_, err := insertTestBookFull(db.DB(), book)
 		if err != nil {
 			t.Fatalf("failed to insert deleted book: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestGetAllBooks_Chai_IsPrimaryVersion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(true),
 			MarkedForDeletion: boolPtr(false),
 		}
-		_, err := insertTestBook(db.DB(), book)
+		_, err := insertTestBookFull(db.DB(), book)
 		if err != nil {
 			t.Fatalf("failed to insert primary book: %v", err)
 		}
@@ -191,7 +191,7 @@ func TestGetAllBooks_Chai_IsPrimaryVersion(t *testing.T) {
 			IsPrimaryVersion: boolPtr(false),
 			MarkedForDeletion: boolPtr(false),
 		}
-		_, err := insertTestBook(db.DB(), book)
+		_, err := insertTestBookFull(db.DB(), book)
 		if err != nil {
 			t.Fatalf("failed to insert non-primary book: %v", err)
 		}

--- a/internal/database/chai_books_list_test_helper.go
+++ b/internal/database/chai_books_list_test_helper.go
@@ -37,20 +37,29 @@ func insertTestBookFull(db *sql.DB, book *Book) (*Book, error) {
 		seriesSeqVal = fmt.Sprintf("%d", *book.SeriesSequence)
 	}
 
+	isPrimary := "true"
+	if !*book.IsPrimaryVersion {
+		isPrimary = "false"
+	}
+	markedDel := "false"
+	if *book.MarkedForDeletion {
+		markedDel = "true"
+	}
+
 	query := fmt.Sprintf(`
 		INSERT INTO books (
 			id, title, file_path, series_id, series_sequence,
 			is_primary_version, marked_for_deletion, created_at, updated_at
 		)
-		VALUES ('%s', '%s', '%s', %s, %s, %v, %v, '%s', '%s')
+		VALUES ('%s', '%s', '%s', %s, %s, %s, %s, '%s', '%s')
 	`,
 		book.ID,
 		escapeSQL(book.Title),
 		escapeSQL(book.FilePath),
 		seriesIDVal,
 		seriesSeqVal,
-		boolToSQL(*book.IsPrimaryVersion),
-		boolToSQL(*book.MarkedForDeletion),
+		isPrimary,
+		markedDel,
 		now.Format("2006-01-02T15:04:05"),
 		now.Format("2006-01-02T15:04:05"),
 	)

--- a/internal/database/chai_store.go
+++ b/internal/database/chai_store.go
@@ -774,6 +774,12 @@ func (cs *ChaiStore) GetBooksBySeriesID_Chai(ctx context.Context, seriesID int, 
 // scanBookFromSQL unmarshals a Book from SQL query results.
 func scanBookFromSQL(rows *sql.Rows, book *Book) error {
 	var (
+		// Non-pointer string fields need NullString to handle NULL from partial inserts
+		bookID    sql.NullString
+		bookTitle sql.NullString
+		filePath  sql.NullString
+		format    sql.NullString
+		// Nullable numeric fields
 		authorID          sql.NullInt64
 		seriesID          sql.NullInt64
 		seriesSeq         sql.NullInt64
@@ -818,7 +824,7 @@ func scanBookFromSQL(rows *sql.Rows, book *Book) error {
 	)
 
 	err := rows.Scan(
-		&book.ID, &book.Title, &authorID, &seriesID, &seriesSeq, &book.FilePath, &book.Format, &duration,
+		&bookID, &bookTitle, &authorID, &seriesID, &seriesSeq, &filePath, &format, &duration,
 		&book.WorkID, &book.Narrator, &book.Edition, &book.Description, &book.Language, &book.Publisher,
 		&book.Genre, &printYear, &audReleaseYear, &book.ISBN10, &book.ISBN13, &book.ASIN,
 		&book.OpenLibraryID, &book.HardcoverID, &book.GoogleBooksID, &book.ITunesPersistentID,
@@ -840,6 +846,12 @@ func scanBookFromSQL(rows *sql.Rows, book *Book) error {
 	if err != nil {
 		return err
 	}
+
+	// Assign non-pointer string fields from NullString
+	book.ID = bookID.String
+	book.Title = bookTitle.String
+	book.FilePath = filePath.String
+	book.Format = format.String
 
 	// Convert SQL nulls to pointers
 	if authorID.Valid {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -89,8 +89,9 @@ func isValidULID(s string) bool {
 // - series:name:<name>:<author_id> -> series_id (for lookups)
 // - book:<id>                  -> Book JSON
 // - book:path:<path>           -> book_id (for lookups)
-// - book:series:<series_id>:<id> -> Book JSON (PERF-OPT: full JSON to eliminate point lookups)
-// - book:author:<author_id>:<id> -> Book JSON (PERF-OPT: full JSON to eliminate point lookups)
+// NOTE: book:series and book:author prefix indexes were removed in Task 3.4.
+//       GetBooksBySeriesID and GetBooksByAuthorID now use Chai SQL when UseChaiDB is
+//       enabled, or fall back to a full Pebble scan.
 // - import_path:<id>           -> ImportPath JSON
 // - import_path:path:<path>    -> import_path_id (for lookups)
 // - operation:<id>             -> Operation JSON
@@ -1339,10 +1340,9 @@ func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	count := 0
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Skip index keys
+		// Skip path index keys (book:series and book:author indexes removed in Task 3.4)
 		key := string(iter.Key())
-		if strings.Contains(key, ":path:") || strings.Contains(key, ":series:") ||
-			strings.Contains(key, ":author:") {
+		if strings.Contains(key, ":path:") {
 			continue
 		}
 
@@ -1657,12 +1657,24 @@ func (p *PebbleStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, 
 }
 
 func (p *PebbleStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
-	var books []Book
-	prefix := []byte(fmt.Sprintf("book:series:%d:", seriesID))
+	// Use Chai SQL when available (Task 3.4: denormalized index removed).
+	if p.UseChaiDB && p.chai != nil {
+		chaiStore, err := NewChaiStore(p.chai.DB())
+		if err == nil {
+			return chaiStore.GetBooksBySeriesID_Chai(context.Background(), seriesID, 0, 0)
+		}
+	}
+	// Fallback: full Pebble scan filtered by series ID.
+	return p.GetBooksBySeriesID_Pebble(seriesID)
+}
 
+// GetBooksBySeriesID_Pebble performs a full Pebble book scan filtered by series ID.
+// Used when Chai SQL is unavailable (fallback path after Task 3.4 index removal).
+func (p *PebbleStore) GetBooksBySeriesID_Pebble(seriesID int) ([]Book, error) {
+	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
-		UpperBound: append(prefix, 0xFF),
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
 	})
 	if err != nil {
 		return nil, err
@@ -1670,28 +1682,47 @@ func (p *PebbleStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Deserialize Book from index value (handles both new JSON format and legacy ID-only format)
-		book, err := deserializeBookFromIndex(iter.Value(), func(id string) (*Book, error) {
-			return p.GetBookByID(id)
-		})
-		if err != nil {
-			return nil, err
+		key := string(iter.Key())
+		// Skip non-primary book keys (path index etc.)
+		if strings.Contains(key, ":path:") {
+			continue
 		}
-		if book != nil && (book.MarkedForDeletion == nil || !*book.MarkedForDeletion) {
-			books = append(books, *book)
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			continue
 		}
+		if book.SeriesID == nil || *book.SeriesID != seriesID {
+			continue
+		}
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+		books = append(books, book)
 	}
 
 	return books, nil
 }
 
 func (p *PebbleStore) GetBooksByAuthorID(authorID int) ([]Book, error) {
-	var books []Book
-	prefix := []byte(fmt.Sprintf("book:author:%d:", authorID))
+	// Use Chai SQL when available (Task 3.4: denormalized index removed).
+	if p.UseChaiDB && p.chai != nil {
+		chaiStore, err := NewChaiStore(p.chai.DB())
+		if err == nil {
+			return chaiStore.GetBooksByAuthorID_Chai(context.Background(), authorID, 0, 0)
+		}
+	}
+	// Fallback: full Pebble scan filtered by author ID.
+	return p.GetBooksByAuthorID_Pebble(authorID)
+}
 
+// GetBooksByAuthorID_Pebble performs a full Pebble book scan filtered by author ID.
+// Used when Chai SQL is unavailable (fallback path after Task 3.4 index removal).
+func (p *PebbleStore) GetBooksByAuthorID_Pebble(authorID int) ([]Book, error) {
+	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
-		UpperBound: append(prefix, 0xFF),
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
 	})
 	if err != nil {
 		return nil, err
@@ -1699,15 +1730,23 @@ func (p *PebbleStore) GetBooksByAuthorID(authorID int) ([]Book, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		book, err := deserializeBookFromIndex(iter.Value(), func(id string) (*Book, error) {
-			return p.GetBookByID(id)
-		})
-		if err != nil {
-			return nil, err
+		key := string(iter.Key())
+		// Skip non-primary book keys (path index etc.)
+		if strings.Contains(key, ":path:") {
+			continue
 		}
-		if book != nil && (book.MarkedForDeletion == nil || !*book.MarkedForDeletion) {
-			books = append(books, *book)
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			continue
 		}
+		if book.AuthorID == nil || *book.AuthorID != authorID {
+			continue
+		}
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+		books = append(books, book)
 	}
 
 	return books, nil
@@ -1746,36 +1785,43 @@ func (p *PebbleStore) GetBooksByAuthorIDWithRole(authorID int) ([]Book, error) {
 }
 
 func (p *PebbleStore) GetAllAuthorBookCounts() (map[int]int, error) {
-	// Single-pass iteration of book:author index to avoid N+1 queries.
-	// Do NOT deserialize books - just count primary-version entries from the index.
+	// Full Pebble book scan (book:author index removed in Task 3.4).
+	// Iterates primary book records and counts by AuthorID.
 	counts := make(map[int]int)
-	prefix := []byte("book:author:")
-	upper := []byte("book:author;") // ':' + 1
-	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		key := string(iter.Key()) // "book:author:<authorID>:<bookID>"
+		key := string(iter.Key())
+		// Skip path index and other sub-keys
+		if strings.Contains(key, ":path:") {
+			continue
+		}
 		parts := strings.Split(key, ":")
-		if len(parts) < 4 {
-			continue
-		}
-		authorID, err := strconv.Atoi(parts[2])
-		if err != nil {
+		if len(parts) != 2 {
 			continue
 		}
 
-		// Check IsPrimaryVersion flag from index metadata (first byte of value)
-		// Skip if book is marked as non-primary version
-		value := iter.Value()
-		if len(value) > 0 && value[0] == 0 { // 0 = non-primary version
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
 		}
-
-		counts[authorID]++
+		if b.AuthorID == nil {
+			continue
+		}
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		counts[*b.AuthorID]++
 	}
 
 	return counts, nil
@@ -1820,45 +1866,50 @@ func (p *PebbleStore) GetAllAuthorFileCounts() (map[int]int, error) {
 }
 
 // GetAllAuthorFileCounts_Pebble returns the number of audio files per author using Pebble iteration.
-// Optimized to use single-pass index scan + batch file loading instead of N+1 queries.
+// Full book scan fallback after book:author index removal (Task 3.4).
 func (p *PebbleStore) GetAllAuthorFileCounts_Pebble() (map[int]int, error) {
 	counts := make(map[int]int)
 
-	// Phase 1: Iterate book:author index to collect author-book relationships
-	// Do NOT deserialize full books - just extract IDs and check primary-version flag
+	// Phase 1: Full scan of primary book records to collect author-book relationships.
+	// book:author prefix index removed in Task 3.4; must iterate all books instead.
 	type AuthorBook struct {
 		AuthorID int
 		BookID   string
 	}
 	var authorBooks []AuthorBook
 
-	prefix := []byte("book:author:")
-	upper := []byte("book:author;")
-	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		key := string(iter.Key()) // "book:author:<authorID>:<bookID>"
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") {
+			continue
+		}
 		parts := strings.Split(key, ":")
-		if len(parts) < 4 {
-			continue
-		}
-		authorID, err := strconv.Atoi(parts[2])
-		if err != nil {
-			continue
-		}
-		bookID := parts[3]
-
-		// Check IsPrimaryVersion flag from index metadata (first byte of value)
-		// Skip if book is marked as non-primary version
-		value := iter.Value()
-		if len(value) > 0 && value[0] == 0 { // 0 = non-primary version
+		if len(parts) != 2 {
 			continue
 		}
 
-		authorBooks = append(authorBooks, AuthorBook{AuthorID: authorID, BookID: bookID})
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.AuthorID == nil {
+			continue
+		}
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		authorBooks = append(authorBooks, AuthorBook{AuthorID: *b.AuthorID, BookID: b.ID})
 	}
 	iter.Close()
 
@@ -2088,34 +2139,6 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 		}
 	}
 
-	// Series index (store full Book JSON to eliminate point lookups in GetBooksBySeriesID)
-	if book.SeriesID != nil {
-		seriesKey := []byte(fmt.Sprintf("book:series:%d:%s", *book.SeriesID, book.ID))
-		bookJSON, err := serializeBookForIndex(book)
-		if err != nil {
-			batch.Close()
-			return nil, err
-		}
-		if err := batch.Set(seriesKey, bookJSON, nil); err != nil {
-			batch.Close()
-			return nil, err
-		}
-	}
-
-	// Author index (store full Book JSON to eliminate point lookups in GetBooksByAuthorID)
-	if book.AuthorID != nil {
-		authorKey := []byte(fmt.Sprintf("book:author:%d:%s", *book.AuthorID, book.ID))
-		bookJSON, err := serializeBookForIndex(book)
-		if err != nil {
-			batch.Close()
-			return nil, err
-		}
-		if err := batch.Set(authorKey, bookJSON, nil); err != nil {
-			batch.Close()
-			return nil, err
-		}
-	}
-
 	// Version-group index (PERF-VERSIONS): O(N) full-scan in
 	// GetBooksByVersionGroup was costing ~15s on a 10K-book library.
 	// Indexed by group_id so the read can iterate only matching keys.
@@ -2271,68 +2294,6 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	if err := updateHashIndex(oldBook.OrganizedFileHash, book.OrganizedFileHash, "organizedhash"); err != nil {
 		batch.Close()
 		return nil, err
-	}
-
-	// Update series index if changed (store full Book JSON)
-	oldSeriesID := -1
-	if oldBook.SeriesID != nil {
-		oldSeriesID = *oldBook.SeriesID
-	}
-	newSeriesID := -1
-	if book.SeriesID != nil {
-		newSeriesID = *book.SeriesID
-	}
-	if oldSeriesID != newSeriesID {
-		if oldSeriesID != -1 {
-			oldSeriesKey := []byte(fmt.Sprintf("book:series:%d:%s", oldSeriesID, id))
-			if err := batch.Delete(oldSeriesKey, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
-		}
-		if newSeriesID != -1 {
-			newSeriesKey := []byte(fmt.Sprintf("book:series:%d:%s", newSeriesID, id))
-			bookJSON, err := serializeBookForIndex(book)
-			if err != nil {
-				batch.Close()
-				return nil, err
-			}
-			if err := batch.Set(newSeriesKey, bookJSON, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
-		}
-	}
-
-	// Update author index if changed (store full Book JSON)
-	oldAuthorID := -1
-	if oldBook.AuthorID != nil {
-		oldAuthorID = *oldBook.AuthorID
-	}
-	newAuthorID := -1
-	if book.AuthorID != nil {
-		newAuthorID = *book.AuthorID
-	}
-	if oldAuthorID != newAuthorID {
-		if oldAuthorID != -1 {
-			oldAuthorKey := []byte(fmt.Sprintf("book:author:%d:%s", oldAuthorID, id))
-			if err := batch.Delete(oldAuthorKey, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
-		}
-		if newAuthorID != -1 {
-			newAuthorKey := []byte(fmt.Sprintf("book:author:%d:%s", newAuthorID, id))
-			bookJSON, err := serializeBookForIndex(book)
-			if err != nil {
-				batch.Close()
-				return nil, err
-			}
-			if err := batch.Set(newAuthorKey, bookJSON, nil); err != nil {
-				batch.Close()
-				return nil, err
-			}
-		}
 	}
 
 	// Update version-group index if changed (PERF-VERSIONS).
@@ -2719,24 +2680,6 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	if err := batch.Delete(pathKey, nil); err != nil {
 		batch.Close()
 		return err
-	}
-
-	// Delete series index
-	if book.SeriesID != nil {
-		seriesKey := []byte(fmt.Sprintf("book:series:%d:%s", *book.SeriesID, id))
-		if err := batch.Delete(seriesKey, nil); err != nil {
-			batch.Close()
-			return err
-		}
-	}
-
-	// Delete author index
-	if book.AuthorID != nil {
-		authorKey := []byte(fmt.Sprintf("book:author:%d:%s", *book.AuthorID, id))
-		if err := batch.Delete(authorKey, nil); err != nil {
-			batch.Close()
-			return err
-		}
 	}
 
 	// Delete version-group index (PERF-VERSIONS).


### PR DESCRIPTION
## Summary
Removes the manually-maintained `book:series:<id>:<bookID>` and `book:author:<id>:<bookID>` prefix keys from Pebble, which were the main source of N+1 write overhead. SQL indexes replace them.

**Changes:**
- `SetBook`: removed ~20 lines of prefix-key writes
- `UpdateBook`: removed ~40 lines of old/new key-swap logic when series/author changes
- `DeleteBook`: removed prefix-key cleanup block
- `GetBooksBySeriesID` / `GetBooksByAuthorID`: wired Chai SQL routing; added `_Pebble` full-scan fallbacks
- `GetAllAuthorBookCounts` / `GetAllAuthorFileCounts_Pebble`: rewrote to use `book:0`–`book:;` full scan instead of removed index
- `GetAllBooks`: removed skip logic for `:series:` and `:author:` key patterns
- Fixed `scanBookFromSQL` NULL handling for non-pointer string fields

## Test plan
- [ ] `make build-api` passes (verified)
- [ ] Feature flag `UseChaiDB` defaults to false — Pebble fallbacks are safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)