### PR TITLE
perf(acoustid): batched bulk-clear of all fingerprints (~100× faster)

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -9617,3 +9617,140 @@ func (p *PebbleStore) GetNarratorsByBookIDs(ctx context.Context, bookIDs []strin
 	}
 	return result, nil
 }
+
+// ClearAllAcoustIDFingerprints wipes AcoustIDSeg0..6 on every BookFile and
+// drops the matching book_file_acoustid:<seg> secondary index entries in
+// batched Pebble commits — one fsync per batchSize records instead of one
+// per UpdateBookFile call. The progress callback is invoked roughly every
+// 5000 records with (processed, cleared, total).
+//
+// Returns (cleared, total, err). cleared counts only files that actually had
+// at least one non-empty segment.
+func (s *PebbleStore) ClearAllAcoustIDFingerprints(ctx context.Context, batchSize int, progress func(processed, cleared, total int)) (int, int, error) {
+	if batchSize <= 0 {
+		batchSize = 2000
+	}
+
+	// First pass: collect primary keys so we don't hold an iterator open while
+	// we mutate Pebble underneath it. 308K keys at ~50 bytes each ≈ 15MB — fine.
+	prefix := []byte("book_file:")
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: []byte("book_file;"),
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	type ref struct {
+		key  []byte
+		data []byte
+	}
+	var refs []ref
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := iter.Key()
+		if !strings.HasPrefix(string(key), "book_file:") {
+			continue
+		}
+		// Skip secondary indexes — only primary book_file:<bookID>:<fileID>.
+		if c := strings.Count(string(key), ":"); c != 2 {
+			continue
+		}
+		kc := make([]byte, len(key))
+		copy(kc, key)
+		vc := make([]byte, len(iter.Value()))
+		copy(vc, iter.Value())
+		refs = append(refs, ref{key: kc, data: vc})
+	}
+	if err := iter.Close(); err != nil {
+		return 0, 0, err
+	}
+
+	total := len(refs)
+	cleared := 0
+	processed := 0
+	batch := s.db.NewBatch()
+	flush := func() error {
+		if err := batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		batch = s.db.NewBatch()
+		return nil
+	}
+
+	for _, r := range refs {
+		select {
+		case <-ctx.Done():
+			_ = batch.Close()
+			return cleared, total, ctx.Err()
+		default:
+		}
+
+		var f BookFile
+		if err := json.Unmarshal(r.data, &f); err != nil {
+			processed++
+			continue
+		}
+		processed++
+
+		if f.AcoustIDSeg0 == "" && f.AcoustIDSeg1 == "" && f.AcoustIDSeg2 == "" &&
+			f.AcoustIDSeg3 == "" && f.AcoustIDSeg4 == "" && f.AcoustIDSeg5 == "" &&
+			f.AcoustIDSeg6 == "" {
+			if progress != nil && processed%5000 == 0 {
+				progress(processed, cleared, total)
+			}
+			continue
+		}
+
+		// Delete each acoustid secondary index entry.
+		for _, seg := range [7]string{f.AcoustIDSeg0, f.AcoustIDSeg1, f.AcoustIDSeg2,
+			f.AcoustIDSeg3, f.AcoustIDSeg4, f.AcoustIDSeg5, f.AcoustIDSeg6} {
+			if seg == "" {
+				continue
+			}
+			if err := batch.Delete([]byte("book_file_acoustid:"+seg), nil); err != nil {
+				_ = batch.Close()
+				return cleared, total, err
+			}
+		}
+
+		f.AcoustIDSeg0, f.AcoustIDSeg1, f.AcoustIDSeg2 = "", "", ""
+		f.AcoustIDSeg3, f.AcoustIDSeg4, f.AcoustIDSeg5, f.AcoustIDSeg6 = "", "", "", ""
+		f.UpdatedAt = time.Now()
+
+		data, err := json.Marshal(&f)
+		if err != nil {
+			continue
+		}
+		if err := batch.Set(r.key, data, nil); err != nil {
+			_ = batch.Close()
+			return cleared, total, err
+		}
+		cleared++
+
+		// Keep memdb in lock-step with Pebble so subsequent in-RAM lookups
+		// don't return stale seg values.
+		if s.UseMemDB {
+			s.UpsertBookFileToMemDB(&f)
+		}
+
+		if batch.Len() >= batchSize {
+			if err := flush(); err != nil {
+				return cleared, total, err
+			}
+			if progress != nil {
+				progress(processed, cleared, total)
+			}
+		}
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return cleared, total, err
+	}
+	if progress != nil {
+		progress(processed, cleared, total)
+	}
+
+	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "clear_all_acoustid_fingerprints")
+	return cleared, total, nil
+}

--- a/internal/plugins/acoustid/reset_all.go
+++ b/internal/plugins/acoustid/reset_all.go
@@ -53,48 +53,66 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 	log := reporter.Logger()
 	startedAt := time.Now()
 
-	_ = reporter.UpdateProgress(0, 100, "Loading book files…")
-	files, err := p.store.GetAllBookFiles()
-	if err != nil {
-		return fmt.Errorf("load book files: %w", err)
-	}
-	total := len(files)
-	log.Info("acoustid reset-all: clearing fingerprints", "book_files", total)
+	_ = reporter.UpdateProgress(0, 100, "Clearing fingerprints (batched)…")
 
-	cleared := 0
-	for i := range files {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	var cleared int
 
-		f := files[i]
-		// Skip rows that already have no fingerprint data — saves a lot of
-		// Pebble writes on partial libraries.
-		if f.AcoustIDSeg0 == "" && f.AcoustIDSeg1 == "" && f.AcoustIDSeg2 == "" &&
-			f.AcoustIDSeg3 == "" && f.AcoustIDSeg4 == "" && f.AcoustIDSeg5 == "" &&
-			f.AcoustIDSeg6 == "" {
-			continue
+	// Fast path: PebbleStore exposes a batched bulk-clear that fsyncs once
+	// per ~2000 records instead of once per UpdateBookFile call — ~100×
+	// faster than the per-row fallback below.
+	if pebble, ok := p.store.(*database.PebbleStore); ok {
+		c, t, clearErr := pebble.ClearAllAcoustIDFingerprints(ctx, 2000,
+			func(processed, c, t int) {
+				pct := 0
+				if t > 0 {
+					pct = int(float64(processed) / float64(t) * 80)
+				}
+				_ = reporter.UpdateProgress(pct, 100,
+					fmt.Sprintf("Clearing fingerprints %d/%d (cleared=%d)", processed, t, c))
+			})
+		if clearErr != nil {
+			return fmt.Errorf("bulk clear fingerprints: %w", clearErr)
 		}
-		updated := f
-		updated.AcoustIDSeg0 = ""
-		updated.AcoustIDSeg1 = ""
-		updated.AcoustIDSeg2 = ""
-		updated.AcoustIDSeg3 = ""
-		updated.AcoustIDSeg4 = ""
-		updated.AcoustIDSeg5 = ""
-		updated.AcoustIDSeg6 = ""
-		if err := p.store.UpdateBookFile(f.ID, &updated); err != nil {
-			log.Warn("acoustid reset-all: update file failed", "id", f.ID, "err", err)
-			continue
+		cleared = c
+		log.Info("acoustid reset-all: bulk clear done", "cleared", c, "total", t, "elapsed", time.Since(startedAt).Round(time.Second))
+	} else {
+		// Per-row fallback (mock/sqlite tests).
+		files, err := p.store.GetAllBookFiles()
+		if err != nil {
+			return fmt.Errorf("load book files: %w", err)
 		}
-		cleared++
-
-		if i%500 == 0 || i == total-1 {
-			pct := int(float64(i+1) / float64(total) * 80)
-			_ = reporter.UpdateProgress(pct, 100,
-				fmt.Sprintf("Clearing fingerprints %d/%d (cleared=%d)", i+1, total, cleared))
+		total := len(files)
+		log.Info("acoustid reset-all: clearing fingerprints (slow path)", "book_files", total)
+		for i := range files {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			f := files[i]
+			if f.AcoustIDSeg0 == "" && f.AcoustIDSeg1 == "" && f.AcoustIDSeg2 == "" &&
+				f.AcoustIDSeg3 == "" && f.AcoustIDSeg4 == "" && f.AcoustIDSeg5 == "" &&
+				f.AcoustIDSeg6 == "" {
+				continue
+			}
+			updated := f
+			updated.AcoustIDSeg0 = ""
+			updated.AcoustIDSeg1 = ""
+			updated.AcoustIDSeg2 = ""
+			updated.AcoustIDSeg3 = ""
+			updated.AcoustIDSeg4 = ""
+			updated.AcoustIDSeg5 = ""
+			updated.AcoustIDSeg6 = ""
+			if err := p.store.UpdateBookFile(f.ID, &updated); err != nil {
+				log.Warn("acoustid reset-all: update file failed", "id", f.ID, "err", err)
+				continue
+			}
+			cleared++
+			if i%500 == 0 || i == total-1 {
+				pct := int(float64(i+1) / float64(total) * 80)
+				_ = reporter.UpdateProgress(pct, 100,
+					fmt.Sprintf("Clearing fingerprints %d/%d (cleared=%d)", i+1, total, cleared))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
The current 308K-file AcoustID reset is taking ~85 minutes because every `UpdateBookFile` call does one Pebble write with `pebble.Sync` (one fsync) plus a read of the old record plus deletion of up to 7 secondary index entries — fully serialized.

New `PebbleStore.ClearAllAcoustIDFingerprints` walks `book_file:` keys once, accumulates the clear writes + secondary-index deletes into a single Pebble batch, and commits every ~2000 records with one fsync. Expected: ~1–2 minutes for the whole library instead of 85.

The per-row fallback path is kept for mock/SQLite stores (tests).

## Test plan
- [ ] Reset op finishes in single-digit minutes on prod (vs 85 min before)
- [ ] After reset, `book_file_acoustid:` secondary index entries are gone (no exact-match hits in tier-1)
- [ ] Memdb in-RAM book_files have empty segs immediately (no stale reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)