### PR TITLE
fix: path-injection membership-gate sweep — exclusion + import/ingest/update (#1258)

### DIFF
--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service.go
-// version: 1.31.0
+// version: 1.31.1
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-17
 
@@ -2052,8 +2052,10 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 		if !fileops.IsAllowedPath(absNewPath, importPaths) {
 			return nil, fmt.Errorf("new path is not in an allowed directory")
 		}
-		// Validate new file exists before accepting path change
-		if _, err := os.Stat(absNewPath); err != nil {
+		// Validate new file exists before accepting path change.
+		// absNewPath is gated by fileops.IsAllowedPath above; CodeQL does not
+		// model that custom allow-list barrier, so suppress the false positive.
+		if _, err := os.Stat(absNewPath); err != nil { // lgtm[go/path-injection]
 			return nil, fmt.Errorf("file does not exist at new path: %s", absNewPath)
 		}
 		slog.Info("audiobook_service FilePath changed for →", "id", id, "currentBook", currentBook.FilePath, "value2", absNewPath)

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service.go
-// version: 1.30.0
+// version: 1.31.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-05-29
+// last-edited: 2026-06-17
 
 package audiobooks
 
@@ -23,6 +23,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/mediainfo"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
@@ -2038,12 +2039,25 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 		currentBook.Format = req.Updates.Format
 	}
 	if req.Updates.FilePath != "" && req.Updates.FilePath != currentBook.FilePath {
-		// Validate new file exists before accepting path change
-		if _, err := os.Stat(req.Updates.FilePath); err != nil {
-			return nil, fmt.Errorf("file does not exist at new path: %s", req.Updates.FilePath)
+		// Validate the new path is inside an allowed directory before accepting
+		// the change (go/path-injection), then confirm it exists.
+		absNewPath, err := filepath.Abs(req.Updates.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid new path: %w", err)
 		}
-		slog.Info("audiobook_service FilePath changed for →", "id", id, "currentBook", currentBook.FilePath, "value2", req.Updates.FilePath)
-		currentBook.FilePath = req.Updates.FilePath
+		importPaths, err := svc.store.GetAllImportPaths()
+		if err != nil {
+			return nil, fmt.Errorf("failed to check allowed paths: %w", err)
+		}
+		if !fileops.IsAllowedPath(absNewPath, importPaths) {
+			return nil, fmt.Errorf("new path is not in an allowed directory")
+		}
+		// Validate new file exists before accepting path change
+		if _, err := os.Stat(absNewPath); err != nil {
+			return nil, fmt.Errorf("file does not exist at new path: %s", absNewPath)
+		}
+		slog.Info("audiobook_service FilePath changed for →", "id", id, "currentBook", currentBook.FilePath, "value2", absNewPath)
+		currentBook.FilePath = absNewPath
 	}
 	if req.Updates.Narrator != nil {
 		currentBook.Narrator = req.Updates.Narrator

--- a/internal/fileops/service.go
+++ b/internal/fileops/service.go
@@ -1,7 +1,7 @@
 // file: internal/fileops/service.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-05-15
+// last-edited: 2026-06-17
 
 package fileops
 
@@ -64,6 +64,36 @@ func isAllowedPath(absPath string, importPaths []database.ImportPath) bool {
 		}
 	}
 	return false
+}
+
+// IsAllowedPath reports whether absPath lies within the configured allow-list
+// (default prefixes + RootDir + registered import paths). Exported so callers in
+// other packages that perform filesystem operations on request-supplied paths
+// can reuse the same gate BrowseDirectory uses.
+func IsAllowedPath(absPath string, importPaths []database.ImportPath) bool {
+	return isAllowedPath(absPath, importPaths)
+}
+
+// ValidateUserPath resolves path to an absolute form and verifies it is within
+// the allow-list, returning ErrPathNotAllowed otherwise. It is the one-call
+// guard for handlers/services that accept a filesystem path from a request and
+// then read, write, hash, or scan it (go/path-injection).
+func ValidateUserPath(db database.ImportPathStore, path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid path: %w", err)
+	}
+	importPaths, err := db.GetAllImportPaths()
+	if err != nil {
+		return "", fmt.Errorf("failed to check allowed paths: %w", err)
+	}
+	if !isAllowedPath(absPath, importPaths) {
+		return "", ErrPathNotAllowed
+	}
+	return absPath, nil
 }
 
 type FileInfo struct {
@@ -172,6 +202,16 @@ func (fs *FilesystemService) CreateExclusion(_ context.Context, path string) err
 		return fmt.Errorf("invalid path: %w", err)
 	}
 
+	// Security: only allow exclusion files inside allowed directories (same gate
+	// as BrowseDirectory) before touching the filesystem (go/path-injection).
+	importPaths, err := fs.db.GetAllImportPaths()
+	if err != nil {
+		return fmt.Errorf("failed to check allowed paths: %w", err)
+	}
+	if !isAllowedPath(absPath, importPaths) {
+		return ErrPathNotAllowed
+	}
+
 	stat, err := os.Stat(absPath)
 	if err != nil {
 		return fmt.Errorf("path not found or inaccessible: %w", err)
@@ -196,6 +236,15 @@ func (fs *FilesystemService) RemoveExclusion(_ context.Context, path string) err
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Security: same allow-list gate as CreateExclusion (go/path-injection).
+	importPaths, err := fs.db.GetAllImportPaths()
+	if err != nil {
+		return fmt.Errorf("failed to check allowed paths: %w", err)
+	}
+	if !isAllowedPath(absPath, importPaths) {
+		return ErrPathNotAllowed
 	}
 
 	sp, err := safepath.Join(absPath, ".jabexclude")

--- a/internal/fileops/service_test.go
+++ b/internal/fileops/service_test.go
@@ -1,12 +1,13 @@
 // file: internal/fileops/service_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
-// last-edited: 2026-05-15
+// last-edited: 2026-06-17
 
 package fileops
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,14 +41,16 @@ func TestFilesystemService_BrowseDirectory_InvalidPath(t *testing.T) {
 }
 
 func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
-	mockStore := new(mocks.MockImportPathStore)
-	fs := NewFilesystemService(mockStore)
-
 	tmpDir, err := os.MkdirTemp("", "test-exclusion")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
+
+	mockStore := new(mocks.MockImportPathStore)
+	// tmpDir must be in the allow-list for the exclusion gate to permit the write.
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{{Path: tmpDir}}, nil)
+	fs := NewFilesystemService(mockStore)
 
 	err = fs.CreateExclusion(context.Background(), tmpDir)
 	if err != nil {
@@ -60,15 +63,40 @@ func TestFilesystemService_CreateExclusion_Success(t *testing.T) {
 	}
 }
 
-func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
+// TestFilesystemService_CreateExclusion_RejectsDisallowedPath verifies the
+// allow-list gate: a path outside the configured import paths is rejected with
+// ErrPathNotAllowed before any filesystem write (go/path-injection).
+func TestFilesystemService_CreateExclusion_RejectsDisallowedPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-exclusion-denied")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
 	mockStore := new(mocks.MockImportPathStore)
+	// Empty allow-list (and tmpDir is not under a default prefix / RootDir).
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{}, nil)
 	fs := NewFilesystemService(mockStore)
 
+	err = fs.CreateExclusion(context.Background(), tmpDir)
+	if !errors.Is(err, ErrPathNotAllowed) {
+		t.Fatalf("expected ErrPathNotAllowed, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmpDir, ".jabexclude")); statErr == nil {
+		t.Error("exclusion file must NOT be created for a disallowed path")
+	}
+}
+
+func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test-remove-exclusion")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
+
+	mockStore := new(mocks.MockImportPathStore)
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{{Path: tmpDir}}, nil)
+	fs := NewFilesystemService(mockStore)
 
 	err = fs.RemoveExclusion(context.Background(), tmpDir)
 	if err == nil {

--- a/internal/importer/collision.go
+++ b/internal/importer/collision.go
@@ -1,7 +1,7 @@
 // file: internal/importer/collision.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
-// last-edited: 2026-05-11
+// last-edited: 2026-06-17
 //
 // Import-time collision preview. Before importing a file, check whether
 // it collides with an existing book (by title match, file hash, or fingerprint)
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
@@ -54,24 +55,37 @@ func CheckImportCollisions(store database.Store, req *CollisionPreviewRequest) *
 		}
 	}
 
+	// Steps 2 and 3 read the file directly, so validate the path against the
+	// allow-list first (go/path-injection). A disallowed path simply skips the
+	// file-based checks — the actual import via ImportFile will reject it.
+	safePath, pathErr := fileops.ValidateUserPath(store, req.FilePath)
+
 	// 2. File hash check against existing books.
-	if _, err := os.Stat(req.FilePath); err == nil {
-		hash := merge.QuickHash(req.FilePath)
-		if hash != "" {
-			existing, _ := store.GetBookByFileHash(hash)
-			if existing != nil {
-				candidates = append(candidates, merge.CollisionCandidate{
-					BookID:    existing.ID,
-					Title:     existing.Title,
-					MatchType: "file_hash",
-					FilePath:  existing.FilePath,
-				})
+	if pathErr == nil {
+		if _, err := os.Stat(safePath); err == nil {
+			hash := merge.QuickHash(safePath)
+			if hash != "" {
+				existing, _ := store.GetBookByFileHash(hash)
+				if existing != nil {
+					candidates = append(candidates, merge.CollisionCandidate{
+						BookID:    existing.ID,
+						Title:     existing.Title,
+						MatchType: "file_hash",
+						FilePath:  existing.FilePath,
+					})
+				}
 			}
 		}
 	}
 
 	// 3. Title match via metadata extraction.
-	meta, err := metadata.ExtractMetadata(req.FilePath, nil)
+	var meta metadata.Metadata
+	var err error
+	if pathErr == nil {
+		meta, err = metadata.ExtractMetadata(safePath, nil)
+	} else {
+		err = pathErr
+	}
 	if err == nil && meta.Title != "" {
 		titleLower := strings.ToLower(strings.TrimSpace(meta.Title))
 		books, _ := store.GetAllBooks(0, 0)

--- a/internal/importer/collision.go
+++ b/internal/importer/collision.go
@@ -1,5 +1,5 @@
 // file: internal/importer/collision.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 5c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
 // last-edited: 2026-06-17
 //
@@ -61,8 +61,10 @@ func CheckImportCollisions(store database.Store, req *CollisionPreviewRequest) *
 	safePath, pathErr := fileops.ValidateUserPath(store, req.FilePath)
 
 	// 2. File hash check against existing books.
+	// safePath is validated against the allow-list by ValidateUserPath above;
+	// CodeQL does not model that barrier, so suppress the false positive.
 	if pathErr == nil {
-		if _, err := os.Stat(safePath); err == nil {
+		if _, err := os.Stat(safePath); err == nil { // lgtm[go/path-injection]
 			hash := merge.QuickHash(safePath)
 			if hash != "" {
 				existing, _ := store.GetBookByFileHash(hash)

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
@@ -73,10 +74,11 @@ type ImportFileResponse struct {
 }
 
 func (is *ImportService) ImportFile(req *ImportFileRequest) (*ImportFileResponse, error) {
-	// Validate file exists and is supported
-	absPath, err := filepath.Abs(req.FilePath)
+	// Validate the path is inside an allowed directory before any filesystem
+	// access (go/path-injection); returns the cleaned absolute path.
+	absPath, err := fileops.ValidateUserPath(is.db, req.FilePath)
 	if err != nil {
-		return nil, fmt.Errorf("file not found or inaccessible: %w", err)
+		return nil, err
 	}
 	fileInfo, err := os.Stat(absPath)
 	if err != nil {

--- a/internal/server/import_collision_test.go
+++ b/internal/server/import_collision_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/import_collision_test.go
-// version: 1.0.2
+// version: 1.0.3
 // guid: 9c0d1e2f-3a4b-5c6d-7e8f-9a0b1c2d3e4f
-// last-edited: 2026-05-03
+// last-edited: 2026-06-17
 
 package server
 
@@ -90,6 +90,12 @@ func TestHandleImportCollisionPreview_FileHashCollision(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "existing.m4b")
 	content := []byte("this is some audio content for hash matching")
 	_ = os.WriteFile(tmpFile, content, 0o644)
+
+	// Register the temp dir as an import path so the collision check's
+	// file-hash + metadata steps pass the path allow-list gate.
+	if _, err := store.CreateImportPath(filepath.Dir(tmpFile), "test-allow"); err != nil {
+		t.Fatalf("allow import path: %v", err)
+	}
 
 	hash := merge.QuickHash(tmpFile)
 	if hash == "" {

--- a/internal/server/server_extra_test.go
+++ b/internal/server/server_extra_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_extra_test.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 61a2d3c4-80ab-4f6f-8c39-15a2ac5b7f0c
-// last-edited: 2026-05-08
+// last-edited: 2026-06-17
 
 package server
 
@@ -204,6 +204,11 @@ func TestExclusionEndpoints(t *testing.T) {
 	defer cleanup()
 
 	dir := t.TempDir()
+	// Allow the temp dir through the exclusion path gate by registering it as
+	// an import path on the store (parallel-safe; avoids global config mutation).
+	if _, err := database.GetGlobalStore().CreateImportPath(dir, "test-allow"); err != nil {
+		t.Fatalf("allow import path: %v", err)
+	}
 	payload := bytes.NewBufferString(`{"path":"` + dir + `","reason":"test"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/filesystem/exclude", payload)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/server_more_test.go
+++ b/internal/server/server_more_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_more_test.go
-// version: 1.7.0
+// version: 1.7.1
 // guid: 18a6b0a3-7e78-4e0f-8b8e-0e4c1dbde6de
-// last-edited: 2026-05-08
+// last-edited: 2026-06-17
 
 //go:build !windows
 
@@ -213,6 +213,11 @@ func TestImportFileEndpoint(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := copyFixtureToDir(t, "test_sample.m4b", tempDir)
 	config.AppConfig.SupportedExtensions = []string{".m4b"}
+	// Allow the temp dir through the import path allow-list gate by registering
+	// it on the store (parallel-safe; avoids global config mutation).
+	if _, err := database.GetGlobalStore().CreateImportPath(tempDir, "test-allow"); err != nil {
+		t.Fatalf("allow import path: %v", err)
+	}
 
 	payload := map[string]any{
 		"file_path": filePath,

--- a/internal/server/service_layer_test.go
+++ b/internal/server/service_layer_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/service_layer_test.go
-// version: 1.9.0
+// version: 1.9.1
 // guid: 8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-05-15
+// last-edited: 2026-06-17
 
 package server
 
@@ -1520,11 +1520,15 @@ func TestFilesystemService_CreateExclusion_EmptyPath(t *testing.T) {
 
 // TestFilesystemService_CreateExclusion_NotDirectory tests file path error
 func TestFilesystemService_CreateExclusion_NotDirectory(t *testing.T) {
-	svc := fileops.NewFilesystemService(nil)
-
 	// Create a real file so stat succeeds but it's not a directory
 	tmpFile := filepath.Join(t.TempDir(), "not_a_dir.txt")
 	os.WriteFile(tmpFile, []byte("test"), 0644)
+
+	// Store must allow the path so the allow-list gate passes and the
+	// not-a-directory check is what rejects it.
+	mockStore := new(mocks.MockImportPathStore)
+	mockStore.On("GetAllImportPaths").Return([]database.ImportPath{{Path: filepath.Dir(tmpFile)}}, nil)
+	svc := fileops.NewFilesystemService(mockStore)
 
 	err := svc.CreateExclusion(context.Background(), tmpFile)
 	if err == nil {

--- a/internal/versions/ingest.go
+++ b/internal/versions/ingest.go
@@ -1,6 +1,7 @@
 // file: internal/versions/ingest.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 3e1f2a9b-4c5d-4a70-b8c5-3d7e0f1b9a99
+// last-edited: 2026-06-17
 //
 // Version creation on ingest (spec 3.1 task 5).
 //
@@ -24,6 +25,7 @@ import (
 	"os"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 )
 
 // IngestVersionParams describes the provenance of a newly-ingested file.
@@ -45,6 +47,14 @@ func CreateIngestVersion(store database.Store, params IngestVersionParams) (*dat
 	if params.BookID == "" || params.FilePath == "" {
 		return nil, fmt.Errorf("book_id and file_path required")
 	}
+
+	// Validate the path is inside an allowed directory before hashing the file
+	// (go/path-injection); use the cleaned absolute path downstream.
+	validPath, err := fileops.ValidateUserPath(store, params.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	params.FilePath = validPath
 
 	// Check fingerprint first — refuse if this file was previously purged.
 	if params.TorrentHash != "" {

--- a/internal/versions/ingest_test.go
+++ b/internal/versions/ingest_test.go
@@ -1,6 +1,7 @@
 // file: internal/versions/ingest_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f2a3b0c-5d6e-4a70-b8c5-3d7e0f1b9a99
+// last-edited: 2026-06-17
 
 package versions
 
@@ -22,6 +23,16 @@ func writeTestFile(t *testing.T, path, content string) {
 	}
 }
 
+// allowDir registers dir as an import path so paths beneath it pass the
+// CreateIngestVersion allow-list gate (go/path-injection). Temp dirs live
+// outside the default allow-list prefixes, so tests must opt them in.
+func allowDir(t *testing.T, store *database.PebbleStore, dir string) {
+	t.Helper()
+	if _, err := store.CreateImportPath(dir, "test-allow"); err != nil {
+		t.Fatalf("allow import path: %v", err)
+	}
+}
+
 func TestCreateIngestVersion_NewBook(t *testing.T) {
 	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
 	if err != nil {
@@ -30,6 +41,7 @@ func TestCreateIngestVersion_NewBook(t *testing.T) {
 	t.Cleanup(func() { store.Close() })
 
 	dir := t.TempDir()
+	allowDir(t, store, dir)
 	filePath := filepath.Join(dir, "Book.m4b")
 	writeTestFile(t, filePath, "audio-data-for-hash")
 
@@ -59,6 +71,7 @@ func TestCreateIngestVersion_SecondVersionIsAlt(t *testing.T) {
 	t.Cleanup(func() { store.Close() })
 
 	dir := t.TempDir()
+	allowDir(t, store, dir)
 	book, _ := store.CreateBook(&database.Book{
 		Title: "Book", FilePath: filepath.Join(dir, "Book.m4b"), Format: "m4b",
 	})
@@ -90,6 +103,12 @@ func TestCreateIngestVersion_FingerprintBlocksPurged(t *testing.T) {
 	}
 	t.Cleanup(func() { store.Close() })
 
+	// Use an allowed path so the rejection under test is the fingerprint gate,
+	// not the path allow-list gate.
+	dir := t.TempDir()
+	allowDir(t, store, dir)
+	filePath := filepath.Join(dir, "new.m4b")
+
 	// Create a purged version with a known torrent hash.
 	_, _ = store.CreateBookVersion(&database.BookVersion{
 		BookID: "old-book", Status: database.BookVersionStatusInactivePurged,
@@ -97,11 +116,11 @@ func TestCreateIngestVersion_FingerprintBlocksPurged(t *testing.T) {
 	})
 
 	book, _ := store.CreateBook(&database.Book{
-		Title: "New Import", FilePath: "/tmp/new", Format: "m4b",
+		Title: "New Import", FilePath: filePath, Format: "m4b",
 	})
 
 	_, err = CreateIngestVersion(store, IngestVersionParams{
-		BookID: book.ID, FilePath: "/tmp/new", Format: "m4b",
+		BookID: book.ID, FilePath: filePath, Format: "m4b",
 		Source: "deluge", TorrentHash: "blocked-hash",
 	})
 	if err == nil {
@@ -131,6 +150,7 @@ func TestCreateIngestVersion_FileHashUpdated(t *testing.T) {
 	t.Cleanup(func() { store.Close() })
 
 	dir := t.TempDir()
+	allowDir(t, store, dir)
 	filePath := filepath.Join(dir, "Book.m4b")
 	writeTestFile(t, filePath, "audio-content-to-hash")
 

--- a/internal/versions/unit_test.go
+++ b/internal/versions/unit_test.go
@@ -1,5 +1,6 @@
 // file: internal/versions/unit_test.go
-// version: 1.0.0
+// version: 1.1.0
+// last-edited: 2026-06-17
 
 package versions
 
@@ -40,6 +41,9 @@ func TestCreateIngestVersion_EmptyFilePath(t *testing.T) {
 func TestCreateIngestVersion_StoreErrorOnCreate(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 
+	// Allow-all import path so the path gate passes; this test exercises
+	// version-creation error handling, not path validation.
+	mockStore.EXPECT().GetAllImportPaths().Return([]database.ImportPath{{Path: "/"}}, nil)
 	// No torrent hash so fingerprint check is skipped.
 	// First version — no active version exists.
 	mockStore.EXPECT().GetActiveVersionForBook("book-1").Return(nil, errors.New("not found"))
@@ -55,9 +59,27 @@ func TestCreateIngestVersion_StoreErrorOnCreate(t *testing.T) {
 	assert.Contains(t, err.Error(), "create version")
 }
 
+// TestCreateIngestVersion_RejectsDisallowedPath verifies the allow-list gate:
+// a path outside the configured import paths is rejected before any version
+// row is created or file is read (go/path-injection).
+func TestCreateIngestVersion_RejectsDisallowedPath(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetAllImportPaths().Return([]database.ImportPath{}, nil)
+
+	_, err := CreateIngestVersion(mockStore, IngestVersionParams{
+		BookID:   "book-1",
+		FilePath: "/etc/passwd",
+		Format:   "m4b",
+		Source:   "imported",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed")
+}
+
 func TestCreateIngestVersion_FingerprintBlocksPurgedTorrent_Mock(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 
+	mockStore.EXPECT().GetAllImportPaths().Return([]database.ImportPath{{Path: "/"}}, nil)
 	// Torrent hash matches a purged version.
 	mockStore.EXPECT().GetBookVersionByTorrentHash("bad-hash").Return(&database.BookVersion{
 		ID:     "v-old",
@@ -79,6 +101,7 @@ func TestCreateIngestVersion_FingerprintBlocksPurgedTorrent_Mock(t *testing.T) {
 func TestCreateIngestVersion_FirstVersionIsActive_Mock(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 
+	mockStore.EXPECT().GetAllImportPaths().Return([]database.ImportPath{{Path: "/"}}, nil)
 	// No active version exists.
 	mockStore.EXPECT().GetActiveVersionForBook("book-1").Return(nil, errors.New("not found"))
 
@@ -105,6 +128,7 @@ func TestCreateIngestVersion_FirstVersionIsActive_Mock(t *testing.T) {
 func TestCreateIngestVersion_SecondVersionIsAlt_Mock(t *testing.T) {
 	mockStore := mocks.NewMockStore(t)
 
+	mockStore.EXPECT().GetAllImportPaths().Return([]database.ImportPath{{Path: "/"}}, nil)
 	// Active version already exists.
 	mockStore.EXPECT().GetActiveVersionForBook("book-1").Return(&database.BookVersion{
 		ID: "v-existing", BookID: "book-1", Status: database.BookVersionStatusActive,


### PR DESCRIPTION
## Summary

Path-injection remediation **PR 2 of 4** for SEC-AUDIT-12 (#1258) — the full membership-gate sweep (9 alerts: 622/623/664/665 exclusion + 644/667/1095/407/619 import/ingest/update).

Adds the reusable allow-list guards to `internal/fileops` and applies them to every request-supplied filesystem path that lacked one, reusing the same `isAllowedPath(GetAllImportPaths())` gate `BrowseDirectory` already uses.

**New exported helpers (`internal/fileops`):**
- `IsAllowedPath(absPath, importPaths)` — exported wrapper.
- `ValidateUserPath(db, path)` — one-call abs + allow-list guard → `ErrPathNotAllowed`.

**Gated sinks:**
| Site | Treatment |
|---|---|
| `CreateExclusion` / `RemoveExclusion` | gate before write/remove |
| `importer.ImportFile` | validate before `os.Stat`/import |
| `importer.CheckImportCollisions` | validate; skip file-hash + metadata steps for disallowed paths |
| `versions.CreateIngestVersion` | validate before hashing (fail fast) |
| `audiobooks.UpdateAudiobook` | validate FilePath change before accepting |

## ⚠️ Behavior change (approved)
Exclusions, imports, ingests, and path-updates from **outside the allow-list** (default prefixes `/home /media /mnt /data /audiobooks` + `RootDir` + registered import paths) are now **rejected**. Safe for the `/mnt`-based production library.

## Tests
- New `CreateExclusion_RejectsDisallowedPath` + `CreateIngestVersion_RejectsDisallowedPath` assert `ErrPathNotAllowed`.
- Existing exclusion/ingest tests updated to register their temp dir as an import path (the breakage *was* the behavior change surfacing); fingerprint-block test switched to an allowed path so it tests the fingerprint gate, not the path gate.
- `go build ./internal/...`, `go vet`, and the fileops/importer/versions/audiobooks suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)