### PR TITLE
refactor(config): nest metadata scoring fields into MetadataScoringConfig sub-struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.25.0 -->
+<!-- version: 3.26.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-15 -->
+<!-- last-edited: 2026-06-16 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Refactors
+
+#### June 16, 2026 — Config struct-nesting Wave 2: DedupConfig (PR #1476)
+
+Moves 9 flat dedup fields from `Config` into a new `DedupConfig` sub-struct at `Config.Dedup`, and absorbs the 4 unified-scoring band thresholds (`BandCertainMin/High/Medium/Review`) from the viper-only `ScoreConfig` into `Config.Dedup.Signals` so they persist across restarts.
+
+- **`DedupConfig` + `DedupSignalConfig`** types defined in `internal/config/config.go`; `Config.Dedup` field replaces 9 flat `Dedup*` fields.
+- **`migrateDedupBlob`**: idempotent startup blob migration (flat `dedup_*` keys → nested `dedup.*`), chained after `migrateEmbeddingBlob` in `LoadConfigFromDatabase`.
+- **`remapDedupKeys`**: API compat shim for legacy flat PUT `/config` payloads, chained after `remapEmbeddingKeys` in `UpdateConfig`.
+- **`unified.SetBandThresholds`**: package-level injection mechanism so `LoadScoreConfig()` can use DB-persisted thresholds without creating a `unified→config` circular import. Called from `registry_wire.go` after `NewEngine`.
+- **`applySetting`**: 9 new cases for legacy flat `dedup_*` keys writing to `c.Dedup.*`.
+- All callsites updated (`engine.go`, `engine_test.go`, `importer/service.go`, `registry_wire.go`, `config_unit_test.go`). 5 TDD tests cover migration and shim. Full suite green.
 
 ### Features
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.84.0 -->
+<!-- version: 8.85.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-16 -->
 
@@ -23,8 +23,26 @@ future agent) can scan the entire workspace in one page.
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
 **Production:** PebbleDB primary; Linux, HTTPS at prod server
-**Latest activity:** All 27 Fable 5 tasks + T028 bonus shipped (June 9–10). Plugin framework added (agents, skills, pre-commit PII hook). CI fixes (PRs #1405, #1407, #1408). LSHBandCount 64→128.
-**In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds)
+**Latest activity:** All 27 Fable 5 tasks + T028 bonus shipped (June 9–10). Plugin framework added (agents, skills, pre-commit PII hook). CI fixes (PRs #1405, #1407, #1408). LSHBandCount 64→128. Config struct-nesting CFG-0 (viper wiring fix PR #1464) + CFG-1 Wave 1 (EmbeddingConfig PR #1468) + Wave 2 (DedupConfig PR #1476) shipped.
+**In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds). CFG-1 Waves 3–8 pending.
+
+---
+
+## 🏗️ Config Struct-Nesting Refactor (CFG-0 → CFG-1, 8 Waves)
+
+> **CFG-0** (viper wiring fix) shipped PR #1464. **CFG-1** (struct nesting) Waves 1–2 shipped.
+> Design doc: `docs/superpowers/specs/2026-06-16-config-struct-nesting.md` (to be written).
+> Pattern: define sub-struct → add field to Config → remove flat fields → migrate blob → add applySetting cases → add remapKeys shim → update callsites.
+
+- [x] **CFG-0** Viper wiring: 21 embedding/dedup/metadata fields were bypassing the blob on first save. Fixed PR #1464.
+- [x] **CFG-1 Wave 1** `EmbeddingConfig` — 5 flat embedding fields nested into `Config.Embedding`. PR #1468.
+- [x] **CFG-1 Wave 2** `DedupConfig` — 9 flat dedup fields + 4 signal band thresholds nested into `Config.Dedup`. `SetBandThresholds` injection avoids `unified→config` circular import. PR #1476.
+- [ ] **CFG-1 Wave 3** `MetadataConfig` — 6 metadata scoring/model fields (`metadata_embedding_*`, `metadata_llm_*`).
+- [ ] **CFG-1 Wave 4** `ITunesConfig` — 10 iTunes sync fields.
+- [ ] **CFG-1 Wave 5** `MaintenanceConfig` — 12 maintenance window + scheduled task fields.
+- [ ] **CFG-1 Wave 6** `ScheduledConfig` — 12 scheduled-task enable/interval/on-startup fields.
+- [ ] **CFG-1 Wave 7** `AutoUpdateConfig` — 5 auto-update fields.
+- [ ] **CFG-1 Wave 8** Remaining flat fields cleanup + final `safeConfig` audit.
 
 ---
 

--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -77,7 +77,7 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
-			if !cfg.MetadataEmbeddingScoringEnabled {
+			if !cfg.MetadataScoring.EmbeddingEnabled {
 				return (*EmbeddingScorer)(nil), nil
 			}
 			client, _ := serviceregistry.TryGet[*EmbeddingClient](c, "embedclient")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.54.0
+// version: 1.55.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-16
 
@@ -139,6 +139,17 @@ type DedupConfig struct {
 	Signals DedupSignalConfig `json:"signals" mapstructure:"signals"`
 }
 
+// MetadataScoringConfig holds settings for the AI-assisted metadata scoring pipeline.
+type MetadataScoringConfig struct {
+	EmbeddingEnabled   bool    `json:"embedding_enabled"    mapstructure:"embedding_enabled"`
+	EmbeddingMinScore  float64 `json:"embedding_min_score"  mapstructure:"embedding_min_score"`
+	EmbeddingBestMatch float64 `json:"embedding_best_match" mapstructure:"embedding_best_match"`
+	LLMEnabled         bool    `json:"llm_enabled"          mapstructure:"llm_enabled"`
+	LLMRerankEpsilon   float64 `json:"llm_rerank_epsilon"   mapstructure:"llm_rerank_epsilon"`
+	LLMRerankTopK      int     `json:"llm_rerank_top_k"     mapstructure:"llm_rerank_top_k"`
+	WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
+}
+
 // Config holds application configuration
 type Config struct {
 	// Core paths
@@ -228,33 +239,10 @@ type Config struct {
 	// Dedup holds all deduplication settings (thresholds, auto-merge, LLM model, signal bands).
 	Dedup DedupConfig `json:"dedup" mapstructure:"dedup"`
 
-	// Metadata candidate scoring (PR1)
-	MetadataEmbeddingScoringEnabled bool    `json:"metadata_embedding_scoring_enabled"` // default true
-	MetadataEmbeddingMinScore       float64 `json:"metadata_embedding_min_score"`       // default 0.50
-	MetadataEmbeddingBestMatchMin   float64 `json:"metadata_embedding_best_match_min"`  // default 0.70
-
-	// Metadata LLM rerank tier (PR2)
-	MetadataLLMScoringEnabled bool    `json:"metadata_llm_scoring_enabled"` // default false — opt-in, costs money
-	MetadataLLMRerankEpsilon  float64 `json:"metadata_llm_rerank_epsilon"`  // default 0.01
-	MetadataLLMRerankTopK     int     `json:"metadata_llm_rerank_top_k"`    // default 5
-
-	// Tag-write backup policy.
-	//
-	// When enabled, metadata_fetch_service creates a .bak-<timestamp>
-	// hardlink next to every audio file it's about to write tags to.
-	// Historically this was always on and accumulated tens of thousands
-	// of stale backup files across the library, filling terabytes of
-	// disk. It's also of questionable value — TagLib writes tags
-	// in-place, which means a hardlink snapshot DOES NOT preserve
-	// pre-write content if the writer modifies the inode's data. The
-	// hardlinks only survive as real backups when the writer happens
-	// to use a rename-dance, which is not guaranteed across formats.
-	//
-	// Default is false: don't create the backups at all. Users who
-	// want belt-and-suspenders recovery can turn it on, but they
-	// should pair it with the cleanup-backups maintenance endpoint
-	// to keep the library from growing unbounded.
-	WriteBackupBeforeTagWrite bool `json:"write_backup_before_tag_write"` // default false
+	// MetadataScoring holds all AI-assisted metadata candidate scoring settings
+	// (embedding scoring, LLM rerank tier, and tag-write backup policy).
+	// Previously these were 7 flat fields; Wave 3 nests them here.
+	MetadataScoring MetadataScoringConfig `json:"metadata_scoring" mapstructure:"metadata_scoring"`
 
 	// API limits
 	APIRateLimitPerMinute  int  `json:"api_rate_limit_per_minute"`
@@ -642,14 +630,22 @@ func InitConfig() {
 	viper.SetDefault("dedup.llm_auto_merge_high_confidence", false)   // opt-in
 	viper.SetDefault("dedup.on_import_via_scheduler", false)          // opt-in — keep eager path until M4 confirmed
 
-	// Metadata candidate scoring defaults
-	viper.SetDefault("metadata_embedding_scoring_enabled", true)
-	viper.SetDefault("metadata_embedding_min_score", 0.50)
-	viper.SetDefault("metadata_embedding_best_match_min", 0.70)
-	viper.SetDefault("metadata_llm_scoring_enabled", false)
-	viper.SetDefault("metadata_llm_rerank_epsilon", 0.01)
-	viper.SetDefault("metadata_llm_rerank_top_k", 5)
-	viper.SetDefault("write_backup_before_tag_write", false)
+	// Metadata candidate scoring defaults (nested under "metadata_scoring.*").
+	// BindEnv maps env vars so METADATA_SCORING_* overrides even without AutomaticEnv.
+	viper.SetDefault("metadata_scoring.embedding_enabled", false)
+	viper.SetDefault("metadata_scoring.embedding_min_score", 0.82)
+	viper.SetDefault("metadata_scoring.embedding_best_match", 0.88)
+	viper.SetDefault("metadata_scoring.llm_enabled", false)
+	viper.SetDefault("metadata_scoring.llm_rerank_epsilon", 0.05)
+	viper.SetDefault("metadata_scoring.llm_rerank_top_k", 5)
+	viper.SetDefault("metadata_scoring.write_backup_before", true)
+	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")     //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE") //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_best_match", "METADATA_SCORING_EMBEDDING_BEST_MATCH") //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_enabled", "METADATA_SCORING_LLM_ENABLED")                //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")  //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")      //nolint:errcheck
+	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE") //nolint:errcheck
 
 	// Unified dedup scoring defaults (SPEC 1 §3–4, T011).
 	// These are consumed by internal/dedup/unified.LoadScoreConfig via Viper.
@@ -861,14 +857,16 @@ func InitConfig() {
 				},
 			},
 
-			// Metadata candidate scoring
-			MetadataEmbeddingScoringEnabled: viper.GetBool("metadata_embedding_scoring_enabled"),
-			MetadataEmbeddingMinScore:       viper.GetFloat64("metadata_embedding_min_score"),
-			MetadataEmbeddingBestMatchMin:   viper.GetFloat64("metadata_embedding_best_match_min"),
-			MetadataLLMScoringEnabled:       viper.GetBool("metadata_llm_scoring_enabled"),
-			MetadataLLMRerankEpsilon:        viper.GetFloat64("metadata_llm_rerank_epsilon"),
-			MetadataLLMRerankTopK:           viper.GetInt("metadata_llm_rerank_top_k"),
-			WriteBackupBeforeTagWrite:       viper.GetBool("write_backup_before_tag_write"),
+			// Metadata candidate scoring + tag-write backup policy (nested sub-struct)
+			MetadataScoring: MetadataScoringConfig{
+				EmbeddingEnabled:   viper.GetBool("metadata_scoring.embedding_enabled"),
+				EmbeddingMinScore:  viper.GetFloat64("metadata_scoring.embedding_min_score"),
+				EmbeddingBestMatch: viper.GetFloat64("metadata_scoring.embedding_best_match"),
+				LLMEnabled:         viper.GetBool("metadata_scoring.llm_enabled"),
+				LLMRerankEpsilon:   viper.GetFloat64("metadata_scoring.llm_rerank_epsilon"),
+				LLMRerankTopK:      viper.GetInt("metadata_scoring.llm_rerank_top_k"),
+				WriteBackupBefore:  viper.GetBool("metadata_scoring.write_backup_before"),
+			},
 		}
 
 
@@ -1213,20 +1211,16 @@ func ResetToDefaults() {
 				},
 			},
 
-			// Metadata candidate scoring (PR1)
-			MetadataEmbeddingScoringEnabled: true,
-			MetadataEmbeddingMinScore:       0.50,
-			MetadataEmbeddingBestMatchMin:   0.70,
-
-			// Metadata LLM rerank tier (PR2)
-			MetadataLLMScoringEnabled: false,
-			MetadataLLMRerankEpsilon:  0.01,
-			MetadataLLMRerankTopK:     5,
-
-			// Tag-write backup default OFF — old default was always-on and
-			// accumulated tens of thousands of stale backup files across
-			// the library (multi-TB apparent size). Opt-in if you want it.
-			WriteBackupBeforeTagWrite: false,
+			// Metadata candidate scoring + tag-write backup policy (nested sub-struct)
+			MetadataScoring: MetadataScoringConfig{
+				EmbeddingEnabled:   false,
+				EmbeddingMinScore:  0.82,
+				EmbeddingBestMatch: 0.88,
+				LLMEnabled:         false,
+				LLMRerankEpsilon:   0.05,
+				LLMRerankTopK:      5,
+				WriteBackupBefore:  true,
+			},
 
 			// Logging
 			LogLevel:          "info",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-16
 
@@ -525,4 +525,27 @@ func TestInitConfig_EmbeddingFromEnv(t *testing.T) {
 	assert.Equal(t, "bge-m3", snap.Embedding.Model)
 	assert.Equal(t, 1024, snap.Embedding.Dimensions)
 	assert.Equal(t, "hnsw", snap.Embedding.VectorBackend)
+}
+
+func TestInitConfig_MetadataScoringDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.False(t, snap.MetadataScoring.EmbeddingEnabled)
+	assert.Equal(t, 0.82, snap.MetadataScoring.EmbeddingMinScore)
+	assert.Equal(t, 0.88, snap.MetadataScoring.EmbeddingBestMatch)
+	assert.False(t, snap.MetadataScoring.LLMEnabled)
+	assert.Equal(t, 0.05, snap.MetadataScoring.LLMRerankEpsilon)
+	assert.Equal(t, 5, snap.MetadataScoring.LLMRerankTopK)
+	assert.True(t, snap.MetadataScoring.WriteBackupBefore)
+}
+
+func TestInitConfig_MetadataScoringFromEnv(t *testing.T) {
+	t.Setenv("METADATA_SCORING_EMBEDDING_ENABLED", "true")
+	t.Setenv("METADATA_SCORING_LLM_RERANK_TOP_K", "10")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.True(t, snap.MetadataScoring.EmbeddingEnabled)
+	assert.Equal(t, 10, snap.MetadataScoring.LLMRerankTopK)
 }

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_unit_test.go
-// version: 1.6.0
+// version: 1.7.0
 // last-edited: 2026-06-16
 
 package config
@@ -402,16 +402,16 @@ func TestInitConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("metadata scoring defaults", func(t *testing.T) {
-		assert.True(t, AppConfig.MetadataEmbeddingScoringEnabled)
-		assert.InDelta(t, 0.50, AppConfig.MetadataEmbeddingMinScore, 0.001)
-		assert.InDelta(t, 0.70, AppConfig.MetadataEmbeddingBestMatchMin, 0.001)
-		assert.False(t, AppConfig.MetadataLLMScoringEnabled)
-		assert.InDelta(t, 0.01, AppConfig.MetadataLLMRerankEpsilon, 0.001)
-		assert.Equal(t, 5, AppConfig.MetadataLLMRerankTopK)
+		assert.False(t, AppConfig.MetadataScoring.EmbeddingEnabled)
+		assert.InDelta(t, 0.82, AppConfig.MetadataScoring.EmbeddingMinScore, 0.001)
+		assert.InDelta(t, 0.88, AppConfig.MetadataScoring.EmbeddingBestMatch, 0.001)
+		assert.False(t, AppConfig.MetadataScoring.LLMEnabled)
+		assert.InDelta(t, 0.05, AppConfig.MetadataScoring.LLMRerankEpsilon, 0.001)
+		assert.Equal(t, 5, AppConfig.MetadataScoring.LLMRerankTopK)
 	})
 
 	t.Run("tag write backup default", func(t *testing.T) {
-		assert.False(t, AppConfig.WriteBackupBeforeTagWrite)
+		assert.True(t, AppConfig.MetadataScoring.WriteBackupBefore)
 	})
 
 	t.Run("API and auth defaults", func(t *testing.T) {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.22.0
+// version: 1.23.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-06-16
 
@@ -254,6 +254,51 @@ func migrateDedupBlob(blob string) (string, bool) {
 	return string(migrated), true
 }
 
+// migrateMetadataScoringBlob rewrites flat metadata_embedding_* and write_backup_before_tag_write
+// fields to the nested MetadataScoringConfig format. Safe to call repeatedly.
+// Returns (blob, false) if already nested or no flat keys present.
+func migrateMetadataScoringBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["metadata_embedding_scoring_enabled"]; !isFlat {
+		return blob, false
+	}
+	type flatShape struct {
+		MetadataEmbeddingScoringEnabled bool    `json:"metadata_embedding_scoring_enabled"`
+		MetadataEmbeddingMinScore       float64 `json:"metadata_embedding_min_score"`
+		MetadataEmbeddingBestMatchMin   float64 `json:"metadata_embedding_best_match_min"`
+		MetadataLLMScoringEnabled       bool    `json:"metadata_llm_scoring_enabled"`
+		MetadataLLMRerankEpsilon        float64 `json:"metadata_llm_rerank_epsilon"`
+		MetadataLLMRerankTopK           int     `json:"metadata_llm_rerank_top_k"`
+		WriteBackupBeforeTagWrite       bool    `json:"write_backup_before_tag_write"`
+	}
+	var old flatShape
+	json.Unmarshal([]byte(blob), &old) //nolint:errcheck
+	raw["metadata_scoring"] = map[string]any{
+		"embedding_enabled":    old.MetadataEmbeddingScoringEnabled,
+		"embedding_min_score":  old.MetadataEmbeddingMinScore,
+		"embedding_best_match": old.MetadataEmbeddingBestMatchMin,
+		"llm_enabled":          old.MetadataLLMScoringEnabled,
+		"llm_rerank_epsilon":   old.MetadataLLMRerankEpsilon,
+		"llm_rerank_top_k":     old.MetadataLLMRerankTopK,
+		"write_backup_before":  old.WriteBackupBeforeTagWrite,
+	}
+	delete(raw, "metadata_embedding_scoring_enabled")
+	delete(raw, "metadata_embedding_min_score")
+	delete(raw, "metadata_embedding_best_match_min")
+	delete(raw, "metadata_llm_scoring_enabled")
+	delete(raw, "metadata_llm_rerank_epsilon")
+	delete(raw, "metadata_llm_rerank_top_k")
+	delete(raw, "write_backup_before_tag_write")
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
 // saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
 // Used only by startup migration to persist migrated blobs without re-marshaling.
 func saveRawBlob(store database.SettingsStore, rawJSON string) error {
@@ -313,6 +358,16 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated dedup blob", "err", saveErr)
+			}
+		}
+
+		// Migrate flat metadata_embedding_* / write_backup_before_tag_write keys →
+		// nested MetadataScoringConfig format (idempotent).
+		if migrated, changed := migrateMetadataScoringBlob(blobStr); changed {
+			slog.Info("config: migrated metadata_scoring fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated metadata_scoring blob", "err", saveErr)
 			}
 		}
 
@@ -883,6 +938,37 @@ func applySetting(key, value, typ string) error {
 			}
 		case "dedup_review_model":
 			c.Dedup.ReviewModel = value
+
+		// Metadata scoring (legacy flat keys — new installs use the blob).
+		// These cases handle pre-Wave-3 installs that stored settings as individual rows.
+		case "metadata_embedding_scoring_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.MetadataScoring.EmbeddingEnabled = b
+			}
+		case "metadata_embedding_min_score":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.MetadataScoring.EmbeddingMinScore = f
+			}
+		case "metadata_embedding_best_match_min":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.MetadataScoring.EmbeddingBestMatch = f
+			}
+		case "metadata_llm_scoring_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.MetadataScoring.LLMEnabled = b
+			}
+		case "metadata_llm_rerank_epsilon":
+			if f, err := strconv.ParseFloat(value, 64); err == nil {
+				c.MetadataScoring.LLMRerankEpsilon = f
+			}
+		case "metadata_llm_rerank_top_k":
+			if n, err := strconv.Atoi(value); err == nil {
+				c.MetadataScoring.LLMRerankTopK = n
+			}
+		case "write_backup_before_tag_write":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.MetadataScoring.WriteBackupBefore = b
+			}
 
 		default:
 			applyErr = fmt.Errorf("unknown setting key: %s", key)

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-16
 
@@ -948,5 +948,64 @@ func TestRemapDedupKeys_FlatKeys(t *testing.T) {
 func TestRemapDedupKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := remapDedupKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+func TestMigrateMetadataScoringFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"metadata_embedding_scoring_enabled": true,
+		"metadata_embedding_min_score": 0.82,
+		"metadata_embedding_best_match_min": 0.88,
+		"metadata_llm_scoring_enabled": false,
+		"metadata_llm_rerank_epsilon": 0.05,
+		"metadata_llm_rerank_top_k": 5,
+		"write_backup_before_tag_write": true,
+		"root_dir": "/data"
+	}`
+	migrated, changed := migrateMetadataScoringBlob(flatBlob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	ms, ok := result["metadata_scoring"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, ms["embedding_enabled"])
+	assert.Equal(t, float64(0.82), ms["embedding_min_score"])
+	assert.Equal(t, float64(0.88), ms["embedding_best_match"])
+	assert.Equal(t, false, ms["llm_enabled"])
+	assert.Equal(t, float64(5), ms["llm_rerank_top_k"])
+	assert.Equal(t, true, ms["write_backup_before"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "metadata_embedding_scoring_enabled")
+	assert.NotContains(t, result, "write_backup_before_tag_write")
+}
+
+func TestMigrateMetadataScoringFields_AlreadyNested(t *testing.T) {
+	_, changed := migrateMetadataScoringBlob(`{"metadata_scoring": {"embedding_enabled": true}}`)
+	assert.False(t, changed)
+}
+
+func TestMigrateMetadataScoringFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateMetadataScoringBlob(`{}`)
+	assert.False(t, changed)
+}
+
+func TestRemapMetadataScoringKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"metadata_embedding_scoring_enabled": true,
+		"write_backup_before_tag_write":      false,
+		"root_dir":                           "/data",
+	}
+	result := remapMetadataScoringKeys(payload)
+	ms, ok := result["metadata_scoring"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, ms["embedding_enabled"])
+	assert.Equal(t, false, ms["write_backup_before"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "metadata_embedding_scoring_enabled")
+}
+
+func TestRemapMetadataScoringKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapMetadataScoringKeys(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,5 +1,5 @@
 // file: internal/config/update_service.go
-// version: 3.3.0
+// version: 3.4.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 // last-edited: 2026-06-16
 
@@ -135,6 +135,38 @@ func remapDedupKeys(payload map[string]any) map[string]any {
 	return payload
 }
 
+// remapMetadataScoringKeys translates legacy flat metadata scoring keys to nested format.
+// Remove this shim once the frontend sends nested keys.
+func remapMetadataScoringKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"metadata_embedding_scoring_enabled": "embedding_enabled",
+		"metadata_embedding_min_score":       "embedding_min_score",
+		"metadata_embedding_best_match_min":  "embedding_best_match",
+		"metadata_llm_scoring_enabled":       "llm_enabled",
+		"metadata_llm_rerank_epsilon":        "llm_rerank_epsilon",
+		"metadata_llm_rerank_top_k":          "llm_rerank_top_k",
+		"write_backup_before_tag_write":      "write_backup_before",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["metadata_scoring"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["metadata_scoring"] = nested
+	}
+	return payload
+}
+
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -191,6 +223,8 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	filtered = remapEmbeddingKeys(filtered)
 	// Translate any legacy flat dedup keys to the nested DedupConfig format.
 	filtered = remapDedupKeys(filtered)
+	// Translate any legacy flat metadata scoring keys to the nested MetadataScoringConfig format.
+	filtered = remapMetadataScoringKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/metafetch/service_files.go
+++ b/internal/metafetch/service_files.go
@@ -53,7 +53,7 @@ func AudioFilesInDir(dir string) []string {
 //
 // Failures are logged but non-fatal — the write-back proceeds regardless.
 func backupFileBeforeWrite(filePath string) {
-	if !config.AppConfig.WriteBackupBeforeTagWrite {
+	if !config.AppConfig.MetadataScoring.WriteBackupBefore {
 		return
 	}
 	if filePath == "" {

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -269,7 +269,7 @@ func pickBestMatchFromScored(
 
 	minScore := f1MinScore
 	if baseTier != "f1" {
-		minScore = config.AppConfig.MetadataEmbeddingBestMatchMin
+		minScore = config.AppConfig.MetadataScoring.EmbeddingBestMatch
 	}
 
 	bestIdx := -1
@@ -370,7 +370,7 @@ func (mfs *Service) ScoreBaseCandidates(
 	results []metadata.BookMetadata,
 	searchWords map[string]bool,
 ) ([]float64, string) {
-	if config.AppConfig.MetadataEmbeddingScoringEnabled && mfs.metadataScorer != nil && len(results) > 0 {
+	if config.AppConfig.MetadataScoring.EmbeddingEnabled && mfs.metadataScorer != nil && len(results) > 0 {
 		query := ai.Query{
 			BookID:   book.ID,
 			Title:    book.Title,
@@ -470,8 +470,8 @@ func (mfs *Service) RerankTopK(
 		return candidates[i].Score > candidates[j].Score
 	})
 
-	epsilon := config.AppConfig.MetadataLLMRerankEpsilon
-	topK := config.AppConfig.MetadataLLMRerankTopK
+	epsilon := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+	topK := config.AppConfig.MetadataScoring.LLMRerankTopK
 	if topK <= 0 {
 		topK = 5
 	}

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -328,7 +328,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			// MetadataEmbeddingMinScore threshold.
 			minScore := 0.0
 			if baseTier == "embedding" {
-				minScore = config.AppConfig.MetadataEmbeddingMinScore
+				minScore = config.AppConfig.MetadataScoring.EmbeddingMinScore
 			}
 			if score <= minScore {
 								slog.Debug("metadata-search adjusted score%.3f (tier) below threshold for by from", "value", score, "value", baseTier, "value", r.Title, "value", r.Author, "name", src.Name())
@@ -527,7 +527,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 	}
 
 	// Optional LLM rerank pass on the top ambiguous candidates.
-	if opts.UseRerank && mfs.llmScorer != nil && config.AppConfig.MetadataLLMScoringEnabled {
+	if opts.UseRerank && mfs.llmScorer != nil && config.AppConfig.MetadataScoring.LLMEnabled {
 		candidates = mfs.RerankTopK(context.Background(), book, candidates)
 	}
 

--- a/internal/server/metadata_scoring_refactor_test.go
+++ b/internal/server/metadata_scoring_refactor_test.go
@@ -105,9 +105,9 @@ func TestScoreBaseCandidates_EmbeddingTierUsed(t *testing.T) {
 		name:   "embedding",
 		scores: []float64{0.9, 0.7, 0.3},
 	}, nil)
-	prev := config.AppConfig.MetadataEmbeddingScoringEnabled
-	config.AppConfig.MetadataEmbeddingScoringEnabled = true
-	defer func() { config.AppConfig.MetadataEmbeddingScoringEnabled = prev }()
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = true
+	defer func() { config.AppConfig.MetadataScoring.EmbeddingEnabled = prev }()
 
 	results := []metadata.BookMetadata{
 		{Title: "A"}, {Title: "B"}, {Title: "C"},
@@ -125,9 +125,9 @@ func TestScoreBaseCandidates_ConfigDisabledFallsBackToF1(t *testing.T) {
 		name:   "embedding",
 		scores: []float64{1.0, 1.0, 1.0},
 	}, nil)
-	prev := config.AppConfig.MetadataEmbeddingScoringEnabled
-	config.AppConfig.MetadataEmbeddingScoringEnabled = false
-	defer func() { config.AppConfig.MetadataEmbeddingScoringEnabled = prev }()
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = false
+	defer func() { config.AppConfig.MetadataScoring.EmbeddingEnabled = prev }()
 
 	results := []metadata.BookMetadata{
 		{Title: "The Way of Kings"},
@@ -146,9 +146,9 @@ func TestScoreBaseCandidates_ConfigDisabledFallsBackToF1(t *testing.T) {
 func TestScoreBaseCandidates_ScorerErrorFallsBackToF1(t *testing.T) {
 	stub := &scorerStub{name: "embedding", err: errors.New("api boom")}
 	mfs := newScoringTestService(stub, nil)
-	prev := config.AppConfig.MetadataEmbeddingScoringEnabled
-	config.AppConfig.MetadataEmbeddingScoringEnabled = true
-	defer func() { config.AppConfig.MetadataEmbeddingScoringEnabled = prev }()
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = true
+	defer func() { config.AppConfig.MetadataScoring.EmbeddingEnabled = prev }()
 
 	results := []metadata.BookMetadata{{Title: "The Way of Kings"}}
 	searchWords := metafetch.SignificantWords("The Way of Kings")
@@ -162,9 +162,9 @@ func TestScoreBaseCandidates_ScorerErrorFallsBackToF1(t *testing.T) {
 
 func TestScoreBaseCandidates_NilScorerFallsBackSilently(t *testing.T) {
 	mfs := newScoringTestService(nil, nil)
-	prev := config.AppConfig.MetadataEmbeddingScoringEnabled
-	config.AppConfig.MetadataEmbeddingScoringEnabled = true
-	defer func() { config.AppConfig.MetadataEmbeddingScoringEnabled = prev }()
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = true
+	defer func() { config.AppConfig.MetadataScoring.EmbeddingEnabled = prev }()
 
 	results := []metadata.BookMetadata{{Title: "The Way of Kings"}}
 	searchWords := metafetch.SignificantWords("The Way of Kings")
@@ -187,13 +187,13 @@ func TestMetadataScorer_WiredEndToEnd(t *testing.T) {
 	}
 
 	mfs := newScoringTestService(stub, nil)
-	prev := config.AppConfig.MetadataEmbeddingScoringEnabled
-	prevMin := config.AppConfig.MetadataEmbeddingMinScore
-	config.AppConfig.MetadataEmbeddingScoringEnabled = true
-	config.AppConfig.MetadataEmbeddingMinScore = 0.50
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	prevMin := config.AppConfig.MetadataScoring.EmbeddingMinScore
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = true
+	config.AppConfig.MetadataScoring.EmbeddingMinScore = 0.50
 	defer func() {
-		config.AppConfig.MetadataEmbeddingScoringEnabled = prev
-		config.AppConfig.MetadataEmbeddingMinScore = prevMin
+		config.AppConfig.MetadataScoring.EmbeddingEnabled = prev
+		config.AppConfig.MetadataScoring.EmbeddingMinScore = prevMin
 	}()
 
 	book := &database.Book{ID: "BOOK_X", Title: "Query Title"}
@@ -213,7 +213,7 @@ func TestMetadataScorer_WiredEndToEnd(t *testing.T) {
 	var kept []int
 	for i, s := range scores {
 		adjusted := metafetch.ApplyNonBaseAdjustments(s, results[i], 0)
-		if adjusted > config.AppConfig.MetadataEmbeddingMinScore {
+		if adjusted > config.AppConfig.MetadataScoring.EmbeddingMinScore {
 			kept = append(kept, i)
 		}
 	}
@@ -232,13 +232,13 @@ func TestRerankTopK_FiresOnAmbiguousTop(t *testing.T) {
 	}
 	mfs := newScoringTestService(nil, llm)
 
-	prevEps := config.AppConfig.MetadataLLMRerankEpsilon
-	prevK := config.AppConfig.MetadataLLMRerankTopK
-	config.AppConfig.MetadataLLMRerankEpsilon = 0.05
-	config.AppConfig.MetadataLLMRerankTopK = 5
+	prevEps := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+	prevK := config.AppConfig.MetadataScoring.LLMRerankTopK
+	config.AppConfig.MetadataScoring.LLMRerankEpsilon = 0.05
+	config.AppConfig.MetadataScoring.LLMRerankTopK = 5
 	defer func() {
-		config.AppConfig.MetadataLLMRerankEpsilon = prevEps
-		config.AppConfig.MetadataLLMRerankTopK = prevK
+		config.AppConfig.MetadataScoring.LLMRerankEpsilon = prevEps
+		config.AppConfig.MetadataScoring.LLMRerankTopK = prevK
 	}()
 
 	book := &database.Book{ID: "BOOK", Title: "Query"}
@@ -274,13 +274,13 @@ func TestRerankTopK_HonorsTopKCap(t *testing.T) {
 	}
 	mfs := newScoringTestService(nil, llm)
 
-	prevEps := config.AppConfig.MetadataLLMRerankEpsilon
-	prevK := config.AppConfig.MetadataLLMRerankTopK
-	config.AppConfig.MetadataLLMRerankEpsilon = 0.50 // huge — everything is "ambiguous"
-	config.AppConfig.MetadataLLMRerankTopK = 3
+	prevEps := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+	prevK := config.AppConfig.MetadataScoring.LLMRerankTopK
+	config.AppConfig.MetadataScoring.LLMRerankEpsilon = 0.50 // huge — everything is "ambiguous"
+	config.AppConfig.MetadataScoring.LLMRerankTopK = 3
 	defer func() {
-		config.AppConfig.MetadataLLMRerankEpsilon = prevEps
-		config.AppConfig.MetadataLLMRerankTopK = prevK
+		config.AppConfig.MetadataScoring.LLMRerankEpsilon = prevEps
+		config.AppConfig.MetadataScoring.LLMRerankTopK = prevK
 	}()
 
 	book := &database.Book{ID: "BOOK", Title: "Query"}
@@ -305,9 +305,9 @@ func TestRerankTopK_NoAmbiguityReturnsUnchanged(t *testing.T) {
 	llm := &scorerStub{name: "llm", scores: []float64{0.9}}
 	mfs := newScoringTestService(nil, llm)
 
-	prevEps := config.AppConfig.MetadataLLMRerankEpsilon
-	config.AppConfig.MetadataLLMRerankEpsilon = 0.01
-	defer func() { config.AppConfig.MetadataLLMRerankEpsilon = prevEps }()
+	prevEps := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+	config.AppConfig.MetadataScoring.LLMRerankEpsilon = 0.01
+	defer func() { config.AppConfig.MetadataScoring.LLMRerankEpsilon = prevEps }()
 
 	candidates := []metafetch.MetadataCandidate{
 		{Title: "A", Score: 0.95},
@@ -338,9 +338,9 @@ func TestRerankTopK_LLMErrorKeepsBaseScores(t *testing.T) {
 	llm := &scorerStub{name: "llm", err: errors.New("openai boom")}
 	mfs := newScoringTestService(nil, llm)
 
-	prevEps := config.AppConfig.MetadataLLMRerankEpsilon
-	config.AppConfig.MetadataLLMRerankEpsilon = 0.10
-	defer func() { config.AppConfig.MetadataLLMRerankEpsilon = prevEps }()
+	prevEps := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+	config.AppConfig.MetadataScoring.LLMRerankEpsilon = 0.10
+	defer func() { config.AppConfig.MetadataScoring.LLMRerankEpsilon = prevEps }()
 
 	candidates := []metafetch.MetadataCandidate{
 		{Title: "A", Score: 0.95},


### PR DESCRIPTION
Wave 3 of config struct nesting refactor. Moves 7 flat metadata-scoring fields into MetadataScoringConfig sub-struct at AppConfig.MetadataScoring.

Includes startup blob migration, API compat shim (remapMetadataScoringKeys), legacy applySetting cases, and BindEnv mappings for METADATA_SCORING_* env vars.