### PR TITLE
feat(maintenance): nightly library size refresh task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.98.0 -->
+<!-- version: 2.99.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-25 -->
 
@@ -8,6 +8,18 @@
 ## [Unreleased]
 
 ### Changes
+
+#### May 25, 2026 — Nightly library-size refresh task
+
+Adds `library.size-refresh` OperationDef + `library_size_refresh` scheduler
+task. Walks the library + import-path trees to repopulate the on-disk size
+cache. Runs nightly via `maintenance.window` (toggle:
+`maintenance_window_library_size_refresh`, default true) and can be
+triggered manually from /scheduler.
+
+Together with the startup warmer (prior entry), this gives Sonarr/Radarr-
+style refresh: scrape at startup, scrape during nightly maintenance,
+trust DB sizes on every read.
 
 #### May 25, 2026 — Startup library-size warmer
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -336,6 +336,7 @@ type Config struct {
 	MaintenanceWindowLibraryScan      bool `json:"maintenance_window_library_scan"`
 	MaintenanceWindowLibraryOrganize  bool `json:"maintenance_window_library_organize"`
 	MaintenanceWindowMetadataRefresh  bool `json:"maintenance_window_metadata_refresh"`
+	MaintenanceWindowLibrarySizeRefresh bool `json:"maintenance_window_library_size_refresh"`
 
 	// Plugin system
 	Plugins map[string]PluginConfig `json:"plugins"`
@@ -483,6 +484,9 @@ func InitConfig() {
 	viper.SetDefault("maintenance_window_library_scan", false)
 	viper.SetDefault("maintenance_window_library_organize", false)
 	viper.SetDefault("maintenance_window_metadata_refresh", false)
+	// FS-walk-based on-disk size refresh — true by default (cheap, runs nightly,
+	// keeps the FS-side cache fresh for any caller that queries physical sizes).
+	viper.SetDefault("maintenance_window_library_size_refresh", true)
 
 	// Download client defaults
 	viper.SetDefault("download_client.torrent.type", "")
@@ -622,6 +626,7 @@ func InitConfig() {
 		MaintenanceWindowLibraryScan:      viper.GetBool("maintenance_window_library_scan"),
 		MaintenanceWindowLibraryOrganize:  viper.GetBool("maintenance_window_library_organize"),
 		MaintenanceWindowMetadataRefresh:  viper.GetBool("maintenance_window_metadata_refresh"),
+		MaintenanceWindowLibrarySizeRefresh: viper.GetBool("maintenance_window_library_size_refresh"),
 
 		// iTunes sync
 		ITunesSyncEnabled:      viper.GetBool("itunes_sync_enabled"),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -113,6 +113,7 @@ func NewTaskScheduler(deps SchedulerDeps) *TaskScheduler {
 		"purge_old_logs",
 		"cleanup_activity_log",
 		"cleanup_old_backups",
+		"library_size_refresh",
 		"db_optimize",
 	}
 	return ts

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -29,6 +29,8 @@ type libraryScanParams struct{}
 
 type libraryOrganizeParams struct{}
 
+type librarySizeRefreshParams struct{}
+
 type authorDedupScanOpParams struct {
 	LegacyOpID string `json:"legacy_op_id"`
 }
@@ -99,6 +101,31 @@ func (ts *TaskScheduler) registerAllTasks() {
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowLibraryOrganize },
+	})
+
+	ts.registerTask(TaskDefinition{
+		Name:        "library_size_refresh",
+		Description: "Walk library + import-path trees to refresh on-disk size cache",
+		Category:    "maintenance",
+		TriggerFn: func(source string) (*database.Operation, error) {
+			store := ts.deps.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "library-size-refresh", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			if _, enqErr := ts.deps.OpRegistry.EnqueueOp(context.Background(), "library.size-refresh", librarySizeRefreshParams{}); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue library.size-refresh: %w", enqErr)
+			}
+			return op, nil
+		},
+		IsEnabled:              func() bool { return true },
+		GetInterval:            func() time.Duration { return 0 },
+		RunOnStart:             func() bool { return false },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowLibrarySizeRefresh },
 	})
 
 	ts.registerTask(TaskDefinition{

--- a/internal/server/library_size_refresh_op.go
+++ b/internal/server/library_size_refresh_op.go
@@ -1,0 +1,81 @@
+// file: internal/server/library_size_refresh_op.go
+// version: 1.0.0
+// guid: 9f1c2d3e-4b5a-6c7d-8e9f-0a1b2c3d4e5f
+
+// library.size-refresh: walks the library root + import-path trees to
+// recompute physical on-disk sizes. Runs nightly via the maintenance
+// window and can be triggered manually from /scheduler.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// RegisterLibrarySizeRefreshOp registers the "library.size-refresh"
+// OperationDef. The op invalidates the package-level size cache and then
+// calls calculateLibrarySizes to repopulate it from a fresh filesystem
+// walk. Used by both the manual /scheduler trigger and the nightly
+// maintenance.window run.
+func (s *Server) RegisterLibrarySizeRefreshOp(reg *opsregistry.Registry) error {
+	return reg.RegisterOp(opsregistry.OperationDef{
+		ID:              "library.size-refresh",
+		Plugin:          "library",
+		DisplayName:     "Library Size Refresh",
+		Description:     "Walk the library + import-path trees to refresh on-disk size cache.",
+		DefaultPriority: opsregistry.PriorityLow,
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ResumePolicy:    opsregistry.ResumeDrop,
+		ConcurrencyKey:  "library.size-refresh",
+		Permissions:     []auth.Permission{auth.PermSettingsManage},
+		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead},
+		Run: func(ctx context.Context, _ json.RawMessage, reporter opsregistry.Reporter) error {
+			store := s.Store()
+			if store == nil {
+				return fmt.Errorf("library.size-refresh: database not initialized")
+			}
+			folders, err := store.GetAllImportPaths()
+			if err != nil {
+				return err
+			}
+			rootDir := strings.TrimSpace(config.AppConfig.RootDir)
+
+			progress := registryProgressAdapter{r: reporter}
+			_ = progress.Log("info", fmt.Sprintf("library size refresh starting (root=%s, import_folders=%d)", rootDir, len(folders)), nil)
+			_ = progress.UpdateProgress(0, 1, "walking filesystem")
+
+			// Invalidate the cache so calculateLibrarySizes does a real walk
+			// instead of returning the existing cached value.
+			resetLibrarySizeCache()
+			started := time.Now()
+			lib, imp := calculateLibrarySizes(rootDir, folders)
+			elapsed := time.Since(started)
+
+			slog.Info("library size refresh complete",
+				"library_bytes", lib,
+				"import_bytes", imp,
+				"duration_ms", elapsed.Milliseconds(),
+			)
+			_ = progress.UpdateProgress(1, 1, "done")
+			_ = progress.Log("info",
+				fmt.Sprintf("library size refresh complete: library=%d import=%d (%dms)", lib, imp, elapsed.Milliseconds()),
+				nil)
+			return nil
+		},
+	})
+}
+
+func init() {
+	addOpRegistrar(func(s *Server, reg *opsregistry.Registry) error { return s.RegisterLibrarySizeRefreshOp(reg) })
+}


### PR DESCRIPTION
## Summary

Registers \`library.size-refresh\` OperationDef + \`library_size_refresh\` scheduler task. Walks the library + import-path trees nightly via \`maintenance.window\` to refresh the on-disk size cache.

Together with #1138 (startup warmer), completes Sonarr/Radarr-style refresh: scrape at startup, scrape nightly, trust DB on every read.

Config flag \`maintenance_window_library_size_refresh\` (default true).

## Test plan

- [x] \`go test ./internal/scheduler/ ./internal/config/\` — passes
- [ ] Post-deploy: \`library_size_refresh\` appears in \`/api/v1/scheduler/tasks\` with \`run_in_maintenance_window=true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)