### PR TITLE
fix(api): unwrap data envelope in updateBook + invalidate shared bookCache

### DIFF
--- a/internal/server/audiobooks_handlers.go
+++ b/internal/server/audiobooks_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/audiobooks_handlers.go
-// version: 2.17.0
+// version: 2.18.0
 // guid: 221bde8e-dd34-458c-8afb-fe71f04597c0
 // last-edited: 2026-05-20
 //
@@ -1738,9 +1738,14 @@ func (s *Server) updateAudiobook(c *gin.Context) {
 		s.writeBackBatcher.Enqueue(id)
 	}
 
-	// Invalidate caches since book-author and book-series relationships may have changed
+	// Invalidate caches since book-author and book-series relationships may have changed.
+	// Also clear the shared audiobookService bookCache — the update service owns a
+	// separate instance, so its InvalidateBookCaches() above didn't flush the GET path.
 	s.authorsCache.InvalidateAll()
 	s.seriesCache.InvalidateAll()
+	if s.audiobookService != nil {
+		s.audiobookService.InvalidateBookCaches()
+	}
 
 	httputil.RespondWithOK(c, s.enrichBookForResponseSingle(updatedBook))
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.35.0
+// version: 2.36.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-05-31
 
@@ -1002,7 +1002,8 @@ export async function updateBook(
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to update audiobook');
   }
-  return response.json();
+  const body = await response.json();
+  return body.data;
 }
 
 // RatingPatchBody is the partial-update payload for PATCH /api/v1/audiobooks/:id/rating.


### PR DESCRIPTION
## Summary

Two bugs that together made metadata edits appear broken:

- **Envelope mismatch (`api.ts`)**: `updateBook` returned `response.json()` directly (the `{data:{...}}` wrapper) instead of `body.data`. `setBook(saved)` then set the book state to the envelope object, so every field rendered as `undefined` / "unknown". Fixed to match `getBook`'s return shape.

- **Split-instance cache (`audiobooks_handlers.go`)**: `audiobookUpdateService` creates its own private `AudiobookService` with its own `bookCache`. Calling `InvalidateBookCaches()` inside the update service cleared only that private instance. The shared `s.audiobookService.bookCache` (used by every GET) remained stale until server restart. Fixed by also calling `s.audiobookService.InvalidateBookCaches()` at the end of `updateAudiobook`.

The cover/versions 404 console errors noted alongside these bugs are expected: no cover = fallback letter avatar; no versions = empty panel. Both have proper error handling already.

## Test plan

- [ ] Edit a metadata field in the dialog → save → title/author/etc should reflect the new value immediately without a page refresh
- [ ] Refresh the page after editing → still shows the new value (not reverting to the pre-edit value)
- [ ] `go test ./internal/server/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)