### PR TITLE
fix(ci): triage_model: gpt-4.1 in nightly-burndown

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 1.9.0
+# version: 2.0.0
 name: Nightly burndown
 
 on:
@@ -24,5 +24,5 @@ jobs:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
-      triage_model: gpt-5.1-codex
+      triage_model: gpt-4.1
     secrets: inherit


### PR DESCRIPTION
## Summary
- Removes `triage_model: gpt-5.1-codex` override (wrong model — more expensive, less suited to classification)
- Sets `triage_model: gpt-4.1` to match the fromenv.go default

🤖 Generated with [Claude Code](https://claude.com/claude-code)