### PR TITLE
fix: bump reusable-burndown SHA (correct image tag)

### DIFF
--- a/.github/workflows/hard-burndown.yml
+++ b/.github/workflows/hard-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@502567550c68249c540be8cbca250e090f1d0e6d # v1.10.7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@cf478e0ede8ec82d9b954b5c2b5f2830725c4499 # v1.10.7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks

--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@502567550c68249c540be8cbca250e090f1d0e6d # v1.10.7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@cf478e0ede8ec82d9b954b5c2b5f2830725c4499 # v1.10.7
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks


### PR DESCRIPTION
Picks up the image tag fix — `483ee343` was never in GHCR, replaced with `09a419b207`.