### PR TITLE
fix(warmer): populate listCache with UI-shaped query keys

### DIFF
--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.16.0
+// version: 2.17.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 // last-edited: 2026-05-20
 //
@@ -283,15 +283,28 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		}
 	}
 
-	// Call service
-	books, err := s.audiobookService.GetAudiobooks(c.Request.Context(), params.Limit, params.Offset, params.Search, authorID, seriesID, filters)
+	showQuarantined := c.Query("show_quarantined") == "true"
+	resp, err := s.buildAudiobookListResponse(c.Request.Context(), params.Limit, params.Offset, params.Search, authorID, seriesID, filters, showQuarantined)
 	if err != nil {
 		httputil.InternalError(c, "failed to list audiobooks", err)
 		return
 	}
+	if len(filters.PerUserFilters) == 0 {
+		s.listCache.Set(cacheKey, resp)
+	}
+	httputil.RespondWithOK(c, resp)
+}
 
-	// Exclude quarantined books unless show_quarantined=true
-	showQuarantined := c.Query("show_quarantined") == "true"
+// buildAudiobookListResponse runs the full /api/v1/audiobooks list pipeline
+// (service call, quarantine filter, enrichment, batch file load, fingerprint
+// compute, count) and returns the response payload. Shared between the HTTP
+// handler and the startup cache warmer so both produce identical results.
+func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset int, search string, authorID, seriesID *int, filters ListFilters, showQuarantined bool) (gin.H, error) {
+	books, err := s.audiobookService.GetAudiobooks(ctx, limit, offset, search, authorID, seriesID, filters)
+	if err != nil {
+		return nil, err
+	}
+
 	if !showQuarantined {
 		filtered := books[:0]
 		for _, b := range books {
@@ -302,10 +315,8 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		books = filtered
 	}
 
-	// Enrich with author and series names
 	enriched := s.audiobookService.EnrichAudiobooksWithNames(books)
 
-	// Batch-load all book files at once instead of per-book (N+1 optimization)
 	bookIDs := make([]string, len(enriched))
 	for i, book := range enriched {
 		bookIDs[i] = book.ID
@@ -328,20 +339,13 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		}
 	}
 
-	// Compute and populate fingerprinting fields for each book
 	for i, book := range enriched {
 		files := bookFilesMap[book.ID]
-
-		// Convert BookFile slice to FileWithFingerprint interface slice
 		fpFiles := make([]fingerprint.FileWithFingerprint, len(files))
 		for j := range files {
 			fpFiles[j] = &files[j]
 		}
-
-		// Compute fingerprinting fields using the calculator
 		status, fpCount, coverage, lastFp := fingerprint.ComputeFingerprintFields(fpFiles)
-
-		// Populate the Book struct fields added in Task 1
 		enriched[i].FingerprintStatus = status
 		enriched[i].FingerprintedFileCount = fpCount
 		enriched[i].TotalFileCount = len(files)
@@ -349,26 +353,21 @@ func (s *Server) listAudiobooks(c *gin.Context) {
 		enriched[i].LastFingerprintedAt = lastFp
 	}
 
-	// Get total count for proper pagination
 	totalCount := len(enriched)
 	hasFilters := filters.IsPrimaryVersion != nil || filters.LibraryState != "" || filters.Tag != "" || len(filters.Tags) > 0
-	if params.Search == "" && authorID == nil && seriesID == nil {
+	if search == "" && authorID == nil && seriesID == nil {
 		if hasFilters {
-			if tc, err := s.audiobookService.CountAudiobooksFiltered(c.Request.Context(), filters); err == nil {
+			if tc, err := s.audiobookService.CountAudiobooksFiltered(ctx, filters); err == nil {
 				totalCount = tc
 			}
 		} else {
-			if tc, err := s.audiobookService.CountAudiobooks(c.Request.Context()); err == nil {
+			if tc, err := s.audiobookService.CountAudiobooks(ctx); err == nil {
 				totalCount = tc
 			}
 		}
 	}
 
-	resp := gin.H{"items": enriched, "count": totalCount, "limit": params.Limit, "offset": params.Offset}
-	if len(filters.PerUserFilters) == 0 {
-		s.listCache.Set(cacheKey, resp)
-	}
-	httputil.RespondWithOK(c, resp)
+	return gin.H{"items": enriched, "count": totalCount, "limit": limit, "offset": offset}, nil
 }
 
 func (s *Server) listSoftDeletedAudiobooks(c *gin.Context) {

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_list_warmer.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e8d9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
 
 // Pre-warms svc.audiobookService.listCache by firing the queries the UI
@@ -12,13 +12,76 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strconv"
 	"time"
 
 	audiobookspkg "github.com/jdfalk/audiobook-organizer/internal/audiobooks"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 )
+
+// buildListCacheRawQuery constructs the URL.RawQuery string in the exact
+// order/format the React UI's URLSearchParams emits in getBooks(). Must
+// match web/src/services/api.ts:getBooks line-for-line or the cache key
+// won't collide with what the handler computes from c.Request.URL.RawQuery.
+func buildListCacheRawQuery(limit, offset int, f audiobookspkg.ListFilters) string {
+	var parts []string
+	add := func(k, v string) { parts = append(parts, k+"="+url.QueryEscape(v)) }
+
+	add("limit", strconv.Itoa(limit))
+	add("offset", strconv.Itoa(offset))
+	if f.SortBy != "" {
+		add("sort_by", f.SortBy)
+	}
+	if f.SortOrder != "" {
+		add("sort_order", f.SortOrder)
+	}
+	if len(f.Tags) > 0 {
+		for _, t := range f.Tags {
+			add("tags[]", t)
+		}
+	} else if f.Tag != "" {
+		add("tag", f.Tag)
+	}
+	if f.LibraryState != "" {
+		add("library_state", f.LibraryState)
+	}
+	// FieldFilters + PerUserFilters travel together in the UI's `filters`
+	// JSON param; the handler splits them after Unmarshal. Combine here so
+	// the cache key matches.
+	combined := append([]audiobookspkg.FieldFilter{}, f.FieldFilters...)
+	combined = append(combined, f.PerUserFilters...)
+	if len(combined) > 0 {
+		if b, err := json.Marshal(combined); err == nil {
+			add("filters", string(b))
+		}
+	}
+	if f.FingerprintStatus != "" {
+		add("fingerprint_status", f.FingerprintStatus)
+	}
+	if f.CoveragePercentMin != nil {
+		add("coverage_percent_min", strconv.Itoa(*f.CoveragePercentMin))
+	}
+	if f.CoveragePercentMax != nil {
+		add("coverage_percent_max", strconv.Itoa(*f.CoveragePercentMax))
+	}
+	// UI always sets is_primary_version=true last; we only set it when the
+	// caller asked for primary-only (the UI's default).
+	if f.IsPrimaryVersion != nil && *f.IsPrimaryVersion {
+		add("is_primary_version", "true")
+	}
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += "&"
+		}
+		out += p
+	}
+	return out
+}
 
 func typeName(v interface{}) string { return fmt.Sprintf("%T", v) }
 
@@ -408,10 +471,10 @@ func (s *Server) warmAudiobookListCache() {
 	})
 
 	slog.Info("library list warm-up starting", "queries", len(queries))
-	hits, misses := 0, 0
+	hits, misses, cached := 0, 0, 0
 	for _, q := range queries {
 		qStart := time.Now()
-		_, err := s.audiobookService.GetAudiobooks(ctx, q.limit, q.offset, "", nil, nil, q.filters)
+		resp, err := s.buildAudiobookListResponse(ctx, q.limit, q.offset, "", nil, nil, q.filters, false)
 		if err != nil {
 			misses++
 			slog.Warn("library list warm-up query failed",
@@ -419,12 +482,22 @@ func (s *Server) warmAudiobookListCache() {
 			continue
 		}
 		hits++
+		// Populate the HTTP handler's listCache with a key that matches
+		// what c.Request.URL.RawQuery will produce for the same UI URL.
+		// PerUserFilters queries are deliberately not cached by the
+		// handler (would leak across users) — skip them here too.
+		if len(q.filters.PerUserFilters) == 0 {
+			raw := buildListCacheRawQuery(q.limit, q.offset, q.filters)
+			s.listCache.Set("list:"+raw, resp)
+			cached++
+		}
 		slog.Debug("library list warm-up query ok",
 			"name", q.name, "offset", q.offset,
 			"duration_ms", time.Since(qStart).Milliseconds())
 	}
 	slog.Info("library list warm-up complete",
 		"queries_warmed", hits,
+		"cache_entries_populated", cached,
 		"failures", misses,
 		"duration_ms", time.Since(started).Milliseconds(),
 	)


### PR DESCRIPTION
## Summary

The library list warmer was calling `AudiobookService.GetAudiobooks` directly, but the HTTP `listCache` is keyed by `c.Request.URL.RawQuery` inside the handler — so warmed results never reached the cache the UI reads. Every UI page load was a full cold miss (a fresh `GET /api/v1/audiobooks?...` in prod logs returned 200 after **4m0s** today).

## Fix

- Extract the post-service pipeline (quarantine filter, enrich, batch file load, fingerprint compute, count) into a shared `buildAudiobookListResponse` helper.
- Warmer calls the helper, then sets `s.listCache["list:"+raw]` with `raw` built in the exact order/encoding that React's `URLSearchParams` emits in `web/src/services/api.ts:getBooks`.
- Per-user filter queries stay uncached (handler skips them to avoid cross-user leaks); warmer mirrors.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/server/...` clean
- [ ] After deploy: first cold `GET /api/v1/audiobooks?limit=20&offset=0&sort_by=title&sort_order=asc&is_primary_version=true` should serve from cache (<10ms) once warmer logs `library list warm-up complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)