### PR TITLE
fix(security): playlist IDOR ownership checks + stop leaking session token in auth bodies

### DIFF
--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 // last-edited: 2026-05-16
 
@@ -212,6 +212,10 @@ type UserPlaylistStore interface {
 	GetUserPlaylistByName(name string) (*UserPlaylist, error)
 	GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error)
 	ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error)
+	// ListUserPlaylistsForUser returns only playlists created by userID. Used by
+	// the API to scope list results per user (prevents cross-user disclosure).
+	// An empty userID matches playlists with an empty CreatedByUserID.
+	ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]UserPlaylist, int, error)
 	UpdateUserPlaylist(pl *UserPlaylist) error
 	DeleteUserPlaylist(id string) error
 	ListDirtyUserPlaylists() ([]UserPlaylist, error)

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.55.0
+// version: 1.56.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-05-16
 
@@ -239,6 +239,7 @@ type MockStore struct {
 	GetUserPlaylistByNameFunc      func(name string) (*UserPlaylist, error)
 	GetUserPlaylistByITunesPIDFunc func(pid string) (*UserPlaylist, error)
 	ListUserPlaylistsFunc          func(playlistType string, limit, offset int) ([]UserPlaylist, int, error)
+	ListUserPlaylistsForUserFunc   func(userID, playlistType string, limit, offset int) ([]UserPlaylist, int, error)
 	UpdateUserPlaylistFunc         func(pl *UserPlaylist) error
 	DeleteUserPlaylistFunc         func(id string) error
 	ListDirtyUserPlaylistsFunc     func() ([]UserPlaylist, error)
@@ -1504,6 +1505,13 @@ func (m *MockStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, error
 func (m *MockStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
 	if m.ListUserPlaylistsFunc != nil {
 		return m.ListUserPlaylistsFunc(playlistType, limit, offset)
+	}
+	return nil, 0, nil
+}
+
+func (m *MockStore) ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	if m.ListUserPlaylistsForUserFunc != nil {
+		return m.ListUserPlaylistsForUserFunc(userID, playlistType, limit, offset)
 	}
 	return nil, 0, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -16216,6 +16216,92 @@ func (_c *MockUserPlaylistStore_ListUserPlaylists_Call) RunAndReturn(run func(pl
 	return _c
 }
 
+// ListUserPlaylistsForUser provides a mock function for the type MockUserPlaylistStore
+func (_mock *MockUserPlaylistStore) ListUserPlaylistsForUser(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error) {
+	ret := _mock.Called(userID, playlistType, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListUserPlaylistsForUser")
+	}
+
+	var r0 []database.UserPlaylist
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) ([]database.UserPlaylist, int, error)); ok {
+		return returnFunc(userID, playlistType, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) []database.UserPlaylist); ok {
+		r0 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, int, int) int); ok {
+		r1 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(string, string, int, int) error); ok {
+		r2 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockUserPlaylistStore_ListUserPlaylistsForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserPlaylistsForUser'
+type MockUserPlaylistStore_ListUserPlaylistsForUser_Call struct {
+	*mock.Call
+}
+
+// ListUserPlaylistsForUser is a helper method to define mock.On call
+//   - userID string
+//   - playlistType string
+//   - limit int
+//   - offset int
+func (_e *MockUserPlaylistStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
+	return &MockUserPlaylistStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
+}
+
+func (_c *MockUserPlaylistStore_ListUserPlaylistsForUser_Call) Run(run func(userID string, playlistType string, limit int, offset int)) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserPlaylistStore_ListUserPlaylistsForUser_Call) Return(userPlaylists []database.UserPlaylist, n int, err error) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Return(userPlaylists, n, err)
+	return _c
+}
+
+func (_c *MockUserPlaylistStore_ListUserPlaylistsForUser_Call) RunAndReturn(run func(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error)) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUserPlaylist provides a mock function for the type MockUserPlaylistStore
 func (_mock *MockUserPlaylistStore) UpdateUserPlaylist(pl *database.UserPlaylist) error {
 	ret := _mock.Called(pl)
@@ -41725,6 +41811,92 @@ func (_c *MockStore_ListUserPlaylists_Call) Return(userPlaylists []database.User
 }
 
 func (_c *MockStore_ListUserPlaylists_Call) RunAndReturn(run func(playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error)) *MockStore_ListUserPlaylists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListUserPlaylistsForUser provides a mock function for the type MockStore
+func (_mock *MockStore) ListUserPlaylistsForUser(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error) {
+	ret := _mock.Called(userID, playlistType, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListUserPlaylistsForUser")
+	}
+
+	var r0 []database.UserPlaylist
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) ([]database.UserPlaylist, int, error)); ok {
+		return returnFunc(userID, playlistType, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) []database.UserPlaylist); ok {
+		r0 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, int, int) int); ok {
+		r1 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(string, string, int, int) error); ok {
+		r2 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockStore_ListUserPlaylistsForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserPlaylistsForUser'
+type MockStore_ListUserPlaylistsForUser_Call struct {
+	*mock.Call
+}
+
+// ListUserPlaylistsForUser is a helper method to define mock.On call
+//   - userID string
+//   - playlistType string
+//   - limit int
+//   - offset int
+func (_e *MockStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockStore_ListUserPlaylistsForUser_Call {
+	return &MockStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
+}
+
+func (_c *MockStore_ListUserPlaylistsForUser_Call) Run(run func(userID string, playlistType string, limit int, offset int)) *MockStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListUserPlaylistsForUser_Call) Return(userPlaylists []database.UserPlaylist, n int, err error) *MockStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Return(userPlaylists, n, err)
+	return _c
+}
+
+func (_c *MockStore_ListUserPlaylistsForUser_Call) RunAndReturn(run func(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error)) *MockStore_ListUserPlaylistsForUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -4933,7 +4933,11 @@ func (p *PebbleStore) listUserPlaylists(playlistType, userFilter string, matchUs
 		if playlistType != "" && pl.Type != playlistType {
 			continue
 		}
-		if matchUser && pl.CreatedByUserID != userFilter {
+		// When scoping to a user, include that user's playlists AND legacy
+		// unowned rows (empty CreatedByUserID, e.g. pre-ownership iTunes
+		// imports) so the refactor doesn't hide pre-existing data. This mirrors
+		// the handler's ownedByCaller semantics.
+		if matchUser && pl.CreatedByUserID != "" && pl.CreatedByUserID != userFilter {
 			continue
 		}
 		all = append(all, pl)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.81.0
+// version: 1.82.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-05-24
 
@@ -4904,6 +4904,18 @@ func (p *PebbleStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, err
 }
 
 func (p *PebbleStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	// matchUser=false → all users.
+	return p.listUserPlaylists(playlistType, "", false, limit, offset)
+}
+
+// ListUserPlaylistsForUser returns only playlists created by userID.
+func (p *PebbleStore) ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	return p.listUserPlaylists(playlistType, userID, true, limit, offset)
+}
+
+// listUserPlaylists scans all user playlists, optionally filtering by type and
+// (when matchUser is true) by CreatedByUserID == userFilter, then paginates.
+func (p *PebbleStore) listUserPlaylists(playlistType, userFilter string, matchUser bool, limit, offset int) ([]UserPlaylist, int, error) {
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("upl:"),
 		UpperBound: []byte("upl:~"),
@@ -4919,6 +4931,9 @@ func (p *PebbleStore) ListUserPlaylists(playlistType string, limit, offset int) 
 			continue
 		}
 		if playlistType != "" && pl.Type != playlistType {
+			continue
+		}
+		if matchUser && pl.CreatedByUserID != userFilter {
 			continue
 		}
 		all = append(all, pl)

--- a/internal/database/sqlite_store_users.go
+++ b/internal/database/sqlite_store_users.go
@@ -1,5 +1,5 @@
 // file: internal/database/sqlite_store_users.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-g34567890123
 // last-edited: 2026-05-01
 
@@ -243,6 +243,9 @@ func (s *SQLiteStore) GetUserPlaylistByITunesPID(pid string) (*UserPlaylist, err
 	return nil, nil
 }
 func (s *SQLiteStore) ListUserPlaylists(playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
+	return nil, 0, nil
+}
+func (s *SQLiteStore) ListUserPlaylistsForUser(userID, playlistType string, limit, offset int) ([]UserPlaylist, int, error) {
 	return nil, 0, nil
 }
 func (s *SQLiteStore) UpdateUserPlaylist(pl *UserPlaylist) error       { return nil }

--- a/internal/itunes/service/playlist_sync.go
+++ b/internal/itunes/service/playlist_sync.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/playlist_sync.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 1e9f0a8b-2c3d-4a70-b8c5-3d7e0f1b9a99
 //
 // iTunes playlist sync (spec 3.4 tasks 5-6).
@@ -87,6 +87,10 @@ func (p *PlaylistSync) MigrateSmartPlaylists(lib *itunes.ITLLibrary) (imported, 
 			ITunesPersistentID:   pid,
 			ITunesRawCriteriaB64: rawB64,
 			Description:          fmt.Sprintf("Imported from iTunes smart playlist %q", pl.Title),
+			// Stamp ownership so the API's per-user playlist isolation does not
+			// hide iTunes-imported playlists. The sync worker runs as the local
+			// admin identity (no per-request user context).
+			CreatedByUserID: adminUserID,
 		})
 		if err != nil {
 			slog.Warn("create playlist", "pl", pl.Title, "err", err)

--- a/internal/server/auth_accept_invite.go
+++ b/internal/server/auth_accept_invite.go
@@ -1,5 +1,5 @@
 // file: internal/server/auth_accept_invite.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
 // last-edited: 2026-06-02
 
@@ -53,5 +53,7 @@ func (s *Server) handleAcceptInvite(c *gin.Context) {
 	}
 
 	handlers.SetSessionCookie(c, sess.ID, sess.ExpiresAt)
-	httputil.RespondWithCreated(c, gin.H{"user": user, "session": sess})
+	// Session token is delivered via the HttpOnly cookie only — never in the
+	// JSON body (would expose the bearer token to page JS, defeating HttpOnly).
+	httputil.RespondWithCreated(c, gin.H{"user": user, "expires_at": sess.ExpiresAt})
 }

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/auth.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
 // last-edited: 2026-06-01
 
@@ -279,9 +279,13 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 	setSessionCookie(c, session.ID, session.ExpiresAt)
+	// The session token lives only in the HttpOnly cookie set above. Do NOT
+	// return session.ID in the JSON body — that would expose the bearer token
+	// to page JavaScript and defeat the HttpOnly protection against XSS theft.
+	// Expose non-authenticating metadata only (expiry) for UI display.
 	httputil.RespondWithOK(c, gin.H{
-		"user":    buildAuthUserResponse(user),
-		"session": session,
+		"user":       buildAuthUserResponse(user),
+		"expires_at": session.ExpiresAt,
 	})
 }
 

--- a/internal/server/handlers/auth_test.go
+++ b/internal/server/handlers/auth_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/auth_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d5e6f7a8-b9c0-1234-5678-90abcdef0123
 // last-edited: 2026-06-01
 
@@ -133,7 +133,9 @@ func TestAuthHandler_Login_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	data := resp["data"].(map[string]any)
 	assert.NotNil(t, data["user"])
-	assert.NotNil(t, data["session"])
+	// Session token must NOT be exposed in the body (HttpOnly cookie only).
+	assert.Nil(t, data["session"])
+	assert.NotNil(t, data["expires_at"])
 }
 
 func TestAuthHandler_Login_WrongPassword(t *testing.T) {

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -2592,6 +2592,92 @@ func (_c *MockPlaylistStore_ListUserPlaylists_Call) RunAndReturn(run func(playli
 	return _c
 }
 
+// ListUserPlaylistsForUser provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) ListUserPlaylistsForUser(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error) {
+	ret := _mock.Called(userID, playlistType, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListUserPlaylistsForUser")
+	}
+
+	var r0 []database.UserPlaylist
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) ([]database.UserPlaylist, int, error)); ok {
+		return returnFunc(userID, playlistType, limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, int, int) []database.UserPlaylist); ok {
+		r0 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.UserPlaylist)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, int, int) int); ok {
+		r1 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(string, string, int, int) error); ok {
+		r2 = returnFunc(userID, playlistType, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockPlaylistStore_ListUserPlaylistsForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserPlaylistsForUser'
+type MockPlaylistStore_ListUserPlaylistsForUser_Call struct {
+	*mock.Call
+}
+
+// ListUserPlaylistsForUser is a helper method to define mock.On call
+//   - userID string
+//   - playlistType string
+//   - limit int
+//   - offset int
+func (_e *MockPlaylistStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
+	return &MockPlaylistStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
+}
+
+func (_c *MockPlaylistStore_ListUserPlaylistsForUser_Call) Run(run func(userID string, playlistType string, limit int, offset int)) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_ListUserPlaylistsForUser_Call) Return(userPlaylists []database.UserPlaylist, n int, err error) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Return(userPlaylists, n, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_ListUserPlaylistsForUser_Call) RunAndReturn(run func(userID string, playlistType string, limit int, offset int) ([]database.UserPlaylist, int, error)) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListUserPositionsForBook provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) ListUserPositionsForBook(userID string, bookID string) ([]database.UserPosition, error) {
 	ret := _mock.Called(userID, bookID)

--- a/internal/server/handlers/playlists.go
+++ b/internal/server/handlers/playlists.go
@@ -92,13 +92,24 @@ func NewPlaylistHandlerWithGetter(store PlaylistStore, indexFn func() *search.Bl
 	return &PlaylistHandler{store: store, indexFn: indexFn}
 }
 
-// ownedByCaller reports whether pl belongs to the calling user. Playlists are
-// per-user; without this check any authenticated user could read or mutate
+// ownedByCaller reports whether pl is accessible to the calling user. Playlists
+// are per-user; without this check any authenticated user could read or mutate
 // another user's playlist by guessing its ID (IDOR). A nil playlist is treated
 // as not-owned. Callers respond 404 (not 403) on failure so the existence of
 // another user's playlist is not disclosed.
+//
+// A playlist with an empty CreatedByUserID is treated as legacy/unowned and is
+// accessible to any caller. Such rows predate ownership tracking (e.g. iTunes
+// smart-playlist imports created before this field was stamped); refusing them
+// would silently hide pre-existing data. New playlists always carry an owner.
 func ownedByCaller(c *gin.Context, pl *database.UserPlaylist) bool {
-	return pl != nil && pl.CreatedByUserID == CallingUserID(c)
+	if pl == nil {
+		return false
+	}
+	if pl.CreatedByUserID == "" {
+		return true
+	}
+	return pl.CreatedByUserID == CallingUserID(c)
 }
 
 // -----------------------------------------------------------------------

--- a/internal/server/handlers/playlists.go
+++ b/internal/server/handlers/playlists.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/playlists.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a7b8c9d0-e1f2-3456-abcd-456789012345
 // last-edited: 2026-06-02
 
@@ -92,6 +92,15 @@ func NewPlaylistHandlerWithGetter(store PlaylistStore, indexFn func() *search.Bl
 	return &PlaylistHandler{store: store, indexFn: indexFn}
 }
 
+// ownedByCaller reports whether pl belongs to the calling user. Playlists are
+// per-user; without this check any authenticated user could read or mutate
+// another user's playlist by guessing its ID (IDOR). A nil playlist is treated
+// as not-owned. Callers respond 404 (not 403) on failure so the existence of
+// another user's playlist is not disclosed.
+func ownedByCaller(c *gin.Context, pl *database.UserPlaylist) bool {
+	return pl != nil && pl.CreatedByUserID == CallingUserID(c)
+}
+
 // -----------------------------------------------------------------------
 // HTTP handlers
 // -----------------------------------------------------------------------
@@ -141,7 +150,8 @@ func (h *PlaylistHandler) ListPlaylists(c *gin.Context) {
 		return
 	}
 	p := httputil.ParsePaginationParams(c)
-	lists, total, err := h.store.ListUserPlaylists(plType, p.Limit, p.Offset)
+	// Scope to the calling user — a user must not see another user's playlists.
+	lists, total, err := h.store.ListUserPlaylistsForUser(CallingUserID(c), plType, p.Limit, p.Offset)
 	if err != nil {
 		httputil.InternalError(c, "failed to list playlists", err)
 		return
@@ -162,6 +172,11 @@ func (h *PlaylistHandler) GetPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
+
+	if !ownedByCaller(c, pl) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}
@@ -206,6 +221,10 @@ func (h *PlaylistHandler) UpdatePlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
+	if !ownedByCaller(c, pl) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}
@@ -256,6 +275,17 @@ func (h *PlaylistHandler) UpdatePlaylist(c *gin.Context) {
 // DeletePlaylist — DELETE /api/v1/playlists/:id
 func (h *PlaylistHandler) DeletePlaylist(c *gin.Context) {
 	id := c.Param("id")
+	// Load first to enforce ownership — without this any user could delete
+	// another user's playlist by ID (IDOR).
+	pl, err := h.store.GetUserPlaylist(id)
+	if err != nil {
+		httputil.InternalError(c, "failed to load playlist", err)
+		return
+	}
+	if !ownedByCaller(c, pl) {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
 	if err := h.store.DeleteUserPlaylist(id); err != nil {
 		httputil.InternalError(c, "failed to delete playlist", err)
 		return
@@ -279,6 +309,10 @@ func (h *PlaylistHandler) AddBooksToPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
+	if !ownedByCaller(c, pl) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}
@@ -315,6 +349,10 @@ func (h *PlaylistHandler) RemoveBookFromPlaylist(c *gin.Context) {
 		return
 	}
 	if pl == nil {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
+	if !ownedByCaller(c, pl) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}
@@ -356,6 +394,10 @@ func (h *PlaylistHandler) ReorderPlaylist(c *gin.Context) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}
+	if !ownedByCaller(c, pl) {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
 	if pl.Type != database.UserPlaylistTypeStatic {
 		httputil.RespondWithBadRequest(c, "cannot reorder smart playlist")
 		return
@@ -384,6 +426,10 @@ func (h *PlaylistHandler) MaterializePlaylist(c *gin.Context) {
 		return
 	}
 	if src == nil {
+		httputil.RespondWithNotFound(c, "playlist", id)
+		return
+	}
+	if !ownedByCaller(c, src) {
 		httputil.RespondWithNotFound(c, "playlist", id)
 		return
 	}

--- a/internal/server/handlers/playlists_test.go
+++ b/internal/server/handlers/playlists_test.go
@@ -1,0 +1,116 @@
+// file: internal/server/handlers/playlists_test.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-cdef-1234567890ab
+// last-edited: 2026-06-03
+
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jdfalk/audiobook-organizer/internal/database"
+	"github.com/jdfalk/audiobook-organizer/internal/server/handlers"
+	handlersmocks "github.com/jdfalk/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// newPlaylistCtxAs builds a gin context whose CallingUserID resolves to userID
+// (via the "auth_user" context key read by servermiddleware.CurrentUser).
+func newPlaylistCtxAs(method, path, userID string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set("auth_user", &database.User{ID: userID})
+	return c, w
+}
+
+// otherUsersPlaylist is a static playlist owned by "userB".
+func otherUsersPlaylist() *database.UserPlaylist {
+	return &database.UserPlaylist{
+		ID:              "pl-1",
+		Name:            "userB private",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{"b1"},
+		CreatedByUserID: "userB",
+	}
+}
+
+// TestPlaylistHandler_GetPlaylist_CrossUser_Returns404 confirms that user A
+// cannot read user B's playlist by ID — the response is 404 (not 200, not 403)
+// so the existence of another user's playlist is not disclosed (IDOR guard).
+func TestPlaylistHandler_GetPlaylist_CrossUser_Returns404(t *testing.T) {
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().GetUserPlaylist("pl-1").Return(otherUsersPlaylist(), nil)
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodGet, "/playlists/pl-1", "userA")
+	c.Params = gin.Params{{Key: "id", Value: "pl-1"}}
+	h.GetPlaylist(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestPlaylistHandler_DeletePlaylist_CrossUser_Returns404 confirms user A
+// cannot delete user B's playlist. DeleteUserPlaylist must never be reached.
+func TestPlaylistHandler_DeletePlaylist_CrossUser_Returns404(t *testing.T) {
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().GetUserPlaylist("pl-1").Return(otherUsersPlaylist(), nil)
+	// DeleteUserPlaylist is intentionally NOT expected — reaching it is a bug.
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodDelete, "/playlists/pl-1", "userA")
+	c.Params = gin.Params{{Key: "id", Value: "pl-1"}}
+	h.DeletePlaylist(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestPlaylistHandler_UpdatePlaylist_CrossUser_Returns404 confirms user A
+// cannot mutate user B's playlist; UpdateUserPlaylist must never be reached.
+func TestPlaylistHandler_UpdatePlaylist_CrossUser_Returns404(t *testing.T) {
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().GetUserPlaylist("pl-1").Return(otherUsersPlaylist(), nil)
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodPut, "/playlists/pl-1", "userA")
+	c.Params = gin.Params{{Key: "id", Value: "pl-1"}}
+	h.UpdatePlaylist(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestPlaylistHandler_GetPlaylist_Owner_Succeeds confirms the owner still has
+// access — the ownership check must not lock out the legitimate user.
+func TestPlaylistHandler_GetPlaylist_Owner_Succeeds(t *testing.T) {
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().GetUserPlaylist("pl-1").Return(otherUsersPlaylist(), nil)
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodGet, "/playlists/pl-1", "userB") // owner
+	c.Params = gin.Params{{Key: "id", Value: "pl-1"}}
+	h.GetPlaylist(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestPlaylistHandler_ListPlaylists_ScopesToCaller confirms the list endpoint
+// passes the calling user's ID to the store so only that user's playlists are
+// returned (no cross-user disclosure).
+func TestPlaylistHandler_ListPlaylists_ScopesToCaller(t *testing.T) {
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().
+		ListUserPlaylistsForUser("userA", "", mock.Anything, mock.Anything).
+		Return([]database.UserPlaylist{}, 0, nil)
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodGet, "/playlists", "userA")
+	h.ListPlaylists(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/server/handlers/playlists_test.go
+++ b/internal/server/handlers/playlists_test.go
@@ -99,6 +99,28 @@ func TestPlaylistHandler_GetPlaylist_Owner_Succeeds(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+// TestPlaylistHandler_GetPlaylist_LegacyUnowned_Accessible confirms that a
+// playlist with an empty CreatedByUserID (legacy / pre-ownership iTunes import)
+// remains accessible to any caller — the IDOR fix must not hide pre-existing data.
+func TestPlaylistHandler_GetPlaylist_LegacyUnowned_Accessible(t *testing.T) {
+	legacy := &database.UserPlaylist{
+		ID:              "pl-legacy",
+		Name:            "iTunes import",
+		Type:            database.UserPlaylistTypeStatic,
+		BookIDs:         []string{"b1"},
+		CreatedByUserID: "", // unowned — created before ownership tracking
+	}
+	store := handlersmocks.NewMockPlaylistStore(t)
+	store.EXPECT().GetUserPlaylist("pl-legacy").Return(legacy, nil)
+
+	h := handlers.NewPlaylistHandler(store, nil)
+	c, w := newPlaylistCtxAs(http.MethodGet, "/playlists/pl-legacy", "userA")
+	c.Params = gin.Params{{Key: "id", Value: "pl-legacy"}}
+	h.GetPlaylist(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 // TestPlaylistHandler_ListPlaylists_ScopesToCaller confirms the list endpoint
 // passes the calling user's ID to the store so only that user's playlists are
 // returned (no cross-user disclosure).

--- a/internal/server/handlers/user.go
+++ b/internal/server/handlers/user.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/user.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
 // last-edited: 2026-06-02
 
@@ -158,7 +158,9 @@ func (h *UserHandler) AcceptInvite(c *gin.Context) {
 	// SetSessionCookie is exported from handlers/auth.go; user.go is in the
 	// same package so we can call it directly.
 	SetSessionCookie(c, sess.ID, sess.ExpiresAt)
-	httputil.RespondWithCreated(c, gin.H{"user": user, "session": sess})
+	// Session token is delivered via the HttpOnly cookie only — never in the
+	// JSON body (would expose the bearer token to page JS, defeating HttpOnly).
+	httputil.RespondWithCreated(c, gin.H{"user": user, "expires_at": sess.ExpiresAt})
 }
 
 // DeactivateUser handles POST /api/v1/users/:id/deactivate — soft-deactivates a user.


### PR DESCRIPTION
## Summary

Fixes two pre-existing vulnerabilities flagged by the automated commit security review during the handler-extraction work.

### 1. Session token disclosure (defeats HttpOnly)
`Login` and `accept-invite` returned the raw session ID — which **is** the bearer token, also set as an HttpOnly cookie — in the JSON response body, exposing it to page JavaScript and defeating HttpOnly's XSS protection.

- `handlers/auth.go` Login, `auth_accept_invite.go`, and `handlers/user.go` AcceptInvite now return `{user, expires_at}` only. The token lives solely in the HttpOnly cookie.

### 2. Playlist IDOR (broken access control)
The 7 by-ID playlist handlers loaded a playlist and operated on it without verifying the caller owns it; `ListPlaylists` returned **all** users' playlists.

- `GetPlaylist`, `UpdatePlaylist`, `DeletePlaylist`, `AddBooksToPlaylist`, `RemoveBookFromPlaylist`, `ReorderPlaylist`, `MaterializePlaylist` now enforce ownership via `ownedByCaller` **before** any read/mutation, returning **404** (no existence disclosure).
- `DeletePlaylist` now loads-then-checks before deleting (previously deleted blindly).
- `ListPlaylists` scoped to the caller via a new `ListUserPlaylistsForUser` store method.

### Regression guard (caught in review)
iTunes-imported playlists were created without `CreatedByUserID`, so the ownership check would have hidden them behind a 404. Fixed without a data migration:
- `playlist_sync.go` now stamps `CreatedByUserID = "_local"` on new iTunes imports.
- `ownedByCaller` + the Pebble list filter treat an **empty** `CreatedByUserID` as legacy/unowned and accessible to any caller, so pre-existing rows stay reachable.

## Tests
- 6 new handler tests: cross-user 404 (Get/Update/Delete), owner-succeeds, legacy-unowned-accessible, list-scopes-to-caller
- Login test updated to assert the session token is absent and `expires_at` present
- `make build-api` clean; handler + iTunes test suites green
- (Two pre-existing `internal/server` test failures — `TestParseAudiobookAIPayloadSplitsAuthors`, `TestUpdateAudiobook_CreatesAuthorSeries...` — confirmed failing on clean main, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)