### PR TITLE
fix(server): replace stale jdfalk import paths with falkcorp in 3 handler files

### DIFF
--- a/internal/server/metadata_cached_handlers.go
+++ b/internal/server/metadata_cached_handlers.go
@@ -1,0 +1,280 @@
+// file: internal/server/metadata_cached_handlers.go
+// version: 1.2.1
+//
+// METADATA-CACHED-MATCHER: handlers for the persistent metadata-cache
+// query surface (Task 8). Adds GET /audiobooks/metadata/cached, the
+// list endpoint that powers the Review popup. Each entry is augmented
+// with the per-book review-status so the UI can split into
+// pending/matched without a second round-trip.
+//
+// Task 12 additions: cache/review (full CandidateResult list sourced
+// from cache), batch-apply-cached, and clear-no-match.
+
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/falkcorp/audiobook-organizer/internal/metabatch"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+)
+
+// listCachedCandidates handles GET /api/v1/audiobooks/metadata/cached.
+//
+// Query params:
+//   - status=pending  → only books whose MetadataReviewStatus is empty/null
+//   - status=matched  → only books with status == "matched"
+//   - (omitted)       → all cached entries
+//
+// Response is { entries: [...], total: N }. Each entry carries the
+// book_id, fetched_at, candidate_count, fresh flag, plus title +
+// review_status pulled from the book row so the UI can render without
+// a second fetch.
+func (s *Server) listCachedCandidates(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+
+	summaries, err := s.metadataFetchService.ListCachedSummaries(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "failed to list metadata cache", err)
+		return
+	}
+
+	statusFilter := c.Query("status")
+	freshCutoff := time.Now().Add(-database.MetadataCacheTTL)
+
+	out := make([]gin.H, 0, len(summaries))
+	for _, sum := range summaries {
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		var reviewStatus string
+		if book.MetadataReviewStatus != nil {
+			reviewStatus = *book.MetadataReviewStatus
+		}
+		switch statusFilter {
+		case "pending":
+			if reviewStatus != "" && reviewStatus != "pending" {
+				continue
+			}
+		case "matched":
+			if reviewStatus != "matched" {
+				continue
+			}
+		}
+		out = append(out, gin.H{
+			"book_id":         sum.BookID,
+			"fetched_at":      sum.FetchedAt,
+			"candidate_count": sum.CandidateCount,
+			"is_fresh":        sum.FetchedAt.After(freshCutoff),
+			"title":           book.Title,
+			"review_status":   reviewStatus,
+		})
+	}
+
+	httputil.RespondWithOK(c, gin.H{"entries": out, "total": len(out)})
+}
+
+// getCacheReviewResults handles GET /api/v1/audiobooks/metadata/cache/review.
+//
+// Returns a paginated list of CandidateResult items sourced entirely from the
+// persistent metadata cache. The shape matches getOperationResults so
+// MetadataReviewDialog can consume it without changing its render logic.
+//
+// Status semantics in the response:
+//   - "matched"  — candidate found, book is pending user review
+//   - "no_match" — user previously rejected (MetadataReviewStatus="no_match")
+//   - "applied"  — metadata was already applied (MetadataReviewStatus="matched")
+func (s *Server) getCacheReviewResults(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+	// Parse limit/offset directly rather than via ParsePaginationParams —
+	// the review dialog needs to request the full set in one call
+	// (limit=0 means "no cap"), which the shared parser clamps to ≤500.
+	limit := httputil.ParseQueryInt(c, "limit", 0)
+	offset := httputil.ParseQueryInt(c, "offset", 0)
+	if limit < 0 {
+		limit = 0
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	summaries, err := s.metadataFetchService.ListCachedSummaries(c.Request.Context())
+	if err != nil {
+		httputil.InternalError(c, "failed to list metadata cache", err)
+		return
+	}
+
+	total := len(summaries)
+
+	// Pre-resolve each summary's reviewStatus so we can sort matched-first
+	// before slicing. Without this the client sees pending matched rows
+	// scattered across pages in cache-insertion order.
+	type entryWithStatus struct {
+		sum    metafetch.MetadataCacheSummary
+		status string // "matched" | "no_match" | "applied"
+	}
+	prepared := make([]entryWithStatus, 0, total)
+	for _, sum := range summaries {
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		st := "matched"
+		if book.MetadataReviewStatus != nil {
+			switch *book.MetadataReviewStatus {
+			case "no_match":
+				st = "no_match"
+			case "matched":
+				st = "applied"
+			}
+		}
+		prepared = append(prepared, entryWithStatus{sum: sum, status: st})
+	}
+	// Stable sort: matched (pending review) first, then no_match, then applied.
+	statusRank := map[string]int{"matched": 0, "no_match": 1, "applied": 2}
+	sort.SliceStable(prepared, func(i, j int) bool {
+		return statusRank[prepared[i].status] < statusRank[prepared[j].status]
+	})
+
+	// limit=0 means "return all rows" — the client now paginates locally.
+	start := offset
+	if start > len(prepared) {
+		start = len(prepared)
+	}
+	end := len(prepared)
+	if limit > 0 {
+		end = start + limit
+		if end > len(prepared) {
+			end = len(prepared)
+		}
+	}
+	page := prepared[start:end]
+
+	// Global counts over the full prepared set so the UI can show accurate
+	// totals even when paginating a subset.
+	var matched, noMatch, applied int
+	for _, p := range prepared {
+		switch p.status {
+		case "no_match":
+			noMatch++
+		case "applied":
+			applied++
+		default:
+			matched++
+		}
+	}
+
+	results := make([]CandidateResult, 0, len(page))
+	for _, p := range page {
+		sum := p.sum
+		book, err := s.Store().GetBookByID(sum.BookID)
+		if err != nil || book == nil {
+			continue
+		}
+		entry, _, err := s.metadataFetchService.GetCachedCandidates(sum.BookID)
+		if err != nil || entry == nil || len(entry.Candidates) == 0 {
+			continue
+		}
+		var cand metafetch.MetadataCandidate
+		if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
+			slog.Warn("getCacheReviewResults decode candidate for", "sum", sum.BookID, "err", err)
+			continue
+		}
+
+		results = append(results, CandidateResult{
+			Book:      metabatch.BuildCandidateBookInfo(s.Store(), book),
+			Candidate: &cand,
+			Status:    p.status,
+		})
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"results":       results,
+		"total_count":   total,
+		"matched":       matched,
+		"no_match":      noMatch,
+		"errors":        0,
+		"total_applied": applied,
+	})
+}
+
+// batchApplyFromCache handles POST /api/v1/audiobooks/metadata/batch-apply-cached.
+//
+// Applies the highest-scored cached candidate for each book_id in the request.
+// Equivalent to the legacy batchApplyCandidates but reads from the persistent
+// cache rather than an operation's result rows.
+func (s *Server) batchApplyFromCache(c *gin.Context) {
+	if s.Store() == nil || s.metadataFetchService == nil {
+		httputil.RespondWithInternalError(c, "metadata service not initialized")
+		return
+	}
+	var body struct {
+		BookIDs []string `json:"book_ids" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		httputil.RespondWithBadRequest(c, "invalid request body")
+		return
+	}
+
+	applied := 0
+	for _, bookID := range body.BookIDs {
+		entry, _, err := s.metadataFetchService.GetCachedCandidates(bookID)
+		if err != nil || entry == nil || len(entry.Candidates) == 0 {
+			slog.Warn("batchApplyFromCache no cached candidates for", "bookID", bookID)
+			continue
+		}
+		var cand metafetch.MetadataCandidate
+		if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
+			slog.Warn("batchApplyFromCache decode candidate for", "bookID", bookID, "err", err)
+			continue
+		}
+		if _, err := s.metadataFetchService.ApplyMetadataCandidate(bookID, cand, nil); err != nil {
+			slog.Warn("batchApplyFromCache apply for", "bookID", bookID, "err", err)
+			continue
+		}
+		_ = s.metadataFetchService.InvalidateCachedCandidates(bookID)
+		if s.writeBackBatcher != nil {
+			s.writeBackBatcher.Enqueue(bookID)
+		}
+		applied++
+	}
+
+	httputil.RespondWithOK(c, gin.H{"applied": applied})
+}
+
+// clearMetadataNoMatch handles POST /api/v1/audiobooks/:id/clear-no-match.
+//
+// Clears a book's MetadataReviewStatus back to null so it re-surfaces in the
+// Review dialog. Inverse of mark-no-match. Does not create a rejection record.
+func (s *Server) clearMetadataNoMatch(c *gin.Context) {
+	id := c.Param("id")
+	store := s.Store()
+	if store == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	book, err := store.GetBookByID(id)
+	if err != nil || book == nil {
+		httputil.RespondWithNotFound(c, "audiobook", id)
+		return
+	}
+	book.MetadataReviewStatus = nil
+	if _, err := store.UpdateBook(id, book); err != nil {
+		httputil.InternalError(c, "failed to clear review status", err)
+		return
+	}
+	httputil.RespondWithOK(c, gin.H{"message": "Review status cleared"})
+}

--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -1,0 +1,395 @@
+// file: internal/server/operations_v2_handlers.go
+// version: 1.2.1
+// guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-05-08
+
+// UOS-06: SSE event hub, /operations/timeline, single-op introspection,
+// cancel, trigger-op, and /op-defs endpoints.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// operationV2Response is the JSON shape returned by the timeline and single-op
+// endpoints. It mirrors the TypeScript OperationV2 interface in api.ts.
+type operationV2Response struct {
+	ID              string     `json:"id"`
+	DefID           string     `json:"def_id"`
+	Plugin          string     `json:"plugin"`
+	DisplayName     string     `json:"display_name"`
+	Status          string     `json:"status"`
+	Priority        int        `json:"priority"`
+	NotifyLevel     int        `json:"notify_level"`
+	ProgressCurrent *int       `json:"progress_current"`
+	ProgressTotal   *int       `json:"progress_total"`
+	ProgressMessage *string    `json:"progress_message"`
+	CurrentPhase    *string    `json:"current_phase"`
+	CurrentItem     *string    `json:"current_item"`
+	ActorUserID     *string    `json:"actor_user_id"`
+	ParentID        *string    `json:"parent_id"`
+	QueuedAt        time.Time  `json:"queued_at"`
+	StartedAt       *time.Time `json:"started_at"`
+	CompletedAt     *time.Time `json:"completed_at"`
+	ErrorMessage    *string    `json:"error_message"`
+	ResumeCount     int        `json:"resume_count"`
+	TraceID         string     `json:"trace_id"`
+	SpanID          string     `json:"span_id"`
+}
+
+// opLogV2Response is the JSON shape for a single log line.
+type opLogV2Response struct {
+	OperationID string    `json:"operation_id"`
+	Level       string    `json:"level"`
+	Message     string    `json:"message"`
+	Attrs       any       `json:"attrs"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// opDefResponse is the JSON shape returned by /op-defs.
+type opDefResponse struct {
+	ID           string   `json:"id"`
+	Plugin       string   `json:"plugin"`
+	DisplayName  string   `json:"display_name"`
+	Description  string   `json:"description"`
+	Cancellable  bool     `json:"cancellable"`
+	Isolate      bool     `json:"isolate"`
+	ResumePolicy string   `json:"resume_policy"`
+	Triggers     []string `json:"triggers"`
+	DependsOn    []string `json:"depends_on"`
+}
+
+// handleGetOperationTimeline implements GET /api/v1/operations/timeline?since=15m.
+// It reads operations from the v2 store that were queued within the given window.
+func (s *Server) handleGetOperationTimeline(c *gin.Context) {
+	sinceStr := c.DefaultQuery("since", "15m")
+	dur, err := parseSinceDuration(sinceStr)
+	if err != nil {
+		httputil.RespondWithBadRequest(c, "invalid since parameter: "+sinceStr)
+		return
+	}
+
+	store := s.opsV2Store()
+	if store == nil {
+		httputil.RespondWithOK(c, gin.H{"operations": []operationV2Response{}})
+		return
+	}
+
+	since := time.Now().UTC().Add(-dur)
+	rows, err := store.ListOperationsV2Since(since, 200)
+	if err != nil {
+		httputil.InternalError(c, "failed to list operations", err)
+		return
+	}
+
+	resp := make([]operationV2Response, 0, len(rows))
+	for _, r := range rows {
+		item := rowToResponse(r, s.displayNameFor(r.DefID), s.notifyLevelFor(r.DefID))
+		if r.Status == "running" && s.opRegistry != nil {
+			if ci := s.opRegistry.GetCurrentItem(r.ID); ci != "" {
+				item.CurrentItem = &ci
+			}
+		}
+		resp = append(resp, item)
+	}
+	httputil.RespondWithOK(c, gin.H{"operations": resp})
+}
+
+// handleGetOperationV2 implements GET /api/v1/operations/v2/:id.
+// Returns the operation plus its last 50 log lines.
+func (s *Server) handleGetOperationV2(c *gin.Context) {
+	id := c.Param("id")
+	store := s.opsV2Store()
+	if store == nil {
+		httputil.RespondWithNotFound(c, "operation", id)
+		return
+	}
+
+	row, err := store.GetOperationV2(id)
+	if err != nil || row == nil {
+		httputil.RespondWithNotFound(c, "operation", id)
+		return
+	}
+
+	logs, err := store.GetOpLogsV2(id, 50)
+	if err != nil {
+		// Non-fatal: return the op without logs.
+		logs = nil
+	}
+
+	logResp := make([]opLogV2Response, 0, len(logs))
+	for _, l := range logs {
+		logResp = append(logResp, logRowToResponse(l))
+	}
+
+	opResp := rowToResponse(*row, s.displayNameFor(row.DefID), s.notifyLevelFor(row.DefID))
+	if row.Status == "running" && s.opRegistry != nil {
+		if ci := s.opRegistry.GetCurrentItem(id); ci != "" {
+			opResp.CurrentItem = &ci
+		}
+	}
+	httputil.RespondWithOK(c, gin.H{
+		"operation": opResp,
+		"logs":      logResp,
+	})
+}
+
+// handleCancelOperationV2 implements DELETE /api/v1/operations/v2/:id.
+// Cancels the operation via the registry (if running) or marks it canceled (if queued).
+func (s *Server) handleCancelOperationV2(c *gin.Context) {
+	id := c.Param("id")
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
+		return
+	}
+	if err := s.opRegistry.Cancel(id); err != nil {
+		httputil.InternalError(c, "cancel failed", err)
+		return
+	}
+	httputil.RespondWithNoContent(c)
+}
+
+// handleTriggerOperationV2 implements POST /api/v1/operations/v2.
+// Body: { "def_id": "...", "params": {...} }
+func (s *Server) handleTriggerOperationV2(c *gin.Context) {
+	if s.opRegistry == nil {
+		httputil.RespondWithInternalError(c, "operations registry not initialized")
+		return
+	}
+
+	var body struct {
+		DefID  string `json:"def_id"`
+		Params any    `json:"params"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil || body.DefID == "" {
+		httputil.RespondWithBadRequest(c, "body must include def_id")
+		return
+	}
+
+	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), body.DefID, body.Params)
+	if err != nil {
+		httputil.InternalError(c, "enqueue failed", err)
+		return
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{"op_id": opID})
+}
+
+// handleListOpDefs implements GET /api/v1/op-defs.
+// Returns the set of registered OperationDefs.
+func (s *Server) handleListOpDefs(c *gin.Context) {
+	if s.opRegistry == nil {
+		httputil.RespondWithOK(c, gin.H{"defs": []opDefResponse{}})
+		return
+	}
+	defs := s.opRegistry.ActiveDefs()
+	resp := make([]opDefResponse, 0, len(defs))
+	for _, d := range defs {
+		resp = append(resp, defToResponse(d))
+	}
+	httputil.RespondWithOK(c, gin.H{"defs": resp})
+}
+
+// handleGetOpDef implements GET /api/v1/op-defs/:id.
+func (s *Server) handleGetOpDef(c *gin.Context) {
+	id := c.Param("id")
+	if s.opRegistry == nil {
+		httputil.RespondWithNotFound(c, "op-def", id)
+		return
+	}
+	for _, d := range s.opRegistry.ActiveDefs() {
+		if d.ID == id {
+			httputil.RespondWithOK(c, gin.H{"def": defToResponse(d)})
+			return
+		}
+	}
+	httputil.RespondWithNotFound(c, "op-def", id)
+}
+
+// handleOperationsSSE implements GET /api/v1/operations/events.
+// Streams SSE events from the opHub to the client until the client disconnects.
+func (s *Server) handleOperationsSSE(c *gin.Context) {
+	if s.opHub == nil {
+		// Hub not initialised; return 503 rather than hanging.
+		httputil.RespondWithServiceUnavailable(c, "operations event hub not initialized")
+		return
+	}
+
+	ch, unsubscribe := s.opHub.Subscribe()
+	defer unsubscribe()
+
+	// Required SSE headers.
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no") // disable nginx buffering
+
+	// Send a heartbeat immediately so the client knows the connection is live.
+	fmt.Fprintf(c.Writer, ": heartbeat\n\n")
+	c.Writer.Flush()
+
+	notify := c.Request.Context().Done()
+	for {
+		select {
+		case <-notify:
+			// Client disconnected.
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				// Hub closed the channel (server shutdown).
+				return
+			}
+			b, err := json.Marshal(ev.Payload)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(c.Writer, "event: %s\ndata: %s\n\n", ev.Name, b)
+			c.Writer.Flush()
+		}
+	}
+}
+
+// --- helpers ---
+
+// opsV2Store returns the OpsV2Store from the server's composite Store, or nil
+// if the store does not implement it.
+func (s *Server) opsV2Store() database.OpsV2Store {
+	if s.Store() == nil {
+		return nil
+	}
+	st, ok := s.Store().(database.OpsV2Store)
+	if !ok {
+		return nil
+	}
+	return st
+}
+
+// displayNameFor looks up the human-readable display name for a def ID.
+// Falls back to the ID itself if the def is not registered.
+func (s *Server) displayNameFor(defID string) string {
+	if s.opRegistry == nil {
+		return defID
+	}
+	for _, d := range s.opRegistry.ActiveDefs() {
+		if d.ID == defID {
+			return d.DisplayName
+		}
+	}
+	return defID
+}
+
+// notifyLevelFor looks up the NotifyLevel for a registered def ID.
+// Returns 0 (NotifyAlert) if the def is not found, preserving old behaviour.
+func (s *Server) notifyLevelFor(defID string) int {
+	if s.opRegistry == nil {
+		return 0
+	}
+	for _, d := range s.opRegistry.ActiveDefs() {
+		if d.ID == defID {
+			return int(d.NotifyLevel)
+		}
+	}
+	return 0
+}
+
+// rowToResponse converts a database.OperationV2Row to the HTTP response shape.
+func rowToResponse(r database.OperationV2Row, displayName string, notifyLevel int) operationV2Response {
+	resp := operationV2Response{
+		ID:           r.ID,
+		DefID:        r.DefID,
+		Plugin:       r.Plugin,
+		DisplayName:  displayName,
+		Status:       r.Status,
+		Priority:     r.Priority,
+		NotifyLevel:  notifyLevel,
+		ActorUserID:  r.ActorUserID,
+		ParentID:     r.ParentID,
+		QueuedAt:     r.QueuedAt,
+		StartedAt:    r.StartedAt,
+		CompletedAt:  r.CompletedAt,
+		ErrorMessage: r.ErrorMessage,
+		ResumeCount:  r.ResumeCount,
+		TraceID:      r.TraceID,
+		SpanID:       r.SpanID,
+		CurrentPhase: r.CurrentPhase,
+	}
+	// Convert scalar progress fields to nullable pointers for the JSON contract.
+	cur := r.ProgressCurrent
+	resp.ProgressCurrent = &cur
+	tot := r.ProgressTotal
+	resp.ProgressTotal = &tot
+	if r.ProgressMessage != "" {
+		resp.ProgressMessage = &r.ProgressMessage
+	}
+	return resp
+}
+
+// logRowToResponse converts a database.OpLogV2Row to the HTTP response shape.
+func logRowToResponse(l database.OpLogV2Row) opLogV2Response {
+	var attrsAny any
+	if l.Attrs != "" && l.Attrs != "{}" {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(l.Attrs), &m); err == nil {
+			attrsAny = m
+		} else {
+			attrsAny = l.Attrs
+		}
+	} else {
+		attrsAny = map[string]any{}
+	}
+	return opLogV2Response{
+		OperationID: l.OperationID,
+		Level:       l.Level,
+		Message:     l.Message,
+		Attrs:       attrsAny,
+		CreatedAt:   l.CreatedAt,
+	}
+}
+
+// defToResponse converts a registry.OperationDef to the HTTP response shape.
+func defToResponse(d opsregistry.OperationDef) opDefResponse {
+	triggers := make([]string, 0, len(d.Triggers))
+	for _, t := range d.Triggers {
+		triggers = append(triggers, t.EventName)
+	}
+	depends := make([]string, len(d.DependsOn))
+	copy(depends, d.DependsOn)
+
+	rp := "unspecified"
+	switch d.ResumePolicy {
+	case opsregistry.ResumeRestart:
+		rp = "restart"
+	case opsregistry.ResumeRequeue:
+		rp = "requeue"
+	case opsregistry.ResumeDrop:
+		rp = "drop"
+	case opsregistry.ResumeAsk:
+		rp = "ask"
+	}
+
+	return opDefResponse{
+		ID:           d.ID,
+		Plugin:       d.Plugin,
+		DisplayName:  d.DisplayName,
+		Description:  d.Description,
+		Cancellable:  d.Cancellable,
+		Isolate:      d.Isolate,
+		ResumePolicy: rp,
+		Triggers:     triggers,
+		DependsOn:    depends,
+	}
+}
+
+// parseSinceDuration parses strings like "15m", "1h", "30s", "2h30m".
+func parseSinceDuration(s string) (time.Duration, error) {
+	return time.ParseDuration(s)
+}

--- a/internal/server/operations_v2_handlers_test.go
+++ b/internal/server/operations_v2_handlers_test.go
@@ -1,0 +1,336 @@
+// file: internal/server/operations_v2_handlers_test.go
+// version: 1.0.1
+// guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1d
+// last-edited: 2026-05-06
+
+// Tests for UOS-06: operations v2 SSE + timeline + introspection endpoints.
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOpsV2Store is a minimal in-memory OpsV2Store for handler tests.
+// Only the two new methods (ListOperationsV2Since / GetOpLogsV2) need
+// real implementations; the rest return zero-value no-ops so the inline
+// MockStore compile-time assertion stays satisfied.
+type fakeOpsV2Store struct {
+	database.MockStore // embed for all Store methods
+	ops                []database.OperationV2Row
+	logs               []database.OpLogV2Row
+}
+
+func (f *fakeOpsV2Store) ListOperationsV2Since(since time.Time, _ int) ([]database.OperationV2Row, error) {
+	var out []database.OperationV2Row
+	for _, op := range f.ops {
+		if !op.QueuedAt.Before(since) {
+			out = append(out, op)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeOpsV2Store) GetOpLogsV2(opID string, limit int) ([]database.OpLogV2Row, error) {
+	var out []database.OpLogV2Row
+	for _, l := range f.logs {
+		if l.OperationID == opID {
+			out = append(out, l)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out, nil
+}
+
+func (f *fakeOpsV2Store) GetOperationV2(id string) (*database.OperationV2Row, error) {
+	for _, op := range f.ops {
+		if op.ID == id {
+			cp := op
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+// makeTimelineServer creates a minimal Server wired for timeline tests.
+func makeTimelineServer(t *testing.T, store *fakeOpsV2Store) (*Server, *gin.Engine) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		store: store,
+	}
+	router := gin.New()
+	router.GET("/operations/timeline", srv.handleGetOperationTimeline)
+	return srv, router
+}
+
+// --- Timeline ordering test ---
+
+func TestHandleGetOperationTimeline_OrderedByStartedAtDesc(t *testing.T) {
+	now := time.Now().UTC()
+
+	started1 := now.Add(-10 * time.Minute)
+	started2 := now.Add(-5 * time.Minute)
+
+	store := &fakeOpsV2Store{
+		ops: []database.OperationV2Row{
+			{
+				ID:        "op-older",
+				Plugin:    "scan",
+				DefID:     "scan",
+				Status:    "completed",
+				QueuedAt:  now.Add(-15 * time.Minute),
+				StartedAt: &started1,
+			},
+			{
+				ID:        "op-newer",
+				Plugin:    "scan",
+				DefID:     "scan",
+				Status:    "running",
+				QueuedAt:  now.Add(-8 * time.Minute),
+				StartedAt: &started2,
+			},
+			// Queued but not started — should appear after running ops.
+			{
+				ID:       "op-queued",
+				Plugin:   "scan",
+				DefID:    "scan",
+				Status:   "queued",
+				QueuedAt: now.Add(-3 * time.Minute),
+			},
+		},
+	}
+	_, router := makeTimelineServer(t, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/timeline?since=30m", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			Operations []operationV2Response `json:"operations"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	ops := body.Data.Operations
+	require.Len(t, ops, 3)
+
+	// The fakeOpsV2Store does a simple filter without ordering, so we just
+	// verify all three IDs are present; the SQLite impl handles the ordering.
+	ids := make(map[string]bool)
+	for _, op := range ops {
+		ids[op.ID] = true
+	}
+	assert.True(t, ids["op-older"])
+	assert.True(t, ids["op-newer"])
+	assert.True(t, ids["op-queued"])
+}
+
+func TestHandleGetOperationTimeline_InvalidSince(t *testing.T) {
+	store := &fakeOpsV2Store{}
+	_, router := makeTimelineServer(t, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/timeline?since=badvalue", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleGetOperationTimeline_NilStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &Server{store: nil}
+	router := gin.New()
+	router.GET("/operations/timeline", srv.handleGetOperationTimeline)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/timeline?since=15m", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	// Should return 200 with empty list, not 500.
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- SSE test ---
+
+func TestHandleOperationsSSE_ReceivesEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	hub := opsregistry.NewEventHub()
+	srv := &Server{
+		store: &fakeOpsV2Store{},
+		opHub: hub,
+	}
+
+	// Use a real httptest.Server so SSE streaming works.
+	router := gin.New()
+	router.GET("/operations/events", srv.handleOperationsSSE)
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Channel to signal test completion.
+	found := make(chan bool, 1)
+
+	// Open SSE connection with a per-request context.
+	// We control cancellation ourselves via the found channel.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/operations/events", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// Read lines from the SSE stream in a background goroutine.
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: op.updated") {
+				found <- true
+				return
+			}
+		}
+		found <- false
+	}()
+
+	// Publish an event after a short delay to let the connection settle.
+	time.Sleep(150 * time.Millisecond)
+	_ = hub.Publish(context.Background(), "op.updated", map[string]any{
+		"op_id": "test-op-1",
+	})
+
+	select {
+	case ok := <-found:
+		// Cancel the context so the SSE handler exits and the test goroutine
+		// can finish its scanner loop.
+		cancel()
+		assert.True(t, ok, "expected op.updated SSE event to be received")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for op.updated SSE event")
+	}
+}
+
+func TestHandleOperationsSSE_NilHub(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &Server{opHub: nil}
+	router := gin.New()
+	router.GET("/operations/events", srv.handleOperationsSSE)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	// Nil hub → 503
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// --- Cancel test ---
+
+func TestHandleCancelOperationV2_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Build a real registry with a fakeStore.
+	fakeStore := &fakeOpsV2Store{
+		ops: []database.OperationV2Row{
+			{
+				ID:       "op-cancel-me",
+				Plugin:   "scan",
+				DefID:    "scan",
+				Status:   "queued",
+				QueuedAt: time.Now().UTC(),
+			},
+		},
+	}
+	reg := opsregistry.NewWithOptions(fakeStore, slog.Default(), 1, opsregistry.Options{})
+	srv := &Server{
+		store:      fakeStore,
+		opRegistry: reg,
+	}
+	router := gin.New()
+	router.DELETE("/operations/v2/:id", srv.handleCancelOperationV2)
+
+	req := httptest.NewRequest(http.MethodDelete, "/operations/v2/op-cancel-me", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestHandleCancelOperationV2_NilRegistry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &Server{opRegistry: nil}
+	router := gin.New()
+	router.DELETE("/operations/v2/:id", srv.handleCancelOperationV2)
+
+	req := httptest.NewRequest(http.MethodDelete, "/operations/v2/any-id", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GetOperationV2 test ---
+
+func TestHandleGetOperationV2_Found(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	now := time.Now().UTC()
+	store := &fakeOpsV2Store{
+		ops: []database.OperationV2Row{
+			{
+				ID:       "op-abc",
+				Plugin:   "scan",
+				DefID:    "scan",
+				Status:   "running",
+				QueuedAt: now.Add(-5 * time.Minute),
+			},
+		},
+	}
+	srv := &Server{store: store}
+	router := gin.New()
+	router.GET("/operations/v2/:id", srv.handleGetOperationV2)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/v2/op-abc", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	data := body["data"].(map[string]any)
+	op := data["operation"].(map[string]any)
+	assert.Equal(t, "op-abc", op["id"])
+}
+
+func TestHandleGetOperationV2_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &fakeOpsV2Store{}
+	srv := &Server{store: store}
+	router := gin.New()
+	router.GET("/operations/v2/:id", srv.handleGetOperationV2)
+
+	req := httptest.NewRequest(http.MethodGet, "/operations/v2/no-such-op", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}


### PR DESCRIPTION
## Summary

Three files in `internal/server/` still had `github.com/jdfalk/audiobook-organizer` import paths, breaking `make build-linux` (cross-compile for deploy):

- `internal/server/metadata_cached_handlers.go`
- `internal/server/operations_v2_handlers.go`
- `internal/server/operations_v2_handlers_test.go`

Replaced all 3 with `github.com/falkcorp/audiobook-organizer` to match `go.mod`.

Discovered during `make deploy` after all Wave 2 Fable 5 tasks landed.

## Test plan
- [ ] `make build-linux` compiles without errors
- [ ] `make ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)