### PR TITLE
fix(itunes): iTunes-conformant mhoh string encoders (fable5 T005)

### DIFF
--- a/internal/itunes/itl.go
+++ b/internal/itunes/itl.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/itl.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 7f2a8b3c-4d5e-6f01-a2b3-c4d5e6f7a8b9
-// last-edited: 2026-06-09
+// last-edited: 2026-06-10
 
 package itunes
 
@@ -709,7 +709,11 @@ func UpdateITLLocations(inputPath, outputPath string, updates []ITLLocationUpdat
 		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
 	}
 
-	// Walk and rewrite — dispatch on endianness
+	// Walk and rewrite — dispatch on endianness.
+	// BE writeback is refused (K12): see ErrBEWritebackUnsupported.
+	if !detectLE(decompressed) {
+		return nil, ErrBEWritebackUnsupported
+	}
 	var newData []byte
 	var updatedCount int
 	if detectLE(decompressed) {
@@ -912,6 +916,13 @@ func RewriteITLExtensions(inputPath, outputPath string, oldExt, newExt string) (
 	decompressed, wasCompressed, err := itlInflate(decrypted)
 	if err != nil {
 		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
+	}
+
+	// rewriteExtensionsInChunks is a BE ("hohm") path. BE writeback is refused
+	// (K12): the BE writer shares CRIT-1's +27 flag invention with no corpus to
+	// validate against. Production is LE; refuse rather than corrupt.
+	if !detectLE(decompressed) {
+		return nil, ErrBEWritebackUnsupported
 	}
 
 	newData, count := rewriteExtensionsInChunks(decompressed, oldExt, newExt)

--- a/internal/itunes/itl_combined_mutate.go
+++ b/internal/itunes/itl_combined_mutate.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_combined_mutate.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
 //
 // Combined ITL mutation: applies removes, adds, and location patches in a
@@ -54,6 +54,11 @@ func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet) (*ITL
 	}
 
 	isLE := detectLE(decompressed)
+	// BE writeback is refused (K12): see ErrBEWritebackUnsupported. Production is
+	// LE (v12.13); the BE path is unvalidated and shares CRIT-1's flag invention.
+	if !isLE {
+		return nil, ErrBEWritebackUnsupported
+	}
 	totalUpdated := 0
 
 	// Phase 1: Removes
@@ -141,11 +146,15 @@ func ApplyITLOperationsInMemory(inputPath string, ops ITLOperationSet) ([]byte, 
 		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
 	}
 	isLE := detectLE(decompressed)
+	// BE writeback is refused (K12): see ErrBEWritebackUnsupported.
+	if !isLE {
+		return nil, ErrBEWritebackUnsupported
+	}
 
-	if len(ops.Removes) > 0 && isLE {
+	if len(ops.Removes) > 0 {
 		decompressed, _ = RemoveTracksByPIDLE(decompressed, ops.Removes)
 	}
-	if len(ops.Adds) > 0 && isLE {
+	if len(ops.Adds) > 0 {
 		decompressed = AddTracksLE(decompressed, ops.Adds)
 	}
 	if len(ops.LocationUpdates) > 0 {
@@ -153,13 +162,9 @@ func ApplyITLOperationsInMemory(inputPath string, ops ITLOperationSet) ([]byte, 
 		for _, u := range ops.LocationUpdates {
 			updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
 		}
-		if isLE {
-			decompressed, _ = rewriteChunksLE(decompressed, updateMap)
-		} else {
-			decompressed, _ = rewriteChunksBE(decompressed, updateMap)
-		}
+		decompressed, _ = rewriteChunksLE(decompressed, updateMap)
 	}
-	if len(ops.MetadataUpdates) > 0 && isLE {
+	if len(ops.MetadataUpdates) > 0 {
 		decompressed, _ = UpdateMetadataLE(decompressed, ops.MetadataUpdates)
 	}
 

--- a/internal/itunes/itl_convert_test.go
+++ b/internal/itunes/itl_convert_test.go
@@ -22,6 +22,17 @@ import (
 // Helpers: build a minimal synthetic ITL file (LE / v12 format)
 // ---------------------------------------------------------------------------
 
+// mustBuildMhohLE wraps the production buildMhohLE (which now returns
+// ([]byte, ok) — ok=false for hohmTypes absent from the corpus table) for use in
+// fixtures where the type is known to be in the table.
+func mustBuildMhohLE(hohmType uint32, value string) []byte {
+	chunk, ok := buildMhohLE(hohmType, value)
+	if !ok {
+		panic("buildMhohLE: hohmType absent from corpus table in test fixture")
+	}
+	return chunk
+}
+
 // buildConvertTestITL constructs a minimal valid ITL binary containing one track
 // and one playlist.  It uses the LE (v12) msdh format the real parser expects.
 func buildConvertTestITL(t *testing.T) []byte {
@@ -33,19 +44,19 @@ func buildConvertTestITL(t *testing.T) []byte {
 	pidLE := [8]byte{0x12, 0x01, 0xCD, 0x23, 0x45, 0x67, 0x89, 0xAB}
 
 	trackContent := buildMithLeForConvert(1001, pidLE, 4096000, 28800000)
-	trackContent = append(trackContent, buildMhohLE(0x02, "Test Audiobook")...)  // Name
-	trackContent = append(trackContent, buildMhohLE(0x04, "Test Author")...)     // Artist
-	trackContent = append(trackContent, buildMhohLE(0x03, "Test Series")...)     // Album
-	trackContent = append(trackContent, buildMhohLE(0x05, "Audiobooks")...)      // Genre
-	trackContent = append(trackContent, buildMhohLE(0x06, "MPEG audio file")...) // Kind
-	trackContent = append(trackContent, buildMhohLE(0x0D,
+	trackContent = append(trackContent, mustBuildMhohLE(0x02, "Test Audiobook")...)  // Name
+	trackContent = append(trackContent, mustBuildMhohLE(0x04, "Test Author")...)     // Artist
+	trackContent = append(trackContent, mustBuildMhohLE(0x03, "Test Series")...)     // Album
+	trackContent = append(trackContent, mustBuildMhohLE(0x05, "Audiobooks")...)      // Genre
+	trackContent = append(trackContent, mustBuildMhohLE(0x06, "MPEG audio file")...) // Kind
+	trackContent = append(trackContent, mustBuildMhohLE(0x0D,
 		"file://localhost/mnt/bigdata/books/test.mp3")...) // Location
 
 	trackMsdh := buildMsdhLE(0x01, trackContent)
 
 	// Playlist: one miph + one mhoh title + one mtph referencing track 1001
 	playlistContent := buildMiphLEMin(1)
-	playlistContent = append(playlistContent, buildMhohLE(0x64, "My Playlist")...) // title
+	playlistContent = append(playlistContent, mustBuildMhohLE(0x64, "My Playlist")...) // title
 	playlistContent = append(playlistContent, buildMtphLEMin(1001)...)
 
 	playlistMsdh := buildMsdhLE(0x02, playlistContent)
@@ -268,9 +279,9 @@ func TestParseITLAsLibrary_LocationFallback(t *testing.T) {
 	pidLE := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
 	trackContent := buildMithLeForConvert(2002, pidLE, 1024, 60000)
-	trackContent = append(trackContent, buildMhohLE(0x02, "Fallback Track")...)
+	trackContent = append(trackContent, mustBuildMhohLE(0x02, "Fallback Track")...)
 	// Only 0x0B (LocalURL), no 0x0D (Location)
-	trackContent = append(trackContent, buildMhohLE(0x0B, "file://localhost/mnt/fallback.mp3")...)
+	trackContent = append(trackContent, mustBuildMhohLE(0x0B, "file://localhost/mnt/fallback.mp3")...)
 
 	trackMsdh := buildMsdhLE(0x01, trackContent)
 
@@ -319,7 +330,7 @@ func TestParseITLAsLibrary_PlayDateConversion(t *testing.T) {
 	// Overwrite PlayCount offset to set LastPlayDate at offset 100.
 	putUint32LE(buf, 100, macSecs)
 
-	trackContent := append(buf, buildMhohLE(0x02, "PlayDate Track")...)
+	trackContent := append(buf, mustBuildMhohLE(0x02, "PlayDate Track")...)
 	trackMsdh := buildMsdhLE(0x01, trackContent)
 
 	version := "12.13.10.3"

--- a/internal/itunes/itl_le.go
+++ b/internal/itunes/itl_le.go
@@ -1,11 +1,12 @@
 // file: internal/itunes/itl_le.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b4e8d927-6c3f-4a81-9e02-f7b3c8d4e56a
 
 package itunes
 
 import (
 	"bytes"
+	"log"
 	"strings"
 )
 
@@ -293,18 +294,13 @@ func parseMhohLE(data []byte, offset, length int, track *ITLTrack) {
 		return
 	}
 	hohmType := int(readUint32LE(data, offset+12))
-	encodingFlag := data[offset+16+11]
 
-	strDataLen := int(readUint32LE(data, offset+28))
-	strStart := offset + 40
-	if strStart+strDataLen > offset+length || strStart+strDataLen > len(data) {
-		strDataLen = offset + length - strStart
-		if strDataLen < 0 {
-			return
-		}
+	// Dual-convention decode (TASK-005): +27!=0 → legacy flag; +27==0 → +24 table.
+	blockLen := length
+	if offset+blockLen > len(data) {
+		blockLen = len(data) - offset
 	}
-
-	s, err := decodeHohmString(data[strStart:strStart+strDataLen], encodingFlag)
+	s, err := decodeMhohBlock(data[offset : offset+blockLen])
 	if err != nil {
 		return
 	}
@@ -411,16 +407,12 @@ func parsePlaylistMhohLE(data []byte, offset, length int, playlist *ITLPlaylist)
 		if length < 40 {
 			return
 		}
-		encodingFlag := data[offset+16+11]
-		strDataLen := int(readUint32LE(data, offset+28))
-		strStart := offset + 40
-		if strStart+strDataLen > offset+length || strStart+strDataLen > len(data) {
-			strDataLen = offset + length - strStart
-			if strDataLen < 0 {
-				return
-			}
+		// Dual-convention decode (TASK-005).
+		blockLen := length
+		if offset+blockLen > len(data) {
+			blockLen = len(data) - offset
 		}
-		s, err := decodeHohmString(data[strStart:strStart+strDataLen], encodingFlag)
+		s, err := decodeMhohBlock(data[offset : offset+blockLen])
 		if err != nil {
 			return
 		}
@@ -737,36 +729,44 @@ func shouldUpdateMhohLE(data []byte, offset, length int, currentPID string, upda
 	return newLoc, ok
 }
 
-// rewriteHohmLocationLE rewrites a location mhoh block with a new location string.
+// rewriteHohmLocationLE rewrites a location/metadata mhoh block with a new
+// string, emitting an iTunes-conformant header via encodeMhohITunes (TASK-005,
+// CRIT-1). This is the "replace" writer path; buildMhohLE is the "append" path —
+// both build the SAME 40-byte header from the SAME inputs, so for identical
+// (hohmType, value) inputs their output is byte-identical.
+//
+// WHY this stops blind-copying +16..+27: the OLD code copied the original
+// block's bytes +16..+27 (including the +24 indicator) and only overwrote +27
+// with an invented "encoding flag" (1/3) — propagating whatever stale/foreign
+// header the source carried and stamping the CRIT-1 corruption byte. The header
+// is now set DETERMINISTICALLY: +24 = corpus indicator, +27 = 0x00, +32..+39 = 0.
+//
+// If the block's hohmType is absent from the corpus table, the original block is
+// returned UNMODIFIED (caller-visible WARN is emitted by shouldUpdateMhohLE
+// callers; the function never invents an encoding for an unknown type).
 func rewriteHohmLocationLE(data []byte, offset, length int, newLocation string) []byte {
-	encodedStr, encodingFlag := encodeHohmString(newLocation)
+	hohmType := readUint32LE(data, offset+12)
 
-	newStrDataLen := len(encodedStr)
-	newTotalLen := 40 + newStrDataLen
-
-	// Preserve the original headerLen (offset+4) — it's the fixed header size (typically 24).
-	// Only update totalLen (offset+8) which includes the variable-length string data.
-	origHeaderLen := readUint32LE(data, offset+4)
-
-	buf := make([]byte, newTotalLen)
-	// Copy tag
-	copy(buf[0:4], data[offset:offset+4])
-	// Preserve original headerLen (LE) — NOT the total length
-	writeUint32LE(buf, 4, origHeaderLen)
-	// New totalLen (LE) — this is the full chunk size including string data
-	writeUint32LE(buf, 8, uint32(newTotalLen))
-	// hohmType (LE)
-	copy(buf[12:16], data[offset+12:offset+16])
-	// Copy the 12-byte header, update encoding flag
-	if offset+28 <= len(data) {
-		copy(buf[16:28], data[offset+16:offset+28])
+	payload, hdr, err := encodeMhohITunes(hohmType, newLocation)
+	if err != nil {
+		// Out-of-corpus type: preserve the original block byte-for-byte rather
+		// than write an invented header (CRIT-1). WARN so the skip is visible.
+		log.Printf("[itl] WARN rewriteHohmLocationLE: hohmType 0x%X absent from corpus table; preserving original block unmodified: %v", hohmType, err)
+		out := make([]byte, length)
+		copy(out, data[offset:offset+length])
+		return out
 	}
-	buf[16+11] = encodingFlag
-	// String data length (LE)
-	writeUint32LE(buf, 28, uint32(newStrDataLen))
-	// 8 bytes zeros at 32-39 (already zero)
-	// String data
-	copy(buf[40:], encodedStr)
+
+	buf := make([]byte, hdr.TotalLen)
+	copy(buf[0:4], data[offset:offset+4]) // tag ("mhoh")
+	writeUint32LE(buf, 4, hdr.HeaderLen)  // headerLen: fixed 24 (NOT totalLen — K5)
+	writeUint32LE(buf, 8, hdr.TotalLen)   // totalLen: 40 + strLen
+	writeUint32LE(buf, 12, hohmType)      // hohmType
+	writeUint32LE(buf, 24, hdr.At24)      // +24: corpus encoding indicator (K3)
+	// byte +27 stays 0x00 (zero-initialized) — iTunes' invariant (K3).
+	writeUint32LE(buf, 28, hdr.StrLen) // strLen
+	// bytes +32..+39 stay zero (reserved tail).
+	copy(buf[40:], payload)
 
 	return buf
 }

--- a/internal/itunes/itl_le_metadata_update.go
+++ b/internal/itunes/itl_le_metadata_update.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_le_metadata_update.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
 //
 // Update track metadata (title, artist, album, genre, etc.) in LE-format
@@ -188,7 +188,12 @@ func UpdateMetadataLE(data []byte, updates []ITLMetadataUpdate) ([]byte, int) {
 		appendOrder := []uint32{0x0D, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0C}
 		for _, ht := range appendOrder {
 			if val, ok := replacements[ht]; ok && !replaced[ht] {
-				newMhohs.Write(buildMhohLE(ht, val))
+				// buildMhohLE returns built=false for hohmTypes absent from the
+				// corpus table — skip rather than write an invented encoding
+				// (CRIT-1). All appendOrder types are present in the table.
+				if chunk, built := buildMhohLE(ht, val); built {
+					newMhohs.Write(chunk)
+				}
 			}
 		}
 

--- a/internal/itunes/itl_le_metadata_update_test.go
+++ b/internal/itunes/itl_le_metadata_update_test.go
@@ -106,7 +106,8 @@ func readMhohString(data []byte, offset int) string {
 // TestBuildMhohLE_FixedHeaderLen verifies that buildMhohLE uses headerLen=24,
 // not headerLen=totalLen. Setting headerLen=totalLen corrupts iTunes library.
 func TestBuildMhohLE_FixedHeaderLen(t *testing.T) {
-	chunk := buildMhohLE(0x02, "My Book Title")
+	chunk, ok := buildMhohLE(0x02, "My Book Title")
+	require.True(t, ok, "0x02 is in the corpus table")
 
 	headerLen := binary.LittleEndian.Uint32(chunk[4:8])
 	totalLen := binary.LittleEndian.Uint32(chunk[8:12])
@@ -270,4 +271,53 @@ func TestUpdateMetadataLE_UnknownPID(t *testing.T) {
 	})
 	assert.Equal(t, 0, count, "no tracks should match an unknown PID")
 	assert.Equal(t, payload, updated, "payload should be unchanged for unknown PID")
+}
+
+// TestUpdateMetadataLE_OutputPassesMhohFormatGuard (TASK-005) is the central
+// CRIT-1 regression: after UpdateMetadataLE replaces AND appends mhoh blocks
+// (incl. a non-ASCII title forcing UTF-16LE), EVERY block in the output must
+// pass the T003 mhoh-format guard — byte +27==0, headerLen==24, +24 ∈ corpus.
+func TestUpdateMetadataLE_OutputPassesMhohFormatGuard(t *testing.T) {
+	pid := [8]byte{0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80}
+	pidHex := "1020304050607080"
+
+	// Start with one existing iTunes-format ASCII name block (replace path),
+	// then update with a CJK name (UTF-16LE) plus new artist/album/genre/kind
+	// (append path) — exercising both writer paths.
+	nameMhoh := buildITunesMhohLE(0x02, "Original Title")
+	trackContent := buildLETrackSection(1, pid, nameMhoh)
+	payload := buildLEPayload(trackContent)
+
+	updated, count := UpdateMetadataLE(payload, []ITLMetadataUpdate{
+		{
+			PersistentID: pidHex,
+			Name:         "日本語のタイトル",    // UTF-16LE, replace path
+			Artist:       "Café Artist", // latin1, append path
+			Album:        "Album",
+			Genre:        "Fiction",
+			Kind:         "MPEG audio file", // 0x06 → UTF-16LE always
+			Location:     `W:\itunes\book.mp3`,
+		},
+	})
+	require.Equal(t, 1, count)
+
+	// Every mhoh in the rewritten payload must satisfy the format contract.
+	res := guardMhohFormat(nil, updated, nil, DefaultContractConfig())
+	assert.Empty(t, res.Violations,
+		"all mhoh blocks written by UpdateMetadataLE must pass mhoh-format (CRIT-1): %+v", res.Violations)
+
+	// And the values must round-trip through the dual-convention reader.
+	lib := parseLEPayloadForTest(t, updated)
+	require.Len(t, lib.Tracks, 1)
+	assert.Equal(t, "日本語のタイトル", lib.Tracks[0].Name)
+	assert.Equal(t, "Café Artist", lib.Tracks[0].Artist)
+}
+
+// parseLEPayloadForTest wraps a decompressed LE payload into an ITLLibrary by
+// walking the chunks directly (the payload is already decrypted/inflated).
+func parseLEPayloadForTest(t *testing.T, payload []byte) *ITLLibrary {
+	t.Helper()
+	lib := &ITLLibrary{}
+	walkChunksLEImpl(payload, lib)
+	return lib
 }

--- a/internal/itunes/itl_le_mutate.go
+++ b/internal/itunes/itl_le_mutate.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_le_mutate.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d5e6f7a8-b9c0-1d2e-3f4a-5b6c7d8e9f00
 //
 // LE-format ITL mutation: add and remove tracks from v10+ (msdh/mith/mhoh)
@@ -70,26 +70,29 @@ func AddTracksLE(data []byte, tracks []ITLNewTrack) []byte {
 	for i, tr := range tracks {
 		trackID := maxTrackID + 1 + i
 
-		// Build mhoh sub-blocks first so we know the total size
+		// Build mhoh sub-blocks first so we know the total size.
+		// appendMhohLE skips types absent from the corpus table (built=false)
+		// rather than writing an invented encoding (CRIT-1) — all six below are
+		// in the table.
 		var mhohData []byte
 		// Location first (0x0D), then metadata — matches iTunes convention
 		if tr.Location != "" {
-			mhohData = append(mhohData, buildMhohLE(0x0D, tr.Location)...)
+			mhohData = appendMhohLE(mhohData, 0x0D, tr.Location)
 		}
 		if tr.Name != "" {
-			mhohData = append(mhohData, buildMhohLE(0x02, tr.Name)...)
+			mhohData = appendMhohLE(mhohData, 0x02, tr.Name)
 		}
 		if tr.Album != "" {
-			mhohData = append(mhohData, buildMhohLE(0x03, tr.Album)...)
+			mhohData = appendMhohLE(mhohData, 0x03, tr.Album)
 		}
 		if tr.Artist != "" {
-			mhohData = append(mhohData, buildMhohLE(0x04, tr.Artist)...)
+			mhohData = appendMhohLE(mhohData, 0x04, tr.Artist)
 		}
 		if tr.Genre != "" {
-			mhohData = append(mhohData, buildMhohLE(0x05, tr.Genre)...)
+			mhohData = appendMhohLE(mhohData, 0x05, tr.Genre)
 		}
 		if tr.Kind != "" {
-			mhohData = append(mhohData, buildMhohLE(0x06, tr.Kind)...)
+			mhohData = appendMhohLE(mhohData, 0x06, tr.Kind)
 		}
 
 		mith := buildMithLE(trackID, tr)
@@ -269,19 +272,45 @@ func buildMithLE(trackID int, tr ITLNewTrack) []byte {
 // see regression test TestRewriteHohmLocationLE_PreservesHeaderLen.
 const mhohFixedHeaderLen = 24
 
-// buildMhohLE builds an LE metadata chunk (mhoh) for a given type and string.
-func buildMhohLE(mhohType uint32, value string) []byte {
-	encodedStr, encFlag := encodeHohmString(value)
-	chunkLen := 40 + len(encodedStr)
-	buf := make([]byte, chunkLen)
+// buildMhohLE builds an LE metadata chunk (mhoh) for a given type and string,
+// emitting an iTunes-conformant header via encodeMhohITunes (TASK-005, CRIT-1).
+//
+// The full 40-byte header is set DETERMINISTICALLY from MhohHeaderBytes: byte
+// +27 is left 0x00 (iTunes never writes a non-zero +27 — K3), the +24 u32 carries
+// the corpus encoding indicator, and bytes +32..+39 stay zero. This is the
+// "append" writer path; rewriteHohmLocationLE is the "replace" path — both build
+// the SAME header from the SAME inputs so their output is byte-identical for
+// identical input.
+//
+// Returns (nil, false) when the type is absent from the corpus table — the
+// caller must then preserve the original block unmodified and WARN, rather than
+// write an invented encoding (SPEC §5 ITW-2: "never invent flags").
+func buildMhohLE(mhohType uint32, value string) ([]byte, bool) {
+	payload, hdr, err := encodeMhohITunes(mhohType, value)
+	if err != nil {
+		return nil, false
+	}
+	buf := make([]byte, hdr.TotalLen)
 	copy(buf[0:4], "mhoh")
-	writeUint32LE(buf, 4, mhohFixedHeaderLen) // headerLen: fixed 24-byte header (NOT totalLen)
-	writeUint32LE(buf, 8, uint32(chunkLen))   // totalLen: full chunk size
+	writeUint32LE(buf, 4, hdr.HeaderLen) // headerLen: fixed 24 (NOT totalLen — K5)
+	writeUint32LE(buf, 8, hdr.TotalLen)  // totalLen: 40 + strLen
 	writeUint32LE(buf, 12, mhohType)
-	buf[16+11] = encFlag
-	writeUint32LE(buf, 28, uint32(len(encodedStr)))
-	copy(buf[40:], encodedStr)
-	return buf
+	writeUint32LE(buf, 24, hdr.At24) // +24: corpus encoding indicator (K3)
+	// byte +27 stays 0x00 (zero-initialized) — iTunes' invariant (K3).
+	writeUint32LE(buf, 28, hdr.StrLen)
+	// bytes +32..+39 stay zero (reserved tail).
+	copy(buf[40:], payload)
+	return buf, true
+}
+
+// appendMhohLE appends an iTunes-conformant mhoh block for (mhohType, value) to
+// dst and returns the result. If the type is absent from the corpus table the
+// block is skipped (no invented encoding — CRIT-1) and dst is returned unchanged.
+func appendMhohLE(dst []byte, mhohType uint32, value string) []byte {
+	if chunk, ok := buildMhohLE(mhohType, value); ok {
+		return append(dst, chunk...)
+	}
+	return dst
 }
 
 // writeUint32LE is defined in itl.go — reuse that.

--- a/internal/itunes/itl_mutation_test.go
+++ b/internal/itunes/itl_mutation_test.go
@@ -623,22 +623,13 @@ func TestMutation_RoundTripWriteAndReparse(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, lib1.Tracks, 2)
 
-	// Update a location
+	// BE fixture — BE writeback refused (K12). The read path above still works.
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	pid0Hex := pidToHex(specs[0].PID)
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err = UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pid0Hex, NewLocation: "/new/path/updated.mp3"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	// Parse updated and verify
-	lib2, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib2.Tracks, 2)
-	assert.Equal(t, "/new/path/updated.mp3", lib2.Tracks[0].Location)
-	assert.Equal(t, specs[1].Location, lib2.Tracks[1].Location) // unchanged
-	assert.Equal(t, specs[0].Name, lib2.Tracks[0].Name)         // metadata preserved
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ===========================================================================
@@ -1027,27 +1018,12 @@ func TestMutation_UpdateOneOfMany(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	// Update only track index 2
+	// BE fixture — BE writeback refused (K12).
 	targetPID := pidToHex(specs[2].PID)
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: targetPID, NewLocation: "/updated/track_002.mp3"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 5)
-
-	for i, tr := range lib.Tracks {
-		if i == 2 {
-			assert.Equal(t, "/updated/track_002.mp3", tr.Location, "track 2 should be updated")
-		} else {
-			assert.Equal(t, specs[i].Location, tr.Location, "track %d should be unchanged", i)
-		}
-		// Metadata should be preserved for all tracks
-		assert.Equal(t, specs[i].Name, tr.Name, "track %d name preserved", i)
-	}
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestMutation_UpdateMultipleOfMany(t *testing.T) {
@@ -1062,25 +1038,14 @@ func TestMutation_UpdateMultipleOfMany(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	// Update tracks 0, 2, 4
+	// BE fixture — BE writeback refused (K12).
 	updates := []ITLLocationUpdate{
 		{PersistentID: pidToHex(specs[0].PID), NewLocation: "/new/track_000.mp3"},
 		{PersistentID: pidToHex(specs[2].PID), NewLocation: "/new/track_002.mp3"},
 		{PersistentID: pidToHex(specs[4].PID), NewLocation: "/new/track_004.mp3"},
 	}
-	result, err := UpdateITLLocations(itlPath, outPath, updates)
-	require.NoError(t, err)
-	assert.Equal(t, 3, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 5)
-
-	assert.Equal(t, "/new/track_000.mp3", lib.Tracks[0].Location)
-	assert.Equal(t, specs[1].Location, lib.Tracks[1].Location) // unchanged
-	assert.Equal(t, "/new/track_002.mp3", lib.Tracks[2].Location)
-	assert.Equal(t, specs[3].Location, lib.Tracks[3].Location) // unchanged
-	assert.Equal(t, "/new/track_004.mp3", lib.Tracks[4].Location)
+	_, err := UpdateITLLocations(itlPath, outPath, updates)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ===========================================================================
@@ -1100,16 +1065,9 @@ func TestMutation_ExtensionRewriteMultiTrack(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	result, err := RewriteITLExtensions(itlPath, outPath, ".flac", ".mp3")
-	require.NoError(t, err)
-	assert.Equal(t, 2, result.UpdatedCount) // only .flac files changed
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 3)
-	assert.Equal(t, "/music/a.mp3", lib.Tracks[0].Location) // changed
-	assert.Equal(t, "/music/b.mp3", lib.Tracks[1].Location) // unchanged
-	assert.Equal(t, "/music/c.mp3", lib.Tracks[2].Location) // changed
+	// BE fixture — extension rewrite is BE-only; BE writeback refused (K12).
+	_, err := RewriteITLExtensions(itlPath, outPath, ".flac", ".mp3")
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ===========================================================================
@@ -1306,33 +1264,12 @@ func TestMutation_SequentialMutations(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, lib2.Tracks, 3)
 
-	// Step 3: Update location of the original first track
+	// Step 3: Update location — BE fixture, so BE writeback is refused (K12).
+	// (InsertITLTracks above still works because it does not route through the
+	// detectLE writeback dispatch; the location-update path does.)
 	path3 := filepath.Join(tmpDir, "step3.itl")
 	_, err = UpdateITLLocations(path2, path3, []ITLLocationUpdate{
 		{PersistentID: pidToHex(specs[0].PID), NewLocation: "/moved/track_000.mp3"},
 	})
-	require.NoError(t, err)
-
-	lib3, err := ParseITL(path3)
-	require.NoError(t, err)
-	require.Len(t, lib3.Tracks, 3)
-	assert.Equal(t, "/moved/track_000.mp3", lib3.Tracks[0].Location)
-	assert.Equal(t, specs[1].Location, lib3.Tracks[1].Location)
-	assert.Equal(t, "/music/new.mp3", lib3.Tracks[2].Location)
-	assert.Equal(t, "New Track", lib3.Tracks[2].Name)
-
-	// Step 4: Add a playlist referencing all three tracks
-	path4 := filepath.Join(tmpDir, "step4.itl")
-	_, err = InsertITLPlaylist(path3, path4, ITLNewPlaylist{
-		Title:    "All Tracks",
-		TrackIDs: []int{lib3.Tracks[0].TrackID, lib3.Tracks[1].TrackID, lib3.Tracks[2].TrackID},
-	})
-	require.NoError(t, err)
-
-	lib4, err := ParseITL(path4)
-	require.NoError(t, err)
-	require.Len(t, lib4.Tracks, 3)
-	require.Len(t, lib4.Playlists, 1)
-	assert.Equal(t, "All Tracks", lib4.Playlists[0].Title)
-	assert.Len(t, lib4.Playlists[0].Items, 3)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }

--- a/internal/itunes/itl_regression_test.go
+++ b/internal/itunes/itl_regression_test.go
@@ -100,9 +100,12 @@ func TestRewriteHohmLocationLE_PreservesHeaderLen(t *testing.T) {
 	assert.Equal(t, uint32(0x0D), hohmType, "hohmType must be preserved")
 }
 
-func TestRewriteHohmLocationLE_DifferentHeaderLens(t *testing.T) {
-	// Some mhoh chunks have headerLen=24, others might have different values.
-	// The rewrite must preserve whatever headerLen was in the original.
+func TestRewriteHohmLocationLE_NormalizesHeaderLenTo24(t *testing.T) {
+	// TASK-005: the rewrite now sets the header DETERMINISTICALLY to the
+	// iTunes-conformant invariant (headerLen==24) regardless of the original
+	// value. A non-24 headerLen in the source is K5 corruption (golden is 100%
+	// headerLen=24); the writer must not propagate it. This supersedes the old
+	// "preserve whatever headerLen was there" behavior.
 	for _, headerLen := range []uint32{20, 24, 28, 32} {
 		t.Run("headerLen="+string(rune('0'+headerLen/4)), func(t *testing.T) {
 			totalLen := uint32(60)
@@ -116,8 +119,11 @@ func TestRewriteHohmLocationLE_DifferentHeaderLens(t *testing.T) {
 			copy(chunk[40:48], []byte("old/path"))
 
 			result := rewriteHohmLocationLE(chunk, 0, int(totalLen), "new/path")
-			assert.Equal(t, headerLen, readUint32LE(result, 4),
-				"headerLen must be preserved regardless of value")
+			assert.Equal(t, uint32(24), readUint32LE(result, 4),
+				"headerLen must be normalized to the iTunes-conformant 24 (K5)")
+			// And byte +27 must be cleared to 0 (K3) — never the legacy flag.
+			assert.Equal(t, byte(0), result[27],
+				"byte +27 must be 0 (iTunes invariant); encoding lives at +24")
 		})
 	}
 }
@@ -194,19 +200,12 @@ func TestSyntheticITL_LongerReplacementPath(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", true, pid, shortPath)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
+	// BE fixture — BE writeback refused (K12).
 	outPath := filepath.Join(tmpDir, "updated.itl")
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: longPath},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	// Parse the updated file and verify the long path survived
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, longPath, lib.Tracks[0].Location,
-		"long replacement path should survive write→parse round-trip")
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestSyntheticITL_ShorterReplacementPath(t *testing.T) {
@@ -219,17 +218,12 @@ func TestSyntheticITL_ShorterReplacementPath(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", true, pid, longPath)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
+	// BE fixture — BE writeback refused (K12).
 	outPath := filepath.Join(tmpDir, "updated.itl")
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: shortPath},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, shortPath, lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ---------------------------------------------------------------------------
@@ -252,19 +246,13 @@ func TestSyntheticITL_UnicodePath(t *testing.T) {
 	require.Len(t, lib.Tracks, 1)
 	assert.Equal(t, unicodePath, lib.Tracks[0].Location)
 
-	// Update with another Unicode path
+	// Update with another Unicode path — BE fixture, BE writeback refused (K12).
 	newPath := "/mnt/books/Ünîcödé Àuthör/Böök Tïtle/file.m4b"
 	outPath := filepath.Join(tmpDir, "updated.itl")
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err = UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newPath},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib2, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib2.Tracks, 1)
-	assert.Equal(t, newPath, lib2.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ---------------------------------------------------------------------------
@@ -320,18 +308,13 @@ func TestSyntheticITL_MultiTrackUpdate_NoCrosstalk(t *testing.T) {
 	itl1Data := buildSyntheticITL(t, "12.0.0", true, pid1, "/old/track1.m4b")
 	require.NoError(t, os.WriteFile(itl1Path, itl1Data, 0644))
 
+	// BE fixture — BE writeback refused (K12).
 	out1Path := filepath.Join(tmpDir, "out1.itl")
-	result, err := UpdateITLLocations(itl1Path, out1Path, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itl1Path, out1Path, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid1), NewLocation: "/new/track1.m4b"},
 		{PersistentID: pidToHex(pid2), NewLocation: "/new/track2.m4b"}, // shouldn't match
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount, "only pid1 should match in track1's ITL")
-
-	lib, err := ParseITL(out1Path)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, "/new/track1.m4b", lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_safety_contract.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 404bbed1-87ba-4e56-b9e4-a492a2281163
 //
 // ITLSafetyContract — the iTunes writeback write-safety contract (fable5 TASK-003).
@@ -1021,26 +1021,23 @@ func forEachTrackLocations(data []byte, fn func(trackOffset int, loc0D, loc0B st
 	}
 }
 
-// decodeMhohString decodes the string carried by an mhoh block, reading the
-// legacy +27 encoding flag (the reader is intentionally permissive so that
-// location-form operates on the DECODED string regardless of how it was stamped
-// — SPEC §2 "on decoded strings").
+// decodeMhohString decodes the string carried by an mhoh block using the
+// DUAL-convention decoder (TASK-005): +27!=0 → legacy flag at +27; +27==0 →
+// corpus +24 indicator (1=latin1, 3=UTF-16LE). This makes location-form operate
+// on the DECODED string regardless of how it was stamped (SPEC §2 "on decoded
+// strings"), correctly handling iTunes-conformant UTF-16LE locations that the
+// old +27-only reader would have mis-decoded as ASCII.
 func decodeMhohString(data []byte, offset, span int) string {
 	if span < 40 || offset+40 > len(data) {
 		return ""
 	}
-	encodingFlag := data[offset+16+11]
-	strLen := int(readUint32LE(data, offset+28))
-	strStart := offset + 40
-	if strStart+strLen > offset+span || strStart+strLen > len(data) {
-		strLen = offset + span - strStart
-		if strLen < 0 {
-			return ""
-		}
+	blockLen := span
+	if offset+blockLen > len(data) {
+		blockLen = len(data) - offset
 	}
-	s, err := decodeHohmString(data[strStart:strStart+strLen], encodingFlag)
+	s, err := decodeMhohBlock(data[offset : offset+blockLen])
 	if err != nil {
-		return string(data[strStart : strStart+strLen])
+		return ""
 	}
 	return s
 }

--- a/internal/itunes/itl_test.go
+++ b/internal/itunes/itl_test.go
@@ -278,19 +278,12 @@ func TestSyntheticITL_ParseAndUpdate(t *testing.T) {
 			assert.Equal(t, 42, lib.Tracks[0].TrackID)
 			assert.Equal(t, pid, lib.Tracks[0].PersistentID)
 
-			// Update
+			// Update — BE fixture, so BE writeback is refused (K12).
 			outPath := filepath.Join(tmpDir, "updated.itl")
-			result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+			_, err = UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 				{PersistentID: pidToHex(pid), NewLocation: newLoc},
 			})
-			require.NoError(t, err)
-			assert.Equal(t, 1, result.UpdatedCount)
-
-			// Verify
-			lib2, err := ParseITL(outPath)
-			require.NoError(t, err)
-			require.Len(t, lib2.Tracks, 1)
-			assert.Equal(t, newLoc, lib2.Tracks[0].Location)
+			require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 		})
 	}
 }
@@ -474,14 +467,9 @@ func TestRewriteITLExtensions(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := RewriteITLExtensions(itlPath, outPath, ".flac", ".mp3")
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, "/music/song.mp3", lib.Tracks[0].Location)
+	// BE fixture — extension rewrite is a BE-only path; BE writeback refused (K12).
+	_, err := RewriteITLExtensions(itlPath, outPath, ".flac", ".mp3")
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestInsertITLPlaylist(t *testing.T) {
@@ -746,21 +734,12 @@ func TestFixtureITL_UpdateLocations(t *testing.T) {
 	tmpDir := t.TempDir()
 	outPath := filepath.Join(tmpDir, "updated.itl")
 
-	// Update The Hobbit's location
+	// BE fixture (buildFixtureITL) — BE writeback refused (K12).
 	hobbitPID := pidToHex(fixtureTracks[0].persistentID)
-	result, err := UpdateITLLocations(fixtureITLPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(fixtureITLPath, outPath, []ITLLocationUpdate{
 		{PersistentID: hobbitPID, NewLocation: "/new/path/The Hobbit.m4b"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	// Parse and verify
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, len(fixtureTracks))
-	assert.Equal(t, "/new/path/The Hobbit.m4b", lib.Tracks[0].Location)
-	// Other tracks unchanged
-	assert.Equal(t, fixtureTracks[1].location, lib.Tracks[1].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // TestFixtureITL_Validate verifies the fixture passes validation.

--- a/internal/itunes/itl_writeback_test.go
+++ b/internal/itunes/itl_writeback_test.go
@@ -17,9 +17,14 @@ import (
 // UpdateITLLocations — path format tests
 // ---------------------------------------------------------------------------
 
+// NOTE (TASK-005 / K12): buildSyntheticITL produces BIG-ENDIAN ("hohm"/"htim")
+// fixtures. BE writeback is now REFUSED (ErrBEWritebackUnsupported) — the BE
+// writer shared CRIT-1's foreign +27 flag invention with no corpus to validate
+// against, and production is LE. These tests therefore assert the refusal rather
+// than a successful round-trip. LE path-format coverage lives in the
+// itl_le_metadata_update / itl_convert / mhoh_string suites.
+
 func TestUpdateITLLocations_PathFormat_WindowsStyle(t *testing.T) {
-	// Verify that Windows-style paths (with drive letters, spaces) survive
-	// a parse-update-reparse round-trip correctly.
 	pid := [8]byte{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE}
 	originalLoc := "W:/itunes/iTunes Media/Audiobooks/Author/book.m4b"
 	newLoc := "W:/itunes/iTunes Media/Audiobooks/New Author/New Book/chapter01.m4b"
@@ -31,16 +36,10 @@ func TestUpdateITLLocations_PathFormat_WindowsStyle(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, originalLoc)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newLoc},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, newLoc, lib.Tracks[0].Location, "location should be the exact new path")
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestUpdateITLLocations_PathFormat_UnixAbsolute(t *testing.T) {
@@ -55,16 +54,10 @@ func TestUpdateITLLocations_PathFormat_UnixAbsolute(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", true, pid, originalLoc)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newLoc},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, newLoc, lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestUpdateITLLocations_PathWithSpaces(t *testing.T) {
@@ -79,16 +72,10 @@ func TestUpdateITLLocations_PathWithSpaces(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, originalLoc)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newLoc},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, newLoc, lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestUpdateITLLocations_PathWithUnicode(t *testing.T) {
@@ -103,16 +90,10 @@ func TestUpdateITLLocations_PathWithUnicode(t *testing.T) {
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, originalLoc)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newLoc},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, newLoc, lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ---------------------------------------------------------------------------
@@ -120,72 +101,38 @@ func TestUpdateITLLocations_PathWithUnicode(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpdateITLLocations_PreservesOtherTracks(t *testing.T) {
-	// Use the fixture ITL which has 9 tracks. Update one, verify others unchanged.
+	// BE fixture (buildFixtureITL) — BE writeback refused (K12).
 	fixtureData := buildFixtureITL()
 	tmpDir := t.TempDir()
 	itlPath := filepath.Join(tmpDir, "fixture.itl")
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	require.NoError(t, os.WriteFile(itlPath, fixtureData, 0644))
 
-	// Update only The Hobbit (index 0)
 	hobbitPID := pidToHex(fixtureTracks[0].persistentID)
-	newHobbitLoc := "/reorganized/The Hobbit.m4b"
-
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
-		{PersistentID: hobbitPID, NewLocation: newHobbitLoc},
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+		{PersistentID: hobbitPID, NewLocation: "/reorganized/The Hobbit.m4b"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, len(fixtureTracks))
-
-	// Verify The Hobbit is updated
-	assert.Equal(t, newHobbitLoc, lib.Tracks[0].Location)
-
-	// Verify all other tracks are unchanged
-	for i := 1; i < len(fixtureTracks); i++ {
-		assert.Equal(t, fixtureTracks[i].location, lib.Tracks[i].Location,
-			"track %d (%s) should be unchanged", i, fixtureTracks[i].name)
-		assert.Equal(t, fixtureTracks[i].name, lib.Tracks[i].Name,
-			"track %d name should be unchanged", i)
-		assert.Equal(t, fixtureTracks[i].artist, lib.Tracks[i].Artist,
-			"track %d artist should be unchanged", i)
-		assert.Equal(t, fixtureTracks[i].trackID, lib.Tracks[i].TrackID,
-			"track %d trackID should be unchanged", i)
-	}
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestUpdateITLLocations_MultipleUpdates(t *testing.T) {
+	// BE fixture (buildFixtureITL) — BE writeback refused (K12).
 	fixtureData := buildFixtureITL()
 	tmpDir := t.TempDir()
 	itlPath := filepath.Join(tmpDir, "fixture.itl")
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	require.NoError(t, os.WriteFile(itlPath, fixtureData, 0644))
 
-	// Update The Hobbit and Dune
 	updates := []ITLLocationUpdate{
 		{PersistentID: pidToHex(fixtureTracks[0].persistentID), NewLocation: "/new/hobbit.m4b"},
 		{PersistentID: pidToHex(fixtureTracks[1].persistentID), NewLocation: "/new/dune.mp3"},
 	}
-
-	result, err := UpdateITLLocations(itlPath, outPath, updates)
-	require.NoError(t, err)
-	assert.Equal(t, 2, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	assert.Equal(t, "/new/hobbit.m4b", lib.Tracks[0].Location)
-	assert.Equal(t, "/new/dune.mp3", lib.Tracks[1].Location)
-
-	// Others unchanged
-	for i := 2; i < len(fixtureTracks); i++ {
-		assert.Equal(t, fixtureTracks[i].location, lib.Tracks[i].Location)
-	}
+	_, err := UpdateITLLocations(itlPath, outPath, updates)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 func TestUpdateITLLocations_NonexistentPID(t *testing.T) {
+	// BE fixture — BE writeback refused (K12) before any PID matching.
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/song.mp3")
 
@@ -194,15 +141,10 @@ func TestUpdateITLLocations_NonexistentPID(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "updated.itl")
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	_, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: "ffffffffffffffff", NewLocation: "/new/path.mp3"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 0, result.UpdatedCount, "non-matching PID should not update anything")
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	assert.Equal(t, "/music/song.mp3", lib.Tracks[0].Location, "original location should be preserved")
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +284,7 @@ func TestUpdateITLLocations_Compressed(t *testing.T) {
 	itlPath := filepath.Join(tmpDir, "compressed.itl")
 	outPath := filepath.Join(tmpDir, "updated.itl")
 
-	// Build with compression enabled
+	// Build with compression enabled (BE fixture).
 	itlData := buildSyntheticITL(t, "12.0.0", true, pid, originalLoc)
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
@@ -351,13 +293,9 @@ func TestUpdateITLLocations_Compressed(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, origLib.UseCompression, "fixture should be compressed")
 
-	result, err := UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
+	// BE writeback refused (K12) — even through the compressed read path.
+	_, err = UpdateITLLocations(itlPath, outPath, []ITLLocationUpdate{
 		{PersistentID: pidToHex(pid), NewLocation: newLoc},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	assert.Equal(t, newLoc, lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }

--- a/internal/itunes/mhoh_string.go
+++ b/internal/itunes/mhoh_string.go
@@ -1,0 +1,300 @@
+// file: internal/itunes/mhoh_string.go
+// version: 1.0.0
+// guid: 6f3b9d12-4a87-4c0e-9b21-7e5d2a8c1f04
+
+// iTunes-conformant mhoh string encoders/decoders (fable5 TASK-005, CRIT-1).
+//
+// WHY this file exists (K3 / corpus facts):
+//
+// Forensics on the golden iTunes library (cmd/itl-audit-encoding, 2026-06-09;
+// internal/itunes/mhoh_encoding_table.go) proved two facts our OLD writer
+// violated:
+//
+//  1. iTunes writes byte +27 of every string mhoh as 0x00 — ALWAYS. Our old
+//     encodeHohmString stamped +27 ∈ {1,3} (its "encoding flag"), a value that
+//     appears in NONE of the 281,790 golden string blocks but in tens of
+//     thousands of blocks of every iTunes-rejected ("Damaged") library. +27 != 0
+//     is a corruption signature foreign to iTunes (CRIT-1 / SPEC §1 K3).
+//
+//  2. iTunes signals string encoding at byte +24 (a little-endian u32), NOT at
+//     +27. Corpus-observed values: 0=ASCII/percent-encoded, 1=Windows-1252 /
+//     Latin-1, 2=UTF-8, 3=UTF-16LE. The allowed set per hohmType is the
+//     authoritative ITunesMhohEncoding table (T002).
+//
+//  3. The OLD code, when it fell back to UTF-16, wrote UTF-16 BIG-endian. The
+//     corpus shows iTunes uses at24==3 == UTF-16 LITTLE-endian. Writing the
+//     correct Unicode string with the wrong byte order is itself corruption
+//     (SPEC §1b rule 4). encodeMhohITunes emits UTF-16LE.
+//
+// encodeMhohITunes is the single iTunes-conformant encoder. It is driven by the
+// corpus table and ERRORS (never guesses) for any hohmType absent from the
+// table — callers must then preserve the original block unmodified and WARN,
+// rather than invent a header iTunes never produces.
+
+package itunes
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+// ErrBEWritebackUnsupported is returned by every writeback entry point when the
+// target library is big-endian (BE / PowerPC-era format).
+//
+// WHY refuse (K12 / LOW-2 / SPEC §3 step 1): all corpus forensics and the
+// iTunes-conformant encoder are LITTLE-endian (production is iTunes v12.13 LE).
+// The BE writer shared the same CRIT-1 +27 flag invention and has no corpus to
+// validate against, so writing BE risks the exact corruption class T005 fixes
+// with zero coverage. Production never produces BE libraries, so refusing is
+// strictly safer than replicating an unvalidated BE encoder.
+var ErrBEWritebackUnsupported = errors.New("iTunes BE writeback unsupported: only little-endian (v10+) libraries can be safely written (K12)")
+
+// mhohFixedHeaderTotal is the fixed-header span (offset of the string payload)
+// of every standard-layout LE mhoh block: 40 bytes. headerLen (the +4 field) is
+// 24, but the string data begins at +40 (+28 strLen, +32..+39 reserved zero).
+const mhohFixedHeaderTotal = 40
+
+// at24 encoding-indicator values, named per the corpus table (mhoh_encoding_table.go).
+// These are the LITTLE-ENDIAN u32 written at byte offset +24 of an mhoh block.
+const (
+	at24ASCII   uint32 = 0 // ASCII / percent-encoded (0x0B LocalURL, advisory strings)
+	at24Latin1  uint32 = 1 // Windows-1252 / Latin-1 (Latin text)
+	at24UTF8    uint32 = 2 // UTF-8 / pure ASCII (0x0B encoded URLs)
+	at24UTF16LE uint32 = 3 // UTF-16 LITTLE-endian (non-Latin text)
+)
+
+// MhohHeaderBytes carries the deterministic per-block header values the LE
+// writers stamp. It exists so both writer paths (buildMhohLE append path and
+// rewriteHohmLocationLE replace path) build the SAME 40-byte header from the
+// SAME inputs — guaranteeing byte-identical output for identical input
+// (TASK-005 acceptance criterion).
+type MhohHeaderBytes struct {
+	HeaderLen uint32 // always mhohFixedHeaderLen (24)
+	At24      uint32 // encoding indicator at byte +24
+	StrLen    uint32 // length of the encoded payload (bytes)
+	TotalLen  uint32 // 40 + StrLen
+}
+
+// encodeMhohITunes encodes s for an mhoh block of hohmType, choosing an encoding
+// that is byte-conformant with iTunes-authored libraries for that type.
+//
+// Returns the encoded string payload, the deterministic header bytes, and an
+// error. The error is non-nil (and payload/hdr zero) when hohmType is absent
+// from the corpus table — callers MUST preserve the original block and WARN
+// rather than write an invented encoding (SPEC §5 ITW-2: "never invent flags").
+//
+// Encoding choice (corpus-driven, per ITunesMhohEncoding[hohmType].AllowedAt24):
+//   - {0} or {2}: ASCII/percent-encoded field (e.g. 0x0B LocalURL). Encoded as
+//     raw bytes; at24 = the single allowed value (2 preferred over 0 when both
+//     are allowed, matching iTunes' dominant rendering for encoded URLs).
+//   - {3} only: UTF-16LE always, even for ASCII (e.g. 0x06 Kind — iTunes encodes
+//     Kind as UTF-16LE uniformly).
+//   - contains both 1 and 3: latin1 when every rune <= 0xFF, else UTF-16LE.
+//   - {1} only: Latin-1 (errors if a rune is non-representable — handled by
+//     falling back to the type's behaviour; {1}-only types in the corpus only
+//     ever hold Latin text).
+func encodeMhohITunes(hohmType uint32, s string) ([]byte, MhohHeaderBytes, error) {
+	entry, ok := ITunesMhohEncoding[hohmType]
+	if !ok {
+		return nil, MhohHeaderBytes{}, fmt.Errorf(
+			"encodeMhohITunes: hohmType 0x%X absent from corpus table; refusing to invent an encoding (CRIT-1)", hohmType)
+	}
+
+	at24 := chooseAt24(entry, s)
+
+	var payload []byte
+	switch at24 {
+	case at24UTF16LE:
+		payload = encodeUTF16LE(s)
+	case at24ASCII, at24UTF8:
+		// ASCII / percent-encoded URL fields: raw bytes. These are pure ASCII
+		// in the corpus (percent-escaped URLs, advisory codes), so byte-identity
+		// holds without transcoding.
+		payload = []byte(s)
+	case at24Latin1:
+		enc := charmap.Windows1252.NewEncoder()
+		out, err := enc.Bytes([]byte(s))
+		if err != nil {
+			// A {1,3} type would have selected UTF-16LE above; reaching here
+			// means a {1}-only type received a non-Latin rune (not seen in the
+			// corpus). Fail rather than silently corrupt.
+			return nil, MhohHeaderBytes{}, fmt.Errorf(
+				"encodeMhohITunes: type 0x%X (latin1-only) cannot encode %q: %w", hohmType, s, err)
+		}
+		payload = out
+	default:
+		return nil, MhohHeaderBytes{}, fmt.Errorf("encodeMhohITunes: unsupported at24 indicator %d for type 0x%X", at24, hohmType)
+	}
+
+	hdr := MhohHeaderBytes{
+		HeaderLen: mhohFixedHeaderLen,
+		At24:      at24,
+		StrLen:    uint32(len(payload)),
+		TotalLen:  uint32(mhohFixedHeaderTotal + len(payload)),
+	}
+	return payload, hdr, nil
+}
+
+// chooseAt24 picks the corpus-allowed encoding indicator for s given the type's
+// AllowedAt24 set. WHY the priority order: it mirrors what iTunes itself writes —
+// UTF-16-only types always 3; URL/ASCII types take their single allowed code;
+// {1,3} text types use latin1 for Latin-representable strings and UTF-16LE
+// otherwise.
+func chooseAt24(entry MhohEncodingEntry, s string) uint32 {
+	allows := func(v uint32) bool { return entry.AllowedAt24Contains(v) }
+
+	// UTF-16LE-only types (e.g. 0x06 Kind): always 3.
+	if allows(at24UTF16LE) && !allows(at24Latin1) && !allows(at24ASCII) && !allows(at24UTF8) {
+		return at24UTF16LE
+	}
+
+	// ASCII / percent-encoded URL types (e.g. 0x0B): prefer 2 (UTF-8/ASCII) over
+	// 0 when both are allowed — iTunes' dominant rendering for encoded URLs.
+	if (allows(at24ASCII) || allows(at24UTF8)) && !allows(at24Latin1) {
+		if allows(at24UTF8) {
+			return at24UTF8
+		}
+		return at24ASCII
+	}
+
+	// Text types allowing latin1: latin1 when Latin-representable, else UTF-16LE.
+	if allows(at24Latin1) {
+		if isLatin1Representable(s) && allows(at24Latin1) {
+			return at24Latin1
+		}
+		if allows(at24UTF16LE) {
+			return at24UTF16LE
+		}
+		return at24Latin1
+	}
+
+	// Fallback: UTF-16LE if allowed, else the first allowed value.
+	if allows(at24UTF16LE) {
+		return at24UTF16LE
+	}
+	if len(entry.AllowedAt24) > 0 {
+		return entry.AllowedAt24[0]
+	}
+	return at24Latin1
+}
+
+// isLatin1Representable reports whether every rune of s is <= 0xFF (encodable in
+// a single Windows-1252/Latin-1 byte). Mirrors how iTunes chooses latin1 vs
+// UTF-16LE for {1,3} text fields in the corpus.
+func isLatin1Representable(s string) bool {
+	for _, r := range s {
+		if r > 0xFF {
+			return false
+		}
+	}
+	return true
+}
+
+// encodeUTF16LE encodes s as UTF-16 LITTLE-endian (at24==3). WHY little-endian:
+// the corpus shows iTunes' at24==3 blocks are UTF-16LE; our OLD encoder wrote
+// big-endian, which was part of the CRIT-1 corruption (SPEC §1b rule 4).
+// Astral-plane runes (> U+FFFF) are emitted as surrogate pairs.
+func encodeUTF16LE(s string) []byte {
+	var buf []byte
+	for _, r := range s {
+		if r > 0xFFFF {
+			r -= 0x10000
+			hi := 0xD800 + (r >> 10)
+			lo := 0xDC00 + (r & 0x3FF)
+			var b [4]byte
+			binary.LittleEndian.PutUint16(b[0:2], uint16(hi))
+			binary.LittleEndian.PutUint16(b[2:4], uint16(lo))
+			buf = append(buf, b[:]...)
+			continue
+		}
+		var b [2]byte
+		binary.LittleEndian.PutUint16(b[:], uint16(r))
+		buf = append(buf, b[:]...)
+	}
+	return buf
+}
+
+// decodeMhohUTF16LE decodes UTF-16 LITTLE-endian bytes (at24==3) into a string,
+// handling surrogate pairs and embedded NULs. The inverse of encodeUTF16LE.
+// (Distinct from smart_criteria_reader.go's decodeUTF16LE, which stops at the
+// first NUL and ignores surrogates — wrong for full mhoh string payloads.)
+func decodeMhohUTF16LE(data []byte) string {
+	if len(data)%2 != 0 {
+		data = append(append([]byte{}, data...), 0)
+	}
+	u16 := make([]uint16, len(data)/2)
+	for i := range u16 {
+		u16[i] = binary.LittleEndian.Uint16(data[i*2 : i*2+2])
+	}
+	runes := make([]rune, 0, len(u16))
+	for i := 0; i < len(u16); i++ {
+		c := u16[i]
+		if c >= 0xD800 && c <= 0xDBFF && i+1 < len(u16) {
+			lo := u16[i+1]
+			if lo >= 0xDC00 && lo <= 0xDFFF {
+				r := (rune(c-0xD800) << 10) + rune(lo-0xDC00) + 0x10000
+				runes = append(runes, r)
+				i++
+				continue
+			}
+		}
+		runes = append(runes, rune(c))
+	}
+	return string(runes)
+}
+
+// decodeMhohBlock decodes the string carried by a 40+-byte LE mhoh block using
+// the DUAL convention (TASK-005):
+//
+//   - byte +27 != 0  → LEGACY block written by our OLD encoder. Decode via the
+//     legacy flag at +27 (decodeHohmString: 1=UTF-16BE, 2=UTF-8, 3=Win-1252,
+//     0=ASCII). This keeps libraries we previously wrote parseable.
+//   - byte +27 == 0  → iTunes-conformant block. Read the +24 u32 indicator and
+//     decode per the corpus semantics (0/2=ASCII/UTF-8, 1=Latin-1, 3=UTF-16LE).
+//
+// The dual path is required because the two conventions assign DIFFERENT
+// meanings to the same numeric value (legacy 3 = Win-1252; corpus 3 = UTF-16LE),
+// so the +27==0 discriminator must select the table before interpreting +24.
+func decodeMhohBlock(block []byte) (string, error) {
+	if len(block) < mhohFixedHeaderTotal {
+		return "", fmt.Errorf("decodeMhohBlock: block too short (%d < 40)", len(block))
+	}
+	strLen := int(binary.LittleEndian.Uint32(block[28:32]))
+	strStart := mhohFixedHeaderTotal
+	if strStart+strLen > len(block) {
+		strLen = len(block) - strStart
+		if strLen < 0 {
+			return "", fmt.Errorf("decodeMhohBlock: negative string length")
+		}
+	}
+	strData := block[strStart : strStart+strLen]
+
+	legacyFlag := block[27]
+	if legacyFlag != 0 {
+		// Legacy block: +27 carries the encoding (our old convention).
+		return decodeHohmString(strData, legacyFlag)
+	}
+
+	// iTunes-conformant block: encoding indicator at +24.
+	at24 := binary.LittleEndian.Uint32(block[24:28])
+	switch at24 {
+	case at24UTF16LE:
+		return decodeMhohUTF16LE(strData), nil
+	case at24Latin1:
+		dec := charmap.Windows1252.NewDecoder()
+		out, err := dec.Bytes(strData)
+		if err != nil {
+			return string(strData), err
+		}
+		return string(out), nil
+	case at24ASCII, at24UTF8:
+		return string(strData), nil
+	default:
+		// Unknown indicator with +27==0: best-effort raw bytes (validated
+		// separately by the mhoh-format guard, which rejects out-of-corpus +24).
+		return string(strData), nil
+	}
+}

--- a/internal/itunes/mhoh_string_test.go
+++ b/internal/itunes/mhoh_string_test.go
@@ -1,0 +1,247 @@
+// file: internal/itunes/mhoh_string_test.go
+// version: 1.0.0
+// guid: 2c8e7a14-9b03-4f6d-8a51-d3f0b6e29c87
+//
+// Tests for the iTunes-conformant mhoh string encoders (TASK-005, CRIT-1):
+//   - property round-trips: encode → parse == input (ASCII, Latin-1, CJK, curly-quote)
+//   - every written block passes the T003 mhoh-format guard (contract imported)
+//   - buildMhohLE (append) and rewriteHohmLocationLE (replace) are byte-identical
+//   - UTF-16 is LITTLE-endian (the OLD code wrote BE — proven with a fixture)
+//   - dual-convention decode (legacy +27 still parses)
+//   - out-of-corpus hohmType is refused (never invented)
+//   - BE writeback returns ErrBEWritebackUnsupported (K12)
+
+package itunes
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roundTripMhoh builds an mhoh block for (hohmType, s) via the production
+// encoder, then decodes it via the dual-convention decoder and returns the
+// decoded string. ok mirrors buildMhohLE's in-table flag.
+func roundTripMhoh(t *testing.T, hohmType uint32, s string) (string, bool) {
+	t.Helper()
+	block, ok := buildMhohLE(hohmType, s)
+	if !ok {
+		return "", false
+	}
+	got, err := decodeMhohBlock(block)
+	require.NoError(t, err)
+	return got, true
+}
+
+// TestEncodeMhohITunes_RoundTrip covers the property: encode → parse == input
+// across encodings, for the writer-relevant hohm types.
+func TestEncodeMhohITunes_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		hohmType uint32
+		value    string
+	}{
+		// 0x02 (Name) allows {1=latin1, 3=utf16le}.
+		{"ascii_name", 0x02, "The Way of Kings"},
+		{"latin1_name", 0x02, "Café Société — naïve"},
+		{"cjk_name", 0x02, "日本語のタイトル"},
+		{"curly_quote_name", 0x02, "It’s a “Test” — dash"},
+		{"emoji_name", 0x02, "Book \U0001F4DA Title"}, // astral plane → surrogate pair
+		// 0x04 (Artist), 0x03 (Album), 0x05 (Genre), 0x0C (Composer/Narrator).
+		{"latin1_artist", 0x04, "Brandon Sanderson"},
+		{"cjk_album", 0x03, "村上春樹"},
+		{"latin1_genre", 0x05, "Fiction"},
+		{"latin1_composer", 0x0C, "Michael Kramer & Kate Reading"},
+		// 0x06 (Kind) is UTF-16LE-only in the corpus, even for ASCII.
+		{"kind_ascii_utf16", 0x06, "MPEG audio file"},
+		{"kind_unicode", 0x06, "AAC オーディオ"},
+		// 0x0D (Location) Windows path, Latin-1 representable.
+		{"location_latin1", 0x0D, `W:\itunes\iTunes Media\Audiobooks\Author\book.mp3`},
+		{"location_unicode", 0x0D, `W:\itunes\著者\タイトル.m4b`},
+		// 0x0B (LocalURL) is ASCII percent-encoded → at24 ∈ {0,2}.
+		{"localurl_ascii", 0x0B, "file://localhost/W:/itunes/iTunes%20Media/x.mp3"},
+		// 0x64 (playlist title).
+		{"playlist_latin1", 0x64, "My Playlist"},
+		{"playlist_cjk", 0x64, "プレイリスト"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := roundTripMhoh(t, tc.hohmType, tc.value)
+			require.True(t, ok, "type 0x%X must be in the corpus table", tc.hohmType)
+			assert.Equal(t, tc.value, got, "encode→parse must equal input")
+		})
+	}
+}
+
+// TestEncodeMhohITunes_Plus27AlwaysZero asserts the CRIT-1 invariant: byte +27
+// is always 0x00 in every block our writers produce. The OLD encoder stamped
+// +27 ∈ {1,3}, the corruption signature foreign to iTunes.
+func TestEncodeMhohITunes_Plus27AlwaysZero(t *testing.T) {
+	for _, ht := range []uint32{0x02, 0x03, 0x04, 0x05, 0x06, 0x0B, 0x0C, 0x0D, 0x64} {
+		for _, s := range []string{"ascii", "café", "日本語", "x’y"} {
+			block, ok := buildMhohLE(ht, s)
+			require.True(t, ok)
+			require.GreaterOrEqual(t, len(block), 40)
+			assert.Equal(t, byte(0), block[27],
+				"type 0x%X value %q: byte +27 must be 0x00 (K3)", ht, s)
+			// headerLen must be the corpus-conformant 24.
+			assert.Equal(t, uint32(24), binary.LittleEndian.Uint32(block[4:8]),
+				"type 0x%X: headerLen must be 24 (K5)", ht)
+			// +24 indicator must be in the corpus-allowed set for the type.
+			at24 := binary.LittleEndian.Uint32(block[24:28])
+			entry := ITunesMhohEncoding[ht]
+			assert.True(t, entry.AllowedAt24Contains(at24),
+				"type 0x%X value %q: +24=%d not in corpus set %v", ht, s, at24, entry.AllowedAt24)
+		}
+	}
+}
+
+// TestEncodeMhohITunes_UTF16IsLittleEndian proves the byte order: the OLD code
+// wrote UTF-16 BIG-endian; the corpus (at24==3) is LITTLE-endian. For "日" (U+65E5)
+// the LE bytes are 0xE5 0x65, NOT 0x65 0xE5.
+func TestEncodeMhohITunes_UTF16IsLittleEndian(t *testing.T) {
+	block, ok := buildMhohLE(0x02, "日") // U+65E5
+	require.True(t, ok)
+
+	// at24 must be 3 (UTF-16LE).
+	assert.Equal(t, uint32(3), binary.LittleEndian.Uint32(block[24:28]), "non-Latin → UTF-16LE (at24=3)")
+
+	strLen := int(binary.LittleEndian.Uint32(block[28:32]))
+	require.Equal(t, 2, strLen, "one BMP rune → 2 bytes")
+	payload := block[40 : 40+strLen]
+	// LITTLE-endian: low byte first.
+	assert.Equal(t, []byte{0xE5, 0x65}, payload,
+		"U+65E5 must be encoded little-endian (0xE5 0x65); big-endian (0x65 0xE5) is the OLD corruption")
+
+	// And it must decode back.
+	got, err := decodeMhohBlock(block)
+	require.NoError(t, err)
+	assert.Equal(t, "日", got)
+}
+
+// TestEncodeMhohITunes_AppendAndReplaceByteIdentical asserts the two writer
+// paths (buildMhohLE append, rewriteHohmLocationLE replace) produce byte-for-byte
+// identical output for identical (hohmType, value) input.
+func TestEncodeMhohITunes_AppendAndReplaceByteIdentical(t *testing.T) {
+	cases := []struct {
+		hohmType uint32
+		value    string
+	}{
+		{0x02, "ASCII Title"},
+		{0x02, "Café"},
+		{0x02, "日本語"},
+		{0x0D, `W:\itunes\book.mp3`},
+		{0x0B, "file://localhost/W:/x.mp3"},
+		{0x06, "MPEG audio file"},
+	}
+	for _, tc := range cases {
+		appendBlock, ok := buildMhohLE(tc.hohmType, tc.value)
+		require.True(t, ok)
+
+		// rewriteHohmLocationLE needs an existing block to read the hohmType from.
+		// Feed it the append block itself (offset 0) with the same value.
+		replaceBlock := rewriteHohmLocationLE(appendBlock, 0, len(appendBlock), tc.value)
+
+		assert.Equal(t, appendBlock, replaceBlock,
+			"append and replace paths must be byte-identical for type 0x%X value %q", tc.hohmType, tc.value)
+	}
+}
+
+// TestEncodeMhohITunes_EveryBlockPassesMhohFormatGuard wraps written blocks in a
+// minimal LE payload and runs the T003 mhoh-format guard (imported from the
+// contract). Every produced block must pass.
+func TestEncodeMhohITunes_EveryBlockPassesMhohFormatGuard(t *testing.T) {
+	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	values := []struct {
+		hohmType uint32
+		value    string
+	}{
+		{0x02, "Latin Café"},
+		{0x03, "日本語アルバム"},
+		{0x04, "Author Name"},
+		{0x05, "Genre"},
+		{0x06, "MPEG audio file"},
+		{0x0C, "Narrator"},
+		{0x0D, `W:\itunes\book.mp3`},
+	}
+	var mhohs [][]byte
+	for _, v := range values {
+		block, ok := buildMhohLE(v.hohmType, v.value)
+		require.True(t, ok)
+		mhohs = append(mhohs, block)
+	}
+
+	trackContent := buildLETrackSection(1, pid, mhohs...)
+	payload := buildLEPayload(trackContent)
+
+	res := guardMhohFormat(nil, payload, nil, DefaultContractConfig())
+	assert.Empty(t, res.Violations, "every written block must pass mhoh-format: %+v", res.Violations)
+}
+
+// TestDecodeMhohBlock_DualConvention verifies the decoder reads BOTH a legacy
+// (+27 nonzero) block AND an iTunes-conformant (+27==0, +24 indicator) block.
+func TestDecodeMhohBlock_DualConvention(t *testing.T) {
+	// 1) iTunes-conformant block via the production encoder.
+	conformant, ok := buildMhohLE(0x02, "Café")
+	require.True(t, ok)
+	require.Equal(t, byte(0), conformant[27])
+	got, err := decodeMhohBlock(conformant)
+	require.NoError(t, err)
+	assert.Equal(t, "Café", got)
+
+	// 2) Legacy block: +27 = 3 (old "Windows-1252" flag), +24 ignored.
+	// Build a block manually with the legacy convention.
+	legacy := make([]byte, 40+len("Café-ish"))
+	copy(legacy[0:4], "mhoh")
+	binary.LittleEndian.PutUint32(legacy[4:8], 24)
+	binary.LittleEndian.PutUint32(legacy[8:12], uint32(len(legacy)))
+	binary.LittleEndian.PutUint32(legacy[12:16], 0x02)
+	// Legacy encoder stamped the flag at +27; encode the bytes as Windows-1252.
+	legacyPayload, _ := encodeHohmString("Café-ish") // returns (latin1 bytes, flag 3)
+	legacy = legacy[:40+len(legacyPayload)]
+	binary.LittleEndian.PutUint32(legacy[28:32], uint32(len(legacyPayload)))
+	legacy[27] = 3 // legacy Windows-1252 flag
+	copy(legacy[40:], legacyPayload)
+
+	gotLegacy, err := decodeMhohBlock(legacy)
+	require.NoError(t, err)
+	assert.Equal(t, "Café-ish", gotLegacy, "legacy +27=3 block must still decode")
+}
+
+// TestEncodeMhohITunes_RefusesOutOfCorpusType asserts the encoder errors (never
+// guesses) for a hohmType absent from the corpus table, and that the LE writers
+// surface that as a skip rather than an invented block.
+func TestEncodeMhohITunes_RefusesOutOfCorpusType(t *testing.T) {
+	const bogusType = 0x7777 // not in ITunesMhohEncoding
+
+	_, _, err := encodeMhohITunes(bogusType, "x")
+	require.Error(t, err, "out-of-corpus type must error, not guess")
+
+	block, ok := buildMhohLE(bogusType, "x")
+	assert.False(t, ok, "buildMhohLE must report not-built for an out-of-corpus type")
+	assert.Nil(t, block)
+
+	// rewriteHohmLocationLE must preserve the original block unmodified.
+	orig := make([]byte, 48)
+	copy(orig[0:4], "mhoh")
+	binary.LittleEndian.PutUint32(orig[4:8], 24)
+	binary.LittleEndian.PutUint32(orig[8:12], 48)
+	binary.LittleEndian.PutUint32(orig[12:16], bogusType)
+	binary.LittleEndian.PutUint32(orig[28:32], 8)
+	copy(orig[40:], []byte("original"))
+
+	out := rewriteHohmLocationLE(orig, 0, len(orig), "replacement")
+	assert.Equal(t, orig, out, "out-of-corpus type must be preserved byte-for-byte")
+}
+
+// TestErrBEWritebackUnsupported_Sentinel documents the K12 sentinel exists and is
+// distinct. (The full BE-refusal behavior of UpdateITLLocations / ApplyITLOperations
+// / RewriteITLExtensions is asserted in itl_writeback_test, itl_mutation_test,
+// itl_regression_test, and itl_test against BE fixtures.)
+func TestErrBEWritebackUnsupported_Sentinel(t *testing.T) {
+	require.Error(t, ErrBEWritebackUnsupported)
+	assert.Contains(t, ErrBEWritebackUnsupported.Error(), "BE writeback unsupported")
+}


### PR DESCRIPTION
## TASK-005: iTunes-conformant mhoh string encoders (CRIT-1)

Fixes the prime suspect for the Apple Devices crash / "(Damaged)" class. Depends on T002 (corpus table) + T003 (ITLSafetyContract), both already on `main`.

### What CRIT-1 was
`encodeHohmString` stamped byte **+27 ∈ {1,3}** — a value present in **none** of the 281,790 golden string blocks but in tens of thousands of blocks of every iTunes-rejected library. iTunes writes **+27==0 always** and signals encoding at **+24** (`1=latin1, 3=utf16LE`). The old UTF-16 fallback was also **big-endian**; the corpus `at24==3` is **UTF-16 little-endian** — writing the right string with the wrong byte order is itself corruption (SPEC §1b rule 4).

### Changes
- **`internal/itunes/mhoh_string.go`** (new): `encodeMhohITunes(hohmType, s) → (payload, MhohHeaderBytes, err)` driven by `ITunesMhohEncoding`. Errors (never guesses) for out-of-corpus types; callers preserve the original block + WARN. Plus `decodeMhohBlock` (dual-convention) and `encodeUTF16LE`/`decodeMhohUTF16LE` (surrogate-aware). `ErrBEWritebackUnsupported` sentinel (K12).
- **`buildMhohLE`** (append) & **`rewriteHohmLocationLE`** (replace): set the full 40-byte header deterministically (headerLen=24, +24 indicator, +27=0, +32..+39 zero); **byte-identical for identical input**. `rewriteHohmLocationLE` no longer blind-copies +16..+27.
- **Dual-convention decode**: `+27` nonzero → legacy decode (libraries we previously wrote); else `+24` corpus semantics. Wired into `parseMhohLE`, `parsePlaylistMhohLE`, and the contract's `decodeMhohString`.
- **BE writeback refused** (K12) at every writeback dispatch (`ApplyITLOperations`, `ApplyITLOperationsInMemory`, `UpdateITLLocations`, `RewriteITLExtensions`).

### Acceptance criteria
- [x] No writer emits +27 != 0 (guard-verified in tests).
- [x] Round-trip property tests pass incl. non-ASCII (ASCII / Latin-1 / CJK / curly-quote / emoji).
- [x] BE writeback returns explicit "BE writeback unsupported" error.
- [x] Every written block passes T003's `mhoh-format` guard (contract imported in tests).
- [x] `encodeHohmString` has no remaining LE-writer callers (retained only for legacy BE/decode-compat & legacy tests).
- [x] `go build`/`go vet` clean; `go test ./internal/itunes/... -count=1` and `make test` green.

### Byte-conformance verification
- `TestEncodeMhohITunes_UTF16IsLittleEndian`: "日" (U+65E5) → payload bytes **`0xE5 0x65`** (LE), not `0x65 0xE5` (the old BE corruption), at24==3, decodes back.
- `TestEncodeMhohITunes_Plus27AlwaysZero`: across 0x02–0x64 × {ascii, café, 日本語, x'y}, asserts **+27==0**, headerLen==24, and +24 ∈ corpus-allowed set.
- `TestEncodeMhohITunes_AppendAndReplaceByteIdentical`: `buildMhohLE` output == `rewriteHohmLocationLE` output for the same input.
- `TestEncodeMhohITunes_EveryBlockPassesMhohFormatGuard` + `TestUpdateMetadataLE_OutputPassesMhohFormatGuard`: real `guardMhohFormat` (T003) finds zero violations on writer output, incl. a UTF-16LE title.
- `TestDecodeMhohBlock_DualConvention`: a legacy +27=3 block still decodes.

### Notes
BE-fixture writeback tests (`buildSyntheticITL`/`buildSyntheticITLMultiTrack` are big-endian `hohm`/`htim`) now assert `ErrBEWritebackUnsupported` instead of a successful round-trip — BE writeback is deliberately unsupported (K12). LE path-format coverage lives in the `itl_le_metadata_update` / `itl_convert` / `mhoh_string` suites. `InsertITLTracks`/`InsertITLPlaylist` are unchanged (out of T005 scope; T004 routes them through SafeWriteITL).

COMPLETED: 8 — encodeMhohITunes; buildMhohLE; rewriteHohmLocationLE; dual-convention decode; BE refusal (4 dispatch sites + sentinel); contract decodeMhohString delegation; new mhoh_string_test.go + extended itl_le_metadata_update_test.go; all acceptance criteria
REMAINING: 0
BLOCKED: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
