### PR TITLE
feat(itunes): mhoh encoding corpus audit tool + iTunes-authored constants table (fable5 T002)

### DIFF
--- a/cmd/itl-audit-encoding/main.go
+++ b/cmd/itl-audit-encoding/main.go
@@ -1,0 +1,90 @@
+// file: cmd/itl-audit-encoding/main.go
+// version: 1.0.0
+// guid: 9d7cc6c7-ae41-4594-b773-93ab73c0a191
+
+// itl-audit-encoding walks every mhoh string block in an iTunes-authored .itl
+// file and emits a per-hohmType histogram of the byte fields that control
+// string encoding (+24 u32, +27 byte, headerLen, totalLen-40-strDataLen delta,
+// bytes 32–39 all-zero check). The resulting JSON report is the empirical
+// ground truth that mhoh_encoding_table.go is derived from.
+//
+// Usage:
+//
+//	go run ./cmd/itl-audit-encoding <path/to/iTunes Library.itl> [output.json]
+//
+// If the output path is omitted the report is written to stdout.
+// The tool walks msdh container types 1 (tracks), 2 (playlists), 9 (albums),
+// and 11 (artists) — all container types that carry mhoh string metadata in
+// an iTunes-authored library.
+//
+// The report JSON has the shape:
+//
+//	{
+//	  "library_path": "...",
+//	  "library_version": "...",
+//	  "audit_date": "2026-06-09",
+//	  "total_mhoh_blocks": 12345,
+//	  "per_type": {
+//	    "2": {
+//	      "hohm_type_hex": "0x02",
+//	      "count": 94575,
+//	      "header_len_values": {"24": 94575},
+//	      "at24_values": {"1": 91000, "3": 3575},
+//	      "at27_values": {"0": 94575},
+//	      "tail_zero": {"true": 94575},
+//	      "len_arithmetic_ok": {"true": 94575}
+//	    }
+//	  }
+//	}
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: itl-audit-encoding <library.itl> [output.json]")
+		os.Exit(1)
+	}
+
+	libPath := os.Args[1]
+	outPath := ""
+	if len(os.Args) >= 3 {
+		outPath = os.Args[2]
+	}
+
+	data, err := os.ReadFile(libPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read error: %v\n", err)
+		os.Exit(1)
+	}
+
+	report, err := itunes.AuditMhohEncoding(data, libPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "audit error: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if outPath == "" {
+		fmt.Println(string(out))
+		return
+	}
+
+	if err := os.WriteFile(outPath, out, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "write error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Report written to %s\n", outPath)
+}
+

--- a/internal/itunes/mhoh_encoding_audit.go
+++ b/internal/itunes/mhoh_encoding_audit.go
@@ -1,0 +1,306 @@
+// file: internal/itunes/mhoh_encoding_audit.go
+// version: 1.0.0
+// guid: 2c46832f-3418-4be7-8e80-2184a8ec9d63
+
+// AuditMhohEncoding walks every mhoh string block in an iTunes .itl payload
+// and collects per-hohmType histograms of the byte fields that govern string
+// encoding. The resulting MhohAuditReport is the empirical ground truth from
+// which ITunesMhohEncoding (mhoh_encoding_table.go) is derived.
+//
+// Fields examined per mhoh block (offsets relative to block start):
+//
+//	+4  u32 LE  headerLen     — iTunes-authored: always 24
+//	+8  u32 LE  totalLen      — must equal 40 + strDataLen per SPEC 2
+//	+12 u32 LE  hohmType      — the field semantic (0x02=Name, 0x0B=LocalURL, etc.)
+//	+24 u32 LE  at24          — iTunes' actual encoding indicator (values 1/2/3 observed)
+//	+27 byte    at27          — our old "encoding flag"; iTunes writes 0x00 always
+//	+28 u32 LE  strDataLen    — byte length of the string payload starting at +40
+//	+32..+39    8 bytes       — iTunes writes these as 0x00 always
+//
+// Container types walked: 1 (tracks), 2 (playlists), 9 (albums), 11 (artists).
+package itunes
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// msdhContainerTypes is the list of msdh blockType values that contain mhoh
+// string metadata in an iTunes-authored library. Types 1 and 2 (tracks and
+// playlists) are well-known; 9 (albums / miah) and 11 (artists / miih) are
+// included per TASK-002 scope.
+var msdhContainerTypes = []int{1, 2, 9, 11}
+
+// MhohTypeAudit holds the per-hohmType histogram data collected by one run of
+// AuditMhohEncoding. All map keys are the string representation of the numeric
+// value for JSON-friendliness (e.g., "24", "0").
+type MhohTypeAudit struct {
+	// HohmTypeHex is the hohmType rendered as "0x02" etc. for readability.
+	HohmTypeHex string `json:"hohm_type_hex"`
+	// Count is the total number of mhoh blocks of this type seen.
+	Count int `json:"count"`
+	// HeaderLenValues is a histogram of the +4 headerLen field values.
+	// iTunes-authored libraries show exclusively "24" here.
+	HeaderLenValues map[string]int `json:"header_len_values"`
+	// At24Values is a histogram of the u32 at byte +24 — iTunes' encoding
+	// indicator. Values 1 (Windows-1252 / ASCII-compatible), 2 (UTF-8 or
+	// pure-ASCII), and 3 (UTF-16LE) have been observed in golden corpus data.
+	At24Values map[string]int `json:"at24_values"`
+	// At27Values is a histogram of the byte at +27. iTunes writes 0x00
+	// exclusively; our old encodeHohmString wrote 1 or 3 (CRIT-1).
+	At27Values map[string]int `json:"at27_values"`
+	// TailZero histograms whether bytes +32..+39 are all 0x00 ("true"/"false").
+	TailZero map[string]int `json:"tail_zero"`
+	// LenArithmeticOK histograms whether totalLen == 40 + strDataLen.
+	LenArithmeticOK map[string]int `json:"len_arithmetic_ok"`
+}
+
+// MhohAuditReport is the top-level result of AuditMhohEncoding.
+type MhohAuditReport struct {
+	// LibraryPath is the path supplied by the caller.
+	LibraryPath string `json:"library_path"`
+	// LibraryVersion is the version string from the hdfm header.
+	LibraryVersion string `json:"library_version"`
+	// AuditDate is the ISO-8601 date the audit was run.
+	AuditDate string `json:"audit_date"`
+	// TotalMhohBlocks is the total number of mhoh blocks visited across all
+	// container types.
+	TotalMhohBlocks int `json:"total_mhoh_blocks"`
+	// TotalContainersWalked counts msdh containers of the target types found.
+	TotalContainersWalked int `json:"total_containers_walked"`
+	// PerType maps uint32 hohmType (as decimal string) to its histogram.
+	PerType map[string]*MhohTypeAudit `json:"per_type"`
+}
+
+// AuditMhohEncoding decrypts, inflates, and walks the payload of an iTunes
+// .itl file, collecting per-hohmType encoding field histograms. The libPath
+// string is embedded in the report metadata verbatim.
+//
+// Returns an error only for fatal decryption/inflation failures; partial data
+// (e.g., truncated containers) is tolerated and counted.
+func AuditMhohEncoding(fileData []byte, libPath string) (*MhohAuditReport, error) {
+	// Decrypt and inflate the payload using the same pipeline as
+	// DecryptAndInflateITL — reuse the exported helper.
+	payload, err := DecryptAndInflateITL(fileData)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt/inflate: %w", err)
+	}
+
+	// Extract the library version from the hdfm header for the provenance
+	// comment in the constants file.
+	hdr, hdrErr := parseHdfmHeader(fileData)
+	libVersion := "(unknown)"
+	if hdrErr == nil {
+		libVersion = hdr.version
+	}
+
+	report := &MhohAuditReport{
+		LibraryPath:    libPath,
+		LibraryVersion: libVersion,
+		AuditDate:      time.Now().UTC().Format("2006-01-02"),
+		PerType:        make(map[string]*MhohTypeAudit),
+	}
+
+	// Walk each target msdh container type.
+	for _, ct := range msdhContainerTypes {
+		off, hdrLen, totalLen := findMsdhByType(payload, ct)
+		if off < 0 {
+			// Container type absent in this library — not an error.
+			continue
+		}
+		report.TotalContainersWalked++
+		contentStart := off + hdrLen
+		contentEnd := off + totalLen
+		if contentEnd > len(payload) {
+			contentEnd = len(payload)
+		}
+		walkContainerForMhoh(payload, contentStart, contentEnd, report)
+	}
+
+	return report, nil
+}
+
+// walkContainerForMhoh recursively descends into the chunk tree rooted at
+// [start, end) and records every mhoh block it encounters.
+func walkContainerForMhoh(data []byte, start, end int, report *MhohAuditReport) {
+	offset := start
+	for offset+12 <= end {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		if offset+8 > len(data) {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+
+		// Determine effective chunk size to advance the walker.
+		//
+		// Only chunks that carry sub-content (mhoh, mith, miah, miph, miih) use
+		// totalLen for advancement. Header-only chunks (mlth and similar) store a
+		// SEMANTIC count at +8, not a byte length, so they MUST advance by
+		// headerLen only — using totalLen for them would skip hundreds of MB of
+		// track data.
+		//
+		// For mhoh: totalLen = 40 + strDataLen. We MUST use totalLen to advance
+		// past the string payload; using headerLen (24) would land us inside the
+		// string bytes and corrupt every subsequent tag read.
+		chunkSize := headerLen
+		isDataChunk := (tag == "mhoh" || tag == "mith" || tag == "miah" || tag == "miph" || tag == "miih") &&
+			totalLen >= headerLen && offset+totalLen <= end
+		if isDataChunk {
+			chunkSize = totalLen
+		}
+		if chunkSize < 8 || offset+chunkSize > end {
+			break
+		}
+
+		switch tag {
+		case "mhoh":
+			// Record the encoding fields of this string block.
+			recordMhohBlock(data, offset, totalLen, report)
+
+		case "mith", "miah", "miph", "miih":
+			// Descend into child blocks at [offset+headerLen, offset+chunkSize).
+			// When totalLen == headerLen (mith with no sub-mhoh children), the
+			// range is empty and we recurse vacuously.
+			childStart := offset + headerLen
+			childEnd := offset + chunkSize
+			if childEnd > end {
+				childEnd = end
+			}
+			if childStart < childEnd {
+				walkContainerForMhoh(data, childStart, childEnd, report)
+			}
+		}
+
+		offset += chunkSize
+	}
+}
+
+// recordMhohBlock extracts the encoding-relevant fields from one mhoh block
+// and updates the per-type histograms in the report.
+func recordMhohBlock(data []byte, offset, totalLen int, report *MhohAuditReport) {
+	// A valid mhoh must be at least 40 bytes so we can safely read all fields.
+	if offset+40 > len(data) {
+		return
+	}
+
+	headerLen := int(readUint32LE(data, offset+4))
+	hohmType := readUint32LE(data, offset+12)
+	at24 := readUint32LE(data, offset+24)
+	at27 := data[offset+27]
+	strDataLen := int(readUint32LE(data, offset+28))
+
+	// Check whether the 8 bytes at +32..+39 are all zero.
+	tailZero := true
+	for i := 32; i < 40; i++ {
+		if offset+i >= len(data) {
+			tailZero = false
+			break
+		}
+		if data[offset+i] != 0 {
+			tailZero = false
+			break
+		}
+	}
+
+	// Length arithmetic: totalLen should equal 40 + strDataLen.
+	lenArithOK := totalLen == 40+strDataLen
+
+	key := strconv.FormatUint(uint64(hohmType), 10)
+	e, ok := report.PerType[key]
+	if !ok {
+		e = &MhohTypeAudit{
+			HohmTypeHex:     fmt.Sprintf("0x%02X", hohmType),
+			HeaderLenValues: make(map[string]int),
+			At24Values:      make(map[string]int),
+			At27Values:      make(map[string]int),
+			TailZero:        make(map[string]int),
+			LenArithmeticOK: make(map[string]int),
+		}
+		report.PerType[key] = e
+	}
+
+	e.Count++
+	report.TotalMhohBlocks++
+	e.HeaderLenValues[strconv.Itoa(headerLen)]++
+	e.At24Values[strconv.FormatUint(uint64(at24), 10)]++
+	e.At27Values[strconv.Itoa(int(at27))]++
+	if tailZero {
+		e.TailZero["true"]++
+	} else {
+		e.TailZero["false"]++
+	}
+	if lenArithOK {
+		e.LenArithmeticOK["true"]++
+	} else {
+		e.LenArithmeticOK["false"]++
+	}
+}
+
+// DeriveEncodingTable converts an MhohAuditReport into the canonical
+// ITunesMhohEncoding map consumed by the mhoh-format guard (T003). Only types
+// where every observed headerLen is 24 are included; types with non-uniform
+// headerLen values are excluded with a warning.
+//
+// The AllowedAt24 set is populated from the observed +24 values in the corpus;
+// At27Uniform is true when every +24 is 0 (invariant in all iTunes libraries).
+func DeriveEncodingTable(report *MhohAuditReport) map[uint32]MhohEncodingEntry {
+	table := make(map[uint32]MhohEncodingEntry)
+
+	// Sort keys for deterministic output.
+	typeKeys := make([]string, 0, len(report.PerType))
+	for k := range report.PerType {
+		typeKeys = append(typeKeys, k)
+	}
+	sort.Strings(typeKeys)
+
+	for _, k := range typeKeys {
+		audit := report.PerType[k]
+		typeNum, err := strconv.ParseUint(k, 10, 32)
+		if err != nil {
+			continue
+		}
+		hohmType := uint32(typeNum)
+
+		// Only include types where headerLen is uniformly 24.
+		if len(audit.HeaderLenValues) != 1 {
+			continue
+		}
+		if _, ok := audit.HeaderLenValues["24"]; !ok {
+			continue
+		}
+
+		// Collect all observed +24 values.
+		var allowed []uint32
+		at24Keys := make([]string, 0, len(audit.At24Values))
+		for k2 := range audit.At24Values {
+			at24Keys = append(at24Keys, k2)
+		}
+		sort.Strings(at24Keys)
+		for _, k2 := range at24Keys {
+			v, err2 := strconv.ParseUint(k2, 10, 32)
+			if err2 == nil {
+				allowed = append(allowed, uint32(v))
+			}
+		}
+
+		// at27Uniform: true when all observed +27 values are 0.
+		at27Uniform := len(audit.At27Values) == 1
+		if _, ok := audit.At27Values["0"]; !ok {
+			at27Uniform = false
+		}
+
+		table[hohmType] = MhohEncodingEntry{
+			HeaderLen:   24,
+			AllowedAt24: allowed,
+			At27Uniform: at27Uniform,
+			Count:       audit.Count,
+		}
+	}
+	return table
+}

--- a/internal/itunes/mhoh_encoding_table.go
+++ b/internal/itunes/mhoh_encoding_table.go
@@ -1,0 +1,292 @@
+// file: internal/itunes/mhoh_encoding_table.go
+// version: 1.1.0
+// guid: a0dacfc4-01c3-4a83-9404-b510ca4d051a
+
+// ITunesMhohEncoding is the authoritative per-hohmType encoding constant table
+// for mhoh string blocks in iTunes-authored .itl files.
+//
+// Provenance: derived by running cmd/itl-audit-encoding against the golden
+// iTunes library (path "/tmp/itunes-libraries/iTunes Library.itl",
+// version 12.13.10.3, 94,575 tracks, 965,223 mhoh blocks audited total)
+// on 2026-06-09. Container types 1 (tracks), 2 (playlists), 9 (albums), 11
+// (artists) were walked. The walker descends into mith/miah/miph/miih children.
+//
+// Shape: map[hohmType uint32] → MhohEncodingEntry. Downstream guard
+// "mhoh-format" (T003 / ITLSafetyContract) consumes this map as follows:
+//
+//	entry, ok := ITunesMhohEncoding[hohmType]
+//	if !ok {
+//	    // hohmType not in corpus — skip +24 check, but still enforce
+//	    // +27==0 and headerLen==24 for all blocks.
+//	    continue
+//	}
+//	if !entry.AllowedAt24Contains(at24) {
+//	    // violation: emit a mhoh-format guard violation
+//	}
+//
+// WHY a map (not a slice): O(1) lookup per block during contract runs over
+// libraries with 965K+ blocks.
+//
+// WHY AllowedAt24 is a []uint32 (not a set): the corpus shows at most 3
+// distinct values per type; a linear scan over 3 elements is cheaper than
+// map allocation for per-block hot-path guard checks.
+//
+// Global invariants confirmed across all 965,223 observed blocks:
+//   - headerLen == 24: 100% uniform across all types.
+//   - byte +27 == 0x00: 100% uniform for all text string types (types where
+//     at24 ∈ {0, 1, 2, 3}); non-zero only in binary-blob types (0x36, 0x65,
+//     0x66, etc.) which store non-string payloads.
+//   - bytes +32..+39 all zero: true for all text string types.
+//
+// Encoding indicator values at byte +24 (not +27 as our old code assumed):
+//   0 = ASCII/percent-encoded (used exclusively by 0x0B LocalURL and similar)
+//   1 = Windows-1252 / Latin-1 (used for Latin text)
+//   2 = UTF-8 / pure ASCII (used by 0x0B LocalURL for encoded URLs)
+//   3 = UTF-16LE (used for non-Latin text with characters > U+00FF)
+//
+// Note: this table covers ALL 44 text string hohmTypes found in the corpus.
+// The guard-critical types (used by our writers) are 0x02, 0x03, 0x04, 0x05,
+// 0x06, 0x0B, 0x0D — see CRIT-1 and SPEC 2 §2.
+package itunes
+
+// MhohEncodingEntry holds the corpus-derived constraints for one hohmType.
+type MhohEncodingEntry struct {
+	// HeaderLen is the exclusively observed headerLen value. In every
+	// iTunes-authored library inspected this is 24. The guard rejects any
+	// block where headerLen differs.
+	HeaderLen uint32
+
+	// AllowedAt24 is the set of u32 values observed at byte offset +24 (the
+	// encoding indicator field) in the corpus. The guard rejects any block
+	// whose +24 value is not in this set.
+	//
+	// Values seen: 0=ASCII/percent-encoded, 1=Windows-1252, 2=UTF-8, 3=UTF-16LE.
+	AllowedAt24 []uint32
+
+	// At27Uniform records whether byte +27 was exclusively 0x00 in the corpus.
+	// For every text string type in the table this is true — it is recorded here
+	// so the guard can distinguish "corpus confirms: must be 0" from "no data".
+	At27Uniform bool
+
+	// Count is the number of blocks of this type observed in the golden corpus.
+	// Informational; not used by the guard at runtime.
+	Count int
+}
+
+// AllowedAt24Contains reports whether v is in e.AllowedAt24.
+func (e MhohEncodingEntry) AllowedAt24Contains(v uint32) bool {
+	for _, a := range e.AllowedAt24 {
+		if a == v {
+			return true
+		}
+	}
+	return false
+}
+
+// ITunesMhohEncoding is the corpus-derived constant table for text string
+// hohmTypes. Binary-blob types (0x36=raw audio data, 0x65=SmartCriteria,
+// 0x66=SmartInfo, etc.) are intentionally excluded — their payload bytes
+// are NOT string encoding headers, so applying the +24/+27 guard to them
+// would produce false positives.
+//
+// Generated from golden library version 12.13.10.3 on 2026-06-09 by
+// cmd/itl-audit-encoding. Re-run the tool to regenerate from a new corpus.
+var ITunesMhohEncoding = map[uint32]MhohEncodingEntry{
+
+	// --------------- Core track metadata (written by our writers) ---------------
+
+	// 0x02 = Name (track title).
+	// Corpus: 94,575 blocks. at24 ∈ {1=latin1, 3=utf16le}. +27=0 uniform.
+	// Non-zero count of 3 (utf16le) for titles with non-Latin characters.
+	0x02: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 94575},
+
+	// 0x03 = Album.
+	// Corpus: 94,174 blocks. at24 ∈ {1, 3}. +27=0 uniform.
+	0x03: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 94174},
+
+	// 0x04 = Artist.
+	// Corpus: 94,339 blocks. at24 ∈ {1, 3}. +27=0 uniform.
+	0x04: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 94339},
+
+	// 0x05 = Genre.
+	// Corpus: 78,495 blocks (not all tracks have genre). at24 ∈ {1, 3}. +27=0.
+	0x05: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 78495},
+
+	// 0x06 = Kind (file format description, e.g. "AAC audio file").
+	// Corpus: 93,539 blocks. ONLY at24=3 observed — iTunes encodes "Kind"
+	// as UTF-16LE exclusively, even for pure-ASCII strings. +27=0 uniform.
+	// WHY: possibly because Kind strings always come from an internal enum,
+	// never from user input, and iTunes chose a uniform encoding for them.
+	0x06: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 93539},
+
+	// 0x0B = LocalURL (file://localhost/... percent-encoded URL, or https:// for podcasts).
+	// Corpus: 94,201 blocks (93,014 local + 1,187 podcast).
+	// IMPORTANT: at24 ∈ {0, 2} — NOT {1, 3}. URLs are pure ASCII (percent-
+	// escaped), so iTunes never needs Windows-1252 or UTF-16LE for this field.
+	// at24=0: appears to be the "plain ASCII" marker (similar to at24=2).
+	// at24=2: appears for the same ASCII strings (iTunes may use 0 or 2
+	// interchangeably for ASCII-only strings in this field).
+	// +27=0 uniform; tail_zero=true.
+	0x0B: {HeaderLen: 24, AllowedAt24: []uint32{0, 2}, At27Uniform: true, Count: 94201},
+
+	// 0x0D = Location (native Windows path, e.g. W:\itunes\...).
+	// Corpus: 93,014 blocks (1,736 are UTF-16LE-encoded for non-ASCII paths;
+	// 91,278 are Latin-1/Windows-1252).
+	// at24 ∈ {1, 3}. +27=0 uniform; tail_zero=true.
+	0x0D: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 93014},
+
+	// --------------- Additional track metadata ---------------
+
+	// 0x08 = Comment.
+	// Corpus: 47,225 blocks. at24 ∈ {1, 3}. +27=0.
+	0x08: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 47225},
+
+	// 0x09 = Podcast episode description or similar (rare).
+	// Corpus: 159 blocks. Only at24=3.
+	0x09: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 159},
+
+	// 0x0C = Composer / Narrator (audiobook narrator stored here).
+	// Corpus: 32,289 blocks. at24 ∈ {1, 3}.
+	0x0C: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 32289},
+
+	// 0x0E = Series / Work name (rare).
+	// Corpus: 1,915 blocks. Only at24=3 (UTF-16LE).
+	0x0E: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 1915},
+
+	// 0x12 = Sort Artist.
+	// Corpus: 12,772 blocks. at24 ∈ {1, 3}.
+	0x12: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 12772},
+
+	// 0x15 = Content rating / advisory string.
+	// Corpus: 9,874 blocks. Only at24=0. +27=0 uniform. Note: len arithmetic
+	// does not hold for this type (tail_zero=false) — it uses a non-standard
+	// length field layout, but the encoding indicator itself is text-style.
+	0x15: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 9874},
+
+	// 0x16 = Album Artist (or similar).
+	// Corpus: 1,712 blocks. at24 ∈ {1, 3}.
+	0x16: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 1712},
+
+	// 0x18 = Sort Album Artist.
+	// Corpus: 47 blocks. Only at24=3.
+	0x18: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 47},
+
+	// 0x19 = Sort Composer.
+	// Corpus: 46 blocks. Only at24=3.
+	0x19: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 46},
+
+	// 0x1B = Sort Name.
+	// Corpus: 36,294 blocks. at24 ∈ {1, 3}.
+	0x1B: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 36294},
+
+	// 0x1C = Sort Album.
+	// Corpus: 65 blocks. Only at24=3.
+	0x1C: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 65},
+
+	// 0x1D = Purchase-related URL or similar.
+	// Corpus: 29 blocks. Only at24=2.
+	0x1D: {HeaderLen: 24, AllowedAt24: []uint32{2}, At27Uniform: true, Count: 29},
+
+	// 0x1E = Content Advisory Rating.
+	// Corpus: 14,444 blocks. at24 ∈ {1, 3}.
+	0x1E: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 14444},
+
+	// 0x1F = Content Description / Advisory.
+	// Corpus: 23,056 blocks. at24 ∈ {1, 3}.
+	0x1F: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 23056},
+
+	// 0x20 = Podcast feed URL.
+	// Corpus: 696 blocks. Only at24=3.
+	0x20: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 696},
+
+	// 0x21 = Podcast episode URL.
+	// Corpus: 252 blocks. Only at24=3.
+	0x21: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 252},
+
+	// 0x22 = Podcast title / channel.
+	// Corpus: 95 blocks. Only at24=3.
+	0x22: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 95},
+
+	// 0x23 = Podcast category (very rare in this corpus).
+	// Corpus: 1 block. Only at24=3.
+	0x23: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 1},
+
+	// 0x25 = Vendor identifier or similar.
+	// Corpus: 1,236 blocks. Only at24=0.
+	0x25: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 1236},
+
+	// 0x2B = iTunes Store URL (rare).
+	// Corpus: 37 blocks. Only at24=3.
+	0x2B: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 37},
+
+	// 0x2E = Additional metadata string (possibly "Work" or "Movement").
+	// Corpus: 6,264 blocks. at24 ∈ {1, 3}.
+	0x2E: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 6264},
+
+	// 0x33 = (Identity string of some kind).
+	// Corpus: 47 blocks. Only at24=1.
+	0x33: {HeaderLen: 24, AllowedAt24: []uint32{1}, At27Uniform: true, Count: 47},
+
+	// 0x39 = Apple Music ID or content identifier.
+	// Corpus: 1,200 blocks. Only at24=0.
+	0x39: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 1200},
+
+	// 0x3A = Related string (very rare).
+	// Corpus: 6 blocks. Only at24=0.
+	0x3A: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 6},
+
+	// 0x3F = Playlist sort field / description.
+	// Corpus: 1,826 blocks. Only at24=3.
+	0x3F: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 1826},
+
+	// 0x40 = Related string field.
+	// Corpus: 881 blocks. Only at24=3.
+	0x40: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 881},
+
+	// 0x64 = Playlist name (miph containers).
+	// Corpus: 338 blocks. at24 ∈ {1, 3}. +27=0.
+	0x64: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 338},
+
+	// 0x69 = Playlist string field (rare, in miph containers).
+	// Corpus: 678 blocks. Only at24=0. +27=0 uniform. Non-standard length layout
+	// (len arithmetic does not hold), but encoding indicator is text-style.
+	0x69: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 678},
+
+	// 0x6C = Playlist string field (rare, in miph containers).
+	// Corpus: 338 blocks. at24 ∈ {0, 3}. +27=0 uniform. Non-standard length layout.
+	0x6C: {HeaderLen: 24, AllowedAt24: []uint32{0, 3}, At27Uniform: true, Count: 338},
+
+	// 0xC8 = Container-level name (very rare, in album/artist containers).
+	// Corpus: 6 blocks. at24 ∈ {1, 3}.
+	0xC8: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 6},
+
+	// --------------- Album/Artist container types (msdh 9 and 11) ---------------
+
+	// 0x12C = Album name (miah containers, msdh type 9).
+	// Corpus: 12,428 blocks. at24 ∈ {1, 3}.
+	0x12C: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 12428},
+
+	// 0x12D = Album artist name (miah containers).
+	// Corpus: 12,444 blocks. at24 ∈ {1, 3}.
+	0x12D: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 12444},
+
+	// 0x12E = Album sort field.
+	// Corpus: 6,197 blocks. at24 ∈ {1, 3}.
+	0x12E: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 6197},
+
+	// 0x130 = Album genre (rare).
+	// Corpus: 17 blocks. Only at24=3.
+	0x130: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 17},
+
+	// 0x131 = Album container string (very rare).
+	// Corpus: 6 blocks. Only at24=0.
+	0x131: {HeaderLen: 24, AllowedAt24: []uint32{0}, At27Uniform: true, Count: 6},
+
+	// 0x190 = Artist name (miih containers, msdh type 11).
+	// Corpus: 3,555 blocks. at24 ∈ {1, 3}.
+	0x190: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 3555},
+
+	// 0x191 = Artist sort field (miih containers).
+	// Corpus: 91 blocks. Only at24=3.
+	0x191: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 91},
+}

--- a/internal/itunes/mhoh_encoding_table_test.go
+++ b/internal/itunes/mhoh_encoding_table_test.go
@@ -1,0 +1,253 @@
+// file: internal/itunes/mhoh_encoding_table_test.go
+// version: 1.0.0
+// guid: 3b7e1fa2-9c4d-4e58-b6f0-2a8d5c9f1e3b
+
+package itunes
+
+import (
+	"testing"
+)
+
+// TestMhohEncodingTable_NonEmpty verifies that the corpus-derived table is
+// populated and contains the minimum required entries for the mhoh-format
+// guard. The guard REQUIRES entries for hohmTypes 0x02, 0x0B, and 0x0D —
+// these are the types written by our location-update and metadata-update
+// paths and are the primary CRIT-1 / SPEC 2 targets.
+func TestMhohEncodingTable_NonEmpty(t *testing.T) {
+	requiredTypes := []uint32{0x02, 0x0B, 0x0D}
+	for _, hohmType := range requiredTypes {
+		entry, ok := ITunesMhohEncoding[hohmType]
+		if !ok {
+			t.Errorf("ITunesMhohEncoding missing required type 0x%02X", hohmType)
+			continue
+		}
+		if entry.Count == 0 {
+			t.Errorf("ITunesMhohEncoding[0x%02X].Count == 0; expected corpus-derived count", hohmType)
+		}
+	}
+}
+
+// TestMhohEncodingTable_AllHeaderLen24 verifies the global corpus invariant:
+// every iTunes-authored mhoh block has headerLen == 24. No entry in the table
+// should deviate from this.
+func TestMhohEncodingTable_AllHeaderLen24(t *testing.T) {
+	for hohmType, entry := range ITunesMhohEncoding {
+		if entry.HeaderLen != 24 {
+			t.Errorf("ITunesMhohEncoding[0x%02X].HeaderLen = %d; want 24",
+				hohmType, entry.HeaderLen)
+		}
+	}
+}
+
+// TestMhohEncodingTable_At27Uniform verifies that every text string type in
+// the table has At27Uniform == true. This is the core CRIT-1 assertion:
+// iTunes writes byte +27 as 0x00 in all text string blocks.
+func TestMhohEncodingTable_At27Uniform(t *testing.T) {
+	for hohmType, entry := range ITunesMhohEncoding {
+		if !entry.At27Uniform {
+			t.Errorf("ITunesMhohEncoding[0x%02X].At27Uniform = false; "+
+				"all text string types must have At27Uniform = true (CRIT-1)",
+				hohmType)
+		}
+	}
+}
+
+// TestMhohEncodingTable_AllowedAt24Values verifies that every entry in the
+// table has at least one AllowedAt24 value, and that all allowed values are
+// in the known set {0, 1, 2, 3}. Values outside this range would indicate a
+// binary-blob type accidentally included in the table.
+func TestMhohEncodingTable_AllowedAt24Values(t *testing.T) {
+	knownValues := map[uint32]bool{0: true, 1: true, 2: true, 3: true}
+
+	for hohmType, entry := range ITunesMhohEncoding {
+		if len(entry.AllowedAt24) == 0 {
+			t.Errorf("ITunesMhohEncoding[0x%02X].AllowedAt24 is empty", hohmType)
+			continue
+		}
+		for _, v := range entry.AllowedAt24 {
+			if !knownValues[v] {
+				t.Errorf("ITunesMhohEncoding[0x%02X].AllowedAt24 contains %d; "+
+					"only {0, 1, 2, 3} are valid encoding indicators in iTunes-authored blocks",
+					hohmType, v)
+			}
+		}
+	}
+}
+
+// TestMhohEncodingTable_LocalURLASCIIOnly verifies that the 0x0B (LocalURL)
+// type only permits encoding values {0, 2} — pure ASCII / percent-encoded
+// values. LocalURL is always percent-encoded (RFC 3986), so UTF-16LE (3) or
+// Windows-1252 (1) must never appear.
+func TestMhohEncodingTable_LocalURLASCIIOnly(t *testing.T) {
+	entry, ok := ITunesMhohEncoding[0x0B]
+	if !ok {
+		t.Fatal("ITunesMhohEncoding missing type 0x0B (LocalURL)")
+	}
+	for _, v := range entry.AllowedAt24 {
+		if v != 0 && v != 2 {
+			t.Errorf("ITunesMhohEncoding[0x0B].AllowedAt24 contains %d; "+
+				"LocalURL is always ASCII-encoded (at24 ∈ {0, 2}); "+
+				"values 1 (latin1) or 3 (utf16le) would indicate a corrupt block",
+				v)
+		}
+	}
+}
+
+// TestMhohEncodingTable_AllowedAt24Contains verifies that
+// MhohEncodingEntry.AllowedAt24Contains works correctly for boundary cases.
+func TestMhohEncodingTable_AllowedAt24Contains(t *testing.T) {
+	entry := MhohEncodingEntry{
+		HeaderLen:   24,
+		AllowedAt24: []uint32{1, 3},
+		At27Uniform: true,
+		Count:       100,
+	}
+
+	tests := []struct {
+		v    uint32
+		want bool
+	}{
+		{0, false},
+		{1, true},
+		{2, false},
+		{3, true},
+		{4, false},
+		{999, false},
+	}
+
+	for _, tt := range tests {
+		got := entry.AllowedAt24Contains(tt.v)
+		if got != tt.want {
+			t.Errorf("AllowedAt24Contains(%d) = %v; want %v", tt.v, got, tt.want)
+		}
+	}
+}
+
+// TestMhohEncodingTable_CriticalTypes verifies the specific corpus-derived
+// values for the types most critical to CRIT-1 / SPEC 2 correctness.
+// These values were derived from 965,223 blocks in the golden iTunes library
+// (version 12.13.10.3, 94,575 tracks, audited 2026-06-09).
+func TestMhohEncodingTable_CriticalTypes(t *testing.T) {
+	tests := []struct {
+		hohmType    uint32
+		name        string
+		wantAt24    []uint32
+		minCount    int
+	}{
+		// 0x02 Name: Latin-1 (1) and UTF-16LE (3) observed; 94,575 tracks.
+		{0x02, "Name", []uint32{1, 3}, 90000},
+		// 0x0B LocalURL: ASCII only ({0, 2}); 94,201 blocks.
+		{0x0B, "LocalURL", []uint32{0, 2}, 90000},
+		// 0x0D Location: Latin-1 and UTF-16LE; 93,014 blocks.
+		{0x0D, "Location", []uint32{1, 3}, 90000},
+		// 0x06 Kind: UTF-16LE only; 93,539 blocks (iTunes encodes Kind as UTF-16LE exclusively).
+		{0x06, "Kind", []uint32{3}, 90000},
+	}
+
+	for _, tt := range tests {
+		entry, ok := ITunesMhohEncoding[tt.hohmType]
+		if !ok {
+			t.Errorf("type 0x%02X (%s): missing from table", tt.hohmType, tt.name)
+			continue
+		}
+
+		if entry.Count < tt.minCount {
+			t.Errorf("type 0x%02X (%s): Count=%d; want >= %d",
+				tt.hohmType, tt.name, entry.Count, tt.minCount)
+		}
+
+		// Verify AllowedAt24 contains exactly the expected values (no more, no fewer).
+		wantSet := make(map[uint32]bool)
+		for _, v := range tt.wantAt24 {
+			wantSet[v] = true
+		}
+		gotSet := make(map[uint32]bool)
+		for _, v := range entry.AllowedAt24 {
+			gotSet[v] = true
+		}
+		for v := range wantSet {
+			if !gotSet[v] {
+				t.Errorf("type 0x%02X (%s): AllowedAt24 missing value %d",
+					tt.hohmType, tt.name, v)
+			}
+		}
+		for v := range gotSet {
+			if !wantSet[v] {
+				t.Errorf("type 0x%02X (%s): AllowedAt24 has unexpected value %d",
+					tt.hohmType, tt.name, v)
+			}
+		}
+	}
+}
+
+// TestMhohEncodingTable_DeriveFromAudit exercises DeriveEncodingTable with a
+// synthetic audit report and verifies that the derivation produces a correct
+// table. This tests the DeriveEncodingTable function used when the audit tool
+// is run against a real library.
+func TestMhohEncodingTable_DeriveFromAudit(t *testing.T) {
+	report := &MhohAuditReport{
+		LibraryVersion:  "12.13.10.3",
+		TotalMhohBlocks: 100,
+		PerType: map[string]*MhohTypeAudit{
+			"2": {
+				HohmTypeHex:     "0x02",
+				Count:           60,
+				HeaderLenValues: map[string]int{"24": 60},
+				At24Values:      map[string]int{"1": 50, "3": 10},
+				At27Values:      map[string]int{"0": 60},
+				TailZero:        map[string]int{"true": 60},
+				LenArithmeticOK: map[string]int{"true": 60},
+			},
+			"11": {
+				HohmTypeHex:     "0x0B",
+				Count:           40,
+				HeaderLenValues: map[string]int{"24": 40},
+				At24Values:      map[string]int{"0": 20, "2": 20},
+				At27Values:      map[string]int{"0": 40},
+				TailZero:        map[string]int{"true": 40},
+				LenArithmeticOK: map[string]int{"true": 40},
+			},
+			// Non-uniform headerLen — should be excluded from derived table.
+			"13": {
+				HohmTypeHex:     "0x0D",
+				Count:           30,
+				HeaderLenValues: map[string]int{"24": 20, "41": 10}, // mixed — exclude
+				At24Values:      map[string]int{"1": 30},
+				At27Values:      map[string]int{"0": 30},
+				TailZero:        map[string]int{"true": 30},
+				LenArithmeticOK: map[string]int{"true": 30},
+			},
+		},
+	}
+
+	table := DeriveEncodingTable(report)
+
+	// Type 2 (Name) should be in the table.
+	e, ok := table[2]
+	if !ok {
+		t.Fatal("DeriveEncodingTable: type 2 missing from derived table")
+	}
+	if e.HeaderLen != 24 {
+		t.Errorf("derived table[2].HeaderLen = %d; want 24", e.HeaderLen)
+	}
+	if !e.AllowedAt24Contains(1) || !e.AllowedAt24Contains(3) {
+		t.Errorf("derived table[2].AllowedAt24 = %v; want {1, 3}", e.AllowedAt24)
+	}
+	if !e.At27Uniform {
+		t.Errorf("derived table[2].At27Uniform = false; want true")
+	}
+
+	// Type 11 (LocalURL) should be in the table with {0, 2}.
+	e11, ok := table[11]
+	if !ok {
+		t.Fatal("DeriveEncodingTable: type 11 (0x0B) missing from derived table")
+	}
+	if !e11.AllowedAt24Contains(0) || !e11.AllowedAt24Contains(2) {
+		t.Errorf("derived table[11].AllowedAt24 = %v; want {0, 2}", e11.AllowedAt24)
+	}
+
+	// Type 13 (Location) should NOT be in the derived table (non-uniform headerLen).
+	if _, ok := table[13]; ok {
+		t.Errorf("DeriveEncodingTable: type 13 (0x0D) should be excluded due to non-uniform headerLen")
+	}
+}


### PR DESCRIPTION
## Summary

- **`cmd/itl-audit-encoding`**: CLI that decrypts/inflates an `.itl`, walks all `mhoh` string blocks across `msdh` container types 1/2/9/11, and emits a per-`hohmType` histogram (encoding fields at +24/+27, headerLen, len arithmetic, tail-zero) as JSON.
- **`internal/itunes/mhoh_encoding_audit.go`**: `AuditMhohEncoding()`, `walkContainerForMhoh()`, `DeriveEncodingTable()` — reuses existing helpers (`DecryptAndInflateITL`, `findMsdhByType`, `readTag`, `readUint32LE`).
- **`internal/itunes/mhoh_encoding_table.go`**: `ITunesMhohEncoding` map — 44 text-string `hohmType` entries derived from golden corpus (iTunes Library.itl v12.13.10.3, 965,223 mhoh blocks across 94,575 tracks). Confirms: `headerLen==24` uniform, byte `+27==0x00` for all text types (CRIT-1 fix basis), bytes `+32..+39` zero, encoding indicator at `+24` ∈ `{0=ASCII, 1=Latin-1, 2=UTF-8, 3=UTF-16LE}`.
- **`internal/itunes/mhoh_encoding_table_test.go`**: 8 table sanity tests covering required guard types, `headerLen` uniformity, `At27Uniform` invariant, `AllowedAt24` value range, LocalURL ASCII-only constraint, `AllowedAt24Contains` helper, critical-type corpus values, and `DeriveEncodingTable` with synthetic audit data.

**Salvage note:** The prior agent built all code but died at a usage limit before verification. This salvage commit re-ran the audit tool against the golden corpus, cross-checked every entry in the table against live output, and added 3 missing text types (`0x15`, `0x69`, `0x6C`) that were confirmed in the corpus but absent from the inherited table.

## Golden corpus provenance

- Path: `/tmp/itunes-libraries/iTunes Library.itl`
- iTunes version: `12.13.10.3`
- Total mhoh blocks audited: `965,223`
- Total containers walked: `4` (msdh types 1, 2, 9, 11)
- All 41 originally-present table entries verified exact match against corpus.
- 3 additional text types added from corpus: `0x15` (9,874 blocks), `0x69` (678 blocks), `0x6C` (338 blocks).
- Binary-blob types (`0x36`, `0x38`, `0x65`, `0x66`, `0x67`, `0x6D`, `0x13`, `0x192`) intentionally excluded — their `+27` is non-zero and `+24` contains non-encoding data.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/itunes/... -count=1` — 8 new mhoh tests pass, full package passes
- [x] `make test` — full backend test suite passes (exit 0)
- [x] Audit tool ran successfully against golden corpus (`go run ./cmd/itl-audit-encoding`)
- [x] All 41 pre-existing table entries verified against live corpus output (exact match)
- [x] 3 missing text types identified and added

## COMPLETED: 5 — all verification steps, table correction (3 missing types added), commit, push, PR
## REMAINING: 0
## BLOCKED: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)