### PR TITLE
fix(ci): cap scheduled burndown at 8 tasks to prevent OpenAI 429 exhaustion

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.4.0
+# version: 2.5.0
 name: Nightly burndown
 
 on:
@@ -33,5 +33,7 @@ jobs:
       hub_repo: falkcorp/burndown-tasks
       cheapest_only: true
       triage_model: gpt-4.1
-      max_tasks: ${{ fromJSON(inputs.max_tasks || '0') }}
+      # Scheduled runs cap at 8 tasks to avoid OpenAI 429 rate-limit exhaustion
+      # from 22+ simultaneous agent calls. Manual dispatch can override to 0 (unlimited).
+      max_tasks: ${{ github.event_name == 'schedule' && 8 || fromJSON(inputs.max_tasks || '0') }}
     secrets: inherit


### PR DESCRIPTION
## Problem

Every recent nightly burndown run has failed with OpenAI 429 rate-limit exhaustion. The scheduled runs use `max_tasks: 0` (unlimited), dispatching 22+ agent jobs simultaneously. With the 2s dispatch stagger, all tasks are alive and hitting the OpenAI API concurrently, exhausting the quota within minutes.

From the June 9 failure log:
- 5 tasks: "exceeded max iterations (90)"
- 13+ tasks: "rate-limit retries exhausted (POST: 429 Too Many Requests)"

## Fix

Cap scheduled runs at 8 tasks. Manual `workflow_dispatch` still supports `max_tasks: 0` (unlimited) for full runs when the API quota has recovered.

```
2 schedule slots/day × 8 tasks = 16 tasks/day
```

The expression `github.event_name == 'schedule' && 8 || fromJSON(inputs.max_tasks || '0')` evaluates to `8` for cron triggers and the user-supplied (or default `0`) value for manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)