### PR TITLE
feat(dedup): count external IDs (ASIN/ISBN) as matched in both_unmatched filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.21.0 -->
+<!-- version: 3.21.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-13 -->
 
@@ -13,11 +13,12 @@
 
 - **`GET /api/v1/dedup/candidates?both_unmatched=true`** — server-side filter that
   returns only pairs where NEITHER book has matched metadata (a triage view for
-  duplicates that both need manual matching). v1 defines "matched" as
-  `MetadataReviewStatus == "matched"` (human-confirmed); the handler has a single
-  documented extension point to later OR in external-ID presence (ASIN/ISBN13).
-  When set, the handler fetches the full status/layer-filtered set, filters on
-  book metadata, and paginates the filtered result (accurate totals).
+  duplicates that both need manual matching). "matched" = `MetadataReviewStatus
+  == "matched"` (human-confirmed) **OR** the book carries an external identifier
+  (ASIN / ISBN13 / ISBN10 — having one means it was matched to a provider). The
+  `isMetadataMatched()` helper is the single extension point for further
+  indicators. When set, the handler fetches the full status/layer-filtered set,
+  filters on book metadata, and paginates the filtered result (accurate totals).
 - **Unified Dedup UI** — a "Both need manual matching" checkbox in the candidate
   toolbar wires `both_unmatched` through and resets pagination.
 

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/handler.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: d1b9e024-d28c-4d62-8f90-96d7064559c4
 // last-edited: 2026-06-13
 
@@ -236,12 +236,21 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 		bookCache[id] = book
 		return book
 	}
-	// isMetadataMatched reports whether a book has authoritative metadata.
-	// v1: only a human-confirmed match (MetadataReviewStatus == "matched")
-	// counts as matched. To widen the net later, OR in external-ID presence
-	// (e.g. ASIN/ISBN13) here — that is the single intended extension point.
+	// isMetadataMatched reports whether a book has authoritative metadata, so it
+	// does NOT need manual matching. A book counts as matched when EITHER a human
+	// confirmed the match (MetadataReviewStatus == "matched") OR it carries an
+	// external identifier (ASIN / ISBN13 / ISBN10) — having one means it was
+	// matched to a provider record. This is the single intended extension point;
+	// add further "matched" indicators here.
+	nonEmpty := func(s *string) bool { return s != nil && *s != "" }
 	isMetadataMatched := func(b *database.Book) bool {
-		return b != nil && b.MetadataReviewStatus != nil && *b.MetadataReviewStatus == "matched"
+		if b == nil {
+			return false
+		}
+		if b.MetadataReviewStatus != nil && *b.MetadataReviewStatus == "matched" {
+			return true
+		}
+		return nonEmpty(b.ASIN) || nonEmpty(b.ISBN13) || nonEmpty(b.ISBN10)
 	}
 	dropped := 0
 	items := make([]gin.H, 0, len(candidates))

--- a/internal/server/handlers/dedup/handler_test.go
+++ b/internal/server/handlers/dedup/handler_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/handler_test.go
-// version: 1.3.1
+// version: 1.3.2
 // guid: 6d8011eb-bed6-430b-959e-2a2b0738ffbc
 // last-edited: 2026-06-12
 
@@ -242,14 +242,19 @@ func TestListDedupCandidates_IncludeBooks(t *testing.T) {
 func TestListDedupCandidates_BothUnmatched(t *testing.T) {
 	h, d := newHandler(t)
 	matched := "matched"
-	insertCandidate(t, d.es, "u1", "u2") // both unmatched → should appear
-	insertCandidate(t, d.es, "u3", "m1") // m1 is matched → pair filtered out
+	asin := "B00ABC1234"
+	insertCandidate(t, d.es, "u1", "u2")    // both unmatched → should appear
+	insertCandidate(t, d.es, "u3", "m1")    // m1 matched (review status) → filtered out
+	insertCandidate(t, d.es, "u4", "asin1") // asin1 matched (external ID) → filtered out
 
 	d.store.EXPECT().GetBookByID("u1").Return(&database.Book{ID: "u1"}, nil).Maybe()
 	d.store.EXPECT().GetBookByID("u2").Return(&database.Book{ID: "u2"}, nil).Maybe()
 	d.store.EXPECT().GetBookByID("u3").Return(&database.Book{ID: "u3"}, nil).Maybe()
+	d.store.EXPECT().GetBookByID("u4").Return(&database.Book{ID: "u4"}, nil).Maybe()
 	d.store.EXPECT().GetBookByID("m1").
 		Return(&database.Book{ID: "m1", MetadataReviewStatus: &matched}, nil).Maybe()
+	d.store.EXPECT().GetBookByID("asin1").
+		Return(&database.Book{ID: "asin1", ASIN: &asin}, nil).Maybe()
 
 	w := doReq(t, h.ListDedupCandidates, http.MethodGet,
 		"/api/v1/dedup/candidates?both_unmatched=true&include_books=true", nil, nil)
@@ -272,7 +277,7 @@ func TestListDedupCandidates_BothUnmatched(t *testing.T) {
 	row := resp.Data.Candidates[0]
 	a, _ := row["entity_a_id"].(string)
 	b, _ := row["entity_b_id"].(string)
-	if a == "m1" || b == "m1" {
+	if a == "m1" || b == "m1" || a == "asin1" || b == "asin1" {
 		t.Fatalf("matched pair leaked through the both_unmatched filter: %v", row)
 	}
 }


### PR DESCRIPTION
Follow-up to #1438. On prod, `MetadataReviewStatus == "matched"` is essentially unused, so the v1 `both_unmatched` filter matched 100% of pending pairs (1,651 of 1,651). This widens "matched" to also count a book with an external identifier (ASIN / ISBN13 / ISBN10) — having one means it was matched to a provider — so the filter actually discriminates.

Single helper change (`isMetadataMatched`); test extended to cover the ASIN-matched exclusion. Backend-only.