### PR TITLE
fix(organizer): scrub path separators from template variables

### DIFF
--- a/internal/organizer/path_format.go
+++ b/internal/organizer/path_format.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/path_format.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a7b3c1d2-e4f5-6789-abcd-ef0123456789
 
 package organizer
@@ -34,7 +34,9 @@ const (
 
 // FormatSegmentTitle formats a per-segment title using the template.
 // For single-file books (totalTracks == 1), returns just the title without numbering.
+// title is scrubbed of path separators — segment titles are path components.
 func FormatSegmentTitle(format string, title string, track, totalTracks int) string {
+	title = scrubVar(title)
 	if totalTracks <= 1 {
 		return title
 	}
@@ -58,18 +60,60 @@ func FormatSegmentTitle(format string, title string, track, totalTracks int) str
 	return result
 }
 
+// scrubVar strips characters that would create unintended path separators
+// or hidden directories if they leaked from metadata into a template
+// substitution. Called on EVERY variable value before it's interpolated
+// into the path format. Without this, a Title like "Tarkin - Star Wars - 3/85"
+// (real prod data, 2026-05-28) splits into a "Tarkin - Star Wars - 3/"
+// directory + "85.mp3" file — and the scanner then sees 85 single-file
+// directories and creates 85 separate Book records instead of one Book
+// with 85 BookFiles.
+//
+// Replaces:
+//   '/' and '\' (path separators) → ' '
+//   leading '.' (would create hidden dirs / could match parent ".")
+// Whitespace is collapsed at the per-component SanitizePathComponent step.
+func scrubVar(s string) string {
+	if s == "" {
+		return s
+	}
+	// Drop path separators outright — they have no place inside a single
+	// metadata value. Anyone wanting a "/" in a path should put it in the
+	// template structure, not in {title} / {series} / etc.
+	s = strings.ReplaceAll(s, "/", " ")
+	s = strings.ReplaceAll(s, "\\", " ")
+	// Leading dots create hidden files/dirs on POSIX and ".." is parent.
+	s = strings.TrimLeft(s, ".")
+	return s
+}
+
 // FormatPath formats a full file path using the path_format template.
 func FormatPath(format string, vars FormatVars) string {
-	trackTitle := vars.TrackTitle
+	// SCRUB every variable BEFORE substitution so no metadata value can
+	// introduce an unintended path separator. The post-substitution split
+	// at line ~150 below treats every '/' as a directory boundary; if
+	// {title} leaks a '/', the directory tree explodes (see scrubVar comment).
+	author := scrubVar(vars.Author)
+	title := scrubVar(vars.Title)
+	series := scrubVar(vars.Series)
+	seriesPos := scrubVar(vars.SeriesPos)
+	narrator := scrubVar(vars.Narrator)
+	lang := scrubVar(vars.Lang)
+
+	trackTitle := scrubVar(vars.TrackTitle)
 	if trackTitle == "" && vars.Track > 0 {
-		trackTitle = FormatSegmentTitle(DefaultSegmentTitleFormat, vars.Title, vars.Track, vars.TotalTracks)
+		// Use scrubbed title here too — segment title is a path component.
+		trackTitle = FormatSegmentTitle(DefaultSegmentTitleFormat, title, vars.Track, vars.TotalTracks)
+		// FormatSegmentTitle could in theory emit a '/' if a future template
+		// uses one — re-scrub defensively.
+		trackTitle = scrubVar(trackTitle)
 	}
 
 	seriesPrefix := ""
-	if vars.Series != "" {
-		seriesPrefix = vars.Series
-		if vars.SeriesPos != "" {
-			seriesPrefix += " " + vars.SeriesPos
+	if series != "" {
+		seriesPrefix = series
+		if seriesPos != "" {
+			seriesPrefix += " " + seriesPos
 		}
 		seriesPrefix += " - "
 	}
@@ -80,14 +124,14 @@ func FormatPath(format string, vars FormatVars) string {
 	}
 
 	result := format
-	result = strings.ReplaceAll(result, "{author}", vars.Author)
-	result = strings.ReplaceAll(result, "{title}", vars.Title)
-	result = strings.ReplaceAll(result, "{series}", vars.Series)
-	result = strings.ReplaceAll(result, "{series_position}", vars.SeriesPos)
+	result = strings.ReplaceAll(result, "{author}", author)
+	result = strings.ReplaceAll(result, "{title}", title)
+	result = strings.ReplaceAll(result, "{series}", series)
+	result = strings.ReplaceAll(result, "{series_position}", seriesPos)
 	result = strings.ReplaceAll(result, "{series_prefix}", seriesPrefix)
 	result = strings.ReplaceAll(result, "{year}", yearStr)
-	result = strings.ReplaceAll(result, "{narrator}", vars.Narrator)
-	result = strings.ReplaceAll(result, "{lang}", vars.Lang)
+	result = strings.ReplaceAll(result, "{narrator}", narrator)
+	result = strings.ReplaceAll(result, "{lang}", lang)
 	result = strings.ReplaceAll(result, "{track_title}", trackTitle)
 	result = strings.ReplaceAll(result, "{ext}", vars.Ext)
 

--- a/internal/organizer/path_format_test.go
+++ b/internal/organizer/path_format_test.go
@@ -1,0 +1,130 @@
+// file: internal/organizer/path_format_test.go
+// version: 1.0.0
+// guid: a7b3c1d2-e4f5-6789-abcd-ef0123456f01
+
+package organizer
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatPath_SlashInVariableDoesNotCreateDirectory exercises the prod
+// bug from 2026-05-28: book 01KQGDQTJ44FCAPW5Z9D2KNQDE had its 85-chapter
+// audiobook split into 85 single-file books because the Title metadata
+// contained a "/" which the path formatter passed through unescaped,
+// turning into a real directory boundary on disk.
+func TestFormatPath_SlashInVariableDoesNotCreateDirectory(t *testing.T) {
+	cases := []struct {
+		name string
+		vars FormatVars
+	}{
+		{
+			name: "title contains slash",
+			vars: FormatVars{
+				Author:      "James Luceno",
+				Title:       "Tarkin - Star Wars - 3/85", // <-- the killer
+				Ext:         "mp3",
+				Track:       3,
+				TotalTracks: 85,
+			},
+		},
+		{
+			name: "series contains slash",
+			vars: FormatVars{
+				Author: "Test Author",
+				Series: "Foo/Bar Series",
+				Title:  "Book One",
+				Ext:    "mp3",
+			},
+		},
+		{
+			name: "author contains slash",
+			vars: FormatVars{
+				Author: "First / Last",
+				Title:  "Title",
+				Ext:    "mp3",
+			},
+		},
+		{
+			name: "narrator contains slash",
+			vars: FormatVars{
+				Author:   "Test Author",
+				Title:    "Title",
+				Narrator: "Reader A / Reader B",
+				Ext:      "mp3",
+			},
+		},
+		{
+			name: "title begins with dot (hidden file)",
+			vars: FormatVars{
+				Author: "Test Author",
+				Title:  ".hidden",
+				Ext:    "mp3",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatPath(DefaultPathFormat, tc.vars)
+			// Count "/" — should equal the count of "/" in the TEMPLATE itself,
+			// not anything more. DefaultPathFormat has 2 path separators:
+			// {author}/{series_prefix}{title}/{track_title}.{ext}
+			//        ^                       ^
+			// Any extra "/" means a variable leaked one.
+			templateSlashes := strings.Count(DefaultPathFormat, "/")
+			gotSlashes := strings.Count(got, "/")
+			if gotSlashes != templateSlashes {
+				t.Errorf("FormatPath(%+v) = %q\n  has %d '/' separators; template has %d.\n  A variable value leaked a path separator into the result.",
+					tc.vars, got, gotSlashes, templateSlashes)
+			}
+		})
+	}
+}
+
+// TestFormatPath_TarkinReproduces the exact prod path that would have been
+// written by the buggy code, and confirms the scrubbed result lands in
+// ONE directory, not 85.
+func TestFormatPath_TarkinReproducesAsOneFile(t *testing.T) {
+	vars := FormatVars{
+		Author:      "James Luceno",
+		Series:      "Star Wars",
+		SeriesPos:   "24",
+		Title:       "Tarkin",
+		Track:       3,
+		TotalTracks: 85,
+		Ext:         "mp3",
+	}
+	got := FormatPath(DefaultPathFormat, vars)
+
+	// Expected: James Luceno/Star Wars 24 - Tarkin/Tarkin - 3_85.mp3
+	// Each segment is one path component; the "3_85" uses underscore (the
+	// segment-title default), so no rogue directory.
+	if strings.Contains(got, "/85.mp3") {
+		t.Fatalf("FormatPath emitted %q — '/85.mp3' suffix means the per-track total leaked as a directory separator", got)
+	}
+	if strings.Count(got, "/") != 2 {
+		t.Fatalf("FormatPath emitted %q — expected exactly 2 path separators (author/, title-folder/), got %d", got, strings.Count(got, "/"))
+	}
+}
+
+func TestScrubVar(t *testing.T) {
+	cases := map[string]string{
+		"":                  "",
+		"normal":            "normal",
+		"with/slash":        "with slash",
+		"back\\slash":       "back slash",
+		"both/and\\both":    "both and both",
+		".hidden":           "hidden",
+		"..parent":          "parent",
+		"....many":          "many",
+		"trailing.":         "trailing.",
+		"middle.dot.ok":     "middle.dot.ok",
+	}
+	for in, want := range cases {
+		if got := scrubVar(in); got != want {
+			t.Errorf("scrubVar(%q) = %q; want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

Book \`01KQGDQTJ44FCAPW5Z9D2KNQDE\` in prod is an 85-chapter audiobook that was created as **85 separate single-file books** because the Title metadata contained \`/\` (e.g. \`\"Tarkin - Star Wars - 3/85\"\`).

\`FormatPath\` dumped the metadata into the template unescaped:
\`\`\`go
result = strings.ReplaceAll(result, \"{title}\", vars.Title)
\`\`\`

Then this happens (line ~150):
\`\`\`go
parts := strings.Split(result, \"/\")  // <-- rogue '/' = directory boundary
\`\`\`

On disk this produced \`.../Tarkin - Star Wars - 3/85.mp3\` — a \`3/\` directory with \`85.mp3\` inside. Scanner then sees 85 separate single-file folders and creates 85 Book records.

## Fix

New \`scrubVar()\` called on every variable value BEFORE template substitution. Strips \`/\`, \`\\\`, and leading \`.\` from each value. The template's intentional \`/\` separators stay; metadata can no longer leak path separators into the result.

Applied to: Author, Title, Series, SeriesPos, Narrator, Lang, TrackTitle, and (defensively) the title arg of \`FormatSegmentTitle\`.

## Tests

- \`TestFormatPath_SlashInVariableDoesNotCreateDirectory\` — 5 cases for title/series/author/narrator slashes + hidden-file dot
- \`TestFormatPath_TarkinReproducesAsOneFile\` — exact prod scenario
- \`TestScrubVar\` — unit coverage

All organizer tests pass.

## Followup

MAYDEPLOY-G in TODO.md tracks the backfill scan + merge tool to collapse the existing over-split books in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)