### PR TITLE
feat(acoustid): serialize scan/rescan/backfill via shared ConcurrencyKey

### DIFF
--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -39,6 +39,7 @@ func (p *Plugin) backfillDef() sdk.OperationDef {
 		Description:     "Generates AcoustID fingerprints for files missing acoustid_seg0.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "acoustid.fingerprint",
 		Schedule:        &sched,
 		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         24 * time.Hour,

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -41,6 +41,7 @@ func (p *Plugin) fingerprintRescanDef() sdk.OperationDef {
 		Description:     "Generates per-file fingerprints on demand with scope and force options.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "acoustid.fingerprint",
 		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         12 * time.Hour,
 		Capabilities: []sdk.Capability{

--- a/internal/plugins/acoustid/scan.go
+++ b/internal/plugins/acoustid/scan.go
@@ -23,7 +23,7 @@ func (p *Plugin) scanDef() sdk.OperationDef {
 		Description:     "Runs AcoustID fingerprint-based dedup scan comparing acoustic fingerprints.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
-		ConcurrencyKey:  "acoustid.scan",
+		ConcurrencyKey:  "acoustid.fingerprint",
 		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         6 * time.Hour,
 		Capabilities: []sdk.Capability{


### PR DESCRIPTION
## Summary

All three acoustid ops now share `ConcurrencyKey: "acoustid.fingerprint"`:
- `acoustid.scan` (was `acoustid.scan` — only serialized against itself)
- `acoustid.fingerprint-rescan` (had no key)
- `acoustid.backfill` (had no key)

The scan reads `BookFile.AcoustIDSeg0–6` that rescan/backfill write. Running concurrently caused stale-read races + doubled fpcalc / disk pressure. Observed in prod with both running at once (screenshot in chat).

UI is already done: `web/src/pages/ActivityLog.tsx:765` has a `Pending` bucket filtering `status === 'queued'` with a gray `default` chip and "Waiting to start…" caption. No frontend changes needed.

## Root cause of "stuck at 1/49915"

**Not** the concurrency issue. `internal/database/pebble_store.go:8783 GetBookFileByAcoustIDFuzzy` does a full Pebble scan of all 308K `book_file:*` keys per call. It's called per segment per file per book → ~10¹¹ record reads to finish one full scan. Filed as **MAYDEPLOY-J** (memdb `acoustid_seg` index).

## Test plan

- [x] `go test ./internal/plugins/acoustid/...`
- [x] `go test -run TestDispatcher ./internal/operations/registry/`
- [ ] Post-deploy: trigger both scan + rescan; confirm second one renders under "Pending" with gray chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)