### PR TITLE
fix(ci): coerce max_tasks string to number with fromJSON

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.2.0
+# version: 2.3.0
 name: Nightly burndown
 
 on:
@@ -30,5 +30,5 @@ jobs:
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
       triage_model: gpt-4.1
-      max_tasks: ${{ inputs.max_tasks || 0 }}
+      max_tasks: ${{ fromJSON(inputs.max_tasks || '0') }}
     secrets: inherit


### PR DESCRIPTION
Fixes persistent startup_failure on burndown dispatch.

reusable-burndown.yml declares max_tasks as type: number. workflow_dispatch inputs are always strings. Passing `"3"` to a number-typed reusable input causes GHA to fail at startup validation before any job runs.

`fromJSON(inputs.max_tasks || '0')` converts the string to an integer before it crosses the workflow_call boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)