### PR TITLE
fix(ui): remove unused Stack import and truncatePath in T017 dedup components

### DIFF
--- a/web/src/components/dedup/BulkActionBar.tsx
+++ b/web/src/components/dedup/BulkActionBar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/BulkActionBar.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: b7a8c9d0-e1f2-3456-abcd-ba7890123456
 // last-edited: 2026-06-10
 
@@ -17,7 +17,6 @@ import {
   DialogContentText,
   DialogTitle,
   Paper,
-  Stack,
   Typography,
 } from '@mui/material';
 import MergeIcon from '@mui/icons-material/MergeType';

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
 // last-edited: 2026-06-10
 
@@ -66,13 +66,6 @@ function deriveBandCounts(stats: DedupStats[]): BandCounts {
   // the table results will reflect the filter accurately.
   const total = pending.reduce((sum, s) => sum + s.count, 0);
   return { CERTAIN: 0, HIGH: 0, MEDIUM: 0, REVIEW: 0, total };
-}
-
-function truncatePath(path: string | undefined | null): string {
-  if (!path) return '';
-  const marker = 'audiobook-organizer/';
-  const idx = path.indexOf(marker);
-  return idx >= 0 ? path.slice(idx + marker.length) : path;
 }
 
 // ---------- component ----------


### PR DESCRIPTION
## Summary

- `BulkActionBar.tsx`: Remove unused `Stack` import from MUI (TS6133)
- `UnifiedDedupTab.tsx`: Remove unused `truncatePath` helper function (TS6133)

These were introduced in T017 (PR #1416) and broke the prerelease build CI job.

## Test plan
- [ ] `npm run build` passes (no TS6133 errors)
- [ ] Frontend Vitest suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)