### PR TITLE
fix(web): track + cancel deferred timers to fix memory-leak CI scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.30.0 -->
+<!-- version: 3.31.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-17 -->
 
@@ -8,6 +8,21 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### June 17, 2026 — Fix `Scan for memory leaks` CI job: track + cancel deferred timers
+
+The repo memory-leak scanner (`scripts/check-memory-leaks.py`) flagged 4 untracked
+`setTimeout` calls in React components, which fail the `Scan for memory leaks` CI job:
+
+- **`UnifiedDedupTab.tsx`** (2 sites) — `handleScan` / `handleForceRescan` scheduled a 2s
+  refresh that calls `loadCandidates()` + `loadStats()` (both `setState`). If the tab
+  unmounted within that window, the timer fired on an unmounted component. Timers are now
+  tracked in a `refreshTimeoutsRef` and cleared in an unmount cleanup effect.
+- **`ActivityLog.tsx`** (2 sites) — 50ms scroll-to-bottom timers (null-safe but flagged).
+  Tracked in a `scrollTimeoutsRef` and cleared on unmount.
+
+Scanner now reports "No memory leak patterns detected". Frontend suite stays green
+(35 files / 246 tests); `tsc` and `eslint` clean.
 
 #### June 17, 2026 — Fix long-red Frontend Unit Tests CI job + backend -race test timeout
 

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
-// last-edited: 2026-06-12
+// last-edited: 2026-06-17
 
 // UnifiedDedupTab is the T017 single surface that replaces the separate Books /
 // Advanced-Scan / Acoustic tabs. It shows a paginated candidate table filtered
@@ -214,6 +214,18 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
   // --- abort controller refs ---
   const fetchAbortRef = useRef<AbortController | null>(null);
   const statsAbortRef = useRef<AbortController | null>(null);
+
+  // Post-scan refresh timers (fire ~2s later to pick up new candidates). Tracked
+  // so they're cancelled on unmount — otherwise the deferred loadCandidates/
+  // loadStats would call setState on an unmounted component.
+  const refreshTimeoutsRef = useRef<number[]>([]);
+  useEffect(
+    () => () => {
+      refreshTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+      refreshTimeoutsRef.current = [];
+    },
+    [],
+  );
 
   // --- sync band filter to URL ---
   const handleBandChange = useCallback(
@@ -508,10 +520,11 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
       const op = await api.triggerDedupScan();
       setToast(trackOp(op, 'Dedup scan'));
       // Refresh after short delay for new candidates to appear.
-      setTimeout(() => {
+      const refreshTimeout = window.setTimeout(() => {
         loadCandidates();
         loadStats();
       }, 2000);
+      refreshTimeoutsRef.current.push(refreshTimeout);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Scan failed');
     } finally {
@@ -566,10 +579,11 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
     try {
       const op = await opt.run();
       setToast(trackOp(op, `Force rescan (${opt.kind})`));
-      setTimeout(() => {
+      const refreshTimeout = window.setTimeout(() => {
         loadCandidates();
         loadStats();
       }, 2000);
+      refreshTimeoutsRef.current.push(refreshTimeout);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Rescan failed');
     } finally {

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,6 +1,7 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.16.0
+// version: 2.17.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-06-17
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -211,6 +212,18 @@ export default function ActivityLog() {
   const feedIntervalRef = useRef<number | null>(null);
   const sourcesDropdownRef = useRef<HTMLDivElement | null>(null);
 
+  // Tracks pending scroll timers so they can be cancelled on unmount — a timer
+  // that fires after unmount would touch a detached ref (harmless here thanks to
+  // optional chaining, but still flagged by the memory-leak scanner).
+  const scrollTimeoutsRef = useRef<number[]>([]);
+  useEffect(
+    () => () => {
+      scrollTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+      scrollTimeoutsRef.current = [];
+    },
+    [],
+  );
+
   // Persist excluded sources
   useEffect(() => {
     localStorage.setItem(STORAGE_KEYS.ACTIVITY_SOURCE_PREFS, JSON.stringify([...excludedSources]));
@@ -247,7 +260,11 @@ export default function ActivityLog() {
     const logs = await api.getOperationLogs(opId);
     setOpLogs(logs.map((l: { message?: string }) => l.message || String(l)));
     setOpLogsLoaded(true);
-    window.setTimeout(() => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }), 50);
+    const scrollTimeout = window.setTimeout(
+      () => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }),
+      50,
+    );
+    scrollTimeoutsRef.current.push(scrollTimeout);
   }, []);
 
   // Load logs once when an operation is expanded. Live lines append via SSE
@@ -282,7 +299,11 @@ export default function ActivityLog() {
     if (!latestLogEvent || latestLogEvent.op_id !== expandedOpId) return;
     setOpLogsLoaded(true);
     setOpLogs((prev) => [...prev, latestLogEvent.message]);
-    window.setTimeout(() => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }), 50);
+    const scrollTimeout = window.setTimeout(
+      () => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }),
+      50,
+    );
+    scrollTimeoutsRef.current.push(scrollTimeout);
   }, [latestLogEvent, expandedOpId]);
 
   // Load sources


### PR DESCRIPTION
## Summary

Fixes the `Scan for memory leaks` CI job (red on main). `scripts/check-memory-leaks.py` flagged **4 untracked `setTimeout`** calls in React components:

- **`UnifiedDedupTab.tsx`** (`handleScan`, `handleForceRescan`) — a 2s post-scan refresh that calls `loadCandidates()` + `loadStats()` (both `setState`). If the tab unmounts within that 2s window the timer fires on an unmounted component (a real leak). Now tracked in `refreshTimeoutsRef` and cancelled in an unmount cleanup effect.
- **`ActivityLog.tsx`** — two 50ms scroll-to-bottom timers (null-safe via optional chaining, but still flagged). Tracked in `scrollTimeoutsRef` and cancelled on unmount.

## Test plan
- `python3 scripts/check-memory-leaks.py` → **exit 0, "No memory leak patterns detected"** (was 4 findings).
- `npx vitest run` → **35 files / 246 tests pass**.
- `npx tsc --noEmit` → clean. `eslint` → 0 errors (2 pre-existing warnings unrelated to these lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)