### PR TITLE
feat(logging): wire logging.Info(ctx) into batch_poller and isbn op flows (SLOG-W13)

### DIFF
--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/isbn.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
 
 package metafetch
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jdfalk/audiobook-organizer/internal/activity"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 	"github.com/jdfalk/audiobook-organizer/internal/metadata"
 )
 
@@ -131,7 +132,7 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *acti
 			checked++
 			found, err := s.EnrichBookISBN(books[i].ID)
 			if err != nil {
-								slog.Warn("ISBN enrichment failed for during batch scan", "id", books[i].ID, "error", err)
+								logging.Warn(ctx, "ISBN enrichment failed for during batch scan", "id", books[i].ID, "error", err)
 			} else if found {
 				updated++
 				activity.LogBatch(w, opID, "isbn-enrich", "isbn-enrichment",

--- a/internal/plugins/maintenance/batch_poller.go
+++ b/internal/plugins/maintenance/batch_poller.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/batch_poller.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: c9d0e1f2-a3b4-5678-2345-890123456789
 // last-edited: 2026-05-07
 
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -41,11 +42,11 @@ func (p *Plugin) runBatchPoller(ctx context.Context, _ json.RawMessage, reporter
 	}
 	processed, err := p.deps.PollBatch(ctx)
 	if err != nil {
-		slog.Warn("batch-poller", "err", err)
+		logging.Warn(ctx, "batch-poller", "err", err)
 	}
 	if processed > 0 {
 		msg := fmt.Sprintf("Processed %d completed batches", processed)
-		slog.Info("batch-poller", "msg", msg)
+		logging.Info(ctx, "batch-poller", "msg", msg)
 		_ = reporter.Log(slog.LevelInfo, msg)
 	}
 	return nil

--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -1,5 +1,5 @@
 // file: internal/server/batch_poller.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: f8a1b2c3-d4e5-6789-abcd-0123456789ab
 
 package server
@@ -14,6 +14,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
 	"github.com/jdfalk/audiobook-organizer/internal/ai/aijobs"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/logging"
 )
 
 // BatchCompletionHandler processes a completed batch.
@@ -74,7 +75,7 @@ func (bp *BatchPoller) Poll(ctx context.Context) (int, error) {
 
 		handler, ok := bp.handlers[b.Type]
 		if !ok {
-			slog.Warn("batch_poller no handler for type %q (batch )", "type", b.Type, "id", b.ID)
+			logging.Warn(ctx, "batch_poller no handler for type %q (batch )", "type", b.Type, "id", b.ID)
 			// Mark as processed so we don't warn repeatedly
 			bp.mu.Lock()
 			bp.processedBatches[b.ID] = true
@@ -83,14 +84,14 @@ func (bp *BatchPoller) Poll(ctx context.Context) (int, error) {
 		}
 
 		if err := handler(ctx, b.ID, b.OutputFileID); err != nil {
-			slog.Error("batch_poller handler for batch failed", "b", b.Type, "b", b.ID, "err", err)
+			logging.Error(ctx, "batch_poller handler for batch failed", "b", b.Type, "b", b.ID, "err", err)
 			// Do NOT mark as processed — retry on next poll
 		} else {
 			bp.mu.Lock()
 			bp.processedBatches[b.ID] = true
 			bp.mu.Unlock()
 			processed++
-			slog.Info("batch_poller processed batch", "b", b.Type, "b", b.ID)
+			logging.Info(ctx, "batch_poller processed batch", "b", b.Type, "b", b.ID)
 		}
 	}
 	return processed, nil
@@ -126,7 +127,7 @@ func (s *Server) registerBatchPollerHandlers() {
 		if err != nil {
 			return fmt.Errorf("download author_dedup results: %w", err)
 		}
-		slog.Info("batch_poller author_dedup batch yielded suggestions", "batchID", batchID, "discoveries_count", len(discoveries))
+		logging.Info(ctx, "batch_poller author_dedup batch yielded suggestions", "batchID", batchID, "discoveries_count", len(discoveries))
 		// Store results in any operation referencing this batch
 		s.storeBatchResultForOperation(batchID, map[string]any{
 			"mode":        "batch-full",
@@ -145,7 +146,7 @@ func (s *Server) registerBatchPollerHandlers() {
 		if err != nil {
 			return fmt.Errorf("download author_review results: %w", err)
 		}
-		slog.Info("batch_poller author_review batch yielded suggestions", "batchID", batchID, "suggestions_count", len(suggestions))
+		logging.Info(ctx, "batch_poller author_review batch yielded suggestions", "batchID", batchID, "suggestions_count", len(suggestions))
 		s.storeBatchResultForOperation(batchID, map[string]any{
 			"mode":        "batch-groups",
 			"suggestions": suggestions,
@@ -163,7 +164,7 @@ func (s *Server) registerBatchPollerHandlers() {
 		if err != nil {
 			return fmt.Errorf("download diagnostics results: %w", err)
 		}
-		slog.Info("batch_poller diagnostics batch yielded results", "batchID", batchID, "rawResults_count", len(rawResults))
+		logging.Info(ctx, "batch_poller diagnostics batch yielded results", "batchID", batchID, "rawResults_count", len(rawResults))
 		s.storeBatchResultForOperation(batchID, map[string]any{
 			"raw_responses": rawResults,
 			"batch_id":      batchID,
@@ -225,12 +226,12 @@ func (s *Server) registerBatchPollerHandlers() {
 				Vector:     r.Vector,
 				Model:      "text-embedding-3-large",
 			}); err != nil {
-				slog.Warn("embed_async upsert book", "r", r.BookID, "err", err)
+				logging.Warn(ctx, "embed_async upsert book", "r", r.BookID, "err", err)
 			} else {
 				stored++
 			}
 		}
-		slog.Info("embed_async stored / embeddings from batch", "stored", stored, "results_count", len(results), "batchID", batchID)
+		logging.Info(ctx, "embed_async stored / embeddings from batch", "stored", stored, "results_count", len(results), "batchID", batchID)
 		return nil
 	})
 }


### PR DESCRIPTION
## Summary
- Migrates 11 raw `slog.*` calls to `logging.Info/Warn(ctx, ...)` in functions that already receive a `context.Context`
- Adds opID/opType/opStatus to every log line emitted inside an active operation in these paths

## Files changed
- `internal/server/batch_poller.go`: `Poll(ctx)` + 5 handler closures (8 calls)
- `internal/plugins/maintenance/batch_poller.go`: `runBatchPoller(ctx)` (2 calls)
- `internal/metafetch/isbn.go`: `EnrichMissingISBNs(ctx)` (1 call)

## Not included
~1299 remaining raw slog calls in metafetch/service_*.go and iTunes service helpers — those functions lack ctx parameters and need a ctx-plumbing pass first before they can be migrated.

## Test plan
- [ ] Build passes: `make build-api`
- [ ] Batch poller log lines include `opID` when polling inside an op context
- [ ] No regression in batch poller behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)