### PR TITLE
perf(acoustid): memdb fuzzy fastpath + skip-fuzzy-on-exact-hit (MAYDEPLOY-J)

### DIFF
--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 )
 
 // Read-side implementations for the queries previously handled by Chai SQL.
@@ -754,6 +756,47 @@ func (m *MemStore) ListBooksByITunesPID(limit, offset int) ([]Book, error) {
 		all = append(all, *b)
 	}
 	return paginate(all, limit, offset), nil
+}
+
+// GetBookFileByAcoustIDFuzzy walks memdb book_files (in-RAM, no Pebble I/O)
+// and returns the first row whose any of AcoustIDSeg0..6 is fuzzy-similar
+// to fp at or above minSimilarity. This replaces a full Pebble prefix scan
+// of all book_file:* keys (308K+) — wedge point for the AcoustIDScan op.
+//
+// Iteration order is arbitrary (memdb's id index is hash-based). The dedup
+// engine only needs ANY match, not a deterministic one, so this is fine.
+func (m *MemStore) GetBookFileByAcoustIDFuzzy(fp string, minSimilarity float64) (*BookFile, error) {
+	if fp == "" {
+		return nil, nil
+	}
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(memTableBookFiles, memIdxID)
+	if err != nil {
+		return nil, fmt.Errorf("memdb fuzzy acoustid scan: %w", err)
+	}
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		bf := obj.(*BookFile)
+		segs := [7]string{
+			bf.AcoustIDSeg0, bf.AcoustIDSeg1, bf.AcoustIDSeg2, bf.AcoustIDSeg3,
+			bf.AcoustIDSeg4, bf.AcoustIDSeg5, bf.AcoustIDSeg6,
+		}
+		for _, seg := range segs {
+			if seg == "" {
+				continue
+			}
+			sim, simErr := fingerprint.HammingSimilarity(fp, seg)
+			if simErr != nil {
+				continue
+			}
+			if sim >= minSimilarity {
+				cp := *bf
+				return &cp, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 func paginate[T any](in []T, limit, offset int) []T {

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -60,31 +60,26 @@ func stripBookForMemdb(src *Book) *Book {
 //
 // Combined expected drop: ~70 MB.
 //
-// Critical: AcoustIDSeg0 is intentionally NOT stripped. It is read on every
-// /api/v1/audiobooks list response by fingerprint.ComputeFingerprintFields
+// Critical: AcoustIDSeg0..6 are intentionally PRESERVED. seg0 is read on
+// every /api/v1/audiobooks list by fingerprint.ComputeFingerprintFields
 // (via the memdb-routed GetBookFilesForIDs path) to compute the per-book
-// fingerprint_status badge. Clearing seg0 would silently make every book
-// report "none".
+// fingerprint_status badge. seg1..6 are read by the memdb-routed
+// MemStore.GetBookFileByAcoustIDFuzzy used by the dedup engine — without
+// them in memdb, the fuzzy lookup has to full-scan Pebble (308K book_file
+// keys per call), which wedged AcoustIDScan at book 1 in prod.
 //
-// Safe to strip because:
-//   - Seg1..6 + diagnostic fields are only read by acoustid backfill,
-//     fingerprint_diagnosis_handler, and dedup. Backfill and dedup fetch
-//     files via GetBookFiles(bookID), which is Pebble-direct (no memdb).
-//     fingerprint_diagnosis_handler is rerouted in this PR to use
-//     getAllBookFilesPebbleScan() so it also bypasses memdb.
-//   - listBookFiles handler (which exposes seg1..6 in API responses) uses
-//     GetBookFiles(bookID) — Pebble-direct, sees the full payload.
+// Heap cost of preserving seg1..6 at steady-state full coverage:
+// 308K × 6 × ~400B ≈ 700 MB worst case; ~70 MB at current fp-coverage.
+// Trivially affordable vs the 30 GB headroom from the May 29 I-batch.
+//
+// Diagnostic fields remain stripped — they're only needed by the
+// fingerprint_diagnosis_handler, which calls GetBookFiles(bookID)
+// Pebble-direct.
 func stripBookFileForMemdb(src *BookFile) *BookFile {
 	if src == nil {
 		return nil
 	}
 	cp := *src
-	cp.AcoustIDSeg1 = ""
-	cp.AcoustIDSeg2 = ""
-	cp.AcoustIDSeg3 = ""
-	cp.AcoustIDSeg4 = ""
-	cp.AcoustIDSeg5 = ""
-	cp.AcoustIDSeg6 = ""
 	cp.FingerprintFailedAt = nil
 	cp.FingerprintFailureReason = nil
 	cp.FingerprintFailureDetail = nil

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -8780,7 +8780,16 @@ func (s *PebbleStore) GetBookFileByAcoustID(fp string) (*BookFile, error) {
 // GetBookFileByAcoustIDFuzzy scans all book_file records and returns the first
 // whose AcoustID fingerprint similarity to fp is >= minSimilarity.
 // O(n) over fingerprinted files — only called when exact match misses.
+//
+// Memdb fastpath: when memdb is warm, walk in-RAM book_files (seg0..6 are
+// preserved post-MAYDEPLOY-J). Falls back to Pebble prefix scan below.
 func (s *PebbleStore) GetBookFileByAcoustIDFuzzy(fp string, minSimilarity float64) (*BookFile, error) {
+	if s.UseMemDB {
+		if m := s.mem(); m != nil {
+			return m.GetBookFileByAcoustIDFuzzy(fp, minSimilarity)
+		}
+	}
+
 	prefix := []byte("book_file:")
 	iter, err := s.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -2177,11 +2177,18 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 				}
 
 				// Tier 1: exact match.
-				if match, _ := de.bookStore.GetBookFileByAcoustID(seg); match != nil && match.BookID != book.ID {
-					emit(book.ID, match.BookID, 1.0)
+				exactHit, _ := de.bookStore.GetBookFileByAcoustID(seg)
+				if exactHit != nil && exactHit.BookID != book.ID {
+					emit(book.ID, exactHit.BookID, 1.0)
 				}
 
-				// Tier 2: fuzzy match (skip if exact already found — same candidate).
+				// Tier 2: fuzzy match — only when exact missed. The previous
+				// code called fuzzy unconditionally; on a 308K-file corpus
+				// fuzzy hits an O(n) Pebble scan per seg per file per book,
+				// which wedged the scan at ~book 1 in prod.
+				if exactHit != nil {
+					continue
+				}
 				if match, _ := de.bookStore.GetBookFileByAcoustIDFuzzy(seg, fingerprint.FuzzyMinSimilarity); match != nil && match.BookID != book.ID {
 					sim, simErr := fingerprint.HammingSimilarity(seg, bestSeg(match))
 					if simErr != nil {


### PR DESCRIPTION
## Summary

Three coupled fixes for the `acoustid.scan` op wedging at book 1/49915 in prod:

1. **engine.go**: only call `GetBookFileByAcoustIDFuzzy` when exact match missed. The comment said "skip if exact already found" but the code didn't actually skip — fuzzy ran every time, even when exact already produced the same candidate. On a 308K-file corpus that's the dominant waste.
2. **memdb_strip.go**: stop stripping `AcoustIDSeg1..6` from memdb. Heap cost: ~70 MB now, ~700 MB at steady-state — trivial vs the 30 GB headroom from May 29's I-batch.
3. **pebble_store.go + memdb_reads.go**: route `GetBookFileByAcoustIDFuzzy` through memdb when warm. Replaces a 308K-row Pebble prefix scan + JSON unmarshal per call with an in-RAM go-memdb iteration + Hamming compute. Still O(n) per query (no LSH yet), but no disk seeks and no unmarshal. Expected speedup: ~100×.

## Why this fixes "stuck at 1/100"

The dedup engine's loop is `O(books × files × segs × fuzzy-scan)`. Tier-1 exact was already O(1) via a Pebble index (`book_file_acoustid:` key), but tier-2 fuzzy was full-Pebble-scan, **called even when exact already hit** — so every iteration paid the fuzzy cost regardless of exact result.

Combined with **PR #1193** (ConcurrencyKey serialization), rescan finishes first then scan runs to completion linearly.

## Tests

- [x] `go test -skip TestNewPebbleStoreExistingCounters ./internal/database/` (the skipped test is a pre-existing async-warmup vs close race, reproducible on plain main; not introduced here)
- [x] `go test ./internal/dedup/ ./internal/plugins/acoustid/`
- [ ] Post-deploy: trigger `acoustid.scan`, confirm linear progress > 1/49915

## Defer (follow-up)

True LSH/bucketed index for fuzzy if the in-RAM walk still dominates wall time on the 49K-book scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)