### PR TITLE
feat(auth): remember-me checkbox + temp-login token URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,30 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.02.0 -->
+<!-- version: 3.03.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-25 -->
+<!-- last-edited: 2026-05-28 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Changes
+
+#### May 28, 2026 — Remember-me login + temp-login URLs
+
+- **Remember me checkbox** on the login page. Checked → session cookie
+  TTL flips from 24h to 7d. Sent to backend as `remember_me: true` in
+  the login payload.
+- **Temp-login token endpoint** for getting yourself onto a new device
+  without re-entering credentials:
+  - `POST /api/v1/auth/temp-tokens` (admin-only, `users.manage` perm) —
+    body `{user_id}`, returns `{token, login_url, expires_at}`. URL is
+    valid for 15 min, single-use.
+  - `GET /auth/temp-login?token=xxx` (public) — validates token,
+    deletes it (single-use), checks user is `active`, creates a 24h
+    session, sets the cookie, redirects to `/`. On failure redirects
+    to `/login?error=<reason>` so the SPA can surface a message.
+- Tokens are in-memory only — server restart invalidates pending ones
+  (acceptable given the 15-min TTL).
 
 #### May 25, 2026 — List warm-up: filter cheatsheet coverage
 

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -65,7 +65,11 @@ func clearFailedLogins(userID string) {
 	delete(loginLockout, userID)
 }
 
-const defaultSessionTTL = 24 * time.Hour
+const (
+	defaultSessionTTL    = 24 * time.Hour
+	rememberMeSessionTTL = 7 * 24 * time.Hour
+	tempLoginTokenTTL    = 15 * time.Minute
+)
 
 type authUserResponse struct {
 	ID        string    `json:"id"`
@@ -206,8 +210,9 @@ func (s *Server) login(c *gin.Context) {
 	}
 
 	var req struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
+		Username   string `json:"username"`
+		Password   string `json:"password"`
+		RememberMe bool   `json:"remember_me"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
@@ -237,11 +242,15 @@ func (s *Server) login(c *gin.Context) {
 	}
 	clearFailedLogins(user.ID)
 
+	ttl := defaultSessionTTL
+	if req.RememberMe {
+		ttl = rememberMeSessionTTL
+	}
 	session, err := s.Store().CreateSession(
 		user.ID,
 		strings.TrimSpace(c.ClientIP()),
 		strings.TrimSpace(c.Request.UserAgent()),
-		defaultSessionTTL,
+		ttl,
 	)
 	if err != nil {
 		httputil.RespondWithInternalError(c, "failed to create session")

--- a/internal/server/auth_temp_login.go
+++ b/internal/server/auth_temp_login.go
@@ -1,0 +1,191 @@
+// file: internal/server/auth_temp_login.go
+// version: 1.0.0
+// guid: 5b6c7d8e-9f0a-1b2c-3d4e-5f6a7b8c9d0e
+
+// Temp-login token: admin mints a short-lived single-use URL for a user.
+// User clicks the URL → server consumes the token → 24h session cookie
+// set. Lets the admin sign themselves (or someone else) in on a new
+// device without re-entering credentials. No SMTP plumbing needed —
+// admin delivers the URL out-of-band.
+
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/auth"
+	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+)
+
+// tempLoginEntry tracks one minted token. Tokens are kept in memory
+// only — a server restart invalidates everything, which is fine given
+// the 15-minute TTL.
+type tempLoginEntry struct {
+	UserID    string
+	ExpiresAt time.Time
+}
+
+var (
+	tempLoginMu      sync.Mutex
+	tempLoginTokens  = map[string]tempLoginEntry{}
+	tempLoginPurgeAt time.Time
+)
+
+// newTempLoginToken returns 32 hex chars (16 random bytes). Cryptographically
+// strong; URL-safe; not guessable.
+func newTempLoginToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// purgeExpiredTempTokens drops expired entries. Called opportunistically
+// (no background goroutine — map stays small at typical admin volume).
+func purgeExpiredTempTokens() {
+	if time.Since(tempLoginPurgeAt) < 5*time.Minute {
+		return
+	}
+	now := time.Now()
+	for tok, entry := range tempLoginTokens {
+		if entry.ExpiresAt.Before(now) {
+			delete(tempLoginTokens, tok)
+		}
+	}
+	tempLoginPurgeAt = now
+}
+
+// createTempLoginToken handles POST /api/v1/auth/temp-tokens.
+// Admin-only. Body: {user_id: "..."} — mints a token + URL the target
+// user can click to log in. Token is single-use, 15-min TTL, exchanges
+// for a 24h session.
+func (s *Server) createTempLoginToken(c *gin.Context) {
+	if s.Store() == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	var req struct {
+		UserID string `json:"user_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	req.UserID = strings.TrimSpace(req.UserID)
+	if req.UserID == "" {
+		httputil.RespondWithBadRequest(c, "user_id is required")
+		return
+	}
+
+	user, err := s.Store().GetUserByID(req.UserID)
+	if err != nil || user == nil {
+		httputil.RespondWithNotFound(c, "user", req.UserID)
+		return
+	}
+
+	token, err := newTempLoginToken()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "failed to generate token")
+		return
+	}
+	expires := time.Now().Add(tempLoginTokenTTL)
+
+	tempLoginMu.Lock()
+	purgeExpiredTempTokens()
+	tempLoginTokens[token] = tempLoginEntry{UserID: user.ID, ExpiresAt: expires}
+	tempLoginMu.Unlock()
+
+	// Build absolute URL from the inbound request. Falls back to a
+	// relative path if the Host header is unset (shouldn't happen in
+	// production but defensive).
+	scheme := "https"
+	if c.Request.TLS == nil && !isHTTPSRequest(c) {
+		scheme = "http"
+	}
+	host := strings.TrimSpace(c.Request.Host)
+	loginURL := fmt.Sprintf("/auth/temp-login?token=%s", token)
+	if host != "" {
+		loginURL = fmt.Sprintf("%s://%s/auth/temp-login?token=%s", scheme, host, token)
+	}
+
+	httputil.RespondWithCreated(c, gin.H{
+		"token":      token,
+		"login_url":  loginURL,
+		"expires_at": expires,
+		"user": gin.H{
+			"id":       user.ID,
+			"username": user.Username,
+		},
+		"session_ttl_hours": int(defaultSessionTTL.Hours()),
+	})
+}
+
+// consumeTempLoginToken handles GET /auth/temp-login?token=xxx.
+// Public — gated only by the token's validity + single-use semantics.
+// On success: creates a 24h session, sets the session cookie, and
+// redirects to the SPA root. On failure: redirects to /login with an
+// error query param so the SPA can show a message.
+func (s *Server) consumeTempLoginToken(c *gin.Context) {
+	if s.Store() == nil {
+		c.Redirect(http.StatusSeeOther, "/login?error=server")
+		return
+	}
+	token := strings.TrimSpace(c.Query("token"))
+	if token == "" {
+		c.Redirect(http.StatusSeeOther, "/login?error=missing_token")
+		return
+	}
+
+	tempLoginMu.Lock()
+	entry, ok := tempLoginTokens[token]
+	if ok {
+		// Single-use: delete on first read so a leaked URL can't be
+		// replayed even before the TTL fires.
+		delete(tempLoginTokens, token)
+	}
+	tempLoginMu.Unlock()
+
+	if !ok || time.Now().After(entry.ExpiresAt) {
+		c.Redirect(http.StatusSeeOther, "/login?error=invalid_or_expired_token")
+		return
+	}
+
+	user, err := s.Store().GetUserByID(entry.UserID)
+	if err != nil || user == nil {
+		c.Redirect(http.StatusSeeOther, "/login?error=user_not_found")
+		return
+	}
+	// Tighten: only "active" users can consume a temp-login token.
+	// Catches the case where an admin minted a token for an account
+	// that was later disabled / suspended — without this check the
+	// user could still log in via the stale URL.
+	if !strings.EqualFold(user.Status, "active") {
+		c.Redirect(http.StatusSeeOther, "/login?error=account_inactive")
+		return
+	}
+
+	session, err := s.Store().CreateSession(
+		user.ID,
+		strings.TrimSpace(c.ClientIP()),
+		strings.TrimSpace(c.Request.UserAgent()),
+		defaultSessionTTL,
+	)
+	if err != nil {
+		c.Redirect(http.StatusSeeOther, "/login?error=session_failed")
+		return
+	}
+	setSessionCookie(c, session.ID, session.ExpiresAt)
+	c.Redirect(http.StatusSeeOther, "/")
+}
+
+// permTempLoginMint returns the permission required to mint temp-login
+// tokens. Kept here so the route registration stays small.
+func permTempLoginMint() auth.Permission { return auth.PermUsersManage }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -827,6 +827,11 @@ func (s *Server) setupRoutes() {
 	// Real-time events (SSE)
 	s.router.GET("/api/events", s.handleEvents)
 
+	// Public temp-login consumer at the root so URLs are short and
+	// browser-friendly. Validates the token, deletes it (single-use),
+	// creates a 24h session, sets the cookie, redirects to the SPA.
+	s.router.GET("/auth/temp-login", s.consumeTempLoginToken)
+
 	// Redirect /api/* to /api/v1/* for v1 compatibility
 	s.router.Use(func(c *gin.Context) {
 		path := c.Request.URL.Path
@@ -892,6 +897,11 @@ func (s *Server) setupRoutes() {
 			authProtected.GET("/sessions", s.listMySessions)
 			authProtected.DELETE("/sessions/:id", s.revokeMySession)
 			authProtected.PUT("/me/password", s.changePassword)
+			// Admin mints a single-use 15-min URL that exchanges for a
+			// 24h session cookie when clicked. Lets the admin sign
+			// themselves (or a user) in on a new device without
+			// re-entering credentials.
+			authProtected.POST("/temp-tokens", s.perm(permTempLoginMint()), s.createTempLoginToken)
 
 			// API key management
 			authProtected.POST("/api-keys", s.createAPIKey)

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -23,7 +23,7 @@ interface AuthContextValue {
   bootstrapReady: boolean;
   isAuthenticated: boolean;
   refresh: () => Promise<void>;
-  login: (username: string, password: string) => Promise<void>;
+  login: (username: string, password: string, rememberMe?: boolean) => Promise<void>;
   logout: () => Promise<void>;
   setupAdmin: (payload: {
     username: string;
@@ -106,8 +106,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     void refresh();
   }, [refresh]);
 
-  const login = useCallback(async (username: string, password: string) => {
-    const response = await api.login({ username, password });
+  const login = useCallback(async (username: string, password: string, rememberMe?: boolean) => {
+    const response = await api.login({ username, password, remember_me: rememberMe });
     setUser(response.user);
     setRequiresAuth(true);
     setBootstrapReady(false);

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -8,7 +8,9 @@ import {
   Alert,
   Box,
   Button,
+  Checkbox,
   CircularProgress,
+  FormControlLabel,
   Paper,
   Stack,
   TextField,
@@ -26,6 +28,7 @@ export function Login() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [email, setEmail] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -56,7 +59,7 @@ export function Login() {
       if (mode === 'setup') {
         await auth.setupAdmin({ username, password, email });
       }
-      await auth.login(username, password);
+      await auth.login(username, password, rememberMe);
       navigate(redirectTo, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed');
@@ -150,6 +153,19 @@ export function Login() {
             required
             fullWidth
           />
+
+          {mode === 'login' && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                  name="remember_me"
+                />
+              }
+              label="Remember me for 1 week"
+            />
+          )}
 
           <Button
             type="submit"

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1903,6 +1903,7 @@ export async function setupAdmin(payload: {
 export async function login(payload: {
   username: string;
   password: string;
+  remember_me?: boolean;
 }): Promise<{ user: AuthUser; session: AuthSession }> {
   const response = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',


### PR DESCRIPTION
## Summary

Two flows so the user doesn't have to log in everywhere:

1. **Remember me (1 week)** — checkbox on login; flips session TTL 24h → 7d when checked.
2. **Temp-login URL** — admin POSTs \`/auth/temp-tokens\` with \`{user_id}\` → gets back a single-use 15-min URL. User clicks → 24h session cookie set, redirected to /.

Auth model for the URL: possession of 16 random bytes from crypto/rand = authentication for one click. After that it's a normal session cookie.

Security:
- Mint endpoint requires \`users.manage\` perm.
- Token TTL 15min, single-use (deleted on first GET before session create).
- Only \`active\` users can consume.
- HttpOnly + Secure + SameSite=Strict cookie afterward.

## Test plan

- [x] \`go build ./...\` + \`make build\` succeed
- [ ] Post-deploy: tick "Remember me", confirm cookie Max-Age ≈ 604800
- [ ] Post-deploy: \`curl -X POST /api/v1/auth/temp-tokens -d '{"user_id":"..."}'\` → click URL → land on \`/\` logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)