### PR TITLE
fix(test): EnrichAudiobooksWithNames mock (E3)

### DIFF
--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -539,6 +539,13 @@ func TestAudiobookService_EnrichAudiobooksWithNames_WithAuthorAndSeries(t *testi
 		},
 	}
 
+	// aggregateFileMetadata (called by EnrichAudiobooksWithNames) tries
+	// GetBookFilesForIDs first, then falls back to per-book GetBookFiles.
+	// MockStore doesn't implement GetBookFilesForIDs, so the per-book path
+	// is taken. The test doesn't care about file aggregates — return empty.
+	mockStore.EXPECT().GetBookFiles("e1").Return(nil, nil).Maybe()
+	mockStore.EXPECT().GetBookFiles("e2").Return(nil, nil).Maybe()
+
 	result := svc.EnrichAudiobooksWithNames(books)
 	assert.Len(t, result, 2)
 


### PR DESCRIPTION
Fixes MAYDEPLOY-E3: aggregateFileMetadata's call path moved from GetAllBookFiles to GetBookFilesForIDs (PR #1149) but the mock expectations weren't updated. Adds matching expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)