### PR TITLE
refactor(config): nest dedup fields into DedupConfig sub-struct (Wave 2)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.53.0
+// version: 1.54.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-16
 
@@ -95,6 +95,50 @@ type EmbeddingConfig struct {
 	VectorBackend string `json:"vector_backend" mapstructure:"vector_backend"`
 }
 
+// DedupSignalConfig holds the band-threshold values for the unified scoring
+// system (SPEC 1 §3). Persisting these in the config blob means they survive
+// across restarts without needing to fall back to Viper every time.
+type DedupSignalConfig struct {
+	// BandCertainMin is the minimum score to classify a pair as CERTAIN (default 97).
+	BandCertainMin float64 `json:"band_certain_min" mapstructure:"band_certain_min"`
+	// BandHighMin is the minimum score to classify a pair as HIGH (default 90).
+	BandHighMin float64 `json:"band_high_min" mapstructure:"band_high_min"`
+	// BandMediumMin is the minimum score to classify a pair as MEDIUM (default 75).
+	BandMediumMin float64 `json:"band_medium_min" mapstructure:"band_medium_min"`
+	// BandReviewMin is the minimum score to classify a pair as REVIEW (default 60).
+	// Pairs scoring below this floor are not persisted.
+	BandReviewMin float64 `json:"band_review_min" mapstructure:"band_review_min"`
+}
+
+// DedupConfig holds all deduplication settings that were previously flat fields
+// in Config. Nesting these here keeps the config blob organised and lets the
+// API shim (remapDedupKeys) translate legacy PUT payloads transparently.
+type DedupConfig struct {
+	// BookHighThreshold is the cosine-similarity floor for "high confidence" book pairs (default 0.95).
+	BookHighThreshold float64 `json:"book_high_threshold" mapstructure:"book_high_threshold"`
+	// BookLowThreshold is the cosine-similarity floor for "low confidence" book pairs (default 0.85).
+	BookLowThreshold float64 `json:"book_low_threshold" mapstructure:"book_low_threshold"`
+	// AuthorHighThreshold is the cosine-similarity floor for "high confidence" author pairs (default 0.92).
+	AuthorHighThreshold float64 `json:"author_high_threshold" mapstructure:"author_high_threshold"`
+	// AuthorLowThreshold is the cosine-similarity floor for "low confidence" author pairs (default 0.80).
+	AuthorLowThreshold float64 `json:"author_low_threshold" mapstructure:"author_low_threshold"`
+	// AutoMergeEnabled controls whether high-confidence pairs are merged automatically (default true).
+	AutoMergeEnabled bool `json:"auto_merge_enabled" mapstructure:"auto_merge_enabled"`
+	// EmbeddingsEnabled controls whether the embedding layer (Layer 2) is active (default true).
+	// Set false on air-gapped / no-internet boxes to skip all embedding API calls.
+	EmbeddingsEnabled bool `json:"embeddings_enabled" mapstructure:"embeddings_enabled"`
+	// LLMAutoMergeHighConfidence, when true, auto-applies merges when the LLM
+	// review returns a "duplicate" verdict with confidence "high" (default false — opt-in).
+	LLMAutoMergeHighConfidence bool `json:"llm_auto_merge_high_confidence" mapstructure:"llm_auto_merge_high_confidence"`
+	// OnImportViaScheduler routes the post-import dedup check through the UOS
+	// dependency scheduler instead of an eager goroutine (default false — opt-in).
+	OnImportViaScheduler bool `json:"on_import_via_scheduler" mapstructure:"on_import_via_scheduler"`
+	// ReviewModel is the OpenAI model used for LLM-layer dedup review (default "gpt-5-mini").
+	ReviewModel string `json:"review_model" mapstructure:"review_model"`
+	// Signals holds the unified scoring band thresholds.
+	Signals DedupSignalConfig `json:"signals" mapstructure:"signals"`
+}
+
 // Config holds application configuration
 type Config struct {
 	// Core paths
@@ -149,9 +193,9 @@ type Config struct {
 	// when empty, for compatibility with the original env-only setup.
 	AcoustIDAPIKey string `json:"acoustid_api_key"`
 
-	// Per-feature OpenAI model selection. Default to gpt-5-mini for all four
+	// Per-feature OpenAI model selection. Default to gpt-5-mini for all three
 	// to preserve historical behavior. See spec docs/superpowers/specs/2026-04-27-per-feature-llm-model-knob-design.md.
-	DedupReviewModel    string `json:"dedup_review_model"    mapstructure:"dedup_review_model"`
+	// Note: DedupReviewModel has moved to Dedup.ReviewModel.
 	MetadataReviewModel string `json:"metadata_review_model" mapstructure:"metadata_review_model"`
 	FilenameParseModel  string `json:"filename_parse_model"  mapstructure:"filename_parse_model"`
 	CoverArtModel       string `json:"cover_art_model"       mapstructure:"cover_art_model"`
@@ -181,36 +225,8 @@ type Config struct {
 	// Embedding holds configuration for the embedding pipeline (model, provider, vector backend).
 	Embedding EmbeddingConfig `json:"embedding" mapstructure:"embedding"`
 
-	DedupBookHighThreshold   float64 `json:"dedup_book_high_threshold"`   // default 0.95
-	DedupBookLowThreshold    float64 `json:"dedup_book_low_threshold"`    // default 0.85
-	DedupAuthorHighThreshold float64 `json:"dedup_author_high_threshold"` // default 0.92
-	DedupAuthorLowThreshold  float64 `json:"dedup_author_low_threshold"`  // default 0.80
-	DedupAutoMergeEnabled    bool    `json:"dedup_auto_merge_enabled"`    // default true
-	// DedupEmbeddingsEnabled controls whether the embedding layer (Layer 2) is
-	// active for dedup.full-scan and per-import dedup checks. Default true
-	// (preserves current behaviour). Set to false on air-gapped / no-internet
-	// boxes to skip all OpenAI embedding calls; Layer 1 (hash/ISBN/title/
-	// duration) still runs and produces candidates. A circuit-breaker in
-	// FullScan also disables the path automatically after 3 consecutive API
-	// failures, so toggling this manually is only needed when you want to
-	// suppress the API calls from the very start.
-	DedupEmbeddingsEnabled bool `json:"dedup_embeddings_enabled"` // default true
-	// DedupOnImportViaScheduler, when true, routes the post-import dedup check
-	// through the UOS dependency scheduler (dedup.check-book op, M4) instead
-	// of firing an eager goroutine. Defaults false so production import behavior
-	// is unchanged until explicitly opted in. Set to true to enable the
-	// scheduled path once book_sig_v1 population is confirmed in the library.
-	DedupOnImportViaScheduler bool `json:"dedup_on_import_via_scheduler"` // default false — opt-in
-	// DedupLLMAutoMergeHighConfidence, when true, automatically
-	// applies a merge when the LLM review (Layer 3) returns a
-	// "duplicate" verdict with confidence "high". Opt-in because
-	// a false-positive high-confidence verdict silently merges
-	// the wrong pair of books. When enabled, every auto-merge
-	// tags the surviving book with
-	// `dedup:merge-survivor:llm-auto` as a system tag so users
-	// can filter the dedup tab for "things the LLM decided
-	// for me" and review them post-hoc.
-	DedupLLMAutoMergeHighConfidence bool `json:"dedup_llm_auto_merge_high_confidence"` // default false — opt-in
+	// Dedup holds all deduplication settings (thresholds, auto-merge, LLM model, signal bands).
+	Dedup DedupConfig `json:"dedup" mapstructure:"dedup"`
 
 	// Metadata candidate scoring (PR1)
 	MetadataEmbeddingScoringEnabled bool    `json:"metadata_embedding_scoring_enabled"` // default true
@@ -477,8 +493,9 @@ func InitConfig() {
 	viper.SetDefault("openai_api_key", "")
 	viper.SetDefault("acoustid_api_key", "")
 
-	// Per-feature model defaults — gpt-5-mini preserves historical behavior
-	viper.SetDefault("dedup_review_model", "gpt-5-mini")
+	// Per-feature model defaults — gpt-5-mini preserves historical behavior.
+	// dedup_review_model has moved to dedup.review_model (nested DedupConfig).
+	viper.SetDefault("dedup.review_model", "gpt-5-mini")
 	viper.SetDefault("metadata_review_model", "gpt-5-mini")
 	viper.SetDefault("filename_parse_model", "gpt-5-mini")
 	viper.SetDefault("cover_art_model", "gpt-5-mini")
@@ -615,15 +632,15 @@ func InitConfig() {
 	viper.BindEnv("embedding.base_url", "EMBEDDING_BASE_URL")         //nolint:errcheck
 	viper.BindEnv("embedding.vector_backend", "VECTOR_INDEX_BACKEND") //nolint:errcheck
 
-	// Dedup threshold + behaviour defaults
-	viper.SetDefault("dedup_book_high_threshold", 0.95)
-	viper.SetDefault("dedup_book_low_threshold", 0.85)
-	viper.SetDefault("dedup_author_high_threshold", 0.92)
-	viper.SetDefault("dedup_author_low_threshold", 0.80)
-	viper.SetDefault("dedup_auto_merge_enabled", true)
-	viper.SetDefault("dedup_embeddings_enabled", true)           // opt-out: set false on no-internet boxes
-	viper.SetDefault("dedup_llm_auto_merge_high_confidence", false) // opt-in
-	viper.SetDefault("dedup_on_import_via_scheduler", false)        // opt-in — keep eager path until M4 confirmed
+	// Dedup threshold + behaviour defaults (nested under "dedup.*").
+	viper.SetDefault("dedup.book_high_threshold", 0.95)
+	viper.SetDefault("dedup.book_low_threshold", 0.85)
+	viper.SetDefault("dedup.author_high_threshold", 0.92)
+	viper.SetDefault("dedup.author_low_threshold", 0.80)
+	viper.SetDefault("dedup.auto_merge_enabled", true)
+	viper.SetDefault("dedup.embeddings_enabled", true)                 // opt-out: set false on no-internet boxes
+	viper.SetDefault("dedup.llm_auto_merge_high_confidence", false)   // opt-in
+	viper.SetDefault("dedup.on_import_via_scheduler", false)          // opt-in — keep eager path until M4 confirmed
 
 	// Metadata candidate scoring defaults
 	viper.SetDefault("metadata_embedding_scoring_enabled", true)
@@ -705,7 +722,6 @@ func InitConfig() {
 			EnableAIParsing:     viper.GetBool("enable_ai_parsing"),
 			OpenAIAPIKey:        viper.GetString("openai_api_key"),
 			AcoustIDAPIKey:      viper.GetString("acoustid_api_key"),
-			DedupReviewModel:    viper.GetString("dedup_review_model"),
 			MetadataReviewModel: viper.GetString("metadata_review_model"),
 			FilenameParseModel:  viper.GetString("filename_parse_model"),
 			CoverArtModel:       viper.GetString("cover_art_model"),
@@ -826,15 +842,24 @@ func InitConfig() {
 				VectorBackend: viper.GetString("embedding.vector_backend"),
 			},
 
-			// Dedup thresholds + behaviour
-			DedupBookHighThreshold:          viper.GetFloat64("dedup_book_high_threshold"),
-			DedupBookLowThreshold:           viper.GetFloat64("dedup_book_low_threshold"),
-			DedupAuthorHighThreshold:        viper.GetFloat64("dedup_author_high_threshold"),
-			DedupAuthorLowThreshold:         viper.GetFloat64("dedup_author_low_threshold"),
-			DedupAutoMergeEnabled:           viper.GetBool("dedup_auto_merge_enabled"),
-			DedupEmbeddingsEnabled:          viper.GetBool("dedup_embeddings_enabled"),
-			DedupLLMAutoMergeHighConfidence: viper.GetBool("dedup_llm_auto_merge_high_confidence"),
-			DedupOnImportViaScheduler:       viper.GetBool("dedup_on_import_via_scheduler"),
+			// Dedup thresholds + behaviour (nested sub-struct)
+			Dedup: DedupConfig{
+				BookHighThreshold:          viper.GetFloat64("dedup.book_high_threshold"),
+				BookLowThreshold:           viper.GetFloat64("dedup.book_low_threshold"),
+				AuthorHighThreshold:        viper.GetFloat64("dedup.author_high_threshold"),
+				AuthorLowThreshold:         viper.GetFloat64("dedup.author_low_threshold"),
+				AutoMergeEnabled:           viper.GetBool("dedup.auto_merge_enabled"),
+				EmbeddingsEnabled:          viper.GetBool("dedup.embeddings_enabled"),
+				LLMAutoMergeHighConfidence: viper.GetBool("dedup.llm_auto_merge_high_confidence"),
+				OnImportViaScheduler:       viper.GetBool("dedup.on_import_via_scheduler"),
+				ReviewModel:                viper.GetString("dedup.review_model"),
+				Signals: DedupSignalConfig{
+					BandCertainMin: viper.GetFloat64("dedup.signals.band_certain_min"),
+					BandHighMin:    viper.GetFloat64("dedup.signals.band_high_min"),
+					BandMediumMin:  viper.GetFloat64("dedup.signals.band_medium_min"),
+					BandReviewMin:  viper.GetFloat64("dedup.signals.band_review_min"),
+				},
+			},
 
 			// Metadata candidate scoring
 			MetadataEmbeddingScoringEnabled: viper.GetBool("metadata_embedding_scoring_enabled"),
@@ -1129,7 +1154,6 @@ func ResetToDefaults() {
 			EnableAIParsing:     true,
 			OpenAIAPIKey:        "",
 			AcoustIDAPIKey:      "",
-			DedupReviewModel:    "gpt-5-mini",
 			MetadataReviewModel: "gpt-5-mini",
 			FilenameParseModel:  "gpt-5-mini",
 			CoverArtModel:       "gpt-5-mini",
@@ -1169,14 +1193,25 @@ func ResetToDefaults() {
 				BaseURL:       "",
 				VectorBackend: "chromem",
 			},
-			DedupBookHighThreshold:          0.95,
-			DedupBookLowThreshold:           0.85,
-			DedupAuthorHighThreshold:        0.92,
-			DedupAuthorLowThreshold:         0.80,
-			DedupAutoMergeEnabled:           true,
-			DedupEmbeddingsEnabled:          true, // opt-out: set false on no-internet boxes
-			DedupLLMAutoMergeHighConfidence: false,
-			DedupOnImportViaScheduler:       false, // opt-in
+
+			// Dedup thresholds + behaviour (nested sub-struct)
+			Dedup: DedupConfig{
+				BookHighThreshold:          0.95,
+				BookLowThreshold:           0.85,
+				AuthorHighThreshold:        0.92,
+				AuthorLowThreshold:         0.80,
+				AutoMergeEnabled:           true,
+				EmbeddingsEnabled:          true,  // opt-out: set false on no-internet boxes
+				LLMAutoMergeHighConfidence: false,
+				OnImportViaScheduler:       false, // opt-in
+				ReviewModel:                "gpt-5-mini",
+				Signals: DedupSignalConfig{
+					BandCertainMin: 97.0,
+					BandHighMin:    90.0,
+					BandMediumMin:  75.0,
+					BandReviewMin:  60.0,
+				},
+			},
 
 			// Metadata candidate scoring (PR1)
 			MetadataEmbeddingScoringEnabled: true,

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_unit_test.go
-// version: 1.5.0
+// version: 1.6.0
 // last-edited: 2026-06-16
 
 package config
@@ -393,12 +393,12 @@ func TestInitConfigDefaults(t *testing.T) {
 	t.Run("embedding dedup defaults", func(t *testing.T) {
 		assert.True(t, AppConfig.Embedding.Enabled)
 		assert.Equal(t, "text-embedding-3-large", AppConfig.Embedding.Model)
-		assert.InDelta(t, 0.95, AppConfig.DedupBookHighThreshold, 0.001)
-		assert.InDelta(t, 0.85, AppConfig.DedupBookLowThreshold, 0.001)
-		assert.InDelta(t, 0.92, AppConfig.DedupAuthorHighThreshold, 0.001)
-		assert.InDelta(t, 0.80, AppConfig.DedupAuthorLowThreshold, 0.001)
-		assert.True(t, AppConfig.DedupAutoMergeEnabled)
-		assert.False(t, AppConfig.DedupLLMAutoMergeHighConfidence)
+		assert.InDelta(t, 0.95, AppConfig.Dedup.BookHighThreshold, 0.001)
+		assert.InDelta(t, 0.85, AppConfig.Dedup.BookLowThreshold, 0.001)
+		assert.InDelta(t, 0.92, AppConfig.Dedup.AuthorHighThreshold, 0.001)
+		assert.InDelta(t, 0.80, AppConfig.Dedup.AuthorLowThreshold, 0.001)
+		assert.True(t, AppConfig.Dedup.AutoMergeEnabled)
+		assert.False(t, AppConfig.Dedup.LLMAutoMergeHighConfidence)
 	})
 
 	t.Run("metadata scoring defaults", func(t *testing.T) {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.21.0
+// version: 1.22.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-06-16
 
@@ -189,6 +189,71 @@ func migrateEmbeddingBlob(blob string) (string, bool) {
 	return string(migrated), true
 }
 
+// migrateDedupBlob rewrites a flat-format config blob to the nested DedupConfig
+// format. Returns the (possibly modified) blob and whether a migration occurred.
+// Safe to call repeatedly: returns (blob, false) if already nested or no flat
+// dedup keys are present.
+func migrateDedupBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+
+	// Check whether any flat dedup keys exist.
+	flatDedupKeys := []string{
+		"dedup_book_high_threshold",
+		"dedup_book_low_threshold",
+		"dedup_author_high_threshold",
+		"dedup_author_low_threshold",
+		"dedup_auto_merge_enabled",
+		"dedup_embeddings_enabled",
+		"dedup_llm_auto_merge_high_confidence",
+		"dedup_on_import_via_scheduler",
+		"dedup_review_model",
+	}
+	hasFlat := false
+	for _, k := range flatDedupKeys {
+		if _, ok := raw[k]; ok {
+			hasFlat = true
+			break
+		}
+	}
+	if !hasFlat {
+		return blob, false
+	}
+
+	// Build the nested "dedup" object, starting from any already-present sub-object.
+	nested, _ := raw["dedup"].(map[string]any)
+	if nested == nil {
+		nested = make(map[string]any)
+	}
+
+	flatToNested := map[string]string{
+		"dedup_book_high_threshold":           "book_high_threshold",
+		"dedup_book_low_threshold":            "book_low_threshold",
+		"dedup_author_high_threshold":         "author_high_threshold",
+		"dedup_author_low_threshold":          "author_low_threshold",
+		"dedup_auto_merge_enabled":            "auto_merge_enabled",
+		"dedup_embeddings_enabled":            "embeddings_enabled",
+		"dedup_llm_auto_merge_high_confidence": "llm_auto_merge_high_confidence",
+		"dedup_on_import_via_scheduler":       "on_import_via_scheduler",
+		"dedup_review_model":                  "review_model",
+	}
+	for flat, short := range flatToNested {
+		if v, ok := raw[flat]; ok {
+			nested[short] = v
+			delete(raw, flat)
+		}
+	}
+	raw["dedup"] = nested
+
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
 // saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
 // Used only by startup migration to persist migrated blobs without re-marshaling.
 func saveRawBlob(store database.SettingsStore, rawJSON string) error {
@@ -239,6 +304,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated blob", "err", saveErr)
+			}
+		}
+
+		// Migrate flat dedup_* keys → nested DedupConfig format (idempotent).
+		if migrated, changed := migrateDedupBlob(blobStr); changed {
+			slog.Info("config: migrated dedup fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated dedup blob", "err", saveErr)
 			}
 		}
 
@@ -772,6 +846,43 @@ func applySetting(key, value, typ string) error {
 			c.BasicAuthUsername = value
 		case "basic_auth_password":
 			c.BasicAuthPassword = value
+
+		// Dedup thresholds + behaviour (legacy flat keys — new installs use the blob).
+		// These cases handle pre-Wave-2 installs that stored settings as individual rows.
+		case "dedup_book_high_threshold":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.Dedup.BookHighThreshold = f
+			}
+		case "dedup_book_low_threshold":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.Dedup.BookLowThreshold = f
+			}
+		case "dedup_author_high_threshold":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.Dedup.AuthorHighThreshold = f
+			}
+		case "dedup_author_low_threshold":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.Dedup.AuthorLowThreshold = f
+			}
+		case "dedup_auto_merge_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Dedup.AutoMergeEnabled = b
+			}
+		case "dedup_embeddings_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Dedup.EmbeddingsEnabled = b
+			}
+		case "dedup_llm_auto_merge_high_confidence":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Dedup.LLMAutoMergeHighConfidence = b
+			}
+		case "dedup_on_import_via_scheduler":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Dedup.OnImportViaScheduler = b
+			}
+		case "dedup_review_model":
+			c.Dedup.ReviewModel = value
 
 		default:
 			applyErr = fmt.Errorf("unknown setting key: %s", key)

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-16
 
@@ -890,5 +890,63 @@ func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
 func TestRemapEmbeddingKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := remapEmbeddingKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+func TestMigrateDedupFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"dedup_book_high_threshold": 0.95,
+		"dedup_book_low_threshold": 0.85,
+		"dedup_author_high_threshold": 0.92,
+		"dedup_author_low_threshold": 0.80,
+		"dedup_auto_merge_enabled": true,
+		"dedup_embeddings_enabled": false,
+		"dedup_llm_auto_merge_high_confidence": false,
+		"dedup_on_import_via_scheduler": true,
+		"dedup_review_model": "gpt-5-mini",
+		"root_dir": "/data"
+	}`
+	migrated, changed := migrateDedupBlob(flatBlob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	d, ok := result["dedup"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0.95), d["book_high_threshold"])
+	assert.Equal(t, "gpt-5-mini", d["review_model"])
+	assert.Equal(t, true, d["auto_merge_enabled"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "dedup_book_high_threshold")
+	assert.NotContains(t, result, "dedup_review_model")
+}
+
+func TestMigrateDedupFields_AlreadyNested(t *testing.T) {
+	_, changed := migrateDedupBlob(`{"dedup": {"book_high_threshold": 0.95}}`)
+	assert.False(t, changed)
+}
+
+func TestMigrateDedupFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateDedupBlob(`{}`)
+	assert.False(t, changed)
+}
+
+func TestRemapDedupKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"dedup_book_high_threshold": float64(0.95),
+		"dedup_review_model":        "gpt-5-mini",
+		"root_dir":                  "/data",
+	}
+	result := remapDedupKeys(payload)
+	d, ok := result["dedup"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0.95), d["book_high_threshold"])
+	assert.Equal(t, "gpt-5-mini", d["review_model"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "dedup_book_high_threshold")
+}
+
+func TestRemapDedupKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapDedupKeys(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,5 +1,5 @@
 // file: internal/config/update_service.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 // last-edited: 2026-06-16
 
@@ -99,6 +99,42 @@ func remapEmbeddingKeys(payload map[string]any) map[string]any {
 	return payload
 }
 
+// remapDedupKeys translates legacy flat dedup keys in a config update payload
+// to the nested DedupConfig format. Merges into any existing "dedup" sub-object
+// to avoid zeroing sibling fields.
+// Remove this shim once the frontend sends nested keys.
+func remapDedupKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"dedup_book_high_threshold":             "book_high_threshold",
+		"dedup_book_low_threshold":              "book_low_threshold",
+		"dedup_author_high_threshold":           "author_high_threshold",
+		"dedup_author_low_threshold":            "author_low_threshold",
+		"dedup_auto_merge_enabled":              "auto_merge_enabled",
+		"dedup_embeddings_enabled":              "embeddings_enabled",
+		"dedup_llm_auto_merge_high_confidence": "llm_auto_merge_high_confidence",
+		"dedup_on_import_via_scheduler":         "on_import_via_scheduler",
+		"dedup_review_model":                    "review_model",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["dedup"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["dedup"] = nested
+	}
+	return payload
+}
+
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -153,6 +189,8 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 
 	// Translate any legacy flat embedding keys to the nested EmbeddingConfig format.
 	filtered = remapEmbeddingKeys(filtered)
+	// Translate any legacy flat dedup keys to the nested DedupConfig format.
+	filtered = remapDedupKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.30.0
+// version: 1.31.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-14
+// last-edited: 2026-06-16
 
 package dedup
 
@@ -203,7 +203,7 @@ func (de *Engine) SetISBNIndexStore(s ISBNIndexStore) {
 // the pattern used by DedupReviewModel and DedupLLMAutoMergeHighConfidence so
 // a runtime settings toggle takes effect on the next FullScan without a restart.
 func (de *Engine) embeddingsEnabled() bool {
-	return de.embedClient != nil && config.AppConfig.DedupEmbeddingsEnabled
+	return de.embedClient != nil && config.AppConfig.Dedup.EmbeddingsEnabled
 }
 
 // SetScoreConfig overrides the unified scoring calibration.  Call this before
@@ -2408,7 +2408,7 @@ func (de *Engine) RunLLMReview(ctx context.Context) error {
 		Store:  de.aiJobsStore,
 		Client: &ai.AIJobsBatchClient{Parser: de.llmParser},
 	}
-	model := config.AppConfig.DedupReviewModel // per-feature model knob (AI-MODEL-1)
+	model := config.AppConfig.Dedup.ReviewModel // per-feature model knob (AI-MODEL-1)
 	if model == "" {
 		model = "gpt-5-mini"
 	}
@@ -2555,7 +2555,7 @@ func (de *Engine) ApplyVerdicts(verdicts []ai.DedupPairVerdict, byIndex map[int]
 		// — author merges are structural and user-visible enough
 		// that we require manual confirmation regardless of
 		// confidence.
-		if !config.AppConfig.DedupLLMAutoMergeHighConfidence {
+		if !config.AppConfig.Dedup.LLMAutoMergeHighConfidence {
 			continue
 		}
 		if candidate.EntityType != "book" {

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_test.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
-// last-edited: 2026-06-14
+// last-edited: 2026-06-16
 
 package dedup
 
@@ -37,9 +37,9 @@ func setupTestEngine(t *testing.T) (*Engine, *database.MockStore, *database.Embe
 
 	// Ensure the global config flag is true so embeddingsEnabled() works as
 	// expected in tests that wire up an embedClient.
-	prev := config.AppConfig.DedupEmbeddingsEnabled
-	config.AppConfig.DedupEmbeddingsEnabled = true
-	t.Cleanup(func() { config.AppConfig.DedupEmbeddingsEnabled = prev })
+	prev := config.AppConfig.Dedup.EmbeddingsEnabled
+	config.AppConfig.Dedup.EmbeddingsEnabled = true
+	t.Cleanup(func() { config.AppConfig.Dedup.EmbeddingsEnabled = prev })
 
 	mock := &database.MockStore{}
 	ms := merge.NewService(mock)
@@ -834,9 +834,9 @@ func TestApplyVerdicts_AutoMergeOnHighConfidence(t *testing.T) {
 	engine, mock, es := setupTestEngine(t)
 
 	// Enable the opt-in flag for this test.
-	prev := config.AppConfig.DedupLLMAutoMergeHighConfidence
-	config.AppConfig.DedupLLMAutoMergeHighConfidence = true
-	defer func() { config.AppConfig.DedupLLMAutoMergeHighConfidence = prev }()
+	prev := config.AppConfig.Dedup.LLMAutoMergeHighConfidence
+	config.AppConfig.Dedup.LLMAutoMergeHighConfidence = true
+	defer func() { config.AppConfig.Dedup.LLMAutoMergeHighConfidence = prev }()
 
 	// Seed two books the merge service can load.
 	authorID := 1
@@ -901,9 +901,9 @@ func TestApplyVerdicts_NoAutoMergeWhenDisabled(t *testing.T) {
 	engine, _, es := setupTestEngine(t)
 
 	// Flag is false by default; be explicit.
-	prev := config.AppConfig.DedupLLMAutoMergeHighConfidence
-	config.AppConfig.DedupLLMAutoMergeHighConfidence = false
-	defer func() { config.AppConfig.DedupLLMAutoMergeHighConfidence = prev }()
+	prev := config.AppConfig.Dedup.LLMAutoMergeHighConfidence
+	config.AppConfig.Dedup.LLMAutoMergeHighConfidence = false
+	defer func() { config.AppConfig.Dedup.LLMAutoMergeHighConfidence = prev }()
 
 	sim := 0.88
 	_ = es.UpsertCandidate(database.DedupCandidate{
@@ -929,9 +929,9 @@ func TestApplyVerdicts_NoAutoMergeWhenDisabled(t *testing.T) {
 func TestApplyVerdicts_NoAutoMergeMediumConfidence(t *testing.T) {
 	engine, _, es := setupTestEngine(t)
 
-	prev := config.AppConfig.DedupLLMAutoMergeHighConfidence
-	config.AppConfig.DedupLLMAutoMergeHighConfidence = true
-	defer func() { config.AppConfig.DedupLLMAutoMergeHighConfidence = prev }()
+	prev := config.AppConfig.Dedup.LLMAutoMergeHighConfidence
+	config.AppConfig.Dedup.LLMAutoMergeHighConfidence = true
+	defer func() { config.AppConfig.Dedup.LLMAutoMergeHighConfidence = prev }()
 
 	sim := 0.88
 	_ = es.UpsertCandidate(database.DedupCandidate{
@@ -1266,7 +1266,7 @@ func TestFullScan_DedupEmbeddingsDisabled_NeverCallsEmbed(t *testing.T) {
 	engine, _, _ := setupTestEngine(t)
 
 	// Override the flag set by setupTestEngine.
-	config.AppConfig.DedupEmbeddingsEnabled = false
+	config.AppConfig.Dedup.EmbeddingsEnabled = false
 	// setupTestEngine already registered a t.Cleanup to restore it.
 
 	books := makePrimaryBooks(70) // more than one chunk

--- a/internal/dedup/unified/config.go
+++ b/internal/dedup/unified/config.go
@@ -1,12 +1,14 @@
 // file: internal/dedup/unified/config.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d8a383db-5083-4257-be54-686ac2e72d32
+// last-edited: 2026-06-16
 
 package unified
 
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/spf13/viper"
 )
@@ -147,13 +149,37 @@ func DefaultScoreConfig() ScoreConfig {
 	}
 }
 
-// LoadScoreConfig reads overrides from Viper (config.yaml dedup.signals.*)
-// on top of DefaultScoreConfig. Returns an error if the resulting config
-// fails Validate.
+// bandOverride holds DB-persisted band thresholds injected by the caller
+// (engine or server init) to avoid a circular import between unified→config.
+// Protected by bandMu; zero values mean "use Viper / defaults".
+var (
+	bandMu       sync.RWMutex
+	bandOverride struct {
+		certainMin, highMin, mediumMin, reviewMin float64
+	}
+)
+
+// SetBandThresholds injects DB-persisted band thresholds into LoadScoreConfig.
+// Called by the dedup engine after AppConfig is loaded from the database.
+// Values of 0 are ignored (treated as "not set").
+func SetBandThresholds(certainMin, highMin, mediumMin, reviewMin float64) {
+	bandMu.Lock()
+	defer bandMu.Unlock()
+	bandOverride.certainMin = certainMin
+	bandOverride.highMin = highMin
+	bandOverride.mediumMin = mediumMin
+	bandOverride.reviewMin = reviewMin
+}
+
+// LoadScoreConfig reads overrides from injected band thresholds (DB-persisted,
+// set via SetBandThresholds) and Viper (config.yaml dedup.signals.*) on top of
+// DefaultScoreConfig.
+// Precedence (highest → lowest): SetBandThresholds > Viper > defaults.
+// Returns an error if the resulting config fails Validate.
 func LoadScoreConfig() (ScoreConfig, error) {
 	cfg := DefaultScoreConfig()
 
-	// Merge band thresholds if overridden.
+	// Merge band thresholds if overridden via Viper (config.yaml / env vars).
 	if viper.IsSet("dedup.signals.band_certain_min") {
 		cfg.BandCertainMin = viper.GetFloat64("dedup.signals.band_certain_min")
 	}
@@ -165,6 +191,24 @@ func LoadScoreConfig() (ScoreConfig, error) {
 	}
 	if viper.IsSet("dedup.signals.band_review_min") {
 		cfg.BandReviewMin = viper.GetFloat64("dedup.signals.band_review_min")
+	}
+
+	// Override with DB-persisted values injected via SetBandThresholds.
+	// Non-zero check: zero values indicate "not set".
+	bandMu.RLock()
+	ov := bandOverride
+	bandMu.RUnlock()
+	if ov.certainMin > 0 {
+		cfg.BandCertainMin = ov.certainMin
+	}
+	if ov.highMin > 0 {
+		cfg.BandHighMin = ov.highMin
+	}
+	if ov.mediumMin > 0 {
+		cfg.BandMediumMin = ov.mediumMin
+	}
+	if ov.reviewMin > 0 {
+		cfg.BandReviewMin = ov.reviewMin
 	}
 
 	// Merge per-kind overrides.

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1,7 +1,7 @@
 // file: internal/importer/service.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
-// last-edited: 2026-06-14
+// last-edited: 2026-06-16
 
 package importer
 
@@ -33,7 +33,7 @@ type ImportService struct {
 	provisioner *itunesservice.TrackProvisioner
 	dedupEngine *dedup.Engine
 	// opRegistry is the UOS operation registry. When set and
-	// config.AppConfig.DedupOnImportViaScheduler is true, post-import dedup
+	// config.AppConfig.Dedup.OnImportViaScheduler is true, post-import dedup
 	// checks are routed through the scheduler (dedup.check-book op) instead
 	// of the eager goroutine. Nil when the registry is not yet available.
 	opRegistry sdk.Registry
@@ -224,7 +224,7 @@ func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse
 	//
 	//   flag OFF (default):
 	//     Eager goroutine — existing behavior, unchanged for instant rollback.
-	if config.AppConfig.DedupOnImportViaScheduler && is.opRegistry != nil {
+	if config.AppConfig.Dedup.OnImportViaScheduler && is.opRegistry != nil {
 		if _, err := is.opRegistry.EnqueueOp(context.Background(), "dedup.check-book",
 			map[string]any{"book_id": created.ID}); err != nil {
 			slog.Warn("dedup-on-import: EnqueueOp dedup.check-book", "id", created.ID, "err", err)

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.12.0
+// version: 1.13.0
 // last-edited: 2026-06-16
 
 package server
@@ -16,6 +16,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/importer"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
@@ -144,11 +145,15 @@ func init() {
 			store := serviceregistry.Get[database.Store](c, "store")
 			mergeSvc := serviceregistry.Get[*merge.Service](c, "merge")
 			engine := dedup.NewEngine(embStore, store, embClient, llmParser, mergeSvc)
-			engine.BookHighThreshold = cfg.DedupBookHighThreshold
-			engine.BookLowThreshold = cfg.DedupBookLowThreshold
-			engine.AuthorHighThreshold = cfg.DedupAuthorHighThreshold
-			engine.AuthorLowThreshold = cfg.DedupAuthorLowThreshold
-			engine.AutoMergeEnabled = cfg.DedupAutoMergeEnabled
+			engine.BookHighThreshold = cfg.Dedup.BookHighThreshold
+			engine.BookLowThreshold = cfg.Dedup.BookLowThreshold
+			engine.AuthorHighThreshold = cfg.Dedup.AuthorHighThreshold
+			engine.AuthorLowThreshold = cfg.Dedup.AuthorLowThreshold
+			engine.AutoMergeEnabled = cfg.Dedup.AutoMergeEnabled
+			// Inject DB-persisted band thresholds into the unified scoring package
+			// to break the unified→config circular import.
+			sigs := cfg.Dedup.Signals
+			unified.SetBandThresholds(sigs.BandCertainMin, sigs.BandHighMin, sigs.BandMediumMin, sigs.BandReviewMin)
 			return engine, nil
 		},
 	})


### PR DESCRIPTION
## Summary

- Moves 9 flat `Config` dedup fields into a new `DedupConfig` sub-struct at `Config.Dedup` (same pattern as Wave 1 `EmbeddingConfig`)
- Adds `DedupSignalConfig` sub-struct absorbing the 4 band thresholds from viper-only `ScoreConfig` into the persisted blob (`Config.Dedup.Signals`)
- `migrateDedupBlob`: idempotent startup blob migration (flat `dedup_*` → nested `dedup.*`), chained after `migrateEmbeddingBlob`
- `remapDedupKeys`: API compat shim for legacy flat PUT payloads, chained after `remapEmbeddingKeys`
- `SetBandThresholds`/`bandOverride` in `unified/config.go` breaks the `unified→config` circular import while still giving `LoadScoreConfig()` access to DB-persisted band thresholds
- All callsites updated (`engine.go`, `engine_test.go`, `importer/service.go`, `registry_wire.go`, `config_unit_test.go`)

## Test plan

- [x] 5 new TDD tests (`TestMigrateDedupFields_*`, `TestRemapDedupKeys_*`) all pass
- [x] `./internal/config/...` suite green
- [x] `./internal/dedup/...` suite green (including `unified/config_test.go`)
- [x] `go build ./...` clean (no circular import)
- [ ] `make test` full suite (running in background)
- [ ] `make deploy` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)