### PR TITLE
feat(dedup): unified composite scoring core — noisy-or-v1 (fable5 T011)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.45.0
+// version: 1.46.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-05-01
+// last-edited: 2026-06-09
 
 package config
 
@@ -526,6 +526,17 @@ func InitConfig() {
 	viper.SetDefault("auto_rename_on_apply", true)
 	viper.SetDefault("auto_write_tags_on_apply", true)
 	viper.SetDefault("verify_after_write", true)
+
+	// Unified dedup scoring defaults (SPEC 1 §3–4, T011).
+	// These are consumed by internal/dedup/unified.LoadScoreConfig via Viper.
+	// Overridable per-kind in config.yaml under dedup.signals.<kind>.*
+	viper.SetDefault("dedup.signals.band_certain_min", 97.0)
+	viper.SetDefault("dedup.signals.band_high_min", 90.0)
+	viper.SetDefault("dedup.signals.band_medium_min", 75.0)
+	viper.SetDefault("dedup.signals.band_review_min", 60.0)
+	// Per-kind boost defaults for supporting signals.
+	viper.SetDefault("dedup.signals.duration.boost", 4.0)
+	viper.SetDefault("dedup.signals.folder_path.boost", 3.0)
 
 	viper.SetDefault("supported_extensions", []string{
 		".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",

--- a/internal/dedup/unified/compose.go
+++ b/internal/dedup/unified/compose.go
@@ -1,0 +1,113 @@
+// file: internal/dedup/unified/compose.go
+// version: 1.0.0
+// guid: 73a952d9-e850-493a-ae72-a7eb16b0e168
+
+package unified
+
+import "time"
+
+// FormulaVersion is the version tag embedded in every UnifiedDedupScore.
+// Changing this constant causes the corpus-wide re-score detector to
+// identify all candidates computed under the old formula.
+const FormulaVersion = "noisy-or-v1"
+
+// ComposeScore combines a set of evidence signals into a single
+// UnifiedDedupScore following SPEC 1 §4.
+//
+// Algorithm:
+//
+//  1. Separate signals into PRIMARY (feed noisy-OR) and SUPPORTING
+//     (duration, folder_path — add bounded boosts only).
+//     WHY: supporting signals alone are not strong enough evidence of
+//     duplication — two books in the same folder could be sequels, not
+//     duplicates. Excluding them from the noisy-OR product prevents
+//     weak corroborating signals from compounding into false positives.
+//
+//  2. Compute the noisy-OR probability over independent primary signals:
+//     P_dup = 1 - Π(1 - Confidence(s))  for all primary signals s
+//     score  = 100 * P_dup
+//     WHY: noisy-OR is the standard model for combining independent
+//     boolean-ish evidence. Unlike a simple max(), it correctly
+//     accumulates mid-strength signals: embedding 0.90 + metadata_fuzzy 0.80
+//     → 1 - (0.10 * 0.20) = 0.98, which satisfies the spec's requirement
+//     that "high in combination" weak signals reach a strong composite.
+//
+//  3. Add bounded supporting boosts (capped at their config values, not
+//     unlimited). Boosts can push a borderline score into a higher band
+//     but cannot create a candidate from supporting signals alone.
+//
+//  4. Cap the score at 100.
+//
+//  5. Assign a band based on capped score.
+//
+// The pair [2]string and suppressors []string are passed through unchanged
+// (not computed here — the caller owns suppressor evaluation).
+//
+// An empty signals slice (no evidence at all) returns score 0 and no band.
+func ComposeScore(signals []Signal, suppressors []string, cfg ScoreConfig, pair [2]string) UnifiedDedupScore {
+	var primarySignals []Signal
+	var supportingSignals []Signal
+
+	for _, s := range signals {
+		if isSupportingKind(s.Kind) {
+			supportingSignals = append(supportingSignals, s)
+		} else {
+			primarySignals = append(primarySignals, s)
+		}
+	}
+
+	// Step 1 + 2: noisy-OR over primary signals.
+	// WHY noisy-OR rather than max: noisy-OR correctly handles the case
+	// where multiple independent mid-confidence signals compound. A single
+	// strong signal (confidence=1.0) drives the product to 0, yielding
+	// P_dup=1.0 — correct for exact-file matches.
+	notDup := 1.0
+	for _, s := range primarySignals {
+		// (1 - Confidence) is the probability this signal is NOT a duplicate.
+		notDup *= (1.0 - s.Confidence)
+	}
+	pDup := 1.0 - notDup
+	score := 100.0 * pDup
+
+	// Step 3: add bounded supporting boosts.
+	// Each boost is the configured additive value for that kind.
+	// Boosts are config-driven, not free-form — see SPEC 1 §4.
+	for _, s := range supportingSignals {
+		score += cfg.BoostFor(s.Kind)
+	}
+
+	// Step 4: cap at 100.
+	if score > 100.0 {
+		score = 100.0
+	}
+
+	// Step 5: determine band.
+	band := bandFor(score, cfg)
+
+	return UnifiedDedupScore{
+		Pair:        pair,
+		Score:       score,
+		Band:        band,
+		Signals:     signals,
+		Suppressors: suppressors,
+		Formula:     FormulaVersion,
+		ComputedAt:  time.Now().UTC(),
+	}
+}
+
+// bandFor maps a capped score to its persistence band using the thresholds
+// from cfg. Returns "" for scores below cfg.BandReviewMin (not persisted).
+func bandFor(score float64, cfg ScoreConfig) string {
+	switch {
+	case score >= cfg.BandCertainMin:
+		return BandCertain
+	case score >= cfg.BandHighMin:
+		return BandHigh
+	case score >= cfg.BandMediumMin:
+		return BandMedium
+	case score >= cfg.BandReviewMin:
+		return BandReview
+	default:
+		return ""
+	}
+}

--- a/internal/dedup/unified/compose_test.go
+++ b/internal/dedup/unified/compose_test.go
@@ -1,0 +1,528 @@
+// file: internal/dedup/unified/compose_test.go
+// version: 1.0.0
+// guid: e1fb3967-2f53-41fd-ac9d-0cbcb3b03668
+
+package unified
+
+import (
+	"math"
+	"testing"
+)
+
+// defaultPair is a canonical pair used across tests.
+var defaultPair = [2]string{"aaa", "bbb"}
+
+// helper: build a Signal with a given kind and confidence.
+func sig(kind SignalKind, conf float64) Signal {
+	return Signal{
+		Kind:       kind,
+		Confidence: conf,
+		Raw:        conf,
+		Evidence:   string(kind),
+	}
+}
+
+// ─── SPEC §4 Worked Examples ──────────────────────────────────────────────────
+//
+// These three tests are EXACT assertions from SPEC 1 §4. They are normative:
+// any change to the scoring formula must be reflected here first.
+
+// TestComposeScore_WorkedExample1_ExactFileOnly verifies:
+//
+//	exact_file only: 1 − (1 − 1.0) → 100 → CERTAIN
+func TestComposeScore_WorkedExample1_ExactFileOnly(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	signals := []Signal{sig(SigExactFile, 1.0)}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+
+	if result.Score != 100.0 {
+		t.Errorf("expected score 100.0, got %.6f", result.Score)
+	}
+	if result.Band != BandCertain {
+		t.Errorf("expected band CERTAIN, got %q", result.Band)
+	}
+	if result.Formula != FormulaVersion {
+		t.Errorf("expected formula %q, got %q", FormulaVersion, result.Formula)
+	}
+}
+
+// TestComposeScore_WorkedExample2_EmbeddingPlusDuration verifies:
+//
+//	embedding 0.93 cos (conf 0.78) + duration match: 78 + 4 = 82 → MEDIUM
+func TestComposeScore_WorkedExample2_EmbeddingPlusDuration(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	signals := []Signal{
+		sig(SigEmbedHigh, 0.78),
+		sig(SigDuration, 0.0), // duration: supporting signal; confidence unused in noisy-OR
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+
+	// noisy-OR over primaries: 100 * (1 - (1 - 0.78)) = 78.0
+	// duration boost: +4  →  82.0
+	const expected = 82.0
+	if result.Score != expected {
+		t.Errorf("expected score %.1f, got %.6f", expected, result.Score)
+	}
+	if result.Band != BandMedium {
+		t.Errorf("expected band MEDIUM, got %q", result.Band)
+	}
+}
+
+// TestComposeScore_WorkedExample3_LSHPlusMetaFuzzy verifies:
+//
+//	lsh_acoustid hamming 0.95 (conf 0.94) + metadata_fuzzy 0.80 (conf 0.78):
+//	1 − (0.06 · 0.22) = 0.9868 → 98.68 → CERTAIN (98.7 ± 0.1)
+func TestComposeScore_WorkedExample3_LSHPlusMetaFuzzy(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	signals := []Signal{
+		sig(SigLSHAcoustID, 0.94),
+		sig(SigMetaFuzzy, 0.78),
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+
+	// noisy-OR: 1 - (1-0.94)*(1-0.78) = 1 - 0.06*0.22 = 1 - 0.0132 = 0.9868
+	// score = 98.68
+	const expected = 98.68
+	const tolerance = 0.1
+	if math.Abs(result.Score-expected) > tolerance {
+		t.Errorf("expected score %.2f ± %.1f, got %.6f", expected, tolerance, result.Score)
+	}
+	if result.Band != BandCertain {
+		t.Errorf("expected band CERTAIN, got %q", result.Band)
+	}
+}
+
+// ─── Band boundary tests ──────────────────────────────────────────────────────
+
+func TestComposeScore_BandBoundaries(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	tests := []struct {
+		name     string
+		score    float64 // approximate input confidence to get near a boundary
+		wantBand string
+	}{
+		// To hit exactly 97: single primary with conf = 0.97 → score=97 → CERTAIN
+		{"certain boundary", 0.97, BandCertain},
+		// Single primary conf=0.90 → score=90 → HIGH
+		{"high lower boundary", 0.90, BandHigh},
+		// Single primary conf=0.75 → score=75 → MEDIUM
+		{"medium lower boundary", 0.75, BandMedium},
+		// Single primary conf=0.60 → score=60 → REVIEW
+		{"review lower boundary", 0.60, BandReview},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			signals := []Signal{sig(SigEmbedHigh, tc.score)}
+			result := ComposeScore(signals, nil, cfg, defaultPair)
+			if result.Band != tc.wantBand {
+				t.Errorf("conf=%.2f: expected band %q, got %q (score=%.4f)", tc.score, tc.wantBand, result.Band, result.Score)
+			}
+		})
+	}
+}
+
+func TestComposeScore_BelowThresholdNoBand(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	// conf=0.50 → score=50 → below review_min=60 → no band
+	signals := []Signal{sig(SigEmbedMedium, 0.50)}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Band != "" {
+		t.Errorf("expected empty band for score below 60, got %q (score=%.2f)", result.Band, result.Score)
+	}
+}
+
+// ─── Property tests ───────────────────────────────────────────────────────────
+
+// TestComposeScore_MonotonicityPrimarySignals verifies that adding a primary
+// signal never lowers the composite score (noisy-OR is monotone increasing).
+func TestComposeScore_MonotonicityPrimarySignals(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	base := []Signal{sig(SigEmbedMedium, 0.70)}
+	baseScore := ComposeScore(base, nil, cfg, defaultPair).Score
+
+	addedSignals := []Signal{
+		sig(SigMetaFuzzy, 0.75),
+		sig(SigLSHAcoustID, 0.90),
+		sig(SigMetaSrcHash, 0.97),
+	}
+
+	// Add signals one at a time and check monotone increase.
+	current := base
+	prev := baseScore
+	for _, extra := range addedSignals {
+		current = append(current, extra)
+		result := ComposeScore(current, nil, cfg, defaultPair)
+		if result.Score < prev {
+			t.Errorf("adding primary signal %q lowered score: prev=%.4f, now=%.4f", extra.Kind, prev, result.Score)
+		}
+		prev = result.Score
+	}
+}
+
+// TestComposeScore_CapRespected verifies that the score never exceeds 100
+// even when many high-confidence signals are present.
+func TestComposeScore_CapRespected(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	// Multiple signals plus supporting boosts — should never exceed 100.
+	signals := []Signal{
+		sig(SigExactFile, 1.0),
+		sig(SigExactAcoustID, 0.99),
+		sig(SigISBNASIN, 0.98),
+		sig(SigMetaSrcHash, 0.97),
+		sig(SigDuration, 0.0), // supporting: +4
+		sig(SigFolderPath, 0.0), // supporting: +3
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Score > 100.0 {
+		t.Errorf("score %.6f exceeds 100.0 cap", result.Score)
+	}
+	if result.Score != 100.0 {
+		t.Errorf("expected capped score 100.0, got %.6f", result.Score)
+	}
+}
+
+// TestComposeScore_SupportingOnlyNeverEligible verifies that a set of
+// ONLY supporting signals never produces a candidate-eligible score (≥ 60).
+// This enforces the SPEC constraint that supporting signals cannot create
+// a candidate on their own.
+func TestComposeScore_SupportingOnlyNeverEligible(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	// Maximum possible supporting-only score: +4 (duration) + +3 (folder) = 7,
+	// which is well below the 60-point persistence threshold.
+	signals := []Signal{
+		sig(SigDuration, 0.0),
+		sig(SigFolderPath, 0.0),
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Score >= 60.0 {
+		t.Errorf("supporting-only signals produced candidate-eligible score %.2f (must be < 60)", result.Score)
+	}
+	if result.Band != "" {
+		t.Errorf("supporting-only signals should produce no band, got %q", result.Band)
+	}
+}
+
+// TestComposeScore_EmptySignals returns score 0 with no band.
+func TestComposeScore_EmptySignals(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	result := ComposeScore(nil, nil, cfg, defaultPair)
+
+	if result.Score != 0.0 {
+		t.Errorf("empty signals: expected score 0, got %.4f", result.Score)
+	}
+	if result.Band != "" {
+		t.Errorf("empty signals: expected no band, got %q", result.Band)
+	}
+}
+
+// TestComposeScore_SuppressorsPassedThrough verifies that suppressor strings
+// are stored verbatim on the result without affecting the score.
+func TestComposeScore_SuppressorsPassedThrough(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	suppressors := []string{"series_volume_differs", "same_dir_multi_file"}
+	signals := []Signal{sig(SigExactFile, 1.0)}
+
+	result := ComposeScore(signals, suppressors, cfg, defaultPair)
+	if len(result.Suppressors) != 2 {
+		t.Errorf("expected 2 suppressors, got %d", len(result.Suppressors))
+	}
+	if result.Score != 100.0 {
+		t.Errorf("suppressors should not affect score; expected 100, got %.2f", result.Score)
+	}
+}
+
+// TestComposeScore_PairPassedThrough verifies canonical pair ordering is
+// preserved verbatim (ordering is the caller's responsibility).
+func TestComposeScore_PairPassedThrough(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	pair := [2]string{"book-a", "book-b"}
+	result := ComposeScore(nil, nil, cfg, pair)
+	if result.Pair != pair {
+		t.Errorf("expected pair %v, got %v", pair, result.Pair)
+	}
+}
+
+// TestComposeScore_FormulaVersion checks that the formula version tag is
+// always set to the expected constant.
+func TestComposeScore_FormulaVersion(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	result := ComposeScore(nil, nil, cfg, defaultPair)
+	if result.Formula != "noisy-or-v1" {
+		t.Errorf("expected formula %q, got %q", "noisy-or-v1", result.Formula)
+	}
+}
+
+// TestComposeScore_ComputedAtSet checks that ComputedAt is non-zero.
+func TestComposeScore_ComputedAtSet(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	result := ComposeScore(nil, nil, cfg, defaultPair)
+	if result.ComputedAt.IsZero() {
+		t.Error("ComputedAt should not be zero")
+	}
+}
+
+// TestComposeScore_DurationBoostApplied verifies that the duration boost
+// is applied exactly as configured (default +4).
+func TestComposeScore_DurationBoostApplied(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	// A single primary signal giving score=78, then +4 duration = 82.
+	signals := []Signal{
+		sig(SigEmbedHigh, 0.78),
+		sig(SigDuration, 0.0),
+	}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Score != 82.0 {
+		t.Errorf("expected 82.0 (78 + 4 duration boost), got %.4f", result.Score)
+	}
+}
+
+// TestComposeScore_FolderPathBoostApplied verifies the folder path boost (+3).
+func TestComposeScore_FolderPathBoostApplied(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	// Single primary giving 78, then +3 folder = 81.
+	signals := []Signal{
+		sig(SigEmbedHigh, 0.78),
+		sig(SigFolderPath, 0.0),
+	}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Score != 81.0 {
+		t.Errorf("expected 81.0 (78 + 3 folder boost), got %.4f", result.Score)
+	}
+}
+
+// TestComposeScore_BothBoostsTogether verifies duration +4 and folder +3 together.
+func TestComposeScore_BothBoostsTogether(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	signals := []Signal{
+		sig(SigEmbedHigh, 0.78),
+		sig(SigDuration, 0.0),
+		sig(SigFolderPath, 0.0),
+	}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	// 78 + 4 + 3 = 85
+	if result.Score != 85.0 {
+		t.Errorf("expected 85.0, got %.4f", result.Score)
+	}
+}
+
+// TestComposeScore_AllPrimaryKinds verifies that all primary kinds contribute
+// to noisy-OR correctly (each with 0.5 confidence; 8 signals → high score).
+func TestComposeScore_AllPrimaryKinds(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	signals := []Signal{
+		sig(SigExactFile, 0.5),
+		sig(SigExactAcoustID, 0.5),
+		sig(SigISBNASIN, 0.5),
+		sig(SigLSHAcoustID, 0.5),
+		sig(SigEmbedHigh, 0.5),
+		sig(SigMetaSrcHash, 0.5),
+		sig(SigMetaFuzzy, 0.5),
+		sig(SigEmbedMedium, 0.5),
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	// noisy-OR with 8 signals each 0.5: 1 - 0.5^8 = 1 - 1/256 ≈ 0.99609 → 99.61
+	expected := (1 - math.Pow(0.5, 8)) * 100
+	if math.Abs(result.Score-expected) > 0.001 {
+		t.Errorf("expected %.4f, got %.4f", expected, result.Score)
+	}
+	if result.Band != BandCertain {
+		t.Errorf("expected CERTAIN, got %q", result.Band)
+	}
+}
+
+// ─── ScoreConfig validation tests ────────────────────────────────────────────
+
+func TestScoreConfig_ValidateDefault(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("default config should be valid: %v", err)
+	}
+}
+
+func TestScoreConfig_ValidateBandOrderingEnforced(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	// Invert two thresholds — validation must reject.
+	cfg.BandCertainMin = 90.0
+	cfg.BandHighMin = 97.0 // now HIGH > CERTAIN — invalid
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for inverted band thresholds, got nil")
+	}
+}
+
+func TestScoreConfig_ValidateConfidenceOutOfRange(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	kc := cfg.Signals[string(SigExactFile)]
+	kc.MinConfidence = 0.0 // zero is excluded: must be in (0, 1]
+	cfg.Signals[string(SigExactFile)] = kc
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for confidence = 0, got nil")
+	}
+}
+
+func TestScoreConfig_ValidateConfidenceAboveOne(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	kc := cfg.Signals[string(SigEmbedHigh)]
+	kc.MaxConfidence = 1.1 // above 1 — invalid
+	cfg.Signals[string(SigEmbedHigh)] = kc
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for confidence > 1, got nil")
+	}
+}
+
+func TestScoreConfig_ValidateMinGTMax(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	kc := cfg.Signals[string(SigEmbedMedium)]
+	kc.MinConfidence = 0.90
+	kc.MaxConfidence = 0.80 // min > max — invalid
+	cfg.Signals[string(SigEmbedMedium)] = kc
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for min_confidence > max_confidence, got nil")
+	}
+}
+
+// ─── isSupportingKind tests ───────────────────────────────────────────────────
+
+func TestIsSupportingKind(t *testing.T) {
+	supporting := []SignalKind{SigDuration, SigFolderPath}
+	primary := []SignalKind{
+		SigExactFile, SigExactAcoustID, SigISBNASIN,
+		SigLSHAcoustID, SigEmbedHigh, SigMetaSrcHash,
+		SigMetaFuzzy, SigEmbedMedium,
+	}
+
+	for _, k := range supporting {
+		if !isSupportingKind(k) {
+			t.Errorf("expected %q to be a supporting kind", k)
+		}
+	}
+	for _, k := range primary {
+		if isSupportingKind(k) {
+			t.Errorf("expected %q to be a primary kind (not supporting)", k)
+		}
+	}
+}
+
+// ─── BoostFor tests ───────────────────────────────────────────────────────────
+
+func TestScoreConfig_BoostForSupportingKinds(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	if cfg.BoostFor(SigDuration) != 4.0 {
+		t.Errorf("expected duration boost 4.0, got %.2f", cfg.BoostFor(SigDuration))
+	}
+	if cfg.BoostFor(SigFolderPath) != 3.0 {
+		t.Errorf("expected folder_path boost 3.0, got %.2f", cfg.BoostFor(SigFolderPath))
+	}
+}
+
+func TestScoreConfig_BoostForPrimaryKindsIsZero(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	for _, k := range []SignalKind{SigExactFile, SigEmbedHigh, SigMetaFuzzy} {
+		if b := cfg.BoostFor(k); b != 0.0 {
+			t.Errorf("primary kind %q should have 0 boost, got %.2f", k, b)
+		}
+	}
+}
+
+// ─── BandFor edge cases ───────────────────────────────────────────────────────
+
+func TestBandFor(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	tests := []struct {
+		score    float64
+		wantBand string
+	}{
+		{100.0, BandCertain},
+		{97.0, BandCertain},
+		{96.99, BandHigh},
+		{90.0, BandHigh},
+		{89.99, BandMedium},
+		{75.0, BandMedium},
+		{74.99, BandReview},
+		{60.0, BandReview},
+		{59.99, ""},
+		{0.0, ""},
+	}
+
+	for _, tc := range tests {
+		got := bandFor(tc.score, cfg)
+		if got != tc.wantBand {
+			t.Errorf("bandFor(%.2f) = %q, want %q", tc.score, got, tc.wantBand)
+		}
+	}
+}
+
+// ─── Signals stored on result ─────────────────────────────────────────────────
+
+func TestComposeScore_SignalsStoredOnResult(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	signals := []Signal{
+		sig(SigExactFile, 1.0),
+		sig(SigDuration, 0.0),
+	}
+
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if len(result.Signals) != 2 {
+		t.Errorf("expected 2 signals on result, got %d", len(result.Signals))
+	}
+}
+
+// ─── Custom config overrides ──────────────────────────────────────────────────
+
+func TestComposeScore_CustomBoostFromConfig(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	// Override duration boost to 10.
+	kc := cfg.Signals[string(SigDuration)]
+	kc.Boost = 10.0
+	cfg.Signals[string(SigDuration)] = kc
+
+	signals := []Signal{
+		sig(SigEmbedHigh, 0.78), // primary: 78
+		sig(SigDuration, 0.0),   // supporting: +10 (custom)
+	}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	if result.Score != 88.0 {
+		t.Errorf("expected 88.0 with custom boost 10, got %.4f", result.Score)
+	}
+}
+
+// TestComposeScore_HighBandBoundary verifies boundary between CERTAIN and HIGH.
+func TestComposeScore_HighBandBoundary(t *testing.T) {
+	cfg := DefaultScoreConfig()
+
+	// Score of 96.99 should be HIGH, not CERTAIN.
+	// Use two signals to compose a known score.
+	// 1 - (1-a)*(1-b) = 0.9699 → (1-a)*(1-b) = 0.0301
+	// Use a=0.94, b=0.49: (0.06)*(0.51) = 0.0306 → score ≈ 96.94 → HIGH
+	signals := []Signal{
+		sig(SigLSHAcoustID, 0.94),
+		sig(SigMetaFuzzy, 0.49),
+	}
+	result := ComposeScore(signals, nil, cfg, defaultPair)
+	// Compute expected
+	expected := (1.0 - (1-0.94)*(1-0.49)) * 100
+	if math.Abs(result.Score-expected) > 0.001 {
+		t.Errorf("score mismatch: expected %.4f, got %.4f", expected, result.Score)
+	}
+	if result.Band != BandHigh {
+		t.Errorf("expected HIGH band for score %.4f, got %q", result.Score, result.Band)
+	}
+}

--- a/internal/dedup/unified/config.go
+++ b/internal/dedup/unified/config.go
@@ -1,0 +1,261 @@
+// file: internal/dedup/unified/config.go
+// version: 1.0.0
+// guid: d8a383db-5083-4257-be54-686ac2e72d32
+
+package unified
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// KindConfig holds per-signal-kind calibration values. All fields have
+// spec-mandated defaults (SPEC 1 §3) and can be overridden in config.yaml
+// under dedup.signals.<kind>.*
+type KindConfig struct {
+	// Base is the default confidence value used when the signal emits at
+	// the midpoint of its range. Collectors that produce a single fixed
+	// confidence (e.g. SigExactFile always 1.0) ignore Scale.
+	Base float64 `mapstructure:"base" json:"base"`
+
+	// Scale is a linear multiplier applied to the raw measurement when
+	// computing the final per-signal Confidence in the collector. Stored
+	// here so consumers can understand the calibration even when the
+	// collector already computed the confidence.
+	Scale float64 `mapstructure:"scale" json:"scale"`
+
+	// MinConfidence is the lower bound for confidence values emitted by
+	// this kind. Values below this floor are clamped (collector-side).
+	MinConfidence float64 `mapstructure:"min_confidence" json:"min_confidence"`
+
+	// MaxConfidence is the upper bound for confidence values emitted by
+	// this kind. Values above this ceiling are clamped (collector-side).
+	MaxConfidence float64 `mapstructure:"max_confidence" json:"max_confidence"`
+
+	// Boost is the additive score points added when this supporting signal
+	// is present. Only meaningful for supporting kinds (SigDuration,
+	// SigFolderPath); ignored for primary kinds.
+	Boost float64 `mapstructure:"boost" json:"boost"`
+}
+
+// ScoreConfig is the top-level config for the unified scoring package,
+// loaded from config.yaml under dedup.signals.*. All fields have
+// SPEC-mandated defaults applied by DefaultScoreConfig.
+type ScoreConfig struct {
+	// Signals maps each SignalKind string to its per-kind calibration.
+	Signals map[string]KindConfig `mapstructure:"signals" json:"signals"`
+
+	// BandCertainMin is the minimum score to be classified as CERTAIN (default 97).
+	BandCertainMin float64 `mapstructure:"band_certain_min" json:"band_certain_min"`
+	// BandHighMin is the minimum score to be classified as HIGH (default 90).
+	BandHighMin float64 `mapstructure:"band_high_min" json:"band_high_min"`
+	// BandMediumMin is the minimum score to be classified as MEDIUM (default 75).
+	BandMediumMin float64 `mapstructure:"band_medium_min" json:"band_medium_min"`
+	// BandReviewMin is the minimum score to be classified as REVIEW (default 60).
+	// Scores below this are not persisted.
+	BandReviewMin float64 `mapstructure:"band_review_min" json:"band_review_min"`
+}
+
+// DefaultScoreConfig returns a ScoreConfig populated with the SPEC 1 §3
+// defaults. These values are the authoritative baseline; config.yaml
+// overrides individual fields.
+func DefaultScoreConfig() ScoreConfig {
+	return ScoreConfig{
+		BandCertainMin: 97.0,
+		BandHighMin:    90.0,
+		BandMediumMin:  75.0,
+		BandReviewMin:  60.0,
+		Signals: map[string]KindConfig{
+			string(SigExactFile): {
+				Base:          1.00,
+				Scale:         1.00,
+				MinConfidence: 1.00,
+				MaxConfidence: 1.00,
+				Boost:         0,
+			},
+			string(SigExactAcoustID): {
+				Base:          0.99,
+				Scale:         1.00,
+				MinConfidence: 0.99,
+				MaxConfidence: 0.99,
+				Boost:         0,
+			},
+			string(SigISBNASIN): {
+				Base:          0.98,
+				Scale:         1.00,
+				MinConfidence: 0.98,
+				MaxConfidence: 0.98,
+				Boost:         0,
+			},
+			string(SigLSHAcoustID): {
+				// Hamming-scaled 0.90–0.97 over hamming similarity 0.85–1.0.
+				Base:          0.90,
+				Scale:         0.14, // (0.97 - 0.90) / (1.0 - 0.85) = 0.4667 — stored per-kind but actual scaling is collector-side
+				MinConfidence: 0.90,
+				MaxConfidence: 0.97,
+				Boost:         0,
+			},
+			string(SigEmbedHigh): {
+				// cosine ≥ 0.95, confidence 0.88–0.95.
+				Base:          0.88,
+				Scale:         1.00,
+				MinConfidence: 0.88,
+				MaxConfidence: 0.95,
+				Boost:         0,
+			},
+			string(SigMetaSrcHash): {
+				Base:          0.97,
+				Scale:         1.00,
+				MinConfidence: 0.97,
+				MaxConfidence: 0.97,
+				Boost:         0,
+			},
+			string(SigMetaFuzzy): {
+				// Levenshtein-scaled 0.70–0.85.
+				Base:          0.70,
+				Scale:         1.00,
+				MinConfidence: 0.70,
+				MaxConfidence: 0.85,
+				Boost:         0,
+			},
+			string(SigEmbedMedium): {
+				// 0.85 ≤ cos < 0.95, confidence 0.65–0.80.
+				Base:          0.65,
+				Scale:         1.00,
+				MinConfidence: 0.65,
+				MaxConfidence: 0.80,
+				Boost:         0,
+			},
+			// Supporting kinds — boosts only, never in noisy-OR product.
+			string(SigDuration): {
+				Base:          0,
+				Scale:         0,
+				MinConfidence: 0,
+				MaxConfidence: 0,
+				Boost:         4.0, // SPEC 1 §4: +4 for duration match within ±2%
+			},
+			string(SigFolderPath): {
+				Base:          0,
+				Scale:         0,
+				MinConfidence: 0,
+				MaxConfidence: 0,
+				Boost:         3.0, // SPEC 1 §4: +3 for matching folder path
+			},
+		},
+	}
+}
+
+// LoadScoreConfig reads overrides from Viper (config.yaml dedup.signals.*)
+// on top of DefaultScoreConfig. Returns an error if the resulting config
+// fails Validate.
+func LoadScoreConfig() (ScoreConfig, error) {
+	cfg := DefaultScoreConfig()
+
+	// Merge band thresholds if overridden.
+	if viper.IsSet("dedup.signals.band_certain_min") {
+		cfg.BandCertainMin = viper.GetFloat64("dedup.signals.band_certain_min")
+	}
+	if viper.IsSet("dedup.signals.band_high_min") {
+		cfg.BandHighMin = viper.GetFloat64("dedup.signals.band_high_min")
+	}
+	if viper.IsSet("dedup.signals.band_medium_min") {
+		cfg.BandMediumMin = viper.GetFloat64("dedup.signals.band_medium_min")
+	}
+	if viper.IsSet("dedup.signals.band_review_min") {
+		cfg.BandReviewMin = viper.GetFloat64("dedup.signals.band_review_min")
+	}
+
+	// Merge per-kind overrides.
+	for _, kind := range []SignalKind{
+		SigExactFile, SigExactAcoustID, SigISBNASIN,
+		SigLSHAcoustID, SigEmbedHigh, SigMetaSrcHash,
+		SigMetaFuzzy, SigEmbedMedium, SigDuration, SigFolderPath,
+	} {
+		key := "dedup.signals." + string(kind)
+		if !viper.IsSet(key) {
+			continue
+		}
+		kc := cfg.Signals[string(kind)]
+		if viper.IsSet(key + ".base") {
+			kc.Base = viper.GetFloat64(key + ".base")
+		}
+		if viper.IsSet(key + ".scale") {
+			kc.Scale = viper.GetFloat64(key + ".scale")
+		}
+		if viper.IsSet(key + ".min_confidence") {
+			kc.MinConfidence = viper.GetFloat64(key + ".min_confidence")
+		}
+		if viper.IsSet(key + ".max_confidence") {
+			kc.MaxConfidence = viper.GetFloat64(key + ".max_confidence")
+		}
+		if viper.IsSet(key + ".boost") {
+			kc.Boost = viper.GetFloat64(key + ".boost")
+		}
+		cfg.Signals[string(kind)] = kc
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return ScoreConfig{}, err
+	}
+	return cfg, nil
+}
+
+// Validate returns an error if the ScoreConfig contains out-of-range values.
+// Confidences must be in (0, 1] for primary kinds; band thresholds must be
+// strictly decreasing (CERTAIN > HIGH > MEDIUM > REVIEW ≥ 0).
+func (c ScoreConfig) Validate() error {
+	var errs []error
+
+	// Band threshold ordering.
+	if !(c.BandCertainMin > c.BandHighMin) {
+		errs = append(errs, fmt.Errorf("band_certain_min (%.2f) must be > band_high_min (%.2f)", c.BandCertainMin, c.BandHighMin))
+	}
+	if !(c.BandHighMin > c.BandMediumMin) {
+		errs = append(errs, fmt.Errorf("band_high_min (%.2f) must be > band_medium_min (%.2f)", c.BandHighMin, c.BandMediumMin))
+	}
+	if !(c.BandMediumMin > c.BandReviewMin) {
+		errs = append(errs, fmt.Errorf("band_medium_min (%.2f) must be > band_review_min (%.2f)", c.BandMediumMin, c.BandReviewMin))
+	}
+	if c.BandReviewMin < 0 {
+		errs = append(errs, fmt.Errorf("band_review_min (%.2f) must be ≥ 0", c.BandReviewMin))
+	}
+
+	// Per-kind confidence range validation for primary kinds.
+	for _, kind := range []SignalKind{
+		SigExactFile, SigExactAcoustID, SigISBNASIN,
+		SigLSHAcoustID, SigEmbedHigh, SigMetaSrcHash,
+		SigMetaFuzzy, SigEmbedMedium,
+	} {
+		kc, ok := c.Signals[string(kind)]
+		if !ok {
+			continue // missing entry uses no confidence — validated at use time
+		}
+		// Per SPEC: confidences must be in (0, 1].
+		if kc.MinConfidence <= 0 || kc.MinConfidence > 1 {
+			errs = append(errs, fmt.Errorf("kind %s: min_confidence (%.4f) must be in (0,1]", kind, kc.MinConfidence))
+		}
+		if kc.MaxConfidence <= 0 || kc.MaxConfidence > 1 {
+			errs = append(errs, fmt.Errorf("kind %s: max_confidence (%.4f) must be in (0,1]", kind, kc.MaxConfidence))
+		}
+		if kc.MinConfidence > kc.MaxConfidence {
+			errs = append(errs, fmt.Errorf("kind %s: min_confidence (%.4f) > max_confidence (%.4f)", kind, kc.MinConfidence, kc.MaxConfidence))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// BoostFor returns the configured additive boost for a supporting signal kind.
+// Returns 0 for primary kinds (which use noisy-OR, not boosts).
+func (c ScoreConfig) BoostFor(k SignalKind) float64 {
+	kc, ok := c.Signals[string(k)]
+	if !ok {
+		return 0
+	}
+	return kc.Boost
+}

--- a/internal/dedup/unified/config_test.go
+++ b/internal/dedup/unified/config_test.go
@@ -1,0 +1,272 @@
+// file: internal/dedup/unified/config_test.go
+// version: 1.0.0
+// guid: 4f7a2c9b-8e3d-4b6f-a1c5-9e7b3d2f6a8c
+
+package unified
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// resetViper clears all Viper state so tests don't bleed into each other.
+func resetViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+// TestLoadScoreConfig_DefaultsWithNoOverrides verifies that LoadScoreConfig
+// returns the SPEC defaults when no Viper keys are set.
+func TestLoadScoreConfig_DefaultsWithNoOverrides(t *testing.T) {
+	resetViper(t)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("LoadScoreConfig with no overrides failed: %v", err)
+	}
+
+	if cfg.BandCertainMin != 97.0 {
+		t.Errorf("default BandCertainMin: expected 97.0, got %.2f", cfg.BandCertainMin)
+	}
+	if cfg.BandHighMin != 90.0 {
+		t.Errorf("default BandHighMin: expected 90.0, got %.2f", cfg.BandHighMin)
+	}
+	if cfg.BandMediumMin != 75.0 {
+		t.Errorf("default BandMediumMin: expected 75.0, got %.2f", cfg.BandMediumMin)
+	}
+	if cfg.BandReviewMin != 60.0 {
+		t.Errorf("default BandReviewMin: expected 60.0, got %.2f", cfg.BandReviewMin)
+	}
+
+	// Spot-check a few per-kind defaults.
+	exactFile, ok := cfg.Signals[string(SigExactFile)]
+	if !ok {
+		t.Fatal("expected SigExactFile in default config")
+	}
+	if exactFile.Base != 1.0 {
+		t.Errorf("SigExactFile base: expected 1.0, got %.4f", exactFile.Base)
+	}
+}
+
+// TestLoadScoreConfig_BandOverrides verifies that band thresholds can be
+// overridden individually via Viper.
+func TestLoadScoreConfig_BandOverrides(t *testing.T) {
+	resetViper(t)
+
+	viper.Set("dedup.signals.band_certain_min", 98.0)
+	viper.Set("dedup.signals.band_high_min", 92.0)
+	viper.Set("dedup.signals.band_medium_min", 80.0)
+	viper.Set("dedup.signals.band_review_min", 65.0)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("LoadScoreConfig with band overrides failed: %v", err)
+	}
+
+	if cfg.BandCertainMin != 98.0 {
+		t.Errorf("BandCertainMin: expected 98.0, got %.2f", cfg.BandCertainMin)
+	}
+	if cfg.BandHighMin != 92.0 {
+		t.Errorf("BandHighMin: expected 92.0, got %.2f", cfg.BandHighMin)
+	}
+	if cfg.BandMediumMin != 80.0 {
+		t.Errorf("BandMediumMin: expected 80.0, got %.2f", cfg.BandMediumMin)
+	}
+	if cfg.BandReviewMin != 65.0 {
+		t.Errorf("BandReviewMin: expected 65.0, got %.2f", cfg.BandReviewMin)
+	}
+}
+
+// TestLoadScoreConfig_PerKindBoostOverride verifies that per-kind boost
+// values can be overridden via Viper.
+func TestLoadScoreConfig_PerKindBoostOverride(t *testing.T) {
+	resetViper(t)
+
+	// Override the duration boost to 8.0.
+	viper.Set("dedup.signals."+string(SigDuration), true) // marks it as "set"
+	viper.Set("dedup.signals."+string(SigDuration)+".boost", 8.0)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("LoadScoreConfig with kind override failed: %v", err)
+	}
+
+	if cfg.BoostFor(SigDuration) != 8.0 {
+		t.Errorf("duration boost after override: expected 8.0, got %.2f", cfg.BoostFor(SigDuration))
+	}
+	// folder_path should be unchanged.
+	if cfg.BoostFor(SigFolderPath) != 3.0 {
+		t.Errorf("folder_path boost should be unchanged: expected 3.0, got %.2f", cfg.BoostFor(SigFolderPath))
+	}
+}
+
+// TestLoadScoreConfig_PerKindBaseOverride verifies that per-kind base
+// values can be overridden via Viper.
+func TestLoadScoreConfig_PerKindBaseOverride(t *testing.T) {
+	resetViper(t)
+
+	viper.Set("dedup.signals."+string(SigMetaFuzzy), true)
+	viper.Set("dedup.signals."+string(SigMetaFuzzy)+".base", 0.75)
+	viper.Set("dedup.signals."+string(SigMetaFuzzy)+".min_confidence", 0.75)
+	viper.Set("dedup.signals."+string(SigMetaFuzzy)+".max_confidence", 0.90)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("LoadScoreConfig with base override failed: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigMetaFuzzy)]
+	if kc.Base != 0.75 {
+		t.Errorf("SigMetaFuzzy base: expected 0.75, got %.4f", kc.Base)
+	}
+	if kc.MinConfidence != 0.75 {
+		t.Errorf("SigMetaFuzzy min_confidence: expected 0.75, got %.4f", kc.MinConfidence)
+	}
+	if kc.MaxConfidence != 0.90 {
+		t.Errorf("SigMetaFuzzy max_confidence: expected 0.90, got %.4f", kc.MaxConfidence)
+	}
+}
+
+// TestLoadScoreConfig_ScaleOverride verifies scale override.
+func TestLoadScoreConfig_ScaleOverride(t *testing.T) {
+	resetViper(t)
+
+	viper.Set("dedup.signals."+string(SigEmbedHigh), true)
+	viper.Set("dedup.signals."+string(SigEmbedHigh)+".scale", 2.0)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigEmbedHigh)]
+	if kc.Scale != 2.0 {
+		t.Errorf("SigEmbedHigh scale: expected 2.0, got %.4f", kc.Scale)
+	}
+}
+
+// TestLoadScoreConfig_InvalidBandsReturnError verifies that LoadScoreConfig
+// returns an error when band overrides produce an invalid ordering.
+func TestLoadScoreConfig_InvalidBandsReturnError(t *testing.T) {
+	resetViper(t)
+
+	// Set CERTAIN lower than HIGH — invalid ordering.
+	viper.Set("dedup.signals.band_certain_min", 80.0)
+	viper.Set("dedup.signals.band_high_min", 90.0)
+
+	_, err := LoadScoreConfig()
+	if err == nil {
+		t.Error("expected error for invalid band ordering, got nil")
+	}
+}
+
+// TestLoadScoreConfig_InvalidConfidenceReturnError verifies that a
+// per-kind confidence override outside (0, 1] returns an error.
+func TestLoadScoreConfig_InvalidConfidenceReturnError(t *testing.T) {
+	resetViper(t)
+
+	// Set SigExactFile max_confidence to 1.5 — invalid.
+	viper.Set("dedup.signals."+string(SigExactFile), true)
+	viper.Set("dedup.signals."+string(SigExactFile)+".min_confidence", 0.5)
+	viper.Set("dedup.signals."+string(SigExactFile)+".max_confidence", 1.5)
+
+	_, err := LoadScoreConfig()
+	if err == nil {
+		t.Error("expected error for confidence > 1, got nil")
+	}
+}
+
+// TestLoadScoreConfig_AllKindsCanBeOverridden exercises the loop over all
+// signal kinds in LoadScoreConfig, touching the non-set path for each.
+func TestLoadScoreConfig_AllKindsCanBeOverridden(t *testing.T) {
+	resetViper(t)
+
+	// Set a known-valid override for every kind via the kind-level key.
+	// This exercises each branch of the per-kind loop in LoadScoreConfig.
+	allKinds := []SignalKind{
+		SigExactFile, SigExactAcoustID, SigISBNASIN, SigLSHAcoustID,
+		SigEmbedHigh, SigMetaSrcHash, SigMetaFuzzy, SigEmbedMedium,
+		SigDuration, SigFolderPath,
+	}
+	for _, k := range allKinds {
+		key := "dedup.signals." + string(k)
+		viper.Set(key, true) // marks the key as set so the branch executes
+	}
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("LoadScoreConfig with all kinds set: %v", err)
+	}
+
+	// Just verify all kinds are present with valid defaults.
+	for _, k := range allKinds {
+		if _, ok := cfg.Signals[string(k)]; !ok {
+			t.Errorf("missing kind %q after override", k)
+		}
+	}
+}
+
+// TestScoreConfig_BoostForMissingKind verifies that BoostFor returns 0
+// when the kind is not present in the config map.
+func TestScoreConfig_BoostForMissingKind(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	// Delete a kind from the map.
+	delete(cfg.Signals, string(SigDuration))
+
+	if b := cfg.BoostFor(SigDuration); b != 0.0 {
+		t.Errorf("BoostFor missing kind: expected 0, got %.2f", b)
+	}
+}
+
+// TestValidate_NegativeReviewMin verifies that a negative BandReviewMin
+// returns a validation error.
+func TestValidate_NegativeReviewMin(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	cfg.BandReviewMin = -1.0
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for negative BandReviewMin, got nil")
+	}
+}
+
+// TestValidate_MediumHighOrderingError verifies band_high_min > band_medium_min.
+func TestValidate_MediumHighOrderingError(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	cfg.BandHighMin = 70.0  // lower than medium
+	cfg.BandMediumMin = 80.0
+	// Now band_high < band_medium — invalid.
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for high < medium band ordering, got nil")
+	}
+}
+
+// TestValidate_MediumReviewOrderingError verifies band_medium_min > band_review_min.
+func TestValidate_MediumReviewOrderingError(t *testing.T) {
+	cfg := DefaultScoreConfig()
+	cfg.BandMediumMin = 55.0  // lower than review
+	cfg.BandReviewMin = 60.0
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for medium < review band ordering, got nil")
+	}
+}
+
+// TestLoadScoreConfig_PerKindMinConfidenceOverride exercises the min_confidence branch.
+func TestLoadScoreConfig_PerKindMinConfidenceOverride(t *testing.T) {
+	resetViper(t)
+
+	viper.Set("dedup.signals."+string(SigEmbedMedium), true)
+	viper.Set("dedup.signals."+string(SigEmbedMedium)+".min_confidence", 0.70)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigEmbedMedium)]
+	if kc.MinConfidence != 0.70 {
+		t.Errorf("min_confidence override: expected 0.70, got %.4f", kc.MinConfidence)
+	}
+}

--- a/internal/dedup/unified/score.go
+++ b/internal/dedup/unified/score.go
@@ -1,0 +1,146 @@
+// file: internal/dedup/unified/score.go
+// version: 1.0.0
+// guid: e12361d1-96ea-4301-919d-3fdb51e12f8f
+
+// Package unified provides the scoring core for the unified deduplication
+// pipeline (SPEC 1, fable5). It is intentionally pure: no I/O, no storage
+// access, no engine changes. This makes it trivially unit-testable and
+// re-runnable over stored signal sets for offline auditing and re-scoring
+// after calibration changes.
+package unified
+
+import "time"
+
+// SignalKind is the identifier for a single evidence signal in the dedup
+// pipeline. Kinds are categorised as PRIMARY (contribute to the noisy-OR
+// product) or SUPPORTING (add bounded boosts after the product is computed).
+// See SPEC 1 §3 and ComposeScore for the exact categorisation logic.
+type SignalKind string
+
+const (
+	// Primary signals — these are independent evidence sources that feed
+	// directly into the noisy-OR product 1 - Π(1 - Confidence(s)).
+
+	// SigExactFile is a whole-file hash match (certainty 1.00).
+	SigExactFile SignalKind = "exact_file"
+
+	// SigExactAcoustID is an exact-match from the book_file_acoustid: index (0.99).
+	SigExactAcoustID SignalKind = "exact_acoustid"
+
+	// SigISBNASIN is an ISBN or ASIN match from external ID data (0.98).
+	SigISBNASIN SignalKind = "isbn_asin"
+
+	// SigLSHAcoustID is an LSH fingerprint band-hit followed by Hamming
+	// refinement — confidence is Hamming-scaled 0.90–0.97.
+	SigLSHAcoustID SignalKind = "lsh_acoustid"
+
+	// SigEmbedHigh is a high-cosine embedding match (cos ≥ 0.95);
+	// confidence 0.88–0.95.
+	SigEmbedHigh SignalKind = "embedding_high"
+
+	// SigMetaSrcHash is a same-external-record metadata source hash match
+	// (same Audible/Google record applied to both; confidence 0.97).
+	SigMetaSrcHash SignalKind = "metadata_hash"
+
+	// SigMetaFuzzy is a normalized title+author Levenshtein similarity
+	// (NEW collector in T014); confidence 0.70–0.85.
+	SigMetaFuzzy SignalKind = "metadata_fuzzy"
+
+	// SigEmbedMedium is a medium-cosine embedding match (0.85 ≤ cos < 0.95);
+	// confidence 0.65–0.80.
+	SigEmbedMedium SignalKind = "embedding_med"
+
+	// Supporting signals — these are NOT included in the noisy-OR product.
+	// They add bounded additive boosts AFTER the primary product is computed.
+	// A set of supporting-only signals can never reach a candidate-eligible
+	// score of ≥ 60, preventing false positives from weak corroborating
+	// evidence alone (see ComposeScore for the enforcement).
+
+	// SigDuration is a duration-match supporting signal (±2% window).
+	// Adds a bounded boost of +4 (config.DurationBoost).
+	SigDuration SignalKind = "duration"
+
+	// SigFolderPath is a matching-folder-path supporting signal.
+	// Adds a bounded boost of +3 (config.FolderBoost).
+	SigFolderPath SignalKind = "folder_path"
+)
+
+// Signal is a single piece of evidence from one collector for one candidate
+// pair. Signals from all collectors are passed to ComposeScore together.
+type Signal struct {
+	// Kind identifies which collector produced this signal.
+	Kind SignalKind `json:"kind"`
+
+	// Raw is the unscaled measurement (e.g. cosine similarity 0.961,
+	// Hamming similarity 0.93, absolute duration delta as a fraction 0.004).
+	Raw float64 `json:"raw"`
+
+	// Confidence is the calibrated probability (0..1) that this signal
+	// alone indicates a duplicate. ComposeScore reads this field; Raw is
+	// stored for human auditing and re-calibration.
+	Confidence float64 `json:"confidence"`
+
+	// Evidence is a human-readable description for UI display and audit
+	// logs (e.g. "whole-file hash 9af3… both sides",
+	// "cosine 0.961 via embedding_high collector").
+	Evidence string `json:"evidence"`
+
+	// FPVersion is the fingerprint-algorithm version that produced the
+	// underlying acoustic data, stored for provenance and invalidation.
+	// Empty for non-acoustic signals.
+	FPVersion string `json:"fp_version,omitempty"`
+}
+
+// UnifiedDedupScore is the composite output of ComposeScore for one candidate
+// pair. It is stored as DedupCandidate.ScoreBreakdown (JSON).
+type UnifiedDedupScore struct {
+	// Pair holds the two book IDs in canonical order (aID < bID).
+	Pair [2]string `json:"pair"`
+
+	// Score is the noisy-OR composite score on a 0–100 scale, capped at 100.
+	// Consumers should use Band for thresholding rather than raw Score,
+	// since calibration changes the meaning of any absolute number.
+	Score float64 `json:"score"`
+
+	// Band is the persistence band derived from Score:
+	//   CERTAIN ≥ 97   — auto-merge eligible
+	//   HIGH    90–96.99 — suggest-merge
+	//   MEDIUM  75–89.99 — review queue
+	//   REVIEW  60–74.99 — LLM phase / manual
+	//   (below 60 is not persisted)
+	Band string `json:"band"`
+
+	// Signals is the full per-signal breakdown, always stored.
+	// Supports re-scoring without re-collection when calibration changes.
+	Signals []Signal `json:"signals"`
+
+	// Suppressors lists the negative-guard identifiers that were fired
+	// before scoring (e.g. "series_volume_differs", "same_dir_multi_file").
+	// Non-empty means the pair was dropped before ComposeScore was called;
+	// the score will be 0 if this ever reaches persistence.
+	Suppressors []string `json:"suppressors"`
+
+	// Formula is the scoring algorithm version tag used to compute this
+	// score. Enables corpus-wide re-score detection after formula upgrades.
+	Formula string `json:"formula"`
+
+	// ComputedAt is the wall-clock time when this score was computed.
+	ComputedAt time.Time `json:"computed_at"`
+}
+
+// Band constants — match exactly the thresholds in ComposeScore.
+const (
+	BandCertain = "CERTAIN" // score ≥ 97
+	BandHigh    = "HIGH"    // 90 ≤ score < 97
+	BandMedium  = "MEDIUM"  // 75 ≤ score < 90
+	BandReview  = "REVIEW"  // 60 ≤ score < 75
+	// Scores < 60 are not persisted; there is intentionally no BandBelow constant.
+)
+
+// isSupportingKind returns true for signal kinds that are excluded from
+// the noisy-OR product and contribute only bounded additive boosts.
+// These signals must never be the sole reason a candidate reaches
+// persistence (score ≥ 60), which is enforced by ComposeScore.
+func isSupportingKind(k SignalKind) bool {
+	return k == SigDuration || k == SigFolderPath
+}


### PR DESCRIPTION
## Summary

New pure-logic package `internal/dedup/unified/` implementing the unified deduplication scoring core from SPEC 1 §3–4 (fable5 TASK-011). No I/O, no engine changes — fully unit-testable foundation that all downstream tasks (T013 LSH collector, T014 collector refactor, T015 candidate schema) build on.

- **score.go** — `SignalKind` constants, `Signal`, `UnifiedDedupScore` types copied verbatim from SPEC §3. `isSupportingKind()` distinguishes `duration`/`folder_path` (supporting) from all other primary signals.
- **compose.go** — `ComposeScore()`: noisy-OR over primary signals (`P_dup = 1 − Π(1−Confidence(s))`), bounded additive boosts for supporting kinds (+4 duration, +3 folder_path per config), cap at 100, banding (CERTAIN≥97 / HIGH 90–96.99 / MEDIUM 75–89.99 / REVIEW 60–74.99), formula version `"noisy-or-v1"`.
- **config.go** — `ScoreConfig` with per-kind calibration, `LoadScoreConfig()` reading `dedup.signals.*` from Viper with SPEC defaults, `Validate()` enforcing confidences ∈ (0,1] and strictly-decreasing band thresholds.
- **config.go (config package)** — `dedup.signals.*` Viper defaults registered in `InitConfig`.
- **compose_test.go + config_test.go** — three SPEC §4 worked examples as exact assertions, property tests, validation rejection tests; **98.7% coverage** (well above the 90% target).

## Acceptance criteria

- [x] Three worked-example tests pass with exact expected scores:
  - `exact_file` only → 100 → CERTAIN
  - `embedding_high` conf=0.78 + `duration` boost → 82 → MEDIUM
  - `lsh_acoustid` conf=0.94 + `metadata_fuzzy` conf=0.78 → 98.68±0.1 → CERTAIN
- [x] Property tests pass:
  - Adding a primary signal never lowers the score (monotonicity)
  - Cap respected (score never exceeds 100)
  - Supporting-only signal sets never reach candidate-eligible score ≥ 60
- [x] Config validation rejects malformed calibration (inverted bands, confidence outside (0,1], min > max)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/dedup/unified/... -count=1 -cover` → **98.7%** coverage
- [x] `make test` green (15 packages, no failures)

## Test plan

- [x] Run `go test ./internal/dedup/unified/... -count=1 -cover -v` and verify all 30+ test cases pass
- [x] Verify three SPEC §4 worked examples match expected values exactly
- [x] Run `make test` across all packages to confirm no regressions

---

COMPLETED: 5 — score.go, compose.go, config.go, compose_test.go, config_test.go  
REMAINING: 0  
BLOCKED: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)