### PR TITLE
docs: update CHANGELOG + TODO for June 10 CI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,29 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.13.0 -->
+<!-- version: 3.14.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-09 -->
+<!-- last-edited: 2026-06-10 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+#### June 10, 2026 — CI workflow fixes: memory-leak-scan YAML error + nightly-burndown SHA updates
+
+- **`memory-leak-scan.yml`** (PR #1405): Fixed YAML parse error at line 126 — git
+  commit message body lines (`${LEAK_COUNT}…`, `Run: ${RUN_URL}`) had zero
+  indentation inside the `run:` block scalar, causing the YAML parser to terminate
+  the block early.
+- **`nightly-burndown.yml`** (PR #1407): Updated SHA pin to
+  `0484decdc8ca852b2f66b9ab004cac5180c7b24d` (v1.11.1) — fixes callers failing with
+  "workflow file issue" because `secrets.JF_CI_GH_PAT` was used in the reusable
+  workflow but not declared in `on.workflow_call.secrets`.
+- **`nightly-burndown.yml`** (PR #1408): Updated SHA pin to
+  `7e9712f314766266a38b856fa187701db45ed245` (v1.11.2) — picks up runner image
+  `ob-18f0014` which removes the broken `ContextManagement` field from
+  `ResponseNewParams`. Every `dispatch-one` call was failing at iter 1 with
+  `400 "Unsupported context_management type: ''"` from OpenAI's Responses API.
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.72.0 -->
+<!-- version: 8.73.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-09 -->
+<!-- last-edited: 2026-06-10 -->
 
 # Project TODO
 
@@ -19,11 +19,11 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — June 9, 2026
+## 🎯 Current Status — June 10, 2026
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
 **Production:** PebbleDB primary; Linux, HTTPS at `172.16.2.30:8484`
-**Latest activity:** Burndown bot: `rebase-stale` job (auto-fix CONFLICTING PRs) + dual schedule (08:00/20:00 UTC) + `full` mode for scheduled runs (PRs #1342, #1353). 31 narrow test-coverage issues queued in burndown-tasks (#79–#109).
+**Latest activity:** CI fixes: `memory-leak-scan.yml` YAML parse error (PR #1405), `nightly-burndown.yml` SHA bumped to v1.11.2 using runner image `ob-18f0014` which removes the broken `ContextManagement` OpenAI param (PRs #1407, #1408).
 **In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds), fingerprint identification pipeline
 
 ---


### PR DESCRIPTION
Records PRs #1405, #1407, #1408 in CHANGELOG; updates current-status in TODO.