### PR TITLE
perf(files): GetAllBookFiles memdb fastpath (C2)

### DIFF
--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -634,6 +634,28 @@ func (m *MemStore) GetBookFilesForIDs(bookIDs []string) (map[string][]BookFile, 
 	return result, nil
 }
 
+// GetAllBookFiles returns every BookFile in the memdb book_files table by
+// iterating the primary ID index. O(N) pointer walk over the in-memory table
+// — no JSON unmarshal, no Pebble disk scan. For 308K book_files this is
+// roughly two orders of magnitude faster than the Pebble full-scan fallback.
+func (m *MemStore) GetAllBookFiles() ([]BookFile, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+	iter, err := txn.Get(memTableBookFiles, memIdxID)
+	if err != nil {
+		return nil, fmt.Errorf("memdb book_files scan: %w", err)
+	}
+	var files []BookFile
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		bf, ok := obj.(*BookFile)
+		if !ok {
+			continue
+		}
+		files = append(files, *bf)
+	}
+	return files, nil
+}
+
 func paginate[T any](in []T, limit, offset int) []T {
 	if offset < 0 {
 		offset = 0

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -8461,10 +8461,21 @@ func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string
 	return result, nil
 }
 
-// GetAllBookFiles returns every BookFile in the database by iterating the
-// book_file: prefix space. Used by bulk-scan operations that would otherwise
-// make one GetBookFiles call per book (N+1 problem).
+// GetAllBookFiles returns every BookFile in the database. When memdb is
+// published, iterates the in-memory book_files table — a pointer walk over
+// ~308K rows — instead of a Pebble prefix scan with per-row JSON unmarshal.
+// Mirrors the GetBookFilesForIDs fastpath from PR #1153.
+//
+// Pebble full-scan retained as fallback for cold-start (before memdb
+// publishes) and tests with no memdb.
 func (s *PebbleStore) GetAllBookFiles() ([]BookFile, error) {
+	if s.UseMemDB && s.mem() != nil {
+		return s.mem().GetAllBookFiles()
+	}
+	return s.getAllBookFilesPebbleScan()
+}
+
+func (s *PebbleStore) getAllBookFilesPebbleScan() ([]BookFile, error) {
 	prefix := []byte("book_file:")
 	iter, err := s.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,


### PR DESCRIPTION
MAYDEPLOY-C2: `PebbleStore.GetAllBookFiles` previously did a full Pebble prefix scan + JSON unmarshal across all ~308K BookFiles every call. This mirrors PR #1153's pattern for `GetBookFilesForIDs`: when memdb is published, route to a new `MemStore.GetAllBookFiles()` that iterates the in-memory book_files table by the primary ID index (pointer walk, no JSON), and keep the Pebble scan as `getAllBookFilesPebbleScan` for cold-start / no-memdb fallback. Benefits the few remaining callers (aggregateFileMetadata fallback, dedup batch ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)