### PR TITLE
feat(dedup): split-book backfill detector + CLI (G2+G4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,126 +1,61 @@
-# Memdb filter pushdown — make filtered queries O(matches), not O(corpus)
+# PLAN: G2+G4 Split-Book Backfill Detector + CLI
 
 ## Goal
 
-Stop materializing all 392K books for any query with a "heavy" filter
-(`library_state`, `review`, `has_cover`, `has_written`, `has_organized`,
-`needs_writeback`, `format`, `language`, etc.). Push each predicate into a
-memdb index iterator so a filtered page query touches at most
-`O(predicate-positives + limit)` rows. Counts use the same indexes without
-materializing structs. After this lands, the warmer can be re-enabled in a
-slim form without OOM risk, and the cache value can shrink from full
-enriched gin.H to ID lists.
+Detect existing split-book clusters (one Book per chapter) in the production
+DB and provide a one-shot CLI that can dry-run and execute a portable merge.
 
-Memory ceiling target: process RSS stays under **3GB** through full
-startup + memdb warm + 50 concurrent UI filter queries (vs the 67GB OOM
-we just hit). And a slow background "trickle warmer" backfills the
-remaining ~170 common filter combos over 20–30 min — one query per
-tick, GC + RSS-guard between each, so total cache coverage is reached
-without ever spiking memory.
+## Files to add
 
-## Affected files
+- `internal/dedup/split_book_detector.go` (+ test) — pure detector.
+- `internal/dedup/split_book_storage.go` — Pebble JSON store of candidates.
+- `internal/dedup/split_book_merge.go` — portable cluster merge.
+- `internal/plugins/dedup/split_book_scan.go` — OperationDef wrapper.
+- `internal/plugins/dedup/plugin.go` — register the new op.
+- `internal/server/split_book_handlers.go` — list/run/merge handlers.
+- `internal/server/server_lifecycle.go` — route bindings.
+- `tools/cmd/merge-split-books/main.go` — CLI.
 
-- `internal/database/memdb_schema.go` — add 7-8 new derived bool/string
-  indexes on `books` table (library_state, review_status, has_cover,
-  has_written, has_organized, needs_writeback, format, language).
-- `internal/database/memdb_indexers.go` — new derived indexers (bool
-  computed from nullable timestamp / string presence, with appropriate
-  byte encoding for memdb radix tree).
-- `internal/database/memdb_reads.go` — new methods:
-  - `ListBookIDsByPredicate(filters []PredicateFilter) ([]string, error)`
-  - `CountBooksByPredicate(filters []PredicateFilter) (int, error)`
-  - `ListBookIDsTitleSorted(asc bool, filters []PredicateFilter, limit, offset int) ([]string, error)`
-- `internal/database/pebble_store.go` — delegate `CountBooksByPredicate`
-  and the new top-K title path to memdb when published.
-- `internal/audiobooks/service.go` — rewrite the `hasHeavyPostFilters`
-  branch (line ~749). Translate `FieldFilter` slice to `PredicateFilter`,
-  call the new top-K method, then enrich only the returned IDs. Same for
-  `CountAudiobooksFiltered`.
-- `internal/server/library_list_warmer.go` — re-enable in slim mode:
-  title-asc-primary first 2 pages only, sequential, `runtime.GC()` between
-  calls, hard RSS cap check (skip remaining warm-ups if RSS > 2GB).
+## Heuristic
 
-## Steps (each step lands as its own commit, reviewable independently)
+Group by `filepath.Dir(FilePath)` (parent) and `filepath.Dir(filepath.Dir(FilePath))` (grandparent).
 
-1. **Indexers**: derived bool/string indexers for the 8 fields, with
-   unit tests for byte encoding (nil timestamps, empty strings, computed
-   `needs_writeback`).
-2. **Schema**: wire indexers into `memdb_schema.go` books table. Verify
-   memdb warmup still publishes (no schema panic).
-3. **Predicate type + index walker**: introduce `PredicateFilter` (field
-   + value + negated) in `database` package. Implement
-   `ListBookIDsByPredicate` — picks the first indexed predicate, walks
-   it, in-memory tests the rest against pointers (not copies). Returns
-   ID slice only.
-4. **Top-K title-sorted iterator**: `ListBookIDsTitleSorted` — walks
-   title index in order, tests each predicate against pointer, skips
-   `offset` count + collects `limit` IDs. Returns IDs only.
-5. **CountBooksByPredicate**: same iteration, just increments counter.
-6. **Service rewrite**: replace the heavy-filter branch with a call to
-   the new top-K method; batch-load only the returned 20 IDs via
-   `GetBookByID`. Same for `CountAudiobooksFiltered`.
-7. **Eager slim warmer (the small one that runs immediately)**:
-   title-asc-primary first 2 pages only, sequential, `runtime.GC()` +
-   `debug.FreeOSMemory()` between calls, `readMemStatsMB() > 2048`
-   guard that skips remaining. Total: ~2 queries, <30s. Covers the
-   "user clicks All Books right after restart" case.
-8. **Trickle warmer (the slow one that fills in the rest over 30 min)**:
-   after the eager warmer drains, a background ticker pops one query
-   per tick from a prioritized backlog (~150-170 entries — same shape
-   as today's 177 minus the eager 2), runs it via the new top-K path,
-   sets cache, then `runtime.GC()` + `debug.FreeOSMemory()`. Design:
-   - Interval: 10–15s per query (operator-tunable env var
-     `LIST_WARMER_TRICKLE_INTERVAL_MS`, default 10s → ~30 min total).
-   - One in flight at a time. Never overlapping with the eager warmer
-     or with itself.
-   - Pre-tick RSS guard: if `readMemStatsMB() > 2048`, skip this tick
-     and back off (double interval up to 60s, reset on success).
-   - Pre-tick cancel: if the entry is already cached (e.g. a user
-     visited that filter before the trickle reached it), skip.
-   - Backlog priority order: highest-value first —
-     `-review:matched` p1-3, `library_state:imported` p1, then the
-     compound triage queries, then the rest. So even if the trickle
-     is interrupted by a deploy after 5 min, the most-useful entries
-     are already warm.
-   - Logs each pop: `"trickle warmer tick name=... cached=N/M rss_mb=X"`
-     so we can observe progress.
-   - On 24h listCache TTL: trickle restarts hourly to keep the cache
-     fresh (re-runs only entries whose cache expired or were evicted).
-9. **(Optional, P2) Cache value shrink**: change `listCache` value from
-   `gin.H` to `[]string` (book IDs). On hit, batch-enrich 20 books and
-   build response. Cuts per-entry memory ~50× but adds small cost per
-   hit. Defer if Phase 1 alone is enough.
+Qualifies as candidate when:
+- ≥3 books in the group
+- all share same AuthorID (or all nil)
+- all share same SeriesID or all nil
+- extracted integers from filename or parent-dir name form near-sequential run (≥70% coverage of [min..max], no gap >2)
+
+Grandparent emit only when every child parent-group has size 1.
+A book is assigned to at most one candidate (parent wins).
+
+## Storage
+
+Pebble keyspace `split_book_candidate:<ulid>` → JSON. List by prefix scan.
+Each entry: ID, ParentFolder, BookIDs, SuggestedTitle, SuggestedAuthor,
+SequentialPattern, CreatedAt.
+
+## Merge (portable; works on Pebble)
+
+For `keepID + srcIDs`:
+1. For each src: GetBookFiles, MoveBookFilesToBook → keepID.
+2. Recompute keep duration as sum of all bookfile durations.
+3. Update keep title to SuggestedTitle.
+4. SoftDelete each src via merge.SoftDeleteBook.
+
+Avoids SQLite-only MergeChapterBooks and avoids merge.MergeBooks (which deletes losers + their files).
+
+## CLI
+
+`tools/cmd/merge-split-books` — mirror reconcile-paths structure.
+Flags: `--api`, `--key`, `--dry-run` (default true), `--execute`,
+`--min-group-size 3`, `--limit 0`.
 
 ## Test strategy
 
-- `go test ./internal/database/... -run TestMemdbPredicate` — unit
-  tests for each indexer (byte encoding) and predicate combo, top-K
-  with offset.
-- `go test ./internal/audiobooks/... -run TestGetAudiobooksFiltered` —
-  filtered queries return identical results to the old full-scan path
-  (table-driven against a 1000-book fixture).
-- Manual prod smoke after each phase:
-  - `time curl ...?library_state=imported&sort_by=title` → <100ms
-  - `time curl ...?filters=[{"field":"review","value":"matched","negated":true}]` → <100ms
-  - `ps -o rss` during a 10-query burst: stays <1.5GB.
-- Re-enable warmer (step 7): watch `journalctl` for
-  `library list warm-up complete` with RSS still under 2GB.
+Unit tests for detector (flat case, grandparent case, qualify/disqualify).
+Manual smoke for CLI (documented in PR body).
 
 ## Rollback
 
-- Each step is its own commit. If any step regresses prod, revert that
-  commit (schema/indexer additions are additive — no data migration).
-- If the service rewrite (step 6) misbehaves, revert it and the heavy
-  filter branch returns to the existing full-scan path (slow but
-  correct). The disabled warmer (PR #1147) stays disabled.
-- Slim warmer (step 7) has its own kill switch (`return` early); flipping
-  takes us back to today's state.
-
-## Out of scope
-
-- Frontend filter URL format does not change.
-- `listCache` HTTP-level cache key contract does not change.
-- `is_primary_version` pushdown is already correct; not touched.
-- Search (`?search=...`) still goes through Bleve — unchanged.
-- Pebble-only fallback (when memdb hasn't published yet) stays on the
-  old full-scan code — slow during 2-3min cold start, not steady-state.
+Pure additive. Revert PR.

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -145,6 +145,17 @@ func (s *EmbeddingStore) Close() error {
 	return closeErr
 }
 
+// PebbleDB returns the underlying Pebble handle. This is provided so
+// adjacent stores (e.g. the split-book candidate keyspace) can share
+// the same shared-database connection without re-opening it. Returns
+// nil if the receiver is nil or already closed.
+func (s *EmbeddingStore) PebbleDB() *pebble.DB {
+	if s == nil || s.closed.Load() {
+		return nil
+	}
+	return s.db
+}
+
 // errClosed is returned by all operations when the store has been closed.
 var errClosed = fmt.Errorf("embedding store closed")
 

--- a/internal/dedup/split_book_detector.go
+++ b/internal/dedup/split_book_detector.go
@@ -1,0 +1,426 @@
+// file: internal/dedup/split_book_detector.go
+// version: 1.0.0
+// guid: 9c1f0a3e-b7d2-4e84-8c12-3fa8e1d6b9c0
+// last-edited: 2026-05-29
+
+// Package dedup — split-book backfill detector.
+//
+// Finds Book rows that look like CHAPTERS of a single physical audiobook
+// but have been stored as separate Books (one per chapter file). This is
+// the same shape that the path_format scrub (PR #1158) blocks at scan
+// time; this detector cleans up the existing mess.
+//
+// Two shapes are handled:
+//
+//	PARENT (flat):  .../Author/Tarkin/01.mp3, .../Author/Tarkin/02.mp3, ...
+//	GRANDPARENT:    .../Author/Tarkin/1/01.mp3, .../Author/Tarkin/2/02.mp3, ...
+//
+// The grandparent shape is the rogue '/' bug from the same scrub: each
+// chapter file lives in its own immediate parent dir, so grouping by
+// parent yields size-1 groups but grouping by grandparent recovers the
+// real cluster.
+//
+// HEURISTIC NOTE: G1 (sibling PR) implements the same detection at scan
+// time. When both land, refactor to share. Decisions made here:
+//
+//  1. Build BOTH parent and grandparent groupings in a single pass.
+//  2. Emit a grandparent candidate ONLY when every child parent-group has
+//     size 1 (the rogue subdir case). Otherwise emit from parent.
+//  3. A book is assigned to at most one candidate (parent wins).
+//  4. Qualifying group: ≥3 books, same AuthorID (allow nil-on-all-sides),
+//     same SeriesID (allow nil-on-all-sides), AND filename or parent-dir-name
+//     yields integers forming a near-sequential run: ≥70% coverage of
+//     [min..max] and no gap >2.
+
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// SplitBookCandidate is one detected cluster of Books that look like
+// chapters of a single audiobook.
+type SplitBookCandidate struct {
+	// ID is a stable identifier (assigned by storage on persist).
+	ID string `json:"id"`
+
+	// ParentFolder is the directory the cluster was grouped by — either
+	// the immediate parent dir of all files (parent shape) or the
+	// grandparent (rogue-subdir shape).
+	ParentFolder string `json:"parent_folder"`
+
+	// BookIDs are the IDs of every book in the cluster, sorted ULID-asc
+	// so the lowest (earliest-created) is BookIDs[0] — the suggested
+	// keep-ID.
+	BookIDs []string `json:"book_ids"`
+
+	// SuggestedTitle is the most common Title across the group, stripped
+	// of any trailing "(N/M)" or " - NN" chapter marker.
+	SuggestedTitle string `json:"suggested_title"`
+
+	// SuggestedAuthor is the author name if all books share one author,
+	// or "" if all books have nil AuthorID.
+	SuggestedAuthor string `json:"suggested_author"`
+
+	// SequentialPattern describes the integer run found, e.g.
+	// "filename:1..85 (85 covered of 85)".
+	SequentialPattern string `json:"sequential_pattern"`
+
+	// Shape is "parent" or "grandparent".
+	Shape string `json:"shape"`
+}
+
+// splitBookSlim is the projection used internally to keep the working set
+// small while scanning the library.
+type splitBookSlim struct {
+	ID       string
+	Title    string
+	FilePath string
+	AuthorID *int
+	SeriesID *int
+}
+
+// DetectSplitBookCandidates walks every book in the store and returns the
+// list of split-book clusters. No DB writes — purely analytical.
+func DetectSplitBookCandidates(ctx context.Context, store database.Store) ([]SplitBookCandidate, error) {
+	all, err := loadSlimBooks(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+	return detectFromSlim(all, func(authorID int) string {
+		if a, err := store.GetAuthorByID(authorID); err == nil && a != nil {
+			return a.Name
+		}
+		return ""
+	}), nil
+}
+
+// loadSlimBooks paginates through every book and projects to splitBookSlim.
+func loadSlimBooks(ctx context.Context, store database.Store) ([]splitBookSlim, error) {
+	const pageSize = 1000
+	var all []splitBookSlim
+	offset := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		batch, err := store.GetAllBooks(pageSize, offset)
+		if err != nil {
+			return nil, fmt.Errorf("split-book detector: GetAllBooks offset=%d: %w", offset, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for i := range batch {
+			b := &batch[i]
+			if b.FilePath == "" {
+				continue
+			}
+			if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+				continue
+			}
+			all = append(all, splitBookSlim{
+				ID:       b.ID,
+				Title:    b.Title,
+				FilePath: b.FilePath,
+				AuthorID: b.AuthorID,
+				SeriesID: b.SeriesID,
+			})
+		}
+		if len(batch) < pageSize {
+			break
+		}
+		offset += len(batch)
+	}
+	return all, nil
+}
+
+// detectFromSlim is the pure detection core; isolated from store lookups
+// so it can be unit-tested without a fake Store.
+func detectFromSlim(all []splitBookSlim, resolveAuthorName func(int) string) []SplitBookCandidate {
+	parentBuckets := make(map[string][]splitBookSlim)
+	grandparentBuckets := make(map[string][]splitBookSlim)
+	for _, b := range all {
+		p := filepath.Dir(b.FilePath)
+		gp := filepath.Dir(p)
+		parentBuckets[p] = append(parentBuckets[p], b)
+		grandparentBuckets[gp] = append(grandparentBuckets[gp], b)
+	}
+
+	assigned := make(map[string]bool, len(all))
+	var out []SplitBookCandidate
+
+	// PARENT pass — emit clusters from flat parent groups.
+	for _, key := range sortedKeys(parentBuckets) {
+		group := parentBuckets[key]
+		if len(group) < 3 {
+			continue
+		}
+		cand, ok := qualifyTypedGroup(group, key, "parent", resolveAuthorName)
+		if !ok {
+			continue
+		}
+		for _, id := range cand.BookIDs {
+			assigned[id] = true
+		}
+		out = append(out, cand)
+	}
+
+	// GRANDPARENT pass — emit only when every child parent-group is size 1.
+	for _, key := range sortedKeys(grandparentBuckets) {
+		group := grandparentBuckets[key]
+		if len(group) < 3 {
+			continue
+		}
+		anyAssigned := false
+		for _, b := range group {
+			if assigned[b.ID] {
+				anyAssigned = true
+				break
+			}
+		}
+		if anyAssigned {
+			continue
+		}
+		parentSizes := make(map[string]int)
+		for _, b := range group {
+			parentSizes[filepath.Dir(b.FilePath)]++
+		}
+		allSizeOne := true
+		for _, n := range parentSizes {
+			if n != 1 {
+				allSizeOne = false
+				break
+			}
+		}
+		if !allSizeOne {
+			continue
+		}
+		cand, ok := qualifyTypedGroup(group, key, "grandparent", resolveAuthorName)
+		if !ok {
+			continue
+		}
+		for _, id := range cand.BookIDs {
+			assigned[id] = true
+		}
+		out = append(out, cand)
+	}
+
+	return out
+}
+
+// chapterMarkerRe matches a trailing chapter marker like " (3/85)",
+// " - Chapter 1", or a bare trailing number. Stripped to derive the
+// suggested merged title.
+var chapterMarkerRe = regexp.MustCompile(
+	`(?i)\s*(?:[-—:]\s*)?` +
+		`(?:` +
+		`\(\s*\d+\s*(?:/|of)\s*\d+\s*\)` + // (3/85), (3 of 85)
+		`|\(\s*(?:chapter|track|part|ch|tr|pt)\s*\d+(?:\.\d+)?\s*\)` + // (Chapter 1)
+		`|\d+\s*(?:/|of)\s*\d+` + // 3/85, 3 of 85
+		`|(?:chapter|track|part|ch|tr|pt)\s*\d+(?:\.\d+)?` +
+		`|\d{1,3}` + // bare trailing number
+		`)\s*$`,
+)
+
+var numericTokenRe = regexp.MustCompile(`\d+`)
+
+// sortedKeys returns map keys sorted ascending for deterministic iteration.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// stripChapterMarker removes a trailing chapter marker from a title.
+func stripChapterMarker(title string) string {
+	t := strings.TrimSpace(title)
+	t = chapterMarkerRe.ReplaceAllString(t, "")
+	return strings.TrimSpace(t)
+}
+
+// extractChapterNumber returns the first integer found in s, or -1 if none.
+func extractChapterNumber(s string) int {
+	m := numericTokenRe.FindString(s)
+	if m == "" {
+		return -1
+	}
+	n := 0
+	for _, r := range m {
+		n = n*10 + int(r-'0')
+		if n > 100000 {
+			break
+		}
+	}
+	return n
+}
+
+// sequentialRun checks whether nums form a near-sequential run: ≥70%
+// coverage of [min..max] across unique values, and no gap >2 between
+// successive unique values.
+func sequentialRun(nums []int) (bool, string) {
+	if len(nums) < 3 {
+		return false, ""
+	}
+	uniq := make(map[int]bool, len(nums))
+	for _, n := range nums {
+		if n >= 0 {
+			uniq[n] = true
+		}
+	}
+	if len(uniq) < 3 {
+		return false, ""
+	}
+	sorted := make([]int, 0, len(uniq))
+	for n := range uniq {
+		sorted = append(sorted, n)
+	}
+	sort.Ints(sorted)
+	lo, hi := sorted[0], sorted[len(sorted)-1]
+	if hi-lo < 2 {
+		return false, ""
+	}
+	span := hi - lo + 1
+	coverage := float64(len(sorted)) / float64(span)
+	if coverage < 0.70 {
+		return false, ""
+	}
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i]-sorted[i-1] > 2 {
+			return false, ""
+		}
+	}
+	return true, fmt.Sprintf("%d..%d (%d covered of %d)", lo, hi, len(sorted), span)
+}
+
+// mostCommon returns the most frequent non-empty string in ss, ties
+// broken lexically.
+func mostCommon(ss []string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	counts := make(map[string]int)
+	for _, s := range ss {
+		if s == "" {
+			continue
+		}
+		counts[s]++
+	}
+	best := ""
+	bestN := 0
+	for s, n := range counts {
+		if n > bestN || (n == bestN && (best == "" || s < best)) {
+			best = s
+			bestN = n
+		}
+	}
+	return best
+}
+
+// sortBookIDsULIDAsc sorts ULID-format IDs ascending. ULIDs sort
+// lexicographically equal to chronologically; the first element is the
+// earliest-created book — our suggested keep-ID.
+func sortBookIDsULIDAsc(ids []string) []string {
+	out := make([]string, len(ids))
+	copy(out, ids)
+	sort.Strings(out)
+	return out
+}
+
+// qualifyTypedGroup applies size/author/series/sequence checks.
+func qualifyTypedGroup(group []splitBookSlim, parentKey, shape string, resolveAuthorName func(int) string) (SplitBookCandidate, bool) {
+	if len(group) < 3 {
+		return SplitBookCandidate{}, false
+	}
+
+	// Author: all-or-nothing on AuthorID equality.
+	var firstAuthor *int
+	for i, b := range group {
+		if i == 0 {
+			firstAuthor = b.AuthorID
+			continue
+		}
+		if (firstAuthor == nil) != (b.AuthorID == nil) {
+			return SplitBookCandidate{}, false
+		}
+		if firstAuthor != nil && *firstAuthor != *b.AuthorID {
+			return SplitBookCandidate{}, false
+		}
+	}
+
+	// Series: same shape.
+	var firstSeries *int
+	for i, b := range group {
+		if i == 0 {
+			firstSeries = b.SeriesID
+			continue
+		}
+		if (firstSeries == nil) != (b.SeriesID == nil) {
+			return SplitBookCandidate{}, false
+		}
+		if firstSeries != nil && *firstSeries != *b.SeriesID {
+			return SplitBookCandidate{}, false
+		}
+	}
+
+	// Extract chapter numbers — filename basename first, fall back to
+	// immediate parent dir name (rogue-subdir case).
+	nums := make([]int, 0, len(group))
+	for _, b := range group {
+		base := strings.TrimSuffix(filepath.Base(b.FilePath), filepath.Ext(b.FilePath))
+		n := extractChapterNumber(base)
+		if n < 0 {
+			n = extractChapterNumber(filepath.Base(filepath.Dir(b.FilePath)))
+		}
+		nums = append(nums, n)
+	}
+	ok, pattern := sequentialRun(nums)
+	if !ok {
+		return SplitBookCandidate{}, false
+	}
+	source := "filename"
+	if shape == "grandparent" {
+		source = "subdir"
+	}
+	pattern = source + ":" + pattern
+
+	// Suggested title: most common stripped Title across the group.
+	titles := make([]string, 0, len(group))
+	for _, b := range group {
+		titles = append(titles, stripChapterMarker(b.Title))
+	}
+	suggestedTitle := mostCommon(titles)
+	if suggestedTitle == "" {
+		suggestedTitle = filepath.Base(parentKey)
+	}
+
+	suggestedAuthor := ""
+	if firstAuthor != nil && resolveAuthorName != nil {
+		suggestedAuthor = resolveAuthorName(*firstAuthor)
+	}
+
+	ids := make([]string, 0, len(group))
+	for _, b := range group {
+		ids = append(ids, b.ID)
+	}
+	ids = sortBookIDsULIDAsc(ids)
+
+	return SplitBookCandidate{
+		ParentFolder:      parentKey,
+		BookIDs:           ids,
+		SuggestedTitle:    suggestedTitle,
+		SuggestedAuthor:   suggestedAuthor,
+		SequentialPattern: pattern,
+		Shape:             shape,
+	}, true
+}

--- a/internal/dedup/split_book_detector_test.go
+++ b/internal/dedup/split_book_detector_test.go
@@ -1,0 +1,219 @@
+// file: internal/dedup/split_book_detector_test.go
+// version: 1.0.0
+// guid: 1f7e3b4c-c2a9-4c0e-9c83-1d5b6f0a8e74
+// last-edited: 2026-05-29
+
+package dedup
+
+import (
+	"fmt"
+	"testing"
+)
+
+func intp(v int) *int { return &v }
+
+// makeSlim is a tiny helper that builds a slim book with the given path
+// under a shared author/series.
+func makeSlim(id, title, path string, author, series *int) splitBookSlim {
+	return splitBookSlim{
+		ID:       id,
+		Title:    title,
+		FilePath: path,
+		AuthorID: author,
+		SeriesID: series,
+	}
+}
+
+func TestDetect_ParentFlat_Tarkin(t *testing.T) {
+	// 5 chapter files in the same parent dir — classic flat split-book.
+	var books []splitBookSlim
+	author := intp(42)
+	for i := 1; i <= 5; i++ {
+		path := fmt.Sprintf("/lib/Star Wars/Tarkin/%02d.mp3", i)
+		books = append(books, makeSlim(
+			fmt.Sprintf("01HZZZZZ%08d", i),
+			"Tarkin",
+			path,
+			author, nil,
+		))
+	}
+	got := detectFromSlim(books, func(id int) string { return "James Luceno" })
+	if len(got) != 1 {
+		t.Fatalf("want 1 candidate, got %d (%+v)", len(got), got)
+	}
+	c := got[0]
+	if c.Shape != "parent" {
+		t.Errorf("shape: want parent, got %q", c.Shape)
+	}
+	if c.SuggestedTitle != "Tarkin" {
+		t.Errorf("title: want Tarkin, got %q", c.SuggestedTitle)
+	}
+	if c.SuggestedAuthor != "James Luceno" {
+		t.Errorf("author: want James Luceno, got %q", c.SuggestedAuthor)
+	}
+	if len(c.BookIDs) != 5 {
+		t.Errorf("want 5 book IDs, got %d", len(c.BookIDs))
+	}
+	if c.BookIDs[0] != "01HZZZZZ00000001" {
+		t.Errorf("keep-ID should be earliest ULID, got %q", c.BookIDs[0])
+	}
+}
+
+func TestDetect_Grandparent_RogueSubdir(t *testing.T) {
+	// Each chapter file in its OWN subdir under the grandparent.
+	// Parent groups would be size 1; grandparent recovers cluster.
+	var books []splitBookSlim
+	author := intp(7)
+	for i := 1; i <= 5; i++ {
+		path := fmt.Sprintf("/lib/Author/Tarkin/%d/chapter%02d.mp3", i, i)
+		books = append(books, makeSlim(
+			fmt.Sprintf("01HXXXXX%08d", i),
+			"Tarkin",
+			path,
+			author, nil,
+		))
+	}
+	got := detectFromSlim(books, func(id int) string { return "" })
+	if len(got) != 1 {
+		t.Fatalf("want 1 candidate, got %d (%+v)", len(got), got)
+	}
+	if got[0].Shape != "grandparent" {
+		t.Errorf("shape: want grandparent, got %q", got[0].Shape)
+	}
+	if got[0].ParentFolder != "/lib/Author/Tarkin" {
+		t.Errorf("parent folder: want /lib/Author/Tarkin, got %q", got[0].ParentFolder)
+	}
+}
+
+func TestDetect_TooSmall(t *testing.T) {
+	// 2 chapters is below the min-group-size of 3.
+	author := intp(1)
+	books := []splitBookSlim{
+		makeSlim("a", "Title", "/lib/A/Title/01.mp3", author, nil),
+		makeSlim("b", "Title", "/lib/A/Title/02.mp3", author, nil),
+	}
+	got := detectFromSlim(books, nil)
+	if len(got) != 0 {
+		t.Fatalf("want 0 candidates, got %d", len(got))
+	}
+}
+
+func TestDetect_AuthorMismatch_Disqualifies(t *testing.T) {
+	a, b := intp(1), intp(2)
+	books := []splitBookSlim{
+		makeSlim("a", "T", "/lib/X/T/01.mp3", a, nil),
+		makeSlim("b", "T", "/lib/X/T/02.mp3", a, nil),
+		makeSlim("c", "T", "/lib/X/T/03.mp3", b, nil),
+	}
+	got := detectFromSlim(books, nil)
+	if len(got) != 0 {
+		t.Fatalf("want 0 candidates, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestDetect_SeriesMismatch_Disqualifies(t *testing.T) {
+	a := intp(1)
+	s1, s2 := intp(10), intp(20)
+	books := []splitBookSlim{
+		makeSlim("a", "T", "/lib/X/T/01.mp3", a, s1),
+		makeSlim("b", "T", "/lib/X/T/02.mp3", a, s1),
+		makeSlim("c", "T", "/lib/X/T/03.mp3", a, s2),
+	}
+	got := detectFromSlim(books, nil)
+	if len(got) != 0 {
+		t.Fatalf("want 0 candidates, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestDetect_NonSequential_Disqualifies(t *testing.T) {
+	// Numbers are 1, 50, 99 — huge gaps; not a chapter cluster.
+	a := intp(1)
+	books := []splitBookSlim{
+		makeSlim("a", "T", "/lib/X/T/01.mp3", a, nil),
+		makeSlim("b", "T", "/lib/X/T/50.mp3", a, nil),
+		makeSlim("c", "T", "/lib/X/T/99.mp3", a, nil),
+	}
+	got := detectFromSlim(books, nil)
+	if len(got) != 0 {
+		t.Fatalf("want 0 candidates, got %d", len(got))
+	}
+}
+
+func TestDetect_ParentBeatsGrandparent(t *testing.T) {
+	// One flat parent cluster of 4 PLUS one rogue grandparent of 3
+	// elsewhere — both should be emitted, and no book double-claimed.
+	a := intp(1)
+	var books []splitBookSlim
+	// Flat cluster under /lib/A/Flat.
+	for i := 1; i <= 4; i++ {
+		books = append(books, makeSlim(
+			fmt.Sprintf("flat-%02d", i),
+			"Flat Book",
+			fmt.Sprintf("/lib/A/Flat/%02d.mp3", i),
+			a, nil,
+		))
+	}
+	// Rogue subdir cluster under /lib/A/Rogue.
+	for i := 1; i <= 3; i++ {
+		books = append(books, makeSlim(
+			fmt.Sprintf("rogue-%02d", i),
+			"Rogue Book",
+			fmt.Sprintf("/lib/A/Rogue/%d/ch%02d.mp3", i, i),
+			a, nil,
+		))
+	}
+	got := detectFromSlim(books, nil)
+	if len(got) != 2 {
+		t.Fatalf("want 2 candidates, got %d (%+v)", len(got), got)
+	}
+	// Confirm no book ID appears in two candidates.
+	seen := make(map[string]int)
+	for _, c := range got {
+		for _, id := range c.BookIDs {
+			seen[id]++
+		}
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("book %s appears in %d candidates", id, n)
+		}
+	}
+}
+
+func TestStripChapterMarker(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Tarkin (3/85)", "Tarkin"},
+		{"Tarkin 3/85", "Tarkin"},
+		{"Tarkin - Chapter 3", "Tarkin"},
+		{"Tarkin 03", "Tarkin"},
+		{"Tarkin", "Tarkin"},
+		{"   Tarkin (Chapter 1)  ", "Tarkin"},
+	}
+	for _, c := range cases {
+		got := stripChapterMarker(c.in)
+		if got != c.want {
+			t.Errorf("stripChapterMarker(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSequentialRun(t *testing.T) {
+	cases := []struct {
+		in   []int
+		want bool
+	}{
+		{[]int{1, 2, 3, 4, 5}, true},
+		{[]int{1, 2, 3, 5}, true},     // gap=2 ok
+		{[]int{1, 2, 3, 6}, false},    // gap=3 fails
+		{[]int{1, 50, 99}, false},     // sparse coverage fails
+		{[]int{5, 5, 5}, false},       // not enough unique
+		{[]int{1, 2}, false},          // too few
+		{[]int{10, 11, 12, 13}, true}, // shifted run ok
+	}
+	for _, c := range cases {
+		got, _ := sequentialRun(c.in)
+		if got != c.want {
+			t.Errorf("sequentialRun(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/dedup/split_book_merge.go
+++ b/internal/dedup/split_book_merge.go
@@ -1,0 +1,127 @@
+// file: internal/dedup/split_book_merge.go
+// version: 1.0.0
+// guid: 3b5d7f9a-2e4c-6b8d-0f1a-3c5e7d9f1b3e
+// last-edited: 2026-05-29
+
+// Split-book cluster merge — portable across SQLite and Pebble.
+//
+// The existing `MergeChapterBooks` store method is SQLite-only
+// (PebbleStore returns nil without doing anything). The existing
+// `merge.Service.MergeBooks` soft-deletes losers but does NOT move
+// their BookFiles to the keeper — for chapter merges that would orphan
+// every chapter file.
+//
+// This function uses the portable `MoveBookFilesToBook` (implemented on
+// both stores) and only soft-deletes after the files have been
+// reassigned. Duration is recomputed as the sum of moved-file durations.
+
+package dedup
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/merge"
+)
+
+// SplitBookMergeResult summarises a successful merge.
+type SplitBookMergeResult struct {
+	KeepID         string `json:"keep_id"`
+	MergedSrcCount int    `json:"merged_src_count"`
+	FilesMoved     int    `json:"files_moved"`
+	NewDuration    int    `json:"new_duration"`
+	Errors         []string `json:"errors,omitempty"`
+}
+
+// MergeSplitBookCluster absorbs every srcID into keepID:
+//
+//  1. For each src: GetBookFiles, MoveBookFilesToBook(ids, src, keep).
+//  2. Recompute keep duration as sum of all bookfile durations.
+//  3. Optionally update keep.Title to suggestedTitle (when non-empty).
+//  4. Soft-delete each src.
+//
+// Per-src errors are collected but do not abort — the remaining sources
+// still get processed so the operator doesn't end up with a half-merged
+// cluster.
+func MergeSplitBookCluster(store database.Store, keepID string, srcIDs []string, suggestedTitle string) (*SplitBookMergeResult, error) {
+	if keepID == "" {
+		return nil, fmt.Errorf("MergeSplitBookCluster: empty keepID")
+	}
+	if len(srcIDs) == 0 {
+		return nil, fmt.Errorf("MergeSplitBookCluster: no srcIDs")
+	}
+	keep, err := store.GetBookByID(keepID)
+	if err != nil || keep == nil {
+		return nil, fmt.Errorf("keep book %s not found: %w", keepID, err)
+	}
+
+	result := &SplitBookMergeResult{KeepID: keepID}
+
+	// Step 1: move bookfiles from each src to keep.
+	for _, srcID := range srcIDs {
+		if srcID == keepID {
+			continue
+		}
+		files, err := store.GetBookFiles(srcID)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("get files for %s: %v", srcID, err))
+			continue
+		}
+		if len(files) == 0 {
+			continue
+		}
+		ids := make([]string, 0, len(files))
+		for _, f := range files {
+			ids = append(ids, f.ID)
+		}
+		if err := store.MoveBookFilesToBook(ids, srcID, keepID); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("move files from %s: %v", srcID, err))
+			continue
+		}
+		result.FilesMoved += len(files)
+	}
+
+	// Step 2: recompute keep duration as sum of all bookfile durations.
+	allFiles, err := store.GetBookFiles(keepID)
+	if err != nil {
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("recount files on keep: %v", err))
+	} else {
+		var total int
+		for _, f := range allFiles {
+			total += int(f.Duration)
+		}
+		if total > 0 {
+			result.NewDuration = total
+			keep.Duration = &total
+		}
+	}
+
+	// Step 3: update keep title if a non-empty suggested title was given.
+	if suggestedTitle != "" && suggestedTitle != keep.Title {
+		keep.Title = suggestedTitle
+	}
+	if _, err := store.UpdateBook(keep.ID, keep); err != nil {
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("update keep book: %v", err))
+	}
+
+	// Step 4: soft-delete each src (files have already been moved away).
+	for _, srcID := range srcIDs {
+		if srcID == keepID {
+			continue
+		}
+		if err := merge.SoftDeleteBook(store, srcID); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("soft-delete %s: %v", srcID, err))
+			slog.Warn("split-book merge soft-delete failed", "src", srcID, "err", err)
+			continue
+		}
+		result.MergedSrcCount++
+	}
+
+	return result, nil
+}

--- a/internal/dedup/split_book_storage.go
+++ b/internal/dedup/split_book_storage.go
@@ -1,0 +1,167 @@
+// file: internal/dedup/split_book_storage.go
+// version: 1.0.0
+// guid: 2a4b6c8e-1f3d-5a7b-9c0e-2d4f6a8b0c1d
+// last-edited: 2026-05-29
+
+// Split-book candidate storage. The detector is purely analytical;
+// these helpers persist its results so the operator-facing CLI and the
+// HTTP list endpoint have something to read.
+//
+// DedupCandidate is pairwise (entity_a / entity_b) and doesn't fit an
+// N-ary chapter cluster, so we use a dedicated Pebble keyspace instead
+// of shoehorning into the existing table.
+//
+// Keys:
+//
+//	split_book_candidate:<ulid>            → JSON-encoded SplitBookCandidate
+//
+// The detector replaces the entire keyspace on each run (DeleteAll +
+// Upsert) so the candidate list reflects only the latest scan.
+
+package dedup
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// splitBookKeyPrefix is the Pebble key prefix for stored candidates.
+// ';' is the next byte after ':' in ASCII — used as the upper bound for
+// prefix iteration in the same style as the rest of pebble_store.go.
+const (
+	splitBookKeyPrefix = "split_book_candidate:"
+	splitBookKeyUpper  = "split_book_candidate;"
+)
+
+// SplitBookStore is implemented by anything that exposes a *pebble.DB.
+// EmbeddingStore satisfies this via its (currently unexported) db field;
+// we wrap it with a thin helper rather than adding methods directly to
+// avoid bloating EmbeddingStore's API surface.
+type SplitBookStore struct {
+	db *pebble.DB
+}
+
+// NewSplitBookStore constructs a SplitBookStore backed by the given
+// Pebble database. The DB is shared; Close is a no-op.
+func NewSplitBookStore(db *pebble.DB) *SplitBookStore {
+	return &SplitBookStore{db: db}
+}
+
+// SaveAll replaces every existing split-book candidate row with the
+// supplied list. Each candidate gets a fresh ULID and CreatedAt as its
+// persisted ID is otherwise meaningless to the detector.
+func (s *SplitBookStore) SaveAll(cands []SplitBookCandidate) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("SplitBookStore: nil db")
+	}
+	// Clear existing rows first.
+	if err := s.deleteAll(); err != nil {
+		return fmt.Errorf("clear existing: %w", err)
+	}
+	now := time.Now()
+	batch := s.db.NewBatch()
+	defer batch.Close()
+	for i := range cands {
+		c := cands[i]
+		if c.ID == "" {
+			c.ID = ulid.Make().String()
+		}
+		type wrapper struct {
+			SplitBookCandidate
+			CreatedAt time.Time `json:"created_at"`
+		}
+		data, err := json.Marshal(wrapper{SplitBookCandidate: c, CreatedAt: now})
+		if err != nil {
+			return fmt.Errorf("marshal candidate %d: %w", i, err)
+		}
+		if err := batch.Set([]byte(splitBookKeyPrefix+c.ID), data, nil); err != nil {
+			return fmt.Errorf("batch set %s: %w", c.ID, err)
+		}
+	}
+	return batch.Commit(pebble.Sync)
+}
+
+// List returns every stored split-book candidate. Results are sorted by
+// the underlying key (ULID lexicographic = chronological).
+func (s *SplitBookStore) List() ([]SplitBookCandidate, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("SplitBookStore: nil db")
+	}
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(splitBookKeyPrefix),
+		UpperBound: []byte(splitBookKeyUpper),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new iter: %w", err)
+	}
+	defer iter.Close()
+	var out []SplitBookCandidate
+	for iter.First(); iter.Valid(); iter.Next() {
+		var w struct {
+			SplitBookCandidate
+			CreatedAt time.Time `json:"created_at"`
+		}
+		if err := json.Unmarshal(iter.Value(), &w); err != nil {
+			// Skip corrupt rows but continue — operator-facing CLI
+			// shouldn't fail wholesale because of one bad record.
+			continue
+		}
+		out = append(out, w.SplitBookCandidate)
+	}
+	return out, iter.Error()
+}
+
+// Get fetches a single candidate by ID, or (nil, nil) if not found.
+func (s *SplitBookStore) Get(id string) (*SplitBookCandidate, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("SplitBookStore: nil db")
+	}
+	key := []byte(splitBookKeyPrefix + id)
+	val, closer, err := s.db.Get(key)
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	var w struct {
+		SplitBookCandidate
+		CreatedAt time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(val, &w); err != nil {
+		return nil, err
+	}
+	return &w.SplitBookCandidate, nil
+}
+
+// Delete removes a candidate by ID. Returns nil if not present.
+func (s *SplitBookStore) Delete(id string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("SplitBookStore: nil db")
+	}
+	return s.db.Delete([]byte(splitBookKeyPrefix+id), pebble.Sync)
+}
+
+// deleteAll wipes every candidate row.
+func (s *SplitBookStore) deleteAll() error {
+	return s.db.DeleteRange(
+		[]byte(splitBookKeyPrefix),
+		[]byte(splitBookKeyUpper),
+		pebble.Sync,
+	)
+}
+
+// PebbleDB exposes the underlying Pebble handle for callers (e.g.
+// EmbeddingStore) that want to construct a SplitBookStore from a
+// pre-existing shared DB. Returns nil if the receiver is nil.
+func (s *SplitBookStore) PebbleDB() *pebble.DB {
+	if s == nil {
+		return nil
+	}
+	return s.db
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -50,6 +50,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.fullScanDef(),
 		p.llmReviewDef(),
 		p.bookSignatureScanDef(),
+		p.splitBookScanDef(),
 	}
 
 	for _, op := range ops {

--- a/internal/plugins/dedup/split_book_scan.go
+++ b/internal/plugins/dedup/split_book_scan.go
@@ -1,0 +1,74 @@
+// file: internal/plugins/dedup/split_book_scan.go
+// version: 1.0.0
+// guid: 4c6e8f0b-3a5b-7c9d-1e2f-4a6b8c0d2e3f
+// last-edited: 2026-05-29
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// splitBookScanDef registers the split-book backfill scan op. It walks
+// every book in the store, runs the chapter-cluster detector, and
+// persists the resulting candidates to the Pebble split-book keyspace
+// so the HTTP list endpoint and the merge-split-books CLI can consume
+// them.
+func (p *Plugin) splitBookScanDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "dedup.split-book-scan",
+		Plugin:          "dedup",
+		DisplayName:     "Split-book backfill scan",
+		Description:     "Scans the library for one-Book-per-chapter clusters and saves merge candidates.",
+		ResumePolicy:    sdk.ResumeRequeue,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "dedup.split-book-scan",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         60 * time.Minute,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+		},
+		Run: p.runSplitBookScan,
+	}
+}
+
+func (p *Plugin) runSplitBookScan(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	if p.store == nil {
+		return fmt.Errorf("split-book scan: store not available")
+	}
+	if p.embeddingStore == nil {
+		return fmt.Errorf("split-book scan: embedding store not available (needed for shared Pebble DB)")
+	}
+
+	_ = reporter.UpdateProgress(0, 100, "Scanning library for split-book clusters...")
+	cands, err := dedupengine.DetectSplitBookCandidates(ctx, p.store)
+	if err != nil {
+		reporter.Logger().Error("split-book detector error", "error", err)
+		return fmt.Errorf("split-book scan: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(80, 100,
+		fmt.Sprintf("Found %d candidate cluster(s); persisting...", len(cands)))
+
+	db := p.embeddingStore.PebbleDB()
+	if db == nil {
+		return fmt.Errorf("split-book scan: shared Pebble DB unavailable")
+	}
+	store := dedupengine.NewSplitBookStore(db)
+	if err := store.SaveAll(cands); err != nil {
+		reporter.Logger().Error("split-book SaveAll error", "error", err)
+		return fmt.Errorf("split-book scan persist: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(100, 100,
+		fmt.Sprintf("Split-book scan complete — %d candidate cluster(s) saved", len(cands)))
+	reporter.Logger().Info("split-book scan complete", "candidates", len(cands))
+	return nil
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1046,6 +1046,11 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/embed", s.perm(auth.PermScanTrigger), s.triggerEmbedScan)
 			protected.POST("/dedup/embed-async", s.perm(auth.PermScanTrigger), s.triggerEmbedAsync)
 
+			// MAYDEPLOY-G2/G4: split-book backfill (chapter-cluster scrub)
+			protected.POST("/dedup/split-book-scan", s.perm(auth.PermScanTrigger), s.triggerSplitBookScan)
+			protected.GET("/dedup/split-book-candidates", s.perm(auth.PermLibraryView), s.listSplitBookCandidates)
+			protected.POST("/dedup/split-book-candidates/:id/merge", s.perm(auth.PermLibraryEditMetadata), s.mergeSplitBookCandidate)
+
 			// File system routes
 			protected.GET("/filesystem/home", s.perm(auth.PermSettingsManage), s.getHomeDirectory)
 			protected.GET("/filesystem/browse", s.perm(auth.PermSettingsManage), s.browseFilesystem)

--- a/internal/server/split_book_handlers.go
+++ b/internal/server/split_book_handlers.go
@@ -1,0 +1,151 @@
+// file: internal/server/split_book_handlers.go
+// version: 1.0.0
+// guid: 5d7e9f1a-4b6c-8d0e-2f3a-5b7c9d1e3f4a
+// last-edited: 2026-05-29
+
+// HTTP handlers for the split-book backfill (MAYDEPLOY-G2 + G4).
+//
+// Endpoints:
+//
+//	POST /api/v1/dedup/split-book-scan                   — enqueue scan
+//	GET  /api/v1/dedup/split-book-candidates             — list candidates
+//	POST /api/v1/dedup/split-book-candidates/:id/merge   — execute merge
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	dedupengine "github.com/jdfalk/audiobook-organizer/internal/dedup"
+	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+)
+
+// triggerSplitBookScan handles POST /api/v1/dedup/split-book-scan.
+// Delegates to the UOS registry (dedup.split-book-scan op).
+func (s *Server) triggerSplitBookScan(c *gin.Context) {
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
+		return
+	}
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.split-book-scan", nil)
+	if err != nil {
+		httputil.InternalError(c, "failed to enqueue split-book scan", err)
+		return
+	}
+	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
+}
+
+// listSplitBookCandidates handles GET /api/v1/dedup/split-book-candidates.
+//
+// Returns every persisted split-book candidate cluster. Pagination is
+// not applied — the candidate set is expected to be small (hundreds at
+// most) and operator-facing tooling reads the whole list at once.
+func (s *Server) listSplitBookCandidates(c *gin.Context) {
+	store, ok := s.splitBookStore()
+	if !ok {
+		httputil.RespondWithServiceUnavailable(c, "split-book store not available")
+		return
+	}
+	cands, err := store.List()
+	if err != nil {
+		httputil.InternalError(c, "failed to list split-book candidates", err)
+		return
+	}
+	if cands == nil {
+		cands = []dedupengine.SplitBookCandidate{}
+	}
+	httputil.RespondWithOK(c, gin.H{
+		"candidates": cands,
+		"total":      len(cands),
+	})
+}
+
+// mergeSplitBookCandidate handles POST /api/v1/dedup/split-book-candidates/:id/merge.
+//
+// Body (optional):
+//
+//	{ "keep_id": "<bookID>" }
+//
+// If keep_id is omitted, the suggested keep-ID from the candidate
+// (BookIDs[0], earliest ULID) is used. On success the candidate row is
+// deleted so subsequent list calls don't surface it again.
+func (s *Server) mergeSplitBookCandidate(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		httputil.RespondWithBadRequest(c, "candidate id required")
+		return
+	}
+	store, ok := s.splitBookStore()
+	if !ok {
+		httputil.RespondWithServiceUnavailable(c, "split-book store not available")
+		return
+	}
+	cand, err := store.Get(id)
+	if err != nil {
+		httputil.InternalError(c, "failed to load split-book candidate", err)
+		return
+	}
+	if cand == nil {
+		httputil.RespondWithNotFound(c, "split_book_candidate", id)
+		return
+	}
+	if len(cand.BookIDs) < 2 {
+		httputil.RespondWithBadRequest(c, "candidate has fewer than 2 books")
+		return
+	}
+
+	var body struct {
+		KeepID string `json:"keep_id"`
+	}
+	_ = c.ShouldBindJSON(&body) // body is optional
+
+	keepID := body.KeepID
+	if keepID == "" {
+		keepID = cand.BookIDs[0]
+	}
+
+	// Validate keepID is in the candidate's BookIDs.
+	srcIDs := make([]string, 0, len(cand.BookIDs)-1)
+	keepFound := false
+	for _, bid := range cand.BookIDs {
+		if bid == keepID {
+			keepFound = true
+			continue
+		}
+		srcIDs = append(srcIDs, bid)
+	}
+	if !keepFound {
+		httputil.RespondWithBadRequest(c, "keep_id not in candidate book_ids")
+		return
+	}
+
+	result, err := dedupengine.MergeSplitBookCluster(s.Store(), keepID, srcIDs, cand.SuggestedTitle)
+	if err != nil {
+		httputil.InternalError(c, "split-book merge failed", err)
+		return
+	}
+
+	// Delete candidate so it's not surfaced again. Best-effort: a
+	// stale row left behind only causes a re-attempt that no-ops on
+	// already-soft-deleted srcs.
+	if delErr := store.Delete(id); delErr != nil {
+		c.Error(delErr) //nolint:errcheck
+	}
+
+	httputil.RespondWithOK(c, result)
+}
+
+// splitBookStore is a small helper that returns the candidate store
+// backed by the shared embedding-store Pebble handle. Returns
+// (nil, false) when the embedding store isn't wired up (e.g. tests).
+func (s *Server) splitBookStore() (*dedupengine.SplitBookStore, bool) {
+	if s.embeddingStore == nil {
+		return nil, false
+	}
+	db := s.embeddingStore.PebbleDB()
+	if db == nil {
+		return nil, false
+	}
+	return dedupengine.NewSplitBookStore(db), true
+}

--- a/tools/cmd/merge-split-books/main.go
+++ b/tools/cmd/merge-split-books/main.go
@@ -1,0 +1,264 @@
+// file: tools/cmd/merge-split-books/main.go
+// version: 1.0.0
+// last-edited: 2026-05-29
+//
+// merge-split-books is the operator-facing CLI for MAYDEPLOY-G2 + G4.
+// It triggers the split-book backfill scan on a running server, lists
+// the resulting candidate clusters, and (in --execute mode) issues the
+// merge API call for each cluster.
+//
+// Default mode is --dry-run: candidates are printed to stdout and no
+// mutations are performed. --execute flips the switch.
+//
+// Usage examples:
+//
+//	merge-split-books -server http://localhost:8484 -api-token-file .api-token
+//	merge-split-books -server https://172.16.2.30:8484 -api-key $TOKEN --execute --limit 5
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Candidate mirrors internal/dedup.SplitBookCandidate. Kept inline so
+// the CLI doesn't import internal/ packages.
+type Candidate struct {
+	ID                string   `json:"id"`
+	ParentFolder      string   `json:"parent_folder"`
+	BookIDs           []string `json:"book_ids"`
+	SuggestedTitle    string   `json:"suggested_title"`
+	SuggestedAuthor   string   `json:"suggested_author"`
+	SequentialPattern string   `json:"sequential_pattern"`
+	Shape             string   `json:"shape"`
+}
+
+type listResponse struct {
+	Data *struct {
+		Candidates []Candidate `json:"candidates"`
+		Total      int         `json:"total"`
+	} `json:"data"`
+	Candidates []Candidate `json:"candidates"`
+	Total      int         `json:"total"`
+}
+
+type scanResponse struct {
+	Data *struct {
+		OpID string `json:"op_id"`
+	} `json:"data"`
+	OpID string `json:"op_id"`
+}
+
+func main() {
+	server := flag.String("server", "http://localhost:8484", "API base URL")
+	apiKey := flag.String("api-key", "", "API key (or AUDIOBOOK_API_KEY env)")
+	apiKeyFile := flag.String("api-token-file", "", "Read API key from file (default: empty)")
+	dryRun := flag.Bool("dry-run", true, "List candidates without merging (default true)")
+	execute := flag.Bool("execute", false, "Execute the merges (overrides --dry-run)")
+	minGroupSize := flag.Int("min-group-size", 3, "Skip clusters smaller than this")
+	limit := flag.Int("limit", 0, "Cap how many groups to merge in one run (0 = no limit)")
+	skipScan := flag.Bool("skip-scan", false, "Don't trigger a fresh scan; read existing candidates only")
+	scanTimeout := flag.Duration("scan-timeout", 5*time.Minute, "How long to poll for scan completion before listing")
+	verbose := flag.Bool("verbose", false, "Verbose logging")
+	flag.Parse()
+
+	key := *apiKey
+	if key == "" && *apiKeyFile != "" {
+		data, err := os.ReadFile(*apiKeyFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "merge-split-books: read api-token-file: %v\n", err)
+			os.Exit(1)
+		}
+		key = strings.TrimSpace(string(data))
+	}
+	if key == "" {
+		key = os.Getenv("AUDIOBOOK_API_KEY")
+	}
+	if key == "" {
+		fmt.Fprintln(os.Stderr, "merge-split-books: API key required: use -api-key, -api-token-file, or AUDIOBOOK_API_KEY env")
+		os.Exit(1)
+	}
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
+
+	if !*skipScan {
+		if *verbose {
+			fmt.Fprintln(os.Stderr, "Triggering split-book scan...")
+		}
+		opID, err := triggerScan(client, *server, key)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "merge-split-books: trigger scan: %v\n", err)
+			os.Exit(1)
+		}
+		if *verbose {
+			fmt.Fprintf(os.Stderr, "Scan op enqueued: %s\n", opID)
+		}
+		// Best-effort wait — we don't poll op status, just give the
+		// server a few seconds to complete. The detector runs in
+		// memory and even on a 100K-book library typically completes
+		// in <30s. Operator can re-run with --skip-scan if needed.
+		waitForScan(*scanTimeout, *verbose)
+	}
+
+	cands, err := listCandidates(client, *server, key)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "merge-split-books: list candidates: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Apply --min-group-size filter.
+	filtered := cands[:0]
+	for _, c := range cands {
+		if len(c.BookIDs) >= *minGroupSize {
+			filtered = append(filtered, c)
+		}
+	}
+	cands = filtered
+
+	if *limit > 0 && len(cands) > *limit {
+		cands = cands[:*limit]
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d candidate cluster(s) (min-group-size=%d, limit=%d)\n",
+		len(cands), *minGroupSize, *limit)
+
+	doExecute := *execute && !*dryRun
+	if *execute {
+		doExecute = true // explicit --execute always wins
+	}
+
+	for i, c := range cands {
+		fmt.Printf("\n=== Cluster %d/%d ===\n", i+1, len(cands))
+		fmt.Printf("  ID:        %s\n", c.ID)
+		fmt.Printf("  Shape:     %s\n", c.Shape)
+		fmt.Printf("  Folder:    %s\n", c.ParentFolder)
+		fmt.Printf("  Title:     %s\n", c.SuggestedTitle)
+		fmt.Printf("  Author:    %s\n", c.SuggestedAuthor)
+		fmt.Printf("  Pattern:   %s\n", c.SequentialPattern)
+		fmt.Printf("  Books:     %d (keep %s, merge %d others)\n",
+			len(c.BookIDs), c.BookIDs[0], len(c.BookIDs)-1)
+		if *verbose {
+			fmt.Printf("  All IDs:   %s\n", strings.Join(c.BookIDs, ", "))
+		}
+		if !doExecute {
+			continue
+		}
+		res, err := mergeCluster(client, *server, key, c.ID)
+		if err != nil {
+			fmt.Printf("  MERGE FAILED: %v\n", err)
+			continue
+		}
+		fmt.Printf("  MERGED: %s\n", res)
+	}
+
+	if !doExecute {
+		fmt.Fprintln(os.Stderr, "\nDRY RUN — no merges performed. Re-run with --execute to apply.")
+	}
+}
+
+func triggerScan(client *http.Client, server, key string) (string, error) {
+	req, err := http.NewRequest("POST", server+"/api/v1/dedup/split-book-scan", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp, body, err := doRetry(client, req, 3)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("scan returned %d: %s", resp.StatusCode, body)
+	}
+	var sr scanResponse
+	_ = json.Unmarshal(body, &sr)
+	if sr.Data != nil {
+		return sr.Data.OpID, nil
+	}
+	return sr.OpID, nil
+}
+
+func waitForScan(d time.Duration, verbose bool) {
+	if d <= 0 {
+		return
+	}
+	if verbose {
+		fmt.Fprintf(os.Stderr, "Waiting %s for scan to complete...\n", d)
+	}
+	time.Sleep(d)
+}
+
+func listCandidates(client *http.Client, server, key string) ([]Candidate, error) {
+	req, err := http.NewRequest("GET", server+"/api/v1/dedup/split-book-candidates", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp, body, err := doRetry(client, req, 3)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("list returned %d: %s", resp.StatusCode, body)
+	}
+	var lr listResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		return nil, fmt.Errorf("decode list: %w", err)
+	}
+	if lr.Data != nil {
+		return lr.Data.Candidates, nil
+	}
+	return lr.Candidates, nil
+}
+
+func mergeCluster(client *http.Client, server, key, id string) (string, error) {
+	url := server + "/api/v1/dedup/split-book-candidates/" + id + "/merge"
+	req, err := http.NewRequest("POST", url, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Content-Type", "application/json")
+	resp, body, err := doRetry(client, req, 3)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("merge returned %d: %s", resp.StatusCode, body)
+	}
+	return string(body), nil
+}
+
+// doRetry runs req once, and re-runs on 5xx up to maxAttempts total.
+// The request body must be re-readable (we only send empty / small JSON).
+func doRetry(client *http.Client, req *http.Request, maxAttempts int) (*http.Response, []byte, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt) * time.Second)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 500 && attempt < maxAttempts {
+			time.Sleep(time.Duration(attempt) * time.Second)
+			continue
+		}
+		return resp, body, nil
+	}
+	return nil, nil, lastErr
+}


### PR DESCRIPTION
## Summary

Adds a backfill scanner that finds Book rows stored as one-Book-per-chapter clusters (e.g. the 85 chapter-Books for Tarkin in prod) and a one-shot CLI that can dry-run and execute the cluster merges. Complements the path_format scrub from PR #1158 — that one stops new ones; this one cleans up the existing mess.

### What's in here

**Detector (G2)**
- `internal/dedup/split_book_detector.go` — pure detector; paginated through `GetAllBooks` via a small slim-projection struct so the working set stays bounded even on a 1M-book library.
- `internal/dedup/split_book_storage.go` — Pebble keyspace `split_book_candidate:<ulid>` with `SaveAll` (replace-all semantics) + `List`/`Get`/`Delete`. Shared with the embedding store via a new `EmbeddingStore.PebbleDB()` accessor.
- `internal/dedup/split_book_merge.go` — portable cluster merge using `MoveBookFilesToBook` + `SoftDeleteBook` (the existing `MergeChapterBooks` is SQLite-only; `merge.MergeBooks` doesn't move BookFiles which would orphan chapter files).
- `internal/plugins/dedup/split_book_scan.go` — `OperationDef` `dedup.split-book-scan`.

**Heuristic decisions**
- Group books by BOTH `filepath.Dir(FilePath)` (parent) and `filepath.Dir(filepath.Dir(FilePath))` (grandparent), in one pass.
- Qualifies when ≥3 books share author/series (all-or-nothing nil), and filename or parent-dir name yields integers forming a near-sequential run: ≥70% coverage of [min..max] with no gap >2.
- Parent pass goes first; grandparent emits only when every child parent-group has size 1 (the rogue `/Tarkin/3/85.mp3` shape). A book is never claimed by two candidates.
- Suggested keep-ID = lowest ULID of the cluster. Suggested title = most-common stripped Title; chapter markers like `(3/85)`, `- Chapter 3`, bare trailing numbers, `(Chapter 1)` stripped.

**Important — why we can't use existing merge paths**
- `database.MergeChapterBooks` returns `nil` without doing anything on PebbleStore (`pebble_store.go:9034`). Prod is Pebble.
- `merge.Service.MergeBooks` soft-deletes losers and reassigns external IDs but does NOT move `book_files` to the keeper — for chapter merges that orphans every chapter file.

The new `MergeSplitBookCluster` uses the portable `MoveBookFilesToBook` (works on both Pebble and SQLite), recomputes duration as the sum of moved-file durations, optionally updates the title, then soft-deletes the sources via `merge.SoftDeleteBook`.

**API**
- `POST /api/v1/dedup/split-book-scan` — enqueue scan op (scan_trigger perm)
- `GET  /api/v1/dedup/split-book-candidates` — list persisted clusters (library_view)
- `POST /api/v1/dedup/split-book-candidates/:id/merge` — execute merge (library_edit_metadata)

The merge endpoint reuses the existing `POST /api/v1/audiobooks/merge` was deliberately NOT chosen — that endpoint doesn't move BookFiles. The new endpoint calls the portable `MergeSplitBookCluster` directly.

**CLI (G4)**
- `tools/cmd/merge-split-books/main.go` — mirrors `tools/cmd/reconcile-paths/main.go` structure (TLS-skip, retry-on-5xx, auth via flag/env/file).
- Flags: `-server`, `-api-key`/`-api-token-file`, `-dry-run` (default true), `-execute`, `-min-group-size 3`, `-limit 0`, `-skip-scan`, `-scan-timeout`, `-verbose`.
- Flow: POST scan → wait `-scan-timeout` → GET candidates → print one cluster per stanza → if `-execute`, POST each merge.

## Heuristic shared with G1

G1 (sibling PR — scan-time detection) is currently empty in its worktree, so the heuristic was authored fresh here and documented in the detector's file-level comment for G1 to reconcile against on land.

## Test plan

- [x] Unit tests for the detector (`internal/dedup/split_book_detector_test.go` — 8 tests covering flat parent, rogue grandparent, author/series/size/sequence disqualifiers, mixed flat+grandparent assignment exclusivity, chapter-marker stripping, sequential-run thresholds). `go test ./internal/dedup/` passes.
- [x] `go build ./...` clean.
- [x] `go vet ./internal/server/...` clean.
- [ ] **Manual smoke procedure** (skipped CLI integration tests by intent):
  1. Local server up with prod-like Pebble DB containing the 85 Tarkin chapter-Books.
  2. `merge-split-books -server http://localhost:8484 -api-token-file .api-token -verbose` → dry-run should print at least one cluster with shape and pattern.
  3. `merge-split-books ... --execute --limit 1` on a backup → verify the keep-Book ends up with 85 BookFiles, sources are soft-deleted, and the keep duration is the sum of file durations.
  4. Re-run the dry-run → cluster should no longer appear (Delete on success).

## Do not merge

Per task brief — landing depends on G1 reconciliation review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)