### PR TITLE
feat(itunes): honest itl-diff/itl-check — inventory, membership, audit (fable5 T007)

### DIFF
--- a/cmd/itl-check/main.go
+++ b/cmd/itl-check/main.go
@@ -1,23 +1,89 @@
+// file: cmd/itl-check/main.go
+// version: 2.0.0
+// guid: 3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
+//
+// itl-check — audit an iTunes Library .itl file against the ITLSafetyContract.
+//
+// Usage:
+//
+//	itl-check <library.itl>
+//
+// Reads the library, runs AuditITL (all eight named guards from T003), and
+// prints a per-guard verdict table plus per-guard violation counts.
+//
+// Exit codes:
+//
+//	0 — all guards passed
+//	1 — one or more guards reported violations
+//	2 — usage error or file could not be read/parsed
+
 package main
 
 import (
 	"fmt"
-	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 	"os"
+
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 )
 
 func main() {
-	lib, err := itunes.ParseITL(os.Args[1])
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: itl-check <library.itl>")
+		os.Exit(2)
+	}
+	path := os.Args[1]
+
+	data, err := os.ReadFile(path)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", path, err)
+		os.Exit(2)
 	}
-	fmt.Printf("Tracks: %d, Playlists: %d, Version: %s\n", len(lib.Tracks), len(lib.Playlists), lib.Version)
-	locs := 0
-	for _, t := range lib.Tracks {
-		if t.Location != "" {
-			locs++
+
+	verdict := itunes.AuditITL(data)
+
+	// Print summary header.
+	fmt.Printf("itl-check: %s\n", path)
+	lib, parseErr := itunes.ParseITL(path)
+	if parseErr == nil {
+		fmt.Printf("Tracks: %d  Playlists: %d  Version: %s\n",
+			len(lib.Tracks), len(lib.Playlists), lib.Version)
+		locs := 0
+		for _, t := range lib.Tracks {
+			if t.Location != "" {
+				locs++
+			}
 		}
+		fmt.Printf("Tracks with Location: %d\n", locs)
 	}
-	fmt.Printf("Tracks with Location: %d\n", locs)
+	fmt.Println()
+
+	// Per-guard table.
+	fmt.Printf("%-24s  %s\n", "Guard", "Result")
+	fmt.Printf("%-24s  %s\n", "------------------------", "------")
+	for _, r := range verdict.Results {
+		status := "PASS"
+		detail := ""
+		if !r.Pass() {
+			status = fmt.Sprintf("FAIL (%d violation(s))", len(r.Violations))
+			// Show the first violation message as a hint.
+			if len(r.Violations) > 0 {
+				v := r.Violations[0]
+				detail = fmt.Sprintf("  -> [%s@%d] %s", v.Chunk, v.Offset, v.Message)
+				if len(r.Violations) > 1 {
+					detail += fmt.Sprintf(" (+%d more)", len(r.Violations)-1)
+				}
+			}
+		}
+		fmt.Printf("%-24s  %s%s\n", r.Guard, status, detail)
+	}
+	fmt.Println()
+
+	if verdict.Pass {
+		fmt.Println("Verdict: PASS — no violations found")
+		os.Exit(0)
+	}
+
+	failed := verdict.FailedGuards()
+	fmt.Printf("Verdict: FAIL — %d guard(s) violated: %v\n", len(failed), failed)
+	os.Exit(1)
 }

--- a/cmd/itl-diff/main.go
+++ b/cmd/itl-diff/main.go
@@ -1,16 +1,17 @@
 // file: cmd/itl-diff/main.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
 //
 // Structural diff between two iTunes Library.itl files. Reports:
-//   - hdfm header comparison (version, header length, file length, max_crypt_size,
-//     full byte-diff of the version "remainder" header trailing bytes)
-//   - msdh container inventory (block-type → header-len, total-len)
-//   - mlth track count
-//   - per-track metadata diff (by Persistent ID): which mhoh fields changed,
-//     which fields are present in A but missing in B (and vice versa)
+//   - hdfm header comparison (version, header length, file length; byte-diff
+//     of the first 96 raw bytes)
+//   - msdh container inventory (block-type → hdrLen/totalLen, Δ between A and B)
+//   - track count deltas and per-track metadata diff (by Persistent ID); string
+//     fields are meaningful when T001's mhoh-descent fix is present
+//   - playlist membership diff (per-playlist added/removed TIDs)
+//   - optional: --audit runs AuditITL on both sides and reports per-guard results
 //
-// Usage: itl-diff <a.itl> <b.itl>
+// Usage: itl-diff [flags] <a.itl> <b.itl>
 
 package main
 
@@ -28,9 +29,10 @@ import (
 func main() {
 	verbose := flag.Bool("v", false, "Verbose: list per-track diffs")
 	max := flag.Int("max", 20, "Max per-track diffs to print in verbose mode")
+	audit := flag.Bool("audit", false, "Run AuditITL (ITLSafetyContract) on both libraries")
 	flag.Parse()
 	if flag.NArg() != 2 {
-		fmt.Fprintln(os.Stderr, "Usage: itl-diff [-v] [-max N] <a.itl> <b.itl>")
+		fmt.Fprintln(os.Stderr, "Usage: itl-diff [-v] [-max N] [--audit] <a.itl> <b.itl>")
 		os.Exit(2)
 	}
 
@@ -41,7 +43,7 @@ func main() {
 
 	fmt.Printf("A: %s\nB: %s\n\n", flag.Arg(0), flag.Arg(1))
 
-	// File bytes for low-level comparison
+	// File bytes for low-level comparison.
 	rawA, _ := os.ReadFile(flag.Arg(0))
 	rawB, _ := os.ReadFile(flag.Arg(1))
 	fmt.Printf("File size:        A=%d  B=%d  (Δ=%+d)\n",
@@ -52,14 +54,17 @@ func main() {
 	fmt.Printf("Playlist count:   A=%d B=%d (Δ=%+d)\n\n",
 		len(a.Playlists), len(b.Playlists), len(b.Playlists)-len(a.Playlists))
 
-	// hdfm header comparison
+	// hdfm header hex diff.
 	if len(rawA) >= 96 && len(rawB) >= 96 {
 		fmt.Println("hdfm header (first 96 bytes):")
 		printHexDiff(rawA[:96], rawB[:96])
 		fmt.Println()
 	}
 
-	// Per-track diff by PID
+	// msdh container inventory diff.
+	printInventoryDiff(rawA, rawB)
+
+	// Per-track diff by PID.
 	indexA := map[string]itunes.ITLTrack{}
 	for _, t := range a.Tracks {
 		indexA[hex.EncodeToString(t.PersistentID[:])] = t
@@ -121,6 +126,138 @@ func main() {
 			diffInt("Year", ta.Year, tb.Year)
 		}
 	}
+
+	// Playlist membership diff.
+	fmt.Println()
+	printMembershipDiff(a, b, *verbose, *max)
+
+	// AuditITL on both sides (--audit flag).
+	if *audit {
+		fmt.Println()
+		printAuditSection("A", rawA)
+		printAuditSection("B", rawB)
+	}
+}
+
+// printInventoryDiff prints the msdh container inventory comparison.
+func printInventoryDiff(rawA, rawB []byte) {
+	payloadA, errA := itunes.DecryptAndInflateITL(rawA)
+	payloadB, errB := itunes.DecryptAndInflateITL(rawB)
+
+	fmt.Println("msdh container inventory:")
+	if errA != nil || errB != nil {
+		if errA != nil {
+			fmt.Printf("  (cannot decode A: %v)\n", errA)
+		}
+		if errB != nil {
+			fmt.Printf("  (cannot decode B: %v)\n", errB)
+		}
+		fmt.Println()
+		return
+	}
+
+	invA := itunes.CollectMsdhInventory(payloadA)
+	invB := itunes.CollectMsdhInventory(payloadB)
+
+	// Print per-container table.
+	indexB := make(map[int]itunes.MsdhEntry, len(invB))
+	for _, e := range invB {
+		indexB[e.BlockType] = e
+	}
+	indexA := make(map[int]itunes.MsdhEntry, len(invA))
+	for _, e := range invA {
+		indexA[e.BlockType] = e
+	}
+
+	// Collect all known block types.
+	allTypes := map[int]struct{}{}
+	for _, e := range invA {
+		allTypes[e.BlockType] = struct{}{}
+	}
+	for _, e := range invB {
+		allTypes[e.BlockType] = struct{}{}
+	}
+	sortedTypes := make([]int, 0, len(allTypes))
+	for bt := range allTypes {
+		sortedTypes = append(sortedTypes, bt)
+	}
+	sort.Ints(sortedTypes)
+
+	fmt.Printf("  %-14s  %-12s  %-12s  %-12s  %-12s  %s\n",
+		"type", "A.hdrLen", "A.totalLen", "B.hdrLen", "B.totalLen", "delta")
+	for _, bt := range sortedTypes {
+		ea, okA := indexA[bt]
+		eb, okB := indexB[bt]
+		name := itunes.MsdhEntry{BlockType: bt}.BlockTypeName()
+		label := fmt.Sprintf("%d (%s)", bt, name)
+		if !okA {
+			fmt.Printf("  %-14s  %-12s  %-12s  %-12d  %-12d  (only in B)\n",
+				label, "-", "-", eb.HeaderLen, eb.TotalLen)
+		} else if !okB {
+			fmt.Printf("  %-14s  %-12d  %-12d  %-12s  %-12s  (only in A)\n",
+				label, ea.HeaderLen, ea.TotalLen, "-", "-")
+		} else {
+			delta := eb.TotalLen - ea.TotalLen
+			marker := " "
+			if delta != 0 {
+				marker = "*"
+			}
+			fmt.Printf("  %s %-13s  %-12d  %-12d  %-12d  %-12d  %+d\n",
+				marker, label, ea.HeaderLen, ea.TotalLen, eb.HeaderLen, eb.TotalLen, delta)
+		}
+	}
+	fmt.Println()
+}
+
+// printMembershipDiff prints playlist membership changes.
+func printMembershipDiff(a, b *itunes.ITLLibrary, verbose bool, maxItems int) {
+	result := itunes.DiffPlaylistMembership(a, b)
+
+	fmt.Printf("Playlist membership diff:\n")
+	fmt.Printf("  Playlists only in A: %d\n", len(result.OnlyA))
+	fmt.Printf("  Playlists only in B: %d\n", len(result.OnlyB))
+	fmt.Printf("  Playlists changed:   %d\n", len(result.Changed))
+
+	if !verbose || len(result.Changed) == 0 {
+		return
+	}
+	fmt.Println()
+	for i, ch := range result.Changed {
+		if i >= maxItems {
+			fmt.Printf("  ...and %d more changed playlists\n", len(result.Changed)-maxItems)
+			break
+		}
+		title := ch.Title
+		if title == "" {
+			title = "(untitled)"
+		}
+		fmt.Printf("  Playlist %s %q:\n", ch.PID, title)
+		if len(ch.Added) > 0 {
+			fmt.Printf("    Added   TIDs: %v\n", ch.Added)
+		}
+		if len(ch.Removed) > 0 {
+			fmt.Printf("    Removed TIDs: %v\n", ch.Removed)
+		}
+	}
+}
+
+// printAuditSection runs AuditITL on a raw library and prints the per-guard verdict.
+func printAuditSection(label string, raw []byte) {
+	fmt.Printf("AuditITL (%s):\n", label)
+	verdict := itunes.AuditITL(raw)
+	for _, r := range verdict.Results {
+		status := "PASS"
+		if !r.Pass() {
+			status = fmt.Sprintf("FAIL (%d violation(s))", len(r.Violations))
+		}
+		fmt.Printf("  %-24s  %s\n", r.Guard, status)
+	}
+	if verdict.Pass {
+		fmt.Printf("  -> %s: all guards passed\n", label)
+	} else {
+		fmt.Printf("  -> %s: VIOLATIONS in guards: %v\n", label, verdict.FailedGuards())
+	}
+	fmt.Println()
 }
 
 func tracksEqual(a, b itunes.ITLTrack) bool {

--- a/internal/itunes/itl_diff_helpers.go
+++ b/internal/itunes/itl_diff_helpers.go
@@ -1,0 +1,267 @@
+// file: internal/itunes/itl_diff_helpers.go
+// version: 1.0.0
+// guid: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+//
+// Testable helpers for itl-diff: msdh container inventory and playlist
+// membership diff. Keeping the diffable walks in this package (rather than
+// in cmd/itl-diff) makes them unit-testable against generated fixtures.
+//
+// Used by: cmd/itl-diff (inventory + membership sections), cmd/itl-check
+// (indirectly via AuditITL which operates on the same decrypted payload).
+
+package itunes
+
+import (
+	"encoding/hex"
+	"sort"
+)
+
+// ---------------------------------------------------------------------------
+// msdh container inventory
+// ---------------------------------------------------------------------------
+
+// MsdhEntry describes one top-level msdh container in a decrypted ITL payload.
+type MsdhEntry struct {
+	// BlockType is the value at msdh+12 (LE uint32). Well-known values:
+	//   1 = master track list, 2 = playlist list, 9 = album list, 11 = artist list.
+	BlockType int
+	// HeaderLen is the fixed header portion length (msdh+4, LE uint32).
+	HeaderLen int
+	// TotalLen is the full container length including all children (msdh+8, LE uint32).
+	TotalLen int
+}
+
+// BlockTypeName returns a human-readable name for known msdh block types.
+func (e MsdhEntry) BlockTypeName() string {
+	switch e.BlockType {
+	case 1:
+		return "track-list"
+	case 2:
+		return "playlist-list"
+	case 9:
+		return "album-list"
+	case 11:
+		return "artist-list"
+	default:
+		return "unknown"
+	}
+}
+
+// CollectMsdhInventory walks all top-level msdh containers in a decrypted LE
+// ITL payload and returns an ordered slice of MsdhEntry (one per container).
+// The payload must be the result of DecryptAndInflateITL or equivalent; it
+// starts with the first "msdh" tag.
+//
+// Returns an empty slice (not nil) if the payload is not LE format.
+func CollectMsdhInventory(payload []byte) []MsdhEntry {
+	if !detectLE(payload) {
+		return []MsdhEntry{}
+	}
+	var entries []MsdhEntry
+	offset := 0
+	for offset+16 <= len(payload) {
+		tag := readTag(payload, offset)
+		if tag != "msdh" {
+			break
+		}
+		hdrLen := int(readUint32LE(payload, offset+4))
+		totalLen := int(readUint32LE(payload, offset+8))
+		blockType := int(readUint32LE(payload, offset+12))
+		if totalLen < 16 || offset+totalLen > len(payload) {
+			break
+		}
+		entries = append(entries, MsdhEntry{
+			BlockType: blockType,
+			HeaderLen: hdrLen,
+			TotalLen:  totalLen,
+		})
+		offset += totalLen
+	}
+	return entries
+}
+
+// MsdhInventoryDiff describes the difference in msdh inventories between two
+// ITL payloads. For containers present in both, the entry records the before/after
+// sizes; containers present in only one side are listed in OnlyA or OnlyB.
+type MsdhInventoryDiff struct {
+	// Changed lists containers present in both A and B but with different sizes.
+	Changed []MsdhInventoryChange
+	// OnlyA lists block types present only in A.
+	OnlyA []MsdhEntry
+	// OnlyB lists block types present only in B.
+	OnlyB []MsdhEntry
+}
+
+// MsdhInventoryChange records a container whose sizes changed between A and B.
+type MsdhInventoryChange struct {
+	BlockType int
+	A         MsdhEntry
+	B         MsdhEntry
+}
+
+// DiffMsdhInventory computes the inventory diff between two decrypted ITL payloads.
+func DiffMsdhInventory(payloadA, payloadB []byte) MsdhInventoryDiff {
+	invA := CollectMsdhInventory(payloadA)
+	invB := CollectMsdhInventory(payloadB)
+
+	indexA := make(map[int]MsdhEntry, len(invA))
+	for _, e := range invA {
+		indexA[e.BlockType] = e
+	}
+	indexB := make(map[int]MsdhEntry, len(invB))
+	for _, e := range invB {
+		indexB[e.BlockType] = e
+	}
+
+	var diff MsdhInventoryDiff
+	for _, ea := range invA {
+		eb, ok := indexB[ea.BlockType]
+		if !ok {
+			diff.OnlyA = append(diff.OnlyA, ea)
+			continue
+		}
+		if ea.HeaderLen != eb.HeaderLen || ea.TotalLen != eb.TotalLen {
+			diff.Changed = append(diff.Changed, MsdhInventoryChange{
+				BlockType: ea.BlockType, A: ea, B: eb,
+			})
+		}
+	}
+	for _, eb := range invB {
+		if _, ok := indexA[eb.BlockType]; !ok {
+			diff.OnlyB = append(diff.OnlyB, eb)
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(diff.Changed, func(i, j int) bool {
+		return diff.Changed[i].BlockType < diff.Changed[j].BlockType
+	})
+	sort.Slice(diff.OnlyA, func(i, j int) bool {
+		return diff.OnlyA[i].BlockType < diff.OnlyA[j].BlockType
+	})
+	sort.Slice(diff.OnlyB, func(i, j int) bool {
+		return diff.OnlyB[i].BlockType < diff.OnlyB[j].BlockType
+	})
+	return diff
+}
+
+// ---------------------------------------------------------------------------
+// Playlist membership diff
+// ---------------------------------------------------------------------------
+
+// PlaylistMembership records the track IDs (as TrackIDs, integer) in a playlist
+// identified by its PID (hex-encoded, BE/MSB-first, matching XML format).
+type PlaylistMembership struct {
+	PID   string // hex-encoded 8-byte playlist persistent ID
+	Title string // decoded title mhoh (may be empty if not present)
+	TIDs  []int  // ordered track IDs in playlist order
+}
+
+// PlaylistMembershipDiff describes what changed for a single playlist.
+type PlaylistMembershipDiff struct {
+	PID     string
+	Title   string
+	Added   []int // TIDs in B but not A
+	Removed []int // TIDs in A but not B
+}
+
+// MembershipDiffResult is the full result of DiffPlaylistMembership.
+type MembershipDiffResult struct {
+	// Changed lists playlists present in both A and B with different membership.
+	Changed []PlaylistMembershipDiff
+	// OnlyA lists playlists present only in A (by PID).
+	OnlyA []PlaylistMembership
+	// OnlyB lists playlists present only in B (by PID).
+	OnlyB []PlaylistMembership
+}
+
+// CollectPlaylistMemberships extracts playlist membership from a parsed library.
+func CollectPlaylistMemberships(lib *ITLLibrary) []PlaylistMembership {
+	out := make([]PlaylistMembership, 0, len(lib.Playlists))
+	for _, p := range lib.Playlists {
+		pid := hex.EncodeToString(p.PersistentID[:])
+		pm := PlaylistMembership{
+			PID:   pid,
+			Title: p.Title,
+			TIDs:  make([]int, len(p.Items)),
+		}
+		copy(pm.TIDs, p.Items)
+		out = append(out, pm)
+	}
+	return out
+}
+
+// DiffPlaylistMembership computes playlist membership differences between two
+// parsed ITL libraries. Two playlists are matched by persistent ID.
+func DiffPlaylistMembership(libA, libB *ITLLibrary) MembershipDiffResult {
+	msA := CollectPlaylistMemberships(libA)
+	msB := CollectPlaylistMemberships(libB)
+
+	indexA := make(map[string]PlaylistMembership, len(msA))
+	for _, m := range msA {
+		indexA[m.PID] = m
+	}
+	indexB := make(map[string]PlaylistMembership, len(msB))
+	for _, m := range msB {
+		indexB[m.PID] = m
+	}
+
+	var result MembershipDiffResult
+
+	for _, ma := range msA {
+		mb, ok := indexB[ma.PID]
+		if !ok {
+			result.OnlyA = append(result.OnlyA, ma)
+			continue
+		}
+		diff := membershipDiff(ma, mb)
+		if len(diff.Added) > 0 || len(diff.Removed) > 0 {
+			result.Changed = append(result.Changed, diff)
+		}
+	}
+	for _, mb := range msB {
+		if _, ok := indexA[mb.PID]; !ok {
+			result.OnlyB = append(result.OnlyB, mb)
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(result.Changed, func(i, j int) bool {
+		return result.Changed[i].PID < result.Changed[j].PID
+	})
+	sort.Slice(result.OnlyA, func(i, j int) bool { return result.OnlyA[i].PID < result.OnlyA[j].PID })
+	sort.Slice(result.OnlyB, func(i, j int) bool { return result.OnlyB[i].PID < result.OnlyB[j].PID })
+	return result
+}
+
+// membershipDiff computes added/removed TIDs between two playlists with the same PID.
+func membershipDiff(a, b PlaylistMembership) PlaylistMembershipDiff {
+	setA := make(map[int]struct{}, len(a.TIDs))
+	for _, tid := range a.TIDs {
+		setA[tid] = struct{}{}
+	}
+	setB := make(map[int]struct{}, len(b.TIDs))
+	for _, tid := range b.TIDs {
+		setB[tid] = struct{}{}
+	}
+
+	var added, removed []int
+	for _, tid := range b.TIDs {
+		if _, ok := setA[tid]; !ok {
+			added = append(added, tid)
+		}
+	}
+	for _, tid := range a.TIDs {
+		if _, ok := setB[tid]; !ok {
+			removed = append(removed, tid)
+		}
+	}
+	sort.Ints(added)
+	sort.Ints(removed)
+
+	title := a.Title
+	if title == "" {
+		title = b.Title
+	}
+	return PlaylistMembershipDiff{PID: a.PID, Title: title, Added: added, Removed: removed}
+}

--- a/internal/itunes/itl_diff_helpers_test.go
+++ b/internal/itunes/itl_diff_helpers_test.go
@@ -1,0 +1,262 @@
+// file: internal/itunes/itl_diff_helpers_test.go
+// version: 1.0.0
+// guid: e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b
+//
+// Tests for itl_diff_helpers.go: msdh container inventory and playlist
+// membership diff. Fixtures are built using the existing synthetic LE
+// builder helpers from itl_le_test.go (same package).
+
+package itunes
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+// buildFixturePayload constructs a minimal LE payload with:
+//   - msdh blockType=1 (track list) containing the given tracks
+//   - msdh blockType=2 (playlist list) containing the given playlists
+//
+// Each track is a mith block followed by its mhoh children.
+// Each playlist is a miph block followed by its mtph children.
+func buildFixturePayload(tracks []fixtureTrk, playlists []fixturePL) []byte {
+	// --- track-list container ---
+	var trackContent []byte
+	for _, tr := range tracks {
+		mith := testBuildMithLE(tr.id, tr.pid, 0, 0)
+		trackContent = append(trackContent, mith...)
+	}
+	trackMsdh := buildMsdhLE(0x01, trackContent)
+
+	// --- playlist-list container ---
+	var playlistContent []byte
+	for _, pl := range playlists {
+		miph := buildMiphLE(pl.pid)
+		playlistContent = append(playlistContent, miph...)
+		for _, tid := range pl.tids {
+			mtph := buildMtphLE(tid)
+			playlistContent = append(playlistContent, mtph...)
+		}
+	}
+	playlistMsdh := buildMsdhLE(0x02, playlistContent)
+
+	var payload []byte
+	payload = append(payload, trackMsdh...)
+	payload = append(payload, playlistMsdh...)
+	return payload
+}
+
+type fixtureTrk struct {
+	id  int
+	pid [8]byte
+}
+
+type fixturePL struct {
+	pid  [8]byte
+	tids []int
+}
+
+// makeLibFromPayload parses a synthetic payload (no encryption, no compression).
+func makeLibFromPayload(payload []byte) *ITLLibrary {
+	lib := &ITLLibrary{}
+	walkChunksLEImpl(payload, lib)
+	return lib
+}
+
+// ---------------------------------------------------------------------------
+// Tests: CollectMsdhInventory
+// ---------------------------------------------------------------------------
+
+func TestCollectMsdhInventory_Basic(t *testing.T) {
+	payload := buildFixturePayload(
+		[]fixtureTrk{{id: 1, pid: [8]byte{1}}},
+		[]fixturePL{{pid: [8]byte{2}, tids: []int{1}}},
+	)
+	inv := CollectMsdhInventory(payload)
+	if len(inv) != 2 {
+		t.Fatalf("expected 2 msdh containers, got %d", len(inv))
+	}
+	if inv[0].BlockType != 1 {
+		t.Errorf("first container: expected blockType=1, got %d", inv[0].BlockType)
+	}
+	if inv[1].BlockType != 2 {
+		t.Errorf("second container: expected blockType=2, got %d", inv[1].BlockType)
+	}
+	// HeaderLen for our builder is always 16.
+	for i, e := range inv {
+		if e.HeaderLen != 16 {
+			t.Errorf("inv[%d].HeaderLen: expected 16, got %d", i, e.HeaderLen)
+		}
+		if e.TotalLen < e.HeaderLen {
+			t.Errorf("inv[%d].TotalLen %d < HeaderLen %d", i, e.TotalLen, e.HeaderLen)
+		}
+	}
+}
+
+func TestCollectMsdhInventory_NonLE(t *testing.T) {
+	// Non-LE payload should return empty slice, not nil.
+	inv := CollectMsdhInventory([]byte("not an LE payload at all"))
+	if inv == nil {
+		t.Fatal("expected non-nil empty slice for non-LE payload")
+	}
+	if len(inv) != 0 {
+		t.Errorf("expected 0 entries for non-LE payload, got %d", len(inv))
+	}
+}
+
+func TestCollectMsdhInventory_BlockTypeName(t *testing.T) {
+	cases := []struct{ bt int; want string }{
+		{1, "track-list"},
+		{2, "playlist-list"},
+		{9, "album-list"},
+		{11, "artist-list"},
+		{99, "unknown"},
+	}
+	for _, c := range cases {
+		e := MsdhEntry{BlockType: c.bt}
+		if got := e.BlockTypeName(); got != c.want {
+			t.Errorf("BlockType %d: expected %q, got %q", c.bt, c.want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DiffMsdhInventory — fixture pair with one removed track
+// ---------------------------------------------------------------------------
+
+func TestDiffMsdhInventory_OneRemovedTrack(t *testing.T) {
+	// Fixture A: 3 tracks, 1 playlist.
+	payloadA := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 2}, {id: 3}},
+		[]fixturePL{{pid: [8]byte{0xAA}, tids: []int{1, 2, 3}}},
+	)
+	// Fixture B: 2 tracks (track 3 removed), same playlist (minus track 3).
+	payloadB := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 2}},
+		[]fixturePL{{pid: [8]byte{0xAA}, tids: []int{1, 2}}},
+	)
+
+	diff := DiffMsdhInventory(payloadA, payloadB)
+
+	// Both inventories have blockType 1 (track-list) and 2 (playlist-list).
+	// At least one should show a changed total size (track list is smaller in B).
+	if len(diff.OnlyA) != 0 {
+		t.Errorf("expected no OnlyA containers, got %v", diff.OnlyA)
+	}
+	if len(diff.OnlyB) != 0 {
+		t.Errorf("expected no OnlyB containers, got %v", diff.OnlyB)
+	}
+	// The track-list container (blockType=1) MUST have changed totalLen.
+	found := false
+	for _, ch := range diff.Changed {
+		if ch.BlockType == 1 {
+			found = true
+			if ch.A.TotalLen <= ch.B.TotalLen {
+				t.Errorf("track-list totalLen should be larger in A (3 tracks) than B (2 tracks): A=%d B=%d",
+					ch.A.TotalLen, ch.B.TotalLen)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected blockType=1 (track-list) to appear in Changed after removing a track")
+	}
+}
+
+func TestDiffMsdhInventory_Identical(t *testing.T) {
+	payload := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 2}},
+		[]fixturePL{{pid: [8]byte{0xBB}, tids: []int{1, 2}}},
+	)
+	diff := DiffMsdhInventory(payload, payload)
+	if len(diff.Changed) != 0 || len(diff.OnlyA) != 0 || len(diff.OnlyB) != 0 {
+		t.Errorf("identical payloads should produce empty diff, got: changed=%d onlyA=%d onlyB=%d",
+			len(diff.Changed), len(diff.OnlyA), len(diff.OnlyB))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DiffPlaylistMembership — fixture pair with a playlist edit
+// ---------------------------------------------------------------------------
+
+func TestDiffPlaylistMembership_OnePlaylistEdit(t *testing.T) {
+	// Both A and B share a playlist with PID {0xCC}.
+	// A has TIDs [1,2,3], B has TIDs [1,3,4]: track 2 removed, track 4 added.
+	pidPL := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCC}
+
+	payloadA := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 2}, {id: 3}},
+		[]fixturePL{{pid: pidPL, tids: []int{1, 2, 3}}},
+	)
+	payloadB := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 3}, {id: 4}},
+		[]fixturePL{{pid: pidPL, tids: []int{1, 3, 4}}},
+	)
+
+	libA := makeLibFromPayload(payloadA)
+	libB := makeLibFromPayload(payloadB)
+
+	result := DiffPlaylistMembership(libA, libB)
+
+	if len(result.OnlyA) != 0 {
+		t.Errorf("expected no OnlyA playlists, got %v", result.OnlyA)
+	}
+	if len(result.OnlyB) != 0 {
+		t.Errorf("expected no OnlyB playlists, got %v", result.OnlyB)
+	}
+	if len(result.Changed) != 1 {
+		t.Fatalf("expected 1 changed playlist, got %d", len(result.Changed))
+	}
+
+	ch := result.Changed[0]
+	if len(ch.Removed) != 1 || ch.Removed[0] != 2 {
+		t.Errorf("expected Removed=[2], got %v", ch.Removed)
+	}
+	if len(ch.Added) != 1 || ch.Added[0] != 4 {
+		t.Errorf("expected Added=[4], got %v", ch.Added)
+	}
+}
+
+func TestDiffPlaylistMembership_PlaylistOnlyInA(t *testing.T) {
+	pidA := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA}
+	pidB := [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xBB}
+
+	payloadA := buildFixturePayload(
+		[]fixtureTrk{{id: 1}},
+		[]fixturePL{{pid: pidA, tids: []int{1}}, {pid: pidB, tids: []int{1}}},
+	)
+	// B only has playlist B.
+	payloadB := buildFixturePayload(
+		[]fixtureTrk{{id: 1}},
+		[]fixturePL{{pid: pidB, tids: []int{1}}},
+	)
+
+	libA := makeLibFromPayload(payloadA)
+	libB := makeLibFromPayload(payloadB)
+	result := DiffPlaylistMembership(libA, libB)
+
+	if len(result.OnlyA) != 1 {
+		t.Fatalf("expected 1 OnlyA playlist, got %d", len(result.OnlyA))
+	}
+	if len(result.OnlyB) != 0 {
+		t.Errorf("expected 0 OnlyB playlists, got %d", len(result.OnlyB))
+	}
+	if len(result.Changed) != 0 {
+		t.Errorf("expected 0 Changed playlists, got %d", len(result.Changed))
+	}
+}
+
+func TestDiffPlaylistMembership_Identical(t *testing.T) {
+	payload := buildFixturePayload(
+		[]fixtureTrk{{id: 1}, {id: 2}},
+		[]fixturePL{{pid: [8]byte{0xDD}, tids: []int{1, 2}}},
+	)
+	lib := makeLibFromPayload(payload)
+	result := DiffPlaylistMembership(lib, lib)
+	if len(result.Changed) != 0 || len(result.OnlyA) != 0 || len(result.OnlyB) != 0 {
+		t.Errorf("identical libraries should produce empty diff, got: changed=%d onlyA=%d onlyB=%d",
+			len(result.Changed), len(result.OnlyA), len(result.OnlyB))
+	}
+}


### PR DESCRIPTION
## Summary

Implements TASK-007 from `docs/plans/fable5-implementation-plan.md` (MED-5): `itl-diff` and `itl-check` now do what they claim to do.

**Problem before T007:** During the production corruption incident, both tools reported "0 changed" on libraries with 167K rewritten blocks. `itl-diff`'s docstring promised an msdh inventory that was not implemented. `itl-check` printed counts only. Neither detected the actual damage.

**Changes:**

### `internal/itunes/itl_diff_helpers.go` (NEW — testable helpers)
- `CollectMsdhInventory(payload)`: walks all top-level msdh containers; returns `[]MsdhEntry{BlockType, HeaderLen, TotalLen}` with `BlockTypeName()` labels
- `DiffMsdhInventory(payloadA, payloadB)`: returns Changed/OnlyA/OnlyB, sorted for deterministic output
- `CollectPlaylistMemberships(lib)` + `DiffPlaylistMembership(libA, libB)`: per-playlist TID diff

### `cmd/itl-diff/main.go` (v1.0.0 → v2.0.0)
- **Docstring corrected** to match what the tool actually does
- **msdh container inventory section** — decrypts both payloads, compares blockType→hdrLen/totalLen with Δ column; uses `DecryptAndInflateITL` + `CollectMsdhInventory`
- **Playlist membership diff section** — added/removed TIDs per playlist; detail with `-v`
- **`--audit` flag** — runs `AuditITL` (T003 ITLSafetyContract, all 8 guards) on both libraries
- String-field diffs meaningful post-T001 (mhoh-descent fix in this branch's ancestry)
- All pre-existing flags (`-v`, `-max`) preserved

### `cmd/itl-check/main.go` (v1.0.0 → v2.0.0)
- Calls `AuditITL` (T003 ITLSafetyContract) and prints per-guard verdict table
- Shows violation counts + first violation hint per failing guard
- **Exits nonzero (code 1) on any violation**, code 2 on usage error
- Retains track/location count display

## Sample output

```
$ itl-check writeback-iTunes\ Library.itl
itl-check: writeback-iTunes Library.itl
Tracks: 374  Playlists: 14  Version: 1.1
Tracks with Location: 374

Guard                     Result
------------------------  ------
parse-roundtrip           PASS
container-tiling          PASS
count-coherence           PASS
no-new-dangling-refs      PASS
mhoh-format               PASS
location-form             PASS
tid-pid-sanity            PASS
bounded-delta             PASS

Verdict: PASS — no violations found
```

## Test plan

- [x] 8 new unit tests in `internal/itunes/itl_diff_helpers_test.go` (all pass)
- [x] `go build ./cmd/itl-diff/ ./cmd/itl-check/` — clean
- [x] `go vet ./cmd/itl-diff/ ./cmd/itl-check/ ./internal/itunes/...` — clean
- [x] `go test ./internal/itunes/... -race -count=1` — PASS (itunes: 19s, itunes/service: 25s)
- [x] `go test ./... -count=1` — PASS (all packages except `internal/server` which times out; confirmed pre-existing on T003 base branch)

## Acceptance criteria (from plan)

- [x] `itl-check <fixture>` exits nonzero naming the guard (AuditITL verdict + FailedGuards())
- [x] `itl-diff` reports playlist membership delta on fixture pair (tested)
- [x] `make test` green for `internal/itunes` (the only package touched by this task)

## Dependencies

- Base branch: `fable5/t003-itl-safety-contract` (requires `AuditITL` / `ContractVerdict`)
- T001 mhoh-descent fix is in ancestry (string-field diffs are now meaningful)

COMPLETED: 4 — itl_diff_helpers.go, itl_diff_helpers_test.go, cmd/itl-diff/main.go, cmd/itl-check/main.go
REMAINING: 0
BLOCKED: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)