### PR TITLE
feat(embeddings): config-driven local embedding backend (Ollama/bge-m3) + re-embed op

### DIFF
--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-06-14
 
@@ -67,19 +67,44 @@ type EmbeddingClient struct {
 // 30 s instead of blocking for the full operation timeout (up to 120 min).
 const defaultRequestTimeout = 30 * time.Second
 
-// NewEmbeddingClient creates a new embedding client using the given API key.
-// Default model is text-embedding-3-large. The returned client has no cache
-// wired up — call WithCache after construction to enable content-hash caching.
+// defaultEmbeddingModel is the model used when none is configured.
+const defaultEmbeddingModel = "text-embedding-3-large"
+
+// NewEmbeddingClient creates a new embedding client using the given API key,
+// with the default model (text-embedding-3-large) and the base URL taken from
+// the OPENAI_BASE_URL env (if set). Preserved for backward compatibility; new
+// callers that need an explicit model or a per-client base URL (e.g. a local
+// Ollama endpoint) should use NewEmbeddingClientWithOptions. The returned
+// client has no cache wired up — call WithCache to enable content-hash caching.
 func NewEmbeddingClient(apiKey string) *EmbeddingClient {
+	return NewEmbeddingClientWithOptions(apiKey, defaultEmbeddingModel, os.Getenv("OPENAI_BASE_URL"))
+}
+
+// NewEmbeddingClientWithOptions creates an embedding client pinned to an
+// explicit model and (optionally) a per-client base URL.
+//
+// baseURL scopes an OpenAI-compatible endpoint override to THIS client only —
+// e.g. "http://127.0.0.1:11434/v1" for a local Ollama. This is deliberately a
+// parameter rather than the process-wide OPENAI_BASE_URL env, because the
+// OpenAI SDK applies that env to every default client (the LLM parser, metadata
+// reranker, etc.), which would silently redirect chat completions to a backend
+// that has no chat model. An empty baseURL uses the OpenAI default.
+//
+// An empty model falls back to the default (text-embedding-3-large) so a
+// zero-valued config field never produces an empty model name.
+func NewEmbeddingClientWithOptions(apiKey, model, baseURL string) *EmbeddingClient {
+	if model == "" {
+		model = defaultEmbeddingModel
+	}
 	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+	if baseURL != "" {
 		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
 	}
 
 	client := openai.NewClient(clientOptions...)
 	c := &EmbeddingClient{
 		client:         &client,
-		model:          "text-embedding-3-large",
+		model:          model,
 		requestTimeout: defaultRequestTimeout,
 	}
 	c.rawEmbed = c.embedBatchRaw

--- a/internal/ai/embedding_client_test.go
+++ b/internal/ai/embedding_client_test.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 
 package ai
@@ -7,12 +7,38 @@ package ai
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewEmbeddingClientWithOptions_Model verifies the explicit-options
+// constructor pins the requested model and falls back to the default when the
+// model is empty (a zero-valued config field must never yield an empty model).
+func TestNewEmbeddingClientWithOptions_Model(t *testing.T) {
+	c := NewEmbeddingClientWithOptions("k", "bge-m3", "http://127.0.0.1:11434/v1")
+	assert.Equal(t, "bge-m3", c.Model())
+
+	cDefault := NewEmbeddingClientWithOptions("k", "", "")
+	assert.Equal(t, defaultEmbeddingModel, cDefault.Model(), "empty model must fall back to the default")
+}
+
+// TestNewEmbeddingClient_BackwardCompat verifies the legacy constructor keeps
+// the default model and still honors the OPENAI_BASE_URL env (existing setups
+// must not regress). We can't observe the SDK's base URL directly, but we can
+// confirm construction succeeds with the env set and the model is unchanged.
+func TestNewEmbeddingClient_BackwardCompat(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "http://example.invalid/v1")
+	c := NewEmbeddingClient("k")
+	assert.Equal(t, defaultEmbeddingModel, c.Model())
+	// Sanity: the env path is exercised (no panic), and clearing it also works.
+	_ = os.Unsetenv("OPENAI_BASE_URL")
+	c2 := NewEmbeddingClient("k")
+	assert.Equal(t, defaultEmbeddingModel, c2.Model())
+}
 
 func TestBuildEmbeddingText_Book(t *testing.T) {
 	result := BuildEmbeddingText("book", "The Way of Kings", "Brandon Sanderson", "Michael Kramer")

--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -1,5 +1,5 @@
 // file: internal/ai/register.go
-// version: 1.0.0
+// version: 1.1.0
 
 // Service registry registrations for the AI cluster (W4).
 //
@@ -15,6 +15,8 @@
 package ai
 
 import (
+	"os"
+
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/serviceregistry"
@@ -33,7 +35,17 @@ func init() {
 				return (*EmbeddingClient)(nil), nil
 			}
 			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
-			client := NewEmbeddingClient(cfg.OpenAIAPIKey)
+			// Base URL is scoped to the embedding client ONLY (see
+			// NewEmbeddingClientWithOptions): cfg.EmbeddingBaseURL points
+			// embeddings at a local OpenAI-compatible backend (e.g. Ollama)
+			// without touching the LLM / metadata clients. Fall back to the
+			// OPENAI_BASE_URL env when the config field is empty for backward
+			// compatibility with env-based setups.
+			baseURL := cfg.EmbeddingBaseURL
+			if baseURL == "" {
+				baseURL = os.Getenv("OPENAI_BASE_URL")
+			}
+			client := NewEmbeddingClientWithOptions(cfg.OpenAIAPIKey, cfg.EmbeddingModel, baseURL)
 			if embStore != nil {
 				client = client.WithCache(embStore)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.49.0
+// version: 1.50.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-14
 
@@ -169,8 +169,20 @@ type Config struct {
 	ActivityLogCompactionDays      int `json:"activity_log_compaction_days"`       // default 14
 
 	// Embedding-based dedup
-	EmbeddingEnabled         bool    `json:"embedding_enabled"`           // default true
-	EmbeddingModel           string  `json:"embedding_model"`             // default "text-embedding-3-large"
+	EmbeddingEnabled bool   `json:"embedding_enabled"` // default true
+	EmbeddingModel   string `json:"embedding_model"`   // default "text-embedding-3-large"
+	// EmbeddingDimensions is the vector dimension of the configured embedding
+	// model. Must match the model's output: text-embedding-3-large = 3072,
+	// bge-m3 = 1024. Sizes the in-memory chromem ANN store. Default 3072.
+	EmbeddingDimensions int `json:"embedding_dimensions"` // default 3072
+	// EmbeddingBaseURL, when non-empty, points the embedding client at an
+	// OpenAI-compatible endpoint (e.g. a local Ollama at
+	// "http://127.0.0.1:11434/v1") for the EMBEDDING client ONLY. The LLM /
+	// metadata clients are unaffected — this is deliberately a per-client
+	// config field rather than the process-wide OPENAI_BASE_URL env, which the
+	// OpenAI SDK applies to every default client. Empty = OpenAI (or, for
+	// backward compat, the OPENAI_BASE_URL env if set). Default "".
+	EmbeddingBaseURL string `json:"embedding_base_url"` // default ""
 	DedupBookHighThreshold   float64 `json:"dedup_book_high_threshold"`   // default 0.95
 	DedupBookLowThreshold    float64 `json:"dedup_book_low_threshold"`    // default 0.85
 	DedupAuthorHighThreshold float64 `json:"dedup_author_high_threshold"` // default 0.92
@@ -774,6 +786,8 @@ func InitConfig() {
 		// Embedding-based dedup (defaults used unless DB settings override)
 		c.EmbeddingEnabled = true
 		c.EmbeddingModel = "text-embedding-3-large"
+		c.EmbeddingDimensions = 3072
+		c.EmbeddingBaseURL = ""
 		c.DedupBookHighThreshold = 0.95
 		c.DedupBookLowThreshold = 0.85
 		c.DedupAuthorHighThreshold = 0.92
@@ -1099,6 +1113,8 @@ func ResetToDefaults() {
 			// Embedding-based dedup
 			EmbeddingEnabled:                true,
 			EmbeddingModel:                  "text-embedding-3-large",
+			EmbeddingDimensions:             3072,
+			EmbeddingBaseURL:                "",
 			DedupBookHighThreshold:          0.95,
 			DedupBookLowThreshold:           0.85,
 			DedupAuthorHighThreshold:        0.92,

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.28.0
+// version: 1.29.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-14
 
@@ -1566,6 +1566,18 @@ func (de *Engine) EmbedBook(ctx context.Context, bookID string) (EmbedStatus, er
 	return results[bookID], nil
 }
 
+// EmbeddingModel returns the model name the wired embedding client is pinned
+// to (e.g. "text-embedding-3-large" or "bge-m3"), or "" if no client is
+// configured. This is the authoritative target model for the re-embed op:
+// vectors Upserted by EmbedBooks are tagged with exactly this value, so the
+// op can skip books already stored at this model (resumable re-embed).
+func (de *Engine) EmbeddingModel() string {
+	if de.embedClient == nil {
+		return ""
+	}
+	return de.embedClient.Model()
+}
+
 // prepBookEmbed runs the per-book skip-checks and builds the embedding text +
 // hash. Returns terminal=true when a final EmbedStatus has been determined
 // (skip cases or pre-existing cache hit by hash) so the caller can record the
@@ -1695,7 +1707,7 @@ func (de *Engine) EmbedBooks(ctx context.Context, bookIDs []string) (map[string]
 			EntityID:   p.id,
 			TextHash:   p.hash,
 			Vector:     vecs[i],
-			Model:      "text-embedding-3-large",
+			Model:      de.embedClient.Model(),
 		}); upErr != nil {
 			slog.Info("dedup upsert embedding for", "p", p.id, "upErr", upErr)
 			continue
@@ -1772,7 +1784,7 @@ func (de *Engine) EmbedAuthor(ctx context.Context, authorID int) error {
 		EntityID:   entityID,
 		TextHash:   hash,
 		Vector:     vec,
-		Model:      "text-embedding-3-large",
+		Model:      de.embedClient.Model(),
 	}); err != nil {
 		return err
 	}

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_test.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
 // last-edited: 2026-06-14
 
@@ -494,6 +494,50 @@ func TestEngine_FullScan_BatchesEmbeddings(t *testing.T) {
 		if calls[i] != n {
 			t.Fatalf("call %d size=%d, want %d (sizes=%v)", i, calls[i], n, calls)
 		}
+	}
+}
+
+// TestEmbedBooks_RecordsClientModel verifies that EmbedBooks tags the stored
+// entity embedding with the embedding client's ACTUAL model — not a hardcoded
+// "text-embedding-3-large". This is load-bearing for the local-embedding
+// cutover: the re-embed op skips books whose stored Model already equals the
+// target, so a mislabeled model would either re-embed forever or skip wrongly.
+func TestEmbedBooks_RecordsClientModel(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	primary := true
+	book := &database.Book{ID: "BOOK_M", Title: "A Real Audiobook", IsPrimaryVersion: &primary}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_M" {
+			return book, nil
+		}
+		return nil, nil
+	}
+
+	// Client pinned to a non-default model (as the Ollama/bge-m3 path would be).
+	client := ai.NewEmbeddingClientWithOptions("test-key", "bge-m3", "")
+	client.SetRawEmbedForTest(func(ctx context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{0.1, 0.2, 0.3, 0.4}
+		}
+		return out, nil
+	})
+	engine.embedClient = client
+
+	if _, err := engine.EmbedBooks(context.Background(), []string{"BOOK_M"}); err != nil {
+		t.Fatalf("EmbedBooks: %v", err)
+	}
+
+	stored, err := es.Get("book", "BOOK_M")
+	if err != nil {
+		t.Fatalf("Get embedding: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("expected a stored embedding for BOOK_M")
+	}
+	if stored.Model != "bge-m3" {
+		t.Errorf("stored embedding Model = %q, want %q (must reflect the client's model, not a hardcode)", stored.Model, "bge-m3")
 	}
 }
 

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-06-14
 
@@ -56,12 +56,13 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.splitBookScanDef(),
 		p.purgeStaleDef(),
 		p.lshIndexBuildDef(),
-		p.purgeLegacyFPDef(),   // T015: legacy fingerprint purge op
-		p.embReencodeDef(),     // T021: float16+zstd re-encode op
-		p.bookfileSegDropDef(), // T020: drop AcoustID segment fields from stored values
-		p.datasetBackfillDef(), // C4: label + suppress residual pending candidates
-		p.checkBookDef(),       // M4: per-book dedup check via dependency scheduler
-		p.buildISBNIndexDef(),  // T022: ISBN/ASIN secondary index backfill
+		p.purgeLegacyFPDef(),     // T015: legacy fingerprint purge op
+		p.embReencodeDef(),       // T021: float16+zstd re-encode op
+		p.bookfileSegDropDef(),   // T020: drop AcoustID segment fields from stored values
+		p.datasetBackfillDef(),   // C4: label + suppress residual pending candidates
+		p.checkBookDef(),         // M4: per-book dedup check via dependency scheduler
+		p.buildISBNIndexDef(),    // T022: ISBN/ASIN secondary index backfill
+		p.reembedEmbeddingsDef(), // Part B: re-embed corpus when the embedding model changes
 	}
 
 	for _, op := range ops {

--- a/internal/plugins/dedup/reembed_embeddings.go
+++ b/internal/plugins/dedup/reembed_embeddings.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/reembed_embeddings.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d8c7b6a-5e4f-3a2b-1c0d-9e8f7a6b5c4d
 // last-edited: 2026-06-14
 
@@ -50,8 +50,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -171,11 +173,29 @@ func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMes
 			b := &batch[i]
 			totalBooks++
 			existing, getErr := p.embeddingStore.Get("book", b.ID)
-			if getErr == nil && existing != nil && existing.Model == targetModel {
-				current++
-				continue
+			if getErr != nil {
+				reporter.Logger().Warn("reembed-embeddings: get embedding during scan",
+					"book_id", b.ID, "err", getErr)
+				existing = nil
 			}
-			toReembed = append(toReembed, b.ID)
+			switch {
+			case existing != nil && existing.Model == targetModel:
+				// Already at the target model — nothing to do.
+				current++
+			case existing != nil:
+				// Stale-model vector present: must be deleted (and re-embedded if
+				// the book is embeddable). Always include so the wrong-dimension
+				// vector can't survive into chromem on the next hydrate.
+				toReembed = append(toReembed, b.ID)
+			case embeddableForReembed(b):
+				// No embedding yet and the book is embeddable — a model switch
+				// must populate it.
+				toReembed = append(toReembed, b.ID)
+			default:
+				// No embedding and not embeddable (non-primary or near-empty
+				// title): nothing to do. Excluding these lets the candidate count
+				// converge to 0 across re-runs instead of re-selecting them forever.
+			}
 		}
 		if len(batch) < scanBatch {
 			break
@@ -205,9 +225,15 @@ func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMes
 	var embedded, skipped int
 	for start := 0; start < needCount; start += batchSize {
 		if reporter.IsCanceled() {
+			// Emit a canceled (not "complete") message so an operator watching
+			// the progress text isn't misled; the worker independently records
+			// the terminal status as canceled from the run context.
+			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf(
+				"Canceled — %d of %d re-embedded (%d skipped). Re-run to continue.",
+				embedded, needCount, skipped))
 			reporter.Logger().Warn("reembed-embeddings: canceled mid-run; re-run to continue",
-				"embedded_so_far", embedded)
-			break
+				"embedded", embedded, "skipped", skipped, "candidates", needCount)
+			return nil
 		}
 		select {
 		case <-ctx.Done():
@@ -260,4 +286,18 @@ func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMes
 		"embedded", embedded, "skipped", skipped, "candidates", needCount,
 		"target_model", targetModel)
 	return nil
+}
+
+// embeddableForReembed reports whether a book with NO stored embedding is one
+// the engine would actually embed — i.e. worth selecting into the re-embed set.
+// Mirrors the engine's prepBookEmbed skip rules (non-primary versions and
+// near-empty titles produce no embedding) so the op's candidate count converges
+// instead of re-selecting un-embeddable books on every run. Books that already
+// carry a stale-model vector are handled separately (they must be deleted
+// regardless of embeddability) and do not go through this check.
+func embeddableForReembed(b *database.Book) bool {
+	if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+		return false
+	}
+	return len([]rune(strings.TrimSpace(b.Title))) > 2
 }

--- a/internal/plugins/dedup/reembed_embeddings.go
+++ b/internal/plugins/dedup/reembed_embeddings.go
@@ -1,0 +1,263 @@
+// file: internal/plugins/dedup/reembed_embeddings.go
+// version: 1.0.0
+// guid: 9d8c7b6a-5e4f-3a2b-1c0d-9e8f7a6b5c4d
+// last-edited: 2026-06-14
+
+// Package dedup — op dedup.reembed-embeddings.
+//
+// Re-embeds the book corpus when the configured embedding model changes
+// (e.g. switching from OpenAI text-embedding-3-large [3072-dim] to a local
+// Ollama bge-m3 [1024-dim]). A model switch invalidates every stored vector:
+// the dimensions differ and the vector spaces are not comparable, so the old
+// vectors must be replaced before the embedding-based dedup layer is re-enabled.
+//
+// # Why a dedicated op (not just EmbedBooks)
+//
+// EmbedBooks/prepBookEmbed short-circuit on a TextHash cache hit — they do NOT
+// compare the stored vector's model. A book whose title/author text is
+// unchanged would therefore keep its OLD-model vector (wrong dimension) and
+// even mirror it into the in-memory chromem ANN store. This op deletes the
+// stale entity embedding first, forcing a genuine re-embed at the new model.
+//
+// # Resumability
+//
+// Stored entity embeddings are tagged with the model that produced them
+// (EmbedBooks records de.embedClient.Model()). The scan phase skips any book
+// already at the target model, so a re-run after interruption only processes
+// the remainder. ResumePolicy is ResumeRequeue.
+//
+// # Cutover sequence (operational)
+//
+//	1. PUT /config {embedding_model, embedding_dimensions, embedding_base_url,
+//	   dedup_embeddings_enabled:false}   ← Layer 2 OFF during re-embed
+//	2. restart (chromem rebuilds at the new dim; embed client points at backend)
+//	3. POST /operations/v2 {def_id:"dedup.reembed-embeddings"}              # dry-run
+//	4. POST /operations/v2 {def_id:"dedup.reembed-embeddings",params:{apply:true}}
+//	5. restart (hydrate chromem from the fresh vectors) → set dedup_embeddings_enabled:true
+//
+// Usage:
+//
+//	POST /api/v1/operations/v2  {"def_id":"dedup.reembed-embeddings"}                       # dry-run
+//	POST /api/v1/operations/v2  {"def_id":"dedup.reembed-embeddings","params":{"apply":true}}  # execute
+//
+// Scope: books only. Author embeddings are a separate, much smaller set and
+// live in a distinct chromem collection ("author"); re-embedding them is left
+// to a follow-up.
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+const (
+	// defaultReembedBatchSize is the number of books embedded per backend call.
+	// One batch = one /v1/embeddings request; bge-m3 on Ollama handles batched
+	// input arrays. Kept modest so a single failed request loses little work.
+	defaultReembedBatchSize = 64
+	maxReembedBatchSize     = 512
+)
+
+// reembedEmbeddingsParams are the JSON parameters accepted by the op.
+type reembedEmbeddingsParams struct {
+	// Apply, if true, deletes stale vectors and writes fresh ones. Default
+	// false (dry-run) — the op counts what it would re-embed and returns.
+	Apply bool `json:"apply"`
+	// BatchSize overrides the per-request book count (1..maxReembedBatchSize).
+	// Zero uses defaultReembedBatchSize.
+	BatchSize int `json:"batch_size"`
+}
+
+// reembedEmbeddingsDef returns the OperationDef for dedup.reembed-embeddings.
+func (p *Plugin) reembedEmbeddingsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.reembed-embeddings",
+		Plugin:      "dedup",
+		DisplayName: "Re-embed corpus (embedding model change)",
+		Description: "Re-embeds every book whose stored embedding was produced by a " +
+			"different model than the one currently configured. Required after switching " +
+			"embedding models (e.g. OpenAI 3072-dim → local bge-m3 1024-dim) because the " +
+			"vector spaces are incompatible. Dry-run by default (pass apply=true to execute). " +
+			"Resumable — re-running skips books already at the target model.",
+		ResumePolicy:    sdk.ResumeRequeue,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "dedup.reembed-embeddings",
+		Cancellable:     true,
+		Isolate:         false,
+		// Re-embedding the full corpus through a CPU-bound local backend can run
+		// for hours; allow generous headroom. Cancellation + resume cover the
+		// case where it genuinely needs longer.
+		Timeout: 12 * time.Hour,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+		},
+		Run: p.runReembedEmbeddings,
+	}
+}
+
+// runReembedEmbeddings implements the reembed-embeddings op.
+func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return fmt.Errorf("dedup engine not available (embeddings disabled?)")
+	}
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	// The target model is whatever the wired embedding client is pinned to —
+	// the authoritative value EmbedBooks will tag fresh vectors with.
+	targetModel := p.engine.EmbeddingModel()
+	if targetModel == "" {
+		return fmt.Errorf("no embedding client configured (need OpenAIAPIKey + EmbeddingEnabled; " +
+			"for a local backend also set embedding_base_url + embedding_model)")
+	}
+
+	// --- Parse params ---
+	var params reembedEmbeddingsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	batchSize := params.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultReembedBatchSize
+	}
+	if batchSize > maxReembedBatchSize {
+		batchSize = maxReembedBatchSize
+	}
+
+	reporter.Logger().Info("reembed-embeddings start",
+		"target_model", targetModel, "apply", params.Apply, "batch_size", batchSize)
+
+	// --- Phase 1: scan, partition books by stored model ---
+	_ = reporter.UpdateProgress(0, 2, "Scanning books for stale-model embeddings…")
+
+	const scanBatch = 500
+	var (
+		totalBooks int
+		current    int // already at target model
+		toReembed  []string
+	)
+	offset := 0
+	for {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		batch, err := p.store.GetAllBooks(scanBatch, offset)
+		if err != nil {
+			return fmt.Errorf("get all books at offset %d: %w", offset, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for i := range batch {
+			b := &batch[i]
+			totalBooks++
+			existing, getErr := p.embeddingStore.Get("book", b.ID)
+			if getErr == nil && existing != nil && existing.Model == targetModel {
+				current++
+				continue
+			}
+			toReembed = append(toReembed, b.ID)
+		}
+		if len(batch) < scanBatch {
+			break
+		}
+		offset += scanBatch
+	}
+
+	needCount := len(toReembed)
+	summary := fmt.Sprintf("%d books total, %d already at %q, %d need re-embedding",
+		totalBooks, current, targetModel, needCount)
+	reporter.Logger().Info("reembed-embeddings: scan complete",
+		"total_books", totalBooks, "already_current", current,
+		"need_reembed", needCount, "target_model", targetModel)
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(2, 2, fmt.Sprintf(
+			"Dry-run — %d books would be re-embedded with %q (%d already current). Pass apply=true to execute.",
+			needCount, targetModel, current))
+		reporter.Logger().Info("reembed-embeddings: dry-run only; no changes written",
+			"would_reembed", needCount)
+		return nil
+	}
+
+	// --- Phase 2: delete stale vectors + re-embed, in batches ---
+	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Re-embedding %d books with %q…", needCount, targetModel))
+
+	var embedded, skipped int
+	for start := 0; start < needCount; start += batchSize {
+		if reporter.IsCanceled() {
+			reporter.Logger().Warn("reembed-embeddings: canceled mid-run; re-run to continue",
+				"embedded_so_far", embedded)
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		end := start + batchSize
+		if end > needCount {
+			end = needCount
+		}
+		chunk := toReembed[start:end]
+
+		// Delete the stale entity embedding first so prepBookEmbed cannot
+		// TextHash-cache-hit the old-model vector and skip the re-embed.
+		for _, id := range chunk {
+			if err := p.embeddingStore.Delete("book", id); err != nil {
+				reporter.Logger().Warn("reembed-embeddings: delete stale embedding",
+					"book_id", id, "err", err)
+			}
+		}
+
+		results, err := p.engine.EmbedBooks(ctx, chunk)
+		if err != nil {
+			// Whole-batch failure (e.g. backend unreachable). Fail visibly so the
+			// operator fixes the backend and re-runs; already-embedded books are
+			// skipped on the re-run (they now carry the target model).
+			reporter.Logger().Error("reembed-embeddings: embed batch failed",
+				"chunk_start", start, "size", len(chunk), "err", err)
+			return fmt.Errorf("embed batch at offset %d (%d books): %w", start, len(chunk), err)
+		}
+		for _, id := range chunk {
+			if results[id] == dedupengine.EmbedStatusEmbedded {
+				embedded++
+			} else {
+				// Cached (shouldn't happen post-delete), SkippedNonPrimary,
+				// SkippedEmptyTitle, or omitted due to a per-book error.
+				skipped++
+			}
+		}
+
+		_ = reporter.UpdateProgress(1, 2, fmt.Sprintf(
+			"Re-embedded %d/%d (%d embedded, %d skipped)…", end, needCount, embedded, skipped))
+	}
+
+	_ = reporter.UpdateProgress(2, 2, fmt.Sprintf(
+		"Complete — %d embedded, %d skipped of %d candidates (target model %q). %s",
+		embedded, skipped, needCount, targetModel, summary))
+	reporter.Logger().Info("reembed-embeddings: complete",
+		"embedded", embedded, "skipped", skipped, "candidates", needCount,
+		"target_model", targetModel)
+	return nil
+}

--- a/internal/plugins/dedup/reembed_embeddings_test.go
+++ b/internal/plugins/dedup/reembed_embeddings_test.go
@@ -1,0 +1,41 @@
+// file: internal/plugins/dedup/reembed_embeddings_test.go
+// version: 1.0.0
+// guid: 3a2b1c0d-9e8f-7a6b-5c4d-3e2f1a0b9c8d
+// last-edited: 2026-06-14
+
+// Unit tests for the reembed-embeddings op's scan-partition helper.
+
+package dedup
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestEmbeddableForReembed(t *testing.T) {
+	primaryTrue := true
+	primaryFalse := false
+
+	cases := []struct {
+		name string
+		book database.Book
+		want bool
+	}{
+		{"primary nil + good title", database.Book{Title: "A Real Book"}, true},
+		{"primary true + good title", database.Book{Title: "Another Book", IsPrimaryVersion: &primaryTrue}, true},
+		{"non-primary excluded", database.Book{Title: "A Real Book", IsPrimaryVersion: &primaryFalse}, false},
+		{"empty title excluded", database.Book{Title: ""}, false},
+		{"whitespace title excluded", database.Book{Title: "   "}, false},
+		{"2-rune title excluded (matches hasUsableTitle >2)", database.Book{Title: "ab"}, false},
+		{"3-rune title included", database.Book{Title: "abc"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := tc.book
+			if got := embeddableForReembed(&b); got != tc.want {
+				t.Errorf("embeddableForReembed(%+v) = %v, want %v", tc.book, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.9.0
+// version: 1.10.0
 
 package server
 
@@ -81,7 +81,17 @@ func init() {
 				return (*database.ChromemEmbeddingStore)(nil), nil
 			}
 			dir := filepath.Dir(cfg.DatabasePath)
-			store, err := database.NewChromemEmbeddingStore(dir, 3072)
+			// Dimension is config-driven so a local model (e.g. bge-m3 = 1024)
+			// can replace OpenAI text-embedding-3-large (3072). Guard against a
+			// zero value: an upgraded install loads an older config_blob that
+			// predates EmbeddingDimensions (whole-struct replace zeroes it), so
+			// fall back to the historical 3072 default rather than build a
+			// 0-dim store.
+			dims := cfg.EmbeddingDimensions
+			if dims <= 0 {
+				dims = 3072
+			}
+			store, err := database.NewChromemEmbeddingStore(dir, dims)
 			if err != nil {
 				return (*database.ChromemEmbeddingStore)(nil), nil
 			}


### PR DESCRIPTION
## Summary

Lets dedup Layer-2 / entity embeddings run through a local OpenAI-compatible backend (e.g. **Ollama `bge-m3`, 1024-dim**) instead of OpenAI `text-embedding-3-large` (3072-dim), fully config-driven. Default behavior is unchanged (still OpenAI/3072 until configured otherwise).

## Changes

- **Config**: `embedding_dimensions` (default 3072), `embedding_base_url` (default `""`). The base URL is **scoped to the embedding client only** — a process-wide `OPENAI_BASE_URL` env would also redirect the LLM/metadata OpenAI clients (which have no chat model on Ollama) and silently break them.
- **Client**: `ai.NewEmbeddingClientWithOptions(apiKey, model, baseURL)`; `NewEmbeddingClient` delegates with prior env-based behavior for back-compat.
- **chromem store** dimension is now config-driven, guarded `<=0 → 3072` (an upgraded install loads an older `config_blob` that zeroes the new field via whole-struct replace).
- **Bug fix**: `EmbedBooks`/`EmbedAuthor` hardcoded `Model: "text-embedding-3-large"` on every stored vector regardless of the actual model — now records `de.embedClient.Model()`. Added `Engine.EmbeddingModel()`.
- **Op `dedup.reembed-embeddings`** (dry-run default, resumable): re-embeds books whose stored model ≠ the configured model; deletes the stale vector first so a same-text cache hit can't reuse a wrong-dimension vector. Converges (excludes non-embeddable books with no stale vector); clean cancel message.

## Activation (post-merge, separate, gated)

Cutover is operator-driven and dry-run-gated: PUT config (`embedding_model`/`embedding_dimensions`/`embedding_base_url`, Layer-2 off) → restart → `dedup.reembed-embeddings` dry-run → apply → restart (hydrate) → enable Layer-2. Infra (Ollama + bge-m3) is already installed on prod.

## Test plan

- [x] Code review passed all 5 target invariants (base-URL scoping, chromem dim guard, config defaults, model-label fix, re-embed delete-then-embed/resumability/cancel)
- [x] `go build ./...`, `go vet ./...` clean; targeted package tests green
- [x] New unit tests: model-label fix locked; embedding-client option model selection; reembed convergence helper
- [ ] Post-deploy: dry-run `dedup.reembed-embeddings` on prod, checkpoint before the real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)