### PR TITLE
chore: migrate jdfalk/ refs to falkcorp/ org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci-minimal.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # feat/reusable-ci-minimal
+    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # feat/reusable-ci-minimal
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Load frontend configuration
         id: frontend-config
-        uses: jdfalk/get-frontend-config-action@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
+        uses: falkcorp/gha-get-frontend-config@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
         with:
           repository-config: ''
           config-file: '.github/repository-config.yml'
@@ -49,7 +49,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/hard-burndown.yml
+++ b/.github/workflows/hard-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       task_filter: failed-batch

--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   full-ci:
     name: Full CI Suite
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v1.12.0
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v1.12.0
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v2.13.1
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v2.13.1
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: jdfalk/ghcommon/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   advanced-security:
     name: Advanced CodeQL Security
-    uses: jdfalk/ghcommon/.github/workflows/reusable-security.yml@main
+    uses: falkcorp/github-common/.github/workflows/reusable-security.yml@main
     with:
       languages: '["go", "javascript", "actions"]'
       skip-codeql: false

--- a/.github/workflows/test-action-integration.yml
+++ b/.github/workflows/test-action-integration.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get frontend configuration
         id: frontend-config
-        uses: jdfalk/get-frontend-config-action@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
+        uses: falkcorp/gha-get-frontend-config@9a5882d405edad2f4f48c3f584fee779d478f4a4 # v1.1.3
         with:
           repository-config: ''
           config-file: '.github/repository-config.yml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2580,16 +2580,16 @@ metadata source finishes, iTunes write-back safety, and a large
 internal refactor of the server package.
 
 ##### Dedup Cluster UX (contributed by @jdfalk)
-- **Per-side "merge as primary" star** ([#230](https://github.com/jdfalk/audiobook-organizer/pull/230)): explicit primary override on each side of a cluster card. `primary_book_id` threaded through `mergeDedupCluster`.
-- **Export current filtered candidate set** ([#231](https://github.com/jdfalk/audiobook-organizer/pull/231)): new CSV/JSON export button with the active filter applied. Backed by `exportDedupCandidates` handler.
-- **Series-aware bulk merge** ([#232](https://github.com/jdfalk/audiobook-organizer/pull/232)): new `listDedupCandidateSeries` + `mergeDedupCandidateSeries` endpoints and "Merge Series" dialog. Lets users fold whole near-duplicate series together in one step.
-- **Multi-select split-cluster workflow** ([#233](https://github.com/jdfalk/audiobook-organizer/pull/233)): checkboxes on each cluster member with a "Remove N selected" action. `removeFromDedupCluster` now accepts `remove_book_ids` plural.
-- **Book alternative titles schema + engine integration** ([#234](https://github.com/jdfalk/audiobook-organizer/pull/234)): migration 046 adds `book_alternative_titles` table; `Store` gains `GetBookAlternativeTitles` / `AddBookAlternativeTitle` / `RemoveBookAlternativeTitle` / `SetBookAlternativeTitles`. Dedup engine's exact-title check walks all normalized forms across both sides using `allNormalizedTitleForms` + `minLevenshteinBetweenForms`.
+- **Per-side "merge as primary" star** ([#230](https://github.com/falkcorp/audiobook-organizer/pull/230)): explicit primary override on each side of a cluster card. `primary_book_id` threaded through `mergeDedupCluster`.
+- **Export current filtered candidate set** ([#231](https://github.com/falkcorp/audiobook-organizer/pull/231)): new CSV/JSON export button with the active filter applied. Backed by `exportDedupCandidates` handler.
+- **Series-aware bulk merge** ([#232](https://github.com/falkcorp/audiobook-organizer/pull/232)): new `listDedupCandidateSeries` + `mergeDedupCandidateSeries` endpoints and "Merge Series" dialog. Lets users fold whole near-duplicate series together in one step.
+- **Multi-select split-cluster workflow** ([#233](https://github.com/falkcorp/audiobook-organizer/pull/233)): checkboxes on each cluster member with a "Remove N selected" action. `removeFromDedupCluster` now accepts `remove_book_ids` plural.
+- **Book alternative titles schema + engine integration** ([#234](https://github.com/falkcorp/audiobook-organizer/pull/234)): migration 046 adds `book_alternative_titles` table; `Store` gains `GetBookAlternativeTitles` / `AddBookAlternativeTitle` / `RemoveBookAlternativeTitle` / `SetBookAlternativeTitles`. Dedup engine's exact-title check walks all normalized forms across both sides using `allNormalizedTitleForms` + `minLevenshteinBetweenForms`.
 
 ##### Metadata Integrations (contributed by @jdfalk)
-- **Resume Last Review button** ([#235](https://github.com/jdfalk/audiobook-organizer/pull/235)): new `GET /metadata/recent-fetches` picks up the latest completed bulk fetch so users don't lose results when the review dialog closes.
-- **Resume Review picker for back-to-back fetches** ([#236](https://github.com/jdfalk/audiobook-organizer/pull/236)): extends #235 to return up to 10 recent completed fetches in a dropdown — fixes "select pages 1-2, then pages 3-4, never see the first batch again".
-- **Audnexus + Hardcover full integration** ([#237](https://github.com/jdfalk/audiobook-organizer/pull/237)):
+- **Resume Last Review button** ([#235](https://github.com/falkcorp/audiobook-organizer/pull/235)): new `GET /metadata/recent-fetches` picks up the latest completed bulk fetch so users don't lose results when the review dialog closes.
+- **Resume Review picker for back-to-back fetches** ([#236](https://github.com/falkcorp/audiobook-organizer/pull/236)): extends #235 to return up to 10 recent completed fetches in a dropdown — fixes "select pages 1-2, then pages 3-4, never see the first batch again".
+- **Audnexus + Hardcover full integration** ([#237](https://github.com/falkcorp/audiobook-organizer/pull/237)):
   - New `ContextualSearch` optional interface and `SearchContext` struct: `Title`, `Author`, `Narrator`, `ISBN10/13`, `ASIN`, `Series`.
   - `ProtectedSource` forwards `SearchByContext` through the circuit breaker via type assertion.
   - Audnexus `SearchByContext` uses `LookupByASIN` when an ASIN is present, falls back gracefully otherwise.
@@ -2597,7 +2597,7 @@ internal refactor of the server package.
   - `metadata_fetch_service.go` tries `SearchByContext` first for any source that supports it, falls back to title-only search otherwise.
 
 ##### iTunes ITL Safety (contributed by @jdfalk)
-- **ITL write-back: backup, validate, restore, narrator** ([#238](https://github.com/jdfalk/audiobook-organizer/pull/238)):
+- **ITL write-back: backup, validate, restore, narrator** ([#238](https://github.com/falkcorp/audiobook-organizer/pull/238)):
   - New `safeWriteITL` pipeline: pre-validate source → backup to `.bak-YYYYMMDD-HHMMSS` → apply → validate temp → rename → validate final → restore-from-backup on post-rename corruption.
   - `itlBackupRetention = 5` with `pruneITLBackups` rotation (lex sort on timestamp suffix).
   - Composer field now populated with narrator on every metadata update (audiobook convention — `album_artist > artist > composer`).
@@ -2606,7 +2606,7 @@ internal refactor of the server package.
   - New `itunes_writeback_batcher_test.go` covers happy path, broken source, temp validation failure, post-rename restore, and backup prune rotation.
 
 ##### Internal — Server Package Refactor (contributed by @jdfalk)
-- **Split monolithic `server.go`** ([#240](https://github.com/jdfalk/audiobook-organizer/pull/240), backlog 4.2): 10,596 lines → 2,670 lines of lifecycle/helpers + ten domain handler files:
+- **Split monolithic `server.go`** ([#240](https://github.com/falkcorp/audiobook-organizer/pull/240), backlog 4.2): 10,596 lines → 2,670 lines of lifecycle/helpers + ten domain handler files:
   - `audiobooks_handlers.go` (1,288) — book CRUD, batch ops, files/segments, tags
   - `entities_handlers.go` (1,104) — authors/series/narrators/works
   - `duplicates_handlers.go` (1,261) — SQL-based dedup flow
@@ -2618,10 +2618,10 @@ internal refactor of the server package.
   - `filesystem_handlers.go` (301) — browse/exclude/import-path CRUD/import-file
   - `organize_handlers.go` (229) — preview/apply rename + organize-book
 - Extraction driven by `split_server.py` — brace-balanced method boundary detection with string/comment/rune awareness so nested closures don't confuse it. No behavioural changes; handler signatures and `setupRoutes` registrations unchanged.
-- **Regenerate mocks via mockery** ([#239](https://github.com/jdfalk/audiobook-organizer/pull/239) prep): `internal/database/mocks/mock_store.go` now comes from `mockery` v3.7.0 (was hand-edited). Backlog 5.9 tracks adding CI enforcement.
+- **Regenerate mocks via mockery** ([#239](https://github.com/falkcorp/audiobook-organizer/pull/239) prep): `internal/database/mocks/mock_store.go` now comes from `mockery` v3.7.0 (was hand-edited). Backlog 5.9 tracks adding CI enforcement.
 
 ##### Documentation (contributed by @jdfalk)
-- **Backlog additions** ([#239](https://github.com/jdfalk/audiobook-organizer/pull/239)):
+- **Backlog additions** ([#239](https://github.com/falkcorp/audiobook-organizer/pull/239)):
   - 5.8 Regenerate ITL test fixtures after format work
   - 5.9 Enforce mockery-generated mocks
   - 6.4 ITL upload / download / partial export — generate a fresh ITL containing only a user-selected subset (e.g., 300 checked-out books out of 12K) for portable laptop iTunes libraries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ All AI agent instructions live in `.github/`. This file is the entry point.
 ## Quick Start
 
 - **Architecture & workflows:** [.github/copilot-instructions.md](.github/copilot-instructions.md)
-- **Coding standards:** [.github/instructions/](https://github.com/jdfalk/audiobook-organizer/tree/main/.github/instructions/)
-- **Prompts:** [.github/prompts/](https://github.com/jdfalk/audiobook-organizer/tree/main/.github/prompts/)
+- **Coding standards:** [.github/instructions/](https://github.com/falkcorp/audiobook-organizer/tree/main/.github/instructions/)
+- **Prompts:** [.github/prompts/](https://github.com/falkcorp/audiobook-organizer/tree/main/.github/prompts/)
 - **Full file index:** [AGENTS.md](AGENTS.md)
 
 ## Build & Test Commands

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -12,7 +12,7 @@ Scanner panic and test issues resolved
 ### 1. Start the Server
 
 ```bash
-cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer.worktrees/worktree-2025-12-22T04-03-46
+cd /Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer.worktrees/worktree-2025-12-22T04-03-46
 ./audiobook-organizer-test serve --port 8888 --dir /path/to/audiobooks
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The app is available at `http://localhost:8484`.
 ### From Source
 
 ```bash
-git clone https://github.com/jdfalk/audiobook-organizer.git
+git clone https://github.com/falkcorp/audiobook-organizer.git
 cd audiobook-organizer
 make build   # builds frontend + backend into a single binary
 ./audiobook-organizer serve --dir /path/to/audiobooks --host 0.0.0.0

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ future agent) can scan the entire workspace in one page.
 
 ## 📚 Project Documentation (TODO — not yet done)
 
-- [ ] **DOCS-1** [hold] Write comprehensive system documentation for `jdfalk/audiobook-organizer` into `docs/` — full process graphs, architecture diagrams, data flow, component inventory, operations runbooks, incident history. Target: ≥9 files, ≥7 Mermaid diagrams (flowchart, sequence, state machine, Gantt). Model after `jdfalk/burndown-tasks/docs/` (PR #73, 2216 lines). Invoke as a dedicated documentation subagent: "write full process graphs, literally all the documentation you can write. The more graphs and charts the better."
+- [ ] **DOCS-1** [hold] Write comprehensive system documentation for `falkcorp/audiobook-organizer` into `docs/` — full process graphs, architecture diagrams, data flow, component inventory, operations runbooks, incident history. Target: ≥9 files, ≥7 Mermaid diagrams (flowchart, sequence, state machine, Gantt). Model after `falkcorp/burndown-tasks/docs/` (PR #73, 2216 lines). Invoke as a dedicated documentation subagent: "write full process graphs, literally all the documentation you can write. The more graphs and charts the better."
 
 ---
 
@@ -1454,7 +1454,7 @@ CI: disabled Docker in prerelease workflow (was exhausting 14GB GitHub runner di
 
 ### v0.206.0 release (2026-04-13)
 
-See [v0.206.0 release notes](https://github.com/jdfalk/audiobook-organizer/releases/tag/v0.206.0) for the full commit list. Highlights folded into §1, §3, §5, §7 above.
+See [v0.206.0 release notes](https://github.com/falkcorp/audiobook-organizer/releases/tag/v0.206.0) for the full commit list. Highlights folded into §1, §3, §5, §7 above.
 
 <details>
 <summary>Session 12-19 archive — click to expand</summary>

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jdfalk/audiobook-organizer
+module github.com/falkcorp/audiobook-organizer
 
 go 1.26.0
 

--- a/scripts/org-migration/create-org-labels.py
+++ b/scripts/org-migration/create-org-labels.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""
+create-org-labels.py
+====================
+Idempotently creates all falkcorp default repository labels via the GitHub API.
+Run this against any org to bring its label set in sync.
+
+Usage:
+    python3 create-org-labels.py [--org falkcorp] [--dry-run]
+
+Requires: gh CLI authenticated with admin:org scope, OR a GH_TOKEN env var
+with `admin:org` scope. Falls back to `gh api` if GH_TOKEN not set.
+
+Exit codes: 0 = success, 1 = partial failure (see stderr).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LABEL INVENTORY
+# Source of truth for all falkcorp org default labels.
+# Last synced: 2026-06-05 from jdfalk/ghcommon (--limit 400) +
+#              jdfalk/burndown-tasks burndown-specific labels.
+# ─────────────────────────────────────────────────────────────────────────────
+LABELS = [
+    # ── GitHub defaults (present in every new org) ──────────────────────────
+    {"name": "bug",              "color": "d73a49", "description": "Something isn't working"},
+    {"name": "documentation",    "color": "0075ca", "description": "Improvements or additions to documentation"},
+    {"name": "duplicate",        "color": "cfd3d7", "description": "This issue or pull request already exists"},
+    {"name": "enhancement",      "color": "a2eeef", "description": "New feature or request"},
+    {"name": "good first issue", "color": "7057FF", "description": "Good for newcomers to the project"},
+    {"name": "help wanted",      "color": "008672", "description": "Extra attention is needed from the community"},
+    {"name": "invalid",          "color": "e4e669", "description": "This doesn't seem right"},
+    {"name": "question",         "color": "d876e3", "description": "Further information is requested"},
+    {"name": "wontfix",          "color": "ffffff", "description": "This will not be worked on"},
+
+    # ── Automation / AI ──────────────────────────────────────────────────────
+    {"name": "codex",            "color": "ff6b9d", "description": "Created or modified by AI/automation agents"},
+    {"name": "automation",       "color": "1f883d", "description": "Automation scripts and tools"},
+    {"name": "ai",               "color": "ededed", "description": ""},
+    {"name": "machine-learning", "color": "ededed", "description": ""},
+    {"name": "auto-generated",   "color": "B60205", "description": ""},
+    {"name": "dogfooding",       "color": "ededed", "description": ""},
+
+    # ── Type taxonomy ────────────────────────────────────────────────────────
+    {"name": "type:bug",           "color": "d73a49", "description": "Something isn't working"},
+    {"name": "type:feature",       "color": "0052cc", "description": "New feature development"},
+    {"name": "type:enhancement",   "color": "a2eeef", "description": "Improvement to existing feature"},
+    {"name": "type:documentation", "color": "0075ca", "description": "Improvements or additions to documentation"},
+    {"name": "type:refactor",      "color": "f1c232", "description": "Code refactoring without feature changes"},
+    {"name": "type:security",      "color": "ee0701", "description": "Security related issues"},
+    {"name": "type:testing",       "color": "1d76db", "description": "Testing related work"},
+    {"name": "type:maintenance",   "color": "6c757d", "description": "Maintenance and housekeeping"},
+    {"name": "type:ci",            "color": "ededed", "description": ""},
+    {"name": "type:docs",          "color": "ededed", "description": ""},
+    {"name": "type:infrastructure","color": "ededed", "description": ""},
+    {"name": "type:protobuf",      "color": "ededed", "description": ""},
+
+    # ── Priority taxonomy (namespaced) ───────────────────────────────────────
+    {"name": "priority:critical",  "color": "d73a49", "description": "Critical priority - immediate attention required"},
+    {"name": "priority:high",      "color": "d93f0b", "description": "High priority"},
+    {"name": "priority:medium",    "color": "fbca04", "description": "Medium priority"},
+    {"name": "priority:normal",    "color": "e4e669", "description": "Standard priority"},
+    {"name": "priority:low",       "color": "0e8a16", "description": "Low priority"},
+    # P0–P3 for burndown bot triage
+    {"name": "priority:P0",        "color": "b60205", "description": "Production outage / data loss / security"},
+    {"name": "priority:P1",        "color": "d93f0b", "description": "Core feature broken; blocks other work"},
+    {"name": "priority:P2",        "color": "e4e669", "description": "Standard bug fix or feature"},
+    {"name": "priority:P3",        "color": "c5def5", "description": "Minor improvement or cleanup"},
+    # Legacy non-namespaced (kept for backwards compat)
+    {"name": "priority-high",      "color": "b60205", "description": "High priority issue"},
+    {"name": "priority-medium",    "color": "fbca04", "description": "Medium priority issue"},
+    {"name": "priority-low",       "color": "0e8a16", "description": "Low priority issue"},
+    {"name": "priority: medium",   "color": "ededed", "description": ""},
+    {"name": "critical",           "color": "d73a49", "description": "Critical priority - immediate attention required"},
+    {"name": "high",               "color": "d93f0b", "description": "High priority"},
+    {"name": "medium",             "color": "fbca04", "description": "Medium priority"},
+    {"name": "low",                "color": "0e8a16", "description": "Low priority"},
+    {"name": "high-priority",      "color": "ededed", "description": ""},
+
+    # ── Status taxonomy ──────────────────────────────────────────────────────
+    {"name": "status:ready",        "color": "c3e6cb", "description": "Ready for implementation"},
+    {"name": "status:in-progress",  "color": "d4edda", "description": "Work in progress"},
+    {"name": "status:on-hold",      "color": "d93f0b", "description": "Paused — not ready for bot pickup"},
+    {"name": "status:blocked",      "color": "f8d7da", "description": "Blocked by external dependencies"},
+    {"name": "status:needs-review", "color": "fff3cd", "description": "Needs code review"},
+    {"name": "status:todo",         "color": "ffffff", "description": "To do - not started"},
+    {"name": "status:duplicate",    "color": "6f42c1", "description": "Duplicate issue"},
+    {"name": "status:wontfix",      "color": "6c757d", "description": "This will not be worked on"},
+    {"name": "status:review",       "color": "9B59B6", "description": "Task is ready for review"},
+    # Legacy non-namespaced
+    {"name": "ready",               "color": "c3e6cb", "description": "Ready for implementation"},
+    {"name": "in-progress",         "color": "d4edda", "description": "Work in progress"},
+    {"name": "blocked",             "color": "f8d7da", "description": "Blocked by external dependencies"},
+    {"name": "needs-review",        "color": "fff3cd", "description": "Needs code review"},
+    {"name": "needs-triage",        "color": "ededed", "description": ""},
+    {"name": "needs-info",          "color": "ededed", "description": ""},
+    {"name": "stale",               "color": "ededed", "description": ""},
+    {"name": "completed",           "color": "ededed", "description": ""},
+
+    # ── Burndown bot ─────────────────────────────────────────────────────────
+    {"name": "triaged",               "color": "0e8a16", "description": "Triage decision written; ready for dispatch"},
+    {"name": "burndown:batch-pending","color": "e4e669", "description": "OpenAI batch triage in flight"},
+    {"name": "[failed-batch]",        "color": "e4b429", "description": "Batch attempt failed; eligible for retry"},
+    {"name": "[failed-batch-hard]",   "color": "b60205", "description": "Hard batch failure; needs manual triage"},
+
+    # ── Size taxonomy ────────────────────────────────────────────────────────
+    {"name": "size:small",  "color": "c2e0c6", "description": "Small change (1-2 hours)"},
+    {"name": "size:medium", "color": "bfd4f2", "description": "Medium change (half day)"},
+    {"name": "size:large",  "color": "f9d0c4", "description": "Large change (1-2 days)"},
+    {"name": "size:epic",   "color": "d73a49", "description": "Epic change (multiple days/weeks)"},
+    # Slash-style size labels (from some tooling)
+    {"name": "size/XS", "color": "ededed", "description": ""},
+    {"name": "size/S",  "color": "ededed", "description": ""},
+    {"name": "size/M",  "color": "ededed", "description": ""},
+    {"name": "size/L",  "color": "ededed", "description": ""},
+    {"name": "size/XL", "color": "ededed", "description": ""},
+
+    # ── Tech taxonomy ────────────────────────────────────────────────────────
+    {"name": "tech:go",         "color": "00add8", "description": "Go programming language"},
+    {"name": "tech:python",     "color": "3572a5", "description": "Python programming language"},
+    {"name": "tech:rust",       "color": "dea584", "description": "Rust programming language"},
+    {"name": "tech:typescript", "color": "3178c6", "description": "TypeScript programming language"},
+    {"name": "tech:javascript", "color": "f1e05a", "description": "JavaScript programming language"},
+    {"name": "tech:docker",     "color": "2496ed", "description": "Docker containerization"},
+    {"name": "tech:kubernetes", "color": "326ce5", "description": "Kubernetes orchestration"},
+    {"name": "tech:protobuf",   "color": "c5def5", "description": "Protocol buffer definitions"},
+    {"name": "tech:grpc",       "color": "bfd4f2", "description": "gRPC service implementations"},
+    {"name": "tech:shell",      "color": "89e051", "description": "Shell scripting (bash, sh)"},
+    # Legacy non-namespaced
+    {"name": "go",         "color": "00add8", "description": "Go programming language"},
+    {"name": "golang",     "color": "30AEF6", "description": ""},
+    {"name": "python",     "color": "3572a5", "description": "Python programming language"},
+    {"name": "javascript", "color": "f1e05a", "description": "JavaScript programming language"},
+    {"name": "docker",     "color": "2496ed", "description": "Docker containerization"},
+    {"name": "kubernetes", "color": "326ce5", "description": "Kubernetes orchestration"},
+    {"name": "grpc",       "color": "bfd4f2", "description": "gRPC service implementations"},
+    {"name": "protobuf",   "color": "c5def5", "description": "Protocol buffer definitions"},
+    {"name": "language:go",      "color": "ededed", "description": ""},
+    {"name": "language: python", "color": "ededed", "description": ""},
+    {"name": "language: rust",   "color": "ededed", "description": ""},
+
+    # ── Workflow taxonomy ────────────────────────────────────────────────────
+    {"name": "workflow:ci-cd",          "color": "28a745", "description": "Continuous integration and deployment"},
+    {"name": "workflow:github-actions", "color": "2088ff", "description": "GitHub Actions workflows"},
+    {"name": "workflow:automation",     "color": "1f883d", "description": "Automation and tooling"},
+    {"name": "workflow:deployment",     "color": "0366d6", "description": "Deployment and release management"},
+    # Legacy non-namespaced
+    {"name": "ci-cd",          "color": "28a745", "description": "Continuous integration and deployment"},
+    {"name": "ci/cd",          "color": "0052cc", "description": "Continuous integration and deployment"},
+    {"name": "ci",             "color": "ededed", "description": ""},
+    {"name": "github-actions", "color": "2088ff", "description": "GitHub Actions related work"},
+    {"name": "workflow",       "color": "0366d6", "description": "GitHub workflow improvements"},
+    {"name": "workflows",      "color": "ededed", "description": ""},
+    {"name": "deployment",     "color": "ededed", "description": ""},
+
+    # ── Module taxonomy ──────────────────────────────────────────────────────
+    {"name": "module:api",          "color": "0366d6", "description": "API development and changes"},
+    {"name": "module:auth",         "color": "0052cc", "description": "Authentication and authorization"},
+    {"name": "module:backend",      "color": "343a40", "description": "Backend development"},
+    {"name": "module:frontend",     "color": "6c757d", "description": "Frontend development"},
+    {"name": "module:ui",           "color": "495057", "description": "User interface development"},
+    {"name": "module:database",     "color": "fd7e14", "description": "Database related work"},
+    {"name": "module:cache",        "color": "5319e7", "description": "Caching and data storage"},
+    {"name": "module:config",       "color": "006b75", "description": "Configuration management"},
+    {"name": "module:metrics",      "color": "6f42c1", "description": "Metrics collection and monitoring"},
+    {"name": "module:queue",        "color": "e99695", "description": "Message queuing and task management"},
+    {"name": "module:web",          "color": "b60205", "description": "Web services and HTTP handling"},
+    {"name": "module:common",       "color": "ededed", "description": ""},
+    {"name": "module:db",           "color": "ededed", "description": ""},
+    {"name": "module:deployment",   "color": "ededed", "description": ""},
+    {"name": "module:grpc",         "color": "ededed", "description": ""},
+    {"name": "module:iam",          "color": "96CEB4", "description": "Identity and Access Management module"},
+    {"name": "module:ledger",       "color": "FFEAA7", "description": "Financial ledger and accounting module"},
+    {"name": "module:log",          "color": "ededed", "description": ""},
+    {"name": "module:monitoring",   "color": "ededed", "description": ""},
+    {"name": "module:notification", "color": "DDA0DD", "description": "Notification and messaging module"},
+    {"name": "module:organization", "color": "98D8C8", "description": "Organization and tenant management module"},
+    {"name": "module:payment",      "color": "F7DC6F", "description": "Payment processing and gateway module"},
+    {"name": "module:plugins",      "color": "ededed", "description": ""},
+    {"name": "module:proto",        "color": "ededed", "description": ""},
+    {"name": "module:security",     "color": "ededed", "description": ""},
+    {"name": "module:wallet",       "color": "BB8FCE", "description": "Digital wallet and balance management module"},
+
+    # ── Project taxonomy ─────────────────────────────────────────────────────
+    {"name": "project:transcription",          "color": "ffa8a8", "description": "Audio transcription features"},
+    {"name": "project:whisper",                "color": "ff6b6b", "description": "Whisper ASR integration"},
+    {"name": "project:media",                  "color": "74c0fc", "description": "Media processing and handling"},
+    {"name": "project:subtitles",              "color": "4c956c", "description": "Subtitle processing and conversion"},
+    {"name": "project:gcommon-refactor",       "color": "f9d0c4", "description": "gcommon refactor initiative"},
+    {"name": "project:github-management",      "color": "6f42c1", "description": "GitHub project management and workflows"},
+    {"name": "project:protobuf-implementation","color": "c5def5", "description": "Protocol buffer implementation work"},
+    {"name": "project:issue-management",       "color": "e99695", "description": "Issue management and tracking workflows"},
+
+    # ── Common standalone ────────────────────────────────────────────────────
+    {"name": "dependencies",     "color": "0366d6", "description": "Pull requests that update a dependency file"},
+    {"name": "security",         "color": "ee0701", "description": "Security related issues"},
+    {"name": "performance",      "color": "ff9500", "description": "Performance improvements"},
+    {"name": "breaking-change",  "color": "c5000b", "description": "Introduces a breaking change"},
+    {"name": "external-dependency","color":"e4b429", "description": "Depends on external systems or libraries"},
+    {"name": "merge-conflict",   "color": "b60205", "description": "Pull request has merge conflicts"},
+    {"name": "gcommon-refactor", "color": "f9d0c4", "description": "gcommon refactoring work"},
+    {"name": "issue-management", "color": "e99695", "description": "Issue tracking and management"},
+    {"name": "refactoring",      "color": "f9d0c4", "description": "Code refactoring"},
+    {"name": "testing",          "color": "1d76db", "description": "Testing related work"},
+    {"name": "ui/ux",            "color": "e99695", "description": "User interface and user experience"},
+    {"name": "good-first-issue", "color": "7057ff", "description": "Good for newcomers"},
+    {"name": "help-wanted",      "color": "008672", "description": "Extra attention is needed"},
+    {"name": "bugfix",           "color": "ededed", "description": ""},
+    {"name": "feature",          "color": "0052cc", "description": "New feature development"},
+    {"name": "ui",               "color": "495057", "description": "User interface development"},
+    {"name": "metrics",          "color": "6f42c1", "description": "Metrics collection and monitoring"},
+    {"name": "queue",            "color": "e99695", "description": "Message queuing and task management"},
+    {"name": "web",              "color": "b60205", "description": "Web services and HTTP handling"},
+    {"name": "auth",             "color": "0052cc", "description": "Authentication and authorization"},
+    {"name": "backend",          "color": "343a40", "description": "Backend development"},
+    {"name": "frontend",         "color": "6c757d", "description": "Frontend development"},
+    {"name": "cache",            "color": "5319e7", "description": "Caching and data storage"},
+    {"name": "config",           "color": "006b75", "description": "Configuration management"},
+    {"name": "database",         "color": "fd7e14", "description": "Database related work"},
+
+    # ── Engineering practice ─────────────────────────────────────────────────
+    {"name": "architecture",      "color": "ededed", "description": ""},
+    {"name": "optimization",      "color": "ededed", "description": ""},
+    {"name": "observability",     "color": "ededed", "description": ""},
+    {"name": "monitoring",        "color": "ededed", "description": ""},
+    {"name": "monitor",           "color": "ededed", "description": ""},
+    {"name": "infrastructure",    "color": "ededed", "description": ""},
+    {"name": "devops",            "color": "ededed", "description": ""},
+    {"name": "containerization",  "color": "ededed", "description": ""},
+    {"name": "orchestration",     "color": "ededed", "description": ""},
+    {"name": "migration",         "color": "ededed", "description": ""},
+    {"name": "integration",       "color": "ededed", "description": ""},
+    {"name": "integration-testing","color":"ededed", "description": ""},
+    {"name": "quality-assurance", "color": "ededed", "description": ""},
+    {"name": "quality",           "color": "ededed", "description": ""},
+    {"name": "e2e",               "color": "ededed", "description": ""},
+    {"name": "test",              "color": "ededed", "description": ""},
+    {"name": "tests",             "color": "ededed", "description": ""},
+    {"name": "debugging",         "color": "ededed", "description": ""},
+    {"name": "troubleshooting",   "color": "ededed", "description": ""},
+    {"name": "benchmarking",      "color": "ededed", "description": ""},
+    {"name": "audit",             "color": "ededed", "description": ""},
+    {"name": "compliance",        "color": "ededed", "description": ""},
+    {"name": "accessibility",     "color": "ededed", "description": ""},
+    {"name": "i18n",              "color": "ededed", "description": ""},
+    {"name": "validation",        "color": "ededed", "description": ""},
+    {"name": "cleanup",           "color": "ededed", "description": ""},
+    {"name": "refactor",          "color": "ededed", "description": ""},
+    {"name": "build",             "color": "ededed", "description": ""},
+    {"name": "sprint",            "color": "ededed", "description": ""},
+    {"name": "planning",          "color": "ededed", "description": ""},
+    {"name": "coordination",      "color": "ededed", "description": ""},
+    {"name": "rebase",            "color": "ededed", "description": ""},
+
+    # ── Project management ───────────────────────────────────────────────────
+    {"name": "epic",              "color": "ededed", "description": ""},
+    {"name": "project",           "color": "ededed", "description": ""},
+    {"name": "milestone",         "color": "ededed", "description": ""},
+    {"name": "management",        "color": "ededed", "description": ""},
+    {"name": "collaboration",     "color": "ededed", "description": ""},
+    {"name": "teamwork",          "color": "ededed", "description": ""},
+    {"name": "community",         "color": "ededed", "description": ""},
+    {"name": "area:community",    "color": "ededed", "description": ""},
+    {"name": "enterprise",        "color": "ededed", "description": ""},
+
+    # ── Versioning / releases ────────────────────────────────────────────────
+    {"name": "versioning",        "color": "ededed", "description": ""},
+    {"name": "version-control",   "color": "ededed", "description": ""},
+    {"name": "changelog",         "color": "ededed", "description": ""},
+    {"name": "release",           "color": "ededed", "description": ""},
+    {"name": "1-1-1-migration",   "color": "ededed", "description": ""},
+
+    # ── Reliability / ops ────────────────────────────────────────────────────
+    {"name": "backup",            "color": "ededed", "description": ""},
+    {"name": "disaster-recovery", "color": "ededed", "description": ""},
+    {"name": "reliability",       "color": "ededed", "description": ""},
+    {"name": "real-time",         "color": "ededed", "description": ""},
+    {"name": "missing-files",     "color": "ededed", "description": ""},
+    {"name": "severity-error",    "color": "ededed", "description": ""},
+    {"name": "compilation-blocker","color":"ededed", "description": ""},
+
+    # ── Misc / tools ─────────────────────────────────────────────────────────
+    {"name": "api",               "color": "ededed", "description": ""},
+    {"name": "issues",            "color": "ededed", "description": ""},
+    {"name": "docs",              "color": "ededed", "description": ""},
+    {"name": "sdk",               "color": "ededed", "description": ""},
+    {"name": "cli",               "color": "ededed", "description": ""},
+    {"name": "scripts",           "color": "ededed", "description": ""},
+    {"name": "search",            "color": "ededed", "description": ""},
+    {"name": "proto",             "color": "ededed", "description": ""},
+    {"name": "providers",         "color": "ededed", "description": ""},
+    {"name": "ops",               "color": "ededed", "description": ""},
+    {"name": "npm",               "color": "e0ae53", "description": ""},
+    {"name": "mysql",             "color": "ededed", "description": ""},
+    {"name": "db",                "color": "ededed", "description": ""},
+    {"name": "dependency",        "color": "ededed", "description": ""},
+    {"name": "devcontainer",      "color": "ededed", "description": ""},
+    {"name": "cockroachdb",       "color": "ededed", "description": ""},
+    {"name": "gcommon",           "color": "ededed", "description": ""},
+    {"name": "metadata",          "color": "ededed", "description": ""},
+    {"name": "compatibility",     "color": "ededed", "description": ""},
+    {"name": "cross-platform",    "color": "ededed", "description": ""},
+    {"name": "mobile",            "color": "ededed", "description": ""},
+    {"name": "analytics",         "color": "ededed", "description": ""},
+    {"name": "business-intelligence","color":"ededed","description": ""},
+    {"name": "advanced-features", "color": "ededed", "description": ""},
+    {"name": "developer-experience","color":"ededed","description": ""},
+    {"name": "developer-tools",   "color": "ededed", "description": ""},
+    {"name": "apps",              "color": "ededed", "description": ""},
+    {"name": "marketplace",       "color": "ededed", "description": ""},
+    {"name": "templates",         "color": "ededed", "description": ""},
+    {"name": "examples",          "color": "ededed", "description": ""},
+    {"name": "example",           "color": "ededed", "description": ""},
+    {"name": "feat",              "color": "ededed", "description": ""},
+    {"name": "dashboard",         "color": "ededed", "description": ""},
+    {"name": "configuration",     "color": "ededed", "description": ""},
+    {"name": "widgets",           "color": "ededed", "description": ""},
+    {"name": "media",             "color": "74c0fc", "description": "Media processing and handling"},
+    {"name": "transcription",     "color": "ffa8a8", "description": "Audio transcription features"},
+    {"name": "whisper",           "color": "ff6b6b", "description": "Whisper ASR integration"},
+
+    # ── gcommon-specific modules ─────────────────────────────────────────────
+    {"name": "module:iam",          "color": "96CEB4", "description": "Identity and Access Management module"},
+    {"name": "module:ledger",       "color": "FFEAA7", "description": "Financial ledger and accounting module"},
+    {"name": "module:notification", "color": "DDA0DD", "description": "Notification and messaging module"},
+    {"name": "module:organization", "color": "98D8C8", "description": "Organization and tenant management module"},
+    {"name": "module:payment",      "color": "F7DC6F", "description": "Payment processing and gateway module"},
+    {"name": "module:wallet",       "color": "BB8FCE", "description": "Digital wallet and balance management module"},
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+def gh_api(method, path, data=None, dry_run=False):
+    cmd = ["gh", "api", "-X", method, path]
+    if data:
+        for k, v in data.items():
+            cmd += ["-f", f"{k}={v}"]
+    if dry_run:
+        print(f"  [DRY RUN] {method} {path} {data or ''}")
+        return {"dry_run": True}
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        return json.loads(result.stdout) if result.stdout.strip() else {}
+    return {"error": result.stderr.strip(), "code": result.returncode}
+
+
+def get_existing_labels(org):
+    """Fetch all existing org labels (paginates via gh api --paginate)."""
+    cmd = ["gh", "api", "--paginate", f"/orgs/{org}/labels",
+           "-H", "Accept: application/vnd.github+json"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        # org labels API returns 404 — fall back to empty set (all will be created)
+        return set()
+    try:
+        data = json.loads(result.stdout)
+        return {l["name"].lower() for l in data}
+    except Exception:
+        return set()
+
+
+def create_label(org, label, dry_run=False):
+    color = label["color"].lstrip("#")
+    cmd = [
+        "gh", "api", "-X", "POST",
+        f"/orgs/{org}/labels",
+        "-H", "Accept: application/vnd.github+json",
+        "-f", f"name={label['name']}",
+        "-f", f"color={color}",
+        "-f", f"description={label['description']}",
+    ]
+    if dry_run:
+        print(f"  [DRY RUN] POST /orgs/{org}/labels  name={label['name']!r}")
+        return True
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--org", default="falkcorp", help="GitHub org (default: falkcorp)")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be created without making changes")
+    parser.add_argument("--skip-existing-check", action="store_true",
+                        help="Skip fetching existing labels and attempt to create all (safe — 422s are ignored)")
+    args = parser.parse_args()
+
+    print(f"Target org: {args.org}  |  Labels in inventory: {len(LABELS)}")
+
+    if args.skip_existing_check:
+        existing = set()
+        print("Skipping existing-label check (--skip-existing-check)")
+    else:
+        print("Fetching existing labels...")
+        existing = get_existing_labels(args.org)
+        print(f"  {len(existing)} labels already exist")
+
+    # Deduplicate inventory by name (keep first occurrence)
+    seen = set()
+    unique_labels = []
+    for l in LABELS:
+        key = l["name"].lower()
+        if key not in seen:
+            seen.add(key)
+            unique_labels.append(l)
+
+    to_create = [l for l in unique_labels if l["name"].lower() not in existing]
+    print(f"  {len(to_create)} labels to create\n")
+
+    created, skipped, failed = [], [], []
+
+    for label in to_create:
+        ok = create_label(args.org, label, dry_run=args.dry_run)
+        if ok:
+            created.append(label["name"])
+            print(f"  ✓ {label['name']}")
+        else:
+            failed.append(label["name"])
+            print(f"  ✗ {label['name']}", file=sys.stderr)
+        if not args.dry_run:
+            time.sleep(0.1)  # stay under secondary rate limits
+
+    print(f"\nDone.  created={len(created)}  failed={len(failed)}")
+    if failed:
+        print("Failed labels:", failed, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/org-migration/deprecate-bsr-jdfalk.sh
+++ b/scripts/org-migration/deprecate-bsr-jdfalk.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run AFTER migrate-bsr.sh and verifying buf.build/falkcorp/gcommon works.
+set -euo pipefail
+
+if [[ -z "${BUF_TOKEN:-}" ]]; then
+    echo "ERROR: BUF_TOKEN not set"
+    exit 1
+fi
+export BUF_TOKEN
+
+buf registry module deprecate buf.build/jdfalk/gcommon \
+    --message "Moved to buf.build/falkcorp/gcommon — update your buf.yaml deps"
+echo "Old BSR module buf.build/jdfalk/gcommon marked deprecated."

--- a/scripts/org-migration/migrate-bsr.sh
+++ b/scripts/org-migration/migrate-bsr.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Phase 10: Migrate gcommon-proto from buf.build/jdfalk to buf.build/falkcorp.
+# Requires: buf CLI + BUF_TOKEN env var
+set -euo pipefail
+
+OLD_ORG="jdfalk"
+NEW_ORG="falkcorp"
+MODULES=("gcommon")
+GCOMMON_PROTO_DIR="${HOME}/repos/github.com/jdfalk/gcommon-proto"
+
+if [[ -z "${BUF_TOKEN:-}" ]]; then
+    echo "ERROR: BUF_TOKEN environment variable not set"
+    exit 1
+fi
+
+export BUF_TOKEN
+
+echo "=== Step 1: Create BSR org buf.build/${NEW_ORG} ==="
+if buf registry organization create "buf.build/${NEW_ORG}" 2>&1 | grep -q "already_exists"; then
+    echo "  SKIP org already exists"
+else
+    echo "  OK created buf.build/${NEW_ORG}"
+fi
+
+echo ""
+echo "=== Step 2: Create modules ==="
+for mod in "${MODULES[@]}"; do
+    if buf registry module get "buf.build/${NEW_ORG}/${mod}" &>/dev/null; then
+        echo "  SKIP buf.build/${NEW_ORG}/${mod} already exists"
+    else
+        buf registry module create "buf.build/${NEW_ORG}/${mod}" \
+            --visibility public \
+            --default-label-name main
+        echo "  OK created buf.build/${NEW_ORG}/${mod}"
+    fi
+done
+
+echo ""
+echo "=== Step 3: Update buf.yaml in gcommon-proto ==="
+if [[ -f "${GCOMMON_PROTO_DIR}/buf.yaml" ]]; then
+    sed -i.bak "s|buf.build/${OLD_ORG}/|buf.build/${NEW_ORG}/|g" "${GCOMMON_PROTO_DIR}/buf.yaml"
+    echo "  OK updated ${GCOMMON_PROTO_DIR}/buf.yaml"
+    diff "${GCOMMON_PROTO_DIR}/buf.yaml.bak" "${GCOMMON_PROTO_DIR}/buf.yaml" || true
+    rm "${GCOMMON_PROTO_DIR}/buf.yaml.bak"
+else
+    echo "  WARN ${GCOMMON_PROTO_DIR}/buf.yaml not found — update manually"
+fi
+
+echo ""
+echo "=== Step 4: Push to new BSR path ==="
+echo "  Run from ${GCOMMON_PROTO_DIR}:"
+echo "    cd ${GCOMMON_PROTO_DIR} && buf push --label main"
+echo ""
+echo "  (CI will auto-push after buf.yaml update is merged)"
+
+echo ""
+echo "=== Next: Run deprecate-bsr-jdfalk.sh after verifying new path works ==="

--- a/scripts/org-migration/rename-repos.py
+++ b/scripts/org-migration/rename-repos.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Phase 2: Rename all in-scope repos within jdfalk personal account.
+Renames happen BEFORE org transfer so redirects are in place.
+GitHub creates automatic redirects for each rename.
+"""
+import subprocess
+import sys
+import time
+
+RENAMES = [
+    # (old_name, new_name)
+    ("ghcommon", "github-common"),
+    ("release-go-action", "gha-release-go"),
+    ("release-python-action", "gha-release-python"),
+    ("release-rust-action", "gha-release-rust"),
+    ("release-docker-action", "gha-release-docker"),
+    ("release-frontend-action", "gha-release-frontend"),
+    ("release-protobuf-action", "gha-release-protobuf-base"),
+    ("auto-module-tagging-action", "gha-auto-module-tagging"),
+    ("ci-workflow-helpers-action", "gha-ci-workflow-helpers"),
+    ("generate-version-action", "gha-generate-version"),
+    ("get-frontend-config-action", "gha-get-frontend-config"),
+    ("package-assets-action", "gha-package-assets"),
+    ("docs-generator-action", "gha-docs-generator"),
+    ("release-strategy-action", "gha-release-strategy"),
+    ("update-action-docker-ref-action", "gha-update-action-docker-ref"),
+    ("load-config-action", "gha-load-config"),
+    ("detect-languages-action", "gha-detect-languages"),
+    ("ci-generate-matrices-action", "gha-ci-generate-matrices"),
+    ("security-summary-action", "gha-security-summary"),
+    ("pr-auto-label-action", "gha-pr-auto-label"),
+    ("jft-github-actions", "gha-template-repo"),
+]
+
+dry_run = "--dry-run" in sys.argv
+
+
+def gh(args):
+    result = subprocess.run(["gh"] + args, capture_output=True, text=True)
+    return result.stdout.strip(), result.stderr.strip(), result.returncode
+
+
+def repo_exists(name):
+    _, _, rc = gh(["repo", "view", f"jdfalk/{name}", "--json", "name"])
+    return rc == 0
+
+
+def rename_repo(old_name, new_name):
+    if not repo_exists(old_name):
+        # Maybe already renamed
+        if repo_exists(new_name):
+            print(f"  SKIP  {old_name} → {new_name} (target already exists, assuming done)")
+            return True
+        print(f"  MISS  {old_name} → {new_name} (source not found on GitHub)")
+        return False
+
+    if dry_run:
+        print(f"  DRY   {old_name} → {new_name}")
+        return True
+
+    stdout, stderr, rc = gh([
+        "api", "-X", "PATCH",
+        f"/repos/jdfalk/{old_name}",
+        "-f", f"name={new_name}",
+    ])
+    if rc == 0:
+        print(f"  OK    {old_name} → {new_name}")
+        return True
+    else:
+        print(f"  FAIL  {old_name} → {new_name}: {stderr or stdout}")
+        return False
+
+
+if dry_run:
+    print("=== DRY RUN (pass no args to execute) ===\n")
+
+ok, fail, skip = 0, 0, 0
+for old, new in RENAMES:
+    result = rename_repo(old, new)
+    if result:
+        ok += 1
+    else:
+        fail += 1
+    time.sleep(0.5)
+
+print(f"\nDone: {ok} renamed, {fail} failed")
+if fail > 0:
+    sys.exit(1)

--- a/scripts/org-migration/setup-org-secrets.py
+++ b/scripts/org-migration/setup-org-secrets.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Phase 5 (partial): Set org-level secrets in falkcorp.
+GitHub App secrets (BURNDOWN_BOT_APP_ID, BURNDOWN_BOT_PRIVATE_KEY) must be
+set after creating the app via web UI.
+
+Run with:
+  BUF_TOKEN=xxx ANTHROPIC_API_KEY=xxx python3 setup-org-secrets.py
+"""
+import os
+import subprocess
+import sys
+
+ORG = "falkcorp"
+
+
+def gh_secret_set(name, value, org=ORG):
+    if not value:
+        print(f"  SKIP  {name} (no value provided)")
+        return False
+    result = subprocess.run(
+        ["gh", "secret", "set", name, "--org", org, "--visibility", "all"],
+        input=value,
+        capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        print(f"  OK    {name}")
+        return True
+    else:
+        print(f"  FAIL  {name}: {result.stderr.strip()}")
+        return False
+
+
+secrets = {
+    "BUF_TOKEN": os.environ.get("BUF_TOKEN", ""),
+    "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
+    # Set these after GitHub App creation:
+    # "BURNDOWN_BOT_APP_ID": os.environ.get("BURNDOWN_BOT_APP_ID", ""),
+    # "BURNDOWN_BOT_PRIVATE_KEY": os.environ.get("BURNDOWN_BOT_PRIVATE_KEY", ""),
+}
+
+print(f"Setting org-level secrets in {ORG}...\n")
+ok = sum(1 for name, value in secrets.items() if gh_secret_set(name, value))
+print(f"\nSet {ok}/{len(secrets)} secrets.")
+print("\nRemaining manual steps:")
+print("  1. Create GitHub App 'falkcorp-burndown-bot' at:")
+print("     https://github.com/organizations/falkcorp/settings/apps/new")
+print("     Permissions: contents R/W, pull_requests R/W, issues R/W,")
+print("                  workflows R/W, metadata R, checks R")
+print("     No events needed (bot polls; no webhooks)")
+print("  2. Install app on falkcorp org (all repos)")
+print("  3. Get App ID and generate private key (.pem)")
+print("  4. Run:")
+print("     BURNDOWN_BOT_APP_ID=<id> gh secret set BURNDOWN_BOT_APP_ID --org falkcorp --visibility all")
+print("     gh secret set BURNDOWN_BOT_PRIVATE_KEY --org falkcorp --visibility all < /path/to/app.pem")
+print("  5. Set ANTHROPIC_API_KEY if not already done:")
+print("     ANTHROPIC_API_KEY=<key> python3 setup-org-secrets.py")

--- a/scripts/org-migration/transfer-repos.py
+++ b/scripts/org-migration/transfer-repos.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Phase 3: Transfer all in-scope repos to falkcorp org.
+Uses post-rename names. Run after rename-repos.py completes.
+Transfers in tier order to minimize broken-reference window.
+"""
+import subprocess
+import sys
+import time
+
+# Ordered by dependency tier (Tier 0 first = fewest dependencies)
+TRANSFERS = [
+    # Tier 0 — standalone action repos
+    "gha-release-go",
+    "gha-release-python",
+    "gha-release-rust",
+    "gha-release-docker",
+    "gha-release-frontend",
+    "gha-release-protobuf",
+    "gha-release-protobuf-base",
+    "gha-auto-module-tagging",
+    "gha-ci-workflow-helpers",
+    "gha-generate-version",
+    "gha-get-frontend-config",
+    "gha-package-assets",
+    "gha-docs-generator",
+    "gha-release-strategy",
+    "gha-update-action-docker-ref",
+    "gha-load-config",
+    "gha-detect-languages",
+    "gha-ci-generate-matrices",
+    "gha-security-summary",
+    "gha-pr-auto-label",
+    "gha-template-repo",
+    # Tier 0 — standalone app/lib repos
+    "safe-ai-util",
+    "gcommon",
+    "gcommon-proto",
+    "transcoderr",
+    "cockroach-rollout-agent",
+    "ubuntu-autoinstall-agent",
+    "mtls-bridge",
+    # Tier 1 — depends on Tier 0
+    "safe-ai-util-mcp",
+    "burndown-runner-image",
+    # Tier 2 — central hub
+    "github-common",
+    "burndown-tasks",
+    # Tier 3 — depends on hub
+    "overnight-burndown",
+    "overnight-burndown-reconcile",
+    "overnight-burndown-closing",
+    "overnight-burndown-providers",
+    # Tier 4 — primary applications
+    "audiobook-organizer",
+    "migrate-loop",
+]
+
+dry_run = "--dry-run" in sys.argv
+new_owner = "falkcorp"
+
+
+def gh(args):
+    result = subprocess.run(["gh"] + args, capture_output=True, text=True)
+    return result.stdout.strip(), result.stderr.strip(), result.returncode
+
+
+def in_falkcorp(name):
+    _, _, rc = gh(["repo", "view", f"{new_owner}/{name}", "--json", "name"])
+    return rc == 0
+
+
+def in_jdfalk(name):
+    _, _, rc = gh(["repo", "view", f"jdfalk/{name}", "--json", "name"])
+    return rc == 0
+
+
+def transfer_repo(name):
+    if in_falkcorp(name):
+        print(f"  SKIP  {name} (already in falkcorp)")
+        return True
+
+    if not in_jdfalk(name):
+        print(f"  MISS  {name} (not found in jdfalk)")
+        return False
+
+    if dry_run:
+        print(f"  DRY   jdfalk/{name} → falkcorp/{name}")
+        return True
+
+    stdout, stderr, rc = gh([
+        "api", "-X", "POST",
+        f"/repos/jdfalk/{name}/transfer",
+        "-f", f"new_owner={new_owner}",
+    ])
+    if rc == 0:
+        print(f"  OK    jdfalk/{name} → falkcorp/{name}")
+        return True
+    else:
+        print(f"  FAIL  {name}: {stderr or stdout}")
+        return False
+
+
+if dry_run:
+    print("=== DRY RUN (pass no args to execute) ===\n")
+
+ok, fail = 0, 0
+for repo in TRANSFERS:
+    result = transfer_repo(repo)
+    if result:
+        ok += 1
+    else:
+        fail += 1
+    time.sleep(1)  # Avoid rate limits; transfer is heavy
+
+print(f"\nDone: {ok} transferred, {fail} failed")
+if fail > 0:
+    sys.exit(1)

--- a/scripts/org-migration/update-remotes.py
+++ b/scripts/org-migration/update-remotes.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Phase 8: Update local git remotes to point to falkcorp."""
+import os
+import subprocess
+import sys
+
+BASE = os.path.expanduser("~/repos/github.com/jdfalk")
+FALKCORP_DIR = os.path.expanduser("~/repos/github.com/falkcorp")
+
+RENAMES = {
+    "ghcommon": "github-common",
+    "release-go-action": "gha-release-go",
+    "release-python-action": "gha-release-python",
+    "release-rust-action": "gha-release-rust",
+    "release-docker-action": "gha-release-docker",
+    "release-frontend-action": "gha-release-frontend",
+    "release-protobuf-action": "gha-release-protobuf-base",
+    "auto-module-tagging-action": "gha-auto-module-tagging",
+    "ci-workflow-helpers-action": "gha-ci-workflow-helpers",
+    "generate-version-action": "gha-generate-version",
+    "get-frontend-config-action": "gha-get-frontend-config",
+    "package-assets-action": "gha-package-assets",
+    "docs-generator-action": "gha-docs-generator",
+    "release-strategy-action": "gha-release-strategy",
+    "update-action-docker-ref-action": "gha-update-action-docker-ref",
+    "load-config-action": "gha-load-config",
+    "detect-languages-action": "gha-detect-languages",
+    "ci-generate-matrices-action": "gha-ci-generate-matrices",
+    "security-summary-action": "gha-security-summary",
+    "pr-auto-label-action": "gha-pr-auto-label",
+    "jft-github-actions": "gha-template-repo",
+}
+
+os.makedirs(FALKCORP_DIR, exist_ok=True)
+
+for entry in sorted(os.listdir(BASE)):
+    repo_dir = os.path.join(BASE, entry)
+    if not os.path.isdir(os.path.join(repo_dir, ".git")):
+        continue
+
+    new_name = RENAMES.get(entry, entry)
+    new_remote = f"https://github.com/falkcorp/{new_name}.git"
+
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True, text=True, cwd=repo_dir
+    )
+    current = result.stdout.strip()
+
+    if not current:
+        print(f"SKIP  {entry} (no remote)")
+        continue
+
+    if "github.com/jdfalk/" in current or (
+        "github.com/falkcorp/" in current and current != new_remote
+    ):
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", new_remote],
+            cwd=repo_dir, check=True
+        )
+        print(f"UPDATE {entry} → {new_remote}")
+    else:
+        print(f"OK    {entry} ({current})")
+
+    # Symlink falkcorp/new_name → jdfalk/old_name
+    symlink = os.path.join(FALKCORP_DIR, new_name)
+    if not os.path.exists(symlink):
+        os.symlink(repo_dir, symlink)
+        print(f"LINK  {symlink} → {repo_dir}")
+
+print("\nDone. Symlinks created at ~/repos/github.com/falkcorp/")

--- a/scripts/org-migration/update-remotes.sh
+++ b/scripts/org-migration/update-remotes.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Phase 8: Update all local git remotes to point to falkcorp.
+# Run from any directory. Reads local clone dirs under ~/repos/github.com/jdfalk/.
+set -eo pipefail
+
+BASE="${HOME}/repos/github.com/jdfalk"
+FALKCORP_DIR="${HOME}/repos/github.com/falkcorp"
+
+# Map of old-name → new-name for repos that were renamed
+declare -A RENAMES=(
+    ["ghcommon"]="github-common"
+    ["release-go-action"]="gha-release-go"
+    ["release-python-action"]="gha-release-python"
+    ["release-rust-action"]="gha-release-rust"
+    ["release-docker-action"]="gha-release-docker"
+    ["release-frontend-action"]="gha-release-frontend"
+    ["release-protobuf-action"]="gha-release-protobuf-base"
+    ["auto-module-tagging-action"]="gha-auto-module-tagging"
+    ["ci-workflow-helpers-action"]="gha-ci-workflow-helpers"
+    ["generate-version-action"]="gha-generate-version"
+    ["get-frontend-config-action"]="gha-get-frontend-config"
+    ["package-assets-action"]="gha-package-assets"
+    ["docs-generator-action"]="gha-docs-generator"
+    ["release-strategy-action"]="gha-release-strategy"
+    ["update-action-docker-ref-action"]="gha-update-action-docker-ref"
+    ["load-config-action"]="gha-load-config"
+    ["detect-languages-action"]="gha-detect-languages"
+    ["ci-generate-matrices-action"]="gha-ci-generate-matrices"
+    ["security-summary-action"]="gha-security-summary"
+    ["pr-auto-label-action"]="gha-pr-auto-label"
+    ["jft-github-actions"]="gha-template-repo"
+)
+
+mkdir -p "${FALKCORP_DIR}"
+
+for dir in "${BASE}"/*/; do
+    [[ -d "${dir}/.git" ]] || continue
+    repo=$(basename "${dir}")
+    new_name="${RENAMES[$repo]:-$repo}"
+    new_remote="https://github.com/falkcorp/${new_name}.git"
+    current_remote=$(git -C "${dir}" remote get-url origin 2>/dev/null || echo "")
+
+    if [[ -z "${current_remote}" ]]; then
+        echo "SKIP  ${repo} (no remote)"
+        continue
+    fi
+
+    if [[ "${current_remote}" == *"github.com/jdfalk/"* ]] || [[ "${current_remote}" == *"github.com/falkcorp/"* && "${current_remote}" != "${new_remote}" ]]; then
+        echo "UPDATE ${repo} → ${new_remote}"
+        git -C "${dir}" remote set-url origin "${new_remote}"
+    else
+        echo "OK    ${repo} (already ${current_remote})"
+    fi
+
+    # Create symlink in falkcorp dir pointing to jdfalk dir
+    symlink="${FALKCORP_DIR}/${new_name}"
+    if [[ ! -e "${symlink}" ]]; then
+        ln -s "${dir}" "${symlink}"
+        echo "LINK  ${FALKCORP_DIR}/${new_name} → ${dir}"
+    fi
+done
+
+echo ""
+echo "Done. Run 'git -C <repo> fetch' in each repo to verify connectivity."
+echo "Symlinks created at ${FALKCORP_DIR}/ for IDE and shell history compatibility."

--- a/scripts/org-migration/update-workflow-refs.py
+++ b/scripts/org-migration/update-workflow-refs.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Phase 4: Update all cross-repo jdfalk/ → falkcorp/ references.
+Opens a PR in each repo that has changes.
+
+Run from any directory. Requires gh CLI and git.
+"""
+import os
+import subprocess
+import sys
+import glob
+import time
+
+BRANCH = "chore/falkcorp-migration"
+COMMIT_MSG = "chore: migrate jdfalk/ refs to falkcorp/ org"
+
+# Order matters — most-specific first to avoid double-substitution
+SUBSTITUTIONS = [
+    # ghcommon → github-common
+    ("jdfalk/ghcommon/", "falkcorp/github-common/"),
+    ("jdfalk/ghcommon@", "falkcorp/github-common@"),
+
+    # buf.build migration
+    ("buf.build/jdfalk/", "buf.build/falkcorp/"),
+
+    # *-action → gha-* renames (uses: references)
+    ("jdfalk/load-config-action@", "falkcorp/gha-load-config@"),
+    ("jdfalk/detect-languages-action@", "falkcorp/gha-detect-languages@"),
+    ("jdfalk/ci-generate-matrices-action@", "falkcorp/gha-ci-generate-matrices@"),
+    ("jdfalk/ci-workflow-helpers-action@", "falkcorp/gha-ci-workflow-helpers@"),
+    ("jdfalk/get-frontend-config-action@", "falkcorp/gha-get-frontend-config@"),
+    ("jdfalk/release-go-action@", "falkcorp/gha-release-go@"),
+    ("jdfalk/release-python-action@", "falkcorp/gha-release-python@"),
+    ("jdfalk/release-rust-action@", "falkcorp/gha-release-rust@"),
+    ("jdfalk/release-docker-action@", "falkcorp/gha-release-docker@"),
+    ("jdfalk/release-frontend-action@", "falkcorp/gha-release-frontend@"),
+    ("jdfalk/release-protobuf-action@", "falkcorp/gha-release-protobuf-base@"),
+    ("jdfalk/auto-module-tagging-action@", "falkcorp/gha-auto-module-tagging@"),
+    ("jdfalk/package-assets-action@", "falkcorp/gha-package-assets@"),
+    ("jdfalk/docs-generator-action@", "falkcorp/gha-docs-generator@"),
+    ("jdfalk/release-strategy-action@", "falkcorp/gha-release-strategy@"),
+    ("jdfalk/update-action-docker-ref-action@", "falkcorp/gha-update-action-docker-ref@"),
+    ("jdfalk/generate-version-action@", "falkcorp/gha-generate-version@"),
+    ("jdfalk/security-summary-action@", "falkcorp/gha-security-summary@"),
+    ("jdfalk/pr-auto-label-action@", "falkcorp/gha-pr-auto-label@"),
+
+    # gha-* repos — org change only
+    ("jdfalk/gha-release-go@", "falkcorp/gha-release-go@"),
+    ("jdfalk/gha-release-python@", "falkcorp/gha-release-python@"),
+    ("jdfalk/gha-release-rust@", "falkcorp/gha-release-rust@"),
+    ("jdfalk/gha-release-docker@", "falkcorp/gha-release-docker@"),
+    ("jdfalk/gha-release-frontend@", "falkcorp/gha-release-frontend@"),
+    ("jdfalk/gha-release-protobuf@", "falkcorp/gha-release-protobuf@"),
+    ("jdfalk/gha-template-repo@", "falkcorp/gha-template-repo@"),
+
+    # ghcr.io image references
+    ("ghcr.io/jdfalk/burndown-runner-image:", "ghcr.io/falkcorp/burndown-runner-image:"),
+    ("ghcr.io/jdfalk/load-config-action:", "ghcr.io/falkcorp/gha-load-config:"),
+    ("ghcr.io/jdfalk/detect-languages-action:", "ghcr.io/falkcorp/gha-detect-languages:"),
+    ("ghcr.io/jdfalk/ci-generate-matrices-action:", "ghcr.io/falkcorp/gha-ci-generate-matrices:"),
+    ("ghcr.io/jdfalk/ci-workflow-helpers-action:", "ghcr.io/falkcorp/gha-ci-workflow-helpers:"),
+    ("ghcr.io/jdfalk/get-frontend-config-action:", "ghcr.io/falkcorp/gha-get-frontend-config:"),
+    ("ghcr.io/jdfalk/release-frontend-action:", "ghcr.io/falkcorp/gha-release-frontend:"),
+    ("ghcr.io/jdfalk/generate-version-action:", "ghcr.io/falkcorp/gha-generate-version:"),
+    ("ghcr.io/jdfalk/auto-module-tagging-action:", "ghcr.io/falkcorp/gha-auto-module-tagging:"),
+    ("ghcr.io/jdfalk/package-assets-action:", "ghcr.io/falkcorp/gha-package-assets:"),
+    ("ghcr.io/jdfalk/release-go-action:", "ghcr.io/falkcorp/gha-release-go:"),
+    ("ghcr.io/jdfalk/release-protobuf-action:", "ghcr.io/falkcorp/gha-release-protobuf-base:"),
+    ("ghcr.io/jdfalk/release-docker-action:", "ghcr.io/falkcorp/gha-release-docker:"),
+    ("ghcr.io/jdfalk/release-rust-action:", "ghcr.io/falkcorp/gha-release-rust:"),
+
+    # Application repo references
+    ("jdfalk/audiobook-organizer", "falkcorp/audiobook-organizer"),
+    ("jdfalk/burndown-tasks", "falkcorp/burndown-tasks"),
+    ("jdfalk/burndown-runner-image", "falkcorp/burndown-runner-image"),
+    ("jdfalk/safe-ai-util-mcp", "falkcorp/safe-ai-util-mcp"),
+    ("jdfalk/safe-ai-util", "falkcorp/safe-ai-util"),
+    ("jdfalk/gcommon-proto", "falkcorp/gcommon-proto"),
+    ("jdfalk/gcommon", "falkcorp/gcommon"),
+    ("jdfalk/overnight-burndown", "falkcorp/overnight-burndown"),
+    ("jdfalk/migrate-loop", "falkcorp/migrate-loop"),
+
+    # go module paths
+    ("github.com/jdfalk/gcommon", "github.com/falkcorp/gcommon"),
+    ("github.com/jdfalk/gcommon-proto", "github.com/falkcorp/gcommon-proto"),
+]
+
+FILE_PATTERNS = [
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    "action.yml",
+    "action.yaml",
+    "*.md",
+    "go.mod",
+    "buf.yaml",
+    "buf.gen.yaml",
+]
+
+BASE = os.path.expanduser("~/repos/github.com/jdfalk")
+dry_run = "--dry-run" in sys.argv
+skip_pr = "--no-pr" in sys.argv
+
+
+def run(cmd, cwd=None, check=True):
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"Command {cmd} failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def apply_substitutions(content):
+    for old, new in SUBSTITUTIONS:
+        content = content.replace(old, new)
+    return content
+
+
+def find_files(repo_dir):
+    files = []
+    for pattern in FILE_PATTERNS:
+        matched = glob.glob(os.path.join(repo_dir, pattern), recursive=False)
+        # Also check in .github/workflows/
+        matched += glob.glob(os.path.join(repo_dir, ".github/workflows", os.path.basename(pattern)), recursive=False)
+        files.extend(matched)
+    # Deduplicate
+    return list(set(files))
+
+
+def process_repo(repo_name, repo_dir):
+    if not os.path.isdir(repo_dir):
+        print(f"  MISS  {repo_name} (not cloned at {repo_dir})")
+        return False
+
+    files = find_files(repo_dir)
+    changed_files = []
+
+    for fpath in files:
+        if not os.path.isfile(fpath):
+            continue
+        try:
+            with open(fpath, "r", encoding="utf-8") as f:
+                original = f.read()
+        except (UnicodeDecodeError, PermissionError):
+            continue
+
+        updated = apply_substitutions(original)
+        if updated != original:
+            changed_files.append((fpath, updated))
+
+    if not changed_files:
+        print(f"  NOOP  {repo_name}")
+        return False
+
+    print(f"  CHANGES {repo_name}: {len(changed_files)} files")
+    for fpath, _ in changed_files:
+        print(f"    {os.path.relpath(fpath, repo_dir)}")
+
+    if dry_run:
+        return False
+
+    # Apply changes
+    for fpath, content in changed_files:
+        with open(fpath, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    # Git operations
+    try:
+        # Check if branch already exists
+        branches = run(["git", "branch", "--list", BRANCH], cwd=repo_dir)
+        if BRANCH in branches:
+            run(["git", "checkout", BRANCH], cwd=repo_dir)
+        else:
+            # Get default branch
+            default = run(["git", "remote", "show", "origin"], cwd=repo_dir)
+            default_branch = "main"
+            for line in default.split("\n"):
+                if "HEAD branch:" in line:
+                    default_branch = line.split(":")[-1].strip()
+                    break
+            run(["git", "fetch", "origin", default_branch], cwd=repo_dir)
+            run(["git", "checkout", "-b", BRANCH, f"origin/{default_branch}"], cwd=repo_dir)
+
+        # Stage and commit
+        for fpath, _ in changed_files:
+            run(["git", "add", fpath], cwd=repo_dir)
+        run(["git", "commit", "-m", COMMIT_MSG], cwd=repo_dir)
+        run(["git", "push", "-u", "origin", BRANCH, "--force-with-lease"], cwd=repo_dir)
+
+        if not skip_pr:
+            # Determine if repo is in jdfalk or falkcorp now
+            remote_url = run(["git", "remote", "get-url", "origin"], cwd=repo_dir)
+            if "falkcorp" in remote_url:
+                repo_ref = f"falkcorp/{repo_name}"
+            else:
+                repo_ref = f"jdfalk/{repo_name}"
+
+            pr_body = f"""## Migrate org references: jdfalk → falkcorp
+
+Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags
+from `jdfalk/` to `falkcorp/` as part of the organization migration.
+
+### Changed files:
+{chr(10).join(f'- `{os.path.relpath(f, repo_dir)}`' for f, _ in changed_files)}
+
+🤖 Generated by `scripts/org-migration/update-workflow-refs.py`"""
+
+            run(["gh", "pr", "create",
+                 "-R", repo_ref,
+                 "--title", "chore: migrate jdfalk/ refs to falkcorp/ org",
+                 "--body", pr_body,
+                 "--head", BRANCH,
+                 "--base", "main"], cwd=repo_dir)
+            print(f"  PR    {repo_name}")
+
+    except RuntimeError as e:
+        print(f"  ERROR {repo_name}: {e}")
+        return False
+
+    return True
+
+
+if dry_run:
+    print("=== DRY RUN (pass no args to execute) ===\n")
+
+# Get all jdfalk repos
+repos = sorted([
+    d for d in os.listdir(BASE)
+    if os.path.isdir(os.path.join(BASE, d)) and not d.startswith(".")
+])
+
+changed, noop, missed = 0, 0, 0
+for repo in repos:
+    result = process_repo(repo, os.path.join(BASE, repo))
+    if result:
+        changed += 1
+    elif os.path.isdir(os.path.join(BASE, repo)):
+        noop += 1
+    else:
+        missed += 1
+    time.sleep(0.2)
+
+print(f"\nDone: {changed} repos with PRs, {noop} no changes, {missed} not found")

--- a/scripts/org-migration/verify-migration.sh
+++ b/scripts/org-migration/verify-migration.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Phase 9: Post-migration health checks.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+check() {
+    local label="$1"
+    local cmd="$2"
+    if eval "${cmd}" &>/dev/null; then
+        echo "  PASS  ${label}"
+        ((PASS++))
+    else
+        echo "  FAIL  ${label}"
+        ((FAIL++))
+    fi
+}
+
+warn_if_found() {
+    local label="$1"
+    local cmd="$2"
+    local result
+    result=$(eval "${cmd}" 2>/dev/null || true)
+    if [[ -n "${result}" ]]; then
+        echo "  WARN  ${label}"
+        echo "${result}" | head -5 | sed 's/^/         /'
+        ((WARN++))
+    else
+        echo "  PASS  ${label}"
+        ((PASS++))
+    fi
+}
+
+echo "=== GitHub Reachability ==="
+check "falkcorp/github-common reachable" "gh repo view falkcorp/github-common --json name"
+check "falkcorp/audiobook-organizer reachable" "gh repo view falkcorp/audiobook-organizer --json name"
+check "falkcorp/burndown-tasks reachable" "gh repo view falkcorp/burndown-tasks --json name"
+check "falkcorp/overnight-burndown reachable" "gh repo view falkcorp/overnight-burndown --json name"
+check "falkcorp/gha-load-config reachable" "gh repo view falkcorp/gha-load-config --json name"
+check "falkcorp/gha-release-go reachable" "gh repo view falkcorp/gha-release-go --json name"
+check "falkcorp/safe-ai-util reachable" "gh repo view falkcorp/safe-ai-util --json name"
+check "falkcorp/burndown-runner-image reachable" "gh repo view falkcorp/burndown-runner-image --json name"
+
+echo ""
+echo "=== Stale jdfalk/ References in Local Clones ==="
+BASE="${HOME}/repos/github.com/jdfalk"
+warn_if_found "No jdfalk/ in workflow uses:" \
+    "grep -r 'uses: jdfalk/' ${BASE}/*/.github/workflows/ 2>/dev/null"
+warn_if_found "No ghcr.io/jdfalk/ image refs in action.yml files" \
+    "grep -r 'ghcr.io/jdfalk/' ${BASE}/*/action.yml 2>/dev/null"
+warn_if_found "No github.com/jdfalk/gcommon in go.mod files" \
+    "grep -r 'github.com/jdfalk/gcommon' ${BASE}/*/go.mod 2>/dev/null"
+
+echo ""
+echo "=== GitHub App Secrets ==="
+check "BURNDOWN_BOT_APP_ID exists in falkcorp" \
+    "gh secret list --org falkcorp | grep -q BURNDOWN_BOT_APP_ID"
+check "BURNDOWN_BOT_PRIVATE_KEY exists in falkcorp" \
+    "gh secret list --org falkcorp | grep -q BURNDOWN_BOT_PRIVATE_KEY"
+check "ANTHROPIC_API_KEY exists in falkcorp" \
+    "gh secret list --org falkcorp | grep -q ANTHROPIC_API_KEY"
+check "BUF_TOKEN exists in falkcorp" \
+    "gh secret list --org falkcorp | grep -q BUF_TOKEN"
+
+echo ""
+echo "=== Local Git Remotes ==="
+for repo in audiobook-organizer burndown-tasks overnight-burndown github-common; do
+    dir="${HOME}/repos/github.com/jdfalk/${repo}"
+    [[ -d "${dir}" ]] || dir="${HOME}/repos/github.com/falkcorp/${repo}"
+    if [[ -d "${dir}" ]]; then
+        remote=$(git -C "${dir}" remote get-url origin 2>/dev/null || echo "")
+        if [[ "${remote}" == *"falkcorp"* ]]; then
+            echo "  PASS  ${repo} remote: ${remote}"
+            ((PASS++))
+        else
+            echo "  FAIL  ${repo} remote still points to: ${remote}"
+            ((FAIL++))
+        fi
+    fi
+done
+
+echo ""
+echo "=== BSR ==="
+check "buf.build/falkcorp/gcommon exists" \
+    "buf registry module get buf.build/falkcorp/gcommon"
+
+echo ""
+echo "==============================="
+echo "PASS: ${PASS}  FAIL: ${FAIL}  WARN: ${WARN}"
+[[ ${FAIL} -eq 0 ]]


### PR DESCRIPTION
## Migrate org references: jdfalk → falkcorp

Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags
from `jdfalk/` to `falkcorp/` as part of the organization migration.

### Changed files:
- `.github/workflows/release-prod.yml`
- `QUICKSTART.md`
- `.github/workflows/frontend-ci.yml`
- `.github/workflows/ci.yml`
- `go.mod`
- `CHANGELOG.md`
- `.github/workflows/nightly-burndown.yml`
- `.github/workflows/security.yml`
- `.github/workflows/nightly.yml`
- `TODO.md`
- `.github/workflows/prerelease.yml`
- `CLAUDE.md`
- `.github/workflows/test-action-integration.yml`
- `README.md`
- `.github/workflows/hard-burndown.yml`

🤖 Generated by `scripts/org-migration/update-workflow-refs.py`