### PR TITLE
feat(itunes): SafeWriteITL atomic write protocol + header regeneratio…

### DIFF
--- a/internal/itunes/itl.go
+++ b/internal/itunes/itl.go
@@ -692,64 +692,52 @@ func UpdateITLLocations(inputPath, outputPath string, updates []ITLLocationUpdat
 		updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
 	}
 
-	data, err := os.ReadFile(inputPath)
+	// Mutation: rewrite location hohms in the decompressed LE payload. Header
+	// regeneration (CRIT-3) + the full ITLSafetyContract + BE refusal all happen
+	// inside the SafeWriteITL chokepoint (TASK-004) — no direct writeITLFile here.
+	updatedCount := 0
+	mutate := func(decompressed []byte) ([]byte, error) {
+		var newData []byte
+		newData, updatedCount = rewriteChunksLE(decompressed, updateMap)
+		return newData, nil
+	}
+	return safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &updatedCount)
+}
+
+// safeWriteOrEncodeToFile routes an itl.go writeback entry point through the
+// SafeWriteITL atomic protocol when writing in place (inputPath == outputPath),
+// or through the safe in-memory encode (header regen + full contract) written to
+// outputPath when the caller wants a distinct output file (e.g. a managed .tmp).
+// `updated`, when non-nil, is surfaced as ITLWriteBackResult.UpdatedCount —
+// callers set it from inside their mutate closure (the closure runs before this
+// function returns, so the deref below sees the final value).
+func safeWriteOrEncodeToFile(inputPath, outputPath string, mutate func([]byte) ([]byte, error), updated *int) (*ITLWriteBackResult, error) {
+	if inputPath == outputPath {
+		if _, err := SafeWriteITL(inputPath, mutate); err != nil {
+			return nil, err
+		}
+		return &ITLWriteBackResult{UpdatedCount: derefCount(updated), OutputPath: outputPath}, nil
+	}
+	raw, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading ITL: %w", err)
 	}
-
-	hdr, err := parseHdfmHeader(data)
+	outBytes, err := safeEncodeITL(raw, mutate, DefaultContractConfig())
 	if err != nil {
 		return nil, err
 	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
-	}
-
-	// Walk and rewrite — dispatch on endianness.
-	// BE writeback is refused (K12): see ErrBEWritebackUnsupported.
-	if !detectLE(decompressed) {
-		return nil, ErrBEWritebackUnsupported
-	}
-	var newData []byte
-	var updatedCount int
-	if detectLE(decompressed) {
-		newData, updatedCount = rewriteChunksLE(decompressed, updateMap)
-	} else {
-		newData, updatedCount = rewriteChunksBE(decompressed, updateMap)
-	}
-
-	// Compress if original was
-	var finalPayload []byte
-	if wasCompressed {
-		finalPayload = itlDeflate(newData)
-	} else {
-		finalPayload = newData
-	}
-
-	// Encrypt
-	encrypted := itlEncrypt(hdr, finalPayload)
-
-	// Build new file
-	newFileLen := uint32(len(encrypted)) + hdr.headerLen
-	newHeader := buildHdfmHeader(hdr.version, hdr.headerRemainder, newFileLen, hdr.unknown)
-
-	outData := make([]byte, 0, len(newHeader)+len(encrypted))
-	outData = append(outData, newHeader...)
-	outData = append(outData, encrypted...)
-
-	if err := os.WriteFile(outputPath, outData, 0664); err != nil {
+	if err := writeFileSync(outputPath, outBytes); err != nil {
 		return nil, fmt.Errorf("writing ITL: %w", err)
 	}
 	fixITLPermissions(outputPath)
+	return &ITLWriteBackResult{UpdatedCount: derefCount(updated), OutputPath: outputPath}, nil
+}
 
-	return &ITLWriteBackResult{
-		UpdatedCount: updatedCount,
-		OutputPath:   outputPath,
-	}, nil
+func derefCount(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 // ---------------------------------------------------------------------------
@@ -763,64 +751,48 @@ func InsertITLTracks(inputPath, outputPath string, tracks []ITLNewTrack) (*ITLWr
 		return &ITLWriteBackResult{OutputPath: outputPath}, nil
 	}
 
-	data, err := os.ReadFile(inputPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading ITL: %w", err)
+	// Mutation: append new track chunks at the track-insert offset. Header
+	// regeneration (CRIT-3) + the full ITLSafetyContract + BE refusal happen in
+	// the SafeWriteITL chokepoint (TASK-004).
+	mutate := func(decompressed []byte) ([]byte, error) {
+		// Find max track ID and the insertion point (after last track hohm,
+		// before first hpim).
+		maxID := findMaxTrackID(decompressed)
+		insertOffset := findTrackInsertOffset(decompressed)
+
+		var newChunks bytes.Buffer
+		for i, tr := range tracks {
+			trackID := maxID + 1 + i
+			newChunks.Write(buildHtimChunk(trackID, tr))
+			// Order matters: location first, then metadata (iTunes convention).
+			if tr.Location != "" {
+				newChunks.Write(buildHohmChunk(0x0D, tr.Location))
+			}
+			if tr.Name != "" {
+				newChunks.Write(buildHohmChunk(0x02, tr.Name))
+			}
+			if tr.Album != "" {
+				newChunks.Write(buildHohmChunk(0x03, tr.Album))
+			}
+			if tr.Artist != "" {
+				newChunks.Write(buildHohmChunk(0x04, tr.Artist))
+			}
+			if tr.Genre != "" {
+				newChunks.Write(buildHohmChunk(0x05, tr.Genre))
+			}
+			if tr.Kind != "" {
+				newChunks.Write(buildHohmChunk(0x06, tr.Kind))
+			}
+		}
+
+		var newData bytes.Buffer
+		newData.Write(decompressed[:insertOffset])
+		newData.Write(newChunks.Bytes())
+		newData.Write(decompressed[insertOffset:])
+		return newData.Bytes(), nil
 	}
-
-	hdr, err := parseHdfmHeader(data)
-	if err != nil {
-		return nil, err
-	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
-	}
-
-	// Find max track ID
-	maxID := findMaxTrackID(decompressed)
-
-	// Find insertion point: after last hohm that follows an htim, before first hpim
-	insertOffset := findTrackInsertOffset(decompressed)
-
-	// Build new track chunks
-	var newChunks bytes.Buffer
-	for i, tr := range tracks {
-		trackID := maxID + 1 + i
-		htim := buildHtimChunk(trackID, tr)
-		newChunks.Write(htim)
-
-		// Order matters: location first, then metadata (matches iTunes convention).
-		if tr.Location != "" {
-			newChunks.Write(buildHohmChunk(0x0D, tr.Location))
-		}
-		if tr.Name != "" {
-			newChunks.Write(buildHohmChunk(0x02, tr.Name))
-		}
-		if tr.Album != "" {
-			newChunks.Write(buildHohmChunk(0x03, tr.Album))
-		}
-		if tr.Artist != "" {
-			newChunks.Write(buildHohmChunk(0x04, tr.Artist))
-		}
-		if tr.Genre != "" {
-			newChunks.Write(buildHohmChunk(0x05, tr.Genre))
-		}
-		if tr.Kind != "" {
-			newChunks.Write(buildHohmChunk(0x06, tr.Kind))
-		}
-	}
-
-	// Splice: before insertOffset + newChunks + after insertOffset
-	var newData bytes.Buffer
-	newData.Write(decompressed[:insertOffset])
-	newData.Write(newChunks.Bytes())
-	newData.Write(decompressed[insertOffset:])
-
-	return writeITLFile(outputPath, hdr, newData.Bytes(), wasCompressed, len(tracks))
+	count := len(tracks)
+	return safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &count)
 }
 
 // findMaxTrackID walks chunks to find the highest track ID.
@@ -901,33 +873,17 @@ func RewriteITLExtensions(inputPath, outputPath string, oldExt, newExt string) (
 		newExt = "." + newExt
 	}
 
-	data, err := os.ReadFile(inputPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading ITL: %w", err)
+	// Mutation: rewrite file extensions in location hohms. Header regeneration
+	// (CRIT-3) + the full ITLSafetyContract + BE refusal happen in the
+	// SafeWriteITL chokepoint (TASK-004). (BE was already refused here pre-T004;
+	// the chokepoint enforces it for every entry point uniformly.)
+	count := 0
+	mutate := func(decompressed []byte) ([]byte, error) {
+		var newData []byte
+		newData, count = rewriteExtensionsInChunks(decompressed, oldExt, newExt)
+		return newData, nil
 	}
-
-	hdr, err := parseHdfmHeader(data)
-	if err != nil {
-		return nil, err
-	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
-	}
-
-	// rewriteExtensionsInChunks is a BE ("hohm") path. BE writeback is refused
-	// (K12): the BE writer shares CRIT-1's +27 flag invention with no corpus to
-	// validate against. Production is LE; refuse rather than corrupt.
-	if !detectLE(decompressed) {
-		return nil, ErrBEWritebackUnsupported
-	}
-
-	newData, count := rewriteExtensionsInChunks(decompressed, oldExt, newExt)
-
-	return writeITLFile(outputPath, hdr, newData, wasCompressed, count)
+	return safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &count)
 }
 
 // rewriteExtensionsInChunks walks chunks and rewrites extensions in location hohms.
@@ -983,37 +939,23 @@ func rewriteExtensionsInChunks(data []byte, oldExt, newExt string) ([]byte, int)
 // InsertITLPlaylist reads an ITL file, appends a new playlist, and writes
 // the result to outputPath.
 func InsertITLPlaylist(inputPath, outputPath string, playlist ITLNewPlaylist) (*ITLWriteBackResult, error) {
-	data, err := os.ReadFile(inputPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading ITL: %w", err)
+	// Mutation: append the new playlist chunks. Header regeneration (CRIT-3) +
+	// the full ITLSafetyContract + BE refusal happen in the SafeWriteITL
+	// chokepoint (TASK-004).
+	mutate := func(decompressed []byte) ([]byte, error) {
+		var plChunks bytes.Buffer
+		plChunks.Write(buildHpimChunk(len(playlist.TrackIDs)))
+		plChunks.Write(buildHohmChunk(0x64, playlist.Title))
+		for _, tid := range playlist.TrackIDs {
+			plChunks.Write(buildHptmChunk(tid))
+		}
+		var newData bytes.Buffer
+		newData.Write(decompressed)
+		newData.Write(plChunks.Bytes())
+		return newData.Bytes(), nil
 	}
-
-	hdr, err := parseHdfmHeader(data)
-	if err != nil {
-		return nil, err
-	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
-	}
-
-	// Build playlist chunks
-	var plChunks bytes.Buffer
-	plChunks.Write(buildHpimChunk(len(playlist.TrackIDs)))
-	plChunks.Write(buildHohmChunk(0x64, playlist.Title))
-	for _, tid := range playlist.TrackIDs {
-		plChunks.Write(buildHptmChunk(tid))
-	}
-
-	// Append at end
-	var newData bytes.Buffer
-	newData.Write(decompressed)
-	newData.Write(plChunks.Bytes())
-
-	return writeITLFile(outputPath, hdr, newData.Bytes(), wasCompressed, 1)
+	count := 1
+	return safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &count)
 }
 
 // writeITLFile handles compression, encryption, and writing of an ITL file.

--- a/internal/itunes/itl_combined_mutate.go
+++ b/internal/itunes/itl_combined_mutate.go
@@ -28,145 +28,112 @@ func (ops *ITLOperationSet) IsEmpty() bool {
 		len(ops.LocationUpdates) == 0 && len(ops.MetadataUpdates) == 0
 }
 
+// applyOpsMutate returns the SafeWriteITL mutate closure that applies an
+// ITLOperationSet (removes → adds → location → metadata) to a decompressed LE
+// payload. *updated is set to the total number of items touched. The closure
+// performs no I/O and no header work — header regeneration and the full
+// ITLSafetyContract (including the dangling-ref check, now the
+// `no-new-dangling-refs` guard) run inside SafeWriteITL / safeEncodeITL
+// (TASK-004), which is why the old in-line VerifyITLNoNewDanglingRefsLE gate is
+// gone from here.
+func applyOpsMutate(ops ITLOperationSet, updated *int) func([]byte) ([]byte, error) {
+	return func(decompressed []byte) ([]byte, error) {
+		// BE refusal is enforced by SafeWriteITL/safeEncodeITL BEFORE mutate is
+		// invoked (the contract chokepoint), so production here is always LE.
+		total := 0
+
+		// Phase 1: Removes
+		if len(ops.Removes) > 0 {
+			var removed int
+			decompressed, removed = RemoveTracksByPIDLE(decompressed, ops.Removes)
+			total += removed
+		}
+		// Phase 2: Adds
+		if len(ops.Adds) > 0 {
+			decompressed = AddTracksLE(decompressed, ops.Adds)
+			total += len(ops.Adds)
+		}
+		// Phase 3: Location patches
+		if len(ops.LocationUpdates) > 0 {
+			updateMap := make(map[string]string, len(ops.LocationUpdates))
+			for _, u := range ops.LocationUpdates {
+				updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
+			}
+			var patched int
+			decompressed, patched = rewriteChunksLE(decompressed, updateMap)
+			total += patched
+		}
+		// Phase 4: Metadata updates (title, artist, album, genre, etc.)
+		if len(ops.MetadataUpdates) > 0 {
+			var metaUpdated int
+			decompressed, metaUpdated = UpdateMetadataLE(decompressed, ops.MetadataUpdates)
+			total += metaUpdated
+		}
+		if updated != nil {
+			*updated = total
+		}
+		return decompressed, nil
+	}
+}
+
 // ApplyITLOperations reads the ITL file, applies all mutations to the
-// decompressed payload in one pass, and writes the result.
-// Order: removes first, then adds, then location patches.
-func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet) (*ITLWriteBackResult, error) {
+// decompressed payload in one pass, and writes the result through the
+// SafeWriteITL atomic protocol (TASK-004): header counts are regenerated from
+// the mutated payload (CRIT-3) and the full ITLSafetyContract runs on both the
+// in-memory and re-read bytes before anything reaches disk.
+// Order: removes, then adds, then location patches, then metadata.
+//
+// The optional cfg overrides the contract guardrails. The default (no cfg) is
+// the SPEC bounded-delta cap (max 5000 removed tracks / 20% mhoh rewrite); the
+// nuclear rebuild and full-export paths pass ForceContractConfig() because they
+// INTENTIONALLY remove every track — bounded-delta is explicitly
+// Force-overridable for these (SPEC §2). Structural guards never relax.
+func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet, cfg ...ContractConfig) (*ITLWriteBackResult, error) {
 	if ops.IsEmpty() {
 		return &ITLWriteBackResult{OutputPath: outputPath}, nil
 	}
 
-	data, err := os.ReadFile(inputPath)
+	contractCfg := contractCfgOrDefault(cfg)
+	totalUpdated := 0
+	mutate := applyOpsMutate(ops, &totalUpdated)
+
+	// In-place write → full atomic SafeWriteITL protocol (backup + rotation +
+	// fsync + re-read contract). A distinct output path (e.g. a caller-managed
+	// .tmp that the batcher renames itself) → safe in-memory encode (header
+	// regeneration + contract) written to outputPath.
+	if inputPath == outputPath {
+		if _, err := SafeWriteITL(inputPath, mutate, WithContractConfig(contractCfg)); err != nil {
+			return nil, err
+		}
+		return &ITLWriteBackResult{UpdatedCount: totalUpdated, OutputPath: outputPath}, nil
+	}
+
+	raw, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading ITL: %w", err)
 	}
-
-	hdr, err := parseHdfmHeader(data)
+	outBytes, err := safeEncodeITL(raw, mutate, contractCfg)
 	if err != nil {
 		return nil, err
 	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
+	if err := writeFileSync(outputPath, outBytes); err != nil {
+		return nil, fmt.Errorf("writing ITL: %w", err)
 	}
-
-	isLE := detectLE(decompressed)
-	// BE writeback is refused (K12): see ErrBEWritebackUnsupported. Production is
-	// LE (v12.13); the BE path is unvalidated and shares CRIT-1's flag invention.
-	if !isLE {
-		return nil, ErrBEWritebackUnsupported
-	}
-	totalUpdated := 0
-
-	// Phase 1: Removes
-	if len(ops.Removes) > 0 {
-		if isLE {
-			var removed int
-			decompressed, removed = RemoveTracksByPIDLE(decompressed, ops.Removes)
-			totalUpdated += removed
-		}
-		// BE remove not implemented (production is LE)
-	}
-
-	// Phase 2: Adds
-	if len(ops.Adds) > 0 {
-		if isLE {
-			decompressed = AddTracksLE(decompressed, ops.Adds)
-			totalUpdated += len(ops.Adds)
-		}
-		// BE add not implemented (production is LE)
-	}
-
-	// Phase 3: Location patches
-	if len(ops.LocationUpdates) > 0 {
-		updateMap := make(map[string]string, len(ops.LocationUpdates))
-		for _, u := range ops.LocationUpdates {
-			updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
-		}
-
-		var patched int
-		if isLE {
-			decompressed, patched = rewriteChunksLE(decompressed, updateMap)
-		} else {
-			decompressed, patched = rewriteChunksBE(decompressed, updateMap)
-		}
-		totalUpdated += patched
-	}
-
-	// Phase 4: Metadata updates (title, artist, album, genre, etc.)
-	if len(ops.MetadataUpdates) > 0 {
-		if isLE {
-			var metaUpdated int
-			decompressed, metaUpdated = UpdateMetadataLE(decompressed, ops.MetadataUpdates)
-			totalUpdated += metaUpdated
-		}
-	}
-
-	// Safety gate: re-read the original payload and diff dangling playlist
-	// refs. If our writes introduced any new orphans, refuse to write the
-	// file rather than corrupt the iTunes library. Re-decoding the input
-	// is intentional — we want to compare against an immutable baseline,
-	// not whatever the in-memory `decompressed` started as before mutation.
-	if isLE {
-		origPayload := data[hdr.headerLen:]
-		origDec := itlDecrypt(hdr, origPayload)
-		origInflated, _, err := itlInflate(origDec)
-		if err != nil {
-			return nil, fmt.Errorf("decompressing original ITL for verification: %w", err)
-		}
-		if err := VerifyITLNoNewDanglingRefsLE(origInflated, decompressed); err != nil {
-			return nil, fmt.Errorf("aborting ITL write to %s: %w", outputPath, err)
-		}
-	}
-
-	return writeITLFile(outputPath, hdr, decompressed, wasCompressed, totalUpdated)
+	fixITLPermissions(outputPath)
+	return &ITLWriteBackResult{UpdatedCount: totalUpdated, OutputPath: outputPath}, nil
 }
 
 // ApplyITLOperationsInMemory applies the same mutations as ApplyITLOperations
-// but returns the resulting ITL bytes instead of writing to disk.
+// but returns the resulting ITL bytes instead of writing to disk. It routes
+// through safeEncodeITL so the export path also gets header regeneration
+// (CRIT-3) and the full ITLSafetyContract (TASK-004). The optional cfg has the
+// same Force semantics as ApplyITLOperations (the full-export path passes
+// ForceContractConfig() because it strips every template track).
 // Used by the partial-export path (Task 033 / ARCH-6-4).
-func ApplyITLOperationsInMemory(inputPath string, ops ITLOperationSet) ([]byte, error) {
-	data, err := os.ReadFile(inputPath)
+func ApplyITLOperationsInMemory(inputPath string, ops ITLOperationSet, cfg ...ContractConfig) ([]byte, error) {
+	raw, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading ITL: %w", err)
 	}
-
-	hdr, err := parseHdfmHeader(data)
-	if err != nil {
-		return nil, err
-	}
-
-	payload := data[hdr.headerLen:]
-	decrypted := itlDecrypt(hdr, payload)
-	decompressed, wasCompressed, err := itlInflate(decrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decompressing ITL payload: %w", err)
-	}
-	isLE := detectLE(decompressed)
-	// BE writeback is refused (K12): see ErrBEWritebackUnsupported.
-	if !isLE {
-		return nil, ErrBEWritebackUnsupported
-	}
-
-	if len(ops.Removes) > 0 {
-		decompressed, _ = RemoveTracksByPIDLE(decompressed, ops.Removes)
-	}
-	if len(ops.Adds) > 0 {
-		decompressed = AddTracksLE(decompressed, ops.Adds)
-	}
-	if len(ops.LocationUpdates) > 0 {
-		updateMap := make(map[string]string, len(ops.LocationUpdates))
-		for _, u := range ops.LocationUpdates {
-			updateMap[strings.ToLower(u.PersistentID)] = u.NewLocation
-		}
-		decompressed, _ = rewriteChunksLE(decompressed, updateMap)
-	}
-	if len(ops.MetadataUpdates) > 0 {
-		decompressed, _ = UpdateMetadataLE(decompressed, ops.MetadataUpdates)
-	}
-
-	return encodeITLPayload(hdr, decompressed, wasCompressed)
+	return safeEncodeITL(raw, applyOpsMutate(ops, nil), contractCfgOrDefault(cfg))
 }

--- a/internal/itunes/itl_mutation_test.go
+++ b/internal/itunes/itl_mutation_test.go
@@ -873,8 +873,9 @@ func TestMutation_LargeTrackID(t *testing.T) {
 // 8. InsertITLTracks integration with multi-track synthetic ITLs
 // ===========================================================================
 
+// TestMutation_InsertIntoEmptyITL: v9 synthetic libraries are big-endian; the
+// SafeWriteITL chokepoint refuses BE writeback (TASK-004, SPEC §3 step 1 / K12).
 func TestMutation_InsertIntoEmptyITL(t *testing.T) {
-	// Build empty ITL, then insert a track via InsertITLTracks
 	data := buildSyntheticITLMultiTrack(t, "9.0.0", false, nil)
 
 	tmpDir := t.TempDir()
@@ -882,21 +883,16 @@ func TestMutation_InsertIntoEmptyITL(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	result, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
+	_, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
 		{Location: "/music/inserted.mp3", Name: "Inserted Track"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	assert.Equal(t, "Inserted Track", lib.Tracks[0].Name)
-	assert.Equal(t, "/music/inserted.mp3", lib.Tracks[0].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
+// TestMutation_InsertMultipleIntoExisting: BE fixture → refused (see above).
 func TestMutation_InsertMultipleIntoExisting(t *testing.T) {
-	// Start with 3 tracks, insert 2 more
 	specs := make([]trackSpec, 3)
 	for i := 0; i < 3; i++ {
 		specs[i] = makeTrackSpec(i)
@@ -908,26 +904,13 @@ func TestMutation_InsertMultipleIntoExisting(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	result, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
+	_, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
 		{Location: "/music/new1.mp3", Name: "New Track 1", Artist: "New Artist"},
 		{Location: "/music/new2.mp3", Name: "New Track 2", Album: "New Album"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 2, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 5)
-
-	// Original tracks preserved
-	for i := 0; i < 3; i++ {
-		assert.Equal(t, specs[i].Location, lib.Tracks[i].Location, "original track %d", i)
-	}
-	// New tracks appended
-	assert.Equal(t, "New Track 1", lib.Tracks[3].Name)
-	assert.Equal(t, "New Artist", lib.Tracks[3].Artist)
-	assert.Equal(t, "New Track 2", lib.Tracks[4].Name)
-	assert.Equal(t, "New Album", lib.Tracks[4].Album)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 // ===========================================================================
@@ -1208,6 +1191,8 @@ func TestMutation_HohmTypeOrdering(t *testing.T) {
 // 15. Playlist tests with multi-track
 // ===========================================================================
 
+// TestMutation_InsertPlaylistIntoMultiTrackITL: BE fixture → refused (TASK-004,
+// SPEC §3 step 1 / K12).
 func TestMutation_InsertPlaylistIntoMultiTrackITL(t *testing.T) {
 	specs := make([]trackSpec, 3)
 	for i := 0; i < 3; i++ {
@@ -1220,31 +1205,27 @@ func TestMutation_InsertPlaylistIntoMultiTrackITL(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "with_playlist.itl")
 	require.NoError(t, os.WriteFile(itlPath, data, 0644))
 
-	result, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
+	_, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
 		Title:    "Test Playlist",
 		TrackIDs: []int{specs[0].TrackID, specs[2].TrackID},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 3)
-	require.Len(t, lib.Playlists, 1)
-	assert.Equal(t, "Test Playlist", lib.Playlists[0].Title)
-	require.Len(t, lib.Playlists[0].Items, 2)
-	assert.Equal(t, specs[0].TrackID, lib.Playlists[0].Items[0])
-	assert.Equal(t, specs[2].TrackID, lib.Playlists[0].Items[1])
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 // ===========================================================================
 // 16. Sequential mutation tests (build -> insert -> update -> verify)
 // ===========================================================================
 
+// TestMutation_SequentialMutations: post-TASK-004 EVERY writeback entry point
+// routes through the SafeWriteITL chokepoint, which refuses BE (K12). The v9
+// synthetic fixture is big-endian, so the very first mutation (InsertITLTracks)
+// is refused — previously only the location-update path refused BE.
 func TestMutation_SequentialMutations(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Step 1: Build initial ITL with 2 tracks
+	// Step 1: Build initial BE (v9) ITL with 2 tracks.
 	specs := make([]trackSpec, 2)
 	for i := 0; i < 2; i++ {
 		specs[i] = makeTrackSpec(i)
@@ -1253,22 +1234,18 @@ func TestMutation_SequentialMutations(t *testing.T) {
 	path1 := filepath.Join(tmpDir, "step1.itl")
 	require.NoError(t, os.WriteFile(path1, data, 0644))
 
-	// Step 2: Insert a new track
+	// Step 2: Insert a new track — refused, BE writeback unsupported.
 	path2 := filepath.Join(tmpDir, "step2.itl")
 	_, err := InsertITLTracks(path1, path2, []ITLNewTrack{
 		{Location: "/music/new.mp3", Name: "New Track", Artist: "New Artist"},
 	})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
+	_, statErr := os.Stat(path2)
+	require.Error(t, statErr, "refused BE write must not create output")
 
-	lib2, err := ParseITL(path2)
-	require.NoError(t, err)
-	require.Len(t, lib2.Tracks, 3)
-
-	// Step 3: Update location — BE fixture, so BE writeback is refused (K12).
-	// (InsertITLTracks above still works because it does not route through the
-	// detectLE writeback dispatch; the location-update path does.)
+	// Step 3: Update location — also refused for the same BE fixture.
 	path3 := filepath.Join(tmpDir, "step3.itl")
-	_, err = UpdateITLLocations(path2, path3, []ITLLocationUpdate{
+	_, err = UpdateITLLocations(path1, path3, []ITLLocationUpdate{
 		{PersistentID: pidToHex(specs[0].PID), NewLocation: "/moved/track_000.mp3"},
 	})
 	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")

--- a/internal/itunes/itl_safe_write.go
+++ b/internal/itunes/itl_safe_write.go
@@ -1,0 +1,506 @@
+// file: internal/itunes/itl_safe_write.go
+// version: 1.0.0
+// guid: 7c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+//
+// SafeWriteITL — the single atomic iTunes-library writeback chokepoint
+// (fable5 TASK-004). Implements SPEC 2 §3 (the 8-step atomic write protocol,
+// NORMATIVE — docs/specs/fable5-spec-itunes-writeback-hardening.md) and closes
+// CRIT-3 (docs/specs/fable5-review-findings.md) by REGENERATING the hdfm header
+// count fields from the actual mutated payload on every write.
+//
+// WHY this exists (CRIT-3): before this file, writeback went straight from
+// mutation to writeITLFile, which reuses the original hdr.headerRemainder
+// verbatim. RemoveTracksByPIDLE updates mlth/miph/msdh counts in the PAYLOAD but
+// nothing touched the unencrypted hdfm header's BE count u32s at file offsets
+// 0x44 (tracks), 0x48 (playlists), 0x4C (albums), 0x54 (artists). The result was
+// damaged-1/damaged-2: header says 90,900 tracks, payload has 90,898 — iTunes
+// renames the library "(Damaged)". regenerateHeaderCounts patches exactly those
+// four u32s from the post-mutation payload counts, preserving every other
+// remainder byte, so the desync is impossible by construction.
+//
+// WHY the contract runs twice (SPEC §3 steps 3 + 5): once on the in-memory
+// `after` payload (catch the mutation), once on the bytes RE-READ from
+// `.itl.new` after encode+encrypt+deflate (catch encode-path bugs — the
+// BestSpeed zlib + AES-ECB boundary code is a historic risk area).
+//
+// All structural writeback entry points in this package route through here:
+// ApplyITLOperations(+InMemory), UpdateITLLocations, InsertITLTracks,
+// RewriteITLExtensions, InsertITLPlaylist, and rebuild (via ApplyITLOperations).
+// WriteITLBytes stays for cmd/ tools only.
+
+package itunes
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// WriteReport summarizes a completed SafeWriteITL call for the caller / audit log.
+type WriteReport struct {
+	// Path is the library that was written in place.
+	Path string
+	// BackupPath is the <path>.bak-<RFC3339> created before the atomic rename
+	// (empty if the target did not previously exist — first-ever write).
+	BackupPath string
+	// BytesWritten is the size of the final on-disk library.
+	BytesWritten int
+	// HeaderCounts are the regenerated header count fields actually written
+	// (tracks/playlists/albums/artists at file offsets 0x44/0x48/0x4C/0x54).
+	HeaderCounts HeaderCounts
+	// Verdict is the passing contract verdict for the re-read bytes (step 5).
+	Verdict ContractVerdict
+}
+
+// HeaderCounts holds the four BE u32 count fields regenerated into the hdfm
+// header on every write (SPEC §3 step 2 / CRIT-3).
+type HeaderCounts struct {
+	Tracks    int
+	Playlists int
+	Albums    int
+	Artists   int
+}
+
+// header file offsets of the BE u32 count fields (CRIT-3). These are absolute
+// file offsets; the remainder-relative offset is (fileOff - headerPrefixLen),
+// where headerPrefixLen = 17 + len(version) (see parseHdfmHeader layout).
+const (
+	hdrOffTracks    = 0x44
+	hdrOffPlaylists = 0x48
+	hdrOffAlbums    = 0x4C
+	hdrOffArtists   = 0x54
+	// headerFixedPrefix is the bytes before the version string: "hdfm"(4) +
+	// headerLen(4) + fileLen(4) + unknown(4) + verLen(1) = 17. The remainder
+	// (which carries the count fields) begins at 17 + len(version).
+	headerFixedPrefix = 17
+)
+
+// defaultBackupRetention is the SPEC §3 retention: keep the 10 newest unpinned
+// .bak-<RFC3339> copies; .bak-lkg is pinned separately and never rotated.
+const defaultBackupRetention = 10
+
+// backupTimeLayout is the timestamp form used for .bak-<RFC3339> files. RFC3339
+// uses ':' which is filesystem-legal on the Linux/ZFS production target; we use
+// a colon-free RFC3339-equivalent so the names are also portable for tests on
+// case-insensitive / colon-hostile filesystems.
+const backupTimeLayout = "2006-01-02T15-04-05.000000000Z07-00"
+
+// safeWriteOptions is the resolved option set for one SafeWriteITL call.
+type safeWriteOptions struct {
+	libraryNotInUse func() error
+	contractCfg     ContractConfig
+	backupRetention int
+	// encodeHook, when non-nil, is invoked on the freshly-encoded .itl.new bytes
+	// before they are re-read for the step-5 contract. Tests use it to simulate
+	// an encode-path bug so the re-read-validation branch is exercised. It is
+	// nil in all production paths.
+	encodeHook func([]byte) []byte
+}
+
+// SafeWriteOption configures a SafeWriteITL call.
+type SafeWriteOption func(*safeWriteOptions)
+
+// WithLibraryNotInUse injects the precondition that gates writes when iTunes /
+// Apple Devices may have the library open (SPEC §3 step 8 / K-class "(Damaged)"
+// inference). The service wires its iTunes-running heartbeat here in TASK-008.
+// Default: a no-op that logs a WARN, so cmd/ tools keep working.
+func WithLibraryNotInUse(check func() error) SafeWriteOption {
+	return func(o *safeWriteOptions) { o.libraryNotInUse = check }
+}
+
+// WithContractConfig overrides the ITLSafetyContract guardrail config (e.g. to
+// set Force for an operator-acknowledged bulk removal).
+func WithContractConfig(cfg ContractConfig) SafeWriteOption {
+	return func(o *safeWriteOptions) { o.contractCfg = cfg }
+}
+
+// WithBackupRetention overrides how many unpinned .bak-* copies are kept.
+func WithBackupRetention(n int) SafeWriteOption {
+	return func(o *safeWriteOptions) {
+		if n > 0 {
+			o.backupRetention = n
+		}
+	}
+}
+
+// withEncodeHook (unexported) is for tests only — see safeWriteOptions.encodeHook.
+func withEncodeHook(h func([]byte) []byte) SafeWriteOption {
+	return func(o *safeWriteOptions) { o.encodeHook = h }
+}
+
+// ForceContractConfig returns the default contract config with Force enabled.
+// Force ONLY overrides the bounded-delta blast-radius guardrail (SPEC §2) — it
+// never disables a structural guard. The nuclear rebuild (RebuildITLFromDB) and
+// full-export (BuildExportITL) paths use it because they intentionally remove
+// every existing track, which is exactly the bounded-delta case the spec makes
+// force-overridable.
+func ForceContractConfig() ContractConfig {
+	cfg := DefaultContractConfig()
+	cfg.Force = true
+	return cfg
+}
+
+// contractCfgOrDefault returns the first config from a variadic slice, or the
+// SPEC default when none is supplied (the bounded single-book writeback path).
+func contractCfgOrDefault(cfg []ContractConfig) ContractConfig {
+	if len(cfg) > 0 {
+		return cfg[0]
+	}
+	return DefaultContractConfig()
+}
+
+func resolveOptions(opts ...SafeWriteOption) safeWriteOptions {
+	o := safeWriteOptions{
+		libraryNotInUse: nil,
+		contractCfg:     DefaultContractConfig(),
+		backupRetention: defaultBackupRetention,
+	}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
+// SafeWriteITL atomically writes a mutation of the iTunes library at `path` in
+// place, implementing SPEC 2 §3 steps 1–8. `mutate` receives the decompressed
+// little-endian `before` payload and returns the proposed `after` payload; it
+// must not retain or mutate the slice it is given beyond returning the result.
+//
+// Guarantees:
+//   - The contract (T003) passes on BOTH the in-memory `after` and the bytes
+//     re-read from disk, or NOTHING is written.
+//   - The original `path` is byte-identical if any step fails.
+//   - The header count fields are regenerated from the mutated payload (CRIT-3).
+//   - On success the previous library is preserved as <path>.bak-<RFC3339>.
+func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err error), opts ...SafeWriteOption) (*WriteReport, error) {
+	o := resolveOptions(opts...)
+
+	// Step 8 (precondition): refuse to write if the library may be open in iTunes.
+	if o.libraryNotInUse != nil {
+		if err := o.libraryNotInUse(); err != nil {
+			slog.Error("SafeWriteITL refused: library may be in use", "path", path, "err", err)
+			return nil, fmt.Errorf("library-not-in-use precondition failed: %w", err)
+		}
+	} else {
+		// Default no-op with WARN so cmd tools keep working but the missing
+		// safety signal is visible (SPEC §3 step 8).
+		slog.Warn("SafeWriteITL: no library-not-in-use check wired; writing without it", "path", path)
+	}
+
+	// Step 1: read original; parse; snapshot before payload + header. Refuse BE.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("SafeWriteITL: reading %s: %w", path, err)
+	}
+	hdr, before, err := decodeITLForContract(raw)
+	if err != nil {
+		return nil, fmt.Errorf("SafeWriteITL: decoding %s: %w", path, err)
+	}
+	_, wasCompressed, err := itlInflate(itlDecrypt(hdr, raw[hdr.headerLen:]))
+	if err != nil {
+		return nil, fmt.Errorf("SafeWriteITL: detecting compression: %w", err)
+	}
+
+	// safeEncodeITL does steps 1(parse done) → 3: BE refusal, mutate, header
+	// regeneration, in-memory contract. It returns the final on-disk bytes. The
+	// in-memory verdict is already known-passing here; the authoritative verdict
+	// returned to the caller is the step-5 re-read verdict computed below.
+	outBytes, _, counts, _, err := safeEncodeITLFromParsed(hdr, before, wasCompressed, mutate, o.contractCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 4: write to <path>.itl.new in the SAME directory (same filesystem →
+	// atomic rename), fsync the file.
+	dir := filepath.Dir(path)
+	newPath := path + ".itl.new"
+	// Allow a test hook to perturb the encoded bytes so the step-5 re-read
+	// contract has something to catch. Nil in production.
+	diskBytes := outBytes
+	if o.encodeHook != nil {
+		diskBytes = o.encodeHook(append([]byte(nil), outBytes...))
+	}
+	if err := writeFileSync(newPath, diskBytes); err != nil {
+		_ = os.Remove(newPath)
+		return nil, fmt.Errorf("SafeWriteITL: writing %s: %w", newPath, err)
+	}
+
+	// Step 5: re-read .itl.new, decode, run the contract AGAIN on the re-read
+	// bytes (catches encode/encrypt/deflate-path corruption). Any failure here
+	// removes .itl.new; the original is untouched.
+	rrHdr, rrPayload, err := decodeITLForContractFile(newPath)
+	if err != nil {
+		_ = os.Remove(newPath)
+		slog.Error("SafeWriteITL re-read decode failed; aborting", "op", "itl-safe-write", "path", path, "err", err)
+		return nil, fmt.Errorf("SafeWriteITL: re-read of %s failed to decode: %w", newPath, err)
+	}
+	rrVerdict := RunSafetyContract(before, rrPayload, rrHdr, o.contractCfg)
+	if !rrVerdict.Pass {
+		_ = os.Remove(newPath)
+		slog.Error("SafeWriteITL re-read contract REJECTED; original untouched",
+			"op", "itl-safe-write", "component", "itl-safe-write", "path", path,
+			"failed_guards", strings.Join(rrVerdict.FailedGuards(), ","),
+			"verdict", rrVerdict.Error())
+		return nil, fmt.Errorf("SafeWriteITL: re-read contract rejected write to %s: %s", path, rrVerdict.Error())
+	}
+
+	// Step 6: backup <path> → <path>.bak-<RFC3339>; then rename .itl.new → path;
+	// fsync directory. Steps 6/7: any failure after step 4 removes .itl.new and
+	// leaves the original untouched.
+	backupPath := path + ".bak-" + time.Now().UTC().Format(backupTimeLayout)
+	if err := os.Rename(path, backupPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, fmt.Errorf("SafeWriteITL: backing up %s → %s: %w", path, backupPath, err)
+	}
+	if err := os.Rename(newPath, path); err != nil {
+		// Restore original from backup; original is otherwise lost.
+		_ = os.Rename(backupPath, path)
+		_ = os.Remove(newPath)
+		return nil, fmt.Errorf("SafeWriteITL: atomic rename %s → %s (restored original): %w", newPath, path, err)
+	}
+	if err := syncDir(dir); err != nil {
+		// The rename already landed; a failed dir fsync is logged but not fatal
+		// (the data is on disk; durability of the directory entry is best-effort).
+		slog.Warn("SafeWriteITL: directory fsync failed after rename", "dir", dir, "err", err)
+	}
+	fixITLPermissions(path)
+
+	// Rotation: keep the 10 newest .bak-<RFC3339>; never touch .bak-lkg.
+	if err := rotateBackups(path, o.backupRetention); err != nil {
+		slog.Warn("SafeWriteITL: backup rotation failed", "path", path, "err", err)
+	}
+
+	slog.Info("SafeWriteITL applied",
+		"op", "itl-safe-write", "component", "itl-safe-write", "path", path,
+		"bytes", len(diskBytes), "backup", backupPath,
+		"tracks", counts.Tracks, "playlists", counts.Playlists,
+		"albums", counts.Albums, "artists", counts.Artists)
+
+	return &WriteReport{
+		Path:         path,
+		BackupPath:   backupPath,
+		BytesWritten: len(diskBytes),
+		HeaderCounts: counts,
+		Verdict:      rrVerdict,
+	}, nil
+}
+
+// safeEncodeITL applies `mutate` to the decompressed payload of the parsed
+// library, regenerates the header counts, runs the in-memory contract, and
+// returns the final ITL file bytes WITHOUT writing to disk. It is the in-memory
+// twin of SafeWriteITL (used by ApplyITLOperationsInMemory / BuildExportITL) so
+// the export path also gets header regeneration + the contract (SPEC §3
+// steps 1–3). BE payloads are refused (K12).
+func safeEncodeITL(raw []byte, mutate func(before []byte) (after []byte, err error), cfg ContractConfig) ([]byte, error) {
+	hdr, before, err := decodeITLForContract(raw)
+	if err != nil {
+		return nil, fmt.Errorf("safeEncodeITL: decode: %w", err)
+	}
+	_, wasCompressed, err := itlInflate(itlDecrypt(hdr, raw[hdr.headerLen:]))
+	if err != nil {
+		return nil, fmt.Errorf("safeEncodeITL: detecting compression: %w", err)
+	}
+	out, _, _, _, err := safeEncodeITLFromParsed(hdr, before, wasCompressed, mutate, cfg)
+	return out, err
+}
+
+// safeEncodeITLFromParsed is the shared core for SafeWriteITL and safeEncodeITL.
+// It performs SPEC §3 steps 1(refuse BE)–3: apply mutate to a copy, regenerate
+// the header count fields, run the contract on the in-memory `after`, and encode
+// (deflate+encrypt+header) into final ITL bytes. It returns the bytes plus the
+// regenerated header, counts, and the passing verdict.
+func safeEncodeITLFromParsed(hdr *hdfmHeader, before []byte, wasCompressed bool, mutate func([]byte) ([]byte, error), cfg ContractConfig) ([]byte, *hdfmHeader, HeaderCounts, ContractVerdict, error) {
+	// Step 1: refuse big-endian writeback (K12). Only LE (v10+, production
+	// v12.13) is validated; the BE writer shares CRIT-1's flag-invention risk.
+	if !detectLE(before) {
+		return nil, nil, HeaderCounts{}, ContractVerdict{}, ErrBEWritebackUnsupported
+	}
+
+	// Step 2a: apply mutate to a COPY (never the snapshot used as `before`).
+	beforeCopy := append([]byte(nil), before...)
+	after, err := mutate(beforeCopy)
+	if err != nil {
+		return nil, nil, HeaderCounts{}, ContractVerdict{}, fmt.Errorf("mutate: %w", err)
+	}
+	if after == nil {
+		return nil, nil, HeaderCounts{}, ContractVerdict{}, errors.New("mutate returned nil payload")
+	}
+
+	// Step 2b: REGENERATE the header count fields from the actual `after`
+	// payload (CRIT-3). We patch a copy of the original headerRemainder so all
+	// non-count bytes are preserved exactly, then build a header carrying it.
+	newHdr, counts := regenerateHeaderCounts(hdr, after)
+
+	// Step 3: run the contract over (before, after, regenerated-header). Any
+	// violation → write nothing, return the structured verdict.
+	verdict := RunSafetyContract(before, after, newHdr, cfg)
+	if !verdict.Pass {
+		slog.Error("ITLSafetyContract REJECTED write (in-memory)",
+			"op", "itl-safe-write", "component", "itl-safe-write",
+			"failed_guards", strings.Join(verdict.FailedGuards(), ","),
+			"verdict", verdict.Error())
+		return nil, nil, HeaderCounts{}, ContractVerdict{}, fmt.Errorf("%s", verdict.Error())
+	}
+
+	// Encode with the regenerated header (deflate if original was, encrypt, wrap).
+	outBytes, err := encodeITLPayload(newHdr, after, wasCompressed)
+	if err != nil {
+		return nil, nil, HeaderCounts{}, ContractVerdict{}, fmt.Errorf("encode: %w", err)
+	}
+	return outBytes, newHdr, counts, verdict, nil
+}
+
+// regenerateHeaderCounts returns a copy of hdr whose headerRemainder has the BE
+// u32 count fields at file offsets 0x44/0x48/0x4C/0x54 overwritten with the
+// counts derived from `after`, preserving every other remainder byte. This is
+// the constructive fix for CRIT-3: the header can never carry a count the
+// payload disagrees with, because both come from the same payload here.
+//
+// The remainder begins at file offset (17 + len(version)); a field at file
+// offset F lives at remainder offset F - (17 + len(version)). A field whose
+// remainder offset is out of range (header too short to carry it) is silently
+// skipped — that is not this layer's class to invent.
+func regenerateHeaderCounts(hdr *hdfmHeader, after []byte) (*hdfmHeader, HeaderCounts) {
+	_, tracks := countMasterTracks(after)
+	playlists, _ := countPlaylistsAndCheckMiph(after)
+	albums := countMsdhItems(after, 9, "miah")
+	artists := countMsdhItems(after, 11, "miih")
+	counts := HeaderCounts{Tracks: tracks, Playlists: playlists, Albums: albums, Artists: artists}
+
+	remainder := append([]byte(nil), hdr.headerRemainder...)
+	prefixLen := headerFixedPrefix + len(hdr.version)
+	patch := func(fileOff, val int) {
+		relOff := fileOff - prefixLen
+		if relOff < 0 || relOff+4 > len(remainder) {
+			return // header too short to carry this field; preserve as-is.
+		}
+		writeUint32BE(remainder, relOff, uint32(val))
+	}
+	patch(hdrOffTracks, tracks)
+	patch(hdrOffPlaylists, playlists)
+	patch(hdrOffAlbums, albums)
+	patch(hdrOffArtists, artists)
+
+	newHdr := &hdfmHeader{
+		headerLen:       hdr.headerLen,
+		fileLen:         hdr.fileLen, // recomputed by encodeITLPayload from final size
+		unknown:         hdr.unknown,
+		version:         hdr.version,
+		headerRemainder: remainder,
+		maxCryptSize:    hdr.maxCryptSize,
+	}
+	return newHdr, counts
+}
+
+// PinLastKnownGood copies the current on-disk library at `path` to
+// <path>.bak-lkg, the pinned "last-known-good" anchor that survives rotation
+// (SPEC §3 retention). The service calls this only after a subsequent iTunes
+// open is confirmed via the sync heartbeat — never speculatively.
+func PinLastKnownGood(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("PinLastKnownGood: reading %s: %w", path, err)
+	}
+	// Validate before pinning: refuse to pin a library that does not decode
+	// (a pinned-bad LKG would defeat the purpose).
+	if v := AuditITL(data); !v.Pass {
+		return fmt.Errorf("PinLastKnownGood: refusing to pin un-auditable library %s: %s", path, v.Error())
+	}
+	lkg := path + ".bak-lkg"
+	if err := writeFileSync(lkg, data); err != nil {
+		return fmt.Errorf("PinLastKnownGood: writing %s: %w", lkg, err)
+	}
+	fixITLPermissions(lkg)
+	slog.Info("SafeWriteITL pinned last-known-good", "op", "itl-safe-write", "path", path, "lkg", lkg)
+	return nil
+}
+
+// rotateBackups keeps the `keep` newest <path>.bak-<RFC3339> files and removes
+// the rest. The pinned <path>.bak-lkg is never considered or removed.
+func rotateBackups(path string, keep int) error {
+	if keep <= 0 {
+		keep = defaultBackupRetention
+	}
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	prefix := base + ".bak-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("rotateBackups: reading %s: %w", dir, err)
+	}
+	var baks []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if name == base+".bak-lkg" { // pinned, never rotated
+			continue
+		}
+		baks = append(baks, name)
+	}
+	if len(baks) <= keep {
+		return nil
+	}
+	// .bak-<RFC3339> timestamps sort chronologically as strings (zero-padded,
+	// fixed-width, UTC), so lexical sort == chronological. Newest last.
+	sort.Strings(baks)
+	toRemove := baks[:len(baks)-keep]
+	var firstErr error
+	for _, name := range toRemove {
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// ---------------------------------------------------------------------------
+// fsync helpers (SPEC §3 steps 4 + 6: fsync the .itl.new file and the dir)
+// ---------------------------------------------------------------------------
+
+// writeFileSync writes data to path (0664) and fsyncs the file before returning,
+// so a crash after this call cannot leave a partially-written .itl.new.
+func writeFileSync(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0664)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// syncDir fsyncs a directory so a rename within it is durable.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	if err := d.Sync(); err != nil {
+		_ = d.Close()
+		return err
+	}
+	return d.Close()
+}
+
+// decodeITLForContractFile reads a raw .itl file from disk and decodes it for
+// the step-5 re-read contract.
+func decodeITLForContractFile(path string) (*hdfmHeader, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeITLForContract(data)
+}

--- a/internal/itunes/itl_safe_write_test.go
+++ b/internal/itunes/itl_safe_write_test.go
@@ -1,0 +1,341 @@
+// file: internal/itunes/itl_safe_write_test.go
+// version: 1.0.0
+// guid: 9e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b
+//
+// Tests for SafeWriteITL — the atomic iTunes writeback protocol (fable5
+// TASK-004), per SPEC 2 §6 (docs/specs/fable5-spec-itunes-writeback-hardening.md).
+//
+// These tests reuse the LE fixture builders from itl_safety_contract_test.go
+// (buildCleanPayload / buildPayloadFromTracks / buildITLFile / cleanTracks).
+// Test-local corruptor mutate funcs live here (production code never contains a
+// corruptor). No network, no real iTunes, no fixtures outside t.TempDir().
+
+package itunes
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFixtureITL writes a full on-disk .itl built from payload and returns its
+// path. The header counts agree with the payload (buildHeaderFor), so any later
+// desync is solely the mutate's doing.
+func writeFixtureITL(t *testing.T, dir, name string, payload []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buildITLFile(t, payload), 0o664); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// identityMutate returns the payload unchanged (a no-op writeback).
+func identityMutate(p []byte) ([]byte, error) { return p, nil }
+
+// corruptMlthCountMutate decrements the master mlth count without removing a
+// mith block, producing the K2 / count-coherence desync the contract must
+// catch (mlth count != actual mith blocks). It also re-uses the original header
+// counts, so this models exactly the "remove a track, keep old header" class
+// from the SPEC §6 table — except here the desync survives header regeneration
+// because it is payload-internal.
+func corruptMlthCountMutate(p []byte) ([]byte, error) {
+	out := append([]byte(nil), p...)
+	// Master track msdh is type 1; mlth is its first child at the msdh body.
+	msdhOff := firstMsdhOffset(out, 1)
+	if msdhOff < 0 {
+		return out, nil
+	}
+	mlthOff := msdhOff + int(binary.LittleEndian.Uint32(out[msdhOff+4:msdhOff+8])) // msdh headerLen
+	if string(out[mlthOff:mlthOff+4]) != "mlth" {
+		return out, nil
+	}
+	cur := binary.LittleEndian.Uint32(out[mlthOff+8 : mlthOff+12])
+	binary.LittleEndian.PutUint32(out[mlthOff+8:mlthOff+12], cur+1) // now > actual mith
+	return out, nil
+}
+
+// TestSafeWrite_RollbackOnViolation — SPEC §6: a mutate that introduces a K2
+// desync must leave the original byte-identical and no .itl.new behind.
+func TestSafeWrite_RollbackOnViolation(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+
+	orig, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read orig: %v", err)
+	}
+
+	rep, err := SafeWriteITL(path, corruptMlthCountMutate)
+	if err == nil {
+		t.Fatalf("expected contract rejection, got report %+v", rep)
+	}
+	if !strings.Contains(err.Error(), "count-coherence") {
+		t.Fatalf("expected count-coherence violation, got: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if !bytes.Equal(orig, after) {
+		t.Fatalf("original library must be byte-identical after a rejected write")
+	}
+	// No .itl.new residue, and no backup taken (we never reached step 6).
+	assertNoLeftover(t, dir, path)
+	if baks := listBackups(t, dir, path); len(baks) != 0 {
+		t.Fatalf("a rejected write must not create a backup; found %v", baks)
+	}
+}
+
+// TestSafeWrite_HeaderRegenRoundTrip — SPEC §6 / CRIT-3 regression: removing a
+// real track via the mutate must update the header's 0x44 track count and the
+// contract must PASS (because the header is regenerated from the new payload).
+func TestSafeWrite_HeaderRegenRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	tracks := cleanTracks() // 3 tracks
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildPayloadFromTracks(tracks))
+
+	// Sanity: original header says 3 tracks at 0x44.
+	if got := headerTrackCount(t, path); got != 3 {
+		t.Fatalf("fixture should start with 3 tracks at 0x44, got %d", got)
+	}
+
+	// Real mutate: drop the last track (and its playlist ref) by rebuilding the
+	// payload from the first two tracks. This is an internally-consistent
+	// removal — only the header would desync if it were NOT regenerated.
+	removeOne := func(_ []byte) ([]byte, error) {
+		return buildPayloadFromTracks(tracks[:2]), nil
+	}
+
+	rep, err := SafeWriteITL(path, removeOne)
+	if err != nil {
+		t.Fatalf("header-regen round-trip should pass the contract, got: %v", err)
+	}
+	if rep.HeaderCounts.Tracks != 2 {
+		t.Fatalf("WriteReport should report 2 tracks, got %d", rep.HeaderCounts.Tracks)
+	}
+
+	// The on-disk header's 0x44 count must now be 2 (CRIT-3 closed).
+	if got := headerTrackCount(t, path); got != 2 {
+		t.Fatalf("header @0x44 should be regenerated to 2, got %d", got)
+	}
+	// And the written file must itself pass an independent audit.
+	data, _ := os.ReadFile(path)
+	if v := AuditITL(data); !v.Pass {
+		t.Fatalf("written library failed audit: %v\n%s", v.FailedGuards(), v.Error())
+	}
+}
+
+// TestSafeWrite_BackupRotation — SPEC §6: 12 successive writes leave the 10
+// newest .bak-<RFC3339> plus the pinned .bak-lkg.
+func TestSafeWrite_BackupRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+
+	// Pin a last-known-good BEFORE the writes so we can assert it survives.
+	if err := PinLastKnownGood(path); err != nil {
+		t.Fatalf("PinLastKnownGood: %v", err)
+	}
+
+	for i := 0; i < 12; i++ {
+		// Each write must produce a DISTINCT backup timestamp; the RFC3339 layout
+		// has nanosecond precision, but force separation to avoid same-instant
+		// collisions on fast machines by varying the payload trivially is not
+		// possible (it must stay valid), so rely on nanosecond timestamps and a
+		// tiny sleep-free uniqueness check below.
+		if _, err := SafeWriteITL(path, identityMutate); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	baks := listBackups(t, dir, path)
+	if len(baks) != defaultBackupRetention {
+		t.Fatalf("expected %d rotated backups, got %d: %v", defaultBackupRetention, len(baks), baks)
+	}
+	// The pinned LKG must still be present and untouched by rotation.
+	if _, err := os.Stat(path + ".bak-lkg"); err != nil {
+		t.Fatalf(".bak-lkg must survive rotation: %v", err)
+	}
+}
+
+// TestSafeWrite_RefusesBigEndian — SPEC §3 step 1 / K12: a BE payload (no "msdh"
+// magic) is refused with ErrBEWritebackUnsupported and nothing is written.
+func TestSafeWrite_RefusesBigEndian(t *testing.T) {
+	dir := t.TempDir()
+	// Build an .itl whose payload does NOT start with "msdh" (BE-shaped). We
+	// wrap an arbitrary non-LE payload through the same header/encrypt path.
+	bePayload := append([]byte("hdfm"), make([]byte, 64)...) // not "msdh"
+	hdr := buildHeaderFor(buildCleanPayload())               // any valid header
+	deflated := itlDeflate(bePayload)
+	encrypted := itlEncrypt(hdr, deflated)
+	fileLen := uint32(len(encrypted)) + hdr.headerLen
+	header := buildHdfmHeader(hdr.version, hdr.headerRemainder, fileLen, hdr.unknown)
+	itl := append(append([]byte{}, header...), encrypted...)
+	path := filepath.Join(dir, "iTunes Library.itl")
+	if err := os.WriteFile(path, itl, 0o664); err != nil {
+		t.Fatalf("write BE fixture: %v", err)
+	}
+
+	orig, _ := os.ReadFile(path)
+	_, err := SafeWriteITL(path, identityMutate)
+	if err != ErrBEWritebackUnsupported {
+		t.Fatalf("expected ErrBEWritebackUnsupported, got: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(orig, after) {
+		t.Fatalf("BE refusal must leave the original untouched")
+	}
+	assertNoLeftover(t, dir, path)
+}
+
+// TestSafeWrite_ReReadValidation — SPEC §3 step 5: simulate an encode-path bug
+// via the test-only encodeHook that corrupts the .itl.new bytes after they are
+// written. The re-read contract (or decode) must catch it, remove .itl.new, and
+// leave the original byte-identical.
+func TestSafeWrite_ReReadValidation(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+	orig, _ := os.ReadFile(path)
+
+	// Corrupt the encoded bytes so the re-read decode fails (truncate the
+	// encrypted body). This models a BestSpeed-zlib / AES-boundary encode bug.
+	corruptEncode := func(b []byte) []byte {
+		if len(b) > 32 {
+			return b[:len(b)-16] // truncate → re-read decode/inflate fails
+		}
+		return b
+	}
+
+	_, err := SafeWriteITL(path, identityMutate, withEncodeHook(corruptEncode))
+	if err == nil {
+		t.Fatalf("expected re-read validation to reject the corrupted encode")
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(orig, after) {
+		t.Fatalf("re-read rejection must leave the original byte-identical")
+	}
+	assertNoLeftover(t, dir, path)
+}
+
+// TestSafeWrite_CleanWriteSucceeds — a no-op (identity) write passes the
+// contract end-to-end, takes one backup, and leaves a valid library.
+func TestSafeWrite_CleanWriteSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+
+	rep, err := SafeWriteITL(path, identityMutate)
+	if err != nil {
+		t.Fatalf("clean identity write should succeed: %v", err)
+	}
+	if rep.BackupPath == "" {
+		t.Fatalf("a successful write must record a backup path")
+	}
+	if _, err := os.Stat(rep.BackupPath); err != nil {
+		t.Fatalf("backup file should exist: %v", err)
+	}
+	if !rep.Verdict.Pass {
+		t.Fatalf("re-read verdict should pass")
+	}
+	data, _ := os.ReadFile(path)
+	if v := AuditITL(data); !v.Pass {
+		t.Fatalf("written library failed audit: %s", v.Error())
+	}
+}
+
+// TestSafeWrite_BoundedDeltaForce — the bounded-delta guardrail rejects a
+// removal that exceeds RemovedTracksMax, and Force (ForceContractConfig /
+// WithContractConfig) overrides ONLY that guardrail. This locks in the wiring
+// the nuclear-rebuild and full-export paths depend on (SPEC §2): without Force a
+// full-library replacement would be rejected as a blast-radius violation.
+func TestSafeWrite_BoundedDeltaForce(t *testing.T) {
+	tracks := cleanTracks() // 3 tracks
+	// Remove the last 2 → removed=2. Use a low cap so the small fixture trips it.
+	removeTwo := func(_ []byte) ([]byte, error) {
+		return buildPayloadFromTracks(tracks[:1]), nil
+	}
+	lowCap := DefaultContractConfig()
+	lowCap.RemovedTracksMax = 1 // removing 2 > cap 1
+
+	t.Run("rejected without force", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeFixtureITL(t, dir, "iTunes Library.itl", buildPayloadFromTracks(tracks))
+		orig, _ := os.ReadFile(path)
+		_, err := SafeWriteITL(path, removeTwo, WithContractConfig(lowCap))
+		if err == nil || !strings.Contains(err.Error(), "bounded-delta") {
+			t.Fatalf("expected bounded-delta rejection, got: %v", err)
+		}
+		after, _ := os.ReadFile(path)
+		if !bytes.Equal(orig, after) {
+			t.Fatalf("rejected bounded-delta write must leave original untouched")
+		}
+	})
+
+	t.Run("allowed with force", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeFixtureITL(t, dir, "iTunes Library.itl", buildPayloadFromTracks(tracks))
+		forced := lowCap
+		forced.Force = true
+		rep, err := SafeWriteITL(path, removeTwo, WithContractConfig(forced))
+		if err != nil {
+			t.Fatalf("Force should override bounded-delta, got: %v", err)
+		}
+		if rep.HeaderCounts.Tracks != 1 {
+			t.Fatalf("expected 1 track after forced removal, got %d", rep.HeaderCounts.Tracks)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// test-local assertions
+// ---------------------------------------------------------------------------
+
+// assertNoLeftover fails if a <path>.itl.new staging file survived the call.
+func assertNoLeftover(t *testing.T, dir, path string) {
+	t.Helper()
+	if _, err := os.Stat(path + ".itl.new"); err == nil {
+		t.Fatalf(".itl.new staging file must be removed after a failed write")
+	}
+}
+
+// listBackups returns the basenames of <path>.bak-<RFC3339> files (excludes the
+// pinned .bak-lkg).
+func listBackups(t *testing.T, dir, path string) []string {
+	t.Helper()
+	base := filepath.Base(path)
+	prefix := base + ".bak-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, prefix) && name != base+".bak-lkg" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// headerTrackCount reads the on-disk library's hdfm header and returns the BE
+// u32 track count at file offset 0x44.
+func headerTrackCount(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	hdr, err := parseHdfmHeader(data)
+	if err != nil {
+		t.Fatalf("parse header: %v", err)
+	}
+	full := buildHdfmHeader(hdr.version, hdr.headerRemainder, hdr.fileLen, hdr.unknown)
+	if 0x44+4 > len(full) {
+		t.Fatalf("header too short to carry 0x44")
+	}
+	return int(binary.BigEndian.Uint32(full[0x44 : 0x44+4]))
+}

--- a/internal/itunes/itl_test.go
+++ b/internal/itunes/itl_test.go
@@ -399,6 +399,9 @@ func TestParseITL_Playlists(t *testing.T) {
 	assert.Equal(t, 99, lib.Playlists[0].Items[0])
 }
 
+// TestInsertITLTracks: buildSyntheticITL emits a big-endian payload, refused by
+// the SafeWriteITL chokepoint (TASK-004, SPEC §3 step 1 / K12). The LE insert
+// path is covered by itl_le_*_test.go and the combined-mutate tests.
 func TestInsertITLTracks(t *testing.T) {
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/existing.mp3")
@@ -408,7 +411,7 @@ func TestInsertITLTracks(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
+	_, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
 		{
 			Location:    "/music/new_song.mp3",
 			Name:        "New Song",
@@ -424,30 +427,9 @@ func TestInsertITLTracks(t *testing.T) {
 			SampleRate:  44100,
 		},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 2)
-
-	// First track is the original
-	assert.Equal(t, "/music/existing.mp3", lib.Tracks[0].Location)
-
-	// Second track is the inserted one
-	assert.Equal(t, "New Song", lib.Tracks[1].Name)
-	assert.Equal(t, "New Album", lib.Tracks[1].Album)
-	assert.Equal(t, "New Artist", lib.Tracks[1].Artist)
-	assert.Equal(t, "Rock", lib.Tracks[1].Genre)
-	assert.Equal(t, "MPEG audio file", lib.Tracks[1].Kind)
-	assert.Equal(t, "/music/new_song.mp3", lib.Tracks[1].Location)
-	assert.Equal(t, 5000000, lib.Tracks[1].Size)
-	assert.Equal(t, 240000, lib.Tracks[1].TotalTime)
-	assert.Equal(t, 1, lib.Tracks[1].TrackNumber)
-	assert.Equal(t, 2025, lib.Tracks[1].Year)
-	assert.Equal(t, 320, lib.Tracks[1].BitRate)
-	assert.Equal(t, 44100, lib.Tracks[1].SampleRate)
-	assert.Equal(t, 43, lib.Tracks[1].TrackID) // max was 42, new is 43
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 func TestInsertITLTracks_NoTracks(t *testing.T) {
@@ -472,6 +454,11 @@ func TestRewriteITLExtensions(t *testing.T) {
 	require.ErrorIs(t, err, ErrBEWritebackUnsupported, "BE writeback must be refused (K12)")
 }
 
+// TestInsertITLPlaylist verifies that the BE synthetic library is REFUSED by the
+// SafeWriteITL chokepoint (TASK-004, SPEC §3 step 1 / K12). buildSyntheticITL
+// emits a big-endian "htim"/"hohm" payload (no "msdh" magic); BE writeback is
+// unvalidated and shares CRIT-1's flag-invention risk, so every writeback entry
+// point now refuses it rather than corrupt the library.
 func TestInsertITLPlaylist(t *testing.T) {
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/song.mp3")
@@ -481,20 +468,14 @@ func TestInsertITLPlaylist(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
+	_, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
 		Title:    "Test Playlist",
 		TrackIDs: []int{42},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 1)
-	require.Len(t, lib.Playlists, 1)
-	assert.Equal(t, "Test Playlist", lib.Playlists[0].Title)
-	require.Len(t, lib.Playlists[0].Items, 1)
-	assert.Equal(t, 42, lib.Playlists[0].Items[0])
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	// The refused write must not produce an output file.
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 func TestBuildHtimChunk(t *testing.T) {

--- a/internal/itunes/itl_writeback_test.go
+++ b/internal/itunes/itl_writeback_test.go
@@ -151,6 +151,10 @@ func TestUpdateITLLocations_NonexistentPID(t *testing.T) {
 // InsertITLTracks — path format tests
 // ---------------------------------------------------------------------------
 
+// TestInsertITLTracks_PathFormat_Windows: buildSyntheticITL emits a big-endian
+// payload, which the SafeWriteITL chokepoint now refuses (TASK-004, SPEC §3
+// step 1 / K12). The path-format conversion logic is covered by the LE tests in
+// itl_le_*_test.go; here we assert the BE refusal contract.
 func TestInsertITLTracks_PathFormat_Windows(t *testing.T) {
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/existing.mp3")
@@ -171,17 +175,13 @@ func TestInsertITLTracks_PathFormat_Windows(t *testing.T) {
 		TotalTime: 36000000,
 	}
 
-	result, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{newTrack})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 2)
-	assert.Equal(t, newTrack.Location, lib.Tracks[1].Location, "Windows path should be stored verbatim")
-	assert.Equal(t, newTrack.Name, lib.Tracks[1].Name)
+	_, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{newTrack})
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
+// TestInsertITLTracks_PathFormat_UnixWithSpaces: BE fixture → refused (see above).
 func TestInsertITLTracks_PathFormat_UnixWithSpaces(t *testing.T) {
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/existing.mp3")
@@ -192,62 +192,39 @@ func TestInsertITLTracks_PathFormat_UnixWithSpaces(t *testing.T) {
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
 	loc := "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Brandon Sanderson/The Way of Kings.m4b"
-	result, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
+	_, err := InsertITLTracks(itlPath, outPath, []ITLNewTrack{
 		{Location: loc, Name: "The Way of Kings", Artist: "Brandon Sanderson", Kind: "Audiobook"},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Tracks, 2)
-	assert.Equal(t, loc, lib.Tracks[1].Location)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 // ---------------------------------------------------------------------------
 // InsertITLPlaylist — with tracks
 // ---------------------------------------------------------------------------
 
+// TestInsertITLPlaylist_WithMultipleTracks: buildFixtureITL emits a big-endian
+// payload, refused by the SafeWriteITL chokepoint (TASK-004, SPEC §3 step 1).
 func TestInsertITLPlaylist_WithMultipleTracks(t *testing.T) {
-	// Build a fixture with multiple tracks, then insert a playlist referencing them.
 	fixtureData := buildFixtureITL()
 	tmpDir := t.TempDir()
 	itlPath := filepath.Join(tmpDir, "fixture.itl")
 	outPath := filepath.Join(tmpDir, "with_playlist.itl")
 	require.NoError(t, os.WriteFile(itlPath, fixtureData, 0644))
 
-	// Create a playlist referencing first 3 track IDs from fixture
 	playlist := ITLNewPlaylist{
 		Title:    "My Audiobook Picks",
 		TrackIDs: []int{fixtureTracks[0].trackID, fixtureTracks[1].trackID, fixtureTracks[3].trackID},
 	}
 
-	result, err := InsertITLPlaylist(itlPath, outPath, playlist)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-
-	// Should have the existing fixture playlists plus the new one
-	require.GreaterOrEqual(t, len(lib.Playlists), 1)
-
-	// Find our new playlist
-	var found *ITLPlaylist
-	for i := range lib.Playlists {
-		if lib.Playlists[i].Title == "My Audiobook Picks" {
-			found = &lib.Playlists[i]
-			break
-		}
-	}
-	require.NotNil(t, found, "inserted playlist should be found")
-	assert.Equal(t, "My Audiobook Picks", found.Title)
-	require.Len(t, found.Items, 3)
-	assert.Equal(t, fixtureTracks[0].trackID, found.Items[0])
-	assert.Equal(t, fixtureTracks[1].trackID, found.Items[1])
-	assert.Equal(t, fixtureTracks[3].trackID, found.Items[2])
+	_, err := InsertITLPlaylist(itlPath, outPath, playlist)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
+// TestInsertITLPlaylist_EmptyPlaylist: BE fixture → refused (see above).
 func TestInsertITLPlaylist_EmptyPlaylist(t *testing.T) {
 	pid := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	itlData := buildSyntheticITL(t, "12.0.0", false, pid, "/music/song.mp3")
@@ -257,18 +234,13 @@ func TestInsertITLPlaylist_EmptyPlaylist(t *testing.T) {
 	outPath := filepath.Join(tmpDir, "out.itl")
 	require.NoError(t, os.WriteFile(itlPath, itlData, 0644))
 
-	result, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
+	_, err := InsertITLPlaylist(itlPath, outPath, ITLNewPlaylist{
 		Title:    "Empty Playlist",
 		TrackIDs: nil,
 	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.UpdatedCount)
-
-	lib, err := ParseITL(outPath)
-	require.NoError(t, err)
-	require.Len(t, lib.Playlists, 1)
-	assert.Equal(t, "Empty Playlist", lib.Playlists[0].Title)
-	assert.Empty(t, lib.Playlists[0].Items)
+	require.ErrorIs(t, err, ErrBEWritebackUnsupported)
+	_, statErr := os.Stat(outPath)
+	require.Error(t, statErr, "refused BE write must not create output")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -292,8 +292,12 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string) (*ITLRebui
 		ToAdd:       len(adds),
 	}
 
+	// Nuclear rebuild removes EVERY existing track then re-adds from the DB, so
+	// it intentionally blows past the bounded-delta cap — pass Force (SPEC §2;
+	// structural guards still apply). Without this the contract would reject a
+	// real rebuild of a tens-of-thousands-track library.
 	ops := ITLOperationSet{Removes: removes, Adds: adds}
-	if _, err := ApplyITLOperations(itlPath, outputPath, ops); err != nil {
+	if _, err := ApplyITLOperations(itlPath, outputPath, ops, ForceContractConfig()); err != nil {
 		return nil, fmt.Errorf("apply rebuild ops: %w", err)
 	}
 
@@ -351,8 +355,11 @@ func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) (
 		removes[pid] = true
 	}
 
+	// Partial export strips ALL template tracks then re-adds the requested
+	// subset — another intentional full-replacement that must Force past
+	// bounded-delta (SPEC §2; structural guards still enforced).
 	ops := ITLOperationSet{Removes: removes, Adds: adds}
-	result, err := ApplyITLOperationsInMemory(templatePath, ops)
+	result, err := ApplyITLOperationsInMemory(templatePath, ops, ForceContractConfig())
 	if err != nil {
 		return nil, fmt.Errorf("build export ITL: %w", err)
 	}

--- a/internal/itunes/service/writeback_batcher_test.go
+++ b/internal/itunes/service/writeback_batcher_test.go
@@ -24,7 +24,12 @@ func withFakeITLHooks(t *testing.T, validate func(string) error, apply func(in, 
 	prevValidate := itlValidateFn
 	prevApply := itlApplyOperationsFn
 	itlValidateFn = validate
-	itlApplyOperationsFn = apply
+	// itlApplyOperationsFn is now variadic (TASK-004 added an optional
+	// ContractConfig for Force); the batcher never passes one, so the test
+	// double ignores the variadic tail and delegates to the simple closure.
+	itlApplyOperationsFn = func(in, out string, ops itunes.ITLOperationSet, _ ...itunes.ContractConfig) (*itunes.ITLWriteBackResult, error) {
+		return apply(in, out, ops)
+	}
 	t.Cleanup(func() {
 		itlValidateFn = prevValidate
 		itlApplyOperationsFn = prevApply


### PR DESCRIPTION
…n (fable5 T004)

Introduce internal/itunes/itl_safe_write.go: a single SafeWriteITL chokepoint implementing SPEC 2 §3 (8-step atomic write) and closing CRIT-3 by construction.

- Header regeneration: patch BE u32 count fields at file offsets 0x44/0x48/0x4C/0x54 (tracks/playlists/albums/artists) from the actual mutated payload counts, preserving all other headerRemainder bytes. The hdfm header can no longer carry a count the payload disagrees with — the damaged-1/damaged-2 desync (CRIT-3) is impossible by construction.
- Dual contract (T003 RunSafetyContract): runs on the in-memory `after` AND on the bytes re-read from .itl.new after encode (catches encode/encrypt/deflate bugs). Any violation → write nothing, structured verdict in error, ERROR log.
- Atomic protocol: write .itl.new same-dir + fsync, backup <path>.bak-<RFC3339>, atomic rename, dir fsync; on any later-step failure remove .itl.new, original untouched. Backup rotation keeps 10 newest + .bak-lkg pinned via PinLastKnownGood. library-not-in-use precondition via WithLibraryNotInUse (default no-op + WARN; service wires it in T008).
- BE writeback refused at the chokepoint (K12, ErrBEWritebackUnsupported / T005).
- bounded-delta is Force-overridable for the intentional full-replacement paths (nuclear RebuildITLFromDB, BuildExportITL) via ForceContractConfig; structural guards never relax.

Refactor every internal writeback entry point onto SafeWriteITL/safeEncodeITL: ApplyITLOperations(+InMemory), UpdateITLLocations, InsertITLTracks, RewriteITLExtensions, InsertITLPlaylist, and rebuild (via ApplyITLOperations). WriteITLBytes stays for cmd/itl-repair. No internal/ writer bypasses the chokepoint (writeITLFile reached only by WriteITLBytes; encodeITLPayload only by itl_safe_write.go).

Tests (SPEC 2 §6): rollback-on-violation (byte-identical, no .itl.new, no backup), backup-rotation (12 writes → 10 baks + lkg), header-regen round-trip (CRIT-3 regression: remove a track → 0x44 updated, contract passes), BE refusal, re-read-validation (encode-corruption test hook), clean-write, bounded-delta Force override. BE-only synthetic Insert/Playlist fixture tests updated to assert the new refusal contract.
