### PR TITLE
refactor(config): nest iTunes fields into ITunesConfig sub-struct

### DIFF
--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/helpers.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234560010
-// last-edited: 2026-05-05
+// last-edited: 2026-06-16
 //
 // Private utilities needed by the audiobooks service package. These mirror
 // equivalent helpers from internal/server/ but are standalone so that the
@@ -256,15 +256,15 @@ func isProtectedPath(store importPathLister, filePath string) bool {
 		}
 	}
 
-	if config.AppConfig.ITunesLibraryReadPath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryReadPath)
+	if config.AppConfig.ITunes.LibraryReadPath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryReadPath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true
 		}
 	}
-	if config.AppConfig.ITunesLibraryWritePath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryWritePath)
+	if config.AppConfig.ITunes.LibraryWritePath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryWritePath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.55.0
+// version: 1.56.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-16
 
@@ -137,6 +137,20 @@ type DedupConfig struct {
 	ReviewModel string `json:"review_model" mapstructure:"review_model"`
 	// Signals holds the unified scoring band thresholds.
 	Signals DedupSignalConfig `json:"signals" mapstructure:"signals"`
+}
+
+// ITunesConfig holds all settings for the iTunes sync and write-back subsystem.
+type ITunesConfig struct {
+	SyncEnabled      bool            `json:"sync_enabled"       mapstructure:"sync_enabled"`
+	SyncInterval     int             `json:"sync_interval"      mapstructure:"sync_interval"`
+	WriteBackEnabled bool            `json:"write_back_enabled" mapstructure:"write_back_enabled"`
+	LibraryWritePath string          `json:"library_write_path" mapstructure:"library_write_path"`
+	LibraryReadPath  string          `json:"library_read_path"  mapstructure:"library_read_path"`
+	AutoWriteBack    bool            `json:"auto_write_back"    mapstructure:"auto_write_back"`
+	PathTrimEnabled  bool            `json:"path_trim_enabled"  mapstructure:"path_trim_enabled"`
+	WindowsRootPath  string          `json:"windows_root_path"  mapstructure:"windows_root_path"`
+	MediaRoot        string          `json:"media_root"         mapstructure:"media_root"`
+	PathMappings     []ITunesPathMap `json:"path_mappings"      mapstructure:"path_mappings"`
 }
 
 // MetadataScoringConfig holds settings for the AI-assisted metadata scoring pipeline.
@@ -280,17 +294,9 @@ type Config struct {
 	LogFormat         string `json:"log_format"` // 'text' or 'json'
 	EnableJsonLogging bool   `json:"enable_json_logging"`
 
-	// iTunes sync
-	ITunesSyncEnabled      bool            `json:"itunes_sync_enabled"`
-	ITunesSyncInterval     int             `json:"itunes_sync_interval"` // minutes
-	ITLWriteBackEnabled    bool            `json:"itl_write_back_enabled"`
-	ITunesLibraryWritePath string          `json:"itunes_library_write_path"` // ITL path used for write-back (always ITL)
-	ITunesLibraryReadPath  string          `json:"itunes_library_read_path"`  // path used for sync (XML or ITL)
-	ITunesPathMappings     []ITunesPathMap `json:"itunes_path_mappings"`      // Stored path mappings for write-back
-	ITunesAutoWriteBack    bool            `json:"itunes_auto_write_back"`    // Auto write-back on every edit (batched)
-	ITunesPathTrimEnabled  bool            `json:"itunes_path_trim_enabled"`  // Trim filenames to fit Windows MAX_PATH for iTunes compatibility
-	ITunesWindowsRootPath  string          `json:"itunes_windows_root_path"`  // Windows equivalent of RootDir, e.g. "W:\audiobook-organizer" (no trailing slash)
-	ITunesMediaRoot        string          `json:"itunes_media_root"`         // Local path to iTunes Media/Audiobooks, e.g. "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks"
+	// ITunes holds all iTunes sync and write-back settings.
+	// Previously these were 10 flat fields; Wave 4 nests them here.
+	ITunes ITunesConfig `json:"itunes" mapstructure:"itunes"`
 
 	// Deluge integration
 	DelugeWebURL           string `json:"deluge_web_url"`           // e.g. "http://172.16.2.30:8112"
@@ -543,16 +549,21 @@ func InitConfig() {
 	viper.SetDefault("scheduled_ai_dedup_batch_interval", 1440)
 	viper.SetDefault("scheduled_ai_dedup_batch_on_startup", false)
 
-	// iTunes sync defaults
-	viper.SetDefault("itunes_sync_enabled", true)
-	viper.SetDefault("itunes_sync_interval", 30)
-	viper.SetDefault("itl_write_back_enabled", false)
-	viper.SetDefault("itunes_library_write_path", "")
-	viper.SetDefault("itunes_library_read_path", "")
-	viper.SetDefault("itunes_auto_write_back", false)
-	viper.SetDefault("itunes_path_trim_enabled", false)
-	viper.SetDefault("itunes_windows_root_path", "")
-	viper.SetDefault("itunes_media_root", "")
+	// iTunes sync defaults (nested under "itunes.*").
+	// BindEnv maps env vars so ITUNES_SYNC_ENABLED etc. override even without AutomaticEnv.
+	viper.SetDefault("itunes.sync_enabled", true)
+	viper.SetDefault("itunes.sync_interval", 30)
+	viper.SetDefault("itunes.write_back_enabled", false)
+	viper.SetDefault("itunes.library_write_path", "")
+	viper.SetDefault("itunes.library_read_path", "")
+	viper.SetDefault("itunes.auto_write_back", false)
+	viper.SetDefault("itunes.path_trim_enabled", false)
+	viper.SetDefault("itunes.windows_root_path", "")
+	viper.SetDefault("itunes.media_root", "")
+	viper.BindEnv("itunes.sync_enabled", "ITUNES_SYNC_ENABLED")           //nolint:errcheck
+	viper.BindEnv("itunes.sync_interval", "ITUNES_SYNC_INTERVAL")         //nolint:errcheck
+	viper.BindEnv("itunes.write_back_enabled", "ITUNES_WRITE_BACK_ENABLED") //nolint:errcheck
+	viper.BindEnv("itunes.auto_write_back", "ITUNES_AUTO_WRITE_BACK")     //nolint:errcheck
 
 	// Auto-update defaults
 	viper.SetDefault("auto_update_enabled", false)
@@ -779,16 +790,19 @@ func InitConfig() {
 			MaintenanceWindowAcoustIDOnlineLookup: viper.GetBool("maintenance_window_acoustid_online_lookup"),
 			AcoustIDOnlineLookupNightlyLimit:      viper.GetInt("acoustid_online_lookup_nightly_limit"),
 
-			// iTunes sync
-			ITunesSyncEnabled:      viper.GetBool("itunes_sync_enabled"),
-			ITunesSyncInterval:     viper.GetInt("itunes_sync_interval"),
-			ITLWriteBackEnabled:    viper.GetBool("itl_write_back_enabled"),
-			ITunesLibraryWritePath: viper.GetString("itunes_library_write_path"),
-			ITunesLibraryReadPath:  viper.GetString("itunes_library_read_path"),
-			ITunesAutoWriteBack:    viper.GetBool("itunes_auto_write_back"),
-			ITunesPathTrimEnabled:  viper.GetBool("itunes_path_trim_enabled"),
-			ITunesWindowsRootPath:  viper.GetString("itunes_windows_root_path"),
-			ITunesMediaRoot:        viper.GetString("itunes_media_root"),
+			// iTunes sync (nested sub-struct)
+			ITunes: ITunesConfig{
+				SyncEnabled:      viper.GetBool("itunes.sync_enabled"),
+				SyncInterval:     viper.GetInt("itunes.sync_interval"),
+				WriteBackEnabled: viper.GetBool("itunes.write_back_enabled"),
+				LibraryWritePath: viper.GetString("itunes.library_write_path"),
+				LibraryReadPath:  viper.GetString("itunes.library_read_path"),
+				AutoWriteBack:    viper.GetBool("itunes.auto_write_back"),
+				PathTrimEnabled:  viper.GetBool("itunes.path_trim_enabled"),
+				WindowsRootPath:  viper.GetString("itunes.windows_root_path"),
+				MediaRoot:        viper.GetString("itunes.media_root"),
+				// PathMappings loaded from DB blob, not viper
+			},
 
 			// Download client integration
 			DownloadClient: DownloadClientConfig{
@@ -946,17 +960,35 @@ func InitConfig() {
 			}
 		}
 
-		// Backward compatibility: map old config key names to new ones
-		if c.ITunesLibraryWritePath == "" {
-			c.ITunesLibraryWritePath = viper.GetString("itunes_library_itl_path")
+		// Backward compatibility: map old flat viper key names to the nested struct.
+		// These keys were set directly (e.g. via viper.Set in tests or old config files)
+		// using the pre-Wave-4 flat names, which are no longer read in the struct literal.
+		if c.ITunes.LibraryWritePath == "" {
+			if v := viper.GetString("itunes_library_write_path"); v != "" {
+				c.ITunes.LibraryWritePath = v
+			}
 		}
-		if c.ITunesLibraryReadPath == "" {
-			c.ITunesLibraryReadPath = viper.GetString("itunes_library_xml_path")
+		if c.ITunes.LibraryWritePath == "" {
+			c.ITunes.LibraryWritePath = viper.GetString("itunes_library_itl_path")
+		}
+		if c.ITunes.LibraryReadPath == "" {
+			if v := viper.GetString("itunes_library_read_path"); v != "" {
+				c.ITunes.LibraryReadPath = v
+			}
+		}
+		if c.ITunes.LibraryReadPath == "" {
+			c.ITunes.LibraryReadPath = viper.GetString("itunes_library_xml_path")
+		}
+		// Also pick up the flat write_back and sync keys if set via old viper keys
+		if !c.ITunes.WriteBackEnabled {
+			if viper.IsSet("itl_write_back_enabled") {
+				c.ITunes.WriteBackEnabled = viper.GetBool("itl_write_back_enabled")
+			}
 		}
 
 		// Auto-enable ITL write-back when a write path is configured
-		if c.ITunesLibraryWritePath != "" && !c.ITLWriteBackEnabled {
-			c.ITLWriteBackEnabled = true
+		if c.ITunes.LibraryWritePath != "" && !c.ITunes.WriteBackEnabled {
+			c.ITunes.WriteBackEnabled = true
 		}
 
 		// Normalize database type
@@ -1255,11 +1287,11 @@ func ResetToDefaults() {
 			MaintenanceWindowAcoustIDOnlineLookup: false,
 			AcoustIDOnlineLookupNightlyLimit:      5000,
 
-			// iTunes sync
-			ITunesSyncEnabled:      true,
-			ITunesSyncInterval:     30,
-			ITLWriteBackEnabled:    false,
-			ITunesLibraryWritePath: "",
+			// iTunes sync (nested sub-struct)
+			ITunes: ITunesConfig{
+				SyncEnabled:  true,
+				SyncInterval: 30,
+			},
 
 			// Download client integration
 			DownloadClient: DownloadClientConfig{

--- a/internal/config/config_coverage_test.go
+++ b/internal/config/config_coverage_test.go
@@ -180,7 +180,7 @@ func TestCoverage_ITunesConfig(t *testing.T) {
 	InitConfig()
 
 	// Test ITunes-related defaults exist
-	if AppConfig.ITunesSyncInterval != 0 && AppConfig.ITunesSyncInterval < 0 {
+	if AppConfig.ITunes.SyncInterval != 0 && AppConfig.ITunes.SyncInterval < 0 {
 		t.Error("ITunesSyncInterval has unexpected negative value")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-16
 
@@ -548,4 +548,24 @@ func TestInitConfig_MetadataScoringFromEnv(t *testing.T) {
 	snap := Snapshot()
 	assert.True(t, snap.MetadataScoring.EmbeddingEnabled)
 	assert.Equal(t, 10, snap.MetadataScoring.LLMRerankTopK)
+}
+
+func TestInitConfig_ITunesDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.True(t, snap.ITunes.SyncEnabled)
+	assert.Equal(t, 30, snap.ITunes.SyncInterval)
+	assert.False(t, snap.ITunes.WriteBackEnabled)
+	assert.False(t, snap.ITunes.AutoWriteBack)
+}
+
+func TestInitConfig_ITunesFromEnv(t *testing.T) {
+	t.Setenv("ITUNES_SYNC_INTERVAL", "60")
+	t.Setenv("ITUNES_AUTO_WRITE_BACK", "true")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.Equal(t, 60, snap.ITunes.SyncInterval)
+	assert.True(t, snap.ITunes.AutoWriteBack)
 }

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -448,9 +448,9 @@ func TestInitConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("iTunes defaults", func(t *testing.T) {
-		assert.True(t, AppConfig.ITunesSyncEnabled)
-		assert.Equal(t, 30, AppConfig.ITunesSyncInterval)
-		assert.False(t, AppConfig.ITunesAutoWriteBack)
+		assert.True(t, AppConfig.ITunes.SyncEnabled)
+		assert.Equal(t, 30, AppConfig.ITunes.SyncInterval)
+		assert.False(t, AppConfig.ITunes.AutoWriteBack)
 	})
 
 	t.Run("auto-update defaults", func(t *testing.T) {
@@ -509,14 +509,14 @@ func TestInitConfigITunesBackwardCompat(t *testing.T) {
 		viper.Reset()
 		viper.Set("itunes_library_itl_path", "/old/path.itl")
 		InitConfig()
-		assert.Equal(t, "/old/path.itl", AppConfig.ITunesLibraryWritePath)
+		assert.Equal(t, "/old/path.itl", AppConfig.ITunes.LibraryWritePath)
 	})
 
 	t.Run("old itunes_library_xml_path maps to read path", func(t *testing.T) {
 		viper.Reset()
 		viper.Set("itunes_library_xml_path", "/old/library.xml")
 		InitConfig()
-		assert.Equal(t, "/old/library.xml", AppConfig.ITunesLibraryReadPath)
+		assert.Equal(t, "/old/library.xml", AppConfig.ITunes.LibraryReadPath)
 	})
 
 	t.Run("new path takes precedence over old", func(t *testing.T) {
@@ -524,7 +524,7 @@ func TestInitConfigITunesBackwardCompat(t *testing.T) {
 		viper.Set("itunes_library_write_path", "/new/path.itl")
 		viper.Set("itunes_library_itl_path", "/old/path.itl")
 		InitConfig()
-		assert.Equal(t, "/new/path.itl", AppConfig.ITunesLibraryWritePath)
+		assert.Equal(t, "/new/path.itl", AppConfig.ITunes.LibraryWritePath)
 	})
 }
 
@@ -533,7 +533,7 @@ func TestInitConfigITLWriteBackAutoEnable(t *testing.T) {
 	viper.Set("itunes_library_write_path", "/some/path.itl")
 	viper.Set("itl_write_back_enabled", false)
 	InitConfig()
-	assert.True(t, AppConfig.ITLWriteBackEnabled, "should auto-enable when write path is set")
+	assert.True(t, AppConfig.ITunes.WriteBackEnabled, "should auto-enable when write path is set")
 }
 
 func TestInitConfigOpenLibraryDumpDir(t *testing.T) {
@@ -610,10 +610,10 @@ func TestApplySettingStringKeys(t *testing.T) {
 		{"log_level", "debug", func() string { return AppConfig.LogLevel }},
 		{"log_format", "json", func() string { return AppConfig.LogFormat }},
 		{"auto_update_channel", "beta", func() string { return AppConfig.AutoUpdateChannel }},
-		{"itunes_library_write_path", "/itl/path", func() string { return AppConfig.ITunesLibraryWritePath }},
-		{"itunes_library_itl_path", "/itl/path2", func() string { return AppConfig.ITunesLibraryWritePath }},
-		{"itunes_library_read_path", "/xml/path", func() string { return AppConfig.ITunesLibraryReadPath }},
-		{"itunes_library_xml_path", "/xml/path2", func() string { return AppConfig.ITunesLibraryReadPath }},
+		{"itunes_library_write_path", "/itl/path", func() string { return AppConfig.ITunes.LibraryWritePath }},
+		{"itunes_library_itl_path", "/itl/path2", func() string { return AppConfig.ITunes.LibraryWritePath }},
+		{"itunes_library_read_path", "/xml/path", func() string { return AppConfig.ITunes.LibraryReadPath }},
+		{"itunes_library_xml_path", "/xml/path2", func() string { return AppConfig.ITunes.LibraryReadPath }},
 		{"basic_auth_username", "admin", func() string { return AppConfig.BasicAuthUsername }},
 		{"basic_auth_password", "secret", func() string { return AppConfig.BasicAuthPassword }},
 	}
@@ -648,9 +648,9 @@ func TestApplySettingBoolKeys(t *testing.T) {
 		{"enable_json_logging", func() bool { return AppConfig.EnableJsonLogging }},
 		{"auto_update_enabled", func() bool { return AppConfig.AutoUpdateEnabled }},
 		{"purge_soft_deleted_delete_files", func() bool { return AppConfig.PurgeSoftDeletedDeleteFiles }},
-		{"itunes_sync_enabled", func() bool { return AppConfig.ITunesSyncEnabled }},
-		{"itl_write_back_enabled", func() bool { return AppConfig.ITLWriteBackEnabled }},
-		{"itunes_auto_write_back", func() bool { return AppConfig.ITunesAutoWriteBack }},
+		{"itunes_sync_enabled", func() bool { return AppConfig.ITunes.SyncEnabled }},
+		{"itl_write_back_enabled", func() bool { return AppConfig.ITunes.WriteBackEnabled }},
+		{"itunes_auto_write_back", func() bool { return AppConfig.ITunes.AutoWriteBack }},
 		{"maintenance_window_enabled", func() bool { return AppConfig.MaintenanceWindowEnabled }},
 		{"maintenance_window_dedup_refresh", func() bool { return AppConfig.MaintenanceWindowDedupRefresh }},
 		{"maintenance_window_series_prune", func() bool { return AppConfig.MaintenanceWindowSeriesPrune }},
@@ -722,7 +722,7 @@ func TestApplySettingIntKeys(t *testing.T) {
 		{"auto_update_window_start", "2", func() int { return AppConfig.AutoUpdateWindowStart }},
 		{"auto_update_window_end", "5", func() int { return AppConfig.AutoUpdateWindowEnd }},
 		{"purge_soft_deleted_after_days", "30", func() int { return AppConfig.PurgeSoftDeletedAfterDays }},
-		{"itunes_sync_interval", "60", func() int { return AppConfig.ITunesSyncInterval }},
+		{"itunes_sync_interval", "60", func() int { return AppConfig.ITunes.SyncInterval }},
 		{"maintenance_window_start", "3", func() int { return AppConfig.MaintenanceWindowStart }},
 		{"maintenance_window_end", "6", func() int { return AppConfig.MaintenanceWindowEnd }},
 		{"scheduled_dedup_refresh_interval", "24", func() int { return AppConfig.ScheduledDedupRefreshInterval }},
@@ -811,8 +811,8 @@ func TestApplySettingJSONKeys(t *testing.T) {
 		data, _ := json.Marshal(mappings)
 		err := applySetting("itunes_path_mappings", string(data), "json")
 		require.NoError(t, err)
-		require.Len(t, AppConfig.ITunesPathMappings, 1)
-		assert.Equal(t, "/itunes", AppConfig.ITunesPathMappings[0].From)
+		require.Len(t, AppConfig.ITunes.PathMappings, 1)
+		assert.Equal(t, "/itunes", AppConfig.ITunes.PathMappings[0].From)
 	})
 }
 

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.23.0
+// version: 1.24.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-06-16
 
@@ -299,6 +299,61 @@ func migrateMetadataScoringBlob(blob string) (string, bool) {
 	return string(migrated), true
 }
 
+// migrateITunesBlob rewrites flat itunes_* / itl_* config fields to the nested
+// ITunesConfig format. Returns the (possibly modified) blob and whether a migration
+// occurred. Safe to call repeatedly: returns (blob, false) if already nested or no
+// flat iTunes keys are present.
+func migrateITunesBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["itunes_sync_enabled"]; !isFlat {
+		return blob, false
+	}
+
+	type flatShape struct {
+		ITunesSyncEnabled      bool   `json:"itunes_sync_enabled"`
+		ITunesSyncInterval     int    `json:"itunes_sync_interval"`
+		ITLWriteBackEnabled    bool   `json:"itl_write_back_enabled"`
+		ITunesLibraryWritePath string `json:"itunes_library_write_path"`
+		ITunesLibraryReadPath  string `json:"itunes_library_read_path"`
+		ITunesAutoWriteBack    bool   `json:"itunes_auto_write_back"`
+		ITunesPathTrimEnabled  bool   `json:"itunes_path_trim_enabled"`
+		ITunesWindowsRootPath  string `json:"itunes_windows_root_path"`
+		ITunesMediaRoot        string `json:"itunes_media_root"`
+	}
+	var old flatShape
+	json.Unmarshal([]byte(blob), &old) //nolint:errcheck — already parsed above
+
+	raw["itunes"] = map[string]any{
+		"sync_enabled":       old.ITunesSyncEnabled,
+		"sync_interval":      old.ITunesSyncInterval,
+		"write_back_enabled": old.ITLWriteBackEnabled,
+		"library_write_path": old.ITunesLibraryWritePath,
+		"library_read_path":  old.ITunesLibraryReadPath,
+		"auto_write_back":    old.ITunesAutoWriteBack,
+		"path_trim_enabled":  old.ITunesPathTrimEnabled,
+		"windows_root_path":  old.ITunesWindowsRootPath,
+		"media_root":         old.ITunesMediaRoot,
+	}
+	delete(raw, "itunes_sync_enabled")
+	delete(raw, "itunes_sync_interval")
+	delete(raw, "itl_write_back_enabled")
+	delete(raw, "itunes_library_write_path")
+	delete(raw, "itunes_library_read_path")
+	delete(raw, "itunes_auto_write_back")
+	delete(raw, "itunes_path_trim_enabled")
+	delete(raw, "itunes_windows_root_path")
+	delete(raw, "itunes_media_root")
+
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
 // saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
 // Used only by startup migration to persist migrated blobs without re-marshaling.
 func saveRawBlob(store database.SettingsStore, rawJSON string) error {
@@ -368,6 +423,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated metadata_scoring blob", "err", saveErr)
+			}
+		}
+
+		// Migrate flat itunes_* / itl_* keys → nested ITunesConfig format (idempotent).
+		if migrated, changed := migrateITunesBlob(blobStr); changed {
+			slog.Info("config: migrated iTunes fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated iTunes blob", "err", saveErr)
 			}
 		}
 
@@ -727,39 +791,40 @@ func applySetting(key, value, typ string) error {
 				c.PurgeSoftDeletedDeleteFiles = b
 			}
 
-		// iTunes sync
+		// iTunes sync (legacy flat keys — new installs use the blob).
+		// These cases handle pre-Wave-4 installs that stored settings as individual rows.
 		case "itunes_sync_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ITunesSyncEnabled = b
+				c.ITunes.SyncEnabled = b
 			}
 		case "itunes_sync_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ITunesSyncInterval = i
+				c.ITunes.SyncInterval = i
 			}
 		case "itl_write_back_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ITLWriteBackEnabled = b
+				c.ITunes.WriteBackEnabled = b
 			}
 		case "itunes_library_write_path", "itunes_library_itl_path":
-			c.ITunesLibraryWritePath = value
+			c.ITunes.LibraryWritePath = value
 		case "itunes_library_read_path", "itunes_library_xml_path":
-			c.ITunesLibraryReadPath = value
+			c.ITunes.LibraryReadPath = value
 		case "itunes_auto_write_back":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ITunesAutoWriteBack = b
+				c.ITunes.AutoWriteBack = b
 			}
 		case "itunes_path_trim_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ITunesPathTrimEnabled = b
+				c.ITunes.PathTrimEnabled = b
 			}
 		case "itunes_windows_root_path":
-			c.ITunesWindowsRootPath = value
+			c.ITunes.WindowsRootPath = value
 		case "itunes_media_root":
-			c.ITunesMediaRoot = value
+			c.ITunes.MediaRoot = value
 		case "itunes_path_mappings":
 			var mappings []ITunesPathMap
 			if err := json.Unmarshal([]byte(value), &mappings); err == nil {
-				c.ITunesPathMappings = mappings
+				c.ITunes.PathMappings = mappings
 			}
 
 		// Maintenance window

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence_test.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-16
 
@@ -1007,5 +1007,65 @@ func TestRemapMetadataScoringKeys_FlatKeys(t *testing.T) {
 func TestRemapMetadataScoringKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := remapMetadataScoringKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+func TestMigrateITunesFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"itunes_sync_enabled": true,
+		"itunes_sync_interval": 30,
+		"itl_write_back_enabled": false,
+		"itunes_library_write_path": "/mnt/itunes.itl",
+		"itunes_library_read_path": "/mnt/iTunes Library.xml",
+		"itunes_auto_write_back": false,
+		"itunes_path_trim_enabled": true,
+		"itunes_windows_root_path": "C:\\Users\\",
+		"itunes_media_root": "/mnt/media",
+		"root_dir": "/data"
+	}`
+	migrated, changed := migrateITunesBlob(flatBlob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	it, ok := result["itunes"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, it["sync_enabled"])
+	assert.Equal(t, float64(30), it["sync_interval"])
+	assert.Equal(t, false, it["write_back_enabled"])
+	assert.Equal(t, "/mnt/itunes.itl", it["library_write_path"])
+	assert.Equal(t, true, it["path_trim_enabled"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "itunes_sync_enabled")
+	assert.NotContains(t, result, "itl_write_back_enabled")
+}
+
+func TestMigrateITunesFields_AlreadyNested(t *testing.T) {
+	_, changed := migrateITunesBlob(`{"itunes": {"sync_enabled": true}}`)
+	assert.False(t, changed)
+}
+
+func TestMigrateITunesFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateITunesBlob(`{}`)
+	assert.False(t, changed)
+}
+
+func TestRemapITunesKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"itunes_sync_enabled":    true,
+		"itl_write_back_enabled": false,
+		"root_dir":               "/data",
+	}
+	result := remapITunesKeys(payload)
+	it, ok := result["itunes"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, it["sync_enabled"])
+	assert.Equal(t, false, it["write_back_enabled"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "itunes_sync_enabled")
+}
+
+func TestRemapITunesKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapITunesKeys(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,5 +1,5 @@
 // file: internal/config/update_service.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 // last-edited: 2026-06-16
 
@@ -167,6 +167,42 @@ func remapMetadataScoringKeys(payload map[string]any) map[string]any {
 	return payload
 }
 
+// remapITunesKeys translates legacy flat iTunes keys in a config update payload
+// to the nested ITunesConfig format. Merges into any existing "itunes" sub-object
+// to avoid zeroing sibling fields.
+// Remove this shim once the frontend sends nested keys.
+func remapITunesKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"itunes_sync_enabled":       "sync_enabled",
+		"itunes_sync_interval":      "sync_interval",
+		"itl_write_back_enabled":    "write_back_enabled",
+		"itunes_library_write_path": "library_write_path",
+		"itunes_library_read_path":  "library_read_path",
+		"itunes_auto_write_back":    "auto_write_back",
+		"itunes_path_trim_enabled":  "path_trim_enabled",
+		"itunes_windows_root_path":  "windows_root_path",
+		"itunes_media_root":         "media_root",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["itunes"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["itunes"] = nested
+	}
+	return payload
+}
+
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -225,6 +261,8 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	filtered = remapDedupKeys(filtered)
 	// Translate any legacy flat metadata scoring keys to the nested MetadataScoringConfig format.
 	filtered = remapMetadataScoringKeys(filtered)
+	// Translate any legacy flat iTunes keys to the nested ITunesConfig format.
+	filtered = remapITunesKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/itunes/backfill.go
+++ b/internal/itunes/backfill.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/backfill.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b8c9d0e1-f2a3-b4c5-d6e7-f8a9b0c1d2e3
 
 package itunes
@@ -120,7 +120,7 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	xmlPath := config.AppConfig.ITunesLibraryReadPath
+	xmlPath := config.AppConfig.ITunes.LibraryReadPath
 	if xmlPath == "" {
 		slog.Info("BackfillITunesTrackPIDs no iTunes XML path configured, skipping")
 		return 0, nil

--- a/internal/itunes/register.go
+++ b/internal/itunes/register.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/register.go
-// version: 1.0.0
+// version: 1.1.0
 
 package itunes
 
@@ -15,11 +15,11 @@ func init() {
 		Groups: []string{"scheduler"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, "config")
-			if cfg.ITunesLibraryReadPath == "" {
+			if cfg.ITunes.LibraryReadPath == "" {
 				return nil, nil
 			}
 			// Create and start the fsnotify watcher for the iTunes Library.xml file.
-			watcher, err := NewLibraryWatcher(cfg.ITunesLibraryReadPath)
+			watcher, err := NewLibraryWatcher(cfg.ITunes.LibraryReadPath)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/itunes/service/config.go
+++ b/internal/itunes/service/config.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/config.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6d05155e-42e3-4319-a2a7-2e80d10be2aa
 
 package itunesservice
@@ -19,8 +19,8 @@ type Config struct {
 	WriteBackMaxBatch   int
 	BackupKeep          int
 	ImportConcurrency   int
-	AutoWriteBack       bool // mirror of config.AppConfig.ITunesAutoWriteBack
-	ITLWriteBackEnabled bool // mirror of config.AppConfig.ITLWriteBackEnabled
+	AutoWriteBack       bool // mirror of config.AppConfig.ITunes.AutoWriteBack
+	ITLWriteBackEnabled bool // mirror of config.AppConfig.ITunes.WriteBackEnabled
 }
 
 // PathMapping is a single ITunesPath → OrganizedPath transform applied

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 
 package itunesservice

--- a/internal/itunes/service/path_repair_test.go
+++ b/internal/itunes/service/path_repair_test.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/path_repair_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6b7e3d51-c0a3-4ab2-8d6c-7e9c1d4a8f01
 
 package itunesservice
@@ -25,11 +25,11 @@ import (
 // ComputeITunesPath, restoring the previous mappings on cleanup.
 func withITunesPathMapping(t *testing.T, dir string) {
 	t.Helper()
-	prev := config.AppConfig.ITunesPathMappings
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	prev := config.AppConfig.ITunes.PathMappings
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "Z:/", To: dir + "/"},
 	}
-	t.Cleanup(func() { config.AppConfig.ITunesPathMappings = prev })
+	t.Cleanup(func() { config.AppConfig.ITunes.PathMappings = prev })
 }
 
 // noopProgressRepair mirrors the reconciler test helper.

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/service.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
 
 package itunesservice

--- a/internal/itunes/service/transfer.go
+++ b/internal/itunes/service/transfer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/transfer.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-01
+// last-edited: 2026-06-16
 //
 // ITL file transfer handlers: download, upload+validate, backup
 // list, and restore. Part of backlog 6.4.
@@ -29,7 +29,7 @@ const maxITLUploadSize = 500 << 20
 
 // TransferService owns the ITL file transfer HTTP handlers: download,
 // upload+validate, backup list, and restore. No store / batcher deps —
-// pure filesystem operations keyed off config.AppConfig.ITunesLibraryWritePath.
+// pure filesystem operations keyed off config.AppConfig.ITunes.LibraryWritePath.
 type TransferService struct{}
 
 func newTransferService() *TransferService { return &TransferService{} }
@@ -38,7 +38,7 @@ func newTransferService() *TransferService { return &TransferService{} }
 //
 // GET /api/v1/itunes/library/download
 func (t *TransferService) HandleDownload(c *gin.Context) {
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithNotFound(c, "ITunesLibraryWritePath is not configured", "")
 		return
@@ -75,7 +75,7 @@ type ITLUploadResponse struct {
 //
 // POST /api/v1/itunes/library/upload?install=true|false
 func (t *TransferService) HandleUpload(c *gin.Context) {
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath is not configured")
 		return
@@ -154,7 +154,7 @@ type ITLBackupEntry struct {
 //
 // GET /api/v1/itunes/library/backups
 func (t *TransferService) HandleBackupList(c *gin.Context) {
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath is not configured")
 		return
@@ -208,7 +208,7 @@ type ITLRestoreRequest struct {
 //
 // POST /api/v1/itunes/library/restore
 func (t *TransferService) HandleRestore(c *gin.Context) {
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath is not configured")
 		return

--- a/internal/itunes/service/transfer_handler_test.go
+++ b/internal/itunes/service/transfer_handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/transfer_handler_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-05-03
+// last-edited: 2026-06-16
 
 package itunesservice
 
@@ -39,13 +39,13 @@ func newTransferRouter(ts *TransferService) *gin.Engine {
 	return r
 }
 
-// setITLPath sets config.AppConfig.ITunesLibraryWritePath for the duration
+// setITLPath sets config.AppConfig.ITunes.LibraryWritePath for the duration
 // of a test and restores it on cleanup.
 func setITLPath(t *testing.T, path string) {
 	t.Helper()
-	orig := config.AppConfig.ITunesLibraryWritePath
-	config.AppConfig.ITunesLibraryWritePath = path
-	t.Cleanup(func() { config.AppConfig.ITunesLibraryWritePath = orig })
+	orig := config.AppConfig.ITunes.LibraryWritePath
+	config.AppConfig.ITunes.LibraryWritePath = path
+	t.Cleanup(func() { config.AppConfig.ITunes.LibraryWritePath = orig })
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/writeback_batcher.go
-// version: 5.2.0
+// version: 5.3.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
 //
 // Combined write-back batcher: handles location updates, track additions,

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
-// last-edited: 2026-05-05
+// last-edited: 2026-06-16
 
 package jobs
 
@@ -44,7 +44,7 @@ func (j *relinkMissingToITunesJob) DefaultParams() any {
 func (j *relinkMissingToITunesJob) CanResume() bool { return false }
 
 func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	iTunesRoot := config.AppConfig.ITunesMediaRoot
+	iTunesRoot := config.AppConfig.ITunes.MediaRoot
 	organizerRoot := config.AppConfig.RootDir
 
 	if iTunesRoot == "" {

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.2.1
+// version: 2.3.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-05-05
+// last-edited: 2026-06-16
 
 package jobs
 
@@ -39,7 +39,7 @@ func (j *relinkReportJob) Description() string {
 func (j *relinkReportJob) CanResume() bool { return false }
 
 func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	iTunesRoot := config.AppConfig.ITunesMediaRoot
+	iTunesRoot := config.AppConfig.ITunes.MediaRoot
 	organizerRoot := config.AppConfig.RootDir
 
 	if iTunesRoot == "" {

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
-// last-edited: 2026-05-01
+// last-edited: 2026-06-16
 
 package jobs
 
@@ -116,7 +116,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 
 	// Parse iTunes XML for PID lookups.
 	pidToLocation := make(map[string]string)
-	if xmlPath := config.AppConfig.ITunesLibraryReadPath; xmlPath != "" {
+	if xmlPath := config.AppConfig.ITunes.LibraryReadPath; xmlPath != "" {
 		if lib, parseErr := itunes.ParseLibrary(xmlPath); parseErr != nil {
 			slog.Warn("repair-missing-files iTunes XML parse error", "opID", opID, "parseErr", parseErr)
 		} else {
@@ -129,8 +129,8 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 		}
 	}
 
-	itunesOpts := itunes.ImportOptions{PathMappings: make([]itunes.PathMapping, len(config.AppConfig.ITunesPathMappings))}
-	for i, m := range config.AppConfig.ITunesPathMappings {
+	itunesOpts := itunes.ImportOptions{PathMappings: make([]itunes.PathMapping, len(config.AppConfig.ITunes.PathMappings))}
+	for i, m := range config.AppConfig.ITunes.PathMappings {
 		itunesOpts.PathMappings[i] = itunes.PathMapping{From: m.From, To: m.To}
 	}
 
@@ -216,7 +216,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 
 // rmfr_searchRoots builds the ordered list of roots to search from config.
 func rmfr_searchRoots() []string {
-	roots := []string{config.AppConfig.ITunesMediaRoot, config.AppConfig.RootDir}
+	roots := []string{config.AppConfig.ITunes.MediaRoot, config.AppConfig.RootDir}
 	var out []string
 	for _, r := range roots {
 		if r != "" {

--- a/internal/metafetch/helpers.go
+++ b/internal/metafetch/helpers.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/helpers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
 
 package metafetch
@@ -119,15 +119,15 @@ func (mfs *Service) isProtectedPath(filePath string) bool {
 	}
 
 	// Check iTunes library paths
-	if config.AppConfig.ITunesLibraryReadPath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryReadPath)
+	if config.AppConfig.ITunes.LibraryReadPath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryReadPath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true
 		}
 	}
-	if config.AppConfig.ITunesLibraryWritePath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryWritePath)
+	if config.AppConfig.ITunes.LibraryWritePath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryWritePath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true

--- a/internal/metafetch/service_files.go
+++ b/internal/metafetch/service_files.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_files.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 969b284a-5657-442b-beba-275e325e000b
-// last-edited: 2026-05-01
+// last-edited: 2026-06-16
 
 package metafetch
 
@@ -100,7 +100,7 @@ func (mfs *Service) ApplyMetadataFileIO(id string) {
 // using the configured path mappings (m.To = Linux prefix, m.From = Windows prefix).
 // Returns an empty string if no mapping matches.
 func ComputeITunesPath(localPath string) string {
-	for _, m := range config.AppConfig.ITunesPathMappings {
+	for _, m := range config.AppConfig.ITunes.PathMappings {
 		if m.To != "" && m.From != "" && strings.HasPrefix(localPath, m.To) {
 			remainder := localPath[len(m.To):]
 			windowsPath := m.From + remainder

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-05-01
+// last-edited: 2026-06-16
 
 package metafetch
 
@@ -1114,7 +1114,7 @@ func TestBuildSearchContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath(t *testing.T) {
-	// ComputeITunesPath reads from config.AppConfig.ITunesPathMappings.
+	// ComputeITunesPath reads from config.AppConfig.ITunes.PathMappings.
 	// With no mappings configured, it should return empty.
 	t.Run("no_mappings", func(t *testing.T) {
 		result := ComputeITunesPath("/some/path")

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/organizer.go
-// version: 1.17.1
+// version: 1.18.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 
 package organizer
@@ -245,9 +245,9 @@ func (o *Organizer) generateTargetPath(book *database.Book) (string, error) {
 
 	// When iTunes path trimming is enabled, shorten the filename stem so the
 	// Windows-equivalent path stays under MAX_PATH (260 chars). This uses
-	// config.ITunesWindowsRootPath as the Windows equivalent of RootDir.
-	if config.AppConfig.ITunesPathTrimEnabled && config.AppConfig.ITunesWindowsRootPath != "" {
-		windowsRoot := strings.TrimRight(config.AppConfig.ITunesWindowsRootPath, `\/`)
+	// config.ITunes.WindowsRootPath as the Windows equivalent of RootDir.
+	if config.AppConfig.ITunes.PathTrimEnabled && config.AppConfig.ITunes.WindowsRootPath != "" {
+		windowsRoot := strings.TrimRight(config.AppConfig.ITunes.WindowsRootPath, `\/`)
 		relDir := strings.ReplaceAll(folderPath, "/", `\`)
 		// Windows path = windowsRoot + \ + relDir + \ + filename
 		prefixLen := len(windowsRoot) + 1 + len(relDir) + 1

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-15
+// last-edited: 2026-06-16
 
 package reconcile
 
@@ -438,8 +438,8 @@ func FindUntrackedFiles(store Store, knownPaths map[string]bool) ([]string, erro
 	}
 
 	// Priority 3: iTunes library paths (lowest priority — never modify these)
-	if config.AppConfig.ITunesLibraryReadPath != "" {
-		itunesMedia := filepath.Dir(config.AppConfig.ITunesLibraryReadPath)
+	if config.AppConfig.ITunes.LibraryReadPath != "" {
+		itunesMedia := filepath.Dir(config.AppConfig.ITunes.LibraryReadPath)
 		// Walk up to find the iTunes Media/Audiobooks folder
 		if sp, err := safepath.Join(itunesMedia, "iTunes Media", "Audiobooks"); err == nil {
 			audiobooks := sp.String()

--- a/internal/server/compute_itunes_path_test.go
+++ b/internal/server/compute_itunes_path_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/compute_itunes_path_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d3e4f5a6-b7c8-d9e0-f1a2-itunes-path01
 
 package server
@@ -17,10 +17,10 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath_AudiobookOrganizerPath(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 	}
 
@@ -31,10 +31,10 @@ func TestComputeITunesPath_AudiobookOrganizerPath(t *testing.T) {
 }
 
 func TestComputeITunesPath_ITunesMediaPath(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/itunes/iTunes Media", To: "/mnt/bigdata/books/itunes/iTunes Media"},
 	}
 
@@ -45,10 +45,10 @@ func TestComputeITunesPath_ITunesMediaPath(t *testing.T) {
 }
 
 func TestComputeITunesPath_NoMatchingMapping(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 	}
 
@@ -62,10 +62,10 @@ func TestComputeITunesPath_EmptyPath(t *testing.T) {
 }
 
 func TestComputeITunesPath_NoMappingsConfigured(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = nil
+	config.AppConfig.ITunes.PathMappings = nil
 
 	result := metafetch.ComputeITunesPath("/mnt/bigdata/books/audiobook-organizer/Author/file.m4b")
 	assert.Equal(t, "", result, "no mappings should return empty string")
@@ -76,10 +76,10 @@ func TestComputeITunesPath_NoMappingsConfigured(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath_SpacesEncoded(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 	}
 
@@ -93,10 +93,10 @@ func TestComputeITunesPath_SpacesEncoded(t *testing.T) {
 }
 
 func TestComputeITunesPath_SpecialCharsInTitle(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 	}
 
@@ -137,10 +137,10 @@ func TestComputeITunesPath_SpecialCharsInTitle(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath_OrganizedVsITunes_Distinction(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 		{From: "W:/itunes/iTunes Media", To: "/mnt/bigdata/books/itunes/iTunes Media"},
 	}
@@ -164,12 +164,12 @@ func TestComputeITunesPath_OrganizedVsITunes_Distinction(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath_FirstMappingWins(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
 	// Both mappings could match a path starting with /mnt/bigdata/books/
 	// but the more specific one should be listed first
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 		{From: "W:/books", To: "/mnt/bigdata/books"},
 	}
@@ -184,11 +184,11 @@ func TestComputeITunesPath_FirstMappingWins(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestComputeITunesPath_TrailingSlashConsistency(t *testing.T) {
-	old := config.AppConfig.ITunesPathMappings
-	defer func() { config.AppConfig.ITunesPathMappings = old }()
+	old := config.AppConfig.ITunes.PathMappings
+	defer func() { config.AppConfig.ITunes.PathMappings = old }()
 
 	// No trailing slash in mapping
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: "/mnt/bigdata/books/audiobook-organizer"},
 	}
 

--- a/internal/server/diagnostics_ops.go
+++ b/internal/server/diagnostics_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/diagnostics_ops.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7d8e9f0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a
 
 // diagnostics_ops registers the diagnostics export OperationDef (v2 UOS).
@@ -48,7 +48,7 @@ func (s *Server) RegisterDiagnosticsExportOp(reg *opsregistry.Registry) error {
 			store := s.Store()
 			ds := s.diagnosticsService
 			if ds == nil {
-				ds = diagnostics.NewService(store, nil, config.AppConfig.ITunesLibraryReadPath)
+				ds = diagnostics.NewService(store, nil, config.AppConfig.ITunes.LibraryReadPath)
 			}
 			prog := sdk.NewProgress(reporter, 0)
 			prog.Start("Generating export data")

--- a/internal/server/handlers/diagnostics.go
+++ b/internal/server/handlers/diagnostics.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/diagnostics.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 14e70c44-73ca-456a-bc67-8dc6ba6e5736
-// last-edited: 2026-06-10
+// last-edited: 2026-06-16
 
 // DiagnosticsHandler hosts the diagnostics HTTP endpoints extracted from the
 // server package: ZIP export start/download, AI batch submit + results, applying
@@ -294,7 +294,7 @@ func (h *DiagnosticsHandler) SubmitAI(c *gin.Context) {
 
 	ds := h.diagService
 	if ds == nil {
-		ds = diagnostics.NewService(store, nil, config.AppConfig.ITunesLibraryReadPath)
+		ds = diagnostics.NewService(store, nil, config.AppConfig.ITunes.LibraryReadPath)
 	}
 
 	category := req.Category

--- a/internal/server/handlers/itunes.go
+++ b/internal/server/handlers/itunes.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/itunes.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0123-defa-123456789012
-// last-edited: 2026-06-10
+// last-edited: 2026-06-16
 
 package handlers
 
@@ -418,14 +418,14 @@ func (h *ITunesHandler) WriteBack(c *gin.Context) {
 		return
 	}
 
-	if !config.AppConfig.ITLWriteBackEnabled || config.AppConfig.ITunesLibraryWritePath == "" {
+	if !config.AppConfig.ITunes.WriteBackEnabled || config.AppConfig.ITunes.LibraryWritePath == "" {
 		httputil.RespondWithBadRequest(c, "ITL write-back is not enabled in config")
 		return
 	}
 
 	pathMappings := req.PathMappings
 	if len(pathMappings) == 0 {
-		for _, m := range config.AppConfig.ITunesPathMappings {
+		for _, m := range config.AppConfig.ITunes.PathMappings {
 			pathMappings = append(pathMappings, itunes.PathMapping{From: m.From, To: m.To})
 		}
 	}
@@ -463,7 +463,7 @@ func (h *ITunesHandler) WriteBack(c *gin.Context) {
 		return
 	}
 
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	itlResult, itlErr := itunes.UpdateITLLocations(itlPath, itlPath+".tmp", itlUpdates)
 	if itlErr != nil {
 		stdlog.Warn("ITL write-back failed", "err", itlErr)
@@ -495,12 +495,12 @@ func (h *ITunesHandler) WriteBackAll(c *gin.Context) {
 		return
 	}
 
-	if !config.AppConfig.ITLWriteBackEnabled {
+	if !config.AppConfig.ITunes.WriteBackEnabled {
 		httputil.RespondWithBadRequest(c, "ITL write-back is not enabled in config")
 		return
 	}
 
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithBadRequest(c, "no ITL library path configured")
 		return
@@ -581,7 +581,7 @@ func (h *ITunesHandler) WriteBackPreview(c *gin.Context) {
 		}
 		libraryPath = cleanLibPath
 	} else {
-		libraryPath = config.AppConfig.ITunesLibraryReadPath
+		libraryPath = config.AppConfig.ITunes.LibraryReadPath
 	}
 	if libraryPath == "" {
 		httputil.RespondWithBadRequest(c, "no iTunes library path configured (set ITunesLibraryReadPath in settings)")
@@ -635,7 +635,7 @@ func (h *ITunesHandler) WriteBackPreview(c *gin.Context) {
 	}
 
 	var previewMappings []itunes.PathMapping
-	for _, m := range config.AppConfig.ITunesPathMappings {
+	for _, m := range config.AppConfig.ITunes.PathMappings {
 		previewMappings = append(previewMappings, itunes.PathMapping{From: m.From, To: m.To})
 	}
 	// Forward-mapper for translating an iTunes location into its local
@@ -911,7 +911,7 @@ func (h *ITunesHandler) Sync(c *gin.Context) {
 		}
 		libraryPath = cleanLibPath
 	} else {
-		libraryPath = config.AppConfig.ITunesLibraryReadPath
+		libraryPath = config.AppConfig.ITunes.LibraryReadPath
 		if libraryPath == "" {
 			libraryPath = h.importer.DiscoverLibraryPath()
 		}
@@ -946,7 +946,7 @@ func (h *ITunesHandler) Sync(c *gin.Context) {
 
 	pathMappings := req.PathMappings
 	if len(pathMappings) == 0 {
-		for _, m := range config.AppConfig.ITunesPathMappings {
+		for _, m := range config.AppConfig.ITunes.PathMappings {
 			pathMappings = append(pathMappings, itunes.PathMapping{From: m.From, To: m.To})
 		}
 	}
@@ -974,7 +974,7 @@ func (h *ITunesHandler) LibraryStats(c *gin.Context) {
 	if !h.itunesEnabledOrError(c) {
 		return
 	}
-	itlPath := config.AppConfig.ITunesLibraryWritePath
+	itlPath := config.AppConfig.ITunes.LibraryWritePath
 	if itlPath == "" {
 		httputil.RespondWithBadRequest(c, "no ITL library path configured")
 		return

--- a/internal/server/handlers/itunes_test.go
+++ b/internal/server/handlers/itunes_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/itunes_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c2a4e71-6b53-4d18-8f0a-2e7c1b9d3a64
-// last-edited: 2026-06-03
+// last-edited: 2026-06-16
 
 package handlers_test
 
@@ -162,7 +162,7 @@ func TestITunesHandler_WriteBack_NilStore_500(t *testing.T) {
 func TestITunesHandler_WriteBack_NotEnabled_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITLWriteBackEnabled = false
+	config.AppConfig.ITunes.WriteBackEnabled = false
 
 	store := handlersmocks.NewMockITunesStore(t)
 	h := handlers.NewITunesHandler(enabledSvc(t), nil, nil, store)
@@ -177,7 +177,7 @@ func TestITunesHandler_WriteBack_NotEnabled_400(t *testing.T) {
 func TestITunesHandler_WriteBackAll_NotEnabled_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITLWriteBackEnabled = false
+	config.AppConfig.ITunes.WriteBackEnabled = false
 
 	store := handlersmocks.NewMockITunesStore(t)
 	h := handlers.NewITunesHandler(enabledSvc(t), nil, nil, store)
@@ -190,8 +190,8 @@ func TestITunesHandler_WriteBackAll_NotEnabled_400(t *testing.T) {
 func TestITunesHandler_WriteBackAll_NoITLPath_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITLWriteBackEnabled = true
-	config.AppConfig.ITunesLibraryWritePath = ""
+	config.AppConfig.ITunes.WriteBackEnabled = true
+	config.AppConfig.ITunes.LibraryWritePath = ""
 
 	store := handlersmocks.NewMockITunesStore(t)
 	h := handlers.NewITunesHandler(enabledSvc(t), nil, nil, store)
@@ -214,7 +214,7 @@ func TestITunesHandler_WriteBackPreview_NilStore_500(t *testing.T) {
 func TestITunesHandler_WriteBackPreview_NoLibraryPath_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITunesLibraryReadPath = ""
+	config.AppConfig.ITunes.LibraryReadPath = ""
 
 	store := handlersmocks.NewMockITunesStore(t)
 	h := handlers.NewITunesHandler(enabledSvc(t), nil, nil, store)
@@ -350,7 +350,7 @@ func TestITunesHandler_Sync_NilRegistry_500(t *testing.T) {
 func TestITunesHandler_Sync_NoLibraryPath_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITunesLibraryReadPath = ""
+	config.AppConfig.ITunes.LibraryReadPath = ""
 
 	store := handlersmocks.NewMockITunesStore(t)
 	reg := handlersmocks.NewMockOperationsRegistry(t)
@@ -370,7 +370,7 @@ func TestITunesHandler_Sync_NoLibraryPath_400(t *testing.T) {
 func TestITunesHandler_LibraryStats_NoITLPath_400(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
-	config.AppConfig.ITunesLibraryWritePath = ""
+	config.AppConfig.ITunes.LibraryWritePath = ""
 
 	h := handlers.NewITunesHandler(enabledSvc(t), nil, nil, handlersmocks.NewMockITunesStore(t))
 	c, w := newITunesCtx(http.MethodGet, "/itunes/library-stats", "", nil)

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/operations/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1b7fbd86-cdda-4921-b2d0-786f5cadb438
-// last-edited: 2026-06-03
+// last-edited: 2026-06-16
 
 // Package operations hosts the background-operation HTTP handlers extracted
 // from the server package: the long-running scan / organize / optimize /
@@ -729,10 +729,10 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 		}
 	case "itunes_sync":
 		if req.Enabled != nil {
-			config.AppConfig.ITunesSyncEnabled = *req.Enabled
+			config.AppConfig.ITunes.SyncEnabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ITunesSyncInterval = *req.IntervalMinutes
+			config.AppConfig.ITunes.SyncInterval = *req.IntervalMinutes
 		}
 	case "series_prune":
 		if req.Enabled != nil {

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,7 +1,7 @@
 // file: internal/server/itl_rebuild.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
-// last-edited: 2026-05-18
+// last-edited: 2026-06-16
 //
 // iTunes library rebuild service: diffs the current DB state
 // against the current ITL file and computes the minimal set of
@@ -47,7 +47,7 @@ type ITLRebuildResult = itunes.ITLRebuildResult
 // Query param: dry_run=true returns the diff preview without
 // applying. Otherwise applies the diff via itunesservice.SafeWriteITL.
 func (s *Server) rebuildITLHandler(c *gin.Context) {
-	rawPath := config.AppConfig.ITunesLibraryWritePath
+	rawPath := config.AppConfig.ITunes.LibraryWritePath
 	if rawPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath not configured")
 		return
@@ -105,7 +105,7 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 // This is the "nuclear" reset path — use rebuildITLHandler (incremental diff) first.
 // Query param: dry_run=true returns a preview without applying.
 func (s *Server) rebuildITLFullHandler(c *gin.Context) {
-	rawPath := config.AppConfig.ITunesLibraryWritePath
+	rawPath := config.AppConfig.ITunes.LibraryWritePath
 	if rawPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath not configured")
 		return
@@ -151,7 +151,7 @@ func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 // it as a downloadable file. Body: {"book_ids": ["id1", "id2", ...]}
 // If book_ids is empty or omitted, all primary-version books with PIDs are included.
 func (s *Server) exportITLPartialHandler(c *gin.Context) {
-	rawPath := config.AppConfig.ITunesLibraryWritePath
+	rawPath := config.AppConfig.ITunes.LibraryWritePath
 	if rawPath == "" {
 		httputil.RespondWithBadRequest(c, "ITunesLibraryWritePath not configured")
 		return

--- a/internal/server/library_core_ops.go
+++ b/internal/server/library_core_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/library_core_ops.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 
 // library_core_ops registers the scan, organize, and transcode OperationDefs
@@ -290,7 +290,7 @@ func (s *Server) RegisterLibraryTranscodeOp(reg *opsregistry.Registry) error {
 			op.AddEntity("books", newBook.ID)
 			progress.Log("info", fmt.Sprintf("Created M4B version %s (group %s), original %s demoted to non-primary", newBook.ID, groupID, p.BookID), nil)
 
-			if !config.AppConfig.ITLWriteBackEnabled &&
+			if !config.AppConfig.ITunes.WriteBackEnabled &&
 				originalBook.ITunesPersistentID != nil &&
 				*originalBook.ITunesPersistentID != "" {
 				if err := s.Store().CreateDeferredITunesUpdate(

--- a/internal/server/organize_service_regression_test.go
+++ b/internal/server/organize_service_regression_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/organize_service_regression_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-organize-regr
 
 package server
@@ -225,11 +225,11 @@ func TestCreateOrganizedVersion_RecomputesITunesPath(t *testing.T) {
 	rootDir := t.TempDir()
 
 	// Set up path mappings so computeITunesPath works
-	oldMappings := config.AppConfig.ITunesPathMappings
-	config.AppConfig.ITunesPathMappings = []config.ITunesPathMap{
+	oldMappings := config.AppConfig.ITunes.PathMappings
+	config.AppConfig.ITunes.PathMappings = []config.ITunesPathMap{
 		{From: "W:/audiobook-organizer", To: rootDir},
 	}
-	defer func() { config.AppConfig.ITunesPathMappings = oldMappings }()
+	defer func() { config.AppConfig.ITunes.PathMappings = oldMappings }()
 
 	var createdFiles []database.BookFile
 	var mu sync.Mutex
@@ -449,7 +449,7 @@ func TestFilterBooksNeedingOrganization_SkipsAllMissingBookFiles(t *testing.T) {
 
 func TestCreateOrganizedVersion_CopiesAllBookFiles(t *testing.T) {
 	rootDir := t.TempDir()
-	config.AppConfig.ITunesPathMappings = nil // no mappings needed for this test
+	config.AppConfig.ITunes.PathMappings = nil // no mappings needed for this test
 
 	var createdFiles []database.BookFile
 	var mu sync.Mutex
@@ -520,7 +520,7 @@ func TestCreateOrganizedVersion_CopiesAllBookFiles(t *testing.T) {
 
 func TestCreateOrganizedVersion_SetsCorrectStates(t *testing.T) {
 	rootDir := t.TempDir()
-	config.AppConfig.ITunesPathMappings = nil
+	config.AppConfig.ITunes.PathMappings = nil
 
 	isPrimary := false
 	var updatedOriginal *database.Book

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.13.0
+// version: 1.14.0
 // last-edited: 2026-06-16
 
 package server
@@ -245,10 +245,10 @@ func init() {
 				Store: store,
 				Config: itunesservice.Config{
 					Enabled:             true,
-					LibraryReadPath:     cfg.ITunesLibraryReadPath,
-					LibraryWritePath:    cfg.ITunesLibraryWritePath,
-					AutoWriteBack:       cfg.ITunesAutoWriteBack,
-					ITLWriteBackEnabled: cfg.ITLWriteBackEnabled,
+					LibraryReadPath:     cfg.ITunes.LibraryReadPath,
+					LibraryWritePath:    cfg.ITunes.LibraryWritePath,
+					AutoWriteBack:       cfg.ITunes.AutoWriteBack,
+					ITLWriteBackEnabled: cfg.ITunes.WriteBackEnabled,
 				},
 				AudiobookRoot: cfg.RootDir,
 				ReportDir:     filepath.Join(cfg.RootDir, "reports"),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.29.0
+// version: 2.30.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-06-15
+// last-edited: 2026-06-16
 
 package server
 
@@ -386,7 +386,7 @@ func NewServer(store database.Store) *Server {
 		seriesCache:  cache.NewWithLimit[*audiobookspkg.SeriesWithCountsResponse]("series", 24*time.Hour, 1),
 		// olService, updater, updateScheduler are container-built;
 		// wireServerFromContainer populates the fields.
-		diagnosticsService: diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunesLibraryReadPath),
+		diagnosticsService: diagnostics.NewService(resolvedStore, nil, config.AppConfig.ITunes.LibraryReadPath),
 		changelogService:   activity.NewChangelogService(resolvedStore),
 	}
 

--- a/internal/server/server_middleware.go
+++ b/internal/server/server_middleware.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_middleware.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: 6a093405-441a-4c14-a9c5-46326ea767c1
-// last-edited: 2026-05-19
+// last-edited: 2026-06-16
 
 package server
 
@@ -99,15 +99,15 @@ func (s *Server) isProtectedPath(filePath string) bool {
 	}
 
 	// Check iTunes library paths
-	if config.AppConfig.ITunesLibraryReadPath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryReadPath)
+	if config.AppConfig.ITunes.LibraryReadPath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryReadPath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true
 		}
 	}
-	if config.AppConfig.ITunesLibraryWritePath != "" {
-		itunesDir := filepath.Dir(config.AppConfig.ITunesLibraryWritePath)
+	if config.AppConfig.ITunes.LibraryWritePath != "" {
+		itunesDir := filepath.Dir(config.AppConfig.ITunes.LibraryWritePath)
 		itunesAbs, _ := filepath.Abs(itunesDir)
 		if strings.HasPrefix(absPath, itunesAbs+"/") || absPath == itunesAbs {
 			return true

--- a/internal/server/server_undo_test.go
+++ b/internal/server/server_undo_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_undo_test.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 package server
@@ -366,8 +366,8 @@ func TestUndoLastApply_WriteBackBatcherEnqueued(t *testing.T) {
 	// Set up a real batcher (with auto write-back enabled)
 	origBatcher := server.writeBackBatcher
 	origConfig := config.AppConfig
-	config.AppConfig.ITunesAutoWriteBack = true
-	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
+	config.AppConfig.ITunes.AutoWriteBack = true
+	config.AppConfig.ITunes.LibraryReadPath = "/fake/path.xml"
 	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil) // long delay so it won't flush
 	server.writeBackBatcher = batcher
 	defer func() {
@@ -416,8 +416,8 @@ func TestApplyAudiobookMetadata_WriteBackTrue(t *testing.T) {
 	// Set up batcher
 	origBatcher := server.writeBackBatcher
 	origConfig := config.AppConfig
-	config.AppConfig.ITunesAutoWriteBack = true
-	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
+	config.AppConfig.ITunes.AutoWriteBack = true
+	config.AppConfig.ITunes.LibraryReadPath = "/fake/path.xml"
 	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
@@ -482,8 +482,8 @@ func TestApplyAudiobookMetadata_WriteBackOmitted(t *testing.T) {
 	// Set up batcher
 	origBatcher := server.writeBackBatcher
 	origConfig := config.AppConfig
-	config.AppConfig.ITunesAutoWriteBack = true
-	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
+	config.AppConfig.ITunes.AutoWriteBack = true
+	config.AppConfig.ITunes.LibraryReadPath = "/fake/path.xml"
 	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {
@@ -547,8 +547,8 @@ func TestApplyAudiobookMetadata_WriteBackFalse(t *testing.T) {
 	// Set up batcher
 	origBatcher := server.writeBackBatcher
 	origConfig := config.AppConfig
-	config.AppConfig.ITunesAutoWriteBack = true
-	config.AppConfig.ITunesLibraryReadPath = "/fake/path.xml"
+	config.AppConfig.ITunes.AutoWriteBack = true
+	config.AppConfig.ITunes.LibraryReadPath = "/fake/path.xml"
 	batcher := itunesservice.NewWriteBackBatcher(1*time.Hour, itunesservice.WriteBackBatcherConfig{AutoWriteBack: true, ITLWriteBackEnabled: true, LibraryWritePath: "/tmp/test.itl"}, nil)
 	server.writeBackBatcher = batcher
 	defer func() {


### PR DESCRIPTION
## Summary

Wave 4 of 7 config struct nesting refactor. See `docs/specs/2026-06-16-config-struct-nesting-design.md`.

- Moves 10 flat `ITunes*` / `ITLWriteBackEnabled` fields into `ITunesConfig` sub-struct at `AppConfig.ITunes`
- `ITLWriteBackEnabled` simplified to `WriteBackEnabled` in app config (itunesservice.Config.ITLWriteBackEnabled unchanged)
- Startup blob migration (`migrateITunesBlob`) chains after Wave 3 metadata scoring migration
- API compat shim (`remapITunesKeys`) handles legacy flat PUT `/config` payloads
- `applySetting` legacy-key cases updated for pre-blob installs
- `viper.SetDefault` keys changed to `itunes.*` dot-notation with `BindEnv` for env override
- 38 files updated; 7 new tests added; full test suite passes

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/config/... -run "TestMigrateITunes|TestRemapITunes|TestInitConfig_ITunes"` — 7/7 pass
- [x] `go test ./internal/config/...` — all pass including pre-existing backward-compat tests
- [x] `go test ./...` — all packages pass
- [ ] Deploy to production and verify iTunes sync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)