### PR TITLE
fix(ci): update reusable-burndown SHA to v1.11.1

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.6.0
+# version: 2.7.0
 name: Nightly burndown
 
 on:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@c3dac07c4af0a9efac2c89f7d15b9c02bcd5e49f # v1.11.0
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@0484decdc8ca852b2f66b9ab004cac5180c7b24d # v1.11.1
     with:
       # Scheduled runs always use full mode (auto-merge ready PRs).
       # Manual dispatch respects the input selection (default: draft-only for safety).


### PR DESCRIPTION
## Problem

`nightly-burndown.yml` was pinned to `c3dac07` (v1.11.0) of `falkcorp/github-common`. That version uses `secrets.JF_CI_GH_PAT` in 4 container credential blocks but never declares it in `on.workflow_call.secrets`. GitHub rejects the workflow at parse time, resulting in **'This run likely failed because of a workflow file issue.'**

## Fix

- Upstream fix: falkcorp/github-common PR #305 (merged, now at `0484decdc8ca852b2f66b9ab004cac5180c7b24d`)
- Updates the SHA pin to v1.11.1 which declares `JF_CI_GH_PAT: required: false`

`actionlint` passes cleanly.