### PR TITLE
fix: bump reusable-burndown SHA to v1.10.7 + explicit hub_repo

### DIFF
--- a/.github/workflows/hard-burndown.yml
+++ b/.github/workflows/hard-burndown.yml
@@ -19,9 +19,10 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@bfb912c8e63e7f8e33df9c20c5c25c04083ec0b4 # v1.10.7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
+      hub_repo: falkcorp/burndown-tasks
       task_filter: failed-batch
       powerful_only: true
     secrets: inherit

--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -19,7 +19,8 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@2b9f83e6f0b215e8a7e709e7df9f8aec293f01a7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@bfb912c8e63e7f8e33df9c20c5c25c04083ec0b4 # v1.10.7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
+      hub_repo: falkcorp/burndown-tasks
     secrets: inherit


### PR DESCRIPTION
Pinned SHA `2b9f83e6` had `default: jdfalk/burndown-tasks` as hub_repo, causing 404 in burndown bot. Bumped to `bfb912c8` (v1.10.7) and added explicit `hub_repo: falkcorp/burndown-tasks` to both `nightly-burndown.yml` and `hard-burndown.yml`.