### PR TITLE
feat(fingerprint+progress+ops-ui): whole-file FP, real-number progress, SSE resume fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,52 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.05.0 -->
+<!-- version: 3.06.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-05-29 -->
+<!-- last-edited: 2026-05-30 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Changes
+
+#### May 30, 2026 — Whole-file fingerprint migration (Step 1 + 2)
+
+Replaces the 7-segment per-BookFile fingerprint with a single whole-file
+chromaprint stored as raw uint32 LE bytes. Step 1 stops new fingerprints
+from being poisoned by ffmpeg's seek-past-EOF behaviour on m4b files
+with wrong duration metadata (the source of the ~14K false-positive
+100% dedup matches and the 71% prod fingerprint coverage gap).
+
+- `internal/fingerprint/wholefile.go` — new `FileWholeFingerprint(path)`
+  extracts from offset 0 to EOF with no `-length` cap and no offset
+  seeking. Rejects results with <80 frames. Exposes `DeriveSeg0(raw)`
+  so the legacy `AcoustIDSeg0` field stays populated as a transition
+  fallback without a second fpcalc invocation. New `WholeFileSimilarity`
+  Hamming-compares the middle 80% of two fps to suppress shared
+  Audible intros / publisher stings / "this has been an Audible
+  production" outros that otherwise make every Audible book partially
+  match every other one.
+- `internal/database/store.go` — new `BookFile.AcoustIDFingerprint []byte`
+  and `AcoustIDFingerprintDurationSec float64`. Legacy `AcoustIDSeg0..6`
+  remain on the struct as deprecated read-only fallbacks.
+- `internal/database/memdb_strip.go` — strips `AcoustIDFingerprint`
+  before memdb insert. ~3 GB potential RSS saving at full coverage.
+- `internal/plugins/acoustid/backfill.go` — `fingerprintBookFile`
+  switched to whole-file path. Force-rescan now clears legacy
+  `Seg1..6` so the AQAAAA sentinel pollution is retired. The
+  eligibility check is now a pure `fingerprintEligibility` function,
+  unit-testable without faking the entire Store interface.
+  `synthesizeBookSignatureForBook` switched from strict
+  `SynthesizeBookSignature` to `SynthesizePartialBookSignature` so
+  books with partial file coverage still produce a usable book sig
+  with `BookSigV1Mask` + `BookSigCoveragePct` set.
+- `internal/dedup/engine.go` — annotation only; Tier-1 exact match
+  still keys on `Seg0` (now derived deterministically from the
+  whole-file fp so the AQAAAA sentinel cannot recur). Whole-file
+  similarity matching is deferred to a future LSH index.
+- Tests: 22 new unit tests covering whole-file extraction failure
+  modes, intro/outro slicing, encode round-trip, eligibility matrix,
+  memdb strip invariant. All affected packages green.
 
 #### May 29, 2026 — MAYDEPLOY A→I sweep + Wave 4 perf audit (33 commits, PRs #1156–#1191)
 

--- a/PLAN-progress-realnums.md
+++ b/PLAN-progress-realnums.md
@@ -1,0 +1,107 @@
+# Plan: Progress Reporting — Real Numbers + Start/End Steps
+
+## Goal
+
+Replace every `UpdateProgress(pct, 100, …)` scaling pattern with real
+`(current, total)` counts, and adopt a uniform **start + N + end** step model so
+no operation ever shows `0/0` (which the UI renders as a broken bar).
+
+## Background
+
+`sdk.Reporter.UpdateProgress(current, total int, message string)` stores raw
+counts; the UI derives `%`. Today most plugins scale work to `(pct, 100)`
+which:
+
+1. Discards the real numerator/denominator (the user can't tell if the op is
+   chewing through 10 items or 300K).
+2. Breaks when `total == 0` — current code paths often pass `(0, 100)` then
+   skip straight to `(100, 100)` with no visible progress.
+3. Inflates the percentage early (e.g. `pct*0.8`) so the bar lies.
+
+## Step Model
+
+Every op gets at least these steps:
+
+```
+step 0           = "starting / loading"            (current=0, total=N+2)
+step 1..N        = each unit of real work          (current=i+1, total=N+2)
+step N+1         = "finalizing / writing results"  (current=N+1, total=N+2)
+step N+2         = "done"                          (current=N+2, total=N+2)
+```
+
+So when `N == 0` we still get `(0,2) → (1,2) → (2,2)` — never `0/0`.
+
+Helper to centralize this:
+
+```go
+// internal/plugins/sdk/progress.go  (new)
+type Progress struct {
+    r        sdk.Reporter
+    total    int   // N+2
+    cur      int
+}
+
+func NewProgress(r sdk.Reporter, n int) *Progress { ... }   // total = n+2
+func (p *Progress) Start(msg string)               { ... }   // (0, total)
+func (p *Progress) Step(msg string)                { ... }   // cur++, with pct in msg
+func (p *Progress) StepN(i, n int, msg string)     { ... }   // jump (start+i, total)
+func (p *Progress) Finalize(msg string)            { ... }   // (total-1, total)
+func (p *Progress) Done(msg string)                { ... }   // (total, total)
+```
+
+Message format (kept consistent across all ops):
+
+```
+"<verb> <i>/<N> (<extra>) (<pct>%)"
+e.g. "Clearing fingerprints 1088/308857 (cleared=1088) (0.35%)"
+```
+
+`pct` formatted `%.2f` when `N >= 100`, `%.0f` otherwise.
+
+## Files To Change (27)
+
+| Area | Files |
+|---|---|
+| acoustid | `reset_all.go` (partial done), `backfill.go` |
+| deluge | `centralization.go`, `path_update.go`, `protected_paths.go` |
+| dedup | `full_scan.go`, `embed_scan.go`, `embed_async.go`, `llm_review.go`, `split_book_scan.go`, `book_signature_scan.go` |
+| maintenance | `metadata.go`, `orphan_book_files.go`, `optimize.go`, `cleanup.go`, `author.go`, `dedup_ops.go` |
+| server | `metadata_handlers.go`, `ai_handlers.go`, `diagnostics_ops.go`, `duplicates_ops.go`, `duplicates_handlers.go`, `scheduler_maintenance_window_op.go` |
+| scheduler | `extra_ops.go` |
+| dedup pkg | `series_dedup.go`, `book_dedup.go` |
+| reconcile | `reconcile.go` |
+
+81 call sites total.
+
+## Order Of Operations
+
+1. **Add helper** `internal/plugins/sdk/progress.go` + unit tests covering
+   `n=0`, `n=1`, large-N, and `pct` formatting.
+2. **Pilot** on `acoustid/reset_all.go` (already partly done) + `backfill.go`,
+   refactor to use the helper, verify on prod-shape data.
+3. **Sweep** remaining 25 files via `/parallel-sweep` — one worktree/PR per
+   plugin package (acoustid / deluge / dedup / maintenance / server /
+   scheduler / dedup-pkg / reconcile = 8 waves).
+4. **Frontend audit**: check `web/src/**` op-progress components handle
+   `total != 100` correctly (they should — they compute `current/total*100`
+   themselves — but verify with one snapshot test).
+
+## Test Strategy
+
+- `progress_test.go` — covers helper math + zero-item case.
+- Each touched plugin keeps its existing tests; add one progress assertion
+  that `total > 0` always and final call satisfies `current == total`.
+- `make ci` per PR.
+- Manual smoke: trigger acoustid.reset-all, observe bar shows real
+  `1088/308857 (0.35%)` not `1/100`.
+
+## Rollback
+
+Each wave is a self-contained PR; revert individually if one op breaks. The
+helper is additive — leaving it in place after revert is harmless.
+
+## Non-Goals
+
+- Not changing the `UpdateProgress` SDK signature.
+- Not changing how the frontend renders progress.
+- Not unifying log lines (separate concern, tracked under UOS-tagging).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,61 +1,115 @@
-# PLAN: G2+G4 Split-Book Backfill Detector + CLI
+<!-- file: PLAN.md
+version: 1.1.0
+guid: fp-wholefile-2026-05-30
+-->
 
-## Goal
+# Whole-File Fingerprint Migration
 
-Detect existing split-book clusters (one Book per chapter) in the production
-DB and provide a one-shot CLI that can dry-run and execute a portable merge.
+**Goal:** Replace the 7-segment per-BookFile fingerprint with a single whole-file chromaprint per BookFile, stored as raw bytes. Add an LSH index later for sub-linear similarity search.
 
-## Files to add
+**Strategy: stop the bleeding first.** Step 1 ships ASAP so any new fingerprint extraction produces a valid whole-file fp. Then run reset + rescan once on prod to fix existing damage. Steps 2–4 follow at normal pace.
 
-- `internal/dedup/split_book_detector.go` (+ test) — pure detector.
-- `internal/dedup/split_book_storage.go` — Pebble JSON store of candidates.
-- `internal/dedup/split_book_merge.go` — portable cluster merge.
-- `internal/plugins/dedup/split_book_scan.go` — OperationDef wrapper.
-- `internal/plugins/dedup/plugin.go` — register the new op.
-- `internal/server/split_book_handlers.go` — list/run/merge handlers.
-- `internal/server/server_lifecycle.go` — route bindings.
-- `tools/cmd/merge-split-books/main.go` — CLI.
+**Branch:** `feat/fingerprint-wholefile`
+**Worktree:** `../audiobook-organizer-fp-wholefile`
 
-## Heuristic
+---
 
-Group by `filepath.Dir(FilePath)` (parent) and `filepath.Dir(filepath.Dir(FilePath))` (grandparent).
+## Why
 
-Qualifies as candidate when:
-- ≥3 books in the group
-- all share same AuthorID (or all nil)
-- all share same SeriesID or all nil
-- extracted integers from filename or parent-dir name form near-sequential run (≥70% coverage of [min..max], no gap >2)
+- **Robust:** `fpcalc path` from offset 0 to EOF has no seek-past-EOF failure mode. Every file that plays gets a fingerprint.
+- **No sentinel pollution:** `AQAAAA` (header-only) came from ffmpeg pipes seeking past lying duration metadata. With whole-file extraction this disappears.
+- **Per-file spec:** "save the AcoustID for every file; multi-part books also get a combined book signature."
+- **Better matching:** full audio fp > 7 × 5-min spot-checks.
+- **Simpler code:** one extraction path, one field.
 
-Grandparent emit only when every child parent-group has size 1.
-A book is assigned to at most one candidate (parent wins).
+---
 
-## Storage
+## Storage Budget
 
-Pebble keyspace `split_book_candidate:<ulid>` → JSON. List by prefix scan.
-Each entry: ID, ParentFolder, BookIDs, SuggestedTitle, SuggestedAuthor,
-SequentialPattern, CreatedAt.
+| Metric | Value |
+|---|---|
+| Per-file raw bytes (avg 2hr file) | ~230 KB |
+| Per-file raw bytes (10hr single-file book) | ~1.15 MB |
+| Reachable files in lib | ~10–15K |
+| Projected fingerprint total | **2–6 GB** raw |
 
-## Merge (portable; works on Pebble)
+Stays in main PebbleDB under `BookFile.AcoustIDFingerprint []byte` field. No separate DB until/unless compaction stalls show up.
 
-For `keepID + srcIDs`:
-1. For each src: GetBookFiles, MoveBookFilesToBook → keepID.
-2. Recompute keep duration as sum of all bookfile durations.
-3. Update keep title to SuggestedTitle.
-4. SoftDelete each src via merge.SoftDeleteBook.
+---
 
-Avoids SQLite-only MergeChapterBooks and avoids merge.MergeBooks (which deletes losers + their files).
+## Step 1 — Schema + Whole-File Extraction (SHIP FIRST)
 
-## CLI
+**Goal:** Stop new fingerprints from being bad. Land + deploy under flag.
 
-`tools/cmd/merge-split-books` — mirror reconcile-paths structure.
-Flags: `--api`, `--key`, `--dry-run` (default true), `--execute`,
-`--min-group-size 3`, `--limit 0`.
+### Files to add
+- `internal/fingerprint/wholefile.go`
+  - `FileWholeFingerprint(path string) (raw []byte, duration float64, err error)`
+  - Runs `fpcalc -raw path` — raw uint32 stream, no base64 wrap, no `-length` cap, no offset.
+  - Parses `DURATION=...` and `FINGERPRINT=...` from fpcalc output.
+  - Returns `[]byte` of length `4 × frame_count`.
+  - Validates: frame count ≥ `MinUsefulFingerprintFrames` (80).
 
-## Test strategy
+### Files to modify
+- `internal/database/store.go`:
+  - Add `BookFile.AcoustIDFingerprint []byte`
+  - Add `BookFile.AcoustIDFingerprintDurationSec float64`
+  - Keep `AcoustIDSeg0..6 string` for back-compat reads.
+- `internal/plugins/acoustid/backfill.go`:
+  - `fingerprintBookFile` switches to `FileWholeFingerprint` when `WHOLEFILE_FINGERPRINTS=true` (env-gated, default ON in this PR so it actually takes effect).
+  - Writes to new field; still writes seg0 (cheap, useful as fallback during transition).
+  - Stops writing seg1..6 entirely (these were the buggy ones anyway).
+- `internal/dedup/engine.go`:
+  - Tier-1 AcoustID compare prefers `AcoustIDFingerprint` when present, falls back to `AcoustIDSeg0`.
 
-Unit tests for detector (flat case, grandparent case, qualify/disqualify).
-Manual smoke for CLI (documented in PR body).
+### Tests
+- `internal/fingerprint/wholefile_test.go`:
+  - known-good m4b fixture → fingerprint non-empty, duration > 0
+  - tiny mp3 (10 sec) → fingerprint non-empty
+  - corrupt file → returns error, no partial data
+  - lying-duration m4b → still produces full fp (this is the key test)
+- `internal/database/` — round-trip `BookFile.AcoustIDFingerprint` through Pebble.
 
-## Rollback
+### Migration
+- No schema rewrite. New field is `nil` for existing rows.
+- After ship: run `acoustid.reset-all` then `fingerprint-rescan` on prod to fix existing damage.
 
-Pure additive. Revert PR.
+### Verify before merge
+- `make ci` passes
+- New field round-trips through PebbleDB
+- Existing dedup tests still pass with fallback path
+
+---
+
+## Step 2 — Book Signature Partial Coverage (next PR)
+
+Wire `synthesizeBookSignatureForBook` to use `SynthesizePartialBookSignature` so books with partial file coverage still get a sig with a coverage % flag. Surface coverage in UI.
+
+---
+
+## Step 3 — LSH Index (later PR)
+
+Add `fpidx:<subfp>:<bookfile_id>` secondary index for sub-linear similarity search. Replaces full-scan dedup with candidate-set + Hamming refine. Bench target: <100ms query at 15K-file scale.
+
+---
+
+## Step 4 — Cleanup (final PR)
+
+Remove `AcoustIDSeg1..6` fields and `FileSegments`. Keep `AcoustIDSeg0` one more release cycle as fallback.
+
+---
+
+## Rollback (Step 1)
+
+- Feature flag `WHOLEFILE_FINGERPRINTS=false` reverts new-write path; reads still work because seg0 is still populated.
+- New `AcoustIDFingerprint` field is additive — reverting code leaves data in place.
+- `acoustid.reset-all` still works to clear everything.
+
+---
+
+## Status
+
+- [ ] Step 1: Schema + whole-file extraction **(in progress)**
+- [ ] Reset + rescan prod
+- [ ] Step 2: Book sig partial coverage
+- [ ] Step 3: LSH index
+- [ ] Step 4: Cleanup

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.55.0 -->
+<!-- version: 8.56.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-05-29 -->
+<!-- last-edited: 2026-05-30 -->
 
 # Project TODO
 
@@ -25,6 +25,39 @@ future agent) can scan the entire workspace in one page.
 **Production:** PebbleDB primary + ChaiDB SQL (write-through sync active); Linux, HTTPS at `172.16.2.30:8484`
 **Latest activity:** Chai SQL migration (Phases 1–4 complete, Tasks 3.2–3.4 landed); N+1 query elimination; cache warm-up memory fix; authors/series caching
 **In flight:** Chai SQL Phase 5+ (remaining read migrations), SEC-AUDIT-11 (CodeQL bulk dismiss), FE-10 (Vitest coverage thresholds)
+
+---
+
+## 🎯 Whole-file fingerprint migration (started May 30, 2026)
+
+PR `feat/fingerprint-wholefile` (Step 1 + 2) ships:
+- New `BookFile.AcoustIDFingerprint []byte` + duration sec
+- `FileWholeFingerprint(path)` extraction (no seek, no offsets)
+- Middle-80% similarity compare (suppresses Audible intros/outros)
+- `synthesizeBookSignatureForBook` switched to partial-coverage synth
+- Memdb strip of the new fingerprint bytes (RSS protection)
+
+**Post-deploy actions for this PR:**
+- [ ] Run `acoustid.reset-all` on prod (retires AQAAAA-poisoned segs)
+- [ ] Run `fingerprint-rescan` on prod (populates new whole-file fp + clean seg0)
+- [ ] Verify dedup stops showing 14K false-positive 100% matches
+- [ ] Verify book-sig coverage % shows up for partial books
+
+**Follow-up PRs (not in this PR):**
+- [ ] **Step 3 — LSH index for whole-file similarity.** Add
+  `fpidx:<subfp>:<bookfile_id>` secondary index in PebbleStore;
+  replace dedup's full-scan fuzzy match with candidate-set + Hamming
+  refine. Bench target: <100ms per query at 15K files. Includes
+  global subfingerprint-frequency masking to learn shared intros
+  from the data instead of relying on the 10% slice rule.
+- [ ] **Step 4 — Drop legacy seg1..6 fields.** After one release
+  cycle of validation: remove `AcoustIDSeg1..6` from `BookFile`,
+  remove `FileSegments` + offset/ffmpeg-pipe code from
+  `internal/fingerprint/fpcalc.go`, migrate prod data to clear
+  the columns.
+- [ ] **Online AcoustID lookup.** Whole-file fps can now be POSTed
+  to `acoustid.org` for MBID enrichment — wire it up as an
+  optional enrichment step after fingerprinting.
 
 ---
 

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -84,5 +84,12 @@ func stripBookFileForMemdb(src *BookFile) *BookFile {
 	cp.FingerprintFailureReason = nil
 	cp.FingerprintFailureDetail = nil
 	cp.FingerprintDiagnosticJSON = nil
+	// AcoustIDFingerprint is the whole-file raw chromaprint stream
+	// (~230 KB per 2hr file). At ~15K reachable files that's 3+ GB of
+	// memdb RSS for data nothing currently reads from memdb — the LSH
+	// index (Step 3) will live in Pebble secondary keys, not memdb rows.
+	// Pebble-direct callers that need the whole-file fp can still fetch
+	// it via GetBookFile / GetBookFiles bypass paths.
+	cp.AcoustIDFingerprint = nil
 	return &cp
 }

--- a/internal/database/memdb_strip_test.go
+++ b/internal/database/memdb_strip_test.go
@@ -1,0 +1,94 @@
+// file: internal/database/memdb_strip_test.go
+// version: 1.0.0
+// guid: e6f7a8b9-c0d1-4e2f-3a4b-5c6d7e8f9012
+
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStripBookFileForMemdb_NilsLargeFields(t *testing.T) {
+	now := time.Now()
+	reason := "corrupt_audio"
+	detail := "ffmpeg returned 1"
+	diag := `{"diagnostic":"data"}`
+
+	src := &BookFile{
+		ID:                             "bf-1",
+		BookID:                         "book-1",
+		FilePath:                       "/tmp/test.m4b",
+		AcoustIDSeg0:                   "AQADtAcSRY",
+		AcoustIDFingerprint:            make([]byte, 256*1024),
+		AcoustIDFingerprintDurationSec: 7200.5,
+		FingerprintFailedAt:            &now,
+		FingerprintFailureReason:       &reason,
+		FingerprintFailureDetail:       &detail,
+		FingerprintDiagnosticJSON:      &diag,
+	}
+
+	stripped := stripBookFileForMemdb(src)
+	if stripped == nil {
+		t.Fatal("stripped is nil")
+	}
+
+	if stripped.AcoustIDFingerprint != nil {
+		t.Errorf("AcoustIDFingerprint not stripped: got len=%d, want nil", len(stripped.AcoustIDFingerprint))
+	}
+	if stripped.FingerprintFailedAt != nil {
+		t.Errorf("FingerprintFailedAt not stripped")
+	}
+	if stripped.FingerprintFailureReason != nil {
+		t.Errorf("FingerprintFailureReason not stripped")
+	}
+	if stripped.FingerprintFailureDetail != nil {
+		t.Errorf("FingerprintFailureDetail not stripped")
+	}
+	if stripped.FingerprintDiagnosticJSON != nil {
+		t.Errorf("FingerprintDiagnosticJSON not stripped")
+	}
+
+	if stripped.ID != "bf-1" {
+		t.Errorf("ID not preserved: %q", stripped.ID)
+	}
+	if stripped.BookID != "book-1" {
+		t.Errorf("BookID not preserved: %q", stripped.BookID)
+	}
+	if stripped.FilePath != "/tmp/test.m4b" {
+		t.Errorf("FilePath not preserved: %q", stripped.FilePath)
+	}
+	if stripped.AcoustIDSeg0 != "AQADtAcSRY" {
+		t.Errorf("AcoustIDSeg0 not preserved: %q", stripped.AcoustIDSeg0)
+	}
+	if stripped.AcoustIDFingerprintDurationSec != 7200.5 {
+		t.Errorf("AcoustIDFingerprintDurationSec not preserved: %v", stripped.AcoustIDFingerprintDurationSec)
+	}
+
+	if src.AcoustIDFingerprint == nil {
+		t.Errorf("source mutated: AcoustIDFingerprint nil on src")
+	}
+	if src.FingerprintFailedAt == nil {
+		t.Errorf("source mutated: FingerprintFailedAt nil on src")
+	}
+}
+
+func TestStripBookFileForMemdb_NilInput(t *testing.T) {
+	if got := stripBookFileForMemdb(nil); got != nil {
+		t.Errorf("nil input: got %v, want nil", got)
+	}
+}
+
+func TestStripBookFileForMemdb_AlreadyEmpty(t *testing.T) {
+	src := &BookFile{ID: "bf-2"}
+	stripped := stripBookFileForMemdb(src)
+	if stripped == nil {
+		t.Fatal("nil result")
+	}
+	if stripped.ID != "bf-2" {
+		t.Errorf("ID corrupted: %q", stripped.ID)
+	}
+	if stripped.AcoustIDFingerprint != nil {
+		t.Errorf("empty input produced non-nil AcoustIDFingerprint")
+	}
+}

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.76.0
+// version: 2.77.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-05-20
+// last-edited: 2026-05-30
 
 package database
 
@@ -673,7 +673,18 @@ type BookFile struct {
 	// tag write. It differs from OriginalFileHash because tag writes add/change
 	// bytes in the header. Store it so pre-write identity is always recoverable.
 	PostMetadataHash string `json:"post_metadata_hash,omitempty"`
-	// 7 acoustic fingerprint segments. [0]=intro, [1-5]=body, [6]=outro.
+	// AcoustIDFingerprint is the whole-file chromaprint, raw uint32 stream
+	// stored as little-endian bytes. 4 bytes per frame at 8 frames/sec.
+	// Populated by FileWholeFingerprint. Preferred over the segment fields
+	// for similarity matching.
+	AcoustIDFingerprint []byte `json:"acoustid_fingerprint,omitempty"`
+	// AcoustIDFingerprintDurationSec is the duration fpcalc actually
+	// measured while decoding (may differ from container metadata when the
+	// container is lying about duration).
+	AcoustIDFingerprintDurationSec float64 `json:"acoustid_fingerprint_duration_sec,omitempty"`
+	// 7-segment fields. Deprecated — kept for back-compat reads during the
+	// whole-file migration. New writes only populate Seg0 as a transition
+	// fallback; Seg1..6 are no longer written.
 	AcoustIDSeg0 string `json:"acoustid_seg0,omitempty"`
 	AcoustIDSeg1 string `json:"acoustid_seg1,omitempty"`
 	AcoustIDSeg2 string `json:"acoustid_seg2,omitempty"`

--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -48,23 +48,27 @@ func ScanBookDuplicates(
 	dismissed map[string]bool,
 	progress ProgressReporter,
 ) (BookScanResult, error) {
-	report := func(pct int, msg string) {
+	// Fixed-step scan: 5 stages (start, hash, folder, metadata, merge, done).
+	const totalSteps = 5
+	report := func(step int, msg string) {
 		if progress != nil {
-			_ = progress.UpdateProgress(pct, 100, msg)
+			pct := float64(step) * 100.0 / float64(totalSteps)
+			_ = progress.UpdateProgress(step, totalSteps,
+				fmt.Sprintf("%s (%d/%d, %.2f%%)", msg, step, totalSteps, pct))
 		}
 	}
 
 	report(0, "Scanning for duplicate books...")
 
 	// Step 1: Hash-based duplicates (high confidence)
-	report(10, "Finding hash-based duplicates...")
+	report(1, "Finding hash-based duplicates...")
 	hashGroups, err := store.GetDuplicateBooks()
 	if err != nil {
 		return BookScanResult{}, fmt.Errorf("hash-based dedup failed: %w", err)
 	}
 
 	// Step 2: Folder duplicates (same title in same folder)
-	report(30, "Finding folder-based duplicates...")
+	report(2, "Finding folder-based duplicates...")
 	folderGroups, err := store.GetFolderDuplicates()
 	if err != nil {
 		slog.Warn("folder dedup failed", "error", err)
@@ -72,14 +76,14 @@ func ScanBookDuplicates(
 	}
 
 	// Step 3: Metadata-based fuzzy matching
-	report(50, "Finding metadata-based duplicates...")
+	report(3, "Finding metadata-based duplicates...")
 	metadataGroups, err := store.GetDuplicateBooksByMetadata(0.85)
 	if err != nil {
 		slog.Warn("metadata dedup failed", "error", err)
 		metadataGroups = nil
 	}
 
-	report(80, "Merging results...")
+	report(4, "Merging results...")
 
 	// Combine all groups, deduplicating by book ID.
 	seenBookIDs := map[string]bool{}
@@ -128,7 +132,7 @@ func ScanBookDuplicates(
 		totalDuplicates += len(g.Books) - 1
 	}
 
-	report(100, fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(allGroups), totalDuplicates))
+	report(5, fmt.Sprintf("Found %d duplicate groups (%d duplicates)", len(allGroups), totalDuplicates))
 
 	return BookScanResult{
 		Groups:          allGroups,
@@ -164,10 +168,16 @@ func MergeBooks(
 		return BookMergeResult{}, fmt.Errorf("keep book %s not found", keepID)
 	}
 
+	total := len(mergeIDs)
 	if progress != nil {
 		_ = progress.Log("info",
-			fmt.Sprintf("Merging %d book(s) into %q", len(mergeIDs), keepBook.Title), nil)
-		_ = progress.UpdateProgress(0, len(mergeIDs), "Starting book merge...")
+			fmt.Sprintf("Merging %d book(s) into %q", total, keepBook.Title), nil)
+		denom := total
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(0, denom,
+			fmt.Sprintf("Starting book merge... (0/%d, 0.00%%)", total))
 	}
 
 	kBook, err := store.GetBookByID(keepID)
@@ -227,8 +237,9 @@ func MergeBooks(
 		}
 
 		if progress != nil {
-			_ = progress.UpdateProgress(i+1, len(mergeIDs),
-				fmt.Sprintf("Merged %d/%d books", i+1, len(mergeIDs)))
+			pct := float64(i+1) * 100.0 / float64(total)
+			_ = progress.UpdateProgress(i+1, total,
+				fmt.Sprintf("Merged %d/%d books (%.2f%%)", i+1, total, pct))
 		}
 	}
 
@@ -241,6 +252,12 @@ func MergeBooks(
 		msg := fmt.Sprintf("Book merge complete: merged %d, %d errors",
 			result.MergedCount, len(result.Errors))
 		_ = progress.Log("info", msg, nil)
+		denom := total
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(denom, denom,
+			fmt.Sprintf("%s (%d/%d, 100.00%%)", msg, total, total))
 	}
 
 	result.UpdatedKeepBook = kBook

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -2241,6 +2241,11 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		}
 
 		for _, f := range files {
+			// Whole-file fingerprint exists on rows written by the
+			// FileWholeFingerprint path (PLAN.md/feat/fingerprint-wholefile).
+			// Tier-1 exact match still keys on Seg0 (derived from the whole-
+			// file fp by DeriveSeg0 so it's free of the AQAAAA sentinels).
+			// Whole-file similarity matching is deferred to Step 3 / LSH.
 			segs := []string{
 				f.AcoustIDSeg0, f.AcoustIDSeg1, f.AcoustIDSeg2,
 				f.AcoustIDSeg3, f.AcoustIDSeg4, f.AcoustIDSeg5,

--- a/internal/dedup/series_dedup.go
+++ b/internal/dedup/series_dedup.go
@@ -131,9 +131,13 @@ func ScanSeriesDuplicates(
 	store database.Store,
 	progress ProgressReporter,
 ) (SeriesScanResult, error) {
-	report := func(pct int, msg string) {
+	// Fixed-step scan: 6 stages (start, load, author-lookup, exact, subseries, done).
+	const totalSteps = 6
+	report := func(step int, msg string) {
 		if progress != nil {
-			_ = progress.UpdateProgress(pct, 100, msg)
+			pct := float64(step) * 100.0 / float64(totalSteps)
+			_ = progress.UpdateProgress(step, totalSteps,
+				fmt.Sprintf("%s (%d/%d, %.2f%%)", msg, step, totalSteps, pct))
 		}
 	}
 
@@ -143,7 +147,7 @@ func ScanSeriesDuplicates(
 	if err != nil {
 		return SeriesScanResult{}, err
 	}
-	report(10, fmt.Sprintf("Loaded %d series, grouping...", len(allSeries)))
+	report(1, fmt.Sprintf("Loaded %d series, grouping...", len(allSeries)))
 
 	// Build exact-match groups (normalised name → series list).
 	exactGroups := make(map[string][]database.Series)
@@ -155,7 +159,7 @@ func ScanSeriesDuplicates(
 		exactGroups[key] = append(exactGroups[key], s)
 	}
 
-	report(20, "Building author lookup...")
+	report(2, "Building author lookup...")
 
 	allAuthors, _ := store.GetAllAuthors()
 	authorNameMap := make(map[int]string, len(allAuthors))
@@ -166,7 +170,7 @@ func ScanSeriesDuplicates(
 	var result []SeriesDupGroup
 	seen := make(map[int]bool)
 
-	report(30, "Finding exact duplicates...")
+	report(3, "Finding exact duplicates...")
 
 	groupKeys := make([]string, 0, len(exactGroups))
 	for k := range exactGroups {
@@ -192,16 +196,16 @@ func ScanSeriesDuplicates(
 			MatchType:     "exact",
 		})
 		processed++
-		if processed%10 == 0 {
-			pct := 30 + (processed*40)/maxInt(totalGroups, 1)
+		if processed%10 == 0 && totalGroups > 0 {
 			if progress != nil {
-				_ = progress.UpdateProgress(minInt(pct, 70), 100,
-					fmt.Sprintf("Processing groups... (%d/%d)", processed, totalGroups))
+				pct := float64(processed) * 100.0 / float64(totalGroups)
+				_ = progress.UpdateProgress(processed, totalGroups,
+					fmt.Sprintf("Processing groups... (%d/%d, %.2f%%)", processed, totalGroups, pct))
 			}
 		}
 	}
 
-	report(70, "Finding sub-series patterns...")
+	report(4, "Finding sub-series patterns...")
 
 	seriesByNormalizedName := make(map[string][]database.Series)
 	for _, s := range allSeries {
@@ -239,7 +243,7 @@ func ScanSeriesDuplicates(
 		}
 	}
 
-	report(100, fmt.Sprintf("Found %d duplicate groups", len(result)))
+	report(6, fmt.Sprintf("Found %d duplicate groups", len(result)))
 
 	return SeriesScanResult{
 		Groups:      result,
@@ -265,6 +269,7 @@ func DedupSeries(
 ) (SeriesDedupResult, error) {
 	if progress != nil {
 		_ = progress.Log("info", "Starting series deduplication...", nil)
+		_ = progress.UpdateProgress(0, 1, "Starting series deduplication... (0/1, 0.00%)")
 	}
 
 	allSeries, err := store.GetAllSeries()
@@ -273,8 +278,12 @@ func DedupSeries(
 	}
 
 	if progress != nil {
-		_ = progress.UpdateProgress(0, len(allSeries),
-			fmt.Sprintf("Scanning %d series for duplicates...", len(allSeries)))
+		denom := len(allSeries)
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(0, denom,
+			fmt.Sprintf("Scanning %d series for duplicates... (0/%d, 0.00%%)", len(allSeries), len(allSeries)))
 	}
 
 	// Group by normalised name.
@@ -294,7 +303,12 @@ func DedupSeries(
 	if progress != nil {
 		msg := fmt.Sprintf("Found %d duplicate groups to merge", len(dupGroups))
 		_ = progress.Log("info", msg, nil)
-		_ = progress.UpdateProgress(0, len(dupGroups), msg)
+		denom := len(dupGroups)
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(0, denom,
+			fmt.Sprintf("%s (0/%d, 0.00%%)", msg, len(dupGroups)))
 	}
 
 	var result SeriesDedupResult
@@ -341,8 +355,10 @@ func DedupSeries(
 		}
 
 		if progress != nil {
+			pct := float64(gi+1) * 100.0 / float64(len(dupGroups))
 			_ = progress.UpdateProgress(gi+1, len(dupGroups),
-				fmt.Sprintf("Merged %d/%d groups (%d series merged)", gi+1, len(dupGroups), result.TotalMerged))
+				fmt.Sprintf("Merged %d/%d groups (%d series merged, %.2f%%)",
+					gi+1, len(dupGroups), result.TotalMerged, pct))
 		}
 	}
 
@@ -354,6 +370,12 @@ func DedupSeries(
 			errDetail := strings.Join(result.Errors[:minInt(len(result.Errors), 10)], "; ")
 			_ = progress.Log("warn", fmt.Sprintf("Merge errors: %s", errDetail), nil)
 		}
+		denom := len(dupGroups)
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(denom, denom,
+			fmt.Sprintf("%s (%d/%d, 100.00%%)", msg, len(dupGroups), len(dupGroups)))
 	}
 
 	return result, nil
@@ -413,10 +435,16 @@ func MergeSeries(
 		}
 	}
 
+	total := len(mergeIDs)
 	if progress != nil {
 		_ = progress.Log("info",
-			fmt.Sprintf("Merging %d series into %q", len(mergeIDs), keepName), nil)
-		_ = progress.UpdateProgress(0, len(mergeIDs), "Starting series merge...")
+			fmt.Sprintf("Merging %d series into %q", total, keepName), nil)
+		denom := total
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(0, denom,
+			fmt.Sprintf("Starting series merge... (0/%d, 0.00%%)", total))
 	}
 
 	// Collect all unique author IDs from the full set of series (keep + merge).
@@ -489,8 +517,9 @@ func MergeSeries(
 		}
 
 		if progress != nil {
-			_ = progress.UpdateProgress(i+1, len(mergeIDs),
-				fmt.Sprintf("Merged %d/%d series", i+1, len(mergeIDs)))
+			pct := float64(i+1) * 100.0 / float64(total)
+			_ = progress.UpdateProgress(i+1, total,
+				fmt.Sprintf("Merged %d/%d series (%.2f%%)", i+1, total, pct))
 		}
 	}
 
@@ -544,6 +573,12 @@ func MergeSeries(
 			errDetail := strings.Join(result.Errors[:minInt(len(result.Errors), 10)], "; ")
 			_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
 		}
+		denom := total
+		if denom == 0 {
+			denom = 1
+		}
+		_ = progress.UpdateProgress(denom, denom,
+			fmt.Sprintf("%s (%d/%d, 100.00%%)", msg, total, total))
 	}
 
 	return result, nil

--- a/internal/fingerprint/wholefile.go
+++ b/internal/fingerprint/wholefile.go
@@ -1,0 +1,202 @@
+// file: internal/fingerprint/wholefile.go
+// version: 1.0.0
+// guid: c4d5e6f7-a8b9-4c0d-1e2f-3a4b5c6d7e8f
+
+package fingerprint
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ErrFingerprintTooShort is returned when fpcalc decoded a file but the
+// resulting fingerprint has fewer than MinUsefulFingerprintFrames frames.
+var ErrFingerprintTooShort = errors.New("fingerprint: extracted fingerprint is too short to be useful")
+
+// WholeFile holds the result of a whole-file fingerprint extraction.
+type WholeFile struct {
+	// Raw is the chromaprint payload as a little-endian uint32 stream
+	// (4 bytes per frame, 8 frames per second). The 4-byte chromaprint
+	// header is NOT included — these are the comparison-ready frames.
+	Raw []byte
+	// DurationSec is the audio duration as fpcalc measured it while
+	// decoding (which is more trustworthy than container metadata).
+	DurationSec float64
+}
+
+// FrameCount returns the number of chromaprint frames in the fingerprint.
+func (w *WholeFile) FrameCount() int {
+	if w == nil {
+		return 0
+	}
+	return len(w.Raw) / 4
+}
+
+// FileWholeFingerprint extracts a whole-file chromaprint for the audio file
+// at path. Unlike FileSegments it does not seek into the file or cap the
+// analysed length — fpcalc decodes from offset 0 to EOF, so this works on
+// any playable file regardless of whether the container's duration metadata
+// is correct.
+//
+// Returns ErrNotAvailable if fpcalc is not on PATH (this path intentionally
+// does not fall back to the ffmpeg chromaprint muxer; the muxer's output
+// alignment varies by ffmpeg version and the call sites that need whole-file
+// fingerprints want a single canonical encoding).
+//
+// Returns ErrFingerprintTooShort if fpcalc produced fewer than
+// MinUsefulFingerprintFrames frames (e.g. <10s of audio, or a corrupt file
+// that decoded only its header).
+func FileWholeFingerprint(path string) (*WholeFile, error) {
+	fpcalc, err := exec.LookPath("fpcalc")
+	if err != nil {
+		return nil, ErrNotAvailable
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(fpcalc, "-json", path)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("fpcalc %s: %s", path, msg)
+	}
+
+	var r Result
+	if err := json.NewDecoder(&stdout).Decode(&r); err != nil {
+		return nil, fmt.Errorf("fpcalc parse %s: %w", path, err)
+	}
+	if r.Fingerprint == "" {
+		return nil, fmt.Errorf("fpcalc returned empty fingerprint for %s", path)
+	}
+
+	frames, err := decodeAnyFingerprint(r.Fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("fpcalc decode %s: %w", path, err)
+	}
+	if len(frames) < MinUsefulFingerprintFrames {
+		return nil, fmt.Errorf("%w: %d frames (< %d)", ErrFingerprintTooShort, len(frames), MinUsefulFingerprintFrames)
+	}
+
+	raw := make([]byte, len(frames)*4)
+	for i, f := range frames {
+		binary.LittleEndian.PutUint32(raw[i*4:], f)
+	}
+
+	return &WholeFile{
+		Raw:         raw,
+		DurationSec: r.Duration,
+	}, nil
+}
+
+// DeriveSeg0 returns the canonical base64 chromaprint for the first
+// SegmentSeconds (5 minutes) of a whole-file raw fingerprint. Used to
+// populate the legacy AcoustIDSeg0 field during the whole-file migration
+// so callers still reading the segment fields keep working without a
+// second fpcalc invocation.
+func DeriveSeg0(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	maxFrames := SegmentSeconds * 8 // 8 fps
+	maxBytes := maxFrames * 4
+	slice := raw
+	if len(slice) > maxBytes {
+		slice = slice[:maxBytes]
+	}
+	return EncodeWholeFingerprint(slice)
+}
+
+// EdgeSkipFraction is the fraction trimmed from each end of a whole-file
+// fingerprint before similarity comparison. Default 0.10 = skip first and
+// last 10% of frames.
+//
+// Why: Audible (and many other publishers) prepend a near-identical
+// intro/sting to every book, and append a similar outro. Comparing those
+// shared sections as if they were content makes every Audible book
+// partially match every other one. Trimming both ends of the fingerprint
+// before comparison kills the false-positive baseline while keeping all
+// extracted data on disk so we can refine the rule later without
+// re-fingerprinting.
+const EdgeSkipFraction = 0.10
+
+// MinMiddleFrames is the smallest middle slice we'll compare. Below this
+// the file is short enough that edge-trimming would leave nothing useful
+// (e.g. a 30-second clip), so we fall back to whole-fingerprint compare.
+const MinMiddleFrames = 240 // ≈30 seconds at 8 fps
+
+// WholeFileSimilarity compares two whole-file fingerprints (raw LE uint32
+// byte streams) using a middle slice of each. It trims EdgeSkipFraction
+// from the head and tail of each fingerprint before Hamming-comparing the
+// overlapping length. For very short fingerprints it compares the whole
+// thing.
+//
+// Returns 0 and an error if either input is empty.
+func WholeFileSimilarity(a, b []byte) (float64, error) {
+	if len(a) == 0 || len(b) == 0 {
+		return 0, errors.New("empty fingerprint")
+	}
+	if len(a)%4 != 0 || len(b)%4 != 0 {
+		return 0, errors.New("fingerprint bytes not uint32-aligned")
+	}
+	sliceA := middleSliceFrames(a)
+	sliceB := middleSliceFrames(b)
+	n := len(sliceA)
+	if len(sliceB) < n {
+		n = len(sliceB)
+	}
+	if n == 0 {
+		return 0, errors.New("middle slice is empty")
+	}
+
+	var matching, total uint32
+	for i := 0; i < n; i += 4 {
+		ai := binary.LittleEndian.Uint32(sliceA[i:])
+		bi := binary.LittleEndian.Uint32(sliceB[i:])
+		matching += 32 - popcount(ai^bi)
+		total += 32
+	}
+	return float64(matching) / float64(total), nil
+}
+
+// middleSliceFrames returns the inner 1-2*EdgeSkipFraction of fp, aligned
+// to uint32 boundaries. If fp is too short, returns fp unchanged.
+func middleSliceFrames(fp []byte) []byte {
+	frames := len(fp) / 4
+	if frames < MinMiddleFrames {
+		return fp
+	}
+	skip := int(float64(frames) * EdgeSkipFraction)
+	if skip <= 0 {
+		return fp
+	}
+	start := skip * 4
+	end := (frames - skip) * 4
+	if end-start < MinMiddleFrames*4 {
+		return fp
+	}
+	return fp[start:end]
+}
+
+
+// canonical base64 chromaprint string (with the standard 4-byte
+// version-1 header). Useful when interoperating with code paths that still
+// expect the base64 form, including potential online AcoustID lookup.
+func EncodeWholeFingerprint(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	header := []byte{0x01, 0x00, 0x00, 0x00}
+	buf := make([]byte, 0, 4+len(raw))
+	buf = append(buf, header...)
+	buf = append(buf, raw...)
+	return base64.StdEncoding.EncodeToString(buf)
+}

--- a/internal/fingerprint/wholefile_test.go
+++ b/internal/fingerprint/wholefile_test.go
@@ -1,0 +1,304 @@
+// file: internal/fingerprint/wholefile_test.go
+// version: 1.0.0
+// guid: d5e6f7a8-b9c0-4d1e-2f3a-4b5c6d7e8f90
+
+package fingerprint
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// makeRawFingerprint builds a synthetic raw uint32 LE fingerprint of n
+// frames. Each frame value is f(i) so the byte stream is deterministic.
+func makeRawFingerprint(n int, f func(i int) uint32) []byte {
+	raw := make([]byte, n*4)
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(raw[i*4:], f(i))
+	}
+	return raw
+}
+
+func TestEncodeWholeFingerprint_RoundTrip(t *testing.T) {
+	raw := makeRawFingerprint(120, func(i int) uint32 { return uint32(i * 0x01020304) })
+	encoded := EncodeWholeFingerprint(raw)
+	if encoded == "" {
+		t.Fatal("encoded fingerprint is empty")
+	}
+	decoded, err := decodeAnyFingerprint(encoded)
+	if err != nil {
+		t.Fatalf("decode encoded fingerprint: %v", err)
+	}
+	if len(decoded) != 120 {
+		t.Fatalf("decoded length: got %d, want 120", len(decoded))
+	}
+	for i, got := range decoded {
+		want := uint32(i * 0x01020304)
+		if got != want {
+			t.Fatalf("frame %d: got %#x, want %#x", i, got, want)
+		}
+	}
+}
+
+func TestEncodeWholeFingerprint_Empty(t *testing.T) {
+	if got := EncodeWholeFingerprint(nil); got != "" {
+		t.Fatalf("nil input: got %q, want \"\"", got)
+	}
+	if got := EncodeWholeFingerprint([]byte{}); got != "" {
+		t.Fatalf("empty input: got %q, want \"\"", got)
+	}
+}
+
+func TestDeriveSeg0_TruncatesTo5Min(t *testing.T) {
+	// SegmentSeconds (300) * 8 fps = 2400 frames max.
+	// Build a 5000-frame whole-file fp.
+	raw := makeRawFingerprint(5000, func(i int) uint32 { return uint32(i) })
+	seg0 := DeriveSeg0(raw)
+	if seg0 == "" {
+		t.Fatal("seg0 empty")
+	}
+	frames, err := decodeAnyFingerprint(seg0)
+	if err != nil {
+		t.Fatalf("decode seg0: %v", err)
+	}
+	if len(frames) != 2400 {
+		t.Fatalf("seg0 frame count: got %d, want 2400", len(frames))
+	}
+	// First 2400 frames of the whole-file fp must match seg0 verbatim.
+	for i := 0; i < 2400; i++ {
+		if frames[i] != uint32(i) {
+			t.Fatalf("frame %d mismatch: got %d, want %d", i, frames[i], i)
+		}
+	}
+}
+
+func TestDeriveSeg0_ShortFingerprintPassesThrough(t *testing.T) {
+	raw := makeRawFingerprint(500, func(i int) uint32 { return uint32(i) })
+	seg0 := DeriveSeg0(raw)
+	frames, err := decodeAnyFingerprint(seg0)
+	if err != nil {
+		t.Fatalf("decode seg0: %v", err)
+	}
+	if len(frames) != 500 {
+		t.Fatalf("seg0 frame count: got %d, want 500 (whole fp, no truncation)", len(frames))
+	}
+}
+
+func TestDeriveSeg0_Empty(t *testing.T) {
+	if got := DeriveSeg0(nil); got != "" {
+		t.Fatalf("nil: got %q, want \"\"", got)
+	}
+}
+
+func TestWholeFileSimilarity_Identical(t *testing.T) {
+	raw := makeRawFingerprint(3000, func(i int) uint32 { return uint32(i * 7) })
+	sim, err := WholeFileSimilarity(raw, raw)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	if sim != 1.0 {
+		t.Fatalf("identical similarity: got %f, want 1.0", sim)
+	}
+}
+
+func TestWholeFileSimilarity_IdenticalIntroDifferentMiddle(t *testing.T) {
+	// Simulate the Audible intro problem: two books share the first
+	// 10% of frames (intro), then diverge. The middle-slice comparison
+	// should detect them as DIFFERENT (low similarity) because the
+	// edge-trimming skips the shared intro.
+	frames := 3000
+	skipFrames := int(float64(frames) * EdgeSkipFraction) // ~300
+
+	a := makeRawFingerprint(frames, func(i int) uint32 {
+		if i < skipFrames {
+			return 0xDEADBEEF // shared intro
+		}
+		return uint32(i)
+	})
+	b := makeRawFingerprint(frames, func(i int) uint32 {
+		if i < skipFrames {
+			return 0xDEADBEEF // shared intro
+		}
+		return uint32(i) ^ 0xFFFFFFFF // inverted middle/outro = very different
+	})
+
+	sim, err := WholeFileSimilarity(a, b)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	// With shared intros trimmed and inverted middles, similarity should
+	// be very low (~0).
+	if sim > 0.10 {
+		t.Fatalf("intro-only-shared books matched too closely: %f (want <0.10)", sim)
+	}
+}
+
+func TestWholeFileSimilarity_IdenticalContentDifferentIntros(t *testing.T) {
+	// Opposite case: the middle is identical (same book content) but the
+	// intros/outros differ (different publisher reads). Middle-slice
+	// comparison should see this as a HIGH match.
+	frames := 3000
+	skipFrames := int(float64(frames) * EdgeSkipFraction)
+
+	a := makeRawFingerprint(frames, func(i int) uint32 {
+		if i < skipFrames || i >= frames-skipFrames {
+			return 0x11111111 // intro A / outro A
+		}
+		return uint32(i) // shared middle
+	})
+	b := makeRawFingerprint(frames, func(i int) uint32 {
+		if i < skipFrames || i >= frames-skipFrames {
+			return 0x22222222 // intro B / outro B
+		}
+		return uint32(i) // shared middle
+	})
+
+	sim, err := WholeFileSimilarity(a, b)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	if sim < 0.99 {
+		t.Fatalf("identical-middle books matched too loosely: %f (want >0.99)", sim)
+	}
+}
+
+func TestWholeFileSimilarity_EmptyError(t *testing.T) {
+	if _, err := WholeFileSimilarity(nil, nil); err == nil {
+		t.Fatal("expected error for empty inputs")
+	}
+	raw := makeRawFingerprint(100, func(i int) uint32 { return 1 })
+	if _, err := WholeFileSimilarity(raw, nil); err == nil {
+		t.Fatal("expected error for one empty input")
+	}
+}
+
+func TestWholeFileSimilarity_UnalignedError(t *testing.T) {
+	raw := makeRawFingerprint(100, func(i int) uint32 { return 1 })
+	bad := raw[:len(raw)-1] // truncate to break uint32 alignment
+	if _, err := WholeFileSimilarity(raw, bad); err == nil {
+		t.Fatal("expected error for non-uint32-aligned input")
+	}
+}
+
+func TestMiddleSliceFrames_ShortPassesThrough(t *testing.T) {
+	// MinMiddleFrames is 240; below that the whole fp is returned.
+	raw := makeRawFingerprint(100, func(i int) uint32 { return uint32(i) })
+	got := middleSliceFrames(raw)
+	if len(got) != len(raw) {
+		t.Fatalf("short fp should pass through: got %d bytes, want %d", len(got), len(raw))
+	}
+}
+
+func TestMiddleSliceFrames_TrimsLong(t *testing.T) {
+	raw := makeRawFingerprint(1000, func(i int) uint32 { return uint32(i) })
+	got := middleSliceFrames(raw)
+	gotFrames := len(got) / 4
+	// 1000 frames * 0.10 = 100 frames trimmed from each end
+	// Expected: 800 frames
+	if gotFrames != 800 {
+		t.Fatalf("middle slice frames: got %d, want 800", gotFrames)
+	}
+}
+
+func TestWholeFileSimilarity_DifferentLengths_ComparesPositionally(t *testing.T) {
+	// WholeFileSimilarity does a positional (index-aligned) compare of
+	// the middle slices. When two fps have different lengths their middle
+	// slices land at different offsets in the original audio, so the
+	// "matching" we measure is byte-position-aligned, not audio-aligned.
+	// This is the right behavior for our use case: dedup compares files
+	// that should be the same length (same source audio); large length
+	// mismatches imply different content anyway. Locking the behavior so
+	// future changes are intentional.
+	a := makeRawFingerprint(1000, func(i int) uint32 { return uint32(i) })
+	b := makeRawFingerprint(500, func(i int) uint32 { return uint32(i) })
+	sim, err := WholeFileSimilarity(a, b)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	// Positional compare of misaligned indices → drifts below 1.0 but
+	// stays well above random (0.5) because incrementing-int patterns
+	// share many low-order bits even when offset.
+	if sim >= 1.0 {
+		t.Fatalf("misaligned indices should not be perfectly similar: %f", sim)
+	}
+	if sim < 0.4 {
+		t.Fatalf("unrelated-but-patterned fps shouldn't be random-low: %f", sim)
+	}
+}
+
+func TestWholeFileSimilarity_SingleBitDifference(t *testing.T) {
+	// Two fingerprints differing by exactly one bit out of 32 frames worth.
+	a := makeRawFingerprint(1000, func(i int) uint32 { return 0xAAAAAAAA })
+	b := makeRawFingerprint(1000, func(i int) uint32 {
+		if i == 500 {
+			return 0xAAAAAAAB // single bit flip in one middle frame
+		}
+		return 0xAAAAAAAA
+	})
+	sim, err := WholeFileSimilarity(a, b)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	// 1 differing bit out of (800 middle frames × 32 bits) = 25600 bits
+	// → similarity = 25599/25600 ≈ 0.99996
+	if sim < 0.999 {
+		t.Fatalf("single-bit flip dropped similarity too far: %f", sim)
+	}
+	if sim == 1.0 {
+		t.Fatalf("single-bit flip incorrectly reported as identical")
+	}
+}
+
+func TestWholeFileSimilarity_AllZeros(t *testing.T) {
+	a := makeRawFingerprint(1000, func(i int) uint32 { return 0 })
+	b := makeRawFingerprint(1000, func(i int) uint32 { return 0 })
+	sim, err := WholeFileSimilarity(a, b)
+	if err != nil {
+		t.Fatalf("similarity: %v", err)
+	}
+	if sim != 1.0 {
+		t.Fatalf("two zero fingerprints should match perfectly: %f", sim)
+	}
+}
+
+func TestEncodeWholeFingerprint_ChainedThroughDeriveSeg0(t *testing.T) {
+	// Critical invariant: encoding the whole fp then deriving seg0 should
+	// produce the same seg0 base64 as directly calling DeriveSeg0 on the
+	// raw bytes. This is the path that keeps the legacy AcoustIDSeg0
+	// field in sync with the new whole-file storage.
+	raw := makeRawFingerprint(3000, func(i int) uint32 { return uint32(i * 13) })
+	direct := DeriveSeg0(raw)
+	if direct == "" {
+		t.Fatal("DeriveSeg0 returned empty")
+	}
+	// Decode direct, verify it's the first 2400 frames of raw.
+	frames, err := decodeAnyFingerprint(direct)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(frames) != 2400 {
+		t.Fatalf("derived seg0 frames: got %d, want 2400", len(frames))
+	}
+	for i := 0; i < 2400; i++ {
+		if frames[i] != uint32(i*13) {
+			t.Fatalf("frame %d: got %d, want %d", i, frames[i], i*13)
+		}
+	}
+}
+
+func TestFileWholeFingerprint_FpcalcMissing(t *testing.T) {
+	// We can't easily un-install fpcalc for the test, so this is just a
+	// smoke check that the function exists and returns a sensible error
+	// type when handed a nonexistent path. The fpcalc-on-path case is
+	// covered by integration tests outside this unit.
+	_, err := FileWholeFingerprint("/this/path/does/not/exist.m4b")
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+	// If fpcalc IS available we'll get a fpcalc error; if not we'll get
+	// ErrNotAvailable. Either is acceptable here.
+	if err != ErrNotAvailable && !strings.Contains(err.Error(), "fpcalc") {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+}

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-05-06
+// last-edited: 2026-05-30
 
 package acoustid
 
@@ -76,7 +76,9 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 		}
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Loading books for fingerprint backfill...")
+	// Start with N=0 until we've loaded books and know the real total.
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Loading books for fingerprint backfill...")
 
 	books, err := p.store.GetAllBooks(100000, 0)
 	if err != nil {
@@ -96,6 +98,17 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 
 	var fingerprinted, skipped, failed int
 	total := len(books)
+
+	// Rebuild with the real N once it's known.
+	prog = sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Backfilling %d books…", total))
+
+	// Nothing to do — still emit Start + Done so the bar never stays at 0/0.
+	if total == 0 || startIdx >= total {
+		prog.Done(fmt.Sprintf("Acoustid backfill complete: fingerprinted=%d skipped=%d failed=%d",
+			fingerprinted, skipped, failed))
+		return nil
+	}
 
 	for i := startIdx; i < total; i++ {
 		select {
@@ -133,8 +146,7 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 		}
 
 		if i%25 == 0 || i == total-1 {
-			pct := 1 + (99 * (i + 1) / total)
-			_ = reporter.UpdateProgress(pct, 100,
+			prog.StepN(i+1,
 				fmt.Sprintf("Books %d/%d (fp=%d skip=%d fail=%d)", i+1, total, fingerprinted, skipped, failed))
 
 			// Checkpoint progress every 25 books for resumability
@@ -147,9 +159,8 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 		}
 	}
 
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Acoustid backfill complete: fingerprinted=%d skipped=%d failed=%d",
-			fingerprinted, skipped, failed))
+	prog.Done(fmt.Sprintf("Acoustid backfill complete: fingerprinted=%d skipped=%d failed=%d",
+		fingerprinted, skipped, failed))
 	return nil
 }
 

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -183,37 +183,60 @@ var audioExtensions = map[string]bool{
 	".wv":   true,
 }
 
-// fingerprintBookFile generates and persists 7-segment chromaprint segments
-// for a single book_file row. Honours `force` and respects eligibility rules.
-func fingerprintBookFile(store database.Store, f database.BookFile, force bool) fingerprintFileOutcome {
-	if f.AcoustIDSeg0 != "" && !force {
-		return fingerprintOutcomeSkipped
+// fingerprintEligibility classifies whether a BookFile is a candidate for
+// fingerprinting. Returns the terminal outcome and `true` when the file is
+// not eligible (skipped or ineligible); returns the zero value and `false`
+// when the caller should proceed with fpcalc. Pure function, no I/O except
+// os.Stat for existence check.
+func fingerprintEligibility(f database.BookFile, force bool) (fingerprintFileOutcome, bool) {
+	if (len(f.AcoustIDFingerprint) > 0 || f.AcoustIDSeg0 != "") && !force {
+		return fingerprintOutcomeSkipped, true
 	}
 	if f.FilePath == "" || f.Missing {
-		return fingerprintOutcomeIneligible
+		return fingerprintOutcomeIneligible, true
 	}
 	if _, ok := audioExtensions[strings.ToLower(filepath.Ext(f.FilePath))]; !ok {
-		return fingerprintOutcomeIneligible
+		return fingerprintOutcomeIneligible, true
 	}
 	if _, err := os.Stat(f.FilePath); err != nil {
-		return fingerprintOutcomeIneligible
+		return fingerprintOutcomeIneligible, true
+	}
+	return 0, false
+}
+
+// fingerprintBookFile generates and persists a whole-file chromaprint for a
+// single book_file row. Also populates AcoustIDSeg0 as a transition
+// fallback for code paths still reading the segment field; Seg1..6 are no
+// longer written (the offset-based segment extraction had a seek-past-EOF
+// failure mode and is being retired — see PLAN.md in this branch).
+func fingerprintBookFile(store database.Store, f database.BookFile, force bool) fingerprintFileOutcome {
+	if outcome, stop := fingerprintEligibility(f, force); stop {
+		return outcome
 	}
 
-	segs, err := fingerprint.FileSegments(f.FilePath, f.Duration)
+	wf, err := fingerprint.FileWholeFingerprint(f.FilePath)
 	if err != nil {
 		slog.Warn("fingerprint", "path", f.FilePath, "err", err)
 		return fingerprintOutcomeFailed
 	}
 
 	updated := f
-	// Normalize at write time: canonicalize fingerprints for uniformity
-	updated.AcoustIDSeg0 = fingerprint.NormalizeForStorage(segs[0])
-	updated.AcoustIDSeg1 = fingerprint.NormalizeForStorage(segs[1])
-	updated.AcoustIDSeg2 = fingerprint.NormalizeForStorage(segs[2])
-	updated.AcoustIDSeg3 = fingerprint.NormalizeForStorage(segs[3])
-	updated.AcoustIDSeg4 = fingerprint.NormalizeForStorage(segs[4])
-	updated.AcoustIDSeg5 = fingerprint.NormalizeForStorage(segs[5])
-	updated.AcoustIDSeg6 = fingerprint.NormalizeForStorage(segs[6])
+	updated.AcoustIDFingerprint = wf.Raw
+	updated.AcoustIDFingerprintDurationSec = wf.DurationSec
+	// Derive Seg0 from the first SegmentSeconds of the whole-file fp so
+	// callers that still read the segment field get a comparable value
+	// without a second fpcalc invocation.
+	updated.AcoustIDSeg0 = fingerprint.NormalizeForStorage(fingerprint.DeriveSeg0(wf.Raw))
+	// Stop writing Seg1..6 — clear them so a force-rescan retires the
+	// poisoned sentinel values that prompted this migration.
+	if force {
+		updated.AcoustIDSeg1 = ""
+		updated.AcoustIDSeg2 = ""
+		updated.AcoustIDSeg3 = ""
+		updated.AcoustIDSeg4 = ""
+		updated.AcoustIDSeg5 = ""
+		updated.AcoustIDSeg6 = ""
+	}
 	if err := store.UpdateBookFile(f.ID, &updated); err != nil {
 		slog.Warn("fingerprint update", "id", f.ID, "err", err)
 		return fingerprintOutcomeFailed
@@ -221,15 +244,20 @@ func fingerprintBookFile(store database.Store, f database.BookFile, force bool) 
 	return fingerprintOutcomeFingerprinted
 }
 
-// synthesizeBookSignatureForBook generates and persists the unified book signature
-// for a single book from its files' 7-segment chromaprint fingerprints.
+// synthesizeBookSignatureForBook generates and persists the unified book
+// signature for a single book from its files' chromaprint fingerprints.
+//
+// Uses SynthesizePartialBookSignature so books with partial file coverage
+// (some files failed to fingerprint, some still missing whole-file fp) still
+// produce a usable book sig with a coverage mask + percentage. The strict
+// SynthesizeBookSignature was dropping ~71% of books in production because
+// any one failing file caused the whole synthesis to bail.
 func synthesizeBookSignatureForBook(store database.Store, bookID string) error {
 	files, err := store.GetBookFiles(bookID)
 	if err != nil {
 		return fmt.Errorf("get book files: %w", err)
 	}
 
-	// Sort files by sort_order or original_filename
 	var orderedFiles []fingerprint.FileWithSegments
 	for _, f := range files {
 		orderedFiles = append(orderedFiles, fingerprint.FileWithSegments{
@@ -248,13 +276,31 @@ func synthesizeBookSignatureForBook(store database.Store, bookID string) error {
 	}
 	fingerprint.SortFilesByOrder(orderedFiles)
 
-	// Extract just the segments in order
-	var segData []fingerprint.FileSegmentData
-	for _, f := range orderedFiles {
-		segData = append(segData, f.Segments)
+	// Build per-file input including Missing flag + EstimatedLen so
+	// partial synthesis can keep positional alignment.
+	inputs := make([]fingerprint.FileSegmentInput, 0, len(orderedFiles))
+	for i, sf := range orderedFiles {
+		inp := fingerprint.FileSegmentInput{Segments: sf.Segments}
+		// A file is "missing" for synthesis purposes when it has neither
+		// the whole-file fp nor seg0.
+		src := files[0]
+		for _, ff := range files {
+			if ff.OriginalFilename == sf.Filename && ff.TrackNumber == sf.SortOrder {
+				src = ff
+				break
+			}
+		}
+		if len(src.AcoustIDFingerprint) == 0 && sf.Segments.Seg0 == "" {
+			inp.Missing = true
+			inp.EstimatedLen = fingerprint.EstimateSegmentCount(
+				src.Duration, int(src.FileSize), src.BitrateKbps, 0,
+			)
+		}
+		_ = i
+		inputs = append(inputs, inp)
 	}
 
-	sig, segCount, err := fingerprint.SynthesizeBookSignature(segData)
+	sig, mask, coverage, preLen, err := fingerprint.SynthesizePartialBookSignature(inputs)
 	if err != nil {
 		if err == fingerprint.ErrIncompleteFingerprint {
 			return nil
@@ -269,8 +315,10 @@ func synthesizeBookSignatureForBook(store database.Store, bookID string) error {
 	}
 
 	book.BookSigV1 = &sig
-	book.BookSigSegments = &segCount
+	book.BookSigSegments = &preLen
 	book.BookSigBuiltAt = &now
+	book.BookSigV1Mask = &mask
+	book.BookSigCoveragePct = &coverage
 
 	_, err = store.UpdateBook(book.ID, book)
 	if err != nil {

--- a/internal/plugins/acoustid/backfill_test.go
+++ b/internal/plugins/acoustid/backfill_test.go
@@ -1,0 +1,174 @@
+// file: internal/plugins/acoustid/backfill_test.go
+// version: 1.0.0
+// guid: f7a8b9c0-d1e2-4f3a-4b5c-6d7e8f9a0123
+
+package acoustid
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+)
+
+// makeBookFile builds a BookFile with sensible defaults plus the overrides
+// in mods. Defaults reflect a "freshly scanned, not yet fingerprinted" row.
+func makeBookFile(mods func(*database.BookFile)) database.BookFile {
+	f := database.BookFile{
+		ID:       "bf-test",
+		BookID:   "book-test",
+		FilePath: "/tmp/does-not-exist.m4b",
+	}
+	if mods != nil {
+		mods(&f)
+	}
+	return f
+}
+
+func TestFingerprintEligibility_SkipsWhenWholeFilePresent(t *testing.T) {
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.AcoustIDFingerprint = []byte("not really a fingerprint but non-empty")
+	})
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true when whole-file fp already present")
+	}
+	if got != fingerprintOutcomeSkipped {
+		t.Errorf("expected skipped, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_SkipsWhenSeg0Present(t *testing.T) {
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.AcoustIDSeg0 = "AQADtAcSRY"
+	})
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true when seg0 already present")
+	}
+	if got != fingerprintOutcomeSkipped {
+		t.Errorf("expected skipped, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_ForceOverridesPresentSeg0(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.m4b")
+	if err := os.WriteFile(path, []byte("not real audio but the path resolves"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.FilePath = path
+		bf.AcoustIDSeg0 = "AQADtAcSRY"
+	})
+	got, stop := fingerprintEligibility(f, true) // force
+	if stop {
+		t.Fatalf("expected stop=false with force=true, got stop=true outcome=%v", got)
+	}
+}
+
+func TestFingerprintEligibility_ForceOverridesWholeFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.flac")
+	if err := os.WriteFile(path, []byte("not real audio"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.FilePath = path
+		bf.AcoustIDFingerprint = []byte("existing fp bytes")
+	})
+	got, stop := fingerprintEligibility(f, true)
+	if stop {
+		t.Fatalf("expected stop=false with force=true, got stop=true outcome=%v", got)
+	}
+}
+
+func TestFingerprintEligibility_IneligibleWhenMissing(t *testing.T) {
+	f := makeBookFile(func(bf *database.BookFile) { bf.Missing = true })
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true when Missing=true")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected ineligible, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_IneligibleWhenEmptyPath(t *testing.T) {
+	f := makeBookFile(func(bf *database.BookFile) { bf.FilePath = "" })
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true with empty file path")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected ineligible, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_IneligibleWhenBadExtension(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.pdf")
+	if err := os.WriteFile(path, []byte("not audio"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := makeBookFile(func(bf *database.BookFile) { bf.FilePath = path })
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true for non-audio extension")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected ineligible, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_IneligibleWhenFileDoesNotExist(t *testing.T) {
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.FilePath = "/this/path/definitely/does/not/exist.m4b"
+	})
+	got, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true when file missing on disk")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected ineligible, got %v", got)
+	}
+}
+
+func TestFingerprintEligibility_ProceedsWhenAllChecksPass(t *testing.T) {
+	tmp := t.TempDir()
+	for _, ext := range []string{".m4b", ".mp3", ".flac", ".m4a", ".ogg", ".opus", ".aac", ".wav"} {
+		ext := ext
+		t.Run(ext, func(t *testing.T) {
+			path := filepath.Join(tmp, "ok"+ext)
+			if err := os.WriteFile(path, []byte("placeholder"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			f := makeBookFile(func(bf *database.BookFile) { bf.FilePath = path })
+			outcome, stop := fingerprintEligibility(f, false)
+			if stop {
+				t.Fatalf("expected stop=false for %s, got outcome=%v", ext, outcome)
+			}
+		})
+	}
+}
+
+func TestAudioExtensions_KnownFormats(t *testing.T) {
+	want := []string{".aac", ".aiff", ".alac", ".ape", ".flac", ".m4a", ".m4b", ".mp3", ".ogg", ".opus", ".wav", ".wma", ".wv"}
+	for _, ext := range want {
+		if !audioExtensions[ext] {
+			t.Errorf("expected %q in audioExtensions", ext)
+		}
+	}
+}
+
+func TestAudioExtensions_RejectsNonAudio(t *testing.T) {
+	for _, ext := range []string{".txt", ".pdf", ".jpg", ".mkv", ".mp4", ".avi", ".epub"} {
+		if audioExtensions[ext] {
+			t.Errorf("did not expect %q in audioExtensions", ext)
+		}
+	}
+}

--- a/internal/plugins/acoustid/reset_all.go
+++ b/internal/plugins/acoustid/reset_all.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/reset_all.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f3b1e8c4-2d7a-4d62-aabb-1f1d6e2c4a01
 // last-edited: 2026-05-30
 
@@ -53,7 +53,11 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 	log := reporter.Logger()
 	startedAt := time.Now()
 
-	_ = reporter.UpdateProgress(0, 100, "Clearing fingerprints (batched)…")
+	// Initial Progress with N=0 — we don't know the real N until we either
+	// get the first callback from the Pebble bulk-clear or load the slow
+	// path's file list. The helper degrades gracefully to a 2-frame bar.
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Clearing fingerprints (batched)…")
 
 	var cleared int
 
@@ -61,13 +65,16 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 	// per ~2000 records instead of once per UpdateBookFile call — ~100×
 	// faster than the per-row fallback below.
 	if pebble, ok := p.store.(*database.PebbleStore); ok {
+		var totalN int
 		c, t, clearErr := pebble.ClearAllAcoustIDFingerprints(ctx, 2000,
 			func(processed, c, t int) {
-				pct := 0
-				if t > 0 {
-					pct = int(float64(processed) / float64(t) * 80)
+				// Rebuild the Progress as soon as we know the real total.
+				if totalN != t {
+					totalN = t
+					prog = sdk.NewProgress(reporter, t)
+					prog.Start("Clearing fingerprints (batched)…")
 				}
-				_ = reporter.UpdateProgress(pct, 100,
+				prog.StepN(processed,
 					fmt.Sprintf("Clearing fingerprints %d/%d (cleared=%d)", processed, t, c))
 			})
 		if clearErr != nil {
@@ -83,6 +90,8 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 		}
 		total := len(files)
 		log.Info("acoustid reset-all: clearing fingerprints (slow path)", "book_files", total)
+		prog = sdk.NewProgress(reporter, total)
+		prog.Start("Clearing fingerprints (slow path)…")
 		for i := range files {
 			select {
 			case <-ctx.Done():
@@ -109,8 +118,7 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 			}
 			cleared++
 			if i%500 == 0 || i == total-1 {
-				pct := int(float64(i+1) / float64(total) * 80)
-				_ = reporter.UpdateProgress(pct, 100,
+				prog.StepN(i+1,
 					fmt.Sprintf("Clearing fingerprints %d/%d (cleared=%d)", i+1, total, cleared))
 			}
 		}
@@ -118,7 +126,7 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 
 	// Drop acoustid-layer pending candidates so the dedup review doesn't
 	// keep showing the 14K+ poisoned rows after the rescan starts.
-	_ = reporter.UpdateProgress(85, 100, "Dropping acoustid dedup candidates…")
+	prog.Finalize("Dropping acoustid dedup candidates…")
 	deleted := 0
 	if p.embeddingStore != nil {
 		offset := 0
@@ -150,16 +158,12 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 		}
 	}
 
-	_ = reporter.UpdateProgress(95, 100,
-		fmt.Sprintf("Cleared %d files, dropped %d candidates", cleared, deleted))
-
 	log.Info("acoustid reset-all: complete",
 		"cleared", cleared,
 		"candidates_deleted", deleted,
 		"elapsed", time.Since(startedAt).Round(time.Second))
 
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Reset complete: %d files cleared, %d candidates dropped (elapsed %s). Now enqueue acoustid.fingerprint-rescan with scope=all force=true.",
-			cleared, deleted, time.Since(startedAt).Round(time.Second)))
+	prog.Done(fmt.Sprintf("Reset complete: %d files cleared, %d candidates dropped (elapsed %s). Now enqueue acoustid.fingerprint-rescan with scope=all force=true.",
+		cleared, deleted, time.Since(startedAt).Round(time.Second)))
 	return nil
 }

--- a/internal/plugins/dedup/book_signature_scan.go
+++ b/internal/plugins/dedup/book_signature_scan.go
@@ -37,23 +37,28 @@ func (p *Plugin) runBookSignatureScan(ctx context.Context, _ json.RawMessage, re
 		return fmt.Errorf("dedup engine not available")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Starting book signature scan...")
+	startProg := sdk.NewProgress(reporter, 0)
+	startProg.Start("Starting book signature scan...")
 
-	var lastPct int
+	var prog *sdk.Progress
 	scanErr := p.engine.BookSignatureScan(ctx, func(done, total int) {
 		if total <= 0 {
 			return
 		}
-		pct := 1 + (98 * done / total)
-		if pct == lastPct {
-			return
+		if prog == nil {
+			prog = sdk.NewProgress(reporter, total)
+			prog.Start(fmt.Sprintf("Scanning books: 0 / %d", total))
 		}
-		lastPct = pct
-		_ = reporter.UpdateProgress(pct, 100, fmt.Sprintf("Scanning books: %d / %d", done, total))
+		prog.StepN(done, fmt.Sprintf("Scanning books: %d / %d", done, total))
 	})
 	if scanErr != nil {
 		reporter.Logger().Error("BookSignatureScan error", "error", scanErr)
 		return fmt.Errorf("book signature scan: %w", scanErr)
+	}
+
+	if prog == nil {
+		prog = sdk.NewProgress(reporter, 0)
+		prog.Start("Scanning books: 0 / 0")
 	}
 
 	pendingCount := 0
@@ -63,7 +68,7 @@ func (p *Plugin) runBookSignatureScan(ctx context.Context, _ json.RawMessage, re
 			pendingCount = total
 		}
 	}
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Book signature scan complete — %d pending candidate(s)", pendingCount))
+	prog.Finalize("writing results...")
+	prog.Done(fmt.Sprintf("Book signature scan complete — %d pending candidate(s)", pendingCount))
 	return nil
 }

--- a/internal/plugins/dedup/embed_async.go
+++ b/internal/plugins/dedup/embed_async.go
@@ -38,18 +38,22 @@ func (p *Plugin) runEmbedAsync(ctx context.Context, _ json.RawMessage, reporter 
 		return errors.New("dedup engine not available (embedding may be disabled or API key not configured)")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Collecting un-embedded books...")
+	collectProg := sdk.NewProgress(reporter, 0)
+	collectProg.Start("Collecting un-embedded books...")
 
 	batchID, count, err := p.engine.EmbedBooksAsync(ctx)
 	if err != nil {
 		return fmt.Errorf("submit embedding batch: %w", err)
 	}
 	if count == 0 {
-		_ = reporter.UpdateProgress(100, 100, "All books already embedded — nothing to submit")
+		collectProg.Done("All books already embedded — nothing to submit")
 		return nil
 	}
 
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Submitted %d books to OpenAI Batch API (batch_id=%s). Results will be ingested automatically within 24h.", count, batchID))
+	prog := sdk.NewProgress(reporter, count)
+	prog.Start(fmt.Sprintf("Submitting %d books to batch API...", count))
+	prog.StepN(count, fmt.Sprintf("Submitted %d / %d books", count, count))
+	prog.Finalize("writing results...")
+	prog.Done(fmt.Sprintf("Submitted %d books to OpenAI Batch API (batch_id=%s). Results will be ingested automatically within 24h.", count, batchID))
 	return nil
 }

--- a/internal/plugins/dedup/embed_scan.go
+++ b/internal/plugins/dedup/embed_scan.go
@@ -37,7 +37,8 @@ func (p *Plugin) runEmbedScan(ctx context.Context, _ json.RawMessage, reporter s
 		return errors.New("dedup engine not available (embedding may be disabled or API key not configured)")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Loading books for embedding...")
+	loadProg := sdk.NewProgress(reporter, 0)
+	loadProg.Start("Loading books for embedding...")
 
 	books, err := p.store.GetAllBooks(0, 0)
 	if err != nil {
@@ -45,9 +46,12 @@ func (p *Plugin) runEmbedScan(ctx context.Context, _ json.RawMessage, reporter s
 	}
 	total := len(books)
 	if total == 0 {
-		_ = reporter.UpdateProgress(100, 100, "No books to embed")
+		loadProg.Done("No books to embed")
 		return nil
 	}
+
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Embedding books: 0 / %d", total))
 
 	var embedded, cached, skipped, errs int
 	for i, book := range books {
@@ -76,15 +80,14 @@ func (p *Plugin) runEmbedScan(ctx context.Context, _ json.RawMessage, reporter s
 		}
 
 		if i%50 == 0 || i == total-1 {
-			pct := 1 + (98 * (i + 1) / total)
-			_ = reporter.UpdateProgress(pct, 100,
+			prog.StepN(i+1,
 				fmt.Sprintf("Embedding books: %d / %d (new=%d cached=%d skipped=%d errors=%d)",
 					i+1, total, embedded, cached, skipped, errs))
 		}
 	}
 
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Embedding complete — %d new, %d cached, %d skipped, %d errors (of %d books)",
-			embedded, cached, skipped, errs, total))
+	prog.Finalize("writing results...")
+	prog.Done(fmt.Sprintf("Embedding complete — %d new, %d cached, %d skipped, %d errors (of %d books)",
+		embedded, cached, skipped, errs, total))
 	return nil
 }

--- a/internal/plugins/dedup/full_scan.go
+++ b/internal/plugins/dedup/full_scan.go
@@ -41,32 +41,37 @@ func (p *Plugin) runFullScan(ctx context.Context, _ json.RawMessage, reporter sd
 		return fmt.Errorf("dedup engine not available")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Purging stale candidates...")
+	// Progress is created lazily once FullScan reports its total. Until then
+	// we emit a Start frame on a zero-N progress so the bar isn't 0/0.
+	startProg := sdk.NewProgress(reporter, 0)
+	startProg.Start("Purging stale candidates...")
 	if deleted, err := p.engine.PurgeStaleCandidates(ctx); err != nil {
 		reporter.Logger().Error("purge stale candidates error", "error", err)
 	} else if deleted > 0 {
 		reporter.Logger().Info("purged stale candidates before scan", "count", deleted)
 	}
 
-	// FullScan reports progress via a callback (done, total). Translate
-	// that into ProgressReporter updates, reserving 5% at the start for
-	// the purge pass and 5% at the end for the "complete" line so the
-	// bar actually moves all the way to 100.
-	var lastPct int
+	// FullScan reports progress via a callback (done, total). Build the
+	// real Progress on the first callback once we know N.
+	var prog *sdk.Progress
 	fullScanErr := p.engine.FullScan(ctx, func(done, total int) {
 		if total <= 0 {
 			return
 		}
-		pct := 5 + (90 * done / total)
-		if pct == lastPct {
-			return
+		if prog == nil {
+			prog = sdk.NewProgress(reporter, total)
+			prog.Start(fmt.Sprintf("Scanning books: 0 / %d", total))
 		}
-		lastPct = pct
-		_ = reporter.UpdateProgress(pct, 100, fmt.Sprintf("Scanning books: %d / %d", done, total))
+		prog.StepN(done, fmt.Sprintf("Scanning books: %d / %d", done, total))
 	})
 	if fullScanErr != nil {
 		reporter.Logger().Error("FullScan error", "error", fullScanErr)
 		return fmt.Errorf("dedup scan: %w", fullScanErr)
+	}
+
+	if prog == nil {
+		prog = sdk.NewProgress(reporter, 0)
+		prog.Start("Scanning books: 0 / 0")
 	}
 
 	// Fetch final candidate counts for the completion message.
@@ -77,7 +82,7 @@ func (p *Plugin) runFullScan(ctx context.Context, _ json.RawMessage, reporter sd
 			pendingCount = total
 		}
 	}
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Dedup scan complete — %d pending candidates", pendingCount))
+	prog.Finalize("writing results...")
+	prog.Done(fmt.Sprintf("Dedup scan complete — %d pending candidates", pendingCount))
 	return nil
 }

--- a/internal/plugins/dedup/llm_review.go
+++ b/internal/plugins/dedup/llm_review.go
@@ -37,11 +37,13 @@ func (p *Plugin) runLLMReview(ctx context.Context, _ json.RawMessage, reporter s
 		return fmt.Errorf("dedup engine not available")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Starting LLM review of ambiguous candidates...")
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Starting LLM review of ambiguous candidates...")
 	if err := p.engine.RunLLMReview(ctx); err != nil {
 		reporter.Logger().Error("LLM review error", "error", err)
 		return fmt.Errorf("LLM review: %w", err)
 	}
-	_ = reporter.UpdateProgress(100, 100, "LLM review complete")
+	prog.Finalize("writing results...")
+	prog.Done("LLM review complete")
 	return nil
 }

--- a/internal/plugins/dedup/split_book_scan.go
+++ b/internal/plugins/dedup/split_book_scan.go
@@ -47,15 +47,16 @@ func (p *Plugin) runSplitBookScan(ctx context.Context, _ json.RawMessage, report
 		return fmt.Errorf("split-book scan: embedding store not available (needed for shared Pebble DB)")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Scanning library for split-book clusters...")
+	scanProg := sdk.NewProgress(reporter, 0)
+	scanProg.Start("Scanning library for split-book clusters...")
 	cands, err := dedupengine.DetectSplitBookCandidates(ctx, p.store)
 	if err != nil {
 		reporter.Logger().Error("split-book detector error", "error", err)
 		return fmt.Errorf("split-book scan: %w", err)
 	}
 
-	_ = reporter.UpdateProgress(80, 100,
-		fmt.Sprintf("Found %d candidate cluster(s); persisting...", len(cands)))
+	prog := sdk.NewProgress(reporter, len(cands))
+	prog.Start(fmt.Sprintf("Found %d candidate cluster(s); persisting...", len(cands)))
 
 	db := p.embeddingStore.PebbleDB()
 	if db == nil {
@@ -67,8 +68,9 @@ func (p *Plugin) runSplitBookScan(ctx context.Context, _ json.RawMessage, report
 		return fmt.Errorf("split-book scan persist: %w", err)
 	}
 
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Split-book scan complete — %d candidate cluster(s) saved", len(cands)))
+	prog.StepN(len(cands), fmt.Sprintf("Persisted %d / %d cluster(s)", len(cands), len(cands)))
+	prog.Finalize("writing results...")
+	prog.Done(fmt.Sprintf("Split-book scan complete — %d candidate cluster(s) saved", len(cands)))
 	reporter.Logger().Info("split-book scan complete", "candidates", len(cands))
 	return nil
 }

--- a/internal/plugins/deluge/centralization.go
+++ b/internal/plugins/deluge/centralization.go
@@ -60,7 +60,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 		_ = json.Unmarshal(params, &checkpoint)
 	}
 
-	_ = reporter.UpdateProgress(0, 100, "Loading Deluge-imported files...")
+	sdk.NewProgress(reporter, 0).Start("Loading Deluge-imported files...")
 
 	// Pull only BookFiles with non-empty DelugeHash AND not yet imported.
 	// Centralized store method routes through the memdb sparse deluge_hash
@@ -76,8 +76,11 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 	}
 
 	total := len(toImport)
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Centralizing %d files...", total))
 	if total == 0 {
-		_ = reporter.UpdateProgress(100, 100, "No files to centralize")
+		prog.Finalize("Writing results...")
+		prog.Done("No files to centralize")
 		return nil
 	}
 
@@ -107,7 +110,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 		srcPath := bf.FilePath
 		if srcPath == "" {
 			skipCount++
-			_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Skipped %d files with no path", skipCount))
+			prog.StepN(i+1, fmt.Sprintf("Skipped %d/%d files with no path", skipCount, total))
 			continue
 		}
 
@@ -127,7 +130,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 		// Skip if already at destination.
 		if srcPath == dest {
 			skipCount++
-			_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Skipped %d files already in library", skipCount))
+			prog.StepN(i+1, fmt.Sprintf("Skipped %d/%d files already in library", skipCount, total))
 			continue
 		}
 
@@ -136,7 +139,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 			errCount++
 			checkpoint.LastError = fmt.Sprintf("mkdir %s: %v", destDir, err)
 			reporter.Logger().Error("mkdir failed", "path", destDir, "error", err)
-			_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Error: %s", checkpoint.LastError))
+			prog.StepN(i+1, fmt.Sprintf("Error (%d/%d): %s", i+1, total, checkpoint.LastError))
 			continue
 		}
 
@@ -146,7 +149,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 				errCount++
 				checkpoint.LastError = fmt.Sprintf("copy %s: %v", srcPath, err)
 				reporter.Logger().Error("copy failed", "src", srcPath, "dest", dest, "error", err)
-				_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Error: %s", checkpoint.LastError))
+				prog.StepN(i+1, fmt.Sprintf("Error (%d/%d): %s", i+1, total, checkpoint.LastError))
 				continue
 			}
 		}
@@ -161,7 +164,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 			errCount++
 			checkpoint.LastError = fmt.Sprintf("update book file: %v", err)
 			reporter.Logger().Error("update book file failed", "id", bf.ID, "error", err)
-			_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Error: %s", checkpoint.LastError))
+			prog.StepN(i+1, fmt.Sprintf("Error (%d/%d): %s", i+1, total, checkpoint.LastError))
 			continue
 		}
 
@@ -182,14 +185,11 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 		// Checkpoint after each file to support fine-grained restart.
 		_ = reporter.Checkpoint(checkpoint)
 
-		progress := (successCount * 100) / total
-		if progress > 100 {
-			progress = 100
-		}
-		_ = reporter.UpdateProgress(progress, 100, fmt.Sprintf("Centralized %d/%d files", successCount, total))
+		prog.StepN(i+1, fmt.Sprintf("Centralized %d/%d files", successCount, total))
 	}
 
-	_ = reporter.UpdateProgress(100, 100, fmt.Sprintf("Done: %d succeeded, %d skipped, %d errors", successCount, skipCount, errCount))
+	prog.Finalize("Writing results...")
+	prog.Done(fmt.Sprintf("Done: %d succeeded, %d skipped, %d errors", successCount, skipCount, errCount))
 	return nil
 }
 

--- a/internal/plugins/deluge/path_update.go
+++ b/internal/plugins/deluge/path_update.go
@@ -81,7 +81,7 @@ func (p *Plugin) runPathUpdate(ctx context.Context, params json.RawMessage, repo
 		return fmt.Errorf("book_id is required")
 	}
 
-	_ = reporter.UpdateProgress(0, 100, fmt.Sprintf("Loading book %s...", bookID))
+	sdk.NewProgress(reporter, 0).Start(fmt.Sprintf("Loading book %s...", bookID))
 
 	// Fetch the book.
 	book, err := p.store.GetBookByID(bookID)
@@ -98,11 +98,13 @@ func (p *Plugin) runPathUpdate(ctx context.Context, params json.RawMessage, repo
 		return fmt.Errorf("load versions: %w", err)
 	}
 
-	_ = reporter.UpdateProgress(50, 100, fmt.Sprintf("Updating %d version(s) in Deluge...", len(versions)))
+	prog := sdk.NewProgress(reporter, len(versions))
+	prog.Start(fmt.Sprintf("Updating %d version(s) in Deluge...", len(versions)))
 
 	// Update each version's torrent path.
 	updated := 0
-	for _, v := range versions {
+	for i, v := range versions {
+		prog.StepN(i+1, fmt.Sprintf("Processing version %d/%d", i+1, len(versions)))
 		if v.TorrentHash == "" {
 			continue // Not a Deluge torrent
 		}
@@ -150,6 +152,7 @@ func (p *Plugin) runPathUpdate(ctx context.Context, params json.RawMessage, repo
 		}
 	}
 
-	_ = reporter.UpdateProgress(100, 100, fmt.Sprintf("Updated %d torrent(s)", updated))
+	prog.Finalize("Writing results...")
+	prog.Done(fmt.Sprintf("Updated %d torrent(s)", updated))
 	return nil
 }

--- a/internal/plugins/deluge/protected_paths.go
+++ b/internal/plugins/deluge/protected_paths.go
@@ -32,7 +32,8 @@ func (p *Plugin) protectedPathsSyncDef() sdk.OperationDef {
 }
 
 func (p *Plugin) runProtectedPathsSync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
-	_ = reporter.UpdateProgress(0, 100, "Refreshing protected paths from Deluge...")
+	prog := sdk.NewProgress(reporter, 1)
+	prog.Start("Refreshing protected paths from Deluge...")
 
 	// Force refresh the protected path cache by invalidating it.
 	p.cache.Invalidate()
@@ -40,8 +41,10 @@ func (p *Plugin) runProtectedPathsSync(ctx context.Context, _ json.RawMessage, r
 	// Trigger the lazy refresh by calling IsProtected with a dummy path.
 	// The next IsProtected call will trigger a fresh fetch from Deluge.
 	p.cache.IsProtected("")
+	prog.Step("Cache refreshed")
 
-	_ = reporter.UpdateProgress(100, 100, "Protected paths refreshed")
+	prog.Finalize("Writing results...")
+	prog.Done("Protected paths refreshed")
 	return nil
 }
 

--- a/internal/plugins/maintenance/author.go
+++ b/internal/plugins/maintenance/author.go
@@ -45,7 +45,8 @@ func (p *Plugin) runAuthorDedupScan(ctx context.Context, _ json.RawMessage, repo
 		return fmt.Errorf("database not initialized")
 	}
 	_ = reporter.Log(slog.LevelInfo, "Starting author dedup scan")
-	_ = reporter.UpdateProgress(0, 100, "Fetching authors...")
+	loadProg := sdk.NewProgress(reporter, 0)
+	loadProg.Start("Fetching authors...")
 
 	authors, err := store.GetAllAuthors()
 	if err != nil {
@@ -62,20 +63,20 @@ func (p *Plugin) runAuthorDedupScan(ctx context.Context, _ json.RawMessage, repo
 	msg := fmt.Sprintf("Fetched %d authors (%d with book counts), running duplicate comparison...",
 		len(authors), booksWithCounts)
 	_ = reporter.Log(slog.LevelInfo, msg)
-	_ = reporter.UpdateProgress(25, 100, msg)
 
 	total := len(authors)
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(msg)
 	groups := dedup.FindDuplicateAuthors(authors, 0.85, func(id int) int { return bookCounts[id] },
 		func(current, t int, message string) {
-			pct := 25 + (70 * current / total)
-			_ = reporter.UpdateProgress(pct, 100, message)
+			prog.StepN(current, message)
 		},
 	)
 
 	resultMsg := fmt.Sprintf("Dedup scan complete: %d duplicate groups found across %d authors",
 		len(groups), total)
 	_ = reporter.Log(slog.LevelInfo, resultMsg)
-	_ = reporter.UpdateProgress(100, 100, resultMsg)
+	prog.Done(resultMsg)
 	return nil
 }
 
@@ -117,6 +118,8 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 	booksUpdated := 0
 	errCount := 0
 	total := len(authors)
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Scanning %d authors for composite names...", total))
 
 	for i, author := range authors {
 		if ctx.Err() != nil {
@@ -126,7 +129,7 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 		parts := dedup.SplitCompositeAuthorName(author.Name)
 		if len(parts) <= 1 {
 			if (i+1)%200 == 0 {
-				_ = reporter.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors", i+1, total))
+				prog.StepN(i+1, fmt.Sprintf("Checked %d/%d authors", i+1, total))
 			}
 			continue
 		}
@@ -219,7 +222,7 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 		}
 
 		if (i+1)%200 == 0 || splitCount%50 == 0 {
-			_ = reporter.UpdateProgress(i+1, total,
+			prog.StepN(i+1,
 				fmt.Sprintf("Checked %d/%d authors, split %d so far", i+1, total, splitCount))
 		}
 	}
@@ -230,7 +233,7 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 	resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors)",
 		splitCount, booksUpdated, errCount)
 	_ = reporter.Log(slog.LevelInfo, resultMsg)
-	_ = reporter.UpdateProgress(total, total, resultMsg)
+	prog.Done(resultMsg)
 	return nil
 }
 
@@ -276,6 +279,8 @@ func (p *Plugin) runResolveProductionAuthors(ctx context.Context, _ json.RawMess
 	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("Found %d production company authors", len(prodAuthors)))
 	total := len(prodAuthors)
 	resolved := 0
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Processing %d production companies", total))
 
 	for i := range prodAuthors {
 		if ctx.Err() != nil {
@@ -284,13 +289,13 @@ func (p *Plugin) runResolveProductionAuthors(ctx context.Context, _ json.RawMess
 		if reporter.IsCanceled() {
 			return context.Canceled
 		}
-		_ = reporter.UpdateProgress(i+1, total,
+		prog.StepN(i+1,
 			fmt.Sprintf("Processed %d/%d production companies (%d resolved)", i+1, total, resolved))
 	}
 
 	p.deps.InvalidateDedupCache()
 	resultMsg := fmt.Sprintf("Resolved %d books across %d production companies", resolved, total)
 	_ = reporter.Log(slog.LevelInfo, resultMsg)
-	_ = reporter.UpdateProgress(total, total, resultMsg)
+	prog.Done(resultMsg)
 	return nil
 }

--- a/internal/plugins/maintenance/cleanup.go
+++ b/internal/plugins/maintenance/cleanup.go
@@ -41,12 +41,13 @@ func (p *Plugin) purgeDeletedDef() sdk.OperationDef {
 
 func (p *Plugin) runPurgeDeleted(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting purge of soft-deleted books")
-	_ = reporter.UpdateProgress(0, 100, "Purging soft-deleted books...")
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Purging soft-deleted books...")
 	opID := ctxOpID(ctx)
 	p.deps.RunAutoPurgeSoftDeleted(opID)
 	p.deps.ActivityFlushOp(opID)
 	_ = reporter.Log(slog.LevelInfo, "Purge complete")
-	_ = reporter.UpdateProgress(100, 100, "Purge complete")
+	prog.Done("Purge complete")
 	return nil
 }
 
@@ -77,14 +78,15 @@ func (p *Plugin) runTombstoneCleanup(_ context.Context, _ json.RawMessage, repor
 		return fmt.Errorf("database not initialized")
 	}
 	_ = reporter.Log(slog.LevelInfo, "Starting author tombstone chain resolution")
-	_ = reporter.UpdateProgress(0, 100, "Resolving tombstone chains...")
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Resolving tombstone chains...")
 	updated, err := store.ResolveTombstoneChains()
 	if err != nil {
 		return fmt.Errorf("tombstone chain resolution failed: %w", err)
 	}
 	resultMsg := fmt.Sprintf("Resolved %d tombstone chains", updated)
 	_ = reporter.Log(slog.LevelInfo, resultMsg)
-	_ = reporter.UpdateProgress(100, 100, resultMsg)
+	prog.Done(resultMsg)
 	return nil
 }
 

--- a/internal/plugins/maintenance/dedup_ops.go
+++ b/internal/plugins/maintenance/dedup_ops.go
@@ -83,7 +83,8 @@ func (p *Plugin) runAIDedupBatch(ctx context.Context, _ json.RawMessage, reporte
 	}
 
 	_ = reporter.Log(slog.LevelInfo, "Building author list for batch AI dedup")
-	_ = reporter.UpdateProgress(0, 100, "Loading authors...")
+	loadProg := sdk.NewProgress(reporter, 0)
+	loadProg.Start("Loading authors...")
 
 	allAuthors, err := store.GetAllAuthors()
 	if err != nil {
@@ -110,21 +111,23 @@ func (p *Plugin) runAIDedupBatch(ctx context.Context, _ json.RawMessage, reporte
 
 	if len(inputs) == 0 {
 		_ = reporter.Log(slog.LevelInfo, "No authors to process")
+		loadProg.Done("No authors to process")
 		return nil
 	}
 
-	_ = reporter.UpdateProgress(10, 100, fmt.Sprintf("Submitting %d authors to OpenAI Batch API...", len(inputs)))
+	// Poll for completion (up to 24h, check every 5 min)
+	pollInterval := 5 * time.Minute
+	maxPolls := 288 // 24h / 5min
+	opID := ctxOpID(ctx)
+
+	prog := sdk.NewProgress(reporter, maxPolls)
+	prog.Start(fmt.Sprintf("Submitting %d authors to OpenAI Batch API...", len(inputs)))
 
 	batchID, err := parser.CreateBatchAuthorDedup(ctx, inputs)
 	if err != nil {
 		return fmt.Errorf("failed to create batch: %w", err)
 	}
 	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("Batch created: %s — polling for completion", batchID))
-
-	// Poll for completion (up to 24h, check every 5 min)
-	pollInterval := 5 * time.Minute
-	maxPolls := 288 // 24h / 5min
-	opID := ctxOpID(ctx)
 
 	for i := 0; i < maxPolls; i++ {
 		if reporter.IsCanceled() {
@@ -142,7 +145,7 @@ func (p *Plugin) runAIDedupBatch(ctx context.Context, _ json.RawMessage, reporte
 			continue
 		}
 
-		_ = reporter.UpdateProgress(10+i, maxPolls, fmt.Sprintf("Batch status: %s", status))
+		prog.StepN(i+1, fmt.Sprintf("Batch status: %s (poll %d/%d)", status, i+1, maxPolls))
 
 		switch status {
 		case "completed":
@@ -165,7 +168,7 @@ func (p *Plugin) runAIDedupBatch(ctx context.Context, _ json.RawMessage, reporte
 					return fmt.Errorf("failed to store results: %w", err)
 				}
 			}
-			_ = reporter.UpdateProgress(100, 100, fmt.Sprintf("Batch complete: %d suggestions", len(discoveries)))
+			prog.Done(fmt.Sprintf("Batch complete: %d suggestions", len(discoveries)))
 			return nil
 
 		case "failed", "expired", "cancelled":

--- a/internal/plugins/maintenance/metadata.go
+++ b/internal/plugins/maintenance/metadata.go
@@ -67,6 +67,8 @@ func (p *Plugin) runMetadataUpgrade(ctx context.Context, _ json.RawMessage, repo
 	if !p.deps.HasMetadataFetchService() {
 		return fmt.Errorf("metadata fetch service not initialized")
 	}
+	prog := sdk.NewProgress(reporter, 0)
+	prog.Start("Scanning for books with upgradeable metadata sources...")
 	_ = reporter.Log(slog.LevelInfo, "Scanning for books with upgradeable metadata sources...")
 	checked, upgraded, skipped, errs, err := p.deps.MetadataUpgradeRun(ctx, 200)
 	if err != nil {
@@ -75,7 +77,7 @@ func (p *Plugin) runMetadataUpgrade(ctx context.Context, _ json.RawMessage, repo
 	msg := fmt.Sprintf("Metadata upgrade complete: checked %d, upgraded %d, skipped %d, errors %d",
 		checked, upgraded, skipped, errs)
 	_ = reporter.Log(slog.LevelInfo, msg)
-	_ = reporter.UpdateProgress(100, 100, msg)
+	prog.Done(msg)
 	return nil
 }
 

--- a/internal/plugins/maintenance/optimize.go
+++ b/internal/plugins/maintenance/optimize.go
@@ -55,7 +55,6 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		"operation_id", opID,
 	)
 	_ = reporter.Log(slog.LevelInfo, "Library optimize sweep started")
-	_ = reporter.UpdateProgress(0, 100, "Starting optimize sweep...")
 
 	children := []childOp{
 		{
@@ -86,6 +85,9 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 	completed := 0
 	failed := 0
 
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start("Starting optimize sweep...")
+
 	for i, ch := range children {
 		if reporter.IsCanceled() {
 			slog.Info("library.optimize: sweep canceled",
@@ -103,8 +105,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		default:
 		}
 
-		pct := 5 + (90 * i / total)
-		_ = reporter.UpdateProgress(pct, 100, fmt.Sprintf("Running child op %d/%d: %s", i+1, total, ch.name))
+		prog.StepN(i, fmt.Sprintf("Running child op %d/%d: %s", i+1, total, ch.name))
 
 		childStart := time.Now()
 		slog.Info("library.optimize: child started",
@@ -174,9 +175,8 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		"children_total", total,
 		"elapsed_ms", totalElapsed.Milliseconds(),
 	)
-	_ = reporter.UpdateProgress(100, 100,
-		fmt.Sprintf("Optimize sweep complete in %s — %d/%d children succeeded",
-			totalElapsed.Round(time.Second), completed, total))
+	prog.Done(fmt.Sprintf("Optimize sweep complete in %s — %d/%d children succeeded",
+		totalElapsed.Round(time.Second), completed, total))
 	_ = reporter.Log(slog.LevelInfo,
 		fmt.Sprintf("Library optimize sweep complete: %d/%d children succeeded, %d failed (elapsed: %s)",
 			completed, total, failed, totalElapsed.Round(time.Second)))

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -62,7 +62,8 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	_ = reporter.Log(slog.LevelInfo, "Starting orphan book_file scan",
 		slog.Bool("delete", params.Delete),
 	)
-	_ = reporter.UpdateProgress(0, 100, "Scanning book_files for orphan rows...")
+	scanProg := sdk.NewProgress(reporter, 0)
+	scanProg.Start("Scanning book_files for orphan rows...")
 
 	orphans, totalFiles, totalBooks, err := findOrphanBookFiles(ctx, store)
 	if err != nil {
@@ -74,9 +75,6 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 		slog.Int("total_book_files", totalFiles),
 		slog.Int("total_books", totalBooks),
 	)
-	_ = reporter.UpdateProgress(50, 100,
-		fmt.Sprintf("Found %d orphan book_file row(s) out of %d (valid books: %d)",
-			len(orphans), totalFiles, totalBooks))
 
 	if !params.Delete || len(orphans) == 0 {
 		msg := fmt.Sprintf("Orphan book_file scan: %d orphan(s) detected (report-only)", len(orphans))
@@ -84,18 +82,22 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 			msg = "Orphan book_file cleanup: no orphans found, nothing to delete"
 		}
 		_ = reporter.Log(slog.LevelInfo, msg)
-		_ = reporter.UpdateProgress(100, 100, msg)
+		scanProg.Done(msg)
 		return nil
 	}
 
-	// Delete pass.
+	// Delete pass — now we know N.
+	total := len(orphans)
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Found %d orphan book_file row(s) out of %d (valid books: %d)",
+		total, totalFiles, totalBooks))
 	var deleted, failed int
 	for i, of := range orphans {
 		if ctx.Err() != nil {
 			_ = reporter.Log(slog.LevelWarn, "Orphan delete cancelled",
 				slog.Int("deleted", deleted),
 				slog.Int("failed", failed),
-				slog.Int("remaining", len(orphans)-i),
+				slog.Int("remaining", total-i),
 			)
 			return ctx.Err()
 		}
@@ -110,18 +112,13 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 			continue
 		}
 		deleted++
-		// Progress: scale the delete pass over 50..100.
-		if total := len(orphans); total > 0 {
-			done := 50 + (50*(i+1))/total
-			_ = reporter.UpdateProgress(done, 100,
-				fmt.Sprintf("Deleting orphan book_files: %d/%d", i+1, total))
-		}
+		prog.StepN(i+1, fmt.Sprintf("Deleting orphan book_files: %d/%d", i+1, total))
 	}
 
 	final := fmt.Sprintf("Orphan book_file cleanup: deleted %d, failed %d (of %d detected)",
-		deleted, failed, len(orphans))
+		deleted, failed, total)
 	_ = reporter.Log(slog.LevelInfo, final)
-	_ = reporter.UpdateProgress(100, 100, final)
+	prog.Done(final)
 	return nil
 }
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -164,7 +164,18 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 		log = logger.New("reconcile")
 	}
 	report := func(current, total int, msg string) {
-		log.UpdateProgress(current, total, msg)
+		if total <= 0 {
+			log.UpdateProgress(current, total, msg)
+			return
+		}
+		pct := float64(current) * 100.0 / float64(total)
+		var pctStr string
+		if total >= 100 {
+			pctStr = fmt.Sprintf("%.2f%%", pct)
+		} else {
+			pctStr = fmt.Sprintf("%.0f%%", pct)
+		}
+		log.UpdateProgress(current, total, fmt.Sprintf("%s (%s)", msg, pctStr))
 	}
 	logMsg := func(level, msg string) {
 		switch level {
@@ -187,7 +198,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 	}
 
 	// Step 1: Find broken DB records
-	report(0, 100, "Loading all books from database...")
+	report(0, 1, "Loading all books from database...")
 	books, err := store.GetAllBooks(100000, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list books: %w", err)
@@ -198,7 +209,12 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 	knownPaths := make(map[string]bool, len(books))
 	var brokenBooks []database.Book
 
-	report(5, 100, fmt.Sprintf("Checking file paths for %d books...", len(books)))
+	totalBooks := len(books)
+	if totalBooks == 0 {
+		report(1, 1, "No books in database — nothing to reconcile")
+		return result, nil
+	}
+	report(0, totalBooks, fmt.Sprintf("Checking file paths for %d books...", totalBooks))
 	for i, book := range books {
 		if book.FilePath == "" {
 			continue
@@ -214,20 +230,20 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 			})
 		}
 		if i%1000 == 0 && i > 0 {
-			pct := 5 + (i*15)/len(books)
-			report(pct, 100, fmt.Sprintf("Checked %d / %d book paths (%d broken so far)...", i, len(books), len(brokenBooks)))
+			report(i, totalBooks, fmt.Sprintf("Checked %d/%d book paths (%d broken so far)", i, totalBooks, len(brokenBooks)))
 		}
 	}
+	report(totalBooks, totalBooks, fmt.Sprintf("Checked %d/%d book paths (%d broken)", totalBooks, totalBooks, len(brokenBooks)))
 
 	logMsg("info", fmt.Sprintf("Found %d broken records out of %d books", len(brokenBooks), len(books)))
 
 	if len(brokenBooks) == 0 {
-		report(100, 100, fmt.Sprintf("All %d books have valid file paths", len(books)))
+		report(1, 1, fmt.Sprintf("All %d books have valid file paths", len(books)))
 		return result, nil
 	}
 
 	// Step 2: Scan directories for untracked audio files
-	report(20, 100, "Scanning directories for untracked audio files...")
+	report(0, 1, "Scanning directories for untracked audio files...")
 	logMsg("info", "Scanning library, import paths, and iTunes directories for untracked files")
 	untrackedFiles, err := FindUntrackedFiles(store, knownPaths)
 	if err != nil {
@@ -238,12 +254,13 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 
 	if len(untrackedFiles) == 0 {
 		result.UnmatchedBooks = result.BrokenRecords
-		report(100, 100, fmt.Sprintf("No untracked files found. %d broken records remain unmatched.", len(brokenBooks)))
+		report(1, 1, fmt.Sprintf("No untracked files found. %d broken records remain unmatched.", len(brokenBooks)))
 		return result, nil
 	}
 
 	// Step 3: Hash untracked files for matching
-	report(40, 100, fmt.Sprintf("Hashing %d untracked files...", len(untrackedFiles)))
+	totalUntracked := len(untrackedFiles)
+	report(0, totalUntracked, fmt.Sprintf("Hashing %d untracked files...", totalUntracked))
 	hashIndex := make(map[string]string)
 	for i, fp := range untrackedFiles {
 		h, err := scanner.ComputeSegmentFileHash(fp)
@@ -252,17 +269,18 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 		}
 		hashIndex[h] = fp
 		if i%100 == 0 && i > 0 {
-			pct := 40 + (i*20)/len(untrackedFiles)
-			report(pct, 100, fmt.Sprintf("Hashed %d / %d untracked files...", i, len(untrackedFiles)))
+			report(i, totalUntracked, fmt.Sprintf("Hashed %d/%d untracked files", i, totalUntracked))
 		}
 	}
+	report(totalUntracked, totalUntracked, fmt.Sprintf("Hashed %d/%d untracked files", totalUntracked, totalUntracked))
 	logMsg("info", fmt.Sprintf("Computed hashes for %d untracked files", len(hashIndex)))
 
 	matchedBooks := make(map[string]bool)
 	matchedFiles := make(map[string]bool)
 
 	// Step 3a: Match by file hash
-	report(60, 100, "Matching by file hash...")
+	totalBroken := len(brokenBooks)
+	report(0, totalBroken, fmt.Sprintf("Matching %d broken records by file hash...", totalBroken))
 	for _, book := range brokenBooks {
 		if book.FileHash != nil && *book.FileHash != "" {
 			if fp, ok := hashIndex[*book.FileHash]; ok && !matchedFiles[fp] {
@@ -305,7 +323,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 	logMsg("info", fmt.Sprintf("Hash matching found %d matches", len(result.Matches)))
 
 	// Step 4: Match by filename pattern
-	report(75, 100, "Matching by filename patterns...")
+	report(0, totalBroken, fmt.Sprintf("Matching %d broken records by filename patterns...", totalBroken))
 	filenameIndex := make(map[string][]string)
 	for _, fp := range untrackedFiles {
 		if matchedFiles[fp] {
@@ -341,7 +359,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 	}
 
 	// Step 4b: Try matching by title contained in filename
-	report(85, 100, "Matching by title in filename...")
+	report(0, totalBroken, fmt.Sprintf("Matching %d broken records by title in filename...", totalBroken))
 	for _, book := range brokenBooks {
 		if matchedBooks[book.ID] {
 			continue
@@ -392,7 +410,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 		len(result.UnmatchedBooks),
 		len(brokenBooks))
 	logMsg("info", summary)
-	report(100, 100, summary)
+	report(totalBroken, totalBroken, summary)
 
 	return result, nil
 }
@@ -491,12 +509,30 @@ func ExecuteReconcile(ctx context.Context, store Store, operationID string, matc
 	}
 
 	total := len(matches)
+	fmtPct := func(cur, tot int) string {
+		if tot <= 0 {
+			return "0%"
+		}
+		pct := float64(cur) * 100.0 / float64(tot)
+		if tot >= 100 {
+			return fmt.Sprintf("%.2f%%", pct)
+		}
+		return fmt.Sprintf("%.0f%%", pct)
+	}
+	if total == 0 {
+		log.UpdateProgress(0, 1, "Reconciliation starting: 0 matches to apply")
+		log.UpdateProgress(1, 1, "Reconciliation complete: 0 applied, 0 skipped (100%)")
+		resultJSON, _ := json.Marshal(result)
+		_ = store.UpdateOperationResultData(operationID, string(resultJSON))
+		return nil
+	}
+	log.UpdateProgress(0, total, fmt.Sprintf("Reconciliation starting: 0/%d (0%%)", total))
 	for i, m := range matches {
 		if log.IsCanceled() {
 			break
 		}
 
-		log.UpdateProgress(i+1, total, fmt.Sprintf("Updating %s", m.BookID))
+		log.UpdateProgress(i+1, total, fmt.Sprintf("Updating %d/%d (%s) %s", i+1, total, fmtPct(i+1, total), m.BookID))
 
 		book, err := store.GetBookByID(m.BookID)
 		if err != nil || book == nil {
@@ -545,7 +581,7 @@ func ExecuteReconcile(ctx context.Context, store Store, operationID string, matc
 	// Store result data on the operation
 	resultJSON, _ := json.Marshal(result)
 	_ = store.UpdateOperationResultData(operationID, string(resultJSON))
-	log.UpdateProgress(total, total, fmt.Sprintf("Reconciliation complete: %d applied, %d skipped", result.Applied, result.Skipped))
+	log.UpdateProgress(total, total, fmt.Sprintf("Reconciliation complete: %d/%d processed (%s) — %d applied, %d skipped", total, total, fmtPct(total, total), result.Applied, result.Skipped))
 
 	if len(result.Errors) > 0 {
 		for _, e := range result.Errors {

--- a/internal/scheduler/extra_ops.go
+++ b/internal/scheduler/extra_ops.go
@@ -1,5 +1,5 @@
 // file: internal/scheduler/extra_ops.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: a9b8c7d6-e5f4-3210-fedc-ba9876543210
 
 // extra_ops registers OperationDefs for 13 scheduler tasks that previously
@@ -37,6 +37,7 @@ import (
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/sweep"
 	"github.com/jdfalk/audiobook-organizer/internal/versions"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
 
 // ExtraOpsDeps holds the typed dependencies needed by ExtraOpsRegistrar.
@@ -188,6 +189,8 @@ func (r *ExtraOpsRegistrar) RegisterMetadataUpgradeOp(reg *opsregistry.Registry)
 		Capabilities:    []opsregistry.Capability{opsregistry.CapLibraryRead, opsregistry.CapLibraryWrite, opsregistry.CapNetworkOpenAI},
 		Run: func(ctx context.Context, rawParams json.RawMessage, reporter opsregistry.Reporter) error {
 			progress := extraOpsProgressAdapter{r: reporter}
+			p := sdk.NewProgress(reporter, 0)
+			p.Start("Scanning for books with upgradeable metadata sources...")
 			if r.Deps.MetadataFetchService == nil {
 				return fmt.Errorf("metadata fetch service not initialized")
 			}
@@ -200,7 +203,7 @@ func (r *ExtraOpsRegistrar) RegisterMetadataUpgradeOp(reg *opsregistry.Registry)
 			msg := fmt.Sprintf("Metadata upgrade complete: checked %d, upgraded %d, skipped %d, errors %d",
 				result.Checked, result.Upgraded, result.Skipped, result.Errors)
 			_ = progress.Log("info", msg, nil)
-			_ = progress.UpdateProgress(100, 100, msg)
+			p.Done(msg)
 			return nil
 		},
 	})
@@ -240,6 +243,8 @@ func (r *ExtraOpsRegistrar) RegisterAuthorSplitScanOp(reg *opsregistry.Registry)
 			booksUpdated := 0
 			errCount := 0
 			total := len(authors)
+			p := sdk.NewProgress(reporter, total)
+			p.Start(fmt.Sprintf("Scanning %d authors for composite names", total))
 
 			for i, author := range authors {
 				if ctx.Err() != nil {
@@ -249,7 +254,7 @@ func (r *ExtraOpsRegistrar) RegisterAuthorSplitScanOp(reg *opsregistry.Registry)
 				parts := dedup.SplitCompositeAuthorName(author.Name)
 				if len(parts) <= 1 {
 					if (i+1)%200 == 0 {
-						_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors", i+1, total))
+						p.StepN(i+1, fmt.Sprintf("Checked %d/%d authors", i+1, total))
 					}
 					continue
 				}
@@ -345,7 +350,7 @@ func (r *ExtraOpsRegistrar) RegisterAuthorSplitScanOp(reg *opsregistry.Registry)
 				}
 
 				if (i+1)%200 == 0 || splitCount%50 == 0 {
-					_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Checked %d/%d authors, split %d so far", i+1, total, splitCount))
+					p.StepN(i+1, fmt.Sprintf("Checked %d/%d authors, split %d so far", i+1, total, splitCount))
 				}
 			}
 
@@ -356,7 +361,7 @@ func (r *ExtraOpsRegistrar) RegisterAuthorSplitScanOp(reg *opsregistry.Registry)
 
 			resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors)", splitCount, booksUpdated, errCount)
 			_ = progress.Log("info", resultMsg, nil)
-			_ = progress.UpdateProgress(total, total, resultMsg)
+			p.Done(resultMsg)
 			return nil
 		},
 	})
@@ -389,10 +394,12 @@ func (r *ExtraOpsRegistrar) RegisterDBOptimizeOp(reg *opsregistry.Registry) erro
 			storesOptimized := 0
 			storesTotal := 3
 			startTotal := time.Now()
+			p := sdk.NewProgress(reporter, storesTotal)
+			p.Start("Starting database optimization")
 
 			// 1. Main store
 			_ = progress.Log("info", "Optimizing main database (VACUUM, ANALYZE, WAL checkpoint)...", nil)
-			_ = progress.UpdateProgress(0, storesTotal, "Optimizing main database...")
+			p.StepN(0, "Optimizing main database (0/3)")
 			t1 := time.Now()
 			if err := store.Optimize(); err != nil {
 				_ = progress.Log("error", fmt.Sprintf("Main DB optimization failed: %v", err), nil)
@@ -400,9 +407,9 @@ func (r *ExtraOpsRegistrar) RegisterDBOptimizeOp(reg *opsregistry.Registry) erro
 				storesOptimized++
 				_ = progress.Log("info", fmt.Sprintf("Main database optimized in %s", time.Since(t1).Round(time.Millisecond)), nil)
 			}
+			p.StepN(1, fmt.Sprintf("Main database done (1/%d)", storesTotal))
 
 			// 2. AI scan store
-			_ = progress.UpdateProgress(1, storesTotal, "Optimizing AI scan database...")
 			if r.Deps.AIScanStore != nil {
 				t2 := time.Now()
 				if err := r.Deps.AIScanStore.Optimize(); err != nil {
@@ -414,9 +421,9 @@ func (r *ExtraOpsRegistrar) RegisterDBOptimizeOp(reg *opsregistry.Registry) erro
 			} else {
 				_ = progress.Log("info", "AI scan store not initialized, skipping", nil)
 			}
+			p.StepN(2, fmt.Sprintf("AI scan database done (2/%d)", storesTotal))
 
 			// 3. OpenLibrary store (accessed via OLService)
-			_ = progress.UpdateProgress(2, storesTotal, "Optimizing OpenLibrary cache...")
 			if r.Deps.OLService != nil && r.Deps.OLService.Store() != nil {
 				t3 := time.Now()
 				if err := r.Deps.OLService.Store().Optimize(); err != nil {
@@ -428,10 +435,10 @@ func (r *ExtraOpsRegistrar) RegisterDBOptimizeOp(reg *opsregistry.Registry) erro
 			} else {
 				_ = progress.Log("info", "OpenLibrary store not initialized, skipping", nil)
 			}
+			p.StepN(3, fmt.Sprintf("OpenLibrary cache done (3/%d)", storesTotal))
 
-			_ = progress.UpdateProgress(storesTotal, storesTotal,
-				fmt.Sprintf("Database optimization complete: %d/%d stores in %s",
-					storesOptimized, storesTotal, time.Since(startTotal).Round(time.Millisecond)))
+			p.Done(fmt.Sprintf("Database optimization complete: %d/%d stores in %s",
+				storesOptimized, storesTotal, time.Since(startTotal).Round(time.Millisecond)))
 			return nil
 		},
 	})
@@ -580,12 +587,13 @@ func (r *ExtraOpsRegistrar) RegisterPurgeDeletedOp(reg *opsregistry.Registry) er
 				return fmt.Errorf("purge-deleted: decode params: %w", err)
 			}
 			progress := extraOpsProgressAdapter{r: reporter}
+			prog := sdk.NewProgress(reporter, 0)
+			prog.Start("Starting purge of soft-deleted books")
 			_ = progress.Log("info", "Starting purge of soft-deleted books", nil)
-			_ = progress.UpdateProgress(0, 100, "Purging soft-deleted books...")
 			r.runAutoPurgeSoftDeleted(ctx, p.LegacyOpID)
 			activity.FlushOperation(r.Deps.ActivityWriter, p.LegacyOpID)
 			_ = progress.Log("info", "Purge complete", nil)
-			_ = progress.UpdateProgress(100, 100, "Purge complete")
+			prog.Done("Purge complete")
 			return nil
 		},
 	})
@@ -614,15 +622,16 @@ func (r *ExtraOpsRegistrar) RegisterTombstoneCleanupOp(reg *opsregistry.Registry
 			if store == nil {
 				return fmt.Errorf("database not initialized")
 			}
+			p := sdk.NewProgress(reporter, 0)
+			p.Start("Resolving tombstone chains")
 			_ = progress.Log("info", "Starting author tombstone chain resolution", nil)
-			_ = progress.UpdateProgress(0, 100, "Resolving tombstone chains...")
 			updated, err := store.ResolveTombstoneChains()
 			if err != nil {
 				return fmt.Errorf("tombstone chain resolution failed: %w", err)
 			}
 			resultMsg := fmt.Sprintf("Resolved %d tombstone chains", updated)
 			_ = progress.Log("info", resultMsg, nil)
-			_ = progress.UpdateProgress(100, 100, resultMsg)
+			p.Done(resultMsg)
 			return nil
 		},
 	})
@@ -667,12 +676,15 @@ func (r *ExtraOpsRegistrar) RegisterResolveProductionAuthorsOp(reg *opsregistry.
 			_ = progress.Log("info", fmt.Sprintf("Found %d production company authors", len(prodAuthors)), nil)
 			total := len(prodAuthors)
 			resolved := 0
+			p := sdk.NewProgress(reporter, total)
+			p.Start(fmt.Sprintf("Processing %d production companies", total))
 			for i, author := range prodAuthors {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
 				books, err := store.GetBooksByAuthorIDWithRole(author.ID)
 				if err != nil {
+					p.StepN(i+1, fmt.Sprintf("Processed %d/%d production companies (%d books resolved)", i+1, total, resolved))
 					continue
 				}
 				for _, book := range books {
@@ -687,7 +699,7 @@ func (r *ExtraOpsRegistrar) RegisterResolveProductionAuthorsOp(reg *opsregistry.
 						}
 					}
 				}
-				_ = progress.UpdateProgress(i+1, total, fmt.Sprintf("Processed %d/%d production companies (%d books resolved)", i+1, total, resolved))
+				p.StepN(i+1, fmt.Sprintf("Processed %d/%d production companies (%d books resolved)", i+1, total, resolved))
 			}
 
 			if r.Deps.DedupCache != nil {
@@ -696,7 +708,7 @@ func (r *ExtraOpsRegistrar) RegisterResolveProductionAuthorsOp(reg *opsregistry.
 
 			resultMsg := fmt.Sprintf("Resolved %d books across %d production companies", resolved, total)
 			_ = progress.Log("info", resultMsg, nil)
-			_ = progress.UpdateProgress(total, total, resultMsg)
+			p.Done(resultMsg)
 			return nil
 		},
 	})
@@ -741,6 +753,7 @@ func (r *ExtraOpsRegistrar) runIsbnEnrichment(ctx context.Context, progress oper
 	if operations.IsManual(ctx) {
 		activity.EmitInfo(r.Deps.ActivityWriter, opID, "isbn-enrich", "isbn-enrichment", startMsg, activity.AlwaysShow)
 	}
+	_ = progress.UpdateProgress(0, 2, "Starting ISBN enrichment (0/2) (0.00%)")
 	checked, updated, err := r.Deps.MetadataFetchService.ISBNEnrichment().EnrichMissingISBNs(ctx, 100, r.Deps.ActivityWriter, opID)
 	if err != nil {
 		return err
@@ -748,7 +761,7 @@ func (r *ExtraOpsRegistrar) runIsbnEnrichment(ctx context.Context, progress oper
 	activity.FlushOperation(r.Deps.ActivityWriter, opID)
 	msg := fmt.Sprintf("ISBN enrichment complete: checked %d, updated %d", checked, updated)
 	_ = progress.Log("info", msg, nil)
-	_ = progress.UpdateProgress(100, 100, msg)
+	_ = progress.UpdateProgress(2, 2, fmt.Sprintf("%s (2/2) (100.00%%)", msg))
 	tags := activity.TagsIf(updated == 0, activity.NoOpTag)
 	if operations.IsManual(ctx) {
 		tags = append(tags, activity.AlwaysShow)
@@ -797,12 +810,20 @@ func (r *ExtraOpsRegistrar) runMetadataRefreshScan(ctx context.Context, progress
 		return fmt.Errorf("database not initialized")
 	}
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
-	_ = progress.UpdateProgress(0, 100, "Scanning books for incomplete metadata...")
 	books, err := store.GetAllBooks(10000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)
 	}
-	_ = progress.Log("info", fmt.Sprintf("Checking %d books for incomplete metadata", len(books)), nil)
+	total := len(books)
+	denom := total + 2
+	fmtPct := func(cur int) float64 {
+		if denom <= 0 {
+			return 0
+		}
+		return float64(cur) / float64(denom) * 100
+	}
+	_ = progress.UpdateProgress(0, denom, fmt.Sprintf("Scanning %d books for incomplete metadata (0/%d) (%.2f%%)", total, denom, fmtPct(0)))
+	_ = progress.Log("info", fmt.Sprintf("Checking %d books for incomplete metadata", total), nil)
 	incomplete := 0
 	for i, book := range books {
 		select {
@@ -815,11 +836,11 @@ func (r *ExtraOpsRegistrar) runMetadataRefreshScan(ctx context.Context, progress
 			_ = progress.Log("debug", fmt.Sprintf("Incomplete: %q (id=%s)", book.Title, book.ID), nil)
 		}
 		if (i+1)%200 == 0 {
-			_ = progress.UpdateProgress(i+1, len(books), fmt.Sprintf("Checked %d/%d books", i+1, len(books)))
+			_ = progress.UpdateProgress(i+1, denom, fmt.Sprintf("Checked %d/%d books (%.2f%%)", i+1, total, fmtPct(i+1)))
 		}
 	}
-	resultMsg := fmt.Sprintf("Found %d books with incomplete metadata out of %d total", incomplete, len(books))
+	resultMsg := fmt.Sprintf("Found %d books with incomplete metadata out of %d total", incomplete, total)
 	_ = progress.Log("info", resultMsg, nil)
-	_ = progress.UpdateProgress(len(books), len(books), resultMsg)
+	_ = progress.UpdateProgress(denom, denom, fmt.Sprintf("%s (%d/%d) (100.00%%)", resultMsg, denom, denom))
 	return nil
 }

--- a/internal/server/ai_handlers.go
+++ b/internal/server/ai_handlers.go
@@ -529,7 +529,9 @@ func (s *Server) aiReviewDuplicateAuthors(c *gin.Context) {
 // aiReviewGroupsMode is the existing Groups mode — local heuristics build groups, AI validates.
 func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.ProgressReporter, parser aiParser, store database.Store, opID string, dedupGroups []dedup.AuthorDedupGroup) error {
 	_ = progress.Log("info", fmt.Sprintf("Starting AI review (groups mode) of %d duplicate author groups", len(dedupGroups)), nil)
-	_ = progress.UpdateProgress(0, len(dedupGroups), "Building AI review input...")
+	// Schedule: 1 setup + N input rows + 1 send + 1 done = len+3 steps.
+	totalSteps := len(dedupGroups) + 3
+	_ = progress.UpdateProgress(0, totalSteps, fmt.Sprintf("Building AI review input for %d groups... (0/%d 0.00%%)", len(dedupGroups), totalSteps))
 
 	var inputs []ai.AuthorDedupInput
 	for i, group := range dedupGroups {
@@ -558,7 +560,8 @@ func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.Pro
 		})
 	}
 
-	_ = progress.UpdateProgress(10, 100, fmt.Sprintf("Sending %d groups to AI for review...", len(inputs)))
+	sent := len(inputs) + 1 // setup + N inputs built
+	_ = progress.UpdateProgress(sent, totalSteps, fmt.Sprintf("Sending %d groups to AI for review... (%d/%d %.2f%%)", len(inputs), sent, totalSteps, float64(sent)/float64(totalSteps)*100))
 
 	suggestions, err := parser.ReviewAuthorDuplicates(ctx, inputs)
 	if err != nil {
@@ -585,7 +588,7 @@ func (s *Server) aiReviewGroupsMode(ctx context.Context, progress operations.Pro
 		return fmt.Errorf("failed to store results: %w", err)
 	}
 
-	_ = progress.UpdateProgress(100, 100, fmt.Sprintf("AI review complete: %d suggestions", len(suggestions)))
+	_ = progress.UpdateProgress(totalSteps, totalSteps, fmt.Sprintf("AI review complete: %d suggestions (%d/%d 100.00%%)", len(suggestions), totalSteps, totalSteps))
 	return nil
 }
 
@@ -595,7 +598,8 @@ func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.Progr
 	database.OperationStore
 }, opID string) error {
 	_ = progress.Log("info", "Starting AI review (full mode) — discovering duplicates from all authors", nil)
-	_ = progress.UpdateProgress(0, 100, "Loading all authors...")
+	// Pre-load total is unknown; use a placeholder (0/1) Start so we never emit 0/0.
+	_ = progress.UpdateProgress(0, 1, "Loading all authors... (0/1 0.00%)")
 
 	allAuthors, err := store.GetAllAuthors()
 	if err != nil {
@@ -603,7 +607,9 @@ func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.Progr
 	}
 
 	_ = progress.Log("info", fmt.Sprintf("Building discovery input for %d authors", len(allAuthors)), nil)
-	_ = progress.UpdateProgress(5, 100, fmt.Sprintf("Building input for %d authors...", len(allAuthors)))
+	// Schedule: N input rows + 1 send + 1 done = len+2 steps.
+	totalSteps := len(allAuthors) + 2
+	_ = progress.UpdateProgress(0, totalSteps, fmt.Sprintf("Building input for %d authors... (0/%d 0.00%%)", len(allAuthors), totalSteps))
 
 	var inputs []ai.AuthorDiscoveryInput
 	for _, author := range allAuthors {
@@ -625,7 +631,8 @@ func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.Progr
 		})
 	}
 
-	_ = progress.UpdateProgress(10, 100, fmt.Sprintf("Sending %d authors to AI for discovery...", len(inputs)))
+	sent := len(inputs)
+	_ = progress.UpdateProgress(sent, totalSteps, fmt.Sprintf("Sending %d authors to AI for discovery... (%d/%d %.2f%%)", len(inputs), sent, totalSteps, float64(sent)/float64(totalSteps)*100))
 
 	discoveries, err := parser.DiscoverAuthorDuplicates(ctx, inputs)
 	if err != nil {
@@ -698,7 +705,7 @@ func (s *Server) aiReviewFullMode(ctx context.Context, progress operations.Progr
 		return fmt.Errorf("failed to store results: %w", err)
 	}
 
-	_ = progress.UpdateProgress(100, 100, fmt.Sprintf("AI discovery complete: %d groups found", len(groups)))
+	_ = progress.UpdateProgress(totalSteps, totalSteps, fmt.Sprintf("AI discovery complete: %d groups found (%d/%d 100.00%%)", len(groups), totalSteps, totalSteps))
 	return nil
 }
 

--- a/internal/server/diagnostics_ops.go
+++ b/internal/server/diagnostics_ops.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/diagnostics"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 )
 
@@ -49,7 +50,8 @@ func (s *Server) RegisterDiagnosticsExportOp(reg *opsregistry.Registry) error {
 			if ds == nil {
 				ds = diagnostics.NewService(store, nil, config.AppConfig.ITunesLibraryReadPath)
 			}
-			_ = reporter.UpdateProgress(0, 100, "Generating export data")
+			prog := sdk.NewProgress(reporter, 0)
+			prog.Start("Generating export data")
 			zipPath, genErr := ds.GenerateExport(p.Category, p.Description)
 			if genErr != nil {
 				if store != nil {
@@ -62,7 +64,7 @@ func (s *Server) RegisterDiagnosticsExportOp(reg *opsregistry.Registry) error {
 				_ = store.UpdateOperationResultData(p.LegacyOpID, string(resultJSON))
 				_ = store.UpdateOperationStatus(p.LegacyOpID, "completed", 100, 100, "Export complete")
 			}
-			_ = reporter.UpdateProgress(100, 100, "Export complete")
+			prog.Done("Export complete")
 			return nil
 		},
 	})

--- a/internal/server/duplicates_handlers.go
+++ b/internal/server/duplicates_handlers.go
@@ -467,7 +467,9 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 		return fmt.Errorf("failed to get series: %w", err)
 	}
 
-	_ = progress.UpdateProgress(0, len(allSeries), fmt.Sprintf("Scanning %d series...", len(allSeries)))
+	// Schedule: scan phase (N=len(allSeries)) + 1 orphan phase + 1 done.
+	totalSteps := len(allSeries) + 2
+	_ = progress.UpdateProgress(0, totalSteps, fmt.Sprintf("Scanning %d series... (0/%d 0.00%%)", len(allSeries), totalSteps))
 
 	// Group by LOWER(TRIM(name)) + author_id
 	type groupKey struct {
@@ -560,7 +562,8 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 	}
 
 	_ = progress.Log("info", fmt.Sprintf("Phase 1 complete: merged %d duplicate series from %d groups", totalMerged, dupGroupCount), nil)
-	_ = progress.UpdateProgress(50, 100, "Scanning for orphan series...")
+	orphanStep := len(allSeries) + 1
+	_ = progress.UpdateProgress(orphanStep, totalSteps, fmt.Sprintf("Scanning for orphan series... (%d/%d %.2f%%)", orphanStep, totalSteps, float64(orphanStep)/float64(totalSteps)*100))
 
 	// Phase 2: Delete orphan series (0 books)
 	orphansDeleted := 0
@@ -617,7 +620,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 		errDetail := strings.Join(mergeErrors[:min(len(mergeErrors), 10)], "; ")
 		_ = progress.Log("warn", fmt.Sprintf("Errors: %s", errDetail), nil)
 	}
-	_ = progress.UpdateProgress(100, 100, resultMsg)
+	_ = progress.UpdateProgress(totalSteps, totalSteps, fmt.Sprintf("%s (%d/%d 100.00%%)", resultMsg, totalSteps, totalSteps))
 
 	if s.dedupCache != nil {
 		s.dedupCache.InvalidateAll()

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/logger"
 	"github.com/jdfalk/audiobook-organizer/internal/logging"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
 
 // ── OperationDef registrations ────────────────────────────────────────────────
@@ -207,7 +208,11 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			progress := registryProgressAdapter{r: reporter}
 
 			logging.Info(ctx, "author duplicate scan starting")
-			_ = progress.UpdateProgress(0, 100, "Fetching authors...")
+			// We don't know the final count until authors load; start with N=0
+			// and reset to a real N once we know it.
+			sp := sdk.NewProgress(reporter, 0)
+			sp.Start("Fetching authors...")
+			_ = progress.Log("info", "Fetching authors...", nil)
 
 			authors, err := store.GetAllAuthors()
 			if err != nil {
@@ -216,7 +221,9 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 				return err
 			}
 			logging.Info(ctx, "authors loaded", "count", len(authors))
-			_ = progress.UpdateProgress(10, 100, fmt.Sprintf("Loaded %d authors, fetching book counts...", len(authors)))
+			// Re-create the helper now that we know N = len(authors).
+			sp = sdk.NewProgress(reporter, len(authors))
+			sp.Start(fmt.Sprintf("Loaded %d authors, fetching book counts...", len(authors)))
 
 			bookCounts, err := store.GetAllAuthorBookCounts()
 			if err != nil {
@@ -225,11 +232,12 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 				return err
 			}
 			bookCountFn := func(authorID int) int { return bookCounts[authorID] }
-			_ = progress.UpdateProgress(20, 100, "Finding duplicate authors...")
+			sp.StepN(0, "Finding duplicate authors...")
 
 			progressFn := func(current, total int, message string) {
-				pct := 20 + (current*70)/max(total, 1)
-				_ = progress.UpdateProgress(pct, 100, message)
+				// Forward the real (current, total) from the dedup callback
+				// verbatim — never re-scale into 0..100.
+				sp.StepN(current, message)
 			}
 
 			groups := dedup.FindDuplicateAuthors(authors, 0.9, bookCountFn, progressFn)
@@ -248,7 +256,7 @@ func (s *Server) RegisterAuthorDedupScanOp(reg *opsregistry.Registry) error {
 			s.dedupCache.SetWithTTL("author-duplicates", result, 30*time.Minute)
 
 			op.SetStatus("success")
-			_ = progress.UpdateProgress(100, 100, fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
+			sp.Done(fmt.Sprintf("Found %d duplicate groups (after filtering reviewed)", len(groups)))
 			logging.Info(ctx, "author duplicate scan complete", "groups", len(groups))
 
 			if s.activityWriter != nil && p.LegacyOpID != "" {

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -908,7 +908,8 @@ func (s *Server) runBulkMetadataFetchAll(
 	}
 	ctx = logging.WithOp(ctx, op)
 
-	_ = progress.UpdateProgress(0, 0, "loading books")
+	// Total unknown until books load; use placeholder (0/1) to avoid 0/0.
+	_ = progress.UpdateProgress(0, 1, "loading books (0/1 0.00%)")
 
 	allBooks, err := store.GetAllBooks(0, 0)
 	if err != nil {
@@ -1666,7 +1667,13 @@ func (s *Server) runIsbnEnrichment(ctx context.Context, progress operations.Prog
 	activity.FlushOperation(s.activityWriter, opID)
 	msg := fmt.Sprintf("ISBN enrichment complete: checked %d, updated %d", checked, updated)
 	_ = progress.Log("info", msg, nil)
-	_ = progress.UpdateProgress(100, 100, msg)
+	// Use real (checked, checked) so the bar is honest. Fall back to (1,1)
+	// when nothing was checked to avoid 0/0.
+	total := checked
+	if total <= 0 {
+		total = 1
+	}
+	_ = progress.UpdateProgress(total, total, fmt.Sprintf("%s (%d/%d 100.00%%)", msg, total, total))
 	tags := activity.TagsIf(updated == 0, activity.NoOpTag)
 	if operations.IsManual(ctx) {
 		tags = append(tags, activity.AlwaysShow)
@@ -1683,7 +1690,8 @@ func (s *Server) runMetadataRefreshScan(ctx context.Context, progress operations
 		return fmt.Errorf("database not initialized")
 	}
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
-	_ = progress.UpdateProgress(0, 100, "Scanning books for incomplete metadata...")
+	// Pre-load total is unknown; placeholder (0/1) avoids 0/0.
+	_ = progress.UpdateProgress(0, 1, "Scanning books for incomplete metadata... (0/1 0.00%)")
 	books, err := store.GetAllBooks(10000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)

--- a/internal/server/scheduler_maintenance_window_op.go
+++ b/internal/server/scheduler_maintenance_window_op.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/operations"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/scheduler"
+	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
 
 // RegisterMaintenanceWindowOp registers the "maintenance.window" OperationDef which
@@ -63,7 +64,8 @@ func (s *Server) RegisterMaintenanceWindowOp(reg *opsregistry.Registry) error {
 				today := time.Now().Format("2006-01-02")
 				if updateDone == nil || updateDone.Value != today {
 					_ = progress.Log("info", "Running auto-update (step 1)", nil)
-					_ = progress.UpdateProgress(0, 100, "Running auto-update...")
+					// Auto-update is a single bounded step (0/1 → done).
+					_ = reporter.UpdateProgress(0, 1, "Running auto-update... (0/1 0%)")
 					_ = store.SetSetting("maintenance_window_update_completed", today, "string", false)
 					if s.updater != nil {
 						channel := config.AppConfig.AutoUpdateChannel
@@ -112,6 +114,8 @@ func (s *Server) RegisterMaintenanceWindowOp(reg *opsregistry.Registry) error {
 				windowStartTags = []string{activity.AlwaysShow, mwTag}
 			}
 
+			sp := sdk.NewProgress(reporter, len(eligible))
+			sp.Start(fmt.Sprintf("Maintenance window starting: %d tasks eligible", len(eligible)))
 			_ = progress.Log("info", fmt.Sprintf("Maintenance window starting: %d tasks eligible: %s", len(eligible), strings.Join(eligible, ", ")), nil)
 			activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
 				fmt.Sprintf("Maintenance window starting: %d tasks: %s", len(eligible), strings.Join(eligible, ", ")),
@@ -138,7 +142,7 @@ func (s *Server) RegisterMaintenanceWindowOp(reg *opsregistry.Registry) error {
 					continue
 				}
 
-				_ = progress.UpdateProgress(i, len(eligible), fmt.Sprintf("Running task %d/%d: %s", i+1, len(eligible), name))
+				sp.StepN(i, fmt.Sprintf("Running task %d/%d: %s", i+1, len(eligible), name))
 				_ = progress.Log("info", fmt.Sprintf("Starting maintenance task: %s", name), nil)
 				ran++
 
@@ -197,13 +201,13 @@ func (s *Server) RegisterMaintenanceWindowOp(reg *opsregistry.Registry) error {
 			summary := strings.Join(summaryParts, ", ")
 
 			if len(failures) > 0 {
-				_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed with errors")
+				sp.Done("Maintenance window completed with errors")
 				activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
 					"Maintenance window done (errors): "+summary,
 					windowStartTags...)
 				return fmt.Errorf("maintenance window: %s", summary)
 			}
-			_ = progress.UpdateProgress(len(eligible), len(eligible), "Maintenance window completed successfully")
+			sp.Done("Maintenance window completed successfully")
 			activity.EmitInfo(s.activityWriter, opID, activity.MaintenanceWindow, "maintenance-window",
 				"Maintenance window done: "+summary,
 				windowStartTags...)

--- a/pkg/plugin/sdk/progress.go
+++ b/pkg/plugin/sdk/progress.go
@@ -1,0 +1,120 @@
+// file: pkg/plugin/sdk/progress.go
+// version: 1.0.0
+// guid: 7b3a9c1e-2d4f-4e6a-8b9c-1a2b3c4d5e6f
+// last-edited: 2026-05-30
+
+package sdk
+
+import "fmt"
+
+// Progress is a thin wrapper around Reporter that:
+//
+//  1. Always uses real (current, total) counts — never the lying
+//     `(pct, 100)` pattern.
+//  2. Reserves a Start step and a Done step so the bar always advances
+//     at least twice even when N == 0. This means UIs never see `0/0`
+//     and the percentage is always derivable.
+//  3. Formats the message uniformly:
+//     "<verb> <i>/<N> (<extra>) (<pct>%)"
+//
+// Step model: total = N + 2.
+//
+//	step 0           "Starting …"           (0,   N+2)
+//	step 1..N        per-item work          (i,   N+2)   1 <= i <= N
+//	step N+1         "Finalizing …"         (N+1, N+2)
+//	step N+2         "Done"                 (N+2, N+2)
+type Progress struct {
+	r     Reporter
+	n     int // number of real units of work
+	total int // n + 2
+	cur   int // most recently reported current
+}
+
+// NewProgress returns a helper that reserves a start + n + finalize + done
+// step schedule. Negative n is clamped to 0, so the worst case still has
+// total == 2 — never 0/0.
+func NewProgress(r Reporter, n int) *Progress {
+	if n < 0 {
+		n = 0
+	}
+	return &Progress{r: r, n: n, total: n + 2}
+}
+
+// Start emits the initial "starting" frame at (0, total).
+func (p *Progress) Start(message string) {
+	if p == nil || p.r == nil {
+		return
+	}
+	p.cur = 0
+	_ = p.r.UpdateProgress(0, p.total, p.format(0, message))
+}
+
+// Step advances the cursor by one and reports (cur, total). Use this when
+// you're iterating through the N units of work in order.
+func (p *Progress) Step(message string) {
+	if p == nil || p.r == nil {
+		return
+	}
+	p.cur++
+	if p.cur > p.n+1 {
+		p.cur = p.n + 1
+	}
+	_ = p.r.UpdateProgress(p.cur, p.total, p.format(p.cur, message))
+}
+
+// StepN jumps directly to the i-th unit of N. Useful when callbacks come
+// with their own (processed, total) pair from a deeper loop (e.g. Pebble
+// bulk operations). i is 1-based; passing i == 0 reports the Start frame.
+func (p *Progress) StepN(i int, message string) {
+	if p == nil || p.r == nil {
+		return
+	}
+	if i < 0 {
+		i = 0
+	}
+	if i > p.n {
+		i = p.n
+	}
+	p.cur = i
+	_ = p.r.UpdateProgress(i, p.total, p.format(i, message))
+}
+
+// Finalize emits the penultimate frame at (total-1, total) — the cleanup
+// or "writing results" phase.
+func (p *Progress) Finalize(message string) {
+	if p == nil || p.r == nil {
+		return
+	}
+	p.cur = p.total - 1
+	_ = p.r.UpdateProgress(p.cur, p.total, p.format(p.cur, message))
+}
+
+// Done emits the final frame at (total, total).
+func (p *Progress) Done(message string) {
+	if p == nil || p.r == nil {
+		return
+	}
+	p.cur = p.total
+	_ = p.r.UpdateProgress(p.total, p.total, p.format(p.total, message))
+}
+
+// N returns the original unit count (excluding start/finalize/done).
+func (p *Progress) N() int { return p.n }
+
+// Total returns the wire total (N + 2).
+func (p *Progress) Total() int { return p.total }
+
+// format appends a "(pct%)" suffix to the supplied message. We compute the
+// percentage from cur/total so the displayed percent always agrees with
+// what the UI would render from the same (current, total) tuple.
+func (p *Progress) format(cur int, msg string) string {
+	if p.total <= 0 {
+		return msg
+	}
+	pct := float64(cur) / float64(p.total) * 100
+	// For large jobs show two decimals so 1088/308857 doesn't read 0.00%.
+	if p.n >= 100 {
+		return fmt.Sprintf("%s (%.2f%%)", msg, pct)
+	}
+	return fmt.Sprintf("%s (%.0f%%)", msg, pct)
+}

--- a/pkg/plugin/sdk/progress_test.go
+++ b/pkg/plugin/sdk/progress_test.go
@@ -1,0 +1,146 @@
+// file: pkg/plugin/sdk/progress_test.go
+// version: 1.0.0
+// guid: 9d4e1f2a-3b5c-4d6e-8f7a-1b2c3d4e5f60
+// last-edited: 2026-05-30
+
+package sdk
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+type recordedFrame struct {
+	current int
+	total   int
+	message string
+}
+
+type fakeReporter struct {
+	frames []recordedFrame
+}
+
+func (f *fakeReporter) UpdateProgress(current, total int, message string) error {
+	f.frames = append(f.frames, recordedFrame{current, total, message})
+	return nil
+}
+
+func (f *fakeReporter) Log(slog.Level, string, ...slog.Attr) error { return nil }
+func (f *fakeReporter) Logger() *slog.Logger                       { return slog.Default() }
+func (f *fakeReporter) Checkpoint(any) error                       { return nil }
+func (f *fakeReporter) IsCanceled() bool                           { return false }
+func (f *fakeReporter) RunPhase(_ context.Context, _ string, fn func(context.Context, Reporter) error) error {
+	return fn(context.Background(), f)
+}
+func (f *fakeReporter) Trigger(context.Context, string, any) error { return nil }
+func (f *fakeReporter) SetCurrentItem(string)                      {}
+
+func TestProgress_ZeroItemsStillAdvances(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, 0)
+	p.Start("starting")
+	p.Finalize("finalizing")
+	p.Done("done")
+
+	if got, want := len(r.frames), 3; got != want {
+		t.Fatalf("frames: got %d want %d", got, want)
+	}
+	if r.frames[0].total != 2 {
+		t.Fatalf("total: got %d want 2 (n+2 with n=0)", r.frames[0].total)
+	}
+	if r.frames[0].current != 0 || r.frames[1].current != 1 || r.frames[2].current != 2 {
+		t.Fatalf("current progression wrong: %+v", r.frames)
+	}
+	for _, f := range r.frames {
+		if f.total == 0 {
+			t.Fatalf("total must never be 0 (would render 0/0)")
+		}
+	}
+}
+
+func TestProgress_StepIncrements(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, 3)
+	p.Start("start")
+	p.Step("a")
+	p.Step("b")
+	p.Step("c")
+	p.Finalize("finalize")
+	p.Done("done")
+
+	wantCurrents := []int{0, 1, 2, 3, 4, 5}
+	for i, f := range r.frames {
+		if f.current != wantCurrents[i] {
+			t.Errorf("frame %d current: got %d want %d", i, f.current, wantCurrents[i])
+		}
+		if f.total != 5 {
+			t.Errorf("frame %d total: got %d want 5", i, f.total)
+		}
+	}
+}
+
+func TestProgress_StepNClamps(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, 10)
+	p.StepN(15, "way past end") // should clamp to 10
+	if r.frames[0].current != 10 {
+		t.Errorf("StepN clamp: got %d want 10", r.frames[0].current)
+	}
+	p.StepN(-3, "negative") // should clamp to 0
+	if r.frames[1].current != 0 {
+		t.Errorf("StepN negative clamp: got %d want 0", r.frames[1].current)
+	}
+}
+
+func TestProgress_LargeNUsesTwoDecimals(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, 308857)
+	p.StepN(1088, "Clearing fingerprints 1088/308857 (cleared=1088)")
+	msg := r.frames[0].message
+	if !strings.Contains(msg, "%") {
+		t.Fatalf("expected percent in message, got %q", msg)
+	}
+	if !strings.Contains(msg, ".") {
+		t.Errorf("expected two-decimal pct for large N, got %q", msg)
+	}
+}
+
+func TestProgress_SmallNUsesZeroDecimals(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, 5)
+	p.StepN(2, "step 2/5")
+	msg := r.frames[0].message
+	if strings.Contains(msg, ".") {
+		t.Errorf("expected zero-decimal pct for small N, got %q", msg)
+	}
+}
+
+func TestProgress_NilSafe(t *testing.T) {
+	var p *Progress
+	// Should not panic on any method.
+	p.Start("x")
+	p.Step("x")
+	p.StepN(1, "x")
+	p.Finalize("x")
+	p.Done("x")
+
+	r2 := &fakeReporter{}
+	p2 := &Progress{r: nil, n: 1, total: 3}
+	_ = r2
+	p2.Start("x") // r nil — should no-op without panic
+}
+
+func TestProgress_NegativeNClampedToZero(t *testing.T) {
+	r := &fakeReporter{}
+	p := NewProgress(r, -10)
+	if p.Total() != 2 {
+		t.Errorf("negative n should clamp to 0 (total=2), got total=%d", p.Total())
+	}
+	p.Start("s")
+	p.Done("d")
+	if r.frames[len(r.frames)-1].total != 2 {
+		t.Fatalf("expected wire total 2, got %d", r.frames[len(r.frames)-1].total)
+	}
+}

--- a/web/src/components/layout/OperationsIndicator.tsx
+++ b/web/src/components/layout/OperationsIndicator.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/OperationsIndicator.tsx
-// version: 3.10.0
+// version: 4.0.0
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
 
 import { useState } from 'react';
@@ -10,6 +10,7 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Collapse,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -26,6 +27,8 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew.js';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty.js';
 import ArticleIcon from '@mui/icons-material/Article.js';
 import CloseIcon from '@mui/icons-material/Close.js';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight.js';
 import { OperationActivityPanel } from '../OperationActivityPanel';
 import {
   useOperationsStore,
@@ -94,7 +97,7 @@ function formatElapsed(op: ActiveOperation): string | null {
 }
 
 function parseMessageDetails(message: string) {
-  const titleMatch = message.match(/\u2014\s*(.+)$/);
+  const titleMatch = message.match(/—\s*(.+)$/);
   const countsMatch = message.match(
     /\(imported (\d+), skipped (\d+), failed (\d+)\)/
   );
@@ -110,6 +113,81 @@ function parseMessageDetails(message: string) {
   };
 }
 
+type CollapseKey = 'running' | 'pending' | 'completed';
+
+const COLLAPSE_STORAGE_KEY = 'ops-indicator-collapse-v1';
+
+function loadCollapseState(): Record<CollapseKey, boolean> {
+  // Defaults: Running open, Pending open, Completed collapsed.
+  const defaults: Record<CollapseKey, boolean> = {
+    running: true,
+    pending: true,
+    completed: false,
+  };
+  try {
+    const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw);
+    return { ...defaults, ...parsed };
+  } catch {
+    return defaults;
+  }
+}
+
+function persistCollapseState(state: Record<CollapseKey, boolean>) {
+  try {
+    localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+function SectionHeader({
+  label,
+  count,
+  open,
+  onToggle,
+}: {
+  label: string;
+  count: number;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Box
+      onClick={onToggle}
+      sx={{
+        px: 2,
+        pt: 1,
+        pb: 0.5,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        cursor: 'pointer',
+        userSelect: 'none',
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      {open ? (
+        <ExpandMoreIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+      ) : (
+        <ChevronRightIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+      )}
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          textTransform: 'uppercase',
+          fontSize: '0.65rem',
+          letterSpacing: '0.08em',
+          fontWeight: 600,
+        }}
+      >
+        {label} ({count})
+      </Typography>
+    </Box>
+  );
+}
 
 export function OperationsIndicator() {
   const activeOperations = useOperationsStore((state) => state.activeOperations);
@@ -117,10 +195,16 @@ export function OperationsIndicator() {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const [activityOpId, setActivityOpId] = useState<string | null>(null);
+  const [collapse, setCollapse] = useState<Record<CollapseKey, boolean>>(loadCollapseState);
   const navigate = useNavigate();
 
-  // Active ops are now discovered exclusively via SSE (op.created) and
-  // loadFromServer (v2 timeline). No v1 polling loop needed here.
+  const toggleSection = (key: CollapseKey) => {
+    setCollapse((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      persistCollapseState(next);
+      return next;
+    });
+  };
 
   const handleCancel = async (opId: string) => {
     setCancelling((prev) => new Set(prev).add(opId));
@@ -136,15 +220,11 @@ export function OperationsIndicator() {
     });
   };
 
-  // Badge only counts alert-level ops (notify_level === 0).
-  // Activity-only ops (single-book fetches, background maintenance) are visible
-  // in the dropdown list but do not increment the badge.
   const alertInProgress = alertOperations.filter(
     (op) => !['completed', 'failed', 'canceled'].includes(op.status)
   );
   const badgeCount = alertInProgress.length;
 
-  // The dropdown shows all ops regardless of notify level.
   const inProgress = activeOperations.filter(
     (op) => !['completed', 'failed', 'canceled'].includes(op.status)
   );
@@ -153,6 +233,8 @@ export function OperationsIndicator() {
   const terminal = activeOperations.filter((op) =>
     ['completed', 'failed', 'canceled'].includes(op.status)
   );
+
+  const empty = running.length === 0 && queued.length === 0 && terminal.length === 0;
 
   return (
     <>
@@ -215,89 +297,217 @@ export function OperationsIndicator() {
 
           <Divider />
 
-          {activeOperations.length === 0 && (
+          {empty && (
             <Typography
               variant="body2"
               color="text.secondary"
               sx={{ px: 2, py: 3, textAlign: 'center' }}
             >
-              No active operations
+              No operations
             </Typography>
           )}
 
-          {/* Queued (pending) operations */}
-          {queued.length > 0 && (
+          {/* ===== RUNNING ===== */}
+          {running.length > 0 && (
             <>
-              <Box sx={{ px: 2, pt: 1, pb: 0.25 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontSize: '0.65rem', letterSpacing: '0.08em' }}>
-                  Pending ({queued.length})
-                </Typography>
-              </Box>
-              {queued.map((op: ActiveOperation) => (
-                <Box key={op.id} sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between', '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' } }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <HourglassEmptyIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-                    <Box>
-                      <Typography variant="body2" fontWeight="bold">{formatOperationType(op.type)}</Typography>
-                      <Typography variant="caption" color="text.secondary">Waiting to start…</Typography>
-                    </Box>
-                  </Box>
-                  <Tooltip title="Cancel">
-                    <IconButton
-                      size="small"
-                      color="error"
-                      onClick={() => handleCancel(op.id)}
-                      disabled={cancelling.has(op.id)}
-                      sx={{ p: 0.25 }}
+              <SectionHeader
+                label="Running"
+                count={running.length}
+                open={collapse.running}
+                onToggle={() => toggleSection('running')}
+              />
+              <Collapse in={collapse.running} unmountOnExit>
+                {running.map((op: ActiveOperation) => {
+                  const progressPct =
+                    op.total > 0 ? Math.round((op.progress / op.total) * 100) : 0;
+                  const eta = formatETA(op);
+                  const elapsed = formatElapsed(op);
+                  const details = parseMessageDetails(op.message);
+
+                  return (
+                    <Box
+                      key={op.id}
+                      sx={{
+                        px: 2,
+                        py: 1.5,
+                        '&:not(:last-child)': {
+                          borderBottom: '1px solid',
+                          borderColor: 'divider',
+                        },
+                      }}
                     >
-                      {cancelling.has(op.id) ? <CircularProgress size={14} /> : <CancelIcon sx={{ fontSize: 18 }} />}
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-              ))}
-              {running.length > 0 && (
-                <Box sx={{ px: 2, pt: 1, pb: 0.25 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', fontSize: '0.65rem', letterSpacing: '0.08em' }}>
-                    Running ({running.length})
-                  </Typography>
-                </Box>
-              )}
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          mb: 0.5,
+                        }}
+                      >
+                        <Typography variant="body2" fontWeight="bold">
+                          {formatOperationType(op.type)}
+                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                          {elapsed && (
+                            <Typography variant="caption" color="text.secondary">
+                              {elapsed}
+                            </Typography>
+                          )}
+                          <Tooltip title="View activity">
+                            <IconButton
+                              size="small"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setActivityOpId(op.id);
+                              }}
+                              sx={{ p: 0.25 }}
+                            >
+                              <ArticleIcon sx={{ fontSize: 18 }} />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Cancel">
+                            <IconButton
+                              size="small"
+                              color="error"
+                              onClick={() => handleCancel(op.id)}
+                              disabled={cancelling.has(op.id)}
+                              sx={{ p: 0.25 }}
+                            >
+                              {cancelling.has(op.id) ? (
+                                <CircularProgress size={14} />
+                              ) : (
+                                <CancelIcon sx={{ fontSize: 18 }} />
+                              )}
+                            </IconButton>
+                          </Tooltip>
+                        </Box>
+                      </Box>
+
+                      {op.total > 0 ? (
+                        <LinearProgress
+                          variant="determinate"
+                          value={progressPct}
+                          sx={{ height: 6, borderRadius: 1, mb: 0.5 }}
+                        />
+                      ) : (
+                        <LinearProgress sx={{ height: 6, borderRadius: 1, mb: 0.5 }} />
+                      )}
+
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          mb: 0.25,
+                        }}
+                      >
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontFamily: 'monospace' }}
+                        >
+                          {op.total > 0 ? (
+                            <>
+                              {op.progress.toLocaleString()} / {op.total.toLocaleString()}
+                              {' '}({progressPct}%)
+                            </>
+                          ) : (
+                            'Starting...'
+                          )}
+                        </Typography>
+                        {eta && (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontStyle="italic"
+                          >
+                            {eta}
+                          </Typography>
+                        )}
+                      </Box>
+
+                      {details.imported !== null && (
+                        <Typography variant="caption" sx={{ display: 'block', mb: 0.25 }}>
+                          <Box component="span" sx={{ color: 'success.main' }}>
+                            {details.imported} imported
+                          </Box>
+                          {details.skipped! > 0 && (
+                            <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>
+                              {details.skipped} skipped
+                            </Box>
+                          )}
+                          {details.failed! > 0 && (
+                            <Box component="span" sx={{ color: 'error.main', ml: 1 }}>
+                              {details.failed} failed
+                            </Box>
+                          )}
+                        </Typography>
+                      )}
+
+                      {details.olType && (
+                        <Typography
+                          variant="caption"
+                          color="info.main"
+                          sx={{ display: 'block', mb: 0.25 }}
+                        >
+                          {details.olType}: {details.olRecords} records
+                        </Typography>
+                      )}
+
+                      {details.currentTitle && (
+                        <Typography
+                          variant="caption"
+                          color="primary.main"
+                          display="block"
+                          noWrap
+                          title={details.currentTitle}
+                        >
+                          {details.currentTitle}
+                        </Typography>
+                      )}
+                    </Box>
+                  );
+                })}
+              </Collapse>
             </>
           )}
 
-          {/* Active (running) operations */}
-          {running.map((op: ActiveOperation) => {
-            const progressPct =
-              op.total > 0 ? Math.round((op.progress / op.total) * 100) : 0;
-            const eta = formatETA(op);
-            const elapsed = formatElapsed(op);
-            const details = parseMessageDetails(op.message);
-
-            return (
-              <Box key={op.id} sx={{ px: 2, py: 1.5, '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' } }}>
-                {/* Row 1: Type + Cancel */}
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
-                  <Typography variant="body2" fontWeight="bold">
-                    {formatOperationType(op.type)}
-                  </Typography>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    {elapsed && (
-                      <Typography variant="caption" color="text.secondary">
-                        {elapsed}
-                      </Typography>
-                    )}
-                    <Tooltip title="View activity">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setActivityOpId(op.id);
-                        }}
-                        sx={{ p: 0.25 }}
-                      >
-                        <ArticleIcon sx={{ fontSize: 18 }} />
-                      </IconButton>
-                    </Tooltip>
+          {/* ===== PENDING ===== */}
+          {queued.length > 0 && (
+            <>
+              <SectionHeader
+                label="Pending"
+                count={queued.length}
+                open={collapse.pending}
+                onToggle={() => toggleSection('pending')}
+              />
+              <Collapse in={collapse.pending} unmountOnExit>
+                {queued.map((op: ActiveOperation) => (
+                  <Box
+                    key={op.id}
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      '&:not(:last-child)': {
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                      },
+                    }}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <HourglassEmptyIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                      <Box>
+                        <Typography variant="body2" fontWeight="bold">
+                          {formatOperationType(op.type)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Waiting to start…
+                        </Typography>
+                      </Box>
+                    </Box>
                     <Tooltip title="Cancel">
                       <IconButton
                         size="small"
@@ -314,176 +524,133 @@ export function OperationsIndicator() {
                       </IconButton>
                     </Tooltip>
                   </Box>
-                </Box>
-
-                {/* Row 2: Progress bar */}
-                {op.total > 0 ? (
-                  <LinearProgress
-                    variant="determinate"
-                    value={progressPct}
-                    sx={{ height: 6, borderRadius: 1, mb: 0.5 }}
-                  />
-                ) : (
-                  <LinearProgress sx={{ height: 6, borderRadius: 1, mb: 0.5 }} />
-                )}
-
-                {/* Row 3: Numbers */}
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.25 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-                    {op.total > 0 ? (
-                      <>
-                        {op.progress.toLocaleString()} / {op.total.toLocaleString()}
-                        {' '}({progressPct}%)
-                      </>
-                    ) : (
-                      'Starting...'
-                    )}
-                  </Typography>
-                  {eta && (
-                    <Typography variant="caption" color="text.secondary" fontStyle="italic">
-                      {eta}
-                    </Typography>
-                  )}
-                </Box>
-
-                {/* Row 4: Import stats (if available) */}
-                {details.imported !== null && (
-                  <Typography variant="caption" sx={{ display: 'block', mb: 0.25 }}>
-                    <Box component="span" sx={{ color: 'success.main' }}>{details.imported} imported</Box>
-                    {details.skipped! > 0 && (
-                      <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>{details.skipped} skipped</Box>
-                    )}
-                    {details.failed! > 0 && (
-                      <Box component="span" sx={{ color: 'error.main', ml: 1 }}>{details.failed} failed</Box>
-                    )}
-                  </Typography>
-                )}
-
-                {/* Row 4 alt: OL import stats */}
-                {details.olType && (
-                  <Typography variant="caption" color="info.main" sx={{ display: 'block', mb: 0.25 }}>
-                    {details.olType}: {details.olRecords} records
-                  </Typography>
-                )}
-
-                {/* Row 5: Current item */}
-                {details.currentTitle && (
-                  <Typography
-                    variant="caption"
-                    color="primary.main"
-                    display="block"
-                    noWrap
-                    title={details.currentTitle}
-                  >
-                    {details.currentTitle}
-                  </Typography>
-                )}
-              </Box>
-            );
-          })}
-
-          {/* Recent completed operations — read from v2 store (terminal ops).
-              V1 getRecentCompletedOperations() is no longer called (UOS-13). */}
-          {terminal.length === 0 && inProgress.length === 0 && (
-            <>
-              <Divider />
-              <Typography
-                variant="body2"
-                color="text.secondary"
-                sx={{ px: 2, py: 1.5, textAlign: 'center', fontSize: '0.8rem' }}
-              >
-                No recent operations
-              </Typography>
+                ))}
+              </Collapse>
             </>
           )}
 
-          {terminal.map((op: ActiveOperation) => (
-            <Box
-              key={`recent-${op.id}`}
-              onClick={() => {
-                setActivityOpId(op.id);
-              }}
-              sx={{
-                px: 2,
-                py: 1,
-                cursor: 'pointer',
-                '&:hover': { bgcolor: 'action.hover' },
-                '&:not(:last-child)': { borderBottom: '1px solid', borderColor: 'divider' },
-              }}
-            >
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
-                <Typography variant="caption" fontWeight="bold" noWrap sx={{ flex: 1 }}>
-                  {formatOperationType(op.type)}
-                </Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
-                  <Chip
-                    label={op.status}
-                    size="small"
-                    color={op.status === 'completed' ? 'success' : op.status === 'failed' ? 'error' : 'default'}
-                    sx={{ height: 18, fontSize: '0.65rem', '& .MuiChip-label': { px: 0.75 } }}
-                  />
-                </Box>
-              </Box>
-              {op.message && (
-                <Typography variant="caption" color="text.secondary" display="block" noWrap title={op.message}>
-                  {op.message}
-                </Typography>
-              )}
-              {op.current_item && op.status === 'running' && (
-                <Tooltip title={op.current_item} placement="bottom-start">
-                  <Typography variant="caption" color="text.disabled" display="block" noWrap
-                    sx={{ fontStyle: 'italic', fontSize: '0.68rem' }}>
-                    {op.current_item}
-                  </Typography>
-                </Tooltip>
-              )}
-              {op.type === 'metadata_candidate_fetch' && op.status === 'completed' && (
-                <Button
-                  size="small"
-                  variant="outlined"
-                  sx={{ mt: 0.5, textTransform: 'none', fontSize: '0.7rem', py: 0, minHeight: 22 }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    setAnchorEl(null);
-                    window.location.href = `/library?reviewOp=${op.id}`;
-                  }}
-                >
-                  Review Results
-                </Button>
-              )}
-              {(op.type === 'organize' || op.type === 'scan_and_organize') && op.status === 'completed' && (
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="warning"
-                  sx={{ mt: 0.5, textTransform: 'none', fontSize: '0.7rem', py: 0, minHeight: 22 }}
-                  onClick={async (e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    try {
-                      const preflight = await getUndoPreflight(op.id);
-                      const conflicts = (preflight.content_changed?.length || 0) +
-                        (preflight.book_deleted?.length || 0) +
-                        (preflight.re_organized?.length || 0);
-                      const msg = conflicts > 0
-                        ? `${preflight.safe} changes can be undone. ${conflicts} conflict(s) detected. Proceed?`
-                        : `Undo ${preflight.safe} change(s) from this operation?`;
-                      if (confirm(msg)) {
-                        await revertOp(op.id);
-                        alert('Operation reverted successfully');
-                      }
-                    } catch (err: unknown) {
-                      const msg = (err as { message?: string })?.message || 'Undo failed';
-                      alert(msg);
-                    }
-                  }}
-                >
-                  Undo
-                </Button>
-              )}
-            </Box>
-          ))}
+          {/* ===== COMPLETED ===== */}
+          {terminal.length > 0 && (
+            <>
+              <SectionHeader
+                label="Completed"
+                count={terminal.length}
+                open={collapse.completed}
+                onToggle={() => toggleSection('completed')}
+              />
+              <Collapse in={collapse.completed} unmountOnExit>
+                {terminal.map((op: ActiveOperation) => {
+                  const statusLabel =
+                    op.status === 'completed' ? 'success' : op.status;
+                  const statusColor =
+                    op.status === 'completed'
+                      ? ('success' as const)
+                      : op.status === 'failed'
+                        ? ('error' as const)
+                        : ('default' as const);
+                  return (
+                    <Box
+                      key={`recent-${op.id}`}
+                      onClick={() => setActivityOpId(op.id)}
+                      sx={{
+                        px: 2,
+                        py: 0.75,
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                        '&:hover': { bgcolor: 'action.hover' },
+                        '&:not(:last-child)': {
+                          borderBottom: '1px solid',
+                          borderColor: 'divider',
+                        },
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        fontWeight="bold"
+                        noWrap
+                        sx={{ flex: 1 }}
+                      >
+                        {formatOperationType(op.type)}
+                      </Typography>
+                      <Chip
+                        label={statusLabel}
+                        size="small"
+                        color={statusColor}
+                        sx={{
+                          height: 18,
+                          fontSize: '0.65rem',
+                          '& .MuiChip-label': { px: 0.75 },
+                        }}
+                      />
+                      {op.type === 'metadata_candidate_fetch' &&
+                        op.status === 'completed' && (
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            sx={{
+                              textTransform: 'none',
+                              fontSize: '0.65rem',
+                              py: 0,
+                              minHeight: 20,
+                            }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              setAnchorEl(null);
+                              window.location.href = `/library?reviewOp=${op.id}`;
+                            }}
+                          >
+                            Review
+                          </Button>
+                        )}
+                      {(op.type === 'organize' || op.type === 'scan_and_organize') &&
+                        op.status === 'completed' && (
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="warning"
+                            sx={{
+                              textTransform: 'none',
+                              fontSize: '0.65rem',
+                              py: 0,
+                              minHeight: 20,
+                            }}
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              try {
+                                const preflight = await getUndoPreflight(op.id);
+                                const conflicts =
+                                  (preflight.content_changed?.length || 0) +
+                                  (preflight.book_deleted?.length || 0) +
+                                  (preflight.re_organized?.length || 0);
+                                const msg =
+                                  conflicts > 0
+                                    ? `${preflight.safe} changes can be undone. ${conflicts} conflict(s) detected. Proceed?`
+                                    : `Undo ${preflight.safe} change(s) from this operation?`;
+                                if (confirm(msg)) {
+                                  await revertOp(op.id);
+                                  alert('Operation reverted successfully');
+                                }
+                              } catch (err: unknown) {
+                                const msg =
+                                  (err as { message?: string })?.message || 'Undo failed';
+                                alert(msg);
+                              }
+                            }}
+                          >
+                            Undo
+                          </Button>
+                        )}
+                    </Box>
+                  );
+                })}
+              </Collapse>
+            </>
+          )}
         </Box>
       </Popover>
 

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -102,6 +102,12 @@ function fromV2(op: api.OperationV2): ActiveOperation {
   };
 }
 
+// Throttle flag for the "unknown op id → reload timeline" path. Without it,
+// a server-resumed op that emits a burst of op.updated events would trigger
+// one loadFromServer per event until the first reload returns. We coalesce
+// to a single reload per 500ms window.
+let unknownOpReloadPending = false;
+
 function formatOpLabel(type: string): string {
   const labels: Record<string, string> = {
     itunes_import: 'iTunes Import',
@@ -306,9 +312,22 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
           get().loadFromServer();
         } else if (name === 'op.updated' && opId) {
           // Partial progress update: merge into existing operation if present.
+          // If the op is unknown locally (e.g. server resumed it after a
+          // restart, so no op.created ever fired), pull the full timeline
+          // so the bar shows up. Throttle the reload to avoid hammering
+          // the API when many updates arrive in a burst.
           set((state) => {
             const existing = state.operations[opId];
-            if (!existing) return state;
+            if (!existing) {
+              if (!unknownOpReloadPending) {
+                unknownOpReloadPending = true;
+                setTimeout(() => {
+                  unknownOpReloadPending = false;
+                  get().loadFromServer();
+                }, 500);
+              }
+              return state;
+            }
             const updated: ActiveOperation = {
               ...existing,
               progress: (p.progress_current as number | undefined) ?? existing.progress,
@@ -339,6 +358,10 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
         // The browser EventSource already retries automatically, but if the
         // connection is truly closed we want the next call to re-open it.
         set({ _sseSource: null });
+        // Reconcile after a likely server restart: pull the timeline so any
+        // ops the server auto-resumed (which won't emit op.created) show up
+        // in the bell again. Delay so we don't fire during transient blips.
+        setTimeout(() => get().loadFromServer(), 1500);
       },
     });
 


### PR DESCRIPTION
## Summary

- **Whole-file fingerprinting**: chromaprint over the whole file with middle-80% Audible intro-slice, BookSig partial synthesis (fp Steps 1-2), 22 unit tests.
- **Progress reporting overhaul**: new `sdk.Progress` helper enforcing `total = N+2` so empty ops never show `0/0`. Swept 27 files / 81 call sites — every `UpdateProgress(pct, 100)` replaced with real `(current, total)` + `(pct%)` suffix.
- **OperationsIndicator UI**: rebuilt into 3 collapsible sections (Running → Pending → Completed), state persisted to localStorage, completed rows slimmed to title + success/failed chip.
- **SSE resume fix**: server-resumed ops (no `op.created` emitted) now backfill via throttled `loadFromServer()` on unknown-id updates and on SSE reconnect.

## Commits

- 95666edb fix(ops-ui): pick up server-resumed ops via SSE + reconnect
- cd8e7446 feat(progress): real-number progress + Start/N/Finalize/Done helper
- b631a5df feat(fingerprint): whole-file chromaprint + partial book-sig synthesis

## Test plan

- [x] `go test ./pkg/plugin/sdk/... ./internal/plugins/... ./internal/scheduler/... ./internal/dedup/... ./internal/reconcile/...` green
- [x] Zero remaining `UpdateProgress(pct, 100, …)` call sites (`grep -c` = 0)
- [ ] Smoke: trigger acoustid reset-all on prod, confirm "Clearing fingerprints 1088/308857 (cleared=1088) (0.35%)" message
- [ ] Smoke: refresh UI mid-op and confirm bell repopulates from timeline
- [ ] Smoke: restart server mid-op, confirm SSE reconnect pulls op back into bell

🤖 Generated with [Claude Code](https://claude.com/claude-code)