### PR TITLE
feat(itunes): ITLSafetyContract — 8 write guards + regression suite (fable5 T003)

### DIFF
--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -1,0 +1,1200 @@
+// file: internal/itunes/itl_safety_contract.go
+// version: 1.0.0
+// guid: 404bbed1-87ba-4e56-b9e4-a492a2281163
+//
+// ITLSafetyContract — the iTunes writeback write-safety contract (fable5 TASK-003).
+//
+// This file implements SPEC 2 §2 (docs/specs/fable5-spec-itunes-writeback-hardening.md):
+// an ordered list of named, individually-testable guards that run over a
+// (before, after) pair of DECOMPRESSED little-endian ITL payloads plus the
+// proposed hdfm header. The contract is DETECTION ONLY — no byte written to
+// disk, no writer behavior changed. SafeWriteITL (TASK-004) wires it in.
+//
+// Why this exists: a corrupt .itl destroys years of curated iTunes playlists.
+// Four production libraries were renamed "(Damaged)" by iTunes; the empirical
+// corruption classes (K1..K12, SPEC §1) are guarded here. Each guard cites the
+// K-number(s) it catches in its doc comment.
+//
+// Every guard returns a structured GuardResult with per-Violation offset/chunk/
+// message — never a bare bool — because auditability is part of the contract
+// (SPEC §2). All guards must pass before any byte reaches disk.
+
+package itunes
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Contract types (NORMATIVE — SPEC 2 §2)
+// ---------------------------------------------------------------------------
+
+// Violation is a single structured finding from a guard. Offset is the payload
+// byte offset of the offending chunk (or -1 when not byte-addressable, e.g. a
+// header-vs-payload count mismatch). Chunk is the 4-byte chunk tag the problem
+// was found in ("mhoh", "mith", "miph", "hdfm", ...).
+type Violation struct {
+	Offset  int
+	Chunk   string
+	Message string
+}
+
+// GuardResult is the outcome of one guard. Violations empty == pass.
+type GuardResult struct {
+	Guard      string // stable name, e.g. "mhoh-format" — normative for tests
+	Violations []Violation
+}
+
+// Pass reports whether the guard found no violations.
+func (r GuardResult) Pass() bool { return len(r.Violations) == 0 }
+
+// ContractSummary captures coarse counts for both payloads, surfaced in the
+// verdict for audit logs / diagnostics.
+type ContractSummary struct {
+	BeforeTracks    int
+	AfterTracks     int
+	AfterPlaylists  int
+	AfterMhohBlocks int
+}
+
+// ContractVerdict is the aggregate result of running every guard.
+type ContractVerdict struct {
+	Pass    bool
+	Results []GuardResult
+	Summary ContractSummary
+}
+
+// FailedGuards returns the names of guards that produced at least one violation.
+func (v ContractVerdict) FailedGuards() []string {
+	var names []string
+	for _, r := range v.Results {
+		if !r.Pass() {
+			names = append(names, r.Guard)
+		}
+	}
+	return names
+}
+
+// Error renders a stable, log-friendly summary of all violations. Returns "" if
+// the verdict passed (so callers can do `if e := v.Error(); e != "" { ... }`).
+func (v ContractVerdict) Error() string {
+	if v.Pass {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("ITLSafetyContract REJECTED write:")
+	for _, r := range v.Results {
+		if r.Pass() {
+			continue
+		}
+		for _, viol := range r.Violations {
+			fmt.Fprintf(&b, " [%s@%d/%s: %s]", r.Guard, viol.Offset, viol.Chunk, viol.Message)
+		}
+	}
+	return b.String()
+}
+
+// ContractConfig holds the tunable guardrails (SPEC 2 §2, `bounded-delta`).
+type ContractConfig struct {
+	// RemovedTracksMax: a single writeback may not remove more than this many
+	// tracks without Force. Default 5000.
+	RemovedTracksMax int
+	// RewrittenMhohPctMax: a single writeback may not rewrite more than this
+	// percent of mhoh blocks without Force. Default 20.
+	RewrittenMhohPctMax int
+	// Force overrides the bounded-delta guardrail only. It does NOT disable any
+	// structural guard — corruption is never opt-out.
+	Force bool
+}
+
+// DefaultContractConfig returns the SPEC-mandated defaults.
+func DefaultContractConfig() ContractConfig {
+	return ContractConfig{
+		RemovedTracksMax:    5000,
+		RewrittenMhohPctMax: 20,
+		Force:               false,
+	}
+}
+
+// guardFn is the pure-function shape every guard satisfies. `before` may be nil
+// in single-library audit mode (AuditITL).
+type guardFn func(before, after []byte, hdr *hdfmHeader, cfg ContractConfig) GuardResult
+
+// orderedGuards lists guards cheapest-first; the order is normative (SPEC §2).
+func orderedGuards() []guardFn {
+	return []guardFn{
+		guardParseRoundtrip,
+		guardContainerTiling,
+		guardCountCoherence,
+		guardNoNewDanglingRefs,
+		guardMhohFormat,
+		guardLocationForm,
+		guardTidPidSanity,
+		guardBoundedDelta,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// RunSafetyContract runs every guard over the (before, after) decompressed LE
+// payloads and the proposed hdfm header, returning the aggregate verdict.
+//
+// `after` is the proposed payload that would be written; `before` is the
+// last-known-good payload (may be nil in audit mode). `hdr` is the proposed
+// hdfm header carrying the BE count fields at file offsets 0x44/0x48/0x4C/0x54
+// — pass the header that WILL be written so K2 (stale-count) is checkable
+// before encryption/compression. cfg may be the zero value, in which case the
+// SPEC defaults are applied.
+func RunSafetyContract(before, after []byte, hdr *hdfmHeader, cfg ContractConfig) ContractVerdict {
+	cfg = normalizeConfig(cfg)
+
+	verdict := ContractVerdict{Pass: true, Summary: summarize(before, after)}
+	for _, g := range orderedGuards() {
+		res := g(before, after, hdr, cfg)
+		verdict.Results = append(verdict.Results, res)
+		if !res.Pass() {
+			verdict.Pass = false
+		}
+	}
+	return verdict
+}
+
+// AuditITL runs the contract in single-library mode (before == nil) against an
+// already-on-disk library, closing HIGH-6: a library corrupted by an old writer
+// (K5 carrier) is detectable at read time. `data` is the raw .itl file bytes;
+// it is parsed (decrypt + fail-closed inflate) here. The bounded-delta and
+// no-new-dangling-refs guards degrade gracefully with no `before` (they only
+// assert absolute properties of `after`).
+func AuditITL(data []byte) ContractVerdict {
+	hdr, payload, err := decodeITLForContract(data)
+	if err != nil {
+		// Fail closed: an un-decodable library is a violation, not a pass.
+		return ContractVerdict{
+			Pass: false,
+			Results: []GuardResult{{
+				Guard: "parse-roundtrip",
+				Violations: []Violation{{
+					Offset: 0, Chunk: "hdfm",
+					Message: fmt.Sprintf("library does not decode: %v", err),
+				}},
+			}},
+		}
+	}
+	return RunSafetyContract(nil, payload, hdr, DefaultContractConfig())
+}
+
+// ---------------------------------------------------------------------------
+// Guard: parse-roundtrip  (catches MED-7, gross corruption)
+// ---------------------------------------------------------------------------
+
+// guardParseRoundtrip asserts `after` is a recognizable LE payload whose master
+// track list can be located. It FAILS CLOSED (inverting the historic fail-open
+// behavior of VerifyITLNoDanglingRefsLE, MED-7) when the payload is not LE, the
+// master-list msdh is unlocatable, or no tracks are present — precisely the
+// states where a library is most damaged.
+//
+// Catches: MED-7 (silent inflate failure → garbage parse), and gross splice
+// corruption that destroys the msdh framing. Also enforces the BE-refusal
+// posture (K12): a BE payload does not begin with "msdh", so it fails here.
+func guardParseRoundtrip(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "parse-roundtrip"
+	if len(after) < 16 {
+		return fail(name, 0, "", "payload too small to be a valid ITL payload")
+	}
+	if !detectLE(after) {
+		// BE or corrupt: refuse. The contract is LE-only; BE writes are refused
+		// rather than guarded (SPEC K12 / LOW-2).
+		return fail(name, 0, readTag(after, 0), "payload is not little-endian (does not start with 'msdh'); BE writeback is refused")
+	}
+	msdhOffset, _, _ := findMsdhByType(after, 1)
+	if msdhOffset < 0 {
+		return fail(name, 0, "msdh", "master track-list msdh (blockType 1) not locatable — fail closed (MED-7)")
+	}
+	tids := CollectMasterTrackIDsLE(after)
+	if tids == nil {
+		return fail(name, msdhOffset, "msdh", "master track list unparseable — fail closed (MED-7)")
+	}
+	if len(tids) == 0 {
+		return fail(name, msdhOffset, "mlth", "master track list parsed to zero tracks — fail closed")
+	}
+	return pass(name)
+}
+
+// ---------------------------------------------------------------------------
+// Guard: container-tiling  (catches truncation/splice errors)
+// ---------------------------------------------------------------------------
+
+// guardContainerTiling asserts the top-level msdh containers tile the payload
+// exactly: every container's totalLen is sane, they are contiguous with no gap
+// or overlap, and they cover the payload to its end. It also descends into the
+// track (type 1) and playlist (type 2) containers and verifies their immediate
+// children walk to contentEnd with no trailing gap.
+//
+// Catches: truncation and splice errors that leave a hole or overrun (the class
+// behind a shrunk msdh totalLen — see TestContract_TruncatedContainer).
+func guardContainerTiling(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "container-tiling"
+	var viol []Violation
+
+	offset := 0
+	for offset+16 <= len(after) {
+		tag := readTag(after, offset)
+		if tag != "msdh" {
+			viol = append(viol, Violation{Offset: offset, Chunk: tag, Message: fmt.Sprintf("expected 'msdh' container at offset %d, found %q", offset, tag)})
+			break
+		}
+		headerLen := int(readUint32LE(after, offset+4))
+		totalLen := int(readUint32LE(after, offset+8))
+		blockType := int(readUint32LE(after, offset+12))
+
+		if totalLen < 16 {
+			viol = append(viol, Violation{Offset: offset, Chunk: "msdh", Message: fmt.Sprintf("msdh totalLen %d < 16", totalLen)})
+			break
+		}
+		if headerLen < 16 || headerLen > totalLen {
+			viol = append(viol, Violation{Offset: offset, Chunk: "msdh", Message: fmt.Sprintf("msdh headerLen %d out of range (totalLen %d)", headerLen, totalLen)})
+			break
+		}
+		if offset+totalLen > len(after) {
+			viol = append(viol, Violation{Offset: offset, Chunk: "msdh", Message: fmt.Sprintf("msdh totalLen %d overruns payload end (offset %d, len %d)", totalLen, offset, len(after))})
+			break
+		}
+
+		// Verify the immediate children of types 1 and 2 tile [contentStart,contentEnd).
+		if blockType == 1 || blockType == 2 {
+			if gapOff, ok := childWalkGap(after, offset+headerLen, offset+totalLen); !ok {
+				viol = append(viol, Violation{Offset: gapOff, Chunk: "msdh", Message: fmt.Sprintf("child chunks of msdh type %d do not tile to contentEnd (gap/overrun near offset %d)", blockType, gapOff)})
+			}
+		}
+
+		offset += totalLen
+	}
+
+	if offset != len(after) && len(viol) == 0 {
+		viol = append(viol, Violation{Offset: offset, Chunk: "msdh", Message: fmt.Sprintf("msdh containers do not tile payload exactly: covered %d of %d bytes", offset, len(after))})
+	}
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// childWalkGap walks the chunks in [start,end) advancing by each chunk's span
+// (totalLen for containers that carry children, else headerLen) and reports
+// whether the walk reaches exactly `end`. Returns (gapOffset, ok).
+func childWalkGap(data []byte, start, end int) (int, bool) {
+	offset := start
+	for offset+12 <= end {
+		tag := readTag(data, offset)
+		if tag == "" {
+			return offset, false
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == "mith" || tag == "mhoh" || tag == "miah" || tag == "miph") && totalLen > headerLen && offset+totalLen <= end {
+			span = totalLen
+		}
+		if span < 8 || offset+span > end {
+			return offset, false
+		}
+		offset += span
+	}
+	return offset, offset == end
+}
+
+// ---------------------------------------------------------------------------
+// Guard: count-coherence  (catches K2, K8 — the CRIT-3 header desync)
+// ---------------------------------------------------------------------------
+
+// guardCountCoherence asserts the proposed hdfm header's BE count fields agree
+// with the actual payload, and that every miph's declared item count matches its
+// actual mtph children. This is the guard for CRIT-3 / K2: damaged-1/2 carried a
+// header that said 90,900 tracks while the payload had 90,898.
+//
+//	header @0x44 (BE) == mlth track count == actual mith blocks
+//	header @0x48 (BE) == miph (playlist) count
+//	header @0x4C (BE) == miah (album) count
+//	header @0x54 (BE) == miih (artist) count
+//	per-miph declared count (+16) == actual mtph children   (K8)
+//
+// The header offsets are file-absolute; we reconstruct the full hdfm bytes from
+// the proposed header so the same 0x44/0x48/0x4C/0x54 offsets used everywhere in
+// the spec apply directly.
+func guardCountCoherence(_, after []byte, hdr *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "count-coherence"
+	var viol []Violation
+
+	actualTracks, actualMith := countMasterTracks(after)
+	actualPlaylists, miphViol := countPlaylistsAndCheckMiph(after)
+	actualAlbums := countMsdhItems(after, 9, "miah")
+	actualArtists := countMsdhItems(after, 11, "miih")
+
+	if actualTracks != actualMith {
+		viol = append(viol, Violation{Offset: -1, Chunk: "mlth", Message: fmt.Sprintf("mlth count %d != actual mith blocks %d", actualTracks, actualMith)})
+	}
+
+	if hdr != nil {
+		full := reconstructHdfmHeader(hdr)
+		check := func(off int, field string, want int) {
+			if off+4 > len(full) {
+				return // header too short to carry this field; not our class to flag
+			}
+			got := int(readUint32BE(full, off))
+			if got != want {
+				viol = append(viol, Violation{Offset: -1, Chunk: "hdfm", Message: fmt.Sprintf("header @0x%X %s=%d != payload count %d (K2/CRIT-3)", off, field, got, want)})
+			}
+		}
+		check(0x44, "tracks", actualMith)
+		check(0x48, "playlists", actualPlaylists)
+		check(0x4C, "albums", actualAlbums)
+		check(0x54, "artists", actualArtists)
+	}
+
+	viol = append(viol, miphViol...)
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// ---------------------------------------------------------------------------
+// Guard: no-new-dangling-refs  (catches K1 — wraps existing verifier, fail-closed)
+// ---------------------------------------------------------------------------
+
+// guardNoNewDanglingRefs wraps the existing VerifyITLNoNewDanglingRefsLE
+// (itl_le_verify.go) and converts it to fail-closed (MED-7): if the master list
+// cannot be collected from `after`, that is itself a violation here rather than
+// a silent pass. In audit mode (before == nil) it asserts the absolute property
+// that `after` carries no dangling mtph refs at all.
+//
+// Catches: K1 — orphan mtph items left behind when mith blocks are excised
+// (the May-2026 corruption class; damaged-1 had 6 orphans across 3 miph parents).
+func guardNoNewDanglingRefs(before, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "no-new-dangling-refs"
+
+	tids := CollectMasterTrackIDsLE(after)
+	if tids == nil {
+		return fail(name, 0, "msdh", "master track list unlocatable — fail closed (was fail-open, MED-7)")
+	}
+	dangling := FindDanglingMtphRefsLE(after, tids)
+	if len(dangling) == 0 {
+		return pass(name)
+	}
+
+	// Subtract pre-existing orphans (iTunes tolerates a small number that were
+	// already present in `before`); only NEW dangling refs are a violation.
+	preExisting := map[uint32]struct{}{}
+	if before != nil && detectLE(before) {
+		if beforeTIDs := CollectMasterTrackIDsLE(before); beforeTIDs != nil {
+			for _, tid := range FindDanglingMtphRefsLE(before, beforeTIDs) {
+				preExisting[tid] = struct{}{}
+			}
+		}
+	}
+
+	var introduced []uint32
+	for _, tid := range dangling {
+		if _, ok := preExisting[tid]; !ok {
+			introduced = append(introduced, tid)
+		}
+	}
+	if len(introduced) == 0 {
+		return pass(name)
+	}
+	sort.Slice(introduced, func(i, j int) bool { return introduced[i] < introduced[j] })
+	return fail(name, -1, "mtph", fmt.Sprintf("%d new dangling playlist→track refs (e.g. TrackIDs %v)", len(introduced), previewU32(introduced)))
+}
+
+// ---------------------------------------------------------------------------
+// Guard: mhoh-format  (catches K3, K5, K7 — the CRIT-1 encoding-flag class)
+// ---------------------------------------------------------------------------
+
+// guardMhohFormat enforces the per-block mhoh byte invariants iTunes-authored
+// libraries satisfy (SPEC §2, §4; T002 corpus table ITunesMhohEncoding):
+//
+//	headerLen == 24            (K5: damaged-1 had ~60K blocks with headerLen 41–210)
+//	byte +27   == 0x00         (K3: iTunes writes 0; our old encoder stamped 1/3)
+//	totalLen   == 40 + strLen  (K7: length-prefix arithmetic)
+//	bytes +32..+39 all zero
+//	+24 ∈ ITunesMhohEncoding[type].AllowedAt24   (when the type is in the table)
+//
+// SCOPE — which mhoh types are checked, and why:
+//   - The T002 corpus table ITunesMhohEncoding enumerates the TEXT-STRING mhoh
+//     types. Types ABSENT from the table are binary-blob payloads (0x36 raw
+//     audio, 0x65 SmartCriteria, 0x66 SmartInfo, ...) whose +24..+39 bytes are
+//     NOT a string-encoding header — applying the format check to them yields
+//     false positives. So format checks (headerLen/+27/len-arithmetic/tail-zero)
+//     are applied only to types present in the table.
+//   - Three IN-table types (0x15, 0x69, 0x6C) are documented in the table as
+//     having a NON-STANDARD length layout (tail_zero=false; totalLen != 40+strLen
+//     does not hold), yet their encoding indicator is text-style. For those we
+//     skip the len-arithmetic + tail-zero checks but still enforce headerLen==24,
+//     +27==0, and +24 ∈ AllowedAt24. This mirrors the corpus exactly.
+func guardMhohFormat(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "mhoh-format"
+	var viol []Violation
+
+	forEachMhoh(after, func(offset, span int) {
+		hohmType := readUint32LE(after, offset+12)
+		entry, inTable := ITunesMhohEncoding[hohmType]
+		if !inTable {
+			// Binary-blob mhoh type — not a string-encoding header; skip.
+			return
+		}
+
+		headerLen := readUint32LE(after, offset+4)
+		if headerLen != entry.HeaderLen {
+			viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X headerLen=%d, want %d (K5)", hohmType, headerLen, entry.HeaderLen)})
+		}
+
+		// byte +27 must be 0x00 (K3): iTunes' encoding indicator lives at +24.
+		if offset+28 <= len(after) && after[offset+27] != 0x00 {
+			viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X byte +27=0x%02X, want 0x00 (K3: foreign encoding flag)", hohmType, after[offset+27])})
+		}
+
+		// +24 encoding indicator ∈ corpus-allowed set for this type.
+		at24 := readUint32LE(after, offset+24)
+		if !entry.AllowedAt24Contains(at24) {
+			viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X +24 indicator=%d not in corpus set %v (K3)", hohmType, at24, entry.AllowedAt24)})
+		}
+
+		// Length arithmetic + tail-zero only for standard-layout text types.
+		if !mhohNonStandardLen(hohmType) {
+			strLen := int(readUint32LE(after, offset+28))
+			totalLen := int(readUint32LE(after, offset+8))
+			if strLen < 0 || offset+40+strLen > len(after) {
+				viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X strLen=%d out of bounds (K7)", hohmType, strLen)})
+			} else if totalLen != 40+strLen {
+				viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X totalLen=%d != 40+strLen=%d (K7)", hohmType, totalLen, 40+strLen)})
+			}
+			// bytes +32..+39 must be zero.
+			if offset+40 <= len(after) {
+				for i := offset + 32; i < offset+40; i++ {
+					if after[i] != 0 {
+						viol = append(viol, Violation{Offset: offset, Chunk: "mhoh", Message: fmt.Sprintf("type 0x%X byte +%d=0x%02X, want 0x00 (reserved tail)", hohmType, i-offset, after[i])})
+						break
+					}
+				}
+			}
+		}
+	})
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// mhohNonStandardLen reports whether a hohmType is one of the three corpus types
+// (0x15, 0x69, 0x6C) documented in ITunesMhohEncoding as having a non-standard
+// length layout (totalLen != 40+strLen, tail not zeroed). These are exempt from
+// the length-arithmetic and tail-zero checks but not from headerLen/+24/+27.
+func mhohNonStandardLen(hohmType uint32) bool {
+	switch hohmType {
+	case 0x15, 0x69, 0x6C:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Guard: location-form  (catches K4 + staging-dir leak — the CRIT-2 class)
+// ---------------------------------------------------------------------------
+
+// guardLocationForm enforces the NORMATIVE Location field contract (SPEC §1b),
+// per-track, on DECODED strings (0x0D may be UTF-16-encoded — 1,736 of golden's
+// 93,014 are):
+//
+//   - if a track has a 0x0D, it must decode to a Windows absolute path
+//     (drive letter + ':\', backslashes, NO "file://", NO "%"-escapes), and its
+//     sibling 0x0B must be a "file://localhost/" URL that round-trips to the same
+//     path (\\→/, RFC-3986 escaping).
+//   - tracks WITHOUT a 0x0D (podcast/stream entries — 1,187 in golden) may carry
+//     any http(s):// URL in 0x0B and are exempt from the pairing rule.
+//   - NO value (0x0B or 0x0D) may contain ".itunes-writeback/" or other staging
+//     markers (damaged-4 leaked staging-dir paths).
+//
+// Catches: K4 (URL written into 0x0D) and the staging-path leak.
+func guardLocationForm(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "location-form"
+	var viol []Violation
+
+	forEachTrackLocations(after, func(trackOffset int, loc0D, loc0B string, has0D, has0B bool) {
+		// Staging-dir leak: applies to either field, present or not.
+		for _, pair := range []struct {
+			present bool
+			val     string
+			field   string
+		}{{has0D, loc0D, "0x0D"}, {has0B, loc0B, "0x0B"}} {
+			if pair.present && strings.Contains(pair.val, ".itunes-writeback/") {
+				viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("%s contains staging marker '.itunes-writeback/': %q", pair.field, truncStr(pair.val))})
+			}
+		}
+
+		if !has0D {
+			// Podcast/stream: 0x0B may hold http(s):// — no pairing requirement.
+			return
+		}
+
+		// 0x0D must be a native Windows absolute path.
+		if !isWindowsAbsPath(loc0D) {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location is not a Windows absolute path: %q (K4)", truncStr(loc0D))})
+		}
+		if strings.Contains(strings.ToLower(loc0D), "file://") {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location contains 'file://' — iTunes stores a native path here (K4): %q", truncStr(loc0D))})
+		}
+		if strings.Contains(loc0D, "%") {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location contains '%%'-escape — native path must be unescaped (K4): %q", truncStr(loc0D))})
+		}
+
+		// Sibling 0x0B must be a round-tripping file://localhost/ URL.
+		if !has0B {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: "track with 0x0D Location is missing its sibling 0x0B LocalURL"})
+			return
+		}
+		if !strings.HasPrefix(loc0B, "file://localhost/") {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0B LocalURL is not a 'file://localhost/' URL: %q", truncStr(loc0B))})
+			return
+		}
+		if want := winPathToLocalURL(loc0D); want != loc0B {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0B LocalURL does not round-trip 0x0D path: got %q, want %q", truncStr(loc0B), truncStr(want))})
+		}
+	})
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// ---------------------------------------------------------------------------
+// Guard: tid-pid-sanity  (catches K6, K9, K11)
+// ---------------------------------------------------------------------------
+
+// guardTidPidSanity asserts the master track list has strictly ascending,
+// unique TrackIDs and unique, nonzero persistent IDs (PIDs). golden is
+// TID-sorted and duplicate-free; this is cheap to keep as a primary assertion.
+//
+// Catches: K6 (TID gaps/duplicates), K9 (PID collisions), K11 (mith ordering).
+func guardTidPidSanity(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+	const name = "tid-pid-sanity"
+	var viol []Violation
+
+	tids, pids := collectMithTidsPids(after)
+
+	prev := int64(-1)
+	for _, t := range tids {
+		if int64(t) <= prev {
+			viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: fmt.Sprintf("TrackIDs not strictly ascending/unique: %d follows %d (K6/K11)", t, prev)})
+			break
+		}
+		prev = int64(t)
+	}
+
+	seen := make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		if p == "0000000000000000" {
+			viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: "track has zero persistent ID (K9)"})
+			break
+		}
+		if _, dup := seen[p]; dup {
+			viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: fmt.Sprintf("duplicate persistent ID %s (K9)", p)})
+			break
+		}
+		seen[p] = struct{}{}
+	}
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// ---------------------------------------------------------------------------
+// Guard: bounded-delta  (blast-radius cap for HIGH-3-style bugs)
+// ---------------------------------------------------------------------------
+
+// guardBoundedDelta is the guardrail: a single writeback may not remove more
+// than cfg.RemovedTracksMax tracks (default 5000) nor rewrite more than
+// cfg.RewrittenMhohPctMax percent of mhoh blocks (default 20) unless cfg.Force.
+// In audit mode (before == nil) there is no delta to bound, so it passes.
+//
+// Catches: the blast-radius class behind HIGH-3 (writeback that re-stamps nearly
+// the whole library every sync) — a runaway removal or rewrite is refused before
+// it reaches disk.
+func guardBoundedDelta(before, after []byte, _ *hdfmHeader, cfg ContractConfig) GuardResult {
+	const name = "bounded-delta"
+	if before == nil || cfg.Force {
+		return pass(name)
+	}
+	var viol []Violation
+
+	beforeTracks, _ := countMasterTracks(before)
+	afterTracks, _ := countMasterTracks(after)
+	removed := beforeTracks - afterTracks
+	if removed > cfg.RemovedTracksMax {
+		viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: fmt.Sprintf("writeback removes %d tracks > cap %d (set Force to override)", removed, cfg.RemovedTracksMax)})
+	}
+
+	beforeMhoh := countMhohBlocks(before)
+	if beforeMhoh > 0 {
+		rewritten := mhohRewriteCount(before, after)
+		pct := rewritten * 100 / beforeMhoh
+		if pct > cfg.RewrittenMhohPctMax {
+			viol = append(viol, Violation{Offset: -1, Chunk: "mhoh", Message: fmt.Sprintf("writeback rewrites %d%% of mhoh blocks > cap %d%% (set Force to override)", pct, cfg.RewrittenMhohPctMax)})
+		}
+	}
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — payload walking
+// ---------------------------------------------------------------------------
+
+// forEachMhoh invokes fn(offset, span) for every mhoh block in the payload,
+// descending into msdh containers (types 1, 2, 9, 11) and their mith/miah/miph
+// children. span is the chunk's full byte length (totalLen for containers).
+func forEachMhoh(data []byte, fn func(offset, span int)) {
+	walkTopMsdh(data, func(msdhOffset, headerLen, totalLen, blockType int) {
+		walkChunksForMhoh(data, msdhOffset+headerLen, msdhOffset+totalLen, fn)
+	})
+}
+
+// walkChunksForMhoh recursively walks [start,end) emitting every mhoh and
+// descending into container chunks that carry children.
+func walkChunksForMhoh(data []byte, start, end int, fn func(offset, span int)) {
+	offset := start
+	for offset+12 <= end {
+		tag := readTag(data, offset)
+		if tag == "" {
+			return
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		isContainer := (tag == "mith" || tag == "mhoh" || tag == "miah" || tag == "miph") && totalLen > headerLen && offset+totalLen <= end
+		if isContainer {
+			span = totalLen
+		}
+		if span < 8 || offset+span > end {
+			return
+		}
+		if tag == "mhoh" {
+			fn(offset, span)
+		} else if isContainer && headerLen >= 8 && headerLen < span {
+			// Descend past the fixed header into children (mith→mhoh, miph→mhoh).
+			walkChunksForMhoh(data, offset+headerLen, offset+span, fn)
+		}
+		offset += span
+	}
+}
+
+// walkTopMsdh invokes fn for each top-level msdh container.
+func walkTopMsdh(data []byte, fn func(offset, headerLen, totalLen, blockType int)) {
+	offset := 0
+	for offset+16 <= len(data) {
+		if readTag(data, offset) != "msdh" {
+			return
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		blockType := int(readUint32LE(data, offset+12))
+		if totalLen < 16 || headerLen < 16 || headerLen > totalLen || offset+totalLen > len(data) {
+			return
+		}
+		fn(offset, headerLen, totalLen, blockType)
+		offset += totalLen
+	}
+}
+
+// countMasterTracks returns (mlth declared count, actual mith block count).
+func countMasterTracks(data []byte) (declared, actual int) {
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, 1)
+	if msdhOffset < 0 {
+		return 0, 0
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	offset := contentStart
+	if contentStart+12 <= contentEnd && readTag(data, contentStart) == "mlth" {
+		declared = int(readUint32LE(data, contentStart+8))
+		offset = contentStart + int(readUint32LE(data, contentStart+4))
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == "mith" || tag == "mhoh" || tag == "miah") && totalLen > headerLen && offset+totalLen <= contentEnd {
+			span = totalLen
+		}
+		if span < 8 || offset+span > contentEnd {
+			break
+		}
+		if tag == "mith" {
+			actual++
+		}
+		offset += span
+	}
+	return declared, actual
+}
+
+// countPlaylistsAndCheckMiph counts miph blocks in the playlist msdh (type 2)
+// and, for each, compares its declared item count (+16) to its actual mtph
+// children — emitting a violation per mismatch (K8).
+func countPlaylistsAndCheckMiph(data []byte) (playlists int, viol []Violation) {
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, 2)
+	if msdhOffset < 0 {
+		return 0, nil
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	offset := contentStart
+	if contentStart+12 <= contentEnd && readTag(data, contentStart) == "mlph" {
+		offset = contentStart + int(readUint32LE(data, contentStart+4))
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == "miph" || tag == "mith" || tag == "mhoh" || tag == "miah") && totalLen > headerLen && offset+totalLen <= contentEnd {
+			span = totalLen
+		}
+		if span < 8 || offset+span > contentEnd {
+			break
+		}
+		if tag == "miph" {
+			playlists++
+			declared := int(readUint32LE(data, offset+16))
+			actual := countMtphChildren(data, offset+headerLen, offset+span)
+			if declared != actual {
+				viol = append(viol, Violation{Offset: offset, Chunk: "miph", Message: fmt.Sprintf("miph declared item count %d != actual mtph children %d (K8)", declared, actual)})
+			}
+		}
+		offset += span
+	}
+	return playlists, viol
+}
+
+// countMtphChildren counts mtph items directly under a miph in [start,end).
+func countMtphChildren(data []byte, start, end int) int {
+	n := 0
+	offset := start
+	for offset+12 <= end {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == "mhoh" || tag == "miph") && totalLen > headerLen && offset+totalLen <= end {
+			span = totalLen
+		}
+		if span < 8 || offset+span > end {
+			break
+		}
+		if tag == "mtph" {
+			n++
+		}
+		offset += span
+	}
+	return n
+}
+
+// countMsdhItems counts the top-level item chunks (itemTag) inside the msdh of
+// the given blockType. Used for album (type 9, miah) and artist (type 11, miih)
+// counts; returns 0 when the container is absent (older libraries lack them).
+func countMsdhItems(data []byte, blockType int, itemTag string) int {
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, blockType)
+	if msdhOffset < 0 {
+		return 0
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	n := 0
+	offset := contentStart
+	// Skip a leading list-header chunk if present (mlah/mlih etc.).
+	if contentStart+12 <= contentEnd {
+		if first := readTag(data, contentStart); first != "" && first != itemTag {
+			offset = contentStart + int(readUint32LE(data, contentStart+4))
+		}
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == itemTag || tag == "mhoh") && totalLen > headerLen && offset+totalLen <= contentEnd {
+			span = totalLen
+		}
+		if span < 8 || offset+span > contentEnd {
+			break
+		}
+		if tag == itemTag {
+			n++
+		}
+		offset += span
+	}
+	return n
+}
+
+// countMhohBlocks returns the total number of mhoh blocks in the payload.
+func countMhohBlocks(data []byte) int {
+	n := 0
+	forEachMhoh(data, func(_, _ int) { n++ })
+	return n
+}
+
+// mhohRewriteCount counts how many mhoh blocks were rewritten (content changed)
+// between before and after, matched by IDENTITY — (enclosing track TID, hohmType)
+// for track mhohs — so that merely removing or adding tracks does not count
+// surviving blocks as rewrites. Blocks present in both with differing bytes are
+// rewrites; blocks only in `after` (newly added) are also counted. This is a
+// blast-radius proxy for the bounded-delta guardrail; exactness is not required.
+func mhohRewriteCount(before, after []byte) int {
+	b := mhohBlocksByIdentity(before)
+	n := 0
+	for key, ablk := range mhohBlocksByIdentity(after) {
+		bblk, ok := b[key]
+		if !ok || !bytesEqual(bblk, ablk) {
+			n++
+		}
+	}
+	return n
+}
+
+// mhohBlocksByIdentity returns track-mhoh blocks keyed by "TID:hohmType". Only
+// mhohs nested under a mith carry a stable identity; container-level mhohs
+// (playlist names etc.) are keyed by their walk index to stay deterministic.
+func mhohBlocksByIdentity(data []byte) map[string][]byte {
+	out := map[string][]byte{}
+	idx := 0
+	walkTopMsdh(data, func(msdhOffset, headerLen, totalLen, blockType int) {
+		// Walk top children of this msdh; for mith, key its child mhohs by TID.
+		offset := msdhOffset + headerLen
+		end := msdhOffset + totalLen
+		for offset+12 <= end {
+			tag := readTag(data, offset)
+			if tag == "" {
+				break
+			}
+			hlen := int(readUint32LE(data, offset+4))
+			tlen := int(readUint32LE(data, offset+8))
+			span := hlen
+			isContainer := (tag == "mith" || tag == "miph" || tag == "miah" || tag == "mhoh") && tlen > hlen && offset+tlen <= end
+			if isContainer {
+				span = tlen
+			}
+			if span < 8 || offset+span > end {
+				break
+			}
+			switch {
+			case tag == "mith" && isContainer:
+				tid := readUint32LE(data, offset+16)
+				walkChunksForMhoh(data, offset+hlen, offset+span, func(mhohOff, mhohSpan int) {
+					ht := readUint32LE(data, mhohOff+12)
+					key := fmtUint(tid) + ":" + fmtUint(ht)
+					out[key] = data[mhohOff : mhohOff+mhohSpan]
+				})
+			case tag == "mhoh":
+				out["idx:"+fmtUint(uint32(idx))] = data[offset : offset+span]
+				idx++
+			case isContainer:
+				walkChunksForMhoh(data, offset+hlen, offset+span, func(mhohOff, mhohSpan int) {
+					out["idx:"+fmtUint(uint32(idx))] = data[mhohOff : mhohOff+mhohSpan]
+					idx++
+				})
+			}
+			offset += span
+		}
+	})
+	return out
+}
+
+func fmtUint(v uint32) string { return fmt.Sprintf("%d", v) }
+
+// collectMithTidsPids returns the TrackIDs (in walk order) and hex PIDs of every
+// mith in the master track list.
+func collectMithTidsPids(data []byte) (tids []uint32, pids []string) {
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, 1)
+	if msdhOffset < 0 {
+		return nil, nil
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	offset := contentStart
+	if contentStart+12 <= contentEnd && readTag(data, contentStart) == "mlth" {
+		offset = contentStart + int(readUint32LE(data, contentStart+4))
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		if (tag == "mith" || tag == "mhoh" || tag == "miah") && totalLen > headerLen && offset+totalLen <= contentEnd {
+			span = totalLen
+		}
+		if span < 8 || offset+span > contentEnd {
+			break
+		}
+		if tag == "mith" {
+			tids = append(tids, readUint32LE(data, offset+16))
+			var pid [8]byte
+			if offset+136 <= len(data) {
+				for i := 0; i < 8; i++ {
+					pid[i] = data[offset+135-i]
+				}
+			}
+			pids = append(pids, pidToHex(pid))
+		}
+		offset += span
+	}
+	return tids, pids
+}
+
+// forEachTrackLocations invokes fn for every mith in the master list, passing
+// the DECODED 0x0D Location and 0x0B LocalURL strings (and presence flags).
+func forEachTrackLocations(data []byte, fn func(trackOffset int, loc0D, loc0B string, has0D, has0B bool)) {
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, 1)
+	if msdhOffset < 0 {
+		return
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	offset := contentStart
+	if contentStart+12 <= contentEnd && readTag(data, contentStart) == "mlth" {
+		offset = contentStart + int(readUint32LE(data, contentStart+4))
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		isMithContainer := tag == "mith" && totalLen > headerLen && offset+totalLen <= contentEnd
+		if (tag == "mith" || tag == "mhoh" || tag == "miah") && totalLen > headerLen && offset+totalLen <= contentEnd {
+			span = totalLen
+		}
+		if span < 8 || offset+span > contentEnd {
+			break
+		}
+		if tag == "mith" {
+			var loc0D, loc0B string
+			var has0D, has0B bool
+			if isMithContainer {
+				walkChunksForMhoh(data, offset+headerLen, offset+span, func(mhohOff, mhohSpan int) {
+					t := readUint32LE(data, mhohOff+12)
+					switch t {
+					case 0x0D:
+						loc0D, has0D = decodeMhohString(data, mhohOff, mhohSpan), true
+					case 0x0B:
+						loc0B, has0B = decodeMhohString(data, mhohOff, mhohSpan), true
+					}
+				})
+			}
+			fn(offset, loc0D, loc0B, has0D, has0B)
+		}
+		offset += span
+	}
+}
+
+// decodeMhohString decodes the string carried by an mhoh block, reading the
+// legacy +27 encoding flag (the reader is intentionally permissive so that
+// location-form operates on the DECODED string regardless of how it was stamped
+// — SPEC §2 "on decoded strings").
+func decodeMhohString(data []byte, offset, span int) string {
+	if span < 40 || offset+40 > len(data) {
+		return ""
+	}
+	encodingFlag := data[offset+16+11]
+	strLen := int(readUint32LE(data, offset+28))
+	strStart := offset + 40
+	if strStart+strLen > offset+span || strStart+strLen > len(data) {
+		strLen = offset + span - strStart
+		if strLen < 0 {
+			return ""
+		}
+	}
+	s, err := decodeHohmString(data[strStart:strStart+strLen], encodingFlag)
+	if err != nil {
+		return string(data[strStart : strStart+strLen])
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — location form
+// ---------------------------------------------------------------------------
+
+// isWindowsAbsPath reports whether s is a native Windows absolute path:
+// drive letter, ':', backslash, no forward slashes (a single C:\ form). It does
+// NOT permit "file://" or percent-escapes (those belong in 0x0B).
+func isWindowsAbsPath(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	c := s[0]
+	if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+		return false
+	}
+	if s[1] != ':' || s[2] != '\\' {
+		return false
+	}
+	if strings.Contains(s, "/") {
+		return false
+	}
+	return true
+}
+
+// winPathToLocalURL renders a native Windows path into the 0x0B canonical form:
+// "file://localhost/" + path with '\'→'/' and RFC-3986 percent-escaping of every
+// byte outside the unreserved set (plus '/' and ':' which are kept literal,
+// matching iTunes' 0x0B rendering, e.g. "file://localhost/W:/itunes/...").
+func winPathToLocalURL(winPath string) string {
+	slashed := strings.ReplaceAll(winPath, "\\", "/")
+	var b strings.Builder
+	b.WriteString("file://localhost/")
+	for i := 0; i < len(slashed); i++ {
+		c := slashed[i]
+		if isURLKeepByte(c) {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+// isURLKeepByte reports whether c is left literal in the 0x0B URL rendering.
+// Unreserved per RFC-3986 (ALPHA / DIGIT / '-' '.' '_' '~') plus the path
+// separators iTunes keeps literal ('/' and ':').
+func isURLKeepByte(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '-', '.', '_', '~', '/', ':':
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — header reconstruction / decode
+// ---------------------------------------------------------------------------
+
+// reconstructHdfmHeader rebuilds the full hdfm header bytes from a parsed header
+// so the file-absolute BE count offsets 0x44/0x48/0x4C/0x54 used throughout the
+// spec apply directly. The remainder already contains those count bytes; we just
+// need the leading 17 + len(version) bytes in front of it.
+func reconstructHdfmHeader(hdr *hdfmHeader) []byte {
+	return buildHdfmHeader(hdr.version, hdr.headerRemainder, hdr.fileLen, hdr.unknown)
+}
+
+// decodeITLForContract parses, decrypts, and fail-closed-inflates a raw .itl
+// file into (header, decompressed LE payload). It surfaces the T010 inflate
+// error rather than silently treating an over-cap payload as uncompressed.
+func decodeITLForContract(data []byte) (*hdfmHeader, []byte, error) {
+	hdr, err := parseHdfmHeader(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse hdfm: %w", err)
+	}
+	if int(hdr.headerLen) > len(data) {
+		return nil, nil, fmt.Errorf("header length %d exceeds file size %d", hdr.headerLen, len(data))
+	}
+	decrypted := itlDecrypt(hdr, data[hdr.headerLen:])
+	payload, _, err := itlInflate(decrypted)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inflate payload: %w", err)
+	}
+	return hdr, payload, nil
+}
+
+// ---------------------------------------------------------------------------
+// Small utilities
+// ---------------------------------------------------------------------------
+
+func normalizeConfig(cfg ContractConfig) ContractConfig {
+	if cfg.RemovedTracksMax == 0 {
+		cfg.RemovedTracksMax = 5000
+	}
+	if cfg.RewrittenMhohPctMax == 0 {
+		cfg.RewrittenMhohPctMax = 20
+	}
+	return cfg
+}
+
+func summarize(before, after []byte) ContractSummary {
+	var s ContractSummary
+	if before != nil {
+		s.BeforeTracks, _ = countMasterTracks(before)
+	}
+	if after != nil {
+		_, s.AfterTracks = countMasterTracks(after)
+		s.AfterPlaylists, _ = countPlaylistsAndCheckMiph(after)
+		s.AfterMhohBlocks = countMhohBlocks(after)
+	}
+	return s
+}
+
+func pass(name string) GuardResult { return GuardResult{Guard: name} }
+
+func fail(name string, offset int, chunk, msg string) GuardResult {
+	return GuardResult{Guard: name, Violations: []Violation{{Offset: offset, Chunk: chunk, Message: msg}}}
+}
+
+func previewU32(s []uint32) []uint32 {
+	const n = 5
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func truncStr(s string) string {
+	const n = 120
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/itunes/itl_safety_contract_test.go
+++ b/internal/itunes/itl_safety_contract_test.go
@@ -1,0 +1,982 @@
+// file: internal/itunes/itl_safety_contract_test.go
+// version: 1.0.0
+// guid: 2eb18728-e3ee-494d-b37d-3bb7e7c516a4
+//
+// Regression suite for ITLSafetyContract (fable5 TASK-003), implementing the
+// 13 contract tests of SPEC 2 §6 (docs/specs/fable5-spec-itunes-writeback-
+// hardening.md), plus a guard-isolation harness.
+//
+// The damaged production libraries are ephemeral evidence, not test inputs;
+// their *signatures* (K1..K9) are encoded as test-local corrupting mutations
+// applied to a minimal valid LE payload built in-memory here (buildCleanPayload).
+// Production code never contains corruptors — all mutators live in this _test.go.
+//
+// Pattern per test: build the clean LE payload → apply ONE specific corruption →
+// assert the NAMED guard fires AND every other guard stays silent. The clean
+// payload is also asserted to pass every guard (TestContract_CleanPasses).
+
+package itunes
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory LE payload fixture builder
+// ---------------------------------------------------------------------------
+//
+// Layout produced (matches the chunk grammar the contract + production walkers
+// expect):
+//
+//	msdh(type 1, tracks)
+//	  mlth(count=N)
+//	  mith[0] (TID=10, PID) { mhoh 0x02 Name, mhoh 0x0D Location, mhoh 0x0B URL }
+//	  mith[1] (TID=20, PID) { ... }
+//	  ...
+//	msdh(type 2, playlists)
+//	  mlph
+//	  miph(declared=K) { mtph(TID=10), mtph(TID=20), ... }
+//
+// Plus a matching hdfm header whose BE count fields (0x44/0x48/0x4C/0x54) agree
+// with the payload, so guardCountCoherence passes on the clean fixture.
+
+const (
+	fxMsdhHeaderLen = 96
+	fxMithHeaderLen = 156
+	fxMlthHeaderLen = 96
+	fxMlphHeaderLen = 96
+	fxMiphHeaderLen = 96
+	fxMtphHeaderLen = 76
+)
+
+type fxTrack struct {
+	tid      uint32
+	name     string
+	location string // native Windows path (0x0D); "" => podcast (no 0x0D)
+	localURL string // 0x0B; for podcasts pass an http(s):// URL
+}
+
+// buildMhoh assembles an iTunes-conformant LE mhoh block: headerLen=24,
+// totalLen=40+strLen, the encoding indicator written as a u32 at +24 (so its
+// high byte at +27 is 0 for the small indicator values), strLen at +28, zeros
+// +32..+39, string at +40.
+func buildMhoh(hohmType uint32, at24 uint32, encFlag byte, str []byte) []byte {
+	total := 40 + len(str)
+	b := make([]byte, total)
+	copy(b[0:4], "mhoh")
+	binary.LittleEndian.PutUint32(b[4:8], 24)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(total))
+	binary.LittleEndian.PutUint32(b[12:16], hohmType)
+	binary.LittleEndian.PutUint32(b[24:28], at24)
+	b[27] = encFlag // legacy flag byte; iTunes-conformant => 0
+	binary.LittleEndian.PutUint32(b[28:32], uint32(len(str)))
+	copy(b[40:], str)
+	return b
+}
+
+// asciiMhoh builds a clean ASCII-encoded text mhoh. For 0x0D/0x0B fields iTunes
+// uses at24=1 (Windows-1252) for 0x0D and at24=0 (ASCII) for 0x0B URLs.
+func asciiMhoh(hohmType uint32, at24 uint32, s string) []byte {
+	return buildMhoh(hohmType, at24, 0x00, []byte(s))
+}
+
+func buildMith(tid uint32, children []byte) []byte {
+	total := fxMithHeaderLen + len(children)
+	b := make([]byte, total)
+	copy(b[0:4], "mith")
+	binary.LittleEndian.PutUint32(b[4:8], fxMithHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(total))
+	binary.LittleEndian.PutUint32(b[16:20], tid)
+	// Unique nonzero PID derived from tid (stored reversed for LE).
+	var pid [8]byte
+	binary.BigEndian.PutUint64(pid[:], uint64(tid)|0x1000000000000000)
+	for i := 0; i < 8; i++ {
+		b[135-i] = pid[i]
+	}
+	copy(b[fxMithHeaderLen:], children)
+	return b
+}
+
+func buildMlth(count int) []byte {
+	b := make([]byte, fxMlthHeaderLen)
+	copy(b[0:4], "mlth")
+	binary.LittleEndian.PutUint32(b[4:8], fxMlthHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(count))
+	return b
+}
+
+func buildMlph(count int) []byte {
+	b := make([]byte, fxMlphHeaderLen)
+	copy(b[0:4], "mlph")
+	binary.LittleEndian.PutUint32(b[4:8], fxMlphHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(count))
+	return b
+}
+
+func buildMtph(tid uint32) []byte {
+	b := make([]byte, fxMtphHeaderLen)
+	copy(b[0:4], "mtph")
+	binary.LittleEndian.PutUint32(b[4:8], fxMtphHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], fxMtphHeaderLen)
+	binary.LittleEndian.PutUint32(b[24:28], tid)
+	return b
+}
+
+func buildMiph(declared int, children []byte) []byte {
+	total := fxMiphHeaderLen + len(children)
+	b := make([]byte, total)
+	copy(b[0:4], "miph")
+	binary.LittleEndian.PutUint32(b[4:8], fxMiphHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(total))
+	binary.LittleEndian.PutUint32(b[16:20], uint32(declared)) // declared item count
+	copy(b[fxMiphHeaderLen:], children)
+	return b
+}
+
+func buildMsdh(blockType int, body []byte) []byte {
+	total := fxMsdhHeaderLen + len(body)
+	b := make([]byte, total)
+	copy(b[0:4], "msdh")
+	binary.LittleEndian.PutUint32(b[4:8], fxMsdhHeaderLen)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(total))
+	binary.LittleEndian.PutUint32(b[12:16], uint32(blockType))
+	copy(b[fxMsdhHeaderLen:], body)
+	return b
+}
+
+// buildTrackMith builds one mith with Name(0x02)+Location(0x0D)+URL(0x0B)
+// children (or just Name+URL for podcasts with empty location).
+func buildTrackMith(tr fxTrack) []byte {
+	var children []byte
+	children = append(children, asciiMhoh(0x02, 1, tr.name)...)
+	if tr.location != "" {
+		children = append(children, asciiMhoh(0x0D, 1, tr.location)...)
+		children = append(children, asciiMhoh(0x0B, 0, winPathToLocalURL(tr.location))...)
+	} else {
+		// Podcast: no 0x0D; 0x0B carries the http(s):// URL as given.
+		children = append(children, asciiMhoh(0x0B, 0, tr.localURL)...)
+	}
+	return buildMith(tr.tid, children)
+}
+
+// buildPayloadFromTracks assembles the full LE payload from a track list. The
+// playlist references every track's TID.
+func buildPayloadFromTracks(tracks []fxTrack) []byte {
+	// Track msdh.
+	trackBody := buildMlth(len(tracks))
+	for _, tr := range tracks {
+		trackBody = append(trackBody, buildTrackMith(tr)...)
+	}
+	trackMsdh := buildMsdh(1, trackBody)
+
+	// Playlist msdh: one playlist referencing all tracks.
+	var mtphChildren []byte
+	for _, tr := range tracks {
+		mtphChildren = append(mtphChildren, buildMtph(tr.tid)...)
+	}
+	plBody := buildMlph(1)
+	plBody = append(plBody, buildMiph(len(tracks), mtphChildren)...)
+	plMsdh := buildMsdh(2, plBody)
+
+	out := append([]byte{}, trackMsdh...)
+	out = append(out, plMsdh...)
+	return out
+}
+
+func cleanTracks() []fxTrack {
+	return []fxTrack{
+		{tid: 10, name: "Chapter One", location: `W:\itunes\Media\Audiobooks\Adrian Tchaikovsky\01 Children of Time.mp3`},
+		{tid: 20, name: "Chapter Two", location: `W:\itunes\Media\Audiobooks\Adrian Tchaikovsky\02 Children of Time.mp3`},
+		{tid: 30, name: "A Podcast Episode", location: "", localURL: "https://feeds.example.com/ep/30.mp3"},
+	}
+}
+
+// buildCleanPayload returns a valid LE payload that passes every guard.
+func buildCleanPayload() []byte {
+	return buildPayloadFromTracks(cleanTracks())
+}
+
+// buildHeaderFor produces a minimal hdfm header whose BE count fields agree with
+// the given payload (tracks @0x44, playlists @0x48, albums @0x4C, artists @0x54).
+// The fixture payload has no album/artist msdh, so those counts are 0.
+func buildHeaderFor(payload []byte) *hdfmHeader {
+	_, tracks := countMasterTracks(payload)
+	playlists, _ := countPlaylistsAndCheckMiph(payload)
+
+	const version = "12.13.10.3"
+	// Remainder must be long enough to reach file offset 0x54+4. The header
+	// begins at 0; remainder begins at 17+len(version). Size it to cover 0x60.
+	remStart := 17 + len(version)
+	remLen := 0x60 - remStart
+	if remLen < 0 {
+		remLen = 0
+	}
+	rem := make([]byte, remLen)
+	put := func(fileOff int, v uint32) {
+		off := fileOff - remStart
+		if off >= 0 && off+4 <= len(rem) {
+			binary.BigEndian.PutUint32(rem[off:off+4], v)
+		}
+	}
+	put(0x44, uint32(tracks))
+	put(0x48, uint32(playlists))
+	put(0x4C, 0)
+	put(0x54, 0)
+
+	return &hdfmHeader{
+		headerLen:       uint32(17 + len(version) + len(rem)),
+		fileLen:         0,
+		unknown:         0,
+		version:         version,
+		headerRemainder: rem,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutation locator helpers (test-local)
+// ---------------------------------------------------------------------------
+
+// firstMhohOffset returns the payload offset of the first mhoh of the given
+// hohmType (0 => any), or -1.
+func firstMhohOffset(t *testing.T, payload []byte, hohmType uint32) int {
+	t.Helper()
+	found := -1
+	forEachMhoh(payload, func(off, _ int) {
+		if found >= 0 {
+			return
+		}
+		if hohmType == 0 || readUint32LE(payload, off+12) == hohmType {
+			found = off
+		}
+	})
+	return found
+}
+
+// firstMsdhOffset returns the offset of the msdh container with the given type.
+func firstMsdhOffset(payload []byte, blockType int) int {
+	off, _, _ := findMsdhByType(payload, blockType)
+	return off
+}
+
+// rewriteMhohString replaces the string body of the mhoh at off with newStr,
+// rebuilding totalLen/strLen and returning a fresh payload (offsets shift).
+func rewriteMhohString(payload []byte, off int, newStr string) []byte {
+	hohmType := readUint32LE(payload, off+12)
+	at24 := readUint32LE(payload, off+24)
+	encFlag := payload[off+27]
+	oldSpan := int(readUint32LE(payload, off+8))
+	rebuilt := buildMhoh(hohmType, at24, encFlag, []byte(newStr))
+	return spliceReplace(payload, off, off+oldSpan, rebuilt)
+}
+
+// spliceReplace replaces payload[start:end] with repl and fixes up the enclosing
+// mith/miph and msdh totalLen fields so the container framing stays exact (so
+// the only intentional corruption is the one the test injects, not a tiling
+// break). It returns a new slice.
+func spliceReplace(payload []byte, start, end int, repl []byte) []byte {
+	delta := len(repl) - (end - start)
+	out := make([]byte, 0, len(payload)+delta)
+	out = append(out, payload[:start]...)
+	out = append(out, repl...)
+	out = append(out, payload[end:]...)
+	if delta == 0 {
+		return out
+	}
+	// Patch any container (msdh/mith/miph) whose [headerStart, contentEnd) span
+	// encloses `start` by adjusting its totalLen at +8.
+	patchEnclosingTotalLens(out, start, delta)
+	return out
+}
+
+// patchEnclosingTotalLens walks the top-level msdh containers and their
+// mith/miph children, adjusting the totalLen of every container that encloses
+// `pos` by delta. Walk uses the ORIGINAL (post-splice) framing except for the
+// container that needs adjusting; since we adjust outermost-in, we recompute as
+// we descend.
+func patchEnclosingTotalLens(data []byte, pos, delta int) {
+	offset := 0
+	for offset+16 <= len(data) {
+		if readTag(data, offset) != "msdh" {
+			return
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		// Was this container's pre-splice span enclosing pos? Use post-splice
+		// totalLen-delta to reconstruct the original end for the container that
+		// contains pos.
+		origEnd := offset + totalLen
+		if pos >= offset && pos < origEnd {
+			binary.LittleEndian.PutUint32(data[offset+8:offset+12], uint32(totalLen+delta))
+			// Descend into mith/miph children of this msdh.
+			patchChildTotalLens(data, offset+headerLen, offset+totalLen+delta, pos, delta)
+			return
+		}
+		offset += totalLen
+	}
+}
+
+func patchChildTotalLens(data []byte, start, end, pos, delta int) {
+	offset := start
+	for offset+12 <= end {
+		tag := readTag(data, offset)
+		if tag == "" {
+			return
+		}
+		headerLen := int(readUint32LE(data, offset+4))
+		totalLen := int(readUint32LE(data, offset+8))
+		span := headerLen
+		isContainer := (tag == "mith" || tag == "miph" || tag == "miah") && totalLen > headerLen
+		if isContainer {
+			span = totalLen
+		}
+		// Only patch ancestors that STRICTLY enclose pos (offset < pos). A leaf
+		// chunk that begins exactly at pos is the replaced block itself — its
+		// totalLen already came from the replacement, so we must not touch it.
+		if isContainer && offset < pos && pos < offset+span {
+			binary.LittleEndian.PutUint32(data[offset+8:offset+12], uint32(totalLen+delta))
+			patchChildTotalLens(data, offset+headerLen, offset+span+delta, pos, delta)
+			return
+		}
+		if span < 8 {
+			return
+		}
+		offset += span
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guard-isolation harness
+// ---------------------------------------------------------------------------
+
+// assertOnlyGuardFires runs the contract and asserts that exactly the named
+// guard reports violations and every other guard passes. `before` may be nil.
+func assertOnlyGuardFires(t *testing.T, before, after []byte, hdr *hdfmHeader, cfg ContractConfig, wantGuard string) {
+	t.Helper()
+	v := RunSafetyContract(before, after, hdr, cfg)
+	if v.Pass {
+		t.Fatalf("expected guard %q to fire, but contract passed", wantGuard)
+	}
+	firedNamed := false
+	for _, r := range v.Results {
+		if r.Guard == wantGuard {
+			if !r.Pass() {
+				firedNamed = true
+			}
+			continue
+		}
+		if !r.Pass() {
+			t.Errorf("unexpected violation from guard %q (only %q should fire): %+v", r.Guard, wantGuard, r.Violations)
+		}
+	}
+	if !firedNamed {
+		t.Fatalf("named guard %q did not fire; failed guards: %v", wantGuard, v.FailedGuards())
+	}
+}
+
+func defCfg() ContractConfig { return DefaultContractConfig() }
+
+// ---------------------------------------------------------------------------
+// SPEC 2 §6 — the 13 contract tests
+// ---------------------------------------------------------------------------
+
+// TestContract_CleanPasses: the unmutated fixture passes every guard.
+func TestContract_CleanPasses(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	v := RunSafetyContract(clean, clean, hdr, defCfg())
+	if !v.Pass {
+		t.Fatalf("clean payload should pass all guards; failed: %v\n%s", v.FailedGuards(), v.Error())
+	}
+	// AuditITL single-library mode is exercised separately (needs a full .itl).
+	auditV := RunSafetyContract(nil, clean, hdr, defCfg())
+	if !auditV.Pass {
+		t.Fatalf("clean payload should pass in audit mode; failed: %v\n%s", auditV.FailedGuards(), auditV.Error())
+	}
+}
+
+// TestContract_DanglingMtph: excise a mith but keep its mtph reference.
+func TestContract_DanglingMtph(t *testing.T) {
+	clean := buildCleanPayload()
+
+	// Use the preserved unsafe remover to drop the first track's mith while
+	// leaving its mtph orphaned (exactly the K1 production signature). It updates
+	// mlth/miph counts and the msdh totalLen, so count-coherence stays silent —
+	// the ONLY remaining fault is the orphaned mtph reference.
+	pid := pidForTID(clean, 10)
+	after, removed := removeTracksByPIDLEUnsafe(clean, map[string]bool{pid: true})
+	if removed != 1 {
+		t.Fatalf("expected to remove 1 mith, removed %d", removed)
+	}
+
+	// before = clean (no pre-existing orphans), after = orphaned.
+	assertOnlyGuardFires(t, clean, after, buildHeaderFor(after), defCfg(), "no-new-dangling-refs")
+}
+
+// TestContract_HeaderCountDesync: remove a track but keep the old header.
+func TestContract_HeaderCountDesync(t *testing.T) {
+	clean := buildCleanPayload()
+	oldHdr := buildHeaderFor(clean) // claims 3 tracks
+
+	// Remove track 10 cleanly (mith + its orphan mtph) so the ONLY inconsistency
+	// is the header vs payload count — not a dangling ref.
+	after := removeTrackAndMtph(clean, 10)
+
+	assertOnlyGuardFires(t, clean, after, oldHdr, defCfg(), "count-coherence")
+}
+
+// TestContract_MhohForeignFlag: set byte +27 = 3 on one mhoh (K3 / CRIT-1).
+func TestContract_MhohForeignFlag(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	off := firstMhohOffset(t, clean, 0x02)
+	if off < 0 {
+		t.Fatal("no 0x02 mhoh found")
+	}
+	after := append([]byte{}, clean...)
+	after[off+27] = 3 // foreign encoding flag iTunes never writes
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "mhoh-format")
+}
+
+// TestContract_MhohHeaderLen: set headerLen = totalLen on one mhoh (K5 / HIGH-6).
+func TestContract_MhohHeaderLen(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	off := firstMhohOffset(t, clean, 0x02)
+	if off < 0 {
+		t.Fatal("no 0x02 mhoh found")
+	}
+	after := append([]byte{}, clean...)
+	totalLen := readUint32LE(after, off+8)
+	binary.LittleEndian.PutUint32(after[off+4:off+8], totalLen) // headerLen := totalLen
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "mhoh-format")
+}
+
+// TestContract_MhohLenArithmetic: totalLen != 40+strLen (K7).
+func TestContract_MhohLenArithmetic(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	off := firstMhohOffset(t, clean, 0x02)
+	if off < 0 {
+		t.Fatal("no 0x02 mhoh found")
+	}
+	after := append([]byte{}, clean...)
+	// Corrupt the declared strLen at +28 so totalLen != 40+strLen, but keep it
+	// in-bounds so the only failure is the arithmetic mismatch.
+	binary.LittleEndian.PutUint32(after[off+28:off+32], 1)
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "mhoh-format")
+}
+
+// TestContract_LocationURLIn0x0D: write a URL into 0x0D (K4 / CRIT-2).
+func TestContract_LocationURLIn0x0D(t *testing.T) {
+	clean := buildCleanPayload()
+	off := firstMhohOffset(t, clean, 0x0D)
+	if off < 0 {
+		t.Fatal("no 0x0D mhoh found")
+	}
+	// Replace the native path with a file:// URL — the exact production bug.
+	after := rewriteMhohString(clean, off, "file://localhost/W:/itunes/Media/Audiobooks/Adrian%20Tchaikovsky/01%20Children%20of%20Time.mp3")
+	hdr := buildHeaderFor(after)
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "location-form")
+}
+
+// TestContract_StagingPathLeak: a location containing ".itunes-writeback/".
+func TestContract_StagingPathLeak(t *testing.T) {
+	clean := buildCleanPayload()
+	off := firstMhohOffset(t, clean, 0x0D)
+	if off < 0 {
+		t.Fatal("no 0x0D mhoh found")
+	}
+	after := rewriteMhohString(clean, off, `W:\audiobook-organizer\.itunes-writeback\Media\book.mp3`)
+	// The sibling 0x0B no longer round-trips after we changed 0x0D; rewrite it
+	// to match so the ONLY violation is the staging marker, not a pairing break.
+	off0B := firstMhohOffsetIn(after, 0x0B)
+	after = rewriteMhohString(after, off0B, winPathToLocalURL(`W:\audiobook-organizer\.itunes-writeback\Media\book.mp3`))
+	hdr := buildHeaderFor(after)
+
+	// Absolute-property test of `after` (no contrasting `before`), so the
+	// delta-based bounded-delta guard has nothing to bound.
+	assertOnlyGuardFires(t, nil, after, hdr, defCfg(), "location-form")
+}
+
+// TestContract_MiphCountMismatch: decrement a miph declared count (K8).
+func TestContract_MiphCountMismatch(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	plMsdh := firstMsdhOffset(clean, 2)
+	if plMsdh < 0 {
+		t.Fatal("no playlist msdh")
+	}
+	// Locate the miph and decrement its declared item count at +16.
+	miphOff := plMsdh + fxMsdhHeaderLen + fxMlphHeaderLen
+	if readTag(clean, miphOff) != "miph" {
+		t.Fatalf("expected miph at %d, got %q", miphOff, readTag(clean, miphOff))
+	}
+	after := append([]byte{}, clean...)
+	declared := readUint32LE(after, miphOff+16)
+	binary.LittleEndian.PutUint32(after[miphOff+16:miphOff+20], declared-1)
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "count-coherence")
+}
+
+// TestContract_TidDuplicate: duplicate a TID in the master list.
+func TestContract_TidDuplicate(t *testing.T) {
+	// Build a payload whose second track reuses the first track's TID.
+	tracks := cleanTracks()
+	tracks[1].tid = tracks[0].tid // duplicate TID (still ascending-broken too)
+	after := buildPayloadFromTracks(tracks)
+	hdr := buildHeaderFor(after)
+
+	// Absolute-property test of `after`; no contrasting `before`.
+	assertOnlyGuardFires(t, nil, after, hdr, defCfg(), "tid-pid-sanity")
+}
+
+// TestContract_TidUnsorted: swap two TIDs so the master list is not ascending.
+func TestContract_TidUnsorted(t *testing.T) {
+	tracks := cleanTracks()
+	tracks[0].tid, tracks[1].tid = tracks[1].tid, tracks[0].tid // 20,10,30 — unsorted
+	after := buildPayloadFromTracks(tracks)
+	hdr := buildHeaderFor(after)
+
+	// Absolute-property test of `after`; no contrasting `before`.
+	assertOnlyGuardFires(t, nil, after, hdr, defCfg(), "tid-pid-sanity")
+}
+
+// TestContract_TruncatedContainer: shrink an msdh totalLen so the containers no
+// longer tile the payload exactly (the truncation/splice class).
+//
+// We shrink the LAST (playlist) msdh totalLen by a whole mtph chunk's worth and
+// drop the corresponding declared count + mtph child, so the only structural
+// fault is that the msdh containers cover fewer bytes than the payload holds —
+// a tiling gap — while every COUNT stays internally consistent (so only
+// container-tiling fires, not count-coherence).
+func TestContract_TruncatedContainer(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	plMsdh := firstMsdhOffset(clean, 2)
+	miphOff := plMsdh + fxMsdhHeaderLen + fxMlphHeaderLen
+	if readTag(clean, miphOff) != "miph" {
+		t.Fatalf("expected miph at %d", miphOff)
+	}
+
+	after := append([]byte{}, clean...)
+	// Shrink the playlist msdh totalLen by one mtph chunk; the trailing mtph
+	// bytes physically remain in the slice but fall OUTSIDE every container's
+	// declared span → containers cover fewer bytes than len(payload).
+	msdhTotal := readUint32LE(after, plMsdh+8)
+	binary.LittleEndian.PutUint32(after[plMsdh+8:plMsdh+12], msdhTotal-uint32(fxMtphHeaderLen))
+	// Keep the miph internally consistent with what now fits: shrink its totalLen
+	// and its declared count so count-coherence does NOT also fire.
+	miphTotal := readUint32LE(after, miphOff+8)
+	binary.LittleEndian.PutUint32(after[miphOff+8:miphOff+12], miphTotal-uint32(fxMtphHeaderLen))
+	declared := readUint32LE(after, miphOff+16)
+	binary.LittleEndian.PutUint32(after[miphOff+16:miphOff+20], declared-1)
+
+	assertOnlyGuardFires(t, clean, after, hdr, defCfg(), "container-tiling")
+}
+
+// TestContract_FailClosedOnUnparseable: corrupt the master-list msdh tag.
+func TestContract_FailClosedOnUnparseable(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	after := append([]byte{}, clean...)
+	copy(after[0:4], "XXXX") // destroy the first msdh tag → not LE / unparseable
+
+	// parse-roundtrip must FAIL CLOSED (the historic fail-open bug, MED-7).
+	v := RunSafetyContract(clean, after, hdr, defCfg())
+	if v.Pass {
+		t.Fatal("expected fail-closed on unparseable payload, got pass")
+	}
+	prFired := false
+	for _, r := range v.Results {
+		if r.Guard == "parse-roundtrip" && !r.Pass() {
+			prFired = true
+		}
+	}
+	if !prFired {
+		t.Fatalf("parse-roundtrip did not fire on unparseable payload; failed: %v", v.FailedGuards())
+	}
+}
+
+// TestContract_BoundedDelta: remove > RemovedTracksMax tracks.
+func TestContract_BoundedDelta(t *testing.T) {
+	// before has 5001 tracks; after has 0 → removed 5001 > cap 5000.
+	before := buildManyTrackPayload(5001)
+	after := buildManyTrackPayload(0)
+	hdr := buildHeaderFor(after)
+
+	cfg := defCfg() // RemovedTracksMax=5000
+	v := RunSafetyContract(before, after, hdr, cfg)
+	if v.Pass {
+		t.Fatal("expected bounded-delta to fire on 5001 removed tracks")
+	}
+	bdFired := false
+	for _, r := range v.Results {
+		if r.Guard == "bounded-delta" && !r.Pass() {
+			bdFired = true
+		}
+	}
+	if !bdFired {
+		t.Fatalf("bounded-delta did not fire; failed: %v", v.FailedGuards())
+	}
+
+	// Force must override the bounded-delta guardrail (only).
+	cfg.Force = true
+	for _, r := range RunSafetyContract(before, after, hdr, cfg).Results {
+		if r.Guard == "bounded-delta" && !r.Pass() {
+			t.Fatal("Force=true should override bounded-delta")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage: AuditITL on a real round-tripped .itl, config defaults
+// ---------------------------------------------------------------------------
+
+// TestAuditITL_FailClosedOnGarbage: AuditITL rejects non-ITL bytes.
+func TestAuditITL_FailClosedOnGarbage(t *testing.T) {
+	v := AuditITL([]byte("not an itl file at all"))
+	if v.Pass {
+		t.Fatal("AuditITL should fail closed on garbage input")
+	}
+}
+
+// buildITLFile encrypts+deflates the payload and prepends a matching hdfm header,
+// producing a complete, decodable .itl byte stream for AuditITL.
+func buildITLFile(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	hdr := buildHeaderFor(payload)
+	deflated := itlDeflate(payload)
+	encrypted := itlEncrypt(hdr, deflated)
+	fileLen := uint32(len(encrypted)) + hdr.headerLen
+	header := buildHdfmHeader(hdr.version, hdr.headerRemainder, fileLen, hdr.unknown)
+	out := append([]byte{}, header...)
+	out = append(out, encrypted...)
+	return out
+}
+
+// TestAuditITL_CleanLibraryPasses: a full in-memory .itl round-trips through
+// decode (decrypt + fail-closed inflate) and passes every guard — exercising the
+// AuditITL success path and decodeITLForContract.
+func TestAuditITL_CleanLibraryPasses(t *testing.T) {
+	itl := buildITLFile(t, buildCleanPayload())
+	v := AuditITL(itl)
+	if !v.Pass {
+		t.Fatalf("AuditITL on clean library should pass; failed: %v\n%s", v.FailedGuards(), v.Error())
+	}
+	if v.Summary.AfterTracks != 3 || v.Summary.AfterPlaylists != 1 {
+		t.Fatalf("unexpected summary: %+v", v.Summary)
+	}
+}
+
+// TestAuditITL_DetectsCorruptLibrary: AuditITL flags a K3 carrier at read time
+// (HIGH-6 — already-corrupt libraries are detectable without a `before`).
+func TestAuditITL_DetectsCorruptLibrary(t *testing.T) {
+	payload := buildCleanPayload()
+	off := firstMhohOffsetIn(payload, 0x02)
+	payload[off+27] = 3 // foreign encoding flag
+	itl := buildITLFile(t, payload)
+
+	v := AuditITL(itl)
+	if v.Pass {
+		t.Fatal("AuditITL should flag a K3-carrier library")
+	}
+	saw := false
+	for _, r := range v.FailedGuards() {
+		if r == "mhoh-format" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("expected mhoh-format to fire; failed: %v", v.FailedGuards())
+	}
+}
+
+// TestLocationForm_PodcastExempt: a podcast track (no 0x0D, http(s):// in 0x0B)
+// passes location-form — the pairing rule does not apply to it.
+func TestLocationForm_PodcastExempt(t *testing.T) {
+	tracks := []fxTrack{
+		{tid: 10, name: "Ep 1", location: "", localURL: "https://feeds.example.com/1.mp3"},
+		{tid: 20, name: "Ep 2", location: "", localURL: "http://feeds.example.com/2.mp3"},
+	}
+	payload := buildPayloadFromTracks(tracks)
+	res := guardLocationForm(nil, payload, nil, defCfg())
+	if !res.Pass() {
+		t.Fatalf("podcast tracks should pass location-form: %+v", res.Violations)
+	}
+}
+
+// TestLocationForm_MissingSibling0B: a track with 0x0D but no 0x0B sibling fails.
+func TestLocationForm_MissingSibling0B(t *testing.T) {
+	// Build a mith with only a 0x0D child (no 0x0B).
+	children := asciiMhoh(0x02, 1, "Name")
+	children = append(children, asciiMhoh(0x0D, 1, `W:\m\a.mp3`)...)
+	mith := buildMith(10, children)
+	trackBody := append(buildMlth(1), mith...)
+	trackMsdh := buildMsdh(1, trackBody)
+	plMsdh := buildMsdh(2, append(buildMlph(1), buildMiph(1, buildMtph(10))...))
+	payload := append(append([]byte{}, trackMsdh...), plMsdh...)
+
+	res := guardLocationForm(nil, payload, nil, defCfg())
+	if res.Pass() {
+		t.Fatal("track with 0x0D but no 0x0B sibling should fail location-form")
+	}
+}
+
+// TestLocationForm_BadURLRoundTrip: a 0x0B URL that does not round-trip the 0x0D
+// path fails location-form.
+func TestLocationForm_BadURLRoundTrip(t *testing.T) {
+	children := asciiMhoh(0x02, 1, "Name")
+	children = append(children, asciiMhoh(0x0D, 1, `W:\m\a.mp3`)...)
+	children = append(children, asciiMhoh(0x0B, 0, "file://localhost/W:/WRONG/path.mp3")...)
+	mith := buildMith(10, children)
+	trackMsdh := buildMsdh(1, append(buildMlth(1), mith...))
+	plMsdh := buildMsdh(2, append(buildMlph(1), buildMiph(1, buildMtph(10))...))
+	payload := append(append([]byte{}, trackMsdh...), plMsdh...)
+
+	res := guardLocationForm(nil, payload, nil, defCfg())
+	if res.Pass() {
+		t.Fatal("non-round-tripping 0x0B should fail location-form")
+	}
+}
+
+// TestParseRoundtrip_EmptyAndBE: too-small and non-LE payloads fail closed.
+func TestParseRoundtrip_EmptyAndBE(t *testing.T) {
+	if guardParseRoundtrip(nil, []byte{1, 2, 3}, nil, defCfg()).Pass() {
+		t.Fatal("tiny payload should fail parse-roundtrip")
+	}
+	be := make([]byte, 32)
+	copy(be[0:4], "hdfm") // not 'msdh' → BE/foreign
+	if guardParseRoundtrip(nil, be, nil, defCfg()).Pass() {
+		t.Fatal("non-LE payload should fail parse-roundtrip (BE refusal)")
+	}
+}
+
+// TestWinPathToLocalURL_Escaping: the 0x0B renderer matches iTunes' escaping.
+func TestWinPathToLocalURL_Escaping(t *testing.T) {
+	got := winPathToLocalURL(`W:\itunes Media\Children of Time.mp3`)
+	want := "file://localhost/W:/itunes%20Media/Children%20of%20Time.mp3"
+	if got != want {
+		t.Fatalf("winPathToLocalURL escaping: got %q want %q", got, want)
+	}
+	if !isWindowsAbsPath(`C:\a\b.mp3`) {
+		t.Fatal("C:\\a\\b.mp3 should be a Windows abs path")
+	}
+	if isWindowsAbsPath("/unix/path") || isWindowsAbsPath(`C:/forward/slash`) {
+		t.Fatal("unix and forward-slash paths must not be Windows abs paths")
+	}
+}
+
+// TestContractConfig_Defaults: zero config normalizes to SPEC defaults.
+func TestContractConfig_Defaults(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	// Pass an explicit zero config; normalizeConfig should apply 5000/20.
+	v := RunSafetyContract(clean, clean, hdr, ContractConfig{})
+	if !v.Pass {
+		t.Fatalf("clean payload with zero config should pass; failed: %v", v.FailedGuards())
+	}
+	d := DefaultContractConfig()
+	if d.RemovedTracksMax != 5000 || d.RewrittenMhohPctMax != 20 || d.Force {
+		t.Fatalf("unexpected defaults: %+v", d)
+	}
+}
+
+// TestContractVerdict_ErrorString: a failing verdict renders a non-empty,
+// guard-named error; a passing verdict renders empty.
+func TestContractVerdict_ErrorString(t *testing.T) {
+	clean := buildCleanPayload()
+	hdr := buildHeaderFor(clean)
+	if e := RunSafetyContract(clean, clean, hdr, defCfg()).Error(); e != "" {
+		t.Fatalf("passing verdict should have empty Error(), got %q", e)
+	}
+	bad := append([]byte{}, clean...)
+	copy(bad[0:4], "ZZZZ")
+	if e := RunSafetyContract(clean, bad, hdr, defCfg()).Error(); e == "" {
+		t.Fatal("failing verdict should have non-empty Error()")
+	}
+}
+
+// TestContract_MhohRewriteBoundedDelta: rewriting >20% of mhoh blocks fires
+// bounded-delta (the HIGH-3 blast-radius cap), and Force overrides it.
+func TestContract_MhohRewriteBoundedDelta(t *testing.T) {
+	before := buildCleanPayload()
+	// Rewrite every Name (0x02) mhoh → ~33% of blocks rewritten.
+	after := append([]byte{}, before...)
+	var offs []int
+	forEachMhoh(after, func(off, _ int) {
+		if readUint32LE(after, off+12) == 0x02 {
+			offs = append(offs, off)
+		}
+	})
+	for _, off := range offs {
+		// Flip a content byte (same length → no reframing needed).
+		after[off+40] ^= 0xFF
+	}
+	hdr := buildHeaderFor(after)
+
+	v := RunSafetyContract(before, after, hdr, defCfg())
+	bdFired := false
+	for _, r := range v.Results {
+		if r.Guard == "bounded-delta" && !r.Pass() {
+			bdFired = true
+		}
+	}
+	if !bdFired {
+		t.Fatalf("expected bounded-delta to fire on >20%% mhoh rewrite; failed: %v", v.FailedGuards())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test-local builders for delta tests
+// ---------------------------------------------------------------------------
+
+// buildManyTrackPayload builds a payload with n tracks (ascending TIDs) and a
+// playlist referencing them. n may be 0 (empty master list + empty playlist).
+func buildManyTrackPayload(n int) []byte {
+	tracks := make([]fxTrack, n)
+	for i := 0; i < n; i++ {
+		tid := uint32((i + 1) * 2)
+		tracks[i] = fxTrack{
+			tid:      tid,
+			name:     "Track",
+			location: `W:\m\` + itoa(i) + `.mp3`,
+		}
+	}
+	return buildPayloadFromTracks(tracks)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// ---------------------------------------------------------------------------
+// PID / removal helpers
+// ---------------------------------------------------------------------------
+
+// pidForTID walks the master list and returns the hex PID of the mith with the
+// given TID (matching the LE-reversed storage used by removeTracksByPIDLEUnsafe).
+func pidForTID(payload []byte, tid uint32) string {
+	tids, pids := collectMithTidsPids(payload)
+	for i, t := range tids {
+		if t == tid {
+			return pids[i]
+		}
+	}
+	return ""
+}
+
+// removeTrackAndMtph removes the mith for tid AND its mtph reference, leaving a
+// clean (consistent except for the stale header) payload — used by the
+// header-desync test so dangling-refs does NOT also fire.
+func removeTrackAndMtph(payload []byte, tid uint32) []byte {
+	// Remove the mith span from the track msdh.
+	out := removeMithByTID(payload, tid)
+	// Remove the matching mtph from the playlist, decrementing the miph count.
+	out = removeMtphByTID(out, tid)
+	return out
+}
+
+func removeMithByTID(payload []byte, tid uint32) []byte {
+	trackMsdh := firstMsdhOffset(payload, 1)
+	headerLen := int(readUint32LE(payload, trackMsdh+4))
+	totalLen := int(readUint32LE(payload, trackMsdh+8))
+	contentStart := trackMsdh + headerLen
+	contentEnd := trackMsdh + totalLen
+	offset := contentStart
+	if readTag(payload, contentStart) == "mlth" {
+		offset = contentStart + int(readUint32LE(payload, contentStart+4))
+	}
+	for offset+12 <= contentEnd {
+		tag := readTag(payload, offset)
+		if tag == "" {
+			break
+		}
+		hlen := int(readUint32LE(payload, offset+4))
+		tlen := int(readUint32LE(payload, offset+8))
+		span := hlen
+		if tag == "mith" && tlen > hlen {
+			span = tlen
+		}
+		if tag == "mith" && readUint32LE(payload, offset+16) == tid {
+			out := spliceReplace(payload, offset, offset+span, nil)
+			// Decrement mlth count.
+			mlthOff := contentStart
+			c := readUint32LE(out, mlthOff+8)
+			binary.LittleEndian.PutUint32(out[mlthOff+8:mlthOff+12], c-1)
+			return out
+		}
+		offset += span
+	}
+	return payload
+}
+
+func removeMtphByTID(payload []byte, tid uint32) []byte {
+	plMsdh := firstMsdhOffset(payload, 2)
+	miphOff := plMsdh + fxMsdhHeaderLen + fxMlphHeaderLen
+	if readTag(payload, miphOff) != "miph" {
+		return payload
+	}
+	miphTotal := int(readUint32LE(payload, miphOff+8))
+	miphHeader := int(readUint32LE(payload, miphOff+4))
+	offset := miphOff + miphHeader
+	end := miphOff + miphTotal
+	for offset+12 <= end {
+		tag := readTag(payload, offset)
+		if tag == "" {
+			break
+		}
+		hlen := int(readUint32LE(payload, offset+4))
+		tlen := int(readUint32LE(payload, offset+8))
+		span := hlen
+		if tag == "mhoh" && tlen > hlen {
+			span = tlen
+		}
+		if tag == "mtph" && readUint32LE(payload, offset+24) == tid {
+			out := spliceReplace(payload, offset, offset+span, nil)
+			// Decrement the miph declared count at +16.
+			d := readUint32LE(out, miphOff+16)
+			binary.LittleEndian.PutUint32(out[miphOff+16:miphOff+20], d-1)
+			return out
+		}
+		offset += span
+	}
+	return payload
+}
+
+// firstMhohOffsetIn is firstMhohOffset without the *testing.T (for chained
+// mutations inside a single test).
+func firstMhohOffsetIn(payload []byte, hohmType uint32) int {
+	found := -1
+	forEachMhoh(payload, func(off, _ int) {
+		if found >= 0 {
+			return
+		}
+		if hohmType == 0 || readUint32LE(payload, off+12) == hohmType {
+			found = off
+		}
+	})
+	return found
+}


### PR DESCRIPTION
## Summary

Implements **TASK-003** of the fable5 program — the iTunes write-safety contract (SPEC 2 §2, the highest-stakes task: a corrupt `.itl` destroys curated playlists). Adds `internal/itunes/itl_safety_contract.go` + test suite. **Detection only — no writer changed.** `SafeWriteITL` (T004) will wire it in.

The contract runs an ordered list of named, individually-testable guards over a `(before, after)` pair of decompressed LE payloads plus the proposed `hdfm` header. Every guard returns structured `Violation{Offset, Chunk, Message}` lists — never a bare bool — and `AuditITL(data)` provides single-library read-time detection (closes HIGH-6).

Types per SPEC 2 §2: `GuardResult`, `Violation`, `ContractVerdict`, `ContractConfig`, `RunSafetyContract(before, after, hdr, cfg)`, `AuditITL(data)`.

## Per-guard checklist

- [x] **parse-roundtrip** — fail CLOSED when payload is not LE / master list unlocatable / inflate errors (inverts the historic fail-open, MED-7; also enforces BE-refusal, K12)
- [x] **container-tiling** — top-level msdh containers tile the payload exactly; type-1/2 children walk to contentEnd with no gap (truncation/splice)
- [x] **count-coherence** — header BE fields @0x44/0x48/0x4C/0x54 == payload mith/miph/miah/miih counts; mlth==actual mith; per-miph declared(+16)==actual mtph children (**K2/CRIT-3**, K8)
- [x] **no-new-dangling-refs** — wraps existing `VerifyITLNoNewDanglingRefsLE`, converted fail-closed (**K1**)
- [x] **mhoh-format** — headerLen==24, byte +27==0, totalLen==40+strLen, bytes +32..+39 zero, +24 ∈ T002 corpus table `ITunesMhohEncoding` (**K3/CRIT-1, K5/HIGH-6, K7**)
- [x] **location-form** — per-track on DECODED strings (0x0D may be UTF-16): 0x0D native Windows path, sibling 0x0B round-tripping `file://localhost/` URL, podcasts exempt, no `.itunes-writeback/` leak (**K4/CRIT-2**)
- [x] **tid-pid-sanity** — TIDs strictly ascending+unique, PIDs unique+nonzero (K6/K9/K11)
- [x] **bounded-delta** — `RemovedTracksMax=5000`, `RewrittenMhohPctMax=20`, `Force` override (blast-radius cap for HIGH-3)

## Tests — all 13 SPEC 2 §6 rows (names verbatim)

`TestContract_{CleanPasses, DanglingMtph, HeaderCountDesync, MhohForeignFlag, MhohHeaderLen, MhohLenArithmetic, LocationURLIn0x0D, StagingPathLeak, MiphCountMismatch, TidDuplicate, TidUnsorted, TruncatedContainer, FailClosedOnUnparseable, BoundedDelta}` plus AuditITL round-trip, podcast-exempt, URL-round-trip, and escaping coverage tests.

Each corruption test asserts the **named** guard fires and **all others stay silent**; the clean fixture passes every guard. Base fixture is a minimal valid LE payload built **in-memory** (the production `generate_test_itls.go` requires a real ITL template that is not present in CI). Corruption mutators are **test-local** (`_test.go`), so production code carries no corruptors.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/itunes/... -count=1` — pass
- `make test` — pass (exit 0)
- **New-file statement coverage: 84.0%** (446/531) — above the 80% gate

## Spec ambiguities resolved

1. **mhoh-format scope vs the table's 3 non-standard-len types.** SPEC §2 says "every mhoh: headerLen==24; +27==0; totalLen==40+strLen", but `ITunesMhohEncoding` documents binary-blob types with non-zero +27 and three text types (0x15/0x69/0x6C) where `totalLen != 40+strLen`. Resolution: format checks apply **only to types present in the table** (the table is the authority on which types are text strings); binary-blob types are skipped entirely (their +24..+39 bytes are not a string header). The 3 documented non-standard-len text types keep headerLen/+24/+27 checks but are exempt from the len-arithmetic + tail-zero checks. Documented inline with WHY + corpus citation.
2. **`before` semantics for absolute-property tests.** bounded-delta is a delta guard; the TID/staging/podcast isolation tests assert properties of `after` alone, so they pass `before=nil` (no delta to bound). The mhoh-rewrite proxy matches blocks by `(TID, hohmType)` identity rather than position, so a track removal does not count surviving blocks as rewrites.
3. **Header offsets.** The proposed `*hdfmHeader` is reconstructed to full bytes via `buildHdfmHeader` so the file-absolute 0x44/0x48/0x4C/0x54 offsets used throughout the spec apply directly.

## Status

- **COMPLETED: 1** — TASK-003 (8 guards + AuditITL + 13 SPEC §6 tests + extra coverage; build/vet/make-test green; 84.0% new-file coverage)
- **REMAINING: 0** — for this task's scope
- **BLOCKED: 0**

Do NOT merge — coordinator line-reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)