### PR TITLE
perf(fingerprint): book-level parallelism + FP_PARALLEL_WORKERS=16

### DIFF
--- a/deploy/audiobook-organizer.service
+++ b/deploy/audiobook-organizer.service
@@ -1,5 +1,5 @@
 # file: deploy/audiobook-organizer.service
-# version: 4.3.0
+# version: 4.4.0
 # guid: f1e2d3c4-b5a6-9870-8765-4321fedcba98
 #
 # systemd service unit for audiobook-organizer on Linux
@@ -74,9 +74,10 @@ Environment="GOMEMLIMIT=9GiB"
 # GC at 200% heap growth instead of 100% -- halves GC frequency at the cost
 # of more memory. GOMEMLIMIT acts as the safety net.
 Environment="GOGC=200"
-# Number of parallel fpcalc workers during fingerprint rescan. 4 is conservative
-# on a shared server; bump to 8-16 on a dedicated machine.
-Environment="FP_PARALLEL_WORKERS=4"
+# Parallel books processed concurrently during fingerprint rescan. Each book
+# runs its files sequentially, so this = concurrent fpcalc calls. 16 suits a
+# dedicated 48-core machine; drop to 4 on a shared server.
+Environment="FP_PARALLEL_WORKERS=16"
 
 # Restart policy: restart on failure with 5-second delay
 Restart=on-failure

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/fingerprint_rescan.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a7b8c9d0-e1f2-3456-def0-123456789abc
 // last-edited: 2026-05-31
 
@@ -104,57 +104,76 @@ func (p *Plugin) runFingerprintRescan(ctx context.Context, params json.RawMessag
 	workers := fpRescanWorkers()
 
 	var (
-		fingerprinted atomic.Int64
-		skipped       atomic.Int64
-		ineligible    atomic.Int64
-		failed        atomic.Int64
+		fingerprinted  atomic.Int64
+		skipped        atomic.Int64
+		ineligible     atomic.Int64
+		failed         atomic.Int64
+		completedBooks atomic.Int64
+		totalFiles     atomic.Int64
+		filesDone      atomic.Int64
 	)
 	startedAt := time.Now()
 
-	// heartbeatTicker fires every 15 seconds so the registry watchdog never
-	// sees the op as idle, regardless of how long individual fpcalc calls take.
-	heartbeat := time.NewTicker(15 * time.Second)
-	defer heartbeat.Stop()
-
-	// progressMsg returns the current counter snapshot as a log string.
-	progressMsg := func(bookIdx, bookTotal, filesDone, filesTotal int) string {
+	progressMsg := func() string {
 		return fmt.Sprintf("Books %d/%d files ~%d/%d (fp=%d skip=%d ineligible=%d fail=%d)",
-			bookIdx, bookTotal, filesDone, filesTotal,
+			completedBooks.Load(), int64(total), filesDone.Load(), totalFiles.Load(),
 			fingerprinted.Load(), skipped.Load(), ineligible.Load(), failed.Load())
 	}
 
-	totalFiles := 0 // rough estimate, updated per book
-	filesDone := 0
+	// Heartbeat goroutine keeps the registry watchdog satisfied independent of
+	// how long individual books take.
+	hbCtx, cancelHB := context.WithCancel(ctx)
+	defer cancelHB()
+	go func() {
+		t := time.NewTicker(15 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				_ = reporter.UpdateProgress(int(completedBooks.Load()), total, progressMsg())
+			case <-hbCtx.Done():
+				return
+			}
+		}
+	}()
 
-	for i, b := range books {
+	// bookSem limits concurrent book processing to `workers`. Files within each
+	// book are processed sequentially — with N books running simultaneously
+	// there are already N concurrent fpcalc calls, which is enough to saturate
+	// the CPU without nested goroutine overhead.
+	bookSem := make(chan struct{}, workers)
+	var bookWg sync.WaitGroup
+
+	for _, b := range books {
 		select {
 		case <-ctx.Done():
+			bookWg.Wait()
 			return ctx.Err()
 		default:
 		}
 
-		files, ferr := p.store.GetBookFiles(b.ID)
-		if ferr != nil {
-			continue
-		}
-		totalFiles += len(files)
+		bookSem <- struct{}{}
+		bookWg.Add(1)
+		go func(book database.Book) {
+			defer func() { <-bookSem; bookWg.Done() }()
 
-		// Fan out file fingerprinting across `workers` goroutines.
-		sem := make(chan struct{}, workers)
-		var wg sync.WaitGroup
-		for _, f := range files {
-			select {
-			case <-ctx.Done():
-				wg.Wait()
-				return ctx.Err()
-			default:
+			if ctx.Err() != nil {
+				completedBooks.Add(1)
+				return
 			}
 
-			sem <- struct{}{} // acquire slot
-			wg.Add(1)
-			go func(bf database.BookFile) {
-				defer func() { <-sem; wg.Done() }()
-				switch fingerprintBookFile(p.store, bf, req.Force) {
+			files, ferr := p.store.GetBookFiles(book.ID)
+			if ferr != nil {
+				completedBooks.Add(1)
+				return
+			}
+			totalFiles.Add(int64(len(files)))
+
+			for _, f := range files {
+				if ctx.Err() != nil {
+					break
+				}
+				switch fingerprintBookFile(p.store, f, req.Force) {
 				case fingerprintOutcomeFingerprinted:
 					fingerprinted.Add(1)
 				case fingerprintOutcomeSkipped:
@@ -164,35 +183,23 @@ func (p *Plugin) runFingerprintRescan(ctx context.Context, params json.RawMessag
 				case fingerprintOutcomeFailed:
 					failed.Add(1)
 				}
-			}(f)
-
-			// Drain the heartbeat ticker non-blocking so we don't miss ticks
-			// while goroutines are running.
-			select {
-			case <-heartbeat.C:
-				_ = reporter.UpdateProgress(i+1, total, progressMsg(i+1, total, filesDone, totalFiles))
-			default:
+				filesDone.Add(1)
 			}
-		}
-		wg.Wait()
-		filesDone += len(files)
 
-		if err := synthesizeBookSignatureForBook(p.store, b.ID); err != nil {
-			reporter.Logger().Warn("synthesize book signature", "book_id", b.ID, "error", err)
-		}
-
-		// Progress after each book; also drain any pending ticker.
-		select {
-		case <-heartbeat.C:
-		default:
-		}
-		_ = reporter.UpdateProgress(i+1, total, progressMsg(i+1, total, filesDone, totalFiles))
+			if err := synthesizeBookSignatureForBook(p.store, book.ID); err != nil {
+				reporter.Logger().Warn("synthesize book signature", "book_id", book.ID, "error", err)
+			}
+			completedBooks.Add(1)
+		}(b)
 	}
+
+	bookWg.Wait()
+	cancelHB()
 
 	_ = reporter.UpdateProgress(total, total,
 		fmt.Sprintf("Fingerprint rescan complete in %s — fp=%d skip=%d ineligible=%d fail=%d (of %d books, %d files)",
 			time.Since(startedAt).Round(time.Second),
-			fingerprinted.Load(), skipped.Load(), ineligible.Load(), failed.Load(), total, filesDone))
+			fingerprinted.Load(), skipped.Load(), ineligible.Load(), failed.Load(), total, filesDone.Load()))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **Book-level parallelism**: replaced inner file semaphore with outer book semaphore. N books now run concurrently; files within each book are sequential. For the common case of single-file books this means N concurrent fpcalc calls instead of 1.
- **Heartbeat goroutine**: replaced non-blocking ticker drain with a dedicated goroutine — cleaner and guaranteed to fire on schedule regardless of book completion rate.
- **FP_PARALLEL_WORKERS=16**: bumped default in service file for the 48-core prod server (was 4).

## Reversibility

- Code: `git revert` + redeploy
- Worker count: edit service file `FP_PARALLEL_WORKERS` + redeploy
- Any fingerprints written: reversible via reset-all (~2 min, batched bulk-clear)

## Test plan

- [ ] `go build ./internal/plugins/acoustid/...` passes ✅
- [ ] Trigger rescan after deploy, confirm 16 fpcalc processes visible in `htop`
- [ ] Confirm heartbeat fires in logs every ~15s during long-running rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)