### PR TITLE
chore(docs): slim copilot-instructions + AGENTS.md — redirect to falkcorp/.github

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,47 +1,36 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 3.0.0 -->
+<!-- version: 4.0.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
-<!-- last-edited: 2026-01-31 -->
+<!-- last-edited: 2026-06-12 -->
 
-# Audiobook Organizer - AI Agent Instructions
+# Audiobook Organizer — Additional Copilot Context
 
-Full-stack web application for managing and organizing audiobook collections.
+Org-wide coding standards (file headers, Go/TS rules, commit format) are at
+**https://github.com/falkcorp/.github** and apply automatically to this repo.
 
-## Repository Architecture
+This file contains audiobook-organizer-specific additions only.
+For full project context see **CLAUDE.md** at the repo root.
 
-- **Backend (Go 1.25):** REST API, file operations, metadata extraction, database management
-- **Frontend (React + TypeScript):** Material-UI web interface with real-time updates via SSE
-- **Database:** SQLite for metadata, PebbleDB for key-value storage
-- **Integration:** Open Library API, OpenAI parsing
+## Project overview
 
-### Key Directories
+Go 1.24 backend (Gin) + React 18/TypeScript frontend (Material UI).
+DB: PebbleDB (primary), NutsDB (activity log). SQLite removed Jun 2026.
+Integration: Open Library, AcoustID fingerprinting, OpenAI batch API.
+
+## Key directories
 
 | Directory | Contents |
-|-----------|----------|
+|---|---|
 | `cmd/` | CLI and server entry points |
-| `internal/` | Go backend packages (server, scanner, database, metadata) |
-| `web/` | React frontend application |
-| `docs/` | Documentation |
-| `.github/` | CI/CD workflows, instructions, prompts |
+| `internal/` | Go backend packages |
+| `web/src/` | React frontend |
+| `docs/specs/` | Design specs |
+| `docs/plans/` | Implementation plans |
+| `.github/prompts/` | AI agent prompts |
 
-## Git Operations Policy
+## Critical constraints
 
-1. **MCP GitHub tools** (preferred) — use for all git operations when available.
-2. **Native git** (fallback) — when MCP tools aren't available.
-
-All commits MUST use conventional commit format: `type(scope): description`.
-See `.github/instructions/commit-messages.instructions.md` for full rules.
-
-## File Organization
-
-All files require versioned headers: `<!-- file: path -->`, `<!-- version: x.y.z -->`, `<!-- guid: uuid -->`, `<!-- last-edited: YYYY-MM-DD -->`.
-
-Always increment version numbers on changes (semantic versioning). Update `last-edited` date.
-
-## Instruction Files
-
-- **Coding standards:** `.github/instructions/*.instructions.md`
-- **Specialized prompts:** `.github/prompts/*.prompt.md`
-- **This file:** Primary context for repository architecture and workflow.
-
-For detailed coding rules, see `.github/instructions/general-coding.instructions.md` and the language-specific instruction files.
+- `UpdateBook` does **full column replacement** — always supply all fields.
+- iTunes XML path must **never** be scanned by the file scanner.
+- Production is Linux (`make deploy`). Do not use macOS-specific commands.
+- Worktree discipline: never commit directly to `main`. All changes via PRs.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".standards"]
+	path = .standards
+	url = https://github.com/falkcorp/.github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,60 +1,11 @@
 <!-- file: AGENTS.md -->
-<!-- version: 4.0.0 -->
+<!-- version: 5.0.0 -->
 <!-- guid: 2e7c1a4b-5d3f-4b8c-9e1f-7a6b2c3d4e5f -->
-<!-- last-edited: 2026-01-31 -->
+<!-- last-edited: 2026-06-12 -->
 
-# AGENTS.md — Instruction File Index
+# AGENTS.md
 
-All coding standards and AI agent instructions for the audiobook organizer.
+See **CLAUDE.md** for all agent instructions and project context.
 
-## Core Instructions
-
-| File | Applies to | Purpose |
-|------|-----------|---------|
-| [copilot-instructions.md](.github/copilot-instructions.md) | All | Repo architecture, workflow policy |
-| [general-coding.instructions.md](.github/instructions/general-coding.instructions.md) | `**` | Universal rules: headers, git, testing |
-| [commit-messages.instructions.md](.github/instructions/commit-messages.instructions.md) | `**` | Conventional commit format |
-| [pull-request-descriptions.instructions.md](.github/instructions/pull-request-descriptions.instructions.md) | `**` | PR description template |
-| [test-generation.instructions.md](.github/instructions/test-generation.instructions.md) | test files | Testing standards |
-| [security.instructions.md](.github/instructions/security.instructions.md) | `**` | Security best practices |
-
-## Language Instructions
-
-| File | Applies to |
-|------|-----------|
-| [go.instructions.md](.github/instructions/go.instructions.md) | `**/*.go` |
-| [typescript.instructions.md](.github/instructions/typescript.instructions.md) | `**/*.{ts,tsx}` |
-| [javascript.instructions.md](.github/instructions/javascript.instructions.md) | `**/*.{js,jsx}` |
-| [python.instructions.md](.github/instructions/python.instructions.md) | `**/*.py` |
-| [shell.instructions.md](.github/instructions/shell.instructions.md) | `**/*.{sh,bash}` |
-| [rust.instructions.md](.github/instructions/rust.instructions.md) | `**/*.rs` |
-| [protobuf.instructions.md](.github/instructions/protobuf.instructions.md) | `**/*.proto` |
-| [markdown.instructions.md](.github/instructions/markdown.instructions.md) | `**/*.md` |
-| [json.instructions.md](.github/instructions/json.instructions.md) | `**/*.json` |
-| [html-css.instructions.md](.github/instructions/html-css.instructions.md) | `**/*.{html,css}` |
-| [github-actions.instructions.md](.github/instructions/github-actions.instructions.md) | `.github/workflows/*.yml` |
-
-## Prompts
-
-All in `.github/prompts/`. Key ones:
-
-- `code-review.prompt.md` — Code review guidance
-- `pull-request.prompt.md` — PR creation
-- `commit-message.prompt.md` — Commit message generation
-- `security-review.prompt.md` — Security review
-- `bug-report.prompt.md` / `feature-request.prompt.md` — Issue templates
-- `merge-conflict-resolution.agent.md` — Merge conflict resolution
-- `ai-rebase-system.prompt.md` — Rebase workflow
-
-## Version Policy
-
-When modifying any file with a version header, **always update the version:**
-
-- **Patch** (x.y.Z): typos, minor fixes
-- **Minor** (x.Y.z): new content, additions
-- **Major** (X.y.z): structural changes
-
-## Git Operations
-
-1. MCP GitHub tools (preferred)
-2. Native git (fallback)
+Org-wide coding standards (file headers, language rules, commit format):
+**https://github.com/falkcorp/.github**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,22 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 4.7.0 -->
+<!-- version: 4.8.0 -->
 <!-- guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f -->
-<!-- last-edited: 2026-05-24 -->
+<!-- last-edited: 2026-06-12 -->
 
 # CLAUDE.md
 
 This is an **audiobook organizer** — Go backend + React/TypeScript frontend.
-All AI agent instructions live in `.github/`. This file is the entry point.
+
+## Coding Standards
+
+Org-wide coding standards are in the `.standards/` git submodule (cloned from `https://github.com/falkcorp/.github`).
+Always clone with `git clone --recurse-submodules` so these are available.
+
+Key files:
+- **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
+- **Go rules:** `.standards/instructions/go.md`
+- **TypeScript rules:** `.standards/instructions/typescript.md`
+- **Commit format:** `.standards/instructions/commit-messages.md`
 
 ## Worktree Discipline (MANDATORY)
 


### PR DESCRIPTION
## Summary

- **Root cause of PR #1340 comment:** `copilot-instructions.md` only described HTML comment format for versioned headers — never mentioned Go `// file:` format. Burndown bot agents skipped updating Go file headers.
- **Fix:** Central standards repo at `falkcorp/.github`. Added as a **git submodule** at `.standards/` so every agent/CI clone gets the standards automatically — no separate setup needed.

## What changed

| File | Change |
|---|---|
| `.standards/` (submodule) | `falkcorp/.github` — org-wide standards |
| `.gitmodules` | Wires the submodule |
| `CLAUDE.md` | References `.standards/instructions/` with relative paths |
| `.github/copilot-instructions.md` | Slimmed to project-specific additions (~35 lines) |
| `AGENTS.md` | 8-line pointer to CLAUDE.md + `falkcorp/.github` |

## What's in falkcorp/.github (`.standards/`)

- `copilot-instructions.md` — Copilot reads this org-wide automatically
- `instructions/file-headers.md` — **explicitly distinguishes Go `//` vs Markdown `<!-- -->` format** (the fix for #1340)
- `instructions/go.md`, `typescript.md`, `commit-messages.md`

## How it works after merge

```bash
# Every clone gets the standards
git clone --recurse-submodules https://github.com/falkcorp/audiobook-organizer

# Standards available at:
.standards/instructions/file-headers.md   ← Go vs Markdown header format
.standards/instructions/go.md
.standards/instructions/typescript.md
```

## Test plan

- [ ] Verify `.standards/` submodule is populated after `--recurse-submodules` clone
- [ ] Verify Copilot picks up `falkcorp/.github/copilot-instructions.md` org-wide on next PR
- [ ] Verify burndown bot PRs no longer get header format complaints

🤖 Generated with [Claude Code](https://claude.com/claude-code)