### PR TITLE
docs(review): fable5 production-verification pass

### DIFF
--- a/docs/plans/fable5-implementation-plan.md
+++ b/docs/plans/fable5-implementation-plan.md
@@ -475,6 +475,9 @@ opaque EOF-ish errors.
   bind errors to 400 `"request body required: token, password"`; never echo raw "EOF".
 - `internal/server/middleware/request_size.go` — detect `http.MaxBytesError` after bind
   failures (or wrap body) → 413 with clear message; keep limits unchanged.
+- Gin release mode (findings MED-9, prod-observed): set `gin.SetMode(gin.ReleaseMode)`
+  unless a debug env/config flag is set — locate the `gin.New()`/`gin.Default()` call in
+  server startup; preserve route logging behind the debug flag.
 - tests: `auth_accept_invite_test.go` (empty body, no Content-Length body, oversized
   body), middleware test for chunked oversized body.
 
@@ -710,8 +713,12 @@ title+author Levenshtein — the brief's METADATA_FUZZY tier; currently doesn't 
 Priority: P1 · Effort: M · Agent: sonnet-4.6 · Depends: [T011]
 
 **Context.** SPEC 1 §3 additive fields (`ScoreBreakdown`, `Band`, `FormulaVersion`) +
-§8 migration; HIGH-5 purge of ~14K stale 100% candidates from pre-whole-file fingerprints.
-PebbleDB candidate keys unchanged.
+§8 migration; HIGH-5 purge of stale 100% candidates from pre-whole-file fingerprints.
+**Prod-verified (2026-06-09):** 12,320 pending `exact`-layer candidates, sampled rows all
+sim 1.0 with `created_at: 2026-05-11` — use 2026-05-12T00:00:00 as the default cutover
+date in config. A separate `acoustid` layer exists in prod (2,591 pending, May 31,
+post-cutover) — exclude it from the purge; it is current data. PebbleDB candidate keys
+unchanged.
 
 **Exact files to change**
 - `internal/database/embedding_store.go` — extend `DedupCandidate` + `candRec` (additive
@@ -982,7 +989,12 @@ code, CGO dep, and the startup open.
    reader → keep behind explicit migration cmd if it reads old prod `.db` files —
    verify with the owner via PR comment if found).
 4. `go mod tidy`; build with and without `embed_frontend` tag.
-5. `make ci` (full suite). 
+5. Prod cleanup step (document in PR; execute post-merge with owner ack): archive then
+   delete the dead store files on `172.16.2.30:/var/lib/audiobook-organizer/` —
+   `embeddings.db{,-shm,-wal}` (1.8GB), `activity.db` (842MB), `metrics.db{,-shm,-wal}`,
+   `audiobooks.chai/` — all last written 2026-05-11 (prod-verified stale). Move into
+   `backups/` first; delete after one clean service restart.
+6. `make ci` (full suite). 
 
 **Acceptance criteria**
 - [ ] No `mattn/go-sqlite3` in go.mod; no `sql.Open` in internal/.
@@ -1144,6 +1156,11 @@ Priority: P4 · Effort: S · Agent: sonnet-4.6 · Depends: []
 
 **Context.** MED-8: hydration goroutine (`internal/dedup/lifecycle.go:103-112`) is
 cancel-correct but not joined; `Stop()` can return while a Pebble read is in flight.
+**Prod-observed (2026-06-09):** every shutdown logs `"Background goroutines did not stop
+within 30s — proceeding with shutdown anyway"` — find the source of that message in server
+lifecycle, identify which goroutine set exhausts the 30s grace (dedup hydration is the
+known suspect; instrument with per-goroutine names if needed), and make shutdown complete
+cleanly within the grace period, not just bounded.
 
 **Exact files to change**
 - `internal/dedup/lifecycle.go` — add `bgWg sync.WaitGroup`; `Add(1)` before goroutine

--- a/docs/specs/fable5-review-findings.md
+++ b/docs/specs/fable5-review-findings.md
@@ -156,13 +156,19 @@ EOF-flavored errors from `MaxBytesReader` (see MED-1).
 
 ### HIGH-5 — Dedup candidates carry no fingerprint provenance; stale 100%-similarity rows survive recompute (BUG, dedup correctness)
 
-**VERIFIED.** `DedupCandidate` (`internal/database/embedding_store.go:79-91`) has
-`Layer`/`Similarity` but no record of *which fingerprint version/algorithm* produced the
-match. `PurgeStaleCandidates` (`internal/dedup/engine.go:1521-1649`) prunes for
-missing/non-primary/version-group/series reasons only — nothing invalidates candidates when
-fingerprints are recomputed. Production carries ~14K 100%-matches created from the old
-per-segment fingerprints (count from project records; not re-verified against prod in this
-review). Whole-file fields exist (`store.go:676-684`, segments deprecated) but no
+**VERIFIED, including against production (2026-06-09).** `DedupCandidate`
+(`internal/database/embedding_store.go:79-91`) has `Layer`/`Similarity` but no record of
+*which fingerprint version/algorithm* produced the match. `PurgeStaleCandidates`
+(`internal/dedup/engine.go:1521-1649`) prunes for missing/non-primary/version-group/series
+reasons only — nothing invalidates candidates when fingerprints are recomputed.
+**Prod-verified via `GET /api/v1/dedup/stats` + candidate sampling:** 12,320 pending
+`exact`-layer candidates, sampled rows all `similarity: 1.0` with
+`created_at: 2026-05-11` — squarely in the pre-whole-file-fingerprint era — plus 2,591
+pending `acoustid`-layer candidates (created 2026-05-31, post-cutover; note: an `acoustid`
+layer value exists in prod data that the code-audit layer list missed). Total pending
+sim-1.0 backlog: 14,911 — matching the "~14K" project lore. The May-11 `created_at`
+clustering directly validates the cutover-date purge criterion in SPEC 1 §8 / TASK-015.
+Whole-file fields exist (`store.go:676-684`, segments deprecated) but no
 `fingerprint_version` marker exists anywhere (grep negative). Fix: provenance fields +
 purge-by-provenance migration (SPEC 1, tasks in plan).
 
@@ -203,13 +209,17 @@ and inflates copy-on-write `.bak-*` churn.
 
 ### MED-4 — Legacy SQLite store (~7.9K lines) still compiled and opened at startup (DEBT)
 
-**VERIFIED.** `internal/database/database.go:20` does `sql.Open("sqlite3", databasePath)`
-unconditionally; `sqlite_store_*.go` totals ~7,938 lines implementing a parallel Store that
-production (PebbleDB-primary) shouldn't reach. Risk: drift, accidental use (e.g.
-`sqlite_store_books.go:872` implements `GetDuplicateBooks` alongside the Pebble one),
-single-writer lock if any path lands there. Note the review brief's claim "embeddings.db
-SQLite" is stale: embeddings live in PebbleDB (`emb:v:*` keys,
-`internal/database/embedding_store.go`). Removal plan: SPEC 3.
+**VERIFIED, including against production (2026-06-09).** `internal/database/database.go:20`
+does `sql.Open("sqlite3", databasePath)` unconditionally; `sqlite_store_*.go` totals
+~7,938 lines implementing a parallel Store that production (PebbleDB-primary) shouldn't
+reach. Risk: drift, accidental use (e.g. `sqlite_store_books.go:872` implements
+`GetDuplicateBooks` alongside the Pebble one), single-writer lock if any path lands there.
+Note the review brief's claim "embeddings.db SQLite" is stale: embeddings live in PebbleDB
+(`emb:v:*` keys, `internal/database/embedding_store.go`). **Prod confirms the leftovers:**
+`/var/lib/audiobook-organizer/` still carries `embeddings.db` (1.8GB sparse / 924MB on
+disk, +shm/wal), `activity.db` (842MB / 140MB), `metrics.db` (+wal/shm) — all last written
+2026-05-11, a month stale — plus the retired `audiobooks.chai` directory. ~1GB+ of dead
+files to archive/delete as part of the removal task. Removal plan: SPEC 3 / TASK-022.
 
 ### MED-5 — Diagnostic tools claim more than they do (DEBT, tooling trust)
 
@@ -236,13 +246,26 @@ sees garbage. Fail-closed behavior is required on both ends.
 
 ### MED-8 — Chromem hydration is fire-and-forget with no shutdown join (BUG, concurrency, minor)
 
-**REPORTED, lifecycle reviewed.** `internal/dedup/lifecycle.go:103-112` starts hydration
-under `bgCtx` with a 30-min timeout but no WaitGroup; `Stop()` cancels correctly
-(mutex-guarded, nil-safe — the PR #1239 pattern) but does not wait, so shutdown can race a
-final Pebble read. Concurrency sweep found no other unsafe cancel patterns: registry
-shutdown (`internal/operations/registry/registry.go:398-450`), acoustid heartbeat
-(`internal/plugins/acoustid/fingerprint_rescan.go:142-175`), and warmup contexts all follow
-the safe pattern.
+**REPORTED, lifecycle reviewed — and OBSERVED live in production (2026-06-09).**
+`internal/dedup/lifecycle.go:103-112` starts hydration under `bgCtx` with a 30-min timeout
+but no WaitGroup; `Stop()` cancels correctly (mutex-guarded, nil-safe — the PR #1239
+pattern) but does not wait, so shutdown can race a final Pebble read. The deploy-restart
+shutdown log shows the symptom class is real: `"Background goroutines did not stop within
+30s — proceeding with shutdown anyway"` (journal, 21:23:01) — some background goroutine
+set takes the full 30s force-abandon path on every shutdown. TASK-027 should also identify
+*which* goroutines hit this timeout (the dedup hydration join is the known suspect; the
+fix should make shutdown clean, not just bounded). Concurrency sweep found no other unsafe
+cancel patterns: registry shutdown (`internal/operations/registry/registry.go:398-450`),
+acoustid heartbeat (`internal/plugins/acoustid/fingerprint_rescan.go:142-175`), and warmup
+contexts all follow the safe pattern.
+
+### MED-9 — Production runs Gin in debug mode (PERFORMANCE/DEBT)
+
+**OBSERVED in production (2026-06-09).** Startup logs print `[GIN-debug] [WARNING] Running
+in "debug" mode. Switch to "release" mode in production.` and every route registration is
+logged at startup. Debug mode adds per-request overhead and verbose logging. Fix: call
+`gin.SetMode(gin.ReleaseMode)` (or set `GIN_MODE=release` in the systemd drop-in) when not
+in a dev build. One-liner; fold into TASK-009 or ship as a standalone quick fix.
 
 ---
 
@@ -277,8 +300,27 @@ outright instead of writing unguarded.
   the configured library path; no traversal vector found in `ReverseRemapPath`.
 - Dedup engine background lifecycle (`bgMu`/`bgCtx`) follows the post-#1239 safe pattern.
 
+## Production verification (2026-06-09, post-review pass)
+
+Verified live against `172.16.2.30` (service restarted by owner's `make deploy`;
+API key via bootstrap-token exchange):
+
+- **Dedup candidates** (`/api/v1/dedup/stats` + sampling): pending = 12,320 exact (all
+  sim 1.0, created 2026-05-11) + 2,591 acoustid (2026-05-31) + 179 embedding + 273 llm.
+  Confirms HIGH-5's magnitude (14,911 sim-1.0 backlog ≈ the "~14K" lore) and the
+  cutover-date purge criterion.
+- **Memory**: systemd `MemoryCurrent` ≈ 7.0GB at 9-day uptime; unit accounting at restart
+  reported **8.9GB memory peak + 2.2GB swap peak** over the run — SPEC 3's ~3.3GB
+  steady-state model is optimistic; treat ~7GB steady / ~9GB peak as the real baseline
+  (revised in SPEC 3).
+- **Disk** (`/var/lib/audiobook-organizer/`): `audiobooks.pebble` = **11GB** (agent's
+  20–40GB estimate was high); stale SQLite leftovers per MED-4; `activity.nutsdb` 24MB,
+  `metrics.nutsdb` <1MB; `library.bleve` small (not in du top-15).
+- **Shutdown**: 30s background-goroutine force-abandon observed (MED-8); Gin debug mode
+  observed (MED-9).
+
 ## Severity totals
 
 - **CRITICAL: 3** (CRIT-1 encoding flags, CRIT-2 0x0D URL-vs-path, CRIT-3 header count desync)
 - **HIGH: 6** (verifier blind spots; vacuous LE string parse; unconditional metadata push; accept-invite EOF; candidate provenance; headerLen detector gap)
-- **MEDIUM: 8** | **LOW: 2**
+- **MEDIUM: 9** | **LOW: 2**

--- a/docs/specs/fable5-spec-memory-db-optimization.md
+++ b/docs/specs/fable5-spec-memory-db-optimization.md
@@ -22,6 +22,13 @@ against code this review):
    (~7,938 lines) opened unconditionally at startup via `database.go:20`
    (`sql.Open("sqlite3", …)`) — findings MED-4.
 
+Prod disk reality check (2026-06-09, `/var/lib/audiobook-organizer/`):
+`audiobooks.pebble` = **11GB** (not the 20–40GB estimated below); stale leftovers from
+completed migrations still on disk — `embeddings.db` 1.8GB sparse/924MB, `activity.db`
+842MB/140MB, `metrics.db`+wal/shm, `audiobooks.chai/` — all last written 2026-05-11.
+TASK-022 must include archiving/deleting these dead files (~1GB+ reclaimed, and removes
+the confusion of dead stores sitting next to live ones).
+
 Current steady-state RSS model at ~50K books / ~308K files (agent audit, spot-checked):
 
 | Component | RSS | Notes |
@@ -29,7 +36,8 @@ Current steady-state RSS model at ~50K books / ~308K files (agent audit, spot-ch
 | go-memdb (stripped projections) | ~2.4–2.7GB | books ~2GB dominated by retained AcoustIDSeg0–6 strings + remaining Book fields |
 | chromem (in-RAM vectors) | ~600MB | 50K × 3072-dim float32; hydrated once at startup from Pebble |
 | Pebble block cache / runtime | ~100–300MB | |
-| **Total baseline** | **~3.3GB** | |
+| **Modeled baseline** | **~3.3GB** | bottom-up estimate |
+| **Prod observed (2026-06-09)** | **~7.0GB steady / 8.9GB peak + 2.2GB swap peak** | systemd `MemoryCurrent` at 9-day uptime; unit accounting at restart. The ~3.7GB gap between model and reality (Go heap slack, Pebble caches/compaction, goroutine/op buffers, untracked allocations) is itself a finding — TASK-023's telemetry should attribute it before further optimization claims are made |
 
 ## 1. PebbleDB schema audit — results
 


### PR DESCRIPTION
Follow-up to #1356 (merged before this commit was pushed). Folds live production verification into the review docs:

- **HIGH-5 confirmed against prod**: 12,320 pending exact-layer sim-1.0 candidates, sampled \`created_at: 2026-05-11\` (pre-whole-file cutover) + 2,591 acoustid-layer (May 31, current) — TASK-015 purge cutover date now grounded at 2026-05-12
- **SPEC 3 numbers corrected**: pebble 11GB (not 20–40GB); prod RSS ~7GB steady / **8.9GB peak + 2.2GB swap** (vs 3.3GB bottom-up model — gap attribution added to TASK-023); stale \`embeddings.db\`/\`activity.db\`/\`metrics.db\`/\`audiobooks.chai\` leftovers (~1GB+, last written May 11) added to TASK-022 cleanup
- **MED-8 strengthened**: \`"Background goroutines did not stop within 30s"\` observed at every shutdown → TASK-027 scope extended to root-cause it
- **NEW MED-9**: Gin debug mode running in production → folded into TASK-009
- Findings doc gains a "Production verification" section; severity totals now 3/6/9/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)