### PR TITLE
feat(database): PebbleDB activity/metrics backends + dual-write + backfill (fable5 T024)

### DIFF
--- a/internal/activity/register.go
+++ b/internal/activity/register.go
@@ -1,10 +1,20 @@
 // file: internal/activity/register.go
-// version: 1.1.0
+// version: 1.2.0
+// guid: c4d5e6f7-a8b9-0009-2345-000000000009
 
+// Package activity — service registry wiring for the activity log.
+//
+// WHY backend selection during the migration window (T024):
+//   - Before the "activity_pebble_v1_done" backfill flag is set in Pebble, reads
+//     come from NutsDB (source of truth). Both backends receive every write.
+//   - After the flag is set, reads flip to Pebble. NutsDB still receives writes
+//     so a rollback (flip ReadFromPebble=false) is safe without data loss.
+//   - The dual-write window ends when NutsDB is removed (follow-up task T024b).
 package activity
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -13,15 +23,35 @@ import (
 )
 
 func init() {
-	// activitystore: NutsDB-backed sidecar store for activity log entries.
-	// Lives in {dirname(DatabasePath)}/activity.nutsdb so it sits next to the
-	// main Pebble DB. Returns nil (Build returns an error, but the container
-	// will fail Resolve before reaching here if DatabasePath is empty) when
-	// DatabasePath is unset — host code must Override "activitystore" with a
-	// pre-built instance in that case (test paths).
+	// pebble-activitystore: PebbleDB-backed activity store, sharing the main
+	// PebbleDB instance. Built only when the main store is a *PebbleStore.
+	// Returns a nil *PebbleActivityStore on other backends so dual-write
+	// wiring below can detect and fall back gracefully.
+	serviceregistry.Register(serviceregistry.ServiceDef{
+		Name:   "pebble-activitystore",
+		Needs:  []string{"store"},
+		Groups: []string{"activity"},
+		Build: func(c *serviceregistry.Container) (any, error) {
+			store := serviceregistry.Get[database.Store](c, "store")
+			ps, ok := store.(*database.PebbleStore)
+			if !ok {
+				// Non-Pebble backend (test double, SQLite) — return nil pointer;
+				// the activitystore Build checks for nil and falls back to NutsDB-only.
+				return (*database.PebbleActivityStore)(nil), nil
+			}
+			s := database.NewPebbleActivityStore(ps.DB())
+			slog.Info("[activity] Pebble activity store initialised")
+			return s, nil
+		},
+	})
+
+	// activitystore: activity log backend, wired to dual-write when Pebble is available.
+	// Lives in {dirname(DatabasePath)}/activity.nutsdb (NutsDB sidecar).
+	// Returns nil when DatabasePath is unset — host code must Override "activitystore"
+	// with a pre-built instance in that case (test paths).
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "activitystore",
-		Needs:  []string{"config"},
+		Needs:  []string{"config", "pebble-activitystore"},
 		Groups: []string{"activity"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
@@ -29,7 +59,26 @@ func init() {
 				return nil, fmt.Errorf("activitystore: DatabasePath not configured")
 			}
 			activityDir := filepath.Join(filepath.Dir(cfg.DatabasePath), "activity.nutsdb")
-			return database.NewNutsActivityStore(activityDir)
+			nutsStore, err := database.NewNutsActivityStore(activityDir)
+			if err != nil {
+				return nil, fmt.Errorf("activitystore: open nutsdb: %w", err)
+			}
+
+			// Try to wrap in dual-write if the Pebble backend is available.
+			pebbleStore, hasPebble := serviceregistry.TryGet[*database.PebbleActivityStore](c, "pebble-activitystore")
+			if !hasPebble || pebbleStore == nil {
+				// Pebble backend not available — NutsDB-only (degraded / test mode).
+				slog.Info("[activity] Pebble activity store not available; using NutsDB-only")
+				return nutsStore, nil
+			}
+
+			// Determine read source from backfill flag.
+			// Checked once at startup — the flag is not expected to change at runtime.
+			readFromPebble := database.IsActivityPebbleBackfillDone(pebbleStore.DB())
+			slog.Info("[activity] dual-write mode enabled",
+				"read_from_pebble", readFromPebble,
+				"flag", database.ActivityPebbleBackfillKey)
+			return database.NewDualWriteActivityStore(nutsStore, pebbleStore, readFromPebble), nil
 		},
 	})
 
@@ -38,7 +87,9 @@ func init() {
 		Needs:  []string{"activitystore"},
 		Groups: []string{"activity"},
 		Build: func(c *serviceregistry.Container) (any, error) {
-			store := serviceregistry.Get[*database.NutsActivityStore](c, "activitystore")
+			// Use the ActivityStorer interface — the activitystore may be any of
+			// *NutsActivityStore, *DualWriteActivityStore (all implement ActivityStorer).
+			store := serviceregistry.Get[database.ActivityStorer](c, "activitystore")
 			return NewService(store), nil
 		},
 	})

--- a/internal/database/dual_write_activity_store.go
+++ b/internal/database/dual_write_activity_store.go
@@ -1,0 +1,206 @@
+// file: internal/database/dual_write_activity_store.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-0006-f012-000000000006
+
+// Package database — dual-write wrapper for the activity migration window.
+//
+// WHY a dual-write wrapper:
+//   - The NutsDB → Pebble migration requires a hot-deploy cutover window during
+//     which BOTH backends receive every write. This prevents data loss if the
+//     Pebble flag is not yet set (e.g., prod hasn't backfilled yet).
+//   - Once the backfill op sets "activity_pebble_v1_done" in Pebble, reads
+//     switch from NutsDB to Pebble. Until then, reads come from NutsDB.
+//   - Once the NutsDB dep is removed (follow-up task), this wrapper can be
+//     collapsed to a simple pass-through to PebbleActivityStore.
+//
+// Behaviour:
+//   - Writes: always go to both primary (Nuts or Pebble) and secondary.
+//   - Reads: routed to whichever backend the ReadFrom flag selects.
+//   - Close: closes both backends.
+package database
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// DualWriteActivityStore writes to two ActivityStorers simultaneously and reads
+// from the one indicated by ReadFromPebble.
+//
+// If ReadFromPebble is false, reads come from nuts (pre-backfill state).
+// If ReadFromPebble is true, reads come from pebble (post-backfill state).
+//
+// Write errors from the secondary backend are logged but not returned to the
+// caller — the primary backend's result is authoritative.
+type DualWriteActivityStore struct {
+	nuts          ActivityStorer
+	pebble        ActivityStorer
+	ReadFromPebble bool
+}
+
+// NewDualWriteActivityStore creates a dual-write wrapper.
+// nuts is the legacy NutsDB backend; pebble is the new Pebble backend.
+// ReadFromPebble controls which backend serves reads.
+func NewDualWriteActivityStore(nuts, pebble ActivityStorer, readFromPebble bool) *DualWriteActivityStore {
+	return &DualWriteActivityStore{
+		nuts:           nuts,
+		pebble:         pebble,
+		ReadFromPebble: readFromPebble,
+	}
+}
+
+// ── ActivityStorer writes — both backends ────────────────────────────────────
+
+// Record inserts into both backends. The nuts result is returned when
+// ReadFromPebble is false; the pebble result otherwise.
+func (d *DualWriteActivityStore) Record(e ActivityEntry) (int64, error) {
+	nutsID, nutsErr := d.nuts.Record(e)
+	pebbleID, pebbleErr := d.pebble.Record(e)
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble Record failed (secondary write error)",
+			"err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts Record failed (secondary write error)",
+			"err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleID, pebbleErr
+	}
+	return nutsID, nutsErr
+}
+
+// Summarize runs on both; returns primary backend's result.
+func (d *DualWriteActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error) {
+	nutsCnt, nutsErr := d.nuts.Summarize(ctx, olderThan, tier)
+	pebbleCnt, pebbleErr := d.pebble.Summarize(ctx, olderThan, tier)
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble Summarize failed", "err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts Summarize failed", "err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleCnt, pebbleErr
+	}
+	return nutsCnt, nutsErr
+}
+
+// Prune runs on both; returns primary backend's result.
+func (d *DualWriteActivityStore) Prune(olderThan time.Time, tier string) (int, error) {
+	nutsCnt, nutsErr := d.nuts.Prune(olderThan, tier)
+	pebbleCnt, pebbleErr := d.pebble.Prune(olderThan, tier)
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble Prune failed", "err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts Prune failed", "err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleCnt, pebbleErr
+	}
+	return nutsCnt, nutsErr
+}
+
+// WipeAllActivity runs on both; returns primary backend's result.
+func (d *DualWriteActivityStore) WipeAllActivity() (int64, error) {
+	nutsCnt, nutsErr := d.nuts.WipeAllActivity()
+	pebbleCnt, pebbleErr := d.pebble.WipeAllActivity()
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble WipeAllActivity failed", "err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts WipeAllActivity failed", "err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleCnt, pebbleErr
+	}
+	return nutsCnt, nutsErr
+}
+
+// CompactByDay runs on both; returns primary backend's result.
+func (d *DualWriteActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
+	nutsRes, nutsErr := d.nuts.CompactByDay(ctx, olderThan)
+	pebbleRes, pebbleErr := d.pebble.CompactByDay(ctx, olderThan)
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble CompactByDay failed", "err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts CompactByDay failed", "err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleRes, pebbleErr
+	}
+	return nutsRes, nutsErr
+}
+
+// MigrateSystemActivityLogs runs only on the primary read backend.
+// This is a one-shot SQLite→nuts migration; the Pebble store has no SQLite data.
+func (d *DualWriteActivityStore) MigrateSystemActivityLogs() (int, error) {
+	if d.ReadFromPebble {
+		return d.pebble.MigrateSystemActivityLogs()
+	}
+	return d.nuts.MigrateSystemActivityLogs()
+}
+
+// RecompactDigests runs on both; returns primary backend's result.
+func (d *DualWriteActivityStore) RecompactDigests(ctx context.Context) (RecompactResult, error) {
+	nutsRes, nutsErr := d.nuts.RecompactDigests(ctx)
+	pebbleRes, pebbleErr := d.pebble.RecompactDigests(ctx)
+
+	if pebbleErr != nil {
+		slog.Warn("[dual-write] pebble RecompactDigests failed", "err", pebbleErr)
+	}
+	if nutsErr != nil {
+		slog.Warn("[dual-write] nuts RecompactDigests failed", "err", nutsErr)
+	}
+
+	if d.ReadFromPebble {
+		return pebbleRes, pebbleErr
+	}
+	return nutsRes, nutsErr
+}
+
+// ── ActivityStorer reads — routed to active backend ──────────────────────────
+
+// Query reads from the active backend only.
+func (d *DualWriteActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
+	if d.ReadFromPebble {
+		return d.pebble.Query(f)
+	}
+	return d.nuts.Query(f)
+}
+
+// GetDistinctSources reads from the active backend only.
+func (d *DualWriteActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
+	if d.ReadFromPebble {
+		return d.pebble.GetDistinctSources(f)
+	}
+	return d.nuts.GetDistinctSources(f)
+}
+
+// Close closes both backends and returns the first error encountered.
+func (d *DualWriteActivityStore) Close() error {
+	nutsErr := d.nuts.Close()
+	pebbleErr := d.pebble.Close()
+	if nutsErr != nil {
+		return fmt.Errorf("dual-write close nuts: %w", nutsErr)
+	}
+	return pebbleErr
+}
+
+// ── interface assertion ───────────────────────────────────────────────────────
+
+var _ ActivityStorer = (*DualWriteActivityStore)(nil)

--- a/internal/database/pebble_activity_backfill.go
+++ b/internal/database/pebble_activity_backfill.go
@@ -1,0 +1,230 @@
+// file: internal/database/pebble_activity_backfill.go
+// version: 1.0.0
+// guid: a7b8c9d0-e1f2-0007-0123-000000000007
+
+// Package database — NutsDB → PebbleDB activity backfill.
+//
+// WHY: During the dual-write window, the Pebble store receives all new writes but
+// historic entries live only in NutsDB. This backfill op copies every existing NutsDB
+// activity entry into the Pebble store in key-ordered (timestamp-ascending) batches.
+// It is idempotent: existing Pebble entries are not overwritten (Set is safe to repeat
+// — the JSON is identical). On completion it writes the sentinel key
+// "system:backfill:activity_pebble_v1_done" in Pebble so subsequent starts skip the
+// work immediately.
+//
+// The backfill is resumable: if interrupted, the next run rescans NutsDB from scratch
+// and re-writes already-copied entries — since Set is idempotent this is safe and
+// merely redundant work.
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// ActivityPebbleBackfillKey is the Pebble sentinel key set when the backfill
+// has completed successfully.  Callers check this key to decide whether to
+// read from Pebble or NutsDB.
+const ActivityPebbleBackfillKey = "system:backfill:activity_pebble_v1_done"
+
+// ActivityBackfillResult holds the outcome of a NutsDB → Pebble backfill run.
+type ActivityBackfillResult struct {
+	TiersProcessed int `json:"tiers_processed"`
+	EntriesCopied  int `json:"entries_copied"`
+	DryRun         bool `json:"dry_run"`
+	AlreadyDone    bool `json:"already_done"`
+}
+
+// BackfillNutsActivityToPebble copies all NutsDB activity entries to the Pebble
+// store.  Call with dryRun=true to get counts without writing.
+//
+// Steps:
+//  1. Check sentinel key — skip if already done.
+//  2. For each tier (including "digest"), scan NutsDB in key order.
+//  3. Batch-write to Pebble (500 entries per batch).
+//  4. Set sentinel key on success.
+func BackfillNutsActivityToPebble(
+	ctx context.Context,
+	nutsStore *NutsActivityStore,
+	pebbleStore *PebbleActivityStore,
+	dryRun bool,
+) (ActivityBackfillResult, error) {
+	res := ActivityBackfillResult{DryRun: dryRun}
+
+	// 1. Check sentinel key — idempotent guard.
+	if !dryRun {
+		if _, closer, err := pebbleStore.db.Get([]byte(ActivityPebbleBackfillKey)); err == nil {
+			closer.Close()
+			slog.Info("[activity-backfill] already done — skipping", "flag", ActivityPebbleBackfillKey)
+			res.AlreadyDone = true
+			return res, nil
+		}
+	}
+
+	slog.Info("[activity-backfill] starting NutsDB → Pebble activity backfill",
+		"dry_run", dryRun, "tiers", len(actTiers))
+
+	// 2. Scan each tier (all tiers, including "digest") from NutsDB.
+	for _, tier := range actTiers {
+		select {
+		case <-ctx.Done():
+			return res, ctx.Err()
+		default:
+		}
+
+		kvs, err := nutsStore.scanTierKeysAndValues(tier, nil, nil)
+		if err != nil {
+			return res, fmt.Errorf("backfill: scan nuts tier=%s: %w", tier, err)
+		}
+		if len(kvs) == 0 {
+			continue
+		}
+
+		// Sort by NutsDB key (already time-keyed; sort ensures key-ordered cursor).
+		sort.Slice(kvs, func(i, j int) bool {
+			return string(kvs[i].key) < string(kvs[j].key)
+		})
+
+		slog.Info("[activity-backfill] processing tier",
+			"tier", tier, "entries", len(kvs), "dry_run", dryRun)
+
+		// 3. Batch-write to Pebble.
+		for i := 0; i < len(kvs); i += 500 {
+			select {
+			case <-ctx.Done():
+				return res, ctx.Err()
+			default:
+			}
+
+			end := i + 500
+			if end > len(kvs) {
+				end = len(kvs)
+			}
+			batch := kvs[i:end]
+
+			if dryRun {
+				res.EntriesCopied += len(batch)
+				continue
+			}
+
+			pebbleBatch := pebbleStore.db.NewBatch()
+			for _, kv := range batch {
+				e := kv.entry
+
+				// Reconstruct the Pebble primary key from the entry's fields.
+				// WHY: NutsDB keys use the same <20d-nano>:<ulid> format but without
+				// the "act:<tier>:" prefix — we need the full Pebble-style key.
+				var entryID string
+				// NutsDB key format: <20d-unix-nano>:<ulid>
+				nutsKey := string(kv.key)
+				if colonIdx := lastIndexByte(nutsKey, ':'); colonIdx >= 0 {
+					entryID = nutsKey[colonIdx+1:]
+				}
+				if entryID == "" {
+					entryID = ulid32()
+				}
+
+				pkey := pactPrimaryKey(tier, e.Timestamp, entryID)
+				b, err := json.Marshal(e)
+				if err != nil {
+					pebbleBatch.Close()
+					return res, fmt.Errorf("backfill: marshal entry: %w", err)
+				}
+				if err := pebbleBatch.Set(pkey, b, nil); err != nil {
+					pebbleBatch.Close()
+					return res, fmt.Errorf("backfill: set entry: %w", err)
+				}
+
+				// Rebuild secondary indexes.
+				if e.OperationID != "" {
+					opKey := []byte(fmt.Sprintf("act:op:%s:%020d:%s", e.OperationID, e.Timestamp.UnixNano(), entryID))
+					ref := pactIndexRef(tier, e.Timestamp, entryID)
+					if err := pebbleBatch.Set(opKey, ref, nil); err != nil {
+						pebbleBatch.Close()
+						return res, fmt.Errorf("backfill: set op index: %w", err)
+					}
+				}
+				if e.BookID != "" {
+					bkKey := []byte(fmt.Sprintf("act:bk:%s:%020d:%s", e.BookID, e.Timestamp.UnixNano(), entryID))
+					ref := pactIndexRef(tier, e.Timestamp, entryID)
+					if err := pebbleBatch.Set(bkKey, ref, nil); err != nil {
+						pebbleBatch.Close()
+						return res, fmt.Errorf("backfill: set book index: %w", err)
+					}
+				}
+			}
+			if err := pebbleBatch.Commit(pebble.Sync); err != nil {
+				pebbleBatch.Close()
+				return res, fmt.Errorf("backfill: commit batch tier=%s: %w", tier, err)
+			}
+			pebbleBatch.Close()
+			res.EntriesCopied += len(batch)
+		}
+		res.TiersProcessed++
+	}
+
+	// 4. Write sentinel key.
+	if !dryRun && res.EntriesCopied >= 0 {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		if err := pebbleStore.db.Set(
+			[]byte(ActivityPebbleBackfillKey),
+			[]byte(ts),
+			pebble.Sync,
+		); err != nil {
+			return res, fmt.Errorf("backfill: write sentinel key: %w", err)
+		}
+		slog.Info("[activity-backfill] complete — sentinel written",
+			"flag", ActivityPebbleBackfillKey,
+			"entries_copied", res.EntriesCopied,
+			"tiers_processed", res.TiersProcessed)
+	} else if dryRun {
+		slog.Info("[activity-backfill] dry-run complete",
+			"entries_would_copy", res.EntriesCopied,
+			"tiers", res.TiersProcessed)
+	}
+
+	return res, nil
+}
+
+// IsActivityPebbleBackfillDone reports whether the Pebble activity sentinel has been
+// written. Callers use this to decide whether to read from Pebble or NutsDB.
+func IsActivityPebbleBackfillDone(db *pebble.DB) bool {
+	_, closer, err := db.Get([]byte(ActivityPebbleBackfillKey))
+	if err == nil {
+		closer.Close()
+		return true
+	}
+	return false
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// lastIndexByte returns the last index of b in s, or -1.
+func lastIndexByte(s string, b byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// ulid32 generates a short random suffix as a fallback when the NutsDB key has
+// no ':' (should not happen with well-formed NutsDB data).
+func ulid32() string {
+	// Use unix nano + 4 digits of a counter as a lightweight unique suffix.
+	return fmt.Sprintf("%020d:fallback", time.Now().UnixNano())
+}
+
+// ── notes ─────────────────────────────────────────────────────────────────────
+
+// BackfillNutsActivityToPebble accesses nutsStore.scanTierKeysAndValues which is
+// an unexported method — the backfill lives in the same package (database) so this
+// is valid.  No NutsDB import is needed beyond what nuts_activity_store.go already
+// provides in the same compilation unit.

--- a/internal/database/pebble_activity_store.go
+++ b/internal/database/pebble_activity_store.go
@@ -1,0 +1,909 @@
+// file: internal/database/pebble_activity_store.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0004-def0-000000000004
+
+// Package database — PebbleDB-backed activity log store.
+//
+// WHY a Pebble backend:
+//   - The NutsDB activity store (nuts_activity_store.go) works but carries an
+//     entire extra storage engine dependency (nutsdb/nutsdb). Pebble is already
+//     the primary database engine. Removing NutsDB requires a Pebble backend
+//     that satisfies the same ActivityStorer interface.
+//   - Key layout mirrors NutsDB verbatim so lexicographic ordering and range
+//     scans behave identically (no behavioral change to callers).
+//
+// Key layout (all keys are []byte; prefixes end with ':'):
+//
+//	act:<tier>:<20d-unix-nano>:<ulid>        = JSON(ActivityEntry)   primary
+//	act:op:<op_id>:<20d-unix-nano>:<ulid>    = []byte("<tier>:<20d-unix-nano>:<ulid>")  op index
+//	act:bk:<book_id>:<20d-unix-nano>:<ulid>  = []byte("<tier>:<20d-unix-nano>:<ulid>")  book index
+//
+// Compared with NutsDB, Pebble is a single shared key-space so every key is
+// scoped with "act:" to avoid collisions with other prefixes. The "tier" component
+// in the primary key separates tiers without needing separate buckets; Pebble range
+// scans over ["act:<tier>:", "act:<tier>;") return exactly that tier's entries in
+// timestamp order because ';' (0x3B) is one above ':' (0x3A) in ASCII.
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/oklog/ulid/v2"
+)
+
+// PebbleActivityStore persists activity log entries in a shared PebbleDB database.
+// It satisfies the ActivityStorer interface and is a drop-in replacement for both
+// ActivityStore (SQLite) and NutsActivityStore.
+//
+// The caller retains ownership of the *pebble.DB — Close() on this store is a no-op.
+type PebbleActivityStore struct {
+	db      *pebble.DB
+	counter atomic.Int64
+}
+
+// NewPebbleActivityStore creates a PebbleActivityStore backed by the provided DB.
+// The caller retains ownership of db; Close() on this store does NOT close db.
+func NewPebbleActivityStore(db *pebble.DB) *PebbleActivityStore {
+	s := &PebbleActivityStore{db: db}
+	// Seed counter from current time so IDs don't collide across restarts.
+	s.counter.Store(time.Now().UnixNano())
+	return s
+}
+
+// Close is a no-op: the caller owns the PebbleDB instance.
+func (s *PebbleActivityStore) Close() error { return nil }
+
+// DB returns the underlying *pebble.DB. Used by callers (e.g., backfill, registry wiring)
+// that need to check the backfill sentinel key directly.
+func (s *PebbleActivityStore) DB() *pebble.DB { return s.db }
+
+// ── Key construction ──────────────────────────────────────────────────────────
+
+// pactPrimaryKey builds the primary key for a tier entry:
+//
+//	act:<tier>:<20d-unix-nano>:<ulid>
+func pactPrimaryKey(tier string, t time.Time, id string) []byte {
+	return []byte(fmt.Sprintf("act:%s:%020d:%s", tier, t.UnixNano(), id))
+}
+
+// pactPrimaryPrefix returns the inclusive lower-bound prefix for a tier range scan:
+//
+//	act:<tier>:
+func pactPrimaryPrefix(tier string) []byte {
+	return []byte("act:" + tier + ":")
+}
+
+// pactPrimaryUpperBound returns the exclusive upper-bound for a tier range scan.
+// ';' is ASCII 0x3B — one above ':' (0x3A) — so the range covers exactly all
+// entries for the tier.
+func pactPrimaryUpperBound(tier string) []byte {
+	return []byte("act:" + tier + ";")
+}
+
+// pactIndexRef encodes the cross-reference value stored in secondary indexes:
+// "<tier>:<20d-unix-nano>:<ulid>" — enough to reconstruct the primary key.
+func pactIndexRef(tier string, t time.Time, id string) []byte {
+	return []byte(fmt.Sprintf("%s:%020d:%s", tier, t.UnixNano(), id))
+}
+
+// pactPrimaryKeyFromRef reconstructs the primary key from an index reference value.
+// ref = "<tier>:<20d-unix-nano>:<ulid>"
+func pactPrimaryKeyFromRef(ref []byte) ([]byte, bool) {
+	s := string(ref)
+	if !strings.Contains(s, ":") {
+		return nil, false
+	}
+	return []byte("act:" + s), true
+}
+
+// ── ActivityStorer implementation ─────────────────────────────────────────────
+
+// Record inserts an ActivityEntry and returns a synthetic int64 ID.
+func (s *PebbleActivityStore) Record(e ActivityEntry) (int64, error) {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+	if e.Level == "" {
+		e.Level = "info"
+	}
+	if e.Tier == "" {
+		e.Tier = "change"
+	}
+
+	id := s.counter.Add(1)
+	e.ID = id
+
+	entryID := ulid.Make().String()
+	primaryKey := pactPrimaryKey(e.Tier, e.Timestamp, entryID)
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		return 0, fmt.Errorf("pebble_activity_store: marshal: %w", err)
+	}
+
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	if err := batch.Set(primaryKey, b, nil); err != nil {
+		return 0, fmt.Errorf("pebble_activity_store: set primary: %w", err)
+	}
+
+	// Secondary index: op_id → primary ref
+	if e.OperationID != "" {
+		opKey := []byte(fmt.Sprintf("act:op:%s:%020d:%s", e.OperationID, e.Timestamp.UnixNano(), entryID))
+		ref := pactIndexRef(e.Tier, e.Timestamp, entryID)
+		if err := batch.Set(opKey, ref, nil); err != nil {
+			return 0, fmt.Errorf("pebble_activity_store: set op index: %w", err)
+		}
+	}
+
+	// Secondary index: book_id → primary ref
+	if e.BookID != "" {
+		bkKey := []byte(fmt.Sprintf("act:bk:%s:%020d:%s", e.BookID, e.Timestamp.UnixNano(), entryID))
+		ref := pactIndexRef(e.Tier, e.Timestamp, entryID)
+		if err := batch.Set(bkKey, ref, nil); err != nil {
+			return 0, fmt.Errorf("pebble_activity_store: set book index: %w", err)
+		}
+	}
+
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return 0, fmt.Errorf("pebble_activity_store: commit: %w", err)
+	}
+
+	return id, nil
+}
+
+// Query returns entries matching f, newest-first, plus the total matching count.
+func (s *PebbleActivityStore) Query(f ActivityFilter) ([]ActivityEntry, int, error) {
+	if f.Limit == 0 {
+		f.Limit = 50
+	}
+
+	// Fast path: op_id or book_id filter → use secondary index.
+	if f.OperationID != "" {
+		return s.queryByIndexPrefix(fmt.Sprintf("act:op:%s:", f.OperationID), f)
+	}
+	if f.BookID != "" {
+		return s.queryByIndexPrefix(fmt.Sprintf("act:bk:%s:", f.BookID), f)
+	}
+
+	// General path: scan tier bucket(s) by time range.
+	tiers := actTiers
+	if f.Tier != "" {
+		tiers = []string{f.Tier}
+	}
+
+	var all []ActivityEntry
+	for _, tier := range tiers {
+		entries, err := s.scanTier(tier, f.Since, f.Until)
+		if err != nil {
+			return nil, 0, err
+		}
+		all = append(all, entries...)
+	}
+
+	// Apply remaining filters in Go.
+	filtered := make([]ActivityEntry, 0, len(all))
+	for _, e := range all {
+		if matchesFilter(e, f) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	// Sort newest-first; digest entries sort last (matching SQL ORDER BY compacted ASC, timestamp DESC).
+	sort.Slice(filtered, func(i, j int) bool {
+		ci := boolInt(filtered[i].Tier == "digest")
+		cj := boolInt(filtered[j].Tier == "digest")
+		if ci != cj {
+			return ci < cj
+		}
+		return filtered[i].Timestamp.After(filtered[j].Timestamp)
+	})
+
+	total := len(filtered)
+
+	// Paginate.
+	start := f.Offset
+	if start > len(filtered) {
+		start = len(filtered)
+	}
+	end := start + f.Limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[start:end], total, nil
+}
+
+// Summarize groups old entries by (operation_id, type), writes a summary row,
+// and deletes the originals. Returns count of deleted rows.
+func (s *PebbleActivityStore) Summarize(ctx context.Context, olderThan time.Time, tier string) (int, error) {
+	kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+	if err != nil {
+		return 0, err
+	}
+
+	type groupKey struct{ opID, typ string }
+	type group struct{ kvs []pactKV }
+	groups := make(map[groupKey]*group)
+
+	for _, kv := range kvs {
+		if kv.entry.PrunedAt != nil {
+			continue
+		}
+		k := groupKey{opID: kv.entry.OperationID, typ: kv.entry.Type}
+		if groups[k] == nil {
+			groups[k] = &group{}
+		}
+		groups[k].kvs = append(groups[k].kvs, kv)
+	}
+	if len(groups) == 0 {
+		return 0, nil
+	}
+
+	totalDeleted := 0
+	now := time.Now().UTC()
+
+	for gk, g := range groups {
+		select {
+		case <-ctx.Done():
+			return totalDeleted, ctx.Err()
+		default:
+		}
+
+		entries := make([]ActivityEntry, len(g.kvs))
+		for i, kv := range g.kvs {
+			entries[i] = kv.entry
+		}
+
+		first := entries[0].Timestamp
+		last := entries[len(entries)-1].Timestamp
+		summaryText := fmt.Sprintf("Summary: %d %s entries (%s to %s)",
+			len(entries), gk.typ,
+			first.Format(time.RFC3339), last.Format(time.RFC3339),
+		)
+
+		prunedAt := now
+		summary := ActivityEntry{
+			ID:          s.counter.Add(1),
+			Timestamp:   now,
+			Tier:        tier,
+			Type:        gk.typ,
+			Level:       "info",
+			Source:      "summarize",
+			OperationID: gk.opID,
+			Summary:     summaryText,
+			PrunedAt:    &prunedAt,
+		}
+
+		summaryID := ulid.Make().String()
+		summaryKey := pactPrimaryKey(tier, now, summaryID)
+		summaryBytes, err := json.Marshal(summary)
+		if err != nil {
+			return totalDeleted, err
+		}
+
+		batch := s.db.NewBatch()
+		if setErr := batch.Set(summaryKey, summaryBytes, nil); setErr != nil {
+			batch.Close()
+			return totalDeleted, setErr
+		}
+		for _, kv := range g.kvs {
+			if delErr := batch.Delete(kv.key, nil); delErr != nil {
+				batch.Close()
+				return totalDeleted, delErr
+			}
+		}
+		if commitErr := batch.Commit(pebble.Sync); commitErr != nil {
+			batch.Close()
+			return totalDeleted, fmt.Errorf("pebble_activity_store: summarize commit: %w", commitErr)
+		}
+		batch.Close()
+		totalDeleted += len(g.kvs)
+	}
+	return totalDeleted, nil
+}
+
+// Prune hard-deletes all entries of the given tier older than olderThan.
+func (s *PebbleActivityStore) Prune(olderThan time.Time, tier string) (int, error) {
+	kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+	if err != nil {
+		return 0, err
+	}
+	if len(kvs) == 0 {
+		return 0, nil
+	}
+
+	deleted := 0
+	// Delete in batches of 500 to keep batch size reasonable.
+	for i := 0; i < len(kvs); i += 500 {
+		end := i + 500
+		if end > len(kvs) {
+			end = len(kvs)
+		}
+		batch := s.db.NewBatch()
+		for _, kv := range kvs[i:end] {
+			if err := batch.Delete(kv.key, nil); err != nil {
+				batch.Close()
+				return deleted, fmt.Errorf("pebble_activity_store: prune batch delete: %w", err)
+			}
+		}
+		if err := batch.Commit(pebble.Sync); err != nil {
+			batch.Close()
+			return deleted, fmt.Errorf("pebble_activity_store: prune batch commit: %w", err)
+		}
+		batch.Close()
+		deleted += end - i
+	}
+	return deleted, nil
+}
+
+// GetDistinctSources returns unique sources with entry counts, ordered by count desc.
+func (s *PebbleActivityStore) GetDistinctSources(f ActivityFilter) ([]SourceCount, error) {
+	tiers := actTiers
+	if f.Tier != "" {
+		tiers = []string{f.Tier}
+	}
+	counts := make(map[string]int)
+	for _, tier := range tiers {
+		entries, err := s.scanTier(tier, f.Since, f.Until)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if matchesFilter(e, f) {
+				counts[e.Source]++
+			}
+		}
+	}
+	out := make([]SourceCount, 0, len(counts))
+	for src, cnt := range counts {
+		out = append(out, SourceCount{Source: src, Count: cnt})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	return out, nil
+}
+
+// WipeAllActivity deletes every entry from all tier buckets. Returns total count.
+func (s *PebbleActivityStore) WipeAllActivity() (int64, error) {
+	var total int64
+	for _, tier := range actTiers {
+		kvs, err := s.scanTierKVs(tier, nil, nil)
+		if err != nil {
+			return total, err
+		}
+		for i := 0; i < len(kvs); i += 500 {
+			end := i + 500
+			if end > len(kvs) {
+				end = len(kvs)
+			}
+			batch := s.db.NewBatch()
+			for _, kv := range kvs[i:end] {
+				if err := batch.Delete(kv.key, nil); err != nil {
+					batch.Close()
+					return total, fmt.Errorf("pebble_activity_store: wipe batch delete: %w", err)
+				}
+			}
+			if err := batch.Commit(pebble.Sync); err != nil {
+				batch.Close()
+				return total, fmt.Errorf("pebble_activity_store: wipe batch commit: %w", err)
+			}
+			batch.Close()
+			total += int64(end - i)
+		}
+	}
+	return total, nil
+}
+
+// CompactByDay collapses all compactable tier entries into daily digest rows.
+// Every tier except "digest" is eligible — newly-introduced tiers are automatically
+// compacted without an allowlist update (denylist approach).
+// Each day is processed atomically.
+func (s *PebbleActivityStore) CompactByDay(ctx context.Context, olderThan time.Time) (CompactResult, error) {
+	var result CompactResult
+
+	// Load all compactable entries (all tiers except "digest").
+	var all []pactKV
+	for _, tier := range actCompactableTiers() {
+		kvs, err := s.scanTierKVs(tier, nil, &olderThan)
+		if err != nil {
+			return result, err
+		}
+		all = append(all, kvs...)
+	}
+	if len(all) == 0 {
+		return result, nil
+	}
+
+	// Group by date.
+	type dayGroup struct{ kvs []pactKV }
+	days := make(map[string]*dayGroup)
+	var dayOrder []string
+	for _, kv := range all {
+		dk := kv.entry.Timestamp.UTC().Format("2006-01-02")
+		if _, ok := days[dk]; !ok {
+			days[dk] = &dayGroup{}
+			dayOrder = append(dayOrder, dk)
+		}
+		days[dk].kvs = append(days[dk].kvs, kv)
+	}
+	sort.Strings(dayOrder)
+
+	for _, dateKey := range dayOrder {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
+		dg := days[dateKey]
+		entries := make([]ActivityEntry, len(dg.kvs))
+		for i, kv := range dg.kvs {
+			entries[i] = kv.entry
+		}
+
+		counts := make(map[string]int)
+		for _, e := range entries {
+			counts[e.Type]++
+		}
+
+		var auditItems, errItems, normalItems []DigestItem
+		for _, e := range entries {
+			item := DigestItem{
+				Type:        e.Type,
+				Tier:        e.Tier,
+				Book:        extractBookName(e),
+				BookID:      e.BookID,
+				OperationID: e.OperationID,
+				Summary:     extractItemSummary(e),
+				Timestamp:   e.Timestamp,
+				Tags:        e.Tags,
+			}
+			switch {
+			case e.Tier == "audit":
+				auditItems = append(auditItems, item)
+			case e.Level == "error" || e.Level == "warn":
+				item.Details = extractErrorDetails(e)
+				errItems = append(errItems, item)
+			default:
+				normalItems = append(normalItems, item)
+			}
+		}
+		items := append(auditItems, errItems...)
+		items = append(items, normalItems...)
+
+		truncated := false
+		truncatedCount := 0
+		if len(items) > maxDigestItems {
+			truncatedCount = len(items) - maxDigestItems
+			items = items[:maxDigestItems]
+			truncated = true
+		}
+
+		dd := DigestDetails{
+			Date:           dateKey,
+			OriginalCount:  len(entries),
+			Counts:         counts,
+			Items:          items,
+			Truncated:      truncated,
+			TruncatedCount: truncatedCount,
+		}
+
+		// Check for existing digest for this date to merge into.
+		existing, existingKey, err := s.findExistingDigest(dateKey)
+		if err != nil {
+			return result, err
+		}
+		if existingKey != nil {
+			// Merge existing digest into dd.
+			for k, v := range existing.Counts {
+				dd.Counts[k] += v
+			}
+			dd.OriginalCount += existing.OriginalCount
+			combined := append(existing.Items, dd.Items...)
+			if existing.Truncated {
+				dd.Truncated = true
+				dd.TruncatedCount += existing.TruncatedCount
+			}
+			if len(combined) > maxDigestItems {
+				dd.TruncatedCount += len(combined) - maxDigestItems
+				combined = combined[:maxDigestItems]
+				dd.Truncated = true
+			}
+			dd.Items = combined
+		}
+
+		detailsBytes, err := json.Marshal(dd)
+		if err != nil {
+			return result, fmt.Errorf("pebble_activity_store: compact marshal: %w", err)
+		}
+
+		startOfDay, err := time.Parse("2006-01-02", dateKey)
+		if err != nil {
+			return result, fmt.Errorf("pebble_activity_store: compact parse date: %w", err)
+		}
+
+		// Populate Details from the DigestDetails map so it survives the ActivityEntry round-trip.
+		var ddMap map[string]any
+		if mapErr := json.Unmarshal(detailsBytes, &ddMap); mapErr != nil {
+			return result, fmt.Errorf("pebble_activity_store: compact unmarshal dd map: %w", mapErr)
+		}
+		digestID := ulid.Make().String()
+		digest := ActivityEntry{
+			ID:        s.counter.Add(1),
+			Timestamp: startOfDay,
+			Tier:      "digest",
+			Type:      "daily_digest",
+			Level:     "info",
+			Source:    "compaction",
+			Summary:   fmt.Sprintf("Daily digest for %s (%d entries)", dateKey, dd.OriginalCount),
+			Details:   ddMap,
+		}
+		digestKey := pactPrimaryKey("digest", startOfDay, digestID)
+		digestBytes, err := json.Marshal(digest)
+		if err != nil {
+			return result, fmt.Errorf("pebble_activity_store: compact marshal digest: %w", err)
+		}
+
+		batch := s.db.NewBatch()
+
+		// Delete old digest if present.
+		if existingKey != nil {
+			if err := batch.Delete(existingKey, nil); err != nil {
+				batch.Close()
+				return result, fmt.Errorf("pebble_activity_store: compact delete old digest: %w", err)
+			}
+		}
+
+		// Write new digest.
+		if err := batch.Set(digestKey, digestBytes, nil); err != nil {
+			batch.Close()
+			return result, fmt.Errorf("pebble_activity_store: compact set digest: %w", err)
+		}
+
+		// Delete originals.
+		for _, kv := range dg.kvs {
+			if err := batch.Delete(kv.key, nil); err != nil {
+				batch.Close()
+				return result, fmt.Errorf("pebble_activity_store: compact delete original: %w", err)
+			}
+		}
+
+		if err := batch.Commit(pebble.Sync); err != nil {
+			batch.Close()
+			return result, fmt.Errorf("pebble_activity_store: compact commit day %s: %w", dateKey, err)
+		}
+		batch.Close()
+
+		result.DaysCompacted++
+		result.EntriesDeleted += len(dg.kvs)
+	}
+	return result, nil
+}
+
+// MigrateSystemActivityLogs is a no-op for PebbleActivityStore since it's not backed by SQLite.
+func (s *PebbleActivityStore) MigrateSystemActivityLogs() (int, error) {
+	return 0, nil
+}
+
+// RecompactDigests re-derives type, tier, and tags on every stored daily-digest
+// entry whose items were compacted before enrichment was added.
+//
+// Algorithm:
+//  1. Range-scan the entire "act:digest:" prefix (all digest keys).
+//  2. Decode each entry's Details map as DigestDetails.
+//  3. Skip entries where no items are legacy (idempotent guard).
+//  4. For each legacy item: call deriveTypeFromMessage + enrichLegacyLogTags.
+//  5. Rebuild Counts and TagCounts, marshal back, and overwrite with the same key.
+func (s *PebbleActivityStore) RecompactDigests(ctx context.Context) (RecompactResult, error) {
+	var result RecompactResult
+
+	type digestKV struct {
+		key   []byte
+		entry ActivityEntry
+		dd    DigestDetails
+	}
+
+	var candidates []digestKV
+
+	// Scan all digest entries.
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: pactPrimaryPrefix("digest"),
+		UpperBound: pactPrimaryUpperBound("digest"),
+	})
+	if err != nil {
+		return result, fmt.Errorf("pebble_activity_store: recompact new iter: %w", err)
+	}
+	for iter.First(); iter.Valid(); iter.Next() {
+		var e ActivityEntry
+		if jsonErr := json.Unmarshal(iter.Value(), &e); jsonErr != nil {
+			continue
+		}
+		if e.Type != "daily_digest" {
+			continue
+		}
+		var dd DigestDetails
+		if e.Details != nil {
+			if b, merr := json.Marshal(e.Details); merr == nil {
+				_ = json.Unmarshal(b, &dd)
+			}
+		}
+		keyCopy := make([]byte, len(iter.Key()))
+		copy(keyCopy, iter.Key())
+		candidates = append(candidates, digestKV{key: keyCopy, entry: e, dd: dd})
+	}
+	if err := iter.Close(); err != nil {
+		return result, fmt.Errorf("pebble_activity_store: recompact iter close: %w", err)
+	}
+
+	slog.Info("[activity] recompact: starting digest re-derivation (pebble)",
+		"digest_count", len(candidates))
+
+	for _, c := range candidates {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
+		// Check if any items need updating.
+		needsUpdate := false
+		for _, item := range c.dd.Items {
+			if isLegacyItem(item) {
+				needsUpdate = true
+				break
+			}
+		}
+		if !needsUpdate {
+			result.Skipped++
+			continue
+		}
+
+		// Re-derive type, tier, and tags on each legacy item.
+		for i, item := range c.dd.Items {
+			if !isLegacyItem(item) {
+				continue
+			}
+			derivedType, derivedTier := deriveTypeFromMessage(item.Summary, "")
+			derivedTags := enrichLegacyLogTags(item.Summary, "", "info")
+			c.dd.Items[i].Type = derivedType
+			c.dd.Items[i].Tier = derivedTier
+			c.dd.Items[i].Tags = derivedTags
+		}
+
+		// Rebuild Counts from updated items.
+		newCounts := make(map[string]int)
+		for _, item := range c.dd.Items {
+			newCounts[item.Type]++
+		}
+		c.dd.Counts = newCounts
+
+		// Rebuild TagCounts from updated items (action: and source: namespaces only).
+		newTagCounts := make(map[string]map[string]int)
+		for _, item := range c.dd.Items {
+			for _, tag := range item.Tags {
+				colonIdx := strings.Index(tag, ":")
+				if colonIdx < 1 {
+					continue
+				}
+				ns := tag[:colonIdx]
+				val := tag[colonIdx+1:]
+				if ns != "action" && ns != "source" {
+					continue
+				}
+				if newTagCounts[ns] == nil {
+					newTagCounts[ns] = make(map[string]int)
+				}
+				newTagCounts[ns][val]++
+			}
+		}
+		if len(newTagCounts) > 0 {
+			c.dd.TagCounts = newTagCounts
+		}
+
+		// Merge updated DigestDetails back into the entry's Details map.
+		ddBytes, merr := json.Marshal(c.dd)
+		if merr != nil {
+			return result, fmt.Errorf("pebble_activity_store: recompact marshal digest key=%s: %w", c.key, merr)
+		}
+		var detailsMap map[string]any
+		if err := json.Unmarshal(ddBytes, &detailsMap); err != nil {
+			return result, fmt.Errorf("pebble_activity_store: recompact unmarshal detailsMap key=%s: %w", c.key, err)
+		}
+		c.entry.Details = detailsMap
+		c.entry.Summary = fmt.Sprintf("Daily digest for %s (%d entries)", c.dd.Date, c.dd.OriginalCount)
+
+		entryBytes, merr := json.Marshal(c.entry)
+		if merr != nil {
+			return result, fmt.Errorf("pebble_activity_store: recompact marshal entry key=%s: %w", c.key, merr)
+		}
+
+		if err := s.db.Set(c.key, entryBytes, pebble.Sync); err != nil {
+			return result, fmt.Errorf("pebble_activity_store: recompact write key=%s: %w", c.key, err)
+		}
+
+		slog.Info("[activity] recompact: updated digest (pebble)",
+			"key", string(c.key), "date", c.dd.Date, "items", len(c.dd.Items))
+		result.Touched++
+	}
+
+	slog.Info("[activity] recompact: complete (pebble)",
+		"touched", result.Touched, "skipped", result.Skipped)
+	return result, nil
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+// pactKV holds a Pebble key and its decoded ActivityEntry.
+type pactKV struct {
+	key   []byte
+	entry ActivityEntry
+}
+
+// scanTier returns all entries from a tier within [since, until].
+// nil bounds mean "no bound". Results are in ascending timestamp order (Pebble
+// lexicographic order over the time-keyed prefix).
+func (s *PebbleActivityStore) scanTier(tier string, since, until *time.Time) ([]ActivityEntry, error) {
+	kvs, err := s.scanTierKVs(tier, since, until)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]ActivityEntry, len(kvs))
+	for i, kv := range kvs {
+		entries[i] = kv.entry
+	}
+	return entries, nil
+}
+
+// scanTierKVs returns key+entry pairs for a tier within the time range.
+func (s *PebbleActivityStore) scanTierKVs(tier string, since, until *time.Time) ([]pactKV, error) {
+	// Default lower/upper bounds cover the entire tier prefix.
+	lower := pactPrimaryPrefix(tier)
+	upper := pactPrimaryUpperBound(tier)
+
+	// Narrow bounds when time constraints are given.
+	if since != nil {
+		lower = pactPrimaryKey(tier, *since, "")
+	}
+	if until != nil {
+		upper = pactPrimaryKey(tier, *until, "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
+	}
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: lower,
+		UpperBound: upper,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pebble_activity_store: scanTierKVs new iter (tier=%s): %w", tier, err)
+	}
+	defer iter.Close()
+
+	var out []pactKV
+	for iter.First(); iter.Valid(); iter.Next() {
+		var e ActivityEntry
+		if jsonErr := json.Unmarshal(iter.Value(), &e); jsonErr != nil {
+			continue
+		}
+		keyCopy := make([]byte, len(iter.Key()))
+		copy(keyCopy, iter.Key())
+		out = append(out, pactKV{key: keyCopy, entry: e})
+	}
+	return out, nil
+}
+
+// queryByIndexPrefix reads ref values from an index prefix, then fetches primary entries.
+// Handles both op and book secondary indexes.
+func (s *PebbleActivityStore) queryByIndexPrefix(prefix string, f ActivityFilter) ([]ActivityEntry, int, error) {
+	// Upper bound: replace trailing ':' with ';' to cover the entire id sub-namespace.
+	upperPrefix := prefix[:len(prefix)-1] + ";"
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(prefix),
+		UpperBound: []byte(upperPrefix),
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("pebble_activity_store: queryByIndex new iter: %w", err)
+	}
+	defer iter.Close()
+
+	var refs [][]byte
+	for iter.First(); iter.Valid(); iter.Next() {
+		valCopy := make([]byte, len(iter.Value()))
+		copy(valCopy, iter.Value())
+		refs = append(refs, valCopy)
+	}
+
+	var all []ActivityEntry
+	for _, ref := range refs {
+		primaryKey, ok := pactPrimaryKeyFromRef(ref)
+		if !ok {
+			continue
+		}
+		val, closer, err := s.db.Get(primaryKey)
+		if err != nil {
+			// Entry may have been deleted (e.g., pruned); skip stale index refs.
+			continue
+		}
+		var entry ActivityEntry
+		jsonErr := json.Unmarshal(val, &entry)
+		closer.Close()
+		if jsonErr != nil {
+			continue
+		}
+		if matchesFilter(entry, f) {
+			all = append(all, entry)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Timestamp.After(all[j].Timestamp)
+	})
+
+	total := len(all)
+	start := f.Offset
+	if start > len(all) {
+		start = len(all)
+	}
+	end := start + f.Limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[start:end], total, nil
+}
+
+// findExistingDigest looks for a digest row for the given date string ("2006-01-02").
+// Returns the DigestDetails, the Pebble key, and any error.
+func (s *PebbleActivityStore) findExistingDigest(dateKey string) (DigestDetails, []byte, error) {
+	day, err := time.Parse("2006-01-02", dateKey)
+	if err != nil {
+		return DigestDetails{}, nil, err
+	}
+	dayEnd := day.Add(24 * time.Hour)
+
+	lower := pactPrimaryKey("digest", day, "")
+	upper := pactPrimaryKey("digest", dayEnd, "")
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: lower,
+		UpperBound: upper,
+	})
+	if err != nil {
+		return DigestDetails{}, nil, fmt.Errorf("pebble_activity_store: findExistingDigest new iter: %w", err)
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		var row struct {
+			ActivityEntry
+			DigestDetails json.RawMessage `json:"digest_details,omitempty"`
+		}
+		if jsonErr := json.Unmarshal(iter.Value(), &row); jsonErr != nil {
+			continue
+		}
+		if row.ActivityEntry.Type != "daily_digest" {
+			continue
+		}
+
+		var dd DigestDetails
+		if row.DigestDetails != nil {
+			// Old format: digest_details at top level.
+			_ = json.Unmarshal(row.DigestDetails, &dd)
+		} else if row.ActivityEntry.Details != nil {
+			// New format: stored in ActivityEntry.Details.
+			if b, merr := json.Marshal(row.ActivityEntry.Details); merr == nil {
+				_ = json.Unmarshal(b, &dd)
+			}
+		}
+		keyCopy := make([]byte, len(iter.Key()))
+		copy(keyCopy, iter.Key())
+		return dd, keyCopy, nil
+	}
+	return DigestDetails{}, nil, nil
+}

--- a/internal/database/pebble_activity_store_test.go
+++ b/internal/database/pebble_activity_store_test.go
@@ -1,0 +1,734 @@
+// file: internal/database/pebble_activity_store_test.go
+// version: 1.0.0
+// guid: c9d0e1f2-a3b4-0010-3456-000000000010
+
+// Package database — parity test suite for PebbleActivityStore.
+//
+// WHY a separate test file:
+//   - The existing activity_store_test.go and activity_compact_test.go test the SQLite
+//     ActivityStore.  The NutsDB variant is tested in activity_compact_test.go (see
+//     TestNutsActivityStore_RecompactDigests).
+//   - This file runs the SAME behavioral scenarios over PebbleActivityStore so any
+//     regression in the new backend is caught at the same granularity as the others.
+//   - "Parity gate" = every test here must pass, matching the Nuts/SQL test names.
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestPebbleActivityStore creates a temp PebbleDB directory and a PebbleActivityStore.
+func newTestPebbleActivityStore(t *testing.T) *PebbleActivityStore {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewPebbleActivityStore(db)
+}
+
+// ── parity: basic record + query ─────────────────────────────────────────────
+
+func TestPebbleActivityStore_RecordAndQuery(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	opID := "op-abc-123"
+	bookID := "book-xyz-456"
+	ts := time.Now().UTC().Truncate(time.Second)
+
+	entry := ActivityEntry{
+		Timestamp:   ts,
+		Tier:        "change",
+		Type:        "metadata_apply",
+		Level:       "info",
+		Source:      "apply_pipeline",
+		OperationID: opID,
+		BookID:      bookID,
+		Summary:     "Applied metadata",
+		Details:     map[string]any{"field": "title", "old": "foo", "new": "bar"},
+		Tags:        []string{"enrichment", "isbn"},
+	}
+
+	id, err := s.Record(entry)
+	require.NoError(t, err)
+	assert.Greater(t, id, int64(0))
+
+	entries, total, err := s.Query(ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, entries, 1)
+
+	got := entries[0]
+	assert.Equal(t, id, got.ID)
+	assert.Equal(t, "change", got.Tier)
+	assert.Equal(t, "metadata_apply", got.Type)
+	assert.Equal(t, "info", got.Level)
+	assert.Equal(t, "apply_pipeline", got.Source)
+	assert.Equal(t, opID, got.OperationID)
+	assert.Equal(t, bookID, got.BookID)
+	assert.Equal(t, "Applied metadata", got.Summary)
+	assert.Nil(t, got.PrunedAt)
+
+	// Details round-trip
+	require.NotNil(t, got.Details)
+	assert.Equal(t, "title", got.Details["field"])
+
+	// Tags round-trip
+	assert.ElementsMatch(t, []string{"enrichment", "isbn"}, got.Tags)
+}
+
+// ── parity: query filters ─────────────────────────────────────────────────────
+
+func TestPebbleActivityStore_QueryFilters(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	now := time.Now().UTC()
+
+	entries := []ActivityEntry{
+		{Tier: "change", Type: "metadata_apply", Level: "info", Source: "s1",
+			OperationID: "op-1", BookID: "book-1", Summary: "A",
+			Tags: []string{"alpha", "beta"}, Timestamp: now.Add(-4 * time.Minute)},
+		{Tier: "change", Type: "tag_write", Level: "warn", Source: "s2",
+			OperationID: "op-1", BookID: "book-2", Summary: "B",
+			Tags: []string{"beta", "gamma"}, Timestamp: now.Add(-3 * time.Minute)},
+		{Tier: "debug", Type: "isbn_lookup", Level: "info", Source: "s3",
+			OperationID: "op-2", BookID: "book-1", Summary: "C",
+			Tags: []string{"gamma"}, Timestamp: now.Add(-2 * time.Minute)},
+		{Tier: "debug", Type: "isbn_lookup", Level: "error", Source: "s4",
+			OperationID: "op-3", BookID: "book-3", Summary: "D",
+			Tags: []string{"alpha"}, Timestamp: now.Add(-1 * time.Minute)},
+	}
+	for _, e := range entries {
+		_, err := s.Record(e)
+		require.NoError(t, err)
+	}
+
+	t.Run("filter_by_tier", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{Tier: "debug", Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, res, 2)
+		for _, r := range res {
+			assert.Equal(t, "debug", r.Tier)
+		}
+	})
+
+	t.Run("filter_by_type", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{Type: "isbn_lookup", Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("filter_by_operation_id", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{OperationID: "op-1", Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("filter_by_book_id", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{BookID: "book-1", Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("filter_single_tag_alpha", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{Tags: []string{"alpha"}, Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("filter_two_tags_requires_both", func(t *testing.T) {
+		// Only entry[0] has both alpha AND beta
+		res, total, err := s.Query(ActivityFilter{Tags: []string{"alpha", "beta"}, Limit: 50})
+		require.NoError(t, err)
+		assert.Equal(t, 1, total)
+		assert.Len(t, res, 1)
+		assert.Equal(t, "A", res[0].Summary)
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{Limit: 2})
+		require.NoError(t, err)
+		assert.Equal(t, 4, total)
+		assert.Len(t, res, 2)
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		res, total, err := s.Query(ActivityFilter{Limit: 50, Offset: 3})
+		require.NoError(t, err)
+		assert.Equal(t, 4, total)
+		assert.Len(t, res, 1)
+	})
+}
+
+// ── parity: prune ─────────────────────────────────────────────────────────────
+
+func TestPebbleActivityStore_Prune(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	cutoff := time.Now().UTC().Add(-1 * time.Hour)
+
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier: "debug", Type: "tag_write", Level: "debug",
+			Source: "writer", Summary: "old debug",
+			Timestamp: cutoff.Add(-time.Duration(i+1) * time.Minute),
+		})
+		require.NoError(t, err)
+	}
+	_, err := s.Record(ActivityEntry{
+		Tier: "audit", Type: "tag_write", Level: "info",
+		Source: "writer", Summary: "old audit",
+		Timestamp: cutoff.Add(-5 * time.Minute),
+	})
+	require.NoError(t, err)
+	_, err = s.Record(ActivityEntry{
+		Tier: "debug", Type: "tag_write", Level: "debug",
+		Source: "writer", Summary: "recent debug",
+		Timestamp: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	deleted, err := s.Prune(cutoff, "debug")
+	require.NoError(t, err)
+	assert.Equal(t, 3, deleted)
+
+	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, all, 2)
+
+	for _, e := range all {
+		assert.NotEqual(t, "old debug", e.Summary)
+	}
+}
+
+// ── parity: wipe all activity ─────────────────────────────────────────────────
+
+func TestPebbleActivityStore_WipeAllActivity(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	for _, tier := range actTiers[:4] { // change/debug/audit/info
+		_, err := s.Record(ActivityEntry{
+			Tier: tier, Type: "test", Level: "info",
+			Source: "test", Summary: "entry in " + tier,
+		})
+		require.NoError(t, err)
+	}
+
+	n, err := s.WipeAllActivity()
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), n)
+
+	_, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+}
+
+// ── parity: GetDistinctSources ────────────────────────────────────────────────
+
+func TestPebbleActivityStore_GetDistinctSources(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	entries := []ActivityEntry{
+		{Tier: "change", Type: "request", Level: "info", Source: "gin", Summary: "req 1"},
+		{Tier: "debug", Type: "request", Level: "debug", Source: "gin", Summary: "req 2"},
+		{Tier: "info", Type: "scan", Level: "info", Source: "scanner", Summary: "scan 1"},
+		{Tier: "change", Type: "metadata_apply", Level: "info", Source: "metadata", Summary: "apply 1"},
+	}
+	for _, e := range entries {
+		_, err := s.Record(e)
+		require.NoError(t, err)
+	}
+
+	t.Run("unfiltered_returns_all_sources", func(t *testing.T) {
+		sources, err := s.GetDistinctSources(ActivityFilter{})
+		require.NoError(t, err)
+		assert.Len(t, sources, 3, "expected gin, scanner, metadata")
+		assert.Equal(t, "gin", sources[0].Source)
+		assert.Equal(t, 2, sources[0].Count)
+	})
+
+	t.Run("filtered_by_tier_debug", func(t *testing.T) {
+		sources, err := s.GetDistinctSources(ActivityFilter{Tier: "debug"})
+		require.NoError(t, err)
+		assert.Len(t, sources, 1)
+		assert.Equal(t, "gin", sources[0].Source)
+		assert.Equal(t, 1, sources[0].Count)
+	})
+}
+
+// ── parity: CompactByDay — basic ──────────────────────────────────────────────
+
+func TestPebbleActivityStore_CompactByDay_Basic(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	day1 := time.Date(2025, 6, 10, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 6, 11, 14, 0, 0, 0, time.UTC)
+	olderThan := time.Date(2025, 6, 12, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:    "change",
+			Type:    "metadata_applied",
+			Level:   "info",
+			Source:  "pipeline",
+			BookID:  "book-1",
+			Summary: "applied metadata",
+			Timestamp: day1.Add(time.Duration(i) * time.Minute),
+			Details: map[string]any{"book_title": "Test Book"},
+		})
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 2; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:    "change",
+			Type:    "tag_written",
+			Level:   "info",
+			Source:  "writer",
+			BookID:  "book-2",
+			Summary: "wrote tags",
+			Timestamp: day2.Add(time.Duration(i) * time.Minute),
+			Details: map[string]any{"title": "Other Book"},
+		})
+		require.NoError(t, err)
+	}
+
+	_, err := s.Record(ActivityEntry{
+		Tier:        "audit",
+		Type:        "user_login",
+		Level:       "info",
+		Source:      "auth",
+		OperationID: "op-login-42",
+		Summary:     "user logged in",
+		Timestamp:   day1.Add(30 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	result, err := s.CompactByDay(context.Background(), olderThan)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.DaysCompacted)
+	assert.Equal(t, 6, result.EntriesDeleted, "5 change + 1 audit folded")
+
+	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+
+	var digestCount, auditSurvived int
+	var day1Digest DigestDetails
+	for _, e := range all {
+		switch e.Tier {
+		case "digest":
+			digestCount++
+			assert.Equal(t, "daily_digest", e.Type)
+			assert.Equal(t, "compaction", e.Source)
+			require.NotNil(t, e.Details)
+			detailsJSON, err := json.Marshal(e.Details)
+			require.NoError(t, err)
+			var dd DigestDetails
+			err = json.Unmarshal(detailsJSON, &dd)
+			require.NoError(t, err)
+			assert.NotEmpty(t, dd.Date)
+			assert.Greater(t, dd.OriginalCount, 0)
+			if dd.Date == "2025-06-10" {
+				day1Digest = dd
+			}
+		case "audit":
+			auditSurvived++
+		}
+	}
+	assert.Equal(t, 2, digestCount, "expected 2 digest rows")
+	assert.Equal(t, 0, auditSurvived, "audit entry must be folded")
+
+	require.Equal(t, "2025-06-10", day1Digest.Date)
+	assert.Equal(t, 4, day1Digest.OriginalCount)
+	assert.Equal(t, 1, day1Digest.Counts["user_login"])
+	assert.Equal(t, 3, day1Digest.Counts["metadata_applied"])
+	require.NotEmpty(t, day1Digest.Items)
+	first := day1Digest.Items[0]
+	assert.Equal(t, "audit", first.Tier, "audit items must sort first")
+	assert.Equal(t, "user_login", first.Type)
+	assert.Equal(t, "op-login-42", first.OperationID, "operation_id preserved")
+}
+
+// ── parity: CompactByDay — idempotent ────────────────────────────────────────
+
+func TestPebbleActivityStore_CompactByDay_Idempotent(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	ts := time.Date(2025, 5, 1, 10, 0, 0, 0, time.UTC)
+	olderThan := time.Date(2025, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	_, err := s.Record(ActivityEntry{
+		Tier:    "change",
+		Type:    "config_changed",
+		Level:   "info",
+		Source:  "settings",
+		Summary: "changed setting",
+		Timestamp: ts,
+	})
+	require.NoError(t, err)
+
+	r1, err := s.CompactByDay(context.Background(), olderThan)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.DaysCompacted)
+	assert.Equal(t, 1, r1.EntriesDeleted)
+
+	r2, err := s.CompactByDay(context.Background(), olderThan)
+	require.NoError(t, err)
+	assert.Equal(t, 0, r2.DaysCompacted)
+	assert.Equal(t, 0, r2.EntriesDeleted)
+}
+
+// ── parity: CompactByDay — truncates large days ───────────────────────────────
+
+func TestPebbleActivityStore_CompactByDay_Truncates(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	day := time.Date(2025, 3, 20, 6, 0, 0, 0, time.UTC)
+	olderThan := time.Date(2025, 3, 21, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 600; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "debug",
+			Type:      "tag_written",
+			Level:     "debug",
+			Source:    "writer",
+			Summary:   "wrote tags",
+			Timestamp: day.Add(time.Duration(i) * time.Second),
+		})
+		require.NoError(t, err)
+	}
+
+	result, err := s.CompactByDay(context.Background(), olderThan)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.DaysCompacted)
+	assert.Equal(t, 600, result.EntriesDeleted)
+
+	all, total, err := s.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, all, 1)
+
+	digest := all[0]
+	assert.Equal(t, "digest", digest.Tier)
+	require.NotNil(t, digest.Details)
+
+	detailsJSON, err := json.Marshal(digest.Details)
+	require.NoError(t, err)
+	var dd DigestDetails
+	err = json.Unmarshal(detailsJSON, &dd)
+	require.NoError(t, err)
+
+	assert.Len(t, dd.Items, 500, "items capped at 500")
+	assert.True(t, dd.Truncated)
+	assert.Equal(t, 100, dd.TruncatedCount)
+	assert.Equal(t, 600, dd.OriginalCount)
+}
+
+// ── parity: CompactByDay — merges into existing digest ───────────────────────
+
+func TestPebbleActivityStore_CompactByDay_MergesExisting(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+
+	day := time.Date(2025, 5, 15, 8, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2025, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier: "change", Type: "metadata_applied", Level: "info",
+			Source: "test", Summary: "initial entry", Timestamp: day,
+		})
+		require.NoError(t, err)
+	}
+
+	r1, err := s.CompactByDay(context.Background(), cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.DaysCompacted)
+	assert.Equal(t, 3, r1.EntriesDeleted)
+
+	lateDay := time.Date(2025, 5, 15, 11, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier: "change", Type: "tag_written", Level: "info",
+			Source: "test", Summary: "late entry", Timestamp: lateDay,
+		})
+		require.NoError(t, err)
+	}
+
+	r2, err := s.CompactByDay(context.Background(), cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r2.DaysCompacted)
+	assert.Equal(t, 5, r2.EntriesDeleted)
+
+	// Exactly one digest row for the day.
+	all, total, err := s.Query(ActivityFilter{Tier: "digest", Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "must be exactly one digest per day")
+
+	detailsJSON, err := json.Marshal(all[0].Details)
+	require.NoError(t, err)
+	var dd DigestDetails
+	require.NoError(t, json.Unmarshal(detailsJSON, &dd))
+
+	assert.Equal(t, 8, dd.OriginalCount, "merged digest: 3 old + 5 new")
+	assert.Equal(t, 3, dd.Counts["metadata_applied"])
+	assert.Equal(t, 5, dd.Counts["tag_written"])
+}
+
+// ── parity: RecompactDigests ──────────────────────────────────────────────────
+
+func TestPebbleActivityStore_RecompactDigests(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	ctx := context.Background()
+
+	day := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	// Insert 3 legacy-style entries (type=system_log, no tags).
+	for i := 0; i < 3; i++ {
+		_, err := s.Record(ActivityEntry{
+			Tier:      "change",
+			Type:      "system_log",
+			Level:     "info",
+			Source:    "compaction",
+			Summary:   "applied metadata to book",
+			Timestamp: day.Add(time.Duration(i) * time.Minute),
+			Tags:      []string{},
+		})
+		require.NoError(t, err)
+	}
+
+	// Compact to create a digest.
+	olderThan := day.Add(24 * time.Hour)
+	_, err := s.CompactByDay(ctx, olderThan)
+	require.NoError(t, err)
+
+	// Run RecompactDigests — should touch exactly 1 digest.
+	res, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Touched, "first run: should touch the one digest")
+	assert.Equal(t, 0, res.Skipped)
+
+	// Read back the digest and verify items got proper types and tags.
+	dd, _, err := s.findExistingDigest(day.Format("2006-01-02"))
+	require.NoError(t, err)
+	require.Len(t, dd.Items, 3, "digest should still have 3 items")
+	for i, item := range dd.Items {
+		assert.NotEqual(t, "system_log", item.Type, "item %d: type should be re-derived", i)
+		assert.NotEmpty(t, item.Tags, "item %d: tags should be populated after recompact", i)
+	}
+
+	// Idempotency: second run should skip all.
+	res2, err := s.RecompactDigests(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, res2.Touched, "second run: should be idempotent")
+	assert.Equal(t, 1, res2.Skipped)
+}
+
+// ── parity: MigrateSystemActivityLogs — no-op ────────────────────────────────
+
+func TestPebbleActivityStore_MigrateSystemActivityLogs_Noop(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	n, err := s.MigrateSystemActivityLogs()
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// ── parity: Close — no-op ────────────────────────────────────────────────────
+
+func TestPebbleActivityStore_Close_Noop(t *testing.T) {
+	s := newTestPebbleActivityStore(t)
+	require.NoError(t, s.Close())
+	// Close must be idempotent.
+	require.NoError(t, s.Close())
+}
+
+// ── dual-write: entry lands in both backends ──────────────────────────────────
+
+// TestDualWriteActivityStore_WritesReplicated verifies that Record writes to both
+// backends (NutsDB and Pebble) so a query on either returns the entry.
+func TestDualWriteActivityStore_WritesReplicated(t *testing.T) {
+	nutsStore := newTestNutsActivityStore(t)
+	pebbleStore := newTestPebbleActivityStore(t)
+
+	// Start in read-from-nuts mode.
+	dual := NewDualWriteActivityStore(nutsStore, pebbleStore, false)
+
+	entry := ActivityEntry{
+		Tier:    "change",
+		Type:    "tag_write",
+		Level:   "info",
+		Source:  "dual-write-test",
+		Summary: "dual write test entry",
+	}
+	id, err := dual.Record(entry)
+	require.NoError(t, err)
+	assert.Greater(t, id, int64(0))
+
+	// Query from NutsDB (primary when ReadFromPebble=false).
+	resNuts, totalNuts, err := dual.Query(ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalNuts)
+	assert.Equal(t, "dual-write-test", resNuts[0].Source)
+
+	// Query Pebble directly to confirm replication.
+	resPebble, totalPebble, err := pebbleStore.Query(ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalPebble, "entry must also land in Pebble")
+	assert.Equal(t, "dual-write-test", resPebble[0].Source)
+
+	// Flip to read-from-pebble and verify reads come from Pebble.
+	dual.ReadFromPebble = true
+	resAfterFlip, totalAfterFlip, err := dual.Query(ActivityFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, totalAfterFlip)
+	assert.Equal(t, "dual-write-test", resAfterFlip[0].Source)
+}
+
+// ── backfill: sentinel check ──────────────────────────────────────────────────
+
+func TestIsActivityPebbleBackfillDone_FalseBeforeFlag(t *testing.T) {
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	assert.False(t, IsActivityPebbleBackfillDone(db))
+}
+
+func TestIsActivityPebbleBackfillDone_TrueAfterFlag(t *testing.T) {
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.Set([]byte(ActivityPebbleBackfillKey), []byte("2026-01-01"), pebble.Sync))
+	assert.True(t, IsActivityPebbleBackfillDone(db))
+}
+
+// ── backfill: dry-run counts ──────────────────────────────────────────────────
+
+func TestBackfillNutsActivityToPebble_DryRun(t *testing.T) {
+	nutsStore := newTestNutsActivityStore(t)
+	pebbleDir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(pebbleDir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+	pebbleStore := NewPebbleActivityStore(db)
+
+	// Write 5 entries across 3 tiers to NutsDB.
+	for _, tier := range []string{"change", "debug", "audit"} {
+		for i := 0; i < 1; i++ {
+			_, err := nutsStore.Record(ActivityEntry{
+				Tier:    tier,
+				Type:    "test",
+				Level:   "info",
+				Source:  "backfill-test",
+				Summary: "test " + tier,
+			})
+			require.NoError(t, err)
+		}
+	}
+	// Also add 2 more to change.
+	for i := 0; i < 2; i++ {
+		_, err := nutsStore.Record(ActivityEntry{
+			Tier: "change", Type: "extra", Level: "info",
+			Source: "backfill-test", Summary: "extra",
+		})
+		require.NoError(t, err)
+	}
+
+	res, err := BackfillNutsActivityToPebble(context.Background(), nutsStore, pebbleStore, true)
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.False(t, res.AlreadyDone)
+	assert.Equal(t, 5, res.EntriesCopied, "dry-run should count 5 entries")
+
+	// Confirm Pebble is still empty (dry-run).
+	_, total, err := pebbleStore.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "dry-run must not write to Pebble")
+
+	// Confirm sentinel NOT written.
+	assert.False(t, IsActivityPebbleBackfillDone(db))
+}
+
+// ── backfill: apply — copies all entries and writes sentinel ─────────────────
+
+func TestBackfillNutsActivityToPebble_Apply(t *testing.T) {
+	nutsStore := newTestNutsActivityStore(t)
+	pebbleDir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(pebbleDir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+	pebbleStore := NewPebbleActivityStore(db)
+
+	// Write 3 entries to NutsDB.
+	for i := 0; i < 3; i++ {
+		_, err := nutsStore.Record(ActivityEntry{
+			Tier:    "change",
+			Type:    "test",
+			Level:   "info",
+			Source:  "backfill-apply-test",
+			Summary: "entry",
+			BookID:  "book-99",
+		})
+		require.NoError(t, err)
+	}
+
+	res, err := BackfillNutsActivityToPebble(context.Background(), nutsStore, pebbleStore, false)
+	require.NoError(t, err)
+	assert.False(t, res.DryRun)
+	assert.False(t, res.AlreadyDone)
+	assert.Equal(t, 3, res.EntriesCopied)
+
+	// Sentinel must be set.
+	assert.True(t, IsActivityPebbleBackfillDone(db))
+
+	// Pebble must have the entries.
+	_, total, err := pebbleStore.Query(ActivityFilter{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 3, total, "Pebble must have all 3 copied entries")
+}
+
+// ── backfill: idempotent after sentinel ───────────────────────────────────────
+
+func TestBackfillNutsActivityToPebble_Idempotent(t *testing.T) {
+	nutsStore := newTestNutsActivityStore(t)
+	pebbleDir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(pebbleDir, "test.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+	pebbleStore := NewPebbleActivityStore(db)
+
+	_, err = nutsStore.Record(ActivityEntry{
+		Tier: "change", Type: "test", Level: "info",
+		Source: "sentinel-test", Summary: "one entry",
+	})
+	require.NoError(t, err)
+
+	// First run.
+	r1, err := BackfillNutsActivityToPebble(context.Background(), nutsStore, pebbleStore, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, r1.EntriesCopied)
+	assert.True(t, IsActivityPebbleBackfillDone(db))
+
+	// Second run — should return AlreadyDone=true with 0 copies.
+	r2, err := BackfillNutsActivityToPebble(context.Background(), nutsStore, pebbleStore, false)
+	require.NoError(t, err)
+	assert.True(t, r2.AlreadyDone, "second run must short-circuit on sentinel")
+	assert.Equal(t, 0, r2.EntriesCopied)
+}

--- a/internal/database/pebble_metrics_store.go
+++ b/internal/database/pebble_metrics_store.go
@@ -1,0 +1,316 @@
+// file: internal/database/pebble_metrics_store.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-0005-ef01-000000000005
+
+// Package database — PebbleDB-backed cache-stats metrics store.
+//
+// WHY a Pebble backend:
+//   - NutsMetricsStore (nuts_metrics_store.go) uses NutsDB's per-entry TTL
+//     (30-day expiry). Pebble has no built-in per-key TTL, so we emulate it:
+//     (a) writes record a 30-day expiry timestamp in each value's JSON, and
+//     (b) a TTL sweep function (called from maintenance) prunes expired entries.
+//     This is equivalent to the NutsDB behaviour and preserves the 30-day window
+//     without requiring a background goroutine.
+//
+// Key layout:
+//
+//	met:<cacheName>:<20d-unix-nano>  = JSON(CacheStatsSnapshot)   primary
+//	met:_idx:<cacheName>             = []byte("1")                cache-name index
+//
+// The "met:" prefix avoids collision with all other PebbleDB key families.
+// Cache names are stored in met:_idx: so GetCacheStatsHistory can enumerate
+// all known names without scanning every met: key.
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+const (
+	// pmetTTLSeconds is the time-to-live for metrics snapshots: 30 days.
+	// Mirrors NutsMetricsStore's metricsTTL constant.
+	pmetTTLSeconds = 30 * 24 * 3600
+
+	pmetKeyMaxNano = "99999999999999999999"
+	pmetIdxPrefix  = "met:_idx:"
+)
+
+// PebbleMetricsStore persists cache-stats snapshots in a shared PebbleDB database.
+// It satisfies the MetricsStorer interface and is a drop-in replacement for
+// NutsMetricsStore.
+//
+// The caller retains ownership of the *pebble.DB — Close() on this store is a no-op.
+type PebbleMetricsStore struct {
+	db *pebble.DB
+}
+
+// NewPebbleMetricsStore creates a PebbleMetricsStore backed by the provided DB.
+// The caller retains ownership of db; Close() on this store does NOT close db.
+func NewPebbleMetricsStore(db *pebble.DB) *PebbleMetricsStore {
+	return &PebbleMetricsStore{db: db}
+}
+
+// Close is a no-op: the caller owns the PebbleDB instance.
+func (s *PebbleMetricsStore) Close() error { return nil }
+
+// ── Key construction ──────────────────────────────────────────────────────────
+
+// pmetKey builds the primary key for a snapshot:
+//
+//	met:<cacheName>:<20d-unix-nano>
+func pmetKey(cacheName string, t time.Time) []byte {
+	return []byte(fmt.Sprintf("met:%s:%020d", cacheName, t.UnixNano()))
+}
+
+// pmetPrefix returns the inclusive lower-bound prefix for a cache-name range scan.
+func pmetPrefix(cacheName string) []byte {
+	return []byte("met:" + cacheName + ":")
+}
+
+// pmetUpperBound returns the exclusive upper-bound for a cache-name range scan.
+// ';' (0x3B) is one above ':' (0x3A).
+func pmetUpperBound(cacheName string) []byte {
+	return []byte("met:" + cacheName + ";")
+}
+
+// pmetIdxKey builds the cache-name index key.
+func pmetIdxKey(cacheName string) []byte {
+	return []byte(pmetIdxPrefix + cacheName)
+}
+
+// ── envelope to track TTL ─────────────────────────────────────────────────────
+
+// pmetValue wraps a CacheStatsSnapshot with an expiry wall-clock timestamp.
+// WHY: Pebble has no built-in per-key TTL; we embed expiry in the value so
+// SweepExpiredMetrics can skip (or delete) entries without re-parsing timestamps.
+type pmetValue struct {
+	ExpiresAt int64            `json:"expires_at"` // Unix seconds
+	Snapshot  CacheStatsSnapshot `json:"snapshot"`
+}
+
+// ── MetricsStorer implementation ──────────────────────────────────────────────
+
+// RecordCacheStatsSnapshots writes all snapshots in a single batch.
+// Buckets / index entries are created on demand.
+func (s *PebbleMetricsStore) RecordCacheStatsSnapshots(snapshots []CacheStatsSnapshot) error {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	batch := s.db.NewBatch()
+	defer batch.Close()
+
+	for _, snap := range snapshots {
+		v := pmetValue{
+			ExpiresAt: snap.Timestamp.Unix() + pmetTTLSeconds,
+			Snapshot:  snap,
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("pebble_metrics_store: marshal %s: %w", snap.CacheName, err)
+		}
+		if err := batch.Set(pmetKey(snap.CacheName, snap.Timestamp), b, nil); err != nil {
+			return fmt.Errorf("pebble_metrics_store: set snapshot %s: %w", snap.CacheName, err)
+		}
+		// Track cache name in the index (idempotent — Set is safe to repeat).
+		if err := batch.Set(pmetIdxKey(snap.CacheName), []byte("1"), nil); err != nil {
+			return fmt.Errorf("pebble_metrics_store: set idx %s: %w", snap.CacheName, err)
+		}
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("pebble_metrics_store: commit: %w", err)
+	}
+	return nil
+}
+
+// GetCacheStatsHistory returns snapshots since the given time, oldest-first.
+// If cacheName is empty, all known caches are returned merged and sorted.
+func (s *PebbleMetricsStore) GetCacheStatsHistory(cacheName string, since time.Time, limit int) ([]CacheStatsSnapshot, error) {
+	names, err := s.cacheNames(cacheName)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Unix()
+	var out []CacheStatsSnapshot
+
+	for _, name := range names {
+		lower := pmetKey(name, since)
+		upper := []byte(fmt.Sprintf("met:%s:%s", name, pmetKeyMaxNano))
+
+		iter, err := s.db.NewIter(&pebble.IterOptions{
+			LowerBound: lower,
+			UpperBound: upper,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("pebble_metrics_store: GetCacheStatsHistory new iter: %w", err)
+		}
+		for iter.First(); iter.Valid(); iter.Next() {
+			var v pmetValue
+			if err := json.Unmarshal(iter.Value(), &v); err != nil {
+				continue
+			}
+			// Skip expired entries (TTL enforcement on read).
+			if v.ExpiresAt <= now {
+				continue
+			}
+			out = append(out, v.Snapshot)
+		}
+		_ = iter.Close()
+	}
+
+	// Sort oldest-first; multi-cache entries from different prefixes need sorting.
+	if len(names) > 1 {
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].Timestamp.Before(out[j].Timestamp)
+		})
+	}
+
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// PruneCacheStatsHistory deletes snapshots older than olderThan.
+// Unlike NutsMetricsStore (which relies solely on TTL), this method provides
+// an explicit prune so maintenance can reclaim space on demand.
+func (s *PebbleMetricsStore) PruneCacheStatsHistory(olderThan time.Time) (int64, error) {
+	names, err := s.cacheNames("")
+	if err != nil {
+		return 0, err
+	}
+
+	var deleted int64
+	for _, name := range names {
+		lower := pmetPrefix(name)
+		upper := pmetKey(name, olderThan)
+
+		iter, err := s.db.NewIter(&pebble.IterOptions{
+			LowerBound: lower,
+			UpperBound: upper,
+		})
+		if err != nil {
+			return deleted, fmt.Errorf("pebble_metrics_store: PruneCacheStatsHistory iter: %w", err)
+		}
+
+		// Collect keys to delete.
+		var keys [][]byte
+		for iter.First(); iter.Valid(); iter.Next() {
+			keyCopy := make([]byte, len(iter.Key()))
+			copy(keyCopy, iter.Key())
+			keys = append(keys, keyCopy)
+		}
+		_ = iter.Close()
+
+		for i := 0; i < len(keys); i += 500 {
+			end := i + 500
+			if end > len(keys) {
+				end = len(keys)
+			}
+			batch := s.db.NewBatch()
+			for _, k := range keys[i:end] {
+				if err := batch.Delete(k, nil); err != nil {
+					batch.Close()
+					return deleted, err
+				}
+			}
+			if err := batch.Commit(pebble.Sync); err != nil {
+				batch.Close()
+				return deleted, fmt.Errorf("pebble_metrics_store: prune commit: %w", err)
+			}
+			batch.Close()
+			deleted += int64(end - i)
+		}
+	}
+	return deleted, nil
+}
+
+// SweepExpiredMetrics deletes snapshots whose embedded ExpiresAt has passed.
+// This is the TTL sweep that replaces NutsDB's per-entry TTL. It is called
+// from the maintenance job registered in jobs/sweep_pebble_metrics_ttl.go.
+//
+// Returns the number of entries deleted.
+func (s *PebbleMetricsStore) SweepExpiredMetrics() (int64, error) {
+	now := time.Now().Unix()
+	names, err := s.cacheNames("")
+	if err != nil {
+		return 0, err
+	}
+
+	var deleted int64
+	for _, name := range names {
+		iter, err := s.db.NewIter(&pebble.IterOptions{
+			LowerBound: pmetPrefix(name),
+			UpperBound: pmetUpperBound(name),
+		})
+		if err != nil {
+			return deleted, fmt.Errorf("pebble_metrics_store: SweepExpiredMetrics iter: %w", err)
+		}
+
+		var keys [][]byte
+		for iter.First(); iter.Valid(); iter.Next() {
+			var v pmetValue
+			if err := json.Unmarshal(iter.Value(), &v); err != nil {
+				continue
+			}
+			if v.ExpiresAt <= now {
+				keyCopy := make([]byte, len(iter.Key()))
+				copy(keyCopy, iter.Key())
+				keys = append(keys, keyCopy)
+			}
+		}
+		_ = iter.Close()
+
+		for i := 0; i < len(keys); i += 500 {
+			end := i + 500
+			if end > len(keys) {
+				end = len(keys)
+			}
+			batch := s.db.NewBatch()
+			for _, k := range keys[i:end] {
+				if err := batch.Delete(k, nil); err != nil {
+					batch.Close()
+					return deleted, err
+				}
+			}
+			if err := batch.Commit(pebble.Sync); err != nil {
+				batch.Close()
+				return deleted, fmt.Errorf("pebble_metrics_store: sweep commit: %w", err)
+			}
+			batch.Close()
+			deleted += int64(end - i)
+		}
+	}
+	return deleted, nil
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+// cacheNames returns [cacheName] when non-empty, or all known names from the index.
+func (s *PebbleMetricsStore) cacheNames(cacheName string) ([]string, error) {
+	if cacheName != "" {
+		return []string{cacheName}, nil
+	}
+	var names []string
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(pmetIdxPrefix),
+		UpperBound: []byte("met:_idx;"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pebble_metrics_store: cacheNames iter: %w", err)
+	}
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		name := key[len(pmetIdxPrefix):]
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}

--- a/internal/database/pebble_metrics_store_test.go
+++ b/internal/database/pebble_metrics_store_test.go
@@ -1,0 +1,168 @@
+// file: internal/database/pebble_metrics_store_test.go
+// version: 1.0.0
+// guid: d0e1f2a3-b4c5-0011-4567-000000000011
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestPebbleMetricsStore creates a temp PebbleDB and a PebbleMetricsStore.
+func newTestPebbleMetricsStore(t *testing.T) *PebbleMetricsStore {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "metrics.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewPebbleMetricsStore(db)
+}
+
+// TestPebbleMetricsStore_RecordAndRetrieve verifies basic round-trip.
+func TestPebbleMetricsStore_RecordAndRetrieve(t *testing.T) {
+	s := newTestPebbleMetricsStore(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	snaps := []CacheStatsSnapshot{
+		{CacheName: "authors", Timestamp: now.Add(-2 * time.Minute), Hits: 10, Misses: 2},
+		{CacheName: "authors", Timestamp: now.Add(-1 * time.Minute), Hits: 20, Misses: 3},
+		{CacheName: "series", Timestamp: now.Add(-30 * time.Second), Hits: 5, Misses: 1},
+	}
+
+	err := s.RecordCacheStatsSnapshots(snaps)
+	require.NoError(t, err)
+
+	t.Run("retrieve_named_cache", func(t *testing.T) {
+		got, err := s.GetCacheStatsHistory("authors", time.Time{}, 100)
+		require.NoError(t, err)
+		assert.Len(t, got, 2, "expected 2 authors snapshots")
+		// oldest-first
+		assert.Equal(t, int64(10), got[0].Hits)
+		assert.Equal(t, int64(20), got[1].Hits)
+	})
+
+	t.Run("retrieve_all_caches", func(t *testing.T) {
+		got, err := s.GetCacheStatsHistory("", time.Time{}, 100)
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("since_filter", func(t *testing.T) {
+		cutoff := now.Add(-90 * time.Second)
+		got, err := s.GetCacheStatsHistory("authors", cutoff, 100)
+		require.NoError(t, err)
+		assert.Len(t, got, 1, "only the latest authors snapshot should be after cutoff")
+		assert.Equal(t, int64(20), got[0].Hits)
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		got, err := s.GetCacheStatsHistory("", time.Time{}, 2)
+		require.NoError(t, err)
+		assert.Len(t, got, 2, "limit should be applied")
+	})
+}
+
+// TestPebbleMetricsStore_Close_Noop verifies Close is a no-op.
+func TestPebbleMetricsStore_Close_Noop(t *testing.T) {
+	s := newTestPebbleMetricsStore(t)
+	require.NoError(t, s.Close())
+}
+
+// TestPebbleMetricsStore_PruneCacheStatsHistory prunes old snapshots.
+func TestPebbleMetricsStore_PruneCacheStatsHistory(t *testing.T) {
+	s := newTestPebbleMetricsStore(t)
+
+	cutoff := time.Now().UTC().Add(-1 * time.Hour)
+
+	// 3 old snapshots.
+	for i := 0; i < 3; i++ {
+		err := s.RecordCacheStatsSnapshots([]CacheStatsSnapshot{
+			{CacheName: "authors", Timestamp: cutoff.Add(-time.Duration(i+1) * time.Minute), Hits: int64(i)},
+		})
+		require.NoError(t, err)
+	}
+
+	// 1 recent snapshot.
+	err := s.RecordCacheStatsSnapshots([]CacheStatsSnapshot{
+		{CacheName: "authors", Timestamp: time.Now().UTC(), Hits: 99},
+	})
+	require.NoError(t, err)
+
+	pruned, err := s.PruneCacheStatsHistory(cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), pruned, "3 old snapshots should be pruned")
+
+	remaining, err := s.GetCacheStatsHistory("authors", time.Time{}, 100)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1, "only the recent snapshot should remain")
+	assert.Equal(t, int64(99), remaining[0].Hits)
+}
+
+// TestPebbleMetricsStore_SweepExpiredMetrics tests TTL sweep.
+func TestPebbleMetricsStore_SweepExpiredMetrics(t *testing.T) {
+	dir := t.TempDir()
+	db, err := pebble.Open(filepath.Join(dir, "metrics.pebble"), &pebble.Options{})
+	require.NoError(t, err)
+	defer db.Close()
+	s := NewPebbleMetricsStore(db)
+
+	// Write one snapshot with a past ExpiresAt to simulate an expired entry.
+	pastTime := time.Now().UTC().Add(-40 * 24 * time.Hour) // 40 days ago (> 30d TTL)
+	err = s.RecordCacheStatsSnapshots([]CacheStatsSnapshot{
+		{CacheName: "expired-cache", Timestamp: pastTime, Hits: 1},
+	})
+	require.NoError(t, err)
+
+	// Write a fresh snapshot that should survive.
+	err = s.RecordCacheStatsSnapshots([]CacheStatsSnapshot{
+		{CacheName: "fresh-cache", Timestamp: time.Now().UTC(), Hits: 42},
+	})
+	require.NoError(t, err)
+
+	// Sweep: should delete the expired entry.
+	deleted, err := s.SweepExpiredMetrics()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted, "one expired snapshot should be deleted")
+
+	// Fresh entry should still be readable.
+	remaining, err := s.GetCacheStatsHistory("fresh-cache", time.Time{}, 100)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+	assert.Equal(t, int64(42), remaining[0].Hits)
+
+	// Expired entry should be gone.
+	expired, err := s.GetCacheStatsHistory("expired-cache", time.Time{}, 100)
+	require.NoError(t, err)
+	assert.Len(t, expired, 0)
+}
+
+// TestPebbleMetricsStore_EmptyStore verifies graceful handling of an empty store.
+func TestPebbleMetricsStore_EmptyStore(t *testing.T) {
+	s := newTestPebbleMetricsStore(t)
+
+	// Get from empty store should return empty slice, no error.
+	snaps, err := s.GetCacheStatsHistory("nonexistent", time.Time{}, 100)
+	require.NoError(t, err)
+	assert.Empty(t, snaps)
+
+	// Prune from empty store.
+	n, err := s.PruneCacheStatsHistory(time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	// Sweep from empty store.
+	n2, err := s.SweepExpiredMetrics()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n2)
+}
+
+// TestPebbleMetricsStore_Implements verifies that PebbleMetricsStore satisfies MetricsStorer.
+func TestPebbleMetricsStore_Implements(t *testing.T) {
+	var _ MetricsStorer = (*PebbleMetricsStore)(nil)
+}

--- a/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
+++ b/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
@@ -1,0 +1,76 @@
+// file: internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
+// version: 1.0.0
+// guid: b8c9d0e1-f2a3-0008-1234-000000000008
+
+// Package jobs — maintenance job: sweep expired Pebble metrics snapshots.
+//
+// WHY: PebbleMetricsStore has no built-in per-key TTL (unlike NutsDB which
+// handled expiry automatically). This job calls PebbleMetricsStore.SweepExpiredMetrics
+// to delete snapshots whose embedded ExpiresAt has passed, preserving the 30-day
+// retention window. Run it on the same schedule as other cleanup tasks.
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+)
+
+func init() { maintenance.Register(&sweepPebbleMetricsTTLJob{}) }
+
+type sweepPebbleMetricsTTLJob struct{}
+
+func (j *sweepPebbleMetricsTTLJob) ID() string       { return "sweep-pebble-metrics-ttl" }
+func (j *sweepPebbleMetricsTTLJob) Name() string     { return "Sweep Pebble Metrics TTL" }
+func (j *sweepPebbleMetricsTTLJob) Category() string { return "cleanup" }
+func (j *sweepPebbleMetricsTTLJob) Description() string {
+	return "Delete expired cache-stats snapshots from the Pebble metrics store (30-day TTL)"
+}
+func (j *sweepPebbleMetricsTTLJob) CanResume() bool { return false }
+func (j *sweepPebbleMetricsTTLJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: false}
+}
+
+// Run sweeps expired Pebble metrics entries.
+//
+// The store parameter must be a *database.PebbleStore; if the server is running
+// a different backend (SQLite or mock) the job is a no-op so CI tests pass.
+func (j *sweepPebbleMetricsTTLJob) Run(
+	ctx context.Context,
+	store database.Store,
+	reporter maintenance.ProgressReporter,
+	dryRun bool,
+) error {
+	ps, ok := store.(*database.PebbleStore)
+	if !ok {
+		// Not a Pebble backend — no-op (test double or SQLite fallback).
+		slog.Info("sweep-pebble-metrics-ttl: store is not a PebbleStore; skipping")
+		reporter.Log("info", "Store is not PebbleStore — skipped", nil)
+		return nil
+	}
+
+	metricsStore := database.NewPebbleMetricsStore(ps.DB())
+
+	if dryRun {
+		reporter.Log("info", "dry-run: would sweep expired Pebble metrics snapshots", nil)
+		slog.Info("[sweep-pebble-metrics-ttl] dry-run: no deletions performed")
+		return nil
+	}
+
+	slog.Info("[sweep-pebble-metrics-ttl] starting TTL sweep")
+	deleted, err := metricsStore.SweepExpiredMetrics()
+	if err != nil {
+		return fmt.Errorf("sweep-pebble-metrics-ttl: %w", err)
+	}
+
+	slog.Info("[sweep-pebble-metrics-ttl] sweep complete", "deleted", deleted)
+	msg := fmt.Sprintf("Swept %d expired metrics snapshot(s)", deleted)
+	reporter.Log("info", msg, nil)
+	reporter.SetTotal(int(deleted))
+	return nil
+}

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.8.0
+// version: 1.9.0
 
 package server
 
@@ -320,7 +320,9 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 	if scanStore, ok := serviceregistry.TryGet[*database.AIScanStore](c, "aiscanstore"); ok && scanStore != nil {
 		s.aiScanStore = scanStore
 	}
-	if ms, ok := serviceregistry.TryGet[*database.NutsMetricsStore](c, "metricsstore"); ok && ms != nil {
+	// WHY MetricsStorer interface: the metricsstore may be a NutsMetricsStore or
+	// a PebbleMetricsStore — both implement MetricsStorer.
+	if ms, ok := serviceregistry.TryGet[database.MetricsStorer](c, "metricsstore"); ok && ms != nil {
 		s.metricsStore = ms
 	}
 	if pm, ok := serviceregistry.TryGet[*aiscan.PipelineManager](c, "pipelinemanager"); ok && pm != nil {


### PR DESCRIPTION
## Summary

Implements TASK-024 of the fable5 plan: replace NutsDB activity log and metrics store with PebbleDB-backed implementations, connected via a dual-write wrapper for safe dark-launch.

- **`PebbleActivityStore`** — full `ActivityStorer` implementation with tier-prefixed lexicographic keys (`act:<tier>:<20d-nano>:<ulid>`), secondary op/book indexes for sub-linear queries, `CompactByDay`, `RecompactDigests`, `Prune`, `WipeAllActivity`
- **`PebbleMetricsStore`** — full `MetricsStorer` implementation with soft-TTL via embedded `ExpiresAt` and `SweepExpiredMetrics()` maintenance job
- **`DualWriteActivityStore`** — writes to both NutsDB and Pebble; reads routed by `ReadFromPebble` flag (flipped after backfill sentinel is set); secondary write errors logged but not propagated
- **Backfill** — `BackfillNutsActivityToPebble` scans all 7 tiers, batch-writes 500/batch, rebuilds secondary indexes, writes idempotent sentinel `system:backfill:activity_pebble_v1_done`; dry-run default
- **Maintenance job** — `sweep-pebble-metrics-ttl` runs `SweepExpiredMetrics()` on the configured `PebbleStore`
- **Wiring** — `internal/activity/register.go` creates `PebbleActivityStore` + `DualWriteActivityStore`; `registry_wire.go` switches `MetricsStorer` lookup to interface type

## Acceptance Criteria

- [x] `PebbleActivityStore` implements `ActivityStorer` (compile-time assertion)
- [x] `PebbleMetricsStore` implements `MetricsStorer` (compile-time assertion)
- [x] 17 parity tests for `PebbleActivityStore` — all PASS
- [x] 6 tests for `PebbleMetricsStore` (including TTL sweep) — all PASS
- [x] 5 dual-write + backfill tests — all PASS
- [x] `go vet ./internal/...` — clean
- [x] `go build ./internal/...` — clean
- [x] Dual-write wrapper: secondary write errors do not abort primary
- [x] Backfill is idempotent (sentinel check before scan)
- [x] Dry-run default prevents accidental data movement
- [x] Maintenance TTL sweep registered (`sweep-pebble-metrics-ttl`)
- [x] `ReadFromPebble` flag auto-set from backfill sentinel at startup

## Parity Test Evidence

```
--- PASS: TestPebbleActivityStore_RecordAndQuery
--- PASS: TestPebbleActivityStore_QueryFilters/filter_by_tier
--- PASS: TestPebbleActivityStore_QueryFilters/filter_by_type
--- PASS: TestPebbleActivityStore_QueryFilters/filter_by_operation_id
--- PASS: TestPebbleActivityStore_QueryFilters/filter_by_book_id
--- PASS: TestPebbleActivityStore_QueryFilters/filter_single_tag_alpha
--- PASS: TestPebbleActivityStore_QueryFilters/filter_two_tags_requires_both
--- PASS: TestPebbleActivityStore_QueryFilters/limit
--- PASS: TestPebbleActivityStore_QueryFilters/offset
--- PASS: TestPebbleActivityStore_Prune
--- PASS: TestPebbleActivityStore_WipeAllActivity
--- PASS: TestPebbleActivityStore_GetDistinctSources/unfiltered_returns_all_sources
--- PASS: TestPebbleActivityStore_GetDistinctSources/filtered_by_tier_debug
--- PASS: TestPebbleActivityStore_CompactByDay_Basic
--- PASS: TestPebbleActivityStore_CompactByDay_Idempotent
--- PASS: TestPebbleActivityStore_CompactByDay_Truncates
--- PASS: TestPebbleActivityStore_CompactByDay_MergesExisting
--- PASS: TestPebbleActivityStore_RecompactDigests
--- PASS: TestPebbleActivityStore_MigrateSystemActivityLogs_Noop
--- PASS: TestPebbleActivityStore_Close_Noop
--- PASS: TestDualWriteActivityStore_WritesReplicated
--- PASS: TestIsActivityPebbleBackfillDone_FalseBeforeFlag
--- PASS: TestIsActivityPebbleBackfillDone_TrueAfterFlag
--- PASS: TestBackfillNutsActivityToPebble_DryRun
--- PASS: TestBackfillNutsActivityToPebble_Apply
--- PASS: TestBackfillNutsActivityToPebble_Idempotent
--- PASS: TestPebbleMetricsStore_RecordAndRetrieve/retrieve_named_cache
--- PASS: TestPebbleMetricsStore_RecordAndRetrieve/retrieve_all_caches
--- PASS: TestPebbleMetricsStore_RecordAndRetrieve/since_filter
--- PASS: TestPebbleMetricsStore_RecordAndRetrieve/limit
--- PASS: TestPebbleMetricsStore_Close_Noop
--- PASS: TestPebbleMetricsStore_PruneCacheStatsHistory
--- PASS: TestPebbleMetricsStore_SweepExpiredMetrics
--- PASS: TestPebbleMetricsStore_EmptyStore
--- PASS: TestPebbleMetricsStore_Implements
ok  github.com/falkcorp/audiobook-organizer/internal/database  3.489s
```

## Follow-up: NutsDB Dependency Removal

NutsDB is intentionally kept in this PR. The dual-write wrapper lets us dark-launch Pebble reads in production, verify parity on real data, then:

1. Set `ReadFromPebble: true` via config after backfill completes
2. Monitor activity log output for parity over 24–48h
3. Remove `NutsActivityStore` / `NutsMetricsStore` and the `nutsdb` import in a follow-up PR (TASK-024b)

## Caller Audit (files touching NutsActivityStore / NutsMetricsStore)

| File | What changes |
|------|-------------|
| `internal/activity/register.go` | Now creates `DualWriteActivityStore`; NutsDB store is the primary until backfill done |
| `internal/server/registry_wire.go` | `TryGet[database.MetricsStorer]` (interface) instead of `TryGet[*database.NutsMetricsStore]` |
| All other callers | Use `ActivityStorer` / `MetricsStorer` interfaces — no changes needed |

## COMPLETED: 6 — PebbleActivityStore, PebbleMetricsStore, DualWriteActivityStore, backfill op, TTL maintenance job, wiring
## REMAINING: 0
## BLOCKED: 0