### PR TITLE
perf(chromem): switch to in-memory NewDB, drop broken persistence (D2)

### DIFF
--- a/internal/database/chromem_embedding_store.go
+++ b/internal/database/chromem_embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/chromem_embedding_store.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 2d0e1f9a-3b4c-4a70-b8c5-3d7e0f1b9a99
 //
 // chromem-go backed embedding vector store (DES-2).
@@ -10,15 +10,34 @@
 // Supports metadata filtering at query time (primary-version,
 // series exclusion, etc.).
 //
-// The SQLite EmbeddingStore stays for DedupCandidate CRUD — this
-// only handles the vector operations.
+// The SQLite/Pebble EmbeddingStore stays as the source of truth for
+// embedding vectors — this only handles the in-memory ANN index.
+//
+// MAYDEPLOY-D2 (2026-05): Switched from chromem.NewPersistentDB to
+// chromem.NewDB (in-memory only). Background:
+//
+//   - chromem-go v0.7.0 persists synchronously by writing one gob file
+//     per document on every AddDocument call. With ~50K books × 3072-dim
+//     vectors that is 50K+ files (~600MB-1.2GB) and 50K fsync-heavy
+//     writes per hydrate cycle — slow and inode-heavy.
+//   - In production the persistent dir was observed as empty (1KB) and
+//     the dedup engine already re-hydrates from the SQLite/Pebble
+//     embedding store on every startup (see dedup/lifecycle.go and
+//     engine.HydrateChromem). The hydrate is the canonical mirror path.
+//   - DEDUP_CHROMEM_LAZY=true (MAYDEPLOY-D1 / PR #1169) is the operator
+//     escape hatch when hydrate is too costly; without persistence the
+//     intent is now unambiguous: chromem is a derived in-memory index,
+//     not a second source of truth.
+//
+// If we ever want on-disk ANN persistence again, the right answer is
+// a different backing store (e.g. HNSW with mmap), not chromem-go's
+// per-document gob files.
 
 package database
 
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -34,13 +53,20 @@ type ChromemEmbeddingStore struct {
 	dims        int
 }
 
-// NewChromemEmbeddingStore opens or creates a persistent chromem-go
-// database at the given directory.
+// NewChromemEmbeddingStore returns an in-memory chromem-go store.
+//
+// The `dir` argument is preserved for backwards compatibility with the
+// service-registry wiring (and to make it cheap to swap back to a
+// persistent backend later), but it is currently unused — chromem-go's
+// NewPersistentDB writes one gob file per document on each Upsert,
+// which does not scale to 50K+ books, and the dedup engine already
+// re-hydrates from the SQLite/Pebble embedding store on startup.
+// See the file-level comment for the full rationale (MAYDEPLOY-D2).
 func NewChromemEmbeddingStore(dir string, dims int) (*ChromemEmbeddingStore, error) {
-	dbPath := filepath.Join(dir, "chromem")
-	db, err := chromem.NewPersistentDB(dbPath, false)
-	if err != nil {
-		return nil, fmt.Errorf("open chromem at %s: %w", dbPath, err)
+	_ = dir // intentionally unused; see NewChromemEmbeddingStore doc.
+	db := chromem.NewDB()
+	if db == nil {
+		return nil, fmt.Errorf("chromem.NewDB returned nil")
 	}
 	return &ChromemEmbeddingStore{
 		db:          db,
@@ -176,7 +202,9 @@ func (s *ChromemEmbeddingStore) CountByType(ctx context.Context, entityType stri
 	return col.Count(), nil
 }
 
-// Close is a no-op for chromem-go (persistence is automatic).
+// Close is a no-op for the in-memory chromem-go store. The dedup
+// engine re-hydrates from the SQLite/Pebble embedding store on
+// startup, so there is nothing to flush here.
 func (s *ChromemEmbeddingStore) Close() error {
 	return nil
 }


### PR DESCRIPTION
## Summary

MAYDEPLOY-D2: chromem-go persistence at `/var/lib/audiobook-organizer/chromem` was empty (1KB) on production despite `chromem.NewPersistentDB` being called. Investigated the chromem-go v0.7.0 API and chose **Option B**: switch to `chromem.NewDB()` (in-memory only) and document hydrate-from-SQLite as the canonical mirror path.

## Investigation

Read the chromem-go v0.7.0 source (`persistence.go`, `db.go`, `collection.go`):

- `NewPersistentDB` does persist synchronously on every write — `AddDocument` calls `persistToFile` inline when `persistDirectory != ""` (collection.go:283-288), and the package doc explicitly states "the persistence is done synchronously on each write operation, and each document addition leads to a new file, encoded as gob" (db.go:60-62).
- So no missing explicit-flush call. The persistence layer should have been working.
- Storage shape: one gob file per document per collection, under `<dir>/<hash2hex(collection)>/<hash2hex(id)>.gob`. With ~50K books × 3072-dim float32 vectors that's 50K+ files (~600MB-1.2GB on disk) and 50K fsync-heavy writes per hydrate.

## Option A vs Option B

**Option A (fix persistence):** No code-side fix needed — the library would persist if invoked. The empty prod dir suggests filesystem perms or a stale `/var/lib` artifact, not a code bug.

**Option B (switch to in-memory):** Chosen. Reasons:

1. The SQLite/Pebble embedding store is already the source of truth (engine.go:1196: *"The SQLite embedding row is the source of truth; chromem is just an index"*). chromem persistence was duplicating data, not protecting it.
2. The dedup engine already re-hydrates from SQLite on every startup (`engine.HydrateChromem`, wired in `dedup/lifecycle.go`). The hydrate is the canonical mirror.
3. `DEDUP_CHROMEM_LAZY=true` (D1 / PR #1169) is the operator escape hatch when hydrate is too costly.
4. Per-document gob files at this scale are operationally painful even when they work (slow startup directory scan, inode pressure on the ZFS special vdev, 50K sync writes per hydrate cycle).
5. Making the persistent path reliable at 50K+ docs would require a backend swap (HNSW + mmap), not a tweak to chromem-go's gob-per-document model.
6. The change is < 10 LOC and makes intent unambiguous: chromem is a derived in-memory index, not a second source of truth.

## Changes

- `internal/database/chromem_embedding_store.go`:
  - `NewChromemEmbeddingStore` now calls `chromem.NewDB()` instead of `chromem.NewPersistentDB(dir, false)`.
  - `dir` parameter preserved (no signature change — service-registry wiring untouched) but explicitly unused.
  - File-level comment and `Close()` comment updated to document the rationale.
  - Version header bumped to 1.1.0.
- Existing tests (`internal/database/chromem_embedding_store_test.go`) all use `NewInMemoryChromemStore`, so they exercise the same in-memory path. No new smoke-test needed for persistence round-trip (option A path not taken).

## Before / After

- **Before:** `NewPersistentDB(dir, false)` — claimed persistence, observed empty on prod, hydrate-from-SQLite still ran on every restart anyway. Intent muddled.
- **After:** `NewDB()` — explicit in-memory ANN index. Hydrate-from-SQLite on startup is the documented canonical path. No on-disk artifact, no per-Upsert fsync overhead. ~150s and ~6GB heap pressure of re-hydrate remain on startup but were already happening; this PR doesn't change them (D1 lazy-hydrate is the lever for that).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/database/ -run Chromem -count=1` — passes
- [x] `go test ./internal/dedup/... -count=1` — passes
- [ ] Deploy to prod, verify `/var/lib/audiobook-organizer/chromem` can be safely removed (no functional dependency)
- [ ] Confirm dedup Layer 2 still uses chromem ANN path after restart (`grep 'chromem-go ANN store active' journal`)

DO NOT MERGE — requires user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)