### PR TITLE
fix(ops): disable Isolate — child-mode handler not wired

### DIFF
--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -40,7 +40,7 @@ func (p *Plugin) backfillDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		Schedule:        &sched,
-		Isolate:         true,
+		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
 		Timeout:         24 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -41,7 +41,7 @@ func (p *Plugin) fingerprintRescanDef() sdk.OperationDef {
 		Description:     "Generates per-file fingerprints on demand with scope and force options.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
-		Isolate:         true,
+		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
 		Timeout:         12 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/scan.go
+++ b/internal/plugins/acoustid/scan.go
@@ -24,7 +24,7 @@ func (p *Plugin) scanDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "acoustid.scan",
-		Isolate:         true,
+		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
 		Timeout:         6 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/itunes/import.go
+++ b/internal/plugins/itunes/import.go
@@ -20,7 +20,7 @@ func (p *Plugin) importDef() sdk.OperationDef {
 		Plugin:                "itunes",
 		DisplayName:           "iTunes Library Import",
 		Description:           "Import audiobooks from the iTunes/Music library into the organizer.",
-		Isolate:               true,
+		Isolate:               false, // subprocess child-mode handler not wired in main.go; in-process until fixed
 		ResumePolicy:          sdk.ResumeRestart,
 		DefaultPriority:       sdk.PriorityNormal,
 		Cancellable:           true,

--- a/internal/plugins/maintenance/backfill.go
+++ b/internal/plugins/maintenance/backfill.go
@@ -54,7 +54,7 @@ func (p *Plugin) movementAtomCleanupDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.movement-atom-cleanup",
 		Cancellable:     false,
-		Isolate:         true, // uses ffmpeg subprocess
+		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
 		Timeout:         60 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -79,7 +79,7 @@ func (p *Plugin) malformedM4BRemuxDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-remux",
 		Cancellable:     false,
-		Isolate:         true, // uses ffmpeg subprocess
+		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
 		Timeout:         120 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -106,7 +106,7 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-transcode",
 		Cancellable:     true,
-		Isolate:         true, // uses ffmpeg subprocess
+		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
 		Timeout:         6 * time.Hour,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},


### PR DESCRIPTION
## The bug

Seven operations were declared with \`Isolate: true\`, expecting the registry to re-exec the binary with \`--operation-runner\` and run them in a subprocess. But \`main.go\` never intercepts that flag — it falls through to cobra root which errors with \"unknown flag: --operation-runner\". Every Isolate op fails ~47ms after dispatch with no useful error in journald.

User-visible: \"Find Acoustic Duplicates\" button silently does nothing. acoustid.scan fails the same way. iTunes import too.

## Fix

Flip \`Isolate: false\` on all seven. Ops run in-process like the rest. The \"uses ffmpeg subprocess\" comments on maintenance ops referred to ffmpeg child processes spawned via \`exec.Cmd\` — unaffected by this flag.

## Proper followup

Wire \`IsChildMode()\`/\`RunChildMode()\` into \`main.go\` so the subprocess infrastructure actually works. Would let us restore isolation for plugins that legitimately need crash containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)