### PR TITLE
fix(dedup): enqueue fingerprint-rescan for books missing fingerprints in lsh-index-build

### DIFF
--- a/internal/plugins/dedup/lsh_index_build.go
+++ b/internal/plugins/dedup/lsh_index_build.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e61b955e-93bf-4ea6-bb1f-7acd30491fdb
-// last-edited: 2026-06-09
+// last-edited: 2026-06-10
 
 package dedup
 
@@ -94,8 +94,11 @@ func (p *Plugin) lshIndexBuildDef() sdk.OperationDef {
 //  2. For each file with a whole-file fingerprint, derive subprints via
 //     fingerprint.Subprints, then call PutLSHEntries — unless HasLSHIndex
 //     already returns true (incremental skip).
-//  3. Report progress every lshBuildBatchSize files.
-//  4. On completion, set lsh_index_v1_done so T013 can gate on it.
+//  3. Files without a fingerprint are collected by BookID; on completion,
+//     acoustid.fingerprint-rescan is enqueued for those books so the next
+//     lsh-index-build run can pick them up.
+//  4. Report progress every lshBuildBatchSize files.
+//  5. On completion, set lsh_index_v1_done so T013 can gate on it.
 func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// Obtain the LSH-capable store via type assertion. The concrete
 	// *PebbleStore satisfies LSHIndexStore; SQLite and mock stores may not.
@@ -124,6 +127,9 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	prog.Start(fmt.Sprintf("Indexing LSH bands: 0 / %d files", total))
 
 	var indexed, skipped, noFP, errs int
+	// Track unique book IDs whose files lack a fingerprint so we can
+	// enqueue acoustid.fingerprint-rescan for them after the main loop.
+	noFPBookSet := make(map[string]struct{})
 
 	for i, f := range files {
 		// Respect cancellation at each file boundary.
@@ -138,10 +144,10 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		default:
 		}
 
-		// Skip files without a whole-file fingerprint — they have nothing
-		// to contribute to the LSH index.
+		// Files without a fingerprint are queued for fingerprinting below.
 		if len(f.AcoustIDFingerprint) == 0 {
 			noFP++
+			noFPBookSet[f.BookID] = struct{}{}
 			continue
 		}
 
@@ -165,6 +171,7 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		if len(subs) == 0 {
 			// Fingerprint too short to sample (< 4 frames after edge trim).
 			noFP++
+			noFPBookSet[f.BookID] = struct{}{}
 			continue
 		}
 
@@ -190,6 +197,33 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 
 	prog.Finalize("writing completion flag…")
 
+	// Enqueue fingerprint-rescan for books that had unfingerprinted files.
+	// A subsequent lsh-index-build run will pick them up once fingerprinted.
+	if len(noFPBookSet) > 0 {
+		noFPBookIDs := make([]string, 0, len(noFPBookSet))
+		for id := range noFPBookSet {
+			noFPBookIDs = append(noFPBookIDs, id)
+		}
+		if p.registry != nil {
+			_, enqErr := p.registry.EnqueueOp(ctx, "acoustid.fingerprint-rescan", map[string]any{
+				"scope":    "books",
+				"book_ids": noFPBookIDs,
+			})
+			if enqErr != nil {
+				reporter.Logger().Warn("lsh-index-build: failed to enqueue fingerprint-rescan",
+					"books", len(noFPBookIDs), "error", enqErr)
+			} else {
+				reporter.Logger().Info("lsh-index-build: queued fingerprint-rescan for unfingerprinted books",
+					"books", len(noFPBookIDs), "files", noFP)
+				slog.Info("lsh-index-build: enqueued fingerprint-rescan",
+					"books", len(noFPBookIDs), "files", noFP)
+			}
+		} else {
+			reporter.Logger().Warn("lsh-index-build: registry unavailable, cannot enqueue fingerprint-rescan",
+				"no_fp_books", len(noFPBookIDs), "no_fp_files", noFP)
+		}
+	}
+
 	// Mark the index as built so T013's probe-collector can enable itself.
 	if flagErr := lshStore.SetLSHIndexBuilt(); flagErr != nil {
 		reporter.Logger().Error("lsh-index-build: failed to set completion flag", "error", flagErr)
@@ -199,11 +233,11 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	}
 
 	summary := fmt.Sprintf(
-		"LSH index build complete — %d indexed, %d skipped (already indexed), %d no-fingerprint, %d errors (of %d files)",
-		indexed, skipped, noFP, errs, total)
+		"LSH index build complete — %d indexed, %d skipped (already indexed), %d no-fingerprint (%d books queued for rescan), %d errors (of %d files)",
+		indexed, skipped, noFP, len(noFPBookSet), errs, total)
 	prog.Done(summary)
 	slog.Info("lsh-index-build: complete",
 		"indexed", indexed, "skipped", skipped,
-		"no_fp", noFP, "errors", errs, "total", total)
+		"no_fp", noFP, "no_fp_books", len(noFPBookSet), "errors", errs, "total", total)
 	return nil
 }

--- a/internal/plugins/dedup/lsh_index_build_test.go
+++ b/internal/plugins/dedup/lsh_index_build_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c1cf5590-1bc1-4f88-9031-62333bcb593f
-// last-edited: 2026-06-09
+// last-edited: 2026-06-10
 
 package dedup
 
@@ -209,5 +209,88 @@ func TestLSHIndexBuild_OpNonLSHStore(t *testing.T) {
 	err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{})
 	if err == nil {
 		t.Fatal("expected error when store doesn't implement LSHIndexStore, got nil")
+	}
+}
+
+// TestLSHIndexBuild_EnqueuesFingerRescanForNoFPBooks verifies that books
+// whose files lack a fingerprint trigger an acoustid.fingerprint-rescan
+// enqueue, and that book IDs are deduplicated (multiple files per book
+// produce exactly one entry).
+func TestLSHIndexBuild_EnqueuesFingerRescanForNoFPBooks(t *testing.T) {
+	fp := synthRawLSH(42, 57600)
+
+	ms := &mockLSHStore{
+		files: []database.BookFile{
+			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp},
+			{ID: "file-2", BookID: "book-nofp-a", AcoustIDFingerprint: nil},
+			{ID: "file-3", BookID: "book-nofp-a", AcoustIDFingerprint: nil}, // same book → deduplicated
+			{ID: "file-4", BookID: "book-nofp-b", AcoustIDFingerprint: nil},
+		},
+		indexedFiles: map[string]bool{},
+	}
+
+	reg := &mockRegistry{}
+	p := &Plugin{
+		store:    &mockLSHStoreAdapter{inner: ms},
+		registry: reg,
+	}
+
+	if err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{}); err != nil {
+		t.Fatalf("runLSHIndexBuild: %v", err)
+	}
+
+	// Exactly one EnqueueOp call should have been made.
+	if len(reg.enqueuedDefs) != 1 {
+		t.Fatalf("expected 1 EnqueueOp call, got %d", len(reg.enqueuedDefs))
+	}
+	if reg.enqueuedDefs[0] != "acoustid.fingerprint-rescan" {
+		t.Errorf("expected acoustid.fingerprint-rescan, got %s", reg.enqueuedDefs[0])
+	}
+
+	// Params must contain 2 unique book IDs (book-nofp-a deduped).
+	params, ok := reg.enqueuedParams[0].(map[string]any)
+	if !ok {
+		t.Fatalf("params not map[string]any")
+	}
+	bookIDs, ok := params["book_ids"].([]string)
+	if !ok {
+		t.Fatalf("book_ids not []string")
+	}
+	if len(bookIDs) != 2 {
+		t.Errorf("expected 2 unique book IDs, got %d: %v", len(bookIDs), bookIDs)
+	}
+	// file-1 (book-has-fp) must NOT be in the list.
+	for _, id := range bookIDs {
+		if id == "book-has-fp" {
+			t.Errorf("book-has-fp (has fingerprint) should not appear in fingerprint-rescan book_ids")
+		}
+	}
+}
+
+// TestLSHIndexBuild_NoEnqueueWhenAllHaveFingerprints verifies that no
+// fingerprint-rescan is enqueued when every file already has a fingerprint.
+func TestLSHIndexBuild_NoEnqueueWhenAllHaveFingerprints(t *testing.T) {
+	fp := synthRawLSH(7, 57600)
+
+	ms := &mockLSHStore{
+		files: []database.BookFile{
+			{ID: "f1", BookID: "b1", AcoustIDFingerprint: fp},
+			{ID: "f2", BookID: "b2", AcoustIDFingerprint: fp},
+		},
+		indexedFiles: map[string]bool{},
+	}
+
+	reg := &mockRegistry{}
+	p := &Plugin{
+		store:    &mockLSHStoreAdapter{inner: ms},
+		registry: reg,
+	}
+
+	if err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{}); err != nil {
+		t.Fatalf("runLSHIndexBuild: %v", err)
+	}
+
+	if len(reg.enqueuedDefs) != 0 {
+		t.Errorf("expected no EnqueueOp calls when all files have fingerprints, got %d", len(reg.enqueuedDefs))
 	}
 }

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-06-10
 
@@ -20,6 +20,7 @@ type Plugin struct {
 	engine         *dedupengine.Engine
 	store          database.Store
 	embeddingStore *database.EmbeddingStore
+	registry       sdk.Registry // set in Register; used by ops that enqueue follow-on work
 }
 
 // New constructs a dedup Plugin. engine and embeddingStore may be nil if embedding is disabled;
@@ -41,6 +42,7 @@ func (p *Plugin) Version() string { return "1.0.0" }
 // UOS-07 registers embed-scan; UOS-09 adds full-scan, llm-review, and book-signature-scan.
 // T012 adds lsh-index-build (fable5).
 func (p *Plugin) Register(r sdk.Registry) error {
+	p.registry = r // save so op runners can enqueue follow-on operations
 	if p.engine == nil {
 		return nil
 	}

--- a/internal/plugins/dedup/plugin_test.go
+++ b/internal/plugins/dedup/plugin_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-4567-def0-123456789abc
-// last-edited: 2026-05-06
+// last-edited: 2026-06-10
 
 package dedup
 
@@ -12,9 +12,12 @@ import (
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
-// mockRegistry is a test double for sdk.Registry that records registered ops.
+// mockRegistry is a test double for sdk.Registry that records both
+// registered ops and enqueued ops.
 type mockRegistry struct {
-	registeredOps []sdk.OperationDef
+	registeredOps  []sdk.OperationDef
+	enqueuedDefs   []string
+	enqueuedParams []any
 }
 
 func (m *mockRegistry) RegisterOp(op sdk.OperationDef) error {
@@ -22,9 +25,10 @@ func (m *mockRegistry) RegisterOp(op sdk.OperationDef) error {
 	return nil
 }
 
-// EnqueueOp is a no-op for testing.
-func (m *mockRegistry) EnqueueOp(ctx context.Context, defID string, params any, opts ...sdk.EnqueueOption) (string, error) {
-	return "", nil
+func (m *mockRegistry) EnqueueOp(_ context.Context, defID string, params any, _ ...sdk.EnqueueOption) (string, error) {
+	m.enqueuedDefs = append(m.enqueuedDefs, defID)
+	m.enqueuedParams = append(m.enqueuedParams, params)
+	return "fake-op-id", nil
 }
 
 func TestPluginRegisterNoEngine(t *testing.T) {


### PR DESCRIPTION
## Problem

`dedup.lsh-index-build` was silently counting files without `AcoustIDFingerprint` as `noFP` and moving on. Those books never got fingerprinted, so they'd never appear in the LSH dedup index.

## Fix

At the end of the main loop, collect the unique `BookID`s of all unfingerprinted files and enqueue `acoustid.fingerprint-rescan` with `scope:"books"`. A subsequent `lsh-index-build` run will pick up the newly fingerprinted files (the existing `HasLSHIndex` incremental skip ensures already-indexed files are free).

**Flow after this fix:**
1. `lsh-index-build` runs → indexes files with fingerprints, queues rescan for N books
2. `acoustid.fingerprint-rescan` runs → generates fingerprints for those N books  
3. `lsh-index-build` re-runs → skips ~300K already-indexed files (fast), indexes the newly fingerprinted ones

## Changes

- `Plugin.registry` stored during `Register()` for use by op runners (nil-guarded)
- `noFPBookSet` collects unique BookIDs during the loop (deduplicates multi-file books)
- `EnqueueOp("acoustid.fingerprint-rescan", ...)` called at completion if any noFP books found
- Summary message includes `no_fp_books` count
- `mockRegistry` in `plugin_test.go` extended to track enqueued ops (was no-op)
- 2 new tests: `EnqueuesFingerRescanForNoFPBooks`, `NoEnqueueWhenAllHaveFingerprints`

## Context

Currently running `lsh-index-build` (op `01KTT2Y86HZCNGRWK8NAK2459T`) at 128 bands — already showing `noFP=4217` at 7.77% progress. That op will complete correctly for files with fingerprints; a follow-up run with this fix will handle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)