### PR TITLE
fix(burndown): use gpt-5.1-codex for triage instead of o4-mini

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.8.0
+# version: 1.9.0
 name: Nightly burndown
 
 on:
@@ -24,4 +24,5 @@ jobs:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
+      triage_model: gpt-5.1-codex
     secrets: inherit


### PR DESCRIPTION
## Summary

- `o4-mini` is a reasoning model — wrong fit and expensive for triage, which is code-reading + classification
- `gpt-5.1-codex` is the right model: understands code context, cheaper than o4-mini, no wasted reasoning budget
- Dispatch stays pinned to `gpt-5.1-codex-mini` (from previous PR)
- Model ladder: triage=`gpt-5.1-codex`, dispatch=`gpt-5.1-codex-mini`, hard-retry=`gpt-5` (powerful_only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)