### PR TITLE
perf(sysinfo): skip filesystem walk in /system/status (use DB sizes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.96.0 -->
+<!-- version: 2.97.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-25 -->
 
@@ -8,6 +8,17 @@
 ## [Unreleased]
 
 ### Changes
+
+#### May 25, 2026 — Skip filesystem walk in /system/status (use DB sizes)
+
+`sysinfo.CollectSystemStatus` no longer calls `calculateLibrarySizes` (which
+ran `filepath.Walk` over the entire library + import-path trees) on the hot
+path. On a 50K-book library this walk took ~28s on the first call after
+restart and gated `/system/status` on it. Now uses `dbStats.OrganizedSize`
+and `dbStats.UnorganizedSize` directly — already aggregated for free during
+the memdb `ComputeLibraryStats` walk. Matches the pattern Sonarr/Radarr use:
+trust DB sizes after the initial scan, refresh on book mutation, never
+re-walk on read.
 
 #### May 25, 2026 — Slow-path cleanup (memdb pushdown for stats, soft-deleted, path-counts)
 

--- a/internal/sysinfo/service.go
+++ b/internal/sysinfo/service.go
@@ -142,13 +142,17 @@ func (ss *SystemService) CollectSystemStatus() (*SystemStatus, error) {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	librarySize, importSize := ss.libSizesFn(rootDir, importFolders)
-	// Fall back to DB file sizes when filesystem walk returns 0 (e.g. paths don't exist on this host)
-	if librarySize+importSize == 0 {
-		librarySize = dbStats.OrganizedSize
-		importSize = dbStats.UnorganizedSize
-	}
+	// Use the DB-aggregated sizes from LibraryStats (computed in memdb at
+	// ComputeLibraryStats time, free as part of the cache). The previous
+	// filesystem-walk path took ~28s on cold cache for a 50K-book library
+	// and gated the first /system/status request after restart on it.
+	// Sonarr/Radarr work the same way: trust DB sizes after the initial
+	// scan populates them, refresh on book mutation, never re-walk on read.
+	librarySize := dbStats.OrganizedSize
+	importSize := dbStats.UnorganizedSize
 	totalSize := librarySize + importSize
+	_ = importFolders // libSizesFn dependency now unused; kept on the type for backwards compat (tests, callers)
+	_ = ss.libSizesFn
 
 	brokenFiles := dbStats.BrokenFiles
 	status := &SystemStatus{


### PR DESCRIPTION
## Summary

`/system/status` cold-call took ~28s on a 50K-book library because `sysinfo.CollectSystemStatus` invoked `calculateLibrarySizes`, which `filepath.Walk`s the entire library + every import-path tree.

`dbStats.OrganizedSize` / `UnorganizedSize` are already aggregated for free during the memdb `ComputeLibraryStats` walk (PR #1136). Use those directly.

Matches Sonarr/Radarr: trust DB sizes after the initial scan, refresh on mutation, never re-walk on read.

## Test plan

- [x] \`go test ./internal/sysinfo/ ./internal/server/\` — passes
- [ ] Post-deploy: \`/system/status\` returns in <100ms on cold call

🤖 Generated with [Claude Code](https://claude.com/claude-code)