### PR TITLE
feat(ci): add hard-burndown.yml + bump ghcommon pin to cc57f803

### DIFF
--- a/.github/workflows/hard-burndown.yml
+++ b/.github/workflows/hard-burndown.yml
@@ -1,10 +1,10 @@
-# file: .github/workflows/nightly-burndown.yml
-# version: 1.7.0
-name: Nightly burndown
+# file: .github/workflows/hard-burndown.yml
+# version: 1.0.0
+name: Hard burndown (failed-batch retry)
 
 on:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 10 * * 0"  # Sundays 10:00 UTC
   workflow_dispatch:
     inputs:
       mode:
@@ -22,4 +22,6 @@ jobs:
     uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@cc57f803033a5a77f1f87cbc0ed81ef79863a9e0
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
+      task_filter: failed-batch
+      powerful_only: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- **`hard-burndown.yml`** — weekly hard run (Sundays 10:00 UTC, also manual)
  - `task_filter: failed-batch` → only picks up `[failed-batch]`-tagged TODO items
  - `powerful_only: true` → bigger model, higher effort
  - Tasks that fail here get upgraded to `[failed-batch-hard]` (need manual decomp)
- **`nightly-burndown.yml`** — bump ghcommon pin to `cc57f803` (adds `task_filter` input)

## Full pipeline now

```
Nightly run     → fail → [failed-batch] written to TODO.md automatically
Hard run (Sun)  → fail → [failed-batch-hard]  → needs decomposition
Hard run (Sun)  → pass → markers removed, task ships normally
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)