### PR TITLE
perf(dedup): ISBN/ASIN secondary index — fix O(N²) checkExactISBN

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,6 +1,7 @@
 # file: .mockery.yaml
-# version: 1.17.0
+# version: 1.18.0
 # guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+# last-edited: 2026-06-14
 
 # Mockery configuration (v3)
 # NOTE: with-expecter is enabled by default in v3
@@ -15,7 +16,7 @@ filename: mock_store.go
 pkgname: mocks
 
 packages:
-  github.com/jdfalk/audiobook-organizer/internal/database:
+  github.com/falkcorp/audiobook-organizer/internal/database:
     interfaces:
       Store:
       LifecycleStore:
@@ -61,20 +62,20 @@ packages:
       RejectedMetadataStore:
       SystemActivityStore:
       OpsV2Store:
-  github.com/jdfalk/audiobook-organizer/internal/operations:
+  github.com/falkcorp/audiobook-organizer/internal/operations:
     config:
       dir: internal/operations/mocks
     interfaces:
       ProgressReporter:
         config:
           filename: mock_progress_reporter.go
-  github.com/jdfalk/audiobook-organizer/internal/scanner:
+  github.com/falkcorp/audiobook-organizer/internal/scanner:
     config:
       dir: internal/scanner/mocks
       filename: mock_scanner.go
     interfaces:
       Scanner:
-  github.com/jdfalk/audiobook-organizer/internal/metadata:
+  github.com/falkcorp/audiobook-organizer/internal/metadata:
     interfaces:
       MetadataExtractor:
         configs:
@@ -98,7 +99,7 @@ packages:
         config:
           dir: internal/metadata/mocks
           filename: mock_contextual_search.go
-  github.com/jdfalk/audiobook-organizer/internal/ai:
+  github.com/falkcorp/audiobook-organizer/internal/ai:
     interfaces:
       MetadataCandidateScorer:
         config:
@@ -114,7 +115,7 @@ packages:
           pkgname: ai
           filename: mock_metadata_llm_backend_test.go
           structname: mockMetadataLLMBackend
-  github.com/jdfalk/audiobook-organizer/internal/logger:
+  github.com/falkcorp/audiobook-organizer/internal/logger:
     config:
       dir: internal/logger/mocks
     interfaces:
@@ -130,7 +131,7 @@ packages:
       RetentionStore:
         config:
           filename: mock_retention_store.go
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers:
     config:
       dir: internal/server/handlers/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -170,7 +171,7 @@ packages:
       AudiobookUpdater:
       DiagnosticsService:
       MergeService:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/entities:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/entities:
     config:
       dir: internal/server/handlers/entities/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -180,7 +181,7 @@ packages:
       WorkService:
       AuthorSeriesService:
       OperationsRegistry:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/operations:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/operations:
     config:
       dir: internal/server/handlers/operations/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -191,7 +192,7 @@ packages:
       Scheduler:
       ScanCanceler:
       AIScanLister:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/system:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/system:
     config:
       dir: internal/server/handlers/system/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -203,7 +204,7 @@ packages:
       PluginHealthChecker:
       EventStreamer:
       OperationLogsProvider:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/dedup:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/dedup:
     config:
       dir: internal/server/handlers/dedup/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -214,7 +215,7 @@ packages:
       MergeService:
       DedupEngine:
       OperationsRegistry:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/duplicates:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/duplicates:
     config:
       dir: internal/server/handlers/duplicates/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -225,7 +226,7 @@ packages:
       MetadataFetchService:
       AudiobookService:
       OperationsRegistry:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/audiobooks:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/audiobooks:
     config:
       dir: internal/server/handlers/audiobooks/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"
@@ -240,7 +241,7 @@ packages:
       BatchService:
       ChangelogService:
       ExternalIDStore:
-  github.com/jdfalk/audiobook-organizer/internal/server/handlers/metadata:
+  github.com/falkcorp/audiobook-organizer/internal/server/handlers/metadata:
     config:
       dir: internal/server/handlers/metadata/mocks
       filename: "mock_{{.InterfaceName | snakecase}}.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,48 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.22.0 -->
+<!-- version: 3.23.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-14 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Performance
+
+#### June 14, 2026 — ISBN/ASIN secondary index (T022)
+
+Fixes O(N²) `checkExactISBN` in the dedup engine by adding set-layout secondary
+indexes to PebbleDB and a backfill operation.
+
+- **Secondary indexes** (`internal/database/pebble_store_isbn_index.go`): Three new
+  Pebble key namespaces — `book:isbn10:<value>:<bookID>`, `book:isbn13:<value>:<bookID>`,
+  `book:asin:<value>:<bookID>`. Value is `[]byte{}` (set-layout); multiple books can
+  share the same ISBN/ASIN (that is the dedup signal). Index rows are written and
+  deleted inside the **same atomic batch** as the book row in `CreateBook`, `UpdateBook`
+  (delta-only via `updateISBNIndex`), and `DeleteBook`.
+- **Lookup method**: `GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error)`
+  added to `BookReader` interface and `*PebbleStore`; performs prefix-scan per
+  non-empty argument and unions results. Only valid after backfill flag is set.
+- **Build flag**: `system:flag:book_isbn_index_v1_done` in Settings; `IsISBNIndexBuilt()`
+  and `SetISBNIndexBuilt()` on `*PebbleStore`.
+- **Backfill op**: `dedup.build-isbn-index` UOS operation
+  (`internal/plugins/dedup/build_isbn_index.go`). Dry-run by default; pass
+  `{"apply":true}` to execute. Iterates all books in 500-row batches via
+  `WriteISBNIndexForBook` (lightweight one-shot Pebble batch, avoids full
+  `UpdateBook` overhead). Sets the completion flag on success. Idempotent.
+- **Engine rewrite**: `checkExactISBN` dispatches to O(matches) indexed path
+  (`checkExactISBNIndexed`) when flag is set and `ISBNIndexStore` is wired; falls
+  back to original O(N) `GetAllBooks` scan (`checkExactISBNScan`) otherwise.
+  Both paths apply identical guards: skip self, skip `MarkedForDeletion`, skip
+  `!hasPlausibleAudio`.
+- **Production wiring**: `lifecycle.go` `PostInit` type-asserts the main store to
+  `*database.PebbleStore` and calls `engine.SetISBNIndexStore(ps)`.
+- **Tests**: 7 store-level tests (`pebble_store_isbn_index_test.go`): create,
+  shared-ISBN union, update old→new, delete, empty values, backfill helper, build
+  flag. 7 engine-level tests (`engine_isbn_test.go`): indexed path used (no
+  GetAllBooks), fallback when not built, fallback when nil store, skip self, skip
+  soft-deleted, skip implausible audio (match side), skip implausible audio
+  (anchor side).
 
 ### Added
 

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,5 +1,5 @@
 // file: internal/batch/service_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -90,7 +90,10 @@ func (m *MockBookStore) GetBookByFilePath(path string) (*database.Book, error) {
 func (m *MockBookStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	return nil, nil
 }
-func (m *MockBookStore) GetBookByFileHash(hash string) (*database.Book, error)      { return nil, nil }
+func (m *MockBookStore) GetBookByFileHash(hash string) (*database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBookByOriginalHash(hash string) (*database.Book, error)  { return nil, nil }
 func (m *MockBookStore) GetBookByOrganizedHash(hash string) (*database.Book, error) { return nil, nil }
 func (m *MockBookStore) GetDuplicateBooks() ([][]database.Book, error)              { return nil, nil }
@@ -168,8 +171,10 @@ func (m *MockBookStore) GetAllBookUserTags() ([]string, error)                  
 func (m *MockBookStore) AdjustRating(id string, delta int) (*database.Book, error)     { return nil, nil }
 func (m *MockBookStore) FlagMetadataHashDuplicate(primaryID, duplicateID string) error { return nil }
 func (m *MockBookStore) RecomputeBookAggregates(_ string) error                        { return nil }
-func (m *MockBookStore) ListBookIDs() ([]string, error)                                        { return nil, nil }
-func (m *MockBookStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error)       { return nil, nil }
+func (m *MockBookStore) ListBookIDs() ([]string, error)                                { return nil, nil }
+func (m *MockBookStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error) {
+	return nil, nil
+}
 
 // Helper to create a test book
 func testBook(id, title string) *database.Book {

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-06-10
+// last-edited: 2026-06-14
 
 package database
 
@@ -46,6 +46,14 @@ type BookReader interface {
 	GetBooksByAuthorID(authorID int) ([]Book, error)
 	GetBooksByVersionGroup(groupID string) ([]Book, error)
 	GetBooksByMetadataSourceHash(hash string) ([]Book, error)
+	// GetBookIDsByISBNASIN returns the distinct book IDs whose ISBN10, ISBN13,
+	// or ASIN match any of the supplied non-empty values.  It is a set-union:
+	// an ID is returned if it appears in any of the three index namespaces.
+	// Returns IDs only — callers load the full Book via GetBookByID when needed.
+	// Returns an empty slice (not nil, not error) when no match is found.
+	// Only valid after the book_isbn_index_v1_done flag is set; callers must
+	// gate on that flag themselves.
+	GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error)
 	SearchBooks(query string, limit, offset int) ([]Book, error)
 	CountBooks() (int, error)
 	GetDistinctGenres() ([]string, error)

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.61.0
+// version: 1.62.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-13
+// last-edited: 2026-06-14
 
 package database
 
@@ -311,6 +311,7 @@ type MockStore struct {
 	// Version Management
 	GetBooksByVersionGroupFunc       func(groupID string) ([]Book, error)
 	GetBooksByMetadataSourceHashFunc func(hash string) ([]Book, error)
+	GetBookIDsByISBNASINFunc         func(isbn10, isbn13, asin string) ([]string, error)
 
 	// iTunes Library Fingerprints
 	SaveLibraryFingerprintFunc func(path string, size int64, modTime time.Time, crc32 uint32) error
@@ -969,6 +970,13 @@ func (m *MockStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 func (m *MockStore) GetBooksByMetadataSourceHash(hash string) ([]Book, error) {
 	if m.GetBooksByMetadataSourceHashFunc != nil {
 		return m.GetBooksByMetadataSourceHashFunc(hash)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
+	if m.GetBookIDsByISBNASINFunc != nil {
+		return m.GetBookIDsByISBNASINFunc(isbn10, isbn13, asin)
 	}
 	return nil, nil
 }

--- a/internal/database/mock_store_coverage_test.go
+++ b/internal/database/mock_store_coverage_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/mock_store_coverage_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9f8e7d6c-5b4a-3c2d-1e0f-a9b8c7d6e5f4
+// last-edited: 2026-06-14
 
 package database
 
@@ -62,6 +63,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	mock.CountFilesFunc = func() (int, error) { return 0, nil }
 	mock.ListSoftDeletedBooksFunc = func(int, int, *time.Time) ([]Book, error) { return nil, nil }
 	mock.GetBooksByVersionGroupFunc = func(string) ([]Book, error) { return nil, nil }
+	mock.GetBookIDsByISBNASINFunc = func(string, string, string) ([]string, error) { return nil, nil }
 
 	// Import Paths
 	mock.GetAllImportPathsFunc = func() ([]ImportPath, error) { return nil, nil }
@@ -180,6 +182,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	_, _ = mock.CountFiles()
 	_, _ = mock.ListSoftDeletedBooks(10, 0, nil)
 	_, _ = mock.GetBooksByVersionGroup("group-1")
+	_, _ = mock.GetBookIDsByISBNASIN("0123456789", "9780123456786", "B001234567")
 	_, _ = mock.GetAllImportPaths()
 	_, _ = mock.GetImportPathByID(1)
 	_, _ = mock.GetImportPathByPath("/path")

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3544,6 +3544,76 @@ func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run fun
 	return _c
 }
 
+// GetBookIDsByISBNASIN provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockBookReader_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockBookReader_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	return &MockBookReader_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(ids, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBooksBySeriesID provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
 	ret := _mock.Called(seriesID)
@@ -6765,6 +6835,76 @@ func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Return(books []databa
 }
 
 func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockBookStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockBookStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	return &MockBookStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(ids, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockBookStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -36964,6 +37104,76 @@ func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Return(books []database.B
 }
 
 func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockStore_GetBooksByMetadataSourceHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockStore_GetBookIDsByISBNASIN_Call {
+	return &MockStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(ids, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.87.0
+// version: 1.88.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-10
+// last-edited: 2026-06-14
 
 package database
 
@@ -2506,6 +2506,18 @@ func (p *PebbleStore) CreateBook(book *Book) (*Book, error) {
 		}
 	}
 
+	// ISBN/ASIN secondary index: set-layout rows so GetBookIDsByISBNASIN can
+	// do a prefix scan instead of a full O(N) book scan.
+	{
+		isbn10 := derefStrISBN(book.ISBN10)
+		isbn13 := derefStrISBN(book.ISBN13)
+		asin := derefStrISBN(book.ASIN)
+		if err := writeISBNIndexRows(batch, book.ID, isbn10, isbn13, asin); err != nil {
+			batch.Close()
+			return nil, err
+		}
+	}
+
 	if err := batch.Commit(pebble.Sync); err != nil {
 		return nil, err
 	}
@@ -2698,6 +2710,21 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	// cache. Missing-key is a no-op in pebble.
 	if identityChanged(oldBook, book) {
 		_ = batch.Delete(metadataCacheKey(id), nil)
+	}
+
+	// ISBN/ASIN secondary index: delete stale rows for old values and write
+	// new rows for changed values, all in the same atomic batch.
+	{
+		oldISBN10 := derefStrISBN(oldBook.ISBN10)
+		newISBN10 := derefStrISBN(book.ISBN10)
+		oldISBN13 := derefStrISBN(oldBook.ISBN13)
+		newISBN13 := derefStrISBN(book.ISBN13)
+		oldASIN := derefStrISBN(oldBook.ASIN)
+		newASIN := derefStrISBN(book.ASIN)
+		if err := updateISBNIndex(batch, id, oldISBN10, newISBN10, oldISBN13, newISBN13, oldASIN, newASIN); err != nil {
+			batch.Close()
+			return nil, err
+		}
 	}
 
 	if err := batch.Commit(pebble.Sync); err != nil {
@@ -3032,6 +3059,17 @@ func (p *PebbleStore) DeleteBook(id string) error {
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := batch.Delete(iter.Key(), nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+
+	// Delete ISBN/ASIN secondary index rows for this book.
+	{
+		isbn10 := derefStrISBN(book.ISBN10)
+		isbn13 := derefStrISBN(book.ISBN13)
+		asin := derefStrISBN(book.ASIN)
+		if err := deleteISBNIndexRows(batch, id, isbn10, isbn13, asin); err != nil {
 			batch.Close()
 			return err
 		}

--- a/internal/database/pebble_store_isbn_index.go
+++ b/internal/database/pebble_store_isbn_index.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_isbn_index.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-06-14
 
@@ -41,7 +41,10 @@ import (
 
 // isbnIndexBuiltFlagKey is stored in Settings when the isbn-index-build op
 // completes.  The v1 suffix lets us force a re-run by bumping to v2.
-const isbnIndexBuiltFlagKey = "system:flag:book_isbn_index_v1_done"
+// No namespace prefix — matches the convention of sibling ops (e.g.
+// purgeLegacyFPDoneFlag = "dedup_fp_purge_v1_done").  The Settings layer
+// adds its own "setting:" storage prefix internally.
+const isbnIndexBuiltFlagKey = "book_isbn_index_v1_done"
 
 // derefStrISBN is a nil-safe string pointer deref used in ISBN index maintenance.
 // Returns "" for nil pointers.

--- a/internal/database/pebble_store_isbn_index.go
+++ b/internal/database/pebble_store_isbn_index.go
@@ -1,0 +1,229 @@
+// file: internal/database/pebble_store_isbn_index.go
+// version: 1.0.0
+// guid: 7a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-06-14
+
+// ISBN/ASIN secondary index for PebbleStore.
+//
+// # Key layout
+//
+//	book:isbn10:<value>:<bookID>  → []byte{}  (presence = membership)
+//	book:isbn13:<value>:<bookID>  → []byte{}
+//	book:asin:<value>:<bookID>    → []byte{}
+//
+// This is a set-layout index (bookID in the key, not the value) because
+// multiple books can legitimately share the same ISBN/ASIN — that is precisely
+// the dedup signal. Compare with the single-value book:hash: index where the
+// value is the bookID.
+//
+// # Maintenance
+//
+// Index rows are written and deleted inside the same atomic pebble.Batch as
+// the book row itself (CreateBook / UpdateBook / DeleteBook).  UpdateBook
+// loads the prior book first (it already does this for path-index maintenance)
+// and uses updateISBNIndex to delete stale rows and write fresh ones when a
+// value changes.
+//
+// # Build flag
+//
+// GetBookIDsByISBNASIN should only be called when IsISBNIndexBuilt() returns
+// true.  Before the backfill op runs, the index is absent for all pre-existing
+// books.  Callers gate on this flag; the build_isbn_index op sets it.
+
+package database
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// isbnIndexBuiltFlagKey is stored in Settings when the isbn-index-build op
+// completes.  The v1 suffix lets us force a re-run by bumping to v2.
+const isbnIndexBuiltFlagKey = "system:flag:book_isbn_index_v1_done"
+
+// derefStrISBN is a nil-safe string pointer deref used in ISBN index maintenance.
+// Returns "" for nil pointers.
+func derefStrISBN(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// IsISBNIndexBuilt reports whether the isbn-index-build backfill op has
+// completed on this database.  Callers that use GetBookIDsByISBNASIN must
+// gate on this flag; an unbuilt index silently returns empty results.
+func (p *PebbleStore) IsISBNIndexBuilt() bool {
+	setting, err := p.GetSetting(isbnIndexBuiltFlagKey)
+	return err == nil && setting != nil && setting.Value == "true"
+}
+
+// SetISBNIndexBuilt marks the isbn-index-build op complete.
+// Called by the build_isbn_index backfill op when the full scan finishes.
+func (p *PebbleStore) SetISBNIndexBuilt() error {
+	return p.SetSetting(isbnIndexBuiltFlagKey, "true", "bool", false)
+}
+
+// isbnIndexKey builds one row key for the ISBN/ASIN secondary index.
+// keyspace is "isbn10", "isbn13", or "asin".
+func isbnIndexKey(keyspace, value, bookID string) []byte {
+	return []byte(fmt.Sprintf("book:%s:%s:%s", keyspace, value, bookID))
+}
+
+// writeISBNIndexRows adds index rows for all non-empty ISBN10/ISBN13/ASIN
+// values to the supplied batch.  No-op for empty values.
+func writeISBNIndexRows(batch *pebble.Batch, bookID, isbn10, isbn13, asin string) error {
+	if isbn10 != "" {
+		if err := batch.Set(isbnIndexKey("isbn10", isbn10, bookID), []byte{}, nil); err != nil {
+			return fmt.Errorf("pebble isbn10 index set: %w", err)
+		}
+	}
+	if isbn13 != "" {
+		if err := batch.Set(isbnIndexKey("isbn13", isbn13, bookID), []byte{}, nil); err != nil {
+			return fmt.Errorf("pebble isbn13 index set: %w", err)
+		}
+	}
+	if asin != "" {
+		if err := batch.Set(isbnIndexKey("asin", asin, bookID), []byte{}, nil); err != nil {
+			return fmt.Errorf("pebble asin index set: %w", err)
+		}
+	}
+	return nil
+}
+
+// deleteISBNIndexRows removes index rows for all non-empty ISBN10/ISBN13/ASIN
+// values from the supplied batch.  Missing keys are a no-op in pebble.
+func deleteISBNIndexRows(batch *pebble.Batch, bookID, isbn10, isbn13, asin string) error {
+	if isbn10 != "" {
+		if err := batch.Delete(isbnIndexKey("isbn10", isbn10, bookID), nil); err != nil {
+			return fmt.Errorf("pebble isbn10 index delete: %w", err)
+		}
+	}
+	if isbn13 != "" {
+		if err := batch.Delete(isbnIndexKey("isbn13", isbn13, bookID), nil); err != nil {
+			return fmt.Errorf("pebble isbn13 index delete: %w", err)
+		}
+	}
+	if asin != "" {
+		if err := batch.Delete(isbnIndexKey("asin", asin, bookID), nil); err != nil {
+			return fmt.Errorf("pebble asin index delete: %w", err)
+		}
+	}
+	return nil
+}
+
+// updateISBNIndex is the UPDATE helper: deletes stale rows for old values and
+// writes fresh rows for new values, only when a value has actually changed.
+// Mirrors the updateHashIndex closure in UpdateBook.
+func updateISBNIndex(batch *pebble.Batch, bookID string, oldISBN10, newISBN10, oldISBN13, newISBN13, oldASIN, newASIN string) error {
+	updateField := func(keyspace, oldVal, newVal string) error {
+		if oldVal == newVal {
+			return nil // unchanged — no index work needed
+		}
+		if oldVal != "" {
+			if err := batch.Delete(isbnIndexKey(keyspace, oldVal, bookID), nil); err != nil {
+				return fmt.Errorf("pebble %s index delete old: %w", keyspace, err)
+			}
+		}
+		if newVal != "" {
+			if err := batch.Set(isbnIndexKey(keyspace, newVal, bookID), []byte{}, nil); err != nil {
+				return fmt.Errorf("pebble %s index set new: %w", keyspace, err)
+			}
+		}
+		return nil
+	}
+
+	if err := updateField("isbn10", oldISBN10, newISBN10); err != nil {
+		return err
+	}
+	if err := updateField("isbn13", oldISBN13, newISBN13); err != nil {
+		return err
+	}
+	return updateField("asin", oldASIN, newASIN)
+}
+
+// WriteISBNIndexForBook writes the isbn10/isbn13/asin secondary-index rows for
+// a single book using a one-shot Pebble batch.  Intended for the backfill op
+// only; ongoing index maintenance goes through CreateBook/UpdateBook/DeleteBook.
+// Calling this on a book that already has index rows is harmless (idempotent
+// Set).  Empty values are skipped.
+func (p *PebbleStore) WriteISBNIndexForBook(bookID, isbn10, isbn13, asin string) error {
+	batch := p.db.NewBatch()
+	if err := writeISBNIndexRows(batch, bookID, isbn10, isbn13, asin); err != nil {
+		batch.Close()
+		return fmt.Errorf("WriteISBNIndexForBook %s: %w", bookID, err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return fmt.Errorf("WriteISBNIndexForBook %s commit: %w", bookID, err)
+	}
+	return nil
+}
+
+// GetBookIDsByISBNASIN returns the union of book IDs whose ISBN10, ISBN13, or
+// ASIN matches any of the supplied non-empty values.  Each non-empty argument
+// triggers a prefix scan of its index namespace; results are deduplicated.
+//
+// This method should only be called when IsISBNIndexBuilt() is true.  Before
+// the backfill op runs, books created before the index existed have no index
+// rows and will be silently missed.
+func (p *PebbleStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
+	seen := make(map[string]struct{})
+
+	scanPrefix := func(keyspace, value string) error {
+		if value == "" {
+			return nil
+		}
+		// Key format: book:<keyspace>:<value>:<bookID>
+		// We scan from "book:<keyspace>:<value>:" to "book:<keyspace>:<value>:~"
+		// (prefixEnd appends +1 to last byte).
+		prefix := []byte(fmt.Sprintf("book:%s:%s:", keyspace, value))
+		upper := prefixEnd(prefix)
+
+		iter, err := p.db.NewIter(&pebble.IterOptions{
+			LowerBound: prefix,
+			UpperBound: upper,
+		})
+		if err != nil {
+			return fmt.Errorf("pebble isbn index iter %s=%q: %w", keyspace, value, err)
+		}
+		defer func() {
+			if cerr := iter.Close(); cerr != nil {
+				slog.Warn("pebble isbn index iter close", "keyspace", keyspace, "error", cerr)
+			}
+		}()
+
+		for iter.First(); iter.Valid(); iter.Next() {
+			key := string(iter.Key())
+			// key = "book:<keyspace>:<value>:<bookID>"
+			// bookID is everything after the last ':'
+			// We already know the prefix is "book:<keyspace>:<value>:", so we can
+			// strip the prefix directly.
+			if len(key) <= len(prefix) {
+				continue // malformed key — skip
+			}
+			bookID := key[len(prefix):]
+			if bookID != "" {
+				seen[bookID] = struct{}{}
+			}
+		}
+		return nil
+	}
+
+	if err := scanPrefix("isbn10", isbn10); err != nil {
+		return nil, err
+	}
+	if err := scanPrefix("isbn13", isbn13); err != nil {
+		return nil, err
+	}
+	if err := scanPrefix("asin", asin); err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/internal/database/pebble_store_isbn_index_test.go
+++ b/internal/database/pebble_store_isbn_index_test.go
@@ -1,0 +1,239 @@
+// file: internal/database/pebble_store_isbn_index_test.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-06-14
+
+// Tests for the book:isbn10:, book:isbn13:, and book:asin: secondary indexes.
+// Covers: create → index present, update ISBN → old row gone/new row present,
+// delete book → index gone, multi-book same-ISBN union, backfill helper.
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// newPebbleStoreForISBN opens a fresh PebbleStore in a temp directory and
+// registers cleanup.  Returns a *PebbleStore so tests can call isbn-specific
+// methods directly.
+func newPebbleStoreForISBN(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "isbn-db"))
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// ptr returns a pointer to s — tiny helper for *string fields.
+func ptr(s string) *string { return &s }
+
+// createTestBookWithISBN inserts a minimal Book with the given ISBNs and
+// returns its ID.
+func createTestBookWithISBN(t *testing.T, s *PebbleStore, title, isbn10, isbn13, asin string) string {
+	t.Helper()
+	b := &Book{
+		Title:    title,
+		FilePath: "/tmp/" + title + ".m4b",
+	}
+	if isbn10 != "" {
+		b.ISBN10 = ptr(isbn10)
+	}
+	if isbn13 != "" {
+		b.ISBN13 = ptr(isbn13)
+	}
+	if asin != "" {
+		b.ASIN = ptr(asin)
+	}
+	created, err := s.CreateBook(b)
+	if err != nil {
+		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	return created.ID
+}
+
+// TestISBNIndex_CreateWritesRows verifies that CreateBook writes the expected
+// index rows for ISBN10, ISBN13, and ASIN.
+func TestISBNIndex_CreateWritesRows(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	id := createTestBookWithISBN(t, s, "book-a", "0123456789", "9780123456786", "B001234567")
+
+	ids, err := s.GetBookIDsByISBNASIN("0123456789", "9780123456786", "B001234567")
+	if err != nil {
+		t.Fatalf("GetBookIDsByISBNASIN: %v", err)
+	}
+	if !containsID(ids, id) {
+		t.Errorf("expected %q in index, got %v", id, ids)
+	}
+}
+
+// TestISBNIndex_TwoBooksShareISBN13 verifies that the union lookup returns
+// both books when they share an ISBN13 value.
+func TestISBNIndex_TwoBooksShareISBN13(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	idA := createTestBookWithISBN(t, s, "book-a", "", "9780123456786", "")
+	idB := createTestBookWithISBN(t, s, "book-b", "", "9780123456786", "")
+
+	ids, err := s.GetBookIDsByISBNASIN("", "9780123456786", "")
+	if err != nil {
+		t.Fatalf("GetBookIDsByISBNASIN: %v", err)
+	}
+	if !containsID(ids, idA) {
+		t.Errorf("expected idA=%q in index, got %v", idA, ids)
+	}
+	if !containsID(ids, idB) {
+		t.Errorf("expected idB=%q in index, got %v", idB, ids)
+	}
+}
+
+// TestISBNIndex_UpdateChangesISBN verifies that UpdateBook deletes the old
+// ISBN index row and writes the new one.
+func TestISBNIndex_UpdateChangesISBN(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	id := createTestBookWithISBN(t, s, "book-a", "", "9780000000001", "")
+
+	// Verify initial index row is present.
+	ids, err := s.GetBookIDsByISBNASIN("", "9780000000001", "")
+	if err != nil {
+		t.Fatalf("initial GetBookIDsByISBNASIN: %v", err)
+	}
+	if !containsID(ids, id) {
+		t.Errorf("expected id in initial index")
+	}
+
+	// Update the book to change ISBN13.
+	updated := &Book{
+		Title:    "book-a",
+		FilePath: "/tmp/book-a.m4b",
+		ISBN13:   ptr("9780000000002"),
+	}
+	if _, err := s.UpdateBook(id, updated); err != nil {
+		t.Fatalf("UpdateBook: %v", err)
+	}
+
+	// Old ISBN13 must be gone.
+	oldIDs, err := s.GetBookIDsByISBNASIN("", "9780000000001", "")
+	if err != nil {
+		t.Fatalf("old GetBookIDsByISBNASIN: %v", err)
+	}
+	if containsID(oldIDs, id) {
+		t.Errorf("old ISBN13 index row still present after update")
+	}
+
+	// New ISBN13 must be present.
+	newIDs, err := s.GetBookIDsByISBNASIN("", "9780000000002", "")
+	if err != nil {
+		t.Fatalf("new GetBookIDsByISBNASIN: %v", err)
+	}
+	if !containsID(newIDs, id) {
+		t.Errorf("expected id in new ISBN13 index, got %v", newIDs)
+	}
+}
+
+// TestISBNIndex_DeleteClearsRows verifies that DeleteBook removes all ISBN
+// index rows for the book.
+func TestISBNIndex_DeleteClearsRows(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	id := createTestBookWithISBN(t, s, "book-a", "0123456789", "9780123456786", "B001234567")
+
+	// Confirm rows exist.
+	ids, err := s.GetBookIDsByISBNASIN("0123456789", "", "")
+	if err != nil {
+		t.Fatalf("pre-delete GetBookIDsByISBNASIN: %v", err)
+	}
+	if !containsID(ids, id) {
+		t.Fatalf("expected id before delete")
+	}
+
+	// Delete the book.
+	if err := s.DeleteBook(id); err != nil {
+		t.Fatalf("DeleteBook: %v", err)
+	}
+
+	// All three namespaces must be empty.
+	for _, tc := range []struct {
+		isbn10, isbn13, asin string
+	}{
+		{"0123456789", "", ""},
+		{"", "9780123456786", ""},
+		{"", "", "B001234567"},
+	} {
+		ids, err := s.GetBookIDsByISBNASIN(tc.isbn10, tc.isbn13, tc.asin)
+		if err != nil {
+			t.Fatalf("GetBookIDsByISBNASIN after delete: %v", err)
+		}
+		if containsID(ids, id) {
+			t.Errorf("stale index row after delete: isbn10=%q isbn13=%q asin=%q, got %v",
+				tc.isbn10, tc.isbn13, tc.asin, ids)
+		}
+	}
+}
+
+// TestISBNIndex_EmptyValues verifies that empty strings are not indexed.
+func TestISBNIndex_EmptyValues(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	// Book with no ISBN at all.
+	_ = createTestBookWithISBN(t, s, "book-noISBN", "", "", "")
+
+	// Querying with all empty args should return nothing (and not panic).
+	ids, err := s.GetBookIDsByISBNASIN("", "", "")
+	if err != nil {
+		t.Fatalf("GetBookIDsByISBNASIN empty: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected no results for empty query, got %v", ids)
+	}
+}
+
+// TestISBNIndex_WriteISBNIndexForBook verifies the backfill helper.
+func TestISBNIndex_WriteISBNIndexForBook(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	// Write index rows directly (simulating backfill for a pre-existing book).
+	const syntheticID = "01BACKFILLTEST00000000000"
+	if err := s.WriteISBNIndexForBook(syntheticID, "0987654321", "9780987654321", "B009876543"); err != nil {
+		t.Fatalf("WriteISBNIndexForBook: %v", err)
+	}
+
+	ids, err := s.GetBookIDsByISBNASIN("0987654321", "9780987654321", "B009876543")
+	if err != nil {
+		t.Fatalf("GetBookIDsByISBNASIN after backfill write: %v", err)
+	}
+	if !containsID(ids, syntheticID) {
+		t.Errorf("expected syntheticID in backfill index, got %v", ids)
+	}
+}
+
+// TestISBNIndex_IsBuiltFlag verifies the IsISBNIndexBuilt / SetISBNIndexBuilt flag.
+func TestISBNIndex_IsBuiltFlag(t *testing.T) {
+	s := newPebbleStoreForISBN(t)
+
+	if s.IsISBNIndexBuilt() {
+		t.Error("expected IsISBNIndexBuilt=false on fresh store")
+	}
+
+	if err := s.SetISBNIndexBuilt(); err != nil {
+		t.Fatalf("SetISBNIndexBuilt: %v", err)
+	}
+
+	if !s.IsISBNIndexBuilt() {
+		t.Error("expected IsISBNIndexBuilt=true after SetISBNIndexBuilt")
+	}
+}
+
+// containsID is a helper that reports whether target appears in ids.
+func containsID(ids []string, target string) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.27.0
+// version: 1.28.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-14
 
@@ -93,6 +93,12 @@ type Engine struct {
 	// lshAcoustIDStore is the narrow interface used by T013's
 	// CollectLSHAcoustID; set via SetLSHStore.
 	lshAcoustIDStore LSHAcoustIDStore
+
+	// isbnIndexStore is the narrow interface used by checkExactISBN to
+	// perform O(1) prefix scans instead of O(N) full-book scans.
+	// Set via SetISBNIndexStore. When nil, checkExactISBN falls back to
+	// the GetAllBooks scan (safe — just slow).
+	isbnIndexStore ISBNIndexStore
 }
 
 // NewEngine creates a Engine with sensible defaults.
@@ -163,6 +169,28 @@ func (de *Engine) SetAcoustIDBookFileStore(s ExactAcoustIDStore) {
 // In production the caller passes the same *database.PebbleStore as bookStore.
 func (de *Engine) SetLSHStore(s LSHAcoustIDStore) {
 	de.lshAcoustIDStore = s
+}
+
+// ISBNIndexStore is the narrow interface that checkExactISBN uses to perform
+// O(1) prefix-scan lookups instead of an O(N) full-book scan.
+// *database.PebbleStore satisfies this interface.
+// Callers set it via SetISBNIndexStore; when nil, checkExactISBN falls back
+// to the full GetAllBooks scan (correct, but slow at 50 K books).
+type ISBNIndexStore interface {
+	// IsISBNIndexBuilt reports whether the isbn-index-build backfill op
+	// has completed. The index must be fully built before being queried;
+	// an unbuilt index silently returns empty results.
+	IsISBNIndexBuilt() bool
+	// GetBookIDsByISBNASIN returns the union of book IDs whose ISBN10,
+	// ISBN13, or ASIN matches any of the supplied non-empty values.
+	GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error)
+}
+
+// SetISBNIndexStore wires the ISBNIndexStore used by checkExactISBN.
+// In production the caller passes the same *database.PebbleStore that
+// was passed to NewEngine as bookStore.
+func (de *Engine) SetISBNIndexStore(s ISBNIndexStore) {
+	de.isbnIndexStore = s
 }
 
 // embeddingsEnabled reports whether the embedding layer (Layer 2) should be
@@ -721,7 +749,19 @@ func (de *Engine) handleFileHashMatch(book, other *database.Book, authorName str
 	})
 }
 
-// checkExactISBN scans all books for matching ISBN10, ISBN13, or ASIN.
+// checkExactISBN finds all other books with a matching ISBN10, ISBN13, or ASIN
+// and emits dedup candidates for each match.
+//
+// Fast path (when isbn-index-build has run): queries the book:isbn10:,
+// book:isbn13:, and book:asin: secondary indexes via GetBookIDsByISBNASIN,
+// then loads only the matching books via GetBookByID. O(matches) instead of
+// O(N books).
+//
+// Fallback (index not built or isbnIndexStore not wired): scans all books in
+// 500-row batches via GetAllBooks — the original O(N) behavior, always correct.
+//
+// Both paths apply the same guards: skip self (book.ID == other.ID), skip
+// MarkedForDeletion books, and skip books where hasPlausibleAudio is false.
 func (de *Engine) checkExactISBN(book *database.Book) error {
 	bookISBN10 := derefStr(book.ISBN10)
 	bookISBN13 := derefStr(book.ISBN13)
@@ -734,6 +774,61 @@ func (de *Engine) checkExactISBN(book *database.Book) error {
 		return nil // stub / unscanned shell — never anchor an exact-ISBN match
 	}
 
+	// Try the indexed fast path first.
+	if de.isbnIndexStore != nil && de.isbnIndexStore.IsISBNIndexBuilt() {
+		return de.checkExactISBNIndexed(book, bookISBN10, bookISBN13, bookASIN)
+	}
+
+	// Fallback: O(N) GetAllBooks scan (original behavior).
+	return de.checkExactISBNScan(book, bookISBN10, bookISBN13, bookASIN)
+}
+
+// checkExactISBNIndexed implements the O(matches) indexed path.
+// Only called when the isbn-index-build backfill has completed.
+func (de *Engine) checkExactISBNIndexed(book *database.Book, bookISBN10, bookISBN13, bookASIN string) error {
+	ids, err := de.isbnIndexStore.GetBookIDsByISBNASIN(bookISBN10, bookISBN13, bookASIN)
+	if err != nil {
+		return fmt.Errorf("isbn index lookup: %w", err)
+	}
+
+	for _, otherID := range ids {
+		if otherID == book.ID {
+			continue
+		}
+		other, err := de.bookStore.GetBookByID(otherID)
+		if err != nil {
+			slog.Warn("dedup isbn index: GetBookByID error", "id", otherID, "err", err)
+			continue
+		}
+		if other == nil {
+			continue // deleted between index scan and point lookup
+		}
+		// GetBookByID does not filter MarkedForDeletion; apply the same filter
+		// that GetAllBooks applies so indexed and scan paths are equivalent.
+		if other.MarkedForDeletion != nil && *other.MarkedForDeletion {
+			continue
+		}
+		if !hasPlausibleAudio(other) {
+			continue // stub / unscanned shell on the other side
+		}
+		sim := 1.0
+		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+			EntityType: "book",
+			EntityAID:  book.ID,
+			EntityBID:  other.ID,
+			Layer:      "exact",
+			Similarity: &sim,
+			Status:     "pending",
+		}); err != nil {
+			slog.Error("dedup upsert ISBN candidate error", "err", err)
+		}
+	}
+	return nil
+}
+
+// checkExactISBNScan implements the O(N) fallback path via GetAllBooks.
+// Used when the isbn-index-build backfill has not yet run.
+func (de *Engine) checkExactISBNScan(book *database.Book, bookISBN10, bookISBN13, bookASIN string) error {
 	const batchSize = 500
 	offset := 0
 	for {

--- a/internal/dedup/engine_isbn_test.go
+++ b/internal/dedup/engine_isbn_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_isbn_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b3c4d5e6-f7a8-9012-bcde-f01234567890
 // last-edited: 2026-06-14
 
@@ -285,4 +285,117 @@ func TestCheckExactISBN_AnchorImplausibleAudio(t *testing.T) {
 
 	assert.Equal(t, 0, fakeIdx.getCallCount, "GetBookIDsByISBNASIN must not be called for implausible anchor")
 	assert.Equal(t, 0, getAllCallCount, "GetAllBooks must not be called for implausible anchor")
+}
+
+// TestCheckExactISBN_ScanIndexedEquivalence is the load-bearing correctness
+// test: on a mixed-coverage dataset, the indexed fast path and the O(N) scan
+// fallback must emit the IDENTICAL set of candidates. This pins the invariant
+// that the indexed path's hand-rolled MarkedForDeletion/hasPlausibleAudio
+// guards (it goes through GetBookByID, which does not filter) stay in lockstep
+// with the scan path's reliance on GetAllBooks filtering.
+//
+// Dataset, all sharing anchor A's ISBN13 except where noted:
+//   - A: anchor, isbn13=X, isbn10="" (empty component must not bleed)
+//   - B: isbn13=X, plausible            → MATCH (the only expected candidate)
+//   - C: asin=Y only                    → no match (different namespace)
+//   - D: isbn10=Z only                  → no match
+//   - E: no IDs at all                  → no match (empty must not match empty)
+//   - G: isbn13=X but soft-deleted      → excluded by BOTH paths
+//   - H: isbn13=X but no audio          → excluded by BOTH paths
+func TestCheckExactISBN_ScanIndexedEquivalence(t *testing.T) {
+	const sharedISBN13 = "9780000000099"
+	falseVal := false
+	trueVal := true
+
+	bookA := plausibleBook("BOOK_A", sharedISBN13)
+	bookA.ISBN10 = nil // anchor has empty isbn10 — must not pull empty-isbn10 books
+
+	bookB := plausibleBook("BOOK_B", sharedISBN13) // genuine duplicate
+
+	bookC := plausibleBook("BOOK_C", "")
+	bookC.ASIN = strPtr("B00ASIN0001")
+
+	bookD := plausibleBook("BOOK_D", "")
+	bookD.ISBN10 = strPtr("0000000010")
+
+	bookE := plausibleBook("BOOK_E", "") // no IDs at all
+
+	bookG := plausibleBook("BOOK_G", sharedISBN13)
+	bookG.MarkedForDeletion = &trueVal // soft-deleted
+
+	bookH := &database.Book{ // shares ISBN13 but no plausible audio (nil duration)
+		ID:                "BOOK_H",
+		Title:             "Book H",
+		FilePath:          "/audio/BOOK_H.m4b",
+		ISBN13:            strPtr(sharedISBN13),
+		MarkedForDeletion: &falseVal,
+	}
+
+	all := []*database.Book{bookA, bookB, bookC, bookD, bookE, bookG, bookH}
+	byID := map[string]*database.Book{}
+	for _, b := range all {
+		byID[b.ID] = b
+	}
+
+	// candidateSet runs one path and returns the set of "other" book IDs paired
+	// with the anchor, so the two paths can be compared regardless of ordering.
+	candidateSet := func(t *testing.T, run func(engine *Engine)) map[string]struct{} {
+		t.Helper()
+		engine, mock, es := setupTestEngine(t)
+
+		// GetAllBooks must mirror the real store: paged AND excludes soft-deleted
+		// (the scan path relies on this filtering, like PebbleStore.GetAllBooks).
+		mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+			if offset > 0 {
+				return nil, nil
+			}
+			out := make([]database.Book, 0, len(all))
+			for _, b := range all {
+				if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+					continue
+				}
+				out = append(out, *b)
+			}
+			return out, nil
+		}
+		// GetBookByID does NOT filter (matches PebbleStore) — returns soft-deleted too.
+		mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+			return byID[id], nil
+		}
+
+		run(engine)
+
+		cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+		require.NoError(t, err)
+		set := map[string]struct{}{}
+		for _, c := range cands {
+			other := c.EntityBID
+			if c.EntityAID != "BOOK_A" {
+				other = c.EntityAID
+			}
+			set[other] = struct{}{}
+		}
+		return set
+	}
+
+	// Scan path: index not built → checkExactISBN falls through to the scan.
+	scanSet := candidateSet(t, func(engine *Engine) {
+		engine.SetISBNIndexStore(&fakeISBNIndexStore{built: false})
+		require.NoError(t, engine.checkExactISBN(bookA))
+	})
+
+	// Indexed path: a fake index returns every book that shares any of A's
+	// non-empty components (exactly what a correct GetBookIDsByISBNASIN would
+	// return) — including the soft-deleted G and implausible H, so the engine's
+	// own guards are what must exclude them.
+	indexedSet := candidateSet(t, func(engine *Engine) {
+		engine.SetISBNIndexStore(&fakeISBNIndexStore{
+			built:     true,
+			returnIDs: []string{"BOOK_A", "BOOK_B", "BOOK_G", "BOOK_H"},
+		})
+		require.NoError(t, engine.checkExactISBN(bookA))
+	})
+
+	assert.Equal(t, map[string]struct{}{"BOOK_B": {}}, scanSet, "scan path should match only B")
+	assert.Equal(t, scanSet, indexedSet, "indexed and scan paths must emit identical candidate sets")
 }

--- a/internal/dedup/engine_isbn_test.go
+++ b/internal/dedup/engine_isbn_test.go
@@ -1,0 +1,288 @@
+// file: internal/dedup/engine_isbn_test.go
+// version: 1.0.0
+// guid: b3c4d5e6-f7a8-9012-bcde-f01234567890
+// last-edited: 2026-06-14
+
+// Tests for checkExactISBN: verifies that the indexed fast path is used when
+// the isbn-index-build flag is set, and that the O(N) GetAllBooks fallback is
+// used when the flag is absent.
+
+package dedup
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeISBNIndexStore implements ISBNIndexStore for tests.
+type fakeISBNIndexStore struct {
+	built bool
+	// getCallCount records how many times GetBookIDsByISBNASIN was called.
+	getCallCount int
+	// returnIDs is the set of book IDs to return from GetBookIDsByISBNASIN.
+	returnIDs []string
+}
+
+func (f *fakeISBNIndexStore) IsISBNIndexBuilt() bool { return f.built }
+func (f *fakeISBNIndexStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
+	f.getCallCount++
+	return f.returnIDs, nil
+}
+
+// plausibleBook returns a Book with enough fields set for hasPlausibleAudio to
+// return true (duration > 0 and a file hash).
+func plausibleBook(id, isbn13 string) *database.Book {
+	dur := 3600
+	marked := false
+	return &database.Book{
+		ID:                id,
+		Title:             "Book " + id,
+		FilePath:          "/audio/" + id + ".m4b",
+		ISBN13:            strPtr(isbn13),
+		Duration:          &dur,
+		MarkedForDeletion: &marked,
+		FileHash:          strPtr("hash-" + id),
+	}
+}
+
+// TestCheckExactISBN_IndexedPathUsed verifies that when the isbn-index is built
+// and ISBNIndexStore is wired, checkExactISBN calls GetBookIDsByISBNASIN instead
+// of GetAllBooks.
+func TestCheckExactISBN_IndexedPathUsed(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+	bookB := plausibleBook("BOOK_B", "9780000000001") // same ISBN13 as A
+
+	// Wire the fake index store — index is built, returns bookB as the match.
+	fakeIdx := &fakeISBNIndexStore{
+		built:     true,
+		returnIDs: []string{"BOOK_B"},
+	}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	// GetAllBooks must NOT be called when indexed path is used.
+	getAllCallCount := 0
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		getAllCallCount++
+		return nil, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "BOOK_B":
+			return bookB, nil
+		}
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, getAllCallCount, "GetAllBooks must not be called when indexed path is active")
+	assert.Equal(t, 1, fakeIdx.getCallCount, "GetBookIDsByISBNASIN must be called exactly once")
+
+	// A dedup candidate should have been created.
+	candidates, total, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "expected 1 candidate from indexed ISBN match")
+	if len(candidates) > 0 {
+		c := candidates[0]
+		assert.Equal(t, "exact", c.Layer)
+		assert.Equal(t, "pending", c.Status)
+		// EntityAID and EntityBID may be in either order.
+		ids := []string{c.EntityAID, c.EntityBID}
+		assert.Contains(t, ids, "BOOK_A")
+		assert.Contains(t, ids, "BOOK_B")
+	}
+}
+
+// TestCheckExactISBN_FallbackWhenIndexNotBuilt verifies that when the isbn-index
+// flag is NOT set (IsISBNIndexBuilt returns false), checkExactISBN falls back to
+// GetAllBooks and does NOT call GetBookIDsByISBNASIN.
+func TestCheckExactISBN_FallbackWhenIndexNotBuilt(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+	bookB := plausibleBook("BOOK_B", "9780000000001")
+
+	// Wire a fake index where built=false.
+	fakeIdx := &fakeISBNIndexStore{built: false}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	getAllCallCount := 0
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		getAllCallCount++
+		if offset == 0 {
+			return []database.Book{*bookA, *bookB}, nil
+		}
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	assert.Greater(t, getAllCallCount, 0, "GetAllBooks must be called on the fallback path")
+	assert.Equal(t, 0, fakeIdx.getCallCount, "GetBookIDsByISBNASIN must not be called when index not built")
+
+	// bookB shares the ISBN13 and is plausible — candidate should be emitted.
+	_, total, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "expected 1 candidate from scan-path ISBN match")
+}
+
+// TestCheckExactISBN_FallbackWhenNoIndexStore verifies that when ISBNIndexStore
+// is not wired at all (nil), GetAllBooks is called.
+func TestCheckExactISBN_FallbackWhenNoIndexStore(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+	// Do NOT call engine.SetISBNIndexStore — leave it nil.
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+
+	getAllCallCount := 0
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		getAllCallCount++
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	assert.Greater(t, getAllCallCount, 0, "GetAllBooks must be called when ISBNIndexStore is nil")
+}
+
+// TestCheckExactISBN_SkipsSelf verifies that the indexed path does not emit a
+// candidate when the only matching book is the anchor book itself.
+func TestCheckExactISBN_SkipsSelf(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+
+	// Index returns BOOK_A itself (self-match).
+	fakeIdx := &fakeISBNIndexStore{
+		built:     true,
+		returnIDs: []string{"BOOK_A"},
+	}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_A" {
+			return bookA, nil
+		}
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "self-match must not produce a candidate")
+}
+
+// TestCheckExactISBN_SkipsMarkedForDeletion verifies that the indexed path
+// does not emit a candidate when the matched book is soft-deleted.
+func TestCheckExactISBN_SkipsMarkedForDeletion(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+
+	// bookB exists but is soft-deleted.
+	bookB := plausibleBook("BOOK_B", "9780000000001")
+	markedTrue := true
+	bookB.MarkedForDeletion = &markedTrue
+
+	fakeIdx := &fakeISBNIndexStore{
+		built:     true,
+		returnIDs: []string{"BOOK_B"},
+	}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_B" {
+			return bookB, nil
+		}
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "soft-deleted book must not produce a candidate")
+}
+
+// TestCheckExactISBN_SkipsImplausibleAudio verifies that the indexed path does
+// not emit a candidate when the matched book has no plausible audio (hasPlausibleAudio
+// returns false — e.g. a stub entry with no duration).
+func TestCheckExactISBN_SkipsImplausibleAudio(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := plausibleBook("BOOK_A", "9780000000001")
+
+	// bookB has no duration — not plausible audio.
+	marked := false
+	bookB := &database.Book{
+		ID:                "BOOK_B",
+		Title:             "Book B",
+		FilePath:          "/audio/BOOK_B.m4b",
+		ISBN13:            strPtr("9780000000001"),
+		MarkedForDeletion: &marked,
+		// Duration intentionally left nil → hasPlausibleAudio = false
+	}
+
+	fakeIdx := &fakeISBNIndexStore{
+		built:     true,
+		returnIDs: []string{"BOOK_B"},
+	}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_B" {
+			return bookB, nil
+		}
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{EntityType: "book"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "book with no plausible audio must not produce a candidate")
+}
+
+// TestCheckExactISBN_AnchorImplausibleAudio verifies that if the anchor book
+// itself has no plausible audio, checkExactISBN returns early without touching
+// the index or GetAllBooks.
+func TestCheckExactISBN_AnchorImplausibleAudio(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	// Anchor has ISBN but no audio.
+	marked := false
+	bookA := &database.Book{
+		ID:                "BOOK_A",
+		Title:             "Book A",
+		ISBN13:            strPtr("9780000000001"),
+		MarkedForDeletion: &marked,
+		// Duration nil → not plausible
+	}
+
+	fakeIdx := &fakeISBNIndexStore{built: true}
+	engine.SetISBNIndexStore(fakeIdx)
+
+	getAllCallCount := 0
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		getAllCallCount++
+		return nil, nil
+	}
+
+	err := engine.checkExactISBN(bookA)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fakeIdx.getCallCount, "GetBookIDsByISBNASIN must not be called for implausible anchor")
+	assert.Equal(t, 0, getAllCallCount, "GetAllBooks must not be called for implausible anchor")
+}

--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -1,5 +1,7 @@
 // file: internal/dedup/lifecycle.go
-// version: 1.2.0
+// version: 1.3.0
+// guid: 3e4f5a6b-7c8d-9e0f-a1b2-c3d4e5f60718
+// last-edited: 2026-06-14
 
 // Lifecycle methods on *dedup.Engine that the serviceregistry container
 // picks up via interface satisfaction. PostInit subscribes to lifecycle
@@ -142,6 +144,15 @@ func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) er
 		de.SetAIJobsStore(jobs)
 		ai.SetDedupVerdictApplier(de)
 		slog.Info("[INFO] Dedup async review (aijobs) wired")
+	}
+
+	// Step 4 — ISBN/ASIN secondary index store.
+	// *database.PebbleStore implements ISBNIndexStore (IsISBNIndexBuilt +
+	// GetBookIDsByISBNASIN). When the index has been built, checkExactISBN
+	// switches to the O(matches) path; otherwise it falls back to GetAllBooks.
+	if ps, ok := de.bookStore.(*database.PebbleStore); ok {
+		de.SetISBNIndexStore(ps)
+		slog.Info("[dedup] PostInit wired ISBNIndexStore (checkExactISBN will use indexed path when flag is set)")
 	}
 
 	return nil

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -53,6 +53,10 @@ func (m *mockRebuildStore) GetBookByITunesPersistentID(persistentID string) (*da
 }
 
 func (m *mockRebuildStore) GetBookByFileHash(hash string) (*database.Book, error) {
+	return nil, nil
+}
+
+func (m *mockRebuildStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
 	return nil, nil
 }
 
@@ -158,8 +162,10 @@ func (m *mockRebuildStore) GetBookFiles(bookID string) ([]database.BookFile, err
 func (m *mockRebuildStore) GetAuthorByID(id int) (*database.Author, error) {
 	return nil, nil
 }
-func (m *mockRebuildStore) ListBookIDs() ([]string, error)                                { return nil, nil }
-func (m *mockRebuildStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error) { return nil, nil }
+func (m *mockRebuildStore) ListBookIDs() ([]string, error) { return nil, nil }
+func (m *mockRebuildStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error) {
+	return nil, nil
+}
 
 func TestBuildNewTrackFromBook(t *testing.T) {
 	// Create a mock book

--- a/internal/plugins/dedup/build_isbn_index.go
+++ b/internal/plugins/dedup/build_isbn_index.go
@@ -1,0 +1,265 @@
+// file: internal/plugins/dedup/build_isbn_index.go
+// version: 1.0.0
+// guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
+// last-edited: 2026-06-14
+
+// Package dedup — op dedup.build-isbn-index.
+//
+// Backfills the book:isbn10:, book:isbn13:, and book:asin: secondary indexes
+// for all books that existed before the write-path maintenance was added.
+// New books (created/updated after the pebble_store.go change ships) have
+// their index rows written inline during CreateBook/UpdateBook.
+//
+// Once this op completes with apply=true the flag book_isbn_index_v1_done is
+// set and checkExactISBN switches to the O(matches) indexed path instead of
+// the O(N²) full-scan fallback.
+//
+// Usage:
+//
+//	POST /api/v1/operations  {"op":"dedup.build-isbn-index"}           # dry-run
+//	POST /api/v1/operations  {"op":"dedup.build-isbn-index","apply":true}  # execute
+//
+// Idempotent: re-running is safe. The flag prevents double-completion noise
+// but does not block re-runs (pass apply=true to force rebuild if needed).
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// isbnIndexDoneFlag is the versioned Settings key set on successful completion.
+// Increment to v2 if the key format changes and a forced rebuild is needed.
+const isbnIndexDoneFlag = "book_isbn_index_v1_done"
+
+// buildISBNIndexParams are the JSON parameters accepted by the op.
+type buildISBNIndexParams struct {
+	// Apply, if true, writes the index rows and sets the completion flag.
+	// Default false (dry-run) — the op counts what it would write and returns.
+	Apply bool `json:"apply"`
+}
+
+// buildISBNIndexDef returns the OperationDef for dedup.build-isbn-index.
+func (p *Plugin) buildISBNIndexDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.build-isbn-index",
+		Plugin:      "dedup",
+		DisplayName: "Build ISBN/ASIN secondary index",
+		Description: "Backfills the book:isbn10:, book:isbn13:, and book:asin: secondary " +
+			"indexes for all books. Dry-run by default (pass apply=true to execute). " +
+			"Sets book_isbn_index_v1_done on completion, enabling O(1) ISBN dedup lookups. " +
+			"Idempotent — safe to re-run.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityHigh,
+		ConcurrencyKey:  "dedup.build-isbn-index",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         60 * time.Minute,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+		},
+		Run: p.runBuildISBNIndex,
+	}
+}
+
+// runBuildISBNIndex implements the build-isbn-index op.
+func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	// --- Parse params ---
+	var params buildISBNIndexParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	reporter.Logger().Info("build-isbn-index start", "apply", params.Apply)
+
+	// --- Check if already complete ---
+	if done, err := p.isFlagSet(isbnIndexDoneFlag); err != nil {
+		reporter.Logger().Warn("build-isbn-index: flag check error (proceeding)", "error", err)
+	} else if done && params.Apply {
+		reporter.Logger().Info("build-isbn-index: already completed; re-running to ensure consistency",
+			"flag", isbnIndexDoneFlag)
+	}
+
+	// --- Load all books ---
+	_ = reporter.UpdateProgress(0, 3, "Loading all books…")
+
+	// Use GetAllBooks in batches so we don't materialise 50K books at once.
+	const batchSize = 500
+	var (
+		totalBooks    int
+		booksWithISBN int
+		indexRows     int
+	)
+
+	// Collect the (bookID, isbn10, isbn13, asin) tuples to write.
+	type isbnEntry struct {
+		bookID string
+		isbn10 string
+		isbn13 string
+		asin   string
+	}
+	var toWrite []isbnEntry
+
+	offset := 0
+	for {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		batch, err := p.store.GetAllBooks(batchSize, offset)
+		if err != nil {
+			return fmt.Errorf("get all books at offset %d: %w", offset, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for i := range batch {
+			b := &batch[i]
+			totalBooks++
+
+			isbn10 := derefStrPlugin(b.ISBN10)
+			isbn13 := derefStrPlugin(b.ISBN13)
+			asin := derefStrPlugin(b.ASIN)
+
+			if isbn10 == "" && isbn13 == "" && asin == "" {
+				continue
+			}
+
+			booksWithISBN++
+			toWrite = append(toWrite, isbnEntry{
+				bookID: b.ID,
+				isbn10: isbn10,
+				isbn13: isbn13,
+				asin:   asin,
+			})
+
+			if isbn10 != "" {
+				indexRows++
+			}
+			if isbn13 != "" {
+				indexRows++
+			}
+			if asin != "" {
+				indexRows++
+			}
+		}
+
+		if len(batch) < batchSize {
+			break
+		}
+		offset += batchSize
+	}
+
+	reporter.Logger().Info("build-isbn-index: scan complete",
+		"total_books", totalBooks,
+		"books_with_isbn", booksWithISBN,
+		"index_rows", indexRows,
+		"apply", params.Apply)
+
+	summary := fmt.Sprintf(
+		"Scan: %d books total, %d with ISBN/ASIN, %d index rows to write",
+		totalBooks, booksWithISBN, indexRows,
+	)
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3,
+			fmt.Sprintf("Dry-run complete — %d index rows would be written. Pass apply=true to execute.", indexRows))
+		reporter.Logger().Info("build-isbn-index: dry-run only; no changes written", "would_write", indexRows)
+		return nil
+	}
+
+	// --- Apply: write index rows via the store's write path ---
+	// We call the individual PebbleStore methods through the database.Store
+	// interface.  The index write happens via WriteISBNIndexRows which is
+	// package-private in database; we trigger it by calling UpdateBook for
+	// each affected book.  However, UpdateBook is expensive (full JSON
+	// marshal + snapshot).  Instead, we call the public
+	// GetBookIDsByISBNASIN-style helpers on the store… but the write helpers
+	// are package-private.
+	//
+	// The cleanest solution: check if the store exposes the typed write
+	// interface. We type-assert to ISBNIndexPebbleStore (which is *PebbleStore)
+	// to call SetISBNIndexBuilt.  For the row writes we use UpdateBook on a
+	// no-op update — it's slightly expensive but preserves all maintenance
+	// (snapshots, memdb write-through, dirty-flag invalidation) and avoids
+	// any direct Pebble batch access from outside the database package.
+	//
+	// For the actual row writes we call a dedicated typed interface:
+	// ISBNIndexWriter which *PebbleStore satisfies via WriteISBNIndexForBook.
+	writer, ok := p.store.(ISBNIndexWriter)
+	if !ok {
+		return fmt.Errorf("store does not implement ISBNIndexWriter (expected *database.PebbleStore)")
+	}
+
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Writing %d index rows…", indexRows))
+
+	var written int
+	for _, e := range toWrite {
+		if reporter.IsCanceled() {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := writer.WriteISBNIndexForBook(e.bookID, e.isbn10, e.isbn13, e.asin); err != nil {
+			reporter.Logger().Error("build-isbn-index: write error",
+				"book_id", e.bookID, "error", err)
+			// Continue — partial progress is better than aborting; the op is idempotent.
+		} else {
+			written++
+		}
+	}
+
+	reporter.Logger().Info("build-isbn-index: write complete",
+		"written", written, "intended", booksWithISBN)
+
+	// --- Set completion flag ---
+	if err := p.store.SetSetting(isbnIndexDoneFlag, "true", "bool", false); err != nil {
+		reporter.Logger().Warn("build-isbn-index: could not set done flag",
+			"flag", isbnIndexDoneFlag, "error", err)
+	} else {
+		reporter.Logger().Info("build-isbn-index: set done flag", "flag", isbnIndexDoneFlag)
+	}
+
+	_ = reporter.UpdateProgress(3, 3,
+		fmt.Sprintf("Complete — %d/%d books indexed. %s", written, booksWithISBN, summary))
+	reporter.Logger().Info("build-isbn-index: complete",
+		"written", written, "intended", booksWithISBN)
+	return nil
+}
+
+// ISBNIndexWriter is the narrow write interface the backfill op uses to write
+// index rows for a single book without going through the full UpdateBook path.
+// *database.PebbleStore implements this via WriteISBNIndexForBook.
+type ISBNIndexWriter interface {
+	WriteISBNIndexForBook(bookID, isbn10, isbn13, asin string) error
+}
+
+// derefStrPlugin is a nil-safe string pointer deref for use in the dedup plugin.
+func derefStrPlugin(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/plugins/dedup/build_isbn_index.go
+++ b/internal/plugins/dedup/build_isbn_index.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/build_isbn_index.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-06-14
 
@@ -32,10 +32,6 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
-
-// isbnIndexDoneFlag is the versioned Settings key set on successful completion.
-// Increment to v2 if the key format changes and a forced rebuild is needed.
-const isbnIndexDoneFlag = "book_isbn_index_v1_done"
 
 // buildISBNIndexParams are the JSON parameters accepted by the op.
 type buildISBNIndexParams struct {
@@ -74,6 +70,15 @@ func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessag
 		return fmt.Errorf("main store not available")
 	}
 
+	// --- Resolve the typed ISBN index interface ---
+	// The store must implement ISBNIndexStore so the op can write index rows
+	// and set/read the completion flag without going through the generic
+	// SetSetting path (which uses a different key from IsISBNIndexBuilt).
+	isbnStore, ok := p.store.(ISBNIndexStore)
+	if !ok {
+		return fmt.Errorf("store does not implement ISBNIndexStore (expected *database.PebbleStore)")
+	}
+
 	// --- Parse params ---
 	var params buildISBNIndexParams
 	if len(rawParams) > 0 {
@@ -85,11 +90,8 @@ func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessag
 	reporter.Logger().Info("build-isbn-index start", "apply", params.Apply)
 
 	// --- Check if already complete ---
-	if done, err := p.isFlagSet(isbnIndexDoneFlag); err != nil {
-		reporter.Logger().Warn("build-isbn-index: flag check error (proceeding)", "error", err)
-	} else if done && params.Apply {
-		reporter.Logger().Info("build-isbn-index: already completed; re-running to ensure consistency",
-			"flag", isbnIndexDoneFlag)
+	if isbnStore.IsISBNIndexBuilt() && params.Apply {
+		reporter.Logger().Info("build-isbn-index: already completed; re-running to ensure consistency")
 	}
 
 	// --- Load all books ---
@@ -186,32 +188,15 @@ func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessag
 		return nil
 	}
 
-	// --- Apply: write index rows via the store's write path ---
-	// We call the individual PebbleStore methods through the database.Store
-	// interface.  The index write happens via WriteISBNIndexRows which is
-	// package-private in database; we trigger it by calling UpdateBook for
-	// each affected book.  However, UpdateBook is expensive (full JSON
-	// marshal + snapshot).  Instead, we call the public
-	// GetBookIDsByISBNASIN-style helpers on the store… but the write helpers
-	// are package-private.
-	//
-	// The cleanest solution: check if the store exposes the typed write
-	// interface. We type-assert to ISBNIndexPebbleStore (which is *PebbleStore)
-	// to call SetISBNIndexBuilt.  For the row writes we use UpdateBook on a
-	// no-op update — it's slightly expensive but preserves all maintenance
-	// (snapshots, memdb write-through, dirty-flag invalidation) and avoids
-	// any direct Pebble batch access from outside the database package.
-	//
-	// For the actual row writes we call a dedicated typed interface:
-	// ISBNIndexWriter which *PebbleStore satisfies via WriteISBNIndexForBook.
-	writer, ok := p.store.(ISBNIndexWriter)
-	if !ok {
-		return fmt.Errorf("store does not implement ISBNIndexWriter (expected *database.PebbleStore)")
-	}
-
+	// --- Apply: write index rows via the store's typed write path ---
+	// Row writes go through ISBNIndexStore.WriteISBNIndexForBook (a dedicated
+	// single-book batch write, idempotent, no UpdateBook overhead).
+	// The completion flag is set only when ALL books were written successfully
+	// (written == booksWithISBN), covering both per-book write failures and
+	// mid-run cancellation.
 	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Writing %d index rows…", indexRows))
 
-	var written int
+	var written, failed int
 	for _, e := range toWrite {
 		if reporter.IsCanceled() {
 			break
@@ -222,38 +207,54 @@ func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessag
 		default:
 		}
 
-		if err := writer.WriteISBNIndexForBook(e.bookID, e.isbn10, e.isbn13, e.asin); err != nil {
+		if err := isbnStore.WriteISBNIndexForBook(e.bookID, e.isbn10, e.isbn13, e.asin); err != nil {
 			reporter.Logger().Error("build-isbn-index: write error",
 				"book_id", e.bookID, "error", err)
 			// Continue — partial progress is better than aborting; the op is idempotent.
+			failed++
 		} else {
 			written++
 		}
 	}
 
 	reporter.Logger().Info("build-isbn-index: write complete",
-		"written", written, "intended", booksWithISBN)
+		"written", written, "failed", failed, "intended", booksWithISBN)
 
-	// --- Set completion flag ---
-	if err := p.store.SetSetting(isbnIndexDoneFlag, "true", "bool", false); err != nil {
-		reporter.Logger().Warn("build-isbn-index: could not set done flag",
-			"flag", isbnIndexDoneFlag, "error", err)
+	// --- Set completion flag only on a complete, error-free backfill ---
+	// written == booksWithISBN guards against both write errors (failed > 0)
+	// and mid-run cancellation (written + failed < booksWithISBN).
+	if written == booksWithISBN {
+		if err := isbnStore.SetISBNIndexBuilt(); err != nil {
+			reporter.Logger().Warn("build-isbn-index: could not set done flag", "error", err)
+		} else {
+			reporter.Logger().Info("build-isbn-index: set done flag")
+		}
 	} else {
-		reporter.Logger().Info("build-isbn-index: set done flag", "flag", isbnIndexDoneFlag)
+		reporter.Logger().Warn("build-isbn-index: done flag NOT set — backfill incomplete",
+			"written", written, "failed", failed, "intended", booksWithISBN,
+			"action", "re-run with apply=true to complete")
 	}
 
 	_ = reporter.UpdateProgress(3, 3,
-		fmt.Sprintf("Complete — %d/%d books indexed. %s", written, booksWithISBN, summary))
+		fmt.Sprintf("Complete — %d/%d books indexed (%d failed). %s", written, booksWithISBN, failed, summary))
 	reporter.Logger().Info("build-isbn-index: complete",
-		"written", written, "intended", booksWithISBN)
+		"written", written, "failed", failed, "intended", booksWithISBN)
 	return nil
 }
 
-// ISBNIndexWriter is the narrow write interface the backfill op uses to write
-// index rows for a single book without going through the full UpdateBook path.
-// *database.PebbleStore implements this via WriteISBNIndexForBook.
-type ISBNIndexWriter interface {
+// ISBNIndexStore is the narrow typed interface the build-isbn-index op uses.
+// It covers both the per-book row write and the single-source-of-truth
+// completion flag methods.  *database.PebbleStore implements all three.
+type ISBNIndexStore interface {
+	// WriteISBNIndexForBook writes isbn10/isbn13/asin secondary-index rows for
+	// a single book (idempotent, one-shot Pebble batch).
 	WriteISBNIndexForBook(bookID, isbn10, isbn13, asin string) error
+	// IsISBNIndexBuilt reports whether the backfill has completed.
+	IsISBNIndexBuilt() bool
+	// SetISBNIndexBuilt marks the backfill complete.  Must use the same
+	// Settings key as IsISBNIndexBuilt — both are on *database.PebbleStore,
+	// so this is guaranteed by construction.
+	SetISBNIndexBuilt() error
 }
 
 // derefStrPlugin is a nil-safe string pointer deref for use in the dedup plugin.

--- a/internal/plugins/dedup/build_isbn_index_test.go
+++ b/internal/plugins/dedup/build_isbn_index_test.go
@@ -1,0 +1,232 @@
+// file: internal/plugins/dedup/build_isbn_index_test.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-fedc-ba0987654321
+// last-edited: 2026-06-14
+
+// End-to-end tests for the build-isbn-index op.
+//
+// These tests use a real PebbleStore (via a temp dir) to exercise the
+// complete flag-write chain: op sets the flag via the store's typed method;
+// IsISBNIndexBuilt() reads the same key back.  They exist specifically to
+// catch BUG 1 (flag-key mismatch) and BUG 2 (flag set on partial backfill).
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// isbnIndexStoreAdapter wraps a *PebbleStore so it satisfies database.Store
+// (via embedding) while also satisfying ISBNIndexStore (WriteISBNIndexForBook
+// + SetISBNIndexBuilt + IsISBNIndexBuilt) and providing GetAllBooks.
+// This is the minimal surface the build-isbn-index op needs.
+type isbnIndexStoreAdapter struct {
+	database.Store // embed for all methods we don't override
+	pebble         *database.PebbleStore
+}
+
+// WriteISBNIndexForBook satisfies ISBNIndexStore — routes to PebbleStore.
+func (a *isbnIndexStoreAdapter) WriteISBNIndexForBook(bookID, isbn10, isbn13, asin string) error {
+	return a.pebble.WriteISBNIndexForBook(bookID, isbn10, isbn13, asin)
+}
+
+// SetISBNIndexBuilt satisfies ISBNIndexFlagWriter — routes to PebbleStore.
+// This is the method the fixed op must call instead of SetSetting directly.
+func (a *isbnIndexStoreAdapter) SetISBNIndexBuilt() error {
+	return a.pebble.SetISBNIndexBuilt()
+}
+
+// IsISBNIndexBuilt routes to PebbleStore.
+func (a *isbnIndexStoreAdapter) IsISBNIndexBuilt() bool {
+	return a.pebble.IsISBNIndexBuilt()
+}
+
+// GetAllBooks routes to PebbleStore (already embedded, but PebbleStore is
+// concrete, not an interface — the embed dispatches correctly).
+func (a *isbnIndexStoreAdapter) GetAllBooks(limit, offset int) ([]database.Book, error) {
+	return a.pebble.GetAllBooks(limit, offset)
+}
+
+// GetSetting / SetSetting route to PebbleStore (used by isFlagSet inside the op).
+func (a *isbnIndexStoreAdapter) GetSetting(key string) (*database.Setting, error) {
+	return a.pebble.GetSetting(key)
+}
+func (a *isbnIndexStoreAdapter) SetSetting(key, value, dataType string, internal bool) error {
+	return a.pebble.SetSetting(key, value, dataType, internal)
+}
+
+// newPebbleForISBNIndexTest opens a fresh PebbleStore in a temp dir.
+func newPebbleForISBNIndexTest(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "isbn-idx-test"))
+	if err != nil {
+		t.Fatalf("open PebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// makePlugin creates a Plugin whose p.store is an isbnIndexStoreAdapter
+// wrapping the given PebbleStore.  engine is nil — build-isbn-index does not
+// use the engine.
+func makePlugin(pebble *database.PebbleStore) *Plugin {
+	adapter := &isbnIndexStoreAdapter{
+		Store:  pebble, // embed satisfies the full Store interface
+		pebble: pebble,
+	}
+	return &Plugin{store: adapter}
+}
+
+// strPtrDedup returns a pointer to s.
+func strPtrDedup(s string) *string { return &s }
+
+// createISBNBook inserts a book with the given ISBN13 and returns its ID.
+func createISBNBook(t *testing.T, pebble *database.PebbleStore, title, isbn13 string) string {
+	t.Helper()
+	b := &database.Book{
+		Title:    title,
+		FilePath: "/audio/" + title + ".m4b",
+		ISBN13:   strPtrDedup(isbn13),
+	}
+	created, err := pebble.CreateBook(b)
+	if err != nil {
+		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	return created.ID
+}
+
+// TestBuildISBNIndex_EndToEnd_FlagAligned is the regression test for BUG 1.
+//
+// It verifies that after the op runs with apply=true over a real PebbleStore,
+// store.IsISBNIndexBuilt() returns true — i.e., the op writes the flag to the
+// SAME key that IsISBNIndexBuilt reads.
+func TestBuildISBNIndex_EndToEnd_FlagAligned(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+
+	// Pre-condition: flag is false on a fresh store.
+	if pebble.IsISBNIndexBuilt() {
+		t.Fatal("precondition: IsISBNIndexBuilt should be false on a fresh store")
+	}
+
+	// Create 2 books sharing an ISBN13.
+	const sharedISBN = "9781234567890"
+	idA := createISBNBook(t, pebble, "book-a", sharedISBN)
+	idB := createISBNBook(t, pebble, "book-b", sharedISBN)
+
+	// Run the op with apply=true.
+	p := makePlugin(pebble)
+	params := `{"apply":true}`
+	err := p.runBuildISBNIndex(context.Background(), json.RawMessage(params), &fakeReporter{})
+	if err != nil {
+		t.Fatalf("runBuildISBNIndex: %v", err)
+	}
+
+	// BUG 1 assertion: IsISBNIndexBuilt must now return true.
+	if !pebble.IsISBNIndexBuilt() {
+		t.Error("BUG 1: IsISBNIndexBuilt() returned false after op completed with apply=true; " +
+			"the flag key written by the op does not match the key IsISBNIndexBuilt reads")
+	}
+
+	// Also verify both books are reachable by the index.
+	ids, err := pebble.GetBookIDsByISBNASIN("", sharedISBN, "")
+	if err != nil {
+		t.Fatalf("GetBookIDsByISBNASIN: %v", err)
+	}
+	containsIDDedup := func(s []string, target string) bool {
+		for _, v := range s {
+			if v == target {
+				return true
+			}
+		}
+		return false
+	}
+	if !containsIDDedup(ids, idA) {
+		t.Errorf("expected idA=%q in index, got %v", idA, ids)
+	}
+	if !containsIDDedup(ids, idB) {
+		t.Errorf("expected idB=%q in index, got %v", idB, ids)
+	}
+}
+
+// TestBuildISBNIndex_EndToEnd_DryRun verifies that dry-run (apply=false) does
+// NOT set the completion flag.
+func TestBuildISBNIndex_EndToEnd_DryRun(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	createISBNBook(t, pebble, "book-a", "9780000000001")
+
+	p := makePlugin(pebble)
+	err := p.runBuildISBNIndex(context.Background(), json.RawMessage(`{}`), &fakeReporter{})
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+
+	if pebble.IsISBNIndexBuilt() {
+		t.Error("dry-run must not set the completion flag")
+	}
+}
+
+// errWriteISBNStore wraps a PebbleStore but injects write errors for selected book IDs.
+type errWriteISBNStore struct {
+	database.Store
+	pebble     *database.PebbleStore
+	failBookID string
+}
+
+func (e *errWriteISBNStore) WriteISBNIndexForBook(bookID, isbn10, isbn13, asin string) error {
+	if bookID == e.failBookID {
+		return errors.New("injected write error")
+	}
+	return e.pebble.WriteISBNIndexForBook(bookID, isbn10, isbn13, asin)
+}
+func (e *errWriteISBNStore) SetISBNIndexBuilt() error {
+	return e.pebble.SetISBNIndexBuilt()
+}
+func (e *errWriteISBNStore) IsISBNIndexBuilt() bool {
+	return e.pebble.IsISBNIndexBuilt()
+}
+func (e *errWriteISBNStore) GetAllBooks(limit, offset int) ([]database.Book, error) {
+	return e.pebble.GetAllBooks(limit, offset)
+}
+func (e *errWriteISBNStore) GetSetting(key string) (*database.Setting, error) {
+	return e.pebble.GetSetting(key)
+}
+func (e *errWriteISBNStore) SetSetting(key, value, dataType string, internal bool) error {
+	return e.pebble.SetSetting(key, value, dataType, internal)
+}
+
+// TestBuildISBNIndex_EndToEnd_PartialFailureDoesNotSetFlag is the regression
+// test for BUG 2.
+//
+// It verifies that when any per-book write fails during apply=true, the
+// completion flag is NOT set.  A partial index must not be treated as complete.
+func TestBuildISBNIndex_EndToEnd_PartialFailureDoesNotSetFlag(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+
+	// Create two books; one will fail.
+	idA := createISBNBook(t, pebble, "book-a", "9780000000001")
+	createISBNBook(t, pebble, "book-b", "9780000000002")
+
+	// Wire a store that fails writes for idA.
+	adapter := &errWriteISBNStore{
+		Store:      pebble,
+		pebble:     pebble,
+		failBookID: idA,
+	}
+	p := &Plugin{store: adapter}
+
+	err := p.runBuildISBNIndex(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{})
+	if err != nil {
+		t.Fatalf("runBuildISBNIndex with partial failure: %v", err)
+	}
+
+	// BUG 2 assertion: flag must NOT be set when there were write failures.
+	if pebble.IsISBNIndexBuilt() {
+		t.Error("BUG 2: IsISBNIndexBuilt() returned true after a partial write failure; " +
+			"the op must not mark the index complete when some books could not be written")
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-06-14
 
@@ -61,6 +61,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.bookfileSegDropDef(), // T020: drop AcoustID segment fields from stored values
 		p.datasetBackfillDef(), // C4: label + suppress residual pending candidates
 		p.checkBookDef(),       // M4: per-book dedup check via dependency scheduler
+		p.buildISBNIndexDef(),  // T022: ISBN/ASIN secondary index backfill
 	}
 
 	for _, op := range ops {

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -603,51 +603,6 @@ func (_c *MockMetadataStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run fun
 	return _c
 }
 
-// RecomputeBookAggregates provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) RecomputeBookAggregates(bookID string) error {
-	ret := _mock.Called(bookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecomputeBookAggregates")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockMetadataStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
-type MockMetadataStore_RecomputeBookAggregates_Call struct {
-	*mock.Call
-}
-
-// RecomputeBookAggregates is a helper method to define mock.On call
-//   - bookID string
-func (_e *MockMetadataStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockMetadataStore_RecomputeBookAggregates_Call {
-	return &MockMetadataStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
-}
-
-func (_c *MockMetadataStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockMetadataStore_RecomputeBookAggregates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockMetadataStore_RecomputeBookAggregates_Call) Return(err error) *MockMetadataStore_RecomputeBookAggregates_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockMetadataStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockMetadataStore_RecomputeBookAggregates_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetAllBookSummaries provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetAllBookSummaries(limit int, offset int) ([]database.BookSummary, error) {
 	ret := _mock.Called(limit, offset)
@@ -1282,6 +1237,80 @@ func (_c *MockMetadataStore_GetBookByOriginalHash_Call) Return(book *database.Bo
 }
 
 func (_c *MockMetadataStore_GetBookByOriginalHash_Call) RunAndReturn(run func(hash string) (*database.Book, error)) *MockMetadataStore_GetBookByOriginalHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockMetadataStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockMetadataStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
+	return &MockMetadataStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockMetadataStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2824,6 +2853,57 @@ func (_c *MockMetadataStore_PruneBookSnapshots_Call) Return(n int, err error) *M
 }
 
 func (_c *MockMetadataStore_PruneBookSnapshots_Call) RunAndReturn(run func(id string, keepCount int) (int, error)) *MockMetadataStore_PruneBookSnapshots_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecomputeBookAggregates provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) RecomputeBookAggregates(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeBookAggregates")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockMetadataStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
+type MockMetadataStore_RecomputeBookAggregates_Call struct {
+	*mock.Call
+}
+
+// RecomputeBookAggregates is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockMetadataStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockMetadataStore_RecomputeBookAggregates_Call {
+	return &MockMetadataStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
+}
+
+func (_c *MockMetadataStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockMetadataStore_RecomputeBookAggregates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_RecomputeBookAggregates_Call) Return(err error) *MockMetadataStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockMetadataStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockMetadataStore_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -890,6 +890,80 @@ func (_c *MockPlaylistStore_GetBookByOriginalHash_Call) RunAndReturn(run func(ha
 	return _c
 }
 
+// GetBookIDsByISBNASIN provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlaylistStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockPlaylistStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockPlaylistStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
+	return &MockPlaylistStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockPlaylistStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookSnapshots provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetBookSnapshots(id string, limit int) ([]database.BookSnapshot, error) {
 	ret := _mock.Called(id, limit)

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -1013,6 +1013,57 @@ func (_c *MockOperationsStore_DeleteOperationState_Call) RunAndReturn(run func(o
 	return _c
 }
 
+// DeleteOperationWithLogs provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) DeleteOperationWithLogs(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOperationWithLogs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOperationsStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
+type MockOperationsStore_DeleteOperationWithLogs_Call struct {
+	*mock.Call
+}
+
+// DeleteOperationWithLogs is a helper method to define mock.On call
+//   - id string
+func (_e *MockOperationsStore_Expecter) DeleteOperationWithLogs(id interface{}) *MockOperationsStore_DeleteOperationWithLogs_Call {
+	return &MockOperationsStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
+}
+
+func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockOperationsStore_DeleteOperationWithLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) Return(err error) *MockOperationsStore_DeleteOperationWithLogs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(id string) error) *MockOperationsStore_DeleteOperationWithLogs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteOperationsByStatus provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) DeleteOperationsByStatus(statuses []string) (int, error) {
 	ret := _mock.Called(statuses)
@@ -1069,51 +1120,6 @@ func (_c *MockOperationsStore_DeleteOperationsByStatus_Call) Return(n int, err e
 }
 
 func (_c *MockOperationsStore_DeleteOperationsByStatus_Call) RunAndReturn(run func(statuses []string) (int, error)) *MockOperationsStore_DeleteOperationsByStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteOperationWithLogs provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) DeleteOperationWithLogs(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteOperationWithLogs")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOperationsStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
-type MockOperationsStore_DeleteOperationWithLogs_Call struct {
-	*mock.Call
-}
-
-// DeleteOperationWithLogs is a helper method to define mock.On call
-//   - id string
-func (_e *MockOperationsStore_Expecter) DeleteOperationWithLogs(id interface{}) *MockOperationsStore_DeleteOperationWithLogs_Call {
-	return &MockOperationsStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
-}
-
-func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockOperationsStore_DeleteOperationWithLogs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) Return(err error) *MockOperationsStore_DeleteOperationWithLogs_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOperationsStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(string) error) *MockOperationsStore_DeleteOperationWithLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1284,51 +1290,6 @@ func (_c *MockOperationsStore_FlagMetadataHashDuplicate_Call) Return(err error) 
 }
 
 func (_c *MockOperationsStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockOperationsStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecomputeBookAggregates provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) RecomputeBookAggregates(bookID string) error {
-	ret := _mock.Called(bookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecomputeBookAggregates")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOperationsStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
-type MockOperationsStore_RecomputeBookAggregates_Call struct {
-	*mock.Call
-}
-
-// RecomputeBookAggregates is a helper method to define mock.On call
-//   - bookID string
-func (_e *MockOperationsStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockOperationsStore_RecomputeBookAggregates_Call {
-	return &MockOperationsStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
-}
-
-func (_c *MockOperationsStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockOperationsStore_RecomputeBookAggregates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockOperationsStore_RecomputeBookAggregates_Call) Return(err error) *MockOperationsStore_RecomputeBookAggregates_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOperationsStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockOperationsStore_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2680,6 +2641,80 @@ func (_c *MockOperationsStore_GetBookChanges_Call) Return(operationChanges []*da
 }
 
 func (_c *MockOperationsStore_GetBookChanges_Call) RunAndReturn(run func(bookID string) ([]*database.OperationChange, error)) *MockOperationsStore_GetBookChanges_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperationsStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockOperationsStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockOperationsStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
+	return &MockOperationsStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockOperationsStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5678,6 +5713,57 @@ func (_c *MockOperationsStore_PruneOperationLogs_Call) Return(n int, err error) 
 }
 
 func (_c *MockOperationsStore_PruneOperationLogs_Call) RunAndReturn(run func(olderThan time.Time) (int, error)) *MockOperationsStore_PruneOperationLogs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecomputeBookAggregates provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) RecomputeBookAggregates(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeBookAggregates")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOperationsStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
+type MockOperationsStore_RecomputeBookAggregates_Call struct {
+	*mock.Call
+}
+
+// RecomputeBookAggregates is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockOperationsStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockOperationsStore_RecomputeBookAggregates_Call {
+	return &MockOperationsStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
+}
+
+func (_c *MockOperationsStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockOperationsStore_RecomputeBookAggregates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_RecomputeBookAggregates_Call) Return(err error) *MockOperationsStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOperationsStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockOperationsStore_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,5 +1,5 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
 
 package sweep
@@ -85,7 +85,10 @@ func (m *MockBookStore) GetBookByFilePath(path string) (*database.Book, error) {
 func (m *MockBookStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	return nil, nil
 }
-func (m *MockBookStore) GetBookByFileHash(hash string) (*database.Book, error)      { return nil, nil }
+func (m *MockBookStore) GetBookByFileHash(hash string) (*database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]string, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBookByOriginalHash(hash string) (*database.Book, error)  { return nil, nil }
 func (m *MockBookStore) GetBookByOrganizedHash(hash string) (*database.Book, error) { return nil, nil }
 func (m *MockBookStore) GetDuplicateBooks() ([][]database.Book, error)              { return nil, nil }
@@ -141,8 +144,10 @@ func (m *MockBookStore) MergeChapterBooks(primaryID string, srcIDs []string, com
 }
 func (m *MockBookStore) FlagMetadataHashDuplicate(primaryID, duplicateID string) error { return nil }
 func (m *MockBookStore) RecomputeBookAggregates(_ string) error                        { return nil }
-func (m *MockBookStore) ListBookIDs() ([]string, error)                                        { return nil, nil }
-func (m *MockBookStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error)       { return nil, nil }
+func (m *MockBookStore) ListBookIDs() ([]string, error)                                { return nil, nil }
+func (m *MockBookStore) ListBooksByITunesPID(limit, offset int) ([]database.Book, error) {
+	return nil, nil
+}
 
 func TestSweepTombstones_EmptyList(t *testing.T) {
 	store := &MockBookStore{


### PR DESCRIPTION
## Problem

`checkExactISBN` loaded **all ~50K books** (`GetAllBooks` in 500-row batches) for **every ISBN-bearing book** during a dedup full-scan — O(N²). This was the deeper root cause of the `dedup.full-scan` stall (it stuck at book 1 even after the embedding-hang fix). ISBN was the **only** exact-check doing a per-book full scan; the siblings (`checkExactTitle` → `GetBooksByAuthorID`, `checkExactMetadataSourceHash` → `GetBooksByMetadataSourceHash`, `checkExactFileHash` → file-hash index) are all already indexed.

## Fix

A PebbleDB secondary index — set-layout, `bookID` in the key (multiple books legitimately share an ISBN; that's the dedup signal):

```
book:isbn10:<value>:<bookID>  → {}
book:isbn13:<value>:<bookID>  → {}
book:asin:<value>:<bookID>    → {}
```

- **Maintenance** is atomic with the book write — `writeISBNIndexRows` / `updateISBNIndex` / `deleteISBNIndexRows` run inside the *same* `pebble.Batch` as `CreateBook` / `UpdateBook` / `DeleteBook`. `UpdateBook` deletes stale rows + writes fresh ones only on value change, across all three namespaces.
- `checkExactISBN` uses the indexed path (`GetBookIDsByISBNASIN`, O(matches)) when `IsISBNIndexBuilt()` is true, else falls back to the original O(N) scan — **safe, identical results** until the backfill runs.
- **Empty components are never indexed** and empty query args skip the scan — no `book:isbn10::` bleed.

## Activation (post-merge, separate step)

The indexed path stays dormant until the `dedup.build-isbn-index` UOS op runs with `{"apply":true}` on prod — it backfills rows for existing books and sets `book_isbn_index_v1_done`. The flag is gated on a **complete** backfill (`written == booksWithISBN`); a partial/failed backfill leaves the flag unset (scan fallback stays active). Deploying the code alone is a no-op behavior change.

## Tests

- `internal/database/pebble_store_isbn_index_test.go` — create/update/delete index maintenance, shared-ISBN union, **empty values not indexed**, backfill helper, build flag.
- `internal/dedup/engine_isbn_test.go` — indexed-path-used / scan-fallback / nil-store-fallback / self-skip / soft-delete-skip / implausible-audio-skip, **and `TestCheckExactISBN_ScanIndexedEquivalence`**: on a mixed-coverage dataset the indexed and scan paths emit *identical* candidate sets (pins the soft-delete/implausible guard parity between the two paths).
- Regenerated mockery `BookReader` mocks + filled three hand-written `BookStore` mocks (batch/sweep/itunes) for the new method. Fixed a stale `github.com/jdfalk` → `github.com/falkcorp` module path in `.mockery.yaml` that had silently broken `make mocks` since the 2026-06-03 rename.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] Full Go suite green (incl. `internal/database`, `internal/server/...`, write-path dependents)
- [ ] Post-deploy: run `dedup.build-isbn-index` `{"apply":true}` on prod, confirm full-scan progresses past book 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)