### PR TITLE
feat(subprocess): wire IsChildMode in main.go + restore Isolate (A1+A2+A3)

### DIFF
--- a/cmd/child_mode.go
+++ b/cmd/child_mode.go
@@ -1,0 +1,89 @@
+// file: cmd/child_mode.go
+// version: 1.0.0
+// guid: 8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/jdfalk/audiobook-organizer/internal/config"
+	"github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// newServer is already defined in root.go as a package-level var pointing
+// to server.NewServer; we use it here to share the test override.
+
+// init registers the parent-side environment provider for
+// registry.runSubprocess. When the parent re-execs the binary as a child,
+// it appends these KEY=VALUE strings to the child's env so the child can
+// open the same store and load the same config the parent has.
+func init() {
+	registry.ChildEnvFunc = func() []string {
+		return []string{
+			fmt.Sprintf("%s=%s", registry.EnvChildDBPath, config.AppConfig.DatabasePath),
+			fmt.Sprintf("%s=%s", registry.EnvChildDBType, config.AppConfig.DatabaseType),
+			fmt.Sprintf("%s=%s", registry.EnvChildRootDir, config.AppConfig.RootDir),
+		}
+	}
+}
+
+// RunOperationRunner is the entry point for operation-runner child mode.
+// It is invoked from main.go before cobra is given a chance to parse args.
+// On success it never returns (registry.RunChildMode calls os.Exit).
+//
+// The child re-uses the same server.NewServer construction path as the
+// parent so every plugin OperationDef is registered. It does NOT call
+// Server.Start — no HTTP listener, no scheduler, no background workers
+// are launched. The child connects to the parent's unix socket
+// (UOS_SOCKET), runs a single op, and exits.
+func RunOperationRunner() {
+	// Resolve database configuration from environment overrides set by the
+	// parent. Fall back to whatever may already be in AppConfig, then to a
+	// reasonable default — but in practice the parent always sets them.
+	if v := os.Getenv(registry.EnvChildDBPath); v != "" {
+		config.AppConfig.DatabasePath = v
+	}
+	if v := os.Getenv(registry.EnvChildDBType); v != "" {
+		config.AppConfig.DatabaseType = v
+	}
+	if v := os.Getenv(registry.EnvChildRootDir); v != "" {
+		config.AppConfig.RootDir = v
+	}
+	if config.AppConfig.DatabasePath == "" {
+		config.AppConfig.DatabasePath = "audiobooks.pebble"
+	}
+	if config.AppConfig.DatabaseType == "" {
+		config.AppConfig.DatabaseType = "pebble"
+	}
+
+	store, err := initializeStore(config.AppConfig.DatabaseType, config.AppConfig.DatabasePath, config.AppConfig.EnableSQLite)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child mode: initializeStore: %v\n", err)
+		os.Exit(2)
+	}
+	// Best-effort: load persisted config so plugin registration sees the
+	// same AppConfig as the parent (notably RootDir, which the maintenance
+	// plugin gate at server.go:413 requires to be non-empty).
+	if err := loadConfigFromDB(store); err != nil {
+		slog.Warn("child mode: loadConfigFromDB", "err", err)
+	}
+	if config.AppConfig.RootDir == "" {
+		// Re-apply env override after loadConfigFromDB may have reset it.
+		if v := os.Getenv(registry.EnvChildRootDir); v != "" {
+			config.AppConfig.RootDir = v
+		}
+	}
+
+	srv := newServer(store)
+	reg := srv.OpRegistry()
+	if reg == nil {
+		fmt.Fprintln(os.Stderr, "child mode: server has no opRegistry")
+		os.Exit(2)
+	}
+
+	// Never returns.
+	registry.RunChildMode(reg)
+}

--- a/internal/operations/registry/subprocess.go
+++ b/internal/operations/registry/subprocess.go
@@ -45,6 +45,22 @@ const childModeArg = "--operation-runner"
 // EnvSocketPath is the environment variable name for the unix socket path.
 const EnvSocketPath = "UOS_SOCKET"
 
+// Env variables propagated from parent to child so the child can open the
+// same store and register the same plugin defs as the parent. The child
+// side (cmd.RunOperationRunner) is the consumer of these.
+const (
+	EnvChildDBPath  = "UOS_DB_PATH"
+	EnvChildDBType  = "UOS_DB_TYPE"
+	EnvChildRootDir = "UOS_ROOT_DIR"
+)
+
+// ChildEnvFunc returns the additional KEY=VALUE strings (without the trailing
+// newline) that should be appended to the child process's environment when
+// the parent re-execs itself as an operation-runner. Production wires this
+// to a closure over internal/config.AppConfig from cmd.init(). Tests may
+// leave it nil — runSubprocess only forwards UOS_SOCKET in that case.
+var ChildEnvFunc func() []string
+
 // childHandshake is the JSON payload sent from parent to child.
 type childHandshake struct {
 	DefID  string          `json:"def_id"`
@@ -152,7 +168,11 @@ func runSubprocess(ctx context.Context, def OperationDef, opID string, params js
 	}
 
 	cmd := exec.CommandContext(ctx, exe, childModeArg, opID)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", EnvSocketPath, socketPath))
+	childEnv := append(os.Environ(), fmt.Sprintf("%s=%s", EnvSocketPath, socketPath))
+	if ChildEnvFunc != nil {
+		childEnv = append(childEnv, ChildEnvFunc()...)
+	}
+	cmd.Env = childEnv
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Capture stdout/stderr.

--- a/internal/operations/registry/subprocess_roundtrip_test.go
+++ b/internal/operations/registry/subprocess_roundtrip_test.go
@@ -1,0 +1,131 @@
+// file: internal/operations/registry/subprocess_roundtrip_test.go
+// version: 1.0.0
+// guid: 9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b
+//
+// Subprocess re-exec roundtrip smoke test (MAYDEPLOY-A / A2).
+//
+// This test exercises the full parent/child wire protocol implemented in
+// subprocess.go end-to-end, without depending on main.go's
+// IsChildMode/RunChildMode wiring (that's covered by the manual smoke
+// test in the PR description). The strategy:
+//
+//   - TestMain notices the TEST_SUBPROCESS_CHILD env var. When set, the
+//     test binary acts as the child: it connects to UOS_SOCKET, reads the
+//     handshake, writes back the result the parent expects, and exits.
+//   - TestSubprocessRoundtrip enqueues an Isolate=true op against a real
+//     Registry. The parent re-execs THIS test binary; because the env var
+//     is set (via ChildEnvFunc), the spawned child runs the stub above
+//     and the parent observes a "completed" terminal state.
+//
+// The existing TestSubprocess_ChildExitsWithErrorWhenNoBinaryKnowsRunner
+// relies on the test binary NOT handling --operation-runner, so we keep
+// the child-mode behavior gated on TEST_SUBPROCESS_CHILD to avoid
+// breaking that case.
+
+package registry_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+)
+
+// testChildEnvVar gates the in-test child-mode handler installed by TestMain.
+const testChildEnvVar = "TEST_SUBPROCESS_CHILD"
+
+// TestMain installs a stub child-mode handler when the gate env var is set.
+// Otherwise it runs the test suite normally.
+func TestMain(m *testing.M) {
+	if os.Getenv(testChildEnvVar) == "1" && len(os.Args) >= 2 && os.Args[1] == "--operation-runner" {
+		runStubChild()
+		// runStubChild always calls os.Exit; this is unreachable.
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runStubChild mimics what registry.RunChildMode does, minus the def
+// lookup. It connects to UOS_SOCKET, reads the handshake, echoes back a
+// success result, and exits 0.
+func runStubChild() {
+	socket := os.Getenv(registry.EnvSocketPath)
+	if socket == "" {
+		fmt.Fprintln(os.Stderr, "stub child: UOS_SOCKET not set")
+		os.Exit(2)
+	}
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stub child: dial: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	// Read handshake (newline-terminated JSON).
+	scanner := bufio.NewScanner(conn)
+	if !scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "stub child: no handshake")
+		os.Exit(1)
+	}
+	var hs struct {
+		DefID  string          `json:"def_id"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(scanner.Bytes(), &hs); err != nil {
+		fmt.Fprintf(os.Stderr, "stub child: bad handshake: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Reply with success.
+	res := []byte(`{"ok":true}` + "\n")
+	if _, err := conn.Write(res); err != nil {
+		fmt.Fprintf(os.Stderr, "stub child: write result: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// TestSubprocessRoundtrip verifies the parent->child handshake completes
+// successfully end-to-end when the child speaks the wire protocol.
+func TestSubprocessRoundtrip(t *testing.T) {
+	// Set ChildEnvFunc so the spawned child has TEST_SUBPROCESS_CHILD=1
+	// and our TestMain stub takes over.
+	prev := registry.ChildEnvFunc
+	registry.ChildEnvFunc = func() []string {
+		return []string{testChildEnvVar + "=1"}
+	}
+	t.Cleanup(func() { registry.ChildEnvFunc = prev })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.New(store, slog.Default(), 1, nil)
+
+	def := makeValidDef("test.subprocess-roundtrip")
+	def.Isolate = true
+	// Parent never calls def.Run for Isolate=true ops; the stub child
+	// short-circuits to ok=true without invoking it.
+	def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		t.Error("def.Run should not be called in-process for Isolate=true")
+		return nil
+	}
+	if err := r.RegisterOp(def); err != nil {
+		t.Fatalf("RegisterOp: %v", err)
+	}
+	r.Start(ctx)
+
+	opID, err := r.EnqueueOp(ctx, "test.subprocess-roundtrip", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+
+	awaitStatus(t, store, opID, "completed", 15*time.Second)
+}

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -40,7 +40,7 @@ func (p *Plugin) backfillDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		Schedule:        &sched,
-		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
+		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
 		Timeout:         24 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -41,7 +41,7 @@ func (p *Plugin) fingerprintRescanDef() sdk.OperationDef {
 		Description:     "Generates per-file fingerprints on demand with scope and force options.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
-		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
+		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
 		Timeout:         12 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/scan.go
+++ b/internal/plugins/acoustid/scan.go
@@ -24,7 +24,7 @@ func (p *Plugin) scanDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "acoustid.scan",
-		Isolate:         false, // subprocess child-mode handler not wired in main.go; in-process until fixed
+		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
 		Timeout:         6 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/itunes/import.go
+++ b/internal/plugins/itunes/import.go
@@ -20,7 +20,7 @@ func (p *Plugin) importDef() sdk.OperationDef {
 		Plugin:                "itunes",
 		DisplayName:           "iTunes Library Import",
 		Description:           "Import audiobooks from the iTunes/Music library into the organizer.",
-		Isolate:               false, // subprocess child-mode handler not wired in main.go; in-process until fixed
+		Isolate:               true, // runs in subprocess (re-exec) — wired via cmd.RunOperationRunner
 		ResumePolicy:          sdk.ResumeRestart,
 		DefaultPriority:       sdk.PriorityNormal,
 		Cancellable:           true,

--- a/internal/plugins/maintenance/backfill.go
+++ b/internal/plugins/maintenance/backfill.go
@@ -54,7 +54,7 @@ func (p *Plugin) movementAtomCleanupDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.movement-atom-cleanup",
 		Cancellable:     false,
-		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
+		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
 		Timeout:         60 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -79,7 +79,7 @@ func (p *Plugin) malformedM4BRemuxDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-remux",
 		Cancellable:     false,
-		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
+		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
 		Timeout:         120 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -106,7 +106,7 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-transcode",
 		Cancellable:     true,
-		Isolate:         false, // child-mode handler not wired in main.go; ffmpeg still spawned in-process via exec.Cmd
+		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
 		Timeout:         6 * time.Hour,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -273,6 +273,13 @@ func (s *Server) Store() database.Store {
 	return database.GetGlobalStore()
 }
 
+// OpRegistry returns the operations registry. Used by the operation-runner
+// child mode (cmd.RunOperationRunner) to dispatch a single op without
+// starting workers or the HTTP server.
+func (s *Server) OpRegistry() *opsregistry.Registry {
+	return s.opRegistry
+}
+
 // publishEvent publishes a lifecycle event to the plugin event bus.
 func (s *Server) publishEvent(ctx context.Context, event plugin.Event) {
 	if s.eventBus != nil {

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // file: main.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 5f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c
 
 package main
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/jdfalk/audiobook-organizer/cmd"
+	"github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/server"
 )
 
@@ -26,6 +27,18 @@ func run() int {
 	cmd.SetVersion(version)
 	server.SetVersion(version)
 	server.SetEmbeddedFS(WebFS)
+
+	// MAYDEPLOY-A: operation-runner child mode must be detected BEFORE
+	// cobra parses os.Args, because --operation-runner is a sentinel arg
+	// (not a registered cobra flag) and would otherwise cause cobra to
+	// exit with "unknown flag". cmd.RunOperationRunner builds a minimal
+	// server (registers all OperationDefs) and then hands off to
+	// registry.RunChildMode, which never returns.
+	if registry.IsChildMode() {
+		cmd.RunOperationRunner()
+		// Unreachable — RunOperationRunner calls os.Exit.
+		return 0
+	}
 
 	if err := executeCmd(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Summary

Completes the subprocess child-mode infrastructure (MAYDEPLOY-A: A1+A2+A3).
Background: PR #1155 (May 28) hot-fixed 7 ops by flipping ``Isolate: true`` to ``false`` because main.go never intercepted the ``--operation-runner`` sentinel arg — every isolate dispatch died ~47ms in with cobra's *unknown flag* error. This PR wires the child-mode handler properly and restores ``Isolate: true`` on those 7 defs.

### A1 — main.go intercepts ``--operation-runner`` before cobra

- ``main.go`` checks ``registry.IsChildMode()`` before ``executeCmd()``. When true, it calls ``cmd.RunOperationRunner()``, which:
  - Resolves DB path/type and root dir from env (``UOS_DB_PATH`` / ``UOS_DB_TYPE`` / ``UOS_ROOT_DIR``) set by the parent.
  - Opens the same Pebble store the parent uses (no separate DB).
  - Calls ``loadConfigFromDB`` so plugin registration sees the parent's persisted config (notably ``RootDir`` — the maintenance plugin gate requires it).
  - Calls ``server.NewServer(store)`` to register every plugin OperationDef. ``Server.Start`` is **not** called: no HTTP listener, no scheduler/workers, no background goroutines other than what ``serviceregistry.PostInit`` may launch (the registry container's ``Start`` step is skipped).
  - Calls ``registry.RunChildMode``, which connects to ``UOS_SOCKET``, runs the op, exits.
- Parent → child env propagation: ``registry.ChildEnvFunc`` is a new package-level func var that ``runSubprocess`` consults to append KEY=VALUE strings to the child env. ``cmd.init()`` wires the func to ``config.AppConfig``. Keeps the registry package free of any direct config-package dependency.
- New ``Server.OpRegistry()`` getter so the child path can grab the registered registry.

### A2 — subprocess re-exec roundtrip smoke test

``internal/operations/registry/subprocess_roundtrip_test.go``:

- New ``TestMain`` for ``registry_test`` package. When ``TEST_SUBPROCESS_CHILD=1`` is in the env *and* ``os.Args[1] == "--operation-runner"``, the test binary acts as a stub child: connects to ``UOS_SOCKET``, reads handshake, replies ``{"ok":true}``, exits 0. Otherwise it runs the test suite normally.
- ``TestSubprocessRoundtrip`` sets ``registry.ChildEnvFunc`` to inject the gate env var, enqueues an ``Isolate=true`` op, and verifies the op reaches ``completed`` — proving the parent-side wire protocol works end-to-end.
- The existing ``TestSubprocess_ChildExitsWithErrorWhenNoBinaryKnowsRunner`` keeps passing because it doesn't install the gate env var, so the test binary still fails the handshake by design in that scenario.

### A3 — restored ``Isolate: true`` on the 7 ops

| Op | File |
| --- | --- |
| ``itunes.import`` | ``internal/plugins/itunes/import.go`` |
| ``acoustid.scan`` | ``internal/plugins/acoustid/scan.go`` |
| ``acoustid.fingerprint-rescan`` | ``internal/plugins/acoustid/fingerprint_rescan.go`` |
| ``acoustid.backfill`` | ``internal/plugins/acoustid/backfill.go`` |
| ``maintenance.movement-atom-cleanup`` | ``internal/plugins/maintenance/backfill.go`` |
| ``maintenance.malformed-m4b-remux`` | ``internal/plugins/maintenance/backfill.go`` |
| ``maintenance.malformed-m4b-transcode`` | ``internal/plugins/maintenance/backfill.go`` |

All 7 comments updated to reflect the new state (no more "child-mode handler not wired in main.go" disclaimers).

## Verification

- ``go build ./...`` clean.
- ``go test ./internal/operations/registry/... ./internal/plugins/... -count=1 -timeout 180s`` — all pass, including the new ``TestSubprocessRoundtrip`` and the existing failure-path tests.
- Manual smoke (darwin/arm64):
  ```text
  $ /tmp/aoz-smoke --operation-runner test-op-id
  ... (NewServer warmup logs — DB migrations, plugin registration, route table) ...
  time=... level=ERROR msg="child mode: UOS_SOCKET not set" op_id=test-op-id
  exit=2
  ```
  Proves the ``--operation-runner`` flag is intercepted before cobra and the child path is reached.

## Operational concerns / not blocking

- **Child startup cost.** ``cmd.RunOperationRunner`` reuses ``server.NewServer``, which opens Pebble, runs the memdb warm-up (50K books in prod), and registers every plugin. That's significant overhead per subprocess invocation. Acceptable for long-running ops (itunes.import, m4b transcode) but worth profiling before this pattern is extended to short ops. If the warmup-on-every-child becomes a problem, the child could opt out of memdb warm via a new env flag.
- **Restart races during deploy.** When systemd restarts the parent during an active isolate op, the child keeps running but loses its parent socket — subprocess.go's ``runSubprocess`` ``cmd.Wait()`` only returns in the parent. The new parent process won't adopt orphans. This is the same behavior as before PR #1155, just exposed again. Worth tracking separately if it bites.
- **Container.Start side effects in child.** ``server.NewServer`` calls ``Resolve``/``Build``/``PostInit`` on the service registry but NOT ``Start``. PostInit launches some lifecycle goroutines (e.g. ``dedup.Engine.PostInit`` starts a chromem hydrate goroutine). The child exits cleanly via ``os.Exit`` after the op runs, so any background goroutines are terminated then. No leakage, but possibly wasted work.

## DO NOT MERGE

Hold for review and an integration smoke on staging before flipping these ops back on in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)