### PR TITLE
fix(ci): bump ghcommon pin to 2d3ef22 — max-parallel 2 to prevent 429s

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.5.0
+# version: 1.6.0
 name: Nightly burndown
 
 on:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@89b4db45c9b91bf4a7669c867187785c289d3e56
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2d3ef226277f250cff9f018e1dd874c2f9245e8f
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
Bumps the ghcommon pin to pick up the max-parallel 4→2 fix (ghcommon PR #291). Prevents 429 rate-limit failures at iter 1 that were occurring when 4 simultaneous dispatch jobs all hit the OpenAI API at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)