### PR TITLE
feat(dedup-ui): surface partial book-sig coverage chip

### DIFF
--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1113,6 +1113,26 @@ function EmbeddingDedupTab() {
               {book.author_name}
             </Typography>
           )}
+          {book.book_sig_coverage_pct != null && book.book_sig_coverage_pct < 100 && (
+            <Tooltip
+              title={`Book signature was synthesized from partial audio (${book.book_sig_coverage_pct}% real, rest is silence-padded). Similarity matches against this book may be less reliable than full-coverage matches.`}
+            >
+              <Chip
+                label={`partial fp ${book.book_sig_coverage_pct}%`}
+                size="small"
+                color="warning"
+                variant="outlined"
+                onClick={(e) => e.stopPropagation()}
+                sx={{
+                  height: 16,
+                  fontSize: '0.6rem',
+                  mt: 0.25,
+                  mr: 0.5,
+                  '& .MuiChip-label': { px: 0.5 },
+                }}
+              />
+            </Tooltip>
+          )}
           {shortPath && (
             <Tooltip
               title={tooltipContent}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -150,6 +150,14 @@ export interface Book {
   // MATCH-1: metadata-source deduplication
   metadata_source_hash?: string | null;
   metadata_source_hash_duplicate_count?: number | null;
+  // Book-level fingerprint signature (whole-file chromaprint synthesis)
+  book_sig_v1?: string | null;
+  book_sig_segments?: number | null;
+  book_sig_built_at?: string | null;
+  book_sig_v1_mask?: string | null;
+  // 0–100 coverage % of real (non-synthesized) audio in the book sig.
+  // null / undefined = full coverage (all files contributed real fingerprints).
+  book_sig_coverage_pct?: number | null;
 }
 
 export interface Author {


### PR DESCRIPTION
## Summary

`SynthesizePartialBookSignature` already records `BookSigCoveragePct` (0..99) when a book's sig is built from incomplete file coverage. That data was invisible in the UI. This PR surfaces a small \`partial fp X%\` chip on each dedup cluster side so the user can spot a less-reliable match before merging.

## Test plan

- [ ] Open BookDedup, find a cluster where one side has partial coverage, confirm the chip appears with the right %
- [ ] Hover the chip, confirm tooltip explains the caveat
- [ ] Full-coverage book (book_sig_coverage_pct == null) shows no chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)