### PR TITLE
refactor(server): extract request/response types to internal/server/handlers/ (ADR-003 Phase 1)

### DIFF
--- a/internal/server/apikey_handlers.go
+++ b/internal/server/apikey_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/apikey_handlers.go
-// version: 2.1.0
-// last-edited: 2026-05-01
+// version: 2.2.0
+// last-edited: 2026-06-01
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
 
 package server
@@ -13,47 +13,11 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 )
 
-type createAPIKeyRequest struct {
-	Name          string   `json:"name" binding:"required"`
-	Description   string   `json:"description"`
-	Scopes        []string `json:"scopes"`
-	ExpiresInDays int      `json:"expires_in_days"`
-	UserID        string   `json:"user_id"`
-}
-
-type createAPIKeyResponse struct {
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
-	Token     string     `json:"token"`
-	Scopes    []string   `json:"scopes"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
-	CreatedAt time.Time  `json:"created_at"`
-}
-
-type apiKeyResponse struct {
-	ID               string     `json:"id"`
-	UserID           string     `json:"user_id"`
-	Name             string     `json:"name"`
-	Description      string     `json:"description"`
-	Scopes           []string   `json:"scopes"`
-	Status           string     `json:"status"`
-	CreatedAt        time.Time  `json:"created_at"`
-	LastUsedAt       *time.Time `json:"last_used_at,omitempty"`
-	LastUsedIP       string     `json:"last_used_ip,omitempty"`
-	UseCount         int64      `json:"use_count"`
-	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
-	DeactivatedAt    *time.Time `json:"deactivated_at,omitempty"`
-	RevokedAt        *time.Time `json:"revoked_at,omitempty"`
-	Identifier       string     `json:"identifier"`
-	DaysSinceLastUse *int       `json:"days_since_last_use"`
-	NeverUsed        bool       `json:"never_used"`
-	Username         string     `json:"username,omitempty"`
-}
-
-func buildAPIKeyResponse(key database.APIKey, username string) apiKeyResponse {
+func buildAPIKeyResponse(key database.APIKey, username string) handlers.APIKeyResponse {
 	var daysSince *int
 	neverUsed := key.LastUsedAt == nil
 	if key.LastUsedAt != nil {
@@ -64,7 +28,7 @@ func buildAPIKeyResponse(key database.APIKey, username string) apiKeyResponse {
 	if len(key.TokenHash) >= 8 {
 		ident = "abk_" + key.TokenHash[:8]
 	}
-	return apiKeyResponse{
+	return handlers.APIKeyResponse{
 		ID:               key.ID,
 		UserID:           key.UserID,
 		Name:             key.Name,
@@ -98,7 +62,7 @@ func (s *Server) createAPIKey(c *gin.Context) {
 		return
 	}
 
-	var req createAPIKeyRequest
+	var req handlers.CreateAPIKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -161,7 +125,7 @@ func (s *Server) createAPIKey(c *gin.Context) {
 
 	slog.Info("apikey created id user name scopes expires", "created", created.ID, "targetUserID", targetUserID, "created", created.Name, "created", created.Scopes, "created", created.ExpiresAt)
 
-	resp := createAPIKeyResponse{
+	resp := handlers.CreateAPIKeyResponse{
 		ID:        created.ID,
 		Name:      created.Name,
 		Token:     rawToken,
@@ -199,7 +163,7 @@ func (s *Server) listAPIKeys(c *gin.Context) {
 
 	// Build username map for admin view.
 	userCache := map[string]string{}
-	results := make([]apiKeyResponse, 0, len(keys))
+	results := make([]handlers.APIKeyResponse, 0, len(keys))
 	for _, k := range keys {
 		username := ""
 		if showAll {

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/auth_handlers.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 1457df2f-af76-46cb-a2f4-c9f6f275f93a
-// last-edited: 2026-05-01
+// last-edited: 2026-06-01
 
 package server
 
@@ -15,6 +15,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/config"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	servermiddleware "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -71,17 +72,8 @@ const (
 	tempLoginTokenTTL    = 15 * time.Minute
 )
 
-type authUserResponse struct {
-	ID        string    `json:"id"`
-	Username  string    `json:"username"`
-	Email     string    `json:"email"`
-	Roles     []string  `json:"roles"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-func buildAuthUserResponse(user *database.User) authUserResponse {
-	return authUserResponse{
+func buildAuthUserResponse(user *database.User) handlers.AuthUserResponse {
+	return handlers.AuthUserResponse{
 		ID:        user.ID,
 		Username:  user.Username,
 		Email:     user.Email,

--- a/internal/server/cache_handlers.go
+++ b/internal/server/cache_handlers.go
@@ -1,12 +1,11 @@
 // file: internal/server/cache_handlers.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-05-01
+// last-edited: 2026-06-01
 
 package server
 
 import (
-	"encoding/json"
 	"log/slog"
 	"strconv"
 	"time"
@@ -15,34 +14,10 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/cache"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_model/go"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 )
-
-// CacheStatsResponse represents the JSON response for GET /api/v1/cache/stats
-type CacheStatsResponse struct {
-	Caches      []CacheStat `json:"caches"`
-	GeneratedAt string      `json:"generated_at"`
-}
-
-// CacheStat represents metrics for a single cache
-type CacheStat struct {
-	Name              string            `json:"name"`
-	Hits              int64             `json:"hits"`
-	Misses            map[string]int64  `json:"misses"`
-	Sets              int64             `json:"sets"`
-	Invalidations     map[string]int64  `json:"invalidations"`
-	Evictions         map[string]int64  `json:"evictions"`
-	Size              int64             `json:"size"`
-	HitRate           *float64          `json:"hit_rate,omitempty"`
-	GetDurationMetric GetDurationMetric `json:"get_duration_seconds"`
-}
-
-// GetDurationMetric represents count and sum of cache get durations
-type GetDurationMetric struct {
-	Count int64   `json:"count"`
-	Sum   float64 `json:"sum"`
-}
 
 // handleCacheStats returns aggregated cache metrics from Prometheus default registry
 // GET /api/v1/cache/stats (public, no auth)
@@ -66,7 +41,7 @@ func (s *Server) handleCacheStats(c *gin.Context) {
 		}
 	}
 
-	resp := CacheStatsResponse{
+	resp := handlers.CacheStatsResponse{
 		Caches:      stats,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 	}
@@ -105,10 +80,10 @@ func (s *Server) handleCacheKeysIntrospection(c *gin.Context) {
 }
 
 // aggregateCacheMetrics extracts all audiobook_organizer_cache_* metrics from Prometheus
-// and builds a CacheStat for each unique cache name.
-func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat {
+// and builds a handlers.CacheStat for each unique cache name.
+func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []handlers.CacheStat {
 	// Map from cache name to its aggregated stats
-	statMap := make(map[string]*CacheStat)
+	statMap := make(map[string]*handlers.CacheStat)
 
 	for _, mf := range mfs {
 		// Only process cache metrics
@@ -119,12 +94,12 @@ func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat
 
 		switch metricName {
 		case "audiobook_organizer_cache_hits_total":
-			processCounterMetric(mf, statMap, func(stat *CacheStat, value int64) {
+			processCounterMetric(mf, statMap, func(stat *handlers.CacheStat, value int64) {
 				stat.Hits = value
 			})
 
 		case "audiobook_organizer_cache_misses_total":
-			processCounterMetricWithReason(mf, statMap, func(stat *CacheStat, reason string, value int64) {
+			processCounterMetricWithReason(mf, statMap, func(stat *handlers.CacheStat, reason string, value int64) {
 				if stat.Misses == nil {
 					stat.Misses = make(map[string]int64)
 				}
@@ -132,12 +107,12 @@ func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat
 			})
 
 		case "audiobook_organizer_cache_sets_total":
-			processCounterMetric(mf, statMap, func(stat *CacheStat, value int64) {
+			processCounterMetric(mf, statMap, func(stat *handlers.CacheStat, value int64) {
 				stat.Sets = value
 			})
 
 		case "audiobook_organizer_cache_invalidations_total":
-			processCounterMetricWithReason(mf, statMap, func(stat *CacheStat, scope string, value int64) {
+			processCounterMetricWithReason(mf, statMap, func(stat *handlers.CacheStat, scope string, value int64) {
 				if stat.Invalidations == nil {
 					stat.Invalidations = make(map[string]int64)
 				}
@@ -145,7 +120,7 @@ func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat
 			})
 
 		case "audiobook_organizer_cache_evictions_total":
-			processCounterMetricWithReason(mf, statMap, func(stat *CacheStat, reason string, value int64) {
+			processCounterMetricWithReason(mf, statMap, func(stat *handlers.CacheStat, reason string, value int64) {
 				if stat.Evictions == nil {
 					stat.Evictions = make(map[string]int64)
 				}
@@ -153,19 +128,19 @@ func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat
 			})
 
 		case "audiobook_organizer_cache_size":
-			processGaugeMetric(mf, statMap, func(stat *CacheStat, value float64) {
+			processGaugeMetric(mf, statMap, func(stat *handlers.CacheStat, value float64) {
 				stat.Size = int64(value)
 			})
 
 		case "audiobook_organizer_cache_get_duration_seconds":
-			processHistogramMetric(mf, statMap, func(stat *CacheStat, count int64, sum float64) {
-				stat.GetDurationMetric = GetDurationMetric{Count: count, Sum: sum}
+			processHistogramMetric(mf, statMap, func(stat *handlers.CacheStat, count int64, sum float64) {
+				stat.GetDurationMetric = handlers.GetDurationMetric{Count: count, Sum: sum}
 			})
 		}
 	}
 
 	// Convert to sorted slice and compute hit rates
-	result := make([]CacheStat, 0, len(statMap))
+	result := make([]handlers.CacheStat, 0, len(statMap))
 	for _, stat := range statMap {
 		// Compute hit_rate = hits / (hits + sum(misses))
 		totalMisses := int64(0)
@@ -197,8 +172,8 @@ func aggregateCacheMetrics(mfs []*io_prometheus_client.MetricFamily) []CacheStat
 
 // processCounterMetric extracts counter metrics with a single {cache} label
 func processCounterMetric(mf *io_prometheus_client.MetricFamily,
-	statMap map[string]*CacheStat,
-	fn func(*CacheStat, int64)) {
+	statMap map[string]*handlers.CacheStat,
+	fn func(*handlers.CacheStat, int64)) {
 	if mf.Metric == nil {
 		return
 	}
@@ -208,7 +183,7 @@ func processCounterMetric(mf *io_prometheus_client.MetricFamily,
 			continue
 		}
 		if _, ok := statMap[cacheName]; !ok {
-			statMap[cacheName] = &CacheStat{Name: cacheName}
+			statMap[cacheName] = &handlers.CacheStat{Name: cacheName}
 		}
 		if m.Counter != nil && m.Counter.Value != nil {
 			fn(statMap[cacheName], int64(*m.Counter.Value))
@@ -218,8 +193,8 @@ func processCounterMetric(mf *io_prometheus_client.MetricFamily,
 
 // processCounterMetricWithReason extracts counter metrics with {cache} and {reason/scope} labels
 func processCounterMetricWithReason(mf *io_prometheus_client.MetricFamily,
-	statMap map[string]*CacheStat,
-	fn func(*CacheStat, string, int64)) {
+	statMap map[string]*handlers.CacheStat,
+	fn func(*handlers.CacheStat, string, int64)) {
 	if mf.Metric == nil {
 		return
 	}
@@ -237,7 +212,7 @@ func processCounterMetricWithReason(mf *io_prometheus_client.MetricFamily,
 			continue
 		}
 		if _, ok := statMap[cacheName]; !ok {
-			statMap[cacheName] = &CacheStat{Name: cacheName}
+			statMap[cacheName] = &handlers.CacheStat{Name: cacheName}
 		}
 		if m.Counter != nil && m.Counter.Value != nil {
 			fn(statMap[cacheName], reason, int64(*m.Counter.Value))
@@ -247,8 +222,8 @@ func processCounterMetricWithReason(mf *io_prometheus_client.MetricFamily,
 
 // processGaugeMetric extracts gauge metrics with a single {cache} label
 func processGaugeMetric(mf *io_prometheus_client.MetricFamily,
-	statMap map[string]*CacheStat,
-	fn func(*CacheStat, float64)) {
+	statMap map[string]*handlers.CacheStat,
+	fn func(*handlers.CacheStat, float64)) {
 	if mf.Metric == nil {
 		return
 	}
@@ -258,7 +233,7 @@ func processGaugeMetric(mf *io_prometheus_client.MetricFamily,
 			continue
 		}
 		if _, ok := statMap[cacheName]; !ok {
-			statMap[cacheName] = &CacheStat{Name: cacheName}
+			statMap[cacheName] = &handlers.CacheStat{Name: cacheName}
 		}
 		if m.Gauge != nil && m.Gauge.Value != nil {
 			fn(statMap[cacheName], *m.Gauge.Value)
@@ -268,8 +243,8 @@ func processGaugeMetric(mf *io_prometheus_client.MetricFamily,
 
 // processHistogramMetric extracts histogram bucket data, returning count and sum
 func processHistogramMetric(mf *io_prometheus_client.MetricFamily,
-	statMap map[string]*CacheStat,
-	fn func(*CacheStat, int64, float64)) {
+	statMap map[string]*handlers.CacheStat,
+	fn func(*handlers.CacheStat, int64, float64)) {
 	if mf.Metric == nil {
 		return
 	}
@@ -279,7 +254,7 @@ func processHistogramMetric(mf *io_prometheus_client.MetricFamily,
 			continue
 		}
 		if _, ok := statMap[cacheName]; !ok {
-			statMap[cacheName] = &CacheStat{Name: cacheName}
+			statMap[cacheName] = &handlers.CacheStat{Name: cacheName}
 		}
 		if m.Histogram != nil {
 			var count int64
@@ -314,17 +289,6 @@ func isNonIntrospectableCache(name string) bool {
 		// Add other DB-backed or external caches here
 	}
 	return nonIntrospectable[name]
-}
-
-// MarshalJSON ensures proper JSON marshaling of CacheStatsResponse
-func (resp CacheStatsResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Caches      []CacheStat `json:"caches"`
-		GeneratedAt string      `json:"generated_at"`
-	}{
-		Caches:      resp.Caches,
-		GeneratedAt: resp.GeneratedAt,
-	})
 }
 
 // gatherCacheSnapshots reads the current Prometheus default registry and

--- a/internal/server/handlers/apikeys.go
+++ b/internal/server/handlers/apikeys.go
@@ -1,0 +1,48 @@
+// file: internal/server/handlers/apikeys.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
+// last-edited: 2026-06-01
+
+package handlers
+
+import "time"
+
+// CreateAPIKeyRequest is the JSON body for POST /api/v1/api-keys.
+type CreateAPIKeyRequest struct {
+	Name          string   `json:"name" binding:"required"`
+	Description   string   `json:"description"`
+	Scopes        []string `json:"scopes"`
+	ExpiresInDays int      `json:"expires_in_days"`
+	UserID        string   `json:"user_id"`
+}
+
+// CreateAPIKeyResponse is returned after successfully creating an API key.
+type CreateAPIKeyResponse struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Token     string     `json:"token"`
+	Scopes    []string   `json:"scopes"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// APIKeyResponse is the JSON shape for a single API key (list and detail endpoints).
+type APIKeyResponse struct {
+	ID               string     `json:"id"`
+	UserID           string     `json:"user_id"`
+	Name             string     `json:"name"`
+	Description      string     `json:"description"`
+	Scopes           []string   `json:"scopes"`
+	Status           string     `json:"status"`
+	CreatedAt        time.Time  `json:"created_at"`
+	LastUsedAt       *time.Time `json:"last_used_at,omitempty"`
+	LastUsedIP       string     `json:"last_used_ip,omitempty"`
+	UseCount         int64      `json:"use_count"`
+	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
+	DeactivatedAt    *time.Time `json:"deactivated_at,omitempty"`
+	RevokedAt        *time.Time `json:"revoked_at,omitempty"`
+	Identifier       string     `json:"identifier"`
+	DaysSinceLastUse *int       `json:"days_since_last_use"`
+	NeverUsed        bool       `json:"never_used"`
+	Username         string     `json:"username,omitempty"`
+}

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -1,0 +1,18 @@
+// file: internal/server/handlers/auth.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-012345678901
+// last-edited: 2026-06-01
+
+package handlers
+
+import "time"
+
+// AuthUserResponse is the JSON shape returned after login and token refresh.
+type AuthUserResponse struct {
+	ID        string    `json:"id"`
+	Username  string    `json:"username"`
+	Email     string    `json:"email"`
+	Roles     []string  `json:"roles"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -1,0 +1,44 @@
+// file: internal/server/handlers/cache.go
+// version: 1.1.0
+// guid: c9d0e1f2-a3b4-5678-cdef-678901234567
+// last-edited: 2026-06-01
+
+package handlers
+
+import "encoding/json"
+
+// CacheStatsResponse represents the JSON response for GET /api/v1/cache/stats.
+type CacheStatsResponse struct {
+	Caches      []CacheStat `json:"caches"`
+	GeneratedAt string      `json:"generated_at"`
+}
+
+// CacheStat represents metrics for a single cache.
+type CacheStat struct {
+	Name              string            `json:"name"`
+	Hits              int64             `json:"hits"`
+	Misses            map[string]int64  `json:"misses"`
+	Sets              int64             `json:"sets"`
+	Invalidations     map[string]int64  `json:"invalidations"`
+	Evictions         map[string]int64  `json:"evictions"`
+	Size              int64             `json:"size"`
+	HitRate           *float64          `json:"hit_rate,omitempty"`
+	GetDurationMetric GetDurationMetric `json:"get_duration_seconds"`
+}
+
+// GetDurationMetric represents count and sum of cache get durations.
+type GetDurationMetric struct {
+	Count int64   `json:"count"`
+	Sum   float64 `json:"sum"`
+}
+
+// MarshalJSON ensures proper JSON marshaling of CacheStatsResponse.
+func (resp CacheStatsResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Caches      []CacheStat `json:"caches"`
+		GeneratedAt string      `json:"generated_at"`
+	}{
+		Caches:      resp.Caches,
+		GeneratedAt: resp.GeneratedAt,
+	})
+}

--- a/internal/server/handlers/doc.go
+++ b/internal/server/handlers/doc.go
@@ -1,0 +1,8 @@
+// file: internal/server/handlers/doc.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
+// last-edited: 2026-06-01
+
+// Package handlers contains the HTTP request/response type definitions for
+// the audiobook-organizer API. Handler implementations live in internal/server.
+package handlers

--- a/internal/server/handlers/itunes.go
+++ b/internal/server/handlers/itunes.go
@@ -1,0 +1,157 @@
+// file: internal/server/handlers/itunes.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-defa-123456789012
+// last-edited: 2026-06-01
+
+package handlers
+
+import "github.com/jdfalk/audiobook-organizer/internal/itunes"
+
+// ITunesValidateRequest represents a validation request for an iTunes library.
+type ITunesValidateRequest struct {
+	LibraryPath  string               `json:"library_path" binding:"required"`
+	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
+}
+
+// ITunesValidateResponse summarizes validation results for an iTunes library.
+type ITunesValidateResponse struct {
+	TotalTracks     int      `json:"total_tracks"`
+	AudiobookTracks int      `json:"audiobook_tracks"`
+	AudiobookCount  int      `json:"audiobook_count"`
+	FilesFound      int      `json:"files_found"`
+	FilesMissing    int      `json:"files_missing"`
+	MissingPaths    []string `json:"missing_paths,omitempty"`
+	PathPrefixes    []string `json:"path_prefixes,omitempty"`
+	DuplicateCount  int      `json:"duplicate_count"`
+	EstimatedTime   string   `json:"estimated_import_time"`
+}
+
+// ITunesImportRequest represents a request to import an iTunes library.
+type ITunesImportRequest struct {
+	LibraryPath      string               `json:"library_path" binding:"required"`
+	ImportMode       string               `json:"import_mode" binding:"required,oneof=organized import organize"`
+	PreserveLocation bool                 `json:"preserve_location"`
+	ImportPlaylists  bool                 `json:"import_playlists"`
+	SkipDuplicates   bool                 `json:"skip_duplicates"`
+	FetchMetadata    bool                 `json:"fetch_metadata"`
+	PathMappings     []itunes.PathMapping `json:"path_mappings,omitempty"`
+}
+
+// ITunesImportResponse acknowledges an iTunes import operation.
+type ITunesImportResponse struct {
+	OperationID string `json:"operation_id"`
+	Status      string `json:"status"`
+	Message     string `json:"message"`
+}
+
+// ITunesWriteBackRequest represents a write-back request for iTunes ITL updates.
+type ITunesWriteBackRequest struct {
+	LibraryPath  string               `json:"library_path"`
+	AudiobookIDs []string             `json:"audiobook_ids"`
+	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
+}
+
+// ITunesWriteBackResponse reports the result of an ITL write-back.
+type ITunesWriteBackResponse struct {
+	Success      bool   `json:"success"`
+	UpdatedCount int    `json:"updated_count"`
+	Message      string `json:"message"`
+}
+
+// ITunesBookMapping is a single book-to-iTunes-path mapping used in preview.
+//
+// Four path columns surface the full picture so users can see exactly what
+// is currently in iTunes vs what AO has on disk vs what AO would write back:
+//
+//   - ITunesPath               — what iTunes currently has, e.g. W:/foo/bar.m4b
+//   - ITunesPathTranslated     — local equivalent of ITunesPath after applying
+//     forward path mappings (so users can stat it)
+//   - AOPath                   — where AO has the file on disk (book.FilePath)
+//   - AOITunesTranslatedPath   — what AO will write into the iTunes ITL when
+//     write-back runs (ReverseRemapPath of AOPath)
+//
+// PathDiffers is true iff AOITunesTranslatedPath != ITunesPath — i.e. the
+// thing AO wants to write does not match what iTunes already has.
+//
+// Backwards compatibility: LocalPath is preserved as an alias of AOPath so
+// older clients keep working through the migration. Remove once no caller
+// reads it.
+type ITunesBookMapping struct {
+	BookID                 string `json:"book_id"`
+	Title                  string `json:"title"`
+	Author                 string `json:"author"`
+	ITunesPersistentID     string `json:"itunes_persistent_id"`
+	ITunesPath             string `json:"itunes_path,omitempty"`
+	ITunesPathTranslated   string `json:"itunes_path_translated,omitempty"`
+	AOPath                 string `json:"ao_path"`
+	AOITunesTranslatedPath string `json:"ao_itunes_translated_path,omitempty"`
+	PathDiffers            bool   `json:"path_differs,omitempty"`
+
+	// LocalPath duplicates AOPath for backwards compatibility with the
+	// previous response shape. Will be removed once no caller reads it.
+	LocalPath string `json:"local_path"`
+}
+
+// ITunesWriteBackPreviewRequest is the wire type for POST /itunes/write-back-preview.
+//
+// LibraryPath is now optional — when empty, the handler uses the configured
+// ITunesLibraryReadPath. The dialog used to require the user to type this
+// path on every preview, which was confusing because the actual write-back
+// always targets the configured ITunesLibraryWritePath (.itl) regardless.
+type ITunesWriteBackPreviewRequest struct {
+	LibraryPath string   `json:"library_path,omitempty"`
+	BookIDs     []string `json:"book_ids,omitempty"`
+}
+
+// ITunesWriteBackPreviewResponse is returned by POST /itunes/write-back-preview.
+type ITunesWriteBackPreviewResponse struct {
+	Items []ITunesBookMapping `json:"items"`
+	Total int                 `json:"total"`
+}
+
+// ITunesImportStatusResponse is returned by GET /itunes/import/:id.
+type ITunesImportStatusResponse struct {
+	OperationID string   `json:"operation_id"`
+	Status      string   `json:"status"`
+	Progress    int      `json:"progress"`
+	Message     string   `json:"message"`
+	TotalBooks  int      `json:"total_books"`
+	Processed   int      `json:"processed"`
+	Imported    int      `json:"imported"`
+	Skipped     int      `json:"skipped"`
+	Failed      int      `json:"failed"`
+	Errors      []string `json:"errors,omitempty"`
+}
+
+// ITunesTestMappingRequest tests a single path mapping against the library.
+type ITunesTestMappingRequest struct {
+	LibraryPath string `json:"library_path" binding:"required"`
+	From        string `json:"from" binding:"required"`
+	To          string `json:"to" binding:"required"`
+}
+
+// ITunesTestMappingResponse returns sample results from testing a mapping.
+type ITunesTestMappingResponse struct {
+	Tested   int                `json:"tested"`
+	Found    int                `json:"found"`
+	Examples []ITunesTestExample `json:"examples"`
+}
+
+// ITunesTestExample is a single found file example.
+type ITunesTestExample struct {
+	Title string `json:"title"`
+	Path  string `json:"path"`
+}
+
+// ITunesSyncRequest is the wire type for POST /itunes/sync.
+type ITunesSyncRequest struct {
+	LibraryPath  string               `json:"library_path,omitempty"`
+	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
+	Force        bool                 `json:"force,omitempty"`
+}
+
+// ITunesSyncResponse acknowledges a sync operation.
+type ITunesSyncResponse struct {
+	OperationID string `json:"operation_id"`
+	Message     string `json:"message"`
+}

--- a/internal/server/handlers/metadata.go
+++ b/internal/server/handlers/metadata.go
@@ -1,0 +1,33 @@
+// file: internal/server/handlers/metadata.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-2345-fabc-345678901234
+// last-edited: 2026-06-01
+
+package handlers
+
+import (
+	"encoding/json"
+
+	"github.com/jdfalk/audiobook-organizer/internal/operations"
+)
+
+// BulkMetadataFetchV2Params is the JSON params for the v2 bulk_metadata_fetch op.
+// Selection replaces the old BookIDs field: the client sends either
+//   - book_ids: an explicit list of IDs (page-level selection), or
+//   - filter: a FilterSpec that the server resolves to IDs at run time
+//     with IsPrimaryVersion=true always applied.
+type BulkMetadataFetchV2Params struct {
+	Selection     operations.SelectionSpec `json:"selection"`
+	PreferAudible bool                     `json:"prefer_audible"`
+	SkipCached    bool                     `json:"skip_cached"`
+}
+
+// RatingPatchRequest is the JSON body for PATCH /api/v1/audiobooks/:id/rating.
+// Each field is a json.RawMessage so the handler can distinguish null (clear)
+// from absent (don't touch) from a numeric value.
+type RatingPatchRequest struct {
+	Overall     json.RawMessage `json:"overall"`
+	Story       json.RawMessage `json:"story"`
+	Performance json.RawMessage `json:"performance"`
+	Notes       json.RawMessage `json:"notes"`
+}

--- a/internal/server/handlers/operations.go
+++ b/internal/server/handlers/operations.go
@@ -1,0 +1,63 @@
+// file: internal/server/handlers/operations.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-1234-efab-234567890123
+// last-edited: 2026-06-01
+
+package handlers
+
+import "time"
+
+// MaintenanceWindowConfigReq is the JSON body for the maintenance window config endpoint.
+type MaintenanceWindowConfigReq struct {
+	Enabled     bool `json:"enabled"`
+	WindowStart int  `json:"window_start"`
+	WindowEnd   int  `json:"window_end"`
+}
+
+// OperationV2Response is the JSON shape returned by the timeline and single-op
+// endpoints. It mirrors the TypeScript OperationV2 interface in api.ts.
+type OperationV2Response struct {
+	ID              string     `json:"id"`
+	DefID           string     `json:"def_id"`
+	Plugin          string     `json:"plugin"`
+	DisplayName     string     `json:"display_name"`
+	Status          string     `json:"status"`
+	Priority        int        `json:"priority"`
+	NotifyLevel     int        `json:"notify_level"`
+	ProgressCurrent *int       `json:"progress_current"`
+	ProgressTotal   *int       `json:"progress_total"`
+	ProgressMessage *string    `json:"progress_message"`
+	CurrentPhase    *string    `json:"current_phase"`
+	CurrentItem     *string    `json:"current_item"`
+	ActorUserID     *string    `json:"actor_user_id"`
+	ParentID        *string    `json:"parent_id"`
+	QueuedAt        time.Time  `json:"queued_at"`
+	StartedAt       *time.Time `json:"started_at"`
+	CompletedAt     *time.Time `json:"completed_at"`
+	ErrorMessage    *string    `json:"error_message"`
+	ResumeCount     int        `json:"resume_count"`
+	TraceID         string     `json:"trace_id"`
+	SpanID          string     `json:"span_id"`
+}
+
+// OpLogV2Response is the JSON shape for a single operation log line.
+type OpLogV2Response struct {
+	OperationID string    `json:"operation_id"`
+	Level       string    `json:"level"`
+	Message     string    `json:"message"`
+	Attrs       any       `json:"attrs"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// OpDefResponse is the JSON shape returned by /op-defs.
+type OpDefResponse struct {
+	ID           string   `json:"id"`
+	Plugin       string   `json:"plugin"`
+	DisplayName  string   `json:"display_name"`
+	Description  string   `json:"description"`
+	Cancellable  bool     `json:"cancellable"`
+	Isolate      bool     `json:"isolate"`
+	ResumePolicy string   `json:"resume_policy"`
+	Triggers     []string `json:"triggers"`
+	DependsOn    []string `json:"depends_on"`
+}

--- a/internal/server/handlers/playlists.go
+++ b/internal/server/handlers/playlists.go
@@ -1,0 +1,38 @@
+// file: internal/server/handlers/playlists.go
+// version: 1.0.0
+// guid: a7b8c9d0-e1f2-3456-abcd-456789012345
+// last-edited: 2026-06-01
+
+package handlers
+
+// PlaylistCreateReq is the payload for POST /api/v1/playlists.
+type PlaylistCreateReq struct {
+	Name        string   `json:"name" binding:"required"`
+	Description string   `json:"description,omitempty"`
+	Type        string   `json:"type" binding:"required"` // static|smart
+	BookIDs     []string `json:"book_ids,omitempty"`
+	Query       string   `json:"query,omitempty"`
+	SortJSON    string   `json:"sort_json,omitempty"`
+	Limit       int      `json:"limit,omitempty"`
+}
+
+// PlaylistUpdateReq mirrors PlaylistCreateReq but all fields are
+// optional — only set ones are applied.
+type PlaylistUpdateReq struct {
+	Name        *string   `json:"name,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	BookIDs     *[]string `json:"book_ids,omitempty"`
+	Query       *string   `json:"query,omitempty"`
+	SortJSON    *string   `json:"sort_json,omitempty"`
+	Limit       *int      `json:"limit,omitempty"`
+}
+
+// PlaylistBooksAddReq is the payload for POST /api/v1/playlists/:id/books.
+type PlaylistBooksAddReq struct {
+	BookIDs []string `json:"book_ids" binding:"required"`
+}
+
+// PlaylistReorderReq is the payload for PUT /api/v1/playlists/:id/books/order.
+type PlaylistReorderReq struct {
+	BookIDs []string `json:"book_ids" binding:"required"`
+}

--- a/internal/server/handlers/reading.go
+++ b/internal/server/handlers/reading.go
@@ -1,0 +1,17 @@
+// file: internal/server/handlers/reading.go
+// version: 1.0.0
+// guid: b8c9d0e1-f2a3-4567-bcde-567890123456
+// last-edited: 2026-06-01
+
+package handlers
+
+// SetPositionRequest is the JSON body for POST /api/v1/books/:id/position.
+type SetPositionRequest struct {
+	SegmentID       string  `json:"segment_id" binding:"required"`
+	PositionSeconds float64 `json:"position_seconds"`
+}
+
+// PatchStatusRequest is the JSON body for PATCH /api/v1/books/:id/status.
+type PatchStatusRequest struct {
+	Status string `json:"status" binding:"required"`
+}

--- a/internal/server/itunes_handlers.go
+++ b/internal/server/itunes_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/itunes_handlers.go
-// version: 2.9.2
+// version: 2.10.0
 // guid: 7f2e1a4c-8b3d-4e5f-9a1b-2c3d4e5f6a7b
-// last-edited: 2026-05-19
+// last-edited: 2026-06-01
 
 // iTunes HTTP handlers. All business logic lives in internal/itunes/service.
 // Handlers that call s.itunesSvc.Importer.* guard with itunesEnabledOrError
@@ -25,6 +25,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/jdfalk/audiobook-organizer/internal/itunes/service"
 	"github.com/jdfalk/audiobook-organizer/internal/security/pathvalidation"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -38,162 +39,11 @@ func (s *Server) itunesEnabledOrError(c *gin.Context) bool {
 	return true
 }
 
-// --- request / response types ---
-
-// ITunesValidateRequest represents a validation request for an iTunes library.
-type ITunesValidateRequest struct {
-	LibraryPath  string               `json:"library_path" binding:"required"`
-	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
-}
-
-// ITunesValidateResponse summarizes validation results for an iTunes library.
-type ITunesValidateResponse struct {
-	TotalTracks     int      `json:"total_tracks"`
-	AudiobookTracks int      `json:"audiobook_tracks"`
-	AudiobookCount  int      `json:"audiobook_count"`
-	FilesFound      int      `json:"files_found"`
-	FilesMissing    int      `json:"files_missing"`
-	MissingPaths    []string `json:"missing_paths,omitempty"`
-	PathPrefixes    []string `json:"path_prefixes,omitempty"`
-	DuplicateCount  int      `json:"duplicate_count"`
-	EstimatedTime   string   `json:"estimated_import_time"`
-}
-
-// ITunesImportRequest represents a request to import an iTunes library.
-type ITunesImportRequest struct {
-	LibraryPath      string               `json:"library_path" binding:"required"`
-	ImportMode       string               `json:"import_mode" binding:"required,oneof=organized import organize"`
-	PreserveLocation bool                 `json:"preserve_location"`
-	ImportPlaylists  bool                 `json:"import_playlists"`
-	SkipDuplicates   bool                 `json:"skip_duplicates"`
-	FetchMetadata    bool                 `json:"fetch_metadata"`
-	PathMappings     []itunes.PathMapping `json:"path_mappings,omitempty"`
-}
-
-// ITunesImportResponse acknowledges an iTunes import operation.
-type ITunesImportResponse struct {
-	OperationID string `json:"operation_id"`
-	Status      string `json:"status"`
-	Message     string `json:"message"`
-}
-
-// ITunesWriteBackRequest represents a write-back request for iTunes ITL updates.
-type ITunesWriteBackRequest struct {
-	LibraryPath  string               `json:"library_path"`
-	AudiobookIDs []string             `json:"audiobook_ids"`
-	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
-}
-
-// ITunesWriteBackResponse reports the result of an ITL write-back.
-type ITunesWriteBackResponse struct {
-	Success      bool   `json:"success"`
-	UpdatedCount int    `json:"updated_count"`
-	Message      string `json:"message"`
-}
-
-// ITunesBookMapping is a single book-to-iTunes-path mapping used in preview.
-//
-// Four path columns surface the full picture so users can see exactly what
-// is currently in iTunes vs what AO has on disk vs what AO would write back:
-//
-//   - ITunesPath               — what iTunes currently has, e.g. W:/foo/bar.m4b
-//   - ITunesPathTranslated     — local equivalent of ITunesPath after applying
-//     forward path mappings (so users can stat it)
-//   - AOPath                   — where AO has the file on disk (book.FilePath)
-//   - AOITunesTranslatedPath   — what AO will write into the iTunes ITL when
-//     write-back runs (ReverseRemapPath of AOPath)
-//
-// PathDiffers is true iff AOITunesTranslatedPath != ITunesPath — i.e. the
-// thing AO wants to write does not match what iTunes already has.
-//
-// Backwards compatibility: LocalPath is preserved as an alias of AOPath so
-// older clients keep working through the migration. Remove once no caller
-// reads it.
-type ITunesBookMapping struct {
-	BookID                 string `json:"book_id"`
-	Title                  string `json:"title"`
-	Author                 string `json:"author"`
-	ITunesPersistentID     string `json:"itunes_persistent_id"`
-	ITunesPath             string `json:"itunes_path,omitempty"`
-	ITunesPathTranslated   string `json:"itunes_path_translated,omitempty"`
-	AOPath                 string `json:"ao_path"`
-	AOITunesTranslatedPath string `json:"ao_itunes_translated_path,omitempty"`
-	PathDiffers            bool   `json:"path_differs,omitempty"`
-
-	// LocalPath duplicates AOPath for backwards compatibility with the
-	// previous response shape. Will be removed once no caller reads it.
-	LocalPath string `json:"local_path"`
-}
-
-// ITunesWriteBackPreviewRequest is the wire type for POST /itunes/write-back-preview.
-//
-// LibraryPath is now optional — when empty, the handler uses the configured
-// ITunesLibraryReadPath. The dialog used to require the user to type this
-// path on every preview, which was confusing because the actual write-back
-// always targets the configured ITunesLibraryWritePath (.itl) regardless.
-type ITunesWriteBackPreviewRequest struct {
-	LibraryPath string   `json:"library_path,omitempty"`
-	BookIDs     []string `json:"book_ids,omitempty"`
-}
-
-// ITunesWriteBackPreviewResponse is returned by POST /itunes/write-back-preview.
-type ITunesWriteBackPreviewResponse struct {
-	Items []ITunesBookMapping `json:"items"`
-	Total int                 `json:"total"`
-}
-
-// ITunesImportStatusResponse is returned by GET /itunes/import/:id.
-type ITunesImportStatusResponse struct {
-	OperationID string   `json:"operation_id"`
-	Status      string   `json:"status"`
-	Progress    int      `json:"progress"`
-	Message     string   `json:"message"`
-	TotalBooks  int      `json:"total_books"`
-	Processed   int      `json:"processed"`
-	Imported    int      `json:"imported"`
-	Skipped     int      `json:"skipped"`
-	Failed      int      `json:"failed"`
-	Errors      []string `json:"errors,omitempty"`
-}
-
-// ITunesTestMappingRequest tests a single path mapping against the library.
-type ITunesTestMappingRequest struct {
-	LibraryPath string `json:"library_path" binding:"required"`
-	From        string `json:"from" binding:"required"`
-	To          string `json:"to" binding:"required"`
-}
-
-// ITunesTestMappingResponse returns sample results from testing a mapping.
-type ITunesTestMappingResponse struct {
-	Tested   int                 `json:"tested"`
-	Found    int                 `json:"found"`
-	Examples []ITunesTestExample `json:"examples"`
-}
-
-// ITunesTestExample is a single found file example.
-type ITunesTestExample struct {
-	Title string `json:"title"`
-	Path  string `json:"path"`
-}
-
-// ITunesSyncRequest is the wire type for POST /itunes/sync.
-type ITunesSyncRequest struct {
-	LibraryPath  string               `json:"library_path,omitempty"`
-	PathMappings []itunes.PathMapping `json:"path_mappings,omitempty"`
-	Force        bool                 `json:"force,omitempty"`
-}
-
-// ITunesSyncResponse acknowledges a sync operation.
-type ITunesSyncResponse struct {
-	OperationID string `json:"operation_id"`
-	Message     string `json:"message"`
-}
-
 // --- handlers ---
 
 // handleITunesValidate validates an iTunes library without importing.
 func (s *Server) handleITunesValidate(c *gin.Context) {
-	var req ITunesValidateRequest
+	var req handlers.ITunesValidateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -217,7 +67,7 @@ func (s *Server) handleITunesValidate(c *gin.Context) {
 		return
 	}
 
-	httputil.RespondWithOK(c, ITunesValidateResponse{
+	httputil.RespondWithOK(c, handlers.ITunesValidateResponse{
 		TotalTracks:     resp.TotalTracks,
 		AudiobookTracks: resp.AudiobookTracks,
 		AudiobookCount:  resp.AudiobookCount,
@@ -232,7 +82,7 @@ func (s *Server) handleITunesValidate(c *gin.Context) {
 
 // handleITunesTestMapping tests a single path mapping against a few tracks.
 func (s *Server) handleITunesTestMapping(c *gin.Context) {
-	var req ITunesTestMappingRequest
+	var req handlers.ITunesTestMappingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -248,11 +98,11 @@ func (s *Server) handleITunesTestMapping(c *gin.Context) {
 		return
 	}
 
-	examples := make([]ITunesTestExample, len(resp.Examples))
+	examples := make([]handlers.ITunesTestExample, len(resp.Examples))
 	for i, e := range resp.Examples {
-		examples[i] = ITunesTestExample{Title: e.Title, Path: e.Path}
+		examples[i] = handlers.ITunesTestExample{Title: e.Title, Path: e.Path}
 	}
-	httputil.RespondWithOK(c, ITunesTestMappingResponse{
+	httputil.RespondWithOK(c, handlers.ITunesTestMappingResponse{
 		Tested:   resp.Tested,
 		Found:    resp.Found,
 		Examples: examples,
@@ -273,7 +123,7 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		return
 	}
 
-	var req ITunesImportRequest
+	var req handlers.ITunesImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -316,7 +166,7 @@ func (s *Server) handleITunesImport(c *gin.Context) {
 		return
 	}
 
-	httputil.RespondWithSuccess(c, http.StatusAccepted, ITunesImportResponse{
+	httputil.RespondWithSuccess(c, http.StatusAccepted, handlers.ITunesImportResponse{
 		OperationID: op.ID,
 		Status:      "queued",
 		Message:     "iTunes import operation queued",
@@ -330,7 +180,7 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 		return
 	}
 
-	var req ITunesWriteBackRequest
+	var req handlers.ITunesWriteBackRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -386,7 +236,7 @@ func (s *Server) handleITunesWriteBack(c *gin.Context) {
 	}
 
 	stdlog.Info("ITL write-back: updated tracks", "count", itlResult.UpdatedCount)
-	httputil.RespondWithOK(c, ITunesWriteBackResponse{
+	httputil.RespondWithOK(c, handlers.ITunesWriteBackResponse{
 		Success:      true,
 		UpdatedCount: itlResult.UpdatedCount,
 		Message:      fmt.Sprintf("Successfully updated %d audiobook locations in ITL", itlResult.UpdatedCount),
@@ -469,7 +319,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 		return
 	}
 
-	var req ITunesWriteBackPreviewRequest
+	var req handlers.ITunesWriteBackPreviewRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -552,7 +402,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 	// historical and not worth refactoring here.
 	forwardOpts := itunes.ImportOptions{PathMappings: previewMappings}
 
-	items := make([]ITunesBookMapping, 0, len(books))
+	items := make([]handlers.ITunesBookMapping, 0, len(books))
 	for _, book := range books {
 		persistentID := *book.ITunesPersistentID
 		itunesPath := itunesLocations[persistentID]
@@ -567,7 +417,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 		if itunesPath != "" {
 			itunesTranslated = forwardOpts.RemapPath(itunesPath)
 		}
-		items = append(items, ITunesBookMapping{
+		items = append(items, handlers.ITunesBookMapping{
 			BookID:                 book.ID,
 			Title:                  book.Title,
 			Author:                 author,
@@ -581,7 +431,7 @@ func (s *Server) handleITunesWriteBackPreview(c *gin.Context) {
 		})
 	}
 
-	httputil.RespondWithOK(c, ITunesWriteBackPreviewResponse{
+	httputil.RespondWithOK(c, handlers.ITunesWriteBackPreviewResponse{
 		Items: items,
 		Total: len(items),
 	})
@@ -635,7 +485,7 @@ func (s *Server) handleListITunesBooks(c *gin.Context) {
 		filtered = filtered[offset:end]
 	}
 
-	items := make([]ITunesBookMapping, 0, len(filtered))
+	items := make([]handlers.ITunesBookMapping, 0, len(filtered))
 	for _, book := range filtered {
 		author := ""
 		if book.AuthorID != nil {
@@ -643,7 +493,7 @@ func (s *Server) handleListITunesBooks(c *gin.Context) {
 				author = a.Name
 			}
 		}
-		items = append(items, ITunesBookMapping{
+		items = append(items, handlers.ITunesBookMapping{
 			BookID:             book.ID,
 			Title:              book.Title,
 			Author:             author,
@@ -678,7 +528,7 @@ func (s *Server) handleITunesImportStatus(c *gin.Context) {
 	progress := calculatePercent(op.Progress, op.Total)
 	snapshot := s.itunesSvc.Importer.GetStatus(op.ID)
 
-	httputil.RespondWithOK(c, ITunesImportStatusResponse{
+	httputil.RespondWithOK(c, handlers.ITunesImportStatusResponse{
 		OperationID: op.ID,
 		Status:      op.Status,
 		Progress:    progress,
@@ -711,7 +561,7 @@ func (s *Server) handleITunesImportStatusBulk(c *gin.Context) {
 
 	snapshots := s.itunesSvc.Importer.GetStatusBulk(req.IDs)
 
-	results := make(map[string]ITunesImportStatusResponse, len(req.IDs))
+	results := make(map[string]handlers.ITunesImportStatusResponse, len(req.IDs))
 	for _, opID := range req.IDs {
 		op, err := s.Store().GetOperationByID(opID)
 		if err != nil || op == nil {
@@ -722,7 +572,7 @@ func (s *Server) handleITunesImportStatusBulk(c *gin.Context) {
 		if snapshot == nil {
 			snapshot = &itunesservice.ImportStatusSnapshot{}
 		}
-		results[opID] = ITunesImportStatusResponse{
+		results[opID] = handlers.ITunesImportStatusResponse{
 			OperationID: op.ID,
 			Status:      op.Status,
 			Progress:    progress,
@@ -804,9 +654,9 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		return
 	}
 
-	var req ITunesSyncRequest
+	var req handlers.ITunesSyncRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		req = ITunesSyncRequest{}
+		req = handlers.ITunesSyncRequest{}
 	}
 
 	libraryPath := req.LibraryPath
@@ -864,7 +714,7 @@ func (s *Server) handleITunesSync(c *gin.Context) {
 		return
 	}
 
-	httputil.RespondWithSuccess(c, http.StatusAccepted, ITunesSyncResponse{
+	httputil.RespondWithSuccess(c, http.StatusAccepted, handlers.ITunesSyncResponse{
 		OperationID: op.ID,
 		Message:     "iTunes sync operation queued",
 	})

--- a/internal/server/metadata_handlers.go
+++ b/internal/server/metadata_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_handlers.go
-// version: 3.7.4
+// version: 3.8.0
 // guid: 0299d0b0-b697-4386-a1ca-47c8bcc390de
-// last-edited: 2026-05-19
+// last-edited: 2026-06-01
 //
 // Metadata HTTP handlers split out of server.go: per-book fetch/
 // search/apply/revert/no-match, bulk fetch and bulk writeback, the
@@ -38,6 +38,7 @@ import (
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
 	"github.com/jdfalk/audiobook-organizer/internal/plugin"
 	"github.com/jdfalk/audiobook-organizer/internal/policy"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -1100,6 +1101,10 @@ func (s *Server) runBulkMetadataFetchAll(
 
 // registryProgressAdapter bridges registry.Reporter → operations.ProgressReporter
 // so runBulkMetadataFetchAll can be called from a v2 op Run function without changes.
+//
+// TODO(ADR-003 Phase 2): registryProgressAdapter cannot move to internal/server/handlers
+// because it has methods and is used across 20+ *_ops.go files in internal/server.
+// Extract it to internal/operations/registry or a dedicated adapter package in Phase 2.
 type registryProgressAdapter struct{ r opsregistry.Reporter }
 
 func (a registryProgressAdapter) UpdateProgress(current, total int, message string) error {
@@ -1123,16 +1128,8 @@ func (a registryProgressAdapter) Log(level, message string, details *string) err
 }
 func (a registryProgressAdapter) IsCanceled() bool { return a.r.IsCanceled() }
 
-// bulkMetadataFetchV2Params is the JSON params for the v2 bulk_metadata_fetch op.
-// Selection replaces the old BookIDs field: the client sends either
-//   - book_ids: an explicit list of IDs (page-level selection), or
-//   - filter: a FilterSpec that the server resolves to IDs at run time
-//     with IsPrimaryVersion=true always applied.
-type bulkMetadataFetchV2Params struct {
-	Selection     operations.SelectionSpec `json:"selection"`
-	PreferAudible bool                     `json:"prefer_audible"`
-	SkipCached    bool                     `json:"skip_cached"`
-}
+// bulkMetadataFetchV2Params aliases the canonical type from internal/server/handlers.
+type bulkMetadataFetchV2Params = handlers.BulkMetadataFetchV2Params
 
 // resolveFilterToBookIDs translates a FilterSpec into a concrete list of primary-
 // version book IDs.  IsPrimaryVersion=true and quarantine exclusion are always
@@ -1843,15 +1840,8 @@ func (s *Server) getMetadataFields(c *gin.Context) {
 	})
 }
 
-// ratingPatchRequest is the JSON body for PATCH /api/v1/audiobooks/:id/rating.
-// Each field is a json.RawMessage so the handler can distinguish null (clear)
-// from absent (don't touch) from a numeric value.
-type ratingPatchRequest struct {
-	Overall     json.RawMessage `json:"overall"`
-	Story       json.RawMessage `json:"story"`
-	Performance json.RawMessage `json:"performance"`
-	Notes       json.RawMessage `json:"notes"`
-}
+// ratingPatchRequest aliases the canonical type from internal/server/handlers.
+type ratingPatchRequest = handlers.RatingPatchRequest
 
 // parseOptionalRating decodes a json.RawMessage into a *float64 and a clear flag.
 // Returns (nil, false, nil) if raw is empty (field omitted).

--- a/internal/server/operations_handlers.go
+++ b/internal/server/operations_handlers.go
@@ -1,6 +1,7 @@
 // file: internal/server/operations_handlers.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: 9326aa39-ca40-4db3-a3be-7e76e6e2a23f
+// last-edited: 2026-06-01
 //
 // Background-operation HTTP handlers split out of server.go: the
 // long-running scan / organize / transcode starters, generic
@@ -24,6 +25,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/scheduler"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	"github.com/jdfalk/audiobook-organizer/internal/sweep"
 )
 
@@ -711,15 +713,9 @@ func calculateNextWindowRun(startHour int) string {
 	return next.Format(time.RFC3339)
 }
 
-type maintenanceWindowConfigReq struct {
-	Enabled     bool `json:"enabled"`
-	WindowStart int  `json:"window_start"`
-	WindowEnd   int  `json:"window_end"`
-}
-
 // updateMaintenanceWindowConfig persists maintenance window schedule settings.
 func (s *Server) updateMaintenanceWindowConfig(c *gin.Context) {
-	var req maintenanceWindowConfigReq
+	var req handlers.MaintenanceWindowConfigReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return

--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/operations_v2_handlers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-05-08
+// last-edited: 2026-06-01
 
 // UOS-06: SSE event hub, /operations/timeline, single-op introspection,
 // cancel, trigger-op, and /op-defs endpoints.
@@ -18,55 +18,8 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	opsregistry "github.com/jdfalk/audiobook-organizer/internal/operations/registry"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 )
-
-// operationV2Response is the JSON shape returned by the timeline and single-op
-// endpoints. It mirrors the TypeScript OperationV2 interface in api.ts.
-type operationV2Response struct {
-	ID              string     `json:"id"`
-	DefID           string     `json:"def_id"`
-	Plugin          string     `json:"plugin"`
-	DisplayName     string     `json:"display_name"`
-	Status          string     `json:"status"`
-	Priority        int        `json:"priority"`
-	NotifyLevel     int        `json:"notify_level"`
-	ProgressCurrent *int       `json:"progress_current"`
-	ProgressTotal   *int       `json:"progress_total"`
-	ProgressMessage *string    `json:"progress_message"`
-	CurrentPhase    *string    `json:"current_phase"`
-	CurrentItem     *string    `json:"current_item"`
-	ActorUserID     *string    `json:"actor_user_id"`
-	ParentID        *string    `json:"parent_id"`
-	QueuedAt        time.Time  `json:"queued_at"`
-	StartedAt       *time.Time `json:"started_at"`
-	CompletedAt     *time.Time `json:"completed_at"`
-	ErrorMessage    *string    `json:"error_message"`
-	ResumeCount     int        `json:"resume_count"`
-	TraceID         string     `json:"trace_id"`
-	SpanID          string     `json:"span_id"`
-}
-
-// opLogV2Response is the JSON shape for a single log line.
-type opLogV2Response struct {
-	OperationID string    `json:"operation_id"`
-	Level       string    `json:"level"`
-	Message     string    `json:"message"`
-	Attrs       any       `json:"attrs"`
-	CreatedAt   time.Time `json:"created_at"`
-}
-
-// opDefResponse is the JSON shape returned by /op-defs.
-type opDefResponse struct {
-	ID           string   `json:"id"`
-	Plugin       string   `json:"plugin"`
-	DisplayName  string   `json:"display_name"`
-	Description  string   `json:"description"`
-	Cancellable  bool     `json:"cancellable"`
-	Isolate      bool     `json:"isolate"`
-	ResumePolicy string   `json:"resume_policy"`
-	Triggers     []string `json:"triggers"`
-	DependsOn    []string `json:"depends_on"`
-}
 
 // handleGetOperationTimeline implements GET /api/v1/operations/timeline?since=15m.
 // It reads operations from the v2 store that were queued within the given window.
@@ -80,7 +33,7 @@ func (s *Server) handleGetOperationTimeline(c *gin.Context) {
 
 	store := s.opsV2Store()
 	if store == nil {
-		httputil.RespondWithOK(c, gin.H{"operations": []operationV2Response{}})
+		httputil.RespondWithOK(c, gin.H{"operations": []handlers.OperationV2Response{}})
 		return
 	}
 
@@ -91,7 +44,7 @@ func (s *Server) handleGetOperationTimeline(c *gin.Context) {
 		return
 	}
 
-	resp := make([]operationV2Response, 0, len(rows))
+	resp := make([]handlers.OperationV2Response, 0, len(rows))
 	for _, r := range rows {
 		item := rowToResponse(r, s.displayNameFor(r.DefID), s.notifyLevelFor(r.DefID))
 		if r.Status == "running" && s.opRegistry != nil {
@@ -126,7 +79,7 @@ func (s *Server) handleGetOperationV2(c *gin.Context) {
 		logs = nil
 	}
 
-	logResp := make([]opLogV2Response, 0, len(logs))
+	logResp := make([]handlers.OpLogV2Response, 0, len(logs))
 	for _, l := range logs {
 		logResp = append(logResp, logRowToResponse(l))
 	}
@@ -188,11 +141,11 @@ func (s *Server) handleTriggerOperationV2(c *gin.Context) {
 // Returns the set of registered OperationDefs.
 func (s *Server) handleListOpDefs(c *gin.Context) {
 	if s.opRegistry == nil {
-		httputil.RespondWithOK(c, gin.H{"defs": []opDefResponse{}})
+		httputil.RespondWithOK(c, gin.H{"defs": []handlers.OpDefResponse{}})
 		return
 	}
 	defs := s.opRegistry.ActiveDefs()
-	resp := make([]opDefResponse, 0, len(defs))
+	resp := make([]handlers.OpDefResponse, 0, len(defs))
 	for _, d := range defs {
 		resp = append(resp, defToResponse(d))
 	}
@@ -302,8 +255,8 @@ func (s *Server) notifyLevelFor(defID string) int {
 }
 
 // rowToResponse converts a database.OperationV2Row to the HTTP response shape.
-func rowToResponse(r database.OperationV2Row, displayName string, notifyLevel int) operationV2Response {
-	resp := operationV2Response{
+func rowToResponse(r database.OperationV2Row, displayName string, notifyLevel int) handlers.OperationV2Response {
+	resp := handlers.OperationV2Response{
 		ID:           r.ID,
 		DefID:        r.DefID,
 		Plugin:       r.Plugin,
@@ -334,7 +287,7 @@ func rowToResponse(r database.OperationV2Row, displayName string, notifyLevel in
 }
 
 // logRowToResponse converts a database.OpLogV2Row to the HTTP response shape.
-func logRowToResponse(l database.OpLogV2Row) opLogV2Response {
+func logRowToResponse(l database.OpLogV2Row) handlers.OpLogV2Response {
 	var attrsAny any
 	if l.Attrs != "" && l.Attrs != "{}" {
 		var m map[string]any
@@ -346,7 +299,7 @@ func logRowToResponse(l database.OpLogV2Row) opLogV2Response {
 	} else {
 		attrsAny = map[string]any{}
 	}
-	return opLogV2Response{
+	return handlers.OpLogV2Response{
 		OperationID: l.OperationID,
 		Level:       l.Level,
 		Message:     l.Message,
@@ -356,7 +309,7 @@ func logRowToResponse(l database.OpLogV2Row) opLogV2Response {
 }
 
 // defToResponse converts a registry.OperationDef to the HTTP response shape.
-func defToResponse(d opsregistry.OperationDef) opDefResponse {
+func defToResponse(d opsregistry.OperationDef) handlers.OpDefResponse {
 	triggers := make([]string, 0, len(d.Triggers))
 	for _, t := range d.Triggers {
 		triggers = append(triggers, t.EventName)
@@ -376,7 +329,7 @@ func defToResponse(d opsregistry.OperationDef) opDefResponse {
 		rp = "ask"
 	}
 
-	return opDefResponse{
+	return handlers.OpDefResponse{
 		ID:           d.ID,
 		Plugin:       d.Plugin,
 		DisplayName:  d.DisplayName,

--- a/internal/server/playlist_handlers.go
+++ b/internal/server/playlist_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/playlist_handlers.go
-// version: 2.2.0
-// last-edited: 2026-05-11
+// version: 2.3.0
+// last-edited: 2026-06-01
 // guid: 7a3d5f2e-8c4b-4a70-b8c5-3d7e0f1b9a79
 //
 // HTTP endpoints for user-created playlists (spec 3.4 task 3).
@@ -26,41 +26,12 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
 	"github.com/jdfalk/audiobook-organizer/internal/playlist"
 	"github.com/jdfalk/audiobook-organizer/internal/search"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 )
-
-// playlistCreateReq is the payload for POST /api/v1/playlists.
-type playlistCreateReq struct {
-	Name        string   `json:"name" binding:"required"`
-	Description string   `json:"description,omitempty"`
-	Type        string   `json:"type" binding:"required"` // static|smart
-	BookIDs     []string `json:"book_ids,omitempty"`
-	Query       string   `json:"query,omitempty"`
-	SortJSON    string   `json:"sort_json,omitempty"`
-	Limit       int      `json:"limit,omitempty"`
-}
-
-// playlistUpdateReq mirrors playlistCreateReq but all fields are
-// optional — only set ones are applied.
-type playlistUpdateReq struct {
-	Name        *string   `json:"name,omitempty"`
-	Description *string   `json:"description,omitempty"`
-	BookIDs     *[]string `json:"book_ids,omitempty"`
-	Query       *string   `json:"query,omitempty"`
-	SortJSON    *string   `json:"sort_json,omitempty"`
-	Limit       *int      `json:"limit,omitempty"`
-}
-
-type playlistBooksAddReq struct {
-	BookIDs []string `json:"book_ids" binding:"required"`
-}
-
-type playlistReorderReq struct {
-	BookIDs []string `json:"book_ids" binding:"required"`
-}
 
 // handleCreatePlaylist — POST /api/v1/playlists
 func (s *Server) handleCreatePlaylist(c *gin.Context) {
-	var req playlistCreateReq
+	var req handlers.PlaylistCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -172,7 +143,7 @@ func (s *Server) handleUpdatePlaylist(c *gin.Context) {
 		return
 	}
 
-	var req playlistUpdateReq
+	var req handlers.PlaylistUpdateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -230,7 +201,7 @@ func (s *Server) handleDeletePlaylist(c *gin.Context) {
 // existing entries. No-op on smart playlists.
 func (s *Server) handleAddBooksToPlaylist(c *gin.Context) {
 	id := c.Param("id")
-	var req playlistBooksAddReq
+	var req handlers.PlaylistBooksAddReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -304,7 +275,7 @@ func (s *Server) handleRemoveBookFromPlaylist(c *gin.Context) {
 // books (use add/remove endpoints for that).
 func (s *Server) handleReorderPlaylist(c *gin.Context) {
 	id := c.Param("id")
-	var req playlistReorderReq
+	var req handlers.PlaylistReorderReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -391,8 +362,8 @@ func (s *Server) handleMaterializePlaylist(c *gin.Context) {
 }
 
 // validatePlaylistCreate checks required fields and type-specific
-// shape of a playlistCreateReq.
-func validatePlaylistCreate(req *playlistCreateReq) error {
+// shape of a handlers.PlaylistCreateReq.
+func validatePlaylistCreate(req *handlers.PlaylistCreateReq) error {
 	if strings.TrimSpace(req.Name) == "" {
 		return fmt.Errorf("name is required")
 	}

--- a/internal/server/reading_handlers.go
+++ b/internal/server/reading_handlers.go
@@ -1,6 +1,6 @@
 // file: internal/server/reading_handlers.go
-// version: 1.2.1
-// last-edited: 2026-05-10
+// version: 1.3.0
+// last-edited: 2026-06-01
 // guid: 7f2c4a1d-5b8e-4f70-a9d6-2e8c0f1b9a57
 //
 // HTTP endpoints for the per-user read/unread tracking system
@@ -20,6 +20,7 @@ import (
 	"github.com/jdfalk/audiobook-organizer/internal/auth"
 	"github.com/jdfalk/audiobook-organizer/internal/database"
 	"github.com/jdfalk/audiobook-organizer/internal/httputil"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
 	svrmw "github.com/jdfalk/audiobook-organizer/internal/server/middleware"
 )
 
@@ -45,11 +46,6 @@ func callingUserID(c *gin.Context) string {
 	return "_local"
 }
 
-type setPositionRequest struct {
-	SegmentID       string  `json:"segment_id" binding:"required"`
-	PositionSeconds float64 `json:"position_seconds"`
-}
-
 // handleSetPosition records one position heartbeat and recomputes
 // derived UserBookState. POST /api/v1/books/:id/position
 func (s *Server) handleSetPosition(c *gin.Context) {
@@ -58,7 +54,7 @@ func (s *Server) handleSetPosition(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "book id required")
 		return
 	}
-	var req setPositionRequest
+	var req handlers.SetPositionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
@@ -109,10 +105,6 @@ func (s *Server) handleGetBookState(c *gin.Context) {
 	httputil.RespondWithOK(c, state)
 }
 
-type patchStatusRequest struct {
-	Status string `json:"status" binding:"required"`
-}
-
 // handleSetBookStatus sets a manual status override. User-forced
 // status takes precedence over auto-derived in future recomputes.
 // PATCH /api/v1/books/:id/status
@@ -122,7 +114,7 @@ func (s *Server) handleSetBookStatus(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "book id required")
 		return
 	}
-	var req patchStatusRequest
+	var req handlers.PatchStatusRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return


### PR DESCRIPTION
## Summary
- Creates `internal/server/handlers/` sub-package for HTTP request/response type definitions
- Moves 34 struct types from `*_handlers.go` files into the new package (9 new files)
- Handler implementations (`func (s *Server) ...`) remain in `internal/server/` for Phase 2
- All 9 source handler files updated to reference `handlers.Foo` directly (no aliases)
- `registryProgressAdapter` left in place with a Phase 2 TODO — it has methods and multi-file usage

## Why
ADR-003 Phase 1: separates API contract types from handler implementation. The new package can be imported by tests and tooling without constructing a full `Server`.

## Test plan
- [x] `make build-api` passes
- [x] `go test ./internal/server/...` passes (pre-existing pebble flake unrelated)
- [x] `grep -r "type.*= handlers\." internal/server/` returns only the 2 in-scope exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)