### PR TITLE
fix(ci): update reusable-burndown SHA pin to v1.10.0

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.1.0
+# version: 2.2.0
 name: Nightly burndown
 
 on:
@@ -24,7 +24,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@cf478e0ede8ec82d9b954b5c2b5f2830725c4499 # v1.10.7
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.10.0
     with:
       mode: ${{ inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks


### PR DESCRIPTION
## Summary

Fixes `startup_failure` on every burndown dispatch.

**Root cause:** `nightly-burndown.yml` was pinned to `cf478e0` which has `reusable-burndown.yml` v1.8.0 — that version doesn't declare the `max_tasks` input. Passing `max_tasks:` to an undeclared input causes GitHub Actions to fail at startup before any job runs.

**Fix:** Update pin to `f602707` (current `github-common` HEAD, v1.10.0) which includes:
- `max_tasks` input (added in PR #300)
- `ob-77dfdfa` image tag (updated in PR #302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)