### PR TITLE
fix(ci): update reusable-burndown SHA to v1.11.2 (ob-18f0014 image)

### DIFF
--- a/.github/workflows/nightly-burndown.yml
+++ b/.github/workflows/nightly-burndown.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/nightly-burndown.yml
-# version: 2.7.0
+# version: 2.8.0
 name: Nightly burndown
 
 on:
@@ -25,7 +25,7 @@ on:
 
 jobs:
   burndown:
-    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@0484decdc8ca852b2f66b9ab004cac5180c7b24d # v1.11.1
+    uses: falkcorp/github-common/.github/workflows/reusable-burndown.yml@7e9712f314766266a38b856fa187701db45ed245 # v1.11.2
     with:
       # Scheduled runs always use full mode (auto-merge ready PRs).
       # Manual dispatch respects the input selection (default: draft-only for safety).


### PR DESCRIPTION
## Problem

Every burndown `dispatch-one` fails immediately at iter 1:
```
400 Bad Request: "Unsupported context_management type: ''."
```

The runner image `ob-77dfdfa` passes `ContextManagement={type:'compaction'}` in `ResponseNewParams`, which OpenAI's Responses API rejects.

## Fix chain

1. **falkcorp/overnight-burndown#62** — removed `ContextManagement` from `ResponseNewParams`; switched to explicit `/responses/compact` endpoint after 80K tokens
2. **falkcorp/burndown-runner-image#23** — triggered rebuild baking the fix → image `ob-18f0014`
3. **falkcorp/github-common#306** — auto-updated `reusable-burndown.yml` to use `ob-18f0014` (auto-merged by retag job)
4. **This PR** — bumps the SHA pin so `nightly-burndown.yml` calls the fixed reusable workflow