### PR TITLE
fix(registry): prevent double-dispatch of the same op

### DIFF
--- a/internal/operations/registry/dispatcher.go
+++ b/internal/operations/registry/dispatcher.go
@@ -44,6 +44,22 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			return
 		}
 
+		// Gate 0: already claimed / running? The worker marks the DB row
+		// "running" only AFTER receiving from nextRun (worker.go:143), but
+		// the dispatcher can fire again (via r.dispatch signal or the
+		// 100ms ticker) in the gap between channel-send and worker-pickup.
+		// Without this in-memory guard, ListQueuedOperationsV2() still
+		// sees the row as "queued" and we re-dispatch the same opID —
+		// observed in prod on dedup.book-merge running twice
+		// (same op_id, two "dispatched op" + "starting run" log lines
+		// 3ms apart, two book-merge complete events).
+		r.mu.RLock()
+		_, alreadyClaimed := r.running[row.ID]
+		r.mu.RUnlock()
+		if alreadyClaimed {
+			continue
+		}
+
 		// Gate 1: def must be registered.
 		r.mu.RLock()
 		def, ok := r.defs[row.DefID]
@@ -87,6 +103,10 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 		// All gates passed — claim and dispatch.
 		r.mu.Lock()
 		// Re-check under write lock to avoid TOCTOU.
+		if _, alreadyClaimed := r.running[row.ID]; alreadyClaimed {
+			r.mu.Unlock()
+			continue
+		}
 		maxC = r.pluginMax[def.Plugin]
 		currentRunning = r.pluginRunning[def.Plugin]
 		if maxC > 0 && currentRunning >= maxC {
@@ -101,6 +121,16 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			r.concurrencyKeys[def.ConcurrencyKey] = row.ID
 		}
 		r.pluginRunning[def.Plugin]++
+		// Stub handle: blocks Gate 0 re-dispatch immediately. The worker
+		// overwrites this with the full handle (with cancel func) on
+		// pickup at worker.go:138.
+		r.running[row.ID] = &runHandle{
+			id:             row.ID,
+			defID:          row.DefID,
+			plugin:         def.Plugin,
+			concurrencyKey: def.ConcurrencyKey,
+			resumePolicy:   def.ResumePolicy,
+		}
 		r.mu.Unlock()
 
 		qr := &queuedRun{
@@ -125,6 +155,9 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 					delete(r.concurrencyKeys, def.ConcurrencyKey)
 				}
 			}
+			// Undo the stub handle we added for Gate 0 — without this,
+			// the op would be permanently un-dispatchable.
+			delete(r.running, row.ID)
 			r.mu.Unlock()
 		}
 	}


### PR DESCRIPTION
## The bug

Prod logs (PR #1153 deploy) show the same \`dedup.book-merge\` op_id \`01KSRJ9PQ0BCMHMNYG8FS34MYZ\` dispatched twice, started twice, and merge-complete logged twice — within 3-19ms of each other.

## Cause

\`dispatcher.dispatchCycle\` reads queued rows via \`ListQueuedOperationsV2()\` and dispatches each one without marking the DB row \"running\" — that only happens after the worker pulls from the \`nextRun\` channel at \`worker.go:143\`. Between channel-send and worker-pickup the row remains \"queued\" in the DB. If the dispatcher re-runs (100ms tick or \`r.dispatch\` signal) in that window, the same op is dispatched again.

For idempotent ops like book-merge the second execution no-ops with a \"book not found\" error. **For non-idempotent ops (organize, delete, rename) the second execution would cause real damage.**

## Fix

In-memory Gate 0 + TOCTOU re-check on \`r.running\`. Dispatcher writes a stub \`*runHandle\` into \`r.running\` at claim time, so subsequent dispatch cycles see the op as already-claimed and skip. Worker overwrites the stub on pickup (existing code path).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/operations/registry/...\` passes
- [ ] Post-deploy: trigger a merge, verify only one \"dispatched op\" / \"starting run\" / \"book merge complete\" log line per op_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)