### PR TITLE
fix(acoustid): rate-limit hardening + optional nightly maintenance task

### DIFF
--- a/internal/acoustid/client.go
+++ b/internal/acoustid/client.go
@@ -1,5 +1,5 @@
 // file: internal/acoustid/client.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5d6e7f80-9a1b-2c3d-4e5f-607182931a2b
 // last-edited: 2026-05-31
 
@@ -30,6 +30,38 @@ import (
 
 // ErrNoAPIKey is returned by Lookup when the env var ACOUSTID_API_KEY is unset.
 var ErrNoAPIKey = errors.New("acoustid: ACOUSTID_API_KEY is not set")
+
+// ErrRateLimited is returned when the API responds with HTTP 429 after
+// the in-client retry budget is exhausted. Callers should react by
+// backing off further (the lookup-online op widens its throttle for the
+// remainder of the run).
+var ErrRateLimited = errors.New("acoustid: rate-limited (HTTP 429)")
+
+// retryDelays are the fallback wait intervals between automatic retries
+// on 429 or 5xx when the server doesn't send Retry-After. Three attempts
+// total (initial + 2 retries) — beyond that we surface ErrRateLimited so
+// the caller can throttle the whole run.
+var retryDelays = []time.Duration{2 * time.Second, 5 * time.Second}
+
+// parseRetryAfter returns the duration encoded in a Retry-After header
+// value. Per RFC 7231 the value is either delta-seconds (an integer) or
+// an HTTP-date — we only honor the integer form because acoustid.org
+// uses it. Caps at 60s so a misconfigured server can't stall an op.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	d := time.Duration(n) * time.Second
+	if d > 60*time.Second {
+		d = 60 * time.Second
+	}
+	return d
+}
 
 // LookupResult is the minimal subset of /v2/lookup's response we care about.
 type LookupResult struct {
@@ -84,26 +116,59 @@ func (c *Client) Lookup(ctx context.Context, fingerprint string, durationSec int
 	form.Set("fingerprint", fingerprint)
 	form.Set("meta", "recordings")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL,
-		strings.NewReader(form.Encode()))
-	if err != nil {
-		return LookupResult{}, err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Retry loop: on 429 or 5xx, honor Retry-After (or fall back to
+	// retryDelays). Budget = 1 initial + len(retryDelays) attempts.
+	var (
+		resp        *http.Response
+		body        []byte
+		lastStatus  int
+		rateLimited bool
+	)
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL,
+			strings.NewReader(form.Encode()))
+		if err != nil {
+			return LookupResult{}, err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return LookupResult{}, err
-	}
-	defer resp.Body.Close()
+		var doErr error
+		resp, doErr = c.HTTP.Do(req)
+		if doErr != nil {
+			return LookupResult{}, doErr
+		}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return LookupResult{}, err
+		body, err = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return LookupResult{}, err
+		}
+		lastStatus = resp.StatusCode
+
+		retryable := lastStatus == http.StatusTooManyRequests || lastStatus/100 == 5
+		if !retryable {
+			break
+		}
+		rateLimited = rateLimited || lastStatus == http.StatusTooManyRequests
+		if attempt >= len(retryDelays) {
+			break
+		}
+		wait := parseRetryAfter(resp.Header.Get("Retry-After"))
+		if wait == 0 {
+			wait = retryDelays[attempt]
+		}
+		select {
+		case <-ctx.Done():
+			return LookupResult{}, ctx.Err()
+		case <-time.After(wait):
+		}
 	}
 
-	if resp.StatusCode/100 != 2 {
-		return LookupResult{Raw: body}, fmt.Errorf("acoustid: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	if lastStatus/100 != 2 {
+		if rateLimited {
+			return LookupResult{Raw: body}, ErrRateLimited
+		}
+		return LookupResult{Raw: body}, fmt.Errorf("acoustid: HTTP %d: %s", lastStatus, strings.TrimSpace(string(body)))
 	}
 
 	var parsed struct {

--- a/internal/acoustid/client_test.go
+++ b/internal/acoustid/client_test.go
@@ -7,6 +7,7 @@ package acoustid
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -88,6 +89,58 @@ func TestLookup_APIError(t *testing.T) {
 	_, err := c.Lookup(context.Background(), "FP", 600)
 	if err == nil || !strings.Contains(err.Error(), "invalid fingerprint") {
 		t.Fatalf("expected API error, got %v", err)
+	}
+}
+
+func TestLookup_429ReturnsErrRateLimited(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`{"status":"error","error":{"code":17,"message":"rate limit"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("TESTKEY")
+	c.BaseURL = srv.URL
+	_, err := c.Lookup(context.Background(), "FP", 600)
+	if err == nil {
+		t.Fatal("expected error after exhausted retries, got nil")
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+	// initial + 2 retries = 3 attempts
+	if calls != 3 {
+		t.Errorf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestLookup_429ThenSucceedsRetries(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(429)
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"ok","results":[{"score":0.95,"recordings":[{"id":"mb-x"}]}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("TESTKEY")
+	c.BaseURL = srv.URL
+	res, err := c.Lookup(context.Background(), "FP", 600)
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if res.RecordingID != "mb-x" {
+		t.Errorf("RecordingID: got %q want mb-x", res.RecordingID)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 attempts, got %d", calls)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -337,6 +337,15 @@ type Config struct {
 	MaintenanceWindowLibraryOrganize  bool `json:"maintenance_window_library_organize"`
 	MaintenanceWindowMetadataRefresh  bool `json:"maintenance_window_metadata_refresh"`
 	MaintenanceWindowLibrarySizeRefresh bool `json:"maintenance_window_library_size_refresh"`
+	// MaintenanceWindowAcoustIDOnlineLookup gates the nightly
+	// acoustid.lookup-online task. Off by default — the task hits a
+	// third-party API and uses quota, so requires explicit opt-in.
+	MaintenanceWindowAcoustIDOnlineLookup bool `json:"maintenance_window_acoustid_online_lookup"`
+	// AcoustIDOnlineLookupNightlyLimit caps the number of files processed
+	// per nightly run, so the maintenance window doesn't get monopolized
+	// by a slow third-party API. 0 = no cap (the op processes everything
+	// eligible). Default 5000 ≈ ~33 min at 400ms throttle.
+	AcoustIDOnlineLookupNightlyLimit int `json:"acoustid_online_lookup_nightly_limit"`
 
 	// Plugin system
 	Plugins map[string]PluginConfig `json:"plugins"`
@@ -626,7 +635,9 @@ func InitConfig() {
 		MaintenanceWindowLibraryScan:      viper.GetBool("maintenance_window_library_scan"),
 		MaintenanceWindowLibraryOrganize:  viper.GetBool("maintenance_window_library_organize"),
 		MaintenanceWindowMetadataRefresh:  viper.GetBool("maintenance_window_metadata_refresh"),
-		MaintenanceWindowLibrarySizeRefresh: viper.GetBool("maintenance_window_library_size_refresh"),
+		MaintenanceWindowLibrarySizeRefresh:   viper.GetBool("maintenance_window_library_size_refresh"),
+		MaintenanceWindowAcoustIDOnlineLookup: viper.GetBool("maintenance_window_acoustid_online_lookup"),
+		AcoustIDOnlineLookupNightlyLimit:      viper.GetInt("acoustid_online_lookup_nightly_limit"),
 
 		// iTunes sync
 		ITunesSyncEnabled:      viper.GetBool("itunes_sync_enabled"),
@@ -1047,6 +1058,11 @@ func ResetToDefaults() {
 		MaintenanceWindowLibraryScan:      false,
 		MaintenanceWindowLibraryOrganize:  false,
 		MaintenanceWindowMetadataRefresh:  false,
+		// AcoustID online lookup is OFF by default — uses third-party
+		// quota and only helps users who set ACOUSTID_API_KEY. Opt-in
+		// via setting + env key.
+		MaintenanceWindowAcoustIDOnlineLookup: false,
+		AcoustIDOnlineLookupNightlyLimit:      5000,
 
 		// iTunes sync
 		ITunesSyncEnabled:      true,

--- a/internal/plugins/acoustid/online_lookup.go
+++ b/internal/plugins/acoustid/online_lookup.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/online_lookup.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e7f8091-a2b3-c4d5-e6f7-08192a3b4c5d
 // last-edited: 2026-05-31
 
@@ -8,6 +8,7 @@ package acoustid
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -22,16 +23,26 @@ import (
 // upload that happened to collide. Tunable later.
 const AcoustIDOnlineMinScore = 0.85
 
-// onlineLookupThrottle paces requests to acoustid.org. The free tier is
-// 3 req/sec per key; 350ms gives us headroom and survives a single dropped
-// + retried request without violating the cap.
-const onlineLookupThrottle = 350 * time.Millisecond
+// onlineLookupThrottleMin paces requests to acoustid.org under normal
+// operation. The free tier is 3 req/sec per API key; 400ms = 2.5 req/sec
+// gives a safety margin even when responses are fast.
+const onlineLookupThrottleMin = 400 * time.Millisecond
+
+// onlineLookupThrottleMax is the throttle the op widens to after a 429
+// surfaces from the client (rate-limited). ~0.5 req/sec is well below
+// any reasonable ceiling and lets the limiter's window decay.
+const onlineLookupThrottleMax = 2 * time.Second
 
 // OnlineLookupParams controls the scope of an online lookup run.
 type OnlineLookupParams struct {
 	// Force re-queries even files that already have an
 	// AcoustIDOnlineLookedUpAt timestamp. Default: skip already-looked-up.
 	Force bool `json:"force,omitempty"`
+	// Limit caps the number of candidates processed in this run. Used by
+	// the nightly maintenance task to stay within a maintenance window
+	// (e.g. process 8000 files per night ≈ 1 hour at 400ms throttle).
+	// 0 = no cap.
+	Limit int `json:"limit,omitempty"`
 }
 
 func (p *Plugin) onlineLookupDef() sdk.OperationDef {
@@ -109,6 +120,9 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 		cands = append(cands, candidate{idx: i, dur: dur, raw: f.AcoustIDFingerprint})
 	}
 
+	if req.Limit > 0 && len(cands) > req.Limit {
+		cands = cands[:req.Limit]
+	}
 	total := len(cands)
 	if total == 0 {
 		prog = sdk.NewProgress(reporter, 0)
@@ -120,7 +134,8 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 	prog = sdk.NewProgress(reporter, total)
 	prog.Start(fmt.Sprintf("Querying acoustid.org for %d file(s)…", total))
 
-	var matched, noMatch, failed int
+	var matched, noMatch, failed, rateLimited int
+	throttle := onlineLookupThrottleMin
 	startedAt := time.Now()
 
 	for i, c := range cands {
@@ -139,6 +154,18 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 		now := time.Now().UTC()
 		if lerr != nil {
 			failed++
+			if errors.Is(lerr, acoustid.ErrRateLimited) {
+				// API limiter told us off — slow down for the rest of the
+				// run. The client already retried 3× with Retry-After
+				// before bubbling this up, so the only honest response is
+				// to widen our own throttle.
+				rateLimited++
+				if throttle < onlineLookupThrottleMax {
+					throttle = onlineLookupThrottleMax
+					log.Warn("acoustid online lookup: rate-limited, widening throttle",
+						"new_throttle_ms", throttle.Milliseconds())
+				}
+			}
 			log.Warn("acoustid online lookup: request failed",
 				"file_id", f.ID, "err", lerr)
 		} else {
@@ -171,16 +198,17 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 			fmt.Sprintf("Looking up %d/%d (matched=%d no_match=%d failed=%d)",
 				i+1, total, matched, noMatch, failed))
 
-		// Respect AcoustID's 3 req/sec free-tier limit.
+		// Respect AcoustID's 3 req/sec free-tier limit. `throttle` widens
+		// to onlineLookupThrottleMax after the first 429.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(onlineLookupThrottle):
+		case <-time.After(throttle):
 		}
 	}
 
-	prog.Done(fmt.Sprintf("Online lookup complete in %s — matched=%d no_match=%d failed=%d (of %d files)",
+	prog.Done(fmt.Sprintf("Online lookup complete in %s — matched=%d no_match=%d failed=%d rate_limited=%d (of %d files)",
 		time.Since(startedAt).Round(time.Second),
-		matched, noMatch, failed, total))
+		matched, noMatch, failed, rateLimited, total))
 	return nil
 }

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -470,6 +470,39 @@ func (ts *TaskScheduler) registerAllTasks() {
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
 	})
 
+	// Nightly AcoustID online lookup. Off unless the user explicitly
+	// enables MaintenanceWindowAcoustIDOnlineLookup. The op itself
+	// refuses to run without ACOUSTID_API_KEY, so flipping the toggle
+	// without setting the env is a no-op.
+	ts.registerTask(TaskDefinition{
+		Name:        "acoustid_online_lookup",
+		Description: "Look up un-queried fingerprints on acoustid.org (rate-limited, bounded)",
+		Category:    "maintenance",
+		TriggerFn: func(source string) (*database.Operation, error) {
+			store := ts.deps.Store()
+			if store == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			opID := ulid.Make().String()
+			op, err := store.CreateOperation(opID, "acoustid-online-lookup", nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create operation: %w", err)
+			}
+			params := map[string]any{
+				"limit": config.AppConfig.AcoustIDOnlineLookupNightlyLimit,
+				"force": false,
+			}
+			if _, enqErr := ts.deps.OpRegistry.EnqueueOp(context.Background(), "acoustid.lookup-online", params); enqErr != nil {
+				return nil, fmt.Errorf("failed to enqueue acoustid.lookup-online: %w", enqErr)
+			}
+			return op, nil
+		},
+		IsEnabled:              func() bool { return config.AppConfig.MaintenanceWindowAcoustIDOnlineLookup },
+		GetInterval:            func() time.Duration { return 0 }, // run only inside the maintenance window
+		RunOnStart:             func() bool { return false },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowAcoustIDOnlineLookup },
+	})
+
 	ts.registerTask(TaskDefinition{
 		Name:        "cleanup_old_backups",
 		Description: "Remove old .bak-* backup files past retention",


### PR DESCRIPTION
## Summary

Rate-limit hardening for the acoustid.org client (free-tier is 3 req/sec):

- Auto-retry on HTTP 429 / 5xx (initial + 2 attempts) honoring \`Retry-After\` when present
- New \`ErrRateLimited\` surfaces when retries are exhausted
- Throttle bumped 350ms → 400ms (2.5 req/sec) for safety margin
- When \`ErrRateLimited\` fires, op widens throttle to 2s (0.5 req/sec) for the remainder of the run
- New \`rate_limited\` counter in the Done message

Optional nightly maintenance task (user-requested):

- New flags \`MaintenanceWindowAcoustIDOnlineLookup\` (default OFF) + \`AcoustIDOnlineLookupNightlyLimit\` (default 5000)
- \`acoustid_online_lookup\` TaskDefinition runs ONLY inside maintenance window AND only when toggle is on
- Op refuses to run without \`ACOUSTID_API_KEY\`, so toggle + no key = no-op

## Test plan

- [x] \`go test ./internal/acoustid/\` — added 429-exhausted + 429-then-200 cases
- [x] \`go build ./...\` clean
- [ ] Smoke: flip \`maintenance_window_acoustid_online_lookup\` on, wait for window, verify task fires and respects limit
- [ ] Smoke: stub a 429 response, confirm op slows down

🤖 Generated with [Claude Code](https://claude.com/claude-code)