### PR TITLE
feat(uos): standard op tags + canonical start/finish + frontend opt-in default

### DIFF
--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -37,11 +37,12 @@ type logEntry struct {
 
 // dbReporter is the UOS-03 DB-backed Reporter.
 type dbReporter struct {
-	opID    string
-	defID   string
-	plugin  string
-	traceID string
-	spanID  string
+	opID        string
+	defID       string
+	displayName string
+	plugin      string
+	traceID     string
+	spanID      string
 
 	store  database.OpsV2Store
 	bus    Bus // may be nil until UOS-06
@@ -51,8 +52,9 @@ type dbReporter struct {
 	logBuf  []logEntry
 	flushCh chan struct{}
 
-	progressMu      sync.Mutex
-	progressCurrent int
+	progressMu          sync.Mutex
+	progressCurrent     int
+	lastProgressMessage string
 
 	// setCurrentItemFn, if non-nil, updates the runHandle's in-memory label.
 	setCurrentItemFn func(string)
@@ -108,23 +110,29 @@ func NewDBReporterForTest(
 	bus Bus,
 	logger *slog.Logger,
 ) Reporter {
-	return newDBReporter(runCtx, opID, defID, plugin, traceID, spanID, store, bus, logger, nil)
+	return newDBReporter(runCtx, opID, defID, "", plugin, traceID, spanID, store, bus, logger, nil)
 }
 
 // newDBReporter creates a DB-backed Reporter.
+// displayName is the human-readable op name (def.DisplayName) bound as the
+// op_name attribute on every log line; empty falls back to defID.
 // setCurrentItemFn, if non-nil, is called by SetCurrentItem to update
 // the registry's in-memory runHandle without a DB write.
 func newDBReporter(
 	runCtx context.Context,
-	opID, defID, plugin, traceID, spanID string,
+	opID, defID, displayName, plugin, traceID, spanID string,
 	store database.OpsV2Store,
 	bus Bus,
 	logger *slog.Logger,
 	setCurrentItemFn func(string),
 ) Reporter {
+	if displayName == "" {
+		displayName = defID
+	}
 	r := &dbReporter{
 		opID:             opID,
 		defID:            defID,
+		displayName:      displayName,
 		plugin:           plugin,
 		traceID:          traceID,
 		spanID:           spanID,
@@ -135,25 +143,24 @@ func newDBReporter(
 		setCurrentItemFn: setCurrentItemFn,
 	}
 
-	// Build a slog.Logger with default attrs and a fanout handler.
-	baseHandler := slog.Default().Handler().WithAttrs([]slog.Attr{
+	// Every log line emitted via reporter.Logger() inherits these attrs.
+	// op_name is the human label (e.g. "AcoustID fingerprint scan") so
+	// digest aggregation can group by name without joining against the
+	// def table.
+	baseAttrs := []slog.Attr{
 		slog.String("op_id", opID),
 		slog.String("def_id", defID),
+		slog.String("op_name", displayName),
 		slog.String("plugin", plugin),
 		slog.String("trace_id", traceID),
 		slog.String("span_id", spanID),
-	})
+	}
+
+	baseHandler := slog.Default().Handler().WithAttrs(baseAttrs)
 	r.logger = slog.New(&fanoutHandler{base: baseHandler, rep: r})
 
 	if logger != nil {
-		// Use the caller-supplied logger's handler as the base for journalctl output.
-		baseHandler2 := logger.Handler().WithAttrs([]slog.Attr{
-			slog.String("op_id", opID),
-			slog.String("def_id", defID),
-			slog.String("plugin", plugin),
-			slog.String("trace_id", traceID),
-			slog.String("span_id", spanID),
-		})
+		baseHandler2 := logger.Handler().WithAttrs(baseAttrs)
 		r.logger = slog.New(&fanoutHandler{base: baseHandler2, rep: r})
 	}
 
@@ -211,7 +218,9 @@ func (r *dbReporter) flushLogs() {
 // UpdateProgress implements Reporter.
 func (r *dbReporter) UpdateProgress(current, total int, message string) error {
 	r.progressMu.Lock()
+	last := r.lastProgressMessage
 	r.progressCurrent = current
+	r.lastProgressMessage = message
 	r.progressMu.Unlock()
 
 	if err := r.store.UpdateOpProgressV2(r.opID, current, total, message); err != nil {
@@ -223,6 +232,16 @@ func (r *dbReporter) UpdateProgress(current, total int, message string) error {
 			"progress_current": current,
 			"progress_total":   total,
 		})
+	}
+	// Emit one log line per *distinct* progress message so the op_log feed
+	// has a searchable trail of the phases the Run went through. Skipping
+	// duplicates keeps a 50K-row scan from producing 50K log lines.
+	if message != "" && message != last {
+		r.logger.LogAttrs(r.runCtx, slog.LevelInfo, message,
+			slog.String("phase", "progress"),
+			slog.Int("progress_current", current),
+			slog.Int("progress_total", total),
+		)
 	}
 	return nil
 }

--- a/internal/operations/registry/subprocess.go
+++ b/internal/operations/registry/subprocess.go
@@ -124,7 +124,7 @@ func RunChildMode(r *Registry) {
 
 	// Create reporter.
 	ctx := context.Background()
-	reporter := newDBReporter(ctx, opID, def.ID, def.Plugin, "", "", r.store, nil, r.logger, nil)
+	reporter := newDBReporter(ctx, opID, def.ID, def.DisplayName, def.Plugin, "", "", r.store, nil, r.logger, nil)
 
 	// Run.
 	runErr := def.Run(ctx, hs.Params, reporter)

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -149,9 +150,23 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	// Build reporter (DB-backed). Pass a setter so SetCurrentItem updates
 	// the runHandle's in-memory currentItem without a DB write.
 	setItemFn := func(label string) { h.setCurrentItem(label) }
-	reporter := newDBReporter(runCtx, qr.opID, qr.defID, qr.plugin,
+	reporter := newDBReporter(runCtx, qr.opID, qr.defID, def.DisplayName, qr.plugin,
 		"", "", // traceID / spanID loaded from DB row in future; empty for now
 		r.store, r.bus, r.logger, setItemFn)
+
+	// Canonical "operation started" log line, with all the tags downstream
+	// readers (op_log feed, activity-log enricher, digest aggregator) need
+	// to group, filter, and search without parsing the message. Every op
+	// gets this even if its Run forgets to emit one.
+	runStartedAt := time.Now().UTC()
+	reporter.Logger().LogAttrs(runCtx, slog.LevelInfo, "operation started",
+		slog.String("phase", "start"),
+		slog.String("op_display", def.DisplayName),
+		slog.Int("params_bytes", len(qr.params)),
+		slog.Bool("isolated", def.Isolate),
+		slog.Int("priority", int(def.DefaultPriority)),
+		slog.String("concurrency_key", def.ConcurrencyKey),
+	)
 
 	// Subprocess path (Isolate=true): re-exec self.
 	if def.Isolate {
@@ -172,6 +187,7 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		if err := r.store.UpdateOperationV2Status(qr.opID, finalStatus, nil, &completedAt, errMsg); err != nil {
 			r.logger.Warn("registry: failed to update subprocess op terminal status", "op_id", qr.opID, "error", err)
 		}
+		emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, true)
 		r.logger.Info("registry: subprocess run finished", "op_id", qr.opID, "status", finalStatus)
 		return false
 	}
@@ -253,8 +269,34 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		r.logger.Warn("registry: failed to update op terminal status", "op_id", qr.opID, "error", err)
 	}
 
+	emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, false)
 	r.logger.Info("registry: run finished", "op_id", qr.opID, "status", finalStatus)
 	return false
+}
+
+// emitOpFinishedLog emits the canonical "operation finished" line through
+// the reporter's tagged logger. Every op gets this line regardless of
+// whether its Run emitted one. Downstream readers can rely on a
+// phase=end tag + structured outcome instead of parsing the message.
+func emitOpFinishedLog(ctx context.Context, rep Reporter, startedAt time.Time, outcome string, runErr error, subprocess bool) {
+	durMs := time.Since(startedAt).Milliseconds()
+	attrs := []slog.Attr{
+		slog.String("phase", "end"),
+		slog.String("outcome", outcome),
+		slog.Int64("duration_ms", durMs),
+		slog.Bool("subprocess", subprocess),
+	}
+	if runErr != nil {
+		attrs = append(attrs, slog.String("error", runErr.Error()))
+	}
+	level := slog.LevelInfo
+	switch outcome {
+	case "failed":
+		level = slog.LevelError
+	case "canceled", "interrupted_dropped", "interrupted_restart":
+		level = slog.LevelWarn
+	}
+	rep.Logger().LogAttrs(ctx, level, "operation finished", attrs...)
 }
 
 // checkInfiniteRestart checks whether an op should be force-dropped due to

--- a/web/src/components/system/MaintenanceTab.tsx
+++ b/web/src/components/system/MaintenanceTab.tsx
@@ -41,7 +41,7 @@ function OptimizeLibraryCard() {
     setError(null);
     setSuccessMsg(null);
     try {
-      const result = await withOptimisticOperation('library.optimize', () => api.startOptimize());
+      const result = await api.startOptimize();
       setSuccessMsg(`Optimize started (op ${result.operation_id})`);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to start optimize');

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1596,7 +1596,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       const path = pathEntry?.path;
       if (!path) return;
       setImportPaths((prev) => prev.map((p) => (p.id === id ? { ...p, status: 'scanning' } : p)));
-      const op = await withOptimisticOperation('scan', () => api.startScan(path));
+      const op = await api.startScan(path);
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to scan import path:', error);
@@ -1610,7 +1610,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       // Mark all paths scanning
       setImportPaths((prev) => prev.map((p) => ({ ...p, status: 'scanning' })));
-      const op = await withOptimisticOperation('scan', () => api.startScan()); // no folder path -> scan all
+      const op = await api.startScan(); // no folder path -> scan all
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to start full scan:', error);
@@ -1624,7 +1624,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       // Mark all paths scanning
       setImportPaths((prev) => prev.map((p) => ({ ...p, status: 'scanning' })));
       // Force full rescan with database path updates
-      const op = await withOptimisticOperation('scan', () => api.startScan(undefined, undefined, true));
+      const op = await api.startScan(undefined, undefined, true);
       startPolling(op.id, 'scan');
     } catch (error) {
       console.error('Failed to start full rescan:', error);
@@ -1637,9 +1637,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       return;
     }
     try {
-      const op = await withOptimisticOperation('fingerprint-rescan', () =>
-        api.triggerFingerprintBackfill('all'),
-      );
+      const op = await api.triggerFingerprintBackfill('all');
       toast(`Fingerprint rescan started. Operation ID: ${op.id}`, 'success');
     } catch (error) {
       console.error('Failed to trigger fingerprint rescan:', error);
@@ -1649,9 +1647,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
 
   const handleFingerprintRescanMissing = async () => {
     try {
-      const op = await withOptimisticOperation('fingerprint-rescan', () =>
-        api.triggerFingerprintBackfill('missing'),
-      );
+      const op = await api.triggerFingerprintBackfill('missing');
       toast(`Fingerprint rescan started. Operation ID: ${op.id}`, 'success');
     } catch (error) {
       console.error('Failed to trigger fingerprint rescan:', error);
@@ -1662,7 +1658,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const handleOrganizeLibrary = async () => {
     try {
       setOrganizeRunning(true);
-      const op = await withOptimisticOperation('organize', () => api.startOrganize());
+      const op = await api.startOrganize();
       startPolling(op.id, 'organize');
     } catch (e) {
       console.error('Failed to start organize', e);

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,12 +1,30 @@
 // file: web/src/services/api.ts
-// version: 2.33.1
+// version: 2.34.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-20
+// last-edited: 2026-05-29
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
 
+import { withOptimisticOperation } from '../utils/withOptimisticOperation';
+
 const API_BASE = '/api/v1';
+
+/**
+ * wrapTrigger is the single seam every op-launching API call funnels through.
+ * It inserts an optimistic placeholder into the ops store BEFORE the network
+ * call, then reconciles it with the server's real op_id (which schedules a
+ * loadFromServer refresh). The bell badge updates instantly; no UI handler
+ * needs to remember to call loadFromServer or beginOptimistic.
+ *
+ * Use for every trigger* / start* function that enqueues a backend op.
+ */
+function wrapTrigger<T extends { id?: string; operation_id?: string }>(
+  opName: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withOptimisticOperation(opName, fn, (r) => r?.id ?? r?.operation_id ?? null);
+}
 
 export class ApiError extends Error {
   readonly status: number;
@@ -1566,17 +1584,19 @@ export async function startBulkMetadataFetch(
   selection: SelectionSpec,
   options?: { prefer_audible?: boolean; skip_cached?: boolean }
 ): Promise<{ operation_id: string }> {
-  const response = await fetch(`${API_BASE}/operations/v2`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      def_id: 'library.bulk-metadata-fetch',
-      params: { selection, ...options },
-    }),
+  return wrapTrigger('library.bulk-metadata-fetch', async () => {
+    const response = await fetch(`${API_BASE}/operations/v2`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        def_id: 'library.bulk-metadata-fetch',
+        params: { selection, ...options },
+      }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start bulk metadata fetch');
+    const body = await response.json();
+    return body?.data ?? { operation_id: '' };
   });
-  if (!response.ok) throw await buildApiError(response, 'Failed to start bulk metadata fetch');
-  const body = await response.json();
-  return body?.data ?? { operation_id: '' };
 }
 
 // Operations
@@ -1585,41 +1605,39 @@ export async function startScan(
   priority?: number,
   forceUpdate?: boolean
 ): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/operations/scan`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      folder_path: folderPath,
-      priority,
-      force_update: forceUpdate,
-    }),
+  return wrapTrigger('library.scan', async () => {
+    const response = await fetch(`${API_BASE}/operations/scan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        folder_path: folderPath,
+        priority,
+        force_update: forceUpdate,
+      }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start scan');
+    return (await response.json()).data;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start scan');
-  }
-  const body = await response.json();
-  return body.data;
 }
 
 export async function startTranscode(
   bookId: string,
   opts?: { output_format?: string; bitrate?: number; keep_original?: boolean }
 ): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/operations/transcode`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      book_id: bookId,
-      output_format: opts?.output_format,
-      bitrate: opts?.bitrate,
-      keep_original: opts?.keep_original,
-    }),
+  return wrapTrigger('library.transcode', async () => {
+    const response = await fetch(`${API_BASE}/operations/transcode`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        book_id: bookId,
+        output_format: opts?.output_format,
+        bitrate: opts?.bitrate,
+        keep_original: opts?.keep_original,
+      }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start transcode');
+    return (await response.json()).data;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start transcode');
-  }
-  const body = await response.json();
-  return body.data;
 }
 
 export async function getOperationStatus(id: string): Promise<Operation> {
@@ -1809,22 +1827,21 @@ export async function startOrganize(
   bookIds?: string[],
   options?: { fetchMetadataFirst?: boolean; syncITunesFirst?: boolean }
 ): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/operations/organize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      folder_path: folderPath,
-      priority,
-      book_ids: bookIds,
-      fetch_metadata_first: options?.fetchMetadataFirst,
-      sync_itunes_first: options?.syncITunesFirst,
-    }),
+  return wrapTrigger('library.organize', async () => {
+    const response = await fetch(`${API_BASE}/operations/organize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        folder_path: folderPath,
+        priority,
+        book_ids: bookIds,
+        fetch_metadata_first: options?.fetchMetadataFirst,
+        sync_itunes_first: options?.syncITunesFirst,
+      }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start organize');
+    return (await response.json()).data;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start organize');
-  }
-  const body = await response.json();
-  return body.data;
 }
 
 export async function getSystemLogs(params?: {
@@ -2275,14 +2292,15 @@ export async function startITunesSync(
   libraryPath?: string,
   force?: boolean
 ): Promise<{ operation_id: string; message: string }> {
-  const response = await fetch(`${API_BASE}/itunes/sync`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ library_path: libraryPath, force: force ?? true }),
+  return wrapTrigger('itunes.sync', async () => {
+    const response = await fetch(`${API_BASE}/itunes/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ library_path: libraryPath, force: force ?? true }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Sync failed');
+    return (await response.json()).data;
   });
-  if (!response.ok) throw await buildApiError(response, 'Sync failed');
-  const body = await response.json();
-  return body.data;
 }
 
 export async function getITunesLibraryStatus(
@@ -3501,15 +3519,15 @@ export async function startOLDumpDownload(
 export async function startOLDumpImport(
   types?: string[]
 ): Promise<{ message: string; types: string[]; operation_id?: string }> {
-  const response = await fetch(`${API_BASE}/openlibrary/import`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ types: types || ['editions', 'authors', 'works'] }),
+  return wrapTrigger('openlibrary.import', async () => {
+    const response = await fetch(`${API_BASE}/openlibrary/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ types: types || ['editions', 'authors', 'works'] }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start OL dump import');
+    return response.json();
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start OL dump import');
-  }
-  return response.json();
 }
 
 export async function uploadOLDump(
@@ -4036,27 +4054,27 @@ export async function getReconcilePreview(): Promise<ReconcilePreview> {
 export async function startReconcile(
   matches: Array<{ book_id: string; new_path: string }>
 ): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/operations/reconcile`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ matches }),
+  return wrapTrigger('library.reconcile', async () => {
+    const response = await fetch(`${API_BASE}/operations/reconcile`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matches }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start reconciliation');
+    return response.json();
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start reconciliation');
-  }
-  return response.json();
 }
 
 export async function startReconcileScan(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/operations/reconcile/scan`, {
-    method: 'POST',
+  return wrapTrigger('library.reconcile-scan', async () => {
+    const response = await fetch(`${API_BASE}/operations/reconcile/scan`, {
+      method: 'POST',
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start reconcile scan');
+    const responseData = await response.json();
+    const raw = responseData.data ?? responseData;
+    return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start reconcile scan');
-  }
-  const responseData = await response.json();
-  const raw = responseData.data ?? responseData;
-  return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
 }
 
 export interface LatestReconcileScan {
@@ -4094,14 +4112,15 @@ export async function startDiagnosticsExport(
   category: string,
   description: string
 ): Promise<{ operation_id: string; status: string }> {
-  const response = await fetch(`${API_BASE}/diagnostics/export`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ category, description }),
+  return wrapTrigger('diagnostics.export', async () => {
+    const response = await fetch(`${API_BASE}/diagnostics/export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ category, description }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start export');
+    return (await response.json()).data;
   });
-  if (!response.ok) throw await buildApiError(response, 'Failed to start export');
-  const body = await response.json();
-  return body.data;
 }
 
 export async function downloadDiagnosticsExport(operationId: string): Promise<Blob> {
@@ -4666,16 +4685,18 @@ export interface SplitBookMergeResult {
 // Backend returns {op_id: "..."} — normalized to an Operation-shaped
 // object so the caller can drop it into useOperationsStore.startPolling.
 export async function triggerSplitBookScan(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/split-book-scan`, {
-    method: 'POST',
+  return wrapTrigger('dedup.split-book-scan', async () => {
+    const response = await fetch(`${API_BASE}/dedup/split-book-scan`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      throw await buildApiError(response, 'Failed to trigger split-book scan');
+    }
+    const responseData = await response.json();
+    const raw = (responseData.data ?? {}) as Record<string, unknown>;
+    const id = (raw.id ?? raw.op_id ?? '') as string;
+    return { ...raw, id, type: (raw.type as string) ?? 'dedup.split-book-scan' } as Operation;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger split-book scan');
-  }
-  const responseData = await response.json();
-  const raw = (responseData.data ?? {}) as Record<string, unknown>;
-  const id = (raw.id ?? raw.op_id ?? '') as string;
-  return { ...raw, id, type: (raw.type as string) ?? 'dedup.split-book-scan' } as Operation;
 }
 
 // Fetch all persisted split-book candidates. The backend does NOT paginate
@@ -4719,48 +4740,41 @@ export async function mergeSplitBookCandidate(
 // 15s background sweep — that wait is what made fast scans look invisible
 // after the user clicked "Re-scan" or "Re-embed All".
 export async function triggerDedupScan(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/scan`, { method: 'POST' });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger dedup scan');
-  }
-  const responseData = await response.json();
-  return responseData.data;
+  return wrapTrigger('dedup.scan', async () => {
+    const response = await fetch(`${API_BASE}/dedup/scan`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger dedup scan');
+    return (await response.json()).data;
+  });
 }
 
 export async function triggerDedupLLM(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/scan-llm`, {
-    method: 'POST',
+  return wrapTrigger('dedup.scan-llm', async () => {
+    const response = await fetch(`${API_BASE}/dedup/scan-llm`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger dedup LLM scan');
+    return (await response.json()).data;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger dedup LLM scan');
-  }
-  const responseData = await response.json();
-  return responseData.data;
 }
 
 export async function triggerDedupAcoustID(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/scan-acoustid`, { method: 'POST' });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger AcoustID scan');
-  }
-  const responseData = await response.json();
-  const raw = responseData.data ?? {};
-  // Backend returns {op_id: "..."} — normalize to Operation shape.
-  return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
+  return wrapTrigger('acoustid.scan', async () => {
+    const response = await fetch(`${API_BASE}/dedup/scan-acoustid`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger AcoustID scan');
+    const raw = (await response.json()).data ?? {};
+    return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
+  });
 }
 
 export async function triggerFingerprintBackfill(scope: 'missing' | 'all' = 'missing'): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/fingerprint-rescan`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ scope }),
+  return wrapTrigger('acoustid.fingerprint-rescan', async () => {
+    const response = await fetch(`${API_BASE}/dedup/fingerprint-rescan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scope }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger fingerprint backfill');
+    const raw = (await response.json()).data ?? {};
+    return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger fingerprint backfill');
-  }
-  const responseData = await response.json();
-  const raw = responseData.data ?? {};
-  return { ...raw, id: raw.id ?? raw.op_id ?? '' } as Operation;
 }
 
 export interface AcoustIDSegmentComparison {
@@ -4790,23 +4804,19 @@ export async function compareAcoustID(bookAID: string, bookBID: string): Promise
 }
 
 export async function triggerDedupRefresh(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/refresh`, {
-    method: 'POST',
+  return wrapTrigger('dedup.refresh', async () => {
+    const response = await fetch(`${API_BASE}/dedup/refresh`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger dedup refresh');
+    return (await response.json()).data;
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger dedup refresh');
-  }
-  const responseData = await response.json();
-  return responseData.data;
 }
 
 export async function triggerEmbedScan(): Promise<Operation> {
-  const response = await fetch(`${API_BASE}/dedup/embed`, { method: 'POST' });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to trigger embedding scan');
-  }
-  const responseData = await response.json();
-  return responseData.data;
+  return wrapTrigger('dedup.embed', async () => {
+    const response = await fetch(`${API_BASE}/dedup/embed`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to trigger embedding scan');
+    return (await response.json()).data;
+  });
 }
 
 // ── API Key management ────────────────────────────────────────────────────────
@@ -5200,14 +5210,14 @@ export async function runMaintenanceJob(jobId: string, dryRun = false): Promise<
 }
 
 export async function startOptimize(): Promise<{ operation_id: string }> {
-  const response = await fetch(`${API_BASE}/operations/optimize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+  return wrapTrigger('library.optimize', async () => {
+    const response = await fetch(`${API_BASE}/operations/optimize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start optimize operation');
+    return response.json();
   });
-  if (!response.ok) {
-    throw await buildApiError(response, 'Failed to start optimize operation');
-  }
-  return response.json();
 }
 
 // QuickQuery matches the QuickQuery interface defined in web/src/types/index.ts.


### PR DESCRIPTION
## Summary

Centralizes UOS op observability so every op gets rich tags and every UI trigger refreshes the bell — without per-op or per-handler code.

### Backend (internal/operations/registry)

- **reporter_db.go**: `newDBReporter` now binds `op_name` (def.DisplayName) on the base slog handler alongside `op_id, def_id, plugin, trace_id, span_id`. Every `reporter.Logger().Info(...)` a plugin emits inherits all five attrs.
- **reporter_db.go**: `UpdateProgress` emits one log line per *distinct* progress message with `phase=progress` + current/total. Duplicate-suppression keeps a 50K-row scan from producing 50K log lines.
- **worker.go**: emits the canonical `"operation started"` line (phase=start, op_display, params_bytes, isolated, priority, concurrency_key) *before* def.Run, and the canonical `"operation finished"` line (phase=end, outcome, duration_ms, subprocess, error) *after*. Both paths (in-process + subprocess). Every op gets these even if its Run forgets.

### Frontend (web/src)

- **services/api.ts**: new `wrapTrigger()` funnels every op-launching API call through `withOptimisticOperation`, which inserts a placeholder into the ops store immediately and schedules `loadFromServer` on reconcile. Every `trigger*` and `start*` function now wraps: triggerDedupAcoustID, triggerDedupScan, triggerDedupLLM, triggerFingerprintBackfill, triggerEmbedScan, triggerDedupRefresh, triggerSplitBookScan, startScan, startTranscode, startOrganize, startBulkMetadataFetch, startITunesSync, startReconcile, startReconcileScan, startDiagnosticsExport, startOLDumpImport, startOptimize.
- **pages/Library.tsx, components/system/MaintenanceTab.tsx**: drop outer `withOptimisticOperation` calls on op-launching paths since api.ts wraps internally.

### Tag schema (now bound on every op log line)

| Tag | Type | Notes |
|---|---|---|
| `op_id` | string | ULID identifying this run |
| `def_id` | string | `"acoustid.scan"` (machine identifier) |
| `op_name` | string | `"AcoustID fingerprint scan"` (human-readable) |
| `plugin` | string | `"acoustid"` |
| `phase` | string | `start` / `progress` / `end` |
| `outcome` | string | `completed` / `failed` / `canceled` (phase=end only) |
| `duration_ms` | int64 | phase=end only |
| `trace_id`, `span_id` | string | OpenTelemetry, when set |

## User pain this fixes

> "when I click an operation it says click the bell to get status, well fucking hell dude if I haven't refreshed there's nothing there"

Every op-launching button now adds a placeholder to the bell instantly + schedules a server refresh — no handler needs to remember.

> "your tags for messages suck. For every job registered there should be a standard starting log line, a standard finishing log line, and all the logs relevant to that inbetween which means all the logs with that operation need to be fuckign tagged"

Every op now gets standard `phase=start` and `phase=end` lines emitted by the worker. Plugin logs in between automatically inherit op_id/def_id/op_name/plugin via slog.With. Digest aggregation can group by `op_name` or `phase` without parsing message text.

## Test plan

- [x] `go test ./internal/operations/registry/` — passes
- [x] `go build ./...` — passes
- [x] `tsc --noEmit` — passes
- [ ] Post-deploy: click "Find Acoustic Duplicates" — bell should update immediately, op should appear with phase=start in journalctl, then phase=end with outcome+duration_ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)