### PR TITLE
feat(ai): add ao- user+metadata tags to all OpenAI call sites

### DIFF
--- a/internal/ai/embedding_batch.go
+++ b/internal/ai/embedding_batch.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_batch.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b8c9d0-e1f2-3456-7890-abcdef012345
 // last-edited: 2026-05-17
 
@@ -74,6 +74,7 @@ func (c *EmbeddingClient) CreateEmbeddingBatch(ctx context.Context, items []Embe
 		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
 		Metadata: map[string]string{
 			"project": "audiobook-organizer",
+			"service": "ao-embedding-batch",
 			"type":    "embed_async",
 		},
 	})

--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package ai
@@ -201,6 +201,7 @@ func (c *EmbeddingClient) embedBatchRaw(ctx context.Context, texts []string) ([]
 				OfArrayOfStrings: texts,
 			},
 			Model: openai.EmbeddingModel(c.model),
+			User:  openai.String("ao-embeddings"),
 		})
 		if err != nil {
 			lastErr = fmt.Errorf("embedding attempt %d: %w", attempt+1, err)

--- a/internal/ai/metadata_llm_review.go
+++ b/internal/ai/metadata_llm_review.go
@@ -1,5 +1,5 @@
 // file: internal/ai/metadata_llm_review.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: e4f92b17-3c8a-4d65-a1f3-9b2e07d84c61
 
 package ai
@@ -161,6 +161,7 @@ Include one score per input candidate, using the same index as the input.`
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 				OfJSONObject: &jsonObjectFormat,
 			},
+			User: openai.String("ao-metadata-review"),
 		})
 
 		if err != nil {

--- a/internal/ai/openai_batch.go
+++ b/internal/ai/openai_batch.go
@@ -1,5 +1,5 @@
 // file: internal/ai/openai_batch.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b3c4d5e6-f7a8-9b0c-1d2e-3f4a5b6c7d8e
 
 package ai
@@ -22,6 +22,7 @@ import (
 func batchMetadata(batchType string) shared.Metadata {
 	return shared.Metadata{
 		"project": "audiobook-organizer",
+		"service": "ao-metadata-batch",
 		"type":    batchType,
 	}
 }

--- a/internal/ai/openai_parser.go
+++ b/internal/ai/openai_parser.go
@@ -1,5 +1,5 @@
 // file: internal/ai/openai_parser.go
-// version: 13.3.0
+// version: 13.4.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
 
 package ai
@@ -174,6 +174,7 @@ Set confidence based on clarity of the filename structure.`
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &jsonObjectFormat,
 		},
+		User: openai.String("ao-metadata"),
 	})
 
 	if err != nil {
@@ -277,6 +278,7 @@ Set confidence based on how much context was available and how unambiguous it is
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &jsonObjectFormat,
 		},
+		User: openai.String("ao-metadata"),
 	})
 
 	if err != nil {
@@ -368,6 +370,7 @@ Set confidence based on clarity of the filename structure.`
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 				OfJSONObject: &jsonObjectFormat,
 			},
+			User: openai.String("ao-metadata"),
 		})
 
 		if err != nil {
@@ -435,6 +438,7 @@ Set confidence based on how clearly the text is readable on the cover.`
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 			OfJSONObject: &jsonObjectFormat,
 		},
+		User: openai.String("ao-metadata"),
 	})
 
 	if err != nil {
@@ -583,6 +587,7 @@ The roles object fields are all optional — only include roles that are detecte
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 				OfJSONObject: &jsonObjectFormat,
 			},
+			User: openai.String("ao-metadata"),
 		})
 
 		if err != nil {
@@ -717,6 +722,7 @@ The roles object fields are all optional — only include roles that are detecte
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
 				OfJSONObject: &jsonObjectFormat,
 			},
+			User: openai.String("ao-metadata"),
 		})
 
 		if err != nil {

--- a/internal/server/bench.go
+++ b/internal/server/bench.go
@@ -1,5 +1,5 @@
 // file: internal/server/bench.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5e6f7a8b-9c0d-1234-ef01-555555555555
 
 //go:build bench
@@ -598,6 +598,9 @@ func benchSubmitBatchJob(ctx context.Context, client *openai.Client, tc benchTes
 		InputFileID:      file.ID,
 		Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
 		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+		Metadata: map[string]string{
+			"service": "ao-bench",
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Adds `User: openai.String("ao-<service>")` to all `Chat.Completions.New` and `Embeddings.New` calls so each service shows up distinctly in the OpenAI usage dashboard
- Adds `"service": "ao-<service>"` to the `Metadata` map on all `Batches.New` calls for filterable API logs
- No logic changes — field additions only

## Service mapping

| File | Service tag |
|------|------------|
| `internal/ai/openai_parser.go` | `ao-metadata` (all 6 chat completion calls) |
| `internal/ai/metadata_llm_review.go` | `ao-metadata-review` |
| `internal/ai/embedding_client.go` | `ao-embeddings` (User on Embeddings.New) |
| `internal/ai/embedding_batch.go` | `ao-embedding-batch` (Metadata on Batches.New) |
| `internal/ai/openai_batch.go` | `ao-metadata-batch` (via updated `batchMetadata()` helper) |
| `internal/server/bench.go` | `ao-bench` (Metadata on Batches.New) |

## Test plan

- [x] `go build ./...` passes cleanly
- [x] `go build -tags bench ./internal/server/...` passes cleanly
- [ ] Verify ao- service names appear in OpenAI dashboard after next API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)