### PR TITLE
refactor(config): nest scheduled task fields into ScheduledTasksConfig sub-struct

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.57.0
+// version: 1.58.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-06-16
 
@@ -185,6 +185,25 @@ type MetadataScoringConfig struct {
 	WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
 }
 
+// ScheduledTaskConfig holds per-task scheduler settings.
+type ScheduledTaskConfig struct {
+	Enabled   bool `json:"enabled"    mapstructure:"enabled"`
+	Interval  int  `json:"interval"   mapstructure:"interval"`
+	OnStartup bool `json:"on_startup" mapstructure:"on_startup"`
+}
+
+// ScheduledTasksConfig holds settings for all background scheduled tasks.
+type ScheduledTasksConfig struct {
+	DedupRefresh             ScheduledTaskConfig `json:"dedup_refresh"               mapstructure:"dedup_refresh"`
+	AuthorSplit              ScheduledTaskConfig `json:"author_split"                mapstructure:"author_split"`
+	DbOptimize               ScheduledTaskConfig `json:"db_optimize"                 mapstructure:"db_optimize"`
+	MetadataRefresh          ScheduledTaskConfig `json:"metadata_refresh"            mapstructure:"metadata_refresh"`
+	ResolveProductionAuthors ScheduledTaskConfig `json:"resolve_production_authors"  mapstructure:"resolve_production_authors"`
+	SeriesPrune              ScheduledTaskConfig `json:"series_prune"                mapstructure:"series_prune"`
+	AIDedupBatch             ScheduledTaskConfig `json:"ai_dedup_batch"              mapstructure:"ai_dedup_batch"`
+	Reconcile                ScheduledTaskConfig `json:"reconcile"                   mapstructure:"reconcile"`
+}
+
 // Config holds application configuration
 type Config struct {
 	// Core paths
@@ -354,38 +373,9 @@ type Config struct {
 	AutoWriteTagsOnApply bool   `json:"auto_write_tags_on_apply"`
 	VerifyAfterWrite     bool   `json:"verify_after_write"`
 
-	// Scheduled maintenance tasks
-	ScheduledDedupRefreshEnabled   bool `json:"scheduled_dedup_refresh_enabled"`
-	ScheduledDedupRefreshInterval  int  `json:"scheduled_dedup_refresh_interval"` // minutes, default 360
-	ScheduledDedupRefreshOnStartup bool `json:"scheduled_dedup_refresh_on_startup"`
-
-	ScheduledAuthorSplitEnabled   bool `json:"scheduled_author_split_enabled"`
-	ScheduledAuthorSplitInterval  int  `json:"scheduled_author_split_interval"` // minutes, default 0 (manual)
-	ScheduledAuthorSplitOnStartup bool `json:"scheduled_author_split_on_startup"`
-
-	ScheduledDbOptimizeEnabled   bool `json:"scheduled_db_optimize_enabled"`
-	ScheduledDbOptimizeInterval  int  `json:"scheduled_db_optimize_interval"` // minutes, default 1440
-	ScheduledDbOptimizeOnStartup bool `json:"scheduled_db_optimize_on_startup"`
-
-	ScheduledMetadataRefreshEnabled   bool `json:"scheduled_metadata_refresh_enabled"`
-	ScheduledMetadataRefreshInterval  int  `json:"scheduled_metadata_refresh_interval"` // minutes
-	ScheduledMetadataRefreshOnStartup bool `json:"scheduled_metadata_refresh_on_startup"`
-
-	ScheduledResolveProductionAuthorsEnabled  bool `json:"scheduled_resolve_production_authors_enabled"`
-	ScheduledResolveProductionAuthorsInterval int  `json:"scheduled_resolve_production_authors_interval"` // minutes, 0 = manual only
-
-	ScheduledSeriesPruneEnabled   bool `json:"scheduled_series_prune_enabled"`
-	ScheduledSeriesPruneInterval  int  `json:"scheduled_series_prune_interval"` // minutes, default 0 (manual)
-	ScheduledSeriesPruneOnStartup bool `json:"scheduled_series_prune_on_startup"`
-
-	// AI Batch API
-	ScheduledAIDedupBatchEnabled   bool `json:"scheduled_ai_dedup_batch_enabled"`
-	ScheduledAIDedupBatchInterval  int  `json:"scheduled_ai_dedup_batch_interval"` // minutes, default 1440 (24h)
-	ScheduledAIDedupBatchOnStartup bool `json:"scheduled_ai_dedup_batch_on_startup"`
-
-	ScheduledReconcileEnabled   bool `json:"scheduled_reconcile_enabled"`
-	ScheduledReconcileInterval  int  `json:"scheduled_reconcile_interval"` // minutes, default 0 (manual)
-	ScheduledReconcileOnStartup bool `json:"scheduled_reconcile_on_startup"`
+	// Scheduled holds settings for all background scheduled tasks.
+	// Previously 23 flat Scheduled* fields (Wave 6 nests them here).
+	Scheduled ScheduledTasksConfig `json:"scheduled" mapstructure:"scheduled"`
 
 	// Plugin system
 	Plugins map[string]PluginConfig `json:"plugins"`
@@ -527,23 +517,54 @@ func InitConfig() {
 	viper.SetDefault("log_format", "text")
 	viper.SetDefault("enable_json_logging", false)
 
-	// Scheduled maintenance task defaults
-	viper.SetDefault("scheduled_dedup_refresh_enabled", false)
-	viper.SetDefault("scheduled_dedup_refresh_interval", 360)
-	viper.SetDefault("scheduled_dedup_refresh_on_startup", false)
-	viper.SetDefault("scheduled_author_split_enabled", false)
-	viper.SetDefault("scheduled_author_split_interval", 0)
-	viper.SetDefault("scheduled_author_split_on_startup", false)
-	viper.SetDefault("scheduled_db_optimize_enabled", false)
-	viper.SetDefault("scheduled_db_optimize_interval", 1440)
-	viper.SetDefault("scheduled_db_optimize_on_startup", false)
-	viper.SetDefault("scheduled_metadata_refresh_enabled", false)
-	viper.SetDefault("scheduled_metadata_refresh_interval", 0)
-	viper.SetDefault("scheduled_metadata_refresh_on_startup", false)
-
-	viper.SetDefault("scheduled_ai_dedup_batch_enabled", false)
-	viper.SetDefault("scheduled_ai_dedup_batch_interval", 1440)
-	viper.SetDefault("scheduled_ai_dedup_batch_on_startup", false)
+	// Scheduled task defaults (nested under "scheduled.*.*")
+	viper.SetDefault("scheduled.dedup_refresh.enabled", false)
+	viper.SetDefault("scheduled.dedup_refresh.interval", 360)
+	viper.SetDefault("scheduled.dedup_refresh.on_startup", false)
+	viper.SetDefault("scheduled.author_split.enabled", false)
+	viper.SetDefault("scheduled.author_split.interval", 0)
+	viper.SetDefault("scheduled.author_split.on_startup", false)
+	viper.SetDefault("scheduled.db_optimize.enabled", false)
+	viper.SetDefault("scheduled.db_optimize.interval", 1440)
+	viper.SetDefault("scheduled.db_optimize.on_startup", false)
+	viper.SetDefault("scheduled.metadata_refresh.enabled", false)
+	viper.SetDefault("scheduled.metadata_refresh.interval", 0)
+	viper.SetDefault("scheduled.metadata_refresh.on_startup", false)
+	viper.SetDefault("scheduled.resolve_production_authors.enabled", false)
+	viper.SetDefault("scheduled.resolve_production_authors.interval", 0)
+	viper.SetDefault("scheduled.series_prune.enabled", false)
+	viper.SetDefault("scheduled.series_prune.interval", 0)
+	viper.SetDefault("scheduled.series_prune.on_startup", false)
+	viper.SetDefault("scheduled.ai_dedup_batch.enabled", false)
+	viper.SetDefault("scheduled.ai_dedup_batch.interval", 1440)
+	viper.SetDefault("scheduled.ai_dedup_batch.on_startup", false)
+	viper.SetDefault("scheduled.reconcile.enabled", false)
+	viper.SetDefault("scheduled.reconcile.interval", 0)
+	viper.SetDefault("scheduled.reconcile.on_startup", false)
+	// BindEnv maps env vars so SCHEDULED_* overrides work even without AutomaticEnv.
+	viper.BindEnv("scheduled.dedup_refresh.enabled", "SCHEDULED_DEDUP_REFRESH_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("scheduled.dedup_refresh.interval", "SCHEDULED_DEDUP_REFRESH_INTERVAL")                             //nolint:errcheck
+	viper.BindEnv("scheduled.dedup_refresh.on_startup", "SCHEDULED_DEDUP_REFRESH_ON_STARTUP")                         //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.enabled", "SCHEDULED_AUTHOR_SPLIT_ENABLED")                                 //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.interval", "SCHEDULED_AUTHOR_SPLIT_INTERVAL")                               //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.on_startup", "SCHEDULED_AUTHOR_SPLIT_ON_STARTUP")                           //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.enabled", "SCHEDULED_DB_OPTIMIZE_ENABLED")                                   //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.interval", "SCHEDULED_DB_OPTIMIZE_INTERVAL")                                 //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.on_startup", "SCHEDULED_DB_OPTIMIZE_ON_STARTUP")                             //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.enabled", "SCHEDULED_METADATA_REFRESH_ENABLED")                         //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.interval", "SCHEDULED_METADATA_REFRESH_INTERVAL")                       //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.on_startup", "SCHEDULED_METADATA_REFRESH_ON_STARTUP")                   //nolint:errcheck
+	viper.BindEnv("scheduled.resolve_production_authors.enabled", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_ENABLED")     //nolint:errcheck
+	viper.BindEnv("scheduled.resolve_production_authors.interval", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_INTERVAL")   //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.enabled", "SCHEDULED_SERIES_PRUNE_ENABLED")                                 //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.interval", "SCHEDULED_SERIES_PRUNE_INTERVAL")                               //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.on_startup", "SCHEDULED_SERIES_PRUNE_ON_STARTUP")                           //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.enabled", "SCHEDULED_AI_DEDUP_BATCH_ENABLED")                             //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.interval", "SCHEDULED_AI_DEDUP_BATCH_INTERVAL")                           //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.on_startup", "SCHEDULED_AI_DEDUP_BATCH_ON_STARTUP")                       //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.enabled", "SCHEDULED_RECONCILE_ENABLED")                                       //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.interval", "SCHEDULED_RECONCILE_INTERVAL")                                     //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.on_startup", "SCHEDULED_RECONCILE_ON_STARTUP")                                 //nolint:errcheck
 
 	// iTunes sync defaults (nested under "itunes.*").
 	// BindEnv maps env vars so ITUNES_SYNC_ENABLED etc. override even without AutomaticEnv.
@@ -887,6 +908,49 @@ func InitConfig() {
 				LLMRerankEpsilon:   viper.GetFloat64("metadata_scoring.llm_rerank_epsilon"),
 				LLMRerankTopK:      viper.GetInt("metadata_scoring.llm_rerank_top_k"),
 				WriteBackupBefore:  viper.GetBool("metadata_scoring.write_backup_before"),
+			},
+
+			// Scheduled background tasks (nested sub-struct)
+			Scheduled: ScheduledTasksConfig{
+				DedupRefresh: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.dedup_refresh.enabled"),
+					Interval:  viper.GetInt("scheduled.dedup_refresh.interval"),
+					OnStartup: viper.GetBool("scheduled.dedup_refresh.on_startup"),
+				},
+				AuthorSplit: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.author_split.enabled"),
+					Interval:  viper.GetInt("scheduled.author_split.interval"),
+					OnStartup: viper.GetBool("scheduled.author_split.on_startup"),
+				},
+				DbOptimize: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.db_optimize.enabled"),
+					Interval:  viper.GetInt("scheduled.db_optimize.interval"),
+					OnStartup: viper.GetBool("scheduled.db_optimize.on_startup"),
+				},
+				MetadataRefresh: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.metadata_refresh.enabled"),
+					Interval:  viper.GetInt("scheduled.metadata_refresh.interval"),
+					OnStartup: viper.GetBool("scheduled.metadata_refresh.on_startup"),
+				},
+				ResolveProductionAuthors: ScheduledTaskConfig{
+					Enabled:  viper.GetBool("scheduled.resolve_production_authors.enabled"),
+					Interval: viper.GetInt("scheduled.resolve_production_authors.interval"),
+				},
+				SeriesPrune: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.series_prune.enabled"),
+					Interval:  viper.GetInt("scheduled.series_prune.interval"),
+					OnStartup: viper.GetBool("scheduled.series_prune.on_startup"),
+				},
+				AIDedupBatch: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.ai_dedup_batch.enabled"),
+					Interval:  viper.GetInt("scheduled.ai_dedup_batch.interval"),
+					OnStartup: viper.GetBool("scheduled.ai_dedup_batch.on_startup"),
+				},
+				Reconcile: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.reconcile.enabled"),
+					Interval:  viper.GetInt("scheduled.reconcile.interval"),
+					OnStartup: viper.GetBool("scheduled.reconcile.on_startup"),
+				},
 			},
 		}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-16
 
@@ -590,4 +590,26 @@ func TestInitConfig_MaintenanceFromEnv(t *testing.T) {
 	snap := Snapshot()
 	assert.True(t, snap.Maintenance.Enabled)
 	assert.Equal(t, 100, snap.Maintenance.AcoustIDNightlyLimit)
+}
+
+func TestInitConfig_ScheduledDefaults(t *testing.T) {
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.False(t, snap.Scheduled.DedupRefresh.Enabled)
+	assert.Equal(t, 360, snap.Scheduled.DedupRefresh.Interval)
+	assert.Equal(t, 1440, snap.Scheduled.DbOptimize.Interval)
+	assert.False(t, snap.Scheduled.AIDedupBatch.Enabled)
+	assert.Equal(t, 1440, snap.Scheduled.AIDedupBatch.Interval)
+	assert.False(t, snap.Scheduled.ResolveProductionAuthors.Enabled)
+}
+
+func TestInitConfig_ScheduledFromEnv(t *testing.T) {
+	t.Setenv("SCHEDULED_DEDUP_REFRESH_ENABLED", "true")
+	t.Setenv("SCHEDULED_AI_DEDUP_BATCH_INTERVAL", "720")
+	viper.Reset()
+	InitConfig()
+	snap := Snapshot()
+	assert.True(t, snap.Scheduled.DedupRefresh.Enabled)
+	assert.Equal(t, 720, snap.Scheduled.AIDedupBatch.Interval)
 }

--- a/internal/config/config_unit_test.go
+++ b/internal/config/config_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/config_unit_test.go
-// version: 1.8.0
+// version: 1.9.0
 // last-edited: 2026-06-16
 
 package config
@@ -664,17 +664,17 @@ func TestApplySettingBoolKeys(t *testing.T) {
 		{"maintenance_window_library_organize", func() bool { return AppConfig.Maintenance.LibraryOrganize }},
 		{"maintenance_window_metadata_refresh", func() bool { return AppConfig.Maintenance.MetadataRefresh }},
 		{"basic_auth_enabled", func() bool { return AppConfig.BasicAuthEnabled }},
-		{"scheduled_dedup_refresh_enabled", func() bool { return AppConfig.ScheduledDedupRefreshEnabled }},
-		{"scheduled_dedup_refresh_on_startup", func() bool { return AppConfig.ScheduledDedupRefreshOnStartup }},
-		{"scheduled_author_split_enabled", func() bool { return AppConfig.ScheduledAuthorSplitEnabled }},
-		{"scheduled_author_split_on_startup", func() bool { return AppConfig.ScheduledAuthorSplitOnStartup }},
-		{"scheduled_db_optimize_enabled", func() bool { return AppConfig.ScheduledDbOptimizeEnabled }},
-		{"scheduled_db_optimize_on_startup", func() bool { return AppConfig.ScheduledDbOptimizeOnStartup }},
-		{"scheduled_metadata_refresh_enabled", func() bool { return AppConfig.ScheduledMetadataRefreshEnabled }},
-		{"scheduled_metadata_refresh_on_startup", func() bool { return AppConfig.ScheduledMetadataRefreshOnStartup }},
-		{"scheduled_resolve_production_authors_enabled", func() bool { return AppConfig.ScheduledResolveProductionAuthorsEnabled }},
-		{"scheduled_series_prune_enabled", func() bool { return AppConfig.ScheduledSeriesPruneEnabled }},
-		{"scheduled_series_prune_on_startup", func() bool { return AppConfig.ScheduledSeriesPruneOnStartup }},
+		{"scheduled_dedup_refresh_enabled", func() bool { return AppConfig.Scheduled.DedupRefresh.Enabled }},
+		{"scheduled_dedup_refresh_on_startup", func() bool { return AppConfig.Scheduled.DedupRefresh.OnStartup }},
+		{"scheduled_author_split_enabled", func() bool { return AppConfig.Scheduled.AuthorSplit.Enabled }},
+		{"scheduled_author_split_on_startup", func() bool { return AppConfig.Scheduled.AuthorSplit.OnStartup }},
+		{"scheduled_db_optimize_enabled", func() bool { return AppConfig.Scheduled.DbOptimize.Enabled }},
+		{"scheduled_db_optimize_on_startup", func() bool { return AppConfig.Scheduled.DbOptimize.OnStartup }},
+		{"scheduled_metadata_refresh_enabled", func() bool { return AppConfig.Scheduled.MetadataRefresh.Enabled }},
+		{"scheduled_metadata_refresh_on_startup", func() bool { return AppConfig.Scheduled.MetadataRefresh.OnStartup }},
+		{"scheduled_resolve_production_authors_enabled", func() bool { return AppConfig.Scheduled.ResolveProductionAuthors.Enabled }},
+		{"scheduled_series_prune_enabled", func() bool { return AppConfig.Scheduled.SeriesPrune.Enabled }},
+		{"scheduled_series_prune_on_startup", func() bool { return AppConfig.Scheduled.SeriesPrune.OnStartup }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.key+"_true", func(t *testing.T) {
@@ -725,12 +725,12 @@ func TestApplySettingIntKeys(t *testing.T) {
 		{"itunes_sync_interval", "60", func() int { return AppConfig.ITunes.SyncInterval }},
 		{"maintenance_window_start", "3", func() int { return AppConfig.Maintenance.WindowStart }},
 		{"maintenance_window_end", "6", func() int { return AppConfig.Maintenance.WindowEnd }},
-		{"scheduled_dedup_refresh_interval", "24", func() int { return AppConfig.ScheduledDedupRefreshInterval }},
-		{"scheduled_author_split_interval", "12", func() int { return AppConfig.ScheduledAuthorSplitInterval }},
-		{"scheduled_db_optimize_interval", "48", func() int { return AppConfig.ScheduledDbOptimizeInterval }},
-		{"scheduled_metadata_refresh_interval", "72", func() int { return AppConfig.ScheduledMetadataRefreshInterval }},
-		{"scheduled_resolve_production_authors_interval", "96", func() int { return AppConfig.ScheduledResolveProductionAuthorsInterval }},
-		{"scheduled_series_prune_interval", "168", func() int { return AppConfig.ScheduledSeriesPruneInterval }},
+		{"scheduled_dedup_refresh_interval", "24", func() int { return AppConfig.Scheduled.DedupRefresh.Interval }},
+		{"scheduled_author_split_interval", "12", func() int { return AppConfig.Scheduled.AuthorSplit.Interval }},
+		{"scheduled_db_optimize_interval", "48", func() int { return AppConfig.Scheduled.DbOptimize.Interval }},
+		{"scheduled_metadata_refresh_interval", "72", func() int { return AppConfig.Scheduled.MetadataRefresh.Interval }},
+		{"scheduled_resolve_production_authors_interval", "96", func() int { return AppConfig.Scheduled.ResolveProductionAuthors.Interval }},
+		{"scheduled_series_prune_interval", "168", func() int { return AppConfig.Scheduled.SeriesPrune.Interval }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.25.0
+// version: 1.26.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-06-16
 
@@ -424,6 +424,85 @@ func migrateMaintenanceBlob(blob string) (string, bool) {
 	return string(migrated), true
 }
 
+// migrateScheduledBlob rewrites flat scheduled_* fields to the nested
+// ScheduledTasksConfig format. Safe to call repeatedly (idempotent).
+// Sentinel key: "scheduled_dedup_refresh_enabled".
+func migrateScheduledBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	if _, isFlat := raw["scheduled_dedup_refresh_enabled"]; !isFlat {
+		return blob, false
+	}
+	raw = remapScheduledKeys(raw)
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
+// remapScheduledKeys translates flat scheduled_* keys in a config map to the
+// nested ScheduledTasksConfig format. Merges into any existing "scheduled"
+// sub-object to avoid zeroing sibling fields.
+func remapScheduledKeys(payload map[string]any) map[string]any {
+	type mapping struct{ group, field string }
+	flatMap := map[string]mapping{
+		"scheduled_dedup_refresh_enabled":               {group: "dedup_refresh", field: "enabled"},
+		"scheduled_dedup_refresh_interval":              {group: "dedup_refresh", field: "interval"},
+		"scheduled_dedup_refresh_on_startup":            {group: "dedup_refresh", field: "on_startup"},
+		"scheduled_author_split_enabled":                {group: "author_split", field: "enabled"},
+		"scheduled_author_split_interval":               {group: "author_split", field: "interval"},
+		"scheduled_author_split_on_startup":             {group: "author_split", field: "on_startup"},
+		"scheduled_db_optimize_enabled":                 {group: "db_optimize", field: "enabled"},
+		"scheduled_db_optimize_interval":                {group: "db_optimize", field: "interval"},
+		"scheduled_db_optimize_on_startup":              {group: "db_optimize", field: "on_startup"},
+		"scheduled_metadata_refresh_enabled":            {group: "metadata_refresh", field: "enabled"},
+		"scheduled_metadata_refresh_interval":           {group: "metadata_refresh", field: "interval"},
+		"scheduled_metadata_refresh_on_startup":         {group: "metadata_refresh", field: "on_startup"},
+		"scheduled_resolve_production_authors_enabled":  {group: "resolve_production_authors", field: "enabled"},
+		"scheduled_resolve_production_authors_interval": {group: "resolve_production_authors", field: "interval"},
+		"scheduled_series_prune_enabled":                {group: "series_prune", field: "enabled"},
+		"scheduled_series_prune_interval":               {group: "series_prune", field: "interval"},
+		"scheduled_series_prune_on_startup":             {group: "series_prune", field: "on_startup"},
+		"scheduled_ai_dedup_batch_enabled":              {group: "ai_dedup_batch", field: "enabled"},
+		"scheduled_ai_dedup_batch_interval":             {group: "ai_dedup_batch", field: "interval"},
+		"scheduled_ai_dedup_batch_on_startup":           {group: "ai_dedup_batch", field: "on_startup"},
+		"scheduled_reconcile_enabled":                   {group: "reconcile", field: "enabled"},
+		"scheduled_reconcile_interval":                  {group: "reconcile", field: "interval"},
+		"scheduled_reconcile_on_startup":                {group: "reconcile", field: "on_startup"},
+	}
+	groups := make(map[string]map[string]any)
+	for flat, m := range flatMap {
+		if v, ok := payload[flat]; ok {
+			if groups[m.group] == nil {
+				groups[m.group] = make(map[string]any)
+			}
+			groups[m.group][m.field] = v
+			delete(payload, flat)
+		}
+	}
+	if len(groups) == 0 {
+		return payload
+	}
+	existing, _ := payload["scheduled"].(map[string]any)
+	if existing == nil {
+		existing = make(map[string]any)
+	}
+	for group, fields := range groups {
+		if existingGroup, ok := existing[group].(map[string]any); ok {
+			for k, v := range fields {
+				existingGroup[k] = v
+			}
+		} else {
+			existing[group] = fields
+		}
+	}
+	payload["scheduled"] = existing
+	return payload
+}
+
 // saveRawBlob writes a pre-marshaled JSON string directly as the config blob.
 // Used only by startup migration to persist migrated blobs without re-marshaling.
 func saveRawBlob(store database.SettingsStore, rawJSON string) error {
@@ -511,6 +590,15 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated maintenance blob", "err", saveErr)
+			}
+		}
+
+		// Migrate flat scheduled_* keys → nested ScheduledTasksConfig format (idempotent).
+		if migrated, changed := migrateScheduledBlob(blobStr); changed {
+			slog.Info("config: migrated scheduled task fields to nested format")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated scheduled blob", "err", saveErr)
 			}
 		}
 
@@ -979,73 +1067,99 @@ func applySetting(key, value, typ string) error {
 		// Scheduled maintenance tasks
 		case "scheduled_dedup_refresh_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledDedupRefreshEnabled = b
+				c.Scheduled.DedupRefresh.Enabled = b
 			}
 		case "scheduled_dedup_refresh_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledDedupRefreshInterval = i
+				c.Scheduled.DedupRefresh.Interval = i
 			}
 		case "scheduled_dedup_refresh_on_startup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledDedupRefreshOnStartup = b
+				c.Scheduled.DedupRefresh.OnStartup = b
 			}
 		case "scheduled_author_split_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledAuthorSplitEnabled = b
+				c.Scheduled.AuthorSplit.Enabled = b
 			}
 		case "scheduled_author_split_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledAuthorSplitInterval = i
+				c.Scheduled.AuthorSplit.Interval = i
 			}
 		case "scheduled_author_split_on_startup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledAuthorSplitOnStartup = b
+				c.Scheduled.AuthorSplit.OnStartup = b
 			}
 		case "scheduled_db_optimize_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledDbOptimizeEnabled = b
+				c.Scheduled.DbOptimize.Enabled = b
 			}
 		case "scheduled_db_optimize_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledDbOptimizeInterval = i
+				c.Scheduled.DbOptimize.Interval = i
 			}
 		case "scheduled_db_optimize_on_startup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledDbOptimizeOnStartup = b
+				c.Scheduled.DbOptimize.OnStartup = b
 			}
 		case "scheduled_metadata_refresh_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledMetadataRefreshEnabled = b
+				c.Scheduled.MetadataRefresh.Enabled = b
 			}
 		case "scheduled_metadata_refresh_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledMetadataRefreshInterval = i
+				c.Scheduled.MetadataRefresh.Interval = i
 			}
 		case "scheduled_metadata_refresh_on_startup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledMetadataRefreshOnStartup = b
+				c.Scheduled.MetadataRefresh.OnStartup = b
 			}
 
 		case "scheduled_resolve_production_authors_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledResolveProductionAuthorsEnabled = b
+				c.Scheduled.ResolveProductionAuthors.Enabled = b
 			}
 		case "scheduled_resolve_production_authors_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledResolveProductionAuthorsInterval = i
+				c.Scheduled.ResolveProductionAuthors.Interval = i
 			}
 
 		case "scheduled_series_prune_enabled":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledSeriesPruneEnabled = b
+				c.Scheduled.SeriesPrune.Enabled = b
 			}
 		case "scheduled_series_prune_interval":
 			if i, err := strconv.Atoi(value); err == nil {
-				c.ScheduledSeriesPruneInterval = i
+				c.Scheduled.SeriesPrune.Interval = i
 			}
 		case "scheduled_series_prune_on_startup":
 			if b, err := strconv.ParseBool(value); err == nil {
-				c.ScheduledSeriesPruneOnStartup = b
+				c.Scheduled.SeriesPrune.OnStartup = b
+			}
+
+		case "scheduled_ai_dedup_batch_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.AIDedupBatch.Enabled = b
+			}
+		case "scheduled_ai_dedup_batch_interval":
+			if i, err := strconv.Atoi(value); err == nil {
+				c.Scheduled.AIDedupBatch.Interval = i
+			}
+		case "scheduled_ai_dedup_batch_on_startup":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.AIDedupBatch.OnStartup = b
+			}
+
+		case "scheduled_reconcile_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.Reconcile.Enabled = b
+			}
+		case "scheduled_reconcile_interval":
+			if i, err := strconv.Atoi(value); err == nil {
+				c.Scheduled.Reconcile.Interval = i
+			}
+		case "scheduled_reconcile_on_startup":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Scheduled.Reconcile.OnStartup = b
 			}
 
 		// Basic auth

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence_test.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-16
 
@@ -1125,5 +1125,70 @@ func TestRemapMaintenanceKeys_FlatKeys(t *testing.T) {
 func TestRemapMaintenanceKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := remapMaintenanceKeys(payload)
+	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+func TestMigrateScheduledFields_FlatBlob(t *testing.T) {
+	flatBlob := `{
+		"scheduled_dedup_refresh_enabled": false,
+		"scheduled_dedup_refresh_interval": 360,
+		"scheduled_dedup_refresh_on_startup": false,
+		"scheduled_ai_dedup_batch_enabled": true,
+		"scheduled_ai_dedup_batch_interval": 1440,
+		"scheduled_resolve_production_authors_enabled": false,
+		"scheduled_resolve_production_authors_interval": 0,
+		"root_dir": "/data"
+	}`
+	migrated, changed := migrateScheduledBlob(flatBlob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	s, ok := result["scheduled"].(map[string]any)
+	require.True(t, ok)
+	dr, ok := s["dedup_refresh"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, dr["enabled"])
+	assert.Equal(t, float64(360), dr["interval"])
+	ai, ok := s["ai_dedup_batch"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, ai["enabled"])
+	rpa, ok := s["resolve_production_authors"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, rpa["enabled"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "scheduled_dedup_refresh_enabled")
+	assert.NotContains(t, result, "scheduled_ai_dedup_batch_enabled")
+}
+
+func TestMigrateScheduledFields_AlreadyNested(t *testing.T) {
+	_, changed := migrateScheduledBlob(`{"scheduled": {"dedup_refresh": {"enabled": false}}}`)
+	assert.False(t, changed)
+}
+
+func TestMigrateScheduledFields_EmptyBlob(t *testing.T) {
+	_, changed := migrateScheduledBlob(`{}`)
+	assert.False(t, changed)
+}
+
+func TestRemapScheduledKeys_FlatKeys(t *testing.T) {
+	payload := map[string]any{
+		"scheduled_dedup_refresh_enabled":  false,
+		"scheduled_ai_dedup_batch_enabled": true,
+		"root_dir":                         "/data",
+	}
+	result := remapScheduledKeys(payload)
+	s, ok := result["scheduled"].(map[string]any)
+	require.True(t, ok)
+	dr := s["dedup_refresh"].(map[string]any)
+	assert.Equal(t, false, dr["enabled"])
+	ai := s["ai_dedup_batch"].(map[string]any)
+	assert.Equal(t, true, ai["enabled"])
+	assert.Equal(t, "/data", result["root_dir"])
+	assert.NotContains(t, result, "scheduled_dedup_refresh_enabled")
+}
+
+func TestRemapScheduledKeys_NoFlatKeys(t *testing.T) {
+	payload := map[string]any{"root_dir": "/data"}
+	result := remapScheduledKeys(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,5 +1,5 @@
 // file: internal/config/update_service.go
-// version: 3.6.0
+// version: 3.7.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
 // last-edited: 2026-06-16
 
@@ -309,6 +309,8 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	filtered = remapITunesKeys(filtered)
 	// Translate any legacy flat maintenance_window_* keys to the nested MaintenanceConfig format.
 	filtered = remapMaintenanceKeys(filtered)
+	// Translate any legacy flat scheduled_* keys to the nested ScheduledTasksConfig format.
+	filtered = remapScheduledKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -1,5 +1,5 @@
 // file: internal/scheduler/tasks.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9b4c7e21-a5f3-4d08-b2e6-3c8d1f7a0e54
 // last-edited: 2026-06-16
 
@@ -179,15 +179,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledDedupRefreshEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.DedupRefresh.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledDedupRefreshInterval
+			mins := config.AppConfig.Scheduled.DedupRefresh.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledDedupRefreshOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.DedupRefresh.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DedupRefresh },
 	})
 
@@ -236,15 +236,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledSeriesPruneEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.SeriesPrune.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledSeriesPruneInterval
+			mins := config.AppConfig.Scheduled.SeriesPrune.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledSeriesPruneOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.SeriesPrune.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.SeriesPrune },
 	})
 
@@ -427,15 +427,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledAuthorSplitEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.AuthorSplit.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledAuthorSplitInterval
+			mins := config.AppConfig.Scheduled.AuthorSplit.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledAuthorSplitOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.AuthorSplit.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.AuthorSplit },
 	})
 
@@ -458,15 +458,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledDbOptimizeEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.DbOptimize.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledDbOptimizeInterval
+			mins := config.AppConfig.Scheduled.DbOptimize.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledDbOptimizeOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.DbOptimize.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DbOptimize },
 	})
 
@@ -603,9 +603,9 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledResolveProductionAuthorsEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.ResolveProductionAuthors.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledResolveProductionAuthorsInterval
+			mins := config.AppConfig.Scheduled.ResolveProductionAuthors.Interval
 			if mins <= 0 {
 				return 0
 			}
@@ -634,15 +634,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledMetadataRefreshEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.MetadataRefresh.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledMetadataRefreshInterval
+			mins := config.AppConfig.Scheduled.MetadataRefresh.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledMetadataRefreshOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.MetadataRefresh.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.MetadataRefresh },
 	})
 
@@ -666,15 +666,15 @@ func (ts *TaskScheduler) registerAllTasks() {
 			}
 			return op, nil
 		},
-		IsEnabled: func() bool { return config.AppConfig.ScheduledReconcileEnabled },
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.Reconcile.Enabled },
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledReconcileInterval
+			mins := config.AppConfig.Scheduled.Reconcile.Interval
 			if mins <= 0 {
 				return 0
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledReconcileOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.Reconcile.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.Reconcile },
 	})
 
@@ -699,16 +699,16 @@ func (ts *TaskScheduler) registerAllTasks() {
 			return op, nil
 		},
 		IsEnabled: func() bool {
-			return config.AppConfig.ScheduledAIDedupBatchEnabled && config.AppConfig.EnableAIParsing
+			return config.AppConfig.Scheduled.AIDedupBatch.Enabled && config.AppConfig.EnableAIParsing
 		},
 		GetInterval: func() time.Duration {
-			mins := config.AppConfig.ScheduledAIDedupBatchInterval
+			mins := config.AppConfig.Scheduled.AIDedupBatch.Interval
 			if mins <= 0 {
 				return 24 * time.Hour
 			}
 			return time.Duration(mins) * time.Minute
 		},
-		RunOnStart:             func() bool { return config.AppConfig.ScheduledAIDedupBatchOnStartup },
+		RunOnStart:             func() bool { return config.AppConfig.Scheduled.AIDedupBatch.OnStartup },
 		RunInMaintenanceWindow: func() bool { return false },
 	})
 

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/operations/handler.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1b7fbd86-cdda-4921-b2d0-786f5cadb438
 // last-edited: 2026-06-16
 
@@ -677,52 +677,52 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 	switch name {
 	case "dedup_refresh":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledDedupRefreshEnabled = *req.Enabled
+			config.AppConfig.Scheduled.DedupRefresh.Enabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ScheduledDedupRefreshInterval = *req.IntervalMinutes
+			config.AppConfig.Scheduled.DedupRefresh.Interval = *req.IntervalMinutes
 		}
 		if req.RunOnStartup != nil {
-			config.AppConfig.ScheduledDedupRefreshOnStartup = *req.RunOnStartup
+			config.AppConfig.Scheduled.DedupRefresh.OnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.DedupRefresh = *req.RunInMaintenanceWindow
 		}
 	case "author_split_scan":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledAuthorSplitEnabled = *req.Enabled
+			config.AppConfig.Scheduled.AuthorSplit.Enabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ScheduledAuthorSplitInterval = *req.IntervalMinutes
+			config.AppConfig.Scheduled.AuthorSplit.Interval = *req.IntervalMinutes
 		}
 		if req.RunOnStartup != nil {
-			config.AppConfig.ScheduledAuthorSplitOnStartup = *req.RunOnStartup
+			config.AppConfig.Scheduled.AuthorSplit.OnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.AuthorSplit = *req.RunInMaintenanceWindow
 		}
 	case "db_optimize":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledDbOptimizeEnabled = *req.Enabled
+			config.AppConfig.Scheduled.DbOptimize.Enabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ScheduledDbOptimizeInterval = *req.IntervalMinutes
+			config.AppConfig.Scheduled.DbOptimize.Interval = *req.IntervalMinutes
 		}
 		if req.RunOnStartup != nil {
-			config.AppConfig.ScheduledDbOptimizeOnStartup = *req.RunOnStartup
+			config.AppConfig.Scheduled.DbOptimize.OnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.DbOptimize = *req.RunInMaintenanceWindow
 		}
 	case "metadata_refresh":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledMetadataRefreshEnabled = *req.Enabled
+			config.AppConfig.Scheduled.MetadataRefresh.Enabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ScheduledMetadataRefreshInterval = *req.IntervalMinutes
+			config.AppConfig.Scheduled.MetadataRefresh.Interval = *req.IntervalMinutes
 		}
 		if req.RunOnStartup != nil {
-			config.AppConfig.ScheduledMetadataRefreshOnStartup = *req.RunOnStartup
+			config.AppConfig.Scheduled.MetadataRefresh.OnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.MetadataRefresh = *req.RunInMaintenanceWindow
@@ -736,13 +736,13 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 		}
 	case "series_prune":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledSeriesPruneEnabled = *req.Enabled
+			config.AppConfig.Scheduled.SeriesPrune.Enabled = *req.Enabled
 		}
 		if req.IntervalMinutes != nil {
-			config.AppConfig.ScheduledSeriesPruneInterval = *req.IntervalMinutes
+			config.AppConfig.Scheduled.SeriesPrune.Interval = *req.IntervalMinutes
 		}
 		if req.RunOnStartup != nil {
-			config.AppConfig.ScheduledSeriesPruneOnStartup = *req.RunOnStartup
+			config.AppConfig.Scheduled.SeriesPrune.OnStartup = *req.RunOnStartup
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.SeriesPrune = *req.RunInMaintenanceWindow
@@ -760,7 +760,7 @@ func (h *Handler) UpdateTaskConfig(c *gin.Context) {
 		}
 	case "reconcile_scan":
 		if req.Enabled != nil {
-			config.AppConfig.ScheduledReconcileEnabled = *req.Enabled
+			config.AppConfig.Scheduled.Reconcile.Enabled = *req.Enabled
 		}
 		if req.RunInMaintenanceWindow != nil {
 			config.AppConfig.Maintenance.Reconcile = *req.RunInMaintenanceWindow


### PR DESCRIPTION
## Summary

Wave 6 of 7 config struct nesting refactor. See docs/specs/2026-06-16-config-struct-nesting-design.md

- Moves 23 flat `Scheduled*` config fields (8 task groups) into `ScheduledTasksConfig` sub-struct
- New types: `ScheduledTaskConfig` (per-task) and `ScheduledTasksConfig` (all tasks)
- Backward compat: `migrateScheduledBlob` migrates old PebbleDB JSON blobs on startup
- API compat: `remapScheduledKeys` maps legacy flat PUT /config keys to nested paths
- `applySetting` updated for pre-blob legacy installs (added missing ai_dedup_batch + reconcile cases that were absent from previous code)
- `BindEnv` wires all 23 SCHEDULED_* env vars to nested viper keys
- Env vars unchanged (SCHEDULED_DEDUP_REFRESH_ENABLED etc. still work)

## Test plan

- [x] `go build ./...` passes (no flat field refs remain)
- [x] `TestMigrateScheduledFields_*` tests pass (3/3)
- [x] `TestRemapScheduledKeys_*` tests pass (2/2)
- [x] `TestInitConfig_Scheduled*` tests pass (2/2)
- [x] `go test ./internal/config/...` passes (all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)