### PR TITLE
fix(handlers): gate relocate to allow-list + /etc package dir (go/path-injection)

### DIFF
--- a/internal/fileops/service.go
+++ b/internal/fileops/service.go
@@ -1,5 +1,5 @@
 // file: internal/fileops/service.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
 // last-edited: 2026-06-17
 
@@ -23,12 +23,15 @@ import (
 var ErrPathNotAllowed = errors.New("path not in allowed directories")
 
 // defaultBrowseAllowPrefixes covers common Linux desktop/server and Docker layouts.
+// "/etc/audiobook-organizer" is the packaged-install dir; the prefix match allows
+// it (and its subtree) while still denying the rest of /etc (e.g. /etc/passwd).
 var defaultBrowseAllowPrefixes = []string{
 	"/home",
 	"/media",
 	"/mnt",
 	"/audiobooks",
 	"/data",
+	"/etc/audiobook-organizer",
 }
 
 type FilesystemService struct {

--- a/internal/fileops/service_test.go
+++ b/internal/fileops/service_test.go
@@ -1,5 +1,5 @@
 // file: internal/fileops/service_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
 // last-edited: 2026-06-17
 
@@ -101,5 +101,26 @@ func TestFilesystemService_RemoveExclusion_NotFound(t *testing.T) {
 	err = fs.RemoveExclusion(context.Background(), tmpDir)
 	if err == nil {
 		t.Error("expected error for nonexistent exclusion")
+	}
+}
+
+// TestIsAllowedPath_EtcPackageDir verifies the packaged-install dir
+// /etc/audiobook-organizer is allowed (and its subtree) while the rest of /etc
+// is denied.
+func TestIsAllowedPath_EtcPackageDir(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/etc/audiobook-organizer", true},
+		{"/etc/audiobook-organizer/config.yaml", true},
+		{"/etc/passwd", false},
+		{"/etc", false},
+		{"/etc/audiobook-organizer-evil/x", false}, // sibling, not subtree
+	}
+	for _, c := range cases {
+		if got := IsAllowedPath(c.path, nil); got != c.want {
+			t.Errorf("IsAllowedPath(%q) = %v, want %v", c.path, got, c.want)
+		}
 	}
 }

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 82f8d1f7-46d5-4ead-b5c1-ba796fd785f9
-// last-edited: 2026-06-03
+// last-edited: 2026-06-17
 
 // File / segment endpoints for the audiobooks domain: segment listing,
 // book-file listing + patch, track-info extraction, relocate, and segment
@@ -20,11 +20,30 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/organizer"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
 )
+
+// relocateTargetAllowed reports whether absPath is inside an allowed directory
+// (registered import paths + RootDir + default prefixes). A relocate target
+// must land inside the library's allowed roots (go/path-injection). Import
+// paths are read from the live store via an inline type assertion (the narrow
+// AudiobooksStore interface does not expose them); when unavailable (e.g. in
+// tests with a mock store) the RootDir/default-prefix allow-list still applies.
+func relocateTargetAllowed(store AudiobooksStore, absPath string) bool {
+	var importPaths []database.ImportPath
+	if ips, ok := store.(interface {
+		GetAllImportPaths() ([]database.ImportPath, error)
+	}); ok {
+		if got, err := ips.GetAllImportPaths(); err == nil {
+			importPaths = got
+		}
+	}
+	return fileops.IsAllowedPath(absPath, importPaths)
+}
 
 // ListAudiobookSegments handles GET /audiobooks/:id/segments. Returns file
 // segments for a multi-file audiobook in the legacy BookSegment JSON shape.
@@ -338,6 +357,10 @@ func (h *Handler) RelocateBookFiles(c *gin.Context) {
 			httputil.RespondWithBadRequest(c, "invalid new_path: "+err.Error())
 			return
 		}
+		if !relocateTargetAllowed(store, cleanNewPath) {
+			httputil.RespondWithBadRequest(c, "new_path is not in an allowed directory")
+			return
+		}
 		for i, f := range files {
 			if f.ID == req.SegmentID {
 				if _, statErr := os.Stat(cleanNewPath); os.IsNotExist(statErr) {
@@ -358,6 +381,10 @@ func (h *Handler) RelocateBookFiles(c *gin.Context) {
 		cleanFolderPath, err := pathvalidation.CleanAbsolutePath(req.FolderPath)
 		if err != nil {
 			httputil.RespondWithBadRequest(c, "invalid folder_path: "+err.Error())
+			return
+		}
+		if !relocateTargetAllowed(store, cleanFolderPath) {
+			httputil.RespondWithBadRequest(c, "folder_path is not in an allowed directory")
 			return
 		}
 		dirEntries, err := os.ReadDir(cleanFolderPath)

--- a/internal/server/handlers/audiobooks/handler_test.go
+++ b/internal/server/handlers/audiobooks/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5cd764d5-8036-425c-842e-c49d0d44acec
-// last-edited: 2026-06-03
+// last-edited: 2026-06-17
 
 // Tests for the audiobooks-domain handlers (main library list / CRUD). The
 // store / audiobook-service / updater / write-back / metadata-state /
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -363,6 +364,24 @@ func TestRelocateBookFiles_BadRequest(t *testing.T) {
 	h.RelocateBookFiles(c)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+// TestRelocateBookFiles_RejectsDisallowedPath verifies the relocate target is
+// gated by the allow-list: a clean absolute path outside the allowed roots
+// (RootDir empty + default prefixes in tests) is rejected (go/path-injection).
+func TestRelocateBookFiles_RejectsDisallowedPath(t *testing.T) {
+	h, d := newHandler(t)
+	d.store.EXPECT().GetBookByID("b1").Return(&database.Book{ID: "b1"}, nil)
+	d.store.EXPECT().GetBookFiles("b1").Return([]database.BookFile{{ID: "s1", BookID: "b1"}}, nil)
+	c, w := newCtx("POST", "/audiobooks/b1/relocate",
+		map[string]any{"segment_id": "s1", "new_path": "/etc/cron.d/evil"}, p("id", "b1"))
+	h.RelocateBookFiles(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "not in an allowed directory") {
+		t.Fatalf("expected allow-list rejection, got: %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Path-injection remediation **PR 3 of 4** for SEC-AUDIT-12 (#1258).

`RelocateBookFiles` (POST `/audiobooks/:id/relocate`) ran `os.Stat`/`os.ReadDir`/`UpdateBookFile` on a request-supplied `new_path`/`folder_path` with only `CleanAbsolutePath` (format validation, no containment). Adds the allow-list gate: the relocate target must be inside a registered import path, `RootDir`, or a default prefix. Import paths are read from the live store via inline type assertion (the narrow `AudiobooksStore` interface doesn't expose them).

Also adds **`/etc/audiobook-organizer`** to the default prefixes for packaged installs — the prefix match allows that dir + subtree while denying the rest of `/etc` (e.g. `/etc/passwd`).

## Tests
- `TestRelocateBookFiles_RejectsDisallowedPath` — out-of-tree path → 400.
- `TestIsAllowedPath_EtcPackageDir` — package dir + subtree allowed; `/etc/passwd`, `/etc`, and sibling `/etc/audiobook-organizer-evil` denied.
- audiobooks-handler + fileops suites green; `go build ./internal/...` clean.

Note: the `os.Stat`/`os.ReadDir` sinks remain CodeQL-flagged (it can't model the allow-list barrier); those pre-existing alerts will be dismissed in the final batch with rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)