### PR TITLE
fix(ci): scheduled burndown uses full mode + add 20:00 UTC slot

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,10 +1,11 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.3.0
+# version: 2.4.0
 name: Nightly burndown
 
 on:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 * * *"   # 08:00 UTC morning run
+    - cron: "0 20 * * *"  # 20:00 UTC evening run (backup + catches GitHub scheduler drift)
   workflow_dispatch:
     inputs:
       mode:
@@ -26,7 +27,9 @@ jobs:
   burndown:
     uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.10.0
     with:
-      mode: ${{ inputs.mode || 'draft-only' }}
+      # Scheduled runs always use full mode (auto-merge ready PRs).
+      # Manual dispatch respects the input selection (default: draft-only for safety).
+      mode: ${{ github.event_name == 'schedule' && 'full' || inputs.mode || 'draft-only' }}
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
       triage_model: gpt-4.1


### PR DESCRIPTION
## Summary

- Scheduled runs now use `full` mode instead of `draft-only` so completed PRs are auto-merged without manual intervention
- Added a second daily schedule slot (20:00 UTC) — GitHub's scheduler can drift 4+ hours, so two slots per day guarantees at least one fires in any 24-hour window
- Manual `workflow_dispatch` still defaults to `draft-only` for safety when a human triggers it

## Root cause

This morning's scheduled run fired at 12:35 UTC (4.5h after the 08:00 UTC cron) and completed in `draft-only` mode, leaving 3 successful PRs open as drafts rather than merging them.

## Test plan
- [ ] Verify evening run (20:00 UTC) fires in `full` mode
- [ ] Verify manual dispatch still shows `draft-only` as default in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)