### PR TITLE
fix(registry): guard nil cancel on dispatcher stub handles (fixes flaky Registry.Shutdown crash)

### DIFF
--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/registry.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
 // last-edited: 2026-06-01
 
@@ -333,7 +333,7 @@ func (r *Registry) Cancel(opID string) error {
 
 	if running {
 		r.logger.Info("registry: canceling running op", "op_id", opID)
-		h.cancel()
+		h.cancelIfActive()
 		return nil
 	}
 
@@ -406,7 +406,7 @@ func (r *Registry) Shutdown(ctx context.Context) error {
 
 	// Cancel all running ops.
 	for _, h := range handles {
-		h.cancel()
+		h.cancelIfActive()
 	}
 
 	// Wait until context expires or all workers drain.

--- a/internal/operations/registry/shutdown_stub_handle_test.go
+++ b/internal/operations/registry/shutdown_stub_handle_test.go
@@ -1,0 +1,75 @@
+// file: internal/operations/registry/shutdown_stub_handle_test.go
+// version: 1.0.0
+// guid: 7b3c9d1e-4a52-4c8f-9e0a-2f6b1d8c4a37
+// last-edited: 2026-06-03
+
+// White-box regression tests for the "stub handle" nil-cancel race.
+//
+// The dispatcher inserts a placeholder runHandle into r.running with a nil
+// cancel func the instant an op is claimed (to block Gate-0 re-dispatch); the
+// worker overwrites it with the full handle on pickup. Between those two
+// events a handle is present in r.running with cancel == nil. Code that walks
+// r.running and cancels (Shutdown, Cancel, the watchdog) must tolerate that —
+// before the fix, hitting this window panicked with a nil-pointer dereference
+// (observed as a flaky crash in setupTestServer cleanup under parallel test
+// load). These tests reproduce the window deterministically by inserting a
+// stub handle directly and asserting no panic.
+package registry
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	databasemocks "github.com/jdfalk/audiobook-organizer/internal/database/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// insertStubHandle mimics the dispatcher's stub insertion: a handle in
+// r.running with a nil cancel func.
+func insertStubHandle(r *Registry, opID string) {
+	r.mu.Lock()
+	r.running[opID] = &runHandle{
+		id:           opID,
+		defID:        "test.stub",
+		resumePolicy: ResumeRequeue,
+		// cancel intentionally left nil — this is the dispatcher stub window.
+	}
+	r.mu.Unlock()
+}
+
+// TestShutdown_StubHandleNilCancel_NoPanic verifies Shutdown does not panic
+// when a stub handle (nil cancel) is present in r.running.
+func TestShutdown_StubHandleNilCancel_NoPanic(t *testing.T) {
+	store := databasemocks.NewMockOpsV2Store(t)
+	// The stub never drains, so Shutdown times out and marks it interrupted.
+	store.EXPECT().
+		UpdateOperationV2Status(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	r := New(store, slog.Default(), 1, nil)
+	insertStubHandle(r, "stub-op")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	require.NotPanics(t, func() {
+		_ = r.Shutdown(ctx)
+	})
+}
+
+// TestCancel_StubHandleNilCancel_NoPanic verifies Cancel does not panic when
+// the targeted op is a stub handle (nil cancel).
+func TestCancel_StubHandleNilCancel_NoPanic(t *testing.T) {
+	store := databasemocks.NewMockOpsV2Store(t)
+
+	r := New(store, slog.Default(), 1, nil)
+	insertStubHandle(r, "stub-op")
+
+	require.NotPanics(t, func() {
+		err := r.Cancel("stub-op")
+		require.NoError(t, err)
+	})
+}

--- a/internal/operations/registry/watchdog.go
+++ b/internal/operations/registry/watchdog.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/watchdog.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b3c4d5e-6f7a-8901-bcde-f01234567890
 // last-edited: 2026-05-06
 
@@ -87,7 +87,7 @@ func (r *Registry) watchdogCycle() {
 				fmt.Sprintf("no progress for %s (timeout=%s)", now.Sub(*row.LastProgressAt).Round(time.Second), progressTimeout))
 			r.logger.Warn("registry: canceling stuck op", "op_id", h.id, "def_id", def.ID,
 				"idle_since", row.LastProgressAt)
-			h.cancel()
+			h.cancelIfActive()
 			continue // don't also check uncheckpointed for the same op
 		}
 

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-06-01
+// last-edited: 2026-06-03
 
 package registry
 
@@ -41,6 +41,23 @@ type runHandle struct {
 	abandoned      bool
 	currentItem    string
 	currentItemMu  sync.Mutex
+}
+
+// cancelIfActive cancels the run's context if it has been wired up.
+//
+// The dispatcher (dispatcher.go) inserts a *stub* handle into r.running with a
+// nil cancel func to block Gate-0 re-dispatch the instant an op is claimed; the
+// worker overwrites it with the full handle (with cancel) on pickup
+// (worker.go). Between those two events a handle is present in r.running with
+// cancel == nil. Callers that walk r.running and cancel (Shutdown, Cancel, the
+// watchdog) must go through this guard so they no-op on a stub instead of
+// panicking with a nil-pointer dereference. For Shutdown this is fully correct:
+// shuttingDown is set before the walk, so a stubbed op is never executed by the
+// worker that eventually picks it up.
+func (h *runHandle) cancelIfActive() {
+	if h != nil && h.cancel != nil {
+		h.cancel()
+	}
 }
 
 func (h *runHandle) setCurrentItem(label string) {


### PR DESCRIPTION
## Summary
Fixes the most frequent flaky-test crash in the suite — a `nil`-pointer panic in `registry.(*Registry).Shutdown` observed via `setupTestServer` cleanup under parallel load (~17–20% of `internal/server` runs) — which is also a **latent production shutdown race**.

## Root cause
The dispatcher inserts a *stub* `runHandle` into `r.running` with a **nil `cancel` func** the instant an op is claimed (to block Gate-0 re-dispatch); the worker overwrites it with the full handle on pickup. Between those two events a handle sits in `r.running` with `cancel == nil`. Any code that walks `r.running` and cancels — `Shutdown`, `Cancel`, and the watchdog — could hit that window and call `h.cancel()` on `nil` → panic.

## Fix
- Add `runHandle.cancelIfActive()` which nil-guards both the handle and its cancel func.
- Route all three call sites (`Shutdown`, `Cancel`, watchdog) through it.
- For `Shutdown` this is fully correct: `shuttingDown` is set *before* the walk, so a stubbed op is never executed by the worker that eventually picks it up — canceling it is a genuine no-op.

## Tests
- New white-box regression tests reproduce the stub-handle window for `Shutdown` and `Cancel`. **Verified they panic without the guard** and pass with it.
- `internal/server` now **6/6 green** (was ~17–20% flake); full `internal/operations/registry` suite green.

Discovered while shipping the handler-extraction refactor (PRs #1236/#1238); this is the pre-existing flake those PRs documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)