### PR TITLE
docs(review): fable5 full-system review — findings, 3 specs, 27-task implementation plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.12.0 -->
+<!-- version: 3.13.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-09 -->
 
@@ -8,6 +8,36 @@
 ## [Unreleased]
 
 ### Changed
+
+#### June 9, 2026 — Fable 5 full-system review: findings, 3 specs, 27-task implementation plan (docs only)
+
+Architecture review across 4 priorities (unified dedup, iTunes writeback hardening,
+memory/DB optimization, general security review). No code changed — deliverables are
+documentation:
+
+- `docs/specs/fable5-review-findings.md` — 3 CRITICAL / 6 HIGH / 8 MEDIUM / 2 LOW.
+  Headline: binary forensics of the 4 "(Damaged)" iTunes libraries vs the golden copy
+  showed the current dangling-ref verifier passes 3 of the 4 libraries iTunes rejected;
+  the live corruption vectors are our writer's invented mhoh encoding-flag bytes
+  (+27 ∈ {1,3}; iTunes writes 0x00 — 0 of 281,790 golden blocks), `file://` URLs written
+  into the 0x0D Windows-path field (83,783 blocks in damaged-1/3), and `hdfm` header
+  track counts never updated on removal (90,900 vs 90,898 desync in damaged-1/2). Also:
+  the LE parser never reads track string metadata at all (diagnostic diffs were vacuous),
+  and the accept-invite HTTP/2 `{"error":"EOF"}` pen-test root cause.
+- `docs/specs/fable5-spec-itunes-writeback-hardening.md` — `ITLSafetyContract` (8 named
+  guards), `SafeWriteITL` atomic write protocol with header regeneration + backup
+  retention, Apple-Devices compatibility checklist, 13-test regression suite design.
+- `docs/specs/fable5-spec-unified-dedup-pipeline.md` — composite scoring (noisy-OR,
+  normalized 0–100 with stored per-signal breakdown), LSH `fpidx:` PebbleDB index design,
+  unified dedup UI tab, provenance purge for ~14K stale 100% candidates. Corrects stale
+  assumptions: folder/metadata-fuzzy "signals" are stubs; embeddings already in PebbleDB.
+- `docs/specs/fable5-spec-memory-db-optimization.md` — corrected premises (embeddings.db
+  and ai_scans.db already migrated to Pebble; memdb warm-up enabled + stripped);
+  prioritized list topped by stripping deprecated AcoustID segments from memdb
+  (~550–900MB RSS) and removing the legacy 7.9K-line SQLite store.
+- `docs/plans/fable5-implementation-plan.md` — TASK-001..027 with dependencies, 5
+  parallel waves, per-task acceptance criteria/idempotency/rollback, Sonnet-executable.
+- `TODO.md` — new "Fable 5 Full-System Review" section with all 27 task stubs.
 
 #### June 9, 2026 — Burndown bot: automatic conflict resolution + schedule reliability
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.71.0 -->
+<!-- version: 8.72.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-09 -->
 
@@ -25,6 +25,52 @@ future agent) can scan the entire workspace in one page.
 **Production:** PebbleDB primary; Linux, HTTPS at `172.16.2.30:8484`
 **Latest activity:** Burndown bot: `rebase-stale` job (auto-fix CONFLICTING PRs) + dual schedule (08:00/20:00 UTC) + `full` mode for scheduled runs (PRs #1342, #1353). 31 narrow test-coverage issues queued in burndown-tasks (#79–#109).
 **In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds), fingerprint identification pipeline
+
+---
+
+## 🔭 Fable 5 Full-System Review — June 9, 2026 (specs + 27-task plan)
+
+Review deliverables (see files for full detail):
+- [`docs/specs/fable5-review-findings.md`](docs/specs/fable5-review-findings.md) — 3 CRITICAL / 6 HIGH / 8 MEDIUM / 2 LOW, iTunes findings grounded in binary forensics of 4 damaged libraries
+- [`docs/specs/fable5-spec-itunes-writeback-hardening.md`](docs/specs/fable5-spec-itunes-writeback-hardening.md) — ITLSafetyContract, SafeWriteITL, regression suite
+- [`docs/specs/fable5-spec-unified-dedup-pipeline.md`](docs/specs/fable5-spec-unified-dedup-pipeline.md) — composite scoring (noisy-OR, 0–100 capped), LSH fpidx index, unified UI tab
+- [`docs/specs/fable5-spec-memory-db-optimization.md`](docs/specs/fable5-spec-memory-db-optimization.md) — corrected premises (embeddings already in Pebble); prioritized list
+- [`docs/plans/fable5-implementation-plan.md`](docs/plans/fable5-implementation-plan.md) — TASK-001..027, dependency graph, 5 waves
+
+### P2 — iTunes writeback hardening (highest stakes; wave 1–4)
+- [ ] **F5-T001** Fix LE parser mhoh descent — track string fields currently never parsed (HIGH-2)
+- [ ] **F5-T002** Golden-corpus mhoh encoding audit tool + constants table
+- [ ] **F5-T003** ⚠ `ITLSafetyContract` — 8 named guards + 13-test regression suite
+- [ ] **F5-T004** ⚠ `SafeWriteITL` atomic write + header count regeneration (CRIT-3)
+- [ ] **F5-T005** ⚠ iTunes-conformant string encoders — stop writing +27∈{1,3} (CRIT-1)
+- [ ] **F5-T006** ⚠ `LocationPair` — 0x0D Windows path / 0x0B URL normalization (CRIT-2)
+- [ ] **F5-T007** itl-diff/itl-check honesty: msdh inventory, playlist membership, AuditITL
+- [ ] **F5-T008** Diff-before-write in writeback batcher (HIGH-3) + library-not-in-use gate
+- [ ] **F5-T010** Fail-closed inflate cap (MED-7)
+
+### P1 — Unified dedup pipeline (waves 1–4)
+- [ ] **F5-T011** `internal/dedup/unified` — Signal/UnifiedDedupScore/ComposeScore (noisy-OR v1)
+- [ ] **F5-T012** ⚠ LSH `fpidx:` Pebble index — build op + write/delete hooks (`lsh_index_v1_done`)
+- [ ] **F5-T013** LSH probe collector; retire `ACOUSTID_FUZZY_ENABLED` O(N) path
+- [ ] **F5-T014** Collector refactor + `PairEligibility` + NEW metadata-fuzzy collector
+- [ ] **F5-T015** ⚠ Candidate schema additions + legacy-fingerprint purge (~14K stale 100% rows, HIGH-5)
+- [ ] **F5-T016** API: band/score/breakdown fields, `/breakdown`, `/rescore`
+- [ ] **F5-T017** Unified Dedup UI tab (feature-flagged until backfill complete)
+- [ ] **F5-T018** Scan op rationalization (merge embed-scan/async; phase ordering)
+
+### P3 — Memory & DB optimization (waves 1–5)
+- [ ] **F5-T019** ⚠ Strip AcoustIDSeg0–6 from memdb (~550–900MB RSS) — after T013
+- [ ] **F5-T020** ⚠ Drop seg fields from `book_file:` Pebble values (sweep + `bookfile_seg_drop_v1_done`)
+- [ ] **F5-T021** Embedding float16+zstd (`emb_f16_v1_done`, dual-read)
+- [ ] **F5-T022** Remove legacy SQLite store (~7.9K lines + CGO dep) (MED-4)
+- [ ] **F5-T023** memdb size telemetry + operation-log retention + dead-prefix sweep
+- [ ] **F5-T024** NutsDB → Pebble activity/metrics migration (dual-write window)
+
+### P4 — Fixes (wave 1–2)
+- [ ] **F5-T009** accept-invite HTTP/2 EOF fix + 413 clarity (HIGH-4 pen-test, MED-1)
+- [ ] **F5-T025** `FilterUnchangedTags` covers custom `AUDIOBOOK_ORGANIZER_*` tags (MED-3)
+- [ ] **F5-T026** Duration/filesize aggregation from BookFiles + backfill (MED-2)
+- [ ] **F5-T027** Chromem hydration shutdown join (MED-8)
 
 ---
 

--- a/docs/plans/fable5-implementation-plan.md
+++ b/docs/plans/fable5-implementation-plan.md
@@ -195,9 +195,11 @@ guards except writer changes (T005/T006) — guards detect; they do not fix.
    `itl_le_verify.go` patterns); also per-miph declared (+16) vs actual mtph children.
 3. `mhoh-format`: enforce headerLen==24, totalLen==40+strLen, +27==0, bytes 32–39 zero,
    `+24` ∈ table from T002 when the table has entries for that hohmType.
-4. `location-form`: 0x0D matches `^[A-Za-z]:\\` and contains no `file://` or `%`; 0x0B
-   starts `file://localhost/`, percent-escaping valid, and no value contains
-   `.itunes-writeback/`.
+4. `location-form` (per SPEC 2 §2, census-corrected): operate on **decoded** strings
+   (0x0D can be UTF-16-encoded); per-track: if 0x0D present → matches `^[A-Za-z]:\\`,
+   no `file://`, no `%`-escapes, and sibling 0x0B is a round-tripping
+   `file://localhost/` URL; tracks without 0x0D (podcasts) may hold `http(s)://` in
+   0x0B; no value contains `.itunes-writeback/`.
 5. `parse-roundtrip`: must FAIL (not skip) when master list unlocatable or payload
    uninflatable — uses T010's fail-closed inflate.
 6. `bounded-delta`: config defaults removedTracksMax=5000, rewrittenMhohPctMax=20, with

--- a/docs/plans/fable5-implementation-plan.md
+++ b/docs/plans/fable5-implementation-plan.md
@@ -1,0 +1,1160 @@
+<!-- file: docs/plans/fable5-implementation-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1e4a7c2b-8f5d-4b9e-a6c3-9d2f5b8e1a4c -->
+
+# Fable 5 Implementation Plan
+
+Companion to:
+- `docs/specs/fable5-review-findings.md` (finding IDs CRIT-*/HIGH-*/MED-*/LOW-*)
+- `docs/specs/fable5-spec-itunes-writeback-hardening.md` (SPEC 2, ITW-* gap IDs)
+- `docs/specs/fable5-spec-unified-dedup-pipeline.md` (SPEC 1)
+- `docs/specs/fable5-spec-memory-db-optimization.md` (SPEC 3)
+
+Coordination model: Fable 5 coordinates and reviews; Sonnet subagents execute one task
+each in an isolated worktree, PR per task, rebase/FF merges, `make ci` (80% coverage)
+gates every PR. Tasks marked **⚠ Fable-review-critical** change iTunes writers or PebbleDB
+schemas and require line-by-line coordinator review before merge.
+
+## Dependency graph
+
+```mermaid
+graph TD
+  subgraph P2 iTunes
+    T001[T001 LE parser mhoh fix] --> T007[T007 tool upgrades]
+    T001 --> T008[T008 diff-before-write]
+    T002[T002 mhoh corpus audit] --> T003[T003 ITLSafetyContract]
+    T002 --> T005[T005 string encoder fix]
+    T003 --> T004[T004 SafeWriteITL + header regen]
+    T004 --> T008
+    T003 --> T007
+    T005 --> T006[T006 LocationPair normalization]
+    T010[T010 fail-closed inflate] --> T003
+  end
+  subgraph P1 Dedup
+    T011[T011 unified score pkg] --> T013[T013 LSH probe collector]
+    T012[T012 fpidx index] --> T013
+    T011 --> T014[T014 collectors refactor]
+    T011 --> T015[T015 candidate schema + fp purge]
+    T014 --> T016[T016 API extensions]
+    T015 --> T016
+    T016 --> T017[T017 Unified UI tab]
+    T014 --> T018[T018 scan op rationalization]
+  end
+  subgraph P3 Memory/DB
+    T013 --> T019[T019 memdb seg strip]
+    T019 --> T020[T020 pebble seg drop]
+    T021[T021 embedding f16+zstd]
+    T022[T022 SQLite store removal]
+    T023[T023 telemetry + retention]
+    T024[T024 NutsDB→Pebble activity]
+  end
+  subgraph P4 Fixes
+    T009[T009 accept-invite EOF]
+    T025[T025 filterUnchangedTags]
+    T026[T026 duration/filesize agg]
+    T027[T027 chromem stop join]
+  end
+```
+
+## Parallel execution groups
+
+| Wave | Tasks (parallel within wave) | Notes |
+|---|---|---|
+| W1 | T001, T002, T009, T010, T011, T012, T023, T027 | all independent; no shared files |
+| W2 | T003, T005, T013, T014, T015, T021, T022, T025, T026 | T003 needs T002+T010; T005 needs T002; serialize T005 after T003 ONLY if both touch `itl_le_mutate.go` in the same wave — prefer T003 first |
+| W3 | T004, T006, T016, T018, T019 | T006 after T005 (same writer files) |
+| W4 | T007, T008, T017, T020 | |
+| W5 | T024 | big, last, optional |
+
+Same-file serialization rules: `internal/itunes/itl_le_mutate.go` (T003→T005→T006);
+`internal/dedup/engine.go` (T013→T014→T018); `internal/database/pebble_store.go`
+(T012→T015→T019→T020). Frontend (T017) parallel with backend once T016's API contract
+is merged. P2 (iTunes) is the highest-stakes track — its wave-1/2 tasks should start first.
+
+---
+
+### TASK-001: Fix LE parser to read track string metadata (mhoh descent)
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** `walkMsdhTracksLE` (`internal/itunes/itl_le.go:49-91`) advances by each
+`mith` chunk's totalLen, which includes its child `mhoh` blocks, so `parseMhohLE` is never
+called for track metadata: every `ITLTrack` string field (Name, Album, Artist, Genre,
+Kind, Location, LocalURL) is empty on LE libraries (findings HIGH-2; verified empirically
+— `itl-diff -v` prints `"" by ""` for all tracks of a 94K-track library). All diagnostic
+tooling and any service code reading these fields is blind. This fix is the prerequisite
+for trustworthy diffs (T007) and diff-before-write (T008).
+
+**Exact files to change**
+- `internal/itunes/itl_le.go` — fix `walkMsdhTracksLE` (and confirm `walkMiahContent` has
+  the same flaw): when tag == "mith", advance only `headerLen`, then walk children in
+  `[offset+headerLen, offset+totalLen)` calling `parseMhohLE` on each mhoh; resume at
+  `offset+totalLen`.
+- `internal/itunes/itl_le_test.go` — new tests parsing a generated fixture and asserting
+  Name/Album/Artist/Location populated.
+- `cmd/itl-check/main.go` — no change needed; its Location counter starts working.
+
+**Step-by-step**
+1. Read `walkMsdhTracksLE` and `parseMithLE`; note `currentTrack` is set but mhoh case is
+   unreachable when `length = totalLen` is used for mith.
+2. Restructure: for mith, parse the mith header (`parseMithLE` with `headerLen`), append
+   track, then inner-walk `[offset+headerLen, offset+min(totalLen, end-offset))` over
+   mhoh chunks calling `parseMhohLE(data, o, l, currentTrack)`; advance outer offset by
+   the same span the old code used (totalLen when valid) so chunk accounting is unchanged.
+3. Apply the same restructuring inside `walkMiahContent`.
+4. Use `generate_test_itls.go` helpers to build a small LE library with known
+   names/locations; add `TestParseLE_TrackStrings` asserting all string fields round-trip.
+5. Run existing tests: `go test ./internal/itunes/...` — `itl_le_test.go`,
+   `itl_regression_test.go`, roundtrip tests must stay green (this is a read-path change;
+   writers untouched).
+6. Build `cmd/itl-check` and run against a generated fixture; assert "Tracks with
+   Location" > 0 in an integration-style test if feasible.
+
+**Acceptance criteria**
+- [ ] `TestParseLE_TrackStrings` passes; Name/Album/Artist/Genre/Kind/Location/LocalURL populated.
+- [ ] All pre-existing `internal/itunes` tests pass unmodified (`make test`).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `TestParseLE_TrackStrings` exists and passes. If interrupted:
+the change is a single-function restructure; re-apply from scratch rather than resume.
+
+**Rollback.** Revert the commit; read-path only, no data or format impact.
+
+---
+
+### TASK-002: Golden-corpus mhoh encoding audit tool + constants
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** Forensics showed iTunes writes byte `+27` of every string mhoh as 0x00 and
+uses `+24` as its encoding indicator (values 1/2/3 observed); our writer invents `+27 ∈
+{1,3}` (CRIT-1). Before fixing writers (T005) and enforcing guards (T003) we need the
+authoritative table of iTunes-authored byte patterns per hohm type, derived from a real
+iTunes library, not invented. Note: the corpus source file is the operator's golden
+library (provided at runtime; the `/tmp/itunes-libraries/` copies are ephemeral). The
+tool must be re-runnable on any iTunes-authored `.itl`.
+
+**Exact files to change**
+- `cmd/itl-audit-encoding/main.go` — NEW: walks every mhoh in a library; emits per
+  (hohmType): histogram of `+24` u32, `+27` byte, headerLen, whether string decodes as
+  ASCII/UTF-16LE/UTF-8 given content heuristics; writes JSON report.
+- `internal/itunes/mhoh_encoding_table.go` — NEW: `var ITunesMhohEncoding = map[uint32]…`
+  constants checked in from the audit run, with provenance comment (library version
+  12.13.10.3, date, counts).
+- `internal/itunes/mhoh_encoding_table_test.go` — table sanity tests.
+
+**Step-by-step**
+1. Reuse `DecryptAndInflateITL` + the chunk-walk patterns from `itl_le_verify.go` to visit
+   every mhoh in track, playlist, album, artist containers (msdh types 1, 2, 9, 11).
+2. For each mhoh record: hohmType (+12), headerLen (+4), totalLen (+8), `+24` u32, `+27`
+   byte, bytes 32–39 zero?, strDataLen (+28) arithmetic check.
+3. Emit JSON: per hohmType → field histograms; flag any non-uniform headerLen.
+4. Run against an operator-supplied iTunes-authored library (document the invocation in
+   the tool's README section of main.go doc comment); capture output into the constants
+   file. If no library is available at execution time, generate the constants file with
+   the empirically-known invariants from SPEC 2 §1 (headerLen=24, +27=0, 32–39 zero) and
+   leave `+24` per-type sets marked `TODO-corpus` — the guard consumes only populated entries.
+5. Add tests: table is non-empty for hohm types 0x02, 0x0B, 0x0D; all entries have
+   headerLen 24.
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] `go run ./cmd/itl-audit-encoding <lib.itl>` produces a JSON histogram report.
+- [ ] `internal/itunes/mhoh_encoding_table.go` exists with provenance comment.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if the cmd and table file exist. Re-running the audit regenerates
+the table deterministically from the same input.
+
+**Rollback.** Delete the new files; nothing depends on them until T003/T005 merge.
+
+---
+
+### TASK-003: `ITLSafetyContract` — guard framework + guards ⚠ Fable-review-critical
+Priority: P2 · Effort: L · Agent: sonnet-4.6 · Depends: [T002, T010]
+
+**Context.** The only structural write-guard today is the dangling-mtph check, which
+passes 3 of the 4 libraries iTunes rejected (HIGH-1). SPEC 2 §2 defines eight named
+guards over (before, after, proposedHeader). This task builds the framework and all
+guards except writer changes (T005/T006) — guards detect; they do not fix.
+
+**Exact files to change**
+- `internal/itunes/itl_safety_contract.go` — NEW: `GuardResult`, `Violation`,
+  `ContractVerdict`, `RunSafetyContract(before, after []byte, hdr *hdfmHeader, cfg ContractConfig)`,
+  plus guards: `parse-roundtrip`, `container-tiling`, `count-coherence`,
+  `no-new-dangling-refs` (wraps existing verify, fail-closed), `mhoh-format`,
+  `location-form`, `tid-pid-sanity`, `bounded-delta`. `AuditITL(data []byte)` single-library mode.
+- `internal/itunes/itl_safety_contract_test.go` — NEW: full suite from SPEC 2 §6 table
+  (12 corruption tests + clean-pass), mutation helpers test-local.
+- `internal/itunes/itl_le_verify.go` — export small helpers if needed (no behavior change
+  to existing functions in this task).
+
+**Step-by-step**
+1. Implement types exactly as SPEC 2 §2; guards are pure funcs
+   `func(before, after []byte, hdr *hdfmHeader, cfg ContractConfig) GuardResult`.
+2. `count-coherence`: read header BE fields at 0x44/0x48/0x4C/0x54 from the proposed
+   header bytes; compare with payload mith/miph/miah/miih counts (walk per
+   `itl_le_verify.go` patterns); also per-miph declared (+16) vs actual mtph children.
+3. `mhoh-format`: enforce headerLen==24, totalLen==40+strLen, +27==0, bytes 32–39 zero,
+   `+24` ∈ table from T002 when the table has entries for that hohmType.
+4. `location-form`: 0x0D matches `^[A-Za-z]:\\` and contains no `file://` or `%`; 0x0B
+   starts `file://localhost/`, percent-escaping valid, and no value contains
+   `.itunes-writeback/`.
+5. `parse-roundtrip`: must FAIL (not skip) when master list unlocatable or payload
+   uninflatable — uses T010's fail-closed inflate.
+6. `bounded-delta`: config defaults removedTracksMax=5000, rewrittenMhohPctMax=20, with
+   `Force bool` override in cfg.
+7. Write the regression tests per SPEC 2 §6 — base fixture from `generate_test_itls.go`;
+   one focused mutation per test; assert the *named* guard fires and others stay silent.
+8. `make ci`; coverage for the new file ≥ 80%.
+
+**Acceptance criteria**
+- [ ] All 13 SPEC-2 §6 contract tests pass; each guard individually triggerable.
+- [ ] `AuditITL` on the clean generated fixture returns Pass.
+- [ ] No existing writeback path behavior changed yet (contract not yet wired).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `itl_safety_contract.go` + its test file exist and pass. Guards
+are additive; partial completion = missing guards, re-runnable per guard.
+
+**Rollback.** Revert; nothing calls the contract until T004.
+
+---
+
+### TASK-004: `SafeWriteITL` atomic write + header regeneration ⚠ Fable-review-critical
+Priority: P2 · Effort: L · Agent: sonnet-4.6 · Depends: [T003]
+
+**Context.** Writes today go straight from mutation to `WriteITLBytes` with only the
+dangling-ref check, and the stale `headerRemainder` is reused verbatim — the observed
+CRIT-3 desync. SPEC 2 §3 defines the 8-step protocol (write `.itl.new`, contract on
+in-memory AND re-read bytes, timestamped backup, atomic rename, retention 10 + lkg pin,
+refuse BE, library-not-in-use precondition).
+
+**Exact files to change**
+- `internal/itunes/itl_safe_write.go` — NEW: `SafeWriteITL(path string, mutate func([]byte) ([]byte, error), opts ...SafeWriteOption) (*WriteReport, error)`;
+  header regeneration (patch 0x44/0x48/0x4C/0x54 from payload counts, preserve all other
+  remainder bytes); backup rotation + `.bak-lkg` pin handling.
+- `internal/itunes/itl_combined_mutate.go` — route `ApplyITLOperationSet` (both paths,
+  lines ~60 and ~137) through `SafeWriteITL`.
+- `internal/itunes/itl.go` — `UpdateITLLocations`, `InsertITLTracks`,
+  `RewriteITLExtensions`, `InsertITLPlaylist` refactored onto `SafeWriteITL`.
+- `internal/itunes/rebuild.go` — rebuild write path onto `SafeWriteITL`.
+- `internal/itunes/itl_safe_write_test.go` — NEW: rollback-on-violation,
+  backup-rotation, header-regen (remove a track → header count updated), BE-refusal tests.
+
+**Step-by-step**
+1. Implement protocol steps 1–8 from SPEC 2 §3 exactly; `library-not-in-use` is an
+   injected `func() error` option (the service wires its iTunes-running signal in T008;
+   default = no-op with WARN log so cmd tools keep working).
+2. Header regeneration: parse original `headerRemainder`; compute payload counts (reuse
+   contract helpers); write BE u32s at remainder-relative offsets corresponding to file
+   offsets 0x44/0x48/0x4C/0x54 (remainder starts after version string — compute from
+   `parseHdfmHeader` layout, header file offset = 17 + len(version)).
+3. fsync the `.itl.new` file and the directory after rename (`os.File.Sync`, open dir).
+4. Backups: `<path>.bak-<RFC3339>`; rotation keeps 10 newest; `.bak-lkg` only via
+   explicit `PinLastKnownGood(path)` API (service calls it after confirmed iTunes open).
+5. Refactor each caller; keep their public signatures; delete now-redundant direct
+   `WriteITLBytes` calls from those paths (keep the function — tools use it).
+6. Tests per SPEC 2 §6 (`TestSafeWrite_RollbackOnViolation` asserts original
+   byte-identical + no `.itl.new`残留; `TestSafeWrite_BackupRotation` 12 writes → 10 baks).
+7. `make ci`.
+
+**Acceptance criteria**
+- [ ] All writeback entry points reach disk only via `SafeWriteITL` (grep: no other
+      callers of `WriteITLBytes` outside cmd/ and itl_safe_write.go).
+- [ ] Header counts correct after a removal round-trip test (regression for CRIT-3).
+- [ ] Rollback + rotation + BE-refusal tests pass; `make ci` green.
+
+**Idempotency.** Done if `itl_safe_write.go` exists and the grep criterion holds. Safe to
+re-run callers refactor file-by-file.
+
+**Rollback.** Revert commit. Backups created by the new path are inert files; no cleanup
+needed beyond normal TTL.
+
+---
+
+### TASK-005: iTunes-conformant string encoders ⚠ Fable-review-critical
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: [T002, T003]
+
+**Context.** CRIT-1: `encodeHohmString` (`internal/itunes/itl.go:373`) stamps +27 ∈ {1,3};
+iTunes-authored blocks have +27 == 0 with the encoding indicator at +24. Writers
+(`buildMhohLE` `itl_le_mutate.go:272`, `rewriteHohmLocationLE` `itl_le.go:656`, BE path
+`itl_be.go:528`) must emit byte-for-byte iTunes-conformant headers per T002's table.
+
+**Exact files to change**
+- `internal/itunes/itl.go` — replace `encodeHohmString` with
+  `encodeMhohITunes(hohmType uint32, s string) (payload []byte, hdr MhohHeaderBytes, err error)`
+  driven by the T002 table; keep `decodeHohmString` reading BOTH legacy (+27) and iTunes
+  (+24) conventions so previously-written libraries still parse.
+- `internal/itunes/itl_le_mutate.go` — `buildMhohLE` uses the new encoder.
+- `internal/itunes/itl_le.go` — `rewriteHohmLocationLE` uses it (and stops blind-copying
+  +16..+27 from the original; sets the full header deterministically).
+- `internal/itunes/itl_be.go` — BE writer: refuse with explicit error (per SPEC 2 K12)
+  instead of adopting the LE table.
+- tests: `itl_le_metadata_update_test.go` extensions — every written mhoh passes the
+  T003 `mhoh-format` guard.
+
+**Step-by-step**
+1. From T002's table choose the canonical encoding per hohmType (expect: +24 patterns for
+   ASCII vs UTF-16 variants; mirror exactly, including how iTunes encodes non-ASCII —
+   verify with a non-ASCII fixture from the corpus report).
+2. Implement `encodeMhohITunes`; error (never guess) for a hohmType absent from the table
+   — callers fall back to preserving the original block unmodified + WARN, rather than
+   writing an invented encoding.
+3. Update the two LE writers; ensure UpdateMetadataLE's append path (`buildMhohLE`) and
+   replace path (`rewriteHohmLocationLE`) produce identical bytes for identical input.
+4. Make `decodeHohmString` dual-convention (+27 nonzero → legacy decode; else +24 table).
+5. Property test: encode→parse round-trip equals input for ASCII, Latin-1, and CJK
+   sample strings; every produced block passes `mhoh-format` guard.
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] No writer emits +27 != 0 (guard-verified in tests).
+- [ ] Round-trip property tests pass incl. non-ASCII.
+- [ ] BE writeback returns explicit "BE writeback unsupported" error.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `encodeMhohITunes` exists and `encodeHohmString` has no remaining
+writer callers (grep). 
+
+**Rollback.** Revert; dual-convention reader means libraries written during the interim
+remain parseable either way.
+
+---
+
+### TASK-006: `LocationPair` — 0x0B/0x0D normalization ⚠ Fable-review-critical
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: [T005]
+
+**Context.** CRIT-2: 0x0D must hold a native Windows path, 0x0B the percent-escaped
+`file://localhost/` URL; our writers pass through whatever callers provide (URLs observed
+in 83,783 0x0D blocks of damaged-1/3, staging-dir paths in damaged-4).
+
+**Exact files to change**
+- `internal/itunes/location_pair.go` — NEW: `type LocationPair struct{ WinPath, URL string }`;
+  constructors `LocationPairFromWinPath`, `LocationPairFromURL` (strict RFC-3986 escaping,
+  drive-letter validation, rejection of `.itunes-writeback/` and relative paths).
+- `internal/itunes/itl_le.go` — location update path (`rewriteChunksLEImpl` decision fn at
+  ~:640) consumes a `LocationPair`; 0x0B gets `.URL`, 0x0D gets `.WinPath`.
+- `internal/itunes/itl_le_metadata_update.go` — `ITLMetadataUpdate.Location` becomes the
+  WinPath side; doc comment updated; `UpdateMetadataLE` derives the pair.
+- `internal/itunes/service/writeback_batcher.go` — construct pairs from `f.ITunesPath`
+  (detect form, normalize); reject unmappable values with per-item error, not write.
+- `internal/itunes/service/track_provisioner.go`, `internal/itunes/service/importer.go` —
+  same construction at the other ITLLocationUpdate sites (:467, :780, :827).
+- tests: pair construction edge cases (spaces, `%` in filenames, UNC, non-ASCII), plus
+  guard-passing assertion via T003 `location-form`.
+
+**Step-by-step**
+1. Implement `LocationPair` with bidirectional conversion (URL→path unescape + slash
+   flip; path→URL escape) and validation errors.
+2. Trace every writer call site (the five files above) and convert.
+3. Where current data may already be URL-shaped in the DB (`f.ITunesPath`), normalize on
+   read with a WARN metric — do not mutate the DB in this task.
+4. Unit tests incl. round-trip property: `FromWinPath(p).URL` → `FromURL(url).WinPath == p`.
+5. Integration test: full `ApplyITLOperationSet` with a location update on a generated
+   fixture → contract passes, 0x0D contains backslash path.
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] `location-form` guard passes on all writer outputs in tests.
+- [ ] URL-in-0x0D regression test (write URL → rejected or normalized, never written raw).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `location_pair.go` exists and all five call sites construct pairs
+(grep `NewLocation:`/`Location:` in the service files shows pair usage).
+
+**Rollback.** Revert; previous behavior restored (with its known corruption risk).
+
+---
+
+### TASK-007: Diagnostic tool upgrades (itl-diff inventory + membership; itl-check audit)
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: [T001, T003]
+
+**Context.** MED-5: `itl-diff` doesn't implement its documented msdh inventory and cannot
+see playlist membership or mhoh-format problems; `itl-check` prints counts only. During
+the corruption incident these tools reported "0 changed" on libraries with 167K rewritten
+blocks. With T001 (real string parsing) and T003 (`AuditITL`) they can be made honest.
+
+**Exact files to change**
+- `cmd/itl-diff/main.go` — add msdh container inventory diff (type → totalLen), playlist
+  membership diff (per-playlist added/removed TIDs), and `--audit` flag running `AuditITL`
+  on both sides; string-field diffs now meaningful via T001.
+- `cmd/itl-check/main.go` — run `AuditITL`, print verdict + per-guard violation counts;
+  exit nonzero on violations.
+- no test files for cmds required beyond `go vet`; core logic stays in `internal/itunes`
+  (add any new diff helpers there WITH tests: `itl_diff_helpers.go` + `_test.go`).
+
+**Step-by-step**
+1. Move diffable walks (container inventory, playlist membership) into
+   `internal/itunes/itl_diff_helpers.go` so they're testable.
+2. Wire into both cmds; keep current flags working.
+3. Fix the `itl-diff` docstring to match reality.
+4. Tests: inventory + membership diff against two generated fixtures differing by one
+   removed track and one playlist edit.
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] `itl-check <fixture-with-violation>` exits nonzero naming the guard.
+- [ ] `itl-diff` reports playlist membership delta on a fixture pair.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `itl-check` has an audit mode (`grep AuditITL cmd/itl-check`).
+
+**Rollback.** Revert; tools-only change.
+
+---
+
+### TASK-008: Diff-before-write in writeback batcher
+Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: [T001, T004]
+
+**Context.** HIGH-3: `writeback_batcher.go:346` pushes `ITLMetadataUpdate` for every
+mapped file on every sync ("Always push metadata"), rewriting ~90K blocks per run —
+maximal corruption blast radius and churn. With T001 the current ITL values are readable;
+with T004 the write is contract-gated. Add change detection so only differing values are
+written, and wire the `library-not-in-use` precondition.
+
+**Exact files to change**
+- `internal/itunes/service/writeback_batcher.go` — before building updates, parse the
+  target library once; compare per-PID current Name/Album/Artist/Composer/Genre/Location
+  with desired; emit updates only for changed fields; wire SafeWriteITL's
+  library-not-in-use option to the existing sync-service iTunes-running signal.
+- `internal/itunes/service/writeback_batcher_test.go` — no-change run produces zero
+  updates; single-field change produces single update.
+
+**Step-by-step**
+1. Load + parse library (one `ParseITL`), index tracks by PID (strings now populated post-T001).
+2. In the per-file loop, drop the unconditional append; compare desired vs current,
+   field-by-field (trim/case-exact — iTunes values are authoritative bytes, compare exact).
+3. Count skipped/changed in the operation log (repo logging discipline: start/progress/
+   complete with counts).
+4. Wire `WithLibraryNotInUse(check)` option from the service's running-state signal.
+5. Tests with generated fixtures; include a Location compare via LocationPair (T006 not
+   required — compare normalized forms via existing helpers if T006 unmerged; note
+   ordering W4 puts this after T006 anyway).
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] Sync against an in-sync fixture library performs zero mhoh rewrites (asserted via
+      WriteReport counts).
+- [ ] Changed-field test writes exactly one update.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if the unconditional append is gone (grep "Always push metadata" →
+absent) and tests exist.
+
+**Rollback.** Revert to unconditional push (safe-but-churny behavior).
+
+---
+
+### TASK-009: accept-invite HTTP/2 EOF fix + request-size 413 clarity
+Priority: P4 · Effort: S · Agent: sonnet-4.6 · Depends: []
+
+**Context.** HIGH-4 (pen-test June 4 2026): `POST /api/v1/auth/accept-invite` returns
+`{"error":"EOF"}` on empty/streamed HTTP/2 bodies — raw bind error passthrough at
+`internal/server/auth_accept_invite.go:28`. MED-1: `middleware/request_size.go:52-58`
+skips the early 413 when Content-Length is absent, surfacing MaxBytesReader truncation as
+opaque EOF-ish errors.
+
+**Exact files to change**
+- `internal/server/auth_accept_invite.go` — map `io.EOF`/`io.ErrUnexpectedEOF`/empty-body
+  bind errors to 400 `"request body required: token, password"`; never echo raw "EOF".
+- `internal/server/middleware/request_size.go` — detect `http.MaxBytesError` after bind
+  failures (or wrap body) → 413 with clear message; keep limits unchanged.
+- tests: `auth_accept_invite_test.go` (empty body, no Content-Length body, oversized
+  body), middleware test for chunked oversized body.
+
+**Step-by-step**
+1. Add a small helper in `internal/server/httputil` (or reuse) `BindJSONStrict(c, &req)`
+   returning categorized errors; use it in accept-invite.
+2. Assert response body never contains the bare string "EOF" (regression test).
+3. Middleware: use `errors.As(err, &maxBytesErr)` to translate.
+4. Reproduce the HTTP/2 shape with httptest (empty body + chunked) in tests.
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] Empty-body POST returns 400 with actionable message, not "EOF" (test asserts).
+- [ ] Oversized chunked body returns 413 (test asserts).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if the regression tests exist and pass.
+
+**Rollback.** Revert; error-shape-only change.
+
+---
+
+### TASK-010: Fail-closed inflate + verify (decompression cap)
+Priority: P2 · Effort: S · Agent: sonnet-4.6 · Depends: []
+
+**Context.** MED-7: `itlInflate` (`internal/itunes/itl.go:302-320`) silently returns the
+*compressed* bytes as if uncompressed when the 512MB cap (or any read error) hits; the
+golden library already inflates to 236MB. Downstream verifiers fail open when parse finds
+no master list. Composition: oversized library → all guards pass on garbage.
+
+**Exact files to change**
+- `internal/itunes/itl.go` — `itlInflate` returns `([]byte, bool, error)`; cap exceeded or
+  read error → error (callers updated: `parseITLData`, `DecryptAndInflateITL`,
+  `ParseITLBytes`); raise cap to 2GB (config const) since legit payloads are ~236MB and
+  growing.
+- `internal/itunes/itl_test.go` — cap-exceeded fixture (small zlib bomb), assert explicit
+  error not silent fallback.
+
+**Step-by-step**
+1. Change signature + thread error through the (few) callers; preserve the "not zlib at
+   all" → `(data, false, nil)` legitimate pass-through for genuinely uncompressed payloads
+   (first byte != 0x78).
+2. Distinguish "not compressed" from "decompression failed" — only the former passes through.
+3. Bomb test + happy-path tests.
+4. `make ci`.
+
+**Acceptance criteria**
+- [ ] Decompression-bomb fixture yields an explicit error end-to-end from `ParseITL`.
+- [ ] Existing parse tests green; `make ci` green.
+
+**Idempotency.** Done if `itlInflate` returns an error value (signature check).
+
+**Rollback.** Revert; restores silent-fallback behavior.
+
+---
+
+### TASK-011: `internal/dedup/unified` — Signal, UnifiedDedupScore, ComposeScore
+Priority: P1 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** SPEC 1 §3–4. Pure scoring core: types, noisy-OR composition, banding,
+config plumbing. No I/O, no engine changes — fully unit-testable foundation everything
+else builds on.
+
+**Exact files to change**
+- `internal/dedup/unified/score.go` — NEW: types from SPEC 1 §3 verbatim.
+- `internal/dedup/unified/compose.go` — NEW: `ComposeScore(signals []Signal, sup []string, cfg ScoreConfig) UnifiedDedupScore`
+  implementing SPEC 1 §4 (noisy-OR over primaries, bounded supporting boosts, cap 100,
+  banding, formula version `"noisy-or-v1"`).
+- `internal/dedup/unified/config.go` — NEW: `ScoreConfig` with per-kind calibration,
+  loaded from config.yaml `dedup.signals.*` with SPEC defaults; validation (confidences ∈
+  (0,1], band thresholds ordered).
+- `internal/config/` — register the new section (follow existing config registration pattern).
+- `internal/dedup/unified/compose_test.go` — worked examples from SPEC 1 §4 as exact
+  assertions; property tests (monotonicity: adding a primary signal never lowers score;
+  cap respected; supporting-only sets never produce a candidate-eligible score ≥ 60).
+
+**Step-by-step**
+1. Copy type definitions from SPEC 1 §3 (they are normative).
+2. Implement noisy-OR + boosts + cap + bands exactly per §4 incl. the three worked
+   examples as test cases (100; 82; 98.7±0.1).
+3. Supporting signals (`duration`, `folder_path`) excluded from the noisy-OR product —
+   enforce via kind metadata, tested.
+4. Config defaults table from SPEC 1 §3 comments; config.yaml override path + validation.
+5. ≥90% coverage on the package (it's pure logic; cheap).
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] Three worked-example tests pass with exact expected scores.
+- [ ] Property tests pass; config validation rejects malformed calibration.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if package exists with passing tests.
+
+**Rollback.** Delete package; nothing references it until T013/T014/T015.
+
+---
+
+### TASK-012: LSH `fpidx:` PebbleDB index — build op + write/delete hooks ⚠ Fable-review-critical
+Priority: P1 · Effort: L · Agent: sonnet-4.6 · Depends: []
+
+**Context.** SPEC 1 §5. `fingerprint.Subprints()` exists (`lsh.go:69-147`); the index and
+wiring do not. Key `fpidx:<subprint-hex16>:<bookfile_id>` → book_id; member list
+`fpidx_member:<bookfile_id>` → JSON array of subprint hexes (for delete/update); versioned
+completion flag `lsh_index_v1_done` per the established backfill pattern.
+
+**Exact files to change**
+- `internal/database/pebble_store_lsh.go` — NEW: `PutLSHEntries(fileID, bookID string, subprints []fingerprint.Subprint)`,
+  `DeleteLSHEntries(fileID)`, `LSHProbe(subprints) map[fileID]bandHits` (point lookups),
+  batch-based.
+- `internal/database/pebble_store.go` — fingerprint write path (the BookFile update that
+  sets `AcoustIDFingerprint`) calls Put/Delete hooks; BookFile delete calls DeleteLSHEntries.
+- `internal/plugins/dedup/lsh_index_build.go` — NEW op `dedup.lsh-index-build`: iterate
+  files with whole-file fingerprints, Subprints → PutLSHEntries, batches of 1,000,
+  progress reporting, cancellable, sets `lsh_index_v1_done`.
+- `internal/plugins/dedup/plugin.go` — register the op.
+- `internal/server/handlers/dedup/handler.go` + `internal/server/wire_handlers.go` —
+  `POST /api/v1/dedup/lsh-index` trigger.
+- tests: store-level (put/probe/delete round-trip; member-list cleanup), op-level with
+  mock store.
+
+**Step-by-step**
+1. Implement key codecs + batch writes; subprint hex = 16 lowercase hex chars of the
+   8-byte subprint.
+2. Hook the single fingerprint-set chokepoint (find it: grep `AcoustIDFingerprint =` in
+   pebble store / file-update paths; if multiple, route through one helper first).
+3. Build the op following an existing plugin op file as template (`embed_scan.go` shape:
+   OperationDef, timeout 120m, ConcurrencyKey "dedup.lsh-index").
+4. Probe: 64 point-gets per probe file; aggregate hits per candidate fileID; return ≥
+   threshold only.
+5. Wire HTTP trigger following existing dedup trigger handlers.
+6. Tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] Round-trip: index 3 fixture fingerprints, probe a near-duplicate → candidate with
+      ≥2 band hits; probe unrelated → empty.
+- [ ] Delete removes all `fpidx:` keys for a file (iterator-verified in test).
+- [ ] Op is resumable (re-run continues; flag set at completion).
+- [ ] `make ci` green.
+
+**Idempotency.** Op itself idempotent (Put overwrites). Task done if
+`pebble_store_lsh.go` + op registered + endpoint wired.
+
+**Rollback.** Index keys are additive; delete by prefix `fpidx:`/`fpidx_member:` +
+clear flag. No reader exists until T013.
+
+---
+
+### TASK-013: LSH probe collector; retire O(N) fuzzy scan
+Priority: P1 · Effort: M · Agent: sonnet-4.6 · Depends: [T011, T012]
+
+**Context.** SPEC 1 §5 probe path: subprints → fpidx point lookups → band-hit filter →
+`WholeFileSimilarity` Hamming refine → `SigLSHAcoustID` signal. Replaces the disabled
+`ACOUSTID_FUZZY_ENABLED` O(N) scan (`engine.go:30-46`).
+
+**Exact files to change**
+- `internal/dedup/collectors_acoustid.go` — NEW: exact-tier collector (wraps existing
+  `book_file_acoustid:` lookup) + LSH collector emitting `Signal{Kind: SigLSHAcoustID,
+  Raw: hamming, Confidence: scale(hamming)}`.
+- `internal/dedup/engine.go` — remove `acoustidFuzzyEnabled` env gating + the O(N) scan
+  path; engine calls collectors.
+- tests: collector tests with fixture fingerprints (true positive, below-band-threshold
+  negative, hamming-refine rejection).
+
+**Step-by-step**
+1. Implement collectors against the `LSHProbe` store API; gate LSH collector on
+   `lsh_index_v1_done` flag (skip with INFO log when index unbuilt — never fall back to O(N)).
+2. Confidence scaling per SPEC 1: hamming 0.85→conf 0.90 linear to 1.0→0.97 (config).
+3. Delete the env-gated fuzzy path; grep `ACOUSTID_FUZZY_ENABLED` → zero hits.
+4. Unit tests incl. flag-unset skip behavior.
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] LSH collector returns calibrated signal for known-similar fixture pair.
+- [ ] `ACOUSTID_FUZZY_ENABLED` no longer referenced anywhere.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if collectors file exists and env var is gone.
+
+**Rollback.** Revert; (the O(N) path returns but stays disabled-by-default as before).
+
+---
+
+### TASK-014: Collector refactor + PairEligibility + metadata-fuzzy collector
+Priority: P1 · Effort: L · Agent: sonnet-4.6 · Depends: [T011]
+
+**Context.** SPEC 1 §2: existing engine checks (`checkExactFileHash`,
+`checkExactMetadataSourceHash`, embedding `findSimilarBooks`, duration gate at
+`engine.go:578-691`, ISBN/ASIN via ext_id) become collectors emitting `Signal`s; the
+negative guards (version-group, series-volume, same-dir: `engine.go:453-536,886-914`)
+become a shared `PairEligibility` pre-filter. NEW metadata-fuzzy collector (normalized
+title+author Levenshtein — the brief's METADATA_FUZZY tier; currently doesn't exist,
+`GetDuplicateBooksByMetadata` is a stub).
+
+**Exact files to change**
+- `internal/dedup/eligibility.go` — NEW: `PairEligibility(a, b *Book) (ok bool, suppressors []string)`
+  extracted from the three guard sites.
+- `internal/dedup/collectors_exact.go`, `collectors_embedding.go`,
+  `collectors_metadata.go` — NEW: wrap existing logic; metadata-fuzzy implements
+  normalized-title/author similarity (reuse the Levenshtein already used by the duration
+  gate) emitting `SigMetaFuzzy` with conf 0.70–0.85 scale.
+- `internal/dedup/engine.go` — `CheckBook`/`FullScan` orchestrate: eligibility →
+  collectors → `unified.ComposeScore` → persist (persistence schema in T015; until T015
+  merges, scorer output maps onto existing `Layer`/`Similarity` fields — keep this task
+  mergeable standalone).
+- `internal/dedup/engine_test.go` + new collector tests — preserve every existing
+  behavioral test; add eligibility extraction tests (same inputs → same drops as before).
+
+**Step-by-step**
+1. Extract guards verbatim into `PairEligibility` with table-driven tests proving
+   identical decisions on the existing test corpus.
+2. Wrap exact-hash, metadata-source-hash, embedding into collectors (logic unchanged —
+   only the emission shape changes).
+3. Convert the duration *gate* into a supporting `SigDuration` signal (±2% window from
+   config; keep the `dedup:duration-match`/`duration-abridged` tagging side-effects).
+4. Implement metadata-fuzzy collector (guarded by eligibility; candidate source =
+   embedding top-K + LSH candidates only — never O(N²) title scan).
+5. Orchestrate in `CheckBook`; compose score; persist via existing upsert.
+6. Full engine test suite green + new tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] All pre-existing dedup engine tests pass unmodified.
+- [ ] Eligibility parity test passes (no behavior change in drops).
+- [ ] A pair matched by embedding+duration produces a composed score with 2-signal breakdown.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if collectors files exist and engine routes through ComposeScore.
+
+**Rollback.** Revert; engine returns to per-layer writes.
+
+---
+
+### TASK-015: Candidate schema additions + legacy-fingerprint purge ⚠ Fable-review-critical
+Priority: P1 · Effort: M · Agent: sonnet-4.6 · Depends: [T011]
+
+**Context.** SPEC 1 §3 additive fields (`ScoreBreakdown`, `Band`, `FormulaVersion`) +
+§8 migration; HIGH-5 purge of ~14K stale 100% candidates from pre-whole-file fingerprints.
+PebbleDB candidate keys unchanged.
+
+**Exact files to change**
+- `internal/database/embedding_store.go` — extend `DedupCandidate` + `candRec` (additive
+  JSON; absent = legacy); upsert stores breakdown; layer-precedence logic gains
+  formula-version awareness (new-formula rows never downgraded by legacy writers).
+- `internal/plugins/dedup/purge_legacy_fp.go` — NEW op `dedup.purge-legacy-fp-candidates`
+  per SPEC 1 §8 step 2 (criteria: CreatedAt < whole-file cutover config date AND
+  sim==1.0 AND layer ∈ {exact, embedding} AND no recomputable file-hash match → mark
+  status `stale-fp`, not delete); versioned flag `dedup_fp_purge_v1_done`.
+- `internal/plugins/dedup/plugin.go` — register; `wire_handlers.go` + dedup handler —
+  trigger endpoint `POST /api/v1/dedup/purge-legacy-fp`.
+- tests: round-trip new fields; purge criteria table-driven (keeps real exact-hash dupes,
+  marks segment-era rows).
+
+**Step-by-step**
+1. Additive struct/JSON changes + round-trip test (old rows decode with empty new fields).
+2. Implement purge op with dry-run mode (default) returning counts; `apply=true` param
+   to execute; progress + final counts in operation log.
+3. Re-score check inside purge: for each match candidate, recompute file-hash equality
+   from current BookFiles before marking (no false purges).
+4. Cutover date in config with documented default (the whole-file migration deploy date).
+5. Wire endpoint; tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] Old candidate rows parse unchanged (compat test).
+- [ ] Dry-run on fixture set reports exactly the planted stale rows; apply marks them
+      `stale-fp`; genuine hash-dupes untouched.
+- [ ] `make ci` green.
+
+**Idempotency.** Purge op re-runnable (marking is idempotent); flag set on completion.
+Task done if struct fields + op + endpoint exist.
+
+**Rollback.** Marked rows can be flipped back (`stale-fp` → `pending`) by an inverse query;
+no deletions performed.
+
+---
+
+### TASK-016: Dedup API extensions
+Priority: P1 · Effort: M · Agent: sonnet-4.6 · Depends: [T014, T015]
+
+**Context.** SPEC 1 §6: extend `/dedup/candidates` (band/score/breakdown fields +
+`band=`/`include_breakdown=` params), add `/dedup/candidates/:id/breakdown`,
+`/dedup/rescore`, keep all existing endpoints stable. This freezes the API contract T017
+builds against.
+
+**Exact files to change**
+- `internal/server/handlers/dedup/handler.go` — extend list response; new breakdown +
+  rescore handlers.
+- `internal/server/wire_handlers.go` — routes.
+- `internal/dedup/engine.go` — `Rescore(ctx)` (ComposeScore over stored signal sets only).
+- handler tests (mock store, follow `handlers/dedup` existing test pattern).
+
+**Step-by-step**
+1. Add fields/params to list handler (omit breakdown unless requested — payload size).
+2. Breakdown endpoint: candidate + both books' comparison payload (covers/metadata/file
+   info/audio-sample URLs — reuse existing book-detail serializers).
+3. Rescore handler → engine method → per-band delta counts response.
+4. OpenAPI/docs comment per repo api-doc conventions.
+5. Tests for filters, omission behavior, 404s; `make ci`.
+
+**Acceptance criteria**
+- [ ] `GET /dedup/candidates?band=CERTAIN` filters correctly (test).
+- [ ] Breakdown endpoint returns signals + both books in one response (test).
+- [ ] Existing dedup API tests unchanged and green; `make ci` green.
+
+**Idempotency.** Done if routes exist (`grep rescore wire_handlers.go`).
+
+**Rollback.** Remove routes; additive only.
+
+---
+
+### TASK-017: Unified Dedup UI tab
+Priority: P1 · Effort: L · Agent: sonnet-4.6 · Depends: [T016]
+
+**Context.** SPEC 1 §7 component tree. Replaces Books/Advanced-Scan/Acoustic tabs with
+one unified surface (those tabs remain mounted behind a "legacy" toggle for one release).
+Feature-flagged default-off until backfill completes (repo rule).
+
+**Exact files to change**
+- `web/src/components/dedup/UnifiedDedupTab.tsx` + `ScoreBadgeRow.tsx`,
+  `BandFilterBar.tsx`, `CandidateCompareDrawer.tsx`, `ScoreBreakdownPanel.tsx`,
+  `FileInfoCompare.tsx`, `AudioSamplePair.tsx`, `BulkActionBar.tsx` — NEW per SPEC 1 §7.
+- `web/src/pages/BookDedup.tsx` — tab wiring + legacy toggle + feature flag.
+- `web/src/components/FingerprintVisualsColumn.tsx` — "compare in Dedup" deep-link.
+- `web/src/api/` typed client additions for the new endpoints.
+- Vitest tests per component (follow existing dedup component test patterns); one
+  Playwright flow (open tab → filter band → open drawer → breakdown renders).
+
+**Step-by-step**
+1. Typed API client for extended candidates + breakdown + rescore.
+2. Build table + band filter from `/dedup/stats` counts; MUI per existing pages.
+3. Drawer with side-by-side compare; breakdown stacked-bar from signal contributions
+   (compute shares client-side from Confidence list — same math as server, render only).
+4. Bulk actions wrap existing merge/dismiss/cluster endpoints scoped by band; CERTAIN
+   auto-merge requires a confirm dialog showing count.
+5. Deep-link from FingerprintVisualsColumn (`/dedup?book=<id>` filter).
+6. Memory-leak discipline per PR #1076 patterns (cleanup effects, AbortController).
+7. `make test-all` + the Playwright flow in `make test-e2e`.
+
+**Acceptance criteria**
+- [ ] Vitest suites pass; Playwright unified-tab flow passes.
+- [ ] Legacy tabs still reachable behind toggle.
+- [ ] Feature flag default-off; `make ci` green.
+
+**Idempotency.** Done if `UnifiedDedupTab.tsx` exists and is wired behind the flag.
+
+**Rollback.** Flag off → old UI exactly as before.
+
+---
+
+### TASK-018: Scan operation rationalization
+Priority: P1 · Effort: S · Agent: sonnet-4.6 · Depends: [T014]
+
+**Context.** SPEC 1 §2 phases: merge `embed-scan`/`embed-async` into one op with async
+flag; enforce phase ordering (hygiene → index → candidates) via concurrency keys; nightly
+schedule wiring.
+
+**Exact files to change**
+- `internal/plugins/dedup/embed_scan.go` / `embed_async.go` — merge (keep both op IDs
+  registered for one release, async one delegating, deprecation note in DisplayName).
+- `internal/plugins/dedup/full_scan.go` — run purge-stale phase first (already does),
+  then collectors pipeline; assert index flags before LSH-dependent phases.
+- scheduler/config — nightly phase-2 entry following existing scheduled-op patterns.
+- op tests updated.
+
+**Step-by-step**
+1. Merge ops; param `async bool`.
+2. Phase-order assertions with clear skip logs.
+3. Schedule config + docs.
+4. Tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] Both op IDs still triggerable; async delegates (test).
+- [ ] full-scan skips LSH collector with logged reason when index flag unset (test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `embed_async.go` delegates.
+
+**Rollback.** Revert; ops were behavior-compatible throughout.
+
+---
+
+### TASK-019: Strip AcoustID segments from memdb ⚠ Fable-review-critical
+Priority: P3 · Effort: S · Agent: sonnet-4.6 · Depends: [T013]
+
+**Context.** SPEC 3 §6 item 1 — the headline RSS win (~550–900MB). `memdb_strip.go`
+currently retains `AcoustIDSeg0–6` on BookFile rows solely for the now-deleted O(N) fuzzy
+path; after T013, memdb has zero segment readers.
+
+**Exact files to change**
+- `internal/database/memdb_strip.go` — nil all Seg0–6 in `stripBookFileForMemdb`; update
+  the sizing comments.
+- `internal/database/memdb_warmup_test.go` / strip tests — assert segs nil post-strip.
+- verify-no-readers step is part of the task, not assumed.
+
+**Step-by-step**
+1. `grep -rn "AcoustIDSeg" --include="*.go" internal/ | grep -v _test` — enumerate
+   readers; confirm none read from memdb-sourced BookFiles (Pebble-direct readers like
+   FingerprintVisualsColumn's API are unaffected — they read via GetBookFile).
+2. Strip fields; adjust comments with new measured numbers.
+3. Add a memdb-sourced-read regression test if a seam exists (skip if not feasible).
+4. `make ci`; record before/after RSS from the memory-leak CI job if available.
+
+**Acceptance criteria**
+- [ ] Strip test asserts Seg0–6 nil in memdb rows.
+- [ ] Reader audit results recorded in PR description (file:line list).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if strip function nils Seg0–6.
+
+**Rollback.** Revert one function; warmup repopulates on restart.
+
+---
+
+### TASK-020: Drop segment fields from `book_file:` Pebble values ⚠ Fable-review-critical
+Priority: P3 · Effort: M · Agent: sonnet-4.6 · Depends: [T019]
+
+**Context.** SPEC 3 §6 item 2: segments deprecated (`store.go:685-694`), LSH replaces the
+last consumer; remove from stored values via lazy rewrite-on-touch + background sweep op,
+flag `bookfile_seg_drop_v1_done`. Disk ~200–400MB + smaller deserialization on every file
+read.
+
+**Exact files to change**
+- `internal/database/pebble_store.go` — BookFile marshal path omits Seg1–6 (json omitempty
+  + explicit nil before write); keep struct fields (decode of old rows still works).
+- `internal/plugins/dedup/bookfile_seg_sweep.go` — NEW sweep op: iterate `book_file:`,
+  rewrite rows containing segments, batched, resumable, sets flag.
+- registration + trigger endpoint + tests (old row decodes; rewritten row lacks segs;
+  sweep resumable).
+
+**Step-by-step**
+1. Decide retention of Seg0 (derivable from whole-file via `DeriveSeg0`,
+   `wholefile.go:100-116`) — drop it too; the deriver covers any legacy need.
+2. Nil segs on every BookFile write (single marshal chokepoint).
+3. Sweep op per the established backfill-op template; dry-run default with counts.
+4. Tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] Old-format row read test passes (compat).
+- [ ] Sweep dry-run/apply counts correct on fixtures; flag set.
+- [ ] `make ci` green.
+
+**Idempotency.** Sweep resumable + re-runnable; flag versioned.
+
+**Rollback.** Segments are derivable (Seg0) or re-computable via fingerprint rescan op;
+rollback = stop sweep, revert marshal change. Document that already-rewritten rows lose
+Seg1–6 until a rescan (acceptable: deprecated fields).
+
+---
+
+### TASK-021: Embedding float16 + zstd encoding
+Priority: P3 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** SPEC 3 §3: `emb:v:` blobs are raw float32 (3072-dim, 12.3KB); target
+float16+zstd (~3.5–4×, ~450MB disk saved), dual-read versioned by header byte, re-encode
+op, flag `emb_f16_v1_done`.
+
+**Exact files to change**
+- `internal/database/embedding_store.go` — `encodeVector`/decode gain a 1-byte version
+  header (v0 absent = legacy float32; v1 = f16+zstd); writes emit v1; reads accept both.
+- `internal/plugins/dedup/emb_reencode.go` — NEW re-encode op (iterate `emb:v:`, rewrite,
+  batched, resumable, flag).
+- registration + endpoint + tests (round-trip cosine drift < 1e-3 on random vectors;
+  dual-read compat; ratio assertion ≥3× on fixture corpus).
+
+**Step-by-step**
+1. f16 conversion (no new heavy dep — implement IEEE 754 half conversion locally or use
+   `x/image/math` equivalent; zstd via existing dependency if present, else
+   klauspost/compress — check go.mod first and prefer what's already there).
+2. Version-byte framing; hydrate path (chromem) dequantizes to float32.
+3. Cosine-drift property test (1K random vectors: |cos_f32 − cos_f16| < 1e-3).
+4. Re-encode op; dry-run; flag.
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] Dual-read test (v0 row decodes; v1 round-trips).
+- [ ] Drift property test passes; compression ratio logged ≥3× on fixtures.
+- [ ] `make ci` green.
+
+**Idempotency.** Re-encode op resumable; rewriting v1 rows is a no-op.
+
+**Rollback.** Dual-read retained → revert writer to v0; v1 rows remain readable.
+
+---
+
+### TASK-022: Remove legacy SQLite store
+Priority: P3 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** MED-4 / SPEC 3 §2: ~7,938 lines `sqlite_store_*.go` + unconditional
+`sql.Open("sqlite3")` at `database.go:20`; PebbleDB is the only production store. Remove
+code, CGO dep, and the startup open.
+
+**Exact files to change**
+- `internal/database/database.go` — remove sql.Open + global `DB`.
+- `internal/database/sqlite_store_*.go` — delete (after caller audit).
+- `internal/database/web.go`, `cache_stats_history_store.go`, `ai_jobs_store.go`,
+  `interface.go` — audit `database/sql` usage; migrate any live reader to Pebble
+  equivalents or delete if dead.
+- `go.mod` — drop `mattn/go-sqlite3` if no remaining importer.
+- tests referencing the SQLite store — delete/port.
+
+**Step-by-step**
+1. Caller audit: `grep -rn "database/sql\|sqlite" --include="*.go" internal/ cmd/ | grep -v _test`
+   — produce the live-path list in the PR description; anything reachable from server
+   startup or any registered op must be ported, not deleted blind.
+2. Confirm prod config cannot select SQLite (server startup reads PebbleDB path only).
+3. Delete store files + startup open; port stragglers (expected: activity-log legacy
+   reader → keep behind explicit migration cmd if it reads old prod `.db` files —
+   verify with the owner via PR comment if found).
+4. `go mod tidy`; build with and without `embed_frontend` tag.
+5. `make ci` (full suite). 
+
+**Acceptance criteria**
+- [ ] No `mattn/go-sqlite3` in go.mod; no `sql.Open` in internal/.
+- [ ] PR description contains the caller-audit table.
+- [ ] `make ci` green; `make build` and `make build-api` succeed.
+
+**Idempotency.** Done when grep criteria hold.
+
+**Rollback.** Revert (pure code removal; no data touched — old `.db` files on prod are
+left in place untouched either way).
+
+---
+
+### TASK-023: memdb telemetry, retention sweeps, dead-prefix hygiene
+Priority: P3 · Effort: S · Agent: sonnet-4.6 · Depends: []
+
+**Context.** SPEC 3 §5/§6 items 5–7: per-table memdb byte telemetry + soft regression
+assert (≤4KB sampled stripped Book); `operation:`/`operationlog:` retention sweep;
+one-off deletion sweep for dead `book:series:`/`book:author:` prefixes.
+
+**Exact files to change**
+- `internal/database/memdb_warmup.go` — post-warmup sampled size metrics → metrics store.
+- `internal/database/memdb_strip_test.go` — sampled stripped-Book ≤4KB assert.
+- maintenance loop (locate existing maintenance op) — operation retention (config days,
+  default 90) + dead-prefix sweep guarded by flag `dead_prefix_sweep_v1_done`.
+- tests for retention boundaries.
+
+**Step-by-step**
+1. Sampled sizing: marshal N=100 random rows per table, extrapolate, emit metric.
+2. Soft assert test (fails CI if Book projection grows past 4KB sampled mean).
+3. Retention sweep with dry-run + counts; wire into maintenance schedule.
+4. Dead-prefix audit grep first (`book:series:`/`book:author:` readers must be zero),
+   then sweep.
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] Metrics emitted post-warmup (test with in-memory store).
+- [ ] Retention test: rows older than cutoff removed, newer kept.
+- [ ] `make ci` green.
+
+**Idempotency.** Sweeps flag-guarded/re-runnable.
+
+**Rollback.** Telemetry/sweeps are removable; retention deletions are intentional and
+non-recoverable (operation logs only — acceptable, documented in PR).
+
+---
+
+### TASK-024: NutsDB → PebbleDB activity/metrics migration
+Priority: P3 · Effort: L · Agent: sonnet-4.6 · Depends: [T023]
+
+**Context.** SPEC 3 §4: remove the NutsDB engine. Key mapping is 1:1
+(`act:<tier>:<nanokey>:<ulid>`, `met:<cache>:<nanokey>` as Pebble prefixes); must
+re-implement TTL (metrics 30d) and digest compaction (`RecompactDigests`) on Pebble; the
+activity Store interface already supports multiple backends — add a Pebble one, dual-write
+window, backfill op, flag `activity_pebble_v1_done`, then retire NutsDB.
+
+**Exact files to change**
+- `internal/database/pebble_activity_store.go` + `pebble_metrics_store.go` — NEW backends
+  implementing the existing activity/metrics interfaces (port from
+  `nuts_activity_store.go`/`nuts_metrics_store.go` semantics incl. CompactByDay,
+  RecompactDigests, op/book reverse indexes).
+- backend selection/config + dual-write wrapper.
+- backfill op (NutsDB → Pebble iteration) + flag.
+- TTL sweep for metrics in maintenance.
+- tests: parity suite run against both backends (table-driven over the interface).
+
+**Step-by-step**
+1. Port key layouts per SPEC 3 §4 table; lexicographic nano-keys preserved.
+2. Interface parity tests first (run existing activity-store test suite against the new
+   backend).
+3. Dual-write wrapper (writes both, reads Pebble-after-flag/Nuts-before).
+4. Backfill op, resumable, counts; flag at completion; flip reads.
+5. One release later (separate follow-up, noted in TODO): remove NutsDB dep.
+6. `make ci`.
+
+**Acceptance criteria**
+- [ ] Parity test suite green on Pebble backend incl. RecompactDigests behavior.
+- [ ] Backfill op dry-run/apply counts correct on fixtures.
+- [ ] Dual-write verified by test (entry lands in both).
+- [ ] `make ci` green.
+
+**Idempotency.** Backfill resumable (key-ordered cursor); dual-write idempotent.
+
+**Rollback.** Flip reads back to NutsDB (dual-write means no data loss during the window).
+
+---
+
+### TASK-025: `FilterUnchangedTags` covers custom tags
+Priority: P4 · Effort: S · Agent: sonnet-4.6 · Depends: []
+
+**Context.** MED-3: `internal/metafetch/service_writeback.go:353-423` compares a fixed
+field set; `AUDIOBOOK_ORGANIZER_*` custom tags fall through to always-write, defeating
+skip detection and inflating `.bak-*` churn.
+
+**Exact files to change**
+- `internal/metafetch/service_writeback.go` — extend the comparison map with every custom
+  tag field written by the tag writer (enumerate from the writer's full tag map builder —
+  `buildFullTagMap` per project memory; verify name by grep).
+- `internal/metafetch/service_writeback_test.go` — table-driven: unchanged custom tag
+  skipped; changed custom tag written; unknown future key still defaults to write
+  (preserve the safe default), with a WARN log so new fields get added consciously.
+
+**Step-by-step**
+1. Enumerate written tags (grep `AUDIOBOOK_ORGANIZER_` in metadata writer).
+2. Extend comparisons reusing existing normalization helpers.
+3. Keep unknown-key → write default; add WARN.
+4. Tests; `make ci`.
+
+**Acceptance criteria**
+- [ ] No-change writeback on a fully-tagged fixture produces empty tag map (test).
+- [ ] Changed custom tag still written (test); `make ci` green.
+
+**Idempotency.** Done when tests exist.
+
+**Rollback.** Revert; behavior returns to always-write (safe, churny).
+
+---
+
+### TASK-026: Duration/filesize aggregation from BookFiles
+Priority: P4 · Effort: M · Agent: sonnet-4.6 · Depends: []
+
+**Context.** MED-2 (and long-standing backlog): `Book.Duration`/`Book.FileSize`
+(`store.go:128,170`) are import-time snapshots; multi-file books show wrong totals. Add
+recompute-from-files at the file-mutation chokepoints + a backfill op.
+
+**Exact files to change**
+- `internal/database/pebble_store.go` — `RecomputeBookAggregates(bookID)` (sum
+  BookFiles.Duration/FileSize where present); call from BookFile create/update/delete
+  paths (single chokepoint preferred — locate the BookFile write helper).
+- backfill op `library.recompute-aggregates` in the appropriate plugin (scanner or
+  maintenance), flag `book_aggregates_v1_done`, dry-run default.
+- tests: multi-file sum; single-file passthrough; missing-duration partial-sum rule
+  (sum known, never zero out a populated snapshot with a less-complete sum — rule: write
+  only if ≥ as many files have durations as before, else WARN).
+
+**Step-by-step**
+1. Implement recompute with the partial-data rule above (explicit, tested).
+2. Hook file-write chokepoints; ensure `UpdateBook` full-replacement semantics respected
+   (read-modify-write under the store's existing locking pattern).
+3. Backfill op, resumable, counts, flag.
+4. Tests incl. virtual-segment single-file books (`metafetch/service.go:365-376` path).
+5. `make ci`.
+
+**Acceptance criteria**
+- [ ] 3-file fixture book shows summed duration/size after file update (test).
+- [ ] Backfill dry-run counts correct; partial-data rule tests pass.
+- [ ] `make ci` green.
+
+**Idempotency.** Recompute idempotent; backfill flag-guarded.
+
+**Rollback.** Snapshots aren't destroyed (sums overwrite only forward); disable hook +
+re-run nothing — old values restorable from book_path_history only if needed (document:
+practically forward-only, low risk).
+
+---
+
+### TASK-027: Chromem hydration shutdown join
+Priority: P4 · Effort: S · Agent: sonnet-4.6 · Depends: []
+
+**Context.** MED-8: hydration goroutine (`internal/dedup/lifecycle.go:103-112`) is
+cancel-correct but not joined; `Stop()` can return while a Pebble read is in flight.
+
+**Exact files to change**
+- `internal/dedup/lifecycle.go` — add `bgWg sync.WaitGroup`; `Add(1)` before goroutine
+  start (under `bgMu`), `defer Done()`; `Stop()` waits with a bounded timeout (5s) and
+  WARNs on timeout.
+- `internal/dedup/lifecycle_test.go` — Stop-during-hydration test (slow mock store):
+  Stop returns only after goroutine exit; no panic on double-Stop.
+
+**Step-by-step**
+1. Add WaitGroup wiring exactly as the PR #1239 pattern extended with join.
+2. Bounded wait in Stop (select on done-channel vs timer) — never hang shutdown.
+3. Race test with `-race` (slow store mock).
+4. `make ci`.
+
+**Acceptance criteria**
+- [ ] `-race` Stop-during-hydration test passes; double-Stop safe.
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `bgWg` exists and Stop joins.
+
+**Rollback.** Revert one file.
+
+---
+
+## Review gates for the coordinator (Fable 5)
+
+Line-by-line review mandatory: T003, T004, T005, T006 (iTunes writers — irreversible
+production stakes), T012, T015, T019, T020 (PebbleDB schema/data), T022 (mass deletion).
+Standard review: all others. Every PR: `make ci` green + the task's acceptance criteria
+checklist pasted and ticked in the PR description + COMPLETED/REMAINING/BLOCKED counts in
+the final status comment.

--- a/docs/plans/fable5-implementation-plan.md
+++ b/docs/plans/fable5-implementation-plan.md
@@ -56,6 +56,19 @@ graph TD
   end
 ```
 
+## Model assignments (authoritative — overrides per-task `Agent:` lines)
+
+Match model to task character to control spend: Haiku for mechanical well-specified
+changes, Sonnet for standard implementation/integration, Opus for the
+irreversible-stakes iTunes writer internals. Fable 5 is coordinator/reviewer only and
+implements nothing.
+
+| Model | Tasks | Rationale |
+|---|---|---|
+| **haiku-4.5** | T009, T010, T018, T023, T025, T027 | S-effort, mechanical, fully specified steps; failure is cheap and caught by `make ci` |
+| **sonnet-4.6** | T001, T002, T007, T008, T011, T012, T013, T014, T015, T016, T017, T019, T020, T021, T022, T024, T026 | standard implementation + integration work; ⚠-flagged ones (T012, T015, T019, T020, T022) get mandatory Fable line-review before merge |
+| **opus-4.8** | T003, T004, T005, T006 | iTunes writer internals — binary-format correctness with irreversible production stakes; cheapest place to pay for the strongest model |
+
 ## Parallel execution groups
 
 | Wave | Tasks (parallel within wave) | Notes |
@@ -327,7 +340,9 @@ Priority: P2 · Effort: M · Agent: sonnet-4.6 · Depends: [T005]
 
 **Context.** CRIT-2: 0x0D must hold a native Windows path, 0x0B the percent-escaped
 `file://localhost/` URL; our writers pass through whatever callers provide (URLs observed
-in 83,783 0x0D blocks of damaged-1/3, staging-dir paths in damaged-4).
+in 83,783 0x0D blocks of damaged-1/3, staging-dir paths in damaged-4). **The normative
+field contract — including the podcast (no-0x0D) and UTF-16 edge cases — is SPEC 2 §1b;
+implement exactly that, it is census-verified and not open to interpretation.**
 
 **Exact files to change**
 - `internal/itunes/location_pair.go` — NEW: `type LocationPair struct{ WinPath, URL string }`;

--- a/docs/specs/fable5-review-findings.md
+++ b/docs/specs/fable5-review-findings.md
@@ -68,9 +68,14 @@ Full treatment: SPEC 2 (`fable5-spec-itunes-writeback-hardening.md`).
 
 ### CRIT-2 — Location (0x0D) written as `file://` URL; iTunes stores a native Windows path (BUG, iTunes corruption, LIVE)
 
-**OBSERVED.** Golden: all 93,014 type-0x0D blocks contain Windows paths
-(`W:\itunes\iTunes Media\Audiobooks\...`); the URL form lives only in type-0x0B
-(`file://localhost/W:/itunes/iTunes%20Media/...`). damaged-1/3 contain 83,783 type-0x0D
+**OBSERVED — owner-challenged and re-verified by full census (2026-06-09).** In the
+untouched library (`itunes-lib-good.itl`, SHA-256-identical to the golden copy), all
+93,014 type-0x0D blocks contain Windows paths and **zero** contain `file://`: 91,278
+plain `W:\itunes\iTunes Media\...` + 1,736 UTF-16-encoded backslash paths (non-ASCII
+titles). The URL form lives only in type-0x0B: 93,014 `file://localhost/W:/itunes/...`
+(1:1 with the 0x0D paths) plus 1,187 `https://` podcast feed/stream URLs on tracks that
+have **no** 0x0D at all. (The familiar `file://W:/...` form appears in 0x0B and in the
+`iTunes Library.xml` export — not in binary 0x0D.) damaged-1/3 contain 83,783 type-0x0D
 blocks holding **URLs** (`file://localhost/W:/audiobook-organizer/...`); damaged-4 has 34.
 damaged-4 also shows locations pointing into our staging dir
 (`.../audiobook-organizer/.itunes-writeback/iTunes%20Media/...`).

--- a/docs/specs/fable5-review-findings.md
+++ b/docs/specs/fable5-review-findings.md
@@ -1,0 +1,279 @@
+<!-- file: docs/specs/fable5-review-findings.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f2b8c1d-9e4a-4f6b-8a2c-5d7e9f0a1b2c -->
+
+# FINDINGS: Security & Bugs — Fable 5 Full-System Review (2026-06-09)
+
+Classification: SECURITY / BUG / PERFORMANCE / DEBT. Severity: CRITICAL / HIGH / MEDIUM / LOW.
+
+Every iTunes finding below is grounded in empirical analysis of the six libraries in
+`/tmp/itunes-libraries/` (golden 30.8MB / writeback 1.0MB / damaged-1..4 at 29.0–29.7MB),
+performed with `cmd/itl-check`, `cmd/itl-diff`, `cmd/itl-repair`, and direct binary
+inspection of the decrypted/inflated payloads. Evidence provenance is tagged:
+
+- **OBSERVED** — seen directly in the damaged-file evidence, with file + counts cited
+- **VERIFIED** — confirmed by reading/running the current code in this repo
+- **REPORTED** — surfaced by a read-only review agent and spot-checked where load-bearing
+
+Baseline facts (OBSERVED, all six libraries):
+
+| Library | Tracks (header @0x44) | Tracks (mlth/mith) | Playlists | Dangling mtph | iTunes verdict |
+|---|---|---|---|---|---|
+| golden `iTunes Library.itl` | 94,575 | 94,575 | 338 | 0 | opens fine |
+| `writeback-iTunes Library.itl` | 374 | 374 | 14 | 0 | (test lib) |
+| damaged-1 | **90,900** | **90,898** | 335 | **6** (3 playlists) | Damaged |
+| damaged-2 | **90,900** | **90,898** | 335 | 0 | Damaged |
+| damaged-3 | 90,900 | 90,900 | 335 | 0 | Damaged |
+| damaged-4 | 90,863 | 90,863 | 335 | 0 | Damaged |
+
+Key implication: **the current safety verifier (`VerifyITLNoDanglingRefsLE`) passes 3 of the
+4 libraries that iTunes itself rejected as damaged.** The dangling-mtph class is real but it
+is the *minority* corruption class in the evidence. damaged-2 is byte-consistent with
+"damaged-1 minus its 6 dangling mtph items" (Δ = 504 bytes = 6 × 84-byte mtph) — i.e. a
+dangling-ref-repaired library is still iTunes-rejected.
+
+---
+
+## CRITICAL
+
+### CRIT-1 — Writeback emits mhoh encoding-flag bytes iTunes never produces (BUG, iTunes corruption, LIVE)
+
+**OBSERVED.** In the golden library, every one of its 281,790 string `mhoh` blocks sampled
+across types 0x02 (Name), 0x0B (LocalURL), 0x0D (Location) has byte `+27` (what our code
+calls the "encoding flag") equal to `0x00`. The damaged libraries contain large numbers of
+blocks with `+27 ∈ {1, 3}` — values that only our writer produces:
+
+| Library | flag=3 location blocks (0x0B+0x0D) | flag=3/1 name blocks (0x02) |
+|---|---|---|
+| golden | 0 | 0 |
+| damaged-1 | 167,562 | 81,195 (flag 3) + 2,586 (flag 1) |
+| damaged-3 | 167,566 | 5,770 (flag 3) + 5 (flag 1) |
+| damaged-4 | 68 | 34 |
+
+**VERIFIED root cause:** `encodeHohmString` (`internal/itunes/itl.go:373`) returns flag 3
+(Windows-1252) for Latin strings and flag 1 (UTF-16BE) otherwise. Both `buildMhohLE`
+(`internal/itunes/itl_le_mutate.go:272`) and `rewriteHohmLocationLE`
+(`internal/itunes/itl_le.go:656`) stamp that flag into byte `+27`. iTunes appears to encode
+strings via a field at byte `+24` (golden shows values 1/2/3 there with `+27` always 0) —
+our `+27` semantics are an invention of our parser, faithfully round-tripped by our own
+tools but foreign to iTunes/Apple Devices.
+
+**Impact:** every metadata/location writeback stamps tens of thousands of blocks with byte
+patterns real iTunes never writes. damaged-4 was rejected by iTunes with only ~34 such
+blocks — tolerance is near-zero. This is the prime suspect for the Apple Devices crash
+class. Fix direction: byte-level corpus study of golden (how iTunes really encodes
+non-ASCII), then make the writer emit byte-identical encodings, with a write-guard that
+rejects any block whose `+24..+27` pattern doesn't occur in iTunes-authored libraries.
+Full treatment: SPEC 2 (`fable5-spec-itunes-writeback-hardening.md`).
+
+### CRIT-2 — Location (0x0D) written as `file://` URL; iTunes stores a native Windows path (BUG, iTunes corruption, LIVE)
+
+**OBSERVED.** Golden: all 93,014 type-0x0D blocks contain Windows paths
+(`W:\itunes\iTunes Media\Audiobooks\...`); the URL form lives only in type-0x0B
+(`file://localhost/W:/itunes/iTunes%20Media/...`). damaged-1/3 contain 83,783 type-0x0D
+blocks holding **URLs** (`file://localhost/W:/audiobook-organizer/...`); damaged-4 has 34.
+damaged-4 also shows locations pointing into our staging dir
+(`.../audiobook-organizer/.itunes-writeback/iTunes%20Media/...`).
+
+**VERIFIED root cause:** the location-update path (`internal/itunes/itl_le.go:640-654`)
+adds a `file://localhost/` prefix only for 0x0B and writes the caller's value into 0x0D
+verbatim; callers pass `f.ITunesPath` / URL-shaped values
+(`internal/itunes/service/writeback_batcher.go:341-345`, `UpdateMetadataLE` `Location`
+field). There is no "0x0D must be a Windows path, 0x0B must be a percent-escaped URL"
+normalization or guard anywhere.
+
+### CRIT-3 — `hdfm` header count fields never updated by mutations (BUG, iTunes corruption, LIVE)
+
+**OBSERVED.** The unencrypted `hdfm` header carries BE count fields at 0x44 (tracks), 0x48
+(playlists), 0x4C (albums = `miah` count), 0x54 (artists = `miih` count) — verified by exact
+match against payload counts in golden, damaged-3, damaged-4. In damaged-1 and damaged-2
+the header says 90,900 tracks while the payload (`mlth` count and actual `mith` blocks) has
+90,898 — a desync of exactly the 2 tracks our `RemoveTracksByPIDLE` removed after iTunes
+last saved.
+
+**VERIFIED root cause:** `RemoveTracksByPIDLE` (`internal/itunes/itl_le_remove_by_pid.go`)
+updates `mlth` count, `miph` counts, and msdh totalLens, but no code path touches the
+header remainder (grep for `hdfm|remainder|0x44` in the mutate/remove files: zero hits).
+`buildHdfmHeader` (`internal/itunes/itl.go:475`) reuses the stale `headerRemainder`
+verbatim on every write. Also note `itl-repair` does not fix this class: damaged-2 (the
+repaired twin of damaged-1) still carries the desync and is still iTunes-rejected.
+
+---
+
+## HIGH
+
+### HIGH-1 — Safety contract has blind spots covering 3 of 4 observed damaged libraries (BUG, iTunes safety)
+
+**OBSERVED + VERIFIED.** The only structural guard run on writeback is the dangling-mtph
+check (`VerifyITLNoNewDanglingRefsLE` / `VerifyITLNoDanglingRefsLE`,
+`internal/itunes/itl_le_verify.go`). Running the full detector over the evidence: damaged-2,
+-3, -4 all report **zero** dangling refs and pass, yet all were renamed "(Damaged)" by
+iTunes. Missing guards include: mhoh format validation (headerLen==24, valid `+24..+27`
+encoding patterns, totalLen == 40+strLen), header-vs-payload count agreement, 0x0D
+path-form validation, and 0x0B URL-escape validation. Additionally both verifiers
+**fail open**: if `CollectMasterTrackIDsLE` returns nil (unparseable master list), they
+return nil ("don't fail-closed on parse surprises", itl_le_verify.go:80-85) — precisely
+when the library is most damaged. Full guard inventory: SPEC 2.
+
+### HIGH-2 — LE parser never reads track string metadata; all string-field diagnostics are vacuous (BUG)
+
+**VERIFIED empirically.** `walkMsdhTracksLE` (`internal/itunes/itl_le.go:49-91`) advances
+by the `mith` chunk's totalLen — which *includes* its child `mhoh` blocks — so the `case
+"mhoh"` branch is unreachable for track metadata. Every `ITLTrack` string field (Name,
+Album, Artist, Genre, Kind, Location, LocalURL) is empty after parse. Confirmed:
+`itl-diff -v` prints `""  by ""` for every track in the golden library; `itl-check` reports
+"Tracks with Location: 0" on a library with 93,014 location blocks. Consequence:
+`itl-diff`'s "Tracks changed: 0" between golden and damaged was **vacuous** for all string
+fields — the very fields our writeback rewrites. Any production logic reading
+`ITLTrack.Location` (path repair, import mapping) sees empty strings on LE libraries.
+
+### HIGH-3 — Writeback unconditionally rewrites metadata for every mapped track (BUG/PERFORMANCE, corruption amplifier)
+
+**VERIFIED + OBSERVED.** `writeback_batcher.go:346` ("Always push metadata so iTunes has
+current values") appends an `ITLMetadataUpdate` for every book file with an iTunes PID on
+every sync — there is no changed-value check. The observed result in the evidence:
+damaged-1 has ~81K rewritten Name blocks and ~167K rewritten location blocks. Combined
+with CRIT-1/2, every full sync re-stamps nearly the whole library with non-iTunes byte
+patterns; blast radius is total instead of incremental. Diff-before-write is the single
+highest-leverage hardening change after the encoders are fixed.
+
+### HIGH-4 — `POST /api/v1/auth/accept-invite` returns `{"error":"EOF"}` under HTTP/2 (SECURITY/BUG, pen-test June 4 2026)
+
+**VERIFIED handler code.** `internal/server/auth_accept_invite.go:28` feeds
+`c.ShouldBindJSON(&req)` errors straight into the 400 response; an empty/streamed HTTP/2
+body yields the raw Go `EOF` error string. (Contrast: `internal/server/fingerprint_rescan.go:45`
+already tolerates EOF for optional bodies — but accept-invite's body is *required*, so the
+right fix is mapping EOF/empty-body to a clear "request body required" message, not
+ignoring it.) Root cause of the pen-test finding is error-message passthrough, not a
+binding failure. REPORTED middleware context: `request_size.go` only pre-rejects on
+`ContentLength > 0`, so chunked/HTTP/2 bodies skip the early 413 and surface as
+EOF-flavored errors from `MaxBytesReader` (see MED-1).
+
+### HIGH-5 — Dedup candidates carry no fingerprint provenance; stale 100%-similarity rows survive recompute (BUG, dedup correctness)
+
+**VERIFIED.** `DedupCandidate` (`internal/database/embedding_store.go:79-91`) has
+`Layer`/`Similarity` but no record of *which fingerprint version/algorithm* produced the
+match. `PurgeStaleCandidates` (`internal/dedup/engine.go:1521-1649`) prunes for
+missing/non-primary/version-group/series reasons only — nothing invalidates candidates when
+fingerprints are recomputed. Production carries ~14K 100%-matches created from the old
+per-segment fingerprints (count from project records; not re-verified against prod in this
+review). Whole-file fields exist (`store.go:676-684`, segments deprecated) but no
+`fingerprint_version` marker exists anywhere (grep negative). Fix: provenance fields +
+purge-by-provenance migration (SPEC 1, tasks in plan).
+
+### HIGH-6 — `headerLen=totalLen` mhoh corruption: fixed at the writer, but no detector for already-corrupt libraries (BUG, partially mitigated)
+
+**OBSERVED.** damaged-1 contains ~60K type-0x02 blocks with headerLen 41–210 (legal value
+is 24 — golden is 100% headerLen=24); damaged-3 has ~3.4K, damaged-4 ~33. **VERIFIED**
+that the cause (`buildMhohLE` writing headerLen=totalLen) is already fixed
+(`internal/itunes/itl_le_mutate.go:266-276`, `mhohFixedHeaderLen = 24`, regression test
+`TestRewriteHohmLocationLE_PreservesHeaderLen`). Remaining gap: nothing *detects* such
+blocks at read/verify time, so a library corrupted by an old version (or any external
+cause) sails through every current guard and gets mutated/re-shipped.
+
+---
+
+## MEDIUM
+
+### MED-1 — Request-size middleware early-413 bypass for chunked/HTTP/2 bodies (SECURITY, hardening)
+
+**REPORTED, spot-checked.** `internal/server/middleware/request_size.go:52-58` pre-rejects
+only when `ContentLength > limit && ContentLength > 0`; bodies without Content-Length fall
+through to `http.MaxBytesReader`, which truncates with an opaque error instead of a clean
+413. Safe (no OOM) but produces the EOF-style failure surface seen in HIGH-4.
+
+### MED-2 — `Book.Duration` / `Book.FileSize` are snapshots, not aggregates of BookFiles (BUG/DEBT)
+
+**REPORTED, consistent with grep.** Fields at `internal/database/store.go:128,170` are set
+at import and never recomputed from `BookFile` rows; no sum-over-files path exists. Known
+backlog item (project memory `duration_filesize_aggregation`); UI shows stale snapshots for
+multi-file books.
+
+### MED-3 — `FilterUnchangedTags` treats custom `AUDIOBOOK_ORGANIZER_*` fields as always-changed (BUG)
+
+**REPORTED.** `internal/metafetch/service_writeback.go:353-423` compares a fixed set of
+standard fields; unknown keys fall through to "write". Effect: every write-back rewrites
+all custom tags even when unchanged — defeats the skip-detection the function exists for,
+and inflates copy-on-write `.bak-*` churn.
+
+### MED-4 — Legacy SQLite store (~7.9K lines) still compiled and opened at startup (DEBT)
+
+**VERIFIED.** `internal/database/database.go:20` does `sql.Open("sqlite3", databasePath)`
+unconditionally; `sqlite_store_*.go` totals ~7,938 lines implementing a parallel Store that
+production (PebbleDB-primary) shouldn't reach. Risk: drift, accidental use (e.g.
+`sqlite_store_books.go:872` implements `GetDuplicateBooks` alongside the Pebble one),
+single-writer lock if any path lands there. Note the review brief's claim "embeddings.db
+SQLite" is stale: embeddings live in PebbleDB (`emb:v:*` keys,
+`internal/database/embedding_store.go`). Removal plan: SPEC 3.
+
+### MED-5 — Diagnostic tools claim more than they do (DEBT, tooling trust)
+
+**VERIFIED.** `cmd/itl-diff/main.go` docstring promises an msdh container inventory that is
+not implemented; it diffs only the 96-byte header hex and per-track parsed fields (which
+HIGH-2 makes vacuous for strings). `cmd/itl-check` prints counts only. Neither inspects
+playlist membership. During an actual corruption incident these tools said "0 changed" on
+libraries with 167K rewritten blocks.
+
+### MED-6 — `ValidateITL` validates almost nothing (BUG, iTunes safety)
+
+**VERIFIED.** `internal/itunes/itl.go:626` checks header decrypt + non-zero track count
+only. It is not a structural validator and must not be treated as one by callers
+(`library_watcher.go`, service validate paths). Superseded by the SPEC 2 safety contract.
+
+### MED-7 — Oversized-payload inflate fails *silently* and verifiers fail open — a bad composition (BUG, iTunes safety)
+
+**VERIFIED.** `itlInflate` (`internal/itunes/itl.go:302-320`) returns `(data, false)` —
+i.e. "treat as uncompressed" — when payload exceeds the 512MB decompression cap (golden
+already inflates to 236MB; a 2.2× larger library trips this). Downstream, parse yields no
+master list, and `VerifyITLNoDanglingRefsLE` returns nil when the master list can't be
+located. Net effect: beyond ~500MB decompressed, every guard silently passes while parse
+sees garbage. Fail-closed behavior is required on both ends.
+
+### MED-8 — Chromem hydration is fire-and-forget with no shutdown join (BUG, concurrency, minor)
+
+**REPORTED, lifecycle reviewed.** `internal/dedup/lifecycle.go:103-112` starts hydration
+under `bgCtx` with a 30-min timeout but no WaitGroup; `Stop()` cancels correctly
+(mutex-guarded, nil-safe — the PR #1239 pattern) but does not wait, so shutdown can race a
+final Pebble read. Concurrency sweep found no other unsafe cancel patterns: registry
+shutdown (`internal/operations/registry/registry.go:398-450`), acoustid heartbeat
+(`internal/plugins/acoustid/fingerprint_rescan.go:142-175`), and warmup contexts all follow
+the safe pattern.
+
+---
+
+## LOW
+
+### LOW-1 — Zero-test packages (DEBT)
+
+**REPORTED.** `internal/quarantine` (354 lines), `internal/httputil` (337), 
+`internal/operations` (318) have no `_test.go` files. `go vet ./...` is clean. Candidates
+for the existing test-coverage burndown queue (#79–#109) rather than new plan tasks.
+
+### LOW-2 — BE-format writer lacks the LE safeguards (DEBT, iTunes)
+
+**VERIFIED.** All verify functions are LE-only and silently no-op on BE payloads
+(`detectLE` gate, `itl_le_verify.go:31,75`); `itl_be.go:528` shares the same
+`encodeHohmString` flag problem as CRIT-1. Production libraries are LE (v12.13), so this is
+exposure only if a PowerPC-era library is ever written. Recommend: refuse BE writeback
+outright instead of writing unguarded.
+
+---
+
+## Defenses confirmed present (for balance)
+
+- Path traversal: `internal/security/pathvalidation` (`CleanAbsolutePath`, `SecureJoin*`)
+  used at user-facing path inputs; recent CodeQL sanitizer commits verified.
+- Auth: bcrypt at default cost; session cookies HttpOnly+Secure+SameSite=Strict; API keys
+  stored as SHA-256 hashes; per-IP and per-account login throttles; bootstrap token
+  rate-limited, written 0600, never logged.
+- SSRF: cover-art fetch restricted to an allowlist (openlibrary.org, books.google.com,
+  amazon.com); other outbound HTTP targets fixed hosts.
+- iTunes path mapping inputs come from the DB (not user-supplied) and the write target is
+  the configured library path; no traversal vector found in `ReverseRemapPath`.
+- Dedup engine background lifecycle (`bgMu`/`bgCtx`) follows the post-#1239 safe pattern.
+
+## Severity totals
+
+- **CRITICAL: 3** (CRIT-1 encoding flags, CRIT-2 0x0D URL-vs-path, CRIT-3 header count desync)
+- **HIGH: 6** (verifier blind spots; vacuous LE string parse; unconditional metadata push; accept-invite EOF; candidate provenance; headerLen detector gap)
+- **MEDIUM: 8** | **LOW: 2**

--- a/docs/specs/fable5-spec-itunes-writeback-hardening.md
+++ b/docs/specs/fable5-spec-itunes-writeback-hardening.md
@@ -87,7 +87,7 @@ Guards (v1, ordered cheapest-first; names are normative for tests):
 | `count-coherence` | `mlth` count == actual mith blocks == proposed header @0x44; playlist count @0x48 == miph count; album @0x4C == miah count; artist @0x54 == miih count; every `miph` declared item count == actual mtph children | **K2**, K8 |
 | `no-new-dangling-refs` | existing `VerifyITLNoNewDanglingRefsLE`, converted to fail-closed | K1 |
 | `mhoh-format` | every mhoh: headerLen == 24; totalLen == 40 + strDataLen; strDataLen bound-checked; byte `+27` == 0x00; bytes `+32..+39` zero; `+24` value ∈ the set observed in iTunes-authored blocks for that hohm type (corpus-derived constant table) | **K3, K5, K7** |
-| `location-form` | every 0x0D value parses as a Windows absolute path (drive letter, backslashes, no `file://`, no `%`-escapes); every 0x0B value is a `file://localhost/` URL with RFC-3986 escaping that round-trips to its sibling 0x0D path; **no value contains `.itunes-writeback/`** or other staging markers | **K4** + staging leak |
+| `location-form` | per-track, on **decoded** strings (0x0D may be UTF-16-encoded — 1,736 of golden's 93,014 are): if a track has a 0x0D, it must parse as a Windows absolute path (drive letter, backslashes, no `file://`, no `%`-escapes) and its sibling 0x0B must be a `file://localhost/` URL with RFC-3986 escaping that round-trips to the 0x0D path; tracks **without** 0x0D (podcast/stream entries — 1,187 in golden) may carry any `http(s)://` URL in 0x0B and are exempt from the pairing rule; **no value contains `.itunes-writeback/`** or other staging markers. Census basis: golden 0x0D = 93,014 blocks, zero `file://`; 0x0B = 94,201 blocks (93,014 `file://localhost/` + 1,187 `https://` podcast) | **K4** + staging leak |
 | `tid-pid-sanity` | TIDs sorted ascending, unique; PIDs unique, nonzero | K6, K9, K11 |
 | `bounded-delta` | guardrail: a single writeback may not remove > N tracks (config, default 5,000) nor rewrite > M% of mhoh blocks (config, default 20%) without an explicit `force` flag | blast-radius cap for HIGH-3-style bugs |
 
@@ -147,8 +147,11 @@ by at least one damaged library unless noted):
    field @0x08 equals on-disk size.
 2. Every mhoh: headerLen == 24; totalLen == 40 + strDataLen; bytes 32–39 zero; byte +27 == 0.
 3. mhoh `+24` encoding indicator ∈ corpus-derived set per hohm type.
-4. 0x0D = absolute Windows path; 0x0B = `file://localhost/` percent-escaped URL; pairwise
-   consistent within a track.
+4. 0x0D (when present) = absolute Windows path, never `file://`; its 0x0B sibling =
+   `file://localhost/` percent-escaped URL, pairwise consistent. Tracks without a local
+   file (podcasts) have no 0x0D and may hold `http(s)://` in 0x0B. Verified by full
+   census of the untouched library (`itunes-lib-good.itl`, SHA-256-identical to golden):
+   93,014 0x0D blocks, zero `file://`; 91,278 ASCII + 1,736 UTF-16-encoded backslash paths.
 5. No `mtph` referencing a TID absent from the master list; per-miph declared count ==
    actual mtph children.
 6. TIDs strictly ascending and unique in the master list; PIDs unique (golden-verified;

--- a/docs/specs/fable5-spec-itunes-writeback-hardening.md
+++ b/docs/specs/fable5-spec-itunes-writeback-hardening.md
@@ -1,0 +1,207 @@
+<!-- file: docs/specs/fable5-spec-itunes-writeback-hardening.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a1c4e9b-2d5f-4a8c-b3e6-0f1a2b3c4d5e -->
+
+# SPEC 2: iTunes Library Writeback Hardening
+
+Goal: rock-solid `.itl` writeback. iTunes opens semi-broken libraries; **Apple Devices
+(Windows iPhone sync) crashes on corrupt tracks** — and iTunes renames a library it
+distrusts to "(Damaged)" and rebuilds from backup, losing whatever the writeback intended.
+This spec defines a formal safety contract, an atomic write protocol, and a regression
+suite, all derived from binary forensics of four real damaged libraries (see
+`fable5-review-findings.md` for the full evidence tables; finding IDs referenced below).
+
+## 1. Damaged Library Analysis (empirical summary)
+
+Method: built and ran `cmd/itl-check`, `cmd/itl-diff`, `cmd/itl-repair` against
+`/tmp/itunes-libraries/{golden, writeback, damaged-1..4}`; then decrypted/inflated payloads
+(AES-128-ECB prefix + zlib, mirroring `parseHdfmHeader → itlDecrypt → itlInflate`) and
+walked every msdh container, every mith/mhoh/miph/mtph chunk.
+
+### What each tool can and cannot detect (mandated statement)
+
+| Tool / guard | Detects | Blind to |
+|---|---|---|
+| `cmd/itl-check` | parse-level track/playlist counts | everything structural; its "Tracks with Location" counter is broken (HIGH-2) |
+| `cmd/itl-diff` | hdfm header hex diff; per-PID numeric fields (Size, TotalTime, BitRate, …); track add/remove sets | playlist membership (`mtph`/`miph`); **all string fields** (Name/Album/Artist/Genre/Kind/Location are never parsed on LE — HIGH-2); mhoh-level encoding; msdh inventory (docstring claims it; not implemented — MED-5) |
+| `cmd/itl-repair` | dangling `mtph` items (and removes them) | header count desync; mhoh format violations; everything else |
+| `VerifyITLNoNewDanglingRefsLE` / `VerifyITLNoDanglingRefsLE` | playlist→track dangling refs (LE only) | all other classes; **fails open** when master list unlocatable (MED-7); silently skips BE (LOW-2) |
+| `ValidateITL` | header decrypts, track count nonzero | structure entirely (MED-6) |
+
+### Corruption classes found, with provenance
+
+| # | Class | Status | Evidence | Current code |
+|---|---|---|---|---|
+| K1 | Dangling `mtph` playlist refs after track removal | **OBSERVED** | damaged-1: 6 items across 3 `miph` parents | guarded (`VerifyITLNoNewDanglingRefsLE`); `RemoveTracksByPIDLE` v1.2.0 removes orphans in-pass |
+| K2 | `hdfm` header count fields stale vs payload (tracks @0x44; albums @0x4C; artists @0x54; playlists @0x48 — BE, inside `headerRemainder`) | **OBSERVED** | damaged-1/2: header 90,900 vs payload 90,898 | **unguarded, live** (CRIT-3). No mutation path touches the header remainder |
+| K3 | mhoh encoding-flag byte `+27` set to 1/3 (iTunes writes only 0x00; its encoding indicator is at `+24`) | **OBSERVED** | golden: 0 of 281,790 blocks; damaged-1: 251K blocks; damaged-3: 173K; damaged-4: 102 | **unguarded, live** (CRIT-1) via `encodeHohmString` |
+| K4 | Location 0x0D holds `file://` URL; iTunes format is native Windows path (URL belongs in 0x0B only) | **OBSERVED** | damaged-1/3: 83,783 blocks; damaged-4: 34 (incl. paths into `.itunes-writeback/` staging) | **unguarded, live** (CRIT-2) |
+| K5 | mhoh `headerLen` written as totalLen (legal value: 24, golden is 100% uniform) | **OBSERVED** | damaged-1: ~60K type-0x02 blocks (headerLen 41–210); damaged-3: ~3.4K; damaged-4: ~33 | writer fixed (`mhohFixedHeaderLen`, regression test exists); **no read-time detector** (HIGH-6) |
+| K6 | Invalid TID sequences/gaps | SPECULATIVE | golden+damaged all have sorted, duplicate-free TIDs (verified) | not needed as a primary guard; cheap to assert |
+| K7 | Malformed mhoh length prefixes (totalLen ≠ 40+strLen) | SPECULATIVE | zero instances in all six libraries | include in contract anyway — trivially cheap |
+| K8 | Playlist sort fields (`mnol`/`mpsl`) pointing at deleted tracks | SPECULATIVE | tags not present in these libraries' containers; per-miph declared-vs-actual counts all consistent (335/335 playlists, all match) | covered indirectly by K1 guard |
+| K9 | PID collisions / format violations | SPECULATIVE | no duplicates observed | cheap assert in contract |
+| K10 | Smart-playlist criteria referencing removed fields | SPECULATIVE | smart data (`msph`/type-21 container) byte-identical across libraries | out of contract v1 |
+| K11 | mith ordering requirements | SPECULATIVE (golden is TID-sorted; damaged too) | preserve-order rule in contract | |
+| K12 | BE writer parity | N/A here (all evidence LE) | **refuse BE writes** rather than replicate guards (LOW-2) | |
+
+### Which corruption breaks Apple Devices specifically?
+
+Not directly testable from this machine (Apple Devices is a Windows app). What the evidence
+supports: iTunes' own damage detector trips on **per-block format violations** (damaged-4
+was rejected with only ~34 K3+K4 blocks and *no* other inconsistency we could find), so the
+crash-causing classes are, in priority order, K3/K5 (string blocks whose declared layout
+disagrees with iTunes' reader — a parser in Apple Devices that trusts `headerLen` or the
+`+24` encoding indicator will read garbage or out-of-bounds) and K4 (path field containing
+a URL — any code that feeds 0x0D to Win32 file APIs gets an invalid path). The
+compatibility checklist (§5) therefore requires byte-pattern conformance with
+iTunes-authored blocks, not merely self-consistency. Marked as inference, not observation.
+
+## 2. `ITLSafetyContract` (write-guard contract)
+
+A single Go type (new file `internal/itunes/itl_safety_contract.go`) that runs an ordered
+list of named, individually testable guards over `(before, after []byte)` decompressed LE
+payloads + the proposed new `hdfm` header. **All guards must pass before any byte reaches
+disk.** Guards are pure functions; each returns a structured violation list (guard name,
+offset, chunk tag, message), never just a bool — auditability is part of the contract.
+
+```
+type GuardResult struct {
+    Guard      string // stable name, e.g. "mhoh-format"
+    Violations []Violation // empty = pass
+}
+type Violation struct {
+    Offset  int
+    Chunk   string // "mhoh", "mith", ...
+    Message string
+}
+ContractVerdict { Pass bool; Results []GuardResult; before/after summary counts }
+```
+
+Guards (v1, ordered cheapest-first; names are normative for tests):
+
+| Guard name | Asserts | Catches |
+|---|---|---|
+| `parse-roundtrip` | `after` decrypts/inflates/parses; master list locatable; **fail closed** on any parse surprise (inverts today's fail-open) | MED-7, gross corruption |
+| `container-tiling` | msdh containers tile the payload exactly; every container's totalLen sums with content; child walk reaches contentEnd with 0 gap in types 1 and 2 | truncation/splice errors |
+| `count-coherence` | `mlth` count == actual mith blocks == proposed header @0x44; playlist count @0x48 == miph count; album @0x4C == miah count; artist @0x54 == miih count; every `miph` declared item count == actual mtph children | **K2**, K8 |
+| `no-new-dangling-refs` | existing `VerifyITLNoNewDanglingRefsLE`, converted to fail-closed | K1 |
+| `mhoh-format` | every mhoh: headerLen == 24; totalLen == 40 + strDataLen; strDataLen bound-checked; byte `+27` == 0x00; bytes `+32..+39` zero; `+24` value ∈ the set observed in iTunes-authored blocks for that hohm type (corpus-derived constant table) | **K3, K5, K7** |
+| `location-form` | every 0x0D value parses as a Windows absolute path (drive letter, backslashes, no `file://`, no `%`-escapes); every 0x0B value is a `file://localhost/` URL with RFC-3986 escaping that round-trips to its sibling 0x0D path; **no value contains `.itunes-writeback/`** or other staging markers | **K4** + staging leak |
+| `tid-pid-sanity` | TIDs sorted ascending, unique; PIDs unique, nonzero | K6, K9, K11 |
+| `bounded-delta` | guardrail: a single writeback may not remove > N tracks (config, default 5,000) nor rewrite > M% of mhoh blocks (config, default 20%) without an explicit `force` flag | blast-radius cap for HIGH-3-style bugs |
+
+Notes:
+- `mhoh-format`'s `+24` allowed-value table must be **derived from the golden corpus by a
+  one-off audit tool**, not hand-invented (Task plan: ITW-1). Until derived, the guard
+  enforces only "+27 == 0" + headerLen + length arithmetic, which already catches every
+  observed instance of K3/K5.
+- Guards run on the *decompressed payload + proposed header pair*, so K2 is checkable
+  before encryption/compression.
+- The contract API also exposes `AuditITL(data []byte)` (single-library mode, `before ==
+  nil`) for use by `cmd/itl-check` and a new maintenance endpoint, so already-corrupt
+  libraries (K5 carriers) are detectable at read time — closing HIGH-6.
+
+## 3. Atomic write protocol
+
+New single chokepoint `SafeWriteITL(path string, mutate func(payload []byte) ([]byte, error), opts ...)` in
+`internal/itunes/itl_safe_write.go`. **All writeback paths (`itl_combined_mutate.go`,
+`UpdateITLLocations`, rebuild, service batcher) are refactored to go through it.** Protocol:
+
+1. Read original; parse; snapshot `before` payload + header. Refuse BE (K12).
+2. Apply `mutate` to a copy. Recompute header count fields (fixes CRIT-3 by construction:
+   header remainder is *regenerated*, with @0x44/0x48/0x4C/0x54 patched from actual payload
+   counts, all other remainder bytes preserved).
+3. Run `ITLSafetyContract(before, after, newHeader)`. Any violation → delete nothing,
+   write nothing, return the structured verdict in the error. Log full verdict at ERROR
+   with op-id tags (per repo logging discipline).
+4. Encode (encrypt+deflate), write to `<path>.itl.new` in the same directory (same
+   filesystem → atomic rename), fsync file.
+5. Re-read `<path>.itl.new` from disk, decode, and run the contract **again** against the
+   re-read bytes (catches encode-path bugs — the BestSpeed zlib + AES boundary code is
+   itself a historic risk area). 
+6. Backup: rename `<path>` → `<path>.bak-<RFC3339>`; then rename `<path>.itl.new` → `<path>`;
+   fsync directory.
+7. On any failure after step 4: remove `.itl.new`, original untouched.
+8. **Lock discipline:** refuse to write if iTunes/Apple Devices may have the file open.
+   On the remote-Windows deployment this means the writeback service must check the
+   configured "iTunes running" signal (existing sync service heartbeat) and the contract
+   gains a precondition `library-not-in-use`. (A library replaced under a running iTunes is
+   a plausible non-structural cause of "(Damaged)" renames for internally-consistent files
+   like damaged-3/4 — we could not falsify structural causes for those two beyond K3/K4/K5
+   counts, so both protections are mandatory. Stated as inference.)
+
+**Backup retention policy:** keep the most recent **10** `.bak-*` per library *plus* one
+"last-known-good" pin (`.bak-lkg`, updated only after a subsequent successful iTunes open
+is confirmed via the sync service), TTL 90 days for unpinned baks, cleanup in the existing
+maintenance loop alongside `.bak-*` copy-on-write cleanup. Rationale: damage is often
+discovered many syncs later (the four damaged files span weeks), so a deep history matters
+more than disk (30MB × 10 = 300MB, negligible on the ZFS pool).
+
+## 4. Apple Devices compatibility checklist (golden-derived invariants)
+
+Every writeback output MUST satisfy (all verified true of the golden library, all violated
+by at least one damaged library unless noted):
+
+1. Header @0x44/0x48/0x4C/0x54 equal actual mith/miph/miah/miih counts; header fileLen
+   field @0x08 equals on-disk size.
+2. Every mhoh: headerLen == 24; totalLen == 40 + strDataLen; bytes 32–39 zero; byte +27 == 0.
+3. mhoh `+24` encoding indicator ∈ corpus-derived set per hohm type.
+4. 0x0D = absolute Windows path; 0x0B = `file://localhost/` percent-escaped URL; pairwise
+   consistent within a track.
+5. No `mtph` referencing a TID absent from the master list; per-miph declared count ==
+   actual mtph children.
+6. TIDs strictly ascending and unique in the master list; PIDs unique (golden-verified;
+   speculative as a *requirement*, cheap to keep).
+7. msdh containers tile the file exactly; all 15 container types present in the same order
+   as the source library (we preserve order by construction — splice-in-place mutations).
+8. Payload inflates below the configured cap with fail-closed behavior at the cap.
+
+## 5. Safeguard gaps → implementations (each is a plan task)
+
+| Gap | Implementation | Plan task |
+|---|---|---|
+| No corpus-derived mhoh encoding table | one-off audit tool reads golden, emits Go constant table + JSON snapshot under `internal/itunes/testdata/` | ITW-1 |
+| K3: writer emits foreign flag bytes | rewrite `encodeHohmString`/`buildMhohLE`/`rewriteHohmLocationLE` to emit iTunes-conformant `+24/+27` bytes per corpus; never invent flags | ITW-2 |
+| K4: 0x0D/0x0B form confusion | central `LocationPair{WinPath, URL}` type with normalization + escaping; all writers take it; guard `location-form` | ITW-3 |
+| K2: stale header counts | header regeneration in SafeWriteITL step 2 | ITW-4 |
+| No safety contract | `ITLSafetyContract` per §2 | ITW-5 |
+| No atomic write | `SafeWriteITL` per §3 + refactor all writers onto it | ITW-6 |
+| HIGH-2: vacuous LE string parse | fix `walkMsdhTracksLE` to descend into mith children (walk `offset+headerLen .. offset+totalLen`); unblocks real diffing | ITW-7 |
+| Tools lie (MED-5) | `itl-diff`: add msdh inventory + playlist-membership diff + mhoh-format audit; `itl-check`: run `AuditITL` | ITW-8 |
+| HIGH-3: full-library rewrite each sync | diff-before-write in writeback_batcher (skip ITLMetadataUpdate when values unchanged — requires ITW-7's parser fix to read current values) | ITW-9 |
+| Fail-open verifier (MED-7) | fail-closed conversions inside contract | ITW-5 |
+| BE writes unguarded (LOW-2) | `SafeWriteITL` refuses BE | ITW-6 |
+| Already-corrupt libraries undetectable (HIGH-6) | `AuditITL` + maintenance/diagnostics endpoint | ITW-8 |
+
+## 6. Regression test suite design
+
+Location: `internal/itunes/itl_safety_contract_test.go` + extend `generate_test_itls.go`.
+Pattern per test: generate minimal valid LE .itl (existing generator) → apply a *specific
+corrupting mutation* with test-local helpers (kept in `_test.go` so production code never
+contains corruptors) → assert the named guard catches it, and that the *other* guards
+don't false-positive on the valid base. All tests idempotent, no real iTunes, no /tmp
+fixtures (the damaged libraries are ephemeral evidence, not test inputs — but their
+*signatures* are encoded in these mutations).
+
+| Test | Mutation | Must be caught by |
+|---|---|---|
+| `TestContract_DanglingMtph` | excise mith, keep mtph (use preserved `removeTracksByPIDLEUnsafe`) | `no-new-dangling-refs` |
+| `TestContract_HeaderCountDesync` | remove a track, keep old header | `count-coherence` |
+| `TestContract_MhohForeignFlag` | set byte+27=3 on one mhoh | `mhoh-format` |
+| `TestContract_MhohHeaderLen` | set headerLen=totalLen on one mhoh | `mhoh-format` |
+| `TestContract_MhohLenArithmetic` | totalLen ≠ 40+strLen | `mhoh-format` |
+| `TestContract_LocationURLIn0x0D` | write URL into 0x0D | `location-form` |
+| `TestContract_StagingPathLeak` | location containing `.itunes-writeback/` | `location-form` |
+| `TestContract_MiphCountMismatch` | decrement a miph declared count | `count-coherence` |
+| `TestContract_TidDuplicate` / `_Unsorted` | duplicate / swap TIDs | `tid-pid-sanity` |
+| `TestContract_TruncatedContainer` | shrink an msdh totalLen | `container-tiling` |
+| `TestContract_FailClosedOnUnparseable` | corrupt master-list msdh tag | `parse-roundtrip` |
+| `TestContract_BoundedDelta` | remove 5,001 tracks | `bounded-delta` |
+| `TestContract_CleanPasses` | no mutation | all guards pass |
+| `TestSafeWrite_RollbackOnViolation` | mutate func introduces K2 | original byte-identical after call; no `.itl.new` left |
+| `TestSafeWrite_BackupRotation` | 12 successive writes | 10 baks + lkg retained |
+| `TestParseLE_TrackStrings` (ITW-7) | golden-shaped fixture | Name/Location populated |
+
+CI: all of the above run under `make test` / `make ci`; no network, no fixtures outside
+testdata.

--- a/docs/specs/fable5-spec-itunes-writeback-hardening.md
+++ b/docs/specs/fable5-spec-itunes-writeback-hardening.md
@@ -57,6 +57,43 @@ a URL — any code that feeds 0x0D to Win32 file APIs gets an invalid path). The
 compatibility checklist (§5) therefore requires byte-pattern conformance with
 iTunes-authored blocks, not merely self-consistency. Marked as inference, not observation.
 
+## 1b. NORMATIVE: the Location field contract (0x0B / 0x0D)
+
+This section is the single source of truth for how location fields are written. It was
+census-verified against the untouched library `itunes-lib-good.itl` (SHA-256-identical to
+golden; 93,014 local tracks + 1,187 podcast entries, zero exceptions found). Any code or
+doc that contradicts it is wrong.
+
+**One source of truth, two derived renderings.** A track's location is a single Windows
+absolute path. It is rendered into the .itl twice:
+
+| Field | hohm type | Content | Example |
+|---|---|---|---|
+| Location | `0x0D` | The plain Windows path. Backslashes. **No** `file://`. **No** percent-escaping. | `W:\itunes\iTunes Media\Audiobooks\Adrian Tchaikovsky\01 Children of Time - 1.mp3` |
+| LocalURL | `0x0B` | `file://localhost/` + the same path with `\`→`/` and RFC-3986 percent-escaping | `file://localhost/W:/itunes/iTunes%20Media/Audiobooks/Adrian%20Tchaikovsky/01%20Children%20of%20Time%20-%201.mp3` |
+
+Rules (all empirically grounded, zero counter-examples in 187,215 censused blocks):
+
+1. **Never write a URL into 0x0D.** Never write a bare path into 0x0B. The two fields are
+   derived from one `LocationPair` value (TASK-006); no caller may pass a raw string to
+   either field directly.
+2. **Pairing:** every track with a local file has BOTH fields, and they round-trip:
+   `FromWinPath(p).URL == sibling 0x0B` and `FromURL(u).WinPath == sibling 0x0D`.
+3. **Podcast/stream tracks have no 0x0D at all** and carry an `http(s)://` URL in 0x0B
+   (1,187 in the census). Writeback must never add a 0x0D to them, and validators must
+   not require one.
+4. **Encoding is orthogonal to content.** Non-ASCII paths are stored UTF-16-encoded
+   (1,736 of 93,014 in the census) with the block's encoding signaled per CRIT-1's
+   corpus rules — writing the correct *string* with wrong encoding bytes is still
+   corruption. TASK-005 (encoders) and TASK-006 (LocationPair) must both land before
+   writeback is considered safe.
+5. The familiar `file://localhost/W:/...` form seen in `iTunes Library.xml` exports is
+   the XML rendering of the location — it corresponds to 0x0B, never to 0x0D.
+
+**The historical bug in one sentence:** callers passed URL-shaped `f.ITunesPath` and the
+writer copied it into 0x0D verbatim, so both fields held the URL form (83,783 blocks in
+damaged-1/3; 34 in damaged-4) — which iTunes rejects.
+
 ## 2. `ITLSafetyContract` (write-guard contract)
 
 A single Go type (new file `internal/itunes/itl_safety_contract.go`) that runs an ordered

--- a/docs/specs/fable5-spec-memory-db-optimization.md
+++ b/docs/specs/fable5-spec-memory-db-optimization.md
@@ -1,0 +1,136 @@
+<!-- file: docs/specs/fable5-spec-memory-db-optimization.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5c8e1a4f-7b2d-4e9a-9c3f-6d0b8e2a5f7c -->
+
+# SPEC 3: Memory & Database Optimization
+
+Scope correction up front — **the review brief's premises were partially stale** (verified
+against code this review):
+
+1. `embeddings.db` (SQLite) **no longer exists**: embeddings live in PebbleDB
+   (`emb:v:<entityType>:<entityID>` records, `emb:c:<model>:<textHash>` content cache,
+   `internal/database/embedding_store.go`). The "eliminate embeddings SQLite" priority is
+   already done; what remains is compression (§3).
+2. The "disabled 69GB cache warm-up" is, in current code, the **memdb warm-up — enabled by
+   default** (`UseMemDB = true`, `pebble_store.go:225`, async at :271-283) and already
+   stripped (`memdb_strip.go`: Description, BookSig*, AcoustIDFingerprint, diagnostics
+   removed before insert). The 69GB incident predates the stripping; the *pattern* fix
+   shipped. What remains is preventing regression (§5) and the remaining big consumers.
+3. `ai_scans.db` is also PebbleDB-backed now (`ai_scan_store.go`, `aiscan:` prefix in
+   shared mode).
+4. What **does** remain on SQLite: the legacy `sqlite_store_*.go` Store implementation
+   (~7,938 lines) opened unconditionally at startup via `database.go:20`
+   (`sql.Open("sqlite3", …)`) — findings MED-4.
+
+Current steady-state RSS model at ~50K books / ~308K files (agent audit, spot-checked):
+
+| Component | RSS | Notes |
+|---|---|---|
+| go-memdb (stripped projections) | ~2.4–2.7GB | books ~2GB dominated by retained AcoustIDSeg0–6 strings + remaining Book fields |
+| chromem (in-RAM vectors) | ~600MB | 50K × 3072-dim float32; hydrated once at startup from Pebble |
+| Pebble block cache / runtime | ~100–300MB | |
+| **Total baseline** | **~3.3GB** | |
+
+## 1. PebbleDB schema audit — results
+
+Full prefix inventory is in the agent audit (45+ prefixes; secondary indexes are already
+minimal ~26B id-pointers — good). Optimization-relevant observations:
+
+- **Dead prefixes:** `book:series:<id>`, `book:author:<id>` (replaced by memdb queries in
+  Task 3.4) — confirm zero live readers, then add a one-off sweep to delete remaining keys.
+- **Fat values on hot paths:** `book:<id>` (2–4KB JSON) is deserialized in full by several
+  count/ID-only paths. The memdb layer already shields most reads; remaining direct-Pebble
+  iterators (e.g. backfills, stats fallbacks) should use the existing stripped decode or a
+  field-subset unmarshal. Estimated win: latency/GC on scans, not resident RSS — measure
+  before investing (§6).
+- **`BookFile.AcoustIDSeg0–6`** are *deprecated* (whole-file migrated, `store.go:685-694`)
+  yet still stored in every `book_file:` value AND retained in memdb (only Seg1–6
+  diagnostics stripped; Seg0+ retained for the disabled tier-2 fuzzy path). Once SPEC 1's
+  LSH index lands, segments have **zero** readers → strip from memdb entirely (~550–900MB
+  RSS, the single biggest memory win available) and drop from Pebble values via lazy
+  rewrite-on-touch + background sweep. This is the headline item.
+- `operation:`/`operationlog:` rows (1–3KB) accumulate unboundedly — add retention sweep
+  to maintenance (cheap, disk-only).
+
+## 2. Eliminate SQLite — remaining plan
+
+Target: delete `internal/database/sqlite_store_*.go` and the `database/sql` +
+`mattn/go-sqlite3` dependency.
+
+1. Inventory callers: `grep -rn "sqlite_store\|DB\b" internal/database/database.go` plus
+   interface-dispatch audit — which constructors can still select the SQLite Store, and
+   does any prod config path reach it? (Expected: no; prod is PebbleDB-only.)
+2. Parity check: for each method implemented only in sqlite_store (none expected; PebbleDB
+   is the canonical impl), port or delete.
+3. Remove `sql.Open` from startup; gate the legacy activity-log SQLite reader (if the
+   legacy activity import path still reads an old `.db`) behind an explicit migration
+   command rather than runtime linkage.
+4. Effort M, savings: ~8K lines, one CGO dependency (faster builds, smaller binary,
+   no lock-contention trap), zero runtime RSS change.
+
+## 3. Embedding compression (PebbleDB, already migrated)
+
+Current: `emb:v:` record stores raw float32 LE blob (3072-dim → 12,288B) in JSON-wrapped
+rec, ~12.5KB/book → ~625MB disk for 50K + ~600MB RAM in chromem.
+
+- **Disk:** float16 quantization (halves to 6,144B) + zstd block compression on the blob
+  before JSON wrap. Cosine ranking loss at float16 is negligible for a 0.85/0.95
+  threshold regime. Combined ≈ 3.5–4× reduction (~160–180MB). Product quantization (PQ)
+  would reach 10×+ but adds an index/codebook lifecycle that is not justified at 625MB on
+  a ZFS pool — recommend **float16+zstd now, PQ never unless corpus 10×es**. (The brief's
+  "300MB raw" assumed 1536-dim; actual model is 3072-dim — verified
+  `chromem_embedding_store.go:19-20`.)
+- **RAM (chromem):** store float16 in Pebble, dequantize to float32 on hydrate (RAM
+  unchanged, startup I/O halved), OR switch chromem collection to float16 if supported —
+  investigate in-task; do not commit to RAM savings here.
+- Migration: versioned flag `emb_f16_v1_done`; dual-read (accept v0 float32 and v1
+  float16 by header byte), write v1; background re-encode op; rollback = keep dual-read.
+
+## 4. NutsDB and Bleve evaluation
+
+- **NutsDB** (activity 7-tier buckets + metrics, `nuts_activity_store.go`): functioning;
+  key formats (`uint64-nano:ulid`) are lexicographic and would map 1:1 onto Pebble
+  prefixes (`act:<tier>:<timekey>` …). Migration is *straightforward but not free*
+  (compaction/TTL re-implementation, 256MB segment semantics differ). Recommendation:
+  **migrate** — it removes an entire storage engine (operational simplicity is the owner's
+  stated goal), and the activity store already has a Store interface with two backends
+  (SQL legacy + NutsDB) so a third (Pebble) slot exists by design. Effort L. Do it after
+  the higher-ROI items; hot-deployable with a cutover op (dual-write window + backfill,
+  flag `activity_pebble_v1_done`).
+- **Bleve** (scorch, `internal/search/bleve_index.go`): 60–100MB index, English analyzers,
+  field boosts, used only by `/api/v1/audiobooks/search`; library listing already runs on
+  memdb. Pebble prefix scans cannot replace stemmed full-text + relevance ranking, and
+  SQLite FTS5 would *re-add* SQLite against the owner's direction. **Keep Bleve.** Only
+  action: make index rebuild incremental/batched (exists: `IndexBookBatch`) and document
+  rebuild-from-Pebble as the recovery path.
+
+## 5. GC-pressure / large-object cache audit
+
+- The 69GB-class pattern (caching full API-response/full-struct objects) has one remaining
+  guardrail gap: nothing *prevents* a new field added to `Book` from ballooning memdb
+  again. Add a startup metric: per-memdb-table approximate bytes (sampled marshal of N
+  rows × count) exported via the existing metrics store + a CI-adjacent soft assert in a
+  test (e.g. stripped Book sample ≤ 4KB).
+- No other full-object caches found (agent sweep: playlist evaluator is per-query;
+  stats cache is a single 1–5KB Pebble value with the dirty-flag pattern from PR #1072).
+- Chromem hydration: one-shot goroutine, add WaitGroup join on Stop (findings MED-8).
+
+## 6. Prioritized optimization list (effort vs savings)
+
+| # | Item | Effort | Savings | Window |
+|---|---|---|---|---|
+| 1 | Strip AcoustIDSeg0–6 from memdb after LSH lands (depends SPEC 1 LSH) | S | **~550–900MB RSS (~25–35%)** | hot deploy |
+| 2 | Drop seg fields from `book_file:` Pebble values (lazy + sweep, flag `bookfile_seg_drop_v1_done`) | M | ~200–400MB disk; faster file scans | hot deploy |
+| 3 | Embedding float16+zstd (`emb_f16_v1_done`) | M | ~450MB disk; ~½ hydrate I/O | hot deploy, dual-read rollback |
+| 4 | Legacy SQLite store removal | M | 8K LOC, CGO dep, drift risk | hot deploy (no data) |
+| 5 | memdb size telemetry + regression assert | S | prevents 69GB-class recurrence | hot deploy |
+| 6 | operation/operationlog retention sweep | S | unbounded growth stopped | hot deploy |
+| 7 | Dead-prefix sweep (`book:series:`, `book:author:`) | S | small disk; schema hygiene | hot deploy |
+| 8 | NutsDB → Pebble activity/metrics migration | L | −1 storage engine | hot deploy w/ dual-write window |
+| 9 | Bleve | — | none — keep | — |
+
+Nothing here requires a production maintenance window; items 2/3/8 need their backfill op
+to complete before flag-flip (repo rule). Items with <10% impact (7) are included only as
+hygiene riders on adjacent tasks per the brief's >10% threshold for full migration plans —
+full before/after key schema + rollback are specified in the implementation plan for items
+1–3 and 8.

--- a/docs/specs/fable5-spec-unified-dedup-pipeline.md
+++ b/docs/specs/fable5-spec-unified-dedup-pipeline.md
@@ -1,0 +1,243 @@
+<!-- file: docs/specs/fable5-spec-unified-dedup-pipeline.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9b3d6f2a-4c8e-4d1b-a7f5-2e6c8a0b4d9f -->
+
+# SPEC 1: Unified Identification & Deduplication Pipeline
+
+Goal: one composite, explainable "is this a duplicate?" answer per candidate pair, at
+~98% correct identification, replacing five siloed surfaces. This spec is grounded in a
+code-level audit of the current pipeline; **several cheat-sheet assumptions were wrong and
+are corrected below** — the design accounts for the code as it actually is.
+
+## 1. Current State Analysis (verified against code)
+
+Signals and their real state:
+
+| Signal | Reality | Citation |
+|---|---|---|
+| File hash exact | Working. `Engine.checkExactFileHash`, similarity hardcoded 1.0, layer `"exact"` | `internal/dedup/engine.go:286-358` |
+| Metadata source hash | Working but **exact-match only** (same external record applied), sim 0.99, layer `"metadata_hash"`. There is **no fuzzy title matcher** in the engine | `engine.go:419-449` |
+| Folder/path duplicates | **Stub — returns nil**. `GetFolderDuplicates` and `GetDuplicateBooksByMetadata(0.85)` do not exist in PebbleStore beyond stubs | `internal/database/pebble_store.go:1826-1834` |
+| Embedding cosine | Working; chromem in-RAM ANN hydrated from **PebbleDB** (`emb:v:*` — NOT SQLite); thresholds book 0.85/0.95, author 0.80/0.92; layer `"embedding"` | `engine.go:107-110,812-928`; `internal/database/embedding_store.go` |
+| AcoustID tier-1 exact | Working, O(1) via `book_file_acoustid:` index | `engine.go:44-45` |
+| AcoustID tier-2 fuzzy | Disabled (`ACOUSTID_FUZZY_ENABLED=1`), O(N) too slow even via memdb (PR #1194) | `engine.go:30-46` |
+| LSH | `Subprints()` implemented (`LSHBandCount=64`, `LSHSubprintBytes=8`, `LSHMinBandHits=2`, `minFramesForLSH=480`); **`fpidx:` Pebble index not built; nothing wired** | `internal/fingerprint/lsh.go:27-49,69-147` |
+| Duration | Implemented as a *gate to layer-exact* (±2% + Levenshtein≤6 title → sim 1.0 + `dedup:duration-match` tag), not a composable signal | `engine.go:543,578-691` |
+| LLM review | Working; verdict/reason stored on candidate; layer precedence `exact > llm > embedding` on upsert | `embedding_store.go:455-464,591-598` |
+| Candidate store | `DedupCandidate` in PebbleDB: `dedup:r:<id16>`, pair index `dedup:p:<type>:<aID>:<bID>`, `dedup:seq` counter. `Similarity *float64`, no clamp, no breakdown, no provenance | `embedding_store.go:79-91,351-374` |
+| UI | 9 tabs in `BookDedup.tsx` (Book/Embedding/AI Review/Acoustic/Advanced Scan/Author/Series/Reconcile/Split); `FingerprintVisualsColumn.tsx` reads legacy seg0–6 for display only, not wired to dedup | `web/src/pages/BookDedup.tsx`; agent audit |
+| Known data issue | ~14K stale 100% candidates from pre-whole-file fingerprints; no provenance/invalidation path (HIGH-5 in findings) | `engine.go:1521-1649` |
+
+Negative-evidence (guards, not bonuses) that already exist and must be preserved: same
+version-group drop, distinct-series-volume drop, same-parent-directory drop
+(`engine.go:886-914,453-536`). There is **no Audible bonus or composite scoring anywhere**
+— the "bonus stacking >100%" of project lore exists only in scattered intent, not code.
+
+## 2. Architecture Design
+
+One new package `internal/dedup/unified/` consumed by the existing `Engine`:
+
+```
+                    ┌────────────────────────────┐
+ signal collectors  │  SignalSet (per pair)      │   scorer            persistence
+ ─ exact hash    ──▶│  []Signal{Kind, Raw,       │──▶ ComposeScore() ──▶ DedupCandidate
+ ─ acoustid exact──▶│    Confidence, Evidence}   │       │              + ScoreBreakdown
+ ─ acoustid LSH  ──▶│                            │       ▼              (new JSON field)
+ ─ isbn/asin     ──▶│  collected lazily, cached  │   UnifiedDedupScore
+ ─ embedding     ──▶│  per scan run              │
+ ─ metadata fuzzy──▶│                            │
+ ─ duration      ──▶│  (supporting only)         │
+ ─ folder path   ──▶│  (supporting only)         │
+                    └────────────────────────────┘
+```
+
+- Collectors are pure: given a pair (or a probe book), emit zero or more `Signal`s.
+  Existing engine checks are refactored *into* collectors; their guard logic (version
+  group, series volume, same-dir) becomes a shared `PairEligibility` pre-filter that runs
+  before any collector.
+- The scorer is deterministic and synchronous — no I/O — so it is trivially unit-testable
+  and re-runnable over stored signal sets (audit requirement).
+- LLM review stays a *post-scorer* refinement for the REVIEW band only (unchanged ops).
+
+### Scan operation rationalization (current 7 ops → 4 phases)
+
+| Phase | Op(s) | Schedule |
+|---|---|---|
+| 1. Index build | `embed-scan`/`embed-async` (embeddings), fingerprint rescan (acoustid plugin), **new: lsh-index-build** | automatic, nightly + on-import incremental |
+| 2. Candidate generation | `full-scan` (renamed semantics: run all collectors, write unified scores), `book-signature-scan`, `split-book-scan` | automatic nightly; on-demand from UI |
+| 3. Refinement | `llm-review` (REVIEW band only) | on-demand / budgeted batch |
+| 4. Hygiene | `purge-stale` (extended with provenance purge, HIGH-5) | automatic, before each phase-2 run |
+
+`embed-scan` vs `embed-async` should collapse to one op with an `async` flag (they differ
+only in execution mode — agent audit). Recommended scan order is the phase order above;
+phase 2 depends on phase 1 indices and must not start while a phase-1 op holds the same
+concurrency key.
+
+## 3. Data Model
+
+```go
+// internal/dedup/unified/score.go
+
+type SignalKind string
+const (
+    SigExactFile     SignalKind = "exact_file"      // certainty 1.00
+    SigExactAcoustID SignalKind = "exact_acoustid"  // 0.99
+    SigISBNASIN      SignalKind = "isbn_asin"       // 0.98
+    SigLSHAcoustID   SignalKind = "lsh_acoustid"    // 0.90–0.97 (hamming-scaled)
+    SigEmbedHigh     SignalKind = "embedding_high"  // 0.88–0.95 (cos ≥ .95)
+    SigMetaSrcHash   SignalKind = "metadata_hash"   // 0.97 (same external record)
+    SigMetaFuzzy     SignalKind = "metadata_fuzzy"  // 0.70–0.85 (NEW collector)
+    SigEmbedMedium   SignalKind = "embedding_med"   // 0.65–0.80 (.85 ≤ cos < .95)
+    SigDuration      SignalKind = "duration"        // supporting only
+    SigFolderPath    SignalKind = "folder_path"     // supporting only
+)
+
+type Signal struct {
+    Kind       SignalKind `json:"kind"`
+    Raw        float64    `json:"raw"`        // e.g. cosine 0.961, hamming 0.93, |Δdur| 0.4%
+    Confidence float64    `json:"confidence"` // calibrated per-kind, 0..1
+    Evidence   string     `json:"evidence"`   // human-readable: "whole-file hash 9af3… both sides"
+    FPVersion  string     `json:"fp_version,omitempty"` // provenance (e.g. "wholefile-v1")
+}
+
+type UnifiedDedupScore struct {
+    Pair        [2]string `json:"pair"`        // canonical aID < bID
+    Score       float64   `json:"score"`       // 0..100, capped (see §7)
+    Band        string    `json:"band"`        // CERTAIN | HIGH | MEDIUM | REVIEW
+    Signals     []Signal  `json:"signals"`     // full breakdown, always persisted
+    Suppressors []string  `json:"suppressors"` // fired negative guards, e.g. "series_volume_differs"
+    Formula     string    `json:"formula"`     // version tag, e.g. "noisy-or-v1" — re-score detection
+    ComputedAt  time.Time `json:"computed_at"`
+}
+```
+
+`DedupCandidate` gains: `ScoreBreakdown *UnifiedDedupScore` (JSON), `Band string`,
+`FormulaVersion string`. `Layer` and `Similarity` remain for backward compatibility
+(Similarity = Score/100). Keys unchanged (`dedup:r:` / `dedup:p:`) — no key migration.
+
+## 4. Scoring formula (decision: **normalize to 0–100, cap at 100**)
+
+Rationale for choosing capped over >100% stacking: every consumer (band thresholds, UI
+bars, sorting, the 98%-accuracy target itself) wants a bounded scale; bonus semantics are
+preserved *inside* the breakdown where they are explainable. The lore that >100% is
+load-bearing found no support in code — nothing today produces >1.0 except by accident.
+
+Noisy-OR over independent primary signals, then bounded supporting boosts, then
+suppressor multipliers:
+
+```
+P_dup = 1 - Π over primary signals s (1 - Confidence(s))
+score = 100 * P_dup
+for each supporting signal (duration ±2%, folder_path):
+    score += boost(kind)            # duration: +4, folder: +3 (config)
+    # supporting signals NEVER create a candidate alone (standalone use forbidden)
+for each suppressor (series-volume differs, version-group same, same-dir multi-file):
+    candidate dropped entirely (existing behavior preserved — not a score penalty)
+score = min(score, 100)
+band:  CERTAIN ≥ 97 → auto-merge eligible
+       HIGH    90–96.99 → suggest-merge
+       MEDIUM  75–89.99 → review queue
+       REVIEW  60–74.99 → LLM phase / manual
+       below 60 → not persisted
+```
+
+Per-kind confidence calibration lives in `config.yaml` under `dedup.signals.<kind>`
+(`base`, `scale`, thresholds) — nothing hardcoded; defaults from §3 table. Noisy-OR makes
+multiple independent mid-strength signals compound (embedding 0.90 + metadata fuzzy 0.80 →
+0.98 — exactly the brief's "high in combination" requirement for weak signals) while one
+strong signal suffices alone. The 98% target is then a calibration exercise: the breakdown
++ formula version stored per candidate lets us re-score the entire corpus offline when
+constants change (no re-collection), and measure accuracy against the merged/dismissed
+history already in the candidate store.
+
+Worked examples:
+- exact_file only: 1−(1−1.0) → 100 → CERTAIN.
+- embedding 0.93 cos (conf 0.78) + duration match: 78 + 4 = 82 → MEDIUM.
+- lsh_acoustid hamming 0.95 (conf 0.94) + metadata_fuzzy 0.80 (conf 0.78): 1−(0.06·0.22)=0.9868 → 98.7 → CERTAIN.
+
+## 5. LSH implementation (the missing Step 3)
+
+PebbleDB secondary index, written at fingerprint-store time:
+
+```
+key   fpidx:<subprint-hex16>:<bookfile_id>     (subprint = 8-byte band sample → 16 hex chars)
+value <book_id> (string)                        — avoids a BookFile read on probe
+```
+
+- **Build**: new plugin op `dedup.lsh-index-build` iterates BookFiles with whole-file
+  fingerprints, calls `fingerprint.Subprints(raw)` (exists), writes ≤64 keys per file in
+  batches of 1,000 with progress reporting. Versioned completion flag
+  `lsh_index_v1_done` (PebbleDB k:v, matching the established backfill-flag pattern).
+- **Update**: hook the BookFile fingerprint write path (single chokepoint in PebbleStore
+  `UpdateBookFile`/fingerprint setter): delete old `fpidx:` keys for the file (old
+  subprints recomputed from previous fingerprint or tracked via a per-file
+  `fpidx_member:<bookfile_id>` → list key), write new ones, same batch.
+- **Delete**: BookFile delete path removes its `fpidx:` keys via the member list.
+- **Probe** (collector `SigLSHAcoustID`): compute probe subprints → 64 point lookups →
+  count band hits per candidate file → candidates with ≥`LSHMinBandHits` (2) proceed to
+  full `WholeFileSimilarity` Hamming comparison (existing function) → emit signal with
+  Raw = hamming similarity, Confidence scaled 0.90–0.97 over hamming 0.85–1.0.
+  Cost: O(64 point-reads + small candidate set) vs today's disabled O(N) scan.
+- Replaces `ACOUSTID_FUZZY_ENABLED` O(N) path; env var retired (default off → removed).
+- Estimated index size: ~308K files × 64 keys × ~60B ≈ 1.2GB max — acceptable; if not,
+  band count can drop to 32 via config (constant already centralized in `lsh.go`).
+
+## 6. API changes
+
+Extend, don't fork (the handlers live in `internal/server/handlers/dedup/`):
+
+- `GET /api/v1/dedup/candidates` — response items gain `band`, `score`,
+  `score_breakdown` (omitted unless `?include_breakdown=1`), `formula_version`. Existing
+  filters keep working; add `band=` filter.
+- `GET /api/v1/dedup/candidates/:id/breakdown` — full `UnifiedDedupScore` + both books'
+  comparison payload (covers, metadata, file info, audio-sample URLs) for the side-by-side
+  panel. One round-trip for the detail view.
+- `POST /api/v1/dedup/scan` — unchanged trigger; op now runs the unified phase-2 pipeline.
+- `POST /api/v1/dedup/lsh-index` — triggers `dedup.lsh-index-build`.
+- `POST /api/v1/dedup/rescore` — re-runs ComposeScore over stored signal sets (no
+  collection) after config changes; returns counts per band delta.
+- Deprecate (UI stops calling; endpoints stay one release): `/dedup/scan-acoustid`'s
+  separate surface, `/audiobooks/:id/compare-acoustid` remains for the BookDetail column.
+
+## 7. UI design
+
+Replace the Books/Advanced-Scan/Acoustic triplet with one **Unified tab** (Author/Series/
+Reconcile/Split/AI-Review tabs unchanged):
+
+```
+web/src/components/dedup/
+  UnifiedDedupTab.tsx          — table: pair, Score chip (0–100 + band color), badge row
+    ├── ScoreBadgeRow.tsx      — "Hash ✓" "AcoustID ✓" "ISBN ✓" "Embed 94%" "LSH 96%" chips
+    ├── BandFilterBar.tsx      — CERTAIN/HIGH/MEDIUM/REVIEW counts (from /dedup/stats) + filters
+    ├── CandidateCompareDrawer.tsx — side-by-side: cover art, metadata diff table
+    │     ├── ScoreBreakdownPanel.tsx — each signal: kind, raw, confidence, evidence line,
+    │     │                              contribution to noisy-OR (rendered as stacked bar)
+    │     ├── FileInfoCompare.tsx     — formats, sizes, durations (±% highlighted)
+    │     └── AudioSamplePair.tsx     — existing audio preview endpoints
+    └── BulkActionBar.tsx      — per band: auto-merge (CERTAIN) / suggest (HIGH) /
+                                  review (MEDIUM) / skip — wraps existing merge/dismiss/cluster APIs
+```
+
+Action mapping: CERTAIN → "Auto-merge all" (existing bulk-merge endpoint, scoped
+`band=CERTAIN`); HIGH → per-row one-click merge; MEDIUM → drawer-first; REVIEW → "Send to
+LLM review". `FingerprintVisualsColumn` in BookDetail gains a "compare in Dedup" link that
+deep-links to the unified tab filtered to that book — closing the "fingerprints not
+connected to dedup" gap.
+
+## 8. Migration plan
+
+1. **Schema-additive only** — new fields on `DedupCandidate` JSON; old rows lack
+   `Band`/`ScoreBreakdown` and are treated as `formula_version=""`.
+2. **Provenance purge (fixes the 14K false positives, HIGH-5):** migration op
+   `dedup.purge-legacy-fp-candidates`: delete/mark-stale every candidate with
+   `Layer ∈ {exact, embedding}` whose similarity came from acoustid segments
+   (identifiable: created before whole-file cutover date — stored `CreatedAt` — AND
+   sim == 1.0 AND no file-hash match recomputable today). Each examined candidate gets
+   re-scored by phase-2 collectors before deletion is final (no data loss: dismissed rows
+   are marked, not erased). Versioned flag `dedup_fp_purge_v1_done`.
+3. **Backfill scores:** phase-2 `full-scan` run populates `Band`/`ScoreBreakdown` for all
+   surviving pending candidates (re-collection, not translation — old `Similarity` is not
+   trusted as input).
+4. **Rollback:** new fields are ignorable by old code; the UI tab ships behind a
+   feature flag (`web` config) defaulting on only after backfill op reports complete —
+   satisfying the repo rule "verify data backfill before enabling flags in production".


### PR DESCRIPTION
## Summary

Documentation-only deliverable from the Fable 5 architecture review (brief: \`docs/fable5-review-prompt.md\`). No source code changed.

- **Findings** (\`docs/specs/fable5-review-findings.md\`): **3 CRITICAL / 6 HIGH / 8 MEDIUM / 2 LOW**, with OBSERVED/VERIFIED/REPORTED provenance tags
- **SPEC 2 — iTunes writeback hardening** (\`docs/specs/fable5-spec-itunes-writeback-hardening.md\`): ITLSafetyContract (8 guards), SafeWriteITL atomic protocol, Apple Devices compatibility checklist, 13-test regression suite
- **SPEC 1 — Unified dedup pipeline** (\`docs/specs/fable5-spec-unified-dedup-pipeline.md\`): noisy-OR composite scoring (0–100 capped, stored breakdown), LSH \`fpidx:\` index design, unified UI tab, ~14K stale-candidate purge
- **SPEC 3 — Memory & DB optimization** (\`docs/specs/fable5-spec-memory-db-optimization.md\`): corrected stale premises (embeddings/ai_scans already in Pebble; warm-up enabled+stripped); prioritized plan topped by ~550–900MB memdb segment strip and 7.9K-line SQLite store removal
- **Implementation plan** (\`docs/plans/fable5-implementation-plan.md\`): TASK-001..027, dependency graph, 5 parallel waves, per-task acceptance/idempotency/rollback
- TODO.md section + CHANGELOG.md prepended entry

## Key empirical results (iTunes forensics, /tmp damaged libraries)

- The current dangling-mtph verifier **passes 3 of the 4 libraries iTunes itself rejected** — the dominant observed corruption vectors are different:
  - our writers stamp mhoh encoding-flag byte +27 ∈ {1,3}; iTunes writes 0x00 in **all 281,790** golden blocks (damaged-1 carries 251K such blocks; damaged-4 was rejected with only ~34)
  - \`file://\` URLs written into 0x0D (iTunes stores native Windows paths there) — 83,783 blocks in damaged-1/3, plus \`.itunes-writeback/\` staging paths in damaged-4
  - \`hdfm\` header track count never updated on removal (header 90,900 vs payload 90,898 in damaged-1/2; survives itl-repair)
- The LE parser never reads track string metadata (mith children unreachable), so \`itl-diff\`'s "0 tracks changed" was vacuous — verified, with fix specced (TASK-001)

Do **not** merge without owner review — this PR sets the work plan for the next several waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)