### PR TITLE
fix(dedup): return 409 not 500 when source book already merged (B2)

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/dedup_handlers.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-20
+// last-edited: 2026-05-28
 
 package server
 
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -928,6 +929,37 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 	if candidate.EntityType == "book" && s.mergeService != nil {
 		mergeResult, mergeErr := s.mergeService.MergeBooks([]string{candidate.EntityAID, candidate.EntityBID}, "")
 		if mergeErr != nil {
+			// MAYDEPLOY-B2: when one of the source books no longer exists (a previous
+			// merge already absorbed it), the candidate is stale rather than the
+			// request being a server error. Treat that as 409 Conflict and mark the
+			// candidate merged so the UI's next refresh drops it.
+			//
+			// We use a substring match on "not found" because the underlying merge
+			// service returns a plain fmt.Errorf("book %s not found", ...) without an
+			// exported sentinel error. Switch to errors.Is if/when that error type
+			// becomes exported.
+			if strings.Contains(mergeErr.Error(), "not found") {
+				if statusErr := s.embeddingStore.UpdateCandidateStatus(id, "merged"); statusErr != nil {
+					slog.Warn("dedup merge already-merged: failed to update candidate status", "candidate_id", id, "err", statusErr)
+				}
+				s.publishEvent(c.Request.Context(), plugin.NewEvent(plugin.EventDedupMerged, candidate.EntityAID, map[string]any{
+					"entity_b_id":   candidate.EntityBID,
+					"entity_type":   candidate.EntityType,
+					"candidate_id":  id,
+					"already_merged": true,
+				}))
+				slog.Info("dedup merge skipped: source book already merged away",
+					"candidate_id", id,
+					"entity_a", candidate.EntityAID,
+					"entity_b", candidate.EntityBID,
+					"err", mergeErr,
+				)
+				c.JSON(http.StatusConflict, gin.H{
+					"status":       "already_merged",
+					"candidate_id": id,
+				})
+				return
+			}
 			httputil.InternalError(c, "failed to merge books", mergeErr)
 			return
 		}


### PR DESCRIPTION
## Summary

MAYDEPLOY-B2: `POST /api/v1/dedup/candidates/:id/merge` returned HTTP 500 when a prior merge had already absorbed one of the candidate's source books — `mergeService.MergeBooks` returns `book <id> not found` and the handler treated it as a server error, so the frontend surfaced a real failure for what was really just a stale candidate.

Now the handler detects the "not found" merge error, marks the candidate `merged`, publishes `EventDedupMerged` (with `already_merged: true`), and responds **409 Conflict** with `{"status": "already_merged", "candidate_id": N}`. Genuine merge failures still return 500. Detection uses `strings.Contains` because the underlying error isn't an exported sentinel — comment notes to switch to `errors.Is` if/when one is introduced.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/server/... -run "Dedup|Merge" -count=1` passes
- [ ] Manual: trigger a dedup candidate whose B-side was already merged; confirm 409 + payload in browser network tab and that the UI refresh drops it silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)