### PR TITLE
fix(ci): pin ghcommon to 89b4db4 — runner image with safe-ai-util-mcp fixed

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.3.0
+# version: 1.5.0
 name: Nightly burndown
 
 on:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2e30fe84da1897e4e336c641a2cb5bc31ea69855
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@89b4db45c9b91bf4a7669c867187785c289d3e56
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
## Root cause chain (all fixed)

Every burndown dispatch job was failing: `safe-ai-util-mcp: executable file not found in $PATH`

| PR | Repo | Fix |
|----|------|-----|
| #5 | safe-ai-util-mcp | Populate empty `pyproject.toml` — `mcp>=1.1.0` dep was never installed |
| #6 | safe-ai-util-mcp | Fix build backend (`setuptools.build_meta`) |
| #12 | burndown-runner-image | Shell wrapper instead of symlink — shebang can't resolve in Docker |
| #290 | ghcommon | Bump runner image pin to `483ee34` |

This PR pins `nightly-burndown.yml` to the ghcommon SHA that uses the fixed image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)