### PR TITLE
fix(warmer): disable list warm-up — OOM hotfix

### DIFF
--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -139,6 +139,16 @@ func (s *Server) resolveDefaultUserID() string {
 // All queries run sequentially against the AudiobookService — no extra
 // HTTP overhead.
 func (s *Server) warmAudiobookListCache() {
+	// HOTFIX 2026-05-28: disabled. Running 177 list queries against a
+	// 392K-book memdb on startup OOM'd at 67GB peak. The transient
+	// per-query working set (full-set load + filter + sort) is the
+	// killer, not the cache itself. See critical-issues memory:
+	// project_cache_warmup_memory_fix. Re-enable only with:
+	//  - bounded concurrency (1 at a time, explicit runtime.GC between)
+	//  - ONLY 1-3 queries the UI hits on first load, not 177 combos
+	//  - a hard memory ceiling check before each call
+	slog.Info("library list warm-up DISABLED (OOM hotfix 2026-05-28)")
+	return
 	if s.audiobookService == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

The list warm-up shipped today caused a **67.8GB RSS peak → OOM-kill** in prod.

## Root cause

In `audiobookservice.GetAudiobooks` (service.go:749), any query with a "heavy post-filter" (LibraryState, Tag, FieldFilters, etc.) calls `summariesPushdown(0, 0, nil, \"\", true)` — fetches every one of the 392K books into a Go slice (~1GB working set), filters in-memory, sorts, slices 20. Running 177 of these speculatively at startup overwhelms GC and trampolines RSS.

## Hotfix

Disable the speculative warmer entirely. Followup needed: push filter predicates into memdb iterators so only matches are materialized.

## Test plan

- [x] `go build ./...` clean
- [ ] Post-deploy: process stays under 5GB RSS through full startup + memdb warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)