### PR TITLE
feat(acoustid): persisted API key with on-page settings form

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,12 @@ type Config struct {
 	EnableAIParsing bool   `json:"enable_ai_parsing"`
 	OpenAIAPIKey    string `json:"openai_api_key"`
 
+	// AcoustIDAPIKey is the acoustid.org client ID used by the
+	// acoustid.lookup-online op. Persisted to the settings DB (masked
+	// in API responses). Falls back to the ACOUSTID_API_KEY env var
+	// when empty, for compatibility with the original env-only setup.
+	AcoustIDAPIKey string `json:"acoustid_api_key"`
+
 	// Per-feature OpenAI model selection. Default to gpt-5-mini for all four
 	// to preserve historical behavior. See spec docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md.
 	DedupReviewModel    string `json:"dedup_review_model"    mapstructure:"dedup_review_model"`
@@ -396,6 +402,7 @@ func InitConfig() {
 	// Set AI parsing defaults
 	viper.SetDefault("enable_ai_parsing", true)
 	viper.SetDefault("openai_api_key", "")
+	viper.SetDefault("acoustid_api_key", "")
 
 	// Per-feature model defaults — gpt-5-mini preserves historical behavior
 	viper.SetDefault("dedup_review_model", "gpt-5-mini")
@@ -577,6 +584,7 @@ func InitConfig() {
 		// AI parsing
 		EnableAIParsing:     viper.GetBool("enable_ai_parsing"),
 		OpenAIAPIKey:        viper.GetString("openai_api_key"),
+		AcoustIDAPIKey:      viper.GetString("acoustid_api_key"),
 		DedupReviewModel:    viper.GetString("dedup_review_model"),
 		MetadataReviewModel: viper.GetString("metadata_review_model"),
 		FilenameParseModel:  viper.GetString("filename_parse_model"),
@@ -974,6 +982,7 @@ func ResetToDefaults() {
 		// AI parsing
 		EnableAIParsing:     true,
 		OpenAIAPIKey:        "",
+		AcoustIDAPIKey:      "",
 		DedupReviewModel:    "gpt-5-mini",
 		MetadataReviewModel: "gpt-5-mini",
 		FilenameParseModel:  "gpt-5-mini",

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -38,6 +38,9 @@ func (us *UpdateService) MaskSecrets(cfg Config) Config {
 	if masked.OpenAIAPIKey != "" {
 		masked.OpenAIAPIKey = database.MaskSecret(masked.OpenAIAPIKey)
 	}
+	if masked.AcoustIDAPIKey != "" {
+		masked.AcoustIDAPIKey = database.MaskSecret(masked.AcoustIDAPIKey)
+	}
 	if masked.GoogleBooksAPIKey != "" {
 		masked.GoogleBooksAPIKey = database.MaskSecret(masked.GoogleBooksAPIKey)
 	}
@@ -54,6 +57,7 @@ func (us *UpdateService) MaskSecrets(cfg Config) Config {
 // JSON round-trip so they are never stored in plaintext in the config blob.
 var secretFieldKeys = []string{
 	"openai_api_key",
+	"acoustid_api_key",
 	"google_books_api_key",
 	"hardcover_api_token",
 	"basic_auth_password",
@@ -88,6 +92,10 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	if val, ok := payloadString(payload, "openai_api_key"); ok {
 		slog.Debug("UpdateConfig updating OpenAI API key (len)", "val_count", len(val))
 		AppConfig.OpenAIAPIKey = val
+	}
+	if val, ok := payloadString(payload, "acoustid_api_key"); ok {
+		slog.Debug("UpdateConfig updating AcoustID API key (len)", "val_count", len(val))
+		AppConfig.AcoustIDAPIKey = val
 	}
 	if val, ok := payloadString(payload, "google_books_api_key"); ok {
 		AppConfig.GoogleBooksAPIKey = val

--- a/internal/plugins/acoustid/online_lookup.go
+++ b/internal/plugins/acoustid/online_lookup.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/acoustid"
+	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/fingerprint"
 	"github.com/jdfalk/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -69,9 +70,15 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 		return fmt.Errorf("database store not available")
 	}
 
-	apiKey := os.Getenv("ACOUSTID_API_KEY")
+	// Prefer the persisted setting (set via PUT /api/v1/config from the
+	// AcousticDedup tab). Fall back to env so the original env-only
+	// setup still works.
+	apiKey := config.AppConfig.AcoustIDAPIKey
 	if apiKey == "" {
-		return fmt.Errorf("ACOUSTID_API_KEY is not set; refusing to run")
+		apiKey = os.Getenv("ACOUSTID_API_KEY")
+	}
+	if apiKey == "" {
+		return fmt.Errorf("AcoustID API key is not configured; set it on the AcoustID Dedup page or via the ACOUSTID_API_KEY env var")
 	}
 	client := acoustid.NewClient(apiKey)
 

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -2390,6 +2390,37 @@ function AcousticDedupTab() {
     }
   };
 
+  // AcoustID API key form. Loads the masked value from /api/v1/config so
+  // the user can see "•••• …xyz" without re-entering it, then PUTs the
+  // new value when they save. The server stores it in the settings DB
+  // and the lookup-online op reads from config.AppConfig.AcoustIDAPIKey
+  // before falling back to the env var.
+  const [acoustidKey, setAcoustidKey] = useState('');
+  const [acoustidKeyMask, setAcoustidKeyMask] = useState('');
+  const [acoustidKeySaving, setAcoustidKeySaving] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    api.getConfig().then((cfg) => {
+      if (!cancelled) setAcoustidKeyMask(cfg.acoustid_api_key || '');
+    }).catch(() => { /* leave blank */ });
+    return () => { cancelled = true; };
+  }, []);
+  const handleSaveAcoustIDKey = async () => {
+    if (!acoustidKey.trim()) return;
+    setAcoustidKeySaving(true);
+    setStatusMsg(null);
+    try {
+      const cfg = await api.updateConfig({ acoustid_api_key: acoustidKey.trim() });
+      setAcoustidKeyMask(cfg.acoustid_api_key || '');
+      setAcoustidKey('');
+      setStatusMsg('AcoustID API key saved.');
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : 'Failed to save AcoustID API key');
+    } finally {
+      setAcoustidKeySaving(false);
+    }
+  };
+
   const [resetting, setResetting] = useState(false);
   const handleResetAcoustID = async () => {
     if (!window.confirm(
@@ -2564,6 +2595,37 @@ function AcousticDedupTab() {
       <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
         Workflow: <strong>Fingerprint Books</strong> (reads audio, ~hours) → <strong>Find Acoustic Duplicates</strong> (compares hashes, seconds). Merge direction: prefer the book with richer metadata (ASIN/ISBN → cover → sane title).
       </Typography>
+
+      {/* AcoustID online lookup — API key form. Saved to the settings
+          DB via PUT /api/v1/config; the server-side op reads from
+          AppConfig.AcoustIDAPIKey before falling back to env. */}
+      <Paper variant="outlined" sx={{ mb: 2, p: 1.5 }}>
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+          <Typography variant="body2" sx={{ fontWeight: 500, minWidth: 0 }}>
+            AcoustID.org API key
+          </Typography>
+          <TextField
+            size="small"
+            type="password"
+            placeholder={acoustidKeyMask ? `Saved: ${acoustidKeyMask}` : 'Get a free key at acoustid.org/login'}
+            value={acoustidKey}
+            onChange={(e) => setAcoustidKey(e.target.value)}
+            sx={{ flex: 1, minWidth: 280 }}
+            inputProps={{ autoComplete: 'off' }}
+          />
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleSaveAcoustIDKey}
+            disabled={acoustidKeySaving || !acoustidKey.trim()}
+          >
+            {acoustidKeySaving ? 'Saving…' : 'Save'}
+          </Button>
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+          Required for "Look Up on AcoustID.org". Stored in the settings database (masked when read back). Falls back to ACOUSTID_API_KEY env var if unset.
+        </Typography>
+      </Paper>
 
       {statusMsg && <Alert severity="info" sx={{ mb: 2 }} onClose={() => setStatusMsg(null)}>{statusMsg}</Alert>}
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -622,6 +622,10 @@ export interface Config {
   enable_ai_parsing: boolean;
   metadata_llm_scoring_enabled?: boolean;
   openai_api_key: string;
+  // Optional acoustid.org client ID for the acoustid.lookup-online op.
+  // Masked when read back from the API; the user re-enters a new value
+  // to change it. Empty value falls through to the ACOUSTID_API_KEY env.
+  acoustid_api_key?: string;
 
   // Performance
   concurrent_scans: number;


### PR DESCRIPTION
## Summary

Adds DB persistence for the acoustid.org API key so users don't need to edit systemd unit files to change it. New \`AcoustIDAPIKey\` field on AppConfig; the op reads from there first, falling back to \`ACOUSTID_API_KEY\` env for backward compatibility.

UI: small inline card on the AcousticDedup tab with a password-typed TextField + Save button. Loads the masked saved value via \`/api/v1/config\` and saves new values via the same endpoint (already handles secret-masking + DB persistence — no new backend route).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/acoustid/ ./internal/plugins/acoustid/\` green
- [ ] Smoke: enter key in form, confirm card reflects masked value after save
- [ ] Smoke: trigger \"Look Up on AcoustID.org\" with the saved key, confirm op runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)