### PR TITLE
fix(deps): pin vite in dependabot + target the real /web manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Dependabot Configuration
-# version: 1.0.0
+# version: 1.1.0
 # guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 version: 2
@@ -46,15 +46,28 @@ updates:
     labels:
       - tech:go
 
-  # Npm
+  # Npm — the manifest lives in /web (root manifests were removed in the
+  # "consolidate root npm deps into web" cleanup), so this MUST target /web or
+  # none of the ignore rules below apply to the real package.json.
   - package-ecosystem: npm
-    directory: /
+    directory: /web
     patterns: ["*"]
     multi-ecosystem-group: dependencies
     labels:
       - tech:nodejs
     ignore:
+      # Block all major version updates (scheduled version updates only).
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Hard-pin the build toolchain. vite 8 (rolldown bundler) is incompatible
+      # with this React 18 + MUI v5 + emotion app — it crashed every page with
+      # React error #130 (see CHANGELOG 2026-06-12). These use `versions` ranges
+      # (not update-types) so they ALSO block dependabot SECURITY updates from
+      # jumping the major, which is how the vite 8 bump slipped in originally.
+      # Remove once the rolldown #130 incompatibility is resolved.
+      - dependency-name: "vite"
+        versions: [">=8.0.0"]
+      - dependency-name: "@vitejs/plugin-react"
+        versions: [">=5.0.0"]
 


### PR DESCRIPTION
## Summary

The npm dependabot config targeted `directory: /`, but the manifests moved to `/web` (root manifests were removed in the "consolidate root npm deps into web" cleanup). So its existing "ignore all major updates" rule **never applied to the real `package.json`** — which is how the vite 7→8 security-update bump that crashed the UI (React #130, app-wide) slipped through.

### Changes
- Point the `npm` ecosystem at `directory: /web`.
- Add explicit ignores for `vite` (`>=8.0.0`) and `@vitejs/plugin-react` (`>=5.0.0`), using **`versions` ranges** (not `update-types`) so they also block dependabot **security** updates from jumping the major — not just scheduled version updates.

Remove these pins once vite 8's rolldown bundler is compatible with this React 18 + MUI v5 + emotion app.

## Test plan
- YAML parses; npm entry resolves to `directory: /web` with three ignore rules (catch-all major + vite ≥8 + plugin-react ≥5). Config-only change, no app build/deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)