### PR TITLE
feat(dedup): LSH probe + exact acoustid collectors; retire O(N) fuzzy scan (fable5 T013)

### DIFF
--- a/internal/dedup/collectors_acoustid.go
+++ b/internal/dedup/collectors_acoustid.go
@@ -1,0 +1,338 @@
+// file: internal/dedup/collectors_acoustid.go
+// version: 1.0.0
+// guid: a7b3c841-d9e2-4f15-88a0-5bc12e347f6d
+// last-edited: 2026-06-10
+
+// Package dedup — acoustic-ID collector family (fable5 T013).
+//
+// # Design
+//
+// Two exported collectors live here; T014 will wire them into the Engine:
+//
+//   - CollectExactAcoustID: exact-tier lookup via the book_file_acoustid: Pebble
+//     secondary index.  O(1) per segment.  Emits SigExactAcoustID (conf 0.99).
+//
+//   - CollectLSHAcoustID: sub-linear candidate fan-out using the fpidx: secondary
+//     index built by T012 (LSHProbe), followed by WholeFileSimilarity Hamming
+//     refinement.  Gated on IsLSHIndexBuilt() — if the index has never been built
+//     the function logs INFO and returns immediately; it NEVER falls back to the
+//     retired O(N) GetBookFileByAcoustIDFuzzy path.
+//
+// Confidence scaling for SigLSHAcoustID (SPEC 1 §3, config-driven):
+//
+//	hamming 0.85 → conf 0.90  (MinConfidence)
+//	hamming 1.00 → conf 0.97  (MaxConfidence)
+//	linear interpolation between these two end-points.
+//
+// Both collectors are pure functions over injected store interfaces so they
+// are trivially unit-testable with fixture data (no PebbleDB required).
+
+package dedup
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// ─── store interfaces ──────────────────────────────────────────────────────────
+// Narrow interfaces so tests can inject stubs without pulling in the whole
+// database.Store.  T014's orchestrator passes a *database.PebbleStore (which
+// implements both) when wiring the Engine.
+
+// ExactAcoustIDStore is the subset of database.BookFileStore required by
+// CollectExactAcoustID.
+type ExactAcoustIDStore interface {
+	// GetBookFileByAcoustID returns the BookFile whose book_file_acoustid: index
+	// entry matches fp exactly, or nil when no match exists.
+	GetBookFileByAcoustID(fp string) (*database.BookFile, error)
+}
+
+// LSHAcoustIDStore is the subset of database.PebbleStore required by
+// CollectLSHAcoustID.  All three methods are implemented by *database.PebbleStore;
+// mocks that satisfy this interface are sufficient for unit tests.
+type LSHAcoustIDStore interface {
+	// IsLSHIndexBuilt reports whether the fpidx: secondary index has been fully
+	// built at least once.  When false, CollectLSHAcoustID skips and returns nil
+	// — it must never fall back to O(N) scanning.
+	IsLSHIndexBuilt() bool
+
+	// LSHProbe performs point-lookups for the supplied subprints and returns the
+	// candidate fileIDs that accumulate >= LSHMinBandHits band hits.
+	LSHProbe(subs []fingerprint.Subprint, bands []byte, maxCandidates int) (map[string]int, error)
+
+	// GetBookFileByID fetches a BookFile by (bookID, fileID).  bookID may be
+	// empty when the caller does not know it — the PebbleStore implements a
+	// scan fallback in that case.
+	GetBookFileByID(bookID, fileID string) (*database.BookFile, error)
+}
+
+// ─── exact-tier collector ─────────────────────────────────────────────────────
+
+// CollectExactAcoustID probes the book_file_acoustid: secondary index for an
+// exact fingerprint match for each segment string on queryFile.  For each hit
+// that belongs to a different book it appends a SigExactAcoustID signal to the
+// returned slice.
+//
+// A single file may carry up to 7 segment strings (AcoustIDSeg0..6, deprecated
+// but still populated on pre-whole-file rows); this collector checks all of them
+// so old data keeps working.
+//
+// queryBookID is used only to suppress self-matches (hits whose BookID equals
+// queryBookID are skipped).
+//
+// Returns nil, nil when queryFile has no segment strings.  Errors from the
+// index lookup are logged and skipped (never returned) — a missing index entry
+// is not an error; a real DB failure produces a single soft skip.
+func CollectExactAcoustID(
+	store ExactAcoustIDStore,
+	queryFile *database.BookFile,
+	queryBookID string,
+) ([]unified.Signal, error) {
+	if queryFile == nil {
+		return nil, nil
+	}
+	segs := [7]string{
+		queryFile.AcoustIDSeg0,
+		queryFile.AcoustIDSeg1,
+		queryFile.AcoustIDSeg2,
+		queryFile.AcoustIDSeg3,
+		queryFile.AcoustIDSeg4,
+		queryFile.AcoustIDSeg5,
+		queryFile.AcoustIDSeg6,
+	}
+
+	var signals []unified.Signal
+	seen := make(map[string]bool) // dedupe by candidate bookID in this call
+
+	for _, seg := range segs {
+		if seg == "" {
+			continue
+		}
+		// Degenerate-fingerprint guard: the sentinel "AQAAAA" (all-zero
+		// chromaprint) matches every other file carrying the same sentinel at
+		// similarity 1.0.  Skip it here — the writer no longer emits it, but
+		// old rows still carry it.
+		if !fingerprint.IsUsefulFingerprint(seg) {
+			continue
+		}
+
+		hit, err := store.GetBookFileByAcoustID(seg)
+		if err != nil {
+			// Index lookup failure: log and continue; one bad seg doesn't abort.
+			slog.Debug("dedup/collectors_acoustid: exact lookup error",
+				"file_id", queryFile.ID, "err", err)
+			continue
+		}
+		if hit == nil || hit.BookID == queryBookID || seen[hit.BookID] {
+			continue
+		}
+		seen[hit.BookID] = true
+
+		const conf = 0.99 // SigExactAcoustID fixed confidence (SPEC 1 §3)
+		signals = append(signals, unified.Signal{
+			Kind:       unified.SigExactAcoustID,
+			Raw:        1.0,
+			Confidence: conf,
+			Evidence: fmt.Sprintf("exact acoustid match: file %s -> book %s",
+				hit.ID, hit.BookID),
+		})
+	}
+	return signals, nil
+}
+
+// ─── LSH probe collector ──────────────────────────────────────────────────────
+
+// lshConfidenceScale maps a Hamming similarity in [minHamming, maxHamming] to a
+// confidence in [minConf, maxConf] using linear interpolation.  Values outside
+// the range are clamped to the nearest bound.
+//
+//	hamming == minHamming (0.85) → minConf (0.90 default)
+//	hamming == maxHamming (1.00) → maxConf (0.97 default)
+//
+// Parameters come from LSHAcoustIDConfig so calibration is config-driven without
+// requiring a code change (SPEC 1 §3).
+func lshConfidenceScale(hamming, minHamming, maxHamming, minConf, maxConf float64) float64 {
+	// Clamp inputs to the defined window.
+	if hamming <= minHamming {
+		return minConf
+	}
+	if hamming >= maxHamming {
+		return maxConf
+	}
+	// Linear interpolation across the [minHamming, maxHamming] window.
+	frac := (hamming - minHamming) / (maxHamming - minHamming)
+	return minConf + frac*(maxConf-minConf)
+}
+
+// LSHAcoustIDConfig holds the calibration parameters for CollectLSHAcoustID.
+// Callers that don't need custom tuning should call DefaultLSHAcoustIDConfig.
+type LSHAcoustIDConfig struct {
+	// MinHamming is the minimum Hamming similarity for a candidate to be
+	// accepted after Hamming refinement.  Default 0.85.
+	MinHamming float64
+
+	// MaxCandidates caps the number of candidates returned by LSHProbe.
+	// A value <= 0 disables the cap.  Default 200.
+	MaxCandidates int
+
+	// MinConfidence and MaxConfidence are the linear interpolation end-points
+	// for the Confidence field of emitted signals.  Defaults: 0.90 and 0.97.
+	MinConfidence float64
+	MaxConfidence float64
+}
+
+// DefaultLSHAcoustIDConfig returns the SPEC 1 §3 default calibration.
+func DefaultLSHAcoustIDConfig() LSHAcoustIDConfig {
+	return LSHAcoustIDConfig{
+		MinHamming:    0.85,
+		MaxCandidates: 200,
+		MinConfidence: 0.90,
+		MaxConfidence: 0.97,
+	}
+}
+
+// CollectLSHAcoustID performs the sub-linear AcoustID fan-out via the fpidx:
+// secondary index (T012) and emits SigLSHAcoustID signals for candidate book
+// files that survive the Hamming refinement step.
+//
+// # Gate: IsLSHIndexBuilt
+//
+// When the index has never been built (IsLSHIndexBuilt returns false), the
+// function logs an INFO message and returns (nil, nil) immediately.  It does
+// NOT fall back to GetBookFileByAcoustIDFuzzy — the O(N) path is retired.
+// Callers that need near-duplicate candidates when the index is absent must
+// schedule a lsh-index-build op first.
+//
+// # Probe -> Hamming pipeline
+//
+//  1. fingerprint.Subprints derives up to LSHBandCount (64) subprints from
+//     queryFile.AcoustIDFingerprint.
+//  2. LSHProbe performs one point-lookup per subprint and counts band hits per
+//     candidate fileID; only candidates with >= LSHMinBandHits (2) are returned.
+//  3. For each candidate, WholeFileSimilarity computes the Hamming similarity
+//     over the trimmed middle slices.  Candidates below cfg.MinHamming (0.85)
+//     are dropped.
+//  4. Accepted candidates emit a Signal with Raw = hamming, Confidence =
+//     lshConfidenceScale(hamming).
+//
+// queryBookID is used to suppress self-matches.  cfg controls calibration;
+// pass DefaultLSHAcoustIDConfig() for spec defaults.
+func CollectLSHAcoustID(
+	store LSHAcoustIDStore,
+	queryFile *database.BookFile,
+	queryBookID string,
+	cfg LSHAcoustIDConfig,
+) ([]unified.Signal, error) {
+	if queryFile == nil || len(queryFile.AcoustIDFingerprint) == 0 {
+		// Nothing to probe — caller should log at the appropriate level.
+		return nil, nil
+	}
+
+	// Gate: skip with INFO when the index has never been built.  This is the
+	// permanent replacement for the ACOUSTID_FUZZY_ENABLED env variable — when
+	// the index is absent we acknowledge it and return, rather than silently
+	// degrading to O(N) scanning that can stall the registry.
+	if !store.IsLSHIndexBuilt() {
+		slog.Info("dedup/collectors_acoustid: LSH index not yet built; skipping LSH probe",
+			"file_id", queryFile.ID,
+			"hint", "run lsh-index-build op to enable sub-linear acoustid matching")
+		return nil, nil
+	}
+
+	// Step 1: derive subprints from the whole-file fingerprint.
+	subs, bands, err := fingerprint.Subprints(queryFile.AcoustIDFingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("dedup/collectors_acoustid: subprints: %w", err)
+	}
+	if len(subs) == 0 {
+		// Fingerprint too short to sample — not an error; nothing to probe.
+		return nil, nil
+	}
+
+	// Step 2: LSH fan-out — point-lookups + band-hit filter.
+	candidates, err := store.LSHProbe(subs, bands, cfg.MaxCandidates)
+	if err != nil {
+		return nil, fmt.Errorf("dedup/collectors_acoustid: lsh probe: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	slog.Debug("dedup/collectors_acoustid: lsh probe returned candidates",
+		"file_id", queryFile.ID,
+		"candidate_count", len(candidates))
+
+	// Step 3 + 4: Hamming refinement and signal emission.
+	var signals []unified.Signal
+	seen := make(map[string]bool) // dedupe by candidate bookID
+
+	for candFileID := range candidates {
+		if candFileID == queryFile.ID {
+			continue
+		}
+
+		// Fetch the candidate BookFile to get its whole-file fingerprint.
+		// We pass "" as bookID because the caller may not know it; the
+		// PebbleStore implementation handles the "" case with a scan fallback.
+		candFile, err := store.GetBookFileByID("", candFileID)
+		if err != nil {
+			slog.Debug("dedup/collectors_acoustid: get candidate file error",
+				"cand_file_id", candFileID, "err", err)
+			continue
+		}
+		if candFile == nil {
+			continue
+		}
+		if candFile.BookID == queryBookID || seen[candFile.BookID] {
+			continue
+		}
+		if len(candFile.AcoustIDFingerprint) == 0 {
+			// Candidate was indexed but fingerprint was subsequently cleared —
+			// skip; stale index entry, harmless.
+			continue
+		}
+
+		// Hamming refinement: compare middle slices of the two fingerprints.
+		hamming, simErr := fingerprint.WholeFileSimilarity(
+			queryFile.AcoustIDFingerprint,
+			candFile.AcoustIDFingerprint,
+		)
+		if simErr != nil {
+			slog.Debug("dedup/collectors_acoustid: hamming similarity error",
+				"query_file", queryFile.ID, "cand_file", candFileID, "err", simErr)
+			continue
+		}
+
+		// Hamming-refine rejection: discard candidates below the threshold.
+		// This is the primary noise filter after the LSH pre-filter step; a
+		// low hamming similarity means the subprint collision was coincidental.
+		if hamming < cfg.MinHamming {
+			continue
+		}
+
+		seen[candFile.BookID] = true
+
+		conf := lshConfidenceScale(hamming, cfg.MinHamming, 1.0, cfg.MinConfidence, cfg.MaxConfidence)
+		signals = append(signals, unified.Signal{
+			Kind:       unified.SigLSHAcoustID,
+			Raw:        hamming,
+			Confidence: conf,
+			Evidence: fmt.Sprintf(
+				"lsh acoustid: file %s -> book %s (hamming %.4f, conf %.4f)",
+				candFile.ID, candFile.BookID, hamming, conf,
+			),
+		})
+	}
+
+	if len(signals) > 0 {
+		slog.Debug("dedup/collectors_acoustid: lsh probe emitted signals",
+			"file_id", queryFile.ID,
+			"signal_count", len(signals))
+	}
+
+	return signals, nil
+}

--- a/internal/dedup/collectors_acoustid_test.go
+++ b/internal/dedup/collectors_acoustid_test.go
@@ -1,0 +1,385 @@
+// file: internal/dedup/collectors_acoustid_test.go
+// version: 1.0.0
+// guid: b8c4d952-e0f3-5a26-99b1-6cd23f458g7e
+// last-edited: 2026-06-10
+
+package dedup
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// ─── test doubles ──────────────────────────────────────────────────────────────
+
+// stubExactStore satisfies ExactAcoustIDStore for CollectExactAcoustID tests.
+type stubExactStore struct {
+	// m maps seg string → *BookFile; nil value means "not found".
+	m map[string]*database.BookFile
+}
+
+func (s *stubExactStore) GetBookFileByAcoustID(fp string) (*database.BookFile, error) {
+	f, ok := s.m[fp]
+	if !ok {
+		return nil, nil
+	}
+	return f, nil
+}
+
+// stubLSHStore satisfies LSHAcoustIDStore for CollectLSHAcoustID tests.
+type stubLSHStore struct {
+	indexBuilt bool
+	// probeResult is returned verbatim from LSHProbe.
+	probeResult map[string]int
+	// filesByID maps fileID → BookFile.
+	filesByID map[string]*database.BookFile
+}
+
+func (s *stubLSHStore) IsLSHIndexBuilt() bool { return s.indexBuilt }
+
+func (s *stubLSHStore) LSHProbe(_ []fingerprint.Subprint, _ []byte, _ int) (map[string]int, error) {
+	return s.probeResult, nil
+}
+
+func (s *stubLSHStore) GetBookFileByID(_, fileID string) (*database.BookFile, error) {
+	f, ok := s.filesByID[fileID]
+	if !ok {
+		return nil, nil
+	}
+	return f, nil
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// makeFP returns a synthetic whole-file fingerprint of n uint32 frames
+// whose content is all zeros (a perfectly matching fingerprint for testing).
+func makeFP(n int) []byte {
+	b := make([]byte, n*4)
+	return b
+}
+
+// makeDifferentFP returns a fingerprint of n uint32 frames with all bits set
+// in the first half and all zeros in the second half, producing a Hamming
+// similarity of 0.50 when compared against makeFP(n).
+func makeDifferentFP(n int) []byte {
+	b := make([]byte, n*4)
+	for i := 0; i < (n/2)*4; i += 4 {
+		binary.LittleEndian.PutUint32(b[i:], 0xFFFFFFFF)
+	}
+	return b
+}
+
+// makeLowHammingFP returns a fingerprint whose Hamming similarity against
+// makeFP(n) will be exactly (n-flipCount)/n*32/32 ≈ 1-(flipCount/n).
+// We flip every bit in the first flipCount frames, yielding:
+//
+//	similarity = (totalBits - flippedBits) / totalBits
+//	           = (n*32 - flipCount*32) / (n*32)
+//	           = (n - flipCount) / n
+//
+// For n=100, flipCount=20 → similarity = 0.80 (below MinHamming 0.85).
+func makeLowHammingFP(n, flipCount int) []byte {
+	b := make([]byte, n*4)
+	for i := 0; i < flipCount*4; i += 4 {
+		binary.LittleEndian.PutUint32(b[i:], 0xFFFFFFFF)
+	}
+	return b
+}
+
+// makeHighHammingFP returns a fingerprint with Hamming similarity ≈ 0.9
+// against makeFP(n) by flipping all bits in 10% of frames.
+// n=100, flipCount=10 → similarity = 0.90.
+func makeHighHammingFP(n, flipCount int) []byte {
+	b := make([]byte, n*4)
+	for i := 0; i < flipCount*4; i += 4 {
+		binary.LittleEndian.PutUint32(b[i:], 0xFFFFFFFF)
+	}
+	return b
+}
+
+// ─── CollectExactAcoustID tests ───────────────────────────────────────────────
+
+// validFP80 is a base64-encoded chromaprint with 80 uint32 frames and a
+// non-zero pattern, satisfying IsUsefulFingerprint (>= MinUsefulFingerprintFrames).
+// Generated deterministically with Python (seed 42) for reproducibility.
+const validFP80 = "AQAAAKQdB75HPzokvRuuvuWMF5htCQgYODyCmweQM7intIxsOXOXSNDfAsPPKbNtWEgoOPbEVxsYYhlc2VmbRM8Mu3aKIPrtYRWOTNWhn+PdXZQytRIMqjvGS/0V2zzeGmJIdaPWXipfWzasRbTwr6YTnKMsibs/KndiRv7tpLGPObBU2MXHDzvTCc9RZ0URN+rykuG4UTeogGbj66V2JUQkQL+QikTAlm7mlmddOSSDfxjCDd0dKKEpy69tmRFjYpl4iEH5jt3yA6+5Hq/jisFFxaVYHUxwKXUB9bnhuUT5gcQuguoc36FN2KSCnDMoYMQqi/XI7YjsAZpTfgUd7l3h/dXPTz4PPuGS8xUWvH3REvvDicUhIal6840rRIjgnG33N+6LwruxNLdQZ/+sp2Bx54V0H0A6EVcGl447lzkCE7ai"
+
+func TestCollectExactAcoustID_HitEmitsSignal(t *testing.T) {
+	queryFile := &database.BookFile{
+		ID:           "qfile1",
+		BookID:       "bookA",
+		AcoustIDSeg0: validFP80,
+	}
+	candidateFile := &database.BookFile{
+		ID:     "cfile1",
+		BookID: "bookB",
+	}
+	store := &stubExactStore{m: map[string]*database.BookFile{validFP80: candidateFile}}
+
+	sigs, err := CollectExactAcoustID(store, queryFile, "bookA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 1 {
+		t.Fatalf("expected 1 signal, got %d", len(sigs))
+	}
+	if sigs[0].Kind != unified.SigExactAcoustID {
+		t.Errorf("expected SigExactAcoustID, got %q", sigs[0].Kind)
+	}
+	if sigs[0].Confidence != 0.99 {
+		t.Errorf("expected confidence 0.99, got %v", sigs[0].Confidence)
+	}
+}
+
+func TestCollectExactAcoustID_SelfMatchSkipped(t *testing.T) {
+	// The candidate lives in the same book as the query — must not emit.
+	queryFile := &database.BookFile{
+		ID:           "qfile1",
+		BookID:       "bookA",
+		AcoustIDSeg0: validFP80,
+	}
+	selfFile := &database.BookFile{ID: "other-file", BookID: "bookA"}
+	store := &stubExactStore{m: map[string]*database.BookFile{validFP80: selfFile}}
+
+	sigs, err := CollectExactAcoustID(store, queryFile, "bookA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals for self-match, got %d", len(sigs))
+	}
+}
+
+func TestCollectExactAcoustID_NoSegments(t *testing.T) {
+	queryFile := &database.BookFile{ID: "qfile1", BookID: "bookA"}
+	store := &stubExactStore{m: map[string]*database.BookFile{}}
+
+	sigs, err := CollectExactAcoustID(store, queryFile, "bookA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals for empty file, got %d", len(sigs))
+	}
+}
+
+// ─── lshConfidenceScale tests ─────────────────────────────────────────────────
+
+func TestLSHConfidenceScale_Boundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		hamming float64
+		want    float64
+	}{
+		{"at_min", 0.85, 0.90},
+		{"at_max", 1.00, 0.97},
+		{"below_min_clamp", 0.70, 0.90},
+		{"above_max_clamp", 1.10, 0.97},
+		{"midpoint", 0.925, 0.935},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lshConfidenceScale(tc.hamming, 0.85, 1.0, 0.90, 0.97)
+			// Allow small floating-point epsilon.
+			const eps = 1e-9
+			diff := got - tc.want
+			if diff < -eps || diff > eps {
+				t.Errorf("lshConfidenceScale(%.3f) = %.6f, want %.6f",
+					tc.hamming, got, tc.want)
+			}
+		})
+	}
+}
+
+// ─── CollectLSHAcoustID tests ─────────────────────────────────────────────────
+
+// TestCollectLSHAcoustID_TruePositive exercises the happy path:
+// two files with >= 2 band hits and a high Hamming similarity emit a signal.
+func TestCollectLSHAcoustID_TruePositive(t *testing.T) {
+	// Use a large fingerprint so Subprints can produce >= LSHBandCount samples.
+	// 1000 uint32 frames at 8 fps ≈ 125s — well above minFramesForLSH.
+	queryFP := makeFP(1000)
+	candFP := makeFP(1000) // identical → Hamming 1.0
+
+	queryFile := &database.BookFile{
+		ID:                  "qfile1",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+	candFile := &database.BookFile{
+		ID:                  "cfile1",
+		BookID:              "bookB",
+		AcoustIDFingerprint: candFP,
+	}
+
+	store := &stubLSHStore{
+		indexBuilt:  true,
+		probeResult: map[string]int{"cfile1": 3}, // 3 band hits >= LSHMinBandHits(2)
+		filesByID:   map[string]*database.BookFile{"cfile1": candFile},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 1 {
+		t.Fatalf("expected 1 signal, got %d (sigs: %+v)", len(sigs), sigs)
+	}
+	sig := sigs[0]
+	if sig.Kind != unified.SigLSHAcoustID {
+		t.Errorf("expected SigLSHAcoustID, got %q", sig.Kind)
+	}
+	// Identical fingerprints → Hamming = 1.0 → MaxConfidence = 0.97.
+	if sig.Raw != 1.0 {
+		t.Errorf("expected raw hamming 1.0, got %v", sig.Raw)
+	}
+	if sig.Confidence != 0.97 {
+		t.Errorf("expected confidence 0.97 for hamming 1.0, got %v", sig.Confidence)
+	}
+}
+
+// TestCollectLSHAcoustID_BelowBandThreshold: LSHProbe returns no candidates
+// (empty map because the stub only returns hits that passed band filtering).
+// Simulates a file that did not accumulate enough band hits.
+func TestCollectLSHAcoustID_BelowBandThreshold(t *testing.T) {
+	queryFP := makeFP(1000)
+	queryFile := &database.BookFile{
+		ID:                  "qfile1",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+
+	store := &stubLSHStore{
+		indexBuilt:  true,
+		probeResult: map[string]int{}, // no candidates passed the band threshold
+		filesByID:   map[string]*database.BookFile{},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals when no band-hit candidates, got %d", len(sigs))
+	}
+}
+
+// TestCollectLSHAcoustID_HammingRefineRejection: a candidate survives band
+// filtering (>= 2 hits) but its Hamming similarity is below MinHamming (0.85)
+// and must therefore be dropped by the Hamming refinement step.
+func TestCollectLSHAcoustID_HammingRefineRejection(t *testing.T) {
+	// n=100 frames, flipCount=20 → Hamming similarity = (100-20)/100 = 0.80 < 0.85.
+	queryFP := makeFP(100)
+	candFP := makeLowHammingFP(100, 20) // similarity 0.80
+
+	queryFile := &database.BookFile{
+		ID:                  "qfile1",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+	candFile := &database.BookFile{
+		ID:                  "cfile_low",
+		BookID:              "bookC",
+		AcoustIDFingerprint: candFP,
+	}
+
+	store := &stubLSHStore{
+		indexBuilt:  true,
+		probeResult: map[string]int{"cfile_low": 4}, // passed band filter
+		filesByID:   map[string]*database.BookFile{"cfile_low": candFile},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals after Hamming rejection, got %d (hamming would be ~0.80)", len(sigs))
+	}
+}
+
+// TestCollectLSHAcoustID_UnbuiltIndexSkip verifies that when IsLSHIndexBuilt
+// returns false the collector returns (nil, nil) without calling LSHProbe.
+func TestCollectLSHAcoustID_UnbuiltIndexSkip(t *testing.T) {
+	queryFP := makeFP(1000)
+	queryFile := &database.BookFile{
+		ID:                  "qfile1",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+
+	store := &stubLSHStore{
+		indexBuilt: false, // LSH index has not been built
+		// probeResult deliberately non-empty to catch spurious probe calls.
+		probeResult: map[string]int{"some-file": 5},
+		filesByID: map[string]*database.BookFile{
+			"some-file": {ID: "some-file", BookID: "bookB"},
+		},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals when index unbuilt, got %d", len(sigs))
+	}
+}
+
+// TestCollectLSHAcoustID_SelfMatchSkipped ensures a candidate whose BookID
+// equals queryBookID is never emitted.
+func TestCollectLSHAcoustID_SelfMatchSkipped(t *testing.T) {
+	queryFP := makeFP(1000)
+	queryFile := &database.BookFile{
+		ID:                  "qfile1",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+	// Candidate is in the same book.
+	selfFile := &database.BookFile{
+		ID:                  "other-qfile",
+		BookID:              "bookA",
+		AcoustIDFingerprint: queryFP,
+	}
+
+	store := &stubLSHStore{
+		indexBuilt:  true,
+		probeResult: map[string]int{"other-qfile": 10},
+		filesByID:   map[string]*database.BookFile{"other-qfile": selfFile},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals for self-book candidate, got %d", len(sigs))
+	}
+}
+
+// TestCollectLSHAcoustID_NoFingerprint: queryFile has no whole-file fingerprint
+// → immediately returns nil without touching the store.
+func TestCollectLSHAcoustID_NoFingerprint(t *testing.T) {
+	queryFile := &database.BookFile{
+		ID:     "qfile1",
+		BookID: "bookA",
+		// AcoustIDFingerprint intentionally left nil
+	}
+
+	store := &stubLSHStore{
+		indexBuilt:  true,
+		probeResult: map[string]int{"some-file": 5},
+	}
+
+	sigs, err := CollectLSHAcoustID(store, queryFile, "bookA", DefaultLSHAcoustIDConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Errorf("expected 0 signals for no-fingerprint file, got %d", len(sigs))
+	}
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.23.0
+// version: 1.24.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-05-18
+// last-edited: 2026-06-10
 
 package dedup
 
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -27,24 +26,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// acoustidFuzzyEnabled gates the tier-2 fuzzy AcoustID lookup. Default OFF.
-//
-// Background: tier-2 is an O(N) similarity scan over all 308K+ BookFile rows
-// per query. The dedup engine calls it per seg per file per book when the
-// tier-1 exact lookup misses — which on a fresh corpus is most segments,
-// because rescan hasn't backfilled fingerprints for neighbouring books yet.
-// Even routed through memdb (PR #1194) the in-RAM walk is too slow to keep
-// the scan moving fast enough to dodge the registry's infinite-restart
-// force-drop guard.
-//
-// Until LSH/minhash bucketing lands (architecture proposal Stage B), tier-2
-// stays off by default. Set ACOUSTID_FUZZY_ENABLED=1 to re-enable for
-// experiments on small corpora.
-//
-// Tier-1 (exact) is O(1) via the pre-built book_file_acoustid: Pebble index
-// and catches the dominant case (identical fingerprints across duplicates).
-var acoustidFuzzyEnabled = os.Getenv("ACOUSTID_FUZZY_ENABLED") == "1"
 
 var dedupTracer = otel.Tracer("audiobook-organizer/dedup")
 
@@ -2260,8 +2241,7 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		for _, f := range files {
 			// Tier-0: whole-file LSH candidate set + Hamming refine.
 			// Sub-linear via the fpidx: secondary index, so it runs
-			// unconditionally (no acoustidFuzzyEnabled gate needed —
-			// the index caps candidates so the work is bounded).
+			// unconditionally (index caps candidates, so work is bounded).
 			if lshStore != nil && len(f.AcoustIDFingerprint) > 0 {
 				cands, _ := lshStore.LookupAcoustIDCandidates(f.AcoustIDFingerprint, 200)
 				for _, candID := range cands {
@@ -2310,20 +2290,6 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 					continue
 				}
 
-				// Tier 2: legacy fuzzy walk over seg strings. Gated by
-				// ACOUSTID_FUZZY_ENABLED — OFF by default. Kept only as
-				// an emergency fallback for libraries without whole-file
-				// fingerprints (rare now that LSH is the default).
-				if !acoustidFuzzyEnabled {
-					continue
-				}
-				if match, _ := de.bookStore.GetBookFileByAcoustIDFuzzy(seg, fingerprint.FuzzyMinSimilarity); match != nil && match.BookID != book.ID {
-					sim, simErr := fingerprint.HammingSimilarity(seg, bestSeg(match))
-					if simErr != nil {
-						sim = fingerprint.FuzzyMinSimilarity
-					}
-					emit(book.ID, match.BookID, sim)
-				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

- **New file `internal/dedup/collectors_acoustid.go`** — two exported collectors for T014 to wire:
  - `CollectExactAcoustID`: O(1) exact match via `book_file_acoustid:` Pebble secondary index; emits `SigExactAcoustID` (conf 0.99, SPEC 1 §3)
  - `CollectLSHAcoustID`: sub-linear fan-out via `fpidx:` secondary index (T012 `LSHProbe`) + `WholeFileSimilarity` Hamming refinement; emits `SigLSHAcoustID` with Hamming-scaled confidence 0.90–0.97 (SPEC 1 §3); gated on `IsLSHIndexBuilt()` — returns `(nil, nil)` + INFO log when unbuilt, NEVER falls back to O(N)
- **`internal/dedup/engine.go`** — removes `acoustidFuzzyEnabled` var and its O(N) `GetBookFileByAcoustIDFuzzy` block entirely; `grep ACOUSTID_FUZZY_ENABLED` returns zero functional hits; version bumped 1.23→1.24
- **`internal/dedup/collectors_acoustid_test.go`** — 9 unit tests: true-positive pair, below-band-threshold negative, Hamming-refine rejection, unbuilt-index skip, self-match suppression, no-fingerprint short-circuit, confidence scaling boundaries

## Acceptance criteria

- [x] LSH collector returns calibrated signal for known-similar fixture pair (`TestCollectLSHAcoustID_TruePositive`)
- [x] `ACOUSTID_FUZZY_ENABLED` no longer referenced anywhere functionally (grep: 0 functional hits)
- [x] `go build ./...`, `go vet ./internal/dedup/...`, `go test ./internal/dedup/... -count=1 -race` all green

## Test plan

- [x] `go test ./internal/dedup/... -count=1 -race` — 9 new tests + existing dedup suite all pass
- [x] `go build ./...` — full binary build clean
- [ ] `make ci` — 80% coverage gate (running in CI)

## Notes

This is T013 in the fable5 execution plan. Collectors are standalone exported functions — T014 will wire them into `Engine.CheckBook`/`AcoustIDScan`. Engine changes in this PR are deliberately minimal (dead-code removal only) to keep T013 independently mergeable and conflict-free with T014's orchestration refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)