### PR TITLE
feat(ci): add max_tasks dispatch input to nightly-burndown

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.0.0
+# version: 2.1.0
 name: Nightly burndown
 
 on:
@@ -16,6 +16,11 @@ on:
           - dry-run
           - draft-only
           - full
+      max_tasks:
+        description: "Cap dispatched tasks (0 = unlimited)"
+        required: false
+        default: "0"
+        type: string
 
 jobs:
   burndown:
@@ -25,4 +30,5 @@ jobs:
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
       triage_model: gpt-4.1
+      max_tasks: ${{ inputs.max_tasks || 0 }}
     secrets: inherit


### PR DESCRIPTION
Exposes `max_tasks` from the reusable workflow so test runs can be capped without changing the scheduled nightly. Default 0 = unlimited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)