### PR TITLE
perf(acoustid): parallel fpcalc workers (4x) + GOMEMLIMIT/GOGC tuning

### DIFF
--- a/deploy/audiobook-organizer.service
+++ b/deploy/audiobook-organizer.service
@@ -1,5 +1,5 @@
 # file: deploy/audiobook-organizer.service
-# version: 4.0.0
+# version: 4.1.0
 # guid: f1e2d3c4-b5a6-9870-8765-4321fedcba98
 #
 # systemd service unit for audiobook-organizer on Linux
@@ -54,6 +54,15 @@ WorkingDirectory=/var/lib/audiobook-organizer
 Environment="HOME=/var/lib/audiobook-organizer"
 Environment="AUDIOBOOK_ROOT_DIR=/var/lib/audiobooks"
 Environment="DATABASE_PATH=/var/lib/audiobook-organizer/audiobooks.pebble"
+# Allow heap to grow to 9 GiB before aggressive GC; reduces GC CPU overhead
+# while fingerprint blobs remain in the fast cache (see GOMEMLIMIT refactor TODO).
+Environment="GOMEMLIMIT=9GiB"
+# GC at 200% heap growth instead of 100% -- halves GC frequency at the cost
+# of more memory. GOMEMLIMIT acts as the safety net.
+Environment="GOGC=200"
+# Number of parallel fpcalc workers during fingerprint rescan. 4 is conservative
+# on a shared server; bump to 8-16 on a dedicated machine.
+Environment="FP_PARALLEL_WORKERS=4"
 
 # Restart policy: restart on failure with 5-second delay
 Restart=on-failure
@@ -61,9 +70,9 @@ RestartSec=5
 StartLimitBurst=5
 StartLimitIntervalSec=60
 
-# Memory limit: prevent service from consuming entire system (previous crash: 81GB)
-# If warm-up cache logic allocates unbounded memory, this kills it gracefully
-MemoryLimit=8G
+# cgroup memory limit — prevents OOM taking down the whole system. Set above
+# GOMEMLIMIT so the Go soft limit triggers GC before systemd kills the process.
+MemoryLimit=12G
 
 # Security hardening — kept minimal to allow reading from various mount points
 # (NFS, external drives, etc). The service needs:

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/fingerprint_rescan.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a7b8c9d0-e1f2-3456-def0-123456789abc
-// last-edited: 2026-05-19
+// last-edited: 2026-05-31
 
 package acoustid
 
@@ -9,10 +9,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
-	"path/filepath"
-	"strings"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jdfalk/audiobook-organizer/internal/database"
@@ -101,8 +101,30 @@ func (p *Plugin) runFingerprintRescan(ctx context.Context, params json.RawMessag
 		return nil
 	}
 
-	var fingerprinted, skipped, ineligible, failed int
+	workers := fpRescanWorkers()
+
+	var (
+		fingerprinted atomic.Int64
+		skipped       atomic.Int64
+		ineligible    atomic.Int64
+		failed        atomic.Int64
+	)
 	startedAt := time.Now()
+
+	// heartbeatTicker fires every 15 seconds so the registry watchdog never
+	// sees the op as idle, regardless of how long individual fpcalc calls take.
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	// progressMsg returns the current counter snapshot as a log string.
+	progressMsg := func(bookIdx, bookTotal, filesDone, filesTotal int) string {
+		return fmt.Sprintf("Books %d/%d files ~%d/%d (fp=%d skip=%d ineligible=%d fail=%d)",
+			bookIdx, bookTotal, filesDone, filesTotal,
+			fingerprinted.Load(), skipped.Load(), ineligible.Load(), failed.Load())
+	}
+
+	totalFiles := 0 // rough estimate, updated per book
+	filesDone := 0
 
 	for i, b := range books {
 		select {
@@ -115,58 +137,74 @@ func (p *Plugin) runFingerprintRescan(ctx context.Context, params json.RawMessag
 		if ferr != nil {
 			continue
 		}
+		totalFiles += len(files)
 
-		for fi, f := range files {
+		// Fan out file fingerprinting across `workers` goroutines.
+		sem := make(chan struct{}, workers)
+		var wg sync.WaitGroup
+		for _, f := range files {
 			select {
 			case <-ctx.Done():
+				wg.Wait()
 				return ctx.Err()
 			default:
 			}
 
-			switch fingerprintBookFileWithForce(p.store, f, req.Force) {
-			case fingerprintOutcomeFingerprinted:
-				fingerprinted++
-				time.Sleep(fingerprintThrottle)
-			case fingerprintOutcomeSkipped:
-				skipped++
-			case fingerprintOutcomeIneligible:
-				ineligible++
-			case fingerprintOutcomeFailed:
-				failed++
-			}
+			sem <- struct{}{} // acquire slot
+			wg.Add(1)
+			go func(bf database.BookFile) {
+				defer func() { <-sem; wg.Done() }()
+				switch fingerprintBookFile(p.store, bf, req.Force) {
+				case fingerprintOutcomeFingerprinted:
+					fingerprinted.Add(1)
+				case fingerprintOutcomeSkipped:
+					skipped.Add(1)
+				case fingerprintOutcomeIneligible:
+					ineligible.Add(1)
+				case fingerprintOutcomeFailed:
+					failed.Add(1)
+				}
+			}(f)
 
-			// Heartbeat from inside the file loop so the registry watchdog
-			// (5-minute idle timeout) doesn't kill the op while we're
-			// grinding through a single book's 30–50 files. We don't bump
-			// progress_current here — that still tracks book index — but
-			// the message refresh keeps the op's last-updated wall clock
-			// fresh. Without this, a 40-file audiobook (4–6 min) can
-			// trigger the stuck-op watchdog.
-			if len(files) > 5 && (fi%5 == 4 || fi == len(files)-1) {
-				_ = reporter.UpdateProgress(i+1, total,
-					fmt.Sprintf("Books %d/%d file %d/%d (fp=%d skip=%d ineligible=%d fail=%d)",
-						i+1, total, fi+1, len(files),
-						fingerprinted, skipped, ineligible, failed))
+			// Drain the heartbeat ticker non-blocking so we don't miss ticks
+			// while goroutines are running.
+			select {
+			case <-heartbeat.C:
+				_ = reporter.UpdateProgress(i+1, total, progressMsg(i+1, total, filesDone, totalFiles))
+			default:
 			}
 		}
+		wg.Wait()
+		filesDone += len(files)
 
-		// After fingerprinting all files for this book, synthesize the book signature
 		if err := synthesizeBookSignatureForBook(p.store, b.ID); err != nil {
 			reporter.Logger().Warn("synthesize book signature", "book_id", b.ID, "error", err)
 		}
 
-		if i%25 == 0 || i == total-1 {
-			_ = reporter.UpdateProgress(i+1, total,
-				fmt.Sprintf("Books %d/%d (fp=%d skip=%d ineligible=%d fail=%d)",
-					i+1, total, fingerprinted, skipped, ineligible, failed))
+		// Progress after each book; also drain any pending ticker.
+		select {
+		case <-heartbeat.C:
+		default:
 		}
+		_ = reporter.UpdateProgress(i+1, total, progressMsg(i+1, total, filesDone, totalFiles))
 	}
 
 	_ = reporter.UpdateProgress(total, total,
-		fmt.Sprintf("Fingerprint rescan complete in %s — fp=%d skip=%d ineligible=%d fail=%d (of %d books)",
+		fmt.Sprintf("Fingerprint rescan complete in %s — fp=%d skip=%d ineligible=%d fail=%d (of %d books, %d files)",
 			time.Since(startedAt).Round(time.Second),
-			fingerprinted, skipped, ineligible, failed, total))
+			fingerprinted.Load(), skipped.Load(), ineligible.Load(), failed.Load(), total, filesDone))
 	return nil
+}
+
+// fpRescanWorkers returns the number of parallel fpcalc workers for rescan.
+// Tunable via FP_PARALLEL_WORKERS env var; defaults to 4.
+func fpRescanWorkers() int {
+	if v := os.Getenv("FP_PARALLEL_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 && n <= 32 {
+			return n
+		}
+	}
+	return 4
 }
 
 // loadBooksForRescan fetches the set of books targeted by the requested scope.
@@ -189,41 +227,3 @@ func loadBooksForRescan(store database.Store, scope string, bookIDs []string) ([
 	}
 }
 
-// fingerprintBookFileWithForce is the same as fingerprintBookFile but accepts a force flag.
-// Used by the fingerprint-rescan operation to optionally recompute existing fingerprints.
-func fingerprintBookFileWithForce(store database.Store, f database.BookFile, force bool) fingerprintFileOutcome {
-	if f.AcoustIDSeg0 != "" && !force {
-		return fingerprintOutcomeSkipped
-	}
-	if f.FilePath == "" || f.Missing {
-		return fingerprintOutcomeIneligible
-	}
-	if _, ok := audioExtensions[strings.ToLower(filepath.Ext(f.FilePath))]; !ok {
-		return fingerprintOutcomeIneligible
-	}
-	if _, err := os.Stat(f.FilePath); err != nil {
-		return fingerprintOutcomeIneligible
-	}
-	if f.SkipScan {
-		slog.Debug("skipping file due to SkipScan flag", "file_id", f.ID, "file_path", f.FilePath)
-		return fingerprintOutcomeSkipped
-	}
-
-	segs, err := fingerprint.FileSegments(f.FilePath, f.Duration)
-	if err != nil {
-		return fingerprintOutcomeFailed
-	}
-
-	updated := f
-	updated.AcoustIDSeg0 = fingerprint.NormalizeForStorage(segs[0])
-	updated.AcoustIDSeg1 = fingerprint.NormalizeForStorage(segs[1])
-	updated.AcoustIDSeg2 = fingerprint.NormalizeForStorage(segs[2])
-	updated.AcoustIDSeg3 = fingerprint.NormalizeForStorage(segs[3])
-	updated.AcoustIDSeg4 = fingerprint.NormalizeForStorage(segs[4])
-	updated.AcoustIDSeg5 = fingerprint.NormalizeForStorage(segs[5])
-	updated.AcoustIDSeg6 = fingerprint.NormalizeForStorage(segs[6])
-	if err := store.UpdateBookFile(f.ID, &updated); err != nil {
-		return fingerprintOutcomeFailed
-	}
-	return fingerprintOutcomeFingerprinted
-}


### PR DESCRIPTION
## Summary
- Replace sequential file fingerprinting loop with N-worker semaphore pool (default 4, tunable via `FP_PARALLEL_WORKERS` env var)
- Switch rescan to `fingerprintBookFile` (whole-file chromaprint) instead of the old 7-segment approach — matches what backfill does
- Heartbeat is now time-based (15s ticker) instead of modulo-per-file — works correctly under parallel execution
- Service file: add `GOMEMLIMIT=9GiB` + `GOGC=200` to reduce GC frequency while fingerprint blobs remain in fast cache; raise cgroup `MemoryLimit` 8G→12G

## Expected speedup
~4x on default 4 workers (server has 48 cores). Tunable to 8-16 via `FP_PARALLEL_WORKERS`.

## Test plan
- [ ] Deploy, re-enqueue rescan — verify progress shows multiple files in flight
- [ ] Check server `top`: expect 4+ concurrent `fpcalc` processes
- [ ] Verify book signatures still synthesize correctly after scan
- [ ] Confirm `GOMEMLIMIT`/`GOGC` are visible in `journalctl` env or `/proc/<pid>/environ`

## Service file update
After deploy, copy updated service file and daemon-reload:
```bash
scp deploy/audiobook-organizer.service user@server:/home/user/
ssh user@server 'sudo cp ~/audiobook-organizer.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl restart audiobook-organizer'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)