### PR TITLE
fix(test): cache init in test Server fixture (E1)

### DIFF
--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -36,9 +36,11 @@ func setupHandlerTest(t *testing.T) (*Server, *mocks.MockStore, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	mockStore := mocks.NewMockStore(t)
 	srv := &Server{
-		store:      mockStore,
-		dedupCache: cache.New[gin.H]("dedup", 5*time.Minute),
-		listCache:  cache.New[gin.H]("list", 30*time.Second),
+		store:        mockStore,
+		dedupCache:   cache.New[gin.H]("dedup", 5*time.Minute),
+		listCache:    cache.New[gin.H]("list", 30*time.Second),
+		authorsCache: cache.New[gin.H]("authors", 30*time.Second),
+		seriesCache:  cache.New[gin.H]("series", 30*time.Second),
 	}
 	router := gin.New()
 	return srv, mockStore, router


### PR DESCRIPTION
Fixes MAYDEPLOY-E1: the `setupHandlerTest` test fixture was leaving `authorsCache` and `seriesCache` nil, so any handler that invalidates a cache (e.g. `renameAuthor` calling `s.authorsCache.InvalidateAll()` at `internal/server/entities_handlers.go:244`) NPEs with a SIGSEGV inside `cache.(*Cache[...]).InvalidateAll`.

Initializes both caches in the fixture to match production wiring in `server.go`.

This was failing on main before today's changes - pre-existing bug surfaced during the May 28 perf sprint test run.

## Verification

Before:
```
--- FAIL: TestHandler_RenameAuthor_Success (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
```

After:
```
ok  github.com/jdfalk/audiobook-organizer/internal/server  1.202s
```

No new failures introduced - pre-existing failures (`TestHandleGetAcoustIDStats_OK`, `TestCoverageListAuthors`, `TestCoverageListSeries`) remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)