### PR TITLE
perf(works): fix N+1 + paginate listWork (H3)

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -46,6 +46,7 @@ type WorkStore interface {
 	UpdateWork(id string, work *Work) (*Work, error)
 	DeleteWork(id string) error
 	GetBooksByWorkID(workID string) ([]Book, error)
+	GetAllWorkBookCounts() (map[string]int, error)
 }
 
 // SessionStore covers authenticated session CRUD.

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -183,6 +183,32 @@ func (m *MemStore) GetAllAuthorBookCounts() (map[int]int, error) {
 	return out, nil
 }
 
+// GetAllWorkBookCounts returns map[workID] → count of primary, not-deleted
+// books for which the work is the WorkID on the Book row. Mirrors
+// GetAllAuthorBookCounts; built with a single memdb iteration so callers
+// avoid N+1 GetBooksByWorkID lookups on a 50K-work corpus.
+func (m *MemStore) GetAllWorkBookCounts() (map[string]int, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	out := make(map[string]int)
+	iter, err := txn.Get(memTableBooks, memIdxIsPrimaryVersion, true)
+	if err != nil {
+		return nil, fmt.Errorf("memdb books scan: %w", err)
+	}
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		b := obj.(*Book)
+		if b.WorkID == nil || *b.WorkID == "" {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		out[*b.WorkID]++
+	}
+	return out, nil
+}
+
 // GetAllSeriesFileCounts returns map[seriesID] → count of non-missing
 // book_files that belong to a primary book in that series.
 func (m *MemStore) GetAllSeriesFileCounts() (map[int]int, error) {

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -749,6 +749,10 @@ func (m *MockStore) GetAllAuthorBookCounts() (map[int]int, error) {
 	return map[int]int{}, nil
 }
 
+func (m *MockStore) GetAllWorkBookCounts() (map[string]int, error) {
+	return map[string]int{}, nil
+}
+
 func (m *MockStore) GetAllAuthorFileCounts() (map[int]int, error) {
 	return map[int]int{}, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -9904,6 +9904,61 @@ func (_c *MockWorkStore_DeleteWork_Call) RunAndReturn(run func(id string) error)
 	return _c
 }
 
+// GetAllWorkBookCounts provides a mock function for the type MockWorkStore
+func (_mock *MockWorkStore) GetAllWorkBookCounts() (map[string]int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllWorkBookCounts")
+	}
+
+	var r0 map[string]int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (map[string]int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() map[string]int); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]int)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWorkStore_GetAllWorkBookCounts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllWorkBookCounts'
+type MockWorkStore_GetAllWorkBookCounts_Call struct {
+	*mock.Call
+}
+
+// GetAllWorkBookCounts is a helper method to define mock.On call
+func (_e *MockWorkStore_Expecter) GetAllWorkBookCounts() *MockWorkStore_GetAllWorkBookCounts_Call {
+	return &MockWorkStore_GetAllWorkBookCounts_Call{Call: _e.mock.On("GetAllWorkBookCounts")}
+}
+
+func (_c *MockWorkStore_GetAllWorkBookCounts_Call) Run(run func()) *MockWorkStore_GetAllWorkBookCounts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockWorkStore_GetAllWorkBookCounts_Call) Return(stringToInt map[string]int, err error) *MockWorkStore_GetAllWorkBookCounts_Call {
+	_c.Call.Return(stringToInt, err)
+	return _c
+}
+
+func (_c *MockWorkStore_GetAllWorkBookCounts_Call) RunAndReturn(run func() (map[string]int, error)) *MockWorkStore_GetAllWorkBookCounts_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllWorks provides a mock function for the type MockWorkStore
 func (_mock *MockWorkStore) GetAllWorks() ([]database.Work, error) {
 	ret := _mock.Called()
@@ -31351,6 +31406,61 @@ func (_c *MockStore_GetAllUserPreferences_Call) Return(userPreferences []databas
 }
 
 func (_c *MockStore_GetAllUserPreferences_Call) RunAndReturn(run func() ([]database.UserPreference, error)) *MockStore_GetAllUserPreferences_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllWorkBookCounts provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllWorkBookCounts() (map[string]int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllWorkBookCounts")
+	}
+
+	var r0 map[string]int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (map[string]int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() map[string]int); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]int)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAllWorkBookCounts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllWorkBookCounts'
+type MockStore_GetAllWorkBookCounts_Call struct {
+	*mock.Call
+}
+
+// GetAllWorkBookCounts is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetAllWorkBookCounts() *MockStore_GetAllWorkBookCounts_Call {
+	return &MockStore_GetAllWorkBookCounts_Call{Call: _e.mock.On("GetAllWorkBookCounts")}
+}
+
+func (_c *MockStore_GetAllWorkBookCounts_Call) Run(run func()) *MockStore_GetAllWorkBookCounts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAllWorkBookCounts_Call) Return(stringToInt map[string]int, err error) *MockStore_GetAllWorkBookCounts_Call {
+	_c.Call.Return(stringToInt, err)
+	return _c
+}
+
+func (_c *MockStore_GetAllWorkBookCounts_Call) RunAndReturn(run func() (map[string]int, error)) *MockStore_GetAllWorkBookCounts_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1872,6 +1872,52 @@ func (p *PebbleStore) GetAllAuthorBookCounts() (map[int]int, error) {
 	return counts, nil
 }
 
+// GetAllWorkBookCounts returns map[workID] → count of primary, not-deleted
+// books per work. Mirrors GetAllAuthorBookCounts; used to avoid N+1
+// GetBooksByWorkID lookups when listing/aggregating works.
+func (p *PebbleStore) GetAllWorkBookCounts() (map[string]int, error) {
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().GetAllWorkBookCounts()
+	}
+	counts := make(map[string]int)
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") {
+			continue
+		}
+		parts := strings.Split(key, ":")
+		if len(parts) != 2 {
+			continue
+		}
+
+		var b Book
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.WorkID == nil || *b.WorkID == "" {
+			continue
+		}
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		counts[*b.WorkID]++
+	}
+
+	return counts, nil
+}
+
 // GetAllAuthorFileCounts returns the number of audio files per author.
 // Uses the in-memory query layer when enabled, otherwise the Pebble fallback.
 func (p *PebbleStore) GetAllAuthorFileCounts() (map[int]int, error) {

--- a/internal/database/sqlite_store_books.go
+++ b/internal/database/sqlite_store_books.go
@@ -1174,6 +1174,31 @@ func (s *SQLiteStore) GetBooksByAuthorIDWithRole(authorID int) ([]Book, error) {
 	return books, rows.Err()
 }
 
+// GetAllWorkBookCounts returns map[workID] → count of primary, not-deleted
+// books per work in a single query, avoiding N+1 GetBooksByWorkID calls.
+func (s *SQLiteStore) GetAllWorkBookCounts() (map[string]int, error) {
+	rows, err := s.db.Query(`SELECT work_id, COUNT(*)
+		FROM books
+		WHERE work_id IS NOT NULL AND work_id != ''
+		  AND COALESCE(marked_for_deletion, 0) = 0
+		  AND COALESCE(is_primary_version, 1) = 1
+		GROUP BY work_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	counts := make(map[string]int)
+	for rows.Next() {
+		var workID string
+		var count int
+		if err := rows.Scan(&workID, &count); err != nil {
+			return nil, err
+		}
+		counts[workID] = count
+	}
+	return counts, rows.Err()
+}
+
 func (s *SQLiteStore) GetAllAuthorBookCounts() (map[int]int, error) {
 	rows, err := s.db.Query(`SELECT ba.author_id, COUNT(DISTINCT ba.book_id)
 		FROM book_authors ba

--- a/internal/server/entities_handlers.go
+++ b/internal/server/entities_handlers.go
@@ -107,23 +107,44 @@ func (s *Server) listWorkBooks(c *gin.Context) {
 	httputil.RespondWithOK(c, gin.H{"items": books, "count": len(books)})
 }
 
-// listWork returns all work items (audiobooks grouped by work entity)
+// listWork returns work items (audiobooks grouped by work entity), paginated.
+// Uses GetAllWorkBookCounts to compute book counts in a single pass instead of
+// per-work GetBooksByWorkID calls (N+1 on a 50K-work corpus). Books for each
+// work in the page are still fetched individually so callers that need the
+// books slice continue to work; pagination bounds the per-request cost.
 func (s *Server) listWork(c *gin.Context) {
 	if s.Store() == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
 
-	// Get all works
+	params := httputil.ParsePaginationParams(c)
+
 	works, err := s.Store().GetAllWorks()
 	if err != nil {
 		httputil.RespondWithInternalError(c, "failed to retrieve works")
 		return
 	}
 
-	// For each work, get associated books
-	items := make([]map[string]any, 0, len(works))
-	for _, work := range works {
+	counts, err := s.Store().GetAllWorkBookCounts()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "failed to retrieve work book counts")
+		return
+	}
+
+	total := len(works)
+	start := params.Offset
+	if start > total {
+		start = total
+	}
+	end := start + params.Limit
+	if end > total {
+		end = total
+	}
+	page := works[start:end]
+
+	items := make([]map[string]any, 0, len(page))
+	for _, work := range page {
 		books, err := s.Store().GetBooksByWorkID(work.ID)
 		if err != nil {
 			books = []database.Book{}
@@ -133,18 +154,22 @@ func (s *Server) listWork(c *gin.Context) {
 			"id":         work.ID,
 			"title":      work.Title,
 			"author_id":  work.AuthorID,
-			"book_count": len(books),
+			"book_count": counts[work.ID],
 			"books":      books,
 		})
 	}
 
 	httputil.RespondWithOK(c, gin.H{
-		"items": items,
-		"total": len(items),
+		"items":  items,
+		"total":  total,
+		"limit":  params.Limit,
+		"offset": params.Offset,
 	})
 }
 
-// getWorkStats returns statistics about work items
+// getWorkStats returns statistics about work items. Uses GetAllWorkBookCounts
+// to compute per-work counts in a single store call instead of N+1
+// GetBooksByWorkID lookups.
 func (s *Server) getWorkStats(c *gin.Context) {
 	if s.Store() == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
@@ -157,16 +182,18 @@ func (s *Server) getWorkStats(c *gin.Context) {
 		return
 	}
 
+	counts, err := s.Store().GetAllWorkBookCounts()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "failed to retrieve work book counts")
+		return
+	}
+
 	totalWorks := len(works)
 	totalBooks := 0
 	worksWithMultipleEditions := 0
 
 	for _, work := range works {
-		books, err := s.Store().GetBooksByWorkID(work.ID)
-		if err != nil {
-			continue
-		}
-		bookCount := len(books)
+		bookCount := counts[work.ID]
 		totalBooks += bookCount
 		if bookCount > 1 {
 			worksWithMultipleEditions++

--- a/internal/server/server_versions_and_work_test.go
+++ b/internal/server/server_versions_and_work_test.go
@@ -80,6 +80,7 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	author2 := 2
 	works := []database.Work{{ID: "w1", Title: "Work One", AuthorID: &author1}, {ID: "w2", Title: "Work Two", AuthorID: &author2}}
 	store.EXPECT().GetAllWorks().Return(works, nil)
+	store.EXPECT().GetAllWorkBookCounts().Return(map[string]int{"w1": 2, "w2": 1}, nil)
 	store.EXPECT().GetBooksByWorkID("w1").Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
 	store.EXPECT().GetBooksByWorkID("w2").Return(nil, assert.AnError)
 
@@ -94,8 +95,7 @@ func TestWorkEndpoints_WithMockStore(t *testing.T) {
 	store2 := dbmocks.NewMockStore(t)
 	store2.EXPECT().SetRootDir(mock.Anything).Return()
 	store2.EXPECT().GetAllWorks().Return(works, nil)
-	store2.EXPECT().GetBooksByWorkID("w1").Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
-	store2.EXPECT().GetBooksByWorkID("w2").Return(nil, assert.AnError)
+	store2.EXPECT().GetAllWorkBookCounts().Return(map[string]int{"w1": 2}, nil)
 	server2, cleanup2 := setupTestServerWithStore(t, store2)
 	defer cleanup2()
 


### PR DESCRIPTION
## Summary

- `listWork` and `getWorkStats` previously fetched every work, then called `GetBooksByWorkID` once per work — N+1 over a 50K-work corpus.
- Adds `GetAllWorkBookCounts() map[string]int` to the `WorkStore` interface, mirroring `GetAllAuthorBookCounts`. Implementations in MemStore (single memdb scan), PebbleStore (delegates to memdb when enabled, otherwise full pebble scan), SQLiteStore (single grouped query), and MockStore.
- `getWorkStats` now consults the precomputed map instead of issuing per-work calls.
- `listWork` now paginates via `httputil.ParsePaginationParams` and only fetches book slices for the requested page; book counts come from the precomputed map for accuracy.
- Regenerated mockery mocks; updated `TestWorkEndpoints_WithMockStore` for the new call surface.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/database/... ./internal/server/... -count=1 -timeout 120s` — no new failures (the 5 server failures and the pebble warmup panic reproduce on `main` as well, unrelated)
- [x] `TestWorkEndpoints_WithMockStore` passes against the new mock expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)