### PR TITLE
docs: close out SEC-AUDIT-12 (log+path injection remediation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,34 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.31.0 -->
+<!-- version: 3.32.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-17 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Security
+
+#### June 17, 2026 — SEC-AUDIT-12: remediate log + path injection (CodeQL)
+
+Closed out the `go/log-injection` (14) and `go/path-injection` (73) CodeQL alert
+classes with runtime guards plus categorized dismissals.
+
+- **Log injection:** new `logger.sanitizeLogLine` escapes CR/LF and C0/DEL control
+  chars in every formatted log line at all three logger sinks, so user-controlled
+  values (file paths, embedded tags, error strings) can't forge log entries or inject
+  terminal escapes (PR #1490). Corrects the prior "`%s` makes it safe" assumption —
+  `%s` interpolates newlines verbatim, which is the injection vector.
+- **Path injection:** added an import-path allow-list gate (`fileops.ValidateUserPath`
+  / `IsAllowedPath`) on the request-supplied filesystem sinks: import-path create +
+  scan (#1491); exclusion writes + import/ingest/merge/update (#1492); relocate (#1494).
+  `/etc/audiobook-organizer` added to the default prefixes for packaged installs (allows
+  that dir + subtree, denies the rest of `/etc`).
+- **iTunes** library-path endpoints treated as accepted-risk (authenticated-admin-only,
+  single configured library file; prod path already under an allowed root).
+- All 87 path+log CodeQL alerts dismissed with per-category rationale; both rule
+  classes now report **0 open**. Guards are defense-in-depth (CodeQL can't model the
+  custom allow-list barrier, hence the dismissals).
 
 ### Fixes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.92.0 -->
+<!-- version: 8.93.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-17 -->
 
@@ -1038,7 +1038,8 @@ incrementally:
 
 ### Phase 12: Log Injection (255 alerts, NEW category post-audit)
 
-- [ ] **SEC-AUDIT-12** [hold] Investigate and remediate log-injection alerts
+- [x] **SEC-AUDIT-12** Investigate and remediate log+path injection alerts — **DONE 2026-06-17**. Current counts were 14 log-injection + 73 path-injection (the "255" was stale). Remediation: runtime sanitizer `logger.sanitizeLogLine` at all log sinks (PR #1490); import-path scan guard (#1491); membership-gate sweep on exclusion/import/ingest/update (#1492); relocate gate + `/etc/audiobook-organizer` package prefix (#1494); iTunes treated as accepted-risk (admin-only, single config file). All 87 path+log CodeQL alerts dismissed with per-category rationale (guarded-at-runtime / sanitized / accepted-risk / triaged false-positive). **`go/path-injection` and `go/log-injection` open counts are now 0.** Note: the original "%s is safe" assessment below was wrong for log-injection (CR/LF in user input forges log lines regardless of `%s`); the sanitizer addresses it.
+  - _(original notes retained for history)_ [hold] Investigate and remediate log-injection alerts
   - **Priority:** P1 (review required; likely low-risk false positives)
   - **Alerts:** 255 open (go/log-injection, error severity)
   - **Affected areas:** dedup, server handlers, system services (all files logging bookID, userInput, or paths)


### PR DESCRIPTION
Marks SEC-AUDIT-12 done + adds a CHANGELOG Security entry. `go/log-injection` and `go/path-injection` are now **0 open** via runtime guards (PRs #1490/#1491/#1492/#1494) + categorized dismissals; iTunes accepted-risk. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)