### PR TITLE
fix(ci): repair red Frontend Unit Tests job + backend -race test timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,31 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.29.0 -->
+<!-- version: 3.30.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-16 -->
+<!-- last-edited: 2026-06-17 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Fixes
+
+#### June 17, 2026 — Fix long-red Frontend Unit Tests CI job + backend -race test timeout
+
+Two CI/test reliability fixes:
+
+- **Frontend Unit Tests (the red CI job):** `web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx`
+  had two stale assertions (`renders candidates in the table`, `shows bulk action bar when a candidate
+  is selected`) that expected a raw entity ULID to appear in the table. The `UnifiedDedupTab` rework
+  renders rich book cards (title / author / file path) from inline `book_a`/`book_b` objects, so the
+  ULID is no longer shown (a missing book renders `(missing book — …)`). The test now seeds realistic
+  `book_a`/`book_b` and asserts on the rendered card title, and selects a candidate by its row checkbox
+  via `within(row)` rather than a brittle `getAllByRole('checkbox')` index (which broke once a toolbar
+  filter checkbox was added). Full frontend suite green: 35 files / 246 tests.
+- **Backend full `-race` suite:** `make test` (and `test-nightly`, which reuses it) panicked with
+  `test timed out after 10m0s` in `internal/server`. That package legitimately runs ~421s without
+  `-race` (heavy per-test setup), exceeding the 600s/package default under the race detector. Raised
+  the full target's timeout to `-timeout 25m`. CI's `-short -race` job already fit the default and was
+  green, so this only affected local `make test` and the nightly run.
 
 #### June 16, 2026 — GetConfig secret-masking bug: all secrets now redacted (PR #1484)
 

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,14 @@ web-lint-memory:
 # --- Testing targets ---
 
 ## test: Run Go backend tests (full — includes slow property tests)
+## NOTE: -timeout 25m (vs the 10m default). internal/server alone runs ~421s
+## WITHOUT -race; under -race it exceeds the 600s/package default and the run
+## fails with "panic: test timed out after 10m0s". The package is large (heavy
+## per-test setup: Pebble + migrations + op-registry workers). CI uses the
+## -short variant which fits the default; this full target needs the headroom.
 test: vet
 	@echo "🧪 Running backend tests (full suite)..."
-	@go test ./... -v -race
+	@go test ./... -v -race -timeout 25m
 	@echo "✅ Backend tests passed"
 
 ## test-short: Run Go backend tests in short mode — skips slow property

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.88.0 -->
+<!-- version: 8.89.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-16 -->
+<!-- last-edited: 2026-06-17 -->
 
 # Project TODO
 
@@ -23,7 +23,7 @@ future agent) can scan the entire workspace in one page.
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
 **Production:** PebbleDB primary; Linux, HTTPS at prod server
-**Latest activity:** CFG-1 Waves 1–8 complete (PRs #1468–#1484). All 77 flat config fields now nested into 7 sub-structs (`EmbeddingConfig`, `DedupConfig`, `MetadataScoringConfig`, `ITunesConfig`, `MaintenanceConfig`, `ScheduledTasksConfig`, `AutoUpdateConfig`). `GetConfig` secret-masking bug fixed (all 5 secrets now masked via `MaskSecrets`). WebUI config API documented at `docs/reference/config-api-shape.md`.
+**Latest activity:** Repo hygiene + red-CI fix (2026-06-17): pruned 51 stale worktrees (55→4) and ~97 merged branches (106→4); fixed the long-red `Frontend Unit Tests` CI job (stale `UnifiedDedupTab` assertions); bumped the full `-race` test timeout (root-caused an `internal/server` timeout). Prior: CFG-1 Waves 1–8 complete (PRs #1468–#1484) — all 77 flat config fields nested into 7 sub-structs; `GetConfig` secret-masking bug fixed; WebUI config API documented at `docs/reference/config-api-shape.md`.
 **In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds). EMB-UI-1 (Ollama download link) still open.
 
 ---
@@ -323,10 +323,11 @@ because the subprocess child-mode handler is never wired into
   access), then call `registry.RunChildMode(r)` which never returns.
   Acceptance: `audiobook-organizer --operation-runner <opID>` with
   `UOS_SOCKET=/tmp/sock` connects to a parent socket and runs.
-- [ ] **A2** Add unit test in `internal/operations/registry/subprocess_test.go`
-  that re-execs the test binary as child and verifies handshake +
-  result roundtrip via the unix socket. (`testscript` or
-  `os/exec.Cmd` with `os.Args[0]`.)
+- [x] **A2** ✅ Done (verified 2026-06-17) — `internal/operations/registry/subprocess_test.go`
+  already contains `TestSubprocess_HandshakeRoundtrip` + `TestSubprocessRoundtrip` (added
+  2026-06-13) which re-exec the test binary as the child and verify handshake + result
+  roundtrip over the unix socket. `go test ./internal/operations/registry/ -run TestSubprocess`
+  passes. The stale auto-burndown PR #1339 is redundant (left for the user to close).
 - [ ] **A3** [hold] After A1+A2 pass in CI, revert `Isolate: false` on the
   7 ops (PR #1155). Restore the original comments. Verify
   acoustid.scan logs both parent "dispatched" AND child stdout
@@ -668,15 +669,26 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ## 🐛 Open Bugs — May 17, 2026
 
-- [ ] **CI-FRONTEND-UNITTESTS-STALE** (2026-06-13) — `Minimal CI / Frontend Unit Tests`
-  is failing on `web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx`: 2 tests
-  (`renders candidates in the table`, `shows bulk action bar when a candidate is selected`)
-  assert a raw ULID `01ABCDEFGHIJKLMNOPQRSTUV01` appears in the table, but the reworked
-  `UnifiedDedupTab` now renders acoustic-style rich cards (title/author/path + metadata
-  chips), not bare ULIDs. The tests are stale vs the cards/filter rework — update them to
-  match the new rendering (query by the card title/path, not the ULID). Also clean up the
-  `getSystemStorage` mock-export warning in the same suite if it surfaces. Failing on every
-  PR (it's a pre-existing red on main, not caused by any one PR).
+- [x] **CI-FRONTEND-UNITTESTS-STALE** (2026-06-13) ✅ **FIXED 2026-06-17** — `UnifiedDedupTab.test.tsx`
+  updated: `mockCandidate` now carries inline `book_a`/`book_b` (the `include_books` shape)
+  and the 2 stale tests assert on the rendered card **title** (`Dune (FLAC rip)`) instead of
+  the raw ULID; the bulk-bar test selects the row checkbox via `within(row)` (robust against
+  the toolbar filter + header select-all checkboxes) instead of a brittle `getAllByRole` index.
+  Full frontend suite green (35 files / 246 tests). No `getSystemStorage` warning surfaced.
+- [x] **CI-BACKEND-RACE-TIMEOUT** (2026-06-17) ✅ **FIXED** — `make test` (full `go test ./... -v -race`,
+  reused by `test-nightly`) failed with `panic: test timed out after 10m0s` in `internal/server`.
+  Root cause: that package runs ~421s **without** `-race` (heavy per-test setup: Pebble + migrations
+  + op-registry workers) and exceeds the 600s/package default under `-race`. Fix: `-timeout 25m` on
+  the full target. CI's `-short -race` job fits the default and was already green, so this never
+  blocked PRs — only local `make test` + nightly.
+- [ ] **NUTSDB-CLOSE-GOROUTINE-LEAK** (2026-06-17, low priority) — `NutsActivityStore.Close()` →
+  `nutsdb.DB.Close()` leaks **1 background goroutine per Open** (the TTL time-wheel; isolation
+  micro-test: 20 open+close cycles → 20 survivors). **Benign in prod** — the activity store is a
+  process-lifetime singleton (one open at startup, `internal/activity/register.go`). Only the test
+  suite (which opens many short-lived stores) accumulates them. Do NOT fork/upgrade nutsdb to chase
+  this — `nuts_activity_store.go` is coupled to v1.1.0-specific error sentinels (`ErrNotFoundBucket`
+  vs `ErrBucketNotFound`) and an upgrade risks breaking empty-scan handling. If it ever matters,
+  add an option to skip the TTL manager, or share one store across the server test package.
 
 - [x] **BUG-ITUNES-WRITEBACK-CORRUPTS-LIBRARY** — Fixed in PR #1319 (2026-06-05). See PD-2.
 

--- a/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
+++ b/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
@@ -1,13 +1,14 @@
 // file: web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-defa-444567890123
-// last-edited: 2026-06-10
+// last-edited: 2026-06-17
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { UnifiedDedupTab } from '../UnifiedDedupTab';
 import * as api from '../../../services/api';
+import type { Book } from '../../../services/api';
 
 // Mock the full api module.
 vi.mock('../../../services/api', () => ({
@@ -27,6 +28,12 @@ vi.mock('../../../stores/useOperationsStore', () => ({
   },
 }));
 
+// The reworked UnifiedDedupTab renders rich book cards (title / author / path)
+// from the inline book_a/book_b objects the API now returns with
+// include_books=true — not the bare entity ULIDs. Tests query by these titles.
+const bookATitle = 'Dune (FLAC rip)';
+const bookBTitle = 'Dune (MP3 rip)';
+
 const mockCandidate = {
   id: 1,
   entity_type: 'book' as const,
@@ -39,6 +46,18 @@ const mockCandidate = {
   updated_at: '2026-01-01T00:00:00Z',
   band: 'HIGH' as const,
   score: 92.5,
+  book_a: {
+    id: '01ABCDEFGHIJKLMNOPQRSTUV01',
+    title: bookATitle,
+    author_name: 'Frank Herbert',
+    file_path: '/audiobooks/dune-flac.m4b',
+  } as Book,
+  book_b: {
+    id: '01ABCDEFGHIJKLMNOPQRSTUV02',
+    title: bookBTitle,
+    author_name: 'Frank Herbert',
+    file_path: '/audiobooks/dune-mp3.m4b',
+  } as Book,
 };
 
 function renderInRouter() {
@@ -113,9 +132,7 @@ describe('UnifiedDedupTab', () => {
 
     renderInRouter();
     await waitFor(() => {
-      expect(
-        screen.getByText(mockCandidate.entity_a_id)
-      ).toBeInTheDocument();
+      expect(screen.getByText(bookATitle)).toBeInTheDocument();
     });
   });
 
@@ -136,15 +153,17 @@ describe('UnifiedDedupTab', () => {
 
     renderInRouter();
 
-    // Wait for table to render.
+    // Wait for the candidate's card to render.
     await waitFor(() => {
-      expect(screen.getByText(mockCandidate.entity_a_id)).toBeInTheDocument();
+      expect(screen.getByText(bookATitle)).toBeInTheDocument();
     });
 
-    // Click the row's checkbox.
-    const checkboxes = screen.getAllByRole('checkbox');
-    // index 0 is the select-all, index 1 is the first row.
-    fireEvent.click(checkboxes[1]);
+    // Select the candidate by clicking ITS row checkbox. Scope the query to the
+    // row so it stays correct regardless of the toolbar filter checkbox and the
+    // table select-all checkbox (which a bare getAllByRole index would conflate).
+    const row = screen.getByText(bookATitle).closest('tr');
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row as HTMLElement).getByRole('checkbox'));
 
     await waitFor(() => {
       expect(screen.getByTestId('bulk-action-bar')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Repairs the long-red `Minimal CI / Frontend Unit Tests` job and a backend `-race` test timeout, plus marks two TODO items done.

### Frontend Unit Tests (the red CI job)
`web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx` had two stale assertions (`renders candidates in the table`, `shows bulk action bar when a candidate is selected`) that expected a raw entity ULID to appear in the table. The reworked `UnifiedDedupTab` renders rich book cards (title / author / file path) from inline `book_a`/`book_b`; a missing book renders `(missing book — …)`, so the bare ULID is never shown.

Fix: seed realistic `book_a`/`book_b` in the mock and assert on the rendered **card title**; select a candidate by its row checkbox via `within(row)` instead of a brittle `getAllByRole('checkbox')` index (which broke once a toolbar filter checkbox was added).

### Backend full `-race` suite
`make test` (and `test-nightly`, which reuses it) panicked with `test timed out after 10m0s` in `internal/server`. That package runs ~421s **without** `-race` and ~697s **with** it (heavy per-test setup: Pebble + migrations + op-registry workers), exceeding the 600s/package default. Raised the full target to `-timeout 25m`. CI's `-short -race` job already fit the default and was green, so this only affected local `make test` and the nightly run.

### Docs / TODO
- Marked `CI-FRONTEND-UNITTESTS-STALE` and `A2` (subprocess handshake test already present in main) done.
- Recorded `NUTSDB-CLOSE-GOROUTINE-LEAK`: `nutsdb.DB.Close()` leaks 1 background goroutine per Open (TTL time-wheel). Benign in prod (activity store is a process-lifetime singleton); only the test suite accumulates them. Explicitly do **not** fork/upgrade nutsdb (coupled to v1.1.0 error sentinels).

## Test plan
- `npx vitest run` (web): **35 files / 246 tests pass**; `tsc --noEmit` clean.
- `make test` (full `go test ./... -v -race -timeout 25m`): **exit 0**, `internal/server` passes at 697s, no timeouts, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)