### PR TITLE
feat(ops): emit op.created on enqueue + resume

### DIFF
--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -287,10 +287,31 @@ func (r *Registry) EnqueueOp(ctx context.Context, defID string, params any, opts
 
 	r.logger.Info("registry: enqueued op", "op_id", opID, "def_id", defID, "priority", priority)
 
+	r.publishOpCreated(row, false)
+
 	// Signal the dispatcher.
 	r.pingDispatch()
 
 	return opID, nil
+}
+
+// publishOpCreated fans out an op.created SSE event so the UI's operations
+// bell can pick up newly enqueued OR server-resumed ops without waiting for
+// the next op.updated event. The "resumed" flag distinguishes startup
+// resume from a fresh enqueue so the client can render a "Resumed" badge
+// if desired (currently it just triggers loadFromServer()).
+func (r *Registry) publishOpCreated(row database.OperationV2Row, resumed bool) {
+	if r.bus == nil {
+		return
+	}
+	_ = r.bus.Publish(context.Background(), "op.created", map[string]any{
+		"op_id":    row.ID,
+		"def_id":   row.DefID,
+		"plugin":   row.Plugin,
+		"status":   row.Status,
+		"priority": row.Priority,
+		"resumed":  resumed,
+	})
 }
 
 // Cancel cancels an operation by id.

--- a/internal/operations/registry/registry_test.go
+++ b/internal/operations/registry/registry_test.go
@@ -204,3 +204,55 @@ func TestActiveDefs_ReturnsAllRegistered(t *testing.T) {
 		t.Errorf("expected 3 defs, got %d", len(defs))
 	}
 }
+
+// --- op.created event tests ---
+
+// recordingBus captures every Publish call so the test can assert on event
+// names. Implements registry.Bus.
+type recordingBus struct {
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	name    string
+	payload any
+}
+
+func (b *recordingBus) Publish(_ context.Context, name string, payload any) error {
+	b.events = append(b.events, recordedEvent{name: name, payload: payload})
+	return nil
+}
+
+func TestEnqueueOp_PublishesOpCreated(t *testing.T) {
+	store := newFakeStore()
+	bus := &recordingBus{}
+	r := registry.New(store, slog.Default(), 4, nil)
+	r.SetBus(bus)
+	_ = r.RegisterOp(makeValidDef("test.opcreated"))
+
+	opID, err := r.EnqueueOp(context.Background(), "test.opcreated", nil)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var found bool
+	for _, ev := range bus.events {
+		if ev.name != "op.created" {
+			continue
+		}
+		p, ok := ev.payload.(map[string]any)
+		if !ok {
+			t.Fatalf("op.created payload not a map: %T", ev.payload)
+		}
+		if p["op_id"] != opID {
+			t.Errorf("op.created op_id: got %v want %v", p["op_id"], opID)
+		}
+		if p["resumed"] != false {
+			t.Errorf("op.created resumed: got %v want false for fresh enqueue", p["resumed"])
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("expected an op.created event, got events: %+v", bus.events)
+	}
+}

--- a/internal/operations/registry/resume.go
+++ b/internal/operations/registry/resume.go
@@ -101,6 +101,12 @@ func (r *Registry) resumeRestart(ctx context.Context, row database.OperationV2Ro
 	r.logger.Info("registry: resumeAfterStartup: re-queued restart op",
 		"op_id", row.ID, "def_id", def.ID, "resume_count_new", row.ResumeCount+1)
 
+	// Emit op.created so the UI can pick the op back up — without this,
+	// connected clients only ever see op.updated for a row they don't know
+	// exists locally.
+	row.Status = "queued"
+	r.publishOpCreated(row, true)
+
 	r.pingDispatch()
 }
 
@@ -137,6 +143,9 @@ func (r *Registry) resumeRequeue(ctx context.Context, row database.OperationV2Ro
 
 	r.logger.Info("registry: resumeAfterStartup: requeued op",
 		"old_op_id", row.ID, "new_op_id", newID, "def_id", def.ID)
+
+	r.publishOpCreated(newRow, true)
+
 	r.pingDispatch()
 }
 


### PR DESCRIPTION
## Summary

The SSE bus previously only published `op.updated` / `op.log` / `op.terminal`, even though `SetBus`'s comment listed `op.created`. Fresh enqueues only became visible once the first `op.updated` fired, and server-resumed ops (which never emit a fresh `op.updated`) were invisible until the next page reload.

Adds `publishOpCreated(row, resumed)` and wires it into:
- `EnqueueOp` — fresh enqueue (resumed=false)
- `resumeRestart` — server restart re-queue (resumed=true)
- `resumeRequeue` — server restart fresh insert (resumed=true)

Companion to PR #1205's client-side fallback — that handled the case where the bus event was missed; this fixes the root cause so the fallback only kicks in for genuine disconnect scenarios.

## Commits

- be30a58c feat(ops): emit op.created on enqueue + resume

## Test plan

- [x] `TestEnqueueOp_PublishesOpCreated` verifies op_id + resumed=false in payload
- [x] Full `internal/operations/registry/...` test suite green
- [ ] Smoke: enqueue an op, confirm bell populates immediately (no 1s lag from first op.updated)
- [ ] Smoke: restart server mid-op, confirm bell repopulates without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)