### PR TITLE
perf(cache): bound LRU caches by entry count (I4)

### DIFF
--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service.go
-// version: 1.28.0
+// version: 1.29.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-05-20
+// last-edited: 2026-05-29
 
 package audiobooks
 
@@ -102,8 +102,10 @@ func (svc *AudiobookService) SetITunesEnqueuer(e ITunesEnqueuer) {
 func NewAudiobookService(store audiobookStore) *AudiobookService {
 	return &AudiobookService{
 		store:     store,
-		bookCache: cache.New[*database.Book]("book", 24*time.Hour),
-		listCache: cache.New[[]database.Book]("audiobook_list", 24*time.Hour),
+		// MAYDEPLOY-I4: cap entry count via LRU so 24h TTL doesn't allow
+		// unbounded growth of full Book payloads.
+		bookCache: cache.NewWithLimit[*database.Book]("book", 24*time.Hour, 5000),
+		listCache: cache.NewWithLimit[[]database.Book]("audiobook_list", 24*time.Hour, 500),
 	}
 }
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,10 +1,11 @@
 // file: internal/cache/cache_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 
 package cache
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -104,6 +105,33 @@ func TestLRUCapacityEviction(t *testing.T) {
 	for _, k := range []string{"a", "c", "d"} {
 		if _, ok := c.Get(k); !ok {
 			t.Fatalf("expected %s to remain after capacity eviction", k)
+		}
+	}
+}
+
+// TestLRUCapacityBoundedAtN inserts N+10 entries with no recency touches and
+// verifies the cap is enforced: only N entries remain, the oldest 10 are
+// evicted, and the newest N are retained. This is the MAYDEPLOY-I4 contract
+// that prevents unbounded growth of the list/facets/dedup/book caches.
+func TestLRUCapacityBoundedAtN(t *testing.T) {
+	const N = 50
+	c := NewWithLimit[int]("test_lru_n_plus_10", time.Minute, N)
+	for i := 0; i < N+10; i++ {
+		c.Set(strconv.Itoa(i), i)
+	}
+	if got := c.Len(); got != N {
+		t.Fatalf("expected exactly %d entries after N+10 inserts, got %d", N, got)
+	}
+	// Oldest 10 (keys 0..9) must be evicted.
+	for i := 0; i < 10; i++ {
+		if _, ok := c.Get(strconv.Itoa(i)); ok {
+			t.Fatalf("expected key %d to be evicted (oldest)", i)
+		}
+	}
+	// Newest N (keys 10..N+9) must be retained.
+	for i := 10; i < N+10; i++ {
+		if _, ok := c.Get(strconv.Itoa(i)); !ok {
+			t.Fatalf("expected key %d to be retained", i)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.20.0
+// version: 2.21.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-20
+// last-edited: 2026-05-29
 
 package server
 
@@ -332,11 +332,15 @@ func NewServer(store database.Store) *Server {
 		audiobookUpdateService: NewAudiobookUpdateService(resolvedStore),
 		authorSeriesService:    audiobookspkg.NewAuthorSeriesService(resolvedStore),
 		importService:          importer.NewImportService(resolvedStore),
-		dedupCache:             cache.New[gin.H]("dedup", 24*time.Hour),
-		listCache:              cache.New[gin.H]("list", 24*time.Hour),
-		facetsCache:            cache.New[gin.H]("facets", 24*time.Hour),
-		authorsCache:           cache.New[gin.H]("authors", 24*time.Hour),
-		seriesCache:            cache.New[gin.H]("series", 24*time.Hour),
+		// MAYDEPLOY-I4: caches were bounded only by 24h TTL and could grow
+		// to hundreds of thousands of entries (estimated 0.5–1.5 GB) on heavy
+		// use. Cap entry count via LRU; defaults are conservative starting
+		// points — watch cache_evictions_total{reason="capacity"} in prod.
+		dedupCache:   cache.NewWithLimit[gin.H]("dedup", 24*time.Hour, 1000),
+		listCache:    cache.NewWithLimit[gin.H]("list", 24*time.Hour, 2000),
+		facetsCache:  cache.NewWithLimit[gin.H]("facets", 24*time.Hour, 100),
+		authorsCache: cache.NewWithLimit[gin.H]("authors", 24*time.Hour, 500),
+		seriesCache:  cache.NewWithLimit[gin.H]("series", 24*time.Hour, 500),
 		// olService, updater, updateScheduler are container-built;
 		// wireServerFromContainer populates the fields.
 		diagnosticsService: diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),


### PR DESCRIPTION
## Summary

MAYDEPLOY-I4 — the 24h `list`, `facets`, `dedup`, `authors`, `series`, `book`, and `audiobook_list` caches were bounded only by TTL and held full `gin.H` / `Book` payloads. Estimated 0.5–1.5 GB unbounded growth on heavy use.

The cache implementation already supports an LRU capacity bound via `NewWithLimit` (`container/list` doubly-linked list + map, capacity eviction emits `cache_evictions_total{reason="capacity"}`). This PR plumbs conservative caps into every server-side cache:

| cache | cap | notes |
|---|---|---|
| `server.dedupCache` | 1000 | gin.H |
| `server.listCache` | 2000 | ~200 KB/page → ~400 MB worst case |
| `server.facetsCache` | 100 | small payloads |
| `server.authorsCache` | 500 | |
| `server.seriesCache` | 500 | |
| `service.bookCache` | 5000 | `*database.Book` |
| `service.listCache` (`audiobook_list`) | 500 | `[]database.Book` |

Capacity evictions are counted; watch `cache_evictions_total{reason="capacity"}` in prod to decide if any cap is too tight. Adds an explicit N+10 → N retention unit test to lock the contract.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cache/... -count=1` passes (incl. new `TestLRUCapacityBoundedAtN`)
- [ ] In prod, observe `cache_evictions_total{reason="capacity"}` rate per cache; raise caps if a hot cache evicts more than ~5% of sets sustained
- [ ] Confirm RSS no longer trends upward in long-running deploys (the original I4 symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)