### PR TITLE
fix(database): root-cause two flaky internal/database tests (FLAKY-DB-TESTS-2026-06-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.32.0 -->
+<!-- version: 3.33.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-17 -->
 
@@ -31,6 +31,30 @@ classes with runtime guards plus categorized dismissals.
   custom allow-list barrier, hence the dismissals).
 
 ### Fixes
+
+#### June 17, 2026 — FLAKY-DB-TESTS-2026-06-17: root-cause two intermittent `internal/database` tests
+
+Two tests passed in isolation but flaked under the full `Minimal CI (short, race)`
+run. Both are now fixed at the source with deterministic regression coverage:
+
+- **`TestGetAcoustIDStats_Mixed`** — `GetAcoustIDStats` scanned book *files*
+  pebble-direct (to avoid memdb's stripped fields) but grouped them by library via
+  `GetAllBooks`, which reads the **asynchronously-warmed memdb**. memdb write-through
+  is a no-op until the warmup goroutine publishes, so under load the warmup could
+  publish an empty/stale memdb — leaving `GetAllBooks` blind to books that exist in
+  Pebble. Every file then collapsed into the `(unknown)` library bucket and the
+  `LibraryRoot` assertion failed. Fix: read books pebble-direct via the new
+  `getAllBooksPebbleScan()`, mirroring the file scan, so library grouping no longer
+  depends on warmup timing. New `TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping`
+  forces the exact race (injects an empty memdb post-write) and is deterministic.
+- **`TestHNSW_RecallVsChromem`** — `hnsw.NewGraph()` seeds its level-generation RNG
+  from `time.Now().UnixNano()`, so graph topology — and recall — varied run to run
+  (~0.75–0.92), intermittently dipping below the 0.80 gate. Fix: added an unexported
+  `HNSWEmbeddingStore.newGraphRng` seam (nil in production → unchanged behavior); the
+  test pins a fixed seed, collapsing the spread to a tight band (floor 0.868 over 50
+  runs) that clears the 0.80 gate with margin. (Not bit-deterministic — coder/hnsw
+  v0.6.1 iterates Go maps during neighbor pruning — but the dominant variance source
+  is removed.)
 
 #### June 17, 2026 — Fix `Scan for memory leaks` CI job: track + cancel deferred timers
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.93.0 -->
+<!-- version: 8.94.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-17 -->
 
@@ -1812,10 +1812,10 @@ Activity page mobile layout, adaptive refresh, version vs snapshot UI polish, co
 
 ## ⚠️ Automated Findings
 
-- [ ] **FLAKY-DB-TESTS-2026-06-17** Two `internal/database` tests fail intermittently under the full `Minimal CI / Go Tests (short, race)` run but **pass in isolation** — order-dependent state pollution surfacing only in the full-package `-race` run. Repeatedly blocked PR #1494 (and others) until re-run; NOT caused by those PRs.
-  - `TestGetAcoustIDStats_Mixed` (`internal/database/pebble_acoustid_stats_test.go:59-62`) — expects import-path `/lib/audiobooks`, counts 2/1; gets different data in the full run. Root cause likely a **shared/global store or memdb cache not isolated per test** (`setupPebbleTestDB` + `database.SetGlobalStore`), or another test's books leaking in. Fix: ensure each test gets a fully isolated store + invalidated caches; audit for `SetGlobalStore` leakage across the package.
-  - `TestHNSW_RecallVsChromem` (`internal/database`, HNSW vector index) — **probabilistic recall** comparison HNSW vs chromem; flakes under CI load. Fix: deterministic seed for the vector set, or assert a tolerance band / move off the `-short` path so it doesn't gate CI.
-  - **Action:** diagnose + fix both (regression-proof the isolation), or quarantine via `t.Skip` under `-short`/`-race` with a tracking note. Per [[feedback_fix_flaky_tests]] — root-cause, don't rerun-and-ignore.
+- [x] **FLAKY-DB-TESTS-2026-06-17** Two `internal/database` tests flaked under the full `Minimal CI / Go Tests (short, race)` run but passed in isolation. **Both root-caused + fixed (not quarantined)** — the "order-dependent state pollution" hypothesis was wrong for both; actual causes below. Verified: targeted `-race -count=20` green; both flakes reproduced before the fix (deterministic repro for #1; 2/20 failures for #2) and gone after.
+  - `TestGetAcoustIDStats_Mixed` — **NOT** store/cache isolation. `GetAcoustIDStats` read book *files* pebble-direct but grouped them by library via `GetAllBooks`, which reads the **async-warmed memdb**. memdb write-through is a no-op until the warmup goroutine publishes (`memSync` returns early while `mem()==nil`), so under load the warmup published an empty/stale memdb → `GetAllBooks` returned no books → files collapsed into the `(unknown)` bucket → `LibraryRoot` assertion failed. Fix: added `getAllBooksPebbleScan()` and switched `GetAcoustIDStats` to read books pebble-direct (mirrors its existing file scan), so grouping no longer depends on warmup timing. Regression: `TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping` injects an empty memdb post-write — fails pre-fix, deterministic post-fix.
+  - `TestHNSW_RecallVsChromem` — **NOT** dataset seeding (data already fixed-seed). `hnsw.NewGraph()` seeds its level RNG from `time.Now().UnixNano()` → graph topology + recall varied ~0.75–0.92, dipping below the 0.80 gate. Fix: unexported `HNSWEmbeddingStore.newGraphRng` seam (nil in prod), test pins seed 1 → tight band (floor 0.868 / 50 runs) clearing 0.80 with margin. Not bit-deterministic (coder/hnsw v0.6.1 iterates Go maps in neighbor pruning) but dominant variance source removed; 0.80 gate kept so a real recall regression is still caught.
+  - **Latent follow-up (not blocking):** the async-warmup write-through drop (`memSync` no-op while `mem()==nil`) is a general hazard for any "create then immediately read via memdb" test. Only `GetAcoustIDStats` was hardened. If other tests surface the same flake, add a `WaitForWarmup()` helper to `setupPebbleTestDB`.
 
 - [x] **MEMLEAK-2026-06-14** [memory-leak] 4 potential memory leak(s) detected by scheduled scan — https://github.com/falkcorp/audiobook-organizer/actions/runs/27492872026. **Fixed by commit `4f68ef9f`** — all 4 timers tracked in `refreshTimeoutsRef`/`scrollTimeoutsRef` with unmount cleanup; `scripts/check-memory-leaks.py` reports clean. Issue #1449 closed 2026-06-17.
   - `src/components/dedup/UnifiedDedupTab.tsx:511` — Untracked setTimeout (may fire after unmount)

--- a/internal/database/hnsw_embedding_store.go
+++ b/internal/database/hnsw_embedding_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-06-15
+// last-edited: 2026-06-17
 
 // HNSW-graph vector store (coder/hnsw) — a sub-linear ANN index alternative to
 // the brute-force chromem store. Selected via config.VectorIndexBackend="hnsw".
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -80,6 +81,14 @@ type HNSWEmbeddingStore struct {
 	graphs map[string]*hnsw.Graph[string]          // entityType → graph
 	meta   map[string]map[string]map[string]string // entityType → id → metadata
 	dims   int
+
+	// newGraphRng, when non-nil, supplies the *rand.Rand used for HNSW level
+	// generation on each lazily-created graph. Production leaves it nil, so the
+	// library's default time-seeded RNG (rand.NewSource(time.Now().UnixNano()))
+	// is used. Tests set it to a fixed seed to make graph topology — and thus
+	// recall — deterministic. Mutated graphs are only built under s.mu, so a
+	// shared *rand.Rand returned here is never used concurrently.
+	newGraphRng func() *rand.Rand
 }
 
 // NewHNSWEmbeddingStore creates an empty HNSW store sized for `dims`-dimensional
@@ -102,6 +111,9 @@ func (s *HNSWEmbeddingStore) graphFor(entityType string) *hnsw.Graph[string] {
 		g.Distance = hnsw.CosineDistance
 		g.M = hnswM
 		g.EfSearch = hnswEfSearch
+		if s.newGraphRng != nil {
+			g.Rng = s.newGraphRng()
+		}
 		s.graphs[entityType] = g
 		s.meta[entityType] = make(map[string]map[string]string)
 	}

--- a/internal/database/hnsw_embedding_store_test.go
+++ b/internal/database/hnsw_embedding_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-06-14
+// last-edited: 2026-06-17
 
 package database
 
@@ -270,6 +270,17 @@ func TestHNSW_RecallVsChromem(t *testing.T) {
 	)
 	rng := rand.New(rand.NewSource(7))
 	h := NewHNSWEmbeddingStore(dim)
+	// Pin the HNSW level-generation RNG. Without this the library seeds from
+	// time.Now().UnixNano() (coder/hnsw graph.go defaultRand), which was the
+	// dominant source of run-to-run recall variance: unseeded the recall spanned
+	// ~0.75–0.92 and intermittently dipped below the 0.80 gate under CI load
+	// (FLAKY-DB-TESTS-2026-06-17). Seeding does NOT make recall bit-deterministic —
+	// coder/hnsw v0.6.1 iterates Go maps during neighbor pruning (graph.go), and
+	// map order is randomized per run — but it collapses the spread to a tight
+	// band (~0.87–0.96 over 50 runs, floor 0.868) that clears the 0.80 assertion
+	// below with ample margin. Keep the gate at the product-meaningful 0.80 so a
+	// real recall regression from an M/EfSearch change is still caught.
+	h.newGraphRng = func() *rand.Rand { return rand.New(rand.NewSource(1)) }
 	c := NewInMemoryChromemStore(dim)
 
 	centroids := make([][]float32, clusters)

--- a/internal/database/pebble_acoustid_stats_test.go
+++ b/internal/database/pebble_acoustid_stats_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_acoustid_stats_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1234-efab-234567890123
-// last-edited: 2026-06-10
+// last-edited: 2026-06-17
 
 package database
 
@@ -57,6 +57,56 @@ func TestGetAcoustIDStats_Mixed(t *testing.T) {
 	assert.Equal(t, 2, stats.TotalFiles)
 	assert.Equal(t, 1, stats.WithFingerprint, "only one file has a fingerprint")
 	assert.Len(t, stats.ByLibrary, 1, "both files belong to same library root")
+	assert.Equal(t, "/lib/audiobooks", stats.ByLibrary[0].LibraryRoot)
+	assert.Equal(t, 2, stats.ByLibrary[0].TotalFiles)
+	assert.Equal(t, 1, stats.ByLibrary[0].WithFingerprint)
+}
+
+// TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping is the deterministic
+// regression for FLAKY-DB-TESTS-2026-06-17. The flake's root cause: GetAcoustIDStats
+// scanned files pebble-direct (correct) but grouped them by library using GetAllBooks,
+// which reads memdb when published. NewPebbleStore publishes memdb asynchronously, and
+// memdb write-through is a no-op until that happens — so under CI -race load the warmup
+// could publish an empty/stale memdb, leaving GetAllBooks blind to books that exist in
+// pebble. Files then collapsed into the "(unknown)" library bucket and the LibraryRoot
+// assertion failed intermittently.
+//
+// This test forces the exact bad state deterministically: it drains the warmup, then
+// overwrites memPtr with a fresh EMPTY MemStore *after* the books are written. With the
+// pre-fix code (book grouping via memdb) ByLibrary collapses to "(unknown)"; with the
+// fix (book grouping pebble-direct) the grouping is correct regardless of memdb state.
+func TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	importPath := "/lib/audiobooks"
+	src := "audible"
+	asin1, asin2 := "B001", "B002"
+	books := []Book{
+		{Title: "Book With Files", MetadataSource: &src, ASIN: &asin1, SourceImportPath: &importPath},
+		{Title: "Book No FP", MetadataSource: &src, ASIN: &asin2, SourceImportPath: &importPath},
+	}
+	for i := range books {
+		created, err := store.CreateBook(&books[i])
+		require.NoError(t, err)
+		books[i].ID = created.ID
+	}
+	require.NoError(t, store.CreateBookFile(&BookFile{BookID: books[0].ID, FilePath: "/lib/audiobooks/book1.m4b", AcoustIDFingerprint: []byte{1, 2, 3, 4}}))
+	require.NoError(t, store.CreateBookFile(&BookFile{BookID: books[1].ID, FilePath: "/lib/audiobooks/book2.m4b"}))
+
+	// Wait for the async warmup to finish so it cannot overwrite the empty memdb we
+	// are about to inject, then publish a fresh empty memdb to simulate the warmup
+	// race window (memdb published with a pre-write snapshot).
+	<-ps.warmupDone
+	emptyMem, err := NewMemStore()
+	require.NoError(t, err)
+	ps.memPtr.Store(emptyMem)
+
+	stats, err := ps.GetAcoustIDStats()
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.TotalFiles)
+	require.Len(t, stats.ByLibrary, 1, "files must group by their book's import path, not collapse to (unknown)")
 	assert.Equal(t, "/lib/audiobooks", stats.ByLibrary[0].LibraryRoot)
 	assert.Equal(t, 2, stats.ByLibrary[0].TotalFiles)
 	assert.Equal(t, 1, stats.ByLibrary[0].WithFingerprint)

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.88.0
+// version: 1.89.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-14
+// last-edited: 2026-06-17
 
 package database
 
@@ -9413,6 +9413,38 @@ func (s *PebbleStore) getAllBookFilesPebbleScan() ([]BookFile, error) {
 	return files, nil
 }
 
+// getAllBooksPebbleScan returns every non-deleted Book by scanning Pebble directly,
+// bypassing memdb. Mirrors the Pebble branch of GetAllBooks (skips ":path:" index
+// keys and MarkedForDeletion rows). Used by callers — like GetAcoustIDStats — that
+// must not depend on the async memdb warmup having published.
+func (s *PebbleStore) getAllBooksPebbleScan() ([]Book, error) {
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var books []Book
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip path index keys (book:path:...).
+		if strings.Contains(string(iter.Key()), ":path:") {
+			continue
+		}
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			return nil, err
+		}
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+		books = append(books, book)
+	}
+	return books, nil
+}
+
 // GetBookFilesNeedingDelugeImport returns book_files that have a non-empty
 // deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
 //
@@ -10551,7 +10583,15 @@ func (p *PebbleStore) GetAcoustIDStats() (*AcoustIDStats, error) {
 	}
 
 	// Build bookID → source_import_path for library grouping.
-	allBooks, _ := p.GetAllBooks(0, 0)
+	//
+	// Read books pebble-direct (not via GetAllBooks) for the same reason the file
+	// scan above is pebble-direct: this method must not depend on the async memdb
+	// warmup. While memdb is unpublished (or transiently empty during the warmup
+	// window), GetAllBooks would return no books and every file would collapse into
+	// the "(unknown)" library bucket. Reading pebble directly keeps the grouping
+	// consistent with the authoritative store regardless of memdb state.
+	// (FLAKY-DB-TESTS-2026-06-17 root cause.)
+	allBooks, _ := p.getAllBooksPebbleScan()
 	bookLib := make(map[string]string, len(allBooks))
 	for _, b := range allBooks {
 		if b.SourceImportPath != nil && *b.SourceImportPath != "" {


### PR DESCRIPTION
## Summary

Two `internal/database` tests passed in isolation but flaked under the full
`Minimal CI / Go Tests (short, race)` run, repeatedly blocking unrelated PRs. Both are
now **fixed at the source** (not quarantined). The original "order-dependent state
pollution" hypothesis was wrong for both — actual root causes below.

## Why this closes the "works locally, fails remotely" concern

The fixes are **structural**, not statistical:

- **`TestGetAcoustIDStats_Mixed`** — `GetAcoustIDStats` scanned book *files* pebble-direct
  (deterministic) but grouped them by library via `GetAllBooks`, which reads the
  **async-warmed memdb**. memdb write-through is a no-op until the warmup goroutine
  publishes (`memSync` returns early while `mem()==nil`), so under load the warmup could
  publish an empty/stale memdb → `GetAllBooks` returned no books → files collapsed into
  the `(unknown)` bucket → `LibraryRoot` assertion failed. **Fix:** read books
  pebble-direct via new `getAllBooksPebbleScan()`, mirroring the file scan. The method no
  longer reads memdb at all, so the timing-dependent flake is **impossible in any
  environment** — not just unobserved locally. Also removes a transient production
  inconsistency in this stats endpoint during the startup warmup window.
  (Endpoint is admin-only `/maintenance/acoustid-stats` behind `PermSettingsManage`,
  not a hot path — the full pebble book scan is fine, and the file scan already dominated.)

- **`TestHNSW_RecallVsChromem`** — `hnsw.NewGraph()` seeds its level-generation RNG from
  `time.Now().UnixNano()`, so graph topology and recall varied run-to-run (~0.75–0.92),
  dipping below the 0.80 gate. This variance is **load-independent** (map/seed order, not
  goroutine scheduling), so the local distribution is representative of CI. **Fix:**
  unexported `HNSWEmbeddingStore.newGraphRng` seam (nil in prod → unchanged behavior); the
  test pins seed 1, collapsing the spread to a tight band (floor **0.868** over 50 runs)
  that clears 0.80 with margin. Not bit-deterministic — coder/hnsw v0.6.1 iterates Go maps
  during neighbor pruning — but the dominant variance source is removed. The 0.80 gate is
  kept so a real recall regression from an M/EfSearch change is still caught.

## Regression coverage

`TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping` forces the exact memdb race
(injects an empty memdb after the writes). **Fails pre-fix on the `LibraryRoot` assertion;
deterministic post-fix.**

## Verification

- Reproduced both pre-fix: deterministic repro for #1; 2/20 failures for #2 (recall 0.75–0.92).
- Post-fix: targeted `-race -count=20` green; full package `-short -race` green (156s).
- `go build ./...` + `go vet` clean.

## Follow-up (documented in TODO, not blocking)

The async-warmup write-through drop (`memSync` no-op while `mem()==nil`) is a general
hazard for any "create then immediately read via memdb" test. Only `GetAcoustIDStats` was
hardened; if other tests surface the same flake, add a `WaitForWarmup()` helper to
`setupPebbleTestDB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)