### PR TITLE
feat(itunes): diff-before-write in writeback batcher (T008)

### DIFF
--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/writeback_batcher.go
-// version: 5.1.0
+// version: 5.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,
@@ -18,6 +18,7 @@ package itunesservice
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -110,6 +111,13 @@ type WriteBackBatcher struct {
 	// (pre-wiring path in older test fixtures); runtime call sites
 	// nil-guard.
 	store WriteBackStore
+
+	// libraryNotInUse is an optional pre-flight check wired to the
+	// iTunes sync-service running-state signal. When non-nil, flush()
+	// calls it before writing; a non-nil error aborts the write and
+	// the batch is re-queued on the next timer tick rather than lost.
+	// Set via SetLibraryNotInUse. Safe to call after construction.
+	libraryNotInUse func() error
 }
 
 // NewWriteBackBatcher creates a batcher with the given debounce delay.
@@ -135,6 +143,16 @@ func (b *WriteBackBatcher) UpdateConfig(cfg WriteBackBatcherConfig) {
 	b.itlWriteBackEnabled = cfg.ITLWriteBackEnabled
 	b.libraryWritePath = cfg.LibraryWritePath
 	b.cfgMu.Unlock()
+}
+
+// SetLibraryNotInUse wires the iTunes-running signal into the batcher.
+// The check function is called immediately before each ITL write; if it
+// returns a non-nil error the write is skipped this cycle and the pending
+// state is preserved for the next timer tick. Safe to call after Start.
+func (b *WriteBackBatcher) SetLibraryNotInUse(check func() error) {
+	b.mu.Lock()
+	b.libraryNotInUse = check
+	b.mu.Unlock()
 }
 
 // autoWriteBackEnabled returns the current AutoWriteBack value under RLock.
@@ -291,9 +309,63 @@ func (b *WriteBackBatcher) flush() {
 		return
 	}
 
+	// Check whether iTunes is currently using the library file. When
+	// the check function is wired, a non-nil error means "in use":
+	// skip this cycle so we don't race a concurrent iTunes write.
+	// The pending state was already snapshotted and cleared above, so
+	// we re-enqueue the book IDs to preserve them for the next tick.
+	b.mu.Lock()
+	notInUse := b.libraryNotInUse
+	b.mu.Unlock()
+	if notInUse != nil {
+		if err := notInUse(); err != nil {
+			slog.Warn("iTunes write-back deferred: library in use", "reason", err)
+			// Re-enqueue so the work is not lost. resetTimer must be called
+			// while b.mu is held (same as Enqueue / EnqueueAdd / EnqueueRemove).
+			b.mu.Lock()
+			for _, id := range bookIDs {
+				b.pendingBooks[id] = true
+			}
+			b.pendingAdds = append(b.pendingAdds, adds...)
+			for pid := range removes {
+				b.pendingRemoves[pid] = true
+			}
+			if b.firstEnqueue.IsZero() && len(bookIDs)+len(adds)+len(removes) > 0 {
+				b.firstEnqueue = time.Now()
+			}
+			b.resetTimer()
+			b.mu.Unlock()
+			return
+		}
+	}
+
+	// Parse the current ITL library to enable diff-before-write.
+	// We build a PID → track index once per flush, then compare each
+	// desired update against the current values. This prevents writing
+	// ~90K mhoh blocks every sync when only a handful of tracks have
+	// actually changed (HIGH-3 / T008 fix).
+	//
+	// Parse failure is non-fatal: if we can't read the library (e.g.
+	// first-run or file temporarily locked), we skip the metadata diff
+	// and write everything. The safety contract in SafeWriteITL still
+	// validates the output before landing it.
+	var tracksByPID map[string]*itunes.ITLTrack
+	if lib, err := parseITLFn(writePath); err != nil {
+		slog.Warn("iTunes write-back could not parse library for diff; writing all metadata updates",
+			"err", err, "path", writePath)
+	} else {
+		tracksByPID = make(map[string]*itunes.ITLTrack, len(lib.Tracks))
+		for i := range lib.Tracks {
+			t := &lib.Tracks[i]
+			pid := strings.ToLower(hex.EncodeToString(t.PersistentID[:]))
+			tracksByPID[pid] = t
+		}
+	}
+
 	// Build location and metadata updates from book IDs
 	var locationUpdates []itunes.ITLLocationUpdate
 	var metadataUpdates []itunes.ITLMetadataUpdate
+	var skippedMetadata, changedMetadata int
 	for _, id := range bookIDs {
 		book, err := store.GetBookByID(id)
 		if err != nil || book == nil {
@@ -337,31 +409,88 @@ func (b *WriteBackBatcher) flush() {
 				if f.ITunesPersistentID == "" {
 					continue
 				}
+				// Diff-before-write (T008 / HIGH-3): only enqueue an
+				// ITLMetadataUpdate (and/or location update) when at
+				// least one field differs from the current library value.
+				// ITLTrack.Composer is not stored in the parsed struct
+				// (0x0C not read), so it is always included in the update
+				// when other fields change.
+				pidKey := strings.ToLower(f.ITunesPersistentID)
+				desiredLoc := ""
 				if f.ITunesPath != "" {
 					// SPEC §1b / TASK-006: normalize f.ITunesPath (which has
-					// historically held BOTH native paths and file:// URLs) into
-					// the canonical WinPath. The LE writer derives the 0x0B URL
-					// from it. Unmappable values (relative, staging-dir leak,
-					// podcast URL) are NOT written — per-item WARN + metric, never
-					// a raw value into 0x0D (the CRIT-2 corruption).
+					// historically held BOTH native paths and file:// URLs)
+					// into the canonical WinPath. Unmappable values are NOT
+					// written — per-item WARN + metric, never a raw value into
+					// 0x0D (the CRIT-2 corruption).
 					if winPath, ok := normalizeITunesLocation(f.ITunesPersistentID, f.ITunesPath); ok {
-						locationUpdates = append(locationUpdates, itunes.ITLLocationUpdate{
-							PersistentID: f.ITunesPersistentID,
-							NewLocation:  winPath,
-						})
+						desiredLoc = winPath
 					}
 				}
-				// Always push metadata so iTunes has current values
-				metadataUpdates = append(metadataUpdates, itunes.ITLMetadataUpdate{
-					PersistentID: f.ITunesPersistentID,
-					Name:         f.Title,
-					Album:        book.Title,
-					Artist:       authorName,
-					Composer:     narrator,
-					Genre:        genre,
-				})
+
+				if cur, ok := tracksByPID[pidKey]; ok {
+					// We have current library state: compare field by field.
+					// Location update is suppressed when the desired path
+					// matches the current 0x0D value (or is unmappable/empty).
+					locationChanged := desiredLoc != "" && cur.Location != desiredLoc
+					metadataChanged := cur.Name != f.Title ||
+						cur.Album != book.Title ||
+						cur.Artist != authorName ||
+						cur.Genre != genre
+
+					if !locationChanged && !metadataChanged {
+						skippedMetadata++
+						continue
+					}
+					if locationChanged {
+						locationUpdates = append(locationUpdates, itunes.ITLLocationUpdate{
+							PersistentID: f.ITunesPersistentID,
+							NewLocation:  desiredLoc,
+						})
+					}
+					if metadataChanged {
+						changedMetadata++
+						metadataUpdates = append(metadataUpdates, itunes.ITLMetadataUpdate{
+							PersistentID: f.ITunesPersistentID,
+							Name:         f.Title,
+							Album:        book.Title,
+							Artist:       authorName,
+							Composer:     narrator,
+							Genre:        genre,
+						})
+					}
+				} else {
+					// No current library state for this PID (track is new or
+					// library parse failed) — emit both unconditionally.
+					if desiredLoc != "" {
+						locationUpdates = append(locationUpdates, itunes.ITLLocationUpdate{
+							PersistentID: f.ITunesPersistentID,
+							NewLocation:  desiredLoc,
+						})
+					}
+					changedMetadata++
+					metadataUpdates = append(metadataUpdates, itunes.ITLMetadataUpdate{
+						PersistentID: f.ITunesPersistentID,
+						Name:         f.Title,
+						Album:        book.Title,
+						Artist:       authorName,
+						Composer:     narrator,
+						Genre:        genre,
+					})
+				}
 			}
 		} else if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
+			pidKey := strings.ToLower(*book.ITunesPersistentID)
+			if cur, ok := tracksByPID[pidKey]; ok {
+				if cur.Name == book.Title &&
+					cur.Album == book.Title &&
+					cur.Artist == authorName &&
+					cur.Genre == genre {
+					skippedMetadata++
+					continue
+				}
+			}
+			changedMetadata++
 			metadataUpdates = append(metadataUpdates, itunes.ITLMetadataUpdate{
 				PersistentID: *book.ITunesPersistentID,
 				Name:         book.Title,
@@ -384,7 +513,12 @@ func (b *WriteBackBatcher) flush() {
 		return
 	}
 
-	slog.Info("iTunes write-back flushing location updates, metadata updates, adds, removes", "locationUpdates_count", len(locationUpdates), "metadataUpdates_count", len(metadataUpdates), "adds_count", len(adds), "removes_count", len(removes))
+	slog.Info("iTunes write-back flushing",
+		"locationUpdates", len(locationUpdates),
+		"metadataUpdates_changed", changedMetadata,
+		"metadataUpdates_skipped", skippedMetadata,
+		"adds", len(adds),
+		"removes", len(removes))
 
 	if dryRun {
 		slog.Info("iTunes write-back DRY-RUN active — no file written",
@@ -416,13 +550,14 @@ func (b *WriteBackBatcher) flush() {
 
 // Test hooks. Production code wires these to the real itunes
 // package functions at package init. Tests override them so the
-// safe-write cycle can be unit-tested without needing a valid
-// ITL fixture on disk — the fixture itself is fragile, format
-// changes have broken it before, and mocking the two external
-// calls lets us test the logic in isolation.
+// safe-write cycle and diff-before-write logic can be unit-tested
+// without needing a valid ITL fixture on disk — the fixture itself
+// is fragile, format changes have broken it before, and mocking the
+// external calls lets us test the logic in isolation.
 var (
 	itlValidateFn        = itunes.ValidateITL
 	itlApplyOperationsFn = itunes.ApplyITLOperations
+	parseITLFn           = itunes.ParseITL
 )
 
 // SafeWriteITL performs a backup → write-temp → validate-temp →

--- a/internal/itunes/service/writeback_batcher_test.go
+++ b/internal/itunes/service/writeback_batcher_test.go
@@ -1,16 +1,19 @@
 // file: internal/itunes/service/writeback_batcher_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0123-def4-56789abcdef0
 
 package itunesservice
 
 import (
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 )
 
@@ -399,5 +402,204 @@ func TestFlush_DryRunSkipsWrite(t *testing.T) {
 	got, _ := os.ReadFile(itlPath)
 	if string(got) != "untouched" {
 		t.Errorf("dry-run modified the ITL file: got %q want %q", string(got), "untouched")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diff-before-write tests (T008 / HIGH-3)
+// ---------------------------------------------------------------------------
+
+// withFakeParseITLHook replaces the parseITLFn package-level hook with a
+// test double that returns the provided library and restores the original on
+// cleanup. Analogous to withFakeITLHooks.
+func withFakeParseITLHook(t *testing.T, lib *itunes.ITLLibrary, err error) {
+	t.Helper()
+	prev := parseITLFn
+	parseITLFn = func(_ string) (*itunes.ITLLibrary, error) { return lib, err }
+	t.Cleanup(func() { parseITLFn = prev })
+}
+
+// makePIDBytes builds an [8]byte PID from a 16-char hex string, stored in
+// the BE (MSB-first) order that parseMithLE writes into ITLTrack.PersistentID.
+func makePIDBytes(hexStr string) [8]byte {
+	var pid [8]byte
+	b, err := hex.DecodeString(hexStr)
+	if err != nil || len(b) != 8 {
+		panic("makePIDBytes: invalid hex " + hexStr)
+	}
+	copy(pid[:], b)
+	return pid
+}
+
+// TestFlush_NoChangeProducesZeroMetadataUpdates is the primary T008 regression
+// guard: when the ITL library already contains identical Name/Album/Artist/
+// Genre/Location values, flush must NOT emit any ITLMetadataUpdate entries and
+// SafeWriteITL must NOT be called. Without the diff-before-write fix this test
+// would have witnessed ~90K unnecessary mhoh writes every sync.
+func TestFlush_NoChangeProducesZeroMetadataUpdates(t *testing.T) {
+	const pid = "aabbccdd11223344"
+	const bookID = "book-no-change"
+
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "x")
+
+	// Build a fake ITL library whose single track already matches
+	// what the DB wants to write. The diff should see no change and
+	// produce zero updates.
+	fakeLib := &itunes.ITLLibrary{
+		Tracks: []itunes.ITLTrack{
+			{
+				PersistentID: makePIDBytes(pid),
+				Name:         "Chapter 1",
+				Album:        "Great Book",
+				Artist:       "Jane Author",
+				Genre:        "Audiobook",
+				Location:     `C:\Books\Great Book\Chapter 1.m4b`,
+				DateAdded:    time.Now(),
+			},
+		},
+	}
+	withFakeParseITLHook(t, fakeLib, nil)
+
+	applyCalls := 0
+	withFakeITLHooks(t,
+		func(string) error { return nil },
+		func(in, out string, _ itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			applyCalls++
+			data, _ := os.ReadFile(in)
+			_ = os.WriteFile(out, data, 0o644)
+			return &itunes.ITLWriteBackResult{UpdatedCount: 0, OutputPath: out}, nil
+		},
+	)
+
+	isPrimary := true
+	title := "Great Book"
+	authorID := 42
+	authorName := "Jane Author"
+	store := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{
+				ID:               bookID,
+				Title:            title,
+				AuthorID:         &authorID,
+				IsPrimaryVersion: &isPrimary,
+			}, nil
+		},
+		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
+			return &database.Author{Name: authorName}, nil
+		},
+		GetBookFilesFunc: func(_ string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{
+					ITunesPersistentID: pid,
+					Title:              "Chapter 1",
+					ITunesPath:         `C:\Books\Great Book\Chapter 1.m4b`,
+				},
+			}, nil
+		},
+	}
+
+	b := &WriteBackBatcher{
+		pendingBooks:        map[string]bool{bookID: true},
+		pendingRemoves:      map[string]bool{},
+		autoWriteBack:       true,
+		itlWriteBackEnabled: true,
+		libraryWritePath:    itlPath,
+		store:               store,
+	}
+	b.flush()
+
+	if applyCalls != 0 {
+		t.Errorf("no-change: expected 0 apply calls (no metadata changes), got %d", applyCalls)
+	}
+}
+
+// TestFlush_SingleFieldChangeProducesOneUpdate verifies that when exactly one
+// field (Album) differs between the DB and the parsed library, flush emits
+// exactly one ITLMetadataUpdate and SafeWriteITL is called once.
+func TestFlush_SingleFieldChangeProducesOneUpdate(t *testing.T) {
+	const pid = "aabbccdd11223344"
+	const bookID = "book-single-change"
+
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "x")
+
+	// Library has stale album name; DB wants "Great Book (New Edition)".
+	fakeLib := &itunes.ITLLibrary{
+		Tracks: []itunes.ITLTrack{
+			{
+				PersistentID: makePIDBytes(pid),
+				Name:         "Chapter 1",
+				Album:        "Great Book", // stale
+				Artist:       "Jane Author",
+				Genre:        "Audiobook",
+				Location:     `C:\Books\Great Book\Chapter 1.m4b`,
+				DateAdded:    time.Now(),
+			},
+		},
+	}
+	withFakeParseITLHook(t, fakeLib, nil)
+
+	var capturedOps itunes.ITLOperationSet
+	applyCalls := 0
+	withFakeITLHooks(t,
+		func(string) error { return nil },
+		func(in, out string, ops itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			applyCalls++
+			capturedOps = ops
+			data, _ := os.ReadFile(in)
+			_ = os.WriteFile(out, data, 0o644)
+			return &itunes.ITLWriteBackResult{UpdatedCount: 1, OutputPath: out}, nil
+		},
+	)
+
+	isPrimary := true
+	updatedTitle := "Great Book (New Edition)"
+	authorID := 42
+	authorName := "Jane Author"
+	store := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{
+				ID:               bookID,
+				Title:            updatedTitle, // DB has new title/album
+				AuthorID:         &authorID,
+				IsPrimaryVersion: &isPrimary,
+			}, nil
+		},
+		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
+			return &database.Author{Name: authorName}, nil
+		},
+		GetBookFilesFunc: func(_ string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{
+					ITunesPersistentID: pid,
+					Title:              "Chapter 1",
+					ITunesPath:         `C:\Books\Great Book\Chapter 1.m4b`,
+				},
+			}, nil
+		},
+	}
+
+	b := &WriteBackBatcher{
+		pendingBooks:        map[string]bool{bookID: true},
+		pendingRemoves:      map[string]bool{},
+		autoWriteBack:       true,
+		itlWriteBackEnabled: true,
+		libraryWritePath:    itlPath,
+		store:               store,
+	}
+	b.flush()
+
+	if applyCalls != 1 {
+		t.Errorf("single-change: expected 1 apply call, got %d", applyCalls)
+	}
+	if len(capturedOps.MetadataUpdates) != 1 {
+		t.Fatalf("single-change: expected 1 MetadataUpdate, got %d", len(capturedOps.MetadataUpdates))
+	}
+	if capturedOps.MetadataUpdates[0].Album != updatedTitle {
+		t.Errorf("single-change: expected Album=%q, got %q", updatedTitle, capturedOps.MetadataUpdates[0].Album)
+	}
+	if strings.ToLower(capturedOps.MetadataUpdates[0].PersistentID) != pid {
+		t.Errorf("single-change: expected PID=%q, got %q", pid, capturedOps.MetadataUpdates[0].PersistentID)
 	}
 }


### PR DESCRIPTION
## Summary

- **HIGH-3 fix**: Parse the ITL library once per flush and compare each track's `Name/Album/Artist/Genre/Location` against the desired DB values before emitting `ITLMetadataUpdate` or location updates. Unchanged tracks are skipped entirely.
- Eliminates the ~90K mhoh block write-storm that occurred on every sync regardless of whether any metadata had changed.
- Adds `SetLibraryNotInUse(check func() error)` method that wires the iTunes-running signal: when set, flush defers and re-enqueues if iTunes is using the library file.
- Adds `parseITLFn` package-level test hook for unit-testing the diff logic without a real ITL file.
- Bumps file headers: `writeback_batcher.go` → v5.2.0, `writeback_batcher_test.go` → v1.2.0

## Idempotency check

`grep "Always push metadata" internal/itunes/service/writeback_batcher.go` → absent ✓

## Test plan

- [x] `TestFlush_NoChangeProducesZeroMetadataUpdates` — in-sync library yields 0 `ApplyITLOperations` calls
- [x] `TestFlush_SingleFieldChangeProducesOneUpdate` — stale Album field yields exactly 1 `ITLMetadataUpdate` with correct PID and Album value
- [x] All existing `writeback_batcher_test.go` and `writeback_batcher_mock_test.go` tests continue to pass
- [x] `go test ./internal/itunes/... ./internal/itunes/service/...` → green

Note: `make mocks-check` and `staticcheck` failures are pre-existing in main (`.mockery.yaml` uses old module path, staticcheck finds unused functions across unrelated packages). All tests themselves pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)