### PR TITLE
fix(ci): bump ghcommon pin to runner image with safe-ai-util-mcp symlink

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.3.0
+# version: 1.4.0
 name: Nightly burndown
 
 on:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2e30fe84da1897e4e336c641a2cb5bc31ea69855
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@8d38c68b533e2bc004275a4c308c72c29ca58a0e
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
## Problem

`nightly-burndown.yml` was pinned to ghcommon `2e30fe8` which uses runner image `cdce859` (May 9) — before the `/opt/venv/bin` PATH setup existed. Every dispatch job failed with `safe-ai-util-mcp: executable file not found in $PATH`.

## Fix

Bump to ghcommon `8d38c68` which uses runner image `d558a337` (June 3). Paired with burndown-runner-image fix that adds the explicit symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)