### PR TITLE
fix(itunes): strip chapter prefix from track Name fallback (MAYDEPLOY-G5a)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -194,15 +194,30 @@ one book × many BookFiles).
   prints dry-run plan, optionally executes. Operator runs once
   against the existing ~thousands of over-split books in the
   library.
-- [ ] **G5** Investigate the WRONG metadata source: book
-  `01KQGDQTJ44FCAPW5Z9D2KNQDE` has title `(76/85) Tarkin` but
-  the only file is `4/85.mp3`. Either the title was set from a
-  different file (cross-file contamination during scan), or the
-  scanner read tags from a stale source. Reproduce by
-  re-importing the folder; trace where the `76` came from.
-  Likely culprit: `audiobookService.extractBookFileMetadata`
-  or similar fills Title from the first/last file in the folder
-  rather than the file the Book represents.
+- [x] **G5a** Strip leading `(N/M)` / `Chapter N` prefix from
+  iTunes per-chapter track Names when fall-back populates
+  `Book.Title`. Root-cause analysis:
+  `docs/perf-audit-2026-05-29-g5-title-mismatch.md`.
+  Source of the `(76/85)` prefix: `buildBookFromAlbumGroup`
+  fell back to `firstTrack.Name` when iTunes Album tag was
+  empty, writing the per-chapter Name into `Book.Title`. The
+  file-vs-title mismatch (file=4, title=76) is a second-order
+  artifact from a later organizer/dedup reassignment, not a
+  second bug. Fix: `stripChapterPrefix` helper in
+  `internal/itunes/service/strip_chapter_prefix.go`, applied
+  only in the empty-Album fall-back branch.
+- [ ] **G5b** Back-fill existing poisoned `Book.Title` rows in
+  PebbleDB. Scan all books for leading `(N/M)`, `(N of M)`,
+  `Chapter NN`, `Track NN`, `Part NN`, `NN -` patterns; strip
+  the prefix; update `Book.Title`; log old→new. Estimated
+  scope: ~85 Tarkin records plus unknown N more from other
+  iTunes-imported series.
+- [ ] **G5c** Tighten `groupTracksByAlbum` to use
+  `stripChapterPrefix(track.Name)` as the album key when the
+  Album tag is empty. Currently every chapter falls back to a
+  unique key (the raw Name) and becomes its own book record.
+  Deferred — risks merging unrelated tracks that happen to
+  share a stripped prefix; needs a separate design pass.
 - [ ] **G6** Once G1 lands, the legacy `book_files` rows for the
   merged-away books should be cleaned up by G3/G4's merge path —
   but verify orphan rows aren't left in the `book_files` table

--- a/docs/perf-audit-2026-05-29-g5-title-mismatch.md
+++ b/docs/perf-audit-2026-05-29-g5-title-mismatch.md
@@ -1,0 +1,94 @@
+<!-- file: docs/perf-audit-2026-05-29-g5-title-mismatch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8c1f4d2a-9b3e-4a7c-8d5e-1f0a2b3c4d5e -->
+
+# MAYDEPLOY-G5 — Title-from-wrong-file mismatch
+
+Date: 2026-05-29
+Trigger book: `01KQGDQTJ44FCAPW5Z9D2KNQDE`
+- `Book.Title`: `(76/85) Tarkin: Star Wars (Unabridged)`
+- Sole `BookFile.FilePath`: `Tarkin - Star Wars - 4/85.mp3`
+
+Title says track 76; the only attached file is track 4. Where did the `76` come from?
+
+## TL;DR — Root cause
+
+The `(76/85) ...` prefix is **a per-chapter iTunes track Name** that leaked into `Book.Title` during iTunes import.
+
+In `internal/itunes/service/importer.go`:
+
+- `groupTracksByAlbum` (line 844) keys groups by `artist|album`. When the Album tag is empty (or unique per chapter), it falls back to `track.Name`:
+  ```go
+  album := strings.TrimSpace(track.Album)
+  if album == "" {
+      album = strings.TrimSpace(track.Name)
+  }
+  key := artist + "|" + album
+  ```
+  Result: each chapter becomes its own `albumGroup`.
+
+- `buildBookFromAlbumGroup` (line 1094-1101) sets `Book.Title` from `firstTrack.Album`, fall-back to `firstTrack.Name`:
+  ```go
+  title := strings.TrimSpace(firstTrack.Album)
+  ...
+  if title == "" {
+      title = strings.TrimSpace(firstTrack.Name)
+  }
+  ```
+  When Album is empty, `Book.Title` = the per-chapter Name, which for this library is shaped `(NN/MM) Tarkin: Star Wars (Unabridged)`.
+
+That fully explains the `76` in the title. The "file is chapter 4" is a **second-order artifact** — at some later point (organizer rename, G1 multi-file merge, or dedup `mergeDedupCandidate`), the BookFile attached to record `01KQGD...` was reassigned to a different chapter, but `Book.Title` was never recomputed because it had already been written at import time.
+
+## Suspects ruled out
+
+| Suspect | Status | Why |
+|--------|--------|-----|
+| Tag-reader writing `(track/total)` into Title | RULED OUT | No code formats `(%d/%d)` into any Title field. The `(N/M)` substring traces to the iTunes track `Name` itself, not a Go formatter. |
+| `extractBookFileMetadata` cross-contaminating | RULED OUT | Reads tags from the file at `book.FilePath`; the result populates `BookFile.Title`, not `Book.Title` (per `service.go:1585,1641,1721`). |
+| Scanner title-from-filename | RULED OUT | Scanner-derived titles come from `baseName` of the file path (`scanner.go:917,921`); the literal `(76/85)` doesn't appear in the file path. |
+| AI metadata-apply / batch ops | RULED OUT for this title | The `(76/85)` shape isn't a pattern any AI suggestion or organizer template emits; it's an iTunes-style per-chapter name. |
+| iTunes import (`buildBookFromAlbumGroup`) | **CONFIRMED** | Exact path producing `Book.Title = firstTrack.Name` when Album is empty. |
+
+## Reproduction recipe
+
+Unit-testable via `importer_test.go`. Pseudo-iTunes input:
+```
+Track{Artist: "James Luceno", Album: "", Name: "(76/85) Tarkin: Star Wars (Unabridged)", PersistentID: "..."}
+```
+Run `buildBookFromAlbumGroup` with a single-track group. Result: `Book.Title == "(76/85) Tarkin: Star Wars (Unabridged)"`.
+
+## Fix shipped in this PR (G5a)
+
+`stripChapterPrefix` helper in `internal/itunes/service/importer.go`, applied when falling back from Album to Name:
+- Strips leading `(N/M) `, `(N of M) `, `Chapter N - `, `Track N - `, `Part N - `, `NN - ` patterns.
+- Preserves the rest of the title verbatim.
+- Idempotent / safe on titles with no prefix.
+
+Applied only in the `firstTrack.Album == ""` branch — when Album exists we trust it. We do NOT touch `groupTracksByAlbum`'s grouping key; merging by stripped-Name across chapters is a riskier change tracked as G5b.
+
+Covered by unit tests:
+- `(76/85) Tarkin: Star Wars (Unabridged)` → `Tarkin: Star Wars (Unabridged)`
+- `(76 of 85) Tarkin: Star Wars` → `Tarkin: Star Wars`
+- `Chapter 03 - The Storm` → `The Storm`
+- `The Hobbit` → `The Hobbit` (unchanged)
+
+## Not fixed here
+
+### MAYDEPLOY-G5b — Back-fill existing poisoned rows
+
+Existing PebbleDB has unknown N records whose `Book.Title` contains a `(N/M)` or `Chapter NN` prefix from prior iTunes imports. Need a one-shot maintenance op that:
+1. Scans all books for the prefix patterns.
+2. Strips the prefix and updates `Book.Title`.
+3. Logs old → new for audit.
+
+Estimated scope: ~85 Tarkin records plus an unknown number from other audiobook series imported through iTunes with per-chapter Name fields.
+
+### MAYDEPLOY-G5c — Group-by-stripped-Name in `groupTracksByAlbum`
+
+Current grouping falls back to `track.Name` when Album is empty, producing N book records for an N-chapter book. Better: when Album is empty, use `stripChapterPrefix(track.Name)` as the album key so all 85 Tarkin chapters merge into ONE album group. Deferred because it changes import grouping semantics; risk of merging unrelated tracks that share a stripped Name prefix.
+
+## File references
+
+- `internal/itunes/service/importer.go:844-863` — `groupTracksByAlbum`
+- `internal/itunes/service/importer.go:1079-1163` — `buildBookFromAlbumGroup`
+- `internal/scanner/multifile_detector.go:65-86` — sequential-number regex patterns (basis for `stripChapterPrefix`)

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.0.4
+// version: 1.0.5
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 
 package itunesservice
@@ -1097,7 +1097,12 @@ func (imp *Importer) buildBookFromAlbumGroup(group albumGroup, libraryPath strin
 		bookFilePath = imp.commonParentDir(group.tracks, opts)
 	}
 	if title == "" {
-		title = strings.TrimSpace(firstTrack.Name)
+		// Album tag was empty/missing — falling back to the per-chapter track
+		// Name. iTunes audiobook tracks frequently have Names shaped like
+		// "(76/85) Tarkin: Star Wars (Unabridged)" — strip the chapter prefix
+		// so Book.Title doesn't carry a chapter number.
+		// See docs/perf-audit-2026-05-29-g5-title-mismatch.md (MAYDEPLOY-G5a).
+		title = stripChapterPrefix(strings.TrimSpace(firstTrack.Name))
 	}
 	if title == "" {
 		title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))

--- a/internal/itunes/service/strip_chapter_prefix.go
+++ b/internal/itunes/service/strip_chapter_prefix.go
@@ -1,0 +1,65 @@
+// file: internal/itunes/service/strip_chapter_prefix.go
+// version: 1.0.0
+// guid: 4d9e2f1a-7b6c-4e5f-8a3b-2c1d4e5f6a7b
+
+package itunesservice
+
+import (
+	"regexp"
+	"strings"
+)
+
+// chapterPrefixPatterns matches a leading chapter/track marker on an iTunes
+// per-chapter track Name. Order matters — most-specific first. Each pattern
+// is anchored at the start of the string; the matched span is stripped.
+//
+// Examples this catches:
+//
+//	"(76/85) Tarkin: Star Wars (Unabridged)"   → "Tarkin: Star Wars (Unabridged)"
+//	"(76 of 85) Tarkin: Star Wars"             → "Tarkin: Star Wars"
+//	"Chapter 03 - The Storm"                   → "The Storm"
+//	"Chapter 03: The Storm"                    → "The Storm"
+//	"Track 12 - Foo"                           → "Foo"
+//	"Part 4 - Bar"                             → "Bar"
+//	"03 - Foo"                                 → "Foo"
+//
+// Does NOT touch titles without a leading marker (e.g. "The Hobbit").
+var chapterPrefixPatterns = []*regexp.Regexp{
+	// "(76 of 85)" / "(76/85)" / "(76-85)" / "(76_85)" with trailing space
+	regexp.MustCompile(`^\(\s*\d{1,4}\s*(?:of|[\s_\-\/])\s*\d{1,4}\s*\)\s+`),
+	// "Chapter 03 - " / "Chapter 03: " / "Chapter 03 "
+	regexp.MustCompile(`(?i)^chapter[\s_\-]+\d{1,4}\s*[\-:\s]\s*`),
+	// "Track 12 - " / "Track 12: "
+	regexp.MustCompile(`(?i)^track[\s_\-]+\d{1,4}\s*[\-:\s]\s*`),
+	// "Part 4 - " / "Part 4 of 8 - "
+	regexp.MustCompile(`(?i)^part[\s_\-]+\d{1,4}(?:\s+of\s+\d{1,4})?\s*[\-:\s]\s*`),
+	// Leading bare number with delimiter: "03 - " / "002. " / "1: "
+	regexp.MustCompile(`^\d{1,4}\s*[\-:\.]\s+`),
+}
+
+// stripChapterPrefix removes a leading chapter/track marker from an iTunes
+// per-chapter track Name, so the residue can be used as a Book.Title without
+// the "(76/85)" / "Chapter 03" prefix leaking in. Idempotent; safe to call on
+// titles that have no prefix.
+//
+// Called by buildBookFromAlbumGroup ONLY when falling back from an empty
+// Album tag to track.Name — when Album is present we trust it verbatim.
+//
+// See docs/perf-audit-2026-05-29-g5-title-mismatch.md for the root-cause
+// analysis that motivated this helper (MAYDEPLOY-G5a).
+func stripChapterPrefix(title string) string {
+	s := strings.TrimSpace(title)
+	if s == "" {
+		return s
+	}
+	// Apply each pattern at most once; first match wins. The patterns are
+	// mutually exclusive in practice (a title can't start with both "(N/M)"
+	// and "Chapter N"), so one pass is sufficient.
+	for _, re := range chapterPrefixPatterns {
+		if loc := re.FindStringIndex(s); loc != nil && loc[0] == 0 {
+			s = strings.TrimSpace(s[loc[1]:])
+			break
+		}
+	}
+	return s
+}

--- a/internal/itunes/service/strip_chapter_prefix_test.go
+++ b/internal/itunes/service/strip_chapter_prefix_test.go
@@ -1,0 +1,61 @@
+// file: internal/itunes/service/strip_chapter_prefix_test.go
+// version: 1.0.0
+// guid: 5e8a3b9c-2d4f-4a1b-8c6d-9e0f1a2b3c4d
+
+package itunesservice
+
+import "testing"
+
+func TestStripChapterPrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"paren_slash", "(76/85) Tarkin: Star Wars (Unabridged)", "Tarkin: Star Wars (Unabridged)"},
+		{"paren_of", "(76 of 85) Tarkin: Star Wars", "Tarkin: Star Wars"},
+		{"paren_dash", "(1-12) Foundation", "Foundation"},
+		{"paren_underscore", "(03_85) Tarkin", "Tarkin"},
+		{"paren_leading_one", "(1/85) Tarkin: Star Wars", "Tarkin: Star Wars"},
+		{"chapter_dash", "Chapter 03 - The Storm", "The Storm"},
+		{"chapter_colon", "Chapter 03: The Storm", "The Storm"},
+		{"chapter_space", "Chapter 12 The Storm", "The Storm"},
+		{"chapter_underscore", "Chapter_05 - Foo", "Foo"},
+		{"track_dash", "Track 12 - Foo", "Foo"},
+		{"part_dash", "Part 4 - Bar", "Bar"},
+		{"part_of", "Part 1 of 8 - Bar", "Bar"},
+		{"bare_dash", "03 - Foo", "Foo"},
+		{"bare_dot", "002. Foo", "Foo"},
+		{"bare_colon", "1: Foo", "Foo"},
+		{"no_prefix", "The Hobbit", "The Hobbit"},
+		{"no_prefix_paren", "Tarkin (Unabridged)", "Tarkin (Unabridged)"},
+		{"empty", "", ""},
+		{"whitespace_only", "   ", ""},
+		{"idempotent", "Tarkin: Star Wars (Unabridged)", "Tarkin: Star Wars (Unabridged)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripChapterPrefix(c.in)
+			if got != c.want {
+				t.Errorf("stripChapterPrefix(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestStripChapterPrefix_Idempotent(t *testing.T) {
+	// Applying twice should yield the same result as applying once.
+	inputs := []string{
+		"(76/85) Tarkin: Star Wars (Unabridged)",
+		"Chapter 03 - The Storm",
+		"03 - Foo",
+		"The Hobbit",
+	}
+	for _, in := range inputs {
+		once := stripChapterPrefix(in)
+		twice := stripChapterPrefix(once)
+		if once != twice {
+			t.Errorf("not idempotent: %q → %q → %q", in, once, twice)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Root cause for MAYDEPLOY-G5: when iTunes Album tag is empty, `buildBookFromAlbumGroup` falls back to `firstTrack.Name` — for audiobook libraries with per-chapter Names like \`(76/85) Tarkin: Star Wars (Unabridged)\` this writes the chapter prefix into \`Book.Title\` verbatim.
- Adds \`stripChapterPrefix\` helper that strips \`(N/M)\`, \`(N of M)\`, \`Chapter N\`, \`Track N\`, \`Part N\`, and bare-number prefixes, applied only in the empty-Album fallback branch.
- The "file is chapter 4 but title says 76" mismatch on \`01KQGDQTJ44FCAPW5Z9D2KNQDE\` is a second-order artifact from a later organizer/dedup reassignment of the BookFile; the title was poisoned at import time.
- Full root-cause analysis: \`docs/perf-audit-2026-05-29-g5-title-mismatch.md\`.

## Follow-ups left in TODO.md
- **G5b** Back-fill existing poisoned \`Book.Title\` rows in PebbleDB (~85 Tarkin records + unknown N more).
- **G5c** Tighten \`groupTracksByAlbum\` to key on \`stripChapterPrefix(track.Name)\` when Album is empty, so chapters merge into one book at import. Deferred — risks merging unrelated tracks.

## Test plan
- [x] \`go test ./internal/itunes/service/\` — full suite passes (existing + 20 new sub-tests).
- [x] \`go build ./...\` — clean.
- [ ] Manual verify: re-import iTunes library on a test instance, confirm new Tarkin-style books land with clean titles.
- [ ] Reviewer signoff before merge — DO NOT auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)