### PR TITLE
perf(server): warm library size cache at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.97.0 -->
+<!-- version: 2.98.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-25 -->
 
@@ -8,6 +8,14 @@
 ## [Unreleased]
 
 ### Changes
+
+#### May 25, 2026 — Startup library-size warmer
+
+`Server.Start` now kicks off `warmLibrarySizes` in a goroutine alongside
+`warmFacetsCache`. Primes the 24h-TTL filesystem-size cache with current
+on-disk numbers so any later refresh path (nightly maintenance, manual
+rescan) starts from fresh data. Hot-path /system/status reads still come
+from DB stats (PR #1137); this is purely an offline refresh.
 
 #### May 25, 2026 — Skip filesystem walk in /system/status (use DB sizes)
 

--- a/internal/server/server_helpers.go
+++ b/internal/server/server_helpers.go
@@ -1,16 +1,18 @@
 // file: internal/server/server_helpers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8a40b808-2bf2-4a35-893c-ad5e3351dbae
-// last-edited: 2026-05-18
+// last-edited: 2026-05-25
 
 package server
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation"
 )
@@ -75,6 +77,35 @@ func nonEmpty(s string) any {
 		return nil
 	}
 	return s
+}
+
+// warmLibrarySizes runs calculateLibrarySizes once at startup so the
+// filesystem-walk path (Sonarr/Radarr-style refresh of physical-on-disk
+// sizes) is primed for any caller that asks for it later. The hot path
+// of /system/status itself reads from DB stats (PR #1137), so this is
+// purely an offline refresh — never blocks any request.
+//
+// Runs in its own goroutine; safe to start before memdb warmup completes.
+func (s *Server) warmLibrarySizes() {
+	if s.Store() == nil {
+		return
+	}
+	folders, err := s.Store().GetAllImportPaths()
+	if err != nil {
+		slog.Info("library size warm-up skipped", "err", err)
+		return
+	}
+	rootDir := strings.TrimSpace(config.AppConfig.RootDir)
+	started := time.Now()
+	slog.Info("library size warm-up starting",
+		"root_dir", rootDir,
+		"import_folders", len(folders))
+	lib, imp := calculateLibrarySizes(rootDir, folders)
+	slog.Info("library size warm-up complete",
+		"library_bytes", lib,
+		"import_bytes", imp,
+		"duration_ms", time.Since(started).Milliseconds(),
+	)
 }
 
 func calculateLibrarySizes(rootDir string, importFolders []database.ImportPath) (librarySize, importSize int64) {

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -220,6 +220,11 @@ func (s *Server) Start(cfg ServerConfig) error {
 
 	// Pre-warm facets cache (genres/languages) - lightweight, <1 second
 	go s.warmFacetsCache()
+	// Pre-warm library size cache via filesystem walk so any later refresh
+	// path (nightly maintenance, manual rescan) starts with current data.
+	// The hot path of /system/status reads DB stats (PR #1137); this just
+	// keeps the FS-based numbers fresh in the 24h-TTL package cache.
+	go s.warmLibrarySizes()
 	// DISABLED: authors/series cache warm-ups consume 22.9GB → 69.9GB peak memory in minutes
 	// ListAuthorsWithCounts/ListSeriesWithCounts build massive gin.H response objects
 	// Root cause: returning full response structure in cache instead of just counts


### PR DESCRIPTION
## Summary

Adds \`warmLibrarySizes\` goroutine to \`Server.Start\` alongside \`warmFacetsCache\`. Walks the library + import-path trees once at boot to populate the 24h-TTL package-level size cache.

Hot-path \`/system/status\` reads still come from DB stats (PR #1137); this is purely an offline refresh so anything that later asks the FS-based numbers gets fresh data instead of an empty cache.

## Test plan

- [x] \`go test ./internal/server/\` passes
- [ ] Post-deploy: \`library size warm-up complete\` log line within ~30s of restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)