### PR TITLE
chore(docs): mark all 27 Fable 5 tasks complete in TODO + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,109 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.16.0 -->
+<!-- version: 3.17.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-10 -->
+<!-- last-edited: 2026-06-12 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+#### June 9–10, 2026 — Fable 5: unified dedup pipeline (T011–T018)
+
+- **`internal/dedup/unified/`** (NEW, T011): `Signal`, `UnifiedDedupScore`, `ComposeScore`
+  — noisy-OR composite scoring engine. Each signal (LSH acoustid, exact acoustid,
+  metadata-fuzzy, embedding) contributes a 0–100 weight; final score is noisy-OR
+  aggregation over all signals. Includes `band` classification (CERTAIN/HIGH/MEDIUM/REVIEW).
+- **`internal/database/pebble_store.go`** (T012): `fpidx:<subfp>:<bookfile_id>` secondary
+  PebbleDB index written on every `CreateBookFile`/`UpdateBookFile`/delete; `BuildLSHIndex`
+  op populates the index from existing rows and sets flag `lsh_index_v1_done`.
+- **`internal/dedup/collectors/`** (T013): LSH probe collector queries `fpidx:` index to
+  produce O(band×k) candidates instead of O(N) full scan; exact AcoustID collector added.
+  `ACOUSTID_FUZZY_ENABLED` O(N) path retired.
+- **`internal/dedup/engine.go`** (T014): Collector refactor — each collector implements
+  `CandidateCollector` interface; `PairEligibility` pre-filter skips same-book and already-
+  resolved pairs; new metadata-fuzzy collector added (title+author Levenshtein).
+- **`internal/database/embedding_store.go`** (T015): `ScoreBreakdown` JSON field added
+  to candidate rows. `dedup.purge-stale-fingerprints` op removes ~14K rows with 100%
+  legacy scores caused by AQAAAA-poisoned segment fingerprints.
+- **`internal/plugins/dedup/scan_ops.go`** (T018): Embed-scan and async-scan merged into
+  single rationalized op; phase ordering enforced (fingerprint → LSH index → candidate
+  collection → score → dedup). Removes duplicate scan triggers.
+
+#### June 9–10, 2026 — Fable 5: iTunes writeback hardening (T001–T008, T010)
+
+- **`internal/itunes/itl_le.go`** (T001): `walkMsdhTracksLE` now descends into each
+  `mhoh` child block so all track string fields (Name, Album, Artist, Genre, Kind,
+  Location, LocalURL) are populated on LE libraries. Previously every field was empty.
+- **`tools/cmd/itl-audit/`** (T002): `mhoh-corpus-audit` tool reads a golden iTunes
+  library and emits a constants table of every observed encoding-flag byte value per
+  field type. Confirms iTunes always writes `0x00`; our writer was producing `+27 ∈ {1,3}`.
+- **`internal/itunes/safety.go`** (T003): `ITLSafetyContract` — 8 named pre-write guards
+  (magic check, version bounds, mhoh encoding-byte whitelist, location contract,
+  inflate/deflate round-trip, header count coherence, atom alignment, file-in-use check)
+  + 13-test regression suite covering all 4 known corruption vectors.
+- **`internal/itunes/itl_write.go`** (T004): `SafeWriteITL` — atomic write protocol:
+  write to `.tmp`, fsync, rename; header `mhit` count regenerated from actual track
+  list after mutations rather than incremented in-place. Eliminates orphan-ref corruption
+  on crash mid-write.
+- **`internal/itunes/mhoh_encode.go`** (T005): iTunes-conformant mhoh string encoders —
+  encoding-flag byte always `0x00` (matches all 281,790 golden-corpus blocks); removed
+  the `+27` offset that was causing iTunes to reject writes as corrupt.
+- **`internal/itunes/location.go`** (T006): `LocationPair` type wraps Windows path
+  (`0x0D` mhoh) + URL (`0x0B` mhoh) as a unit; writeback enforces that both fields are
+  updated together and that the URL form is a valid `file://` or `itms://` URI.
+- **`tools/cmd/itl-diff/`** + **`tools/cmd/itl-check/`** (T007): Honest diff/check tools
+  — `itl-diff` now inventories `msdh` (library container) atom, reports playlist
+  membership deltas, and calls `AuditITL` to surface any safety-contract violations;
+  `itl-check` exits non-zero on any violation.
+- **`internal/itunes/writeback_batcher.go`** (T008): Diff-before-write — batcher now
+  reads the current ITL, diffs proposed changes against live values, and skips writes
+  where no field changed. Added `library-not-in-use` gate: aborts if iTunes process is
+  running on the host.
+- **`internal/itunes/inflate.go`** (T010): Fail-closed inflate cap — `zlib.NewReader`
+  wrapped with a 256 MB hard limit; inflate errors now return explicit `ErrInflateCap`
+  rather than silently producing a truncated buffer.
+
+#### June 9–10, 2026 — Fable 5: memory & DB optimization (T019–T024)
+
+- **`internal/memdb/strip.go`** (T019): `stripBookFileForMemdb` strips `AcoustIDSeg0..6`
+  from in-memory projections at warm time. Expected RSS savings: 550–900 MB. Seg data
+  is still readable from Pebble via `GetBookFileByID` for the dedup path.
+- **`internal/database/pebble_store.go`** (T021): Float16+zstd embedding encoding —
+  embeddings written as `float16` arrays then zstd-compressed (`emb_f16_v1_done` flag).
+  Dual-read: decodes both legacy float32 and new float16+zstd rows. `re-encode-embeddings`
+  op backfills existing rows. Reduces embedding storage ~75%.
+- **`internal/database/`** (T022): Legacy SQLite backend and CGO dependency removed —
+  ~7.9K lines deleted, `mattn/go-sqlite3` dropped from `go.mod`. All callers migrated
+  to PebbleDB. Build no longer requires a C compiler.
+- **`internal/memdb/telemetry.go`** + **`internal/plugins/core/plugin.go`** (T023):
+  memdb size telemetry — `memdb.SizeMB()` reports live RSS contribution per table;
+  operation-log retention policy (default 30 days, configurable); dead-prefix sweep
+  removes orphaned Pebble key ranges from removed features.
+- **`internal/database/pebble_activity.go`** + **`internal/database/pebble_metrics.go`**
+  (T024): PebbleDB activity and metrics backends with dual-write window — new writes go
+  to both NutsDB (existing) and Pebble (new); reads prefer Pebble when available.
+  `backfill-activity-to-pebble` op migrates historical NutsDB records.
+
+#### June 9–10, 2026 — Fable 5: general fixes (T009, T025–T028)
+
+- **`internal/server/auth_handlers.go`** (T009): `POST /api/v1/auth/accept-invite` —
+  explicit body read + close before `json.Unmarshal` prevents HTTP/2 stream-reset EOF;
+  413 response now includes `{"error":"request body too large","max_bytes":N}`; Gin set
+  to release mode. Resolves pen-test finding MED-5.
+- **`internal/metadata/tag_filter.go`** (T025): `FilterUnchangedTags` now covers all
+  `AUDIOBOOK_ORGANIZER_*` custom tag fields in skip detection; previously only standard
+  fields were checked, causing unnecessary tag writes on every apply.
+- **`internal/database/pebble_store.go`** (T026): `RecomputeBookAggregates` + background
+  op — book `Duration` and `FileSize` are recomputed as sums over `BookFile` rows rather
+  than stored as snapshots. `backfill-book-aggregates` op updates all existing rows.
+- **`internal/server/server.go`** + **`internal/operations/registry/`** (T027): Background
+  goroutines (chromem hydration, scanner, dedup engine) now joined on shutdown via
+  `sync.WaitGroup`; scanner goroutine leak behind CI race condition fixed.
+- **`internal/config/app_config.go`** (T028, bonus): `AppConfig` field reads and writes
+  protected by `sync.RWMutex`; all write sites converted to use `Set*` accessors.
+  Eliminates data races under concurrent scan + metadata-apply.
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.75.0 -->
+<!-- version: 8.76.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-10 -->
+<!-- last-edited: 2026-06-12 -->
 
 # Project TODO
 
@@ -19,58 +19,61 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — June 10, 2026
+## 🎯 Current Status — June 12, 2026
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
-**Production:** PebbleDB primary; Linux, HTTPS at `172.16.2.30:8484`
-**Latest activity:** CI fixes: `memory-leak-scan.yml` YAML parse error (PR #1405), `nightly-burndown.yml` SHA bumped to v1.11.2 using runner image `ob-18f0014` which removes the broken `ContextManagement` OpenAI param (PRs #1407, #1408).
-**In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds), fingerprint identification pipeline
+**Production:** PebbleDB primary; Linux, HTTPS at prod server
+**Latest activity:** All 27 Fable 5 tasks + T028 bonus shipped (June 9–10). Plugin framework added (agents, skills, pre-commit PII hook). CI fixes (PRs #1405, #1407, #1408). LSHBandCount 64→128.
+**In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds)
 
 ---
 
-## 🔭 Fable 5 Full-System Review — June 9, 2026 (specs + 27-task plan)
+## ✅ Fable 5 Full-System Review — COMPLETE (June 9–10, 2026)
 
-Review deliverables (see files for full detail):
-- [`docs/specs/fable5-review-findings.md`](docs/specs/fable5-review-findings.md) — 3 CRITICAL / 6 HIGH / 8 MEDIUM / 2 LOW, iTunes findings grounded in binary forensics of 4 damaged libraries
-- [`docs/specs/fable5-spec-itunes-writeback-hardening.md`](docs/specs/fable5-spec-itunes-writeback-hardening.md) — ITLSafetyContract, SafeWriteITL, regression suite
-- [`docs/specs/fable5-spec-unified-dedup-pipeline.md`](docs/specs/fable5-spec-unified-dedup-pipeline.md) — composite scoring (noisy-OR, 0–100 capped), LSH fpidx index, unified UI tab
-- [`docs/specs/fable5-spec-memory-db-optimization.md`](docs/specs/fable5-spec-memory-db-optimization.md) — corrected premises (embeddings already in Pebble); prioritized list
-- [`docs/plans/fable5-implementation-plan.md`](docs/plans/fable5-implementation-plan.md) — TASK-001..027, dependency graph, 5 waves
+All 27 planned tasks + 1 bonus task shipped. Specs and plan docs:
+- [`docs/specs/fable5-review-findings.md`](docs/specs/fable5-review-findings.md) — 3 CRITICAL / 6 HIGH / 8 MEDIUM / 2 LOW
+- [`docs/specs/fable5-spec-itunes-writeback-hardening.md`](docs/specs/fable5-spec-itunes-writeback-hardening.md)
+- [`docs/specs/fable5-spec-unified-dedup-pipeline.md`](docs/specs/fable5-spec-unified-dedup-pipeline.md)
+- [`docs/specs/fable5-spec-memory-db-optimization.md`](docs/specs/fable5-spec-memory-db-optimization.md)
+- [`docs/plans/fable5-implementation-plan.md`](docs/plans/fable5-implementation-plan.md)
 
-### P2 — iTunes writeback hardening (highest stakes; wave 1–4)
-- [ ] **F5-T001** Fix LE parser mhoh descent — track string fields currently never parsed (HIGH-2)
-- [ ] **F5-T002** Golden-corpus mhoh encoding audit tool + constants table
-- [ ] **F5-T003** ⚠ `ITLSafetyContract` — 8 named guards + 13-test regression suite
-- [ ] **F5-T004** ⚠ `SafeWriteITL` atomic write + header count regeneration (CRIT-3)
-- [ ] **F5-T005** ⚠ iTunes-conformant string encoders — stop writing +27∈{1,3} (CRIT-1)
-- [ ] **F5-T006** ⚠ `LocationPair` — 0x0D Windows path / 0x0B URL normalization (CRIT-2)
-- [ ] **F5-T007** itl-diff/itl-check honesty: msdh inventory, playlist membership, AuditITL
-- [ ] **F5-T008** Diff-before-write in writeback batcher (HIGH-3) + library-not-in-use gate
-- [ ] **F5-T010** Fail-closed inflate cap (MED-7)
+### P2 — iTunes writeback hardening ✅ all done
+- [x] **F5-T001** Fix LE parser mhoh descent — track string fields now parsed in LE libraries ✅ Jun 9
+- [x] **F5-T002** Golden-corpus mhoh encoding audit tool + constants table ✅ Jun 10
+- [x] **F5-T003** ⚠ `ITLSafetyContract` — 8 named guards + 13-test regression suite ✅ Jun 10
+- [x] **F5-T004** ⚠ `SafeWriteITL` atomic write + header count regeneration (CRIT-3) ✅ Jun 10
+- [x] **F5-T005** ⚠ iTunes-conformant string encoders — stop writing +27∈{1,3} (CRIT-1) ✅ Jun 10
+- [x] **F5-T006** ⚠ `LocationPair` — 0x0D Windows path / 0x0B URL normalization (CRIT-2) ✅ Jun 10
+- [x] **F5-T007** itl-diff/itl-check honesty: msdh inventory, playlist membership, AuditITL ✅ Jun 10
+- [x] **F5-T008** Diff-before-write in writeback batcher (HIGH-3) + library-not-in-use gate ✅ Jun 10
+- [x] **F5-T010** Fail-closed inflate cap (MED-7) ✅ Jun 9
 
-### P1 — Unified dedup pipeline (waves 1–4)
-- [ ] **F5-T011** `internal/dedup/unified` — Signal/UnifiedDedupScore/ComposeScore (noisy-OR v1)
-- [ ] **F5-T012** ⚠ LSH `fpidx:` Pebble index — build op + write/delete hooks (`lsh_index_v1_done`)
-- [ ] **F5-T013** LSH probe collector; retire `ACOUSTID_FUZZY_ENABLED` O(N) path
-- [ ] **F5-T014** Collector refactor + `PairEligibility` + NEW metadata-fuzzy collector
-- [ ] **F5-T015** ⚠ Candidate schema additions + legacy-fingerprint purge (~14K stale 100% rows, HIGH-5)
+### P1 — Unified dedup pipeline ✅ all done
+- [x] **F5-T011** `internal/dedup/unified` — Signal/UnifiedDedupScore/ComposeScore (noisy-OR v1) ✅ Jun 9
+- [x] **F5-T012** ⚠ LSH `fpidx:` Pebble index — build op + write/delete hooks (`lsh_index_v1_done`) ✅ Jun 10
+- [x] **F5-T013** LSH probe collector; retire `ACOUSTID_FUZZY_ENABLED` O(N) path ✅ Jun 10
+- [x] **F5-T014** Collector refactor + `PairEligibility` + NEW metadata-fuzzy collector ✅ Jun 10
+- [x] **F5-T015** ⚠ Candidate schema additions + legacy-fingerprint purge (~14K stale 100% rows) ✅ Jun 10
 - [x] **F5-T016** API: band/score/breakdown fields, `/breakdown`, `/rescore` ✅ PR #1414
-- [x] **F5-T017** Unified Dedup UI tab (feature-flagged until backfill complete) ✅ PR #1416
-- [ ] **F5-T018** Scan op rationalization (merge embed-scan/async; phase ordering)
+- [x] **F5-T017** Unified Dedup UI tab (flag removed; always live after backfill) ✅ PR #1416
+- [x] **F5-T018** Scan op rationalization (merge embed-scan/async; phase ordering) ✅ Jun 10
 
-### P3 — Memory & DB optimization (waves 1–5)
-- [ ] **F5-T019** ⚠ Strip AcoustIDSeg0–6 from memdb (~550–900MB RSS) — after T013
-- [x] **F5-T020** ✅ Drop seg fields from `book_file:` Pebble values (sweep + `bookfile_seg_drop_v1_done`)
-- [ ] **F5-T021** Embedding float16+zstd (`emb_f16_v1_done`, dual-read)
-- [ ] **F5-T022** Remove legacy SQLite store (~7.9K lines + CGO dep) (MED-4)
-- [ ] **F5-T023** memdb size telemetry + operation-log retention + dead-prefix sweep
-- [ ] **F5-T024** NutsDB → Pebble activity/metrics migration (dual-write window)
+### P3 — Memory & DB optimization ✅ all done
+- [x] **F5-T019** ⚠ Strip AcoustIDSeg0–6 from memdb (~550–900MB RSS) ✅ Jun 10
+- [x] **F5-T020** ✅ Drop seg fields from `book_file:` Pebble values (sweep + `bookfile_seg_drop_v1_done`) ✅ Jun 10
+- [x] **F5-T021** Embedding float16+zstd (`emb_f16_v1_done`, dual-read) ✅ Jun 10
+- [x] **F5-T022** Remove legacy SQLite store (~7.9K lines + CGO dep) ✅ Jun 10
+- [x] **F5-T023** memdb size telemetry + operation-log retention + dead-prefix sweep ✅ Jun 9
+- [x] **F5-T024** NutsDB → Pebble activity/metrics migration (dual-write window) ✅ Jun 10
 
-### P4 — Fixes (wave 1–2)
-- [ ] **F5-T009** accept-invite HTTP/2 EOF fix + 413 clarity (HIGH-4 pen-test, MED-1)
-- [ ] **F5-T025** `FilterUnchangedTags` covers custom `AUDIOBOOK_ORGANIZER_*` tags (MED-3)
-- [ ] **F5-T026** Duration/filesize aggregation from BookFiles + backfill (MED-2)
-- [ ] **F5-T027** Chromem hydration shutdown join (MED-8)
+### P4 — Fixes ✅ all done
+- [x] **F5-T009** accept-invite HTTP/2 EOF fix + 413 clarity (resolves pen-test MED-5) ✅ Jun 9
+- [x] **F5-T025** `FilterUnchangedTags` covers custom `AUDIOBOOK_ORGANIZER_*` tags ✅ Jun 10
+- [x] **F5-T026** Duration/filesize aggregation from BookFiles + backfill ✅ Jun 10
+- [x] **F5-T027** Chromem hydration shutdown join ✅ Jun 10
+
+### Bonus
+- [x] **F5-T028** `AppConfig` RWMutex-guarded accessors — convert all write sites ✅ Jun 10
 
 ---
 
@@ -99,9 +102,9 @@ Review deliverables (see files for full detail):
 
 ## 🔐 Security (pen-test 2026-06-04)
 
-10 of 11 findings fixed in `fix/security-pentest-findings` (see CHANGELOG). One deferred:
+All 11 pen-test findings fixed:
 
-- [ ] **MED-5** `POST /api/v1/auth/accept-invite` reportedly returns `{"error":"EOF"}` under HTTP/2 (curl default); `--http1.1` works. Deferred from the remediation PR — needs empirical repro before a fix. **Findings so far:** the route shares the exact middleware chain (apiRateLimiter + MaxRequestBodySize) and `ShouldBindJSON` pattern as `/auth/login` and `/auth/bootstrap`, which the pen test exercised fine under HTTP/2 — so it is **not accept-invite-specific in code**. Leading hypotheses to check during repro: (1) the tester POSTed to `/api/auth/accept-invite` (non-`v1`) and hit the `/api/*`→`/api/v1/*` 301 redirect, where curl drops the POST body; (2) an h2 stream-reset when the handler returns before the body is fully read. Repro needs the TLS+HTTP/2 server up with a valid invite token seeded. If confirmed as the redirect case, the fix is client-side (use the `/api/v1/` path) or making the redirect 307/308 to preserve the body.
+- [x] **MED-5** `POST /api/v1/auth/accept-invite` EOF + 413 clarity — fixed in F5-T009 (Jun 9). `ShouldBindJSON` upgraded to explicit body-read + close; 413 response body now includes `{"error":"request body too large","max_bytes":N}`; Gin set to release mode to suppress debug headers. ✅
 
 ---
 
@@ -137,17 +140,8 @@ PR `feat/fingerprint-wholefile` (Step 1 + 2) ships:
 - [x] Verified fixed by Security run `26727789014`.
 
 **Follow-up PRs (not in this PR):**
-- [ ] **Step 3 — LSH index for whole-file similarity.** [hold] Add
-  `fpidx:<subfp>:<bookfile_id>` secondary index in PebbleStore;
-  replace dedup's full-scan fuzzy match with candidate-set + Hamming
-  refine. Bench target: <100ms per query at 15K files. Includes
-  global subfingerprint-frequency masking to learn shared intros
-  from the data instead of relying on the 10% slice rule.
-- [ ] **Step 4 — Drop legacy seg1..6 fields.** After one release
-  cycle of validation: remove `AcoustIDSeg1..6` from `BookFile`,
-  remove `FileSegments` + offset/ffmpeg-pipe code from
-  `internal/fingerprint/fpcalc.go`, migrate prod data to clear
-  the columns.
+- [x] **Step 3 — LSH index for whole-file similarity.** ✅ F5-T012 + T013 (Jun 10): `fpidx:<subfp>:<bookfile_id>` Pebble secondary index + build op; LSH probe collector replaces O(N) `ACOUSTID_FUZZY_ENABLED` path.
+- [x] **Step 4 — Drop legacy seg1..6 fields.** ✅ F5-T019 + T020 (Jun 10): seg fields stripped from memdb projections (T019) and from all new Pebble `book_file:` writes (T020); `SweepBookFileSegDrop` backfills legacy rows.
 - [ ] **Online AcoustID lookup.** Whole-file fps can now be POSTed
   to `acoustid.org` for MBID enrichment — wire it up as an
   optional enrichment step after fingerprinting.


### PR DESCRIPTION
## Summary

- Marks all F5-T001..T027 plus bonus T028 as `[x] ✅` in TODO — all landed June 9–10 but post-task hygiene was skipped
- Marks MED-5 security pen-test finding resolved (fixed by T009 accept-invite EOF fix)
- Marks fingerprint Steps 3+4 done (T012/T013 = LSH index; T019/T020 = seg drop)
- Adds CHANGELOG entries for every task not already documented: T001–T015, T018–T019, T021–T028
- Updates Current Status date and summary to June 12

## Test plan

- [ ] Verify TODO Fable 5 section shows all tasks checked
- [ ] Verify CHANGELOG Unreleased section has new June 9–10 entries above existing T016/T017/T020 entries
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)