### PR TITLE
fix(database): TestPebbleStoreReset (E2)

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -7062,6 +7062,18 @@ func (p *PebbleStore) Reset() error {
 		return fmt.Errorf("failed to flush after reset: %w", err)
 	}
 
+	// Clear the in-memory query layer so it no longer returns stale rows
+	// that were wiped from Pebble. Reads check `p.mem() != nil`, so swapping
+	// in a fresh empty MemStore (or nil-ing the pointer if construction
+	// fails) immediately bypasses the stale snapshot. Without this, reads
+	// from memdb-backed paths (e.g. GetAllAuthors) would continue to return
+	// entries that were just deleted from Pebble.
+	if fresh, err := NewMemStore(); err == nil {
+		p.memPtr.Store(fresh)
+	} else {
+		p.memPtr.Store(nil)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes MAYDEPLOY-E2: `PebbleStore.Reset()` wiped the Pebble keyspace and reinitialized counters, but left the in-memory query layer (memdb) populated. Reads such as `GetAllAuthors` check `p.mem() != nil` and prefer the memdb snapshot — so an author created before `Reset()` continued to surface afterwards, causing `TestPebbleStoreReset` to fail with `Expected 0 authors after reset, got 1`. The fix replaces `p.memPtr` with a fresh empty `MemStore` at the end of `Reset()` so memdb stays consistent with the wiped Pebble store.

Verified:
- `go test ./internal/database/... -run TestPebbleStoreReset -count=1` now passes.
- Pre-existing `TestNewPebbleStoreExistingCounters` panic ("pebble: closed" from warmup goroutine outliving Close) reproduces on main and is unrelated to this change.

[Claude Code](https://claude.com/claude-code)