### PR TITLE
fix(burndown): set cheapest_only=true on nightly dispatch

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.7.0
+# version: 1.8.0
 name: Nightly burndown
 
 on:
@@ -23,4 +23,5 @@ jobs:
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks
+      cheapest_only: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- Dispatch tasks were escalating to `gpt-5.3-codex` / `gpt-5` for complexity ≥3 tasks, burning \$25 in a single day
- The burndown bot's purpose is to dispatch well-scoped tasks to smaller/cheaper models — `gpt-5.1-codex-mini` is the right tool
- Sets `cheapest_only: true` on the nightly call so all dispatch tasks are locked to `gpt-5.1-codex-mini`
- Triage stays on `o4-mini`; `hard-burndown.yml` keeps `powerful_only: true` as the explicit retry path for tasks that fail on mini

## Test plan

- [x] Workflow passes `cheapest_only: true` to reusable-burndown
- [ ] Next nightly run shows only `gpt-5.1-codex-mini` in dispatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)