### PR TITLE
perf(dedup): lazy chromem hydrate flag (D1)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.21.2
+// version: 1.22.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-05-18
 
@@ -832,12 +832,18 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 				})
 			}
 		}
-	} else {
-		var fErr error
-		results, fErr = de.embedStore.FindSimilar("book", emb.Vector, float32(de.BookLowThreshold), 20)
+	}
+	// SQLite linear-scan fallback. Hit when chromem isn't wired at all,
+	// OR when chromem is wired but empty (the DEDUP_CHROMEM_LAZY=true
+	// path skips the eager HydrateChromem at startup to save ~6GB heap).
+	// SQLite full-scan + cosine is ~50-200ms per query for 42K books vs
+	// chromem's <10ms; dedup queries are rare so the tradeoff is fine.
+	if len(results) == 0 && de.embedStore != nil {
+		fallback, fErr := de.embedStore.FindSimilar("book", emb.Vector, float32(de.BookLowThreshold), 20)
 		if fErr != nil {
 			return fErr
 		}
+		results = fallback
 	}
 
 	for _, r := range results {
@@ -935,12 +941,16 @@ func (de *Engine) CheckAuthor(ctx context.Context, authorID int) error {
 				results = append(results, database.SimilarityResult{EntityID: cr.EntityID, Similarity: cr.Similarity})
 			}
 		}
-	} else {
-		var fErr error
-		results, fErr = de.embedStore.FindSimilar("author", emb.Vector, float32(de.AuthorLowThreshold), 20)
+	}
+	// SQLite linear-scan fallback. Hit when chromem isn't wired, or when
+	// chromem is wired-but-empty under DEDUP_CHROMEM_LAZY=true. See the
+	// matching block in CheckBook above for the tradeoff rationale.
+	if len(results) == 0 && de.embedStore != nil {
+		fallback, fErr := de.embedStore.FindSimilar("author", emb.Vector, float32(de.AuthorLowThreshold), 20)
 		if fErr != nil {
 			return fErr
 		}
+		results = fallback
 	}
 
 	for _, r := range results {

--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/lifecycle.go
-// version: 1.0.1
+// version: 1.1.0
 
 // Lifecycle methods on *dedup.Engine that the serviceregistry container
 // picks up via interface satisfaction. PostInit subscribes to lifecycle
@@ -15,6 +15,8 @@ package dedup
 import (
 	"context"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/ai"
@@ -22,6 +24,29 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/serviceregistry"
 )
+
+// dedupChromemLazy reports whether the eager HydrateChromem at startup
+// should be skipped. Controlled by env var DEDUP_CHROMEM_LAZY (default
+// false / eager). When true, the chromem store stays empty and
+// FindSimilar in engine.go falls back to the SQLite linear-scan path
+// (EmbeddingStore.FindSimilar at internal/database/embedding_store.go).
+//
+// Tradeoff: skipping hydrate saves ~6GB heap on the 392K-book / 42K-
+// embedding production library, but each dedup FindSimilar goes from
+// chromem ANN (<10ms) to SQLite full-scan + cosine (~50-200ms). Dedup
+// queries are rare (operator-triggered scans, dedup-on-import), so the
+// memory savings dominate for memory-constrained deployments.
+func dedupChromemLazy() bool {
+	v := os.Getenv("DEDUP_CHROMEM_LAZY")
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}
 
 // PostInit wires the dedup engine into the rest of the container. Called
 // by Container.PostInit after Build completes. Three steps:
@@ -67,17 +92,25 @@ func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) er
 	if chromemStore, ok := serviceregistry.TryGet[*database.ChromemEmbeddingStore](c, "chromemstore"); ok && chromemStore != nil {
 		de.SetChromemStore(chromemStore)
 		slog.Info("[INFO] chromem-go ANN store active for dedup Layer 2")
-		// Hydrate asynchronously on the engine's bg-context.
-		go func() {
-			hCtx, cancel := context.WithTimeout(bgCtx, 30*time.Minute)
-			defer cancel()
-			books, authors, err := de.HydrateChromem(hCtx)
-			if err != nil {
-				slog.Warn("chromem hydrate finished with error", "err", err, "books", books, "authors", authors)
-				return
-			}
-			slog.Info("chromem hydrate complete", "books", books, "authors", authors)
-		}()
+		if dedupChromemLazy() {
+			// Skip the eager hydrate. Chromem stays empty; FindSimilar in
+			// engine.go falls back to the SQLite linear-scan path via
+			// EmbeddingStore.FindSimilar (slower per-query but no upfront
+			// ~6GB heap from mirroring 42K book vectors into memory).
+			slog.Info("chromem hydrate skipped (DEDUP_CHROMEM_LAZY=true) — dedup FindSimilar will use SQLite linear-scan fallback")
+		} else {
+			// Hydrate asynchronously on the engine's bg-context.
+			go func() {
+				hCtx, cancel := context.WithTimeout(bgCtx, 30*time.Minute)
+				defer cancel()
+				books, authors, err := de.HydrateChromem(hCtx)
+				if err != nil {
+					slog.Warn("chromem hydrate finished with error", "err", err, "books", books, "authors", authors)
+					return
+				}
+				slog.Info("chromem hydrate complete", "books", books, "authors", authors)
+			}()
+		}
 	}
 
 	// Step 3 — aijobs store + verdict applier


### PR DESCRIPTION
## Summary

Adds `DEDUP_CHROMEM_LAZY=true` env var (default false) that skips the eager `HydrateChromem` startup goroutine, which today reads ~1.8GB of book embeddings from SQLite and mirrors them into chromem-go's in-memory index, adding ~6GB to baseline heap on the 392K-book / 42K-embedding production library. When the flag is set, chromem stays empty and dedup `FindSimilar` (book + author paths) falls back to `EmbeddingStore.FindSimilar` — a SQLite linear-scan + cosine path that runs ~50-200ms per query vs chromem's <10ms. Dedup queries are rare (operator scans, dedup-on-import), so the memory savings dominate for memory-constrained deployments.

Implementation: env-var helper `dedupChromemLazy()` in `lifecycle.go` gates the existing hydrate goroutine. In `engine.go`, the chromem branches in `CheckBook` and `CheckAuthor` now fall through to the SQLite path when chromem returns zero results (covers both unwired chromem and the new wired-but-empty lazy case).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/dedup/... -count=1 -timeout 120s` passes
- [ ] Stage with `DEDUP_CHROMEM_LAZY=true`, confirm "chromem hydrate skipped" log + heap delta
- [ ] Run dedup-on-import on a book in lazy mode; verify SQLite fallback produces candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)