### PR TITLE
perf(memdb): drop Works + strip BookFile (I2+I3)

### DIFF
--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -98,24 +98,10 @@ func (m *MemStore) GetAllAuthorAliases() ([]AuthorAlias, error) {
 	return out, nil
 }
 
-// GetAllWorks returns every Work sorted by Title.
-func (m *MemStore) GetAllWorks() ([]Work, error) {
-	txn := m.db.Txn(false)
-	defer txn.Abort()
-
-	iter, err := txn.Get(memTableWorks, memIdxID)
-	if err != nil {
-		return nil, fmt.Errorf("memdb works scan: %w", err)
-	}
-	var out []Work
-	for obj := iter.Next(); obj != nil; obj = iter.Next() {
-		out = append(out, *(obj.(*Work)))
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return strings.ToLower(out[i].Title) < strings.ToLower(out[j].Title)
-	})
-	return out, nil
-}
+// GetAllWorks is intentionally NOT implemented on MemStore — Works are not
+// resident in memdb (dropped to save ~120MB heap across 211K rows). Callers
+// hit PebbleStore.GetAllWorks_Pebble directly via the routing in
+// PebbleStore.GetAllWorks.
 
 // CountFiles returns the total number of non-missing BookFile rows.
 func (m *MemStore) CountFiles() (int, error) {

--- a/internal/database/memdb_schema.go
+++ b/internal/database/memdb_schema.go
@@ -18,7 +18,6 @@ const (
 	memTableImportPaths      = "import_paths"
 	memTableAuthorAliases    = "author_aliases"
 	memTableBlockedHashes    = "blocked_hashes"
-	memTableWorks            = "works"
 )
 
 // Index names.
@@ -41,7 +40,6 @@ const (
 	memIdxEnabled           = "enabled"
 	memIdxAliasName         = "alias_name"
 	memIdxHash              = "hash"
-	memIdxWorkAuthor        = "author_id"
 	memIdxDelugeHash        = "deluge_hash"
 )
 
@@ -333,31 +331,6 @@ func memdbSchema() *memdb.DBSchema {
 				},
 			},
 
-			memTableWorks: {
-				Name: memTableWorks,
-				Indexes: map[string]*memdb.IndexSchema{
-					memIdxID: {
-						Name:    memIdxID,
-						Unique:  true,
-						Indexer: &memdb.StringFieldIndex{Field: "ID"},
-					},
-					memIdxTitle: {
-						Name:         memIdxTitle,
-						AllowMissing: true,
-						Indexer:      &memdb.StringFieldIndex{Field: "Title", Lowercase: true},
-					},
-					memIdxWorkAuthor: {
-						Name:         memIdxWorkAuthor,
-						AllowMissing: true,
-						Indexer:      &nullableIntFieldIndex{Field: "AuthorID"},
-					},
-					memIdxSeriesID: {
-						Name:         memIdxSeriesID,
-						AllowMissing: true,
-						Indexer:      &nullableIntFieldIndex{Field: "SeriesID"},
-					},
-				},
-			},
 		},
 	}
 }

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -44,3 +44,50 @@ func stripBookForMemdb(src *Book) *Book {
 	cp.Series = nil
 	return &cp
 }
+
+// stripBookFileForMemdb returns a shallow copy of `src` with heavy
+// fingerprint-diagnostic fields cleared before memdb insertion. Mirrors the
+// stripBookForMemdb pattern: memdb holds a projection sufficient for indexed
+// iteration and predicate filtering; callers needing the full payload fetch
+// it from Pebble via GetBookFiles(bookID).
+//
+// Memory math (~308K book_files in production):
+//
+//	AcoustIDSeg1..6 (6 strings × ~300-500B each)  → ~60-90 MB total
+//	FingerprintDiagnosticJSON (*string, KB-class) → can dominate when populated
+//	FingerprintFailureReason / Detail (*string)   → small but per-row
+//	FingerprintFailedAt (*time.Time)              → 24B + heap overhead
+//
+// Combined expected drop: ~70 MB.
+//
+// Critical: AcoustIDSeg0 is intentionally NOT stripped. It is read on every
+// /api/v1/audiobooks list response by fingerprint.ComputeFingerprintFields
+// (via the memdb-routed GetBookFilesForIDs path) to compute the per-book
+// fingerprint_status badge. Clearing seg0 would silently make every book
+// report "none".
+//
+// Safe to strip because:
+//   - Seg1..6 + diagnostic fields are only read by acoustid backfill,
+//     fingerprint_diagnosis_handler, and dedup. Backfill and dedup fetch
+//     files via GetBookFiles(bookID), which is Pebble-direct (no memdb).
+//     fingerprint_diagnosis_handler is rerouted in this PR to use
+//     getAllBookFilesPebbleScan() so it also bypasses memdb.
+//   - listBookFiles handler (which exposes seg1..6 in API responses) uses
+//     GetBookFiles(bookID) — Pebble-direct, sees the full payload.
+func stripBookFileForMemdb(src *BookFile) *BookFile {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	cp.AcoustIDSeg1 = ""
+	cp.AcoustIDSeg2 = ""
+	cp.AcoustIDSeg3 = ""
+	cp.AcoustIDSeg4 = ""
+	cp.AcoustIDSeg5 = ""
+	cp.AcoustIDSeg6 = ""
+	cp.FingerprintFailedAt = nil
+	cp.FingerprintFailureReason = nil
+	cp.FingerprintFailureDetail = nil
+	cp.FingerprintDiagnosticJSON = nil
+	return &cp
+}

--- a/internal/database/memdb_sync.go
+++ b/internal/database/memdb_sync.go
@@ -99,7 +99,7 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		if fileErr == nil {
 			for i := range files {
 				bf := files[i]
-				if err := txn.Insert(memTableBookFiles, &bf); err != nil {
+				if err := txn.Insert(memTableBookFiles, stripBookFileForMemdb(&bf)); err != nil {
 					return fmt.Errorf("insert book_file: %w", err)
 				}
 			}
@@ -141,7 +141,7 @@ func (p *PebbleStore) UpsertBookFileToMemDB(bf *BookFile) {
 		return
 	}
 	p.memSync("UpsertBookFile", func(txn memTxn) error {
-		return txn.Insert(memTableBookFiles, bf)
+		return txn.Insert(memTableBookFiles, stripBookFileForMemdb(bf))
 	})
 }
 
@@ -323,28 +323,14 @@ func (p *PebbleStore) DeleteBlockedHashFromMemDB(hash string) {
 }
 
 // ── Work ───────────────────────────────────────────────────────────────────
+//
+// Works are NOT mirrored into memdb (dropped in PR for I2 — 211K rows × ~590B
+// = ~120MB heap saved). The write-through helpers are kept as no-op stubs so
+// existing call sites compile without churn; Pebble remains source of truth.
 
-func (p *PebbleStore) UpsertWorkToMemDB(w *Work) {
-	if w == nil {
-		return
-	}
-	p.memSync("UpsertWork", func(txn memTxn) error {
-		return txn.Insert(memTableWorks, w)
-	})
-}
+func (p *PebbleStore) UpsertWorkToMemDB(w *Work) {}
 
-func (p *PebbleStore) DeleteWorkFromMemDB(id string) {
-	if id == "" {
-		return
-	}
-	p.memSync("DeleteWork", func(txn memTxn) error {
-		obj, err := txn.First(memTableWorks, memIdxID, id)
-		if err == nil && obj != nil {
-			return txn.Delete(memTableWorks, obj)
-		}
-		return nil
-	})
-}
+func (p *PebbleStore) DeleteWorkFromMemDB(id string) {}
 
 // ── Internal helpers ───────────────────────────────────────────────────────
 

--- a/internal/database/memdb_warmup.go
+++ b/internal/database/memdb_warmup.go
@@ -110,6 +110,8 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 	}
 
 	// BookFiles: book_file:<bookID>:<fileID>
+	// Strip AcoustIDSeg1..6 and fingerprint-diagnostic fields before
+	// insertion — see memdb_strip.go. Cuts ~70MB heap across 308K rows.
 	if n, err := warmIter(ctx, p.db, "book_file:", func(key string, val []byte) error {
 		if strings.Count(key, ":") != 2 {
 			return nil
@@ -118,7 +120,7 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		if err := json.Unmarshal(val, &bf); err != nil {
 			return nil
 		}
-		return safeInsert(memTableBookFiles, &bf, key)
+		return safeInsert(memTableBookFiles, stripBookFileForMemdb(&bf), key)
 	}); err != nil {
 		return fmt.Errorf("warmup book_files: %w", err)
 	} else {
@@ -214,18 +216,12 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		counts[memTableBlockedHashes] = n
 	}
 
-	// Works: work:<id>
-	if n, err := warmIter(ctx, p.db, "work:", func(key string, val []byte) error {
-		var w Work
-		if err := json.Unmarshal(val, &w); err != nil {
-			return nil
-		}
-		return safeInsert(memTableWorks, &w, key)
-	}); err != nil {
-		return fmt.Errorf("warmup works: %w", err)
-	} else {
-		counts[memTableWorks] = n
-	}
+	// Works: intentionally NOT warmed into memdb. Works are queried in
+	// <0.1% of requests and a 211K-row × ~590B memdb residency cost
+	// ~120MB of heap for no measurable read-path win. GetAllWorks
+	// now routes through PebbleStore.GetAllWorks_Pebble (a streaming
+	// prefix scan + JSON unmarshal). The scanner uses a single
+	// GetAllWorks at scan start, which is the only meaningful caller.
 
 	txn.Commit()
 
@@ -241,7 +237,6 @@ func (m *MemStore) WarmFromPebble(ctx context.Context, p *PebbleStore) error {
 		"import_paths", counts[memTableImportPaths],
 		"author_aliases", counts[memTableAuthorAliases],
 		"blocked_hashes", counts[memTableBlockedHashes],
-		"works", counts[memTableWorks],
 		"skipped_total", sumInts(skips),
 	)
 	if len(skips) > 0 {

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1138,12 +1138,12 @@ func (p *PebbleStore) GetAllSeriesFileCounts() (map[int]int, error) {
 
 // ---- Work operations (logical title-level grouping) ----
 
-// GetAllWorks returns all works. Uses the in-memory query layer when enabled,
-// otherwise falls back to the Pebble prefix scan.
+// GetAllWorks returns all works by iterating the Pebble "work:" prefix.
+// Works are intentionally NOT mirrored into memdb — 211K rows × ~590B is
+// ~120MB of heap for a query path used in <0.1% of requests. The single
+// meaningful hot caller (scanner-side work lookup) batches one call at
+// scan start, which Pebble handles in tens of milliseconds.
 func (p *PebbleStore) GetAllWorks() ([]Work, error) {
-	if p.UseMemDB && p.mem() != nil {
-		return p.mem().GetAllWorks()
-	}
 	return p.GetAllWorks_Pebble()
 }
 
@@ -9510,7 +9510,11 @@ func (p *PebbleStore) GetAcoustIDStats() (*AcoustIDStats, error) {
 // GetFilesWithFingerprintFailures scans all book_files and returns those where
 // FingerprintFailedAt is set, optionally filtered to a specific reason string.
 func (p *PebbleStore) GetFilesWithFingerprintFailures(reason string, limit, offset int) ([]BookFile, int64, error) {
-	allFiles, err := p.GetAllBookFiles()
+	// Bypass memdb deliberately: memdb-resident BookFiles have their
+	// fingerprint-diagnostic fields stripped (see stripBookFileForMemdb),
+	// so the Failed/Reason/Detail/Diagnostic columns this endpoint
+	// surfaces are only available from Pebble.
+	allFiles, err := p.getAllBookFilesPebbleScan()
 	if err != nil {
 		return nil, 0, fmt.Errorf("GetFilesWithFingerprintFailures: %w", err)
 	}


### PR DESCRIPTION
## Summary

Two combined memdb heap reductions targeting the largest remaining contributors after PR #1152's Book strip.

### I2 — Drop Works from memdb (~120 MB)
- `works` table removed from `memdbSchema()`, the `work:` warmup pass, and the read/sync helpers.
- `PebbleStore.GetAllWorks` now routes directly to `GetAllWorks_Pebble` (streaming prefix scan + JSON unmarshal).
- `UpsertWorkToMemDB` / `DeleteWorkFromMemDB` reduced to no-op stubs so existing call sites keep compiling.
- Justification: Works are queried in <0.1% of requests. The only hot path was the scanner per-book `GetAllWorks` N² regression, which sibling task H6 fixes with a single GetAllWorks at scan start — Pebble handles that in tens of ms.

### I3 — Strip BookFile fingerprint data (~70 MB)
- New `stripBookFileForMemdb` clears `AcoustIDSeg1..6` + the 4 diagnostic fields (`FingerprintFailedAt`, `FingerprintFailureReason`, `FingerprintFailureDetail`, `FingerprintDiagnosticJSON`) before memdb insertion. Mirror of PR #1152's `stripBookForMemdb`.
- Applied at warmup and at `UpsertBookFileToMemDB` / `UpsertBookToMemDB` book_file reload.
- `AcoustIDSeg0` is **intentionally kept** because `fingerprint.ComputeFingerprintFields` reads it on every `/api/v1/audiobooks` list response via the memdb-routed `GetBookFilesForIDs`. Stripping seg0 would silently make every book report `fingerprint_status: "none"`.
- `GetFilesWithFingerprintFailures` rerouted from `GetAllBookFiles()` (memdb-fast) to `getAllBookFilesPebbleScan()` so the failures diagnostic endpoint still sees the diagnostic columns.

### Safety verification
- `dedup/engine.go` uses `GetBookFiles(bookID)` — Pebble-direct, sees full segs.
- `listBookFiles` handler (file-detail API exposing seg1..6) uses `GetBookFiles(bookID)` — Pebble-direct.
- `acoustid` backfill/rescan uses `GetBookFiles(bookID)` and writes through Pebble — unaffected.
- `fingerprint_diagnosis_handler` now correct because store call bypasses memdb.

### Combined expected memdb baseline drop: ~190 MB

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/database/ -run 'MemDB|MemStore|Warm|Strip|BookFile'` pass
- [x] `go test ./internal/audiobooks/` pass
- [ ] Deploy to staging, verify `fingerprint_status` badges still render on library list
- [ ] Verify `/api/v1/diagnostics/fingerprint-failures` still returns diagnostic JSON
- [ ] Verify dedup acoustid scan still emits candidates
- [ ] Heap profile before/after: expect ~190 MB drop in memdb-resident allocations

Note: two pre-existing test flakes (TestNewPebbleStoreExistingCounters, TestBatchWriteBackEndpoint_ReturnsSummary registry shutdown panic) reproduce on `main` and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)