### PR TITLE
fix(dedup): suppress same-folder candidates + Cleanup Stale button

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -2152,10 +2152,44 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		return a + ":" + b
 	}
 
+	// Per-book parent-directory cache so we don't fetch BookFiles twice per
+	// comparison. Empty string = unknown / no files / different parents.
+	parentDirCache := make(map[string]string)
+	parentDirForBook := func(bookID string) string {
+		if v, ok := parentDirCache[bookID]; ok {
+			return v
+		}
+		bfs, err := de.bookStore.GetBookFiles(bookID)
+		if err != nil || len(bfs) == 0 {
+			parentDirCache[bookID] = ""
+			return ""
+		}
+		dir := filepath.Dir(bfs[0].FilePath)
+		for _, bf := range bfs[1:] {
+			if filepath.Dir(bf.FilePath) != dir {
+				parentDirCache[bookID] = ""
+				return ""
+			}
+		}
+		parentDirCache[bookID] = dir
+		return dir
+	}
+
 	emit := func(bookAID, bookBID string, sim float64) {
 		key := pairKey(bookAID, bookBID)
 		if _, already := emitted[key]; already {
 			return
+		}
+		// Suppress when both books' files live in the same directory: those
+		// are chapter/part files of one multi-file book, not duplicates.
+		// The scanner's split-book detection (PR #1167) prevents this for
+		// new imports, but the library has thousands of pre-PR splits that
+		// would otherwise be flagged as 100% AcoustID matches just because
+		// their fingerprint segments happen to overlap.
+		if dirA := parentDirForBook(bookAID); dirA != "" {
+			if dirB := parentDirForBook(bookBID); dirB == dirA {
+				return
+			}
 		}
 		emitted[key] = struct{}{}
 		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
@@ -2182,6 +2216,28 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		if err != nil {
 			slog.Info("[dedup] acoustid scan get files for", "book", book.ID, "err", err)
 			continue
+		}
+
+		// Prime cache for this book (avoids the duplicate GetBookFiles
+		// inside parentDirForBook when emit is called for this side).
+		if _, cached := parentDirCache[book.ID]; !cached {
+			if len(files) == 0 {
+				parentDirCache[book.ID] = ""
+			} else {
+				dir := filepath.Dir(files[0].FilePath)
+				ok := true
+				for _, bf := range files[1:] {
+					if filepath.Dir(bf.FilePath) != dir {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					parentDirCache[book.ID] = dir
+				} else {
+					parentDirCache[book.ID] = ""
+				}
+			}
 		}
 
 		for _, f := range files {

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1131,6 +1131,29 @@ func (s *Server) triggerDedupAcoustID(c *gin.Context) {
 	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
 }
 
+// purgeStaleCandidates handles POST /api/v1/dedup/purge-stale.
+// Runs Engine.PurgeStaleCandidates synchronously (fast, no full rescan)
+// to delete pending candidates that are no longer valid: same parent
+// directory (chapter files of one multi-file book), same version group,
+// distinct series volume numbers, etc. Returns the count deleted.
+//
+// Wired to the UI as "Cleanup chapter/split-book candidates" because the
+// dominant case in the wild is thousands of pre-PR-1167 split-books that
+// are flagged as 100% AcoustID matches just because chapter files share
+// fingerprint segments.
+func (s *Server) purgeStaleCandidates(c *gin.Context) {
+	if s.dedupEngine == nil {
+		httputil.RespondWithInternalError(c, "dedup engine not initialized")
+		return
+	}
+	deleted, err := s.dedupEngine.PurgeStaleCandidates(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "failed to purge stale candidates", err)
+		return
+	}
+	httputil.RespondWithSuccess(c, http.StatusOK, map[string]int{"deleted": deleted})
+}
+
 // triggerEmbedScan handles POST /api/v1/dedup/embed.
 // Delegates to the UOS registry (dedup.embed-scan op) since UOS-07.
 func (s *Server) triggerEmbedScan(c *gin.Context) {

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1043,6 +1043,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/dedup/scan-book-signature", s.perm(auth.PermScanTrigger), s.triggerBookSignatureScan)
 			protected.POST("/dedup/fingerprint-rescan", s.perm(auth.PermScanTrigger), s.triggerFingerprintRescan)
 			protected.POST("/dedup/refresh", s.perm(auth.PermScanTrigger), s.triggerDedupRefresh)
+			protected.POST("/dedup/purge-stale", s.perm(auth.PermScanTrigger), s.purgeStaleCandidates)
 			protected.POST("/dedup/embed", s.perm(auth.PermScanTrigger), s.triggerEmbedScan)
 			protected.POST("/dedup/embed-async", s.perm(auth.PermScanTrigger), s.triggerEmbedAsync)
 

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -2203,6 +2203,7 @@ function AcousticDedupTab() {
   const [bookCache, setBookCache] = useState<Map<string, Book>>(new Map());
   const [selectedCandIds, setSelectedCandIds] = useState<Set<number>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  const [purging, setPurging] = useState(false);
   const [resolving, setResolving] = useState<Set<number>>(new Set());
   const [compareA, setCompareA] = useState('');
   const [compareB, setCompareB] = useState('');
@@ -2318,6 +2319,24 @@ function AcousticDedupTab() {
       setStatusMsg(err instanceof Error ? err.message : 'Dismiss failed');
     } finally {
       setResolving((s) => { const next = new Set(s); next.delete(candidateId); return next; });
+    }
+  };
+
+  // One-shot cleanup of pending candidates that are no longer real duplicates:
+  // chapter files of one multi-file book (same parent directory), books in the
+  // same version group, distinct numbered series volumes. Runs server-side via
+  // Engine.PurgeStaleCandidates; no rescan required.
+  const handlePurgeStale = async () => {
+    setPurging(true);
+    setStatusMsg(null);
+    try {
+      const { deleted } = await api.purgeStaleCandidates();
+      setStatusMsg(`Cleanup complete — ${deleted.toLocaleString()} stale candidate(s) removed.`);
+      await loadCandidates();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : 'Cleanup failed');
+    } finally {
+      setPurging(false);
     }
   };
 
@@ -2449,6 +2468,12 @@ function AcousticDedupTab() {
         <Tooltip title="Compare already-stored fingerprints across all books to find audio-level duplicate pairs. Fast — no file I/O.">
           <Button variant="outlined" startIcon={<GraphicEqIcon />} onClick={handleScan} disabled={scanning}>
             {scanning ? 'Queuing…' : 'Find Acoustic Duplicates'}
+          </Button>
+        </Tooltip>
+
+        <Tooltip title="Delete pending candidates that are no longer valid duplicates: chapter files of one multi-file book, same-version-group books, distinct series volumes. Fast — no rescan.">
+          <Button variant="outlined" color="warning" onClick={handlePurgeStale} disabled={purging}>
+            {purging ? 'Cleaning…' : 'Cleanup Stale (same-folder, etc)'}
           </Button>
         </Tooltip>
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -4811,6 +4811,16 @@ export async function triggerDedupRefresh(): Promise<Operation> {
   });
 }
 
+// Runs PurgeStaleCandidates synchronously on the backend — wipes pending
+// candidates that are no longer valid (chapter files in the same folder,
+// same version-group books, distinct series volumes). Cheap and fast; no
+// op queued.
+export async function purgeStaleCandidates(): Promise<{ deleted: number }> {
+  const response = await fetch(`${API_BASE}/dedup/purge-stale`, { method: 'POST' });
+  if (!response.ok) throw await buildApiError(response, 'Failed to purge stale candidates');
+  return (await response.json()).data ?? { deleted: 0 };
+}
+
 export async function triggerEmbedScan(): Promise<Operation> {
   return wrapTrigger('dedup.embed', async () => {
     const response = await fetch(`${API_BASE}/dedup/embed`, { method: 'POST' });


### PR DESCRIPTION
## User report

Screenshot showing two candidate rows where both Book A and Book B sit in the same parent directory — chapter files of one multi-file book flagged as 100% duplicates. \"Thousands like that.\"

## Fixes

1. **engine.AcoustIDScan**: parent-directory cache + emit guard. When both candidates' files live in the same directory, drop the pair before `UpsertCandidate`. Future scans stop producing the junk.
2. **POST /api/v1/dedup/purge-stale** (new): direct endpoint hitting `Engine.PurgeStaleCandidates`. That method already handled same-folder cleanup but only ran inside a full FullScan; exposing it as a one-shot lets the user wipe the existing thousands of bad rows immediately.
3. **AcousticDedup tab**: \"Cleanup Stale (same-folder, etc)\" button next to \"Find Acoustic Duplicates\". Synchronous; reports count deleted.

## Follow-up (not in this PR)

Auto-merge same-folder books as multi-file audiobooks (not just delete the candidate row) — the chapter files DO belong together, they're just not duplicates of each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)