### PR TITLE
fix(dedup): drop rows on Keep A/B and surface merge errors visibly

### DIFF
--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.26.0
+// version: 3.27.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
-// last-edited: 2026-05-20
+// last-edited: 2026-05-31
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSearchParams, useNavigate, Link as RouterLink } from 'react-router-dom';
@@ -2215,6 +2215,7 @@ function AcousticDedupTab() {
   const [scanning, setScanning] = useState(false);
   const [fingerprinting, setFingerprinting] = useState(false);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [statusSeverity, setStatusSeverity] = useState<'info' | 'error'>('info');
   const [page, setPage] = useState(0);
   // Bigger default than 25 and exposes 50/100/250 because 12K candidates at
   // 25/page is 512 clicks — the user understandably refuses to triage that
@@ -2324,6 +2325,7 @@ function AcousticDedupTab() {
       await api.mergeDedupCandidate(candidateId, keepId);
       setCandidates((prev) => prev.filter((c) => c.id !== candidateId));
     } catch (err) {
+      setStatusSeverity('error');
       setStatusMsg(err instanceof Error ? err.message : 'Merge failed');
     } finally {
       setResolving((s) => { const next = new Set(s); next.delete(candidateId); return next; });
@@ -2336,6 +2338,7 @@ function AcousticDedupTab() {
       await api.dismissDedupCandidate(candidateId);
       setCandidates((prev) => prev.filter((c) => c.id !== candidateId));
     } catch (err) {
+      setStatusSeverity('error');
       setStatusMsg(err instanceof Error ? err.message : 'Dismiss failed');
     } finally {
       setResolving((s) => { const next = new Set(s); next.delete(candidateId); return next; });
@@ -2627,7 +2630,7 @@ function AcousticDedupTab() {
         </Typography>
       </Paper>
 
-      {statusMsg && <Alert severity="info" sx={{ mb: 2 }} onClose={() => setStatusMsg(null)}>{statusMsg}</Alert>}
+      {statusMsg && <Alert severity={statusSeverity} sx={{ mb: 2 }} onClose={() => { setStatusMsg(null); setStatusSeverity('info'); }}>{statusMsg}</Alert>}
 
       {loading ? (
         <LinearProgress />

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.34.0
+// version: 2.35.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-05-29
+// last-edited: 2026-05-31
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -4518,6 +4518,9 @@ export async function mergeDedupCandidate(id: number, keepId?: string): Promise<
     init.body = JSON.stringify({ keep_id: keepId });
   }
   const response = await fetch(`${API_BASE}/dedup/candidates/${id}/merge`, init);
+  // 409 = candidate was already merged/stale — the backend already marked it
+  // merged and fired the event. Treat as success so the UI drops the row.
+  if (response.status === 409) return;
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to merge dedup candidate');
   }


### PR DESCRIPTION
## Summary
- `api.mergeDedupCandidate`: treat HTTP 409 (already-merged/stale candidate) as success — the backend already marked it merged and fired the event, so the UI should drop the row instead of keeping it stuck
- `BookDedup.tsx`: add `statusSeverity` state so merge/dismiss failures render as red `error` alerts instead of the previous silent blue `info` banner

## Root cause
The backend returns 409 when one of the books in a candidate pair was already absorbed by a previous merge. `fetch` returns `response.ok = false` for 409, so the frontend threw, caught the error, and left the row in place. The user saw no obvious feedback (blue info alerts blend into the page) and the row never disappeared.

## Test plan
- [ ] Click Keep A or Keep B on a pending candidate — row disappears immediately
- [ ] Click Keep A/B on a stale candidate (one book already merged) — row still disappears, no error shown
- [ ] Trigger a real merge failure (e.g. network error) — red error alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)