### PR TITLE
fix(pebble): return empty instead of error for MetadataRejection stubs

### DIFF
--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -9580,19 +9580,16 @@ func (s *PebbleStore) SetBookFileHash(id, hash string) error {
 }
 
 // AddMetadataRejection is not supported on PebbleStore.
-func (p *PebbleStore) AddMetadataRejection(_ MetadataRejection) error {
-	return fmt.Errorf("RejectedMetadataStore.AddMetadataRejection: not supported by PebbleStore")
-}
+// AddMetadataRejection is a no-op on PebbleStore (rejections not persisted).
+func (p *PebbleStore) AddMetadataRejection(_ MetadataRejection) error { return nil }
 
-// GetMetadataRejections is not supported on PebbleStore.
+// GetMetadataRejections returns empty on PebbleStore (rejections not persisted).
 func (p *PebbleStore) GetMetadataRejections(_ string) ([]MetadataRejection, error) {
-	return nil, fmt.Errorf("RejectedMetadataStore.GetMetadataRejections: not supported by PebbleStore")
+	return []MetadataRejection{}, nil
 }
 
-// DeleteMetadataRejections is not supported on PebbleStore.
-func (p *PebbleStore) DeleteMetadataRejections(_ string) error {
-	return fmt.Errorf("RejectedMetadataStore.DeleteMetadataRejections: not supported by PebbleStore")
-}
+// DeleteMetadataRejections is a no-op on PebbleStore (rejections not persisted).
+func (p *PebbleStore) DeleteMetadataRejections(_ string) error { return nil }
 
 // GetDuplicateFilesByHash is not supported on PebbleStore.
 func (p *PebbleStore) GetDuplicateFilesByHash(_ int) ([]DuplicateFileGroup, error) {


### PR DESCRIPTION
## Summary
- `GetMetadataRejections`, `AddMetadataRejection`, `DeleteMetadataRejections` on PebbleStore were returning real errors — PebbleStore is now the primary store on prod, so every book detail panel open triggered a 500 on `/api/v1/audiobooks/:id/metadata-rejections`
- Fix: stubs return `nil`/empty slice instead of erroring (PebbleStore never persisted rejections; SQLite legacy only)

## Test plan
- [ ] Open any book detail panel — no more 500 in browser console on metadata-rejections endpoint
- [ ] Fetch metadata on a book — no error logged server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)