### PR TITLE
fix(dedup): Keep A/B choice honored in merge

### DIFF
--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -968,9 +968,26 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 		return
 	}
 
+	// Optional JSON body {"keep_id": "<bookID>"} lets the caller pick
+	// which side of the candidate pair becomes the merge primary. When
+	// absent or empty, fall back to MergeService's auto-select (by
+	// format/bitrate/size). When present, it must match one of the two
+	// candidate entities — otherwise the caller is confused and we
+	// refuse rather than silently auto-picking.
+	var body struct {
+		KeepID string `json:"keep_id"`
+	}
+	// Ignore parse errors: an empty/missing body is valid (back-compat).
+	_ = c.ShouldBindJSON(&body)
+	keepID := body.KeepID
+	if keepID != "" && keepID != candidate.EntityAID && keepID != candidate.EntityBID {
+		httputil.RespondWithBadRequest(c, "keep_id must match the candidate's entity_a_id or entity_b_id")
+		return
+	}
+
 	var result interface{}
 	if candidate.EntityType == "book" && s.mergeService != nil {
-		mergeResult, mergeErr := s.mergeService.MergeBooks([]string{candidate.EntityAID, candidate.EntityBID}, "")
+		mergeResult, mergeErr := s.mergeService.MergeBooks([]string{candidate.EntityAID, candidate.EntityBID}, keepID)
 		if mergeErr != nil {
 			// MAYDEPLOY-B2: when one of the source books no longer exists (a previous
 			// merge already absorbed it), the candidate is stale rather than the
@@ -1036,7 +1053,7 @@ func (s *Server) mergeDedupCandidate(c *gin.Context) {
 		"candidate_id": id,
 	}))
 
-	httputil.RespondWithOK(c, gin.H{"status": "merged", "result": result})
+	httputil.RespondWithOK(c, gin.H{"status": "merged", "result": result, "keep_id": keepID})
 }
 
 // dismissDedupCandidate handles POST /api/v1/dedup/candidates/:id/dismiss.

--- a/internal/server/dedup_merge_keepid_test.go
+++ b/internal/server/dedup_merge_keepid_test.go
@@ -1,0 +1,186 @@
+// file: internal/server/dedup_merge_keepid_test.go
+// version: 1.0.0
+// guid: e8a5ab90-9d5c-4cbb-8a19-2f3b5cc8a401
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// newDedupMergeKeepIDTestServer wires up the minimal Server needed to exercise
+// mergeDedupCandidate's keep_id validation path. mergeService is left nil on
+// purpose — that branch is skipped, leaving just the input-validation logic
+// (which is what this fix changed) and the status update.
+func newDedupMergeKeepIDTestServer(t *testing.T) (*Server, *database.EmbeddingStore) {
+	t.Helper()
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	es := database.NewEmbeddingStore(db)
+	srv := &Server{embeddingStore: es}
+	return srv, es
+}
+
+// insertCandidate creates a pending book dedup candidate and returns its
+// numeric id, plus the canonicalised A/B ids (UpsertCandidate swaps so A < B).
+func insertCandidate(t *testing.T, es *database.EmbeddingStore, aID, bID string) (int64, string, string) {
+	t.Helper()
+	sim := 0.95
+	if err := es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  aID,
+		EntityBID:  bID,
+		Layer:      "embedding",
+		Similarity: &sim,
+		Status:     "pending",
+	}); err != nil {
+		t.Fatalf("UpsertCandidate: %v", err)
+	}
+
+	// Canonicalise: UpsertCandidate swaps so smaller ID is A.
+	cA, cB := aID, bID
+	if cA > cB {
+		cA, cB = cB, cA
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	for _, c := range cands {
+		if c.EntityAID == cA && c.EntityBID == cB {
+			return c.ID, cA, cB
+		}
+	}
+	t.Fatalf("inserted candidate not found in list")
+	return 0, "", ""
+}
+
+func doMergeRequest(t *testing.T, srv *Server, candidateID int64, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	var reqBody []byte
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reqBody = b
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(candidateID, 10)+"/merge",
+		bytes.NewReader(reqBody))
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatInt(candidateID, 10)}}
+
+	srv.mergeDedupCandidate(c)
+	return w
+}
+
+// TestMergeDedupCandidate_KeepID_Invalid asserts a keep_id that matches
+// neither side returns 400.
+func TestMergeDedupCandidate_KeepID_Invalid(t *testing.T) {
+	srv, es := newDedupMergeKeepIDTestServer(t)
+	id, _, _ := insertCandidate(t, es, "book-aaa", "book-bbb")
+
+	w := doMergeRequest(t, srv, id, map[string]string{"keep_id": "book-not-in-pair"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid keep_id: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestMergeDedupCandidate_KeepID_A asserts keep_id=A is accepted and echoed.
+// (mergeService is nil so MergeBooks is skipped; we're validating the
+// boundary between handler input parsing and the merge call.)
+func TestMergeDedupCandidate_KeepID_A(t *testing.T) {
+	srv, es := newDedupMergeKeepIDTestServer(t)
+	id, aID, _ := insertCandidate(t, es, "book-aaa", "book-bbb")
+
+	w := doMergeRequest(t, srv, id, map[string]string{"keep_id": aID})
+	if w.Code != http.StatusOK {
+		t.Fatalf("keep_id=A: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Status string `json:"status"`
+			KeepID string `json:"keep_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode resp: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.KeepID != aID {
+		t.Errorf("keep_id echoed = %q, want %q", resp.Data.KeepID, aID)
+	}
+}
+
+// TestMergeDedupCandidate_KeepID_B asserts keep_id=B is accepted and echoed.
+func TestMergeDedupCandidate_KeepID_B(t *testing.T) {
+	srv, es := newDedupMergeKeepIDTestServer(t)
+	id, _, bID := insertCandidate(t, es, "book-aaa", "book-bbb")
+
+	w := doMergeRequest(t, srv, id, map[string]string{"keep_id": bID})
+	if w.Code != http.StatusOK {
+		t.Fatalf("keep_id=B: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			KeepID string `json:"keep_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode resp: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.KeepID != bID {
+		t.Errorf("keep_id echoed = %q, want %q", resp.Data.KeepID, bID)
+	}
+}
+
+// TestMergeDedupCandidate_KeepID_Empty asserts back-compat: no body / no
+// keep_id is still accepted (auto-select path).
+func TestMergeDedupCandidate_KeepID_Empty(t *testing.T) {
+	srv, es := newDedupMergeKeepIDTestServer(t)
+	id, _, _ := insertCandidate(t, es, "book-aaa", "book-bbb")
+
+	w := doMergeRequest(t, srv, id, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("empty body: status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			KeepID string `json:"keep_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode resp: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.KeepID != "" {
+		t.Errorf("keep_id with empty body = %q, want empty", resp.Data.KeepID)
+	}
+}

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -2280,15 +2280,20 @@ function AcousticDedupTab() {
     }
   };
 
-  const handleMerge = async (candidateId: number) => {
+  const handleMerge = async (candidateId: number, keepId?: string) => {
     // The sync /dedup/candidates/:id/merge endpoint performs the merge,
     // updates candidate status, publishes the event, and cleans up orphan
     // candidates (PR #1167). Previously we also fired /audiobooks/merge
     // (async) here, which caused a race + UI flicker + spurious 409 from
     // the sync call when the async one won. (B1)
+    //
+    // keepId, when provided, tells the backend which side of the pair to
+    // keep as the merge primary. Without it the backend auto-selects by
+    // format/bitrate/size — which historically ignored the user's
+    // Keep A / Keep B click.
     setResolving((s) => new Set(s).add(candidateId));
     try {
-      await api.mergeDedupCandidate(candidateId);
+      await api.mergeDedupCandidate(candidateId, keepId);
       setCandidates((prev) => prev.filter((c) => c.id !== candidateId));
     } catch (err) {
       setStatusMsg(err instanceof Error ? err.message : 'Merge failed');
@@ -2404,13 +2409,13 @@ function AcousticDedupTab() {
                       <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
                         <Tooltip title="Keep Book A, merge B into it">
                           <Button size="small" variant={recommendA ? 'contained' : 'outlined'} color="primary"
-                            disabled={busy} onClick={() => handleMerge(c.id)}>
+                            disabled={busy} onClick={() => handleMerge(c.id, c.entity_a_id)}>
                             Keep A
                           </Button>
                         </Tooltip>
                         <Tooltip title="Keep Book B, merge A into it">
                           <Button size="small" variant={recommendB ? 'contained' : 'outlined'} color="primary"
-                            disabled={busy} onClick={() => handleMerge(c.id)}>
+                            disabled={busy} onClick={() => handleMerge(c.id, c.entity_b_id)}>
                             Keep B
                           </Button>
                         </Tooltip>

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -4476,10 +4476,17 @@ export async function getDedupStats(): Promise<{ stats: DedupStats[] }> {
   return responseData.data;
 }
 
-export async function mergeDedupCandidate(id: number): Promise<void> {
-  const response = await fetch(`${API_BASE}/dedup/candidates/${id}/merge`, {
-    method: 'POST',
-  });
+export async function mergeDedupCandidate(id: number, keepId?: string): Promise<void> {
+  // When keepId is provided, the backend uses it as the merge primary
+  // (which book is kept). When omitted, the backend falls back to
+  // auto-select by format/bitrate/size. keepId must match the candidate's
+  // entity_a_id or entity_b_id, otherwise the server returns 400.
+  const init: RequestInit = { method: 'POST' };
+  if (keepId) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify({ keep_id: keepId });
+  }
+  const response = await fetch(`${API_BASE}/dedup/candidates/${id}/merge`, init);
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge dedup candidate');
   }


### PR DESCRIPTION
## Summary

Fixes a bug from PR #1170: the Dedup Candidates page's **Keep A** and **Keep B** buttons both produced the same backend call, so the merge service auto-selected the primary by format/bitrate/size — silently ignoring the user's choice.

## The fix

**Backend** (`internal/server/dedup_handlers.go`): `POST /api/v1/dedup/candidates/:id/merge` now accepts an **optional** JSON body:

` + "```json" + `
{ "keep_id": "<bookID>" }
` + "```" + `

- When present, `keep_id` is validated to match the candidate's `entity_a_id` or `entity_b_id`. Mismatch → `400 Bad Request`.
- When absent / empty body, the handler falls back to the existing auto-select path (back-compat: existing callers keep working).
- The validated `keep_id` is passed as `primaryID` to `mergeService.MergeBooks(...)` instead of the prior hardcoded `""`.
- Response now includes the chosen `keep_id` so the UI can confirm.
- All existing paths preserved: 409 already_merged (#1160), candidate-status update, event publication, and B3 orphan-cleanup (#1167) all still run.

**Frontend**:
- `web/src/services/api.ts` — `mergeDedupCandidate(id, keepId?)` gains an optional second arg; sends a JSON body only when `keepId` is set.
- `web/src/pages/BookDedup.tsx` — Keep A passes `c.entity_a_id`; Keep B passes `c.entity_b_id`. `handleMerge(candidateId, keepId?)` threads it through.

## API contract change

This is a **back-compat extension** of the existing endpoint, not a break:

| Caller | Behavior |
|---|---|
| Old caller, no body | Auto-select primary (unchanged) |
| New caller, `keep_id` = A or B | `keep_id` is the merge primary |
| New caller, `keep_id` = something else | `400 Bad Request` |

## Test plan

- [x] `go build ./...` clean
- [x] `make build` — full backend + embedded frontend builds clean
- [x] New unit tests in `internal/server/dedup_merge_keepid_test.go`:
  - invalid `keep_id` → 400
  - `keep_id` = A → 200, response echoes A
  - `keep_id` = B → 200, response echoes B
  - empty body → 200, response echoes empty (auto-select fallback)
- [x] `go test ./internal/server/... -run "Dedup|Merge|Candidate"` passes
- [ ] Manual smoke: click Keep B on a candidate where the auto-pick would have chosen A; verify B becomes the primary and A is merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)