### PR TITLE
feat(dedup): purge-stale is now a real UOS op (bell + log lines)

### DIFF
--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -51,6 +51,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.llmReviewDef(),
 		p.bookSignatureScanDef(),
 		p.splitBookScanDef(),
+		p.purgeStaleDef(),
 	}
 
 	for _, op := range ops {

--- a/internal/plugins/dedup/purge_stale.go
+++ b/internal/plugins/dedup/purge_stale.go
@@ -1,0 +1,63 @@
+// file: internal/plugins/dedup/purge_stale.go
+// version: 1.0.0
+// guid: 7f3e1b2c-4a8d-4e1f-9c2a-3e5b8d0a1c47
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// purgeStaleDef defines the dedup.purge-stale operation. It's a fast,
+// synchronous-feeling sweep over pending candidates that removes the ones
+// that are no longer real duplicates: chapter files in the same parent
+// directory, books already in the same version group, distinct numbered
+// series volumes, etc. Implementation lives in
+// dedup.Engine.PurgeStaleCandidates; this op exists so the user gets bell
+// progress + start/end log lines + a queryable history of cleanup runs.
+//
+// Why an op and not a plain HTTP handler: the user explicitly asked for
+// every user-triggered backend action to show up in the bell. The previous
+// version (PR #1200) was a sync HTTP handler that silently returned a
+// count, so the bell never knew anything happened.
+func (p *Plugin) purgeStaleDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "dedup.purge-stale",
+		Plugin:          "dedup",
+		DisplayName:     "Cleanup stale dedup candidates",
+		Description:     "Deletes pending dedup candidates that are no longer valid (chapter files in same folder, same version-group, distinct series volumes).",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityHigh, // user-triggered, finishes in seconds
+		ConcurrencyKey:  "dedup.purge-stale",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         10 * time.Minute,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+		},
+		Run: p.runPurgeStale,
+	}
+}
+
+func (p *Plugin) runPurgeStale(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return fmt.Errorf("dedup engine not available")
+	}
+
+	_ = reporter.UpdateProgress(0, 1, "Scanning pending candidates for stale rows…")
+	deleted, err := p.engine.PurgeStaleCandidates(ctx)
+	if err != nil {
+		reporter.Logger().Error("purge stale candidates error", "error", err)
+		return fmt.Errorf("purge stale candidates: %w", err)
+	}
+	_ = reporter.UpdateProgress(1, 1,
+		fmt.Sprintf("Cleanup complete — %d stale candidate(s) removed", deleted))
+	reporter.Logger().Info("purged stale candidates", "deleted", deleted)
+	return nil
+}

--- a/internal/server/dedup_handlers.go
+++ b/internal/server/dedup_handlers.go
@@ -1132,26 +1132,21 @@ func (s *Server) triggerDedupAcoustID(c *gin.Context) {
 }
 
 // purgeStaleCandidates handles POST /api/v1/dedup/purge-stale.
-// Runs Engine.PurgeStaleCandidates synchronously (fast, no full rescan)
-// to delete pending candidates that are no longer valid: same parent
-// directory (chapter files of one multi-file book), same version group,
-// distinct series volume numbers, etc. Returns the count deleted.
-//
-// Wired to the UI as "Cleanup chapter/split-book candidates" because the
-// dominant case in the wild is thousands of pre-PR-1167 split-books that
-// are flagged as 100% AcoustID matches just because chapter files share
-// fingerprint segments.
+// Enqueues the dedup.purge-stale UOS op so the cleanup shows up in the
+// bell with proper start/end log lines, instead of silently running and
+// returning a count. Engine.PurgeStaleCandidates still does the actual
+// work — see internal/plugins/dedup/purge_stale.go.
 func (s *Server) purgeStaleCandidates(c *gin.Context) {
-	if s.dedupEngine == nil {
-		httputil.RespondWithInternalError(c, "dedup engine not initialized")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return
 	}
-	deleted, err := s.dedupEngine.PurgeStaleCandidates(c.Request.Context())
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), "dedup.purge-stale", nil)
 	if err != nil {
-		httputil.InternalError(c, "failed to purge stale candidates", err)
+		httputil.InternalError(c, "failed to enqueue dedup purge-stale", err)
 		return
 	}
-	httputil.RespondWithSuccess(c, http.StatusOK, map[string]int{"deleted": deleted})
+	httputil.RespondWithSuccess(c, http.StatusAccepted, map[string]string{"op_id": opID})
 }
 
 // triggerEmbedScan handles POST /api/v1/dedup/embed.

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -2330,9 +2330,16 @@ function AcousticDedupTab() {
     setPurging(true);
     setStatusMsg(null);
     try {
-      const { deleted } = await api.purgeStaleCandidates();
-      setStatusMsg(`Cleanup complete — ${deleted.toLocaleString()} stale candidate(s) removed.`);
-      await loadCandidates();
+      const { op_id } = await api.purgeStaleCandidates();
+      setStatusMsg(
+        op_id
+          ? `Cleanup queued — see bell for progress (op ${op_id.slice(-6)}).`
+          : 'Cleanup queued — see bell for progress.',
+      );
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        if (!isUnmountedRef.current) loadCandidates();
+      }, 3000);
     } catch (err) {
       setStatusMsg(err instanceof Error ? err.message : 'Cleanup failed');
     } finally {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -4811,14 +4811,17 @@ export async function triggerDedupRefresh(): Promise<Operation> {
   });
 }
 
-// Runs PurgeStaleCandidates synchronously on the backend — wipes pending
-// candidates that are no longer valid (chapter files in the same folder,
-// same version-group books, distinct series volumes). Cheap and fast; no
-// op queued.
-export async function purgeStaleCandidates(): Promise<{ deleted: number }> {
-  const response = await fetch(`${API_BASE}/dedup/purge-stale`, { method: 'POST' });
-  if (!response.ok) throw await buildApiError(response, 'Failed to purge stale candidates');
-  return (await response.json()).data ?? { deleted: 0 };
+// Enqueues the dedup.purge-stale UOS op so the cleanup appears in the bell
+// just like every other user-triggered backend action. Returns the op id;
+// the actual deleted count lands in the op's final progress message which
+// the bell reads.
+export async function purgeStaleCandidates(): Promise<{ op_id: string }> {
+  return wrapTrigger('dedup.purge-stale', async () => {
+    const response = await fetch(`${API_BASE}/dedup/purge-stale`, { method: 'POST' });
+    if (!response.ok) throw await buildApiError(response, 'Failed to purge stale candidates');
+    const data = (await response.json()).data ?? {};
+    return { op_id: data.op_id ?? '', id: data.op_id ?? '' } as { op_id: string; id: string };
+  });
 }
 
 export async function triggerEmbedScan(): Promise<Operation> {


### PR DESCRIPTION
## Summary

User reported that PR #1200's cleanup button didn't generate a bell event. Converting it to a real UOS op so user-triggered backend actions consistently appear in the bell + activity log.

## Changes

- New op def `dedup.purge-stale` (`internal/plugins/dedup/purge_stale.go`) wraps `Engine.PurgeStaleCandidates`. PriorityHigh + Cancellable + ConcurrencyKey.
- Registered in `plugin.go` op list.
- HTTP handler enqueues via `opRegistry` instead of running synchronously; returns `{op_id}`.
- `api.ts purgeStaleCandidates()` wraps via `wrapTrigger` so the optimistic placeholder lands in the bell instantly.
- `BookDedup handlePurgeStale` updates status to reflect queued op id.

## Net effect

Clicking Cleanup Stale now produces a bell entry "Cleanup stale dedup candidates" with `phase=start` + `phase=end` log lines (from the UOS standard tagging in PR #1195) and the final progress message reports the count deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)