### PR TITLE
fix(activity): use denylist for CompactByDay; expand NutsDB actTiers

### DIFF
--- a/internal/database/activity_store.go
+++ b/internal/database/activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/activity_store.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: e2d3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
 
 package database
@@ -685,24 +685,22 @@ func nullableJSON(v map[string]any) (any, error) {
 	return string(b), nil
 }
 
-// CompactByDay collapses old change, debug, and audit entries into one
-// daily_digest row per UTC day. Audit entries are folded into the digest
-// (preserving their type, summary, and operation_id in DigestItem) so the
-// audit record survives compaction in summarized form. Existing 'digest'
-// rows are never re-compacted. Each day is processed in its own transaction
-// for atomicity.
+// CompactByDay collapses all activity entries (except existing 'digest' rows)
+// into one daily_digest row per UTC day. Every tier is eligible — the denylist
+// approach means newly-introduced tiers are automatically compacted without
+// requiring an allowlist update. Existing 'digest' rows are never re-compacted.
+// Each day is processed in its own transaction for atomicity.
 func (s *ActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
 	var result CompactResult
 
 	// 1. Fetch all compactable entries.
-	// Include 'system' tier so legacy migrated rows (which used to be hardcoded
-	// to tier='system') are also compacted into daily digests and produce
-	// breakdown chips via TagCounts.
+	// Denylist: exclude only 'digest' (already-compacted rows must not be
+	// re-compacted). Every other tier — including any future ones — is eligible.
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, tier, type, level, source, operation_id,
 		       book_id, summary, details, tags
 		FROM   activity_log
-		WHERE  tier IN ('change', 'debug', 'audit', 'system')
+		WHERE  tier != 'digest'
 		  AND  compacted = 0
 		  AND  timestamp < ?
 		ORDER BY timestamp ASC`,

--- a/internal/database/nuts_activity_store.go
+++ b/internal/database/nuts_activity_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/nuts_activity_store.go
-// version: 1.2.3
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-0003-cdef-000000000003
 
 package database
@@ -66,7 +66,14 @@ func actBucket(tier string) string       { return "act:" + tier }
 func actOpBucket(opID string) string     { return "act:op:" + opID }
 func actBookBucket(bookID string) string { return "act:bk:" + bookID }
 
-var actTiers = []string{"change", "debug", "audit", "digest"}
+// actTiers is the full list of tier buckets used for queries, sources, wipe,
+// and compaction. digest must be last (it is excluded from compaction but
+// included in queries). Add new tiers here when introducing them.
+var actTiers = []string{"change", "debug", "audit", "info", "batch", "system", "digest"}
+
+// actCompactableTiers returns all tiers eligible for compaction (everything
+// except digest, which is the compaction output and must not be re-compacted).
+func actCompactableTiers() []string { return actTiers[:len(actTiers)-1] }
 
 func actTimeKey(t time.Time, id string) []byte {
 	return []byte(fmt.Sprintf("%020d:%s", t.UnixNano(), id))
@@ -402,24 +409,21 @@ func (s *NutsActivityStore) WipeAllActivity() (int64, error) {
 	return total, nil
 }
 
-// CompactByDay collapses old change/debug/audit entries into daily digest rows.
-// Existing digest entries are merged (not re-compacted). Each day is processed
-// atomically.
+// CompactByDay collapses all compactable tier entries into daily digest rows.
+// Every tier except "digest" is eligible — the denylist approach means newly-
+// introduced tiers are automatically compacted without an allowlist update.
+// Each day is processed atomically.
 func (s *NutsActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
 	var result CompactResult
 
-	// Load all compactable entries.
+	// Load all compactable entries (all tiers except "digest").
 	var all []ActivityEntry
-	for _, tier := range []string{"change", "debug", "audit"} {
+	for _, tier := range actCompactableTiers() {
 		entries, err := s.scanTier(tier, nil, &olderThan)
 		if err != nil {
 			return result, err
 		}
-		for _, e := range entries {
-			if e.Tier != "digest" {
-				all = append(all, e)
-			}
-		}
+		all = append(all, entries...)
 	}
 	if len(all) == 0 {
 		return result, nil
@@ -443,7 +447,7 @@ func (s *NutsActivityStore) CompactByDay(ctx context.Context, olderThan time.Tim
 
 	// Build key lookup for bulk deletes.
 	keyLookup := make(map[int64]entryKV)
-	for _, tier := range []string{"change", "debug", "audit"} {
+	for _, tier := range actCompactableTiers() {
 		kvs, err := s.scanTierKeysAndValues(tier, nil, &olderThan)
 		if err != nil {
 			return result, err


### PR DESCRIPTION
## Summary

- **SQL `activity_store`**: change compaction `WHERE` from `tier IN ('change','debug','audit','system')` to `tier != 'digest'` — every tier except the compaction output is now eligible, so newly-introduced tiers compact automatically without an allowlist update.

- **NutsDB `nuts_activity_store`**: expand `actTiers` to include `info`, `batch`, `system` (previously invisible to `Query`/`GetDistinctSources`/`WipeAllActivity`). Add `actCompactableTiers()` helper and update `CompactByDay` + key-lookup to use it.

## Test plan

- [x] `go test ./internal/database/ -run "Compact|ActivityStore|NutsActivity|Summarize|Prune"` — 21/21 pass
- [x] `go build ./internal/database/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)