### PR TITLE
design+plan(uos): dependency & condition scheduling (spec + M1 plan)

### DIFF
--- a/docs/plans/2026-06-13-uos-dependency-scheduling-m1.md
+++ b/docs/plans/2026-06-13-uos-dependency-scheduling-m1.md
@@ -1,0 +1,317 @@
+<!-- file: docs/plans/2026-06-13-uos-dependency-scheduling-m1.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6b1e9c34-2f85-4a07-9d61-3c8a5e7f2b40 -->
+<!-- last-edited: 2026-06-13 -->
+
+# UOS Dependency Scheduling — M1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development to execute task-by-task. Steps use `- [ ]` checkboxes.
+
+**Goal:** Land the core dependency engine for the unified operations system —
+prerequisite (`op_completed`) requirements, the `dep_rev` freshness model,
+completion recording, a `waiting_deps` parked state with event-driven + sweep
+re-evaluation, failure propagation, and a cycle guard. **Additive:** ops without
+`Requires` behave exactly as today.
+
+**Architecture:** New `deps.go` (pure evaluator + dep_rev helpers) + new persistence
+methods on the op store, integrated at three registry seams: enqueue (park if
+unmet), worker-complete (record completion + wake dependents), worker-fail
+(propagate failure). M1 ships op-completed requirements only; field-set (M2) and
+batching (M3) extend the same machinery.
+
+**Spec:** `docs/specs/2026-06-13-uos-dependency-scheduling-design.md`
+
+**Tech stack:** Go, the existing `internal/operations/registry` package, the Pebble
+op store (`internal/database/pebble_store_ops_v2.go`), `OperationV2Row`.
+
+---
+
+## Pre-flight (the implementer does this first, before Task 1)
+
+Read these to pin the real integration points (the plan references them but exact
+signatures must be confirmed):
+- `internal/operations/registry/registry.go` — `EnqueueOp(ctx, defID, params, opts...)`,
+  `EnqueueOptions`/`EnqueueOption`, where the row is created + set to `"queued"`.
+- `internal/operations/registry/worker.go` — where status becomes `"completed"`
+  (~line 211) and `"failed"` (~line 207); this is where C2/failure-propagation hook.
+- `internal/operations/registry/dispatcher.go` — how `"queued"` rows are picked up
+  (so `"waiting_deps"` rows are NOT picked up until promoted).
+- `internal/database/iface_ops_v2.go` + `pebble_store_ops_v2.go` — `OperationV2Row`
+  fields + the op-store interface to extend; the keyspace prefix convention.
+- `internal/operations/registry/types.go` — `OperationDef`, `EnqueueOption`.
+
+Confirm: the op-store interface name, how to add fields to `OperationV2Row`
+(migration vs additive JSON), and how the registry resolves a subject from params
+(there may be no convention yet — if not, Task 3 introduces `SubjectFromParams`).
+
+---
+
+## File structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `internal/operations/registry/types.go` | `Subject`, `Requirement`, `RequirementKind`, `OperationDef.Requires`, `WithRequires` option | Modify |
+| `internal/operations/registry/deps.go` | requirement evaluator + `dep_rev` helpers + cycle check | Create |
+| `internal/operations/registry/deps_test.go` | evaluator/cycle unit tests | Create |
+| `internal/database/iface_ops_v2.go` | op-store interface: completion + dep_rev + waiting-deps queries | Modify |
+| `internal/database/pebble_store_ops_v2.go` | Pebble impl of the new store methods | Modify |
+| `internal/database/pebble_store_ops_v2_test.go` | store round-trip tests | Modify/Create |
+| `internal/operations/registry/registry.go` | enqueue: park if unmet; promotion API | Modify |
+| `internal/operations/registry/worker.go` | record completion on success; propagate failure | Modify |
+| `internal/operations/registry/deps_scheduler.go` | event-driven + sweep re-evaluation loop | Create |
+
+---
+
+## Task 1: Types — `Subject`, `Requirement`, `OperationDef.Requires`, `WithRequires`
+
+**Files:** Modify `internal/operations/registry/types.go`; Test `deps_test.go` (compile-only here).
+
+- [ ] **Step 1: Add the types**
+
+```go
+// Subject identifies the entity a requirement/completion is about. v1: book.
+type Subject struct {
+	Type string // "book"
+	ID   string
+}
+
+type RequirementKind string
+
+const (
+	ReqOpCompleted RequirementKind = "op_completed"
+	ReqFieldSet    RequirementKind = "field_set" // M2; type defined now for stability
+)
+
+// Requirement is a single prerequisite/condition for an op to become runnable.
+type Requirement struct {
+	Kind        RequirementKind `json:"kind"`
+	OpType      string          `json:"op_type,omitempty"`      // ReqOpCompleted: required op def ID
+	Field       string          `json:"field,omitempty"`        // ReqFieldSet: subject field (M2)
+	SubjectType string          `json:"subject_type,omitempty"` // override; default = dependent's subject type
+	AllFiles    bool            `json:"all_files,omitempty"`    // book subject: require completion for every file
+}
+```
+
+Add to `OperationDef` (near `DependsOn`, with a comment distinguishing them):
+
+```go
+	// Requires are standing prerequisites evaluated before this op runs. Unlike
+	// DependsOn (which means "must NOT run concurrently"), Requires means "these
+	// must be SATISFIED first". Op-completed requirements only in M1.
+	Requires []Requirement
+```
+
+Add the enqueue option (mirror the existing `WithPriority`/`WithParent` pattern in
+types.go):
+
+```go
+// WithRequires adds per-enqueue requirements on top of the def's Requires.
+func WithRequires(reqs ...Requirement) EnqueueOption {
+	return func(o *EnqueueOptions) { o.Requires = append(o.Requires, reqs...) }
+}
+```
+
+Add `Requires []Requirement` to the `EnqueueOptions` struct.
+
+- [ ] **Step 2: Build** `go build ./internal/operations/... ` → clean.
+- [ ] **Step 3: Commit** `feat(uos): dependency requirement + subject types`.
+
+## Task 2: Op store — completion records + dep_rev + waiting-deps persistence
+
+**Files:** Modify `internal/database/iface_ops_v2.go`, `pebble_store_ops_v2.go`; Test `pebble_store_ops_v2_test.go`.
+
+- [ ] **Step 1: Write failing store round-trip test**
+
+```go
+func TestOpCompletionAndDepRev_RoundTrip(t *testing.T) {
+	s := newTestOpStore(t) // mirror existing op-store test setup
+	sub := database.OpSubject{Type: "book", ID: "b1"}
+
+	// dep_rev starts at 0; bump → 1.
+	if got, _ := s.GetDepRev(sub); got != 0 { t.Fatalf("dep_rev0=%d", got) }
+	if _, err := s.BumpDepRev(sub); err != nil { t.Fatal(err) }
+	if got, _ := s.GetDepRev(sub); got != 1 { t.Fatalf("dep_rev1=%d", got) }
+
+	// record a completion at rev 1, then assert it reads back.
+	if err := s.RecordOpCompletion(sub, "acoustid.fingerprint-extract", "", 1); err != nil { t.Fatal(err) }
+	rev, ok, _ := s.GetOpCompletion(sub, "acoustid.fingerprint-extract")
+	if !ok || rev != 1 { t.Fatalf("completion rev=%d ok=%v", rev, ok) }
+
+	// bump again → completion (rev1) is now stale vs current rev2.
+	s.BumpDepRev(sub)
+	cur, _ := s.GetDepRev(sub)
+	if cur != 2 { t.Fatalf("cur=%d", cur) }
+}
+```
+
+> NOTE: name the subject type to match what the store package can import without a
+> cycle — if `registry.Subject` would cause an import cycle, define the persisted
+> shape as `database.OpSubject` here and convert in the registry. Check import
+> direction (registry imports database, not vice-versa) and choose accordingly.
+
+- [ ] **Step 2: Run → fails** (methods undefined).
+- [ ] **Step 3: Implement the store methods** in `pebble_store_ops_v2.go`, mirroring
+the existing Pebble JSON-value + `db.Set/Get` pattern in that file. Keyspaces:
+`op:completion:<type>:<id>:<opType>[:<fileID>]` and `op:deprev:<type>:<id>`.
+Add to the op-store interface in `iface_ops_v2.go`:
+
+```go
+type OpSubject struct{ Type, ID string }
+
+GetDepRev(sub OpSubject) (uint64, error)
+BumpDepRev(sub OpSubject) (uint64, error)
+RecordOpCompletion(sub OpSubject, opType, fileID string, depRev uint64) error
+GetOpCompletion(sub OpSubject, opType string) (depRev uint64, ok bool, err error)
+ListFileCompletions(sub OpSubject, opType string) (map[string]uint64, error) // fileID->rev, for AllFiles
+ListWaitingDepsOps() ([]OperationV2Row, error)                               // status == "waiting_deps"
+```
+
+Add `OperationV2Row` fields: `SubjectType, SubjectID string`, `Requirements string`
+(JSON), `ReqSnapshotRev uint64`. Persist them with the row (additive — old rows
+read back with zero values, which means "no requirements").
+
+- [ ] **Step 4: Run → passes.** Also run the existing op-store tests (no regression).
+- [ ] **Step 5: Commit** `feat(uos): op-store completion records + dep_rev keyspace`.
+
+## Task 3: Requirement evaluator + cycle check (`deps.go`)
+
+**Files:** Create `internal/operations/registry/deps.go`, `deps_test.go`.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestEvaluate_OpCompleted_FreshVsStale(t *testing.T) {
+	st := newFakeDepStore() // implements the small DepStore interface (Task 3 defines it)
+	sub := Subject{Type: "book", ID: "b1"}
+	st.depRev[key(sub)] = 2
+	req := Requirement{Kind: ReqOpCompleted, OpType: "fp"}
+
+	// no completion → unmet
+	if ok, _ := Satisfied(st, req, sub); ok { t.Fatal("should be unmet without completion") }
+	// completion at rev1 but current rev2 → stale → unmet
+	st.completion[ckey(sub, "fp")] = 1
+	if ok, _ := Satisfied(st, req, sub); ok { t.Fatal("stale completion must not satisfy") }
+	// completion at rev2 → satisfied
+	st.completion[ckey(sub, "fp")] = 2
+	if ok, _ := Satisfied(st, req, sub); !ok { t.Fatal("fresh completion must satisfy") }
+}
+
+func TestEvaluate_AllFiles_Coverage(t *testing.T) {
+	st := newFakeDepStore()
+	sub := Subject{Type: "book", ID: "b1"}
+	st.depRev[key(sub)] = 1
+	st.files[sub.ID] = []string{"f1", "f2"}
+	req := Requirement{Kind: ReqOpCompleted, OpType: "fp", AllFiles: true}
+	st.fileCompletion[ckey(sub, "fp")] = map[string]uint64{"f1": 1} // only f1 done
+	if ok, _ := Satisfied(st, req, sub); ok { t.Fatal("partial coverage must not satisfy") }
+	st.fileCompletion[ckey(sub, "fp")]["f2"] = 1
+	if ok, _ := Satisfied(st, req, sub); !ok { t.Fatal("full coverage must satisfy") }
+}
+
+func TestCycleDetection(t *testing.T) {
+	defs := map[string][]Requirement{
+		"a": {{Kind: ReqOpCompleted, OpType: "b"}},
+		"b": {{Kind: ReqOpCompleted, OpType: "a"}},
+	}
+	if err := CheckRequirementCycle(defs); err == nil { t.Fatal("expected cycle error") }
+}
+```
+
+- [ ] **Step 2: Run → fails.**
+- [ ] **Step 3: Implement.** Define a narrow `DepStore` interface (the subset of the
+op store the evaluator needs: `GetDepRev`, `GetOpCompletion`, `ListFileCompletions`,
+plus a `BookFiles(bookID) []string`). Implement:
+- `Satisfied(store DepStore, req Requirement, sub Subject) (bool, string, error)` —
+  op-completed (fresh ≥ current rev), AllFiles (every file covered at ≥ current rev),
+  `ReqFieldSet` returns `(false, "field_set not implemented in M1", nil)` for now.
+- `AllSatisfied(store, reqs []Requirement, sub Subject) (bool, firstUnmet string, err error)`.
+- `CheckRequirementCycle(defReqsByOpType map[string][]Requirement) error` — DFS,
+  returns an error naming the cycle.
+- [ ] **Step 4: Run → passes;** `gofmt`/`go vet` clean.
+- [ ] **Step 5: Commit** `feat(uos): requirement evaluator + cycle detection`.
+
+## Task 4: Enqueue integration — park unmet ops as `waiting_deps`
+
+**Files:** Modify `registry.go`; Test `registry_test.go`.
+
+- [ ] **Step 1: Failing test** — enqueue an op (registered with a `Requires` on an
+op-type not yet completed for its subject) and assert its row status is
+`"waiting_deps"`, not `"queued"`; the dispatcher does not pick it up.
+- [ ] **Step 2: Run → fails.**
+- [ ] **Step 3: Implement.** In `EnqueueOp`, after resolving def + options:
+  - Combine `def.Requires` + `opts.Requires`.
+  - Resolve the op's `Subject` from params (introduce `SubjectFromParams(params) Subject`
+    — v1: read `book_id`; empty subject + non-empty requirements is an error unless all
+    requirements carry an explicit `SubjectType`).
+  - If requirements is empty → existing path (`"queued"`).
+  - Else evaluate `AllSatisfied`. If satisfied → `"queued"`. If not → create the row
+    with status `"waiting_deps"`, persisting `Requirements` (JSON) + `ReqSnapshotRev`
+    (current dep_rev of the subject). Index it for wakeups (Task 5).
+  - Run `CheckRequirementCycle` over registered defs once at registry startup (not per
+    enqueue) and fail registration of a cycle.
+- [ ] **Step 4: Run → passes;** existing registry tests still pass.
+- [ ] **Step 5: Commit** `feat(uos): park ops with unmet requirements as waiting_deps`.
+
+## Task 5: Completion recording + dependent wakeup + failure propagation
+
+**Files:** Modify `worker.go`; Create `deps_scheduler.go`; Test `registry_test.go`.
+
+- [ ] **Step 1: Failing test** — enqueue dependent D requiring op-type X for book b1
+(parked). Enqueue + complete an X op for b1. Assert D is promoted `waiting_deps →
+queued`. Separately: when X **fails**, assert D moves to `"failed"` with reason
+containing `unmet dependency`.
+- [ ] **Step 2: Run → fails.**
+- [ ] **Step 3: Implement.**
+  - In `worker.go` on `"completed"`: if the op has a subject, call
+    `store.RecordOpCompletion(sub, defID, fileID, currentDepRev(sub))`, then notify the
+    scheduler (`deps_scheduler.OnOpCompleted(sub, defID)`).
+  - In `worker.go` on `"failed"`: notify `deps_scheduler.OnOpFailed(sub, defID)`.
+  - `deps_scheduler.go`:
+    - `OnOpCompleted(sub, opType)`: find `waiting_deps` ops whose subject == sub (use
+      an in-memory index keyed by `(subjectType, subjectID)` rebuilt from
+      `ListWaitingDepsOps()` at startup). Re-evaluate each; promote satisfied ones to
+      `"queued"` (and signal the dispatcher).
+    - `OnOpFailed(sub, opType)`: fail any `waiting_deps` op hard-requiring `opType` for
+      `sub` with reason `unmet dependency: <opType> failed`.
+    - `BumpAndReevaluate(sub)`: bump dep_rev + re-evaluate (callable by producers; used
+      in M-later).
+    - `SweepTick()`: re-evaluate all `waiting_deps` ops (self-heal + future field
+      conditions); wire to a low-frequency ticker started with the registry.
+- [ ] **Step 4: Run → passes.** Add a restart test: parked ops re-load via
+`ListWaitingDepsOps()` and a subsequent completion still promotes them.
+- [ ] **Step 5: Commit** `feat(uos): wake/fail dependents on op completion + sweep`.
+
+## Task 6: End-to-end proof + gofmt/vet/full tests
+
+- [ ] **Step 1:** Add an integration test in the registry package: register two test
+op defs where `B` has `Requires{ReqOpCompleted, OpType: "A"}`; enqueue B (parks),
+enqueue+run A for the same subject, assert B runs and completes. This proves the
+whole M1 path with no production op touched.
+- [ ] **Step 2:** `gofmt -l internal/operations/registry internal/database` (empty),
+`go vet ./internal/operations/... ./internal/database/...` (clean),
+`go test ./internal/operations/... ./internal/database/...` (PASS).
+- [ ] **Step 3: Commit** `test(uos): end-to-end dependency-ordering integration test`.
+
+---
+
+## Self-review
+
+- **Spec coverage (M1 slice):** types (Task 1), persistence/dep_rev/completion
+  (Task 2), evaluator + cycle (Task 3), enqueue parking (Task 4), wake/fail/sweep
+  (Task 5), e2e proof (Task 6). field-set evaluator returns "not implemented"
+  (M2); batching is M3; dedup migration is M4 — all out of M1 scope by design.
+- **Additive guarantee:** ops with no `Requires` skip every new branch → behavior
+  identical to today. The `waiting_deps` status is only ever set for ops that opt in.
+- **Type consistency:** `Subject`(registry) ↔ `OpSubject`(database) conversion is
+  the one boundary to keep straight (Task 2 NOTE) — pick one persisted shape and
+  convert at the registry edge to avoid an import cycle.
+- **Riskiest seam:** `worker.go` status transitions (Task 5). The implementer must
+  confirm the exact transition points (~worker.go:207/211) and that notifying the
+  scheduler there can't deadlock the worker (notify async / via a channel, not under
+  a held lock).
+
+## Execution
+
+Subagent-driven, one task per subagent, spec-review + quality-review each, final
+holistic review. **Do NOT auto-merge/deploy** — this is the core op registry; open a
+PR for human review before it reaches prod.

--- a/docs/specs/2026-06-13-uos-dependency-scheduling-design.md
+++ b/docs/specs/2026-06-13-uos-dependency-scheduling-design.md
@@ -1,0 +1,286 @@
+<!-- file: docs/specs/2026-06-13-uos-dependency-scheduling-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f8b1a52-9c47-4e60-bd13-7a2e5c8f4d09 -->
+<!-- last-edited: 2026-06-13 -->
+
+# Unified Operations System — Dependency & Condition Scheduling
+
+## Motivation
+
+Today the unified operations system (UOS) can run, serialize, schedule (cron), and
+event-trigger operations, but it cannot express **"run this op only after these
+other things are done / these fields are populated."** Concretely:
+
+- `OperationDef.DependsOn []string` is **misnamed** — it means "op def IDs that must
+  NOT be running concurrently with this op" (anti-concurrency), the *inverse* of a
+  prerequisite. We keep it as-is and add a real prerequisite concept beside it.
+- There is no way to say "dedup for book B requires fingerprinting + metadata for B
+  to have completed first," so dedup-on-import is wired as an **eager
+  `CheckBook` goroutine** (`internal/importer/service.go`) that fires before the
+  book is even fingerprinted — meaning whole-book-signature matching can't run there
+  at all (the signature doesn't exist yet).
+- Bulk imports spawn **N per-book operations** instead of batching, flooding the
+  queue.
+
+This spec adds a **systemd-inspired dependency, condition, and batching layer** to
+the UOS so ordering is *declarative and correct everywhere*, not hand-wired per
+caller. Dedup is the motivating consumer, but the mechanism is general.
+
+### systemd mapping (the mental model)
+
+| systemd | this design |
+|---|---|
+| `After=` / `Before=` | implied ordering from a satisfied `Requires` |
+| `Requires=` | hard prerequisite — op-completed requirement (fail dependent if it fails) |
+| `Wants=` | soft prerequisite (later milestone) |
+| `ExecCondition=` / `Condition*=` | `fieldSet` condition — skip/park until true |
+| `ConditionPathExists=` / `AssertPathExists=` | path condition (deferred, M-later) |
+
+## Goals
+
+- Declare, per op, **prerequisites** that must be satisfied before it runs:
+  - **op-completed**: op-type X has completed for this subject *since the subject
+    last changed*.
+  - **field-populated**: a named field on the subject is non-empty.
+- Allow these to be declared **statically** in the `OperationDef` *and* **added at
+  enqueue time**.
+- **Re-trigger on change**: when a subject's relevant data changes, its prerequisites
+  become unsatisfied again (freshness, not "ever").
+- **Batch** burst enqueues of the same batchable op-type into one operation.
+- Survive restart (parked ops, completion records, and revisions persist).
+- Migrate dedup-on-import off the eager hook onto declarative requirements.
+
+## Non-goals (v1)
+
+- Path/file conditions (`ConditionPathExists`) — deferred.
+- Soft `Wants` dependencies — deferred (v1 is hard `Requires` only).
+- True file-level dependency subjects — v1 subjects are **book**-scoped, with an
+  all-files-of-book aggregator for per-file prerequisites.
+- Cross-machine / distributed scheduling — single-process registry as today.
+
+## Decisions (locked during design)
+
+1. **Declaration:** both def-level defaults (`OperationDef.Requires`) and
+   per-enqueue additions (`WithRequires(...)` option).
+2. **Freshness:** "since subject last changed" via a dedicated per-subject
+   **`dep_rev`** counter (not `Book.UpdatedAt`, which churns for unrelated reasons).
+3. **v1 conditions:** op-completed prerequisites **and** field-populated conditions.
+   Path conditions deferred.
+4. **Batching:** time-window **debounce** — batchable ops bucket by op-type and
+   dispatch one batched op after the window quiesces.
+5. **Prereq failure:** a hard `Requires` whose prerequisite op fails terminally
+   **fails the dependent** with reason `unmet dependency: <opType> failed`. (Soft
+   `Wants` that proceeds anyway is a later addition.)
+6. **Subject granularity:** v1 subject = **book**. Per-file ops record completion
+   keyed to their **book**; a book-level op-completed requirement is satisfied only
+   when the op has completed for **all** of the book's files at the current `dep_rev`.
+7. **`dep_rev` bump triggers:** a dedicated per-subject counter bumped by the
+   specific events that matter (file content/hash change, metadata apply), emitted
+   by the producers of those changes.
+
+## Data model
+
+### Subject
+
+```go
+// Subject identifies the entity a requirement / completion is about.
+type Subject struct {
+    Type string // "book" (v1); "file" reserved
+    ID   string
+}
+```
+
+A running op's subject is derived from its params (e.g. `book_id`). Ops that don't
+operate on a subject (global maintenance, cron sweeps) have an empty subject and
+cannot be required-on (they may still *have* requirements that are global).
+
+### Requirement
+
+```go
+type RequirementKind string
+
+const (
+    ReqOpCompleted RequirementKind = "op_completed" // op-type X done for subject @ current dep_rev
+    ReqFieldSet    RequirementKind = "field_set"    // named field non-empty on subject
+)
+
+type Requirement struct {
+    Kind    RequirementKind
+    OpType  string // for ReqOpCompleted: the required op def ID
+    Field   string // for ReqFieldSet:  the subject field that must be non-empty
+    // Subject defaults to the dependent op's own subject. A non-empty SubjectType
+    // override lets an op require something about a related subject (rare in v1).
+    SubjectType string
+    AllFiles    bool // ReqOpCompleted + book subject: require completion for ALL files of the book
+}
+```
+
+### OperationDef additions
+
+```go
+// Dependencies & conditions. Optional.
+Requires []Requirement // standing prerequisites for every enqueue of this op
+// Batching. Optional.
+Batchable   bool          // coalesce burst enqueues of this op type
+BatchWindow time.Duration // debounce window; 0 with Batchable => default (e.g. 5s)
+BatchMaxWait time.Duration // hard cap so a steady trickle still dispatches; 0 => default (e.g. 60s)
+```
+
+`EnqueueOption` gains `WithRequires(reqs ...Requirement)` (additive to the def's).
+
+### Persistence (Pebble keyspaces in the op store)
+
+- `op:completion:<subjectType>:<subjectID>:<opType>` → `{dep_rev, file_id?, completed_at}`
+  (one row per (subject, op-type); for `AllFiles` requirements we store per-file
+  completion rows `...:<opType>:<fileID>` and the requirement checks coverage).
+- `op:deprev:<subjectType>:<subjectID>` → `uint64` current revision (default 0).
+- Parked ops use the existing `OperationV2Row` with a new status **`waiting_deps`**
+  plus a serialized `requirements` blob and a snapshot of `dep_rev` at enqueue.
+
+`OperationV2Row` gains: `Status` value `"waiting_deps"`, `SubjectType`, `SubjectID`,
+`Requirements string` (JSON), `RequirementsSnapshotRev uint64`.
+
+## Components
+
+### C1. Requirement evaluation (`internal/operations/registry/deps.go`)
+
+Pure-ish evaluator: `Satisfied(store, req, subject) (bool, reason string, error)`.
+- `ReqOpCompleted` (non-AllFiles): a completion row exists for `(subject, opType)`
+  with `dep_rev >= currentDepRev(subject)`.
+- `ReqOpCompleted` + `AllFiles`: every file of the book has a completion row for
+  `opType` at `>= currentDepRev`. (Files enumerated via the store.)
+- `ReqFieldSet`: load the subject (book) and check the named field non-empty. A
+  small allow-list maps field names → accessors (`book_sig_v1`,
+  `acoustid_fingerprint`, `metadata_source_hash`, …) so this stays type-safe.
+
+`AllSatisfied(store, reqs, subject)` returns `(ready bool, firstUnmet string)`.
+
+### C2. Completion recording (`registry/worker.go`)
+
+When an op transitions to `completed`, if it has a subject, write/refresh
+`op:completion:<…>:<opType>` with the **current** `dep_rev` of the subject (and the
+file id when the op is file-scoped). This is the signal `ReqOpCompleted` reads.
+
+### C3. dep_rev bumping (`registry/deps.go` + producers)
+
+`BumpDepRev(store, subject)` increments `op:deprev:<…>`. Called by the events that
+change a subject's content/metadata:
+- file content/hash change (scanner / writeback),
+- metadata apply (metadata pipeline).
+Producers call a thin `registry.BumpDepRev(book)` (or publish a `subject.changed`
+event the registry subscribes to — see C5). Bumping invalidates prior completions
+for that subject (they now have a lower `dep_rev`), so dependents re-require.
+
+### C4. Scheduler integration (`registry/registry.go`, `dispatcher.go`)
+
+- **Enqueue:** if an op has any requirements, evaluate them. If all satisfied →
+  normal `queued`. Else → persist as `waiting_deps` with its requirements + the
+  current snapshot rev.
+- **Readiness re-evaluation:**
+  - **Event-driven:** after every op `completed` (C2) and every `dep_rev` bump
+    (C3) / `subject.changed` event, re-evaluate `waiting_deps` ops whose subject or
+    required op-type matches. Satisfied → move to `queued`. (Index parked ops by
+    `(subjectType, subjectID)` and by required `opType` for O(matches) wakeups.)
+  - **Periodic sweep:** a low-frequency tick re-evaluates all `waiting_deps` ops to
+    catch `field_set` conditions satisfied by non-op events and to self-heal missed
+    wakeups.
+- **Failure propagation:** when a required op fails terminally, any `waiting_deps`
+  op that hard-requires it (`ReqOpCompleted` on that op-type for that subject) is
+  moved to `failed` with `unmet dependency: <opType> failed`.
+- **Cycle / starvation guards:** detect a requirement cycle at enqueue (DFS over
+  def-level `Requires` by op-type) and reject with a clear error; a parked op past a
+  max-wait (configurable, e.g. 24h) is failed with `dependency timeout`.
+
+### C5. Change events (optional wiring)
+
+Reuse the existing event bus (`Triggers`/`EventSubscription`). Producers publish
+`subject.changed{type,id,reason}`; the registry subscribes and calls `BumpDepRev`
++ re-evaluation. Direct `BumpDepRev` calls are the fallback where an event is
+overkill.
+
+### C6. Batching (`registry/batch.go`)
+
+For `Batchable` op defs, `EnqueueOp` does not immediately create a row; it adds the
+subject to a per-op-type **bucket** with a debounce timer (`BatchWindow`, capped by
+`BatchMaxWait`). When the timer fires, one `OperationV2Row` is created whose params
+carry the collected subject set (`{"subjects": [...]}`); the op's `Run` iterates the
+set. Requirements on a batched op are evaluated **per subject** at dispatch — only
+subjects whose requirements are met are included; the rest stay bucketed (or re-park).
+Persistence: the bucket is journaled (`op:batch:<opType>` → pending subject set) so a
+restart mid-window doesn't drop subjects.
+
+## Migration: dedup-on-import (M4)
+
+Replace the eager `CheckBook` goroutine in `internal/importer/service.go` with a
+declarative enqueue:
+
+```go
+// on import, instead of: go dedupEngine.CheckBook(book)
+registry.EnqueueOp(ctx, "dedup.check-book", params(book),
+    registry.WithRequires(
+        Requirement{Kind: ReqOpCompleted, OpType: "acoustid.fingerprint-extract", AllFiles: true},
+        Requirement{Kind: ReqFieldSet, Field: "book_sig_v1"},
+        Requirement{Kind: ReqOpCompleted, OpType: "<metadata-backfill op id>"},
+    ),
+)
+```
+
+The dedup op type is `Batchable` so a 50-book import produces one batched dedup pass
+once each book's fingerprint + signature + metadata are ready. Whole-book-signature
+matching now works because the signature is guaranteed populated by the
+`fieldSet` requirement.
+
+> Exact op IDs (`dedup.check-book` as an op vs the engine method; the metadata
+> backfill op id) are pinned during M4 against the real registry.
+
+## Milestones
+
+- **M1 — core dependency engine + persistence + scheduler.** `Requirement`/`Subject`
+  types, `OperationDef.Requires`, `WithRequires`, completion recording, `dep_rev`,
+  `waiting_deps` state + event-driven & sweep re-evaluation, failure propagation,
+  cycle guard. Op-completed requirements only. Additive — no existing op changes
+  behavior. Wire ONE real dependency end-to-end as proof (e.g. a test op requiring a
+  fingerprint completion).
+- **M2 — field-populated conditions.** `ReqFieldSet` + the field allow-list +
+  periodic sweep coverage.
+- **M3 — batching.** `Batchable`/`BatchWindow`, the bucket + debounce dispatch,
+  journaled buckets, per-subject requirement gating at dispatch.
+- **M4 — migrate dedup-on-import.** Drop the `CheckBook` goroutine; enqueue
+  `dedup.check-book` with `Requires`; make it batchable; verify ordering on prod.
+
+Each milestone is independently shippable and additive until M4 (which changes the
+import path behavior and is the one to validate carefully on prod).
+
+## Testing
+
+- C1 evaluator unit tests: op-completed (fresh vs stale `dep_rev`), AllFiles
+  coverage (partial vs full), field-set (set/unset), unknown field rejected.
+- C2/C3: completion row written on complete with correct `dep_rev`; bump
+  invalidates a prior completion (dependent re-parks).
+- C4: enqueue with unmet reqs → `waiting_deps`; completing the prereq moves it to
+  `queued` (event-driven) and the sweep also promotes it; prereq failure fails the
+  dependent with the right reason; cycle rejected at enqueue; restart re-loads parked
+  ops and re-evaluates.
+- C6: 50 rapid enqueues of a batchable op → one dispatched op carrying 50 subjects;
+  a subject with unmet reqs is excluded and stays bucketed; restart mid-window keeps
+  the bucket.
+- M4 integration: import N books → exactly one dedup op runs, after fingerprint +
+  signature + metadata, with the signature populated.
+
+## Rollback
+
+M1–M3 are additive: ops without `Requires`/`Batchable` behave exactly as today, so
+the feature is dormant until a def opts in. M4 is the only behavior change; it sits
+behind keeping the old `CheckBook` path available under a config flag
+(`DedupOnImportViaScheduler`, default off until validated) so we can revert the
+import wiring instantly.
+
+## Open questions (resolved — recorded for the plan)
+
+1. ~~Declaration site~~ → both (def + enqueue).
+2. ~~Freshness~~ → dedicated `dep_rev` counter, "since changed".
+3. ~~Condition types v1~~ → op-completed + field-set.
+4. ~~Batching~~ → time-window debounce.
+5. ~~Prereq failure~~ → fail the dependent (hard Requires).
+6. ~~Subject granularity~~ → book v1, all-files-of-book aggregator.
+7. ~~dep_rev source~~ → dedicated counter bumped by content/metadata producers.


### PR DESCRIPTION
Design spec + M1 implementation plan for adding **systemd-inspired dependency/condition/batching scheduling** to the unified operations system. **Docs only — no code yet.** Opening for your review before implementation, because the build touches the core op registry that runs every job.

## Why
The UOS can't express "run op A only after op B completed for this book / these fields are populated." Today dedup-on-import is an eager `CheckBook` goroutine that fires *before* fingerprinting, so whole-book-signature matching can't even run there. Bulk imports spawn N ops instead of batching.

## Design (locked decisions)
- Declaration: **def-level `Requires` + per-enqueue `WithRequires`**.
- Freshness: **`dep_rev` counter** — a prereq is satisfied only if the op completed *since the subject last changed* (re-imports re-trigger the chain).
- v1 conditions: **op-completed + field-populated** (path conditions deferred).
- Batching: **time-window debounce** (50 imports → 1 dedup pass).
- Prereq failure: **fails the dependent** (hard `Requires`; soft `Wants` later).
- Subject = **book** v1, with an all-files-of-book aggregator for per-file prereqs.

## Milestones
M1 core engine (this plan) → M2 field conditions → M3 batching → M4 migrate dedup-on-import off the hook.

Spec: `docs/specs/2026-06-13-uos-dependency-scheduling-design.md`
Plan: `docs/plans/2026-06-13-uos-dependency-scheduling-m1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)