### PR TITLE
fix(ci): update burndown SHA pin to v1.11.0 — rebase-stale job

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.5.0
+# version: 2.6.0
 name: Nightly burndown
 
 on:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.10.0
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@c3dac07c4af0a9efac2c89f7d15b9c02bcd5e49f # v1.11.0
     with:
       # Scheduled runs always use full mode (auto-merge ready PRs).
       # Manual dispatch respects the input selection (default: draft-only for safety).


### PR DESCRIPTION
## Summary

- Updates `nightly-burndown.yml` SHA pin: `f602707` (v1.10.0) → `c3dac07` (v1.11.0)
- Picks up the new `rebase-stale` job added in falkcorp/github-common#303

## What changes at runtime

Every burndown run now starts a `rebase-stale` job in parallel with `preflight`:
1. Finds all open `automation`-labeled PRs with `mergeable == CONFLICTING`
2. Rebases each branch onto `main` and force-pushes
3. If rebase fails: applies `status:conflict-unresolvable` label + comment

`triage` waits for both `preflight` and `rebase-stale` before dispatching new tasks.

## Test plan
- [ ] Trigger a manual run — verify `rebase-stale` job appears
- [ ] PR #1339 (currently CONFLICTING) should auto-rebase on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)