### PR TITLE
perf(deluge): memdb fastpath for needing-deluge-import (H2+H8)

### DIFF
--- a/internal/database/memdb_indexers.go
+++ b/internal/database/memdb_indexers.go
@@ -217,6 +217,47 @@ func (i *effectiveIntFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	}
 }
 
+// nonEmptyStringFieldIndex indexes a struct field of type string, skipping
+// rows where the value is the empty string. The schema must set
+// AllowMissing=true. Useful for sparse predicates like "DelugeHash != \"\""
+// where we want an index over only the small subset of matching rows rather
+// than scanning every row in the table.
+type nonEmptyStringFieldIndex struct{ Field string }
+
+func (i *nonEmptyStringFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	v := reflect.ValueOf(obj)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	fv := v.FieldByName(i.Field)
+	if !fv.IsValid() {
+		return false, nil, fmt.Errorf("nonEmptyStringFieldIndex: field %q missing", i.Field)
+	}
+	if fv.Kind() != reflect.String {
+		return false, nil, fmt.Errorf("nonEmptyStringFieldIndex: field %q is not a string", i.Field)
+	}
+	s := fv.String()
+	if s == "" {
+		return false, nil, nil
+	}
+	return true, []byte(s + "\x00"), nil
+}
+
+func (i *nonEmptyStringFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("nonEmptyStringFieldIndex: must provide exactly one arg")
+	}
+	switch v := args[0].(type) {
+	case string:
+		if v == "" {
+			return nil, fmt.Errorf("nonEmptyStringFieldIndex: cannot query with empty string")
+		}
+		return []byte(v + "\x00"), nil
+	default:
+		return nil, fmt.Errorf("nonEmptyStringFieldIndex: unsupported arg type %T", args[0])
+	}
+}
+
 // plainBoolFieldIndex indexes a struct field of type bool (not pointer).
 type plainBoolFieldIndex struct{ Field string }
 
@@ -329,6 +370,8 @@ var (
 	_ memdb.Indexer       = (*effectiveIntFieldIndex)(nil)
 	_ memdb.SingleIndexer = (*plainBoolFieldIndex)(nil)
 	_ memdb.Indexer       = (*plainBoolFieldIndex)(nil)
+	_ memdb.SingleIndexer = (*nonEmptyStringFieldIndex)(nil)
+	_ memdb.Indexer       = (*nonEmptyStringFieldIndex)(nil)
 	_ memdb.SingleIndexer = titleSortIndex{}
 	_ memdb.Indexer       = titleSortIndex{}
 	_ memdb.PrefixIndexer = titleSortIndex{}

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -656,6 +656,36 @@ func (m *MemStore) GetAllBookFiles() ([]BookFile, error) {
 	return files, nil
 }
 
+// GetBookFilesNeedingDelugeImport returns BookFiles that have a non-empty
+// DelugeHash AND have not yet been imported (ImportedFromDelugeAt is nil).
+//
+// Walks the sparse memdb deluge_hash index — only rows with a non-empty
+// DelugeHash exist in that index — then post-filters on the
+// ImportedFromDelugeAt nil check. This is O(deluge-hash-present rows), not
+// O(308K), which mirrors the GetAllBookFiles fastpath from PR #1166 but
+// trims the working set to the deluge-relevant subset for the discovery
+// handler and centralization plugin (H2 + H8).
+func (m *MemStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+	iter, err := txn.Get(memTableBookFiles, memIdxDelugeHash)
+	if err != nil {
+		return nil, fmt.Errorf("memdb deluge_hash scan: %w", err)
+	}
+	var out []BookFile
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		bf, ok := obj.(*BookFile)
+		if !ok {
+			continue
+		}
+		if bf.ImportedFromDelugeAt != nil {
+			continue
+		}
+		out = append(out, *bf)
+	}
+	return out, nil
+}
+
 func paginate[T any](in []T, limit, offset int) []T {
 	if offset < 0 {
 		offset = 0

--- a/internal/database/memdb_reads_test.go
+++ b/internal/database/memdb_reads_test.go
@@ -248,6 +248,44 @@ func TestMemStore_CountFiles(t *testing.T) {
 	}
 }
 
+func TestMemStore_GetBookFilesNeedingDelugeImport(t *testing.T) {
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	now := time.Now()
+	files := []BookFile{
+		// Match: has DelugeHash, not yet imported.
+		{ID: "f1", BookID: "b1", DelugeHash: "aaa"},
+		// Match: has DelugeHash, not yet imported.
+		{ID: "f2", BookID: "b1", DelugeHash: "bbb"},
+		// Skip: DelugeHash present but already imported.
+		{ID: "f3", BookID: "b2", DelugeHash: "ccc", ImportedFromDelugeAt: &now},
+		// Skip: no DelugeHash (not in the sparse index at all).
+		{ID: "f4", BookID: "b3"},
+		// Skip: empty DelugeHash, with ImportedFromDelugeAt nil — must not
+		// leak into results just because the post-filter passes.
+		{ID: "f5", BookID: "b4", DelugeHash: ""},
+	}
+	seedMemStore(t, m, nil, files, nil, nil)
+
+	got, err := m.GetBookFilesNeedingDelugeImport()
+	if err != nil {
+		t.Fatalf("GetBookFilesNeedingDelugeImport: %v", err)
+	}
+	gotIDs := map[string]bool{}
+	for _, f := range got {
+		gotIDs[f.ID] = true
+	}
+	if len(gotIDs) != 2 || !gotIDs["f1"] || !gotIDs["f2"] {
+		ids := []string{}
+		for _, f := range got {
+			ids = append(ids, f.ID)
+		}
+		t.Errorf("expected [f1 f2], got %v", ids)
+	}
+}
+
 func TestMemStore_GetAllAuthorsSeriesImportPaths_Sort(t *testing.T) {
 	m, err := NewMemStore()
 	if err != nil {

--- a/internal/database/memdb_schema.go
+++ b/internal/database/memdb_schema.go
@@ -41,6 +41,7 @@ const (
 	memIdxAliasName         = "alias_name"
 	memIdxHash              = "hash"
 	memIdxWorkAuthor        = "author_id"
+	memIdxDelugeHash        = "deluge_hash"
 )
 
 // memdbSchema returns the complete schema for the in-memory query layer.
@@ -175,6 +176,16 @@ func memdbSchema() *memdb.DBSchema {
 						Name:         memIdxFilePath,
 						AllowMissing: true,
 						Indexer:      &memdb.StringFieldIndex{Field: "FilePath"},
+					},
+					memIdxDelugeHash: {
+						// Sparse: only rows with non-empty DelugeHash are
+						// indexed. Backs GetBookFilesNeedingDelugeImport
+						// (deluge discovery handler + centralization plugin)
+						// so they don't have to scan all 308K BookFiles to
+						// find the small subset that came from Deluge.
+						Name:         memIdxDelugeHash,
+						AllowMissing: true,
+						Indexer:      &nonEmptyStringFieldIndex{Field: "DelugeHash"},
 					},
 				},
 			},

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -8510,9 +8510,17 @@ func (s *PebbleStore) getAllBookFilesPebbleScan() ([]BookFile, error) {
 
 // GetBookFilesNeedingDelugeImport returns book_files that have a non-empty
 // deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
-// PebbleStore is not the primary backend for deluge operations, so this returns
-// results by filtering GetAllBookFiles in memory.
+//
+// When memdb is published, walks the sparse deluge_hash index — only rows
+// where DelugeHash is non-empty are indexed — and post-filters on the
+// ImportedFromDelugeAt nil check. Drops the deluge discovery handler +
+// centralization plugin from a 308K full BookFile scan to walking just the
+// (much smaller) deluge-touched subset (H2 + H8). Pebble full-scan retained
+// as the cold-start fallback.
 func (s *PebbleStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+	if s.UseMemDB && s.mem() != nil {
+		return s.mem().GetBookFilesNeedingDelugeImport()
+	}
 	all, err := s.GetAllBookFiles()
 	if err != nil {
 		return nil, err

--- a/internal/plugins/deluge/centralization.go
+++ b/internal/plugins/deluge/centralization.go
@@ -62,19 +62,17 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 
 	_ = reporter.UpdateProgress(0, 100, "Loading Deluge-imported files...")
 
-	// Fetch all BookFiles that have a DelugeHash set (these were imported from Deluge).
-	bookFiles, err := p.store.GetAllBookFiles()
+	// Pull only BookFiles with non-empty DelugeHash AND not yet imported.
+	// Centralized store method routes through the memdb sparse deluge_hash
+	// index when published, avoiding the full 308K BookFile scan.
+	pending, err := p.store.GetBookFilesNeedingDelugeImport()
 	if err != nil {
-		return fmt.Errorf("load book files: %w", err)
+		return fmt.Errorf("load deluge-pending book files: %w", err)
 	}
 
-	// Filter to only those with DelugeHash that haven't been imported yet.
-	var toImport []*database.BookFile
-	for i := range bookFiles {
-		bf := &bookFiles[i]
-		if bf.DelugeHash != "" && bf.ImportedFromDelugeAt == nil {
-			toImport = append(toImport, bf)
-		}
+	toImport := make([]*database.BookFile, 0, len(pending))
+	for i := range pending {
+		toImport = append(toImport, &pending[i])
 	}
 
 	total := len(toImport)

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
-	"github.com/jdfalk/audiobook-organizer/internal/database"
 	delugeclient "github.com/jdfalk/audiobook-organizer/internal/deluge"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/importer"
@@ -131,18 +130,13 @@ func (s *Server) handleDiscoveryImport(c *gin.Context) {
 		return
 	}
 
-	files, err := store.GetAllBookFiles()
+	// Centralized store method — uses the memdb deluge_hash fastpath
+	// when published (avoids loading all 308K BookFiles just to filter
+	// to the small Deluge-touched subset).
+	pending, err := store.GetBookFilesNeedingDelugeImport()
 	if err != nil {
 		httputil.InternalError(c, "failed to load book files", err)
 		return
-	}
-
-	var pending []database.BookFile
-	for i := range files {
-		f := &files[i]
-		if f.DelugeHash != "" && f.ImportedFromDelugeAt == nil {
-			pending = append(pending, *f)
-		}
 	}
 
 	if req.MaxBooks > 0 && len(pending) > req.MaxBooks {


### PR DESCRIPTION
## Summary

- Adds a sparse memdb index on `BookFile.DelugeHash` (only rows with non-empty hash are indexed) plus a new `nonEmptyStringFieldIndex` indexer.
- Implements `(*MemStore).GetBookFilesNeedingDelugeImport`: walks the deluge_hash index, post-filters on `ImportedFromDelugeAt == nil`. O(deluge-touched rows) instead of O(308K).
- Routes `PebbleStore.GetBookFilesNeedingDelugeImport` through memdb when published (mirrors the #1166 GetAllBookFiles fastpath); Pebble full-scan retained as cold-start fallback.
- Switches the deluge discovery HTTP handler (`internal/server/deluge_discovery.go`) and the deluge centralization plugin (`internal/plugins/deluge/centralization.go`) from inlined `GetAllBookFiles` + filter loops to the centralized store method, so both pick up the fastpath automatically.

Folds MAYDEPLOY-H2 (discovery handler) and H8 (centralization plugin) — both call sites had the same hot full-scan pattern.

## Test plan

- [x] `go test ./internal/database/ -run TestMemStore_GetBookFilesNeedingDelugeImport` (new unit test covering: match, already-imported skip, no-hash skip, empty-hash skip)
- [x] `go test ./internal/plugins/deluge/...` clean
- [x] `go test ./internal/server/ -run Deluge` clean
- [x] `go build ./...` clean
- [ ] Production: verify deluge discovery POST `/api/v1/deluge/discover/import` returns the same set as before but with dramatically reduced latency on the 308K-file library

🤖 Generated with [Claude Code](https://claude.com/claude-code)