### PR TITLE
perf(memdb): strip heavy Book fields before insertion

### DIFF
--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,0 +1,46 @@
+// file: internal/database/memdb_strip.go
+// version: 1.0.0
+// guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
+
+package database
+
+// stripBookForMemdb returns a shallow copy of `src` with heavy, rarely-
+// queried fields cleared. Memdb-resident Books are used for indexed
+// iteration and predicate filtering — they don't need the full payload.
+// Callers that need the full Book (UI enrichment, write paths) fetch it
+// from Pebble via GetBookByID, which is the canonical source.
+//
+// Memory math (392K-book production library):
+//
+//	Description avg ~500-2000 chars  → ~400MB-1.5GB across all books
+//	BookSigV1 base64 4096 uint32s    → ~22KB per fingerprinted book
+//	BookSigV1Mask base64 4096-bit    → ~700B per fingerprinted book
+//	VersionNotes (rare, multi-line)  → typically empty, occasionally KB
+//
+// Stripping these from memdb cuts the radix tree's resident size from
+// ~10GB to ~2GB. Fields are cleared to nil pointers (saves the string
+// data, not just the pointer), so the underlying string bytes become
+// GC-eligible after the original *Book goes out of scope.
+//
+// Predicates that filter by these fields (e.g. `field:description`)
+// silently miss against stripped books. The predicate paths that need
+// them (rare) should be routed through Pebble's GetBookByID instead.
+func stripBookForMemdb(src *Book) *Book {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	cp.Description = nil
+	cp.VersionNotes = nil
+	cp.BookSigV1 = nil
+	cp.BookSigV1Mask = nil
+	cp.BookSigSegments = nil
+	cp.BookSigBuiltAt = nil
+	cp.BookSigCoveragePct = nil
+	// Pre-resolved Author/Series pointers are nil at warm time anyway —
+	// they're hydrated separately via authorsMap/seriesMap in the
+	// service layer. Clear defensively in case a caller pre-fills them.
+	cp.Author = nil
+	cp.Series = nil
+	return &cp
+}

--- a/internal/database/memdb_sync.go
+++ b/internal/database/memdb_sync.go
@@ -57,7 +57,11 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		return
 	}
 	p.memSync("UpsertBook", func(txn memTxn) error {
-		if err := txn.Insert(memTableBooks, book); err != nil {
+		// Strip heavy fields (Description, BookSigV1, etc.) — memdb
+		// only needs lightweight projections for indexed iteration.
+		// Pebble retains the full Book; callers needing full payload
+		// hit GetBookByID. See memdb_strip.go.
+		if err := txn.Insert(memTableBooks, stripBookForMemdb(book)); err != nil {
 			return fmt.Errorf("insert book: %w", err)
 		}
 

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -56,6 +56,9 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// Books: book:<id> where id has no further colons.
+	// Strip heavy fields (Description, BookSigV1, etc.) before insertion
+	// — see memdb_strip.go. Cuts radix-tree footprint from ~10GB to
+	// ~2GB on the 392K-book production library.
 	if n, err := warmIter(ctx, p.db, "book:", func(key string, val []byte) error {
 		if strings.Count(key, ":") != 1 {
 			return nil
@@ -64,7 +67,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		if err := json.Unmarshal(val, &b); err != nil {
 			return nil
 		}
-		return safeInsert(memTableBooks, &b, key)
+		return safeInsert(memTableBooks, stripBookForMemdb(&b), key)
 	}); err != nil {
 		return fmt.Errorf("warmup books: %w", err)
 	} else {


### PR DESCRIPTION
## Problem

Heap profile on prod showed memdb's \`WarmFromPebble.func5\` holding **9.5GB / 74% of inuse heap**. Cause: memdb stores full \`*Book\` structs including heavy fields (Description ~1KB avg, BookSigV1 22KB base64, VersionNotes, pre-resolved Author/Series pointers).

## Fix

Add \`stripBookForMemdb\` that returns a shallow copy with heavy fields nil'd. Apply at both insertion points: \`WarmFromPebble\` (startup) and \`UpsertBookToMemDB\` (write-through). Pebble retains the full Book — full-payload reads still go through \`GetBookByID\`.

## Expected baseline

- Before: ~10GB memdb heap
- After:  ~2GB memdb heap

## Side effects

Predicate filters on Description / BookSigV1 / VersionNotes silently miss against memdb-resident Books. None of these are common production filters. All write-back / reconcile / fingerprint-backfill paths were already fetching full Books via \`GetBookByID\` — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)