### PR TITLE
perf(server): aggressive audiobook list cache pre-warm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.00.0 -->
+<!-- version: 3.01.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-05-25 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Changes
+
+#### May 25, 2026 — Aggressive audiobook list cache pre-warm
+
+After memdb publishes, fire ~50 of the most common library-page queries to
+populate `audiobookService.listCache` before any user hits the page. Covers
+the first 20 pages of `title asc / is_primary=true`, the first 5 pages of
+the reverse sort, first 10 pages of `-review:matched` (unmatched books),
+and `library_state` filter combinations. Adds `IsMemReady()` to
+PebbleStore so the warmer can wait for memdb before firing.
+
+Eliminates the ~3-minute cold-miss the user saw on the first library load
+after restart. Caches are 24h TTL; RAM consumed here saves Pebble-cache
+thrash and transient query allocations.
 
 #### May 25, 2026 — Per-book "Rescan Files" button
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -135,6 +135,12 @@ type PebbleStore struct {
 // `p.mem() != nil` instead.
 func (p *PebbleStore) mem() *MemStore { return p.memPtr.Load() }
 
+// IsMemReady reports whether the in-memory query layer is published and
+// serving reads. Used by the server-side list-cache warmer to gate on
+// memdb readiness so warm-up queries hit the fast O(log n) memdb path
+// instead of the slow Pebble JSON-unmarshal path.
+func (p *PebbleStore) IsMemReady() bool { return p.memPtr.Load() != nil }
+
 const statsLibraryKey = "stats:library"
 const statsLibraryTTL = 10 * time.Minute
 const defaultLibraryCountsMinIntervalSeconds = 600 // 10 minutes

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -1,0 +1,168 @@
+// file: internal/server/library_list_warmer.go
+// version: 1.0.0
+// guid: 7e8d9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+
+// Pre-warms svc.audiobookService.listCache by firing the queries the UI
+// is most likely to hit on first load — library page (first few pages,
+// title asc + desc), default plain list. Runs once at startup after
+// memdb is published; otherwise the first user load eats the full
+// pushdown + cache-miss cost (~3+ minutes on a 50K-book library).
+
+package server
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
+)
+
+// memReadyChecker is satisfied by *database.PebbleStore. Decoupled
+// behind an interface so tests can stub it.
+type memReadyChecker interface {
+	IsMemReady() bool
+}
+
+// warmAudiobookListCache waits for memdb to publish, then fires the
+// common library-page queries to populate svc.audiobookService.listCache.
+// All queries run sequentially against the AudiobookService — no extra
+// HTTP overhead.
+func (s *Server) warmAudiobookListCache() {
+	if s.audiobookService == nil {
+		return
+	}
+	store := s.Store()
+	checker, ok := store.(memReadyChecker)
+	if !ok {
+		// Store doesn't expose memdb state — skip; we'd just warm cold
+		// queries with no upside.
+		return
+	}
+
+	// Wait up to 5 minutes for memdb. Memdb warmup on a 50K-book DB
+	// typically takes ~2.5 min, so 5 min is comfortable headroom.
+	deadline := time.Now().Add(5 * time.Minute)
+	for !checker.IsMemReady() {
+		if time.Now().After(deadline) {
+			slog.Warn("library list warm-up: memdb not ready after 5 min, skipping")
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	started := time.Now()
+	ctx := context.Background()
+
+	// Each query mirrors what the UI sends on a fresh library-page load.
+	// Pagination keys are independent cache entries, so we warm a lot of
+	// pages — RAM here means less Pebble cache thrash + zero cold-miss
+	// for the user. The server has plenty of memory.
+	type qry struct {
+		name    string
+		limit   int
+		offset  int
+		filters audiobookspkg.ListFilters
+	}
+	primaryTrue := true
+	queries := []qry{}
+	// Default UI sort: title asc, primary only — warm the first 20 pages
+	// (400 books deep). Covers nearly all browsing without the user
+	// hitting a cold cache.
+	for off := 0; off < 400; off += 20 {
+		queries = append(queries, qry{
+			name:    "title-asc-primary",
+			limit:   20,
+			offset:  off,
+			filters: audiobookspkg.ListFilters{IsPrimaryVersion: &primaryTrue, SortBy: "title", SortOrder: "asc"},
+		})
+	}
+	// Title desc — first 5 pages.
+	for off := 0; off < 100; off += 20 {
+		queries = append(queries, qry{
+			name:    "title-desc-primary",
+			limit:   20,
+			offset:  off,
+			filters: audiobookspkg.ListFilters{IsPrimaryVersion: &primaryTrue, SortBy: "title", SortOrder: "desc"},
+		})
+	}
+	// "-review:matched" — books that have NOT yet been matched to metadata.
+	// One of the most common filters per user feedback. First 10 pages.
+	for off := 0; off < 200; off += 20 {
+		queries = append(queries, qry{
+			name:   "review-not-matched",
+			limit:  20,
+			offset: off,
+			filters: audiobookspkg.ListFilters{
+				IsPrimaryVersion: &primaryTrue,
+				SortBy:           "title",
+				SortOrder:        "asc",
+				FieldFilters: []audiobookspkg.FieldFilter{
+					{Field: "review", Value: "matched", Negated: true},
+				},
+			},
+		})
+	}
+	// "review:matched" inverse (already-matched books).
+	for off := 0; off < 100; off += 20 {
+		queries = append(queries, qry{
+			name:   "review-matched",
+			limit:  20,
+			offset: off,
+			filters: audiobookspkg.ListFilters{
+				IsPrimaryVersion: &primaryTrue,
+				SortBy:           "title",
+				SortOrder:        "asc",
+				FieldFilters: []audiobookspkg.FieldFilter{
+					{Field: "review", Value: "matched"},
+				},
+			},
+		})
+	}
+	// library_state filter — organized vs imported. Common left-rail filter.
+	for _, state := range []string{"organized", "imported"} {
+		for off := 0; off < 100; off += 20 {
+			queries = append(queries, qry{
+				name:   "library-state-" + state,
+				limit:  20,
+				offset: off,
+				filters: audiobookspkg.ListFilters{
+					IsPrimaryVersion: &primaryTrue,
+					LibraryState:     state,
+					SortBy:           "title",
+					SortOrder:        "asc",
+				},
+			})
+		}
+	}
+	// Plain list, no filter — sidebar/import flow first page.
+	queries = append(queries, qry{name: "plain-page-1", limit: 20, offset: 0})
+	queries = append(queries, qry{
+		name:    "primary-no-sort",
+		limit:   20,
+		offset:  0,
+		filters: audiobookspkg.ListFilters{IsPrimaryVersion: &primaryTrue},
+	})
+
+	slog.Info("library list warm-up starting", "queries", len(queries))
+	hits, misses := 0, 0
+	for _, q := range queries {
+		qStart := time.Now()
+		_, err := s.audiobookService.GetAudiobooks(ctx, q.limit, q.offset, "", nil, nil, q.filters)
+		if err != nil {
+			misses++
+			slog.Warn("library list warm-up query failed",
+				"name", q.name, "offset", q.offset, "err", err)
+			continue
+		}
+		hits++
+		slog.Debug("library list warm-up query ok",
+			"name", q.name, "offset", q.offset,
+			"duration_ms", time.Since(qStart).Milliseconds())
+	}
+	slog.Info("library list warm-up complete",
+		"queries_warmed", hits,
+		"failures", misses,
+		"duration_ms", time.Since(started).Milliseconds(),
+	)
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -225,6 +225,11 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// The hot path of /system/status reads DB stats (PR #1137); this just
 	// keeps the FS-based numbers fresh in the 24h-TTL package cache.
 	go s.warmLibrarySizes()
+	// Pre-warm the audiobook list cache after memdb is published. Fires
+	// the most common library-page queries (title asc/desc, -review:matched,
+	// library_state filter) so the user's first load doesn't pay the full
+	// cold-miss cost (~3 min on 50K-book library).
+	go s.warmAudiobookListCache()
 	// DISABLED: authors/series cache warm-ups consume 22.9GB → 69.9GB peak memory in minutes
 	// ListAuthorsWithCounts/ListSeriesWithCounts build massive gin.H response objects
 	// Root cause: returning full response structure in cache instead of just counts


### PR DESCRIPTION
## Summary

After memdb publishes, fires ~50 of the most common library-page queries to populate \`audiobookService.listCache\` before any user hits the page. Eliminates the 3-minute cold-miss the user saw on first library load after restart.

Coverage:
- title asc + is_primary=true: first 20 pages (400 books deep)
- title desc + is_primary=true: first 5 pages
- \`-review:matched\` (unmatched books): first 10 pages
- \`review:matched\` (already-matched): first 5 pages
- \`library_state=organized\` / \`=imported\`: first 5 pages each
- plain list, primary-no-sort: page 1

Adds \`PebbleStore.IsMemReady()\` so the warmer can poll-wait for memdb to publish before firing. Falls back gracefully when the store doesn't expose readiness (tests, alt backends).

RAM tradeoff is favorable per user feedback: caching here saves Pebble-cache thrash + transient query allocations elsewhere.

## Test plan

- [x] \`go test ./internal/server/\` — passes
- [ ] Post-deploy: \`library list warm-up complete\` log line appears within ~3 min of restart
- [ ] First library page load is fast (no 3-min stall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)