### PR TITLE
refactor(config): nest maintenance fields into MaintenanceConfig sub-struct

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.56.0
+// version: 1.57.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-16
 
@@ -151,6 +151,27 @@ type ITunesConfig struct {
 	WindowsRootPath  string          `json:"windows_root_path"  mapstructure:"windows_root_path"`
 	MediaRoot        string          `json:"media_root"         mapstructure:"media_root"`
 	PathMappings     []ITunesPathMap `json:"path_mappings"      mapstructure:"path_mappings"`
+}
+
+// MaintenanceConfig holds settings for the nightly maintenance window.
+type MaintenanceConfig struct {
+	Enabled              bool `json:"enabled"                mapstructure:"enabled"`
+	WindowStart          int  `json:"window_start"           mapstructure:"window_start"`
+	WindowEnd            int  `json:"window_end"             mapstructure:"window_end"`
+	DedupRefresh         bool `json:"dedup_refresh"          mapstructure:"dedup_refresh"`
+	SeriesPrune          bool `json:"series_prune"           mapstructure:"series_prune"`
+	AuthorSplit          bool `json:"author_split"           mapstructure:"author_split"`
+	TombstoneCleanup     bool `json:"tombstone_cleanup"      mapstructure:"tombstone_cleanup"`
+	Reconcile            bool `json:"reconcile"              mapstructure:"reconcile"`
+	PurgeDeleted         bool `json:"purge_deleted"          mapstructure:"purge_deleted"`
+	PurgeOldLogs         bool `json:"purge_old_logs"         mapstructure:"purge_old_logs"`
+	DbOptimize           bool `json:"db_optimize"            mapstructure:"db_optimize"`
+	LibraryScan          bool `json:"library_scan"           mapstructure:"library_scan"`
+	LibraryOrganize      bool `json:"library_organize"       mapstructure:"library_organize"`
+	MetadataRefresh      bool `json:"metadata_refresh"       mapstructure:"metadata_refresh"`
+	LibrarySizeRefresh   bool `json:"library_size_refresh"   mapstructure:"library_size_refresh"`
+	AcoustIDOnlineLookup bool `json:"acoustid_online_lookup" mapstructure:"acoustid_online_lookup"`
+	AcoustIDNightlyLimit int  `json:"acoustid_nightly_limit" mapstructure:"acoustid_nightly_limit"`
 }
 
 // MetadataScoringConfig holds settings for the AI-assisted metadata scoring pipeline.
@@ -317,9 +338,7 @@ type Config struct {
 	AutoUpdateWindowEnd    int    `json:"auto_update_window_end"`    // hour 0-23, e.g. 4
 
 	// Maintenance window (unified — replaces separate auto-update window)
-	MaintenanceWindowEnabled bool `json:"maintenance_window_enabled"`
-	MaintenanceWindowStart   int  `json:"maintenance_window_start"` // hour 0-23, default 1
-	MaintenanceWindowEnd     int  `json:"maintenance_window_end"`   // hour 0-23, default 4
+	Maintenance MaintenanceConfig `json:"maintenance" mapstructure:"maintenance"`
 
 	// Download client integration
 	DownloadClient DownloadClientConfig `json:"download_client"`
@@ -367,29 +386,6 @@ type Config struct {
 	ScheduledReconcileEnabled   bool `json:"scheduled_reconcile_enabled"`
 	ScheduledReconcileInterval  int  `json:"scheduled_reconcile_interval"` // minutes, default 0 (manual)
 	ScheduledReconcileOnStartup bool `json:"scheduled_reconcile_on_startup"`
-
-	// Per-task maintenance window toggles
-	MaintenanceWindowDedupRefresh       bool `json:"maintenance_window_dedup_refresh"`
-	MaintenanceWindowSeriesPrune        bool `json:"maintenance_window_series_prune"`
-	MaintenanceWindowAuthorSplit        bool `json:"maintenance_window_author_split"`
-	MaintenanceWindowTombstoneCleanup   bool `json:"maintenance_window_tombstone_cleanup"`
-	MaintenanceWindowReconcile          bool `json:"maintenance_window_reconcile"`
-	MaintenanceWindowPurgeDeleted       bool `json:"maintenance_window_purge_deleted"`
-	MaintenanceWindowPurgeOldLogs       bool `json:"maintenance_window_purge_old_logs"`
-	MaintenanceWindowDbOptimize         bool `json:"maintenance_window_db_optimize"`
-	MaintenanceWindowLibraryScan        bool `json:"maintenance_window_library_scan"`
-	MaintenanceWindowLibraryOrganize    bool `json:"maintenance_window_library_organize"`
-	MaintenanceWindowMetadataRefresh    bool `json:"maintenance_window_metadata_refresh"`
-	MaintenanceWindowLibrarySizeRefresh bool `json:"maintenance_window_library_size_refresh"`
-	// MaintenanceWindowAcoustIDOnlineLookup gates the nightly
-	// acoustid.lookup-online task. Off by default — the task hits a
-	// third-party API and uses quota, so requires explicit opt-in.
-	MaintenanceWindowAcoustIDOnlineLookup bool `json:"maintenance_window_acoustid_online_lookup"`
-	// AcoustIDOnlineLookupNightlyLimit caps the number of files processed
-	// per nightly run, so the maintenance window doesn't get monopolized
-	// by a slow third-party API. 0 = no cap (the op processes everything
-	// eligible). Default 5000 ≈ ~33 min at 400ms throttle.
-	AcoustIDOnlineLookupNightlyLimit int `json:"acoustid_online_lookup_nightly_limit"`
 
 	// Plugin system
 	Plugins map[string]PluginConfig `json:"plugins"`
@@ -573,25 +569,34 @@ func InitConfig() {
 	viper.SetDefault("auto_update_window_end", 4)
 
 	// Maintenance window defaults
-	viper.SetDefault("maintenance_window_enabled", true)
-	viper.SetDefault("maintenance_window_start", 1)
-	viper.SetDefault("maintenance_window_end", 4)
-	// Per-task defaults — maintenance tasks default true
-	viper.SetDefault("maintenance_window_dedup_refresh", true)
-	viper.SetDefault("maintenance_window_series_prune", true)
-	viper.SetDefault("maintenance_window_author_split", true)
-	viper.SetDefault("maintenance_window_tombstone_cleanup", true)
-	viper.SetDefault("maintenance_window_reconcile", true)
-	viper.SetDefault("maintenance_window_purge_deleted", true)
-	viper.SetDefault("maintenance_window_purge_old_logs", true)
-	viper.SetDefault("maintenance_window_db_optimize", true)
+	viper.SetDefault("maintenance.enabled", true)
+	viper.SetDefault("maintenance.window_start", 1)
+	viper.SetDefault("maintenance.window_end", 4)
+	// Per-task defaults — most maintenance tasks default true
+	viper.SetDefault("maintenance.dedup_refresh", true)
+	viper.SetDefault("maintenance.series_prune", true)
+	viper.SetDefault("maintenance.author_split", true)
+	viper.SetDefault("maintenance.tombstone_cleanup", true)
+	viper.SetDefault("maintenance.reconcile", true)
+	viper.SetDefault("maintenance.purge_deleted", true)
+	viper.SetDefault("maintenance.purge_old_logs", true)
+	viper.SetDefault("maintenance.db_optimize", true)
 	// Non-maintenance tasks default false
-	viper.SetDefault("maintenance_window_library_scan", false)
-	viper.SetDefault("maintenance_window_library_organize", false)
-	viper.SetDefault("maintenance_window_metadata_refresh", false)
+	viper.SetDefault("maintenance.library_scan", false)
+	viper.SetDefault("maintenance.library_organize", false)
+	viper.SetDefault("maintenance.metadata_refresh", false)
 	// FS-walk-based on-disk size refresh — true by default (cheap, runs nightly,
 	// keeps the FS-side cache fresh for any caller that queries physical sizes).
-	viper.SetDefault("maintenance_window_library_size_refresh", true)
+	viper.SetDefault("maintenance.library_size_refresh", true)
+	// AcoustID online lookup is OFF by default — uses third-party quota
+	viper.SetDefault("maintenance.acoustid_online_lookup", false)
+	viper.SetDefault("maintenance.acoustid_nightly_limit", 5000)
+	// BindEnv maps env vars so MAINTENANCE_ENABLED etc. override even without AutomaticEnv.
+	viper.BindEnv("maintenance.enabled", "MAINTENANCE_ENABLED")                                //nolint:errcheck
+	viper.BindEnv("maintenance.window_start", "MAINTENANCE_WINDOW_START")                      //nolint:errcheck
+	viper.BindEnv("maintenance.window_end", "MAINTENANCE_WINDOW_END")                          //nolint:errcheck
+	viper.BindEnv("maintenance.acoustid_online_lookup", "MAINTENANCE_ACOUSTID_ONLINE_LOOKUP")  //nolint:errcheck
+	viper.BindEnv("maintenance.acoustid_nightly_limit", "MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT")  //nolint:errcheck
 
 	// Download client defaults
 	viper.SetDefault("download_client.torrent.type", "")
@@ -771,24 +776,26 @@ func InitConfig() {
 			AutoUpdateWindowStart:  viper.GetInt("auto_update_window_start"),
 			AutoUpdateWindowEnd:    viper.GetInt("auto_update_window_end"),
 
-			// Maintenance window
-			MaintenanceWindowEnabled:              viper.GetBool("maintenance_window_enabled"),
-			MaintenanceWindowStart:                viper.GetInt("maintenance_window_start"),
-			MaintenanceWindowEnd:                  viper.GetInt("maintenance_window_end"),
-			MaintenanceWindowDedupRefresh:         viper.GetBool("maintenance_window_dedup_refresh"),
-			MaintenanceWindowSeriesPrune:          viper.GetBool("maintenance_window_series_prune"),
-			MaintenanceWindowAuthorSplit:          viper.GetBool("maintenance_window_author_split"),
-			MaintenanceWindowTombstoneCleanup:     viper.GetBool("maintenance_window_tombstone_cleanup"),
-			MaintenanceWindowReconcile:            viper.GetBool("maintenance_window_reconcile"),
-			MaintenanceWindowPurgeDeleted:         viper.GetBool("maintenance_window_purge_deleted"),
-			MaintenanceWindowPurgeOldLogs:         viper.GetBool("maintenance_window_purge_old_logs"),
-			MaintenanceWindowDbOptimize:           viper.GetBool("maintenance_window_db_optimize"),
-			MaintenanceWindowLibraryScan:          viper.GetBool("maintenance_window_library_scan"),
-			MaintenanceWindowLibraryOrganize:      viper.GetBool("maintenance_window_library_organize"),
-			MaintenanceWindowMetadataRefresh:      viper.GetBool("maintenance_window_metadata_refresh"),
-			MaintenanceWindowLibrarySizeRefresh:   viper.GetBool("maintenance_window_library_size_refresh"),
-			MaintenanceWindowAcoustIDOnlineLookup: viper.GetBool("maintenance_window_acoustid_online_lookup"),
-			AcoustIDOnlineLookupNightlyLimit:      viper.GetInt("acoustid_online_lookup_nightly_limit"),
+			// Maintenance window (nested sub-struct)
+			Maintenance: MaintenanceConfig{
+				Enabled:              viper.GetBool("maintenance.enabled"),
+				WindowStart:          viper.GetInt("maintenance.window_start"),
+				WindowEnd:            viper.GetInt("maintenance.window_end"),
+				DedupRefresh:         viper.GetBool("maintenance.dedup_refresh"),
+				SeriesPrune:          viper.GetBool("maintenance.series_prune"),
+				AuthorSplit:          viper.GetBool("maintenance.author_split"),
+				TombstoneCleanup:     viper.GetBool("maintenance.tombstone_cleanup"),
+				Reconcile:            viper.GetBool("maintenance.reconcile"),
+				PurgeDeleted:         viper.GetBool("maintenance.purge_deleted"),
+				PurgeOldLogs:         viper.GetBool("maintenance.purge_old_logs"),
+				DbOptimize:           viper.GetBool("maintenance.db_optimize"),
+				LibraryScan:          viper.GetBool("maintenance.library_scan"),
+				LibraryOrganize:      viper.GetBool("maintenance.library_organize"),
+				MetadataRefresh:      viper.GetBool("maintenance.metadata_refresh"),
+				LibrarySizeRefresh:   viper.GetBool("maintenance.library_size_refresh"),
+				AcoustIDOnlineLookup: viper.GetBool("maintenance.acoustid_online_lookup"),
+				AcoustIDNightlyLimit: viper.GetInt("maintenance.acoustid_nightly_limit"),
+			},
 
 			// iTunes sync (nested sub-struct)
 			ITunes: ITunesConfig{
@@ -1267,25 +1274,28 @@ func ResetToDefaults() {
 			AutoUpdateWindowEnd:    4,
 
 			// Maintenance window
-			MaintenanceWindowEnabled:          true,
-			MaintenanceWindowStart:            1,
-			MaintenanceWindowEnd:              4,
-			MaintenanceWindowDedupRefresh:     true,
-			MaintenanceWindowSeriesPrune:      true,
-			MaintenanceWindowAuthorSplit:      true,
-			MaintenanceWindowTombstoneCleanup: true,
-			MaintenanceWindowReconcile:        true,
-			MaintenanceWindowPurgeDeleted:     true,
-			MaintenanceWindowPurgeOldLogs:     true,
-			MaintenanceWindowDbOptimize:       true,
-			MaintenanceWindowLibraryScan:      false,
-			MaintenanceWindowLibraryOrganize:  false,
-			MaintenanceWindowMetadataRefresh:  false,
-			// AcoustID online lookup is OFF by default — uses third-party
-			// quota and only helps users who set ACOUSTID_API_KEY. Opt-in
-			// via setting + env key.
-			MaintenanceWindowAcoustIDOnlineLookup: false,
-			AcoustIDOnlineLookupNightlyLimit:      5000,
+			Maintenance: MaintenanceConfig{
+				Enabled:          true,
+				WindowStart:      1,
+				WindowEnd:        4,
+				DedupRefresh:     true,
+				SeriesPrune:      true,
+				AuthorSplit:      true,
+				TombstoneCleanup: true,
+				Reconcile:        true,
+				PurgeDeleted:     true,
+				PurgeOldLogs:     true,
+				DbOptimize:       true,
+				LibraryScan:      false,
+				LibraryOrganize:  false,
+				MetadataRefresh:  false,
+				LibrarySizeRefresh: true,
+				// AcoustID online lookup is OFF by default — uses third-party
+				// quota and only helps users who set ACOUSTID_API_KEY. Opt-in
+				// via setting + env key.
+				AcoustIDOnlineLookup: false,
+				AcoustIDNightlyLimit: 5000,
+			},
 
 			// iTunes sync (nested sub-struct)
 			ITunes: ITunesConfig{

--- a/internal/config/config_coverage_test.go
+++ b/internal/config/config_coverage_test.go
@@ -1,5 +1,6 @@
 // file: internal/config/config_coverage_test.go
-// version: 1.0.0
+// version: 1.1.0
+// last-edited: 2026-06-16
 
 package config
 
@@ -257,11 +258,13 @@ func TestCoverage_MaintenanceWindowDefaults(t *testing.T) {
 	// MaintenanceWindow defaults should be sensible
 	// These are only set during migration, so test the struct
 	cfg := Config{
-		MaintenanceWindowEnabled: true,
-		MaintenanceWindowStart:   1,
-		MaintenanceWindowEnd:     4,
+		Maintenance: MaintenanceConfig{
+			Enabled:     true,
+			WindowStart: 1,
+			WindowEnd:   4,
+		},
 	}
-	if cfg.MaintenanceWindowStart != 1 || cfg.MaintenanceWindowEnd != 4 {
+	if cfg.Maintenance.WindowStart != 1 || cfg.Maintenance.WindowEnd != 4 {
 		t.Error("maintenance window fields not set correctly")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-16
 
@@ -568,4 +568,26 @@ func TestInitConfig_ITunesFromEnv(t *testing.T) {
 	snap := Snapshot()
 	assert.Equal(t, 60, snap.ITunes.SyncInterval)
 	assert.True(t, snap.ITunes.AutoWriteBack)
+}
+
+func TestInitConfig_MaintenanceDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.True(t, snap.Maintenance.Enabled)
+	assert.Equal(t, 1, snap.Maintenance.WindowStart)
+	assert.Equal(t, 4, snap.Maintenance.WindowEnd)
+	assert.True(t, snap.Maintenance.DedupRefresh)
+	assert.False(t, snap.Maintenance.AcoustIDOnlineLookup)
+	assert.Equal(t, 5000, snap.Maintenance.AcoustIDNightlyLimit)
+}
+
+func TestInitConfig_MaintenanceFromEnv(t *testing.T) {
+	t.Setenv("MAINTENANCE_ENABLED", "true")
+	t.Setenv("MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT", "100")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.True(t, snap.Maintenance.Enabled)
+	assert.Equal(t, 100, snap.Maintenance.AcoustIDNightlyLimit)
 }

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_unit_test.go
-// version: 1.7.0
+// version: 1.8.0
 // last-edited: 2026-06-16
 
 package config
@@ -437,14 +437,14 @@ func TestInitConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("maintenance window defaults", func(t *testing.T) {
-		assert.True(t, AppConfig.MaintenanceWindowEnabled)
-		assert.Equal(t, 1, AppConfig.MaintenanceWindowStart)
-		assert.Equal(t, 4, AppConfig.MaintenanceWindowEnd)
-		assert.True(t, AppConfig.MaintenanceWindowDedupRefresh)
-		assert.True(t, AppConfig.MaintenanceWindowDbOptimize)
-		assert.False(t, AppConfig.MaintenanceWindowLibraryScan)
-		assert.False(t, AppConfig.MaintenanceWindowLibraryOrganize)
-		assert.False(t, AppConfig.MaintenanceWindowMetadataRefresh)
+		assert.True(t, AppConfig.Maintenance.Enabled)
+		assert.Equal(t, 1, AppConfig.Maintenance.WindowStart)
+		assert.Equal(t, 4, AppConfig.Maintenance.WindowEnd)
+		assert.True(t, AppConfig.Maintenance.DedupRefresh)
+		assert.True(t, AppConfig.Maintenance.DbOptimize)
+		assert.False(t, AppConfig.Maintenance.LibraryScan)
+		assert.False(t, AppConfig.Maintenance.LibraryOrganize)
+		assert.False(t, AppConfig.Maintenance.MetadataRefresh)
 	})
 
 	t.Run("iTunes defaults", func(t *testing.T) {
@@ -651,18 +651,18 @@ func TestApplySettingBoolKeys(t *testing.T) {
 		{"itunes_sync_enabled", func() bool { return AppConfig.ITunes.SyncEnabled }},
 		{"itl_write_back_enabled", func() bool { return AppConfig.ITunes.WriteBackEnabled }},
 		{"itunes_auto_write_back", func() bool { return AppConfig.ITunes.AutoWriteBack }},
-		{"maintenance_window_enabled", func() bool { return AppConfig.MaintenanceWindowEnabled }},
-		{"maintenance_window_dedup_refresh", func() bool { return AppConfig.MaintenanceWindowDedupRefresh }},
-		{"maintenance_window_series_prune", func() bool { return AppConfig.MaintenanceWindowSeriesPrune }},
-		{"maintenance_window_author_split", func() bool { return AppConfig.MaintenanceWindowAuthorSplit }},
-		{"maintenance_window_tombstone_cleanup", func() bool { return AppConfig.MaintenanceWindowTombstoneCleanup }},
-		{"maintenance_window_reconcile", func() bool { return AppConfig.MaintenanceWindowReconcile }},
-		{"maintenance_window_purge_deleted", func() bool { return AppConfig.MaintenanceWindowPurgeDeleted }},
-		{"maintenance_window_purge_old_logs", func() bool { return AppConfig.MaintenanceWindowPurgeOldLogs }},
-		{"maintenance_window_db_optimize", func() bool { return AppConfig.MaintenanceWindowDbOptimize }},
-		{"maintenance_window_library_scan", func() bool { return AppConfig.MaintenanceWindowLibraryScan }},
-		{"maintenance_window_library_organize", func() bool { return AppConfig.MaintenanceWindowLibraryOrganize }},
-		{"maintenance_window_metadata_refresh", func() bool { return AppConfig.MaintenanceWindowMetadataRefresh }},
+		{"maintenance_window_enabled", func() bool { return AppConfig.Maintenance.Enabled }},
+		{"maintenance_window_dedup_refresh", func() bool { return AppConfig.Maintenance.DedupRefresh }},
+		{"maintenance_window_series_prune", func() bool { return AppConfig.Maintenance.SeriesPrune }},
+		{"maintenance_window_author_split", func() bool { return AppConfig.Maintenance.AuthorSplit }},
+		{"maintenance_window_tombstone_cleanup", func() bool { return AppConfig.Maintenance.TombstoneCleanup }},
+		{"maintenance_window_reconcile", func() bool { return AppConfig.Maintenance.Reconcile }},
+		{"maintenance_window_purge_deleted", func() bool { return AppConfig.Maintenance.PurgeDeleted }},
+		{"maintenance_window_purge_old_logs", func() bool { return AppConfig.Maintenance.PurgeOldLogs }},
+		{"maintenance_window_db_optimize", func() bool { return AppConfig.Maintenance.DbOptimize }},
+		{"maintenance_window_library_scan", func() bool { return AppConfig.Maintenance.LibraryScan }},
+		{"maintenance_window_library_organize", func() bool { return AppConfig.Maintenance.LibraryOrganize }},
+		{"maintenance_window_metadata_refresh", func() bool { return AppConfig.Maintenance.MetadataRefresh }},
 		{"basic_auth_enabled", func() bool { return AppConfig.BasicAuthEnabled }},
 		{"scheduled_dedup_refresh_enabled", func() bool { return AppConfig.ScheduledDedupRefreshEnabled }},
 		{"scheduled_dedup_refresh_on_startup", func() bool { return AppConfig.ScheduledDedupRefreshOnStartup }},
@@ -723,8 +723,8 @@ func TestApplySettingIntKeys(t *testing.T) {
 		{"auto_update_window_end", "5", func() int { return AppConfig.AutoUpdateWindowEnd }},
 		{"purge_soft_deleted_after_days", "30", func() int { return AppConfig.PurgeSoftDeletedAfterDays }},
 		{"itunes_sync_interval", "60", func() int { return AppConfig.ITunes.SyncInterval }},
-		{"maintenance_window_start", "3", func() int { return AppConfig.MaintenanceWindowStart }},
-		{"maintenance_window_end", "6", func() int { return AppConfig.MaintenanceWindowEnd }},
+		{"maintenance_window_start", "3", func() int { return AppConfig.Maintenance.WindowStart }},
+		{"maintenance_window_end", "6", func() int { return AppConfig.Maintenance.WindowEnd }},
 		{"scheduled_dedup_refresh_interval", "24", func() int { return AppConfig.ScheduledDedupRefreshInterval }},
 		{"scheduled_author_split_interval", "12", func() int { return AppConfig.ScheduledAuthorSplitInterval }},
 		{"scheduled_db_optimize_interval", "48", func() int { return AppConfig.ScheduledDbOptimizeInterval }},
@@ -1102,23 +1102,22 @@ func TestMigrateMaintenanceWindow(t *testing.T) {
 		store.settings["maintenance_window_migrated"] = &database.Setting{
 			Key: "maintenance_window_migrated", Value: "true", Type: "bool",
 		}
-		AppConfig = Config{MaintenanceWindowStart: 0, MaintenanceWindowEnd: 0}
+		AppConfig = Config{Maintenance: MaintenanceConfig{WindowStart: 0, WindowEnd: 0}}
 		MigrateMaintenanceWindow(store)
 		// Should not change defaults since migration was already done
-		assert.Equal(t, 0, AppConfig.MaintenanceWindowStart)
+		assert.Equal(t, 0, AppConfig.Maintenance.WindowStart)
 	})
 
 	t.Run("migrates from auto-update window", func(t *testing.T) {
 		store := newMockSettingsStore()
 		AppConfig = Config{
-			AutoUpdateWindowStart:  2,
-			AutoUpdateWindowEnd:    5,
-			MaintenanceWindowStart: 0,
-			MaintenanceWindowEnd:   0,
+			AutoUpdateWindowStart: 2,
+			AutoUpdateWindowEnd:   5,
+			Maintenance:           MaintenanceConfig{WindowStart: 0, WindowEnd: 0},
 		}
 		MigrateMaintenanceWindow(store)
-		assert.Equal(t, 2, AppConfig.MaintenanceWindowStart)
-		assert.Equal(t, 5, AppConfig.MaintenanceWindowEnd)
+		assert.Equal(t, 2, AppConfig.Maintenance.WindowStart)
+		assert.Equal(t, 5, AppConfig.Maintenance.WindowEnd)
 		assert.Equal(t, "true", store.settings["maintenance_window_migrated"].Value)
 	})
 
@@ -1126,8 +1125,8 @@ func TestMigrateMaintenanceWindow(t *testing.T) {
 		store := newMockSettingsStore()
 		AppConfig = Config{}
 		MigrateMaintenanceWindow(store)
-		assert.Equal(t, 1, AppConfig.MaintenanceWindowStart)
-		assert.Equal(t, 4, AppConfig.MaintenanceWindowEnd)
+		assert.Equal(t, 1, AppConfig.Maintenance.WindowStart)
+		assert.Equal(t, 4, AppConfig.Maintenance.WindowEnd)
 	})
 }
 

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.24.0
+// version: 1.25.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-06-16
 
@@ -354,6 +354,76 @@ func migrateITunesBlob(blob string) (string, bool) {
 	return string(migrated), true
 }
 
+// migrateMaintenanceBlob rewrites flat maintenance_window_* fields to the nested
+// MaintenanceConfig format. Safe to call repeatedly.
+func migrateMaintenanceBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["maintenance_window_enabled"]; !isFlat {
+		return blob, false
+	}
+	type flatShape struct {
+		Enabled              bool `json:"maintenance_window_enabled"`
+		WindowStart          int  `json:"maintenance_window_start"`
+		WindowEnd            int  `json:"maintenance_window_end"`
+		DedupRefresh         bool `json:"maintenance_window_dedup_refresh"`
+		SeriesPrune          bool `json:"maintenance_window_series_prune"`
+		AuthorSplit          bool `json:"maintenance_window_author_split"`
+		TombstoneCleanup     bool `json:"maintenance_window_tombstone_cleanup"`
+		Reconcile            bool `json:"maintenance_window_reconcile"`
+		PurgeDeleted         bool `json:"maintenance_window_purge_deleted"`
+		PurgeOldLogs         bool `json:"maintenance_window_purge_old_logs"`
+		DbOptimize           bool `json:"maintenance_window_db_optimize"`
+		LibraryScan          bool `json:"maintenance_window_library_scan"`
+		LibraryOrganize      bool `json:"maintenance_window_library_organize"`
+		MetadataRefresh      bool `json:"maintenance_window_metadata_refresh"`
+		LibrarySizeRefresh   bool `json:"maintenance_window_library_size_refresh"`
+		AcoustIDOnlineLookup bool `json:"maintenance_window_acoustid_online_lookup"`
+		AcoustIDNightlyLimit int  `json:"acoustid_online_lookup_nightly_limit"`
+	}
+	var old flatShape
+	json.Unmarshal([]byte(blob), &old) //nolint:errcheck — already parsed above
+	raw["maintenance"] = map[string]any{
+		"enabled":                old.Enabled,
+		"window_start":           old.WindowStart,
+		"window_end":             old.WindowEnd,
+		"dedup_refresh":          old.DedupRefresh,
+		"series_prune":           old.SeriesPrune,
+		"author_split":           old.AuthorSplit,
+		"tombstone_cleanup":      old.TombstoneCleanup,
+		"reconcile":              old.Reconcile,
+		"purge_deleted":          old.PurgeDeleted,
+		"purge_old_logs":         old.PurgeOldLogs,
+		"db_optimize":            old.DbOptimize,
+		"library_scan":           old.LibraryScan,
+		"library_organize":       old.LibraryOrganize,
+		"metadata_refresh":       old.MetadataRefresh,
+		"library_size_refresh":   old.LibrarySizeRefresh,
+		"acoustid_online_lookup": old.AcoustIDOnlineLookup,
+		"acoustid_nightly_limit": old.AcoustIDNightlyLimit,
+	}
+	// delete all flat keys
+	for _, k := range []string{
+		"maintenance_window_enabled", "maintenance_window_start", "maintenance_window_end",
+		"maintenance_window_dedup_refresh", "maintenance_window_series_prune",
+		"maintenance_window_author_split", "maintenance_window_tombstone_cleanup",
+		"maintenance_window_reconcile", "maintenance_window_purge_deleted",
+		"maintenance_window_purge_old_logs", "maintenance_window_db_optimize",
+		"maintenance_window_library_scan", "maintenance_window_library_organize",
+		"maintenance_window_metadata_refresh", "maintenance_window_library_size_refresh",
+		"maintenance_window_acoustid_online_lookup", "acoustid_online_lookup_nightly_limit",
+	} {
+		delete(raw, k)
+	}
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
 // saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
 // Used only by startup migration to persist migrated blobs without re-marshaling.
 func saveRawBlob(store database.SettingsStore, rawJSON string) error {
@@ -432,6 +502,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated iTunes blob", "err", saveErr)
+			}
+		}
+
+		// Migrate flat maintenance_window_* keys → nested MaintenanceConfig format (idempotent).
+		if migrated, changed := migrateMaintenanceBlob(blobStr); changed {
+			slog.Info("config: migrated maintenance fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated maintenance blob", "err", saveErr)
 			}
 		}
 
@@ -553,18 +632,18 @@ func MigrateMaintenanceWindow(store database.SettingsStore) {
 	var logStart, logEnd int
 	Mutate(func(c *Config) {
 		// Migrate auto-update window start/end if maintenance window not yet configured
-		if c.MaintenanceWindowStart == 0 && c.AutoUpdateWindowStart > 0 {
-			c.MaintenanceWindowStart = c.AutoUpdateWindowStart
+		if c.Maintenance.WindowStart == 0 && c.AutoUpdateWindowStart > 0 {
+			c.Maintenance.WindowStart = c.AutoUpdateWindowStart
 		}
-		if c.MaintenanceWindowEnd == 0 && c.AutoUpdateWindowEnd > 0 {
-			c.MaintenanceWindowEnd = c.AutoUpdateWindowEnd
+		if c.Maintenance.WindowEnd == 0 && c.AutoUpdateWindowEnd > 0 {
+			c.Maintenance.WindowEnd = c.AutoUpdateWindowEnd
 		}
 		// Ensure sensible defaults
-		if c.MaintenanceWindowStart == 0 && c.MaintenanceWindowEnd == 0 {
-			c.MaintenanceWindowStart = 1
-			c.MaintenanceWindowEnd = 4
+		if c.Maintenance.WindowStart == 0 && c.Maintenance.WindowEnd == 0 {
+			c.Maintenance.WindowStart = 1
+			c.Maintenance.WindowEnd = 4
 		}
-		logStart, logEnd = c.MaintenanceWindowStart, c.MaintenanceWindowEnd
+		logStart, logEnd = c.Maintenance.WindowStart, c.Maintenance.WindowEnd
 	})
 
 	_ = store.SetSetting("maintenance_window_migrated", "true", "bool", false)
@@ -830,59 +909,71 @@ func applySetting(key, value, typ string) error {
 		// Maintenance window
 		case "maintenance_window_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowEnabled = b
+				c.Maintenance.Enabled = b
 			}
 		case "maintenance_window_start":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.MaintenanceWindowStart = i
+				c.Maintenance.WindowStart = i
 			}
 		case "maintenance_window_end":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.MaintenanceWindowEnd = i
+				c.Maintenance.WindowEnd = i
 			}
 		case "maintenance_window_dedup_refresh":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowDedupRefresh = b
+				c.Maintenance.DedupRefresh = b
 			}
 		case "maintenance_window_series_prune":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowSeriesPrune = b
+				c.Maintenance.SeriesPrune = b
 			}
 		case "maintenance_window_author_split":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowAuthorSplit = b
+				c.Maintenance.AuthorSplit = b
 			}
 		case "maintenance_window_tombstone_cleanup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowTombstoneCleanup = b
+				c.Maintenance.TombstoneCleanup = b
 			}
 		case "maintenance_window_reconcile":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowReconcile = b
+				c.Maintenance.Reconcile = b
 			}
 		case "maintenance_window_purge_deleted":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowPurgeDeleted = b
+				c.Maintenance.PurgeDeleted = b
 			}
 		case "maintenance_window_purge_old_logs":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowPurgeOldLogs = b
+				c.Maintenance.PurgeOldLogs = b
 			}
 		case "maintenance_window_db_optimize":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowDbOptimize = b
+				c.Maintenance.DbOptimize = b
 			}
 		case "maintenance_window_library_scan":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowLibraryScan = b
+				c.Maintenance.LibraryScan = b
 			}
 		case "maintenance_window_library_organize":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowLibraryOrganize = b
+				c.Maintenance.LibraryOrganize = b
 			}
 		case "maintenance_window_metadata_refresh":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.MaintenanceWindowMetadataRefresh = b
+				c.Maintenance.MetadataRefresh = b
+			}
+		case "maintenance_window_library_size_refresh":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Maintenance.LibrarySizeRefresh = b
+			}
+		case "maintenance_window_acoustid_online_lookup":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Maintenance.AcoustIDOnlineLookup = b
+			}
+		case "acoustid_online_lookup_nightly_limit":
+			if i, err := strconv.Atoi(value); err == nil {
+				c.Maintenance.AcoustIDNightlyLimit = i
 			}
 
 		// Scheduled maintenance tasks

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence_test.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-16
 
@@ -1067,5 +1067,63 @@ func TestRemapITunesKeys_FlatKeys(t *testing.T) {
 func TestRemapITunesKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := remapITunesKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+func TestMigrateMaintenanceFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"maintenance_window_enabled": false,
+		"maintenance_window_start": 2,
+		"maintenance_window_end": 5,
+		"maintenance_window_dedup_refresh": true,
+		"maintenance_window_series_prune": true,
+		"maintenance_window_db_optimize": true,
+		"acoustid_online_lookup_nightly_limit": 500,
+		"root_dir": "/data"
+	}`
+	migrated, changed := migrateMaintenanceBlob(flatBlob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	m, ok := result["maintenance"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, m["enabled"])
+	assert.Equal(t, float64(2), m["window_start"])
+	assert.Equal(t, float64(5), m["window_end"])
+	assert.Equal(t, true, m["dedup_refresh"])
+	assert.Equal(t, float64(500), m["acoustid_nightly_limit"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "maintenance_window_enabled")
+	assert.NotContains(t, result, "acoustid_online_lookup_nightly_limit")
+}
+
+func TestMigrateMaintenanceFields_AlreadyNested(t *testing.T) {
+	_, changed := migrateMaintenanceBlob(`{"maintenance": {"enabled": false}}`)
+	assert.False(t, changed)
+}
+
+func TestMigrateMaintenanceFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateMaintenanceBlob(`{}`)
+	assert.False(t, changed)
+}
+
+func TestRemapMaintenanceKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"maintenance_window_enabled":           false,
+		"acoustid_online_lookup_nightly_limit": float64(500),
+		"root_dir":                             "/data",
+	}
+	result := remapMaintenanceKeys(payload)
+	m, ok := result["maintenance"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, m["enabled"])
+	assert.Equal(t, float64(500), m["acoustid_nightly_limit"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "maintenance_window_enabled")
+}
+
+func TestRemapMaintenanceKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapMaintenanceKeys(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,5 +1,5 @@
 // file: internal/config/update_service.go
-// version: 3.5.0
+// version: 3.6.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 // last-edited: 2026-06-16
 
@@ -203,6 +203,50 @@ func remapITunesKeys(payload map[string]any) map[string]any {
 	return payload
 }
 
+// remapMaintenanceKeys translates legacy flat maintenance_window_* keys in a config
+// update payload to the nested MaintenanceConfig format. Merges into any existing
+// "maintenance" sub-object to avoid zeroing sibling fields.
+// Remove this shim once the frontend sends nested keys.
+func remapMaintenanceKeys(payload map[string]any) map[string]any {
+	flatToNested := map[string]string{
+		"maintenance_window_enabled":                "enabled",
+		"maintenance_window_start":                  "window_start",
+		"maintenance_window_end":                    "window_end",
+		"maintenance_window_dedup_refresh":          "dedup_refresh",
+		"maintenance_window_series_prune":           "series_prune",
+		"maintenance_window_author_split":           "author_split",
+		"maintenance_window_tombstone_cleanup":      "tombstone_cleanup",
+		"maintenance_window_reconcile":              "reconcile",
+		"maintenance_window_purge_deleted":          "purge_deleted",
+		"maintenance_window_purge_old_logs":         "purge_old_logs",
+		"maintenance_window_db_optimize":            "db_optimize",
+		"maintenance_window_library_scan":           "library_scan",
+		"maintenance_window_library_organize":       "library_organize",
+		"maintenance_window_metadata_refresh":       "metadata_refresh",
+		"maintenance_window_library_size_refresh":   "library_size_refresh",
+		"maintenance_window_acoustid_online_lookup": "acoustid_online_lookup",
+		"acoustid_online_lookup_nightly_limit":      "acoustid_nightly_limit",
+	}
+	nested := make(map[string]any)
+	for flat, short := range flatToNested {
+		if v, ok := payload[flat]; ok {
+			nested[short] = v
+			delete(payload, flat)
+		}
+	}
+	if len(nested) == 0 {
+		return payload
+	}
+	if existing, ok := payload["maintenance"].(map[string]any); ok {
+		for k, v := range nested {
+			existing[k] = v
+		}
+	} else {
+		payload["maintenance"] = nested
+	}
+	return payload
+}
+
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -263,6 +307,8 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	filtered = remapMetadataScoringKeys(filtered)
 	// Translate any legacy flat iTunes keys to the nested ITunesConfig format.
 	filtered = remapITunesKeys(filtered)
+	// Translate any legacy flat maintenance_window_* keys to the nested MaintenanceConfig format.
+	filtered = remapMaintenanceKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/scheduler/maintenance.go
+++ b/internal/scheduler/maintenance.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/maintenance.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7d2e8f4a-c3b1-4a09-8e5f-2d6c0b9a3e71
-// last-edited: 2026-05-11
+// last-edited: 2026-06-16
 
 package scheduler
 
@@ -25,11 +25,11 @@ const IgnoreWindowKey MaintenanceCtxKey = "ignore_window"
 // IsInMaintenanceWindowAt checks if a given hour falls within the configured window.
 // Supports midnight-spanning windows (e.g., start=23, end=2).
 func IsInMaintenanceWindowAt(hour int) bool {
-	if !config.AppConfig.MaintenanceWindowEnabled {
+	if !config.AppConfig.Maintenance.Enabled {
 		return false
 	}
-	start := config.AppConfig.MaintenanceWindowStart
-	end := config.AppConfig.MaintenanceWindowEnd
+	start := config.AppConfig.Maintenance.WindowStart
+	end := config.AppConfig.Maintenance.WindowEnd
 
 	if start < end {
 		return hour >= start && hour < end

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 3f7a9c21-b4d8-4e05-a6f2-8c1d0e3b7a94
-// last-edited: 2026-05-11
+// last-edited: 2026-06-16
 
 // Package scheduler implements the unified task scheduling system.
 // TaskScheduler manages all registered tasks, their schedules, and manual
@@ -179,13 +179,13 @@ func (ts *TaskScheduler) Start(shutdown chan struct{}, wg *sync.WaitGroup) {
 	}
 
 	// Maintenance window checker — runs every 60 seconds
-	if config.AppConfig.MaintenanceWindowEnabled {
+	if config.AppConfig.Maintenance.Enabled {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			ticker := time.NewTicker(60 * time.Second)
 			defer ticker.Stop()
-			slog.Info("Maintenance window enabled 00 - 00", "value0", config.AppConfig.MaintenanceWindowStart, "value1", config.AppConfig.MaintenanceWindowEnd)
+			slog.Info("Maintenance window enabled 00 - 00", "value0", config.AppConfig.Maintenance.WindowStart, "value1", config.AppConfig.Maintenance.WindowEnd)
 			for {
 				select {
 				case <-ticker.C:

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4e8b2f1c-9a3d-4c07-b5e8-6f2a0d7c3b94
-// last-edited: 2026-05-11
+// last-edited: 2026-06-16
 
 package scheduler
 
@@ -49,9 +49,9 @@ func TestIsInMaintenanceWindowAt(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.AppConfig.MaintenanceWindowEnabled = tt.enabled
-			config.AppConfig.MaintenanceWindowStart = tt.start
-			config.AppConfig.MaintenanceWindowEnd = tt.end
+			config.AppConfig.Maintenance.Enabled = tt.enabled
+			config.AppConfig.Maintenance.WindowStart = tt.start
+			config.AppConfig.Maintenance.WindowEnd = tt.end
 			got := IsInMaintenanceWindowAt(tt.hour)
 			assert.Equal(t, tt.want, got)
 		})
@@ -126,9 +126,9 @@ func TestGetTask_UnknownTask(t *testing.T) {
 func TestIsInMaintenanceWindowAt_FullDayCoverage(t *testing.T) {
 	// A window of start=0, end=0: start < end is false, so falls into the
 	// midnight-span branch: hour >= 0 || hour < 0 — always true for valid hours.
-	config.AppConfig.MaintenanceWindowEnabled = true
-	config.AppConfig.MaintenanceWindowStart = 0
-	config.AppConfig.MaintenanceWindowEnd = 0
+	config.AppConfig.Maintenance.Enabled = true
+	config.AppConfig.Maintenance.WindowStart = 0
+	config.AppConfig.Maintenance.WindowEnd = 0
 	got := IsInMaintenanceWindowAt(12)
 	assert.True(t, got, "0==0 wraps to always-open")
 }

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/tasks.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 9b4c7e21-a5f3-4d08-b2e6-3c8d1f7a0e54
-// last-edited: 2026-05-11
+// last-edited: 2026-06-16
 
 // Package scheduler — task registrations.
 // All 22 registered tasks are defined here. Each task's TriggerFn and
@@ -75,7 +75,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return config.AppConfig.ScanOnStartup },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return config.AppConfig.ScanOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowLibraryScan },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.LibraryScan },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -100,7 +100,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowLibraryOrganize },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.LibraryOrganize },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -125,7 +125,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowLibrarySizeRefresh },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.LibrarySizeRefresh },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -188,7 +188,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledDedupRefreshOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowDedupRefresh },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DedupRefresh },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -245,7 +245,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledSeriesPruneOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowSeriesPrune },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.SeriesPrune },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -302,7 +302,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		// picks it up periodically; the 6h interval keeps it from going
 		// completely silent.
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowMetadataRefresh },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.MetadataRefresh },
 	})
 
 	// iTunes position sync is now registered via UOS plugin (UOS-10)
@@ -405,7 +405,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return ts.deps.HasMetadataFetchSvc() },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowMetadataRefresh },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.MetadataRefresh },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -436,7 +436,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledAuthorSplitOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowAuthorSplit },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.AuthorSplit },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -467,7 +467,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledDbOptimizeOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DbOptimize },
 	})
 
 	// Nightly AcoustID online lookup. Off unless the user explicitly
@@ -489,7 +489,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 				return nil, fmt.Errorf("failed to create operation: %w", err)
 			}
 			params := map[string]any{
-				"limit": config.AppConfig.AcoustIDOnlineLookupNightlyLimit,
+				"limit": config.AppConfig.Maintenance.AcoustIDNightlyLimit,
 				"force": false,
 			}
 			if _, enqErr := ts.deps.OpRegistry.EnqueueOp(context.Background(), "acoustid.lookup-online", params); enqErr != nil {
@@ -497,10 +497,10 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled:              func() bool { return config.AppConfig.MaintenanceWindowAcoustIDOnlineLookup },
+		IsEnabled:              func() bool { return config.AppConfig.Maintenance.AcoustIDOnlineLookup },
 		GetInterval:            func() time.Duration { return 0 }, // run only inside the maintenance window
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowAcoustIDOnlineLookup },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.AcoustIDOnlineLookup },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -522,10 +522,10 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled:              func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
+		IsEnabled:              func() bool { return config.AppConfig.Maintenance.DbOptimize },
 		GetInterval:            func() time.Duration { return 0 },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowDbOptimize },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DbOptimize },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -556,7 +556,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return 0
 		},
 		RunOnStart:             func() bool { return config.AppConfig.PurgeSoftDeletedAfterDays > 0 },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowPurgeDeleted },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.PurgeDeleted },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -581,7 +581,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return true },
 		GetInterval:            func() time.Duration { return 24 * time.Hour },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowTombstoneCleanup },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.TombstoneCleanup },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -643,7 +643,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledMetadataRefreshOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowMetadataRefresh },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.MetadataRefresh },
 	})
 
 	// Reconcile — find broken file paths and match to untracked files on disk
@@ -675,7 +675,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return time.Duration(mins) * time.Minute
 		},
 		RunOnStart:             func() bool { return config.AppConfig.ScheduledReconcileOnStartup },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowReconcile },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.Reconcile },
 	})
 
 	// AI Dedup Batch — uses OpenAI Batch API at 50% cost
@@ -765,7 +765,7 @@ func (ts *TaskScheduler) registerAllTasks() {
 		IsEnabled:              func() bool { return config.AppConfig.LogRetentionDays > 0 },
 		GetInterval:            func() time.Duration { return 7 * 24 * time.Hour },
 		RunOnStart:             func() bool { return false },
-		RunInMaintenanceWindow: func() bool { return config.AppConfig.MaintenanceWindowPurgeOldLogs },
+		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.PurgeOldLogs },
 	})
 
 	// Activity Log Cleanup — summarize old change entries and prune old debug entries

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -686,7 +686,7 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 			config.AppConfig.ScheduledDedupRefreshOnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowDedupRefresh = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.DedupRefresh = *req.RunInMaintenanceWindow
 		}
 	case "author_split_scan":
 		if req.Enabled != nil {
@@ -699,7 +699,7 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 			config.AppConfig.ScheduledAuthorSplitOnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowAuthorSplit = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.AuthorSplit = *req.RunInMaintenanceWindow
 		}
 	case "db_optimize":
 		if req.Enabled != nil {
@@ -712,7 +712,7 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 			config.AppConfig.ScheduledDbOptimizeOnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowDbOptimize = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.DbOptimize = *req.RunInMaintenanceWindow
 		}
 	case "metadata_refresh":
 		if req.Enabled != nil {
@@ -725,7 +725,7 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 			config.AppConfig.ScheduledMetadataRefreshOnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowMetadataRefresh = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.MetadataRefresh = *req.RunInMaintenanceWindow
 		}
 	case "itunes_sync":
 		if req.Enabled != nil {
@@ -745,37 +745,37 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 			config.AppConfig.ScheduledSeriesPruneOnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowSeriesPrune = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.SeriesPrune = *req.RunInMaintenanceWindow
 		}
 	case "purge_deleted":
 		if req.IntervalMinutes != nil {
 			// purge interval is fixed at 6h, but we can update retention days
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowPurgeDeleted = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.PurgeDeleted = *req.RunInMaintenanceWindow
 		}
 	case "tombstone_cleanup":
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowTombstoneCleanup = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.TombstoneCleanup = *req.RunInMaintenanceWindow
 		}
 	case "reconcile_scan":
 		if req.Enabled != nil {
 			config.AppConfig.ScheduledReconcileEnabled = *req.Enabled
 		}
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowReconcile = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.Reconcile = *req.RunInMaintenanceWindow
 		}
 	case "purge_old_logs":
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowPurgeOldLogs = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.PurgeOldLogs = *req.RunInMaintenanceWindow
 		}
 	case "library_scan":
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowLibraryScan = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.LibraryScan = *req.RunInMaintenanceWindow
 		}
 	case "library_organize":
 		if req.RunInMaintenanceWindow != nil {
-			config.AppConfig.MaintenanceWindowLibraryOrganize = *req.RunInMaintenanceWindow
+			config.AppConfig.Maintenance.LibraryOrganize = *req.RunInMaintenanceWindow
 		}
 	default:
 		httputil.RespondWithBadRequest(c, fmt.Sprintf("task %q config is not configurable", name))
@@ -820,11 +820,11 @@ func (h *Handler) GetMaintenanceWindowStatus(c *gin.Context) {
 	}
 	cfg := config.AppConfig
 	httputil.RespondWithOK(c, gin.H{
-		"enabled":           cfg.MaintenanceWindowEnabled,
-		"window_start":      cfg.MaintenanceWindowStart,
-		"window_end":        cfg.MaintenanceWindowEnd,
+		"enabled":           cfg.Maintenance.Enabled,
+		"window_start":      cfg.Maintenance.WindowStart,
+		"window_end":        cfg.Maintenance.WindowEnd,
 		"last_run_date":     sched.GetLastMaintenanceRunDate(),
-		"next_run_estimate": calculateNextWindowRun(cfg.MaintenanceWindowStart),
+		"next_run_estimate": calculateNextWindowRun(cfg.Maintenance.WindowStart),
 		"currently_running": sched.IsMaintenanceRunning(),
 	})
 }
@@ -852,9 +852,9 @@ func (h *Handler) UpdateMaintenanceWindowConfig(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "window_start and window_end must be 0-23")
 		return
 	}
-	config.AppConfig.MaintenanceWindowEnabled = req.Enabled
-	config.AppConfig.MaintenanceWindowStart = req.WindowStart
-	config.AppConfig.MaintenanceWindowEnd = req.WindowEnd
+	config.AppConfig.Maintenance.Enabled = req.Enabled
+	config.AppConfig.Maintenance.WindowStart = req.WindowStart
+	config.AppConfig.Maintenance.WindowEnd = req.WindowEnd
 	if h.store != nil {
 		if err := config.SaveConfigToDatabase(h.store); err != nil {
 			httputil.InternalError(c, "failed to save maintenance window config", err)

--- a/internal/server/maintenance_window_handlers_test.go
+++ b/internal/server/maintenance_window_handlers_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_window_handlers_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d5e6f7a8-b9c0-1234-efab-456789012345
-// last-edited: 2026-05-11
+// last-edited: 2026-06-16
 
 package server
 
@@ -79,9 +79,9 @@ func TestGetMaintenanceWindowStatus(t *testing.T) {
 	orig := config.AppConfig
 	defer func() { config.AppConfig = orig }()
 
-	config.AppConfig.MaintenanceWindowEnabled = true
-	config.AppConfig.MaintenanceWindowStart = 2
-	config.AppConfig.MaintenanceWindowEnd = 5
+	config.AppConfig.Maintenance.Enabled = true
+	config.AppConfig.Maintenance.WindowStart = 2
+	config.AppConfig.Maintenance.WindowEnd = 5
 
 	srv := setupMaintenanceTestServer(t)
 
@@ -131,9 +131,9 @@ func TestUpdateMaintenanceWindowConfig_Valid(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "expected 200 OK: %s", w.Body.String())
 
 	// Verify config was updated.
-	assert.True(t, config.AppConfig.MaintenanceWindowEnabled)
-	assert.Equal(t, 3, config.AppConfig.MaintenanceWindowStart)
-	assert.Equal(t, 5, config.AppConfig.MaintenanceWindowEnd)
+	assert.True(t, config.AppConfig.Maintenance.Enabled)
+	assert.Equal(t, 3, config.AppConfig.Maintenance.WindowStart)
+	assert.Equal(t, 5, config.AppConfig.Maintenance.WindowEnd)
 
 	// GET status and confirm round-trip.
 	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/maintenance-window/status", nil)


### PR DESCRIPTION
## Summary

Wave 5 of 7. Moves 17 flat \`MaintenanceWindow*\` and \`AcoustIDOnlineLookupNightlyLimit\` fields into \`MaintenanceConfig\` sub-struct at \`Config.Maintenance\`.

- Startup blob migration handles in-place upgrade of existing stored configs (idempotent)
- API backwards-compat shim in \`UpdateConfig\` maps legacy flat key names
- \`applySetting\` updated for all 17 fields + 3 previously missing cases
- \`MigrateMaintenanceWindow\` updated to use nested struct fields
- All callsites in scheduler and server packages updated via sed sweep
- BindEnv wires \`MAINTENANCE_ENABLED\`, \`MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT\` etc.
- \`ResetToDefaults\` now includes \`LibrarySizeRefresh: true\` (was missing before)

## Test plan
- [x] \`TestMigrateMaintenanceFields_FlatBlob\` — flat blob migration
- [x] \`TestMigrateMaintenanceFields_AlreadyNested\` — idempotency
- [x] \`TestMigrateMaintenanceFields_EmptyBlob\` — empty blob no-op
- [x] \`TestRemapMaintenanceKeys_FlatKeys\` — API shim
- [x] \`TestRemapMaintenanceKeys_NoFlatKeys\` — no-op pass-through
- [x] \`TestInitConfig_MaintenanceDefaults\` — viper defaults
- [x] \`TestInitConfig_MaintenanceFromEnv\` — env override
- [x] \`./internal/config/...\` — all pass
- [x] \`./internal/scheduler/...\` — all pass
- [x] \`./internal/server/handlers/...\` — all pass
- [ ] \`internal/server\` — pre-existing timeout flake (TestConsumeBootstrapToken followup hangs at 1m, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)