### PR TITLE
chore(ci): bump ghcommon pin to 2b9f83e6 (decompose job)

### DIFF
--- a/.github/workflows/hard-burndown.yml
+++ b/.github/workflows/hard-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@cc57f803033a5a77f1f87cbc0ed81ef79863a9e0
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       task_filter: failed-batch

--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@cc57f803033a5a77f1f87cbc0ed81ef79863a9e0
+    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit


### PR DESCRIPTION
Picks up ghcommon PR #292 (task_filter input) and #293 (decompose job). Hard runs now automatically decompose [failed-batch-hard] tasks via Claude Haiku.