### PR TITLE
feat(dedup): FileSize-aware catcher for the stub residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.19.1 -->
+<!-- version: 3.20.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Added
+
+#### June 13, 2026 — Dedup: FileSize-aware residual catcher
+
+- **`internal/dedup/dataset/rules.go`** — new `implausibleAudio` catcher: a pair is
+  labeled `not_dup` when either side has no plausible audio (zero/unknown duration
+  **and** a largest file below the 256 KiB stub floor). This is the dataset
+  counterpart to the engine emission gate and catches the post-cutover stub /
+  unscanned-placeholder residual that `missingFile` (file records exist) and
+  `partVsWhole` (zero duration → ratio 0) both miss. A genuine unscanned copy
+  (large file, zero duration) is **not** suppressed.
+- **`internal/database/dedup_label.go`** — `BookFeatures.FileSizeBytes` (largest known
+  file size per book) added to carry the size signal.
+- **`internal/dedup/dataset/builder.go`** — populates `FileSizeBytes` (max over the
+  book's files, at least the book-level size).
+- Running `dedup.dataset-backfill --apply` now suppresses the existing stub residual
+  (the ~3,154 post-cutover false positives) in addition to part-vs-whole pairs.
 
 #### June 13, 2026 — Dedup tuning dataset: engine gate + labeled store + backfill op
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.78.0 -->
+<!-- version: 8.79.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -131,11 +131,12 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   candidates. Idempotent. ✅ Jun 13
 
 ### Deferred follow-ups (open)
-- [ ] **C5-gate** FileSize-aware catcher for residual stub pairs: when both sides have
-  `FileSize > 0` but `Duration == 0`, compare file sizes. Currently these pairs are
-  unlabeled (left for human/ML review) because `DurationRatio == 0` does not fire
-  `partVsWhole`. A separate `fileSizeMismatch` catcher would catch the dominant residual
-  class (0-second stubs vs. real books with large file sizes).
+- [x] **C5-gate** FileSize-aware catcher for residual stub pairs ✅ Jun 13 — `implausibleAudio`
+  catcher (`internal/dedup/dataset/rules.go`): labels `not_dup` when a side has zero/unknown
+  duration AND a largest file below the 256 KiB stub floor; `BookFeatures.FileSizeBytes` added
+  + populated. Catches the dominant residual class (0-second stubs) that `partVsWhole`
+  (`DurationRatio == 0`) and `missingFile` (file records exist) miss; genuine unscanned-large
+  copies are not suppressed. Run `dedup.dataset-backfill --apply` to clear the existing ~3,154.
 - [ ] **C5-sig** Offset/subsequence containment: `signatureRelation` currently returns only
   `match`, `disjoint`, or `unknown`. The `a_contains_b` / `b_contains_a` values in the
   spec require comparing signature subsequences — deferred to a future milestone.

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,5 +1,5 @@
 // file: internal/database/dedup_label.go
-// version: 1.0.3
+// version: 1.0.4
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
 // last-edited: 2026-06-13
 
@@ -35,6 +35,11 @@ type BookFeatures struct {
 	RecordingIDs        []string `json:"recording_ids,omitempty"`
 	ITunesPIDPresent    bool     `json:"itunes_pid_present"`
 	WholeBookSigPresent bool     `json:"whole_book_sig_present"`
+	// FileSizeBytes is the largest known file size for the book (max over its
+	// BookFiles, falling back to the book-level size). Mirrors the engine's
+	// hasPlausibleAudio signal so the dataset can tell a genuine but unscanned
+	// copy (large file, zero duration) from a stub/placeholder (tiny file).
+	FileSizeBytes int64 `json:"file_size_bytes"`
 }
 
 // LabeledExample is one labeled dedup candidate pair plus the features behind

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.1.2
+// version: 1.1.3
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-06-13
 
@@ -100,12 +100,21 @@ func buildFeatures(bk *database.Book, files []database.BookFile) database.BookFe
 		if bk.CoverURL != nil && *bk.CoverURL != "" {
 			f.HasCover = true
 		}
+		// Book-level size as a baseline; the per-file max below can exceed it.
+		if bk.FileSize != nil && *bk.FileSize > f.FileSizeBytes {
+			f.FileSizeBytes = *bk.FileSize
+		}
 	}
 	var total float64
 	for i := range files {
 		fl := &files[i]
 		if f.PrimaryPath == "" && fl.FilePath != "" {
 			f.PrimaryPath = fl.FilePath
+		}
+		// Largest file size across the book's files — the signal for "has real
+		// audio" vs a stub. A genuine unscanned copy keeps a large size here.
+		if fl.FileSize > f.FileSizeBytes {
+			f.FileSizeBytes = fl.FileSize
 		}
 		// Prefer fpcalc-measured duration; fall back to container duration (int seconds).
 		if fl.AcoustIDFingerprintDurationSec > 0 {

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
 // last-edited: 2026-06-13
 
@@ -273,5 +273,36 @@ func TestBuildExample_FolderRelation_PrefixNotAncestor(t *testing.T) {
 	}
 	if ex.FolderRelation != "unrelated" {
 		t.Fatalf("folder relation = %q, want unrelated (Series is not an ancestor of Series-Extra)", ex.FolderRelation)
+	}
+}
+
+func TestBuildExample_FileSizeBytes(t *testing.T) {
+	// FileSizeBytes is the largest known size: max over BookFiles, and at least
+	// the book-level FileSize. A genuine large file must win over a tiny one so
+	// the implausibleAudio catcher does not suppress a real (multi-file) book.
+	bookSize := int64(1000)
+	bkA := &database.Book{ID: "a", Title: "Big", FileSize: &bookSize}
+	bkB := &database.Book{ID: "b", Title: "Stub"}
+	fs := &fakeStore{
+		books: map[string]*database.Book{"a": bkA, "b": bkB},
+		files: map[string][]database.BookFile{
+			"a": {
+				{BookID: "a", FilePath: "/lib/a/part1.m4b", FileSize: 100},
+				{BookID: "a", FilePath: "/lib/a/part2.m4b", FileSize: 184_741_714},
+			},
+			"b": {{BookID: "b", FilePath: "/lib/b/stub", FileSize: 32}},
+		},
+	}
+	cand := database.DedupCandidate{ID: 20, EntityAID: "a", EntityBID: "b", Layer: "exact"}
+
+	ex, err := BuildExample(fs, cand)
+	if err != nil {
+		t.Fatalf("BuildExample: %v", err)
+	}
+	if ex.A.FileSizeBytes != 184_741_714 {
+		t.Fatalf("A.FileSizeBytes = %d, want 184741714 (max over files)", ex.A.FileSizeBytes)
+	}
+	if ex.B.FileSizeBytes != 32 {
+		t.Fatalf("B.FileSizeBytes = %d, want 32 (stub)", ex.B.FileSizeBytes)
 	}
 }

--- a/internal/dedup/dataset/rules.go
+++ b/internal/dedup/dataset/rules.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/rules.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
 // last-edited: 2026-06-13
 
@@ -16,6 +16,11 @@ import (
 // A ratio below 0.5 means the shorter side is less than half the longer side.
 const partVsWholeRatioMax = 0.5
 
+// minPlausibleAudioBytes mirrors the engine-side hasPlausibleAudio floor
+// (internal/dedup/engine.go). A book with no positive duration AND a largest
+// file below this size is a stub/placeholder, not real audio.
+const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
+
 // Classify runs the deterministic catchers in priority order and returns the
 // first firing rule's (label, reason, fires=true). If no rule fires, it returns
 // ("", "", false). The caller (backfill op) uses fires=false as "unsure" and
@@ -24,12 +29,16 @@ const partVsWholeRatioMax = 0.5
 // Priority order (highest first):
 //  1. wholeBookSignatureMatch → true_dup  (strong positive oracle)
 //  2. missingFile             → not_dup  (hard negative: never merge a ghost)
-//  3. partVsWhole             → not_dup  (hard negative: duration mismatch)
+//  3. implausibleAudio        → not_dup  (hard negative: stub/placeholder side)
+//  4. partVsWhole             → not_dup  (hard negative: duration mismatch)
 func Classify(ex database.LabeledExample) (label, reason string, fires bool) {
 	if l, r, ok := wholeBookSignatureMatch(ex); ok {
 		return l, r, true
 	}
 	if l, r, ok := missingFile(ex); ok {
+		return l, r, true
+	}
+	if l, r, ok := implausibleAudio(ex); ok {
 		return l, r, true
 	}
 	if l, r, ok := partVsWhole(ex); ok {
@@ -58,6 +67,31 @@ func missingFile(ex database.LabeledExample) (string, string, bool) {
 		return "not_dup", "side B has no resolvable files", true
 	}
 	return "", "", false
+}
+
+// implausibleAudio fires not_dup when either side has no plausible audio — no
+// positive duration AND a largest file below the stub floor. This is the dataset
+// counterpart to the engine emission gate (hasPlausibleAudio) and catches the
+// residual stub / unscanned-placeholder pairs that missingFile (file records
+// exist) and partVsWhole (zero duration → ratio 0) both miss.
+//
+// A genuine unscanned copy (large file, zero duration) has FileSizeBytes at or
+// above the floor and is deliberately NOT suppressed — it is a real duplicate
+// awaiting a scan, left unlabeled for the signature/duration catchers later.
+func implausibleAudio(ex database.LabeledExample) (string, string, bool) {
+	if sideImplausibleAudio(ex.A) {
+		return "not_dup", "side A is a stub/placeholder (no duration, file < 256 KiB)", true
+	}
+	if sideImplausibleAudio(ex.B) {
+		return "not_dup", "side B is a stub/placeholder (no duration, file < 256 KiB)", true
+	}
+	return "", "", false
+}
+
+// sideImplausibleAudio reports whether a book side has no evidence of real audio
+// content: zero/unknown duration AND a largest file below the plausible floor.
+func sideImplausibleAudio(f database.BookFeatures) bool {
+	return f.TotalDurationSec <= 0 && f.FileSizeBytes < minPlausibleAudioBytes
 }
 
 // partVsWhole fires when both durations are known and the min/max ratio is below

--- a/internal/dedup/dataset/rules_test.go
+++ b/internal/dedup/dataset/rules_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/rules_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: c1d4e8b5-7f23-4a90-9b01-6e2c5d8f3a47
 // last-edited: 2026-06-13
 
@@ -87,6 +87,38 @@ func TestCatchers(t *testing.T) {
 				SignatureRelation: "disjoint",
 			},
 			wantFires: false,
+		},
+		{
+			// stub side (no duration, tiny file) is implausible audio → not_dup.
+			// This is the post-cutover residual class missingFile + partVsWhole miss:
+			// file records exist (FilesExist true) and duration=0 makes the ratio 0.
+			name: "stub side (32 bytes, no duration) => not_dup",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 36000, FileSizeBytes: 184_741_714},
+				B: database.BookFeatures{FilesExist: true, TotalDurationSec: 0, FileSizeBytes: 32},
+			},
+			wantFires: true, wantLabel: "not_dup",
+		},
+		{
+			// genuine unscanned copy: large file, zero duration → NOT suppressed.
+			// This is the false-positive the catcher must avoid (a real duplicate
+			// awaiting a scan). No catcher fires; left unlabeled.
+			name: "genuine unscanned-large copy is not suppressed",
+			ex: database.LabeledExample{
+				A:                 database.BookFeatures{FilesExist: true, TotalDurationSec: 36000, FileSizeBytes: 184_741_714},
+				B:                 database.BookFeatures{FilesExist: true, TotalDurationSec: 0, FileSizeBytes: 184_741_714},
+				SignatureRelation: "unknown",
+			},
+			wantFires: false,
+		},
+		{
+			// both sides are tiny placeholders matched by title → not_dup.
+			name: "both stubs (182 bytes each) => not_dup",
+			ex: database.LabeledExample{
+				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 0, FileSizeBytes: 182},
+				B: database.BookFeatures{FilesExist: true, TotalDurationSec: 0, FileSizeBytes: 182},
+			},
+			wantFires: true, wantLabel: "not_dup",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Follow-up to #1436. Adds the dataset counterpart to the engine `hasPlausibleAudio` gate so the **existing** stub/unscanned residual can be cleared (the part #1436 deliberately left).

## What
New `implausibleAudio` catcher (`internal/dedup/dataset/rules.go`): a pair → `not_dup` when either side has **no plausible audio** — zero/unknown duration AND a largest file below the 256 KiB stub floor. Mirrors the engine emission gate.

- Catches the dominant post-cutover residual class (0-second stub vs real book) that `missingFile` (file records exist) and `partVsWhole` (duration=0 → ratio 0) both miss.
- A **genuine unscanned copy** (large file, zero duration) is **not** suppressed — it's a real duplicate awaiting a scan.
- `BookFeatures.FileSizeBytes` (max known file size) added + populated in the builder.
- Wired into `Classify` after `missingFile`, before `partVsWhole`.

## Tests
`go build ./...` clean · vet clean · gofmt clean · dataset + database tests PASS. New cases: stub→not_dup, both-stubs→not_dup, genuine unscanned-large NOT suppressed, `FileSizeBytes` = max over files.

## To clear the existing ~3,154 residual
Deploy, then run `dedup.dataset-backfill` with `{"apply":true}` — it will now suppress the stub pairs (status→dismissed) in addition to part-vs-whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)