### PR TITLE
fix(database): fix book_files schema — BIGINT columns and column name alignment

### DIFF
--- a/internal/database/schema.sql
+++ b/internal/database/schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE books (
     itunes_play_count INTEGER,
     itunes_last_played TIMESTAMP,
     itunes_rating INTEGER,
-    itunes_bookmark INTEGER,
+    itunes_bookmark BIGINT,
     itunes_import_source TEXT,
     itunes_path TEXT,
 
@@ -99,7 +99,7 @@ CREATE TABLE books (
 
     -- File hash tracking for deduplication
     file_hash TEXT,
-    file_size INTEGER,
+    file_size BIGINT,
     original_file_hash TEXT,
     organized_file_hash TEXT,
 
@@ -171,8 +171,8 @@ CREATE TABLE books (
     source_import_path TEXT,
 
     -- Scan cache (set by scanner, not user-facing)
-    last_scan_mtime INTEGER,
-    last_scan_size INTEGER,
+    last_scan_mtime BIGINT,
+    last_scan_size BIGINT,
     needs_rescan BOOLEAN DEFAULT false,
 
     -- Foreign keys
@@ -232,8 +232,8 @@ CREATE TABLE book_files (
     -- Audio format/codec info
     format TEXT,
     codec TEXT,
-    duration INTEGER,
-    file_size INTEGER,
+    duration_ms BIGINT,
+    file_size_bytes BIGINT,
     bitrate_kbps INTEGER,
     sample_rate_hz INTEGER,
     channels INTEGER,
@@ -265,6 +265,7 @@ CREATE TABLE book_files (
     -- File state
     missing BOOLEAN DEFAULT false,
     skip_scan BOOLEAN DEFAULT false,
+    marked_for_deletion BOOLEAN DEFAULT false,
 
     -- Timestamps
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- Fix `book_files` INSERT column name mismatch: schema had `duration`/`file_size` but INSERT used `duration_ms`/`file_size_bytes`; Chai was silently creating dynamic INTEGER fields, causing `integer out of range` for files >2GB
- Change 6 columns to `BIGINT`: `book_files.duration_ms`, `book_files.file_size_bytes`, `books.file_size`, `books.itunes_bookmark`, `books.last_scan_mtime`, `books.last_scan_size`
- Add `book_files.marked_for_deletion BOOLEAN` (was in INSERT but missing from schema)

## Test plan
- [ ] Re-run Chai backfill (`POST /api/v1/maintenance/backfill-chai`) — should complete without `integer out of range` errors
- [ ] Verify `book_files` rows are populated in Chai DB for large files

🤖 Generated with [Claude Code](https://claude.com/claude-code)