### PR TITLE
fix(scanner): detect multi-file audiobooks at import (G1)

### DIFF
--- a/PLAN-G1.md
+++ b/PLAN-G1.md
@@ -1,0 +1,52 @@
+# PLAN: MAYDEPLOY-G1 — Scanner Multi-File Audiobook Detection
+
+## Goal
+
+Detect at scan time that N audio files in a single folder belong to ONE
+multi-file audiobook (chapters/tracks of one work) and create a single
+Book with N BookFiles instead of N separate single-file Books.
+
+## Existing detection (already in tree)
+
+1. `groupFilesIntoBooks` (scanner.go) — groups when ALL sampled files share
+   exact album tag.
+2. `consolidateChapterGroups` (chapter_consolidation.go) — only matches
+   `^\d+[\s\-\.]+` leading-numeric stems, requires avg duration < 10min.
+3. `DetectChapterGroups` (chapter_consolidator.go) — post-scan over DB.
+
+## Gap this PR fills
+
+- `Title - NN_MM.ext` (Tarkin pattern, `/` becomes `_` on disk)
+- `Title (NN of MM).ext`, `Title (NN-MM).ext`
+- `Chapter NN.ext`, `Part N of M.ext`, `Part NN.ext`, `Track NN.ext`
+- Tag quorum (≥75%) instead of 100% album-tag agreement
+
+## Files to change
+
+- NEW `internal/scanner/multifile_detector.go`
+- NEW `internal/scanner/multifile_detector_test.go`
+- EDIT `internal/scanner/scanner.go` — invoke detector at top of
+  `groupFilesIntoBooks`; positive match returns one Book with SegmentFiles.
+
+## Detection rules
+
+Positive when:
+- N ≥ 3 files in directory, AND
+- ≥75% of files yield a sequential index via the pattern set, AND
+  detected indices are dense in [min..max] (≥75% fill), AND
+- ≥75% of files have non-empty album OR album_artist, and those agree
+  (case-insensitive normalized).
+
+## Tests
+
+Positive: Tarkin `(NN of 85)` ×85; `Chapter NN` ×12; `Part N of M` ×8;
+bare `NN` ×5. Negative: 5 distinct titles; 2 files (below min); 4 files
+with disagreeing albums.
+
+## Build/test
+
+`go build ./...`, `go test ./internal/scanner/... -count=1 -timeout 120s`.
+
+## Rollback
+
+Revert PR — single new file plus a small additive block in scanner.go.

--- a/internal/scanner/multifile_detector.go
+++ b/internal/scanner/multifile_detector.go
@@ -1,0 +1,315 @@
+// file: internal/scanner/multifile_detector.go
+// version: 1.0.0
+// guid: 7a3e4c8b-1d2f-4a5b-9c6d-8e0f1a2b3c4d
+// last-edited: 2026-05-29
+
+// Package scanner — multi-file audiobook detection.
+//
+// MAYDEPLOY-G1: when a folder contains N≥3 audio files matching a sequential
+// naming pattern AND their album / album_artist tags agree across files
+// (quorum ≥ 75% of files with a non-empty value), the whole folder is one
+// audiobook with N BookFiles — not N separate Books.
+//
+// This file provides the pure detection helper. The scanner's tag-reading
+// code populates MultiFileInfo for each candidate file and calls
+// DetectMultiFileGroup; the scanner is responsible for the file IO.
+
+package scanner
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// MultiFileInfo carries the per-file information the detector needs.
+// All fields except Path are best-effort — empties are tolerated.
+type MultiFileInfo struct {
+	Path        string // absolute or relative file path
+	Album       string // tag: album   (TALB / ©alb / ALBUM)
+	AlbumArtist string // tag: album_artist (TPE2 / aART / ALBUMARTIST)
+	TrackNum    int    // tag: track number, 0 = unknown
+	TotalTracks int    // tag: track total, 0 = unknown
+}
+
+// detectedNum is a per-file detection result used internally.
+type detectedNum struct {
+	idx       int // index back into the input slice
+	number    int // detected sequential number (1-based), 0 = none
+	total     int // detected total (from "N of M" or tag), 0 = unknown
+	source    string
+}
+
+// MultiFileDetectionConfig tunes the detector. Defaults via DefaultMultiFileConfig().
+type MultiFileDetectionConfig struct {
+	MinFiles      int     // minimum files in folder to consider; default 3
+	TagQuorum     float64 // fraction of files needed for tag agreement; default 0.75
+	PatternQuorum float64 // fraction of files needed to yield a sequential number; default 0.75
+	DensityRatio  float64 // (#detected) / (max-min+1); default 0.75
+}
+
+// DefaultMultiFileConfig returns the standard thresholds.
+func DefaultMultiFileConfig() MultiFileDetectionConfig {
+	return MultiFileDetectionConfig{
+		MinFiles:      3,
+		TagQuorum:     0.75,
+		PatternQuorum: 0.75,
+		DensityRatio:  0.75,
+	}
+}
+
+// Compiled sequential-number patterns, applied in priority order on the
+// filename stem. Each regex must capture the sequential number in group 1,
+// optionally the total in group 2.
+var multiFileNumPatterns = []*regexp.Regexp{
+	// "Chapter 01", "chapter_05"
+	regexp.MustCompile(`(?i)\bchapter[\s_\-]+(\d{1,4})\b`),
+	// "Part 1 of 8" / "Part 1"
+	regexp.MustCompile(`(?i)\bpart[\s_\-]+(\d{1,4})(?:[\s_\-]+of[\s_\-]+(\d{1,4}))?\b`),
+	// "Track 01"
+	regexp.MustCompile(`(?i)\btrack[\s_\-]+(\d{1,4})\b`),
+	// "Disc 01" / "CD 01"
+	regexp.MustCompile(`(?i)\b(?:disc|cd)[\s_\-]+(\d{1,4})\b`),
+	// "(76 of 85)"
+	regexp.MustCompile(`\((\d{1,4})\s*of\s*(\d{1,4})\)`),
+	// "(76/85)" or "(76_85)" or "(76-85)"
+	regexp.MustCompile(`\((\d{1,4})[\s_\-\/](\d{1,4})\)`),
+	// trailing " - 1_85" / " - 1/85" / "_1_85" near end of stem
+	regexp.MustCompile(`[\s_\-](\d{1,4})[\s_\-\/](\d{1,4})$`),
+	// "01 of 85"
+	regexp.MustCompile(`(?i)\b(\d{1,4})\s+of\s+(\d{1,4})\b`),
+	// leading "01 - ", "002. ", "1_"
+	regexp.MustCompile(`^(\d{1,4})[\s_\-\.\:]`),
+	// bare "01"
+	regexp.MustCompile(`^(\d{1,4})$`),
+}
+
+// extractSeqNumber returns (number, total) extracted from a filename stem.
+// number == 0 means no sequential number found.
+func extractSeqNumber(stem string) (number int, total int) {
+	for _, re := range multiFileNumPatterns {
+		m := re.FindStringSubmatch(stem)
+		if m == nil {
+			continue
+		}
+		number = atoiSafe(m[1])
+		if number <= 0 {
+			continue
+		}
+		if len(m) > 2 {
+			total = atoiSafe(m[2])
+		}
+		return number, total
+	}
+	return 0, 0
+}
+
+func atoiSafe(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+		if n > 1_000_000 {
+			return 0
+		}
+	}
+	return n
+}
+
+// normalizeTagValue lowercases, strips diacritic-irrelevant whitespace and
+// collapses spaces for case/punctuation-insensitive comparison.
+func normalizeTagValue(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	// Collapse any run of whitespace/underscore/dash to a single space.
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range s {
+		if r == ' ' || r == '\t' || r == '_' || r == '-' {
+			if !prevSpace {
+				b.WriteRune(' ')
+			}
+			prevSpace = true
+		} else {
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// majorityValue returns the (value, count) of the most common non-empty
+// entry. If no non-empty entries exist, returns ("", 0).
+func majorityValue(values []string) (string, int) {
+	counts := make(map[string]int)
+	for _, v := range values {
+		v = normalizeTagValue(v)
+		if v == "" {
+			continue
+		}
+		counts[v]++
+	}
+	best := ""
+	bestN := 0
+	for k, n := range counts {
+		if n > bestN {
+			best = k
+			bestN = n
+		}
+	}
+	return best, bestN
+}
+
+// DetectMultiFileGroup decides whether the given audio files in a single
+// directory should be treated as ONE multi-file audiobook. When isMultiFile
+// is true, sortedFiles contains the input files ordered by detected track
+// number (files without a number are appended at the end in their original
+// order).
+//
+// Detection rules (all must hold):
+//   - len(files) >= cfg.MinFiles
+//   - sequential numbers extractable from ≥ cfg.PatternQuorum fraction of files
+//   - detected numbers are dense in [min..max]:
+//     #detected / (max-min+1) >= cfg.DensityRatio
+//   - ≥ cfg.TagQuorum fraction of files share the same non-empty
+//     normalized album OR album_artist
+//
+// The detector does NO file IO; the caller pre-extracts tag metadata.
+func DetectMultiFileGroup(files []MultiFileInfo, cfg MultiFileDetectionConfig) (bool, []MultiFileInfo) {
+	if cfg.MinFiles <= 0 {
+		cfg.MinFiles = 3
+	}
+	if cfg.TagQuorum <= 0 {
+		cfg.TagQuorum = 0.75
+	}
+	if cfg.PatternQuorum <= 0 {
+		cfg.PatternQuorum = 0.75
+	}
+	if cfg.DensityRatio <= 0 {
+		cfg.DensityRatio = 0.75
+	}
+
+	n := len(files)
+	if n < cfg.MinFiles {
+		return false, files
+	}
+
+	// Step 1: extract a sequential number per file.
+	detections := make([]detectedNum, n)
+	for i, f := range files {
+		stem := strings.TrimSuffix(filepath.Base(f.Path), filepath.Ext(f.Path))
+		num, tot := extractSeqNumber(stem)
+		if num == 0 && f.TrackNum > 0 {
+			// Fall back to the audio tag's track number if the stem doesn't
+			// reveal a sequence number — many ripped audiobooks have clean
+			// titles but proper track tags.
+			num = f.TrackNum
+			tot = f.TotalTracks
+		}
+		detections[i] = detectedNum{idx: i, number: num, total: tot}
+	}
+
+	// Step 2: pattern quorum.
+	numbered := 0
+	for _, d := range detections {
+		if d.number > 0 {
+			numbered++
+		}
+	}
+	if float64(numbered)/float64(n) < cfg.PatternQuorum {
+		return false, files
+	}
+
+	// Step 3: density check on detected numbers.
+	min, max := 0, 0
+	first := true
+	for _, d := range detections {
+		if d.number <= 0 {
+			continue
+		}
+		if first {
+			min, max = d.number, d.number
+			first = false
+		} else {
+			if d.number < min {
+				min = d.number
+			}
+			if d.number > max {
+				max = d.number
+			}
+		}
+	}
+	span := max - min + 1
+	if span <= 0 {
+		return false, files
+	}
+	// Reject if the span is wildly larger than the file count — e.g. files
+	// numbered 1, 2 and 500 are not a sequence.
+	if float64(numbered)/float64(span) < cfg.DensityRatio {
+		return false, files
+	}
+	// Numbers should also not all collide on one value.
+	seen := make(map[int]bool, numbered)
+	for _, d := range detections {
+		if d.number > 0 {
+			seen[d.number] = true
+		}
+	}
+	if len(seen) < int(float64(numbered)*0.5) {
+		return false, files
+	}
+
+	// Step 4: tag agreement.
+	albums := make([]string, n)
+	albumArtists := make([]string, n)
+	for i, f := range files {
+		albums[i] = f.Album
+		albumArtists[i] = f.AlbumArtist
+	}
+	_, albumCount := majorityValue(albums)
+	_, artistCount := majorityValue(albumArtists)
+	required := int(float64(n)*cfg.TagQuorum + 0.5)
+	if required < 1 {
+		required = 1
+	}
+	tagAgrees := albumCount >= required || artistCount >= required
+	if !tagAgrees {
+		return false, files
+	}
+
+	// Positive — sort by detected number, then by original index for stable
+	// placement of un-numbered files at the end.
+	sorted := make([]MultiFileInfo, n)
+	copy(sorted, files)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ni, nj := detections[indexOf(files, sorted[i].Path)].number,
+			detections[indexOf(files, sorted[j].Path)].number
+		switch {
+		case ni > 0 && nj > 0:
+			return ni < nj
+		case ni > 0 && nj == 0:
+			return true
+		case ni == 0 && nj > 0:
+			return false
+		default:
+			return false
+		}
+	})
+	return true, sorted
+}
+
+// indexOf returns the index of a file with the given path in files,
+// or -1 if not found. Linear scan — N is small (single folder).
+func indexOf(files []MultiFileInfo, path string) int {
+	for i, f := range files {
+		if f.Path == path {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/scanner/multifile_detector_test.go
+++ b/internal/scanner/multifile_detector_test.go
@@ -1,0 +1,236 @@
+// file: internal/scanner/multifile_detector_test.go
+// version: 1.0.0
+// guid: 9b4f5d2c-3e6a-4b7c-8d9e-0f1a2b3c4d5e
+// last-edited: 2026-05-29
+
+package scanner
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mk builds a MultiFileInfo with the given filename under a fixed directory.
+func mk(name, album, albumArtist string) MultiFileInfo {
+	return MultiFileInfo{
+		Path:        "/library/Tarkin/" + name,
+		Album:       album,
+		AlbumArtist: albumArtist,
+	}
+}
+
+func mkTrack(name, album, albumArtist string, track, total int) MultiFileInfo {
+	f := mk(name, album, albumArtist)
+	f.TrackNum = track
+	f.TotalTracks = total
+	return f
+}
+
+func TestExtractSeqNumber(t *testing.T) {
+	cases := []struct {
+		stem    string
+		wantNum int
+		wantTot int
+	}{
+		{"Chapter 01", 1, 0},
+		{"Chapter_12", 12, 0},
+		{"Part 1 of 8", 1, 8},
+		{"Part 03", 3, 0},
+		{"Track 07", 7, 0},
+		{"(76 of 85) Tarkin", 76, 85},
+		{"(1/85) Tarkin", 1, 85},
+		{"Tarkin - 1_85", 1, 85},
+		{"01 - Intro", 1, 0},
+		{"002. Foo", 2, 0},
+		{"01", 1, 0},
+		{"Disc 02", 2, 0},
+		{"CD 03", 3, 0},
+		{"Just a title with no number", 0, 0},
+		{"Book Title (final)", 0, 0},
+	}
+	for _, c := range cases {
+		gotNum, gotTot := extractSeqNumber(c.stem)
+		if gotNum != c.wantNum || gotTot != c.wantTot {
+			t.Errorf("extractSeqNumber(%q) = (%d, %d), want (%d, %d)",
+				c.stem, gotNum, gotTot, c.wantNum, c.wantTot)
+		}
+	}
+}
+
+func TestNormalizeTagValue(t *testing.T) {
+	cases := map[string]string{
+		"":                              "",
+		"Tarkin":                        "tarkin",
+		"  TARKIN  ":                    "tarkin",
+		"Star_Wars - Tarkin":            "star wars tarkin",
+		"Star  Wars\t\tTarkin":          "star wars tarkin",
+	}
+	for in, want := range cases {
+		got := normalizeTagValue(in)
+		if got != want {
+			t.Errorf("normalizeTagValue(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDetectMultiFileGroup_Tarkin85(t *testing.T) {
+	var files []MultiFileInfo
+	for i := 1; i <= 85; i++ {
+		files = append(files, mk(
+			fmt.Sprintf("(%d of 85) Tarkin - Star Wars.mp3", i),
+			"Tarkin: Star Wars",
+			"James Luceno",
+		))
+	}
+	ok, sorted := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected positive detection for 85-chapter Tarkin set")
+	}
+	if len(sorted) != 85 {
+		t.Fatalf("expected 85 sorted files, got %d", len(sorted))
+	}
+	// First sorted file should have number 1.
+	if got := sorted[0].Path; got != "/library/Tarkin/(1 of 85) Tarkin - Star Wars.mp3" {
+		t.Errorf("sort order wrong: first = %s", got)
+	}
+	if got := sorted[84].Path; got != "/library/Tarkin/(85 of 85) Tarkin - Star Wars.mp3" {
+		t.Errorf("sort order wrong: last = %s", got)
+	}
+}
+
+func TestDetectMultiFileGroup_ChapterNN(t *testing.T) {
+	var files []MultiFileInfo
+	for i := 1; i <= 12; i++ {
+		files = append(files, mk(
+			fmt.Sprintf("Chapter %02d.mp3", i),
+			"The Great Hunt",
+			"Robert Jordan",
+		))
+	}
+	ok, sorted := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected positive detection for 12 Chapter NN files")
+	}
+	if len(sorted) != 12 {
+		t.Fatalf("expected 12 files, got %d", len(sorted))
+	}
+}
+
+func TestDetectMultiFileGroup_PartNofM(t *testing.T) {
+	var files []MultiFileInfo
+	for i := 1; i <= 8; i++ {
+		files = append(files, mk(
+			fmt.Sprintf("Part %d of 8.m4b", i),
+			"Foundation",
+			"Isaac Asimov",
+		))
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected positive detection for Part N of M files")
+	}
+}
+
+func TestDetectMultiFileGroup_BareNN(t *testing.T) {
+	var files []MultiFileInfo
+	for i := 1; i <= 5; i++ {
+		files = append(files, mk(
+			fmt.Sprintf("%02d.mp3", i),
+			"Some Audiobook",
+			"Some Author",
+		))
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected positive detection for bare NN files")
+	}
+}
+
+func TestDetectMultiFileGroup_TrackTagFallback(t *testing.T) {
+	// Filenames have no obvious sequence (just a clean title), but ID3
+	// track numbers + matching album tags should still trigger detection.
+	files := []MultiFileInfo{
+		mkTrack("Intro.mp3", "Foundation", "Isaac Asimov", 1, 5),
+		mkTrack("The Plan.mp3", "Foundation", "Isaac Asimov", 2, 5),
+		mkTrack("The Encyclopedia.mp3", "Foundation", "Isaac Asimov", 3, 5),
+		mkTrack("Trantor.mp3", "Foundation", "Isaac Asimov", 4, 5),
+		mkTrack("Outro.mp3", "Foundation", "Isaac Asimov", 5, 5),
+	}
+	ok, sorted := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected detection via track-number tag fallback")
+	}
+	if sorted[0].TrackNum != 1 || sorted[4].TrackNum != 5 {
+		t.Errorf("track-tag fallback sort order wrong: %+v", sorted)
+	}
+}
+
+func TestDetectMultiFileGroup_RejectsDistinctTitles(t *testing.T) {
+	files := []MultiFileInfo{
+		mk("The Hobbit.mp3", "The Hobbit", "J.R.R. Tolkien"),
+		mk("The Silmarillion.mp3", "The Silmarillion", "J.R.R. Tolkien"),
+		mk("Unfinished Tales.mp3", "Unfinished Tales", "J.R.R. Tolkien"),
+		mk("Children of Hurin.mp3", "Children of Hurin", "J.R.R. Tolkien"),
+		mk("Beren and Luthien.mp3", "Beren and Luthien", "J.R.R. Tolkien"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if ok {
+		t.Fatalf("expected NEGATIVE detection for 5 distinct titles with no sequence numbers")
+	}
+}
+
+func TestDetectMultiFileGroup_RejectsTooFew(t *testing.T) {
+	files := []MultiFileInfo{
+		mk("Chapter 01.mp3", "Book", "Author"),
+		mk("Chapter 02.mp3", "Book", "Author"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if ok {
+		t.Fatalf("expected NEGATIVE detection for fewer than MinFiles=3 files")
+	}
+}
+
+func TestDetectMultiFileGroup_RejectsDisagreeingAlbums(t *testing.T) {
+	// Sequential numbering present, but album/album_artist disagree across
+	// all files — clearly distinct books happening to use the same numeric
+	// prefix.
+	files := []MultiFileInfo{
+		mk("01 - One.mp3", "Album A", "Artist A"),
+		mk("02 - Two.mp3", "Album B", "Artist B"),
+		mk("03 - Three.mp3", "Album C", "Artist C"),
+		mk("04 - Four.mp3", "Album D", "Artist D"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if ok {
+		t.Fatalf("expected NEGATIVE detection when album tags disagree across all files")
+	}
+}
+
+func TestDetectMultiFileGroup_QuorumToleratesOneOddFile(t *testing.T) {
+	// 4 of 5 files match the pattern + album tag; one doesn't. Detector
+	// should still trigger via quorum.
+	files := []MultiFileInfo{
+		mk("Chapter 01.mp3", "Book", "Author"),
+		mk("Chapter 02.mp3", "Book", "Author"),
+		mk("Chapter 03.mp3", "Book", "Author"),
+		mk("Chapter 04.mp3", "Book", "Author"),
+		mk("Bonus Material.mp3", "Book", "Author"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatalf("expected positive detection with 4/5 quorum")
+	}
+}
+
+func TestDetectMultiFileGroup_RejectsSparseNumbers(t *testing.T) {
+	// Three files with numbers 1, 2, and 500 — not a dense sequence.
+	files := []MultiFileInfo{
+		mk("01.mp3", "Album", "Artist"),
+		mk("02.mp3", "Album", "Artist"),
+		mk("500.mp3", "Album", "Artist"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if ok {
+		t.Fatalf("expected NEGATIVE detection for sparse numbering (1, 2, 500)")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -1347,6 +1348,29 @@ func quickReadAlbum(filePath string) string {
 	return strings.TrimSpace(m.Album())
 }
 
+// quickReadMultiFileInfo reads album, album_artist, and track tags from an
+// audio file in one open/parse pass, returning a MultiFileInfo for the
+// multi-file detector. Best-effort: unreadable files yield an info with
+// only Path populated.
+func quickReadMultiFileInfo(filePath string) MultiFileInfo {
+	info := MultiFileInfo{Path: filePath}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return info
+	}
+	defer f.Close()
+	m, err := tag.ReadFrom(f)
+	if err != nil {
+		return info
+	}
+	info.Album = strings.TrimSpace(m.Album())
+	info.AlbumArtist = strings.TrimSpace(m.AlbumArtist())
+	tn, tt := m.Track()
+	info.TrackNum = tn
+	info.TotalTracks = tt
+	return info
+}
+
 // groupFilesIntoBooks groups audio files from a single directory into logical books.
 // When all files in a directory share the same non-empty album tag, they become a
 // single directory-based Book (with segments created later). Otherwise, each file
@@ -1361,6 +1385,35 @@ func groupFilesIntoBooks(files []string) []Book {
 			})
 		}
 		return books
+	}
+
+	// MAYDEPLOY-G1: multi-file audiobook detection — if the folder contains
+	// N≥3 audio files matching a sequential naming pattern (Chapter NN,
+	// Part N of M, (NN of MM), bare NN, etc.) AND ≥75% of files share an
+	// album or album_artist tag, treat the whole folder as ONE Book with
+	// N BookFiles rather than letting the existing per-file paths kick in.
+	if len(files) >= 3 {
+		infos := make([]MultiFileInfo, len(files))
+		for i, f := range files {
+			infos[i] = quickReadMultiFileInfo(f)
+		}
+		if ok, sorted := DetectMultiFileGroup(infos, DefaultMultiFileConfig()); ok {
+			segs := make([]string, len(sorted))
+			for i, s := range sorted {
+				segs[i] = s.Path
+			}
+			slog.Info("scanner multi-file group detected",
+				"dir", filepath.Dir(segs[0]),
+				"count", len(segs),
+				"first", filepath.Base(segs[0]),
+				"last", filepath.Base(segs[len(segs)-1]),
+			)
+			return []Book{{
+				FilePath:     segs[0],
+				Format:       strings.ToLower(filepath.Ext(segs[0])),
+				SegmentFiles: segs,
+			}}
+		}
 	}
 
 	// Sample up to 3 files to quickly check if directory is a single-album book


### PR DESCRIPTION
## Summary

Adds scanner-side detection of multi-file audiobooks so that a folder
containing N>=3 audio files matching a sequential naming pattern AND
agreeing on album/album_artist tags becomes ONE Book with N BookFiles
- instead of N separate single-file Books with fabricated titles.

This is the input-side companion to PR #1158 (which fixed the organizer
output side). Triggered by the user's 85-chapter Tarkin audiobook being
imported as 85 separate \"books\".

## What changed

- NEW \`internal/scanner/multifile_detector.go\` - pure detector
  \`DetectMultiFileGroup(files []MultiFileInfo, cfg)\` returning
  \`(isMultiFile bool, sortedFiles []MultiFileInfo)\`. No file IO; caller
  pre-extracts tag metadata.
- NEW \`internal/scanner/multifile_detector_test.go\` - 12 table-driven
  unit tests, all passing.
- EDIT \`internal/scanner/scanner.go\` - new \`quickReadMultiFileInfo\`
  helper reads album+album_artist+track tags in one pass. The detector
  is invoked at the top of \`groupFilesIntoBooks\` BEFORE the existing
  exact-album-match path; on positive match returns one Book with all
  files as \`SegmentFiles\`. Existing logic (exact-album, playlist,
  \`consolidateChapterGroups\`) remains as fallback.

## Detection rules

Positive when ALL hold:
- \`N >= 3\` files in the folder
- \`>= 75%\` of files yield a sequential index from filename or track tag
- Detected indices are dense in \`[min..max]\` (>= 75% fill ratio)
- \`>= 75%\` of files share the same non-empty normalized album OR
  album_artist tag

## Filename patterns recognized

- \`Chapter NN.ext\` / \`Chapter_NN.ext\`
- \`Part N of M.ext\` / \`Part NN.ext\`
- \`Track NN.ext\`
- \`Disc NN.ext\` / \`CD NN.ext\`
- \`(NN of MM) Title.ext\`
- \`(NN/MM) Title.ext\` / \`(NN_MM)\` / \`(NN-MM)\`
- \`Title - NN_MM.ext\` (Tarkin pattern with '/' written as '_')
- \`01 - Title.ext\` (leading numeric prefix)
- bare \`NN.ext\`
- audio-tag track number as fallback when filename has no number

## Tests

\`\`\`
=== RUN   TestExtractSeqNumber                    PASS
=== RUN   TestNormalizeTagValue                   PASS
=== RUN   TestDetectMultiFileGroup_Tarkin85       PASS  (85 files)
=== RUN   TestDetectMultiFileGroup_ChapterNN      PASS  (12 files)
=== RUN   TestDetectMultiFileGroup_PartNofM       PASS  (8 files)
=== RUN   TestDetectMultiFileGroup_BareNN         PASS  (5 files)
=== RUN   TestDetectMultiFileGroup_TrackTagFallback   PASS
=== RUN   TestDetectMultiFileGroup_RejectsDistinctTitles    PASS
=== RUN   TestDetectMultiFileGroup_RejectsTooFew           PASS
=== RUN   TestDetectMultiFileGroup_RejectsDisagreeingAlbums PASS
=== RUN   TestDetectMultiFileGroup_QuorumToleratesOneOddFile PASS
=== RUN   TestDetectMultiFileGroup_RejectsSparseNumbers    PASS
\`\`\`

Full scanner package: \`go test ./internal/scanner/... -count=1\`
passes except for \`TestScanRegistration\` (pre-existing failure on
main, missing \`embeddingstore\` service dep; unrelated to this PR).

Full \`go build ./...\` clean.

## Test plan

- [ ] Manual smoke: rescan a folder with the Tarkin layout on prod;
      confirm one Book with 85 BookFiles instead of 85 Books
- [ ] Verify existing single-file folders still produce single Books
- [ ] Verify existing same-album multi-file folders (the original
      \`groupFilesIntoBooks\` path) still produce one Book - the new
      detector runs first but exits negative when no sequence number
      is extractable, falling through to existing logic
- [ ] Confirm tags are correctly aggregated into the resulting Book
      via the existing \`SegmentFiles\` pipeline

## Notes

- Detector is pure, has no file IO, depends only on the \`MultiFileInfo\`
  passed in. Caller (\`groupFilesIntoBooks\`) does the tag IO via the
  new \`quickReadMultiFileInfo\` helper.
- Falls back to all existing detection paths (exact album,
  playlist groups, \`consolidateChapterGroups\`) when negative.
- See PLAN-G1.md for the full design rationale.

Closes TODO item MAYDEPLOY-G1.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)