### PR TITLE
perf(stats): stale-while-revalidate on library stats cache

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -3201,55 +3201,73 @@ func (p *PebbleStore) GetBookSizesByLocation(rootDir string) (librarySize, impor
 // Only when a cache miss (TTL expiry, or recent compute + dirty but outside min-interval)
 // requires recompute, a per-process mutex gates the work to prevent concurrent stampedes.
 func (p *PebbleStore) GetDashboardStats() (*DashboardStats, error) {
-	// Fast path: check if cached value exists and is recent (within min-interval)
-	if cached := p.readCachedLibraryStats(); cached != nil {
+	// Stale-while-revalidate. ANY cached value — even a week-old one —
+	// is returned immediately; if stale beyond the min-interval, kick a
+	// background recompute for next time. This eliminates the cold-start
+	// 87s spike where memdb wasn't warm yet and computeLibraryStats fell
+	// through to a slow Pebble scan blocking the dashboard.
+	cached := p.readCachedLibraryStats()
+
+	if cached != nil {
 		ageSec := time.Since(cached.ComputedAt).Seconds()
 		minIntervalSec := float64(getLibraryCountsMinIntervalSeconds())
-		if ageSec < minIntervalSec {
-			slog.Debug("library_counts cache hit (within min interval)",
+		if ageSec >= minIntervalSec {
+			// Stale: kick off background recompute. TryLock so we don't
+			// queue duplicate recomputes — one in flight is enough.
+			if p.libraryCountsRecomputeMu.TryLock() {
+				go func() {
+					defer p.libraryCountsRecomputeMu.Unlock()
+					start := time.Now()
+					stats, err := p.computeLibraryStats()
+					if err != nil {
+						slog.Warn("library_counts background recompute failed",
+							"component", "library_counts_cache", "error", err)
+						return
+					}
+					p.writeCachedLibraryStats(stats)
+					slog.Info("library_counts cache recomputed (background)",
+						"component", "library_counts_cache",
+						"total_books", stats.TotalBooks,
+						"duration_ms", time.Since(start).Milliseconds(),
+						"reason", "stale-while-revalidate",
+					)
+				}()
+			}
+		} else {
+			slog.Debug("library_counts cache hit (fresh)",
 				"component", "library_counts_cache",
 				"age_seconds", ageSec,
 				"min_interval_seconds", minIntervalSec,
 			)
-			return cached, nil
 		}
-		// Cached but outside min-interval; allow recompute (fall through)
+		return cached, nil
 	}
 
-	// Slow path: recompute needed. Gate with mutex to prevent stampede when N
-	// concurrent callers all see dirty cache simultaneously.
+	// No cache at all (first boot or post-Invalidate restart). Block on
+	// recompute — nothing to serve in the meantime.
 	p.libraryCountsRecomputeMu.Lock()
 	defer p.libraryCountsRecomputeMu.Unlock()
 
-	// Double-check: another goroutine may have just recomputed while we waited for the lock
+	// Double-check: a peer goroutine may have populated the cache while
+	// we waited for the lock.
 	if cached := p.readCachedLibraryStats(); cached != nil {
-		ageSec := time.Since(cached.ComputedAt).Seconds()
-		minIntervalSec := float64(getLibraryCountsMinIntervalSeconds())
-		if ageSec < minIntervalSec {
-			slog.Debug("library_counts cache hit (within min interval, after lock wait)",
-				"component", "library_counts_cache",
-				"age_seconds", ageSec,
-				"min_interval_seconds", minIntervalSec,
-			)
-			return cached, nil
-		}
+		return cached, nil
 	}
 
-	// Perform recompute
 	start := time.Now()
 	stats, err := p.computeLibraryStats()
 	if err != nil {
 		return nil, err
 	}
 	p.writeCachedLibraryStats(stats)
-	slog.Info("library_counts cache recomputed",
+	slog.Info("library_counts cache recomputed (cold)",
 		"component", "library_counts_cache",
 		"total_books", stats.TotalBooks,
 		"organized_books", stats.OrganizedBooks,
 		"unorganized_books", stats.UnorganizedBooks,
 		"broken_files", stats.BrokenFiles,
 		"duration_ms", time.Since(start).Milliseconds(),
-		"reason", "expired",
+		"reason", "cold-cache",
 	)
 	return stats, nil
 }


### PR DESCRIPTION
## Summary

GetDashboardStats now returns ANY cached value immediately (even week-old), and kicks a background recompute when stale beyond the min-interval. Eliminates the 87s cold-start dashboard hang.

## Why

Previously, when the cache aged out:
1. Request blocks on synchronous recompute
2. Recompute calls computeLibraryStats
3. Memdb not warm yet → falls through to Pebble scan
4. Pebble scan takes 87s → request hangs

User observation: dashboard hangs ~1.5 min after every restart.

## After

- Any cached value (persisted in Pebble at `stats:library`) → returned instantly
- If stale → background recompute via TryLock (no duplicate-recompute storms)
- Only completely empty cache → blocking compute (first boot ever)

🤖 Generated with [Claude Code](https://claude.com/claude-code)