### PR TITLE
fix(fingerprint): mark permanently-failed files to stop infinite rescan loop

### DIFF
--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
-// last-edited: 2026-06-10
+// last-edited: 2026-06-11
 
 package database
 
@@ -60,9 +60,14 @@ func stripBookForMemdb(src *Book) *Book {
 //	AcoustIDFingerprint (~230 KB per 2hr file)       → ~3+ GB (already stripped)
 //	FingerprintDiagnosticJSON (*string, KB-class)    → can dominate when populated
 //	FingerprintFailureReason / Detail (*string)      → small but per-row
-//	FingerprintFailedAt (*time.Time)                 → 24B + heap overhead
+//	FingerprintFailedAt (*time.Time)                 → 24B retained (needed by LSH builder)
 //
 // Combined drop from Seg0..6 + diagnostic fields: ~550-900 MB + diagnostic overhead.
+//
+// FingerprintFailedAt is intentionally NOT stripped: it is 24 bytes per row (~7 MB
+// at 308K rows) and is read by the LSH index builder to skip permanently-failed files
+// from the fingerprint-rescan enqueue queue. Stripping it would cause the builder to
+// re-enqueue those books on every warm-memdb run, triggering an infinite retry loop.
 //
 // AcoustIDSeg0..6 strip rationale (fable5 T019):
 //
@@ -84,7 +89,7 @@ func stripBookFileForMemdb(src *BookFile) *BookFile {
 		return nil
 	}
 	cp := *src
-	cp.FingerprintFailedAt = nil
+	// FingerprintFailedAt is intentionally kept — see comment above.
 	cp.FingerprintFailureReason = nil
 	cp.FingerprintFailureDetail = nil
 	cp.FingerprintDiagnosticJSON = nil

--- a/internal/database/memdb_strip_test.go
+++ b/internal/database/memdb_strip_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e6f7a8b9-c0d1-4e2f-3a4b-5c6d7e8f9012
-// last-edited: 2026-06-10
+// last-edited: 2026-06-11
 
 package database
 
@@ -12,8 +12,10 @@ import (
 )
 
 // TestStripBookFileForMemdb_NilsLargeFields verifies that stripBookFileForMemdb
-// strips all fingerprint diagnostic fields AND all AcoustIDSeg0..6 fields (fable5 T019),
-// while preserving identity fields and AcoustIDFingerprintDurationSec.
+// strips heavy fingerprint diagnostic fields AND all AcoustIDSeg0..6 fields (fable5 T019),
+// while preserving identity fields, AcoustIDFingerprintDurationSec, and FingerprintFailedAt.
+// FingerprintFailedAt is intentionally preserved (it is 24B per row and is read by the
+// LSH index builder to skip permanently-failed files from rescan enqueue).
 func TestStripBookFileForMemdb_NilsLargeFields(t *testing.T) {
 	now := time.Now()
 	reason := "corrupt_audio"
@@ -44,12 +46,9 @@ func TestStripBookFileForMemdb_NilsLargeFields(t *testing.T) {
 		t.Fatal("stripped is nil")
 	}
 
-	// --- Diagnostic fields must be nil ---
+	// --- Heavy fields must be nil ---
 	if stripped.AcoustIDFingerprint != nil {
 		t.Errorf("AcoustIDFingerprint not stripped: got len=%d, want nil", len(stripped.AcoustIDFingerprint))
-	}
-	if stripped.FingerprintFailedAt != nil {
-		t.Errorf("FingerprintFailedAt not stripped")
 	}
 	if stripped.FingerprintFailureReason != nil {
 		t.Errorf("FingerprintFailureReason not stripped")
@@ -101,6 +100,11 @@ func TestStripBookFileForMemdb_NilsLargeFields(t *testing.T) {
 	// for GetAcoustIDSeg0's memdb fallback path (bookfile_fingerprint.go).
 	if stripped.AcoustIDFingerprintDurationSec != 7200.5 {
 		t.Errorf("AcoustIDFingerprintDurationSec not preserved: %v", stripped.AcoustIDFingerprintDurationSec)
+	}
+	// FingerprintFailedAt is preserved for the LSH index builder to skip
+	// permanently-failed files from fingerprint-rescan enqueue.
+	if stripped.FingerprintFailedAt == nil {
+		t.Errorf("FingerprintFailedAt should be preserved (needed by LSH builder)")
 	}
 
 	// --- Source must not be mutated ---

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-05-31
+// last-edited: 2026-06-11
 
 package acoustid
 
@@ -201,8 +201,15 @@ var audioExtensions = map[string]bool{
 // the caller should stop. Returns the zero value and `false` when the caller
 // should proceed with fpcalc. Pure function, no I/O except os.Stat.
 func fingerprintEligibility(f database.BookFile, force bool) (fingerprintFileOutcome, string, bool) {
-	if (len(f.AcoustIDFingerprint) > 0 || f.AcoustIDSeg0 != "") && !force {
+	// AcoustIDFingerprintDurationSec > 0 is the memdb-safe proxy for "has whole-file fp"
+	// (AcoustIDFingerprint itself is stripped from memdb rows by stripBookFileForMemdb).
+	if (len(f.AcoustIDFingerprint) > 0 || f.AcoustIDSeg0 != "" || f.AcoustIDFingerprintDurationSec > 0) && !force {
 		return fingerprintOutcomeSkipped, "", true
+	}
+	// Permanently-failed files (too short, corrupt, DRM) are skipped unless
+	// force=true, which allows an operator to retry specific files intentionally.
+	if f.FingerprintFailedAt != nil && !force {
+		return fingerprintOutcomeIneligible, "permanent_failure", true
 	}
 	if f.FilePath == "" {
 		return fingerprintOutcomeIneligible, "empty_path", true
@@ -238,16 +245,20 @@ func doFingerprintFile(store database.Store, f database.BookFile, force bool) fi
 	wf, err := fingerprint.FileWholeFingerprint(f.FilePath)
 	if err != nil && !errors.Is(err, fingerprint.ErrNotAvailable) {
 		slog.Warn("fingerprint", "path", f.FilePath, "err", err)
+		markFingerprintFailure(store, f, "fpcalc_error", err.Error())
 		return fingerprintOutcomeFailed
 	}
 
 	updated := f
 
 	if err == nil {
-		// Whole-file path (fpcalc available).
+		// Whole-file path (fpcalc available). Clear any prior failure tombstone.
 		updated.AcoustIDFingerprint = wf.Raw
 		updated.AcoustIDFingerprintDurationSec = wf.DurationSec
 		updated.AcoustIDSeg0 = fingerprint.NormalizeForStorage(fingerprint.DeriveSeg0(wf.Raw))
+		updated.FingerprintFailedAt = nil
+		updated.FingerprintFailureReason = nil
+		updated.FingerprintFailureDetail = nil
 		if force {
 			updated.AcoustIDSeg1 = ""
 			updated.AcoustIDSeg2 = ""
@@ -261,6 +272,7 @@ func doFingerprintFile(store database.Store, f database.BookFile, force bool) fi
 		segs, serr := fingerprint.FileSegments(f.FilePath, f.Duration)
 		if serr != nil {
 			slog.Warn("fingerprint segments", "path", f.FilePath, "err", serr)
+			markFingerprintFailure(store, f, "ffmpeg_error", serr.Error())
 			return fingerprintOutcomeFailed
 		}
 		updated.AcoustIDSeg0 = fingerprint.NormalizeForStorage(segs[0])
@@ -270,6 +282,9 @@ func doFingerprintFile(store database.Store, f database.BookFile, force bool) fi
 		updated.AcoustIDSeg4 = fingerprint.NormalizeForStorage(segs[4])
 		updated.AcoustIDSeg5 = fingerprint.NormalizeForStorage(segs[5])
 		updated.AcoustIDSeg6 = fingerprint.NormalizeForStorage(segs[6])
+		updated.FingerprintFailedAt = nil
+		updated.FingerprintFailureReason = nil
+		updated.FingerprintFailureDetail = nil
 	}
 
 	if err := store.UpdateBookFile(f.ID, &updated); err != nil {
@@ -277,6 +292,20 @@ func doFingerprintFile(store database.Store, f database.BookFile, force bool) fi
 		return fingerprintOutcomeFailed
 	}
 	return fingerprintOutcomeFingerprinted
+}
+
+// markFingerprintFailure writes a permanent failure tombstone to the BookFile row so
+// future fingerprint scans skip it (unless force=true). The tombstone survives
+// service restarts — only a successful fingerprinting run clears it.
+func markFingerprintFailure(store database.Store, f database.BookFile, reason, detail string) {
+	now := time.Now()
+	updated := f
+	updated.FingerprintFailedAt = &now
+	updated.FingerprintFailureReason = &reason
+	updated.FingerprintFailureDetail = &detail
+	if err := store.UpdateBookFile(f.ID, &updated); err != nil {
+		slog.Warn("fingerprint: mark failure", "id", f.ID, "reason", reason, "err", err)
+	}
 }
 
 // synthesizeBookSignatureForBook generates and persists the unified book

--- a/internal/plugins/acoustid/backfill_test.go
+++ b/internal/plugins/acoustid/backfill_test.go
@@ -1,6 +1,7 @@
 // file: internal/plugins/acoustid/backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f7a8b9c0-d1e2-4f3a-4b5c-6d7e8f9a0123
+// last-edited: 2026-06-11
 
 package acoustid
 
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
@@ -170,5 +172,57 @@ func TestAudioExtensions_RejectsNonAudio(t *testing.T) {
 		if audioExtensions[ext] {
 			t.Errorf("did not expect %q in audioExtensions", ext)
 		}
+	}
+}
+
+func TestFingerprintEligibility_IneligibleWhenPermanentlyFailed(t *testing.T) {
+	now := time.Now()
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.FingerprintFailedAt = &now
+	})
+	got, reason, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true for permanently-failed file")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected fingerprintOutcomeIneligible, got %v", got)
+	}
+	if reason != "permanent_failure" {
+		t.Errorf("expected reason=permanent_failure, got %q", reason)
+	}
+}
+
+func TestFingerprintEligibility_ForceOverridesPermanentFailure(t *testing.T) {
+	now := time.Now()
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.FingerprintFailedAt = &now
+		// File doesn't exist on disk — expect file_not_found ineligible,
+		// not permanent_failure (force bypasses the tombstone check).
+	})
+	got, reason, stop := fingerprintEligibility(f, true)
+	if !stop {
+		t.Fatal("expected stop=true because file does not exist on disk")
+	}
+	if got != fingerprintOutcomeIneligible {
+		t.Errorf("expected fingerprintOutcomeIneligible, got %v", got)
+	}
+	// With force=true, permanent_failure is bypassed; we get file_not_found.
+	if reason == "permanent_failure" {
+		t.Errorf("force=true should bypass permanent_failure tombstone, got %q", reason)
+	}
+}
+
+func TestFingerprintEligibility_SkipsWhenDurationProxySet(t *testing.T) {
+	// AcoustIDFingerprintDurationSec > 0 means the file has a whole-file fp
+	// in Pebble even if AcoustIDFingerprint is nil (stripped from memdb rows).
+	f := makeBookFile(func(bf *database.BookFile) {
+		bf.AcoustIDFingerprintDurationSec = 3600.0 // 1 hour, fingerprint present
+	})
+	got, _, stop := fingerprintEligibility(f, false)
+	if !stop {
+		t.Fatal("expected stop=true when AcoustIDFingerprintDurationSec > 0")
+	}
+	if got != fingerprintOutcomeSkipped {
+		t.Errorf("expected fingerprintOutcomeSkipped for duration proxy, got %v", got)
 	}
 }

--- a/internal/plugins/dedup/lsh_index_build.go
+++ b/internal/plugins/dedup/lsh_index_build.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e61b955e-93bf-4ea6-bb1f-7acd30491fdb
-// last-edited: 2026-06-10
+// last-edited: 2026-06-11
 
 package dedup
 
@@ -126,9 +126,12 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	prog := sdk.NewProgress(reporter, total)
 	prog.Start(fmt.Sprintf("Indexing LSH bands: 0 / %d files", total))
 
-	var indexed, skipped, noFP, errs int
+	var indexed, skipped, noFP, noFPPermFailed, errs int
 	// Track unique book IDs whose files lack a fingerprint so we can
 	// enqueue acoustid.fingerprint-rescan for them after the main loop.
+	// Books are only added if at least one file has never been tried
+	// (FingerprintFailedAt == nil) — permanently-failed files are excluded
+	// to prevent an infinite rescan loop.
 	noFPBookSet := make(map[string]struct{})
 
 	for i, f := range files {
@@ -144,10 +147,19 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		default:
 		}
 
-		// Files without a fingerprint are queued for fingerprinting below.
-		if len(f.AcoustIDFingerprint) == 0 {
+		// Files without a fingerprint: only enqueue for fingerprinting if
+		// they haven't permanently failed. Permanently-failed files (too short,
+		// corrupt, DRM) will never yield a fingerprint — don't trigger an
+		// infinite rescan loop. AcoustIDFingerprintDurationSec > 0 is the
+		// memdb-safe proxy for "has whole-file fp" (fingerprint blob stripped
+		// from memdb rows by stripBookFileForMemdb).
+		if len(f.AcoustIDFingerprint) == 0 && f.AcoustIDFingerprintDurationSec == 0 {
 			noFP++
-			noFPBookSet[f.BookID] = struct{}{}
+			if f.FingerprintFailedAt == nil {
+				noFPBookSet[f.BookID] = struct{}{}
+			} else {
+				noFPPermFailed++
+			}
 			continue
 		}
 
@@ -156,6 +168,14 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		// when re-running after a partial build.
 		if lshStore.HasLSHIndex(f.ID) {
 			skipped++
+			continue
+		}
+
+		// If the fingerprint bytes are nil but the duration proxy indicates a
+		// fingerprint was written (memdb strips AcoustIDFingerprint to save RAM),
+		// we cannot compute subprints. Skip silently; a Pebble-direct run
+		// (UseMemDB=false or cold-start) will index this file on the next pass.
+		if len(f.AcoustIDFingerprint) == 0 {
 			continue
 		}
 
@@ -170,8 +190,13 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		}
 		if len(subs) == 0 {
 			// Fingerprint too short to sample (< 4 frames after edge trim).
+			// Apply same permanent-failure exclusion as the noFP path above.
 			noFP++
-			noFPBookSet[f.BookID] = struct{}{}
+			if f.FingerprintFailedAt == nil {
+				noFPBookSet[f.BookID] = struct{}{}
+			} else {
+				noFPPermFailed++
+			}
 			continue
 		}
 
@@ -186,12 +211,12 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 		// Progress every lshBuildBatchSize files and at the last file.
 		if (i+1)%lshBuildBatchSize == 0 || i == total-1 {
 			prog.StepN(i+1, fmt.Sprintf(
-				"Indexing LSH bands: %d / %d files (indexed=%d skipped=%d noFP=%d errors=%d)",
-				i+1, total, indexed, skipped, noFP, errs))
+				"Indexing LSH bands: %d / %d files (indexed=%d skipped=%d noFP=%d permFailed=%d errors=%d)",
+				i+1, total, indexed, skipped, noFP, noFPPermFailed, errs))
 			slog.Info("lsh-index-build: progress",
 				"processed", i+1, "total", total,
 				"indexed", indexed, "skipped", skipped,
-				"no_fp", noFP, "errors", errs)
+				"no_fp", noFP, "no_fp_perm_failed", noFPPermFailed, "errors", errs)
 		}
 	}
 
@@ -233,11 +258,12 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	}
 
 	summary := fmt.Sprintf(
-		"LSH index build complete — %d indexed, %d skipped (already indexed), %d no-fingerprint (%d books queued for rescan), %d errors (of %d files)",
-		indexed, skipped, noFP, len(noFPBookSet), errs, total)
+		"LSH index build complete — %d indexed, %d skipped (already indexed), %d no-fingerprint (%d books queued for rescan, %d permanently failed), %d errors (of %d files)",
+		indexed, skipped, noFP, len(noFPBookSet), noFPPermFailed, errs, total)
 	prog.Done(summary)
 	slog.Info("lsh-index-build: complete",
 		"indexed", indexed, "skipped", skipped,
-		"no_fp", noFP, "no_fp_books", len(noFPBookSet), "errors", errs, "total", total)
+		"no_fp", noFP, "no_fp_books", len(noFPBookSet),
+		"no_fp_perm_failed", noFPPermFailed, "errors", errs, "total", total)
 	return nil
 }

--- a/internal/plugins/dedup/lsh_index_build_test.go
+++ b/internal/plugins/dedup/lsh_index_build_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c1cf5590-1bc1-4f88-9031-62333bcb593f
-// last-edited: 2026-06-10
+// last-edited: 2026-06-11
 
 package dedup
 
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
@@ -292,5 +293,66 @@ func TestLSHIndexBuild_NoEnqueueWhenAllHaveFingerprints(t *testing.T) {
 
 	if len(reg.enqueuedDefs) != 0 {
 		t.Errorf("expected no EnqueueOp calls when all files have fingerprints, got %d", len(reg.enqueuedDefs))
+	}
+}
+
+// TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue verifies that books
+// whose noFP files are ALL permanently failed (FingerprintFailedAt != nil) are
+// NOT enqueued for fingerprint-rescan. This prevents an infinite retry loop for
+// structurally impossible files (too short, corrupt, DRM-protected).
+//
+// A book is only enqueued if at least one of its noFP files has
+// FingerprintFailedAt == nil (i.e., was never tried).
+func TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue(t *testing.T) {
+	fp := synthRawLSH(42, 57600)
+	now := time.Now()
+
+	ms := &mockLSHStore{
+		files: []database.BookFile{
+			// book-has-fp: has fingerprint → indexed
+			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp},
+			// book-perm-fail: noFP but ALL files permanently failed → no enqueue
+			{ID: "file-2", BookID: "book-perm-fail", FingerprintFailedAt: &now},
+			{ID: "file-3", BookID: "book-perm-fail", FingerprintFailedAt: &now},
+			// book-never-tried: noFP, never attempted → should be enqueued
+			{ID: "file-4", BookID: "book-never-tried"},
+		},
+		indexedFiles: map[string]bool{},
+	}
+
+	reg := &mockRegistry{}
+	p := &Plugin{
+		store:    &mockLSHStoreAdapter{inner: ms},
+		registry: reg,
+	}
+
+	if err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{}); err != nil {
+		t.Fatalf("runLSHIndexBuild: %v", err)
+	}
+
+	// Exactly one EnqueueOp for the one book with never-tried files.
+	if len(reg.enqueuedDefs) != 1 {
+		t.Fatalf("expected 1 EnqueueOp call, got %d", len(reg.enqueuedDefs))
+	}
+
+	params, ok := reg.enqueuedParams[0].(map[string]any)
+	if !ok {
+		t.Fatalf("params not map[string]any")
+	}
+	bookIDs, ok := params["book_ids"].([]string)
+	if !ok {
+		t.Fatalf("book_ids not []string")
+	}
+	if len(bookIDs) != 1 {
+		t.Errorf("expected 1 book_id (book-never-tried only), got %d: %v", len(bookIDs), bookIDs)
+	}
+	if len(bookIDs) > 0 && bookIDs[0] != "book-never-tried" {
+		t.Errorf("expected book-never-tried, got %s", bookIDs[0])
+	}
+	// book-perm-fail must not appear in the enqueue list.
+	for _, id := range bookIDs {
+		if id == "book-perm-fail" {
+			t.Errorf("book-perm-fail (all files permanently failed) should not be enqueued")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **`doFingerprintFile`**: writes `FingerprintFailedAt` + `FingerprintFailureReason` on fpcalc/ffmpeg failure, so future scans skip them (unless `force=true`)
- **`fingerprintEligibility`**: returns `permanent_failure` ineligible for files with `FingerprintFailedAt` set; also adds `AcoustIDFingerprintDurationSec > 0` as memdb-safe "has fingerprint" proxy
- **`lsh_index_build`**: skips permanently-failed files from `noFPBookSet`; handles nil fingerprint bytes on memdb path (uses duration proxy to determine "has fp"); guards against calling `Subprints` on nil bytes
- **`memdb_strip`**: preserves `FingerprintFailedAt` (~24B/row, ~7MB library-wide) so LSH builder can check it on warm-memdb runs; strips only the expensive string fields

## Context

Production diagnosed 4,882 fingerprint failures: 2,208 too-short intro/credits tracks and 2,670 corrupt-or-empty (includes iTunes FairPlay DRM-protected M4Bs). Without this fix, `lsh-index-build` re-enqueues these books for rescan on every run.

Also fixes a latent memdb path bug: when memdb is warm, `GetAllBookFiles()` returns `AcoustIDFingerprint = nil` for all rows. The old code treated all 308K files as no-FP and enqueued 28K books. The fix uses `AcoustIDFingerprintDurationSec > 0` as the memdb-safe presence proxy, correctly distinguishing fingerprinted files from truly no-FP ones.

## Test plan

- [ ] `TestFingerprintEligibility_IneligibleWhenPermanentlyFailed` — tombstone blocks retry
- [ ] `TestFingerprintEligibility_ForceOverridesPermanentFailure` — force=true bypasses tombstone
- [ ] `TestFingerprintEligibility_SkipsWhenDurationProxySet` — memdb-safe proxy works
- [ ] `TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue` — perm-failed books excluded from rescan enqueue
- [ ] `TestStripBookFileForMemdb_NilsLargeFields` — updated to assert FingerprintFailedAt is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)