### PR TITLE
fix(config): wire embedding/dedup/scoring fields through cobra+viper

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.51.0
+// version: 1.52.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-06-14
+// last-edited: 2026-06-15
 
 package config
 
@@ -604,6 +604,32 @@ func InitConfig() {
 	viper.SetDefault("auto_write_tags_on_apply", true)
 	viper.SetDefault("verify_after_write", true)
 
+	// Embedding + vector index defaults
+	viper.SetDefault("embedding_enabled", true)
+	viper.SetDefault("embedding_model", "text-embedding-3-large")
+	viper.SetDefault("embedding_dimensions", 3072)
+	viper.SetDefault("embedding_base_url", "")
+	viper.SetDefault("vector_index_backend", "chromem")
+
+	// Dedup threshold + behaviour defaults
+	viper.SetDefault("dedup_book_high_threshold", 0.95)
+	viper.SetDefault("dedup_book_low_threshold", 0.85)
+	viper.SetDefault("dedup_author_high_threshold", 0.92)
+	viper.SetDefault("dedup_author_low_threshold", 0.80)
+	viper.SetDefault("dedup_auto_merge_enabled", true)
+	viper.SetDefault("dedup_embeddings_enabled", true)           // opt-out: set false on no-internet boxes
+	viper.SetDefault("dedup_llm_auto_merge_high_confidence", false) // opt-in
+	viper.SetDefault("dedup_on_import_via_scheduler", false)        // opt-in — keep eager path until M4 confirmed
+
+	// Metadata candidate scoring defaults
+	viper.SetDefault("metadata_embedding_scoring_enabled", true)
+	viper.SetDefault("metadata_embedding_min_score", 0.50)
+	viper.SetDefault("metadata_embedding_best_match_min", 0.70)
+	viper.SetDefault("metadata_llm_scoring_enabled", false)
+	viper.SetDefault("metadata_llm_rerank_epsilon", 0.01)
+	viper.SetDefault("metadata_llm_rerank_top_k", 5)
+	viper.SetDefault("write_backup_before_tag_write", false)
+
 	// Unified dedup scoring defaults (SPEC 1 §3–4, T011).
 	// These are consumed by internal/dedup/unified.LoadScoreConfig via Viper.
 	// Overridable per-kind in config.yaml under dedup.signals.<kind>.*
@@ -786,31 +812,33 @@ func InitConfig() {
 
 			SupportedExtensions: supportedExtensions,
 			ExcludePatterns:     excludePatterns,
+
+			// Embedding + vector index
+			EmbeddingEnabled:   viper.GetBool("embedding_enabled"),
+			EmbeddingModel:     viper.GetString("embedding_model"),
+			EmbeddingDimensions: viper.GetInt("embedding_dimensions"),
+			EmbeddingBaseURL:   viper.GetString("embedding_base_url"),
+			VectorIndexBackend: viper.GetString("vector_index_backend"),
+
+			// Dedup thresholds + behaviour
+			DedupBookHighThreshold:          viper.GetFloat64("dedup_book_high_threshold"),
+			DedupBookLowThreshold:           viper.GetFloat64("dedup_book_low_threshold"),
+			DedupAuthorHighThreshold:        viper.GetFloat64("dedup_author_high_threshold"),
+			DedupAuthorLowThreshold:         viper.GetFloat64("dedup_author_low_threshold"),
+			DedupAutoMergeEnabled:           viper.GetBool("dedup_auto_merge_enabled"),
+			DedupEmbeddingsEnabled:          viper.GetBool("dedup_embeddings_enabled"),
+			DedupLLMAutoMergeHighConfidence: viper.GetBool("dedup_llm_auto_merge_high_confidence"),
+			DedupOnImportViaScheduler:       viper.GetBool("dedup_on_import_via_scheduler"),
+
+			// Metadata candidate scoring
+			MetadataEmbeddingScoringEnabled: viper.GetBool("metadata_embedding_scoring_enabled"),
+			MetadataEmbeddingMinScore:       viper.GetFloat64("metadata_embedding_min_score"),
+			MetadataEmbeddingBestMatchMin:   viper.GetFloat64("metadata_embedding_best_match_min"),
+			MetadataLLMScoringEnabled:       viper.GetBool("metadata_llm_scoring_enabled"),
+			MetadataLLMRerankEpsilon:        viper.GetFloat64("metadata_llm_rerank_epsilon"),
+			MetadataLLMRerankTopK:           viper.GetInt("metadata_llm_rerank_top_k"),
+			WriteBackupBeforeTagWrite:       viper.GetBool("write_backup_before_tag_write"),
 		}
-
-		// Embedding-based dedup (defaults used unless DB settings override)
-		c.EmbeddingEnabled = true
-		c.EmbeddingModel = "text-embedding-3-large"
-		c.EmbeddingDimensions = 3072
-		c.EmbeddingBaseURL = ""
-		c.VectorIndexBackend = "chromem"
-		c.DedupBookHighThreshold = 0.95
-		c.DedupBookLowThreshold = 0.85
-		c.DedupAuthorHighThreshold = 0.92
-		c.DedupAuthorLowThreshold = 0.80
-		c.DedupAutoMergeEnabled = true
-		c.DedupEmbeddingsEnabled = true           // opt-out: set false on no-internet boxes
-		c.DedupLLMAutoMergeHighConfidence = false // opt-in
-		c.DedupOnImportViaScheduler = false       // opt-in — keep eager path until M4 is confirmed
-
-		// Metadata candidate scoring (defaults used unless DB settings override)
-		c.MetadataEmbeddingScoringEnabled = true
-		c.MetadataEmbeddingMinScore = 0.50
-		c.MetadataEmbeddingBestMatchMin = 0.70
-		c.MetadataLLMScoringEnabled = false
-		c.MetadataLLMRerankEpsilon = 0.01
-		c.MetadataLLMRerankTopK = 5
-		c.WriteBackupBeforeTagWrite = false
 
 		// Default Open Library dump dir to {RootDir}/openlibrary-dumps if not set
 		if c.OpenLibraryDumpDir == "" && c.RootDir != "" {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
-// last-edited: 2026-06-10
+// last-edited: 2026-06-15
 
 package config
 
@@ -818,6 +818,15 @@ func SyncConfigFromEnv() {
 		if viper.IsSet("enable_ai_parsing") {
 			c.EnableAIParsing = viper.GetBool("enable_ai_parsing")
 		}
-		// Add more env overrides as needed
+		if viper.IsSet("embedding_base_url") {
+			if val := viper.GetString("embedding_base_url"); val != "" {
+				c.EmbeddingBaseURL = val
+			}
+		}
+		if viper.IsSet("acoustid_api_key") {
+			if val := viper.GetString("acoustid_api_key"); val != "" {
+				c.AcoustIDAPIKey = val
+			}
+		}
 	})
 }


### PR DESCRIPTION
## Summary
- 21 config fields (embedding, dedup thresholds, metadata scoring) were set as raw Go assignments after the struct literal in `InitConfig`, bypassing viper entirely
- `EMBEDDING_ENABLED`, `EMBEDDING_BASE_URL`, `DEDUP_BOOK_HIGH_THRESHOLD`, and all `METADATA_EMBEDDING_*` / `METADATA_LLM_*` env vars were silently ignored
- These fields also could not be set via `config.yaml`

## Changes
- Add `viper.SetDefault` for all 21 affected fields
- Move post-struct hardcoded assignments into the struct literal as `viper.GetX()` calls, matching the pattern every other field uses
- Add `embedding_base_url` and `acoustid_api_key` to `SyncConfigFromEnv()` so env overrides survive the DB blob load at startup

## Test plan
- [x] `go build ./internal/config/...` — clean
- [x] `go test ./internal/config/...` — all pass (0.378s)
- [ ] Manual: set `EMBEDDING_BASE_URL=http://localhost:11434/v1` and verify it is applied after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)