### PR TITLE
fix(itunes): parse mhoh string metadata in LE track walker (fable5 T001)

### DIFF
--- a/internal/itunes/itl_le.go
+++ b/internal/itunes/itl_le.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_le.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b4e8d927-6c3f-4a81-9e02-f7b3c8d4e56a
 
 package itunes
@@ -46,6 +46,13 @@ func walkChunksLEImpl(data []byte, lib *ITLLibrary) {
 }
 
 // walkMsdhTracksLE walks mith/mhoh blocks inside a track-list msdh container.
+//
+// iTunes LE libraries pack mhoh string blocks as children of mith — the mith
+// totalLen field encompasses both the fixed track header and its mhoh children.
+// Advancing by totalLen after parsing the mith header would skip every child,
+// leaving all string fields (Name, Album, Artist …) empty. The invariant is:
+//   - advance outer cursor by totalLen (so chunk accounting matches the on-disk layout)
+//   - but inner-walk [offset+headerLen, offset+totalLen) to reach the mhoh children
 func walkMsdhTracksLE(data []byte, start, end int, lib *ITLLibrary) {
 	offset := start
 	var currentTrack *ITLTrack
@@ -55,42 +62,84 @@ func walkMsdhTracksLE(data []byte, start, end int, lib *ITLLibrary) {
 		if tag == "" {
 			break
 		}
-		// In LE format: mith/mhoh have headerLen at +4, totalLen at +8.
-		// Use totalLen for mith/mhoh (includes sub-data), headerLen for others (mlth).
+		// headerLen is the fixed portion; totalLen covers headerLen + all children.
 		headerLen := int(readUint32LE(data, offset+4))
 		totalLen := int(readUint32LE(data, offset+8))
-		length := headerLen // default: use headerLen
+
+		// For containers that carry children, outer advancement uses totalLen;
+		// non-container tags (mlth, mhoh as sibling) use headerLen.
+		advanceBy := headerLen
 		if (tag == "mith" || tag == "mhoh" || tag == "miah" || tag == "miph") && totalLen > headerLen && totalLen <= end-offset {
-			length = totalLen // container: use totalLen
+			advanceBy = totalLen
 		}
-		if length < 8 || offset+length > end {
+		if advanceBy < 8 || offset+advanceBy > end {
 			break
 		}
 
 		switch tag {
 		case "mlth":
-			// Track list header — skip
+			// Track list header — no children to walk.
 
 		case "miah":
-			// Track item array — descend into it
-			walkMiahContent(data, offset, length, lib, &currentTrack)
+			// Track item array — descend into it.
+			walkMiahContent(data, offset, advanceBy, lib, &currentTrack)
 
 		case "mith":
-			t := parseMithLE(data, offset, length)
+			// Parse fixed track fields from the header portion only.
+			t := parseMithLE(data, offset, headerLen)
 			lib.Tracks = append(lib.Tracks, t)
 			currentTrack = &lib.Tracks[len(lib.Tracks)-1]
+			// When mith has children (totalLen > headerLen), the mhoh string
+			// blocks live in [offset+headerLen, offset+totalLen); walk them now
+			// rather than relying on the outer loop where they are unreachable.
+			if totalLen > headerLen {
+				childEnd := offset + totalLen
+				if childEnd > end {
+					childEnd = end
+				}
+				innerOffset := offset + headerLen
+				for innerOffset+8 <= childEnd {
+					childTag := readTag(data, innerOffset)
+					if childTag == "" {
+						break
+					}
+					childHeaderLen := int(readUint32LE(data, innerOffset+4))
+					childTotalLen := int(readUint32LE(data, innerOffset+8))
+					childLen := childHeaderLen
+					if childTag == "mhoh" && childTotalLen > childHeaderLen && innerOffset+childTotalLen <= childEnd {
+						childLen = childTotalLen
+					}
+					if childLen < 8 || innerOffset+childLen > childEnd {
+						break
+					}
+					if childTag == "mhoh" {
+						parseMhohLE(data, innerOffset, childLen, currentTrack)
+					}
+					innerOffset += childLen
+				}
+			}
 
 		case "mhoh":
+			// Flat-sibling layout (used by tests and some older writers):
+			// mhoh appears directly after mith with no nesting.
 			if currentTrack != nil {
-				parseMhohLE(data, offset, length, currentTrack)
+				mhohLen := headerLen
+				if totalLen > headerLen && totalLen <= end-offset {
+					mhohLen = totalLen
+				}
+				parseMhohLE(data, offset, mhohLen, currentTrack)
 			}
 		}
 
-		offset += length
+		offset += advanceBy
 	}
 }
 
 // walkMiahContent walks the sub-blocks inside a miah (track item array) wrapper.
+//
+// Mirrors the mhoh-descent fix applied in walkMsdhTracksLE: when a mith block
+// carries children (totalLen > headerLen), the mhoh string blocks live inside the
+// mith span and are invisible to the outer loop unless we inner-walk them here.
 func walkMiahContent(data []byte, miahStart, miahLen int, lib *ITLLibrary, currentTrack **ITLTrack) {
 	miahHeaderLen := int(readUint32LE(data, miahStart+4))
 	if miahHeaderLen < 8 {
@@ -104,30 +153,65 @@ func walkMiahContent(data []byte, miahStart, miahLen int, lib *ITLLibrary, curre
 		if tag == "" {
 			break
 		}
-		// In LE format: mith/mhoh have headerLen at +4, totalLen at +8.
-		// Use totalLen for mith/mhoh (includes sub-data), headerLen for others (mlth).
 		headerLen := int(readUint32LE(data, offset+4))
 		totalLen := int(readUint32LE(data, offset+8))
-		length := headerLen // default: use headerLen
+
+		// Outer advancement uses totalLen for containers (matches on-disk layout);
+		// inner-walk descends into [offset+headerLen, offset+totalLen) for children.
+		advanceBy := headerLen
 		if (tag == "mith" || tag == "mhoh" || tag == "miah" || tag == "miph") && totalLen > headerLen && totalLen <= end-offset {
-			length = totalLen // container: use totalLen
+			advanceBy = totalLen
 		}
-		if length < 8 || offset+length > end {
+		if advanceBy < 8 || offset+advanceBy > end {
 			break
 		}
 
 		switch tag {
 		case "mith":
-			t := parseMithLE(data, offset, length)
+			// Parse fixed track fields from the header portion only.
+			t := parseMithLE(data, offset, headerLen)
 			lib.Tracks = append(lib.Tracks, t)
 			*currentTrack = &lib.Tracks[len(lib.Tracks)-1]
+			// When mith has children (totalLen > headerLen), inner-walk the mhoh
+			// string blocks rather than skipping them via the outer advance.
+			if totalLen > headerLen {
+				childEnd := offset + totalLen
+				if childEnd > end {
+					childEnd = end
+				}
+				innerOffset := offset + headerLen
+				for innerOffset+8 <= childEnd {
+					childTag := readTag(data, innerOffset)
+					if childTag == "" {
+						break
+					}
+					childHeaderLen := int(readUint32LE(data, innerOffset+4))
+					childTotalLen := int(readUint32LE(data, innerOffset+8))
+					childLen := childHeaderLen
+					if childTag == "mhoh" && childTotalLen > childHeaderLen && innerOffset+childTotalLen <= childEnd {
+						childLen = childTotalLen
+					}
+					if childLen < 8 || innerOffset+childLen > childEnd {
+						break
+					}
+					if childTag == "mhoh" && *currentTrack != nil {
+						parseMhohLE(data, innerOffset, childLen, *currentTrack)
+					}
+					innerOffset += childLen
+				}
+			}
 
 		case "mhoh":
+			// Flat-sibling layout: mhoh appears directly after mith with no nesting.
 			if *currentTrack != nil {
-				parseMhohLE(data, offset, length, *currentTrack)
+				mhohLen := headerLen
+				if totalLen > headerLen && totalLen <= end-offset {
+					mhohLen = totalLen
+				}
+				parseMhohLE(data, offset, mhohLen, *currentTrack)
 			}
 		}
-		offset += length
+		offset += advanceBy
 	}
 }
 

--- a/internal/itunes/itl_le_test.go
+++ b/internal/itunes/itl_le_test.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_le_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c5f9e038-7d4a-4b92-af13-g8c4d9e5f67b
 
 package itunes
@@ -505,6 +505,158 @@ func TestDetectLE(t *testing.T) {
 				t.Errorf("detectLE(%q): expected %v, got %v", tc.data, tc.want, got)
 			}
 		})
+	}
+}
+
+// buildMithLEWithChildren builds an iTunes-style mith container where the mhoh string
+// blocks are embedded as children of the mith chunk (totalLen > headerLen). This is
+// the actual on-disk layout produced by iTunes 10+ that caused HIGH-2: the outer walker
+// advanced by totalLen after parseMithLE, making the mhoh case unreachable.
+func buildMithLEWithChildren(trackID int, pid [8]byte, size, totalTime int, mhohChildren [][]byte) []byte {
+	// Fixed mith header: same 156-byte layout as testBuildMithLE
+	headerLen := 156
+	header := make([]byte, headerLen)
+	copy(header[0:4], "mith")
+	// headerLen at +4 will be set after we know the children total
+	putUint32LE(header, 16, uint32(trackID))
+	putUint32LE(header, 36, uint32(size))
+	putUint32LE(header, 40, uint32(totalTime))
+	putUint16LE(header, 44, 3)     // TrackNumber
+	putUint16LE(header, 48, 12)    // TrackCount
+	putUint16LE(header, 54, 2024)  // Year
+	putUint16LE(header, 58, 320)   // BitRate
+	putUint16LE(header, 60, 44100) // SampleRate
+	putUint32LE(header, 76, 5)     // PlayCount
+	putUint16LE(header, 104, 1)    // DiscNumber
+	putUint16LE(header, 106, 2)    // DiscCount
+	header[108] = 80               // Rating
+	copy(header[128:136], pid[:])
+
+	// Concatenate header + children
+	var children []byte
+	for _, c := range mhohChildren {
+		children = append(children, c...)
+	}
+	totalLen := headerLen + len(children)
+
+	// Write headerLen and totalLen into the header
+	putUint32LE(header, 4, uint32(headerLen))
+	putUint32LE(header, 8, uint32(totalLen))
+
+	return append(header, children...)
+}
+
+// TestParseLE_TrackStrings is the acceptance test for HIGH-2 / TASK-001. It builds a
+// fixture where mhoh string blocks are embedded as children of mith (the real iTunes
+// on-disk layout) and asserts that all seven string fields round-trip correctly.
+// Pre-fix: walkMsdhTracksLE advanced by totalLen after parseMithLE, skipping every mhoh
+// child so all string fields were empty. Post-fix: the inner-walk descends into
+// [offset+headerLen, offset+totalLen) and calls parseMhohLE on each child.
+func TestParseLE_TrackStrings(t *testing.T) {
+	pid := [8]byte{0x22, 0x11, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA}
+
+	wantName     := "The Great Audiobook"
+	wantAlbum    := "Great Series Vol 1"
+	wantArtist   := "Jane Narrator"
+	wantGenre    := "Audiobooks"
+	wantKind     := "AAC audio file"
+	wantLocation := `W:\audiobooks\Great Series Vol 1\chapter.m4b`
+	wantLocalURL := "file://localhost/W:/audiobooks/Great+Series+Vol+1/chapter.m4b"
+
+	// Build mhoh children in the iTunes-native layout (children of mith, not siblings).
+	mhohChildren := [][]byte{
+		testBuildMhohLE(0x02, wantName),
+		testBuildMhohLE(0x03, wantAlbum),
+		testBuildMhohLE(0x04, wantArtist),
+		testBuildMhohLE(0x05, wantGenre),
+		testBuildMhohLE(0x06, wantKind),
+		testBuildMhohLE(0x0D, wantLocation),
+		testBuildMhohLE(0x0B, wantLocalURL),
+	}
+
+	// mith with children embedded (totalLen > headerLen) — the layout that
+	// broke walkMsdhTracksLE before this fix.
+	mith := buildMithLEWithChildren(42, pid, 1024000, 360000, mhohChildren)
+
+	// Wrap in a track-list msdh. No sibling mhoh blocks — the string data is only
+	// reachable via the inner-walk of the mith span.
+	data := buildMsdhLE(0x01, mith)
+
+	lib := &ITLLibrary{}
+	walkChunksLEImpl(data, lib)
+
+	if len(lib.Tracks) != 1 {
+		t.Fatalf("expected 1 track, got %d", len(lib.Tracks))
+	}
+	tr := lib.Tracks[0]
+
+	if tr.Name != wantName {
+		t.Errorf("Name: expected %q, got %q", wantName, tr.Name)
+	}
+	if tr.Album != wantAlbum {
+		t.Errorf("Album: expected %q, got %q", wantAlbum, tr.Album)
+	}
+	if tr.Artist != wantArtist {
+		t.Errorf("Artist: expected %q, got %q", wantArtist, tr.Artist)
+	}
+	if tr.Genre != wantGenre {
+		t.Errorf("Genre: expected %q, got %q", wantGenre, tr.Genre)
+	}
+	if tr.Kind != wantKind {
+		t.Errorf("Kind: expected %q, got %q", wantKind, tr.Kind)
+	}
+	if tr.Location != wantLocation {
+		t.Errorf("Location: expected %q, got %q", wantLocation, tr.Location)
+	}
+	if tr.LocalURL != wantLocalURL {
+		t.Errorf("LocalURL: expected %q, got %q", wantLocalURL, tr.LocalURL)
+	}
+	if tr.TrackID != 42 {
+		t.Errorf("TrackID: expected 42, got %d", tr.TrackID)
+	}
+	pidHex := hex.EncodeToString(tr.PersistentID[:])
+	if pidHex != "aabbccddeeff1122" {
+		t.Errorf("PersistentID: expected aabbccddeeff1122, got %s", pidHex)
+	}
+}
+
+// TestParseLE_TrackStrings_ViaMiah verifies the same mhoh-descent fix applies when
+// the mith+children are wrapped in a miah (track item array) container. Both
+// walkMsdhTracksLE and walkMiahContent must descend into the mith span.
+func TestParseLE_TrackStrings_ViaMiah(t *testing.T) {
+	pid := [8]byte{0x44, 0x33, 0x22, 0x11, 0x88, 0x77, 0x66, 0x55}
+
+	wantName     := "Miah-Nested Book"
+	wantArtist   := "Miah Author"
+	wantLocation := `W:\audiobooks\Miah Author\Miah-Nested Book\chapter.m4b`
+
+	mhohChildren := [][]byte{
+		testBuildMhohLE(0x02, wantName),
+		testBuildMhohLE(0x04, wantArtist),
+		testBuildMhohLE(0x0D, wantLocation),
+	}
+	mith := buildMithLEWithChildren(99, pid, 512000, 180000, mhohChildren)
+
+	// Wrap in miah → msdh hierarchy
+	miah := buildMiahLE(mith)
+	data := buildMsdhLE(0x01, miah)
+
+	lib := &ITLLibrary{}
+	walkChunksLEImpl(data, lib)
+
+	if len(lib.Tracks) != 1 {
+		t.Fatalf("expected 1 track via miah, got %d", len(lib.Tracks))
+	}
+	tr := lib.Tracks[0]
+
+	if tr.Name != wantName {
+		t.Errorf("Name: expected %q, got %q", wantName, tr.Name)
+	}
+	if tr.Artist != wantArtist {
+		t.Errorf("Artist: expected %q, got %q", wantArtist, tr.Artist)
+	}
+	if tr.Location != wantLocation {
+		t.Errorf("Location: expected %q, got %q", wantLocation, tr.Location)
 	}
 }
 


### PR DESCRIPTION
## Summary

`walkMsdhTracksLE` and `walkMiahContent` both advanced by `mith.totalLen` after parsing the fixed mith header, skipping all child mhoh string blocks. In the real iTunes on-disk layout, mhoh blocks (Name, Album, Artist, Genre, Kind, Location, LocalURL) are children of mith — embedded in `[offset+headerLen, offset+totalLen)`. The outer loop's `case "mhoh"` branch was therefore unreachable, leaving every string field empty on LE libraries (finding HIGH-2).

**Fix:** advance the outer cursor by `totalLen` (preserving chunk accounting) but inner-walk `[offset+headerLen, offset+totalLen)` calling `parseMhohLE` on each child when `totalLen > headerLen`. Flat-sibling layouts (as in existing tests) are preserved: when `totalLen == headerLen` the inner-walk is skipped and sibling mhoh blocks are handled by the outer loop as before.

**Files changed:**
- `internal/itunes/itl_le.go` — restructured `walkMsdhTracksLE` and `walkMiahContent` to descend into mith children; version bumped 1.0.0 → 1.1.0
- `internal/itunes/itl_le_test.go` — added `TestParseLE_TrackStrings`, `TestParseLE_TrackStrings_ViaMiah`, and `buildMithLEWithChildren` helper; version bumped 1.1.0 → 1.2.0

## Acceptance criteria

- [x] `TestParseLE_TrackStrings` passes; Name/Album/Artist/Genre/Kind/Location/LocalURL all populated from nested-mhoh fixture.
- [x] All pre-existing `internal/itunes` tests pass unmodified (`make test` / `go test ./internal/itunes/...`).
- [x] `go build ./...` and `go vet ./...` clean.

## Test results

```
ok  github.com/falkcorp/audiobook-organizer/internal/itunes         6.973s
ok  github.com/falkcorp/audiobook-organizer/internal/itunes/service 18.250s
```

`TestParseLE_TrackStrings` and `TestParseLE_TrackStrings_ViaMiah` both PASS. Zero FAIL lines across the itunes package.

---

COMPLETED: 3 — TestParseLE_TrackStrings passes, pre-existing tests green, go build+vet clean
REMAINING: 0
BLOCKED: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)