### PR TITLE
fix(activity): apply Copilot review fixes from PR #1224

### DIFF
--- a/internal/activity/api.go
+++ b/internal/activity/api.go
@@ -1,5 +1,5 @@
 // file: internal/activity/api.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 9a4f2e1b-3c7d-4b8e-a6f0-5d2c8e1b7a3f
 
 package activity
@@ -345,16 +345,16 @@ func detailsTags(e *database.ActivityEntry) []string {
 		return nil
 	}
 	var tags []string
-	for key, prefix := range map[string]string{
-		"def_id":  "def",
-		"plugin":  "plugin",
-		"phase":   "phase",
-		"status":  "status",
-		"outcome": "status",
+	for _, kp := range []struct{ key, prefix string }{
+		{"def_id", "def"},
+		{"plugin", "plugin"},
+		{"phase", "phase"},
+		{"status", "status"},
+		{"outcome", "status"},
 	} {
-		if v, ok := e.Details[key]; ok {
+		if v, ok := e.Details[kp.key]; ok {
 			if s, ok := v.(string); ok && s != "" {
-				tags = append(tags, prefix+":"+s)
+				tags = append(tags, kp.prefix+":"+s)
 			}
 		}
 	}

--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
 // last-edited: 2026-06-01
 
@@ -427,9 +427,6 @@ func levelString(l slog.Level) string {
 func tierForLevel(level string) string {
 	if level == "debug" {
 		return "debug"
-	}
-	if level == "info" {
-		return "info"
 	}
 	return "change"
 }

--- a/internal/server/activity_handlers_test.go
+++ b/internal/server/activity_handlers_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/activity_handlers_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 
 package server
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -237,4 +238,65 @@ func TestListActivitySources(t *testing.T) {
 	assert.Equal(t, 2, resp.Data.Sources[0].Count)
 	assert.Equal(t, "scanner", resp.Data.Sources[1].Source)
 	assert.Equal(t, 1, resp.Data.Sources[1].Count)
+}
+
+// TestListOperationActivity_FallbackToOpLogs verifies that when the activity
+// store has no rows for an operation, the handler falls back to op_logs_v2 and
+// returns those entries with the correct shape and tags.
+func TestListOperationActivity_FallbackToOpLogs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Main store: SQLiteStore implements OpsV2Store (has op_logs_v2 table).
+	sqlStore, err := database.NewSQLiteStore(filepath.Join(dir, "main.db"))
+	require.NoError(t, err)
+	require.NoError(t, database.RunMigrations(sqlStore))
+	defer sqlStore.Close()
+
+	// Activity service backed by a fresh empty store — no entries for the op.
+	actStore, err := database.NewActivityStore(filepath.Join(dir, "activity.db"))
+	require.NoError(t, err)
+	defer actStore.Close()
+	actSvc := activity.NewService(actStore)
+
+	opID := "test-fallback-op-001"
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, sqlStore.AppendOpLogsV2([]database.OpLogV2Row{
+		{OperationID: opID, Level: "info", Message: "started processing", CreatedAt: now},
+		{OperationID: opID, Level: "debug", Message: "processing item 1", CreatedAt: now.Add(time.Second)},
+	}))
+
+	gin.SetMode(gin.TestMode)
+	srv := &Server{store: sqlStore, activityService: actSvc}
+	r := gin.New()
+	r.GET("/api/v1/operations/:id/activity", srv.listOperationActivity)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/operations/"+opID+"/activity", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			OperationID string                   `json:"operation_id"`
+			Entries     []operationActivityEntry `json:"entries"`
+			Total       int                      `json:"total"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, opID, resp.Data.OperationID)
+	require.Len(t, resp.Data.Entries, 2)
+	assert.Equal(t, "started processing", resp.Data.Entries[0].Message)
+	assert.Equal(t, "info", resp.Data.Entries[0].Level)
+
+	// Tags should include an op: tag for the operation ID.
+	hasOpTag := false
+	for _, tag := range resp.Data.Entries[0].Tags {
+		if strings.HasPrefix(tag, "op:") {
+			hasOpTag = true
+		}
+	}
+	assert.True(t, hasOpTag, "expected op: tag in fallback entry tags")
+	assert.Equal(t, 2, resp.Data.Total)
 }

--- a/web/src/components/OperationActivityPanel.tsx
+++ b/web/src/components/OperationActivityPanel.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/OperationActivityPanel.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: f7a1e2c3-9b4d-4e5a-8c6f-1d3b5a7e9c0f
 
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
@@ -216,16 +216,20 @@ export function OperationActivityPanel({
   // full reload path; no timer should repaint the log while a user is reading.
   useEffect(() => {
     if (!latestLogEvent || latestLogEvent.op_id !== operationId) return;
-    setEntries((prev) => [
-      ...prev,
-      {
-        timestamp: latestLogEvent.created_at,
-        level: latestLogEvent.level,
-        operation_id: latestLogEvent.op_id,
-        operation_type: op?.def_id ?? op?.type ?? '',
-        message: latestLogEvent.message,
-      },
-    ]);
+    const cap = limit ?? 1000;
+    setEntries((prev) => {
+      const next = [
+        ...prev,
+        {
+          timestamp: latestLogEvent.created_at,
+          level: latestLogEvent.level,
+          operation_id: latestLogEvent.op_id,
+          operation_type: op?.def_id ?? op?.type ?? '',
+          message: latestLogEvent.message,
+        },
+      ];
+      return next.length > cap ? next.slice(next.length - cap) : next;
+    });
     setTotal((prev) => prev + 1);
   }, [latestLogEvent, operationId, op]);
 

--- a/web/src/stores/useOperationsStore.test.ts
+++ b/web/src/stores/useOperationsStore.test.ts
@@ -1,5 +1,5 @@
 // file: web/src/stores/useOperationsStore.test.ts
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-05-08
 
@@ -148,5 +148,52 @@ describe('useOperationsStore', () => {
     expect(ops[0].id).toBe('op-99');
     expect(ops[0].status).toBe('queued');
     expect(ops[0].type).toBe('scan');
+  });
+
+  it('op.log SSE event updates latestLogEvent', () => {
+    useOperationsStore.setState({ latestLogEvent: null, _sseSource: null } as Parameters<typeof useOperationsStore.setState>[0]);
+
+    let capturedOnEvent: ((name: api.OperationSSEEventName, payload: unknown) => void) | null = null;
+    vi.mocked(api.openOperationsSSE).mockImplementation(({ onEvent }) => {
+      capturedOnEvent = onEvent;
+      return {} as EventSource;
+    });
+
+    useOperationsStore.getState().openSSE();
+    expect(capturedOnEvent).not.toBeNull();
+
+    capturedOnEvent!('op.log', {
+      op_id: 'test-op-log',
+      message: 'Processing file 1',
+      level: 'info',
+      created_at: '2026-06-01T12:00:00Z',
+    });
+
+    const { latestLogEvent } = useOperationsStore.getState();
+    expect(latestLogEvent).not.toBeNull();
+    expect(latestLogEvent?.op_id).toBe('test-op-log');
+    expect(latestLogEvent?.message).toBe('Processing file 1');
+    expect(latestLogEvent?.level).toBe('info');
+  });
+
+  it('op.log SSE event with empty message is ignored', () => {
+    useOperationsStore.setState({ latestLogEvent: null, _sseSource: null } as Parameters<typeof useOperationsStore.setState>[0]);
+
+    let capturedOnEvent: ((name: api.OperationSSEEventName, payload: unknown) => void) | null = null;
+    vi.mocked(api.openOperationsSSE).mockImplementation(({ onEvent }) => {
+      capturedOnEvent = onEvent;
+      return {} as EventSource;
+    });
+
+    useOperationsStore.getState().openSSE();
+
+    capturedOnEvent!('op.log', {
+      op_id: 'test-op-log',
+      message: '',
+      level: 'info',
+      created_at: '2026-06-01T12:00:00Z',
+    });
+
+    expect(useOperationsStore.getState().latestLogEvent).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `detailsTags`: use ordered slice instead of map to guarantee deterministic tag emission
- `tierForLevel`: drop `info→info` branch; `CompactByDay` only processes `change/debug/audit/system` so info-tiered rows would accumulate forever
- `OperationActivityPanel`: cap SSE-appended entries to `limit` (default 1000) to prevent unbounded memory growth for chatty operations
- Add `TestListOperationActivity_FallbackToOpLogs`: covers the op_logs_v2 fallback path
- Add `op.log` SSE tests for `useOperationsStore`: asserts `latestLogEvent` updates and empty-message guard

## Test plan

- [x] `go test ./internal/activity/... ./internal/operations/registry/... ./internal/server/` passes
- [x] `npx vitest run src/stores/useOperationsStore.test.ts` — 6/6 pass
- [x] `go build ./internal/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)