### PR TITLE
fix(ci): update nightly + frontend-ci SHA pins to f602707

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/frontend-ci.yml
-# version: 2.9.1
+# version: 2.9.2
 # guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 # last-edited: 2026-05-01
 
@@ -49,7 +49,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly.yml
-# version: 1.0.1
+# version: 1.0.2
 # guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 # last-edited: 2026-05-01
 
@@ -28,7 +28,7 @@ permissions:
 jobs:
   full-ci:
     name: Full CI Suite
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v1.12.0
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'


### PR DESCRIPTION
Fixes startup_failure on every nightly and frontend-ci run.

**Root cause:** both workflows pinned `reusable-ci.yml@fe1e308` which internally calls `jdfalk/ghcommon/.github/workflows/reusable-advanced-cache.yml`. After the org migration to `falkcorp`, `jdfalk/ghcommon` refs fail to resolve → 0 jobs, instant startup_failure.

**Fix:** update both pins to `f602707` (current github-common HEAD, `reusable-ci.yml` v1.12.1) which has all refs migrated to `falkcorp/`.

Note: `ci.yml` was unaffected because it uses `reusable-ci-minimal.yml` which doesn't have the `reusable-advanced-cache` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)