### PR TITLE
feat(maintenance): orphan book_file cleanup op (MAYDEPLOY-G6)

### DIFF
--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,0 +1,174 @@
+// file: internal/plugins/maintenance/orphan_book_files.go
+// version: 1.0.0
+// guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
+// last-edited: 2026-05-29
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// OrphanBookFilesCleanupParams are the JSON parameters for the orphan
+// book_files cleanup op. When Delete is false (default), the op reports the
+// count of orphan rows but does not modify the database.
+type OrphanBookFilesCleanupParams struct {
+	// Delete, when true, removes each detected orphan book_file row via
+	// Store.DeleteBookFile. When false (default), the op is a dry run.
+	Delete bool `json:"delete"`
+}
+
+// orphanBookFilesCleanupDef registers the maintenance.orphan-book-files-cleanup
+// OperationDef. It runs nightly during the maintenance window (02:15 daily) so
+// it sits between purge-old-logs (02:00 Sun) and purge-deleted (03:00) without
+// competing for the same minute.
+func (p *Plugin) orphanBookFilesCleanupDef() sdk.OperationDef {
+	sched := "15 2 * * *" // 02:15 daily — nightly maintenance window
+	return sdk.OperationDef{
+		ID:              "maintenance.orphan-book-files-cleanup",
+		Plugin:          "maintenance",
+		DisplayName:     "Orphan book_file cleanup",
+		Description:     "Detects book_file rows whose book_id no longer references an existing book. Reports the count by default; pass {\"delete\": true} to remove the orphans.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "maintenance.orphan-book-files-cleanup",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Schedule:        &sched,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runOrphanBookFilesCleanup,
+	}
+}
+
+func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params OrphanBookFilesCleanupParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	_ = reporter.Log(slog.LevelInfo, "Starting orphan book_file scan",
+		slog.Bool("delete", params.Delete),
+	)
+	_ = reporter.UpdateProgress(0, 100, "Scanning book_files for orphan rows...")
+
+	orphans, totalFiles, totalBooks, err := findOrphanBookFiles(ctx, store)
+	if err != nil {
+		return fmt.Errorf("scan failed: %w", err)
+	}
+
+	_ = reporter.Log(slog.LevelInfo, "Orphan scan complete",
+		slog.Int("orphan_count", len(orphans)),
+		slog.Int("total_book_files", totalFiles),
+		slog.Int("total_books", totalBooks),
+	)
+	_ = reporter.UpdateProgress(50, 100,
+		fmt.Sprintf("Found %d orphan book_file row(s) out of %d (valid books: %d)",
+			len(orphans), totalFiles, totalBooks))
+
+	if !params.Delete || len(orphans) == 0 {
+		msg := fmt.Sprintf("Orphan book_file scan: %d orphan(s) detected (report-only)", len(orphans))
+		if params.Delete && len(orphans) == 0 {
+			msg = "Orphan book_file cleanup: no orphans found, nothing to delete"
+		}
+		_ = reporter.Log(slog.LevelInfo, msg)
+		_ = reporter.UpdateProgress(100, 100, msg)
+		return nil
+	}
+
+	// Delete pass.
+	var deleted, failed int
+	for i, of := range orphans {
+		if ctx.Err() != nil {
+			_ = reporter.Log(slog.LevelWarn, "Orphan delete cancelled",
+				slog.Int("deleted", deleted),
+				slog.Int("failed", failed),
+				slog.Int("remaining", len(orphans)-i),
+			)
+			return ctx.Err()
+		}
+		if err := store.DeleteBookFile(of.ID); err != nil {
+			failed++
+			_ = reporter.Log(slog.LevelWarn, "Failed to delete orphan book_file",
+				slog.String("book_file_id", of.ID),
+				slog.String("book_id", of.BookID),
+				slog.String("file_path", of.FilePath),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		deleted++
+		// Progress: scale the delete pass over 50..100.
+		if total := len(orphans); total > 0 {
+			done := 50 + (50*(i+1))/total
+			_ = reporter.UpdateProgress(done, 100,
+				fmt.Sprintf("Deleting orphan book_files: %d/%d", i+1, total))
+		}
+	}
+
+	final := fmt.Sprintf("Orphan book_file cleanup: deleted %d, failed %d (of %d detected)",
+		deleted, failed, len(orphans))
+	_ = reporter.Log(slog.LevelInfo, final)
+	_ = reporter.UpdateProgress(100, 100, final)
+	return nil
+}
+
+// findOrphanBookFiles returns every BookFile whose BookID does not match any
+// existing book ID. Returns the orphan slice, the total number of book_files
+// scanned, and the number of valid book IDs found. The scan uses the memdb
+// fastpath via Store.GetAllBookFiles / Store.GetAllBooks; both calls return
+// projections of the underlying tables without per-row decoding cost.
+//
+// This is the testable core of runOrphanBookFilesCleanup. It does not delete
+// anything — callers that want to delete iterate over the result and call
+// Store.DeleteBookFile themselves.
+func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFile, totalFiles int, totalBooks int, err error) {
+	if ctx.Err() != nil {
+		return nil, 0, 0, ctx.Err()
+	}
+	files, ferr := store.GetAllBookFiles()
+	if ferr != nil {
+		return nil, 0, 0, fmt.Errorf("GetAllBookFiles: %w", ferr)
+	}
+	if ctx.Err() != nil {
+		return nil, 0, 0, ctx.Err()
+	}
+	// GetAllBooks(0, 0) is the unbounded form across the existing maintenance
+	// plugin (see pebble_store.go:9210, 9256, 9318) — limit=0 means "all".
+	books, berr := store.GetAllBooks(0, 0)
+	if berr != nil {
+		return nil, 0, 0, fmt.Errorf("GetAllBooks: %w", berr)
+	}
+	valid := make(map[string]struct{}, len(books))
+	for _, b := range books {
+		valid[b.ID] = struct{}{}
+	}
+	orphans = make([]database.BookFile, 0)
+	for _, f := range files {
+		if ctx.Err() != nil {
+			return nil, 0, 0, ctx.Err()
+		}
+		if f.BookID == "" {
+			// Empty book_id is its own kind of broken row, but treat it as
+			// an orphan so it surfaces in the count.
+			orphans = append(orphans, f)
+			continue
+		}
+		if _, ok := valid[f.BookID]; !ok {
+			orphans = append(orphans, f)
+		}
+	}
+	return orphans, len(files), len(books), nil
+}

--- a/internal/plugins/maintenance/orphan_book_files_test.go
+++ b/internal/plugins/maintenance/orphan_book_files_test.go
@@ -1,0 +1,105 @@
+// file: internal/plugins/maintenance/orphan_book_files_test.go
+// version: 1.0.0
+// guid: 0bd4f9a2-1c3e-4f5a-8b6c-7d9e0f1a2b3c
+// last-edited: 2026-05-29
+
+package maintenance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// TestFindOrphanBookFiles_ReportOnly verifies the core scan: given a mix of
+// book_files where some BookIDs reference existing books and some don't, the
+// function returns exactly the orphan rows without touching the database.
+//
+// This mirrors the G6 scenario where a partial merge or pre-existing data
+// inconsistency leaves book_file rows pointing at a now-missing book_id.
+func TestFindOrphanBookFiles_ReportOnly(t *testing.T) {
+	// Three valid books, plus one "ghost" book ID that was deleted directly
+	// (bypassing the normal cascade), simulating a partial merge.
+	books := []database.Book{
+		{ID: "book-keep-1", Title: "Kept 1"},
+		{ID: "book-keep-2", Title: "Kept 2"},
+		{ID: "book-keep-3", Title: "Kept 3"},
+	}
+	files := []database.BookFile{
+		{ID: "f1", BookID: "book-keep-1", FilePath: "/lib/a.m4b"},
+		{ID: "f2", BookID: "book-keep-2", FilePath: "/lib/b.m4b"},
+		{ID: "f3", BookID: "book-ghost-9", FilePath: "/lib/orphan-1.m4b"}, // orphan
+		{ID: "f4", BookID: "book-keep-3", FilePath: "/lib/c.m4b"},
+		{ID: "f5", BookID: "book-ghost-9", FilePath: "/lib/orphan-2.m4b"}, // orphan
+		{ID: "f6", BookID: "", FilePath: "/lib/orphan-empty.m4b"},         // empty-id orphan
+	}
+
+	var deleteCalls []string
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+			return files, nil
+		},
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			return books, nil
+		},
+		DeleteBookFileFunc: func(id string) error {
+			deleteCalls = append(deleteCalls, id)
+			return nil
+		},
+	}
+
+	orphans, totalFiles, totalBooks, err := findOrphanBookFiles(context.Background(), store)
+	if err != nil {
+		t.Fatalf("findOrphanBookFiles returned error: %v", err)
+	}
+	if totalFiles != len(files) {
+		t.Errorf("totalFiles = %d, want %d", totalFiles, len(files))
+	}
+	if totalBooks != len(books) {
+		t.Errorf("totalBooks = %d, want %d", totalBooks, len(books))
+	}
+	if got, want := len(orphans), 3; got != want {
+		t.Fatalf("len(orphans) = %d, want %d (orphans: %+v)", got, want, orphans)
+	}
+
+	// The exact orphan IDs should be f3, f5, f6.
+	wantIDs := map[string]bool{"f3": true, "f5": true, "f6": true}
+	for _, o := range orphans {
+		if !wantIDs[o.ID] {
+			t.Errorf("unexpected orphan id %q (book_id=%q)", o.ID, o.BookID)
+		}
+		delete(wantIDs, o.ID)
+	}
+	for missing := range wantIDs {
+		t.Errorf("expected orphan id %q not returned", missing)
+	}
+
+	// Report-only mode: DeleteBookFile MUST NOT have been called.
+	if len(deleteCalls) != 0 {
+		t.Errorf("report-only scan called DeleteBookFile %d times: %v",
+			len(deleteCalls), deleteCalls)
+	}
+}
+
+// TestFindOrphanBookFiles_NoOrphans verifies the clean-library case returns an
+// empty slice with no error.
+func TestFindOrphanBookFiles_NoOrphans(t *testing.T) {
+	books := []database.Book{{ID: "b1"}, {ID: "b2"}}
+	files := []database.BookFile{
+		{ID: "f1", BookID: "b1"},
+		{ID: "f2", BookID: "b2"},
+		{ID: "f3", BookID: "b1"},
+	}
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBooksFunc:     func(limit, offset int) ([]database.Book, error) { return books, nil },
+	}
+	orphans, _, _, err := findOrphanBookFiles(context.Background(), store)
+	if err != nil {
+		t.Fatalf("findOrphanBookFiles returned error: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Errorf("expected no orphans, got %d", len(orphans))
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -40,6 +40,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.cleanupOldBackupsDef(),
 		p.trashCleanupDef(),
 		p.archiveSweepDef(),
+		p.orphanBookFilesCleanupDef(),
 
 		// --- database ---
 		p.dbOptimizeDef(),


### PR DESCRIPTION
## Summary
- Adds `maintenance.orphan-book-files-cleanup` op that detects `book_file` rows whose `book_id` no longer references an existing book.
- Memdb-fastpath scan (`GetAllBookFiles` + `GetAllBooks`); reports count via progress reporter.
- Report-only by default; pass `{"delete": true}` to remove orphans via `Store.DeleteBookFile`.
- Scheduled nightly at 02:15, normal priority, non-isolated, cancellable, 30 min timeout.
- Registered in `Plugin.Register`.

## Why
When books get merged (G2/G4 PR #1173 paths) the merge service moves `book_files` from the merged-away book to the kept one. A partial merge or pre-existing inconsistency can leave `book_file` rows pointing at a vanished `book_id` — they consume Pebble + memdb space but never surface in any UI. This op makes them visible and optionally collectable.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/plugins/maintenance/... -count=1 -timeout 60s` passes
- [ ] Manual: trigger op via admin endpoint in staging, verify count matches direct DB scan
- [ ] Manual: run with `{"delete": true}` against a seeded orphan, verify rows gone and totals decrement

## Op ID
`maintenance.orphan-book-files-cleanup`

DO NOT MERGE — coordination pending.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>