### PR TITLE
fix(handlers): validate import path before scan (go/path-injection #1094)

### DIFF
--- a/internal/server/handlers/filesystem.go
+++ b/internal/server/handlers/filesystem.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/filesystem.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4d5e6f7-a8b9-0123-cdef-012345678901
-// last-edited: 2026-06-02
+// last-edited: 2026-06-17
 
 // Package handlers — FilesystemHandler covers home-directory, filesystem
 // browse, exclusion CRUD, import-path CRUD, and the on-demand single-file
@@ -27,6 +27,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/organizer"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
+	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -223,7 +224,17 @@ func (h *FilesystemHandler) AddImportPath(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return
 	}
-	createdPath, err := h.pathCreator.CreateImportPath(req.Path, req.Name)
+	// Reject traversal sequences and require an absolute path before the value
+	// reaches the store and the directory scanner (go/path-injection). Import
+	// roots are intentionally arbitrary absolute directories, so we normalize
+	// rather than confine to a fixed root; CleanAbsolutePath's return value is
+	// the sanitized path used downstream.
+	cleanPath, err := pathvalidation.CleanAbsolutePath(req.Path)
+	if err != nil {
+		httputil.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	createdPath, err := h.pathCreator.CreateImportPath(cleanPath, req.Name)
 	if err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
 		return

--- a/internal/server/server_import_paths_and_blocklist_test.go
+++ b/internal/server/server_import_paths_and_blocklist_test.go
@@ -132,6 +132,34 @@ func TestAddImportPath_Returns201(t *testing.T) {
 	require.Equal(t, http.StatusCreated, w.Code)
 }
 
+// TestAddImportPath_RejectsTraversal verifies that a request path containing
+// traversal sequences is rejected with 400 before any store write or directory
+// scan. Guards against go/path-injection at the AddImportPath entry point: the
+// mock store sets no CreateImportPath expectation, so the test fails if the
+// unvalidated path reaches the store.
+func TestAddImportPath_RejectsTraversal(t *testing.T) {
+	origCfg := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = origCfg })
+	config.AppConfig.AutoOrganize = false
+	config.AppConfig.RootDir = ""
+
+	store := dbmocks.NewMockStore(t)
+	store.EXPECT().SetRootDir(mock.Anything).Return()
+	// No CreateImportPath / CreateOperation expectation: mockery fails the test
+	// if the handler calls the store despite the traversal path.
+
+	server, cleanup := setupTestServerWithStore(t, store)
+	defer cleanup()
+
+	body := bytes.NewBufferString(`{"path":"/mnt/books/../../etc","name":"Evil"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/import-paths", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestBlockedHashes_CRUD(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Path-injection remediation **PR 1 of 4** for SEC-AUDIT-12 (#1258). Fixes the **one genuinely REAL** finding from the triage of 73 `go/path-injection` alerts.

`AddImportPath` (POST `/api/v1/import-paths`) stored `req.Path` with **zero validation**, then passed it to `os.Stat` and `scanner.ScanDirectory` (which walks and reads the directory tree). Every other flagged sink had at least format validation; this one had none.

## Fix
Route `req.Path` through `pathvalidation.CleanAbsolutePath` before it reaches the store/scanner: rejects `..` traversal sequences, requires an absolute path, and the **sanitized return value** is what flows downstream (so CodeQL treats it as cleaned).

Import roots are intentionally arbitrary absolute directories (e.g. `/mnt/bigdata/books`), so we normalize rather than confine to a fixed root — root-containment would break the feature.

## Tests
- New `TestAddImportPath_RejectsTraversal`: posts `/mnt/books/../../etc`, asserts 400, and the mock store has **no** `CreateImportPath` expectation — so the test fails if an unvalidated path reaches the store. (Verified red before the fix, green after.)
- Existing `TestAddImportPath_Returns201` still green.

Closes the path-injection portion of #1258 for alert #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)