### PR TITLE
feat(dedup): extend API with band filter, breakdown, rescore endpoints (T016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,46 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.14.0 -->
+<!-- version: 3.15.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-10 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+#### June 10, 2026 — T016: dedup API extensions (band filter, candidate breakdown, rescore) (PR #1414)
+
+- **`GET /api/v1/dedup/candidates`**: Added `band=` query parameter for store-level
+  filtering (CERTAIN/HIGH/MEDIUM/REVIEW). Returned `total` now reflects the filtered
+  count before pagination. Added `include_breakdown=true` query parameter to opt into
+  per-candidate `score` (normalized 0–100 float) and `score_breakdown` (per-signal
+  contributions) in list items. Added top-level `band` and `formula_version` fields to
+  every candidate item. Pre-T015 rows without a stored `ScoreBreakdown` emit the band
+  from the stored record and omit `score`/`score_breakdown`.
+
+- **`GET /api/v1/dedup/candidates/:id/breakdown`** (new endpoint): Returns the raw
+  candidate record plus both books' full detail (metadata + file list) for side-by-side
+  comparison in the dedup UI. Requires `PermLibraryView`. Returns 404 if the candidate
+  does not exist, 503 if the store is unavailable.
+
+- **`POST /api/v1/dedup/rescore`** (new endpoint): Dry-runs (`{}`) or applies
+  (`{"apply":true}`) a full re-score sweep over all pending candidates using
+  `unified.ComposeScore`. Returns `{ inspected, skipped, changed, applied,
+  band_deltas }`. Requires `PermScanTrigger`. Skips candidates with no stored signal
+  set (pre-T015 rows). When `apply=true`, calls `EmbeddingStore.UpdateCandidateScore`
+  to persist the new score, band, and formula version.
+
+- **`internal/database/embedding_store.go`**: Added `Band` field to `CandidateFilter`
+  for store-level band filtering (avoids post-filter pagination inaccuracies). Added
+  `UpdateCandidateScore` method for persisting re-scored results.
+
+- **`internal/dedup/engine.go`**: Added `RescoreResult` struct and `Rescore` method to
+  `*Engine`. The method lists all pending candidates, re-runs `ComposeScore` over
+  stored signal sets, and optionally writes the updated scores back to PebbleDB via
+  `UpdateCandidateScore`.
+
+This API contract is frozen as the T017 (Unified Dedup UI) build target.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.73.0 -->
+<!-- version: 8.74.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-10 -->
 
@@ -54,7 +54,7 @@ Review deliverables (see files for full detail):
 - [ ] **F5-T013** LSH probe collector; retire `ACOUSTID_FUZZY_ENABLED` O(N) path
 - [ ] **F5-T014** Collector refactor + `PairEligibility` + NEW metadata-fuzzy collector
 - [ ] **F5-T015** ⚠ Candidate schema additions + legacy-fingerprint purge (~14K stale 100% rows, HIGH-5)
-- [ ] **F5-T016** API: band/score/breakdown fields, `/breakdown`, `/rescore`
+- [x] **F5-T016** API: band/score/breakdown fields, `/breakdown`, `/rescore` ✅ PR #1414
 - [ ] **F5-T017** Unified Dedup UI tab (feature-flagged until backfill complete)
 - [ ] **F5-T018** Scan op rationalization (merge embed-scan/async; phase ordering)
 

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 2.2.0
+// version: 2.3.0
 // last-edited: 2026-06-10
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
@@ -166,8 +166,13 @@ type CandidateFilter struct {
 	Layer         string
 	MinSimilarity *float64
 	MaxSimilarity *float64
-	Limit         int
-	Offset        int
+	// Band filters by the unified scoring band (CERTAIN/HIGH/MEDIUM/REVIEW).
+	// Empty means no band filter. The filter is evaluated on the stored Band
+	// field (set by the T015/T016 unified pipeline); pre-T015 rows with an
+	// empty band will not match any non-empty Band filter.
+	Band   string
+	Limit  int
+	Offset int
 }
 
 // CandidateStat holds a count for one grouping.
@@ -632,6 +637,9 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 		if f.MaxSimilarity != nil && (c.Similarity == nil || *c.Similarity > *f.MaxSimilarity) {
 			continue
 		}
+		if f.Band != "" && c.Band != f.Band {
+			continue
+		}
 		all = append(all, c)
 	}
 	if err := iter.Error(); err != nil {
@@ -670,6 +678,18 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 func (s *EmbeddingStore) UpdateCandidateStatus(id int64, status string) error {
 	return s.updateCandidate(id, func(rec *candRec) {
 		rec.Status = status
+		rec.UpdatedAt = time.Now().UnixNano()
+	})
+}
+
+// UpdateCandidateScore persists a new ScoreBreakdown, Band, and
+// FormulaVersion onto an existing candidate. Called by Engine.Rescore
+// when apply=true to commit re-computed scores without re-collecting signals.
+func (s *EmbeddingStore) UpdateCandidateScore(id int64, score *unified.UnifiedDedupScore, band, formulaVersion string) error {
+	return s.updateCandidate(id, func(rec *candRec) {
+		rec.ScoreBreakdown = score
+		rec.Band = band
+		rec.FormulaVersion = formulaVersion
 		rec.UpdatedAt = time.Now().UnixNano()
 	})
 }

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.25.0
+// version: 1.26.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-10
 
@@ -1894,6 +1894,94 @@ func (de *Engine) CleanupCandidatesAfterMerge(mergedAwayBookIDs []string) int {
 		)
 	}
 	return total
+}
+
+// RescoreResult is returned by Engine.Rescore. It summarises how many
+// candidates changed band (per-band breakdown), how many were skipped
+// (no stored signals, i.e. pre-unified-pipeline rows), and whether the
+// changes were persisted (apply=true) or are dry-run only.
+type RescoreResult struct {
+	// Inspected is the total number of pending candidates examined.
+	Inspected int `json:"inspected"`
+	// Skipped is the count of candidates with no stored signal set
+	// (pre-T015 rows; re-scoring without signals is impossible).
+	Skipped int `json:"skipped"`
+	// Changed is the count of candidates whose band or score changed.
+	Changed int `json:"changed"`
+	// Applied is true when changes were written back to the store.
+	Applied bool `json:"applied"`
+	// BandDeltas maps old_band→new_band to occurrence count.
+	// Key format: "<old>→<new>" (e.g. "HIGH→CERTAIN").
+	BandDeltas map[string]int `json:"band_deltas,omitempty"`
+}
+
+// Rescore re-runs unified.ComposeScore over the stored signal set of every
+// pending candidate and returns a summary of band changes.
+//
+// "Stored signal sets only" means no re-collection or re-embedding: only
+// candidates that have a non-nil ScoreBreakdown (i.e., were scored by the
+// T015+ unified pipeline) are eligible. Pre-unified-pipeline rows are
+// counted as Skipped.
+//
+// By default (apply=false) this is a dry-run: scores are computed but NOT
+// written back to the store. Set apply=true to persist new scores and bands;
+// this is the equivalent of "re-calibrate in production". The T016 HTTP
+// handler exposes this via the {"apply": true} body pattern already used by
+// emb-reencode and purge-legacy-fp.
+func (de *Engine) Rescore(ctx context.Context, apply bool) (RescoreResult, error) {
+	if de.embedStore == nil {
+		return RescoreResult{}, nil
+	}
+
+	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
+		Status: "pending",
+		Limit:  100000,
+	})
+	if err != nil {
+		return RescoreResult{}, fmt.Errorf("rescore: list candidates: %w", err)
+	}
+
+	cfg := de.getScoreConfig()
+	result := RescoreResult{
+		Applied:    apply,
+		BandDeltas: make(map[string]int),
+	}
+
+	for _, cand := range candidates {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		result.Inspected++
+		if cand.ScoreBreakdown == nil || len(cand.ScoreBreakdown.Signals) == 0 {
+			result.Skipped++
+			continue
+		}
+		sb := cand.ScoreBreakdown
+		newScore := unified.ComposeScore(sb.Signals, sb.Suppressors, cfg, sb.Pair)
+		if newScore.Band == cand.Band && newScore.Score == sb.Score {
+			continue // no change
+		}
+		result.Changed++
+		deltaKey := cand.Band + "→" + newScore.Band
+		result.BandDeltas[deltaKey]++
+
+		if apply {
+			if err := de.embedStore.UpdateCandidateScore(cand.ID, &newScore, newScore.Band, newScore.Formula); err != nil {
+				slog.Warn("dedup rescore: update candidate score",
+					"candidate_id", cand.ID,
+					"err", err,
+				)
+			}
+		}
+	}
+
+	slog.Info("dedup rescore",
+		"inspected", result.Inspected,
+		"skipped", result.Skipped,
+		"changed", result.Changed,
+		"applied", result.Applied,
+	)
+	return result, nil
 }
 
 func (de *Engine) PurgeStaleCandidates(ctx context.Context) (int, error) {

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d1b9e024-d28c-4d62-8f90-96d7064559c4
 // last-edited: 2026-06-10
 
@@ -128,7 +128,26 @@ func (h *Handler) resolveEmbeddingStore() *database.EmbeddingStore {
 
 // ListDedupCandidates handles GET /api/v1/dedup/candidates.
 //
-// Query params: entity_type, status, layer, min_similarity (float), limit (int, default 50), offset (int).
+// Query params:
+//
+//	entity_type — filter by entity type (e.g. "book")
+//	status      — filter by status (e.g. "pending")
+//	layer       — filter by detection layer (e.g. "embedding")
+//	min_similarity (float) — lower-bound on raw similarity score
+//	band        — filter by unified scoring band: CERTAIN|HIGH|MEDIUM|REVIEW
+//	             (T016 extension; empty = no filter; pre-T015 rows without
+//	             a stored band will not match any non-empty band filter)
+//	include_breakdown=true — include score_breakdown (full signal array)
+//	                         in each row; default false (payload savings)
+//	limit (int, default 50), offset (int) — pagination
+//
+// Response shape (T016 contract, frozen for T017):
+//
+//	{ "candidates": [ candidateListItem, ... ], "total": N }
+//
+// Each candidateListItem extends DedupCandidate with a top-level "score"
+// field (the composite 0–100 value). "band" is already part of
+// DedupCandidate. "score_breakdown" is omitted unless include_breakdown=true.
 func (h *Handler) ListDedupCandidates(c *gin.Context) {
 	es := h.resolveEmbeddingStore()
 	if es == nil {
@@ -155,6 +174,13 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 		}
 		filter.MinSimilarity = &f
 	}
+	// T016: band filter — evaluated at the store scan level so pagination
+	// totals are accurate even on large datasets.
+	if v := c.Query("band"); v != "" {
+		filter.Band = v
+	}
+	includeBreakdown := c.Query("include_breakdown") == "true"
+
 	p := httputil.ParsePaginationParams(c)
 	limit, offset := p.Limit, p.Offset
 	filter.Limit = limit
@@ -173,7 +199,6 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 	// the UI never shows a candidate that would 404 when clicked.
 	// Non-book entities (e.g. author) skip the existence check.
 	store := h.resolveStore()
-	filtered := candidates[:0]
 	existCache := make(map[string]bool, len(candidates)*2)
 	bookExists := func(id string) bool {
 		if id == "" {
@@ -188,6 +213,7 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 		return exists
 	}
 	dropped := 0
+	items := make([]gin.H, 0, len(candidates))
 	for _, cand := range candidates {
 		if cand.EntityType == "book" {
 			if !bookExists(cand.EntityAID) || !bookExists(cand.EntityBID) {
@@ -195,12 +221,36 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 				continue
 			}
 		}
-		filtered = append(filtered, cand)
+		// Build the response item: always include band + top-level score;
+		// conditionally include score_breakdown.
+		row := gin.H{
+			"id":              cand.ID,
+			"entity_type":     cand.EntityType,
+			"entity_a_id":     cand.EntityAID,
+			"entity_b_id":     cand.EntityBID,
+			"layer":           cand.Layer,
+			"similarity":      cand.Similarity,
+			"llm_verdict":     cand.LLMVerdict,
+			"llm_reason":      cand.LLMReason,
+			"status":          cand.Status,
+			"created_at":      cand.CreatedAt,
+			"updated_at":      cand.UpdatedAt,
+			"band":            cand.Band,
+			"formula_version": cand.FormulaVersion,
+		}
+		// Surface top-level score (avoids T017 having to unpack score_breakdown).
+		if cand.ScoreBreakdown != nil {
+			row["score"] = cand.ScoreBreakdown.Score
+		}
+		if includeBreakdown {
+			row["score_breakdown"] = cand.ScoreBreakdown
+		}
+		items = append(items, row)
 	}
 	if dropped > 0 {
 		slog.Warn("dedup.list_candidates: filtered dead-book candidate rows",
 			"dropped", dropped,
-			"returned", len(filtered),
+			"returned", len(items),
 			"page_size", len(candidates),
 			"note", "B3 cleanup may be lagging")
 		// Reflect the filtered count in the total so pagination
@@ -211,9 +261,118 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 	}
 
 	httputil.RespondWithOK(c, gin.H{
-		"candidates": filtered,
+		"candidates": items,
 		"total":      total,
 	})
+}
+
+// GetDedupCandidateBreakdown handles GET /api/v1/dedup/candidates/:id/breakdown.
+//
+// Returns a single candidate's full comparison payload: the candidate row
+// (including the full score_breakdown with all signals), plus both books'
+// details (title, author, files) so the UI can render a side-by-side
+// comparison without issuing additional requests.
+//
+// T016 contract (frozen for T017):
+//
+//	{
+//	  "candidate": { ...DedupCandidate with score_breakdown... },
+//	  "book_a":    { id, title, author_id, series_id, files: [...] },
+//	  "book_b":    { id, title, author_id, series_id, files: [...] }
+//	}
+//
+// Returns 404 when the candidate ID is not found.
+// Returns 503 when the embedding store is unavailable.
+func (h *Handler) GetDedupCandidateBreakdown(c *gin.Context) {
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		httputil.RespondWithBadRequest(c, "invalid candidate id")
+		return
+	}
+
+	candidate, err := es.GetCandidateByID(id)
+	if err != nil {
+		httputil.InternalError(c, "failed to get candidate", err)
+		return
+	}
+	if candidate == nil {
+		httputil.RespondWithNotFound(c, "candidate", idStr)
+		return
+	}
+
+	// Fetch both books and their files for the side-by-side comparison view.
+	store := h.resolveStore()
+	type bookDetail struct {
+		*database.Book
+		Files []database.BookFile `json:"files"`
+	}
+	fetchBook := func(bookID string) *bookDetail {
+		book, err := store.GetBookByID(bookID)
+		if err != nil || book == nil {
+			return nil
+		}
+		files, _ := store.GetBookFiles(bookID)
+		return &bookDetail{Book: book, Files: files}
+	}
+
+	bookA := fetchBook(candidate.EntityAID)
+	bookB := fetchBook(candidate.EntityBID)
+
+	httputil.RespondWithOK(c, gin.H{
+		"candidate": candidate,
+		"book_a":    bookA,
+		"book_b":    bookB,
+	})
+}
+
+// RescoreDedupCandidates handles POST /api/v1/dedup/rescore.
+//
+// Re-runs unified.ComposeScore over the stored signal sets of all pending
+// candidates and returns a per-band delta summary. Signals are read from the
+// stored ScoreBreakdown — no re-collection or re-embedding is performed.
+// Pre-T015 candidates with no stored signals are counted as "skipped".
+//
+// Request body (JSON, optional):
+//
+//	{ "apply": true }   // persist new scores+bands (default: false = dry-run)
+//
+// Response:
+//
+//	{
+//	  "inspected":   N,   // total pending candidates examined
+//	  "skipped":     N,   // pre-T015 rows with no stored signals
+//	  "changed":     N,   // rows whose band or score changed
+//	  "applied":     bool,
+//	  "band_deltas": { "HIGH→CERTAIN": 3, ... }
+//	}
+//
+// Returns 503 when the dedup engine is unavailable.
+func (h *Handler) RescoreDedupCandidates(c *gin.Context) {
+	if h.dedupEngine == nil {
+		httputil.RespondWithServiceUnavailable(c, "dedup engine not available")
+		return
+	}
+
+	var body struct {
+		Apply bool `json:"apply"`
+	}
+	// Ignore parse errors; missing body → dry-run (apply=false).
+	_ = c.ShouldBindJSON(&body)
+
+	result, err := h.dedupEngine.Rescore(c.Request.Context(), body.Apply)
+	if err != nil {
+		httputil.InternalError(c, "rescore failed", err)
+		return
+	}
+
+	httputil.RespondWithOK(c, result)
 }
 
 // ExportDedupCandidates handles GET /api/v1/dedup/candidates/export.

--- a/internal/server/handlers/dedup/handler_test.go
+++ b/internal/server/handlers/dedup/handler_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6d8011eb-bed6-430b-959e-2a2b0738ffbc
 // last-edited: 2026-06-10
 
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	unifiedpkg "github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	deduphandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/dedup"
@@ -608,5 +610,236 @@ func TestPurgeLegacyFPCandidates_NoRegistry(t *testing.T) {
 	w := doReq(t, h.PurgeLegacyFPCandidates, http.MethodPost, "/api/v1/dedup/purge-legacy-fp", nil, nil)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status=%d want 500; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ──────────────── T016: band filter, breakdown, rescore ─────────────────────
+
+// insertCandidateWithBand creates a pending book candidate with the given band
+// set directly in the store via UpsertCandidate. Uses the same canonicalisation
+// logic as insertCandidate.
+func insertCandidateWithBand(t *testing.T, es *database.EmbeddingStore, aID, bID, band string) (int64, string, string) {
+	t.Helper()
+	sim := 0.95
+	score := 95.0
+	if err := es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  aID,
+		EntityBID:  bID,
+		Layer:      "embedding",
+		Similarity: &sim,
+		Status:     "pending",
+		Band:       band,
+		ScoreBreakdown: &unifiedpkg.UnifiedDedupScore{
+			Score:  score,
+			Band:   band,
+			Pair:   [2]string{aID, bID},
+			Formula: unifiedpkg.FormulaVersion,
+			Signals: []unifiedpkg.Signal{
+				{Kind: unifiedpkg.SigEmbedHigh, Raw: 0.95, Confidence: 0.90, Evidence: "test"},
+			},
+		},
+		FormulaVersion: unifiedpkg.FormulaVersion,
+	}); err != nil {
+		t.Fatalf("UpsertCandidate: %v", err)
+	}
+	cA, cB := aID, bID
+	if cA > cB {
+		cA, cB = cB, cA
+	}
+	cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	for _, c := range cands {
+		if c.EntityAID == cA && c.EntityBID == cB {
+			return c.ID, cA, cB
+		}
+	}
+	t.Fatalf("inserted candidate not found")
+	return 0, "", ""
+}
+
+// TestListDedupCandidates_BandFilter verifies that band=CERTAIN filters correctly:
+// a CERTAIN and a HIGH candidate are inserted; only the CERTAIN one is returned.
+func TestListDedupCandidates_BandFilter(t *testing.T) {
+	h, d := newHandler(t)
+	insertCandidateWithBand(t, d.es, "book-c1", "book-c2", "CERTAIN")
+	insertCandidateWithBand(t, d.es, "book-h1", "book-h2", "HIGH")
+
+	// Both books must "exist" to pass the dead-book filter.
+	d.store.EXPECT().GetBookByID(mock.Anything).Return(&database.Book{ID: "x"}, nil).Maybe()
+
+	w := doReq(t, h.ListDedupCandidates, http.MethodGet, "/api/v1/dedup/candidates?band=CERTAIN", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Total      int              `json:"total"`
+			Candidates []map[string]any `json:"candidates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.Total != 1 {
+		t.Errorf("total=%d want 1 (only CERTAIN band)", resp.Data.Total)
+	}
+	if len(resp.Data.Candidates) != 1 {
+		t.Errorf("candidates len=%d want 1", len(resp.Data.Candidates))
+		return
+	}
+	if band, _ := resp.Data.Candidates[0]["band"].(string); band != "CERTAIN" {
+		t.Errorf("returned candidate band=%q want CERTAIN", band)
+	}
+}
+
+// TestListDedupCandidates_BreakdownOmitted verifies that score_breakdown is NOT
+// included by default (include_breakdown not set).
+func TestListDedupCandidates_BreakdownOmitted(t *testing.T) {
+	h, d := newHandler(t)
+	insertCandidateWithBand(t, d.es, "book-x1", "book-x2", "HIGH")
+	d.store.EXPECT().GetBookByID(mock.Anything).Return(&database.Book{ID: "x"}, nil).Maybe()
+
+	w := doReq(t, h.ListDedupCandidates, http.MethodGet, "/api/v1/dedup/candidates", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Candidates []map[string]any `json:"candidates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	if len(resp.Data.Candidates) == 0 {
+		t.Fatal("want at least one candidate")
+	}
+	if _, hasBreakdown := resp.Data.Candidates[0]["score_breakdown"]; hasBreakdown {
+		t.Error("score_breakdown should be omitted without include_breakdown=true")
+	}
+}
+
+// TestListDedupCandidates_BreakdownIncluded verifies that score_breakdown is
+// present when include_breakdown=true.
+func TestListDedupCandidates_BreakdownIncluded(t *testing.T) {
+	h, d := newHandler(t)
+	insertCandidateWithBand(t, d.es, "book-y1", "book-y2", "HIGH")
+	d.store.EXPECT().GetBookByID(mock.Anything).Return(&database.Book{ID: "x"}, nil).Maybe()
+
+	w := doReq(t, h.ListDedupCandidates, http.MethodGet, "/api/v1/dedup/candidates?include_breakdown=true", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Candidates []map[string]any `json:"candidates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	if len(resp.Data.Candidates) == 0 {
+		t.Fatal("want at least one candidate")
+	}
+	if _, hasBreakdown := resp.Data.Candidates[0]["score_breakdown"]; !hasBreakdown {
+		t.Error("score_breakdown should be present with include_breakdown=true")
+	}
+}
+
+// TestGetDedupCandidateBreakdown_OK verifies the breakdown endpoint returns
+// candidate + both books.
+func TestGetDedupCandidateBreakdown_OK(t *testing.T) {
+	h, d := newHandler(t)
+	id, aID, bID := insertCandidateWithBand(t, d.es, "book-ba", "book-bb", "HIGH")
+	d.store.EXPECT().GetBookByID(aID).Return(&database.Book{ID: aID, Title: "Book A"}, nil).Once()
+	d.store.EXPECT().GetBookByID(bID).Return(&database.Book{ID: bID, Title: "Book B"}, nil).Once()
+	d.store.EXPECT().GetBookFiles(aID).Return([]database.BookFile{}, nil).Once()
+	d.store.EXPECT().GetBookFiles(bID).Return([]database.BookFile{}, nil).Once()
+
+	w := doReq(t, h.GetDedupCandidateBreakdown, http.MethodGet,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/breakdown",
+		nil, gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Candidate map[string]any `json:"candidate"`
+			BookA     map[string]any `json:"book_a"`
+			BookB     map[string]any `json:"book_b"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.Candidate == nil {
+		t.Error("candidate should be present in breakdown response")
+	}
+	if resp.Data.BookA == nil || resp.Data.BookB == nil {
+		t.Error("book_a and book_b should be present in breakdown response")
+	}
+}
+
+// TestGetDedupCandidateBreakdown_NotFound verifies 404 for unknown candidate IDs.
+func TestGetDedupCandidateBreakdown_NotFound(t *testing.T) {
+	h, _ := newHandler(t)
+	w := doReq(t, h.GetDedupCandidateBreakdown, http.MethodGet, "/api/v1/dedup/candidates/99999/breakdown",
+		nil, gin.Params{{Key: "id", Value: "99999"}})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestGetDedupCandidateBreakdown_NoEmbedStore verifies 503 when the embedding
+// store is unavailable.
+func TestGetDedupCandidateBreakdown_NoEmbedStore(t *testing.T) {
+	h, _ := newHandler(t, noEmbed)
+	w := doReq(t, h.GetDedupCandidateBreakdown, http.MethodGet, "/api/v1/dedup/candidates/1/breakdown",
+		nil, gin.Params{{Key: "id", Value: "1"}})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestRescoreDedupCandidates_DryRun verifies that a dry-run rescore returns 200
+// with the result summary and does not persist any changes.
+func TestRescoreDedupCandidates_DryRun(t *testing.T) {
+	h, d := newHandler(t)
+	expected := dedupengine.RescoreResult{Inspected: 5, Skipped: 1, Changed: 2, Applied: false,
+		BandDeltas: map[string]int{"HIGH→CERTAIN": 2}}
+	d.engine.EXPECT().Rescore(mock.Anything, false).Return(expected, nil).Once()
+
+	w := doReq(t, h.RescoreDedupCandidates, http.MethodPost, "/api/v1/dedup/rescore", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestRescoreDedupCandidates_Apply verifies that apply=true is forwarded to
+// the engine.
+func TestRescoreDedupCandidates_Apply(t *testing.T) {
+	h, d := newHandler(t)
+	expected := dedupengine.RescoreResult{Inspected: 10, Changed: 3, Applied: true,
+		BandDeltas: map[string]int{"MEDIUM→HIGH": 3}}
+	d.engine.EXPECT().Rescore(mock.Anything, true).Return(expected, nil).Once()
+
+	w := doReq(t, h.RescoreDedupCandidates, http.MethodPost, "/api/v1/dedup/rescore",
+		map[string]bool{"apply": true}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestRescoreDedupCandidates_NoEngine verifies 503 when the dedup engine is
+// unavailable.
+func TestRescoreDedupCandidates_NoEngine(t *testing.T) {
+	h, _ := newHandler(t, noEngine)
+	w := doReq(t, h.RescoreDedupCandidates, http.MethodPost, "/api/v1/dedup/rescore", nil, nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503; body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/server/handlers/dedup/interfaces.go
+++ b/internal/server/handlers/dedup/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e84f746d-28e9-4c8a-9520-66191e582881
-// last-edited: 2026-06-03
+// last-edited: 2026-06-10
 
 // Narrow dependency interfaces for the dedup-domain HTTP handlers (candidate /
 // cluster / series listing, merge / dismiss / remove, bulk merge, stats,
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
@@ -65,10 +66,18 @@ type MergeService interface {
 	MergeBooks(bookIDs []string, primaryID string) (*merge.Result, error)
 }
 
-// DedupEngine is the narrow *dedup.Engine subset used by mergeDedupCandidate's
-// post-merge orphan-candidate sweep. The concrete *dedup.Engine satisfies it.
+// DedupEngine is the narrow *dedup.Engine subset used by:
+//   - mergeDedupCandidate's post-merge orphan-candidate sweep (CleanupCandidatesAfterMerge)
+//   - the T016 rescore endpoint (Rescore)
+//
+// The concrete *dedup.Engine satisfies it.
 type DedupEngine interface {
 	CleanupCandidatesAfterMerge(mergedAwayBookIDs []string) int
+	// Rescore re-runs unified.ComposeScore over stored signal sets for every
+	// pending candidate. When apply=false this is a dry-run (no writes);
+	// apply=true persists new bands and scores. Returns a delta summary
+	// suitable for the HTTP response body.
+	Rescore(ctx context.Context, apply bool) (dedup.RescoreResult, error)
 }
 
 // OperationsRegistry is the narrow operations-registry subset the dedup scan

--- a/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
@@ -5,6 +5,9 @@
 package dedupmocks
 
 import (
+	"context"
+
+	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -82,6 +85,72 @@ func (_c *MockDedupEngine_CleanupCandidatesAfterMerge_Call) Return(n int) *MockD
 }
 
 func (_c *MockDedupEngine_CleanupCandidatesAfterMerge_Call) RunAndReturn(run func(mergedAwayBookIDs []string) int) *MockDedupEngine_CleanupCandidatesAfterMerge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Rescore provides a mock function for the type MockDedupEngine
+func (_mock *MockDedupEngine) Rescore(ctx context.Context, apply bool) (dedup.RescoreResult, error) {
+	ret := _mock.Called(ctx, apply)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Rescore")
+	}
+
+	var r0 dedup.RescoreResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (dedup.RescoreResult, error)); ok {
+		return returnFunc(ctx, apply)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) dedup.RescoreResult); ok {
+		r0 = returnFunc(ctx, apply)
+	} else {
+		r0 = ret.Get(0).(dedup.RescoreResult)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
+		r1 = returnFunc(ctx, apply)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDedupEngine_Rescore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Rescore'
+type MockDedupEngine_Rescore_Call struct {
+	*mock.Call
+}
+
+// Rescore is a helper method to define mock.On call
+//   - ctx context.Context
+//   - apply bool
+func (_e *MockDedupEngine_Expecter) Rescore(ctx interface{}, apply interface{}) *MockDedupEngine_Rescore_Call {
+	return &MockDedupEngine_Rescore_Call{Call: _e.mock.On("Rescore", ctx, apply)}
+}
+
+func (_c *MockDedupEngine_Rescore_Call) Run(run func(ctx context.Context, apply bool)) *MockDedupEngine_Rescore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDedupEngine_Rescore_Call) Return(rescoreResult dedup.RescoreResult, err error) *MockDedupEngine_Rescore_Call {
+	_c.Call.Return(rescoreResult, err)
+	return _c
+}
+
+func (_c *MockDedupEngine_Rescore_Call) RunAndReturn(run func(ctx context.Context, apply bool) (dedup.RescoreResult, error)) *MockDedupEngine_Rescore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_handlers.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
 // last-edited: 2026-06-10
 
@@ -837,6 +837,9 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	protected.GET("/dedup/candidates", s.perm(auth.PermLibraryView), dedupH.ListDedupCandidates)
 	protected.GET("/dedup/candidates/export", s.perm(auth.PermLibraryView), dedupH.ExportDedupCandidates)
 	protected.GET("/dedup/stats", s.perm(auth.PermLibraryView), dedupH.GetDedupStats)
+	// T016: breakdown and rescore endpoints (frozen API contract for T017).
+	protected.GET("/dedup/candidates/:id/breakdown", s.perm(auth.PermLibraryView), dedupH.GetDedupCandidateBreakdown)
+	protected.POST("/dedup/rescore", s.perm(auth.PermScanTrigger), dedupH.RescoreDedupCandidates)
 	protected.POST("/dedup/candidates/:id/merge", s.perm(auth.PermLibraryEditMetadata), dedupH.MergeDedupCandidate)
 	protected.POST("/dedup/candidates/:id/dismiss", s.perm(auth.PermLibraryEditMetadata), dedupH.DismissDedupCandidate)
 	protected.POST("/dedup/candidates/bulk-merge", s.perm(auth.PermLibraryEditMetadata), dedupH.BulkMergeDedupCandidates)


### PR DESCRIPTION
## Summary

- Extends `GET /dedup/candidates` with `band=` filter (store-level for correct pagination totals), `include_breakdown=true` param, and always-present top-level `score` field (so T017 can sort/display without unpacking the full signal breakdown)
- Adds `GET /dedup/candidates/:id/breakdown` — returns full candidate + both books' detail in one response (no extra round-trips for T017 UI)
- Adds `POST /dedup/rescore` — re-runs `unified.ComposeScore` over stored signal sets; dry-run by default, `{"apply":true}` persists new bands/scores
- All existing dedup API tests pass unchanged and green; 9 new tests cover band filter accuracy, breakdown omission/inclusion, 404s, and rescore dry-run/apply/503

**T017 API contract** (frozen by this PR):
- List response: `{ candidates: [{...DedupCandidate, score?: float, score_breakdown?: obj}], total: N }`
- Breakdown response: `{ candidate, book_a, book_b }` (band + full signals always in candidate)
- Rescore response: `{ inspected, skipped, changed, applied, band_deltas }`

## Test plan

- [ ] `make test` green on `internal/dedup/...`, `internal/database/...`, `internal/server/handlers/dedup/...`
- [ ] `GET /dedup/candidates?band=CERTAIN` returns only CERTAIN-band rows with correct total
- [ ] `GET /dedup/candidates` omits `score_breakdown`; `?include_breakdown=true` includes it
- [ ] `GET /dedup/candidates/:id/breakdown` returns 404 for unknown ID, 200 with both books for valid ID
- [ ] `POST /dedup/rescore` returns 200 with delta summary; `{"apply":true}` persists; 503 without engine

Note: `make mocks-check` and `internal/server` panic test are pre-existing failures on this branch (module path mismatch in `.mockery.yaml`, and a pebble/registry race in server integration tests); they are not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)