### PR TITLE
fix(dedup): cleanup orphan candidates referencing merged-away books (B3)

### DIFF
--- a/internal/database/embedding_candidates_test.go
+++ b/internal/database/embedding_candidates_test.go
@@ -160,6 +160,182 @@ func TestDedupCandidates_RemoveForEntity(t *testing.T) {
 	assert.Equal(t, "b4", remaining[0].EntityBID)
 }
 
+// TestDedupCandidates_MarkAsMergedForEntity covers MAYDEPLOY-B3: after a merge
+// collapses book B into book A, any other candidate row referencing book B
+// must be flipped to status="merged" so the candidates UI drops the orphan.
+func TestDedupCandidates_MarkAsMergedForEntity(t *testing.T) {
+	t.Run("zero matches", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "b1", EntityBID: "b2",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "b99")
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		// Existing row untouched.
+		results, _, err := store.ListCandidates(CandidateFilter{})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "pending", results[0].Status)
+	})
+
+	t.Run("match on entity_a_id side", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "bA", EntityBID: "bX",
+			Layer: "embedding", Status: "pending",
+		}))
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "bY", EntityBID: "bZ",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "bA")
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		got, _, err := store.ListCandidates(CandidateFilter{EntityType: "book"})
+		require.NoError(t, err)
+		statuses := map[string]string{}
+		for _, c := range got {
+			statuses[c.EntityAID+"|"+c.EntityBID] = c.Status
+		}
+		// UpsertCandidate canonicalizes so the pair becomes (bA, bX).
+		assert.Equal(t, "merged", statuses["bA|bX"])
+		assert.Equal(t, "pending", statuses["bY|bZ"])
+	})
+
+	t.Run("match on entity_b_id side", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		// UpsertCandidate canonicalizes so the merged-away book ends up on
+		// whichever side it sorts to; constructing a pair where the target
+		// will land on the B side requires the target ID to sort *after* its
+		// partner.
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "aaa", EntityBID: "zzz",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "zzz")
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		results, _, err := store.ListCandidates(CandidateFilter{})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "merged", results[0].Status)
+	})
+
+	t.Run("both sides match across rows", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		// Target book = "bMid". It appears on the A side in one row and on
+		// the B side in another after canonicalization.
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "bMid", EntityBID: "zOther",
+			Layer: "embedding", Status: "pending",
+		}))
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "aOther", EntityBID: "bMid",
+			Layer: "embedding", Status: "pending",
+		}))
+		// Unrelated row must stay pending.
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "x1", EntityBID: "x2",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "bMid")
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		results, _, err := store.ListCandidates(CandidateFilter{})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+		merged := 0
+		pending := 0
+		for _, c := range results {
+			switch c.Status {
+			case "merged":
+				merged++
+				// Each merged row must touch bMid.
+				assert.True(t, c.EntityAID == "bMid" || c.EntityBID == "bMid", "merged row should reference bMid")
+			case "pending":
+				pending++
+				assert.False(t, c.EntityAID == "bMid" || c.EntityBID == "bMid", "pending row should not reference bMid")
+			}
+		}
+		assert.Equal(t, 2, merged)
+		assert.Equal(t, 1, pending)
+	})
+
+	t.Run("already merged rows untouched in count", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "bA", EntityBID: "bX",
+			Layer: "embedding", Status: "merged",
+		}))
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "bA", EntityBID: "bY",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "bA")
+		require.NoError(t, err)
+		// Only the pending row counts as newly transitioned.
+		assert.Equal(t, 1, n)
+
+		results, _, err := store.ListCandidates(CandidateFilter{})
+		require.NoError(t, err)
+		for _, c := range results {
+			assert.Equal(t, "merged", c.Status)
+		}
+	})
+
+	t.Run("entity_type filter respected", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "x1", EntityBID: "x2",
+			Layer: "embedding", Status: "pending",
+		}))
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "author", EntityAID: "x1", EntityBID: "x2",
+			Layer: "metadata", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("book", "x1")
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		results, _, err := store.ListCandidates(CandidateFilter{})
+		require.NoError(t, err)
+		statuses := map[string]string{}
+		for _, c := range results {
+			statuses[c.EntityType] = c.Status
+		}
+		assert.Equal(t, "merged", statuses["book"])
+		assert.Equal(t, "pending", statuses["author"])
+	})
+
+	t.Run("empty inputs noop", func(t *testing.T) {
+		store := newTestEmbeddingStore(t)
+		require.NoError(t, store.UpsertCandidate(DedupCandidate{
+			EntityType: "book", EntityAID: "b1", EntityBID: "b2",
+			Layer: "embedding", Status: "pending",
+		}))
+
+		n, err := store.MarkCandidatesAsMergedForEntity("", "b1")
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		n, err = store.MarkCandidatesAsMergedForEntity("book", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+}
+
 // TestDedupCandidates_LayerPrecedence verifies that an upsert with a
 // lower-confidence layer does not downgrade an existing higher-confidence
 // row. Precedence: exact > llm > embedding. This locks in the fix for a

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -633,6 +633,84 @@ func (s *EmbeddingStore) DeleteCandidate(id int64) error {
 	return b.Commit(pebble.Sync)
 }
 
+// MarkCandidatesAsMergedForEntity sets status="merged" on every candidate row
+// that references the given entity on either side (entity_a_id OR entity_b_id),
+// regardless of current layer or status — *except* rows whose status is already
+// "merged", which are left untouched so the returned count reflects only newly
+// transitioned rows.
+//
+// Use case (MAYDEPLOY-B3): when a Merge operation collapses book B into book A,
+// any other dedup candidate that still references book B (e.g. a separate row
+// comparing book B vs book C) becomes a stale "orphan" — clicking Merge on it
+// would fail because book B is gone. Marking those rows as merged here causes
+// the candidates UI to drop them on its next refresh, instead of the user
+// having to dismiss each one manually.
+//
+// Returns the number of rows whose status was newly changed.
+func (s *EmbeddingStore) MarkCandidatesAsMergedForEntity(entityType, entityID string) (int, error) {
+	if entityType == "" || entityID == "" {
+		return 0, nil
+	}
+
+	prefix := []byte(dedupRecPfx)
+	upper := prefixUpperBound(prefix)
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return 0, fmt.Errorf("mark candidates merged for entity: %w", err)
+	}
+
+	type target struct {
+		id  int64
+		rec candRec
+	}
+	var targets []target
+	for iter.First(); iter.Valid(); iter.Next() {
+		idHex := string(iter.Key())[len(dedupRecPfx):]
+		id, err := strconv.ParseInt(idHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		var rec candRec
+		if err := json.Unmarshal(iter.Value(), &rec); err != nil {
+			continue
+		}
+		if rec.EntityType != entityType {
+			continue
+		}
+		if rec.EntityAID != entityID && rec.EntityBID != entityID {
+			continue
+		}
+		if rec.Status == "merged" {
+			continue
+		}
+		targets = append(targets, target{id: id, rec: rec})
+	}
+	iter.Close()
+	if err := iter.Error(); err != nil {
+		return 0, err
+	}
+
+	now := time.Now().UnixNano()
+	b := s.db.NewBatch()
+	defer b.Close()
+	for _, t := range targets {
+		t.rec.Status = "merged"
+		t.rec.UpdatedAt = now
+		data, err := json.Marshal(t.rec)
+		if err != nil {
+			return 0, fmt.Errorf("mark candidates merged marshal %d: %w", t.id, err)
+		}
+		if err := b.Set(dedupRecKey(t.id), data, nil); err != nil {
+			return 0, fmt.Errorf("mark candidates merged set %d: %w", t.id, err)
+		}
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return 0, fmt.Errorf("mark candidates merged commit: %w", err)
+	}
+	return len(targets), nil
+}
+
 // RemoveCandidatesForEntity deletes all candidate rows that involve the given
 // entity (as either entity_a or entity_b). Returns the number of rows deleted.
 func (s *EmbeddingStore) RemoveCandidatesForEntity(entityType, entityID string) (int, error) {

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1455,6 +1455,40 @@ func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) 
 // after the backfill completes and again at the start of a user-triggered
 // Re-scan so the candidate table stays clean after the Layer 1 + Layer 2
 // rules tighten.
+// CleanupCandidatesAfterMerge marks dedup candidate rows referencing any of
+// the given merged-away book IDs as status="merged" so the candidates UI drops
+// them on its next refresh. Without this, candidate Y comparing book B vs book
+// C remains pending after book B was collapsed into book A by a separate
+// candidate row — clicking Merge on Y then 500s ("book not found"), the
+// 409-hotfix path in PR #1160 notwithstanding.
+//
+// Best-effort: per-ID errors are logged, not returned. Returns total rows
+// transitioned across all IDs.
+func (de *Engine) CleanupCandidatesAfterMerge(mergedAwayBookIDs []string) int {
+	if de == nil || de.embedStore == nil || len(mergedAwayBookIDs) == 0 {
+		return 0
+	}
+	total := 0
+	for _, id := range mergedAwayBookIDs {
+		if id == "" {
+			continue
+		}
+		n, err := de.embedStore.MarkCandidatesAsMergedForEntity("book", id)
+		if err != nil {
+			slog.Warn("dedup cleanup candidates after merge", "book_id", id, "err", err)
+			continue
+		}
+		total += n
+	}
+	if total > 0 {
+		slog.Info("dedup cleanup candidates after merge",
+			"merged_away_count", len(mergedAwayBookIDs),
+			"orphan_candidates_marked_merged", total,
+		)
+	}
+	return total
+}
+
 func (de *Engine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 	_, span := dedupTracer.Start(ctx, "dedup.purge_stale_candidates")
 	defer span.End()

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -964,6 +964,22 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 			return
 		}
 		result = mergeResult
+
+		// MAYDEPLOY-B3: sweep orphan candidates. Any *other* pending candidate
+		// row that still references the merged-away book(s) is now stale —
+		// clicking Merge on it would 500 ("book not found") absent the
+		// PR #1160 409-hotfix path. Mark them merged proactively so the UI
+		// drops them on the next refresh rather than the user having to
+		// dismiss each by hand.
+		if s.dedupEngine != nil && mergeResult != nil {
+			var mergedAway []string
+			for _, bid := range []string{candidate.EntityAID, candidate.EntityBID} {
+				if bid != "" && bid != mergeResult.PrimaryID {
+					mergedAway = append(mergedAway, bid)
+				}
+			}
+			s.dedupEngine.CleanupCandidatesAfterMerge(mergedAway)
+		}
 	}
 
 	if err := s.embeddingStore.UpdateCandidateStatus(id, "merged"); err != nil {


### PR DESCRIPTION
## Summary

Adds `EmbeddingStore.MarkCandidatesAsMergedForEntity(entityType, entityID)` which iterates the dedup candidate index in PebbleDB and flips `status="merged"` on every row whose `entity_a_id` OR `entity_b_id` matches the given entity ID, skipping rows already merged. `Engine.CleanupCandidatesAfterMerge` wraps this for best-effort per-ID logging.

The `mergeDedupCandidate` handler (`internal/server/dedup_handlers.go`) now invokes `s.dedupEngine.CleanupCandidatesAfterMerge` after a successful `mergeService.MergeBooks` call, passing the candidate's `[EntityAID, EntityBID]` minus `mergeResult.PrimaryID` -- i.e., the IDs that were soft-deleted by the merge.

This is the proper fix for MAYDEPLOY-B3. The 409-hotfix from PR #1160 is now mostly unnecessary because stale candidates auto-clear from the pending list on the next UI refresh instead of having to be dismissed one at a time; #1160 stays as defense-in-depth for any pre-existing orphans or future race conditions.

Call site chosen: handler post-call (`mergeDedupCandidate`), not an engine event subscriber. Rationale: avoids creating a circular import between `internal/merge` and `internal/dedup`, keeps the cleanup tightly scoped to the UI-driven Merge button path (the only path that creates the orphan-row problem), and lets us derive the merged-away IDs precisely from `mergeResult.PrimaryID` without re-querying the DB.

## Test plan

- [x] Unit tests in `internal/database/embedding_candidates_test.go` covering: zero matches, A-side match, B-side match, both-side match across rows, already-merged rows untouched, entity_type filter, empty-input no-op
- [x] `go build ./...` clean
- [x] `go test ./internal/dedup/... ./internal/server/... ./internal/database/... -count=1 -timeout 180s -run "Dedup|Embedding|Merge|Candidate"` -- all pass
- [ ] Manual smoke on prod after deploy: trigger a merge from the candidates UI, confirm any sibling candidate rows referencing the loser book disappear from the pending list on next refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)