### PR TITLE
refactor(config): nest embedding fields under EmbeddingConfig sub-struct (W1)

### DIFF
--- a/docs/plans/2026-06-16-config-struct-nesting.md
+++ b/docs/plans/2026-06-16-config-struct-nesting.md
@@ -1,0 +1,886 @@
+<!-- file: docs/plans/2026-06-16-config-struct-nesting.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f2a7c3e8-9b4d-4f1a-8c6e-2d5b0a3f7e9c -->
+<!-- last-edited: 2026-06-16 -->
+
+# Config Struct Nesting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `AppConfig` from 155+ flat fields into logical nested sub-structs, one wave per PR, with startup blob migration and API compatibility shims.
+
+**Architecture:** Each wave defines a new sub-struct type, replaces flat fields in `Config`, migrates old flat blobs to nested format on startup, and shims the update API to accept both old flat keys and new nested keys during the UI transition period. Wave 1 (EmbeddingConfig) is the template — Waves 2–7 follow the identical 6-step pattern with different field names.
+
+**Tech Stack:** Go 1.24, Viper, PebbleDB (config_blob), `encoding/json`, `github.com/spf13/viper`, testify
+
+**Spec:** `docs/specs/2026-06-16-config-struct-nesting-design.md`
+
+---
+
+## Files Modified (all waves)
+
+| File | Role |
+|------|------|
+| `internal/config/config.go` | Sub-struct type definition, `Config` struct, `InitConfig` Mutate block, `ResetToDefaults` |
+| `internal/config/persistence.go` | Blob migration function, `applySetting` case updates, `SyncConfigFromEnv` additions |
+| `internal/config/update_service.go` | Flat-key compat shim called before `json.Unmarshal` |
+| `internal/config/config_test.go` | Tests for `InitConfig` defaults + env var wiring |
+| `internal/config/persistence_test.go` | Migration test + compat shim test |
+| All callsite files (per wave) | Mechanical field path updates: `AppConfig.EmbeddingEnabled` → `AppConfig.Embedding.Enabled` |
+
+Wave 2 also modifies: `internal/dedup/unified/config.go`
+Wave 4 also modifies: `internal/itunes/service/config.go`
+
+---
+
+## WAVE 1 — EmbeddingConfig (5 fields)
+
+Fields moving: `EmbeddingEnabled`, `EmbeddingModel`, `EmbeddingDimensions`, `EmbeddingBaseURL`, `VectorIndexBackend`
+
+### Task W1-1: Create worktree + branch
+
+- [ ] **Create isolated worktree**
+  ```bash
+  git worktree add ../audiobook-organizer-config-embedding -b refactor/config-embedding-struct
+  cd ../audiobook-organizer-config-embedding
+  git status  # must show clean working tree
+  ```
+
+---
+
+### Task W1-2: Write failing tests for migration + compat shim
+
+**Files:**
+- Modify: `internal/config/persistence_test.go`
+
+- [ ] **Add migration test (will fail — function doesn't exist yet)**
+
+Open `internal/config/persistence_test.go` and add at the end of the file:
+
+```go
+func TestMigrateEmbeddingFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"embedding_enabled": true,
+		"embedding_model": "text-embedding-3-large",
+		"embedding_dimensions": 3072,
+		"embedding_base_url": "http://localhost:11434/v1",
+		"vector_index_backend": "hnsw",
+		"root_dir": "/data"
+	}`
+
+	migrated, changed := migrateEmbeddingBlob(flatBlob)
+	require.True(t, changed, "flat blob should be migrated")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+
+	emb, ok := result["embedding"].(map[string]any)
+	require.True(t, ok, "embedding key should exist as object")
+	assert.Equal(t, true, emb["enabled"])
+	assert.Equal(t, "text-embedding-3-large", emb["model"])
+	assert.Equal(t, float64(3072), emb["dimensions"])
+	assert.Equal(t, "http://localhost:11434/v1", emb["base_url"])
+	assert.Equal(t, "hnsw", emb["vector_backend"])
+
+	// flat keys must be gone
+	assert.NotContains(t, result, "embedding_enabled")
+	assert.NotContains(t, result, "embedding_model")
+	assert.NotContains(t, result, "embedding_dimensions")
+	assert.NotContains(t, result, "embedding_base_url")
+	assert.NotContains(t, result, "vector_index_backend")
+
+	// unrelated keys must be preserved
+	assert.Equal(t, "/data", result["root_dir"])
+}
+
+func TestMigrateEmbeddingFields_AlreadyNested(t *testing.T) {
+	nestedBlob := `{"embedding": {"enabled": true, "model": "bge-m3"}, "root_dir": "/data"}`
+	_, changed := migrateEmbeddingBlob(nestedBlob)
+	assert.False(t, changed, "already-nested blob should be a no-op")
+}
+
+func TestMigrateEmbeddingFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateEmbeddingBlob(`{}`)
+	assert.False(t, changed, "empty blob should be a no-op")
+}
+
+func TestRemapEmbeddingKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"embedding_enabled":    true,
+		"embedding_model":      "bge-m3",
+		"embedding_dimensions": float64(1024),
+		"root_dir":             "/data",
+	}
+	result := remapEmbeddingKeys(payload)
+
+	emb, ok := result["embedding"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, emb["enabled"])
+	assert.Equal(t, "bge-m3", emb["model"])
+	assert.Equal(t, float64(1024), emb["dimensions"])
+	assert.Equal(t, "/data", result["root_dir"]) // untouched
+	assert.NotContains(t, result, "embedding_enabled")
+	assert.NotContains(t, result, "embedding_model")
+}
+
+func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
+	// Client sends both flat legacy key AND new nested key — merge, don't overwrite
+	payload := map[string]any{
+		"embedding_enabled": false,
+		"embedding":         map[string]any{"model": "bge-m3"},
+	}
+	result := remapEmbeddingKeys(payload)
+	emb := result["embedding"].(map[string]any)
+	assert.Equal(t, false, emb["enabled"])
+	assert.Equal(t, "bge-m3", emb["model"])
+}
+
+func TestRemapEmbeddingKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapEmbeddingKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+```
+
+- [ ] **Run tests — expect compile failure** (functions not defined yet)
+  ```bash
+  cd ../audiobook-organizer-config-embedding
+  go test ./internal/config/... 2>&1 | head -20
+  ```
+  Expected: `undefined: migrateEmbeddingBlob` and `undefined: remapEmbeddingKeys`
+
+---
+
+### Task W1-3: Write failing test for InitConfig viper wiring
+
+**Files:**
+- Modify: `internal/config/config_test.go`
+
+- [ ] **Add env var wiring tests**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestInitConfig_EmbeddingDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+
+	assert.True(t, snap.Embedding.Enabled)
+	assert.Equal(t, "text-embedding-3-large", snap.Embedding.Model)
+	assert.Equal(t, 3072, snap.Embedding.Dimensions)
+	assert.Equal(t, "", snap.Embedding.BaseURL)
+	assert.Equal(t, "chromem", snap.Embedding.VectorBackend)
+}
+
+func TestInitConfig_EmbeddingFromEnv(t *testing.T) {
+	t.Setenv("EMBEDDING_ENABLED", "false")
+	t.Setenv("EMBEDDING_BASE_URL", "http://localhost:11434/v1")
+	t.Setenv("EMBEDDING_MODEL", "bge-m3")
+	t.Setenv("EMBEDDING_DIMENSIONS", "1024")
+	t.Setenv("VECTOR_INDEX_BACKEND", "hnsw")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+
+	assert.False(t, snap.Embedding.Enabled)
+	assert.Equal(t, "http://localhost:11434/v1", snap.Embedding.BaseURL)
+	assert.Equal(t, "bge-m3", snap.Embedding.Model)
+	assert.Equal(t, 1024, snap.Embedding.Dimensions)
+	assert.Equal(t, "hnsw", snap.Embedding.VectorBackend)
+}
+```
+
+- [ ] **Run — expect compile failure** (`snap.Embedding` undefined)
+  ```bash
+  go test ./internal/config/... 2>&1 | head -10
+  ```
+
+---
+
+### Task W1-4: Define EmbeddingConfig struct + replace flat fields
+
+**Files:**
+- Modify: `internal/config/config.go`
+
+- [ ] **Add EmbeddingConfig type above the Config struct**
+
+Find the line that says `type Config struct {` and insert immediately before it:
+
+```go
+// EmbeddingConfig holds all settings for the local/remote embedding pipeline.
+type EmbeddingConfig struct {
+	Enabled       bool   `json:"enabled"        mapstructure:"enabled"`
+	Model         string `json:"model"          mapstructure:"model"`
+	Dimensions    int    `json:"dimensions"     mapstructure:"dimensions"`
+	BaseURL       string `json:"base_url"       mapstructure:"base_url"`
+	VectorBackend string `json:"vector_backend" mapstructure:"vector_backend"`
+}
+```
+
+- [ ] **Replace the 5 flat fields in Config with the sub-struct**
+
+Inside `type Config struct`, find:
+```go
+EmbeddingEnabled bool   `json:"embedding_enabled"` // default true
+EmbeddingModel   string `json:"embedding_model"`   // default "text-embedding-3-large"
+// EmbeddingDimensions is the vector dimension of the configured embedding
+// ...
+EmbeddingDimensions int `json:"embedding_dimensions"` // default 3072
+// EmbeddingBaseURL, when non-empty, points the embedding client at an
+// ...
+EmbeddingBaseURL string `json:"embedding_base_url"` // default ""
+// VectorIndexBackend selects the in-memory ANN backend for dedup Layer 2:
+// ...
+VectorIndexBackend       string  `json:"vector_index_backend"`        // default "chromem"
+```
+Replace all 5 fields (including any multi-line comments between them) with:
+```go
+// Embedding holds configuration for the embedding pipeline (model, provider, vector backend).
+Embedding EmbeddingConfig `json:"embedding" mapstructure:"embedding"`
+```
+
+- [ ] **Update viper.SetDefault calls in InitConfig**
+
+Find the block:
+```go
+viper.SetDefault("embedding_enabled", true)
+viper.SetDefault("embedding_model", "text-embedding-3-large")
+viper.SetDefault("embedding_dimensions", 3072)
+viper.SetDefault("embedding_base_url", "")
+viper.SetDefault("vector_index_backend", "chromem")
+```
+Replace with:
+```go
+viper.SetDefault("embedding.enabled", true)
+viper.SetDefault("embedding.model", "text-embedding-3-large")
+viper.SetDefault("embedding.dimensions", 3072)
+viper.SetDefault("embedding.base_url", "")
+viper.SetDefault("embedding.vector_backend", "chromem")
+```
+
+- [ ] **Update the Mutate struct literal in InitConfig**
+
+Inside the `*c = Config{...}` literal, find the section that had the flat embedding fields (they were in the post-struct block — already moved to the struct literal in PR #1464). Find:
+```go
+// Embedding + vector index
+EmbeddingEnabled:   viper.GetBool("embedding_enabled"),
+EmbeddingModel:     viper.GetString("embedding_model"),
+EmbeddingDimensions: viper.GetInt("embedding_dimensions"),
+EmbeddingBaseURL:   viper.GetString("embedding_base_url"),
+VectorIndexBackend: viper.GetString("vector_index_backend"),
+```
+Replace with:
+```go
+Embedding: EmbeddingConfig{
+    Enabled:       viper.GetBool("embedding.enabled"),
+    Model:         viper.GetString("embedding.model"),
+    Dimensions:    viper.GetInt("embedding.dimensions"),
+    BaseURL:       viper.GetString("embedding.base_url"),
+    VectorBackend: viper.GetString("embedding.vector_backend"),
+},
+```
+
+- [ ] **Update ResetToDefaults**
+
+Find the 5 flat embedding field lines in `ResetToDefaults` and replace with:
+```go
+Embedding: EmbeddingConfig{
+    Enabled:       true,
+    Model:         "text-embedding-3-large",
+    Dimensions:    3072,
+    BaseURL:       "",
+    VectorBackend: "chromem",
+},
+```
+
+- [ ] **Verify the package compiles (many callsite errors expected)**
+  ```bash
+  go build ./internal/config/... 2>&1
+  ```
+  Expected: compile errors in other packages referencing `AppConfig.EmbeddingEnabled` etc.
+
+---
+
+### Task W1-5: Implement migration function + compat shim
+
+**Files:**
+- Modify: `internal/config/persistence.go`
+- Modify: `internal/config/update_service.go`
+
+- [ ] **Add migrateEmbeddingBlob to persistence.go**
+
+Add after the import block but before any existing functions:
+
+```go
+// migrateEmbeddingBlob rewrites a flat-format config blob to the nested EmbeddingConfig
+// format. Returns the (possibly modified) blob and whether a migration occurred.
+// Safe to call repeatedly: returns (blob, false) if already nested.
+func migrateEmbeddingBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["embedding_enabled"]; !isFlat {
+		return blob, false
+	}
+
+	type flatShape struct {
+		EmbeddingEnabled    bool    `json:"embedding_enabled"`
+		EmbeddingModel      string  `json:"embedding_model"`
+		EmbeddingDimensions int     `json:"embedding_dimensions"`
+		EmbeddingBaseURL    string  `json:"embedding_base_url"`
+		VectorIndexBackend  string  `json:"vector_index_backend"`
+	}
+	var old flatShape
+	json.Unmarshal([]byte(blob), &old) //nolint:errcheck — already parsed above
+
+	raw["embedding"] = map[string]any{
+		"enabled":        old.EmbeddingEnabled,
+		"model":          old.EmbeddingModel,
+		"dimensions":     old.EmbeddingDimensions,
+		"base_url":       old.EmbeddingBaseURL,
+		"vector_backend": old.VectorIndexBackend,
+	}
+	delete(raw, "embedding_enabled")
+	delete(raw, "embedding_model")
+	delete(raw, "embedding_dimensions")
+	delete(raw, "embedding_base_url")
+	delete(raw, "vector_index_backend")
+
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+```
+
+- [ ] **Call migrateEmbeddingBlob inside LoadConfigFromDatabase**
+
+In `LoadConfigFromDatabase`, find the line that reads the blob value and does `json.Unmarshal`. Add the migration call immediately after reading the blob string, before unmarshal:
+
+```go
+// After reading blob.Value:
+blobStr := blob.Value
+if migrated, changed := migrateEmbeddingBlob(blobStr); changed {
+    slog.Info("config: migrated embedding fields to nested format")
+    blobStr = migrated
+    // Write migrated blob back immediately so next startup skips migration
+    if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+        slog.Warn("config: failed to persist migrated blob", "err", saveErr)
+    }
+}
+// Use blobStr (not blob.Value) for json.Unmarshal below
+```
+
+You also need a `saveRawBlob` helper (add near `SaveConfigToDatabase`):
+
+```go
+// saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
+// Used only by startup migration to persist migrated blobs without re-marshaling.
+func saveRawBlob(store database.SettingsStore, rawJSON string) error {
+	return store.Set(database.Setting{
+		Key:   "config_blob",
+		Value: rawJSON,
+	})
+}
+```
+
+- [ ] **Update SyncConfigFromEnv in persistence.go**
+
+Find the block added in PR #1464:
+```go
+if viper.IsSet("embedding_base_url") {
+    if val := viper.GetString("embedding_base_url"); val != "" {
+        c.Embedding.BaseURL = val
+    }
+}
+```
+Update to use the new viper key:
+```go
+if viper.IsSet("embedding.base_url") {
+    if val := viper.GetString("embedding.base_url"); val != "" {
+        c.Embedding.BaseURL = val
+    }
+}
+```
+(The env var `EMBEDDING_BASE_URL` still works — viper maps `embedding.base_url` → `EMBEDDING_BASE_URL` automatically via `AutomaticEnv`.)
+
+- [ ] **Update applySetting cases for the 5 moved fields**
+
+In `persistence.go`, in the `applySetting` switch, find and update:
+```go
+// Before:
+case "embedding_enabled":
+    if b, err := strconv.ParseBool(value); err == nil {
+        c.EmbeddingEnabled = b
+    }
+case "embedding_model":
+    c.EmbeddingModel = value
+// (and embedding_dimensions, embedding_base_url, vector_index_backend)
+```
+Update each to write to the nested path:
+```go
+case "embedding_enabled":
+    if b, err := strconv.ParseBool(value); err == nil {
+        c.Embedding.Enabled = b
+    }
+case "embedding_model":
+    c.Embedding.Model = value
+case "embedding_dimensions":
+    if n, err := strconv.Atoi(value); err == nil {
+        c.Embedding.Dimensions = n
+    }
+case "embedding_base_url":
+    c.Embedding.BaseURL = value
+case "vector_index_backend":
+    c.Embedding.VectorBackend = value
+```
+
+- [ ] **Add remapEmbeddingKeys to update_service.go**
+
+Add before the `UpdateConfig` function:
+
+```go
+// remapEmbeddingKeys translates legacy flat embedding keys in a config update
+// payload to the nested EmbeddingConfig format. Merges into any existing
+// "embedding" sub-object to avoid zeroing sibling fields.
+// Remove this shim once the frontend sends nested keys.
+func remapEmbeddingKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"embedding_enabled":    "enabled",
+		"embedding_model":      "model",
+		"embedding_dimensions": "dimensions",
+		"embedding_base_url":   "base_url",
+		"vector_index_backend": "vector_backend",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["embedding"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["embedding"] = nested
+	}
+	return payload
+}
+```
+
+- [ ] **Call remapEmbeddingKeys inside UpdateConfig**
+
+In `update_service.go`, in `UpdateConfig`, find the line that builds `filtered` (the cleaned payload map) before the JSON round-trip. Add the remap call immediately after building `filtered`:
+
+```go
+filtered = remapEmbeddingKeys(filtered)
+```
+
+- [ ] **Run tests — all new tests should now pass**
+  ```bash
+  go test ./internal/config/... -run "TestMigrateEmbedding|TestRemapEmbedding|TestInitConfig_Embedding" -v
+  ```
+  Expected: all 8 new tests PASS
+
+---
+
+### Task W1-6: Update all callsites
+
+**Files:**
+- All files that reference `AppConfig.EmbeddingEnabled`, `AppConfig.EmbeddingModel`, `AppConfig.EmbeddingDimensions`, `AppConfig.EmbeddingBaseURL`, `AppConfig.VectorIndexBackend` (and any `cfg.EmbeddingXxx` where `cfg` is a `*Config`)
+
+- [ ] **Find all callsites**
+  ```bash
+  grep -rn "\.EmbeddingEnabled\|\.EmbeddingModel\|\.EmbeddingDimensions\|\.EmbeddingBaseURL\|\.VectorIndexBackend" \
+    --include="*.go" . | grep -v "_test.go" | grep -v "worktrees/"
+  ```
+
+- [ ] **Apply mechanical renames** (one sed per field):
+  ```bash
+  find . -name "*.go" -not -path "./.worktrees/*" -not -path "./docs/*" | xargs sed -i '' \
+    -e 's/\.EmbeddingEnabled/.Embedding.Enabled/g' \
+    -e 's/\.EmbeddingModel/.Embedding.Model/g' \
+    -e 's/\.EmbeddingDimensions/.Embedding.Dimensions/g' \
+    -e 's/\.EmbeddingBaseURL/.Embedding.BaseURL/g' \
+    -e 's/\.VectorIndexBackend/.Embedding.VectorBackend/g'
+  ```
+
+- [ ] **Verify clean build**
+  ```bash
+  go build ./... 2>&1
+  ```
+  Expected: no errors
+
+- [ ] **Run full config test suite**
+  ```bash
+  go test ./internal/config/... -v 2>&1 | tail -20
+  ```
+  Expected: all tests pass
+
+- [ ] **Run full backend test suite**
+  ```bash
+  make test 2>&1 | tail -10
+  ```
+  Expected: PASS
+
+---
+
+### Task W1-7: Update file headers + commit + PR
+
+**Files:**
+- Modify: `internal/config/config.go` (header)
+- Modify: `internal/config/persistence.go` (header)
+- Modify: `internal/config/update_service.go` (header)
+
+- [ ] **Bump version headers** on all 3 modified files (increment minor version, update last-edited to today)
+
+- [ ] **Commit**
+  ```bash
+  git add -u
+  git commit -m "refactor(config): nest embedding fields into EmbeddingConfig sub-struct
+
+  Moves EmbeddingEnabled, EmbeddingModel, EmbeddingDimensions,
+  EmbeddingBaseURL, VectorIndexBackend into a nested EmbeddingConfig
+  sub-struct at AppConfig.Embedding.
+
+  - Startup migration rewrites old flat blobs to nested format on first boot
+  - API compat shim maps legacy flat PUT /config keys to nested paths
+  - applySetting updated for pre-blob legacy installs
+  - Env vars unchanged: EMBEDDING_ENABLED, EMBEDDING_BASE_URL etc. still work
+    (viper maps embedding.enabled -> EMBEDDING_ENABLED automatically)
+
+  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+  ```
+
+- [ ] **Push + open PR**
+  ```bash
+  git push -u origin HEAD
+  gh pr create --title "refactor(config): nest embedding fields into EmbeddingConfig sub-struct" \
+    --body "See docs/specs/2026-06-16-config-struct-nesting-design.md — Wave 1 of 7."
+  ```
+
+- [ ] **Admin-merge + deploy**
+  ```bash
+  gh pr merge <number> --rebase --admin --delete-branch
+  # In primary checkout:
+  git checkout main && git pull --ff-only origin main
+  make deploy
+  ```
+
+---
+
+## WAVE 2 — DedupConfig (9 fields + ScoreConfig absorption)
+
+Same 6-step pattern as Wave 1. Field map:
+
+### Sub-struct definitions
+
+```go
+type DedupSignalConfig struct {
+	BandCertainMin  float64 `json:"band_certain_min"  mapstructure:"band_certain_min"`
+	BandHighMin     float64 `json:"band_high_min"     mapstructure:"band_high_min"`
+	BandMediumMin   float64 `json:"band_medium_min"   mapstructure:"band_medium_min"`
+	BandReviewMin   float64 `json:"band_review_min"   mapstructure:"band_review_min"`
+	DurationBoost   float64 `json:"duration_boost"    mapstructure:"duration_boost"`
+	FolderPathBoost float64 `json:"folder_path_boost" mapstructure:"folder_path_boost"`
+}
+
+type DedupConfig struct {
+	BookHighThreshold          float64          `json:"book_high_threshold"            mapstructure:"book_high_threshold"`
+	BookLowThreshold           float64          `json:"book_low_threshold"             mapstructure:"book_low_threshold"`
+	AuthorHighThreshold        float64          `json:"author_high_threshold"          mapstructure:"author_high_threshold"`
+	AuthorLowThreshold         float64          `json:"author_low_threshold"           mapstructure:"author_low_threshold"`
+	AutoMergeEnabled           bool             `json:"auto_merge_enabled"             mapstructure:"auto_merge_enabled"`
+	EmbeddingsEnabled          bool             `json:"embeddings_enabled"             mapstructure:"embeddings_enabled"`
+	LLMAutoMergeHighConfidence bool             `json:"llm_auto_merge_high_confidence" mapstructure:"llm_auto_merge_high_confidence"`
+	OnImportViaScheduler       bool             `json:"on_import_via_scheduler"        mapstructure:"on_import_via_scheduler"`
+	ReviewModel                string           `json:"review_model"                   mapstructure:"review_model"`
+	Signals                    DedupSignalConfig `json:"signals"                       mapstructure:"signals"`
+}
+// On Config:
+Dedup DedupConfig `json:"dedup" mapstructure:"dedup"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path | Old viper key | New viper key |
+|---|---|---|---|
+| `DedupBookHighThreshold` | `Dedup.BookHighThreshold` | `dedup_book_high_threshold` | `dedup.book_high_threshold` |
+| `DedupBookLowThreshold` | `Dedup.BookLowThreshold` | `dedup_book_low_threshold` | `dedup.book_low_threshold` |
+| `DedupAuthorHighThreshold` | `Dedup.AuthorHighThreshold` | `dedup_author_high_threshold` | `dedup.author_high_threshold` |
+| `DedupAuthorLowThreshold` | `Dedup.AuthorLowThreshold` | `dedup_author_low_threshold` | `dedup.author_low_threshold` |
+| `DedupAutoMergeEnabled` | `Dedup.AutoMergeEnabled` | `dedup_auto_merge_enabled` | `dedup.auto_merge_enabled` |
+| `DedupEmbeddingsEnabled` | `Dedup.EmbeddingsEnabled` | `dedup_embeddings_enabled` | `dedup.embeddings_enabled` |
+| `DedupLLMAutoMergeHighConfidence` | `Dedup.LLMAutoMergeHighConfidence` | `dedup_llm_auto_merge_high_confidence` | `dedup.llm_auto_merge_high_confidence` |
+| `DedupOnImportViaScheduler` | `Dedup.OnImportViaScheduler` | `dedup_on_import_via_scheduler` | `dedup.on_import_via_scheduler` |
+| `DedupReviewModel` | `Dedup.ReviewModel` | `dedup_review_model` | `dedup.review_model` |
+
+### Signal fields absorbed from Viper-only ScoreConfig
+
+| Old viper key | New viper key | `DedupSignalConfig` field |
+|---|---|---|
+| `dedup.signals.band_certain_min` | `dedup.signals.band_certain_min` | `BandCertainMin` |
+| `dedup.signals.band_high_min` | `dedup.signals.band_high_min` | `BandHighMin` |
+| `dedup.signals.band_medium_min` | `dedup.signals.band_medium_min` | `BandMediumMin` |
+| `dedup.signals.band_review_min` | `dedup.signals.band_review_min` | `BandReviewMin` |
+| `dedup.signals.duration.boost` | `dedup.signals.duration_boost` | `DurationBoost` |
+| `dedup.signals.folder_path.boost` | `dedup.signals.folder_path_boost` | `FolderPathBoost` |
+
+**Extra step for Wave 2:** After absorbing signals into `AppConfig.Dedup.Signals`, update `internal/dedup/unified/config.go` — `LoadScoreConfig()` should read from `config.AppConfig.Dedup.Signals` instead of `viper.Get("dedup.signals.*")`. The `ScoreConfig` struct in that file can then be reduced to a thin wrapper or removed if no longer needed.
+
+Blob migration sentinel: check for `"dedup_book_high_threshold"` at top level.
+Compat shim flat keys: all `dedup_*` keys listed in the table above.
+
+---
+
+## WAVE 3 — MetadataScoringConfig (7 fields)
+
+### Sub-struct definition
+
+```go
+type MetadataScoringConfig struct {
+	EmbeddingEnabled   bool    `json:"embedding_enabled"    mapstructure:"embedding_enabled"`
+	EmbeddingMinScore  float64 `json:"embedding_min_score"  mapstructure:"embedding_min_score"`
+	EmbeddingBestMatch float64 `json:"embedding_best_match" mapstructure:"embedding_best_match"`
+	LLMEnabled         bool    `json:"llm_enabled"          mapstructure:"llm_enabled"`
+	LLMRerankEpsilon   float64 `json:"llm_rerank_epsilon"   mapstructure:"llm_rerank_epsilon"`
+	LLMRerankTopK      int     `json:"llm_rerank_top_k"     mapstructure:"llm_rerank_top_k"`
+	WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
+}
+// On Config:
+MetadataScoring MetadataScoringConfig `json:"metadata_scoring" mapstructure:"metadata_scoring"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path | Old viper key | New viper key |
+|---|---|---|---|
+| `MetadataEmbeddingScoringEnabled` | `MetadataScoring.EmbeddingEnabled` | `metadata_embedding_scoring_enabled` | `metadata_scoring.embedding_enabled` |
+| `MetadataEmbeddingMinScore` | `MetadataScoring.EmbeddingMinScore` | `metadata_embedding_min_score` | `metadata_scoring.embedding_min_score` |
+| `MetadataEmbeddingBestMatchMin` | `MetadataScoring.EmbeddingBestMatch` | `metadata_embedding_best_match_min` | `metadata_scoring.embedding_best_match` |
+| `MetadataLLMScoringEnabled` | `MetadataScoring.LLMEnabled` | `metadata_llm_scoring_enabled` | `metadata_scoring.llm_enabled` |
+| `MetadataLLMRerankEpsilon` | `MetadataScoring.LLMRerankEpsilon` | `metadata_llm_rerank_epsilon` | `metadata_scoring.llm_rerank_epsilon` |
+| `MetadataLLMRerankTopK` | `MetadataScoring.LLMRerankTopK` | `metadata_llm_rerank_top_k` | `metadata_scoring.llm_rerank_top_k` |
+| `WriteBackupBeforeTagWrite` | `MetadataScoring.WriteBackupBefore` | `write_backup_before_tag_write` | `metadata_scoring.write_backup_before` |
+
+Blob migration sentinel: check for `"metadata_embedding_scoring_enabled"` at top level.
+
+---
+
+## WAVE 4 — ITunesConfig (10 fields)
+
+### Sub-struct definition
+
+```go
+type ITunesConfig struct {
+	SyncEnabled      bool            `json:"sync_enabled"       mapstructure:"sync_enabled"`
+	SyncInterval     int             `json:"sync_interval"      mapstructure:"sync_interval"`
+	WriteBackEnabled bool            `json:"write_back_enabled" mapstructure:"write_back_enabled"`
+	LibraryWritePath string          `json:"library_write_path" mapstructure:"library_write_path"`
+	LibraryReadPath  string          `json:"library_read_path"  mapstructure:"library_read_path"`
+	AutoWriteBack    bool            `json:"auto_write_back"    mapstructure:"auto_write_back"`
+	PathTrimEnabled  bool            `json:"path_trim_enabled"  mapstructure:"path_trim_enabled"`
+	WindowsRootPath  string          `json:"windows_root_path"  mapstructure:"windows_root_path"`
+	MediaRoot        string          `json:"media_root"         mapstructure:"media_root"`
+	PathMappings     []ITunesPathMap `json:"path_mappings"      mapstructure:"path_mappings"`
+}
+// On Config:
+ITunes ITunesConfig `json:"itunes" mapstructure:"itunes"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path | Old viper key | New viper key |
+|---|---|---|---|
+| `ITunesSyncEnabled` | `ITunes.SyncEnabled` | `itunes_sync_enabled` | `itunes.sync_enabled` |
+| `ITunesSyncInterval` | `ITunes.SyncInterval` | `itunes_sync_interval` | `itunes.sync_interval` |
+| `ITLWriteBackEnabled` | `ITunes.WriteBackEnabled` | `itl_write_back_enabled` | `itunes.write_back_enabled` |
+| `ITunesLibraryWritePath` | `ITunes.LibraryWritePath` | `itunes_library_write_path` | `itunes.library_write_path` |
+| `ITunesLibraryReadPath` | `ITunes.LibraryReadPath` | `itunes_library_read_path` | `itunes.library_read_path` |
+| `ITunesAutoWriteBack` | `ITunes.AutoWriteBack` | `itunes_auto_write_back` | `itunes.auto_write_back` |
+| `ITunesPathTrimEnabled` | `ITunes.PathTrimEnabled` | `itunes_path_trim_enabled` | `itunes.path_trim_enabled` |
+| `ITunesWindowsRootPath` | `ITunes.WindowsRootPath` | `itunes_windows_root_path` | `itunes.windows_root_path` |
+| `ITunesMediaRoot` | `ITunes.MediaRoot` | `itunes_media_root` | `itunes.media_root` |
+| `ITunesPathMappings` | `ITunes.PathMappings` | `itunes_path_mappings` | `itunes.path_mappings` |
+
+Blob migration sentinel: check for `"itunes_sync_enabled"` at top level.
+
+**Extra step for Wave 4:** Update `internal/itunes/service/config.go` — the local `Config` slice struct is now redundant. Simplify service construction to take `config.ITunesConfig` directly, or just embed `config.AppConfig.ITunes` at construction time.
+
+---
+
+## WAVE 5 — MaintenanceConfig (17 fields)
+
+### Sub-struct definition
+
+```go
+type MaintenanceConfig struct {
+	Enabled              bool `json:"enabled"                mapstructure:"enabled"`
+	WindowStart          int  `json:"window_start"           mapstructure:"window_start"`
+	WindowEnd            int  `json:"window_end"             mapstructure:"window_end"`
+	DedupRefresh         bool `json:"dedup_refresh"          mapstructure:"dedup_refresh"`
+	SeriesPrune          bool `json:"series_prune"           mapstructure:"series_prune"`
+	AuthorSplit          bool `json:"author_split"           mapstructure:"author_split"`
+	TombstoneCleanup     bool `json:"tombstone_cleanup"      mapstructure:"tombstone_cleanup"`
+	Reconcile            bool `json:"reconcile"              mapstructure:"reconcile"`
+	PurgeDeleted         bool `json:"purge_deleted"          mapstructure:"purge_deleted"`
+	PurgeOldLogs         bool `json:"purge_old_logs"         mapstructure:"purge_old_logs"`
+	DbOptimize           bool `json:"db_optimize"            mapstructure:"db_optimize"`
+	LibraryScan          bool `json:"library_scan"           mapstructure:"library_scan"`
+	LibraryOrganize      bool `json:"library_organize"       mapstructure:"library_organize"`
+	MetadataRefresh      bool `json:"metadata_refresh"       mapstructure:"metadata_refresh"`
+	LibrarySizeRefresh   bool `json:"library_size_refresh"   mapstructure:"library_size_refresh"`
+	AcoustIDOnlineLookup bool `json:"acoustid_online_lookup" mapstructure:"acoustid_online_lookup"`
+	AcoustIDNightlyLimit int  `json:"acoustid_nightly_limit" mapstructure:"acoustid_nightly_limit"`
+}
+// On Config:
+Maintenance MaintenanceConfig `json:"maintenance" mapstructure:"maintenance"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path | Old viper key | New viper key |
+|---|---|---|---|
+| `MaintenanceWindowEnabled` | `Maintenance.Enabled` | `maintenance_window_enabled` | `maintenance.enabled` |
+| `MaintenanceWindowStart` | `Maintenance.WindowStart` | `maintenance_window_start` | `maintenance.window_start` |
+| `MaintenanceWindowEnd` | `Maintenance.WindowEnd` | `maintenance_window_end` | `maintenance.window_end` |
+| `MaintenanceWindowDedupRefresh` | `Maintenance.DedupRefresh` | `maintenance_window_dedup_refresh` | `maintenance.dedup_refresh` |
+| `MaintenanceWindowSeriesPrune` | `Maintenance.SeriesPrune` | `maintenance_window_series_prune` | `maintenance.series_prune` |
+| `MaintenanceWindowAuthorSplit` | `Maintenance.AuthorSplit` | `maintenance_window_author_split` | `maintenance.author_split` |
+| `MaintenanceWindowTombstoneCleanup` | `Maintenance.TombstoneCleanup` | `maintenance_window_tombstone_cleanup` | `maintenance.tombstone_cleanup` |
+| `MaintenanceWindowReconcile` | `Maintenance.Reconcile` | `maintenance_window_reconcile` | `maintenance.reconcile` |
+| `MaintenanceWindowPurgeDeleted` | `Maintenance.PurgeDeleted` | `maintenance_window_purge_deleted` | `maintenance.purge_deleted` |
+| `MaintenanceWindowPurgeOldLogs` | `Maintenance.PurgeOldLogs` | `maintenance_window_purge_old_logs` | `maintenance.purge_old_logs` |
+| `MaintenanceWindowDbOptimize` | `Maintenance.DbOptimize` | `maintenance_window_db_optimize` | `maintenance.db_optimize` |
+| `MaintenanceWindowLibraryScan` | `Maintenance.LibraryScan` | `maintenance_window_library_scan` | `maintenance.library_scan` |
+| `MaintenanceWindowLibraryOrganize` | `Maintenance.LibraryOrganize` | `maintenance_window_library_organize` | `maintenance.library_organize` |
+| `MaintenanceWindowMetadataRefresh` | `Maintenance.MetadataRefresh` | `maintenance_window_metadata_refresh` | `maintenance.metadata_refresh` |
+| `MaintenanceWindowLibrarySizeRefresh` | `Maintenance.LibrarySizeRefresh` | `maintenance_window_library_size_refresh` | `maintenance.library_size_refresh` |
+| `MaintenanceWindowAcoustIDOnlineLookup` | `Maintenance.AcoustIDOnlineLookup` | `maintenance_window_acoustid_online_lookup` | `maintenance.acoustid_online_lookup` |
+| `AcoustIDOnlineLookupNightlyLimit` | `Maintenance.AcoustIDNightlyLimit` | `acoustid_online_lookup_nightly_limit` | `maintenance.acoustid_nightly_limit` |
+
+Blob migration sentinel: check for `"maintenance_window_enabled"` at top level.
+
+---
+
+## WAVE 6 — ScheduledTasksConfig (~15 fields)
+
+### Sub-struct definition
+
+```go
+type ScheduledTaskConfig struct {
+	Enabled   bool `json:"enabled"    mapstructure:"enabled"`
+	Interval  int  `json:"interval"   mapstructure:"interval"`
+	OnStartup bool `json:"on_startup" mapstructure:"on_startup"`
+}
+
+type ScheduledTasksConfig struct {
+	DedupRefresh    ScheduledTaskConfig `json:"dedup_refresh"    mapstructure:"dedup_refresh"`
+	AuthorSplit      ScheduledTaskConfig `json:"author_split"     mapstructure:"author_split"`
+	DbOptimize       ScheduledTaskConfig `json:"db_optimize"      mapstructure:"db_optimize"`
+	MetadataRefresh  ScheduledTaskConfig `json:"metadata_refresh" mapstructure:"metadata_refresh"`
+	AIDedupBatch     ScheduledTaskConfig `json:"ai_dedup_batch"   mapstructure:"ai_dedup_batch"`
+}
+// On Config:
+Scheduled ScheduledTasksConfig `json:"scheduled" mapstructure:"scheduled"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path |
+|---|---|
+| `ScheduledDedupRefreshEnabled` | `Scheduled.DedupRefresh.Enabled` |
+| `ScheduledDedupRefreshInterval` | `Scheduled.DedupRefresh.Interval` |
+| `ScheduledDedupRefreshOnStartup` | `Scheduled.DedupRefresh.OnStartup` |
+| `ScheduledAuthorSplitEnabled` | `Scheduled.AuthorSplit.Enabled` |
+| `ScheduledAuthorSplitInterval` | `Scheduled.AuthorSplit.Interval` |
+| `ScheduledAuthorSplitOnStartup` | `Scheduled.AuthorSplit.OnStartup` |
+| `ScheduledDbOptimizeEnabled` | `Scheduled.DbOptimize.Enabled` |
+| `ScheduledDbOptimizeInterval` | `Scheduled.DbOptimize.Interval` |
+| `ScheduledDbOptimizeOnStartup` | `Scheduled.DbOptimize.OnStartup` |
+| `ScheduledMetadataRefreshEnabled` | `Scheduled.MetadataRefresh.Enabled` |
+| `ScheduledMetadataRefreshInterval` | `Scheduled.MetadataRefresh.Interval` |
+| `ScheduledMetadataRefreshOnStartup` | `Scheduled.MetadataRefresh.OnStartup` |
+| `ScheduledAIDedupBatchEnabled` | `Scheduled.AIDedupBatch.Enabled` |
+| `ScheduledAIDedupBatchInterval` | `Scheduled.AIDedupBatch.Interval` |
+| `ScheduledAIDedupBatchOnStartup` | `Scheduled.AIDedupBatch.OnStartup` |
+
+**Before implementing:** run `grep -n "Scheduled" internal/config/config.go` to get the definitive list of all scheduled task fields — there may be more than the 5 task groups listed here.
+
+Blob migration sentinel: check for `"scheduled_dedup_refresh_enabled"` at top level.
+
+---
+
+## WAVE 7 — AutoUpdateConfig (5 fields)
+
+### Sub-struct definition
+
+```go
+type AutoUpdateConfig struct {
+	Enabled      bool   `json:"enabled"       mapstructure:"enabled"`
+	Channel      string `json:"channel"       mapstructure:"channel"`
+	CheckMinutes int    `json:"check_minutes" mapstructure:"check_minutes"`
+	WindowStart  int    `json:"window_start"  mapstructure:"window_start"`
+	WindowEnd    int    `json:"window_end"    mapstructure:"window_end"`
+}
+// On Config:
+AutoUpdate AutoUpdateConfig `json:"auto_update" mapstructure:"auto_update"`
+```
+
+### Flat → nested field map
+
+| Old flat field | New path | Old viper key | New viper key |
+|---|---|---|---|
+| `AutoUpdateEnabled` | `AutoUpdate.Enabled` | `auto_update_enabled` | `auto_update.enabled` |
+| `AutoUpdateChannel` | `AutoUpdate.Channel` | `auto_update_channel` | `auto_update.channel` |
+| `AutoUpdateCheckMinutes` | `AutoUpdate.CheckMinutes` | `auto_update_check_minutes` | `auto_update.check_minutes` |
+| `AutoUpdateWindowStart` | `AutoUpdate.WindowStart` | `auto_update_window_start` | `auto_update.window_start` |
+| `AutoUpdateWindowEnd` | `AutoUpdate.WindowEnd` | `auto_update_window_end` | `auto_update.window_end` |
+
+Blob migration sentinel: check for `"auto_update_enabled"` at top level.
+
+---
+
+## WAVE 8 — ToolConfig (deferred)
+
+Implement as part of TOOL-1..6 work. See `docs/research/2026-06-15-config-architecture-evaluation.md` Finding 10 and `TODO.md` TOOL-1 for scope. Branch name suggestion: `refactor/config-tool-struct`.
+
+---
+
+## Cross-Wave Notes
+
+**Testing command for any wave:**
+```bash
+go test ./internal/config/... -v
+make test
+```
+
+**Verifying env vars still work after a wave:**
+```bash
+EMBEDDING_ENABLED=false go run ./cmd/... serve --db /tmp/test.pebble &
+curl -s http://localhost:8080/api/v1/config | jq '.embedding.enabled'
+# Expected: false
+```
+
+**Verifying migration ran on startup:**
+```bash
+grep "migrated.*nested" /var/log/audiobook-organizer.log
+```
+
+**Verifying compat shim works (PUT with flat keys):**
+```bash
+curl -X PUT http://localhost:8080/api/v1/config \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"embedding_enabled": false}'
+curl http://localhost:8080/api/v1/config | jq '.embedding.enabled'
+# Expected: false
+```

--- a/docs/research/2026-06-15-config-architecture-evaluation.md
+++ b/docs/research/2026-06-15-config-architecture-evaluation.md
@@ -1,0 +1,390 @@
+<!-- file: docs/research/2026-06-15-config-architecture-evaluation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c7f3a821-94e0-4b2d-b8e1-3d5f8ac22019 -->
+<!-- last-edited: 2026-06-15 -->
+
+# Config Architecture Evaluation — AppConfig / ToolConfig / Nested Structs
+
+**Date:** 2026-06-15
+**Status:** Research complete — pending design decision
+**Method:** 3-agent parallel read-only investigation (go-specialist × 2, expert × 1)
+**Next step:** CFG-1 decision doc at `docs/specs/config-architecture-decision.md`
+
+---
+
+## Executive Summary
+
+`AppConfig` (type `Config` in `internal/config/config.go`) has grown to **155+ flat fields** with no structural plan and is now showing classic God-Object symptoms:
+
+- Contributors are **escaping the struct** (dedup scoring lives in a parallel Viper-only system)
+- **40% of fields have no frontend representation** (Settings UI type is hand-curated and lagging)
+- **`internal/config` is not a leaf package** — it imports `internal/database` and `internal/serviceregistry`, coupling config to the domain layer
+- **`mapstructure` tags on 4 of 155+ fields** — `viper.Unmarshal` is silently broken for almost everything
+- **18+ production env vars bypass `AppConfig` entirely** via `os.Getenv`
+- **1,434 direct field access sites**, most without the read lock, despite the struct being mutable at runtime
+
+The right action is a **phased restructuring** — not a big-bang rewrite. Three changes deliver most of the value with manageable blast radius.
+
+---
+
+## Current State
+
+### The `Config` struct (`internal/config/config.go`)
+
+| Group | Field count | Example fields |
+|---|---|---|
+| Core paths | 6 | `RootDir`, `DatabasePath`, `DatabaseType` |
+| Library organization | 8 | `OrganizationStrategy`, `FolderNamingPattern`, `AutoOrganize` |
+| Storage quotas | 4 | `EnableDiskQuota`, `DiskQuotaPercent` |
+| Metadata sources | 10 | `AutoFetchMetadata`, `MetadataSources`, `Language` |
+| AI / LLM | 8 | `OpenAIAPIKey`, `DedupReviewModel`, `MetadataReviewModel` |
+| Performance | 9 | `ConcurrentScans`, `MinBookSizeBytes`, `LogRetentionDays` |
+| Embedding / dedup | 13 | `EmbeddingEnabled`, `EmbeddingModel`, `DedupBookHighThreshold` |
+| Metadata scoring | 7 | `MetadataEmbeddingScoringEnabled`, `MetadataLLMRerankTopK` |
+| API / auth | 9 | `EnableAuth`, `APIRateLimitPerMinute`, `BasicAuthUsername` |
+| Memory / cache | 6 | `CacheSize`, `MemoryLimitMB`, `MetadataFetchCacheTTLDays` |
+| Lifecycle / retention | 6 | `PurgeSoftDeletedAfterDays`, `ActivityLogRetentionChangeDays` |
+| Logging | 3 | `LogLevel`, `LogFormat`, `EnableJsonLogging` |
+| iTunes sync | 10 | `ITunesSyncEnabled`, `ITunesLibraryWritePath`, `ITunesPathMappings` |
+| Deluge integration | 6 | `DelugeWebURL`, `DelugeWebPassword`, `DelugeMoveEnabled` |
+| Auto-update | 5 | `AutoUpdateEnabled`, `AutoUpdateChannel` |
+| Maintenance window | 17 | `MaintenanceWindowEnabled`, 15 per-task bools |
+| Scheduled tasks | ~18 | `ScheduledAIDedupEnabled`, `ScheduledReconcileInterval`, etc. |
+| Path formatting / apply | 5 | `PathFormat`, `AutoRenameOnApply`, `VerifyAfterWrite` |
+| Download client | nested | `DownloadClient DownloadClientConfig` (already nested) |
+| Plugin system | 3 | `Plugins map[string]PluginConfig`, `SupportedExtensions` |
+| **TOTAL (approx)** | **~155** | |
+
+### Load Path (startup sequence)
+
+```
+Cobra OnInitialize
+  └─ initConfig()                    [cmd/root.go]
+       ├─ viper.AutomaticEnv()       [no prefix, no key replacer]
+       ├─ viper.ReadInConfig()       [~/.audiobook-organizer.yaml]
+       ├─ viper.BindPFlag(...)       [4 CLI flags only]
+       └─ config.InitConfig()        [viper.SetDefault + Mutate onto AppConfig]
+
+serveCmd.RunE
+  ├─ initializeStore()               [open PebbleDB]
+  ├─ initEncryption()                [AES key for secrets]
+  ├─ config.LoadConfigFromDatabase() [blob → applySetting() legacy → YAML fallback]
+  ├─ config.SyncConfigFromEnv()      [re-reads viper for 4 specific fields post-DB]
+  └─ config.AppConfig.Validate()     [structural checks]
+```
+
+**Precedence (lowest → highest):**
+`viper.SetDefault` → YAML file → env vars → CLI flags → DB blob → `SyncConfigFromEnv` re-read
+
+### Other Config Structs (not part of AppConfig)
+
+| Struct | Location | Load mechanism | Relationship to AppConfig |
+|---|---|---|---|
+| `itunesservice.Config` | `internal/itunes/service/config.go` | Snapshot copy at construction | Mirrors iTunes fields — the only real isolation |
+| `unified.ScoreConfig` | `internal/dedup/unified/config.go` | `viper.Get("dedup.signals.*")` directly | Parallel Viper system — **completely outside AppConfig** |
+| `telemetry.Config` | `internal/telemetry/config.go` | `os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")` | No connection to AppConfig |
+| `server.ServerConfig` | `internal/server/server.go` | CLI flags → hardcoded defaults | No connection to AppConfig; not persisted |
+| `mtls.Dir` | `internal/mtls/config.go` | Filesystem (cert dir) | Not a config struct; cert manager |
+
+---
+
+## Key Findings
+
+### Finding 1: `internal/config` is not a leaf package
+
+`internal/config` imports:
+- `github.com/falkcorp/audiobook-organizer/internal/database` (for `SettingsStore`, `DecryptValue`, `MaskSecret`)
+- `github.com/falkcorp/audiobook-organizer/internal/serviceregistry` (via `register.go` `init()`)
+
+**Impact:** Any package importing `config` transitively pulls in `database` and `serviceregistry`. Tests that call `InitConfig()` trigger the registry `init()` side effect. This makes the config package unusable as a pure data layer.
+
+**Fix:** Move `persistence.go`, `update_service.go`, and `register.go` into `internal/config/persistence` (or leave them in server wiring). The leaf `internal/config` becomes pure: struct definition + Viper defaults + `Mutate`/`Snapshot` — zero internal imports.
+
+---
+
+### Finding 2: `mapstructure` tags on 4 of 155+ fields — viper.Unmarshal is silently broken
+
+Only `DedupReviewModel`, `MetadataReviewModel`, `FilenameParseModel`, and `CoverArtModel` have `mapstructure` tags. All other fields rely on the json round-trip path or explicit viper key reads. This means `viper.Unmarshal(&AppConfig)` (or `viper.UnmarshalKey`) would silently leave ~151 fields at their zero values. If any future code attempts a Viper unmarshal instead of the manual `Mutate` pattern, the result is a completely misconfigured server with no error.
+
+**Fix:** Either add `mapstructure` tags to all fields (mechanical, ~155 additions) or explicitly document that Viper unmarshal is banned and only the `Mutate` pattern is used.
+
+---
+
+### Finding 3: Embedding/dedup defaults bypass viper entirely
+
+Fields in the embedding and dedup groups (`EmbeddingEnabled`, `EmbeddingModel`, `EmbeddingDimensions`, `DedupBookHighThreshold`, all `MetadataEmbedding*`, all `MetadataLLM*`) are set via **hardcoded Go assignments inside the `Mutate` block**, not via `viper.SetDefault`. This means:
+
+- `EMBEDDING_ENABLED=false` (env var) **does nothing** — viper sets it but `InitConfig` ignores the viper key
+- These fields cannot be changed via YAML config file
+- `applySetting()` does not handle them, so legacy installs cannot restore them from individual DB rows
+- Only the `config_blob` path restores them correctly
+
+This is the same "escape the struct" pattern as dedup signals — it happened organically when contributors found the viper path inconvenient.
+
+**Fix:** Convert all hardcoded Mutate assignments to `viper.SetDefault` + `viper.GetX(key)`. This is mechanical.
+
+---
+
+### Finding 4: The dedup signal scoring system is a parallel config universe
+
+`internal/dedup/unified/config.go` defines `ScoreConfig` with ~15 fields, loaded directly from `viper.Get("dedup.signals.*")` keys that are set via `viper.SetDefault` in `InitConfig`. These are:
+- **Not in `AppConfig`** — no struct fields
+- **Not in the Settings UI** — no TypeScript type
+- **Not in `config_blob`** — not persisted to DB
+- **Not in `applySetting()`** — not loadable from legacy individual keys
+- **Not changeable at runtime via `PUT /api/v1/config`**
+
+This is fully functional but creates a two-tier config system where critical dedup calibration values are only configurable via YAML or environment variables — not through the same API path as everything else.
+
+**Fix:** Absorb `ScoreConfig` into a `DedupConfig` sub-struct inside `AppConfig`. The `dedup.signals.*` Viper defaults become `viper.SetDefault("dedup.signal_band_count", ...)` etc. with matching fields.
+
+---
+
+### Finding 5: 18+ production `os.Getenv` bypasses
+
+The following env vars are read with `os.Getenv` directly, bypassing viper, `AppConfig`, and the settings API entirely:
+
+| Env var | Location | Notes |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `internal/telemetry/config.go` | Intentional — telemetry is always env-only |
+| `OPENAI_BASE_URL` | `internal/ai/` (3 files) | Overlaps with `AppConfig.EmbeddingBaseURL`; fallback |
+| `LIBRARY_COUNTS_CACHE_MIN_INTERVAL_SECONDS` | `internal/database/pebble_store.go` | Tuning knob; no field in AppConfig |
+| `DEDUP_CHROMEM_LAZY` | `internal/dedup/lifecycle.go` | Lazy vs eager vector index init |
+| `ITUNES_WRITEBACK_DRYRUN` | `internal/itunes/service/writeback_batcher.go` | Dry-run mode |
+| `AUDIBLE_BASE_URL` / `AUDNEXUS_BASE_URL` / `GOOGLE_BOOKS_BASE_URL` / `OPENLIBRARY_BASE_URL` | `internal/metadata/*.go` | Test override URLs |
+| `FP_PARALLEL_WORKERS` | `internal/plugins/acoustid/fingerprint_rescan.go` | |
+| `ACOUSTID_API_KEY` | `internal/plugins/acoustid/online_lookup.go` | Fallback; primary is AppConfig field |
+| `BLEVE_DESCRIPTION_MAX_CHARS` | `internal/search/index_builder.go` | |
+| `LIST_WARMER_HEAP_DELTA_MB` / `LIST_WARMER_MAX_HEAP_MB` / `LIST_WARMER_TRICKLE_INTERVAL_MS` | `internal/server/library_list_warmer.go` | Memory tuning |
+| `OPENAI_API_KEY` | `internal/server/bench.go` | Uses raw env, not DB-loaded key |
+| `PPROF_ADDR` | `pprof_debug.go` | Debug only |
+
+The `OPENAI_BASE_URL` / `ACOUSTID_API_KEY` cases are the most dangerous: there are now two code paths for the same semantic setting, and the env var path bypasses the DB-backed update API.
+
+**Fix categorized:**
+- **Should move to AppConfig:** `LIBRARY_COUNTS_CACHE_MIN_INTERVAL_SECONDS`, `FP_PARALLEL_WORKERS`, `BLEVE_DESCRIPTION_MAX_CHARS`, `DEDUP_CHROMEM_LAZY`, List Warmer knobs
+- **Should deduplicate (env → AppConfig fallback):** `OPENAI_BASE_URL` (should route through `EmbeddingBaseURL`), `ACOUSTID_API_KEY`
+- **Fine as env-only (intentional/test):** `OTEL_EXPORTER_OTLP_ENDPOINT`, metadata base URLs, `ITUNES_WRITEBACK_DRYRUN`, `PPROF_ADDR`
+
+---
+
+### Finding 6: Race hazard — 1,434 direct reads without read lock
+
+`AppConfig` is a live-mutating global protected by a `sync.RWMutex` inside `Mutate`/`Snapshot`. However, 1,434 direct `config.AppConfig.Field` accesses in production code operate **without the read lock**. The documented stance is "direct reads of fields set once at startup are tolerated." But many fields are mutable at runtime via `PUT /api/v1/config`:
+
+- `RootDir` (215 reads) — mutable at runtime
+- `OpenAIAPIKey` (67 reads) — mutable at runtime
+- `ConcurrentScans` (36 reads, including in scanner goroutines) — mutable at runtime
+- `DedupEmbeddingsEnabled` (read in dedup hot path) — mutable at runtime
+
+The Go race detector would flag these. They haven't caused production issues yet, likely because config updates are infrequent and writes are atomic on most architectures for the field types in use. But this is undefined behavior in the Go memory model.
+
+**Fix:** Add `Snapshot()` usage at goroutine dispatch boundaries. A goroutine should call `cfg := config.Snapshot()` once at entry and use `cfg.Field` throughout — not `config.AppConfig.Field`. The `Snapshot()` API already exists; adoption is the gap.
+
+---
+
+### Finding 7: `EmbeddingBaseURL` env var doesn't survive startup
+
+Steps:
+1. User sets `EMBEDDING_BASE_URL=http://localhost:11434/v1`
+2. Phase 1: `viper.AutomaticEnv()` maps it to viper key `embedding_base_url`
+3. `InitConfig()` reads it (unclear — depends on whether there's a Mutate assignment for it; there is: `AppConfig.EmbeddingBaseURL = viper.GetString("embedding_base_url")`)
+4. Phase 2: `LoadConfigFromDatabase()` loads config blob → unmarshals full struct including `EmbeddingBaseURL` from blob → **overwrites the env var value with whatever was last saved to DB**
+5. `SyncConfigFromEnv()` re-reads only: `root_dir`, `openai_api_key`, `google_books_api_key`, `enable_ai_parsing` — **does not re-read `embedding_base_url`**
+
+Result: `EMBEDDING_BASE_URL` is silently ignored after a config blob exists. To change `EmbeddingBaseURL`, users must use `PUT /api/v1/config` or modify the blob directly.
+
+**Fix:** Add `embedding_base_url` to `SyncConfigFromEnv()`.
+
+---
+
+### Finding 8: `applySetting()` legacy path missing ~70 fields
+
+The `applySetting(key, value string)` switch statement handles 106 recognized keys for the pre-blob (legacy individual DB rows) load path. Approximately 70 fields added since the blob path was introduced have no case in `applySetting`. This means:
+
+- Legacy installs (pre-blob DB) cannot restore these fields from DB rows
+- If a migration tool writes individual DB rows for these fields, they are silently ignored
+- New installs start with blob immediately, so this is only a risk for upgrades from old versions
+
+**Fix:** Long-term, `applySetting` can be retired once all production installs have migrated to the blob path. Short-term, add a warning log for unrecognized keys rather than the current silent discard.
+
+---
+
+### Finding 9: Frontend Config interface 40% behind Go struct
+
+`web/src/services/api.ts` defines a `Config` TypeScript interface that is a **manually-curated subset** of the Go `Config` struct. Approximately 60 Go fields have no TypeScript representation, including:
+
+- All 5 `Embedding*` fields (no Settings UI for embedding config)
+- All 9 dedup threshold fields (`DedupBookHighThreshold`, etc.)
+- All `MetadataLLM*` and `MetadataEmbedding*` scoring fields
+- All 18 `Scheduled*` task fields
+- Most `MaintenanceWindow*` per-task booleans
+- `ITunesPathMappings`, `ITunesWindowsRootPath`, `ITunesMediaRoot`
+- `Plugins map[string]PluginConfig`
+- All 4 LLM model fields (`DedupReviewModel`, etc.)
+
+Adding a new configurable field requires updates at 5 separate sites: Go struct → `InitConfig` defaults → `applySetting` → `ResetToDefaults` → TypeScript type. Missing any step produces silent zero-value behavior.
+
+**Fix:** Generate the TypeScript interface from the Go struct using `go generate` or a build-time script rather than maintaining it manually. This is a significant but high-leverage change.
+
+---
+
+### Finding 10: No `ToolConfig` struct exists
+
+External binary tool configuration is handled in three incompatible ways:
+
+1. **Hardcoded `exec.LookPath`** — `fpcalc`, `ffmpeg`, `ffprobe` are looked up in PATH at each invocation across 5+ packages with zero override mechanism
+2. **Flat `AppConfig` field** — `EmbeddingBaseURL` is the only tool-adjacent field in Config
+3. **`os.Getenv` bypass** — `OPENAI_BASE_URL` used as a fallback in 3 AI files
+
+The managed-tool lifecycle spec (TOOL-1..6, captured in TODO.md) requires a `ToolConfig` sub-struct as its foundation. No `ToolConfig` type or variable exists anywhere in the codebase today.
+
+---
+
+## Growth Trajectory
+
+**Current:** ~155 flat fields, `applySetting` switch ~300 lines
+
+**Projected at current rate (10–15 new fields per major feature wave, 4–6 waves in 6 months):**
+- +40–90 fields in 6 months → **195–245 total fields**
+- `applySetting` → 400–500+ lines
+- TypeScript gap grows from ~60 missing fields to 90+ unless generation is adopted
+
+The dedup signal escape-hatch (putting signals in Viper-only) shows contributors are already working around the flat struct. Without a restructure, expect more satellite config systems to emerge.
+
+---
+
+## Proposed Restructuring — Three Changes
+
+### Change A: Extract leaf `internal/config` (no internal imports)
+
+**Move** `persistence.go`, `update_service.go`, `register.go` into `internal/config/persistence` or into `internal/server/config_service/`. The leaf `internal/config` becomes:
+- `config.go` — `Config` struct, `AppConfig`, `Mutate`, `Snapshot`, `InitConfig`, `Validate`, `ResetToDefaults`
+- Zero internal imports (only `viper`, `sync`, `os`, `regexp`, `strings`, `fmt`, `runtime`)
+
+**Impact:** Eliminates `config → database` coupling. Tests that need `AppConfig` don't pull in the database layer. This is a pure package boundary change — no API surface changes.
+
+**Effort:** Medium. ~5 files move; all import paths that import `internal/config/persistence` or `register.go` need updating. The `config.LoadConfigFromDatabase` and `config.SaveConfigToDatabase` callsites in `cmd/root.go` would import from the new location.
+
+---
+
+### Change B: Introduce nested sub-structs for cohesive groups
+
+**Priority order** (by impact/feasibility):
+
+1. **`ToolConfig`** — highest priority; required by TOOL-1..6
+   ```go
+   type ToolConfig struct {
+       FfmpegPath  string `json:"ffmpeg_path"  mapstructure:"ffmpeg_path"`
+       FfprobePath string `json:"ffprobe_path" mapstructure:"ffprobe_path"`
+       FpcalcPath  string `json:"fpcalc_path"  mapstructure:"fpcalc_path"`
+       OllamaURL   string `json:"ollama_url"   mapstructure:"ollama_url"`
+   }
+   // In Config:
+   Tools ToolConfig `json:"tools" mapstructure:"tools"`
+   ```
+   Binary path lookup pattern: `path := c.Tools.FfmpegPath; if path == "" { path, _ = exec.LookPath("ffmpeg") }`
+
+2. **`EmbeddingConfig`** — absorbs 5 flat fields + fixes the `EMBEDDING_BASE_URL` SyncConfigFromEnv gap
+   ```go
+   type EmbeddingConfig struct {
+       Enabled       bool   `json:"enabled"`
+       Model         string `json:"model"`
+       Dimensions    int    `json:"dimensions"`
+       BaseURL       string `json:"base_url"`
+       VectorBackend string `json:"vector_backend"`
+   }
+   // In Config:
+   Embedding EmbeddingConfig `json:"embedding"`
+   ```
+
+3. **`DedupConfig`** — absorbs 9 flat fields + absorbs `unified.ScoreConfig` (ends the parallel Viper system)
+   ```go
+   type DedupConfig struct {
+       BookHighThreshold           float64           `json:"book_high_threshold"`
+       // ... 8 more threshold/flag fields
+       Signals                     DedupSignalConfig `json:"signals"`
+   }
+   // In Config:
+   Dedup DedupConfig `json:"dedup"`
+   ```
+
+4. **`MaintenanceConfig`** — absorbs `MaintenanceWindowEnabled` + 15 per-task booleans + window hours
+5. **`ITunesConfig`** — absorbs 10 iTunes fields; aligns with the existing `itunesservice.Config` slice
+
+**Migration concern:** Nesting changes the JSON key paths in `config_blob`. `"embedding_enabled": true` becomes `"embedding": {"enabled": true}`. A one-time migration in `LoadConfigFromDatabase` must read both old flat keys and new nested keys during the transition window.
+
+**Effort:** High per sub-struct. Each requires: struct definition, `InitConfig` update, `applySetting` update (or retirement), `ResetToDefaults` update, `config_blob` migration, TypeScript interface update, and callsite updates for `config.AppConfig.EmbeddingEnabled` → `config.AppConfig.Embedding.Enabled`.
+
+**Recommendation:** Do one sub-struct at a time as part of feature work. `ToolConfig` first (prerequisite for TOOL-1..6). `EmbeddingConfig` second (small, low-blast-radius). `DedupConfig` third (ends the parallel Viper system). Others later.
+
+---
+
+### Change C: `Snapshot()` adoption at goroutine boundaries
+
+This is a discipline/convention change, not a structural change.
+
+**Rule:** Any goroutine that reads multiple `AppConfig` fields should call `cfg := config.Snapshot()` at entry and use `cfg.*` throughout. Direct `config.AppConfig.Field` reads are permitted only in code that is demonstrably single-threaded or reads only one field.
+
+**Priority callsites:**
+- Scanner goroutines (reads `ConcurrentScans`, `ExcludePatterns`, `SupportedExtensions`, `MinBookSizeBytes`, `RootDir`)
+- Dedup engine hot path (reads `DedupEmbeddingsEnabled`, thresholds)
+- Maintenance window dispatcher (reads all `MaintenanceWindow*` fields)
+- Basic auth middleware (reads `BasicAuthEnabled`, `BasicAuthUsername`, `BasicAuthPassword`)
+
+**Effort:** Low per callsite. A grep for `config.AppConfig.` in goroutine-dispatching files gives the target list.
+
+---
+
+## Naming Consistency Issues (Appendix)
+
+| Issue | Detail |
+|---|---|
+| `EnableSQLite` JSON/viper mismatch | JSON blob: `enable_sqlite`; viper/flag/env: `enable_sqlite3_i_know_the_risks` |
+| `EmbeddingBaseURL` → `OPENAI_BASE_URL` overlap | Same semantic, two env var paths |
+| `AcoustIDAPIKey` dual fallback | `AppConfig` field + `os.Getenv("ACOUSTID_API_KEY")` in consumer |
+| Embedding defaults not in viper | `EmbeddingEnabled` etc. hardcoded in Mutate; `EMBEDDING_ENABLED` env var does nothing |
+| `MetadataFetchCacheTTLDays` comment says "default 7" | Actual viper default is 180 |
+| Old key aliases undocumented | `itunes_library_itl_path` / `itunes_library_xml_path` still work but deprecated |
+| `mapstructure` tags on 4/155 fields | `viper.Unmarshal` silently broken for 151 fields |
+| `OperationLogRetentionDays` | No viper default; only set in `ResetToDefaults`; zero value = no retention limit |
+| `ActivityLogRetention*` fields (3) | No viper defaults; only set in `ResetToDefaults`; zero = disables retention (dangerous) |
+
+---
+
+## Recommended Next Steps
+
+**Immediate (no code — just discipline fixes):**
+1. Add `embedding_base_url` to `SyncConfigFromEnv()` — one line, fixes env var override gap
+2. Add `mapstructure` tags to all remaining `Config` fields — mechanical, can be done in one PR
+3. Document the ban on `viper.Unmarshal` in a code comment
+
+**Short-term (CFG-1 decision, then one sub-struct per feature wave):**
+4. Write decision doc to `docs/specs/config-architecture-decision.md` (CFG-1)
+5. Add `ToolConfig` sub-struct as part of TOOL-1 implementation (prerequisite)
+6. Add `EmbeddingConfig` sub-struct in next embedding work wave
+
+**Medium-term:**
+7. Extract leaf `internal/config` (Change A) — do this before adding many new sub-structs
+8. Absorb `unified.ScoreConfig` into `DedupConfig` (ends parallel Viper system)
+9. Adopt `Snapshot()` at goroutine boundaries (Change C) — low effort, high safety
+
+**Long-term:**
+10. Generate TypeScript `Config` interface from Go struct to eliminate the 40% gap
+11. Retire `applySetting()` once all installs are confirmed on blob path
+
+---
+
+## Files Investigated
+
+- `internal/config/config.go` — main struct, `InitConfig`, `Validate`, `ResetToDefaults`
+- `internal/config/persistence.go` — `LoadConfigFromDatabase`, `SaveConfigToDatabase`, `applySetting`, `SyncConfigFromEnv`
+- `internal/config/update_service.go` — runtime update path, JSON round-trip
+- `internal/config/register.go` — service registry wiring via `init()`
+- `cmd/root.go` — Cobra/Viper init, load sequence
+- `internal/dedup/unified/config.go` — parallel Viper-only `ScoreConfig`
+- `internal/itunes/service/config.go` — isolated iTunes config slice
+- `internal/telemetry/config.go` — env-only telemetry config
+- `internal/server/server.go` — `ServerConfig` (HTTP only, not persisted)
+- `web/src/services/api.ts` — TypeScript `Config` interface (hand-curated)
+- ~100 production files importing `internal/config`

--- a/docs/research/2026-06-15-sonarr-radarr-advanced-settings.md
+++ b/docs/research/2026-06-15-sonarr-radarr-advanced-settings.md
@@ -1,0 +1,82 @@
+<!-- file: docs/research/2026-06-15-sonarr-radarr-advanced-settings.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2c3d4e5-f6a7-8901-bcde-f12345678901 -->
+<!-- last-edited: 2026-06-15 -->
+
+# Sonarr/Radarr "Show Advanced" Settings Toggle — Research
+
+> Captured 2026-06-15. Input for `<ToolsPanel>` and broader Settings page UX.
+> Sources: github.com/Sonarr/Sonarr, github.com/Radarr/Radarr
+
+---
+
+## State Management & Persistence
+
+- **Mechanism:** Redux with Redux-Actions
+- **State path:** `state.settings.advancedSettings` (boolean)
+- **Toggle action:** `toggleAdvancedSettings()` — inverts the boolean
+- **Persistence:** The boolean is in the Redux persistence list → survives page refresh and browser restart (localStorage)
+- **Button component:** `AdvancedSettingsButton` is a pure presentational component; parent wires Redux dispatch and selector
+
+---
+
+## Component Pattern
+
+Two props on a `FormGroup` wrapper:
+
+```tsx
+<FormGroup isAdvanced advancedSettings={showAdvanced}>
+  {/* advanced field content */}
+</FormGroup>
+```
+
+- `isAdvanced` — static declaration at author time: "this field is advanced"
+- `advancedSettings` — runtime boolean from Redux: "user has toggled advanced on"
+- `FormGroup` renders `null` when `isAdvanced && !advancedSettings`
+
+This separates **what is advanced** (declaration, co-located with the field) from **show advanced?** (runtime state, global). No central registry of advanced fields needed.
+
+Works at any granularity: wrap an entire section or a single field.
+
+---
+
+## Key Design Decisions
+
+1. **Co-located declaration** — `isAdvanced` lives next to the field, not in a separate config. Easy to add, easy to audit, easy to grep.
+2. **Single persisted boolean** — only the toggle state is persisted, not individual field values.
+3. **Stateless button** — `AdvancedSettingsButton` doesn't manage state; the parent Redux setup does. The button is reusable anywhere.
+4. **Cascading via cloneElement** — `FormGroup` clones children and injects `isAdvanced` prop, so nested components can know their context without prop-drilling.
+
+---
+
+## Recommended Pattern for audiobook-organizer
+
+Since the project uses React + MUI (not Redux), adapt as follows:
+
+```tsx
+// Global context (or per-settings-tab useState + localStorage)
+const { showAdvanced, toggleAdvanced } = useAdvancedSettings();
+
+// Wrapper component
+function AdvancedField({ children }: { children: React.ReactNode }) {
+  const { showAdvanced } = useAdvancedSettings();
+  if (!showAdvanced) return null;
+  return <>{children}</>;
+}
+
+// Usage in any settings form
+<AdvancedField>
+  <TextField label="Managed tools directory" ... />
+</AdvancedField>
+
+// Toggle button (anywhere in the settings header)
+<Button onClick={toggleAdvanced} size="small" variant="outlined">
+  {showAdvanced ? 'Hide Advanced' : 'Show Advanced'}
+</Button>
+```
+
+**Persistence:** `localStorage.setItem('settings.showAdvanced', ...)` on toggle, read at init.
+
+**Scope:** one global toggle is simpler and matches Sonarr/Radarr. Per-tab toggles add complexity for marginal benefit — start global, reconsider only if specific tabs need different defaults.
+
+**Wizard:** advanced fields in the wizard should always show (the wizard is already the guided path; hiding fields there defeats the purpose of the "Let me choose" branch).

--- a/docs/specs/2026-06-16-config-struct-nesting-design.md
+++ b/docs/specs/2026-06-16-config-struct-nesting-design.md
@@ -1,0 +1,469 @@
+<!-- file: docs/superpowers/specs/2026-06-16-config-struct-nesting-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a3f8b2c1-7e4d-4a9f-b6c3-8d2e1f5a0c7b -->
+<!-- last-edited: 2026-06-16 -->
+
+# Config Struct Nesting — Design Spec
+
+**Status:** Approved — ready for implementation planning
+**Scope:** Go backend only. UI/TypeScript changes are a follow-up after all waves land.
+**Parent task:** CFG-1 (config architecture decision) from TODO.md
+**Research basis:** `docs/research/2026-06-15-config-architecture-evaluation.md`
+
+---
+
+## Problem
+
+`AppConfig` (`internal/config/config.go`) has grown to 155+ flat fields with no structural grouping. Symptoms:
+
+- Embedding/dedup/scoring fields were added without proper viper wiring (fixed in PR #1464), which reveals the flat struct makes it easy to skip the standard pattern
+- `applySetting()` switch is ~300 lines and growing
+- The dedup team already escaped to a parallel Viper-only config system (`dedup.signals.*`) rather than extend the flat struct
+- `ResetToDefaults` is 240+ lines of flat field assignments
+- 40% of fields have no frontend representation — the TypeScript interface is hand-curated and drifting
+
+**Goal:** Introduce logical nested sub-structs one wave at a time, so each group of related fields is self-contained, testable, and navigable.
+
+---
+
+## Approach: Wave-by-Wave (Option A)
+
+Each wave is one PR that:
+1. Defines a new sub-struct
+2. Migrates the blob on startup (detect old flat keys → rewrite to nested format, once)
+3. Adds an API compatibility shim so existing flat-key clients keep working during the transition
+4. Updates `applySetting`, `ResetToDefaults`, `InitConfig`, and all callsites
+
+This approach lets each wave be independently reviewed, deployed, and rolled back.
+
+---
+
+## Wave Schedule
+
+| Wave | Sub-struct | Fields moved | Notes |
+|------|-----------|-------------|-------|
+| 1 | `EmbeddingConfig` | 5 | Tightest subsystem; viper just fixed in #1464 |
+| 2 | `DedupConfig` | 9 + absorbs `unified.ScoreConfig` | Ends parallel Viper-only scoring system |
+| 3 | `MetadataScoringConfig` | 7 | Same consumers as dedup |
+| 4 | `ITunesConfig` | 10 | Aligns with existing `itunesservice.Config` slice |
+| 5 | `MaintenanceConfig` | 17 | Scheduler-only consumers |
+| 6 | `ScheduledTasksConfig` | ~18 | Same consumers as maintenance |
+| 7 | `AutoUpdateConfig` | 5 | Small, self-contained |
+| 8 | `ToolConfig` | 0→4 (new) | Reserved for TOOL-1..6 work; skip until then |
+
+---
+
+## Per-Wave Implementation Pattern
+
+Every wave follows these 6 steps in order. Steps are the same for every wave — only the struct definitions and field names change.
+
+### Step 1 — Define the sub-struct
+
+In `config.go`, add a new named type above the `Config` struct:
+
+```go
+type EmbeddingConfig struct {
+    Enabled       bool    `json:"enabled"        mapstructure:"enabled"`
+    Model         string  `json:"model"          mapstructure:"model"`
+    Dimensions    int     `json:"dimensions"     mapstructure:"dimensions"`
+    BaseURL       string  `json:"base_url"       mapstructure:"base_url"`
+    VectorBackend string  `json:"vector_backend" mapstructure:"vector_backend"`
+}
+```
+
+Rules:
+- All fields get both `json` and `mapstructure` tags (fixing the missing-mapstructure-tags gap identified in research)
+- Field names inside the sub-struct are the **short** names (drop the prefix — `EmbeddingEnabled` → `Enabled` inside `EmbeddingConfig`)
+- The sub-struct's field on `Config` uses the group name as the json key: `Embedding EmbeddingConfig \`json:"embedding" mapstructure:"embedding"\``
+
+### Step 2 — Replace flat fields in Config + update InitConfig
+
+Remove the flat fields from `Config`. Add the sub-struct field.
+
+Update `viper.SetDefault` calls to use the nested viper key path:
+```go
+// Before:
+viper.SetDefault("embedding_enabled", true)
+// After:
+viper.SetDefault("embedding.enabled", true)
+```
+
+**Env var compatibility is preserved automatically.** Viper's `AutomaticEnv()` maps env vars to keys by uppercasing and replacing `.` with `_`. So `embedding.enabled` → `EMBEDDING_ENABLED` — the same env var name as before. Users with existing env var setups do not need to change anything.
+
+Update the `InitConfig` Mutate struct literal:
+```go
+// Before:
+EmbeddingEnabled: viper.GetBool("embedding_enabled"),
+// After (inside Embedding sub-struct):
+Embedding: EmbeddingConfig{
+    Enabled:       viper.GetBool("embedding.enabled"),
+    Model:         viper.GetString("embedding.model"),
+    Dimensions:    viper.GetInt("embedding.dimensions"),
+    BaseURL:       viper.GetString("embedding.base_url"),
+    VectorBackend: viper.GetString("embedding.vector_backend"),
+},
+```
+
+### Step 3 — Startup blob migration in LoadConfigFromDatabase
+
+After the blob is read but before `Mutate`, insert a one-time migration check:
+
+```go
+func migrateEmbeddingFields(store database.SettingsStore, blob string) (string, bool) {
+    // Check if blob is old flat format
+    var raw map[string]any
+    if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+        return blob, false
+    }
+    if _, isFlat := raw["embedding_enabled"]; !isFlat {
+        return blob, false // already nested or field absent
+    }
+
+    // Shim struct matching old flat shape
+    type flatEmbedding struct {
+        EmbeddingEnabled    bool    `json:"embedding_enabled"`
+        EmbeddingModel      string  `json:"embedding_model"`
+        EmbeddingDimensions int     `json:"embedding_dimensions"`
+        EmbeddingBaseURL    string  `json:"embedding_base_url"`
+        VectorIndexBackend  string  `json:"vector_index_backend"`
+    }
+    var old flatEmbedding
+    json.Unmarshal([]byte(blob), &old)
+
+    // Write nested keys into raw map
+    raw["embedding"] = map[string]any{
+        "enabled":        old.EmbeddingEnabled,
+        "model":          old.EmbeddingModel,
+        "dimensions":     old.EmbeddingDimensions,
+        "base_url":       old.EmbeddingBaseURL,
+        "vector_backend": old.VectorIndexBackend,
+    }
+    delete(raw, "embedding_enabled")
+    delete(raw, "embedding_model")
+    delete(raw, "embedding_dimensions")
+    delete(raw, "embedding_base_url")
+    delete(raw, "vector_index_backend")
+
+    migrated, _ := json.Marshal(raw)
+    return string(migrated), true
+}
+```
+
+Call this before `json.Unmarshal` into `Config`. If it returns `true` (migrated), write the updated blob back to DB immediately and log `"config blob migrated: embedding fields nested"`.
+
+**No migration flag needed** — the sentinel key check (`"embedding_enabled"` at the top level) is idempotent. If the blob was already migrated, the check returns false and the function is a no-op.
+
+### Step 4 — API compatibility shim in UpdateConfig
+
+In `update_service.go`, before `json.Unmarshal(payloadJSON, c)`, remap old flat keys:
+
+```go
+func remapEmbeddingKeys(payload map[string]any) map[string]any {
+    emb := make(map[string]any)
+    for old, newKey := range map[string]string{
+        "embedding_enabled":    "enabled",
+        "embedding_model":      "model",
+        "embedding_dimensions": "dimensions",
+        "embedding_base_url":   "base_url",
+        "vector_index_backend": "vector_backend",
+    } {
+        if v, ok := payload[old]; ok {
+            emb[newKey] = v
+            delete(payload, old)
+        }
+    }
+    if len(emb) > 0 {
+        // Merge into existing nested map to avoid zeroing sibling fields
+        if existing, ok := payload["embedding"].(map[string]any); ok {
+            for k, v := range emb {
+                existing[k] = v
+            }
+        } else {
+            payload["embedding"] = emb
+        }
+    }
+    return payload
+}
+```
+
+The merge-into-existing logic handles the partial-update hazard: if a client sends both `"embedding_enabled": true` AND `"embedding": {"model": "bge-m3"}`, both are preserved.
+
+This shim lives until the frontend is updated. It is then deleted.
+
+### Step 5 — Update applySetting
+
+Change each moved case to write to the nested path:
+
+```go
+// Before:
+case "embedding_enabled":
+    if b, err := strconv.ParseBool(value); err == nil {
+        c.EmbeddingEnabled = b
+    }
+// After:
+case "embedding_enabled":
+    if b, err := strconv.ParseBool(value); err == nil {
+        c.Embedding.Enabled = b
+    }
+```
+
+The string key ("embedding_enabled") stays the same — only the Go assignment path changes. This preserves backward compatibility for any pre-blob installs restoring from individual DB rows.
+
+### Step 6 — Update ResetToDefaults
+
+Replace flat field assignments with a full sub-struct literal:
+
+```go
+// Before:
+EmbeddingEnabled:    true,
+EmbeddingModel:      "text-embedding-3-large",
+EmbeddingDimensions: 3072,
+EmbeddingBaseURL:    "",
+VectorIndexBackend:  "chromem",
+
+// After:
+Embedding: EmbeddingConfig{
+    Enabled:       true,
+    Model:         "text-embedding-3-large",
+    Dimensions:    3072,
+    BaseURL:       "",
+    VectorBackend: "chromem",
+},
+```
+
+Then update all callsites: `config.AppConfig.EmbeddingEnabled` → `config.AppConfig.Embedding.Enabled` etc. (mechanical find-replace + compile to find all missed sites).
+
+---
+
+## Wave 1 Field Definitions: EmbeddingConfig
+
+```go
+type EmbeddingConfig struct {
+    Enabled       bool   `json:"enabled"        mapstructure:"enabled"`
+    Model         string `json:"model"          mapstructure:"model"`
+    Dimensions    int    `json:"dimensions"     mapstructure:"dimensions"`
+    BaseURL       string `json:"base_url"       mapstructure:"base_url"`
+    VectorBackend string `json:"vector_backend" mapstructure:"vector_backend"`
+}
+// On Config:
+Embedding EmbeddingConfig `json:"embedding" mapstructure:"embedding"`
+```
+
+Viper key mapping (old → new):
+
+| Old flat key | New nested viper key |
+|---|---|
+| `embedding_enabled` | `embedding.enabled` |
+| `embedding_model` | `embedding.model` |
+| `embedding_dimensions` | `embedding.dimensions` |
+| `embedding_base_url` | `embedding.base_url` |
+| `vector_index_backend` | `embedding.vector_backend` |
+
+---
+
+## Wave 2 Field Definitions: DedupConfig
+
+Absorbs 9 flat fields AND the `unified.ScoreConfig` Viper-only system (which currently lives outside `AppConfig` entirely).
+
+```go
+type DedupSignalConfig struct {
+    BandCertainMin  float64 `json:"band_certain_min"  mapstructure:"band_certain_min"`
+    BandHighMin     float64 `json:"band_high_min"     mapstructure:"band_high_min"`
+    BandMediumMin   float64 `json:"band_medium_min"   mapstructure:"band_medium_min"`
+    BandReviewMin   float64 `json:"band_review_min"   mapstructure:"band_review_min"`
+    DurationBoost   float64 `json:"duration_boost"    mapstructure:"duration_boost"`
+    FolderPathBoost float64 `json:"folder_path_boost" mapstructure:"folder_path_boost"`
+}
+
+type DedupConfig struct {
+    BookHighThreshold          float64          `json:"book_high_threshold"           mapstructure:"book_high_threshold"`
+    BookLowThreshold           float64          `json:"book_low_threshold"            mapstructure:"book_low_threshold"`
+    AuthorHighThreshold        float64          `json:"author_high_threshold"         mapstructure:"author_high_threshold"`
+    AuthorLowThreshold         float64          `json:"author_low_threshold"          mapstructure:"author_low_threshold"`
+    AutoMergeEnabled           bool             `json:"auto_merge_enabled"            mapstructure:"auto_merge_enabled"`
+    EmbeddingsEnabled          bool             `json:"embeddings_enabled"            mapstructure:"embeddings_enabled"`
+    LLMAutoMergeHighConfidence bool             `json:"llm_auto_merge_high_confidence" mapstructure:"llm_auto_merge_high_confidence"`
+    OnImportViaScheduler       bool             `json:"on_import_via_scheduler"       mapstructure:"on_import_via_scheduler"`
+    ReviewModel                string           `json:"review_model"                  mapstructure:"review_model"`
+    Signals                    DedupSignalConfig `json:"signals"                      mapstructure:"signals"`
+}
+// On Config:
+Dedup DedupConfig `json:"dedup" mapstructure:"dedup"`
+```
+
+**Special:** Wave 2 also updates `internal/dedup/unified/config.go` (`LoadScoreConfig`) to read from `AppConfig.Dedup.Signals` instead of `viper.Get("dedup.signals.*")` directly. This ends the parallel config system.
+
+---
+
+## Wave 3 Field Definitions: MetadataScoringConfig
+
+```go
+type MetadataScoringConfig struct {
+    EmbeddingEnabled   bool    `json:"embedding_enabled"    mapstructure:"embedding_enabled"`
+    EmbeddingMinScore  float64 `json:"embedding_min_score"  mapstructure:"embedding_min_score"`
+    EmbeddingBestMatch float64 `json:"embedding_best_match" mapstructure:"embedding_best_match"`
+    LLMEnabled         bool    `json:"llm_enabled"          mapstructure:"llm_enabled"`
+    LLMRerankEpsilon   float64 `json:"llm_rerank_epsilon"   mapstructure:"llm_rerank_epsilon"`
+    LLMRerankTopK      int     `json:"llm_rerank_top_k"     mapstructure:"llm_rerank_top_k"`
+    WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
+}
+// On Config:
+MetadataScoring MetadataScoringConfig `json:"metadata_scoring" mapstructure:"metadata_scoring"`
+```
+
+---
+
+## Wave 4 Field Definitions: ITunesConfig
+
+Aligns with existing `itunesservice.Config` slice pattern. After this wave, the iTunes service construction becomes a direct struct copy.
+
+```go
+type ITunesPathMap struct {
+    // existing type, unchanged
+}
+
+type ITunesConfig struct {
+    SyncEnabled      bool            `json:"sync_enabled"       mapstructure:"sync_enabled"`
+    SyncInterval     int             `json:"sync_interval"      mapstructure:"sync_interval"`
+    WriteBackEnabled bool            `json:"write_back_enabled" mapstructure:"write_back_enabled"`
+    LibraryWritePath string          `json:"library_write_path" mapstructure:"library_write_path"`
+    LibraryReadPath  string          `json:"library_read_path"  mapstructure:"library_read_path"`
+    AutoWriteBack    bool            `json:"auto_write_back"    mapstructure:"auto_write_back"`
+    PathTrimEnabled  bool            `json:"path_trim_enabled"  mapstructure:"path_trim_enabled"`
+    WindowsRootPath  string          `json:"windows_root_path"  mapstructure:"windows_root_path"`
+    MediaRoot        string          `json:"media_root"         mapstructure:"media_root"`
+    PathMappings     []ITunesPathMap `json:"path_mappings"      mapstructure:"path_mappings"`
+}
+// On Config:
+ITunes ITunesConfig `json:"itunes" mapstructure:"itunes"`
+```
+
+---
+
+## Wave 5 Field Definitions: MaintenanceConfig
+
+```go
+type MaintenanceConfig struct {
+    Enabled              bool `json:"enabled"               mapstructure:"enabled"`
+    WindowStart          int  `json:"window_start"          mapstructure:"window_start"`
+    WindowEnd            int  `json:"window_end"            mapstructure:"window_end"`
+    DedupRefresh         bool `json:"dedup_refresh"         mapstructure:"dedup_refresh"`
+    SeriesPrune          bool `json:"series_prune"          mapstructure:"series_prune"`
+    AuthorSplit          bool `json:"author_split"          mapstructure:"author_split"`
+    TombstoneCleanup     bool `json:"tombstone_cleanup"     mapstructure:"tombstone_cleanup"`
+    Reconcile            bool `json:"reconcile"             mapstructure:"reconcile"`
+    PurgeDeleted         bool `json:"purge_deleted"         mapstructure:"purge_deleted"`
+    PurgeOldLogs         bool `json:"purge_old_logs"        mapstructure:"purge_old_logs"`
+    DbOptimize           bool `json:"db_optimize"           mapstructure:"db_optimize"`
+    LibraryScan          bool `json:"library_scan"          mapstructure:"library_scan"`
+    LibraryOrganize      bool `json:"library_organize"      mapstructure:"library_organize"`
+    MetadataRefresh      bool `json:"metadata_refresh"      mapstructure:"metadata_refresh"`
+    LibrarySizeRefresh   bool `json:"library_size_refresh"  mapstructure:"library_size_refresh"`
+    AcoustIDOnlineLookup bool `json:"acoustid_online_lookup" mapstructure:"acoustid_online_lookup"`
+    AcoustIDNightlyLimit int  `json:"acoustid_nightly_limit" mapstructure:"acoustid_nightly_limit"`
+}
+// On Config:
+Maintenance MaintenanceConfig `json:"maintenance" mapstructure:"maintenance"`
+```
+
+---
+
+## Wave 6 Field Definitions: ScheduledTasksConfig
+
+```go
+type ScheduledTaskConfig struct {
+    Enabled   bool `json:"enabled"    mapstructure:"enabled"`
+    Interval  int  `json:"interval"   mapstructure:"interval"`
+    OnStartup bool `json:"on_startup" mapstructure:"on_startup"`
+}
+
+type ScheduledTasksConfig struct {
+    DedupRefresh    ScheduledTaskConfig `json:"dedup_refresh"    mapstructure:"dedup_refresh"`
+    AuthorSplit      ScheduledTaskConfig `json:"author_split"     mapstructure:"author_split"`
+    DbOptimize       ScheduledTaskConfig `json:"db_optimize"      mapstructure:"db_optimize"`
+    MetadataRefresh  ScheduledTaskConfig `json:"metadata_refresh" mapstructure:"metadata_refresh"`
+    AIDedupBatch     ScheduledTaskConfig `json:"ai_dedup_batch"   mapstructure:"ai_dedup_batch"`
+}
+// On Config:
+Scheduled ScheduledTasksConfig `json:"scheduled" mapstructure:"scheduled"`
+```
+
+---
+
+## Wave 7 Field Definitions: AutoUpdateConfig
+
+```go
+type AutoUpdateConfig struct {
+    Enabled      bool   `json:"enabled"       mapstructure:"enabled"`
+    Channel      string `json:"channel"       mapstructure:"channel"`
+    CheckMinutes int    `json:"check_minutes" mapstructure:"check_minutes"`
+    WindowStart  int    `json:"window_start"  mapstructure:"window_start"`
+    WindowEnd    int    `json:"window_end"    mapstructure:"window_end"`
+}
+// On Config:
+AutoUpdate AutoUpdateConfig `json:"auto_update" mapstructure:"auto_update"`
+```
+
+---
+
+## Wave 8 (deferred): ToolConfig
+
+Deferred until TOOL-1..6 work begins. When ready:
+
+```go
+type ToolConfig struct {
+    FfmpegPath  string `json:"ffmpeg_path"  mapstructure:"ffmpeg_path"`
+    FfprobePath string `json:"ffprobe_path" mapstructure:"ffprobe_path"`
+    FpcalcPath  string `json:"fpcalc_path"  mapstructure:"fpcalc_path"`
+    OllamaURL   string `json:"ollama_url"   mapstructure:"ollama_url"`
+}
+// On Config:
+Tools ToolConfig `json:"tools" mapstructure:"tools"`
+```
+
+---
+
+## What Stays Flat
+
+These fields remain at the top level of `Config` after all waves — they are either singletons, cross-cutting, or already appropriately named:
+
+- Core paths: `RootDir`, `DatabasePath`, `DatabaseType`, `EnableSQLite`, `PlaylistDir`, `SetupComplete`
+- Library organization: `OrganizationStrategy`, `ScanOnStartup`, `AutoOrganize`, `AutoScanEnabled`, `AutoScanDebounceSeconds`, `FolderNamingPattern`, `FileNamingPattern`, `CreateBackups`
+- Storage quotas: `EnableDiskQuota`, `DiskQuotaPercent`, `EnableUserQuotas`, `DefaultUserQuotaGB`
+- Metadata: `AutoFetchMetadata`, `WriteBackMetadata`, `EmbedCoverArt`, `Language`, `MetadataSources`, `MetadataReviewDefaultView`, `HardcoverAPIToken`, `GoogleBooksAPIKey`
+- AI: `EnableAIParsing`, `OpenAIAPIKey`, `AcoustIDAPIKey`, `DedupReviewModel`, `MetadataReviewModel`, `FilenameParseModel`, `CoverArtModel`
+- Performance: `ConcurrentScans`, `ChapterConsolidationThresholdMin`, `OperationTimeoutMinutes`, `MinBookSizeBytes`
+- Logging: `LogLevel`, `LogFormat`, `EnableJsonLogging`
+- Retention: `LogRetentionDays`, `OperationLogRetentionDays`, `ActivityLogRetention*`, `PurgeSoftDeleted*`
+- Auth / rate limits: `EnableAuth`, `EnableRateLimit`, `APIRateLimitPerMinute`, `AuthRateLimitPerMinute`, `JSONBodyLimitMB`, `UploadBodyLimitMB`, `BasicAuth*`
+- Memory / cache: `MemoryLimitType`, `CacheSize`, `MetadataFetchCacheTTLDays`, `MemoryLimitPercent`, `MemoryLimitMB`, `CacheInvalidateOnBookUpdate`
+- Paths / apply: `PathFormat`, `SegmentTitleFormat`, `AutoRenameOnApply`, `AutoWriteTagsOnApply`, `VerifyAfterWrite`
+- Open Library: `OpenLibraryDumpEnabled`, `OpenLibraryDumpDir`
+- Deluge (flat): `DelugeWebURL`, `DelugeWebPassword`, `DelugeDiscoveryLabel`, `DelugeDiscoveryEnabled`, `DelugeMoveEnabled`, `ProtectedPaths`
+- Already nested: `DownloadClient DownloadClientConfig`, `Plugins map[string]PluginConfig`
+
+---
+
+## Testing Strategy
+
+Each wave:
+1. Existing config tests must pass unchanged (the blob round-trip tests cover migration)
+2. Add a test for the migration function: load a flat blob, assert the migrated blob has nested keys, assert field values are preserved
+3. Add a test for the `UpdateConfig` compat shim: send flat keys, assert nested fields are updated
+4. `go vet ./...` and `go build ./...` must be clean before PR opens
+5. Deploy to prod and verify settings page still saves/loads correctly
+
+---
+
+## Files Modified Per Wave
+
+| File | Change |
+|---|---|
+| `internal/config/config.go` | Add sub-struct type, replace flat fields, update `InitConfig` + `ResetToDefaults` |
+| `internal/config/persistence.go` | Add migration function, update `applySetting` cases, add compat shim call in `UpdateConfig` path |
+| `internal/config/update_service.go` | Add flat-key remapping shim |
+| `internal/config/*_test.go` | Migration test + compat shim test |
+| All callsite files | Mechanical find-replace of field path |
+
+Wave 2 also modifies: `internal/dedup/unified/config.go` (switch from Viper reads to `AppConfig.Dedup.Signals`)
+Wave 4 also modifies: `internal/itunes/service/config.go` (simplify construction from `ITunes ITunesConfig` directly)

--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -1,5 +1,6 @@
 // file: internal/ai/register.go
-// version: 1.1.0
+// version: 1.2.0
+// last-edited: 2026-06-16
 
 // Service registry registrations for the AI cluster (W4).
 //
@@ -31,21 +32,21 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
-			if cfg.OpenAIAPIKey == "" || !cfg.EmbeddingEnabled {
+			if cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled {
 				return (*EmbeddingClient)(nil), nil
 			}
 			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")
 			// Base URL is scoped to the embedding client ONLY (see
-			// NewEmbeddingClientWithOptions): cfg.EmbeddingBaseURL points
+			// NewEmbeddingClientWithOptions): cfg.Embedding.BaseURL points
 			// embeddings at a local OpenAI-compatible backend (e.g. Ollama)
 			// without touching the LLM / metadata clients. Fall back to the
 			// OPENAI_BASE_URL env when the config field is empty for backward
 			// compatibility with env-based setups.
-			baseURL := cfg.EmbeddingBaseURL
+			baseURL := cfg.Embedding.BaseURL
 			if baseURL == "" {
 				baseURL = os.Getenv("OPENAI_BASE_URL")
 			}
-			client := NewEmbeddingClientWithOptions(cfg.OpenAIAPIKey, cfg.EmbeddingModel, baseURL)
+			client := NewEmbeddingClientWithOptions(cfg.OpenAIAPIKey, cfg.Embedding.Model, baseURL)
 			if embStore != nil {
 				client = client.WithCache(embStore)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.52.0
+// version: 1.53.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-06-15
+// last-edited: 2026-06-16
 
 package config
 
@@ -84,6 +84,15 @@ type SABnzbdConfig struct {
 type PluginConfig struct {
 	Enabled  bool              `json:"enabled"`
 	Settings map[string]string `json:"settings"` // plugin-specific key-value pairs
+}
+
+// EmbeddingConfig holds all settings for the local/remote embedding pipeline.
+type EmbeddingConfig struct {
+	Enabled       bool   `json:"enabled"        mapstructure:"enabled"`
+	Model         string `json:"model"          mapstructure:"model"`
+	Dimensions    int    `json:"dimensions"     mapstructure:"dimensions"`
+	BaseURL       string `json:"base_url"       mapstructure:"base_url"`
+	VectorBackend string `json:"vector_backend" mapstructure:"vector_backend"`
 }
 
 // Config holds application configuration
@@ -169,26 +178,9 @@ type Config struct {
 	ActivityLogRetentionDebugDays  int `json:"activity_log_retention_debug_days"`  // default 30
 	ActivityLogCompactionDays      int `json:"activity_log_compaction_days"`       // default 14
 
-	// Embedding-based dedup
-	EmbeddingEnabled bool   `json:"embedding_enabled"` // default true
-	EmbeddingModel   string `json:"embedding_model"`   // default "text-embedding-3-large"
-	// EmbeddingDimensions is the vector dimension of the configured embedding
-	// model. Must match the model's output: text-embedding-3-large = 3072,
-	// bge-m3 = 1024. Sizes the in-memory chromem ANN store. Default 3072.
-	EmbeddingDimensions int `json:"embedding_dimensions"` // default 3072
-	// EmbeddingBaseURL, when non-empty, points the embedding client at an
-	// OpenAI-compatible endpoint (e.g. a local Ollama at
-	// "http://127.0.0.1:11434/v1") for the EMBEDDING client ONLY. The LLM /
-	// metadata clients are unaffected — this is deliberately a per-client
-	// config field rather than the process-wide OPENAI_BASE_URL env, which the
-	// OpenAI SDK applies to every default client. Empty = OpenAI (or, for
-	// backward compat, the OPENAI_BASE_URL env if set). Default "".
-	EmbeddingBaseURL string `json:"embedding_base_url"` // default ""
-	// VectorIndexBackend selects the in-memory ANN backend for dedup Layer 2:
-	// "chromem" (default, brute-force O(n) cosine scan) or "hnsw" (coder/hnsw
-	// graph, sub-linear search — preferred once the corpus is large). Both are
-	// derived indexes hydrated from the PebbleDB embedding store on boot.
-	VectorIndexBackend       string  `json:"vector_index_backend"`        // default "chromem"
+	// Embedding holds configuration for the embedding pipeline (model, provider, vector backend).
+	Embedding EmbeddingConfig `json:"embedding" mapstructure:"embedding"`
+
 	DedupBookHighThreshold   float64 `json:"dedup_book_high_threshold"`   // default 0.95
 	DedupBookLowThreshold    float64 `json:"dedup_book_low_threshold"`    // default 0.85
 	DedupAuthorHighThreshold float64 `json:"dedup_author_high_threshold"` // default 0.92
@@ -608,12 +600,20 @@ func InitConfig() {
 	viper.SetDefault("auto_write_tags_on_apply", true)
 	viper.SetDefault("verify_after_write", true)
 
-	// Embedding + vector index defaults
-	viper.SetDefault("embedding_enabled", true)
-	viper.SetDefault("embedding_model", "text-embedding-3-large")
-	viper.SetDefault("embedding_dimensions", 3072)
-	viper.SetDefault("embedding_base_url", "")
-	viper.SetDefault("vector_index_backend", "chromem")
+	// Embedding + vector index defaults (nested under "embedding.*").
+	// BindEnv maps each dot-notation key to its uppercase env var name so that
+	// EMBEDDING_ENABLED, EMBEDDING_MODEL, etc. override the defaults even when
+	// AutomaticEnv() is not active (e.g. in unit tests that call InitConfig directly).
+	viper.SetDefault("embedding.enabled", true)
+	viper.SetDefault("embedding.model", "text-embedding-3-large")
+	viper.SetDefault("embedding.dimensions", 3072)
+	viper.SetDefault("embedding.base_url", "")
+	viper.SetDefault("embedding.vector_backend", "chromem")
+	viper.BindEnv("embedding.enabled", "EMBEDDING_ENABLED")           //nolint:errcheck
+	viper.BindEnv("embedding.model", "EMBEDDING_MODEL")               //nolint:errcheck
+	viper.BindEnv("embedding.dimensions", "EMBEDDING_DIMENSIONS")     //nolint:errcheck
+	viper.BindEnv("embedding.base_url", "EMBEDDING_BASE_URL")         //nolint:errcheck
+	viper.BindEnv("embedding.vector_backend", "VECTOR_INDEX_BACKEND") //nolint:errcheck
 
 	// Dedup threshold + behaviour defaults
 	viper.SetDefault("dedup_book_high_threshold", 0.95)
@@ -817,12 +817,14 @@ func InitConfig() {
 			SupportedExtensions: supportedExtensions,
 			ExcludePatterns:     excludePatterns,
 
-			// Embedding + vector index
-			EmbeddingEnabled:   viper.GetBool("embedding_enabled"),
-			EmbeddingModel:     viper.GetString("embedding_model"),
-			EmbeddingDimensions: viper.GetInt("embedding_dimensions"),
-			EmbeddingBaseURL:   viper.GetString("embedding_base_url"),
-			VectorIndexBackend: viper.GetString("vector_index_backend"),
+			// Embedding pipeline (nested sub-struct)
+			Embedding: EmbeddingConfig{
+				Enabled:       viper.GetBool("embedding.enabled"),
+				Model:         viper.GetString("embedding.model"),
+				Dimensions:    viper.GetInt("embedding.dimensions"),
+				BaseURL:       viper.GetString("embedding.base_url"),
+				VectorBackend: viper.GetString("embedding.vector_backend"),
+			},
 
 			// Dedup thresholds + behaviour
 			DedupBookHighThreshold:          viper.GetFloat64("dedup_book_high_threshold"),
@@ -1159,12 +1161,14 @@ func ResetToDefaults() {
 			ActivityLogRetentionDebugDays:  30,
 			ActivityLogCompactionDays:      14,
 
-			// Embedding-based dedup
-			EmbeddingEnabled:                true,
-			EmbeddingModel:                  "text-embedding-3-large",
-			EmbeddingDimensions:             3072,
-			EmbeddingBaseURL:                "",
-			VectorIndexBackend:              "chromem",
+			// Embedding pipeline
+			Embedding: EmbeddingConfig{
+				Enabled:       true,
+				Model:         "text-embedding-3-large",
+				Dimensions:    3072,
+				BaseURL:       "",
+				VectorBackend: "chromem",
+			},
 			DedupBookHighThreshold:          0.95,
 			DedupBookLowThreshold:           0.85,
 			DedupAuthorHighThreshold:        0.92,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,7 @@
 // file: internal/config/config_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-10
+// last-edited: 2026-06-16
 
 package config
 
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestInitConfig tests configuration initialization with defaults
@@ -495,4 +496,33 @@ func TestAppConfigRace_MutateSnapshot(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestInitConfig_EmbeddingDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+
+	assert.True(t, snap.Embedding.Enabled)
+	assert.Equal(t, "text-embedding-3-large", snap.Embedding.Model)
+	assert.Equal(t, 3072, snap.Embedding.Dimensions)
+	assert.Equal(t, "", snap.Embedding.BaseURL)
+	assert.Equal(t, "chromem", snap.Embedding.VectorBackend)
+}
+
+func TestInitConfig_EmbeddingFromEnv(t *testing.T) {
+	t.Setenv("EMBEDDING_ENABLED", "false")
+	t.Setenv("EMBEDDING_BASE_URL", "http://localhost:11434/v1")
+	t.Setenv("EMBEDDING_MODEL", "bge-m3")
+	t.Setenv("EMBEDDING_DIMENSIONS", "1024")
+	t.Setenv("VECTOR_INDEX_BACKEND", "hnsw")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+
+	assert.False(t, snap.Embedding.Enabled)
+	assert.Equal(t, "http://localhost:11434/v1", snap.Embedding.BaseURL)
+	assert.Equal(t, "bge-m3", snap.Embedding.Model)
+	assert.Equal(t, 1024, snap.Embedding.Dimensions)
+	assert.Equal(t, "hnsw", snap.Embedding.VectorBackend)
 }

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,6 +1,6 @@
 // file: internal/config/config_unit_test.go
-// version: 1.4.0
-// last-edited: 2026-06-15
+// version: 1.5.0
+// last-edited: 2026-06-16
 
 package config
 
@@ -391,8 +391,8 @@ func TestInitConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("embedding dedup defaults", func(t *testing.T) {
-		assert.True(t, AppConfig.EmbeddingEnabled)
-		assert.Equal(t, "text-embedding-3-large", AppConfig.EmbeddingModel)
+		assert.True(t, AppConfig.Embedding.Enabled)
+		assert.Equal(t, "text-embedding-3-large", AppConfig.Embedding.Model)
 		assert.InDelta(t, 0.95, AppConfig.DedupBookHighThreshold, 0.001)
 		assert.InDelta(t, 0.85, AppConfig.DedupBookLowThreshold, 0.001)
 		assert.InDelta(t, 0.92, AppConfig.DedupAuthorHighThreshold, 0.001)

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence.go
-// version: 1.20.0
+// version: 1.21.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
-// last-edited: 2026-06-15
+// last-edited: 2026-06-16
 
 package config
 
@@ -147,6 +147,54 @@ func SaveConfigToFile() error {
 	return nil
 }
 
+// migrateEmbeddingBlob rewrites a flat-format config blob to the nested EmbeddingConfig
+// format. Returns the (possibly modified) blob and whether a migration occurred.
+// Safe to call repeatedly: returns (blob, false) if already nested.
+func migrateEmbeddingBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["embedding_enabled"]; !isFlat {
+		return blob, false
+	}
+
+	type flatShape struct {
+		EmbeddingEnabled    bool   `json:"embedding_enabled"`
+		EmbeddingModel      string `json:"embedding_model"`
+		EmbeddingDimensions int    `json:"embedding_dimensions"`
+		EmbeddingBaseURL    string `json:"embedding_base_url"`
+		VectorIndexBackend  string `json:"vector_index_backend"`
+	}
+	var old flatShape
+	json.Unmarshal([]byte(blob), &old) //nolint:errcheck — already parsed above
+
+	raw["embedding"] = map[string]any{
+		"enabled":        old.EmbeddingEnabled,
+		"model":          old.EmbeddingModel,
+		"dimensions":     old.EmbeddingDimensions,
+		"base_url":       old.EmbeddingBaseURL,
+		"vector_backend": old.VectorIndexBackend,
+	}
+	delete(raw, "embedding_enabled")
+	delete(raw, "embedding_model")
+	delete(raw, "embedding_dimensions")
+	delete(raw, "embedding_base_url")
+	delete(raw, "vector_index_backend")
+
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
+// saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
+// Used only by startup migration to persist migrated blobs without re-marshaling.
+func saveRawBlob(store database.SettingsStore, rawJSON string) error {
+	return store.SetSetting("config_blob", rawJSON, "json", false)
+}
+
 // LoadConfigFromDatabase loads settings from database and applies them to AppConfig.
 //
 // Load order (blob-first):
@@ -184,8 +232,18 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 		// WHY Snapshot: reads AppConfig.DatabaseType under the read lock.
 		savedDBType := Snapshot().DatabaseType
 
+		// Migrate flat embedding keys → nested EmbeddingConfig format (idempotent).
+		blobStr := blob.Value
+		if migrated, changed := migrateEmbeddingBlob(blobStr); changed {
+			slog.Info("config: migrated embedding fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated blob", "err", saveErr)
+			}
+		}
+
 		var loaded Config
-		if err := json.Unmarshal([]byte(blob.Value), &loaded); err == nil {
+		if err := json.Unmarshal([]byte(blobStr), &loaded); err == nil {
 			// WHY Mutate: whole-struct assignment races with HTTP readers.
 			Mutate(func(c *Config) {
 				*c = loaded
@@ -818,9 +876,9 @@ func SyncConfigFromEnv() {
 		if viper.IsSet("enable_ai_parsing") {
 			c.EnableAIParsing = viper.GetBool("enable_ai_parsing")
 		}
-		if viper.IsSet("embedding_base_url") {
-			if val := viper.GetString("embedding_base_url"); val != "" {
-				c.EmbeddingBaseURL = val
+		if viper.IsSet("embedding.base_url") {
+			if val := viper.GetString("embedding.base_url"); val != "" {
+				c.Embedding.BaseURL = val
 			}
 		}
 		if viper.IsSet("acoustid_api_key") {

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,6 +1,7 @@
 // file: internal/config/persistence_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-06-16
 
 package config
 
@@ -12,7 +13,9 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func resetConfigTestState() {
@@ -805,4 +808,87 @@ func TestLifecycleRetentionSettings(t *testing.T) {
 			t.Errorf("expected PurgeSoftDeletedDeleteFiles to be true, got %v", AppConfig.PurgeSoftDeletedDeleteFiles)
 		}
 	})
+}
+
+func TestMigrateEmbeddingFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"embedding_enabled": true,
+		"embedding_model": "text-embedding-3-large",
+		"embedding_dimensions": 3072,
+		"embedding_base_url": "http://localhost:11434/v1",
+		"vector_index_backend": "hnsw",
+		"root_dir": "/data"
+	}`
+
+	migrated, changed := migrateEmbeddingBlob(flatBlob)
+	require.True(t, changed, "flat blob should be migrated")
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+
+	emb, ok := result["embedding"].(map[string]any)
+	require.True(t, ok, "embedding key should exist as object")
+	assert.Equal(t, true, emb["enabled"])
+	assert.Equal(t, "text-embedding-3-large", emb["model"])
+	assert.Equal(t, float64(3072), emb["dimensions"])
+	assert.Equal(t, "http://localhost:11434/v1", emb["base_url"])
+	assert.Equal(t, "hnsw", emb["vector_backend"])
+
+	// flat keys must be gone
+	assert.NotContains(t, result, "embedding_enabled")
+	assert.NotContains(t, result, "embedding_model")
+	assert.NotContains(t, result, "embedding_dimensions")
+	assert.NotContains(t, result, "embedding_base_url")
+	assert.NotContains(t, result, "vector_index_backend")
+
+	// unrelated keys must be preserved
+	assert.Equal(t, "/data", result["root_dir"])
+}
+
+func TestMigrateEmbeddingFields_AlreadyNested(t *testing.T) {
+	nestedBlob := `{"embedding": {"enabled": true, "model": "bge-m3"}, "root_dir": "/data"}`
+	_, changed := migrateEmbeddingBlob(nestedBlob)
+	assert.False(t, changed, "already-nested blob should be a no-op")
+}
+
+func TestMigrateEmbeddingFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateEmbeddingBlob(`{}`)
+	assert.False(t, changed, "empty blob should be a no-op")
+}
+
+func TestRemapEmbeddingKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"embedding_enabled":    true,
+		"embedding_model":      "bge-m3",
+		"embedding_dimensions": float64(1024),
+		"root_dir":             "/data",
+	}
+	result := remapEmbeddingKeys(payload)
+
+	emb, ok := result["embedding"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, emb["enabled"])
+	assert.Equal(t, "bge-m3", emb["model"])
+	assert.Equal(t, float64(1024), emb["dimensions"])
+	assert.Equal(t, "/data", result["root_dir"]) // untouched
+	assert.NotContains(t, result, "embedding_enabled")
+	assert.NotContains(t, result, "embedding_model")
+}
+
+func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
+	// Client sends both flat legacy key AND new nested key — merge, don't overwrite
+	payload := map[string]any{
+		"embedding_enabled": false,
+		"embedding":         map[string]any{"model": "bge-m3"},
+	}
+	result := remapEmbeddingKeys(payload)
+	emb := result["embedding"].(map[string]any)
+	assert.Equal(t, false, emb["enabled"])
+	assert.Equal(t, "bge-m3", emb["model"])
+}
+
+func TestRemapEmbeddingKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapEmbeddingKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,7 +1,7 @@
 // file: internal/config/update_service.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
-// last-edited: 2026-06-10
+// last-edited: 2026-06-16
 
 package config
 
@@ -67,6 +67,38 @@ var secretFieldKeys = []string{
 // immutableFieldKeys cannot be changed at runtime and are rejected if present.
 var immutableFieldKeys = []string{"database_type", "enable_sqlite"}
 
+// remapEmbeddingKeys translates legacy flat embedding keys in a config update
+// payload to the nested EmbeddingConfig format. Merges into any existing
+// "embedding" sub-object to avoid zeroing sibling fields.
+// Remove this shim once the frontend sends nested keys.
+func remapEmbeddingKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"embedding_enabled":    "enabled",
+		"embedding_model":      "model",
+		"embedding_dimensions": "dimensions",
+		"embedding_base_url":   "base_url",
+		"vector_index_backend": "vector_backend",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["embedding"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["embedding"] = nested
+	}
+	return payload
+}
+
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -118,6 +150,9 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	for _, k := range secretFieldKeys {
 		delete(filtered, k)
 	}
+
+	// Translate any legacy flat embedding keys to the nested EmbeddingConfig format.
+	filtered = remapEmbeddingKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/plugins/dedup/reembed_embeddings.go
+++ b/internal/plugins/dedup/reembed_embeddings.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/reembed_embeddings.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9d8c7b6a-5e4f-3a2b-1c0d-9e8f7a6b5c4d
-// last-edited: 2026-06-15
+// last-edited: 2026-06-16
 
 // Package dedup — op dedup.reembed-embeddings.
 //
@@ -109,7 +109,7 @@ func (p *Plugin) reembedEmbeddingsDef() sdk.OperationDef {
 // runReembedEmbeddings implements the reembed-embeddings op.
 func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
 	// Guard: local re-embed requires Ollama to be running.
-	if config.AppConfig.EmbeddingBaseURL != "" {
+	if config.AppConfig.Embedding.BaseURL != "" {
 		if p.toolRegistry != nil && !p.toolRegistry.Available("ollama") {
 			return fmt.Errorf("reembed-embeddings: local embedding base URL configured but Ollama is not available — install or enable via Settings → Tools: %w", tools.ErrToolNotAvailable)
 		}

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.11.0
+// version: 1.12.0
+// last-edited: 2026-06-16
 
 package server
 
@@ -92,11 +93,11 @@ func init() {
 			// predates EmbeddingDimensions (whole-struct replace zeroes it), so
 			// fall back to the historical 3072 default rather than build a
 			// 0-dim store.
-			dims := cfg.EmbeddingDimensions
+			dims := cfg.Embedding.Dimensions
 			if dims <= 0 {
 				dims = 3072
 			}
-			if cfg.VectorIndexBackend == "hnsw" {
+			if cfg.Embedding.VectorBackend == "hnsw" {
 				return database.NewHNSWEmbeddingStore(dims), nil
 			}
 			store, err := database.NewChromemEmbeddingStore(dir, dims)
@@ -131,7 +132,7 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
-			if cfg.OpenAIAPIKey == "" || !cfg.EmbeddingEnabled {
+			if cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled {
 				return (*dedup.Engine)(nil), nil
 			}
 			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, "embeddingstore")


### PR DESCRIPTION
## Summary

- Introduces `EmbeddingConfig` sub-struct and moves 5 flat `Config` fields (`EmbeddingEnabled`, `EmbeddingModel`, `EmbeddingDimensions`, `EmbeddingBaseURL`, `VectorIndexBackend`) into `Config.Embedding`
- Viper wiring updated to dot-notation keys (`embedding.enabled`, etc.) with explicit `BindEnv` calls so unit tests work without `AutomaticEnv()`
- `migrateEmbeddingBlob` rewrites legacy flat `config_blob` JSON to nested format on load (idempotent, persists the migrated blob back to DB)
- `remapEmbeddingKeys` frontend compat shim translates legacy flat update-API keys to nested format so existing UI continues working without a simultaneous frontend deploy
- Callsites updated in `internal/ai/register.go`, `internal/server/registry_wire.go`, `internal/plugins/dedup/reembed_embeddings.go`

## Test plan

- [x] 71 tests in `internal/config/` pass (8 new: `TestMigrateEmbeddingFields_*`, `TestRemapEmbeddingKeys_*`, `TestInitConfig_EmbeddingDefaults`, `TestInitConfig_EmbeddingFromEnv`)
- [x] `go build ./...` exits 0 — no remaining callsite errors
- [x] Pre-existing `config_unit_test.go` tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)