### PR TITLE
chore(triage): upgrade triage model o3 → gpt-5.4-mini

### DIFF
--- a/.github/workflows/triage-poll.yml
+++ b/.github/workflows/triage-poll.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/triage-poll.yml
-# version: 1.0.1
+# version: 1.0.2
 name: Triage poll
 
 on:
@@ -22,5 +22,5 @@ jobs:
     uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@acbc1ec5a64c5fb497a5077c3a56e56d5e7b4873
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
-      triage_model: o3
+      triage_model: gpt-5.4-mini
     secrets: inherit


### PR DESCRIPTION
## Summary

- Updates `triage_model` from `o3` to `gpt-5.4-mini` in the triage-poll workflow
- `gpt-5.4-mini` is OpenAI's current cost-optimised model — full Batch API + structured-output support, faster and cheaper than o3

## Test plan
- [ ] Triage-poll workflow runs successfully after runner image rebuild completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)