### PR TITLE
fix(dedup): tighten title normalizer — don't merge books with bare numeric prefixes

### DIFF
--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,5 +1,5 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000010-0000-0000-0000-000000000010
 // last-edited: 2026-05-01
 
@@ -484,7 +484,12 @@ func ddNormalizeDedupTitle(title string) string {
 		return ""
 	}
 	s = strings.ReplaceAll(s, "(unabridged)", "")
-	reLeadNum := regexp.MustCompile(`^\s*(\(\d+[/\-]\d+\)|\d+[\.\-\s])\s*`)
+	// Strip leading chapter markers but require an explicit delimiter (dot, dash,
+	// colon) with surrounding whitespace — NOT a bare "001 Title" where a space
+	// alone follows the number. "001 Title" could be a real title (series position,
+	// box-set index); only "001 - Title", "001. Title", "03: Title", or "(76/85)
+	// Title" are unambiguous chapter markers.
+	reLeadNum := regexp.MustCompile(`^\s*(\(\s*\d+\s*[/\-]\s*\d+\s*\)\s+|\d+\s*[\.\-:]\s+)`)
 	s = reLeadNum.ReplaceAllString(s, "")
 	s = ddNonAlphanumRE.ReplaceAllString(s, " ")
 	fields := strings.FieldsFunc(s, unicode.IsSpace)

--- a/internal/maintenance/jobs/dedup_books_normalize_test.go
+++ b/internal/maintenance/jobs/dedup_books_normalize_test.go
@@ -1,0 +1,41 @@
+// file: internal/maintenance/jobs/dedup_books_normalize_test.go
+// version: 1.0.0
+// guid: 7f3c9a12-b4d8-4e21-9c6f-0a1b2d3e4f58
+// last-edited: 2026-06-01
+
+package jobs
+
+import "testing"
+
+func TestDdNormalizeDedupTitle(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		desc string
+	}{
+		// Unambiguous chapter markers — should be stripped.
+		{"001 - The Hobbit", "the hobbit", "number + space-dash-space"},
+		{"003: Midnight Run", "midnight run", "number + colon-space"},
+		{"01. Chapter Name", "chapter name", "number + dot-space"},
+		{"(76/85) Tarkin: Star Wars", "tarkin star wars", "N/M fraction prefix"},
+		{"(3 of 85) Tarkin", "3 of 85 tarkin", "N of M — not matched by regex (no parens)"},
+
+		// Bare number + space only — must NOT be stripped; could be a real title.
+		{"001 Tarkin", "001 tarkin", "bare number+space is NOT a chapter marker"},
+		{"2001 A Space Odyssey", "2001 a space odyssey", "year-like number"},
+		{"007 James Bond", "007 james bond", "brand-identifier number"},
+
+		// Noise removed, case folded.
+		{"The Hobbit (Unabridged)", "the hobbit", "unabridged suffix"},
+		{"The Hobbit", "the hobbit", "plain title unchanged"},
+		{"", "", "empty"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := ddNormalizeDedupTitle(c.in)
+			if got != c.want {
+				t.Errorf("ddNormalizeDedupTitle(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `ddNormalizeDedupTitle` previously stripped any leading number+space (e.g. `"001 Title"` → `"Title"`), causing Phase 3 dedup to incorrectly merge books whose titles began with a filename-derived track number with unrelated books in the same directory
- The fix requires an explicit delimiter (dash, dot, or colon with surrounding whitespace) after the number — matching the same precision as `StripChapterPrefix` in `titleutil`
- Unambiguous chapter markers (`"001 - Title"`, `"003: Name"`, `"01. Title"`, `"(76/85) Title"`) still strip correctly; bare `"001 Title"` no longer normalizes to `"Title"`

## Test plan

- [ ] `go test ./internal/maintenance/jobs/...` — 11 new normalize cases pass
- [ ] Verify books with titles like `"001 Something"` are no longer flagged as Phase 3 dedup candidates against a differently-named book in the same directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)