### PR TITLE
fix(web): vite 8 manualChunks must be a function

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,7 @@
 // file: web/vite.config.ts
-// version: 1.1.1
+// version: 1.2.0
 // guid: 9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d
-// last-edited: 2025-05-01
+// last-edited: 2026-06-12
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -29,9 +29,23 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
-          mui: ['@mui/material', '@mui/icons-material'],
+        // Function form (not the object form) because vite 8's rolldown bundler
+        // only accepts manualChunks as a function — the object form throws
+        // "manualChunks is not a function" at build time. Splits the same two
+        // long-lived vendor chunks (react core + MUI) for better browser caching.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          if (id.includes('/@mui/')) return 'mui';
+          if (
+            id.includes('/react/') ||
+            id.includes('/react-dom/') ||
+            id.includes('/react-router/') ||
+            id.includes('/react-router-dom/') ||
+            id.includes('/scheduler/')
+          ) {
+            return 'vendor';
+          }
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Summary

`make web-build` / `make deploy` are broken on `main`: the vite 7→8 bump switched the bundler to **rolldown**, which rejects the object form of `build.rollupOptions.output.manualChunks` with `TypeError: manualChunks is not a function`.

Convert `manualChunks` to the function form (accepted by both rollup and rolldown), preserving the same two long-lived vendor chunks (react core + MUI) for browser caching.

## Test plan

- `make web-build` → exit 0, `vendor` and `mui` chunks emitted, `✓ built` (previously hard-failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)