### PR TITLE
fix(ci): update stale fe1e3081 SHA pins → f602707 (ci/prerelease/release-prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.1
+# version: 3.0.2
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-05-01
+# last-edited: 2026-06-09
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -28,7 +28,7 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # feat/reusable-ci-minimal
+    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.9.2
+# version: 2.9.3
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-# last-edited: 2026-05-01
+# last-edited: 2026-06-09
 
 name: Prerelease on Merge
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # v2.13.1
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v2.13.4
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.8.1
+# version: 4.8.2
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-# last-edited: 2026-05-01
+# last-edited: 2026-06-09
 
 name: Production Release
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@fe1e3081e230dd5ac3d358f9c6a3e4dc0b209529 # latest
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v2.13.4
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false


### PR DESCRIPTION
## Problem

Three workflow files still pinned to `fe1e3081` — the pre-migration SHA of `falkcorp/github-common` that contains `jdfalk/` internal action references. `jdfalk/gha-release-frontend` and `jdfalk/gha-release-go` were deleted during the `jdfalk→falkcorp` org migration, causing **every push to main** to fail the \"Prerelease on Merge\" workflow.

```
Unable to resolve action `jdfalk/gha-release-frontend@f77c3d10...`
Unable to resolve action `jdfalk/gha-release-go@c7f72a3d...`
```

## Changes

| File | Old SHA | New SHA |
|------|---------|---------|
| `ci.yml` | `fe1e3081` (reusable-ci-minimal) | `f602707` |
| `prerelease.yml` | `fe1e3081` (reusable-release) | `f602707` |
| `release-prod.yml` | `fe1e3081` (reusable-release) | `f602707` |

`f602707` is the current HEAD of `falkcorp/github-common` with all `falkcorp/` internal refs. Already in use by `frontend-ci.yml` and `nightly.yml` where CI has been green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)