### PR TITLE
fix(ops): disable Isolate again — Pebble single-writer blocks child re-open

### DIFF
--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -40,7 +40,7 @@ func (p *Plugin) backfillDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		Schedule:        &sched,
-		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         24 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -41,7 +41,7 @@ func (p *Plugin) fingerprintRescanDef() sdk.OperationDef {
 		Description:     "Generates per-file fingerprints on demand with scope and force options.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
-		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         12 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/acoustid/scan.go
+++ b/internal/plugins/acoustid/scan.go
@@ -24,7 +24,7 @@ func (p *Plugin) scanDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "acoustid.scan",
-		Isolate:         true, // uses ffmpeg/fpcalc subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         6 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,

--- a/internal/plugins/itunes/import.go
+++ b/internal/plugins/itunes/import.go
@@ -20,7 +20,7 @@ func (p *Plugin) importDef() sdk.OperationDef {
 		Plugin:                "itunes",
 		DisplayName:           "iTunes Library Import",
 		Description:           "Import audiobooks from the iTunes/Music library into the organizer.",
-		Isolate:               true, // runs in subprocess (re-exec) — wired via cmd.RunOperationRunner
+		Isolate:               false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		ResumePolicy:          sdk.ResumeRestart,
 		DefaultPriority:       sdk.PriorityNormal,
 		Cancellable:           true,

--- a/internal/plugins/maintenance/backfill.go
+++ b/internal/plugins/maintenance/backfill.go
@@ -54,7 +54,7 @@ func (p *Plugin) movementAtomCleanupDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.movement-atom-cleanup",
 		Cancellable:     false,
-		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         60 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -79,7 +79,7 @@ func (p *Plugin) malformedM4BRemuxDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-remux",
 		Cancellable:     false,
-		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         120 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
@@ -106,7 +106,7 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.malformed-m4b-transcode",
 		Cancellable:     true,
-		Isolate:         true, // uses ffmpeg subprocess — runs in re-exec child
+		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         6 * time.Hour,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},


### PR DESCRIPTION
Hotfix. PR #1172 wired subprocess child-mode but the child can't open Pebble while parent holds the lock. Every Isolate op fails immediately with 'resource temporarily unavailable'. Flipping Isolate:false again until we have a real RPC bridge or read-only child path.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)