### PR TITLE
fix(dedup): exact-title file-validity gate + tuning-dataset foundation (M0–M1)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 4.1.0 -->
+<!-- version: 4.1.1 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -47,8 +47,9 @@ sides** of a pair before emitting a `DedupCandidate`. This prevents stub or
 unscanned books (zero duration, zero file size) from being emitted as candidates
 and flooding the review queue with false positives.
 
-`checkExactAcoustID` is **intentionally NOT gated** — an AcoustID match is
-itself sufficient evidence of audio content.
+The AcoustID collector `CollectExactAcoustID` (`internal/dedup/collectors_acoustid.go`)
+is **intentionally NOT gated** — an AcoustID match is itself sufficient evidence of
+audio content.
 
 ### Labeled training dataset
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 4.0.0 -->
+<!-- version: 4.1.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
-<!-- last-edited: 2026-06-12 -->
+<!-- last-edited: 2026-06-13 -->
 
 # Audiobook Organizer — Additional Copilot Context
 
@@ -34,3 +34,46 @@ Integration: Open Library, AcoustID fingerprinting, OpenAI batch API.
 - iTunes XML path must **never** be scanned by the file scanner.
 - Production is Linux (`make deploy`). Do not use macOS-specific commands.
 - Worktree discipline: never commit directly to `main`. All changes via PRs.
+
+## Dedup architecture
+
+### Candidate emission gate (`hasPlausibleAudio`)
+
+`internal/dedup/engine.go` — `hasPlausibleAudio(book *database.Book) bool`
+returns true when `Duration > 0` OR `FileSize >= 256 KiB` (256 × 1024 bytes).
+
+The `checkExactTitle` and `checkExactISBN` emitters call this gate for **both
+sides** of a pair before emitting a `DedupCandidate`. This prevents stub or
+unscanned books (zero duration, zero file size) from being emitted as candidates
+and flooding the review queue with false positives.
+
+`checkExactAcoustID` is **intentionally NOT gated** — an AcoustID match is
+itself sufficient evidence of audio content.
+
+### Labeled training dataset
+
+The dataset subsystem lives in two packages:
+
+- **`internal/database/dedup_label.go`** — PebbleDB keyspace `dedup:label:`.
+  Stores `LabeledExample` records: candidate pair + per-book feature snapshots
+  (`BookFeatures`) + label fields (`label`, `label_source`, `label_reason`,
+  `decided_at`). Empty `label` means unlabeled (features only, for future ML).
+
+- **`internal/dedup/dataset/`** — pure package; no DB side effects.
+  - `BuildExample` computes: duration ratio, folder relation (unrelated /
+    same_dir / a_ancestor_of_b / b_ancestor_of_a), recording-ID overlap,
+    whole-book signature relation (unknown / match / disjoint).
+  - `Classify` runs three deterministic catchers in priority order:
+    1. `wholeBookSignatureMatch` → `true_dup` (positive oracle; similarity ≥ 0.95)
+    2. `missingFile` → `not_dup` (never merge a book with no files)
+    3. `partVsWhole` → `not_dup` (duration ratio < 0.5 with both durations known)
+
+### Backfill op
+
+`internal/plugins/dedup/dataset_backfill.go` — `dedup.dataset-backfill` UOS op.
+Dry-run by default; `apply=true` writes labeled examples and dismisses
+rule-confirmed `not_dup` candidates (status → `dismissed`). Idempotent.
+
+Known gap: pairs where one side has `Duration=0` but file records exist are NOT
+caught by the current catchers; they remain unlabeled. The engine gate stops NEW
+such pairs; a future FileSize-aware catcher will handle the existing residual.

--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,6 @@ delete-*.py
 
 # Backup tarballs
 backups/
+
+# dedup-dataset-audit CLI build artifact (run from tools/cmd/dedup-dataset-audit)
+/dedup-dataset-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.19.0 -->
+<!-- version: 3.19.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -15,8 +15,9 @@
   Returns true when a book has positive duration OR file size >= 256 KiB. The
   `checkExactTitle` and `checkExactISBN` emitters now call this gate for both sides of
   a candidate pair before emitting; stub/unscanned books with no audio evidence are
-  blocked from producing new false-positive candidates. `checkExactAcoustID` is
-  intentionally not gated (AcoustID match is its own evidence of audio content).
+  blocked from producing new false-positive candidates. The AcoustID collector
+  `CollectExactAcoustID` (`internal/dedup/collectors_acoustid.go`) is intentionally
+  not gated (an AcoustID match is its own evidence of audio content).
 
 - **`internal/database/dedup_label.go`** (NEW) — PebbleDB keyspace `dedup:label:` for the
   labeled dedup training dataset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,64 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.18.0 -->
+<!-- version: 3.19.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-12 -->
+<!-- last-edited: 2026-06-13 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+#### June 13, 2026 — Dedup tuning dataset: engine gate + labeled store + backfill op
+
+- **`internal/dedup/engine.go`** — `hasPlausibleAudio(book *database.Book) bool` gate added.
+  Returns true when a book has positive duration OR file size >= 256 KiB. The
+  `checkExactTitle` and `checkExactISBN` emitters now call this gate for both sides of
+  a candidate pair before emitting; stub/unscanned books with no audio evidence are
+  blocked from producing new false-positive candidates. `checkExactAcoustID` is
+  intentionally not gated (AcoustID match is its own evidence of audio content).
+
+- **`internal/database/dedup_label.go`** (NEW) — PebbleDB keyspace `dedup:label:` for the
+  labeled dedup training dataset.
+  - `LabeledExample`: stores one candidate pair with computed feature snapshot and
+    label fields (`label`, `label_source`, `label_reason`, `decided_at`,
+    `formula_version`).
+  - `BookFeatures`: per-book evidence snapshot (title, author, primary_path,
+    total_duration_sec, file_count, has_cover, files_exist, recording_ids,
+    itunes_pid_present, whole_book_sig_present).
+  - `LabeledExampleFilter`: narrows list/count queries by label, label_source, band,
+    folder_relation, signature_relation.
+  - Store methods on `*EmbeddingStore`: `UpsertLabeledExample`, `GetLabeledExample`,
+    `ListLabeledExamples`, `CountLabeledExamples`.
+
+- **`internal/dedup/dataset/`** (NEW package) — pure builder + deterministic catchers.
+  - `BuildExample(BuilderStore, DedupCandidate) (LabeledExample, error)`: loads both
+    books, computes duration ratio, folder relation, recording-ID overlap,
+    whole-book signature relation. No side effects; label fields left empty.
+  - `Classify(LabeledExample) (label, reason string, fires bool)`: runs three
+    deterministic catchers in priority order:
+    1. `wholeBookSignatureMatch` → `true_dup` (positive oracle; both sigs present +
+       similarity >= 0.95)
+    2. `missingFile` → `not_dup` (hard negative; never merge a book with no files)
+    3. `partVsWhole` → `not_dup` (duration ratio < 0.5 when both durations known)
+
+- **`internal/plugins/dedup/dataset_backfill.go`** (NEW) — `dedup.dataset-backfill` UOS op.
+  Iterates all pending candidates, builds a LabeledExample per pair, runs catchers, and
+  writes to the `dedup:label:` keyspace. With `apply=true`, any candidate a catcher
+  labels `not_dup` is dismissed (status → `dismissed`). Dry-run by default. Idempotent:
+  re-running is safe; done-flags are unnecessary because `UpsertLabeledExample` overwrites
+  and re-dismissing a dismissed candidate is a no-op.
+
+### Changed
+
+#### June 13, 2026 — M0: legacy false-positive purge applied on production
+
+- Applied `dedup.purge-legacy-fp-candidates` on production: 12,322 candidates with
+  `layer=exact` and `similarity=1.0` promoted from legacy fingerprint-hash equality
+  (pre-unified-pipeline) were moved to `stale-fp` status. Idempotency flag
+  `dedup_fp_purge_v1_done` set. These were never meaningful dedup candidates — they
+  fired on segment-fingerprint equality across parts of the same audiobook series, not
+  actual duplicates. The pending queue is now limited to acoustically meaningful pairs.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.77.0 -->
+<!-- version: 8.78.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -95,6 +95,64 @@ All 27 planned tasks + 1 bonus task shipped. Specs and plan docs:
 
 ### Bonus
 - [x] **F5-T028** `AppConfig` RWMutex-guarded accessors — convert all write sites ✅ Jun 10
+
+---
+
+## ✅ Dedup Tuning Dataset — COMPLETE (June 13, 2026)
+
+Spec: [`docs/specs/2026-06-13-dedup-tuning-dataset-design.md`](docs/specs/2026-06-13-dedup-tuning-dataset-design.md)
+Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md)
+
+### M0 — Legacy false-positive purge ✅ applied on production June 13
+- [x] **M0** `dedup.purge-legacy-fp-candidates` applied: 12,322 candidates (`layer=exact`,
+  `similarity=1.0`) → `stale-fp`. Idempotency flag `dedup_fp_purge_v1_done` set. ✅ Jun 13
+
+### Milestone A — Engine gate ✅
+- [x] **A1** `hasPlausibleAudio(book *database.Book) bool` in `internal/dedup/engine.go`:
+  returns true when `Duration > 0` OR `FileSize >= 256 KiB`. ✅ Jun 13
+- [x] **A2** Gate applied to `checkExactTitle` (both sides, before emit). ✅ Jun 13
+- [x] **A3** Gate applied to `checkExactISBN` (both sides, before emit). ✅ Jun 13
+  Note: `checkExactAcoustID` intentionally not gated (AcoustID is its own evidence).
+
+### Milestone B — Dataset store + builder + catchers ✅
+- [x] **B1** `internal/database/dedup_label.go`: `LabeledExample`, `BookFeatures`,
+  `LabeledExampleFilter`; PebbleDB keyspace `dedup:label:<id16hex>`. ✅ Jun 13
+- [x] **B2** `*EmbeddingStore` methods: `UpsertLabeledExample`, `GetLabeledExample`,
+  `ListLabeledExamples`, `CountLabeledExamples`. ✅ Jun 13
+- [x] **B3** `internal/dedup/dataset/builder.go`: `BuildExample` (pure; computes duration
+  ratio, folder relation, recording-ID overlap, signature relation). ✅ Jun 13
+- [x] **B4** `internal/dedup/dataset/rules.go`: `Classify` — three catchers in priority
+  order: `wholeBookSignatureMatch` → `true_dup`; `missingFile` → `not_dup`;
+  `partVsWhole` (ratio < 0.5) → `not_dup`. ✅ Jun 13
+
+### Milestone C — Backfill op ✅
+- [x] **C1–C4** `internal/plugins/dedup/dataset_backfill.go`: `dedup.dataset-backfill` UOS
+  op. Dry-run by default; `apply=true` writes and suppresses rule-labeled `not_dup`
+  candidates. Idempotent. ✅ Jun 13
+
+### Deferred follow-ups (open)
+- [ ] **C5-gate** FileSize-aware catcher for residual stub pairs: when both sides have
+  `FileSize > 0` but `Duration == 0`, compare file sizes. Currently these pairs are
+  unlabeled (left for human/ML review) because `DurationRatio == 0` does not fire
+  `partVsWhole`. A separate `fileSizeMismatch` catcher would catch the dominant residual
+  class (0-second stubs vs. real books with large file sizes).
+- [ ] **C5-sig** Offset/subsequence containment: `signatureRelation` currently returns only
+  `match`, `disjoint`, or `unknown`. The `a_contains_b` / `b_contains_a` values in the
+  spec require comparing signature subsequences — deferred to a future milestone.
+- [ ] **C5-folder** `sibling_parts` folder relation: `folderRelation` currently returns only
+  `unrelated`, `same_dir`, `a_ancestor_of_b`, `b_ancestor_of_a`. The `sibling_parts`
+  value (same parent, different child dirs matching a series pattern) is planned but not
+  yet implemented.
+- [ ] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path
+  so each new candidate automatically gets a feature snapshot + deterministic label on
+  creation (no separate backfill needed going forward).
+- [ ] **C6** Review UI: web panel listing `dedup:label:` examples filterable by label,
+  label_source, band; human can override label and set `label_source=human`.
+- [ ] **C7** JSONL export: admin endpoint or CLI tool to export labeled examples as JSONL
+  for offline ML training; include `formula_version` for dataset versioning.
+- [ ] **C8** Auto-bug-filing: after backfill, emit a GitHub issue per `not_dup` cluster
+  where rule-suppressed count exceeds a threshold (surfacing systematic false-positive
+  sources for human review).
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.76.0 -->
+<!-- version: 8.77.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-12 -->
+<!-- last-edited: 2026-06-13 -->
 
 # Project TODO
 
@@ -25,6 +25,27 @@ future agent) can scan the entire workspace in one page.
 **Production:** PebbleDB primary; Linux, HTTPS at prod server
 **Latest activity:** All 27 Fable 5 tasks + T028 bonus shipped (June 9–10). Plugin framework added (agents, skills, pre-commit PII hook). CI fixes (PRs #1405, #1407, #1408). LSHBandCount 64→128.
 **In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds)
+
+---
+
+## 🔮 Needs Serious Planning — Open Audiobook Acoustic-Fingerprint Index (a community-owned "AcoustID for audiobooks")
+
+> Captured 2026-06-13. **Not yet specced — needs a dedicated brainstorming → spec session.**
+> Related: [`docs/specs/2026-06-13-dedup-tuning-dataset-design.md`](docs/specs/2026-06-13-dedup-tuning-dataset-design.md)
+
+**Vision.** MusicBrainz/AcoustID model audiobooks poorly (their DB is song/recording-based; a 9-hour book is not a "recording"). Build our own, better, **community-usable** index of audiobook acoustic fingerprints + verified identity (title/author/series/narrator/edition). It should be good enough that submitting back to AcoustID becomes unnecessary.
+
+**Why a Git repo as the store (the constraint that shapes everything).** No public server, no hosting budget. A **GitHub repository + GitHub Actions is free, durable, and world-pullable**:
+- **Disaster recovery:** if our prod data is wiped, the organizer rehydrates its identity layer by pulling the repo — the index lives outside our box.
+- **Distribution:** anyone can clone it and skip the manual fingerprint/identify work we do today.
+- **Provenance:** every record change is a reviewable commit/PR — human-verified records are auditable.
+
+**Open design questions for the planning session:**
+- **Format** — a sane, diffable, version-controlled on-disk layout (sharded JSON/JSONL by fingerprint-prefix? Parquet? a checked-in SQLite/Pebble snapshot artifact?). Must stay mergeable (avoid giant single files that conflict). Possibly a parallel **AI-queryable representation** (embeddings / structured docs) so the index can be asked natural-language questions.
+- **The PR-bot loop** — a process that emits **PRs of new human-verified records**, and **CI workflows that validate (schema, dedup, no-regression) and apply** them to the canonical index. Bounded batch sizes, signed/attributed records, conflict resolution rules.
+- **Identity unit** — what a "record" keys on (whole-book signature from `internal/fingerprint/book_signature.go` + part fingerprints + metadata), and how editions/abridgements/re-narrations are represented.
+- **Trust & governance** — who can merge, how bad records are challenged/reverted, license (so the world can actually use it).
+- **Relationship to AcoustID submission** — likely **supersedes** it; keep submission as an optional downstream export, not a dependency.
 
 ---
 

--- a/docs/AI-REFERENCE.md
+++ b/docs/AI-REFERENCE.md
@@ -101,7 +101,7 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 - **audiobook.go** — `Audiobook` struct (mostly superseded by `database.Book`)
 
 ### `internal/dedup` — Book deduplication engine
-- **engine.go** — `Engine` type; per-layer candidate collectors (`checkExactTitle`, `checkExactISBN`, `checkExactAcoustID`, LSH-probe, metadata-fuzzy); `PairEligibility` pre-filter; `hasPlausibleAudio(book) bool` gate (returns true when `Duration > 0` OR `FileSize >= 256 KiB`). The exact-title and exact-ISBN emitters call this gate for both sides before emitting a candidate — prevents stub/unscanned books from creating false-positive pairs.
+- **engine.go** — `Engine` type; per-layer candidate emitters (`checkExactTitle`, `checkExactISBN`, `checkExactFileHash`, `checkExactMetadataSourceHash`, `checkDurationMatch`; the AcoustID/LSH/embedding/metadata-fuzzy collectors live in `collectors_*.go`); `PairEligibility` pre-filter; `hasPlausibleAudio(book) bool` gate (returns true when `Duration > 0` OR `FileSize >= 256 KiB`). The exact-title and exact-ISBN emitters call this gate for both sides before emitting a candidate — prevents stub/unscanned books from creating false-positive pairs.
 - **dataset/** (sub-package) — Pure builder + deterministic catchers for the labeled training dataset. No side effects.
   - `BuilderStore` interface: `GetBook(id string)`, `GetBookFiles(id string)`
   - `BuildExample(BuilderStore, DedupCandidate) (LabeledExample, error)` — loads both books, computes `DurationRatio`, `FolderRelation`, `SharesRecordingID`, `SignatureRelation`. Label fields left empty; caller must run `Classify`.
@@ -425,7 +425,7 @@ Background operations run with configurable timeout (default 30min, currently se
 All files require versioned headers. Bump version on every change:
 ```go
 // file: internal/server/itunes.go
-// version: 2.11.0
+// version: 2.11.1
 // guid: 719912e9-7b5f-48e1-afa6-1b0b7f57c2fa
 ```
 

--- a/docs/AI-REFERENCE.md
+++ b/docs/AI-REFERENCE.md
@@ -349,7 +349,7 @@ u:<user_ulid>                  → User JSON
 sess:<session_ulid>            → Session JSON
 ```
 
-### Dedup / Embedding keyspace (separate EmbeddingStore PebbleDB)
+### Dedup / Embedding keyspace (within the main audiobooks.pebble DB)
 
 ```
 emb:v:<entityType>:<entityID>  → embRec JSON          (embedding vector record)

--- a/docs/AI-REFERENCE.md
+++ b/docs/AI-REFERENCE.md
@@ -3,7 +3,7 @@
 > **Purpose**: Complete project reference for AI agents. Read this before making any changes.
 > Keep this file updated with every architectural change.
 
-**Last updated**: 2026-03-12 | **Server version**: 1.116.0 | **Total API routes**: 189
+**Last updated**: 2026-06-13 | **Server version**: 1.117.0 | **Total API routes**: 189
 
 ## Quick Facts
 
@@ -49,6 +49,8 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 ### `internal/database` — Data layer
 - **store.go** — `Store` interface (255 methods), ALL entity struct definitions (Book, Author, Series, Work, Narrator, BookSegment, Operation, etc.)
 - **pebble_store.go** — Primary implementation. Key schema: `book:<ulid>`, `book:path:<filepath>`, `book:hash:<hash>`, `author:<id>`, `series:<id>`, etc.
+- **embedding_store.go** — `EmbeddingStore` wrapping a separate PebbleDB for embeddings + dedup candidates + labeled dataset. Key-space: `emb:v:*`, `emb:c:*`, `dedup:r:*`, `dedup:p:*`, `dedup:seq`, `dedup:label:*`.
+- **dedup_label.go** — Labeled dedup training dataset keyspace (`dedup:label:<candidateID,16hex>`). Types: `LabeledExample` (candidate pair + feature snapshot + label fields), `BookFeatures` (per-book evidence: title, author, path, durations, file count, has_cover, files_exist, recording_ids, itunes_pid_present, whole_book_sig_present), `LabeledExampleFilter`. Methods on `*EmbeddingStore`: `UpsertLabeledExample`, `GetLabeledExample`, `ListLabeledExamples`, `CountLabeledExamples`.
 - **ai_scan_store.go** — Separate PebbleDB (`ai_scans.db`) for AI dedup pipeline
 - **sqlite_store.go** — Alternative SQLite implementation
 - **mock_store.go** — Test mock (generated with mockery patterns)
@@ -97,6 +99,19 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 
 ### `internal/models` — Legacy models
 - **audiobook.go** — `Audiobook` struct (mostly superseded by `database.Book`)
+
+### `internal/dedup` — Book deduplication engine
+- **engine.go** — `Engine` type; per-layer candidate collectors (`checkExactTitle`, `checkExactISBN`, `checkExactAcoustID`, LSH-probe, metadata-fuzzy); `PairEligibility` pre-filter; `hasPlausibleAudio(book) bool` gate (returns true when `Duration > 0` OR `FileSize >= 256 KiB`). The exact-title and exact-ISBN emitters call this gate for both sides before emitting a candidate — prevents stub/unscanned books from creating false-positive pairs.
+- **dataset/** (sub-package) — Pure builder + deterministic catchers for the labeled training dataset. No side effects.
+  - `BuilderStore` interface: `GetBook(id string)`, `GetBookFiles(id string)`
+  - `BuildExample(BuilderStore, DedupCandidate) (LabeledExample, error)` — loads both books, computes `DurationRatio`, `FolderRelation`, `SharesRecordingID`, `SignatureRelation`. Label fields left empty; caller must run `Classify`.
+  - `Classify(LabeledExample) (label, reason string, fires bool)` — three catchers in priority order: `wholeBookSignatureMatch` (→ `true_dup`; both sigs present + similarity ≥ 0.95), `missingFile` (→ `not_dup`), `partVsWhole` (→ `not_dup`; ratio < 0.5 with both durations known). Returns `("","",false)` when no catcher fires.
+  - Note: `BookFeatures.Author` is left empty — author name resolution would require an additional store method not in `BuilderStore`.
+
+### `internal/plugins/dedup` — Dedup plugin operations
+- **dataset_backfill.go** — `dedup.dataset-backfill` UOS op. Iterates all pending candidates, calls `dataset.BuildExample` + `dataset.Classify`, writes `LabeledExample` to `dedup:label:` keyspace. With `apply=true`, dismisses candidates labeled `not_dup` by a catcher. Dry-run by default. Idempotent.
+  - `builderAdapter` bridges `database.Store.GetBookByID` → `BuilderStore.GetBook` (name mismatch bridged without touching either interface).
+  - Known limitation: pairs where one side has `Duration=0` but file records exist are NOT caught by the current catchers — they are left unlabeled for human/ML review. The engine gate stops NEW such pairs from being created; existing residual pairs need a future FileSize-aware catcher.
 
 ---
 
@@ -334,6 +349,19 @@ u:<user_ulid>                  → User JSON
 sess:<session_ulid>            → Session JSON
 ```
 
+### Dedup / Embedding keyspace (separate EmbeddingStore PebbleDB)
+
+```
+emb:v:<entityType>:<entityID>  → embRec JSON          (embedding vector record)
+emb:c:<model>:<textHash>       → raw float32 blob      (embedding cache)
+dedup:r:<id16hex>              → DedupCandidate JSON   (candidate record)
+dedup:p:<type>:<aID>:<bID>     → id16hex               (pair uniqueness index)
+dedup:seq                      → [8]byte LE int64      (auto-increment counter)
+dedup:label:<id16hex>          → LabeledExample JSON   (labeled training dataset)
+```
+
+Key format note: `<id16hex>` is a 16-character lowercase hex string encoding a signed int64 as uint64 (e.g., `fmt.Sprintf("%016x", uint64(candidateID))`). This zero-pads the key so prefix scans return rows in stable order.
+
 ---
 
 ## Critical Implementation Details
@@ -415,7 +443,8 @@ All diagrams are in `docs/diagrams/` in both Mermaid (`.mmd`) and Graphviz DOT (
 | Book Scan Flow | `flow-book-scan.mmd` | Directory scan → metadata extraction → dedup → save |
 | Organize Flow | `flow-organize.mmd` | File moves, renames, tag writing |
 | Metadata Fetch Flow | `flow-metadata-fetch.mmd` | Multi-source search → apply with provenance |
-| AI Dedup Flow | `flow-ai-dedup.mmd` | Multi-model scan → cross-validation → apply |
+| AI Dedup Flow | `flow-ai-dedup.mmd` | Multi-model scan → cross-validation → apply (AUTHOR dedup via OpenAI batch API) |
+| Book Dedup Candidate Lifecycle | `flow-book-dedup.mmd` | Scan → exact/LSH emitters (gated by `hasPlausibleAudio`) → candidate → backfill op → labeled dataset → (future) review UI / JSONL export |
 
 Render Mermaid: `mmdc -i file.mmd -o file.svg`
 Render DOT: `dot -Tsvg file.dot -o file.svg`

--- a/docs/database-pebble-schema.md
+++ b/docs/database-pebble-schema.md
@@ -1,7 +1,7 @@
 <!-- file: docs/database-pebble-schema.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 8f6e2c1b-7d4a-4f86-9f2a-5a6b7c8d9e0f -->
-<!-- last-edited: 2026-01-19 -->
+<!-- last-edited: 2026-06-13 -->
 
 # PebbleDB Keyspace Schema and Data Model
 
@@ -557,6 +557,45 @@ number
 - Segments for book: scan `bfi:<bookID>:` then fetch `bf:<segmentID>`
 - Recent playback events: reverse-iterate `playe:<userID>:<bookID>:`
 - Recent operations: scan `op:` (ULID provides time order)
+
+## Dedup / Embedding store (separate PebbleDB instance)
+
+The dedup and embedding data lives in a separate `EmbeddingStore` PebbleDB
+(not the main audiobooks.pebble). This separation keeps LSH/candidate churn
+from amplifying compaction on book records.
+
+### Embedding keyspace
+
+| Key pattern | Value | Notes |
+|-------------|-------|-------|
+| `emb:v:<entityType>:<entityID>` | `embRec` JSON | Embedding vector record |
+| `emb:c:<model>:<textHash>` | raw float32 blob | Embedding cache (no JSON overhead) |
+
+### Dedup candidate keyspace
+
+| Key pattern | Value | Notes |
+|-------------|-------|-------|
+| `dedup:r:<id16hex>` | `DedupCandidate` JSON | Candidate record; primary row |
+| `dedup:p:<type>:<aID>:<bID>` | `<id16hex>` | Pair uniqueness index (prevents re-emission) |
+| `dedup:seq` | `[8]byte` little-endian int64 | Auto-increment counter for candidate IDs |
+
+### Labeled dataset keyspace
+
+| Key pattern | Value | Notes |
+|-------------|-------|-------|
+| `dedup:label:<id16hex>` | `LabeledExample` JSON | One labeled (or unlabeled) candidate pair with feature snapshot |
+
+`<id16hex>` is `fmt.Sprintf("%016x", uint64(candidateID))` — zero-padded
+16-char lowercase hex encoding the candidate's int64 ID. Zero-padding ensures
+fixed-width keys so prefix scans return rows in stable integer order.
+
+`LabeledExample` key fields: `candidate_id`, `entity_a_id`, `entity_b_id`,
+`layer`, `band`, `score`, `score_breakdown`; `a`/`b` `BookFeatures` snapshots
+(title, author, primary_path, total_duration_sec, file_count, has_cover,
+files_exist, recording_ids, itunes_pid_present, whole_book_sig_present);
+`duration_ratio`, `folder_relation`, `shares_recording_id`,
+`signature_relation`; `label`, `label_source`, `label_reason`, `decided_at`,
+`formula_version`. Empty `label` = unlabeled, features only.
 
 ## Write patterns & atomicity
 

--- a/docs/database-pebble-schema.md
+++ b/docs/database-pebble-schema.md
@@ -1,5 +1,5 @@
 <!-- file: docs/database-pebble-schema.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.2.1 -->
 <!-- guid: 8f6e2c1b-7d4a-4f86-9f2a-5a6b7c8d9e0f -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -558,11 +558,13 @@ number
 - Recent playback events: reverse-iterate `playe:<userID>:<bookID>:`
 - Recent operations: scan `op:` (ULID provides time order)
 
-## Dedup / Embedding store (separate PebbleDB instance)
+## Dedup / Embedding store (within the main audiobooks.pebble DB)
 
-The dedup and embedding data lives in a separate `EmbeddingStore` PebbleDB
-(not the main audiobooks.pebble). This separation keeps LSH/candidate churn
-from amplifying compaction on book records.
+The dedup and embedding data lives in the same `audiobooks.pebble` PebbleDB as
+the main book store. `EmbeddingStore` receives a `*pebble.DB` reference from the
+main store via `NewEmbeddingStore(db *pebble.DB)` with `owned: false`, so no
+separate file or process is opened. Keyspace isolation is achieved purely by
+prefix: `emb:` for embeddings, `dedup:` for candidates and labels.
 
 ### Embedding keyspace
 

--- a/docs/diagrams/flow-book-dedup.mmd
+++ b/docs/diagrams/flow-book-dedup.mmd
@@ -1,6 +1,6 @@
 flowchart TD
     %% file: docs/diagrams/flow-book-dedup.mmd
-    %% version: 1.0.0
+    %% version: 1.0.1
     %% guid: 7c3e9a21-4f6b-4d08-b1a2-8e5d0c7f3b92
     %% Book Dedup Candidate Lifecycle
 
@@ -10,7 +10,7 @@ flowchart TD
     LSH --> Collectors["Candidate collectors\n(engine.go)"]
     Collectors --> ExactTitle["checkExactTitle\nexact title+author match"]
     Collectors --> ExactISBN["checkExactISBN\nexact ISBN match"]
-    Collectors --> ExactAcoustID["checkExactAcoustID\nAcoustID hash match"]
+    Collectors --> ExactAcoustID["CollectExactAcoustID\n(collectors_acoustid.go)"]
     Collectors --> LSHProbe["LSH probe collector\nO(band×k) fingerprint candidates"]
     Collectors --> MetaFuzzy["Metadata-fuzzy collector\nLevenshtein title+author"]
 

--- a/docs/diagrams/flow-book-dedup.mmd
+++ b/docs/diagrams/flow-book-dedup.mmd
@@ -1,0 +1,56 @@
+flowchart TD
+    %% file: docs/diagrams/flow-book-dedup.mmd
+    %% version: 1.0.0
+    %% guid: 7c3e9a21-4f6b-4d08-b1a2-8e5d0c7f3b92
+    %% Book Dedup Candidate Lifecycle
+
+    Scan([Book scan / rescan]) --> Fingerprint["Fingerprint files\n(fpcalc → AcoustIDFingerprintDurationSec)"]
+    Fingerprint --> LSH["Build LSH index\n(dedup.lsh-index-build op)\nfpidx:&lt;subfp&gt;:&lt;bookfile_id&gt;"]
+
+    LSH --> Collectors["Candidate collectors\n(engine.go)"]
+    Collectors --> ExactTitle["checkExactTitle\nexact title+author match"]
+    Collectors --> ExactISBN["checkExactISBN\nexact ISBN match"]
+    Collectors --> ExactAcoustID["checkExactAcoustID\nAcoustID hash match"]
+    Collectors --> LSHProbe["LSH probe collector\nO(band×k) fingerprint candidates"]
+    Collectors --> MetaFuzzy["Metadata-fuzzy collector\nLevenshtein title+author"]
+
+    ExactTitle --> Gate1{hasPlausibleAudio?\nDuration > 0 OR\nFileSize >= 256 KiB}
+    ExactISBN --> Gate2{hasPlausibleAudio?\nboth sides}
+    Gate1 -->|both sides pass| Emit["Emit DedupCandidate\ndedup:r:&lt;id16hex&gt;\ndedup:p: pair index"]
+    Gate2 -->|both sides pass| Emit
+    Gate1 -->|either side fails| Drop1[Drop — stub/unscanned book]
+    Gate2 -->|either side fails| Drop1
+    ExactAcoustID -->|not gated| Emit
+    LSHProbe --> Emit
+    MetaFuzzy --> Emit
+
+    Emit --> Score["Compose unified score\n(noisy-OR: LSH+AcoustID+meta+embed)\nband: CERTAIN/HIGH/MEDIUM/REVIEW"]
+    Score --> CandStore[("PebbleDB\ndedup:r:&lt;id16hex&gt;\nstatus=pending")]
+
+    CandStore --> Backfill["dedup.dataset-backfill op\n(dry-run or apply=true)"]
+    Backfill --> BuildEx["dataset.BuildExample\n(load books+files; compute features)"]
+    BuildEx --> Classify["dataset.Classify\n(deterministic catchers)"]
+
+    Classify --> SigMatch{"wholeBookSignatureMatch?\nboth sigs + similarity >= 0.95"}
+    SigMatch -->|yes| LabelDup["label=true_dup\nlabel_source=rule"]
+    SigMatch -->|no| MissingFile{"missingFile?\neither side FilesExist=false"}
+    MissingFile -->|yes| LabelNotDup["label=not_dup\nlabel_source=rule"]
+    MissingFile -->|no| PartWhole{"partVsWhole?\nDurationRatio < 0.5\nwith both durations known"}
+    PartWhole -->|yes| LabelNotDup
+    PartWhole -->|no| LabelUnlabeled["label=empty\n(unlabeled — features only\nfor human or ML review)"]
+
+    LabelDup --> WriteLabel[("dedup:label:&lt;id16hex&gt;\nLabeledExample JSON")]
+    LabelNotDup --> WriteLabel
+    LabelUnlabeled --> WriteLabel
+
+    LabelNotDup -->|apply=true| Suppress["UpdateCandidateStatus\n→ dismissed"]
+    LabelDup -->|apply=true, human review| Merge["Merge books\n(future: review UI)"]
+
+    WriteLabel --> FutureExport["(future)\nJSONL export / review UI\n/ ML training pipeline"]
+
+    style Drop1 fill:#fdd,stroke:#c33
+    style LabelDup fill:#dfd,stroke:#3a3
+    style LabelNotDup fill:#ffd,stroke:#aa3
+    style LabelUnlabeled fill:#ddf,stroke:#33a
+    style FutureExport fill:#f5f5f5,stroke:#aaa,stroke-dasharray:5 5
+    style Merge fill:#f5f5f5,stroke:#aaa,stroke-dasharray:5 5

--- a/docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md
+++ b/docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md
@@ -1,0 +1,1220 @@
+<!-- file: docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7f2c9a14-5e63-4b80-9d21-3a8c6f4e1b09 -->
+<!-- last-edited: 2026-06-13 -->
+
+# Dedup Exact-Gate + Tuning Dataset (M1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the live dedup "exact" layer from flagging stub/unscanned files as 100% duplicates, then build the labeled-dataset foundation (feature builder + deterministic catchers + store) and a backfill op that cleans the existing residual.
+
+**Architecture:** Three milestones. **A** adds a file-validity gate to the metadata-based exact emitters in `internal/dedup/engine.go` (root-cause fix for the post-cutover residual). **B** adds `internal/dedup/dataset` (pure feature builder + catcher predicates over a new `database.LabeledExample`) plus a `dedup:label:` Pebble keyspace on `EmbeddingStore`. **C** adds a `dedup.dataset-backfill` UOS op that runs the catchers over all candidates, writes labeled examples, and (with `apply`) suppresses the missing-file / part-vs-whole residual. All additive; dry-run by default.
+
+**Tech Stack:** Go 1.24, PebbleDB (`github.com/cockroachdb/pebble/v2`), the UOS plugin SDK (`pkg/plugin/sdk`), existing `internal/dedup` + `internal/database` packages, `internal/fingerprint/book_signature.go`.
+
+**Spec:** `docs/specs/2026-06-13-dedup-tuning-dataset-design.md`. This plan covers the root-cause fix + spec milestones M1 and (the cleanup half of) M2. Live capture, auto-bug-filing (C5), review UI (C6) and JSONL export (C7) are a follow-up plan.
+
+---
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `internal/dedup/engine.go` | `hasPlausibleAudio` helper + gate in `checkExactTitle`/`checkExactISBN` | Modify |
+| `internal/dedup/engine_test.go` | Engine gate tests | Modify |
+| `internal/database/dedup_label.go` | `LabeledExample` type + `dedup:label:` store methods | Create |
+| `internal/database/dedup_label_test.go` | Store round-trip + filter tests | Create |
+| `internal/dedup/dataset/builder.go` | `BuildExample` — pure feature computation per candidate | Create |
+| `internal/dedup/dataset/builder_test.go` | Builder unit tests | Create |
+| `internal/dedup/dataset/rules.go` | Deterministic catcher predicates | Create |
+| `internal/dedup/dataset/rules_test.go` | Catcher unit tests | Create |
+| `internal/plugins/dedup/dataset_backfill.go` | `dedup.dataset-backfill` op | Create |
+| `internal/plugins/dedup/plugin.go` | Register the new op in the `ops` slice | Modify |
+
+**Boundaries:** the `dataset` package is pure (store-interface in, `database.LabeledExample` out, no side effects). `LabeledExample` lives in `internal/database` (alongside `DedupCandidate`) so the store can marshal it without an import cycle (`database` must not import `dedup`). The op is the only component with side effects.
+
+---
+
+## Milestone A — Root-cause fix: file-validity gate on the exact emitters
+
+**Why:** `checkExactTitle` (`engine.go:815`) emits `layer="exact"`, `sim=1.0` on title+author match with no check that either book has real audio. Verified on prod: 300/300 residual pairs are title-equal, 279/300 have one side that is a stub (<100 KB) or unscanned (`duration=0`). File **size** is the right validity signal — genuine same-file-different-folder duplicates keep a large size even when unscanned (184 MB, `duration=0`), while stub placeholders are 32–182 bytes.
+
+### Task 1: `hasPlausibleAudio` helper
+
+**Files:**
+- Modify: `internal/dedup/engine.go` (add helper near `hasUsableTitle`, line ~1050)
+- Test: `internal/dedup/engine_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/dedup/engine_test.go`:
+
+```go
+func TestHasPlausibleAudio(t *testing.T) {
+	dur := func(v int) *int { return &v }
+	sz := func(v int64) *int64 { return &v }
+
+	cases := []struct {
+		name string
+		book *database.Book
+		want bool
+	}{
+		{"nil book", nil, false},
+		{"32-byte stub, no duration", &database.Book{FileSize: sz(32)}, false},
+		{"182-byte stub, no duration", &database.Book{FileSize: sz(182)}, false},
+		{"large unscanned copy (genuine dupe)", &database.Book{FileSize: sz(184_741_714)}, true},
+		{"positive duration, no size", &database.Book{Duration: dur(3600)}, true},
+		{"empty book", &database.Book{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPlausibleAudio(tc.book); got != tc.want {
+				t.Fatalf("hasPlausibleAudio(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/dedup/ -run TestHasPlausibleAudio -v`
+Expected: FAIL — `undefined: hasPlausibleAudio`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `internal/dedup/engine.go` (just below `hasUsableTitle`):
+
+```go
+// minPlausibleAudioBytes is the smallest file size we treat as a real audio
+// file. Anything smaller is a placeholder/stub (a 32-byte .url shortcut, a
+// 182-byte broken download) that must never anchor an exact-duplicate match.
+const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
+
+// hasPlausibleAudio reports whether a book references real audio content rather
+// than a stub or a never-scanned placeholder. A book qualifies if it has a
+// positive duration OR a file size at/above the plausible-audio floor. This is
+// the engine-side counterpart to the dataset missingFile catcher: it stops the
+// exact-title / ISBN emitters from flagging "100% duplicate" when one side is a
+// 32-byte stub or an unscanned shell. A large unscanned copy (real size, zero
+// duration) still qualifies — it is a genuine duplicate, not garbage.
+func hasPlausibleAudio(book *database.Book) bool {
+	if book == nil {
+		return false
+	}
+	if book.Duration != nil && *book.Duration > 0 {
+		return true
+	}
+	if book.FileSize != nil && *book.FileSize >= minPlausibleAudioBytes {
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/dedup/ -run TestHasPlausibleAudio -v`
+Expected: PASS (all 6 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/dedup/engine.go internal/dedup/engine_test.go
+git commit -m "feat(dedup): add hasPlausibleAudio file-validity helper"
+```
+
+### Task 2: Gate `checkExactTitle`
+
+**Files:**
+- Modify: `internal/dedup/engine.go:815-887` (`checkExactTitle`)
+- Test: `internal/dedup/engine_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/dedup/engine_test.go`. This mirrors the `setupTestEngine` pattern used by `TestEngine_ExactMatch_ISBN`:
+
+```go
+func TestEngine_ExactTitle_RejectsStubFile(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	authorID := "author-1"
+	sz := func(v int64) *int64 { return &v }
+
+	real := &database.Book{ID: "book-real", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(254_192_471)}
+	stub := &database.Book{ID: "book-stub", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(32)}
+	mock.SetBooksByAuthor(authorID, []database.Book{*real, *stub})
+
+	if err := engine.checkExactTitle(real, "Joshua Dalzelle"); err != nil {
+		t.Fatalf("checkExactTitle: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates (stub side must be rejected), got %d", len(cands))
+	}
+}
+
+func TestEngine_ExactTitle_KeepsGenuineLargePair(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	authorID := "author-2"
+	sz := func(v int64) *int64 { return &v }
+
+	a := &database.Book{ID: "book-a", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
+	// Genuine same-file copy in another folder: large size, not yet scanned.
+	b := &database.Book{ID: "book-b", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
+	mock.SetBooksByAuthor(authorID, []database.Book{*a, *b})
+
+	if err := engine.checkExactTitle(a, "Jae"); err != nil {
+		t.Fatalf("checkExactTitle: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate (genuine large dupe kept), got %d", len(cands))
+	}
+}
+```
+
+> NOTE: if `database.MockStore` does not already expose `SetBooksByAuthor`, add a thin setter mirroring its existing `GetBooksByAuthorID` backing map (check `internal/database/mock_store.go`; the existing `TestEngine_ExactMatch_ISBN` shows the established way to seed books — follow whichever seeding method that test uses, e.g. `mock.AddBook(...)`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/dedup/ -run 'TestEngine_ExactTitle_RejectsStubFile|TestEngine_ExactTitle_KeepsGenuineLargePair' -v`
+Expected: `TestEngine_ExactTitle_RejectsStubFile` FAILS (1 candidate emitted for the stub pair); the "Keeps" test passes.
+
+- [ ] **Step 3: Add the gate**
+
+In `internal/dedup/engine.go`, in `checkExactTitle`, add the book-level guard after the existing `hasUsableTitle(book.Title)` check (line ~821):
+
+```go
+	if !hasUsableTitle(book.Title) {
+		return nil
+	}
+	if !hasPlausibleAudio(book) {
+		return nil // stub / unscanned shell — never anchor an exact-title match
+	}
+```
+
+And inside the `for i := range others` loop, after the existing `hasUsableTitle(other.Title)` check (line ~837):
+
+```go
+		if !hasUsableTitle(other.Title) {
+			continue
+		}
+		if !hasPlausibleAudio(other) {
+			continue // stub / unscanned shell on the other side
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/dedup/ -run 'TestEngine_ExactTitle' -v`
+Expected: both PASS. Then run the full package to confirm no regression: `go test ./internal/dedup/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/dedup/engine.go internal/dedup/engine_test.go
+git commit -m "fix(dedup): gate exact-title emitter on file validity (stop stub matches)"
+```
+
+### Task 3: Gate `checkExactISBN`
+
+**Files:**
+- Modify: `internal/dedup/engine.go:712-768` (`checkExactISBN`)
+- Test: `internal/dedup/engine_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestEngine_ExactISBN_RejectsStubFile(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	sz := func(v int64) *int64 { return &v }
+	isbn := func(v string) *string { return &v }
+
+	real := &database.Book{ID: "r", Title: "X", ISBN13: isbn("9781234567890"), FileSize: sz(120_000_000)}
+	stub := &database.Book{ID: "s", Title: "X", ISBN13: isbn("9781234567890"), FileSize: sz(182)}
+	mock.SetAllBooks([]database.Book{*real, *stub}) // backs GetAllBooks
+
+	if err := engine.checkExactISBN(real); err != nil {
+		t.Fatalf("checkExactISBN: %v", err)
+	}
+	cands, _, _ := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates (stub rejected), got %d", len(cands))
+	}
+}
+```
+
+> NOTE: use whichever `GetAllBooks` seeding helper the existing `TestEngine_ExactMatch_ISBN` uses; replace `SetAllBooks` with that.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/dedup/ -run TestEngine_ExactISBN_RejectsStubFile -v`
+Expected: FAIL — 1 candidate emitted.
+
+- [ ] **Step 3: Add the gate**
+
+In `checkExactISBN`, add an early guard after computing the book's ISBNs (after line ~719) and a per-`other` guard before the `matched` block:
+
+```go
+	if bookISBN10 == "" && bookISBN13 == "" && bookASIN == "" {
+		return nil
+	}
+	if !hasPlausibleAudio(book) {
+		return nil
+	}
+```
+
+and inside the loop, right after `if other.ID == book.ID { continue }`:
+
+```go
+			if !hasPlausibleAudio(other) {
+				continue
+			}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/dedup/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/dedup/engine.go internal/dedup/engine_test.go
+git commit -m "fix(dedup): gate exact-ISBN emitter on file validity"
+```
+
+---
+
+## Milestone B — Dataset foundation (spec M1: C1 builder, C2 catchers, C3 store)
+
+### Task 4: `LabeledExample` type + `dedup:label:` store
+
+**Files:**
+- Create: `internal/database/dedup_label.go`
+- Test: `internal/database/dedup_label_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/database/dedup_label_test.go`:
+
+```go
+package database
+
+import (
+	"os"
+	"testing"
+)
+
+func newTestEmbeddingStore(t *testing.T) *EmbeddingStore {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "abk-label-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	ps, err := NewPebbleStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ps.Close() })
+	return NewEmbeddingStore(ps.DB())
+}
+
+func TestLabeledExample_RoundTripAndFilter(t *testing.T) {
+	es := newTestEmbeddingStore(t)
+
+	ex := LabeledExample{
+		CandidateID:      42,
+		EntityAID:        "a",
+		EntityBID:        "b",
+		Layer:            "exact",
+		Label:            "not_dup",
+		LabelSource:      "rule",
+		LabelReason:      "duration ratio 0.02 — part vs whole",
+		FolderRelation:   "sibling_parts",
+		SignatureRelation: "unknown",
+	}
+	if err := es.UpsertLabeledExample(ex); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := es.GetLabeledExample(42)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v (nil=%v)", err, got == nil)
+	}
+	if got.LabelReason != ex.LabelReason || got.Label != "not_dup" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	list, err := es.ListLabeledExamples(LabeledExampleFilter{Label: "not_dup", Limit: 10})
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list by label: err=%v len=%d", err, len(list))
+	}
+	n, err := es.CountLabeledExamples(LabeledExampleFilter{LabelSource: "rule"})
+	if err != nil || n != 1 {
+		t.Fatalf("count by source: err=%v n=%d", err, n)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/database/ -run TestLabeledExample_RoundTripAndFilter -v`
+Expected: FAIL — `undefined: LabeledExample` (and the store methods).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/database/dedup_label.go`:
+
+```go
+// file: internal/database/dedup_label.go
+// version: 1.0.0
+// guid: 1c4d7a90-2b35-4e68-8f01-9d2a5c7e3b46
+// last-edited: 2026-06-13
+
+package database
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// dedupLabelPfx is the Pebble keyspace for labeled dedup examples.
+// Key layout: dedup:label:<candidateID, 16-hex> → LabeledExample JSON.
+const dedupLabelPfx = "dedup:label:"
+
+// dedupLabelKey renders the fixed-width key for a candidate ID so that range
+// scans over the prefix return rows in a stable order.
+func dedupLabelKey(candidateID int64) []byte {
+	return []byte(fmt.Sprintf("%s%016x", dedupLabelPfx, uint64(candidateID)))
+}
+
+// BookFeatures captures the per-book evidence a judge needs. Computed by the
+// dataset feature builder, snapshotted at capture time.
+type BookFeatures struct {
+	Title             string   `json:"title"`
+	Author            string   `json:"author"`
+	PrimaryPath       string   `json:"primary_path"`
+	TotalDurationSec  float64  `json:"total_duration_sec"`
+	FileCount         int      `json:"file_count"`
+	HasCover          bool     `json:"has_cover"`
+	FilesExist        bool     `json:"files_exist"`
+	RecordingIDs      []string `json:"recording_ids,omitempty"`
+	ITunesPIDPresent  bool     `json:"itunes_pid_present"`
+	WholeBookSigPresent bool   `json:"whole_book_sig_present"`
+}
+
+// LabeledExample is one labeled dedup candidate pair plus the features behind
+// the label. Stored at dedup:label:<candidateID>.
+type LabeledExample struct {
+	CandidateID int64  `json:"candidate_id"`
+	EntityAID   string `json:"entity_a_id"`
+	EntityBID   string `json:"entity_b_id"`
+
+	Layer          string       `json:"layer"`
+	Band           string       `json:"band,omitempty"`
+	Score          float64      `json:"score,omitempty"`
+	ScoreBreakdown json.RawMessage `json:"score_breakdown,omitempty"`
+	Similarity     *float64     `json:"similarity,omitempty"`
+
+	A BookFeatures `json:"a"`
+	B BookFeatures `json:"b"`
+
+	DurationRatio     float64 `json:"duration_ratio"`
+	FolderRelation    string  `json:"folder_relation"`    // unrelated|same_dir|a_ancestor_of_b|b_ancestor_of_a|sibling_parts
+	SharesRecordingID bool    `json:"shares_recording_id"`
+	SignatureRelation string  `json:"signature_relation"` // unknown|match|disjoint|a_contains_b|b_contains_a
+
+	Label       string `json:"label"`        // true_dup|not_dup|unsure
+	LabelSource string `json:"label_source"` // rule|itunes_attr|human|llm_judge
+	LabelReason string `json:"label_reason"`
+	DecidedAt   string `json:"decided_at,omitempty"` // RFC3339; caller-stamped
+	FormulaVersion string `json:"formula_version,omitempty"`
+}
+
+// LabeledExampleFilter narrows ListLabeledExamples / CountLabeledExamples.
+// Empty fields are ignored. Filtering is in-memory over the prefix scan, which
+// is fine at dataset scale (tens of thousands of rows).
+type LabeledExampleFilter struct {
+	Label             string
+	LabelSource       string
+	Band              string
+	FolderRelation    string
+	SignatureRelation string
+	Limit             int
+	Offset            int
+}
+
+func (f LabeledExampleFilter) matches(ex *LabeledExample) bool {
+	if f.Label != "" && ex.Label != f.Label {
+		return false
+	}
+	if f.LabelSource != "" && ex.LabelSource != f.LabelSource {
+		return false
+	}
+	if f.Band != "" && ex.Band != f.Band {
+		return false
+	}
+	if f.FolderRelation != "" && ex.FolderRelation != f.FolderRelation {
+		return false
+	}
+	if f.SignatureRelation != "" && ex.SignatureRelation != f.SignatureRelation {
+		return false
+	}
+	return true
+}
+
+// UpsertLabeledExample writes (or overwrites) a labeled example.
+func (s *EmbeddingStore) UpsertLabeledExample(ex LabeledExample) error {
+	data, err := json.Marshal(ex)
+	if err != nil {
+		return fmt.Errorf("marshal labeled example %d: %w", ex.CandidateID, err)
+	}
+	return s.db.Set(dedupLabelKey(ex.CandidateID), data, pebble.Sync)
+}
+
+// GetLabeledExample returns the example for a candidate, or nil if absent.
+func (s *EmbeddingStore) GetLabeledExample(candidateID int64) (*LabeledExample, error) {
+	val, closer, err := s.db.Get(dedupLabelKey(candidateID))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = closer.Close() }()
+	var ex LabeledExample
+	if err := json.Unmarshal(val, &ex); err != nil {
+		return nil, fmt.Errorf("unmarshal labeled example %d: %w", candidateID, err)
+	}
+	return &ex, nil
+}
+
+// ListLabeledExamples returns examples matching the filter (prefix scan).
+func (s *EmbeddingStore) ListLabeledExamples(f LabeledExampleFilter) ([]LabeledExample, error) {
+	prefix := []byte(dedupLabelPfx)
+	upper := append([]byte(dedupLabelPfx[:len(dedupLabelPfx)-1]), dedupLabelPfx[len(dedupLabelPfx)-1]+1)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var out []LabeledExample
+	skipped := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		var ex LabeledExample
+		if err := json.Unmarshal(iter.Value(), &ex); err != nil {
+			continue // skip a corrupt row rather than abort the scan
+		}
+		if !f.matches(&ex) {
+			continue
+		}
+		if f.Offset > 0 && skipped < f.Offset {
+			skipped++
+			continue
+		}
+		out = append(out, ex)
+		if f.Limit > 0 && len(out) >= f.Limit {
+			break
+		}
+	}
+	return out, iter.Error()
+}
+
+// CountLabeledExamples counts examples matching the filter (Limit/Offset ignored).
+func (s *EmbeddingStore) CountLabeledExamples(f LabeledExampleFilter) (int, error) {
+	cf := f
+	cf.Limit, cf.Offset = 0, 0
+	list, err := s.ListLabeledExamples(cf)
+	if err != nil {
+		return 0, err
+	}
+	return len(list), nil
+}
+
+// ensure binary import is used (key helper alternative); kept for forward use.
+var _ = binary.BigEndian
+```
+
+> NOTE: drop the trailing `binary` usage line if `gofmt`/`go vet` flags the unused import; it is only there as a reminder that a fixed-width binary key is an alternative to the hex string. The hex key above is self-contained.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/database/ -run TestLabeledExample_RoundTripAndFilter -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/database/dedup_label.go internal/database/dedup_label_test.go
+git commit -m "feat(dedup): LabeledExample type + dedup:label Pebble store"
+```
+
+### Task 5: Feature builder
+
+**Files:**
+- Create: `internal/dedup/dataset/builder.go`
+- Test: `internal/dedup/dataset/builder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/dedup/dataset/builder_test.go`:
+
+```go
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeStore implements BuilderStore for tests.
+type fakeStore struct {
+	books map[string]*database.Book
+	files map[string][]database.BookFile
+}
+
+func (f *fakeStore) GetBook(id string) (*database.Book, error)              { return f.books[id], nil }
+func (f *fakeStore) GetBookFiles(id string) ([]database.BookFile, error)    { return f.files[id], nil }
+
+func TestBuildExample_PartVsWholeFeatures(t *testing.T) {
+	whole := &database.Book{ID: "whole", Title: "The Crafter's Defense"}
+	part := &database.Book{ID: "part", Title: "The Crafter's Defense"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"whole": whole, "part": part},
+		files: map[string][]database.BookFile{
+			"whole": {{BookID: "whole", FilePath: "/lib/Crafter/whole.m4b", Duration: 36000}},
+			"part":  {{BookID: "part", FilePath: "/lib/Crafter/part-1.m4b", Duration: 1200}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 7, EntityAID: "whole", EntityBID: "part", Layer: "exact"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.A.TotalDurationSec != 36000 || ex.B.TotalDurationSec != 1200 {
+		t.Fatalf("durations: a=%v b=%v", ex.A.TotalDurationSec, ex.B.TotalDurationSec)
+	}
+	wantRatio := 1200.0 / 36000.0
+	if ex.DurationRatio < wantRatio-1e-9 || ex.DurationRatio > wantRatio+1e-9 {
+		t.Fatalf("duration ratio = %v, want %v", ex.DurationRatio, wantRatio)
+	}
+	if ex.FolderRelation != "same_dir" {
+		t.Fatalf("folder relation = %q, want same_dir", ex.FolderRelation)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/dedup/dataset/ -run TestBuildExample_PartVsWholeFeatures -v`
+Expected: FAIL — package/`BuildExample` not defined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/dedup/dataset/builder.go`:
+
+```go
+// file: internal/dedup/dataset/builder.go
+// version: 1.0.0
+// guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
+// last-edited: 2026-06-13
+
+// Package dataset builds labeled dedup examples and runs deterministic catchers
+// over them. Pure: a store interface in, a database.LabeledExample out, no
+// side effects. This is the audit CLI's per-pair logic promoted to a reusable,
+// unit-tested package (spec C1/C2).
+package dataset
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// BuilderStore is the narrow store surface BuildExample needs.
+type BuilderStore interface {
+	GetBook(id string) (*database.Book, error)
+	GetBookFiles(id string) ([]database.BookFile, error)
+}
+
+// BuildExample loads both books once and computes every feature for the pair.
+func BuildExample(store BuilderStore, cand database.DedupCandidate) (database.LabeledExample, error) {
+	ex := database.LabeledExample{
+		CandidateID: cand.ID,
+		EntityAID:   cand.EntityAID,
+		EntityBID:   cand.EntityBID,
+		Layer:       cand.Layer,
+		Band:        cand.Band,
+		Similarity:  cand.Similarity,
+	}
+
+	a, aFiles, err := loadSide(store, cand.EntityAID)
+	if err != nil {
+		return ex, err
+	}
+	b, bFiles, err := loadSide(store, cand.EntityBID)
+	if err != nil {
+		return ex, err
+	}
+	ex.A = buildFeatures(a, aFiles)
+	ex.B = buildFeatures(b, bFiles)
+
+	ex.DurationRatio = durationRatio(ex.A.TotalDurationSec, ex.B.TotalDurationSec)
+	ex.FolderRelation = folderRelation(ex.A.PrimaryPath, ex.B.PrimaryPath)
+	ex.SharesRecordingID = sharesAny(ex.A.RecordingIDs, ex.B.RecordingIDs)
+	ex.SignatureRelation = signatureRelation(a, b)
+	return ex, nil
+}
+
+func loadSide(store BuilderStore, id string) (*database.Book, []database.BookFile, error) {
+	bk, err := store.GetBook(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	files, err := store.GetBookFiles(id)
+	if err != nil {
+		return bk, nil, err
+	}
+	return bk, files, nil
+}
+
+func buildFeatures(bk *database.Book, files []database.BookFile) database.BookFeatures {
+	f := database.BookFeatures{FileCount: len(files)}
+	if bk != nil {
+		f.Title = bk.Title
+		f.WholeBookSigPresent = bk.BookSigV1 != nil && *bk.BookSigV1 != ""
+		if bk.CoverURL != nil && *bk.CoverURL != "" {
+			f.HasCover = true
+		}
+	}
+	var total float64
+	allExist := len(files) > 0
+	for i := range files {
+		fl := &files[i]
+		if f.PrimaryPath == "" && fl.FilePath != "" {
+			f.PrimaryPath = fl.FilePath
+		}
+		// Prefer fpcalc-measured duration; fall back to container duration.
+		if fl.AcoustIDFingerprintDurationSec > 0 {
+			total += fl.AcoustIDFingerprintDurationSec
+		} else if fl.Duration > 0 {
+			total += float64(fl.Duration)
+		}
+		if fl.AcoustIDOnlineRecordingID != "" {
+			f.RecordingIDs = append(f.RecordingIDs, fl.AcoustIDOnlineRecordingID)
+		}
+		if fl.ITunesPersistentID != "" {
+			f.ITunesPIDPresent = true
+		}
+	}
+	f.TotalDurationSec = total
+	f.FilesExist = allExist
+	return f
+}
+
+func durationRatio(a, b float64) float64 {
+	if a <= 0 || b <= 0 {
+		return 0
+	}
+	lo, hi := a, b
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	return lo / hi
+}
+
+// folderRelation classifies how two primary paths sit relative to each other.
+func folderRelation(a, b string) string {
+	if a == "" || b == "" {
+		return "unrelated"
+	}
+	da, db := filepath.Dir(a), filepath.Dir(b)
+	if da == db {
+		return "same_dir"
+	}
+	if isAncestor(da, db) {
+		return "a_ancestor_of_b"
+	}
+	if isAncestor(db, da) {
+		return "b_ancestor_of_a"
+	}
+	return "unrelated"
+}
+
+func isAncestor(anc, desc string) bool {
+	anc = strings.TrimRight(anc, "/")
+	return anc != "" && strings.HasPrefix(desc, anc+"/")
+}
+
+func sharesAny(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// signatureRelation reports the whole-book-signature relationship. M1 ships the
+// presence/match cases (same-coordinate similarity); offset/subsequence
+// containment (a_contains_b / b_contains_a) is deferred (spec C2 note) and
+// returns "unknown" until implemented.
+func signatureRelation(a, b *database.Book) string {
+	if a == nil || b == nil {
+		return "unknown"
+	}
+	if a.BookSigV1 == nil || *a.BookSigV1 == "" || b.BookSigV1 == nil || *b.BookSigV1 == "" {
+		return "unknown"
+	}
+	// Wired in Task 6 via fingerprint.BookSignatureSimilarity; until then,
+	// equal raw signatures are a definite match.
+	if *a.BookSigV1 == *b.BookSigV1 {
+		return "match"
+	}
+	return "unknown"
+}
+```
+
+> NOTE: confirm field names against `internal/database/store.go`: `Book.CoverURL` (`cover_url`), `BookFile.AcoustIDFingerprintDurationSec`, `BookFile.AcoustIDOnlineRecordingID`, `BookFile.ITunesPersistentID`, `BookFile.Duration`. The audit CLI (`tools/cmd/dedup-dataset-audit/main.go:94-110`) uses exactly these; mirror it. If `Book.CoverURL` differs, adjust `HasCover`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/dedup/dataset/ -run TestBuildExample_PartVsWholeFeatures -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/dedup/dataset/builder.go internal/dedup/dataset/builder_test.go
+git commit -m "feat(dedup): dataset feature builder (BuildExample)"
+```
+
+### Task 6: Deterministic catchers + signature similarity wiring
+
+**Files:**
+- Create: `internal/dedup/dataset/rules.go`
+- Modify: `internal/dedup/dataset/builder.go` (wire real signature similarity)
+- Test: `internal/dedup/dataset/rules_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/dedup/dataset/rules_test.go`:
+
+```go
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestCatchers(t *testing.T) {
+	cases := []struct {
+		name       string
+		ex         database.LabeledExample
+		wantFires  bool
+		wantLabel  string
+	}{
+		{
+			name: "part vs whole by duration ratio",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{TotalDurationSec: 36000, FilesExist: true},
+				B: database.BookFeatures{TotalDurationSec: 1200, FilesExist: true},
+				DurationRatio: 1200.0 / 36000.0,
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			name: "missing file one side",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 100},
+				B: database.BookFeatures{FilesExist: false},
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			name: "whole-book signature match => true_dup",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				B: database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				SignatureRelation: "match", DurationRatio: 1.0,
+			},
+			wantFires: true, wantLabel: "true_dup",
+		},
+		{
+			name: "no rule fires",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 36000},
+				B: database.BookFeatures{FilesExist: true, TotalDurationSec: 35900},
+				DurationRatio: 35900.0 / 36000.0, SignatureRelation: "unknown",
+			},
+			wantFires: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, reason, fires := Classify(tc.ex)
+			if fires != tc.wantFires {
+				t.Fatalf("fires=%v want %v (reason=%q)", fires, tc.wantFires, reason)
+			}
+			if fires && label != tc.wantLabel {
+				t.Fatalf("label=%q want %q", label, tc.wantLabel)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/dedup/dataset/ -run TestCatchers -v`
+Expected: FAIL — `undefined: Classify`.
+
+- [ ] **Step 3: Write the catchers**
+
+Create `internal/dedup/dataset/rules.go`:
+
+```go
+// file: internal/dedup/dataset/rules.go
+// version: 1.0.0
+// guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
+// last-edited: 2026-06-13
+
+package dataset
+
+import (
+	"fmt"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// partVsWholeRatioMax — below this duration ratio (and both durations known) a
+// pair is a part matched against a whole book, not a duplicate.
+const partVsWholeRatioMax = 0.5
+
+// Classify runs the deterministic catchers in priority order and returns the
+// first firing rule's (label, reason, fires). The order matters: the strong
+// positive (signature match) and the hard negatives (missing file, part vs
+// whole) take precedence over weaker signals.
+func Classify(ex database.LabeledExample) (label, reason string, fires bool) {
+	if l, r, ok := wholeBookSignatureMatch(ex); ok {
+		return l, r, true
+	}
+	if l, r, ok := missingFile(ex); ok {
+		return l, r, true
+	}
+	if l, r, ok := partVsWhole(ex); ok {
+		return l, r, true
+	}
+	return "", "", false
+}
+
+// wholeBookSignatureMatch: both sides have a whole-book signature and it matches
+// => true_dup. This is the auto-positive oracle.
+func wholeBookSignatureMatch(ex database.LabeledExample) (string, string, bool) {
+	if ex.A.WholeBookSigPresent && ex.B.WholeBookSigPresent && ex.SignatureRelation == "match" {
+		return "true_dup", "whole-book signatures match", true
+	}
+	return "", "", false
+}
+
+// missingFile: either side has no resolvable files => not_dup (never merge a
+// candidate whose file is gone — "we have to actually have the file").
+func missingFile(ex database.LabeledExample) (string, string, bool) {
+	if !ex.A.FilesExist {
+		return "not_dup", "side A has no resolvable files", true
+	}
+	if !ex.B.FilesExist {
+		return "not_dup", "side B has no resolvable files", true
+	}
+	return "", "", false
+}
+
+// partVsWhole: both durations known and the ratio is below the floor => a part
+// matched against the whole book.
+func partVsWhole(ex database.LabeledExample) (string, string, bool) {
+	if ex.A.TotalDurationSec > 0 && ex.B.TotalDurationSec > 0 && ex.DurationRatio > 0 && ex.DurationRatio < partVsWholeRatioMax {
+		return "not_dup", fmt.Sprintf("duration ratio %.3f — part vs whole", ex.DurationRatio), true
+	}
+	return "", "", false
+}
+```
+
+- [ ] **Step 4: Wire real signature similarity in the builder**
+
+In `internal/dedup/dataset/builder.go`, replace the `signatureRelation` body's raw-equality fallback with the real comparator:
+
+```go
+import (
+	// ...existing imports...
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// sigMatchThreshold — BookSignatureSimilarity at/above this is a content match.
+const sigMatchThreshold = 0.95
+
+func signatureRelation(a, b *database.Book) string {
+	if a == nil || b == nil ||
+		a.BookSigV1 == nil || *a.BookSigV1 == "" ||
+		b.BookSigV1 == nil || *b.BookSigV1 == "" {
+		return "unknown"
+	}
+	sim, err := fingerprint.BookSignatureSimilarity(*a.BookSigV1, *b.BookSigV1)
+	if err != nil {
+		return "unknown"
+	}
+	if sim >= sigMatchThreshold {
+		return "match"
+	}
+	return "disjoint"
+}
+```
+
+> NOTE: confirm `fingerprint.BookSignatureSimilarity(a, b string) (float64, error)` (it is at `internal/fingerprint/book_signature.go:131`). Offset/subsequence containment (`a_contains_b`) stays unimplemented in M1 per the spec C2 note.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/dedup/dataset/...`
+Expected: PASS (both builder and rules tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/dedup/dataset/rules.go internal/dedup/dataset/rules_test.go internal/dedup/dataset/builder.go
+git commit -m "feat(dedup): deterministic catchers + whole-book signature similarity"
+```
+
+---
+
+## Milestone C — Backfill op (cleans the existing residual)
+
+### Task 7: `dedup.dataset-backfill` op
+
+**Files:**
+- Create: `internal/plugins/dedup/dataset_backfill.go`
+- Modify: `internal/plugins/dedup/plugin.go` (register the op)
+
+- [ ] **Step 1: Write the op**
+
+Create `internal/plugins/dedup/dataset_backfill.go`, mirroring `purge_legacy_fp.go`'s structure (def + run, dry-run default, `{"apply":true}`):
+
+```go
+// file: internal/plugins/dedup/dataset_backfill.go
+// version: 1.0.0
+// guid: 2d6f8a13-7c40-4e92-8b15-9a3e5c7d2f64
+// last-edited: 2026-06-13
+
+// Package dedup — op dedup.dataset-backfill (spec C4 backfill).
+//
+// Iterates all pending candidates, builds a LabeledExample for each, runs the
+// deterministic catchers, and writes the labeled example. With apply=true, any
+// candidate a catcher labels not_dup is suppressed (status -> "dismissed") so
+// the residual part-vs-whole / missing-file false positives leave the queue.
+// Dry-run by default: reports counts, writes nothing.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+type datasetBackfillParams struct {
+	Apply bool `json:"apply"`
+}
+
+func (p *Plugin) datasetBackfillDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.dataset-backfill",
+		Plugin:      "dedup",
+		DisplayName: "Backfill dedup tuning dataset",
+		Description: "Builds a labeled example per pending candidate, runs catchers, " +
+			"and (apply=true) suppresses rule-labeled not_dup candidates. Dry-run by default.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.dataset-backfill",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runDatasetBackfill,
+	}
+}
+
+// builderAdapter satisfies dataset.BuilderStore using the plugin's main store.
+type builderAdapter struct{ store database.Store }
+
+func (b builderAdapter) GetBook(id string) (*database.Book, error) {
+	return b.store.GetBook(id)
+}
+func (b builderAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
+	return b.store.GetBookFiles(id)
+}
+
+func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil || p.store == nil {
+		return fmt.Errorf("stores not available")
+	}
+	var params datasetBackfillParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	adapter := builderAdapter{store: p.store}
+
+	_ = reporter.UpdateProgress(0, 2, "Loading pending candidates…")
+	cands, _, err := p.embeddingStore.ListCandidates(database.CandidateFilter{Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list candidates: %w", err)
+	}
+
+	var examined, labeled, suppressed, notDup, trueDup int
+	for i := range cands {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		c := cands[i]
+		examined++
+
+		ex, err := dataset.BuildExample(adapter, c)
+		if err != nil {
+			reporter.Logger().Warn("dataset-backfill: build error", "candidate_id", c.ID, "error", err)
+			continue
+		}
+		if label, reason, fires := dataset.Classify(ex); fires {
+			ex.Label = label
+			ex.LabelSource = "rule"
+			ex.LabelReason = reason
+			switch label {
+			case "not_dup":
+				notDup++
+			case "true_dup":
+				trueDup++
+			}
+		}
+
+		if params.Apply {
+			if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
+				reporter.Logger().Error("dataset-backfill: upsert label error", "candidate_id", c.ID, "error", err)
+			} else {
+				labeled++
+			}
+			if ex.Label == "not_dup" {
+				if err := p.embeddingStore.UpdateCandidateStatus(c.ID, "dismissed"); err != nil {
+					reporter.Logger().Error("dataset-backfill: suppress error", "candidate_id", c.ID, "error", err)
+				} else {
+					suppressed++
+				}
+			}
+		}
+	}
+
+	summary := fmt.Sprintf("examined=%d not_dup=%d true_dup=%d labeled=%d suppressed=%d (apply=%v)",
+		examined, notDup, trueDup, labeled, suppressed, params.Apply)
+	reporter.Logger().Info("dataset-backfill complete", "summary", summary)
+	_ = reporter.UpdateProgress(2, 2, summary)
+	return nil
+}
+```
+
+> NOTE: confirm `database.Store` exposes `GetBook(id string) (*database.Book, error)` and `GetBookFiles`. `purge_legacy_fp.go` uses `p.store.GetAllBookFiles()` and `p.embeddingStore.ListCandidates`, so the store handle and patterns are established; adjust the getter name if `GetBook` is `GetBookByID`.
+
+- [ ] **Step 2: Register the op**
+
+In `internal/plugins/dedup/plugin.go`, add to the `ops := []sdk.OperationDef{...}` slice (after `p.purgeStaleDef()` / near the other defs):
+
+```go
+		p.datasetBackfillDef(),
+```
+
+- [ ] **Step 3: Build to verify it compiles + registers**
+
+Run: `go build ./... && go test ./internal/plugins/dedup/...`
+Expected: build PASS; existing dedup-plugin tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/plugins/dedup/dataset_backfill.go internal/plugins/dedup/plugin.go
+git commit -m "feat(dedup): dataset-backfill op (label + suppress residual)"
+```
+
+### Task 8: Full verification + format/vet
+
+- [ ] **Step 1: Format and vet**
+
+Run: `gofmt -l internal/dedup internal/database internal/plugins/dedup && go vet ./internal/dedup/... ./internal/database/... ./internal/plugins/dedup/...`
+Expected: `gofmt -l` prints nothing; `go vet` clean. If `gofmt -l` lists files, run `gofmt -w` on them and amend.
+
+- [ ] **Step 2: Full package tests**
+
+Run: `go test ./internal/dedup/... ./internal/database/... ./internal/plugins/dedup/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit any format fixes**
+
+```bash
+git add -A && git commit -m "chore(dedup): gofmt + vet for dataset milestone" || echo "nothing to format"
+```
+
+---
+
+## Deployment / runtime validation (after merge)
+
+1. Deploy (`make deploy`). The engine gate (Milestone A) takes effect for all new scans — no new stub matches.
+2. Dry-run the backfill: `POST /api/v1/operations/v2/trigger` (or the existing op-trigger path) for `dedup.dataset-backfill` with no body → poll `/operations/:id/status` → read the `examined / not_dup / suppressed` summary.
+3. Approve, then `apply=true` → confirms the residual `exact`/sim=1 pending count drops (the part-vs-whole and missing-file pairs move to `dismissed`).
+
+> NOTE: a generic op-trigger endpoint may be needed for `dedup.dataset-backfill` (the purge op got a dedicated `POST /dedup/purge-legacy-fp` handler). If no generic trigger exists, add a one-line handler + route mirroring `PurgeLegacyFPCandidates` (`internal/server/handlers/dedup/handler.go:1499`, route `wire_handlers.go:858`). This is a small follow-up, not part of the core dataset logic.
+
+---
+
+## Self-Review
+
+**Spec coverage (M1 = C1, C2, C3; plus root-cause fix and C4 backfill):**
+- C1 feature builder → Task 5 ✓
+- C2 catchers (partVsWhole, missingFile, wholeBookSignatureMatch) → Task 6 ✓ (folderAncestorOrSibling features computed in Task 5; a `folderAncestorOrSibling` catcher is a trivial add over `FolderRelation` — fold into Task 6 if desired, or defer with live capture)
+- C3 store → Task 4 ✓
+- C4 backfill (cleanup half) → Task 7 ✓
+- Root-cause fix (engine gate) → Tasks 1–3 ✓
+- **Deferred to follow-up plan:** C4 live capture, C5 auto-bug-filing, C6 review UI, C7 JSONL export. Stated explicitly above.
+
+**Placeholder scan:** All code steps contain complete code. The `> NOTE:` blocks flag field-name confirmations against `store.go` (the one place the executing engineer must verify exact identifiers) — these are verification reminders, not unfinished code.
+
+**Type consistency:** `LabeledExample`/`BookFeatures` (Task 4) are used unchanged by `BuildExample` (Task 5), `Classify` (Task 6), and the backfill op (Task 7). `BuilderStore` (Task 5) is satisfied by `builderAdapter` (Task 7). `signatureRelation` returns the same enum values (`match`/`disjoint`/`unknown`) the catcher reads. `Classify(ex) (label, reason string, fires bool)` signature matches its test and its caller.
+
+**Known follow-up:** add a `folderAncestorOrSibling` catcher and the generic/dedicated op-trigger route; both noted inline.

--- a/docs/specs/2026-06-13-dedup-tuning-dataset-design.md
+++ b/docs/specs/2026-06-13-dedup-tuning-dataset-design.md
@@ -1,0 +1,276 @@
+<!-- file: docs/specs/2026-06-13-dedup-tuning-dataset-design.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 2b9f4c6a-1d83-4e57-9a02-7c5b8e3d1f64 -->
+<!-- last-edited: 2026-06-13 -->
+
+# Dedup Tuning Dataset & Feedback Loop — Sub-project #1 Design
+
+## Where this fits (the larger vision, decomposed)
+
+The goal is a **self-improving dedup system**: continuously look at matches, learn
+what a good dedup match looks like, auto-file bugs for the nonsense it finds, and
+feed corrections back into scoring. That is multiple subsystems, sequenced:
+
+1. **Labeled match dataset (THIS spec)** — capture every match + the reasoning +
+   the context a judge needs + the human/auto verdict. The substrate everything
+   else learns from.
+2. **Deterministic bug-catchers** — cheap rules (duration-ratio, folder
+   ancestor/part-of) that catch obvious false positives, suppress them, and
+   auto-file dedup bug issues. Built from the same features as #1.
+3. **AI-review loop (later)** — feed match JSON to an LLM-as-judge that scores
+   good/bad, explains why, files bugs, proposes scoring tweaks. Uses the existing
+   OpenAI batch infrastructure.
+4. **Fine-tuning (later, gated on data)** — train a model on the labeled dataset
+   once enough labels accrue. **Not viable yet** (see Experiment 0).
+5. **Feedback into scoring** — adjust signal weights / band thresholds from what
+   is learned.
+6. **Vision model (deferred, probably never needed)** — "see" the rendered
+   comparison. Reserved for what structured data genuinely can't express; the
+   same-folder/part-of bug is encoded losslessly in JSON, so vision is the most
+   expensive possible way to learn it.
+7. **Community-owned audiobook fingerprint index (separate future track)** — a
+   public, Git-repo-backed "AcoustID for audiobooks" seeded by the verified
+   records this loop produces. Captured in `TODO.md` ("Open Audiobook
+   Acoustic-Fingerprint Index"); needs its own brainstorming → spec session. It
+   **supersedes** the earlier "submit to AcoustID.org" idea: their model is
+   song/recording-based and fits audiobooks poorly, so we build a better index
+   we control rather than feeding theirs. The labeled dataset in THIS spec is the
+   upstream source of truth that loop will export from.
+
+This spec covers **#1 + #2 only**. #3–#7 are named here for context and get their
+own spec/plan when reached.
+
+## Experiment 0 — measured, not assumed
+
+Run `tools/cmd/dedup-dataset-audit` against a copy of the prod PebbleDB
+(2026-06-13, full set). Results:
+
+- **18,075 candidates**, **9,842 distinct books**.
+- **Bands: 100% empty.** Every candidate has a nil unified `Band` /
+  `ScoreBreakdown`. Layers: `exact` 85.9%, `acoustid` 10.8%, `embedding` 1.7%,
+  `llm` 1.5%. (This is why the UI shows Certain/High/Medium/Review all = 0.)
+- **recording_id oracle coverage: 0 / 9,842 books (0.0%).** The AcoustID online
+  lookup has never persisted a MusicBrainz recording_id. → **No auto-label pair
+  oracle exists today.**
+- **iTunes PID: 2,931 / 9,842 books (29.8%)** carry a live PID — but the map is
+  one-PID→one-book, so it is a per-book *attribute*, not a pair link.
+- **Deterministic catchers:** duration known on both sides for 5,135 pairs; of
+  those **1,023 (19.9%) are part-vs-whole (<0.5 duration ratio)**, and **163
+  scored `exact`/high** — confirmed false positives. Plain shared-parent-folder
+  caught only 14 (the real bug is parent/child folder nesting, not a shared
+  parent).
+
+### What Experiment 0 forces
+
+1. **No fine-tuning yet.** Zero auto-labels and only 81 human-resolved candidates
+   (77 merged + 4 dismissed). Bootstrap labels from deterministic rules + an
+   LLM-as-judge + human review; revisit fine-tuning once labels accrue.
+2. **The builder computes its own features.** Since `ScoreBreakdown` is empty on
+   100% of rows, the dataset builder derives features directly from books/files
+   (durations, folder relationship, recording_id, PID, paths) — it does **not**
+   depend on a populated breakdown. It still snapshots whatever breakdown exists
+   (forward-compatible for when unified scoring is run).
+3. **The real near-term oracle is our own whole-book signature, not
+   acoustid.org.** `internal/fingerprint/book_signature.go` already decodes each
+   file's chromaprint into `[]uint32` and concatenates a book's parts into one
+   whole-book signature (with downsampling + a compare function). Two books whose
+   whole-book signatures match are the same content — an **internal, dependency-
+   free pair oracle** we fully control, unlike acoustid.org lookup (which returns
+   0% because their DB has no audiobook recordings). This is the "combine the
+   parts into the full fingerprint" idea — it is already built, just not wired as
+   a dedup signal. M1's feature builder computes the whole-book signature (and
+   keeps per-part signatures) per book; a new catcher compares them.
+4. **Duration is a cheap interim proxy that the signature subsumes.** Part-vs-
+   whole is intrinsic to signature length/containment (a part's signature is a
+   subsequence of the whole; the whole's length encodes total runtime). So we do
+   **not** build a dedicated duration-extraction backfill — duration stays only
+   as the ~28%-coverage fallback until signature coverage is high.
+
+### M0 — the screenshot garbage is already-purgeable legacy data (do this first)
+
+The "exact 100%" part-vs-part rows in the bug screenshot (e.g. "The Crafter's
+Defense" matched against its own parts) are **stale legacy candidates**, not a
+live scoring bug. Before the whole-file fingerprint cutover (~2026-05-12) the
+engine compared *per-segment* acoustid hashes, so any two files sharing even one
+segment were flagged 100% identical — ~12,320 false `exact`-layer rows.
+
+A dedicated op already exists for them: **`dedup.purge-legacy-fp-candidates`**
+(shipped as F5-T015, `internal/plugins/dedup/purge_legacy_fp.go`; dry-run
+default, `{"apply":true}` to commit, idempotency flag `dedup_fp_purge_v1_done`,
+excludes the `acoustid` layer). **The 2026-06-13 audit proves it was never
+applied on prod:** the by-status histogram shows 99.6% `pending` and **zero
+`stale-fp`** rows. Running it (dry-run → `apply`) clears most of the screenshot
+garbage immediately, with no new code and independent of M1–M4. M0 in the build
+sequence is just "run the op that's already there."
+
+## Storage decision
+
+SQLite was deliberately removed (fable5 T022) and cannot be re-enabled; do not
+reintroduce it. Use:
+
+- **System of record: a new PebbleDB keyspace** `dedup:label:<candidateID16hex>`
+  → JSON `LabeledExample`. Mutable (humans re-label), queryable (serves the
+  review view), co-located with the rest of state, no new dependency.
+- **Export artifact: JSONL on disk** via an endpoint/job
+  (`GET /api/v1/dedup/dataset/export.jsonl`). Immutable, append-only, and the
+  exact format OpenAI fine-tuning ingests; trivially `scp`-able for offline
+  analysis.
+
+## Data model — `LabeledExample`
+
+One row per candidate pair, written/updated at capture time.
+
+```
+LabeledExample {
+  candidate_id       int64
+  entity_a_id        string   // book IDs
+  entity_b_id        string
+
+  // --- the match as scored ---
+  layer              string   // exact|acoustid|embedding|llm
+  band               string   // may be "" until unified scoring is run
+  score              float64  // 0 if no breakdown
+  score_breakdown    json     // UnifiedDedupScore snapshot (may be empty today)
+  similarity         *float64
+
+  // --- computed features (builder-derived; the judge's real evidence) ---
+  a / b each: {
+    title, author, primary_path string
+    total_duration_sec  float64
+    file_count          int
+    has_cover           bool
+    files_exist         bool      // every referenced path resolves on disk
+    recording_ids       []string  // MusicBrainz online recording_ids (often empty)
+    itunes_pid_present  bool
+    part_of_m           *int      // parsed N-of-M if a single part
+    whole_book_sig_present bool    // book_signature.go produced a signature
+  }
+  duration_ratio       float64    // min/max of the two totals (0 if unknown)
+  folder_relation      enum       // unrelated | same_dir | a_ancestor_of_b | b_ancestor_of_a | sibling_parts
+  shares_recording_id  bool
+  signature_relation   enum       // unknown | match | disjoint | a_contains_b | b_contains_a (whole-book sig)
+
+  // --- the label ---
+  label                enum       // true_dup | not_dup | unsure
+  label_source         enum       // rule | itunes_attr | human | llm_judge
+  label_reason         string     // e.g. "duration ratio 0.02 — part vs whole"
+  decided_at           timestamp
+  formula_version      string
+}
+```
+
+## Components
+
+### C1. Feature builder (`internal/dedup/dataset`)
+Pure function `BuildExample(store, candidate) LabeledExample` that loads both
+books' files once and computes every feature above. This is the audit CLI's
+per-pair logic, promoted to a reusable, unit-tested package. One clear input
+(candidate + store), one clear output (example); no side effects.
+
+### C2. Deterministic catchers (`internal/dedup/dataset/rules.go`)
+Pure predicates over a `LabeledExample`, each returning (fires?, reason):
+- `wholeBookSignatureMatch` (the strong oracle): both books have a whole-book
+  signature (from `book_signature.go`) and they match within tolerance →
+  `true_dup` (`label_source = rule`, high confidence). Disjoint signatures with
+  comparable runtime → `not_dup`. This is the auto-**positive** oracle the
+  recording_id approach failed to provide.
+- `partVsWhole`: signature-containment (one side's whole-book signature aligns as
+  an offset subsequence of the other) OR, as fallback, `duration_ratio < 0.5`
+  with both durations known → `not_dup` ("a part matched against the whole
+  book"). NOTE: `book_signature.go` provides the signature primitives, but its
+  `BookSignatureSimilarityMasked` is *same-coordinate* masking; true offset/
+  subsequence alignment (the part sits at an unknown position in the whole) is
+  M1 implementation work, not a solved primitive. Until it lands, the
+  duration-ratio fallback carries this rule.
+- `folderAncestorOrSibling`: one path is an ancestor of the other, or they are
+  `sibling_parts` of one multi-file book → `not_dup`.
+- `missingFile`: either side's `files_exist == false` → flag (don't merge a
+  candidate whose file is gone — the "we have to actually have the file" point).
+Each fired rule produces an auto label (`label_source = rule`) and, for rules
+that contradict a high scorer band, an auto-filed bug issue (C5).
+
+### C3. Store (`internal/database`, Pebble keyspace `dedup:label:`)
+`UpsertLabeledExample`, `GetLabeledExample`, `ListLabeledExamples(filter)`,
+`CountLabeledExamples(filter)`. Filter supports band, label, label_source,
+folder_relation, signature_relation, duration-ratio buckets, agreement-with-
+score — the axes the review view stratifies on.
+
+### C4. Population
+- **Backfill job** (`dedup.dataset-backfill` UOS op): iterate all candidates,
+  `BuildExample`, run catchers, write/auto-label. Dry-run default; `apply`
+  commits. Reuses the audit CLI's traversal.
+- **Live capture**: `MergeDedupCandidate` / `DismissDedupCandidate` /
+  Keep-A/Keep-B write a `human`-labeled example at decision time (score as it
+  was), and suppress at the same point if a catcher fires.
+
+### C5. Auto bug-filing
+When a catcher fires on a candidate the scorer ranked high, file a deduplicated
+dedup-bug issue (grouped by rule kind) capturing the example JSON. Wire to the
+existing issue/burndown path; dedupe by `(rule, formula_version)` so we don't
+file 1,000 identical issues — file one per class with a count and examples.
+
+### C6. Curated review view (frontend)
+A stratified queue that surfaces the off-diagonal cells (high score × likely
+not-dup; low score × likely dup) so humans label *failures* fast, not 18k easy
+agreements. Built on `ListLabeledExamples` filters. Each row: the rich card +
+the computed features + one-click `true_dup` / `not_dup` / `unsure` that writes
+a `human` label.
+
+### C7. JSONL export
+`GET /api/v1/dedup/dataset/export.jsonl[?label=&source=]` streams examples as
+JSONL for offline analysis / future fine-tuning.
+
+## Build sequence (milestones)
+
+0. **M0 — run the existing legacy-FP purge** (no new code). `dedup.purge-legacy-
+   fp-candidates` dry-run → review count → `apply`. Clears the ~12K stale
+   `exact`-layer false positives that dominate the screenshot. Do this first; it
+   is independent of all code below and immediately quiets the worst garbage.
+1. **M1 — features + catchers + store** (C1, C2, C3) with unit tests. Promote
+   the audit logic; wire the whole-book signature (`book_signature.go`) into the
+   feature builder; prove the catchers reproduce Experiment 0's counts.
+2. **M2 — backfill op + live capture** (C4). Run dry-run on prod, compare to
+   Experiment 0, then `apply` to populate the dataset and suppress remaining
+   part-vs-whole / folder false positives that M0 didn't cover.
+3. **M3 — auto bug-filing** (C5).
+4. **M4 — review view** (C6) + **JSONL export** (C7).
+
+LLM-as-judge (#3) and fine-tuning (#4) are **separate later specs**, unblocked
+once M1–M4 have produced labels. The whole-book signature oracle (C2) is the
+internal auto-positive source; acoustid.org lookup/submission is **not** a
+dependency (superseded by the community-index track, vision item #7).
+
+## Testing
+
+- C1/C2 unit tests with synthetic books/files covering: whole-book signature
+  match (auto-positive), signature containment (part-vs-whole), signature
+  disjoint, nested folder, sibling parts, missing file, no-signature fallback to
+  duration ratio, no-duration.
+- C3 store round-trip + filter tests (Pebble temp dir, the existing pattern).
+- C4 backfill dry-run asserts counts match the audit on a fixture set.
+- Handler tests for export + the live-capture write on merge/dismiss.
+- M0 acceptance: after `dedup.purge-legacy-fp-candidates --apply`, the by-status
+  histogram shows the legacy `exact` rows moved `pending → stale-fp` and the
+  Crafter's-Defense part-vs-part rows no longer surface in the dedup UI.
+- M2 acceptance: any residual part-vs-whole pairs are present as `not_dup`
+  examples with `label_source = rule`.
+
+## Rollback
+
+All additive: a new keyspace, a new package, new opt-in op, new endpoints. The
+backfill is dry-run by default and the catchers can be feature-flagged off. No
+change to existing candidate storage or the merge engine.
+
+## Resolved decisions (were open questions)
+
+1. **AcoustID online lookup: dropped.** Its recording_id coverage is 0% and the
+   DB has no audiobook recordings, so it cannot be the oracle. The internal
+   whole-book signature (`book_signature.go`) is the auto-positive oracle
+   instead. Contributing verified records goes to the community-index track
+   (vision #7), not acoustid.org.
+2. **Auto-bug-filing target: the existing burndown/issue system**, deduped by
+   rule class (`(rule, formula_version)`). One issue per class with a count +
+   example payloads, not 1,000 duplicates.
+3. **No duration-extraction backfill.** Part-vs-whole is intrinsic to signature
+   containment; duration stays a ~28%-coverage fallback only. Effort goes into
+   whole-book signature coverage, not duration extraction.

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
 // last-edited: 2026-06-13
 
@@ -46,7 +46,7 @@ type LabeledExample struct {
 
 	Layer          string          `json:"layer"`
 	Band           string          `json:"band,omitempty"`
-	Score          float64         `json:"score,omitempty"`
+	Score          float64         `json:"score"`
 	ScoreBreakdown json.RawMessage `json:"score_breakdown,omitempty"`
 	Similarity     *float64        `json:"similarity,omitempty"`
 
@@ -99,6 +99,9 @@ func (f LabeledExampleFilter) matches(ex *LabeledExample) bool {
 
 // UpsertLabeledExample writes (or overwrites) a labeled example.
 func (s *EmbeddingStore) UpsertLabeledExample(ex LabeledExample) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
 	data, err := json.Marshal(ex)
 	if err != nil {
 		return fmt.Errorf("marshal labeled example %d: %w", ex.CandidateID, err)
@@ -108,12 +111,15 @@ func (s *EmbeddingStore) UpsertLabeledExample(ex LabeledExample) error {
 
 // GetLabeledExample returns the example for a candidate, or nil if absent.
 func (s *EmbeddingStore) GetLabeledExample(candidateID int64) (*LabeledExample, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
 	val, closer, err := s.db.Get(dedupLabelKey(candidateID))
 	if err == pebble.ErrNotFound {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get labeled example %d: %w", candidateID, err)
 	}
 	defer func() { _ = closer.Close() }()
 	var ex LabeledExample
@@ -125,11 +131,14 @@ func (s *EmbeddingStore) GetLabeledExample(candidateID int64) (*LabeledExample, 
 
 // ListLabeledExamples returns examples matching the filter (prefix scan).
 func (s *EmbeddingStore) ListLabeledExamples(f LabeledExampleFilter) ([]LabeledExample, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
 	prefix := []byte(dedupLabelPfx)
 	upper := prefixUpperBound(prefix)
 	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list labeled examples: %w", err)
 	}
 	defer func() { _ = iter.Close() }()
 
@@ -157,6 +166,9 @@ func (s *EmbeddingStore) ListLabeledExamples(f LabeledExampleFilter) ([]LabeledE
 
 // CountLabeledExamples counts examples matching the filter (Limit/Offset ignored).
 func (s *EmbeddingStore) CountLabeledExamples(f LabeledExampleFilter) (int, error) {
+	if err := s.checkClosed(); err != nil {
+		return 0, err
+	}
 	cf := f
 	cf.Limit, cf.Offset = 0, 0
 	list, err := s.ListLabeledExamples(cf)

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
 // last-edited: 2026-06-13
 
@@ -54,7 +54,7 @@ type LabeledExample struct {
 	B BookFeatures `json:"b"`
 
 	DurationRatio     float64 `json:"duration_ratio"`
-	FolderRelation    string  `json:"folder_relation"` // unrelated|same_dir|a_ancestor_of_b|b_ancestor_of_a|sibling_parts
+	FolderRelation    string  `json:"folder_relation"` // unrelated|same_dir|a_ancestor_of_b|b_ancestor_of_a (sibling_parts: planned, not yet produced)
 	SharesRecordingID bool    `json:"shares_recording_id"`
 	SignatureRelation string  `json:"signature_relation"` // unknown|match|disjoint|a_contains_b|b_contains_a
 

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label.go
-// version: 1.0.2
+// version: 1.0.3
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
 // last-edited: 2026-06-13
 
@@ -44,8 +44,9 @@ type LabeledExample struct {
 	EntityAID   string `json:"entity_a_id"`
 	EntityBID   string `json:"entity_b_id"`
 
-	Layer          string          `json:"layer"`
-	Band           string          `json:"band,omitempty"`
+	Layer string `json:"layer"`
+	Band  string `json:"band,omitempty"`
+	// Score is 0 when no ScoreBreakdown is available; populated from the candidate's UnifiedDedupScore.Score when present.
 	Score          float64         `json:"score"`
 	ScoreBreakdown json.RawMessage `json:"score_breakdown,omitempty"`
 	Similarity     *float64        `json:"similarity,omitempty"`

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,0 +1,167 @@
+// file: internal/database/dedup_label.go
+// version: 1.0.0
+// guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
+// last-edited: 2026-06-13
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// dedupLabelPfx is the Pebble keyspace for labeled dedup examples.
+// Key layout: dedup:label:<candidateID, 16-hex> → LabeledExample JSON.
+const dedupLabelPfx = "dedup:label:"
+
+// dedupLabelKey renders the fixed-width key for a candidate ID so that range
+// scans over the prefix return rows in a stable order.
+func dedupLabelKey(candidateID int64) []byte {
+	return []byte(fmt.Sprintf("%s%016x", dedupLabelPfx, uint64(candidateID)))
+}
+
+// BookFeatures captures the per-book evidence a judge needs. Computed by the
+// dataset feature builder, snapshotted at capture time.
+type BookFeatures struct {
+	Title               string   `json:"title"`
+	Author              string   `json:"author"`
+	PrimaryPath         string   `json:"primary_path"`
+	TotalDurationSec    float64  `json:"total_duration_sec"`
+	FileCount           int      `json:"file_count"`
+	HasCover            bool     `json:"has_cover"`
+	FilesExist          bool     `json:"files_exist"`
+	RecordingIDs        []string `json:"recording_ids,omitempty"`
+	ITunesPIDPresent    bool     `json:"itunes_pid_present"`
+	WholeBookSigPresent bool     `json:"whole_book_sig_present"`
+}
+
+// LabeledExample is one labeled dedup candidate pair plus the features behind
+// the label. Stored at dedup:label:<candidateID>.
+type LabeledExample struct {
+	CandidateID int64  `json:"candidate_id"`
+	EntityAID   string `json:"entity_a_id"`
+	EntityBID   string `json:"entity_b_id"`
+
+	Layer          string          `json:"layer"`
+	Band           string          `json:"band,omitempty"`
+	Score          float64         `json:"score,omitempty"`
+	ScoreBreakdown json.RawMessage `json:"score_breakdown,omitempty"`
+	Similarity     *float64        `json:"similarity,omitempty"`
+
+	A BookFeatures `json:"a"`
+	B BookFeatures `json:"b"`
+
+	DurationRatio     float64 `json:"duration_ratio"`
+	FolderRelation    string  `json:"folder_relation"` // unrelated|same_dir|a_ancestor_of_b|b_ancestor_of_a|sibling_parts
+	SharesRecordingID bool    `json:"shares_recording_id"`
+	SignatureRelation string  `json:"signature_relation"` // unknown|match|disjoint|a_contains_b|b_contains_a
+
+	Label          string `json:"label"`        // true_dup|not_dup|unsure
+	LabelSource    string `json:"label_source"` // rule|itunes_attr|human|llm_judge
+	LabelReason    string `json:"label_reason"`
+	DecidedAt      string `json:"decided_at,omitempty"` // RFC3339; caller-stamped
+	FormulaVersion string `json:"formula_version,omitempty"`
+}
+
+// LabeledExampleFilter narrows ListLabeledExamples / CountLabeledExamples.
+// Empty fields are ignored. Filtering is in-memory over the prefix scan, which
+// is fine at dataset scale (tens of thousands of rows).
+type LabeledExampleFilter struct {
+	Label             string
+	LabelSource       string
+	Band              string
+	FolderRelation    string
+	SignatureRelation string
+	Limit             int
+	Offset            int
+}
+
+func (f LabeledExampleFilter) matches(ex *LabeledExample) bool {
+	if f.Label != "" && ex.Label != f.Label {
+		return false
+	}
+	if f.LabelSource != "" && ex.LabelSource != f.LabelSource {
+		return false
+	}
+	if f.Band != "" && ex.Band != f.Band {
+		return false
+	}
+	if f.FolderRelation != "" && ex.FolderRelation != f.FolderRelation {
+		return false
+	}
+	if f.SignatureRelation != "" && ex.SignatureRelation != f.SignatureRelation {
+		return false
+	}
+	return true
+}
+
+// UpsertLabeledExample writes (or overwrites) a labeled example.
+func (s *EmbeddingStore) UpsertLabeledExample(ex LabeledExample) error {
+	data, err := json.Marshal(ex)
+	if err != nil {
+		return fmt.Errorf("marshal labeled example %d: %w", ex.CandidateID, err)
+	}
+	return s.db.Set(dedupLabelKey(ex.CandidateID), data, pebble.Sync)
+}
+
+// GetLabeledExample returns the example for a candidate, or nil if absent.
+func (s *EmbeddingStore) GetLabeledExample(candidateID int64) (*LabeledExample, error) {
+	val, closer, err := s.db.Get(dedupLabelKey(candidateID))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = closer.Close() }()
+	var ex LabeledExample
+	if err := json.Unmarshal(val, &ex); err != nil {
+		return nil, fmt.Errorf("unmarshal labeled example %d: %w", candidateID, err)
+	}
+	return &ex, nil
+}
+
+// ListLabeledExamples returns examples matching the filter (prefix scan).
+func (s *EmbeddingStore) ListLabeledExamples(f LabeledExampleFilter) ([]LabeledExample, error) {
+	prefix := []byte(dedupLabelPfx)
+	upper := prefixUpperBound(prefix)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var out []LabeledExample
+	skipped := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		var ex LabeledExample
+		if err := json.Unmarshal(iter.Value(), &ex); err != nil {
+			continue // skip a corrupt row rather than abort the scan
+		}
+		if !f.matches(&ex) {
+			continue
+		}
+		if f.Offset > 0 && skipped < f.Offset {
+			skipped++
+			continue
+		}
+		out = append(out, ex)
+		if f.Limit > 0 && len(out) >= f.Limit {
+			break
+		}
+	}
+	return out, iter.Error()
+}
+
+// CountLabeledExamples counts examples matching the filter (Limit/Offset ignored).
+func (s *EmbeddingStore) CountLabeledExamples(f LabeledExampleFilter) (int, error) {
+	cf := f
+	cf.Limit, cf.Offset = 0, 0
+	list, err := s.ListLabeledExamples(cf)
+	if err != nil {
+		return 0, err
+	}
+	return len(list), nil
+}

--- a/internal/database/dedup_label_test.go
+++ b/internal/database/dedup_label_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 28cfcafd-ac95-4175-8fe7-b0fc46bd05bb
 // last-edited: 2026-06-13
 
@@ -58,5 +58,42 @@ func TestLabeledExample_RoundTripAndFilter(t *testing.T) {
 	n, err := es.CountLabeledExamples(LabeledExampleFilter{LabelSource: "rule"})
 	if err != nil || n != 1 {
 		t.Fatalf("count by source: err=%v n=%d", err, n)
+	}
+}
+
+func TestLabeledExample_AbsentAndOffset(t *testing.T) {
+	es := newTestLabelStore(t)
+
+	// Absent key returns (nil, nil) — no error.
+	got, err := es.GetLabeledExample(99999)
+	if err != nil {
+		t.Fatalf("get absent: unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("get absent: expected nil, got %+v", got)
+	}
+
+	// Upsert two examples with the same label so offset paging can be tested.
+	for _, id := range []int64{1, 2} {
+		ex := LabeledExample{
+			CandidateID: id,
+			EntityAID:   "a",
+			EntityBID:   "b",
+			Layer:       "exact",
+			Label:       "not_dup",
+			LabelSource: "rule",
+		}
+		if err := es.UpsertLabeledExample(ex); err != nil {
+			t.Fatalf("upsert id=%d: %v", id, err)
+		}
+	}
+
+	// Offset=1 on two matching rows must return exactly 1 row.
+	page, err := es.ListLabeledExamples(LabeledExampleFilter{Label: "not_dup", Offset: 1, Limit: 10})
+	if err != nil {
+		t.Fatalf("list with offset: %v", err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("list with offset: expected 1 row, got %d", len(page))
 	}
 }

--- a/internal/database/dedup_label_test.go
+++ b/internal/database/dedup_label_test.go
@@ -1,0 +1,62 @@
+// file: internal/database/dedup_label_test.go
+// version: 1.0.0
+// guid: 28cfcafd-ac95-4175-8fe7-b0fc46bd05bb
+// last-edited: 2026-06-13
+
+package database
+
+import (
+	"os"
+	"testing"
+)
+
+func newTestLabelStore(t *testing.T) *EmbeddingStore {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "abk-label-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	ps, err := NewPebbleStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ps.Close() })
+	return NewEmbeddingStore(ps.DB())
+}
+
+func TestLabeledExample_RoundTripAndFilter(t *testing.T) {
+	es := newTestLabelStore(t)
+
+	ex := LabeledExample{
+		CandidateID:       42,
+		EntityAID:         "a",
+		EntityBID:         "b",
+		Layer:             "exact",
+		Label:             "not_dup",
+		LabelSource:       "rule",
+		LabelReason:       "duration ratio 0.02 — part vs whole",
+		FolderRelation:    "sibling_parts",
+		SignatureRelation: "unknown",
+	}
+	if err := es.UpsertLabeledExample(ex); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := es.GetLabeledExample(42)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v (nil=%v)", err, got == nil)
+	}
+	if got.LabelReason != ex.LabelReason || got.Label != "not_dup" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	list, err := es.ListLabeledExamples(LabeledExampleFilter{Label: "not_dup", Limit: 10})
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list by label: err=%v len=%d", err, len(list))
+	}
+	n, err := es.CountLabeledExamples(LabeledExampleFilter{LabelSource: "rule"})
+	if err != nil || n != 1 {
+		t.Fatalf("count by source: err=%v n=%d", err, n)
+	}
+}

--- a/internal/database/dedup_label_test.go
+++ b/internal/database/dedup_label_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: 28cfcafd-ac95-4175-8fe7-b0fc46bd05bb
 // last-edited: 2026-06-13
 
@@ -36,7 +36,7 @@ func TestLabeledExample_RoundTripAndFilter(t *testing.T) {
 		Label:             "not_dup",
 		LabelSource:       "rule",
 		LabelReason:       "duration ratio 0.02 — part vs whole",
-		FolderRelation:    "sibling_parts",
+		FolderRelation:    "sibling_parts", // planned value, not yet produced by the builder; exercises round-trip storage of an arbitrary valid string
 		SignatureRelation: "unknown",
 	}
 	if err := es.UpsertLabeledExample(ex); err != nil {

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.3.0
-// last-edited: 2026-06-10
+// version: 2.3.1
+// last-edited: 2026-06-13
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -27,22 +27,23 @@ import (
 // The vector blob stored in embRec.Vector carries a 1-byte version header so
 // old and new code can coexist during a rolling upgrade and after rollback.
 //
-//   v0 (absent/legacy): raw little-endian float32 — no header byte.
-//     Encoded as:  [f32_0 LE][f32_1 LE]…  (4N bytes for N-dim vector)
+//	v0 (absent/legacy): raw little-endian float32 — no header byte.
+//	  Encoded as:  [f32_0 LE][f32_1 LE]…  (4N bytes for N-dim vector)
 //
-//   v1 (T021, SPEC 3 §3): float16 + zstd block compression.
-//     Encoded as:  [0x01][zstd_compressed( [f16_0 LE][f16_1 LE]… )]
-//     (1 + zstd_len bytes — typically ~3.5–4× smaller than v0 for 3072-dim)
+//	v1 (T021, SPEC 3 §3): float16 + zstd block compression.
+//	  Encoded as:  [0x01][zstd_compressed( [f16_0 LE][f16_1 LE]… )]
+//	  (1 + zstd_len bytes — typically ~3.5–4× smaller than v0 for 3072-dim)
 //
 // Why float16 is safe at our threshold regime (0.85/0.95):
-//   For OpenAI text-embedding-3-large (3072 dims) the vectors are L2-normalised
-//   before storage.  Float16 has 10 bits of mantissa → ~0.1% relative error per
-//   element.  Over 3072 dims these errors average out (central-limit tendency),
-//   and the resulting cosine-drift is empirically |Δcos| < 1e-3 across random
-//   unit-vector pairs (see TestEncodeDecodeV1_CosineDrift).  Our accept threshold
-//   is 0.85 and our high-confidence threshold is 0.95; a drift of <0.001 is
-//   well inside the guard band on either side and cannot flip a genuine
-//   accept/reject decision.
+//
+//	For OpenAI text-embedding-3-large (3072 dims) the vectors are L2-normalised
+//	before storage.  Float16 has 10 bits of mantissa → ~0.1% relative error per
+//	element.  Over 3072 dims these errors average out (central-limit tendency),
+//	and the resulting cosine-drift is empirically |Δcos| < 1e-3 across random
+//	unit-vector pairs (see TestEncodeDecodeV1_CosineDrift).  Our accept threshold
+//	is 0.85 and our high-confidence threshold is 0.95; a drift of <0.001 is
+//	well inside the guard band on either side and cannot flip a genuine
+//	accept/reject decision.
 const (
 	embVecVersion0 = byte(0x00) // sentinel (not written; any blob without header is v0)
 	embVecVersion1 = byte(0x01) // float16 + zstd (T021)
@@ -76,6 +77,7 @@ func init() {
 //	dedup:r:<id16hex>               → candRec JSON      (dedup candidate)
 //	dedup:p:<type>:<aID>:<bID>      → id16hex           (pair uniqueness index)
 //	dedup:seq                       → [8]byte LE int64  (auto-increment counter)
+//	dedup:label:<id16hex>           → LabeledExample JSON   (dataset labels)
 const (
 	embVecPfx    = "emb:v:"
 	embCachePfx  = "emb:c:"
@@ -1095,7 +1097,8 @@ func CosineSimilarity(a, b []float32) float32 {
 }
 
 // encodeVector serialises a float32 slice to the v1 wire format:
-//   [0x01][zstd_compressed( [f16_0 LE][f16_1 LE]… )]
+//
+//	[0x01][zstd_compressed( [f16_0 LE][f16_1 LE]… )]
 //
 // All new writes use v1.  See the version-constant block at the top of this
 // file for the rationale behind float16 being safe at our scoring thresholds.
@@ -1119,9 +1122,12 @@ func encodeVector(v []float32) []byte {
 // decodeVector deserialises a vector blob produced by encodeVector (v0 or v1).
 //
 // v0 (no header byte / header byte != 0x01): raw little-endian float32 — kept
-//   forever for backward compatibility with blobs written before T021.
+//
+//	forever for backward compatibility with blobs written before T021.
+//
 // v1 (header byte 0x01): float16 + zstd.  Decompresses then dequantises back
-//   to float32 for use in the in-memory cosine engine (chromem hydration path).
+//
+//	to float32 for use in the in-memory cosine engine (chromem hydration path).
 func decodeVector(b []byte) []float32 {
 	if len(b) == 0 {
 		return nil
@@ -1276,4 +1282,3 @@ func vectorEncodeRatio(v []float32) float64 {
 	}
 	return float64(len(v0)) / float64(len(v1))
 }
-

--- a/internal/dedup/collectors_exact.go
+++ b/internal/dedup/collectors_exact.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_exact.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: c9d0e1f2-a3b4-4c5d-8e6f-7a8b9c0d1e2f
-// last-edited: 2026-06-10
+// last-edited: 2026-06-13
 
 // Package dedup — exact-tier collector family (fable5 T014).
 //
@@ -69,6 +69,12 @@ type MetaSrcHashStore interface {
 //
 // Logic unchanged from checkExactFileHash (engine.go:276-333); emission shape
 // only.
+//
+// Note on gate omission: this collector runs over the unified SCORING pipeline
+// (re-scoring pre-existing candidates), NOT the emission path. The
+// hasPlausibleAudio gate — which lives on checkExactTitle/checkExactISBN in
+// engine.go — is intentionally not applied here; it is an emission-time guard
+// and does not belong on a scoring-only collector.
 func CollectExactFileHash(
 	store ExactFileHashStore,
 	book *database.Book,
@@ -133,6 +139,12 @@ func CollectExactFileHash(
 // IDs are skipped immediately.
 //
 // Logic unchanged from checkExactISBN (engine.go:350-426); emission shape only.
+//
+// Note on gate omission: this collector runs over the unified SCORING pipeline
+// (re-scoring pre-existing candidates), NOT the emission path. The
+// hasPlausibleAudio gate — which lives on checkExactISBN in engine.go — is
+// intentionally not applied here; it is an emission-time guard and does not
+// belong on a scoring-only collector.
 func CollectISBNASIN(
 	store ISBNASINStore,
 	book *database.Book,

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-06-13
 
@@ -10,6 +10,7 @@
 package dataset
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 
@@ -39,6 +40,20 @@ func BuildExample(store BuilderStore, cand database.DedupCandidate) (database.La
 		Layer:       cand.Layer,
 		Band:        cand.Band,
 		Similarity:  cand.Similarity,
+	}
+
+	// Populate Score and ScoreBreakdown snapshot from the candidate's unified
+	// score when present. On current production data these are nil (Experiment 0
+	// found 100% empty) — this is forward-correctness for rows produced by the
+	// T015/T016 unified pipeline. A nil ScoreBreakdown leaves Score at 0 and
+	// ex.ScoreBreakdown nil, which is the safe/zero value.
+	if cand.ScoreBreakdown != nil {
+		ex.Score = cand.ScoreBreakdown.Score
+		if raw, err := json.Marshal(cand.ScoreBreakdown); err == nil {
+			ex.ScoreBreakdown = raw
+		}
+		// On marshal error: Score is still set; ScoreBreakdown is left nil.
+		// BuildExample never fails due to a snapshot marshal error.
 	}
 
 	a, aFiles, err := loadSide(store, cand.EntityAID)

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-06-13
 
@@ -14,7 +14,12 @@ import (
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 )
+
+// sigMatchThreshold is the BookSignatureSimilarity score at/above which two
+// whole-book signatures are treated as a content match (spec: 0.95).
+const sigMatchThreshold = 0.95
 
 // BuilderStore is the narrow store surface BuildExample needs.
 type BuilderStore interface {
@@ -156,9 +161,11 @@ func sharesAny(a, b []string) bool {
 }
 
 // signatureRelation reports the whole-book-signature relationship between two books.
-// Task 5 (M1 initial): uses raw byte equality as a definite match; sim-threshold
-// comparison is wired in Task 6 via fingerprint.BookSignatureSimilarity.
+// Uses fingerprint.BookSignatureSimilarity with a 0.95 threshold for "match".
 // Returns one of: match, disjoint, unknown.
+// "unknown" is returned when either signature is absent or the comparator errors
+// (e.g. corrupt/short base64). Offset/subsequence containment (a_contains_b /
+// b_contains_a) is deferred to a later spec milestone.
 func signatureRelation(a, b *database.Book) string {
 	if a == nil || b == nil {
 		return "unknown"
@@ -166,10 +173,12 @@ func signatureRelation(a, b *database.Book) string {
 	if a.BookSigV1 == nil || *a.BookSigV1 == "" || b.BookSigV1 == nil || *b.BookSigV1 == "" {
 		return "unknown"
 	}
-	// Exact string equality is a definite match. Task 6 replaces this with the
-	// real similarity comparison so near-identical sigs also return "match".
-	if *a.BookSigV1 == *b.BookSigV1 {
+	sim, err := fingerprint.BookSignatureSimilarity(*a.BookSigV1, *b.BookSigV1)
+	if err != nil {
+		return "unknown"
+	}
+	if sim >= sigMatchThreshold {
 		return "match"
 	}
-	return "unknown"
+	return "disjoint"
 }

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-06-13
 
@@ -123,6 +123,7 @@ func durationRatio(a, b float64) float64 {
 
 // folderRelation classifies how two primary file paths sit relative to each other.
 // Returns one of: unrelated, same_dir, a_ancestor_of_b, b_ancestor_of_a.
+// Note: currently produces only these four values; sibling_parts is planned but not yet returned.
 func folderRelation(a, b string) string {
 	if a == "" || b == "" {
 		return "unrelated"

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,0 +1,175 @@
+// file: internal/dedup/dataset/builder.go
+// version: 1.0.0
+// guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
+// last-edited: 2026-06-13
+
+// Package dataset builds labeled dedup examples and runs deterministic catchers
+// over them. Pure: a store interface in, a database.LabeledExample out, no
+// side effects. This is the audit CLI's per-pair logic promoted to a reusable,
+// unit-tested package (spec C1/C2).
+package dataset
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// BuilderStore is the narrow store surface BuildExample needs.
+type BuilderStore interface {
+	GetBook(id string) (*database.Book, error)
+	GetBookFiles(id string) ([]database.BookFile, error)
+}
+
+// BuildExample loads both books and computes every feature for the candidate pair.
+// It is pure: it reads from the store and returns a LabeledExample with no side
+// effects. Label fields are left empty — callers should run Classify to populate
+// them.
+func BuildExample(store BuilderStore, cand database.DedupCandidate) (database.LabeledExample, error) {
+	ex := database.LabeledExample{
+		CandidateID: cand.ID,
+		EntityAID:   cand.EntityAID,
+		EntityBID:   cand.EntityBID,
+		Layer:       cand.Layer,
+		Band:        cand.Band,
+		Similarity:  cand.Similarity,
+	}
+
+	a, aFiles, err := loadSide(store, cand.EntityAID)
+	if err != nil {
+		return ex, err
+	}
+	b, bFiles, err := loadSide(store, cand.EntityBID)
+	if err != nil {
+		return ex, err
+	}
+	ex.A = buildFeatures(a, aFiles)
+	ex.B = buildFeatures(b, bFiles)
+
+	ex.DurationRatio = durationRatio(ex.A.TotalDurationSec, ex.B.TotalDurationSec)
+	ex.FolderRelation = folderRelation(ex.A.PrimaryPath, ex.B.PrimaryPath)
+	ex.SharesRecordingID = sharesAny(ex.A.RecordingIDs, ex.B.RecordingIDs)
+	ex.SignatureRelation = signatureRelation(a, b)
+	return ex, nil
+}
+
+func loadSide(store BuilderStore, id string) (*database.Book, []database.BookFile, error) {
+	bk, err := store.GetBook(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	files, err := store.GetBookFiles(id)
+	if err != nil {
+		return bk, nil, err
+	}
+	return bk, files, nil
+}
+
+// buildFeatures computes the per-book feature snapshot from a book and its files.
+// Note: BookFeatures.Author is left empty — BuilderStore provides only Book and
+// BookFile records; author name resolution would require a separate store method.
+func buildFeatures(bk *database.Book, files []database.BookFile) database.BookFeatures {
+	f := database.BookFeatures{
+		FileCount:  len(files),
+		FilesExist: len(files) > 0,
+	}
+	if bk != nil {
+		f.Title = bk.Title
+		f.WholeBookSigPresent = bk.BookSigV1 != nil && *bk.BookSigV1 != ""
+		if bk.CoverURL != nil && *bk.CoverURL != "" {
+			f.HasCover = true
+		}
+	}
+	var total float64
+	for i := range files {
+		fl := &files[i]
+		if f.PrimaryPath == "" && fl.FilePath != "" {
+			f.PrimaryPath = fl.FilePath
+		}
+		// Prefer fpcalc-measured duration; fall back to container duration (int seconds).
+		if fl.AcoustIDFingerprintDurationSec > 0 {
+			total += fl.AcoustIDFingerprintDurationSec
+		} else if fl.Duration > 0 {
+			total += float64(fl.Duration)
+		}
+		if fl.AcoustIDOnlineRecordingID != "" {
+			f.RecordingIDs = append(f.RecordingIDs, fl.AcoustIDOnlineRecordingID)
+		}
+		if fl.ITunesPersistentID != "" {
+			f.ITunesPIDPresent = true
+		}
+	}
+	f.TotalDurationSec = total
+	return f
+}
+
+// durationRatio returns min/max of the two durations, or 0 if either is ≤0.
+func durationRatio(a, b float64) float64 {
+	if a <= 0 || b <= 0 {
+		return 0
+	}
+	lo, hi := a, b
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	return lo / hi
+}
+
+// folderRelation classifies how two primary file paths sit relative to each other.
+// Returns one of: unrelated, same_dir, a_ancestor_of_b, b_ancestor_of_a.
+func folderRelation(a, b string) string {
+	if a == "" || b == "" {
+		return "unrelated"
+	}
+	da, db := filepath.Dir(a), filepath.Dir(b)
+	if da == db {
+		return "same_dir"
+	}
+	if isAncestor(da, db) {
+		return "a_ancestor_of_b"
+	}
+	if isAncestor(db, da) {
+		return "b_ancestor_of_a"
+	}
+	return "unrelated"
+}
+
+// isAncestor reports whether anc is a strict path ancestor of desc.
+func isAncestor(anc, desc string) bool {
+	anc = strings.TrimRight(anc, "/")
+	return anc != "" && strings.HasPrefix(desc, anc+"/")
+}
+
+// sharesAny reports whether the two recording-ID slices share any element.
+func sharesAny(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// signatureRelation reports the whole-book-signature relationship between two books.
+// Task 5 (M1 initial): uses raw byte equality as a definite match; sim-threshold
+// comparison is wired in Task 6 via fingerprint.BookSignatureSimilarity.
+// Returns one of: match, disjoint, unknown.
+func signatureRelation(a, b *database.Book) string {
+	if a == nil || b == nil {
+		return "unknown"
+	}
+	if a.BookSigV1 == nil || *a.BookSigV1 == "" || b.BookSigV1 == nil || *b.BookSigV1 == "" {
+		return "unknown"
+	}
+	// Exact string equality is a definite match. Task 6 replaces this with the
+	// real similarity comparison so near-identical sigs also return "match".
+	if *a.BookSigV1 == *b.BookSigV1 {
+		return "match"
+	}
+	return "unknown"
+}

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,15 +1,30 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
 // last-edited: 2026-06-13
 
 package dataset
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
+
+// makeTestSig builds a valid BookSigV1 string: 4096 uint32 words encoded as
+// little-endian bytes then base64. All words are set to the given seed value
+// so two sigs with the same seed are identical (sim=1.0) and two with different
+// seeds are fully dissimilar (sim=0.0 when seed bits are all-1 vs all-0).
+func makeTestSig(seed uint32) string {
+	const n = 4096
+	buf := make([]byte, n*4)
+	for i := 0; i < n; i++ {
+		binary.LittleEndian.PutUint32(buf[i*4:], seed)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
 
 // fakeStore implements BuilderStore for tests.
 type fakeStore struct {
@@ -109,6 +124,67 @@ func TestBuildExample_HasCover(t *testing.T) {
 	}
 	if ex.B.HasCover {
 		t.Fatal("expected B.HasCover=false")
+	}
+}
+
+func TestBuildExample_SignatureRelation_Match(t *testing.T) {
+	// Two books with identical 4096-uint32 sigs → sim=1.0 → "match"
+	sig := makeTestSig(0xDEADBEEF)
+	bkA := &database.Book{ID: "a", Title: "Same Book", BookSigV1: &sig}
+	bkB := &database.Book{ID: "b", Title: "Same Book", BookSigV1: &sig}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{},
+	}
+	cand := database.DedupCandidate{ID: 10, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.SignatureRelation != "match" {
+		t.Fatalf("SignatureRelation = %q, want match (identical sigs)", ex.SignatureRelation)
+	}
+}
+
+func TestBuildExample_SignatureRelation_Disjoint(t *testing.T) {
+	// seed=0x00000000 gives all-zero words; seed=0xFFFFFFFF gives all-one words.
+	// XOR of these is all-ones → every bit differs → sim=0.0 → "disjoint"
+	sigA := makeTestSig(0x00000000)
+	sigB := makeTestSig(0xFFFFFFFF)
+	bkA := &database.Book{ID: "a", Title: "Book A", BookSigV1: &sigA}
+	bkB := &database.Book{ID: "b", Title: "Book B", BookSigV1: &sigB}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{},
+	}
+	cand := database.DedupCandidate{ID: 11, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.SignatureRelation != "disjoint" {
+		t.Fatalf("SignatureRelation = %q, want disjoint (fully dissimilar sigs)", ex.SignatureRelation)
+	}
+}
+
+func TestBuildExample_SignatureRelation_Unknown_NoSig(t *testing.T) {
+	// Book with no BookSigV1 → "unknown"
+	bkA := &database.Book{ID: "a", Title: "No Sig"}
+	bkB := &database.Book{ID: "b", Title: "No Sig"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{},
+	}
+	cand := database.DedupCandidate{ID: 12, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.SignatureRelation != "unknown" {
+		t.Fatalf("SignatureRelation = %q, want unknown (no sigs)", ex.SignatureRelation)
 	}
 }
 

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
 // last-edited: 2026-06-13
 
@@ -206,5 +206,72 @@ func TestBuildExample_FolderRelation_Ancestor(t *testing.T) {
 	}
 	if ex.FolderRelation != "a_ancestor_of_b" {
 		t.Fatalf("folder relation = %q, want a_ancestor_of_b", ex.FolderRelation)
+	}
+}
+
+func TestBuildExample_FolderRelation_BAncestorOfA(t *testing.T) {
+	// B's directory is an ancestor of A's path → b_ancestor_of_a.
+	bkA := &database.Book{ID: "a", Title: "Child"}
+	bkB := &database.Book{ID: "b", Title: "Parent"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {{BookID: "a", FilePath: "/lib/Series/Part1/part.m4b", Duration: 3600}},
+			"b": {{BookID: "b", FilePath: "/lib/Series/whole.m4b", Duration: 36000}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 3, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.FolderRelation != "b_ancestor_of_a" {
+		t.Fatalf("folder relation = %q, want b_ancestor_of_a", ex.FolderRelation)
+	}
+}
+
+func TestBuildExample_FolderRelation_Unrelated(t *testing.T) {
+	// Two completely disjoint directories → unrelated.
+	bkA := &database.Book{ID: "a", Title: "Book A"}
+	bkB := &database.Book{ID: "b", Title: "Book B"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {{BookID: "a", FilePath: "/lib/AuthorOne/book.m4b", Duration: 3600}},
+			"b": {{BookID: "b", FilePath: "/lib/AuthorTwo/book.m4b", Duration: 3600}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 4, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.FolderRelation != "unrelated" {
+		t.Fatalf("folder relation = %q, want unrelated", ex.FolderRelation)
+	}
+}
+
+func TestBuildExample_FolderRelation_PrefixNotAncestor(t *testing.T) {
+	// /lib/Series is NOT an ancestor of /lib/Series-Extra — the trailing-slash
+	// guard in isAncestor must prevent a false positive here.
+	bkA := &database.Book{ID: "a", Title: "Book"}
+	bkB := &database.Book{ID: "b", Title: "Book Extra"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {{BookID: "a", FilePath: "/lib/Series/book.m4b", Duration: 3600}},
+			"b": {{BookID: "b", FilePath: "/lib/Series-Extra/book.m4b", Duration: 3600}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 5, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.FolderRelation != "unrelated" {
+		t.Fatalf("folder relation = %q, want unrelated (Series is not an ancestor of Series-Extra)", ex.FolderRelation)
 	}
 }

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,0 +1,134 @@
+// file: internal/dedup/dataset/builder_test.go
+// version: 1.0.0
+// guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
+// last-edited: 2026-06-13
+
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeStore implements BuilderStore for tests.
+type fakeStore struct {
+	books map[string]*database.Book
+	files map[string][]database.BookFile
+}
+
+func (f *fakeStore) GetBook(id string) (*database.Book, error)           { return f.books[id], nil }
+func (f *fakeStore) GetBookFiles(id string) ([]database.BookFile, error) { return f.files[id], nil }
+
+func TestBuildExample_PartVsWholeFeatures(t *testing.T) {
+	whole := &database.Book{ID: "whole", Title: "The Crafter's Defense"}
+	part := &database.Book{ID: "part", Title: "The Crafter's Defense"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"whole": whole, "part": part},
+		files: map[string][]database.BookFile{
+			"whole": {{BookID: "whole", FilePath: "/lib/Crafter/whole.m4b", Duration: 36000}},
+			"part":  {{BookID: "part", FilePath: "/lib/Crafter/part-1.m4b", Duration: 1200}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 7, EntityAID: "whole", EntityBID: "part", Layer: "exact"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.A.TotalDurationSec != 36000 || ex.B.TotalDurationSec != 1200 {
+		t.Fatalf("durations: a=%v b=%v", ex.A.TotalDurationSec, ex.B.TotalDurationSec)
+	}
+	wantRatio := 1200.0 / 36000.0
+	if ex.DurationRatio < wantRatio-1e-9 || ex.DurationRatio > wantRatio+1e-9 {
+		t.Fatalf("duration ratio = %v, want %v", ex.DurationRatio, wantRatio)
+	}
+	if ex.FolderRelation != "same_dir" {
+		t.Fatalf("folder relation = %q, want same_dir", ex.FolderRelation)
+	}
+}
+
+func TestBuildExample_CandidateFieldsCarried(t *testing.T) {
+	sim := 0.97
+	bk := &database.Book{ID: "a", Title: "Test"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bk, "b": bk},
+		files: map[string][]database.BookFile{},
+	}
+	cand := database.DedupCandidate{ID: 99, EntityAID: "a", EntityBID: "b", Layer: "lsh", Band: "HIGH", Similarity: &sim}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.CandidateID != 99 || ex.Layer != "lsh" || ex.Band != "HIGH" {
+		t.Fatalf("candidate fields not carried: %+v", ex)
+	}
+	if ex.Similarity == nil || *ex.Similarity != sim {
+		t.Fatalf("similarity not carried: %v", ex.Similarity)
+	}
+}
+
+func TestBuildExample_RecordingIDSharing(t *testing.T) {
+	bkA := &database.Book{ID: "a", Title: "Shared"}
+	bkB := &database.Book{ID: "b", Title: "Shared"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {{BookID: "a", FilePath: "/x/a.m4b", Duration: 3600, AcoustIDOnlineRecordingID: "mbid-123"}},
+			"b": {{BookID: "b", FilePath: "/y/b.m4b", Duration: 3600, AcoustIDOnlineRecordingID: "mbid-123"}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 1, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if !ex.SharesRecordingID {
+		t.Fatal("expected SharesRecordingID=true when both sides have the same AcoustID recording ID")
+	}
+}
+
+func TestBuildExample_HasCover(t *testing.T) {
+	coverURL := "https://example.com/cover.jpg"
+	bkA := &database.Book{ID: "a", Title: "Cover Book", CoverURL: &coverURL}
+	bkB := &database.Book{ID: "b", Title: "No Cover Book"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{},
+	}
+	cand := database.DedupCandidate{ID: 5, EntityAID: "a", EntityBID: "b", Layer: "exact"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if !ex.A.HasCover {
+		t.Fatal("expected A.HasCover=true")
+	}
+	if ex.B.HasCover {
+		t.Fatal("expected B.HasCover=false")
+	}
+}
+
+func TestBuildExample_FolderRelation_Ancestor(t *testing.T) {
+	bkA := &database.Book{ID: "a", Title: "Parent"}
+	bkB := &database.Book{ID: "b", Title: "Child"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {{BookID: "a", FilePath: "/lib/Series/whole.m4b", Duration: 36000}},
+			"b": {{BookID: "b", FilePath: "/lib/Series/Part1/part.m4b", Duration: 3600}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 2, EntityAID: "a", EntityBID: "b", Layer: "lsh"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.FolderRelation != "a_ancestor_of_b" {
+		t.Fatalf("folder relation = %q, want a_ancestor_of_b", ex.FolderRelation)
+	}
+}

--- a/internal/dedup/dataset/rules.go
+++ b/internal/dedup/dataset/rules.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/rules.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
 // last-edited: 2026-06-13
 
@@ -63,6 +63,12 @@ func missingFile(ex database.LabeledExample) (string, string, bool) {
 // partVsWhole fires when both durations are known and the min/max ratio is below
 // partVsWholeRatioMax, indicating the shorter entry is a chapter or excerpt of
 // the longer one rather than a full duplicate.
+//
+// Note: when either side has TotalDurationSec == 0 (unknown duration),
+// BuildExample sets DurationRatio = 0, so this catcher deliberately does
+// not fire — the pair is left unlabeled for human/ML review (do not "fix"
+// this by classifying zero-duration pairs as not_dup; size cannot prove a
+// part-vs-whole relationship).
 func partVsWhole(ex database.LabeledExample) (string, string, bool) {
 	if ex.A.TotalDurationSec > 0 && ex.B.TotalDurationSec > 0 &&
 		ex.DurationRatio > 0 && ex.DurationRatio < partVsWholeRatioMax {

--- a/internal/dedup/dataset/rules.go
+++ b/internal/dedup/dataset/rules.go
@@ -1,0 +1,72 @@
+// file: internal/dedup/dataset/rules.go
+// version: 1.0.0
+// guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
+// last-edited: 2026-06-13
+
+package dataset
+
+import (
+	"fmt"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// partVsWholeRatioMax is the duration-ratio ceiling below which a pair is
+// classified as a part matched against a whole book (not a duplicate).
+// A ratio below 0.5 means the shorter side is less than half the longer side.
+const partVsWholeRatioMax = 0.5
+
+// Classify runs the deterministic catchers in priority order and returns the
+// first firing rule's (label, reason, fires=true). If no rule fires, it returns
+// ("", "", false). The caller (backfill op) uses fires=false as "unsure" and
+// leaves the example unlabeled for human or ML review.
+//
+// Priority order (highest first):
+//  1. wholeBookSignatureMatch → true_dup  (strong positive oracle)
+//  2. missingFile             → not_dup  (hard negative: never merge a ghost)
+//  3. partVsWhole             → not_dup  (hard negative: duration mismatch)
+func Classify(ex database.LabeledExample) (label, reason string, fires bool) {
+	if l, r, ok := wholeBookSignatureMatch(ex); ok {
+		return l, r, true
+	}
+	if l, r, ok := missingFile(ex); ok {
+		return l, r, true
+	}
+	if l, r, ok := partVsWhole(ex); ok {
+		return l, r, true
+	}
+	return "", "", false
+}
+
+// wholeBookSignatureMatch is the positive oracle: both sides have a computed
+// whole-book signature and signatureRelation is "match" (sim ≥ 0.95 per Task 6
+// wiring in builder.go). Returns true_dup.
+func wholeBookSignatureMatch(ex database.LabeledExample) (string, string, bool) {
+	if ex.A.WholeBookSigPresent && ex.B.WholeBookSigPresent && ex.SignatureRelation == "match" {
+		return "true_dup", "whole-book signatures match", true
+	}
+	return "", "", false
+}
+
+// missingFile fires when either side has no resolvable files. We must never
+// merge a book whose files are gone — there is nothing to consolidate into.
+func missingFile(ex database.LabeledExample) (string, string, bool) {
+	if !ex.A.FilesExist {
+		return "not_dup", "side A has no resolvable files", true
+	}
+	if !ex.B.FilesExist {
+		return "not_dup", "side B has no resolvable files", true
+	}
+	return "", "", false
+}
+
+// partVsWhole fires when both durations are known and the min/max ratio is below
+// partVsWholeRatioMax, indicating the shorter entry is a chapter or excerpt of
+// the longer one rather than a full duplicate.
+func partVsWhole(ex database.LabeledExample) (string, string, bool) {
+	if ex.A.TotalDurationSec > 0 && ex.B.TotalDurationSec > 0 &&
+		ex.DurationRatio > 0 && ex.DurationRatio < partVsWholeRatioMax {
+		return "not_dup", fmt.Sprintf("duration ratio %.3f — part vs whole", ex.DurationRatio), true
+	}
+	return "", "", false
+}

--- a/internal/dedup/dataset/rules_test.go
+++ b/internal/dedup/dataset/rules_test.go
@@ -1,11 +1,12 @@
 // file: internal/dedup/dataset/rules_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: c1d4e8b5-7f23-4a90-9b01-6e2c5d8f3a47
 // last-edited: 2026-06-13
 
 package dataset
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -107,15 +108,16 @@ func TestClassify_ReasonContainsRatio(t *testing.T) {
 		B:             database.BookFeatures{TotalDurationSec: 1200, FilesExist: true},
 		DurationRatio: 1200.0 / 36000.0,
 	}
-	_, reason, fires := Classify(ex)
+	label, reason, fires := Classify(ex)
 	if !fires {
 		t.Fatal("expected catcher to fire")
 	}
-	if len(reason) == 0 {
-		t.Fatal("expected non-empty reason")
+	// Label assertion: must be not_dup.
+	if label != "not_dup" {
+		t.Fatalf("label = %q, want not_dup", label)
 	}
-	// Reason should mention the ratio numerically (smoke check, not an exact match).
-	if reason == "not_dup" {
-		t.Fatalf("reason should describe the cause, not just repeat the label; got %q", reason)
+	// Reason assertion: must describe the rule, not just echo the label.
+	if !strings.Contains(reason, "part vs whole") {
+		t.Fatalf("reason should describe the rule (want substring %q); got %q", "part vs whole", reason)
 	}
 }

--- a/internal/dedup/dataset/rules_test.go
+++ b/internal/dedup/dataset/rules_test.go
@@ -1,0 +1,121 @@
+// file: internal/dedup/dataset/rules_test.go
+// version: 1.0.0
+// guid: c1d4e8b5-7f23-4a90-9b01-6e2c5d8f3a47
+// last-edited: 2026-06-13
+
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestCatchers(t *testing.T) {
+	cases := []struct {
+		name      string
+		ex        database.LabeledExample
+		wantFires bool
+		wantLabel string
+	}{
+		{
+			name: "part vs whole by duration ratio",
+			ex: database.LabeledExample{
+				A:             database.BookFeatures{TotalDurationSec: 36000, FilesExist: true},
+				B:             database.BookFeatures{TotalDurationSec: 1200, FilesExist: true},
+				DurationRatio: 1200.0 / 36000.0,
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			name: "missing file one side",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 100},
+				B: database.BookFeatures{FilesExist: false},
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			name: "whole-book signature match => true_dup",
+			ex: database.LabeledExample{
+				A:                 database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				B:                 database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				SignatureRelation: "match", DurationRatio: 1.0,
+			},
+			wantFires: true, wantLabel: "true_dup",
+		},
+		{
+			name: "no rule fires",
+			ex: database.LabeledExample{
+				A:                 database.BookFeatures{FilesExist: true, TotalDurationSec: 36000},
+				B:                 database.BookFeatures{FilesExist: true, TotalDurationSec: 35900},
+				DurationRatio:     35900.0 / 36000.0,
+				SignatureRelation: "unknown",
+			},
+			wantFires: false,
+		},
+		{
+			// The signature match catcher must fire BEFORE the missing-file catcher
+			// to respect priority order. Both sigs present + "match" wins even if
+			// one side is somehow also flagged missing (unlikely but tests priority).
+			name: "signature match beats missing file (priority check)",
+			ex: database.LabeledExample{
+				A:                 database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				B:                 database.BookFeatures{FilesExist: false, WholeBookSigPresent: true},
+				SignatureRelation: "match",
+			},
+			wantFires: true, wantLabel: "true_dup",
+		},
+		{
+			// missing-file fires before part-vs-whole
+			name: "missing file beats part-vs-whole (priority check)",
+			ex: database.LabeledExample{
+				A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000},
+				B:             database.BookFeatures{FilesExist: false, TotalDurationSec: 100},
+				DurationRatio: 100.0 / 36000.0,
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			// disjoint signature should not trigger signature-match catcher
+			name: "disjoint signature does not fire match catcher",
+			ex: database.LabeledExample{
+				A:                 database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				B:                 database.BookFeatures{FilesExist: true, WholeBookSigPresent: true, TotalDurationSec: 36000},
+				DurationRatio:     1.0,
+				SignatureRelation: "disjoint",
+			},
+			wantFires: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, reason, fires := Classify(tc.ex)
+			if fires != tc.wantFires {
+				t.Fatalf("fires=%v want %v (reason=%q)", fires, tc.wantFires, reason)
+			}
+			if fires && label != tc.wantLabel {
+				t.Fatalf("label=%q want %q (reason=%q)", label, tc.wantLabel, reason)
+			}
+		})
+	}
+}
+
+func TestClassify_ReasonContainsRatio(t *testing.T) {
+	ex := database.LabeledExample{
+		A:             database.BookFeatures{TotalDurationSec: 36000, FilesExist: true},
+		B:             database.BookFeatures{TotalDurationSec: 1200, FilesExist: true},
+		DurationRatio: 1200.0 / 36000.0,
+	}
+	_, reason, fires := Classify(ex)
+	if !fires {
+		t.Fatal("expected catcher to fire")
+	}
+	if len(reason) == 0 {
+		t.Fatal("expected non-empty reason")
+	}
+	// Reason should mention the ratio numerically (smoke check, not an exact match).
+	if reason == "not_dup" {
+		t.Fatalf("reason should describe the cause, not just repeat the label; got %q", reason)
+	}
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -819,6 +819,9 @@ func (de *Engine) checkExactTitle(book *database.Book, authorName string) error 
 	if !hasUsableTitle(book.Title) {
 		return nil
 	}
+	if !hasPlausibleAudio(book) {
+		return nil // stub / unscanned shell — never anchor an exact-title match
+	}
 
 	others, err := de.bookStore.GetBooksByAuthorID(*book.AuthorID)
 	if err != nil {
@@ -834,6 +837,9 @@ func (de *Engine) checkExactTitle(book *database.Book, authorName string) error 
 		}
 		if !hasUsableTitle(other.Title) {
 			continue
+		}
+		if !hasPlausibleAudio(other) {
+			continue // stub / unscanned shell on the other side
 		}
 		otherForms := de.allNormalizedTitleForms(other)
 		// Closest-form distance: a match exists if ANY form of book is

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -717,6 +717,9 @@ func (de *Engine) checkExactISBN(book *database.Book) error {
 	if bookISBN10 == "" && bookISBN13 == "" && bookASIN == "" {
 		return nil
 	}
+	if !hasPlausibleAudio(book) {
+		return nil // stub / unscanned shell — never anchor an exact-ISBN match
+	}
 
 	const batchSize = 500
 	offset := 0
@@ -733,6 +736,9 @@ func (de *Engine) checkExactISBN(book *database.Book) error {
 			other := &batch[i]
 			if other.ID == book.ID {
 				continue
+			}
+			if !hasPlausibleAudio(other) {
+				continue // stub / unscanned shell on the other side
 			}
 			matched := false
 			if bookISBN10 != "" && derefStr(other.ISBN10) == bookISBN10 {

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.26.1
+// version: 1.26.2
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-13
 
@@ -777,6 +777,11 @@ func (de *Engine) checkExactISBN(book *database.Book) error {
 // share the same metadata_source_hash (sha256 of source:canonical_id) they
 // were applied from the exact same external record and are almost certainly
 // duplicates. Creates a dedup candidate with similarity 0.99.
+//
+// Note: intentionally NOT gated by hasPlausibleAudio. A shared
+// metadata-source hash is a valid duplicate signal even when one side is an
+// unscanned/incomplete file — unlike the title/ISBN emitters, this match is
+// anchored to a concrete external record, not just a name collision.
 func (de *Engine) checkExactMetadataSourceHash(book *database.Book) error {
 	if book.MetadataSourceHash == nil || *book.MetadataSourceHash == "" {
 		return nil

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.26.0
+// version: 1.26.1
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-10
+// last-edited: 2026-06-13
 
 package dedup
 
@@ -1050,6 +1050,31 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 func hasUsableTitle(title string) bool {
 	trimmed := strings.TrimSpace(title)
 	return len([]rune(trimmed)) > 2
+}
+
+// minPlausibleAudioBytes is the smallest file size we treat as a real audio
+// file. Anything smaller is a placeholder/stub (a 32-byte .url shortcut, a
+// 182-byte broken download) that must never anchor an exact-duplicate match.
+const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
+
+// hasPlausibleAudio reports whether a book references real audio content rather
+// than a stub or a never-scanned placeholder. A book qualifies if it has a
+// positive duration OR a file size at/above the plausible-audio floor. This is
+// the engine-side counterpart to the dataset missingFile catcher: it stops the
+// exact-title / ISBN emitters from flagging "100% duplicate" when one side is a
+// 32-byte stub or an unscanned shell. A large unscanned copy (real size, zero
+// duration) still qualifies — it is a genuine duplicate, not garbage.
+func hasPlausibleAudio(book *database.Book) bool {
+	if book == nil {
+		return false
+	}
+	if book.Duration != nil && *book.Duration > 0 {
+		return true
+	}
+	if book.FileSize != nil && *book.FileSize >= minPlausibleAudioBytes {
+		return true
+	}
+	return false
 }
 
 // seriesNumberOf returns a stable string representation of a book's

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1023,6 +1023,55 @@ func TestEmbedStatus_String(t *testing.T) {
 	}
 }
 
+func TestEngine_ExactTitle_RejectsStubFile(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	authorID := 1
+	sz := func(v int64) *int64 { return &v }
+
+	real := &database.Book{ID: "book-real", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(254_192_471)}
+	stub := &database.Book{ID: "book-stub", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(32)}
+	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
+		return []database.Book{*real, *stub}, nil
+	}
+
+	if err := engine.checkExactTitle(real, "Joshua Dalzelle"); err != nil {
+		t.Fatalf("checkExactTitle: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates (stub side must be rejected), got %d", len(cands))
+	}
+}
+
+func TestEngine_ExactTitle_KeepsGenuineLargePair(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	authorID := 2
+	sz := func(v int64) *int64 { return &v }
+
+	a := &database.Book{ID: "book-a", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
+	// Genuine same-file copy in another folder: large size, not yet scanned.
+	b := &database.Book{ID: "book-b", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
+	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
+		return []database.Book{*a, *b}, nil
+	}
+
+	if err := engine.checkExactTitle(a, "Jae"); err != nil {
+		t.Fatalf("checkExactTitle: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate (genuine large dupe kept), got %d", len(cands))
+	}
+}
+
 func TestHasPlausibleAudio(t *testing.T) {
 	dur := func(v int) *int { return &v }
 	sz := func(v int64) *int64 { return &v }

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -299,8 +299,9 @@ func TestEngine_ExactMatch_ISBN(t *testing.T) {
 	engine, mock, es := setupTestEngine(t)
 
 	authorID := 1
-	bookA := &database.Book{ID: "BOOK_A", Title: "Title A", AuthorID: &authorID, ISBN13: strPtr("9780134685991")}
-	bookB := &database.Book{ID: "BOOK_B", Title: "Title B", AuthorID: &authorID, ISBN13: strPtr("9780134685991")}
+	sz := func(v int64) *int64 { return &v }
+	bookA := &database.Book{ID: "BOOK_A", Title: "Title A", AuthorID: &authorID, ISBN13: strPtr("9780134685991"), FileSize: sz(300_000_000)}
+	bookB := &database.Book{ID: "BOOK_B", Title: "Title B", AuthorID: &authorID, ISBN13: strPtr("9780134685991"), FileSize: sz(300_000_000)}
 
 	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
 		if id == "BOOK_A" {
@@ -1020,6 +1021,29 @@ func TestEmbedStatus_String(t *testing.T) {
 		if got := tc.status.String(); got != tc.want {
 			t.Errorf("EmbedStatus(%d).String() = %q, want %q", tc.status, got, tc.want)
 		}
+	}
+}
+
+func TestEngine_ExactISBN_RejectsStubFile(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	sz := func(v int64) *int64 { return &v }
+	isbn := func(v string) *string { return &v }
+
+	real := &database.Book{ID: "r", Title: "X", ISBN13: isbn("9781234567890"), FileSize: sz(120_000_000)}
+	stub := &database.Book{ID: "s", Title: "X", ISBN13: isbn("9781234567890"), FileSize: sz(182)}
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		if offset == 0 {
+			return []database.Book{*real, *stub}, nil
+		}
+		return nil, nil
+	}
+
+	if err := engine.checkExactISBN(real); err != nil {
+		t.Fatalf("checkExactISBN: %v", err)
+	}
+	cands, _, _ := es.ListCandidates(database.CandidateFilter{Limit: 100})
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates (stub rejected), got %d", len(cands))
 	}
 }
 

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/engine_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
+// last-edited: 2026-06-13
 
 package dedup
 
@@ -1019,5 +1020,30 @@ func TestEmbedStatus_String(t *testing.T) {
 		if got := tc.status.String(); got != tc.want {
 			t.Errorf("EmbedStatus(%d).String() = %q, want %q", tc.status, got, tc.want)
 		}
+	}
+}
+
+func TestHasPlausibleAudio(t *testing.T) {
+	dur := func(v int) *int { return &v }
+	sz := func(v int64) *int64 { return &v }
+
+	cases := []struct {
+		name string
+		book *database.Book
+		want bool
+	}{
+		{"nil book", nil, false},
+		{"32-byte stub, no duration", &database.Book{FileSize: sz(32)}, false},
+		{"182-byte stub, no duration", &database.Book{FileSize: sz(182)}, false},
+		{"large unscanned copy (genuine dupe)", &database.Book{FileSize: sz(184_741_714)}, true},
+		{"positive duration, no size", &database.Book{Duration: dur(3600)}, true},
+		{"empty book", &database.Book{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPlausibleAudio(tc.book); got != tc.want {
+				t.Fatalf("hasPlausibleAudio(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_test.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
 // last-edited: 2026-06-13
 
@@ -1110,6 +1110,7 @@ func TestHasPlausibleAudio(t *testing.T) {
 		{"182-byte stub, no duration", &database.Book{FileSize: sz(182)}, false},
 		{"large unscanned copy (genuine dupe)", &database.Book{FileSize: sz(184_741_714)}, true},
 		{"positive duration, no size", &database.Book{Duration: dur(3600)}, true},
+		{"zero duration pointer (scanned, found nothing)", &database.Book{Duration: dur(0)}, false},
 		{"empty book", &database.Book{}, false},
 	}
 	for _, tc := range cases {

--- a/internal/plugins/dedup/dataset_backfill.go
+++ b/internal/plugins/dedup/dataset_backfill.go
@@ -1,0 +1,197 @@
+// file: internal/plugins/dedup/dataset_backfill.go
+// version: 1.0.0
+// guid: 2d6f8a13-7c40-4e92-8b15-9a3e5c7d2f64
+// last-edited: 2026-06-13
+
+// Package dedup — op dedup.dataset-backfill (spec C4 backfill).
+//
+// Iterates all pending candidates, builds a LabeledExample for each, runs the
+// deterministic catchers (Classify), and writes the labeled example to the
+// dedup:label keyspace. With apply=true, any candidate a catcher labels
+// "not_dup" is suppressed (status → "dismissed") so residual part-vs-whole /
+// missing-file false positives leave the review queue.
+//
+// Dry-run by default: reports counts, writes nothing.
+//
+// NOTE on suppression counts: in practice, the dominant residual class (stub /
+// unscanned-file pairs with one side duration=0) is NOT caught by the
+// duration-ratio or missing-file catchers when file records exist but the file
+// is 0-second. The op labels and suppresses only what the catchers actually
+// fire on — counters are always honest and may be lower than the total pending
+// backlog. That is by design.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// datasetBackfillParams are the JSON parameters accepted by the op.
+type datasetBackfillParams struct {
+	// Apply, if true, writes labeled examples and suppresses not_dup candidates.
+	// Default false (dry-run) — the op only reports counts, writes nothing.
+	Apply bool `json:"apply"`
+}
+
+// datasetBackfillDef returns the OperationDef for dedup.dataset-backfill.
+func (p *Plugin) datasetBackfillDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.dataset-backfill",
+		Plugin:      "dedup",
+		DisplayName: "Backfill dedup tuning dataset",
+		Description: "Builds a labeled example per pending candidate, runs deterministic catchers, " +
+			"and (apply=true) suppresses rule-labeled not_dup candidates (status → dismissed). " +
+			"Dry-run by default.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.dataset-backfill",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runDatasetBackfill,
+	}
+}
+
+// builderAdapter satisfies dataset.BuilderStore using the plugin's main store.
+// dataset.BuilderStore requires GetBook(id string) and GetBookFiles(id string).
+// database.Store exposes GetBookByID (not GetBook), so the adapter bridges the
+// name mismatch while keeping the interface names canonical.
+type builderAdapter struct{ store database.Store }
+
+func (b builderAdapter) GetBook(id string) (*database.Book, error) {
+	return b.store.GetBookByID(id)
+}
+
+func (b builderAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
+	return b.store.GetBookFiles(id)
+}
+
+// runDatasetBackfill implements the dedup.dataset-backfill op.
+func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	// --- Parse params ---
+	var params datasetBackfillParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	reporter.Logger().Info("dataset-backfill start", "apply", params.Apply)
+
+	// --- Load all pending candidates ---
+	_ = reporter.UpdateProgress(0, 2, "Loading pending candidates…")
+	filter := database.CandidateFilter{
+		Status: "pending",
+		Limit:  1_000_000,
+	}
+	cands, _, err := p.embeddingStore.ListCandidates(filter)
+	if err != nil {
+		return fmt.Errorf("list candidates: %w", err)
+	}
+
+	reporter.Logger().Info("dataset-backfill: candidates loaded", "count", len(cands))
+
+	adapter := builderAdapter{store: p.store}
+
+	var (
+		examined   int
+		labeled    int
+		suppressed int
+		notDup     int
+		trueDup    int
+		buildErrs  int
+	)
+
+	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Processing %d candidates…", len(cands)))
+
+	for i := range cands {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		c := cands[i]
+		examined++
+
+		// Build feature vector for the candidate pair.
+		ex, err := dataset.BuildExample(adapter, c)
+		if err != nil {
+			buildErrs++
+			reporter.Logger().Warn("dataset-backfill: build error",
+				"candidate_id", c.ID,
+				"entity_a", c.EntityAID,
+				"entity_b", c.EntityBID,
+				"error", err)
+			continue
+		}
+
+		// Run deterministic catchers.
+		if label, reason, fires := dataset.Classify(ex); fires {
+			ex.Label = label
+			ex.LabelSource = "rule"
+			ex.LabelReason = reason
+			switch label {
+			case "not_dup":
+				notDup++
+			case "true_dup":
+				trueDup++
+			}
+		}
+		// If no catcher fired, ex.Label remains "" — example is unlabeled, written
+		// as-is so features are captured for future human/ML labeling.
+
+		if params.Apply {
+			// Write the labeled (or unlabeled) example to the store.
+			if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
+				reporter.Logger().Error("dataset-backfill: upsert error",
+					"candidate_id", c.ID, "error", err)
+				// Continue — partial progress is better than aborting.
+			} else {
+				labeled++
+			}
+
+			// Suppress only catchers-confirmed not_dup candidates.
+			if ex.Label == "not_dup" {
+				if err := p.embeddingStore.UpdateCandidateStatus(c.ID, "dismissed"); err != nil {
+					reporter.Logger().Error("dataset-backfill: suppress error",
+						"candidate_id", c.ID, "error", err)
+				} else {
+					suppressed++
+				}
+			}
+		}
+	}
+
+	summary := fmt.Sprintf(
+		"examined=%d not_dup=%d true_dup=%d labeled=%d suppressed=%d build_errs=%d (apply=%v)",
+		examined, notDup, trueDup, labeled, suppressed, buildErrs, params.Apply,
+	)
+	reporter.Logger().Info("dataset-backfill complete", "summary", summary)
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(2, 2,
+			fmt.Sprintf("Dry-run complete — %d not_dup, %d true_dup of %d examined. Pass apply=true to write.", notDup, trueDup, examined))
+	} else {
+		_ = reporter.UpdateProgress(2, 2,
+			fmt.Sprintf("Complete — %d/%d labeled, %d suppressed. %s", labeled, examined, suppressed, summary))
+	}
+
+	return nil
+}

--- a/internal/plugins/dedup/dataset_backfill.go
+++ b/internal/plugins/dedup/dataset_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/dataset_backfill.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 2d6f8a13-7c40-4e92-8b15-9a3e5c7d2f64
 // last-edited: 2026-06-13
 
@@ -11,7 +11,9 @@
 // "not_dup" is suppressed (status → "dismissed") so residual part-vs-whole /
 // missing-file false positives leave the review queue.
 //
-// Dry-run by default: reports counts, writes nothing.
+// Dry-run by default: reports counts, writes nothing. The apply path is
+// idempotent — UpsertLabeledExample overwrites and re-dismissing an already-
+// dismissed candidate is a no-op, so re-running is safe (no done-flag needed).
 //
 // NOTE on suppression counts: in practice, the dominant residual class (stub /
 // unscanned-file pairs with one side duration=0) is NOT caught by the

--- a/internal/plugins/dedup/dataset_backfill.go
+++ b/internal/plugins/dedup/dataset_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/dataset_backfill.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: 2d6f8a13-7c40-4e92-8b15-9a3e5c7d2f64
 // last-edited: 2026-06-13
 
@@ -132,6 +132,11 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 		c := cands[i]
 		examined++
 
+		// Periodic progress update so the op doesn't appear frozen on large sets.
+		if examined%1000 == 0 {
+			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Processed %d/%d candidates…", examined, len(cands)))
+		}
+
 		// Build feature vector for the candidate pair.
 		ex, err := dataset.BuildExample(adapter, c)
 		if err != nil {
@@ -149,6 +154,7 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 			ex.Label = label
 			ex.LabelSource = "rule"
 			ex.LabelReason = reason
+			ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
 			switch label {
 			case "not_dup":
 				notDup++

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-06-10
+// last-edited: 2026-06-13
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -56,9 +56,10 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.splitBookScanDef(),
 		p.purgeStaleDef(),
 		p.lshIndexBuildDef(),
-		p.purgeLegacyFPDef(),    // T015: legacy fingerprint purge op
-		p.embReencodeDef(),      // T021: float16+zstd re-encode op
-		p.bookfileSegDropDef(),  // T020: drop AcoustID segment fields from stored values
+		p.purgeLegacyFPDef(),   // T015: legacy fingerprint purge op
+		p.embReencodeDef(),     // T021: float16+zstd re-encode op
+		p.bookfileSegDropDef(), // T020: drop AcoustID segment fields from stored values
+		p.datasetBackfillDef(), // C4: label + suppress residual pending candidates
 	}
 
 	for _, op := range ops {

--- a/tools/cmd/dedup-dataset-audit/main.go
+++ b/tools/cmd/dedup-dataset-audit/main.go
@@ -1,0 +1,270 @@
+// file: tools/cmd/dedup-dataset-audit/main.go
+// version: 1.0.0
+// guid: 4e7a1c92-8b3d-4f10-9c21-7a5b6c4d3e2f
+// last-edited: 2026-06-13
+
+// Command dedup-dataset-audit is a READ-ONLY analysis tool that measures, over
+// the full dedup candidate set, how well an auto-labeling "oracle" could label
+// pairs and how much deterministic catchers (same-folder, duration-ratio) would
+// move the needle. It backs "Experiment 0" of the dedup tuning-dataset design.
+//
+// It answers:
+//   - recording_id oracle yield: how many candidate pairs have a MusicBrainz
+//     recording_id on BOTH sides (auto-labelable), and of those, same recording
+//     (auto-positive) vs disjoint (auto-negative).
+//   - disagreement: oracle-negative pairs that the scorer ranked CERTAIN/exact
+//     (false positives) and oracle-positive pairs ranked REVIEW (false negatives).
+//   - deterministic-catcher impact: same-folder pairs and low duration-ratio
+//     (part-vs-whole) pairs, cross-tabbed by band — i.e. how much obvious garbage
+//     a rule would suppress without any model.
+//   - attribute coverage: distinct candidate books carrying a recording_id and/or
+//     a (non-tombstoned) iTunes PID.
+//
+// Pebble is RW-only with an exclusive lock, so run this against a COPY/snapshot of
+// the prod DB (the server holds the lock on the live one), e.g.:
+//
+//	cp -a --reflink=auto /var/lib/audiobook-organizer/audiobooks.pebble /tmp/abk-snap
+//	dedup-dataset-audit -db /tmp/abk-snap
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// bookAgg is the per-book rollup we need for pair analysis, memoised so books
+// that appear in many candidate pairs are only read once.
+type bookAgg struct {
+	recIDs      map[string]struct{} // non-empty MusicBrainz online recording IDs
+	dirs        map[string]struct{} // distinct parent directories of the book's files
+	totalDurSec float64             // summed best-available duration across files
+	hasITunes   bool                // any non-tombstoned iTunes PID on the book/files
+	fileCount   int
+}
+
+func bandOf(b string) string {
+	if b == "" {
+		return "(none)"
+	}
+	return b
+}
+
+func main() {
+	dbPath := flag.String("db", "", "path to the PebbleDB directory (a COPY of prod — the live DB is locked by the server)")
+	durRatioThresh := flag.Float64("dur-ratio", 0.5, "duration ratio (min/max) below which a pair is flagged part-vs-whole")
+	flag.Parse()
+	if *dbPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: dedup-dataset-audit -db <pebble-dir-copy>")
+		os.Exit(2)
+	}
+
+	ps, err := database.NewPebbleStore(*dbPath)
+	if err != nil {
+		log.Fatalf("open pebble store at %s: %v", *dbPath, err)
+	}
+	defer ps.Close()
+	es := database.NewEmbeddingStore(ps.DB())
+
+	// One ListCandidates call loads + sorts the whole table; a huge limit gets
+	// every row in a single pass (the candidate set is ~tens of thousands).
+	cands, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Limit:      5_000_000,
+	})
+	if err != nil {
+		log.Fatalf("list candidates: %v", err)
+	}
+	log.Printf("loaded %d candidates (store reports total=%d)", len(cands), total)
+
+	aggCache := map[string]*bookAgg{}
+	getAgg := func(bookID string) *bookAgg {
+		if a, ok := aggCache[bookID]; ok {
+			return a
+		}
+		a := &bookAgg{recIDs: map[string]struct{}{}, dirs: map[string]struct{}{}}
+		files, ferr := ps.GetBookFiles(bookID)
+		if ferr == nil {
+			a.fileCount = len(files)
+			for _, f := range files {
+				if f.AcoustIDOnlineRecordingID != "" {
+					a.recIDs[f.AcoustIDOnlineRecordingID] = struct{}{}
+				}
+				if f.FilePath != "" {
+					a.dirs[filepath.Dir(f.FilePath)] = struct{}{}
+				}
+				if f.ITunesPersistentID != "" {
+					a.hasITunes = true
+				}
+				// Prefer the fpcalc-measured duration; fall back to the
+				// container duration. Sum across files = the book's total runtime.
+				if f.AcoustIDFingerprintDurationSec > 0 {
+					a.totalDurSec += f.AcoustIDFingerprintDurationSec
+				} else if f.Duration > 0 {
+					a.totalDurSec += float64(f.Duration)
+				}
+			}
+		}
+		if !a.hasITunes {
+			if maps, merr := ps.GetExternalIDsForBook(bookID); merr == nil {
+				for _, m := range maps {
+					if !m.Tombstoned {
+						a.hasITunes = true
+						break
+					}
+				}
+			}
+		}
+		aggCache[bookID] = a
+		return a
+	}
+
+	// Counters.
+	var (
+		byBand         = map[string]int{}
+		byStatus       = map[string]int{}
+		byLayer        = map[string]int{}
+		oracleElig     int // both sides have ≥1 recording_id
+		oraclePos      int // shared recording_id
+		oracleNeg      int // disjoint recording_ids
+		falsePos       int // oracle-negative but band CERTAIN/HIGH (or exact layer)
+		falseNeg       int // oracle-positive but band REVIEW/MEDIUM
+		sameFolder     int
+		sameFolderCert int
+		lowDurRatio    int // pairs below dur-ratio threshold
+		lowDurHighBand int // ...that also scored CERTAIN/HIGH/exact
+		bothHaveDur    int
+	)
+	booksWithRec := map[string]struct{}{}
+	booksWithITunes := map[string]struct{}{}
+	allBooks := map[string]struct{}{}
+
+	isHighBand := func(c database.DedupCandidate) bool {
+		return c.Band == "CERTAIN" || c.Band == "HIGH" || c.Layer == "exact"
+	}
+	isLowBand := func(c database.DedupCandidate) bool {
+		return c.Band == "REVIEW" || c.Band == "MEDIUM"
+	}
+
+	for _, c := range cands {
+		byBand[bandOf(c.Band)]++
+		byStatus[c.Status]++
+		byLayer[c.Layer]++
+		a := getAgg(c.EntityAID)
+		b := getAgg(c.EntityBID)
+		allBooks[c.EntityAID] = struct{}{}
+		allBooks[c.EntityBID] = struct{}{}
+		if len(a.recIDs) > 0 {
+			booksWithRec[c.EntityAID] = struct{}{}
+		}
+		if len(b.recIDs) > 0 {
+			booksWithRec[c.EntityBID] = struct{}{}
+		}
+		if a.hasITunes {
+			booksWithITunes[c.EntityAID] = struct{}{}
+		}
+		if b.hasITunes {
+			booksWithITunes[c.EntityBID] = struct{}{}
+		}
+
+		// recording_id pair oracle.
+		if len(a.recIDs) > 0 && len(b.recIDs) > 0 {
+			oracleElig++
+			shared := false
+			for r := range a.recIDs {
+				if _, ok := b.recIDs[r]; ok {
+					shared = true
+					break
+				}
+			}
+			if shared {
+				oraclePos++
+				if isLowBand(c) {
+					falseNeg++
+				}
+			} else {
+				oracleNeg++
+				if isHighBand(c) {
+					falsePos++
+				}
+			}
+		}
+
+		// same-folder (shared parent directory) — the screenshot bug class.
+		sf := false
+		for d := range a.dirs {
+			if _, ok := b.dirs[d]; ok {
+				sf = true
+				break
+			}
+		}
+		if sf {
+			sameFolder++
+			if c.Band == "CERTAIN" || c.Layer == "exact" {
+				sameFolderCert++
+			}
+		}
+
+		// duration ratio (part-vs-whole).
+		if a.totalDurSec > 0 && b.totalDurSec > 0 {
+			bothHaveDur++
+			lo, hi := a.totalDurSec, b.totalDurSec
+			if lo > hi {
+				lo, hi = hi, lo
+			}
+			if hi > 0 && lo/hi < *durRatioThresh {
+				lowDurRatio++
+				if isHighBand(c) {
+					lowDurHighBand++
+				}
+			}
+		}
+	}
+
+	pct := func(n, d int) string {
+		if d == 0 {
+			return "n/a"
+		}
+		return fmt.Sprintf("%.1f%%", 100*float64(n)/float64(d))
+	}
+	printMap := func(title string, m map[string]int) {
+		fmt.Printf("\n%s:\n", title)
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return m[keys[i]] > m[keys[j]] })
+		for _, k := range keys {
+			fmt.Printf("  %-12s %6d  (%s)\n", k, m[k], pct(m[k], len(cands)))
+		}
+	}
+
+	fmt.Printf("\n================ DEDUP DATASET AUDIT ================\n")
+	fmt.Printf("candidates analysed: %d   distinct books: %d\n", len(cands), len(allBooks))
+	printMap("by band", byBand)
+	printMap("by status", byStatus)
+	printMap("by layer", byLayer)
+
+	fmt.Printf("\n---- recording_id pair oracle ----\n")
+	fmt.Printf("books with ≥1 online recording_id: %d / %d  (%s)\n", len(booksWithRec), len(allBooks), pct(len(booksWithRec), len(allBooks)))
+	fmt.Printf("books with a live iTunes PID:       %d / %d  (%s)\n", len(booksWithITunes), len(allBooks), pct(len(booksWithITunes), len(allBooks)))
+	fmt.Printf("pairs auto-labelable (both sides have recording_id): %d  (%s of all pairs)\n", oracleElig, pct(oracleElig, len(cands)))
+	fmt.Printf("  ├─ auto-POSITIVE (shared recording):   %d  (%s of eligible)\n", oraclePos, pct(oraclePos, oracleElig))
+	fmt.Printf("  └─ auto-NEGATIVE (disjoint recordings): %d  (%s of eligible)\n", oracleNeg, pct(oracleNeg, oracleElig))
+	fmt.Printf("  DISAGREEMENT with scorer:\n")
+	fmt.Printf("    false positives (auto-neg but band CERTAIN/HIGH/exact): %d\n", falsePos)
+	fmt.Printf("    false negatives (auto-pos but band REVIEW/MEDIUM):      %d\n", falseNeg)
+
+	fmt.Printf("\n---- deterministic catchers (no model) ----\n")
+	fmt.Printf("same-folder pairs (shared parent dir): %d  (%s of all pairs)\n", sameFolder, pct(sameFolder, len(cands)))
+	fmt.Printf("  └─ of those scored CERTAIN/exact:    %d  (%s) — the screenshot bug class\n", sameFolderCert, pct(sameFolderCert, sameFolder))
+	fmt.Printf("pairs with both durations known:       %d\n", bothHaveDur)
+	fmt.Printf("low duration-ratio (<%.2f) pairs:      %d  (%s of dur-known)\n", *durRatioThresh, lowDurRatio, pct(lowDurRatio, bothHaveDur))
+	fmt.Printf("  └─ of those scored CERTAIN/HIGH/exact: %d — part-vs-whole false positives\n", lowDurHighBand)
+	fmt.Printf("====================================================\n")
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the dedup "100% duplicate against a stub/part" bug, plus the foundation for a self-improving dedup tuning loop. **Not merged / not deployed — ready for your review.** The engine change alters production dedup *emission* behavior and there's a new admin op, so I left merge + deploy to you.

Spec: `docs/specs/2026-06-13-dedup-tuning-dataset-design.md` · Plan: `docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`

## What's in here

**Root cause (verified on prod):** the `exact` layer has 5 sim=1.0 emitters; `checkExactTitle` (and `checkExactISBN`) emitted on title/ISBN identity with **no check that the books reference real audio**. Result: a real book flagged "100% duplicate" against a 32-byte stub or an unscanned `duration=0` shell. Measured: 300/300 residual pairs title-equal, 279/300 with one stub/unscanned side, 0 sharing ASIN/ISBN/hash.

**Milestone A — engine gate (the fix).** `hasPlausibleAudio(*Book)` (file size ≥256 KiB OR duration > 0) now gates `checkExactTitle`/`checkExactISBN` on both sides. File size is the right signal: genuine same-file-different-folder duplicates stay large (184 MB) even when unscanned; stubs are 32–182 bytes. `CollectExactAcoustID` is intentionally not gated (a fingerprint match is its own audio evidence).

**Milestone B — dataset foundation.**
- New Pebble keyspace `dedup:label:<candidateID16hex>` → `LabeledExample` (`internal/database/dedup_label.go`), within the shared `audiobooks.pebble`.
- New pure package `internal/dedup/dataset`: `BuildExample` (feature builder — durations, folder relation, recording-id sharing, whole-book `signatureRelation` via `fingerprint.BookSignatureSimilarity`) + `Classify` catchers (`wholeBookSignatureMatch`→true_dup, `missingFile`/`partVsWhole`→not_dup).

**Milestone C — backfill op.** `dedup.dataset-backfill` (`internal/plugins/dedup/dataset_backfill.go`): labels every pending candidate and, with `{"apply":true}`, suppresses rule-labeled `not_dup` candidates. Dry-run by default, idempotent.

## Already done on prod (with approval)
`dedup.purge-legacy-fp-candidates` was **applied** 2026-06-13: 12,322 legacy pre-cutover `exact`/sim=1 false positives → `stale-fp` (flag `dedup_fp_purge_v1_done` set). Pending `exact`/sim=1 dropped 15,476 → 3,154.

## ⚠️ Known limitation (read before merging)
The engine gate stops **new** stub emissions, but the **existing 3,154 residual** is dominated by stub/unscanned pairs (one side `duration=0`, file-records present). Those are **not** caught by the current `missingFile`/`partVsWhole` catchers (file rows exist; duration-ratio is 0). Clearing the existing residual needs a follow-up **FileSize-aware catcher** (next plan). The backfill op reports honest counts and will suppress relatively few of the current residual — by design.

## Deferred to a follow-up plan
FileSize-aware residual catcher · offset-containment signature alignment (`a_contains_b`) · live-capture on merge/dismiss · auto-bug-filing (C5) · review UI (C6) · JSONL export (C7).

## Testing
`go build ./...` clean · `go vet` clean · `go test ./internal/dedup/... ./internal/database/... ./internal/plugins/dedup/...` PASS · all 11 touched files gofmt-clean (pre-existing repo gofmt debt untouched). Built TDD, every task spec-reviewed + quality-reviewed + a final holistic review.

## Docs
AI-REFERENCE, `database-pebble-schema.md` (new `dedup:label:` keyspace), copilot-instructions architecture notes, a new Mermaid diagram `docs/diagrams/flow-book-dedup.mmd`, CHANGELOG (prepended), TODO (M0 + A/B/C marked done; follow-ups + community-index item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
