### PR TITLE
fix(triage): gpt-5.4-mini → gpt-5.3-codex (Responses API batch)

### DIFF
--- a/.github/workflows/triage-poll.yml
+++ b/.github/workflows/triage-poll.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/triage-poll.yml
-# version: 1.0.2
+# version: 1.0.3
 name: Triage poll
 
 on:
@@ -22,5 +22,5 @@ jobs:
     uses: jdfalk/ghcommon/.github/workflows/reusable-triage-poll.yml@acbc1ec5a64c5fb497a5077c3a56e56d5e7b4873
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
-      triage_model: gpt-5.4-mini
+      triage_model: gpt-5.3-codex
     secrets: inherit


### PR DESCRIPTION
## Summary

- Follows overnight-burndown PR #40 which migrated the batch endpoint to `/v1/responses`
- `gpt-5.3-codex` supports the Responses API batch mode and is purpose-built for code/engineering tasks (vs general mini models)
- Two consecutive batches (May 17 + June 3) failed with 100% request failure — root cause was wrong endpoint + model combination
- Runner image rebuild will pick up the batch.go changes; this PR wires in the correct model string

## Test plan

- [x] Workflow file only changes `triage_model` string — no injection risk (fixed value, not user input)
- [ ] Runner image rebuild deploys new binary; next 30-min cron verifies batch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)