### PR TITLE
feat(audiobooks): per-book Rescan Files button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 2.99.0 -->
+<!-- version: 3.00.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-25 -->
 
@@ -8,6 +8,16 @@
 ## [Unreleased]
 
 ### Changes
+
+#### May 25, 2026 — Per-book "Rescan Files" button
+
+New `POST /api/v1/audiobooks/{id}/rescan` endpoint re-stats each of a book's
+files on disk, updates `FileSize` (per file + book aggregate), and
+invalidates the library-counts cache. Surfaced as a "Rescan Files" button
+in `BookDetailActions` next to "Rescan Folder". Gives the user an out
+when DB sizes have drifted from disk (e.g. after a manual file replacement).
+
+Cheap: O(file_count) per book, no full library scan.
 
 #### May 25, 2026 — Nightly library-size refresh task
 

--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -441,6 +441,108 @@ func (s *Server) runAutoPurgeSoftDeleted(opID string) {
 	}
 }
 
+// rescanAudiobook re-stats the book's files on disk and updates FileSize
+// fields in the DB to match physical reality. Cheap (O(file_count) per
+// book) and intended for the "this number looks wrong" button on the
+// book detail page — gives the user an out when DB sizes have drifted
+// from disk (e.g. after a manual file replacement).
+//
+// Also invalidates the library_counts cache so the dashboard reflects
+// the updated number immediately.
+func (s *Server) rescanAudiobook(c *gin.Context) {
+	id := c.Param("id")
+	store := s.Store()
+	if store == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	book, err := store.GetBookByID(id)
+	if err != nil || book == nil {
+		httputil.RespondWithNotFound(c, "audiobook", id)
+		return
+	}
+
+	type fileResult struct {
+		ID       string `json:"id"`
+		Path     string `json:"path"`
+		OldSize  int64  `json:"old_size"`
+		NewSize  int64  `json:"new_size"`
+		Missing  bool   `json:"missing"`
+	}
+
+	results := []fileResult{}
+	var newTotal int64
+
+	files, _ := store.GetBookFiles(id)
+	if len(files) > 0 {
+		for i := range files {
+			f := files[i]
+			fr := fileResult{ID: f.ID, Path: f.FilePath, OldSize: f.FileSize}
+			info, statErr := os.Stat(f.FilePath)
+			if statErr != nil {
+				fr.Missing = true
+				if !f.Missing {
+					f.Missing = true
+					_ = store.UpdateBookFile(f.ID, &f)
+				}
+				results = append(results, fr)
+				continue
+			}
+			size := info.Size()
+			fr.NewSize = size
+			if f.FileSize != size || f.Missing {
+				f.FileSize = size
+				f.Missing = false
+				if upErr := store.UpdateBookFile(f.ID, &f); upErr != nil {
+					httputil.InternalError(c, "failed to update book file", upErr)
+					return
+				}
+			}
+			newTotal += size
+			results = append(results, fr)
+		}
+	} else if book.FilePath != "" {
+		// Legacy single-file book with no BookFile rows — stat the main path.
+		fr := fileResult{Path: book.FilePath}
+		if book.FileSize != nil {
+			fr.OldSize = *book.FileSize
+		}
+		if info, statErr := os.Stat(book.FilePath); statErr == nil {
+			fr.NewSize = info.Size()
+			newTotal = info.Size()
+		} else {
+			fr.Missing = true
+		}
+		results = append(results, fr)
+	}
+
+	// Update the Book.FileSize aggregate if it changed.
+	oldBookSize := int64(0)
+	if book.FileSize != nil {
+		oldBookSize = *book.FileSize
+	}
+	if newTotal != oldBookSize {
+		book.FileSize = &newTotal
+		if _, upErr := store.UpdateBook(id, book); upErr != nil {
+			httputil.InternalError(c, "failed to update book", upErr)
+			return
+		}
+		// Invalidate the dashboard cache so the next /system/status sees
+		// the new sum.
+		if inv, ok := store.(interface{ InvalidateLibraryStats() }); ok {
+			inv.InvalidateLibraryStats()
+		}
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"book_id":      id,
+		"old_total":    oldBookSize,
+		"new_total":    newTotal,
+		"file_count":   len(results),
+		"files":        results,
+	})
+}
+
 func (s *Server) restoreAudiobook(c *gin.Context) {
 	id := c.Param("id")
 	updated, err := s.audiobookService.RestoreAudiobook(c.Request.Context(), id)

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -917,6 +917,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/audiobooks/soft-deleted", s.perm(auth.PermLibraryView), s.listSoftDeletedAudiobooks)
 			protected.DELETE("/audiobooks/purge-soft-deleted", s.perm(auth.PermLibraryDelete), s.purgeSoftDeletedAudiobooks)
 			protected.POST("/audiobooks/:id/restore", s.perm(auth.PermLibraryOrganize), s.restoreAudiobook)
+			protected.POST("/audiobooks/:id/rescan", s.perm(auth.PermLibraryEditMetadata), s.rescanAudiobook)
 			protected.POST("/audiobooks/:id/quarantine", s.perm(auth.PermSettingsManage), s.quarantineBook)
 			protected.DELETE("/audiobooks/:id/quarantine", s.perm(auth.PermSettingsManage), s.unquarantineBook)
 			protected.GET("/audiobooks/:id", s.perm(auth.PermLibraryView), s.getAudiobook)

--- a/web/src/components/bookdetail/BookDetailActions.tsx
+++ b/web/src/components/bookdetail/BookDetailActions.tsx
@@ -40,6 +40,7 @@ export interface BookDetailActionsProps {
   onOpenHistory: () => void;
   onParseWithAI: () => void;
   onRescanFolder: () => void;
+  onRescanFiles: () => void;
   onRefresh: () => void;
   onOpenEdit: () => void;
   onFetchMetadata: () => void;
@@ -67,6 +68,7 @@ export const BookDetailActions = ({
   onOpenHistory,
   onParseWithAI,
   onRescanFolder,
+  onRescanFiles,
   onRefresh,
   onOpenEdit,
   onFetchMetadata,
@@ -122,6 +124,18 @@ export const BookDetailActions = ({
           >
             {rescanningFolder ? 'Scanning...' : 'Rescan Folder'}
           </Button>
+          <Tooltip title="Re-stat this book's files on disk and update size">
+            <span>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={onRescanFiles}
+                disabled={actionLoading || isSoftDeleted}
+              >
+                Rescan Files
+              </Button>
+            </span>
+          </Tooltip>
         </Stack>
         <Stack
           direction="row"

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -20,6 +20,7 @@ import type { Book, BookFile, BookSegment, BookTags, SegmentTags, OverridePayloa
 import * as api from '../services/api';
 import { useToast } from '../components/toast/ToastProvider';
 import type { Audiobook } from '../types';
+import { formatBytes } from '../components/bookdetail/bookDetailUtils';
 import { BookDetailHeader } from '../components/bookdetail/BookDetailHeader';
 import { BookDetailStatusAlerts } from '../components/bookdetail/BookDetailStatusAlerts';
 import { BookDetailActions } from '../components/bookdetail/BookDetailActions';
@@ -332,6 +333,29 @@ export const BookDetail = () => {
     } catch (error) {
       console.error('Failed to restore audiobook', error);
       toast('Failed to restore audiobook.', 'error');
+    } finally {
+      setActionLabel(null);
+      setActionLoading(false);
+    }
+  };
+
+  const handleRescanFiles = async () => {
+    if (!book) return;
+    setActionLoading(true);
+    setActionLabel('Rescanning files...');
+    try {
+      const result = await api.rescanBookFiles(book.id);
+      const changed = result.old_total !== result.new_total;
+      toast(
+        changed
+          ? `File size updated (${formatBytes(result.old_total)} → ${formatBytes(result.new_total)})`
+          : `Files in sync, no changes (${result.file_count} file${result.file_count === 1 ? '' : 's'} checked)`,
+        'success'
+      );
+      await loadBook();
+    } catch (error) {
+      console.error('Failed to rescan files', error);
+      toast('Failed to rescan files.', 'error');
     } finally {
       setActionLabel(null);
       setActionLoading(false);
@@ -941,6 +965,7 @@ export const BookDetail = () => {
         onOpenHistory={() => setHistoryDialogOpen(true)}
         onParseWithAI={handleParseWithAI}
         onRescanFolder={handleRescanFolder}
+        onRescanFiles={handleRescanFiles}
         onRefresh={() => { loadBook(); loadVersions(); refreshFilesTab(); }}
         onOpenEdit={() => setEditDialogOpen(true)}
         onFetchMetadata={handleFetchMetadata}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -903,6 +903,31 @@ export async function restoreSoftDeletedBook(bookId: string): Promise<void> {
   }
 }
 
+export interface RescanBookResult {
+  book_id: string;
+  old_total: number;
+  new_total: number;
+  file_count: number;
+  files: Array<{
+    id?: string;
+    path: string;
+    old_size: number;
+    new_size: number;
+    missing: boolean;
+  }>;
+}
+
+export async function rescanBookFiles(bookId: string): Promise<RescanBookResult> {
+  const response = await fetch(`${API_BASE}/audiobooks/${bookId}/rescan`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to rescan book files');
+  }
+  const json = await response.json();
+  return json.data ?? json;
+}
+
 export async function deleteBook(
   bookId: string,
   options: { softDelete?: boolean; blockHash?: boolean } = {}


### PR DESCRIPTION
## Summary

New \`POST /api/v1/audiobooks/{id}/rescan\` endpoint re-stats each of a book's files on disk, updates \`FileSize\` (per file + book aggregate), and invalidates the library-counts cache so the dashboard refreshes immediately.

Surfaced as a "Rescan Files" button in \`BookDetailActions\` next to "Rescan Folder". Gives the user an out when DB sizes have drifted from disk.

Cheap: O(file_count) per book, no full library scan.

Completes the Sonarr/Radarr-style refresh model:
- scrape at full scan
- scrape at startup (#1138)
- scrape during nightly maintenance (#1139)
- **per-book button for ad-hoc drift correction (this PR)**
- trust DB sizes on every read (#1137)

## Test plan

- [x] \`make build\` (full backend + frontend) succeeds
- [ ] Post-deploy: click button on a book, toast shows old → new size

🤖 Generated with [Claude Code](https://claude.com/claude-code)