### PR TITLE
fix(hnsw): gate HydrateChromem on snapshot to prevent crash loop

### DIFF
--- a/internal/database/hnsw_embedding_store.go
+++ b/internal/database/hnsw_embedding_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store.go
-// version: 1.3.0
+// version: 1.5.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-06-17
+// last-edited: 2026-06-18
 
 // HNSW-graph vector store (coder/hnsw) — a sub-linear ANN index alternative to
 // the brute-force chromem store. Selected via config.VectorIndexBackend="hnsw".
@@ -140,7 +140,14 @@ func (s *HNSWEmbeddingStore) Upsert(_ context.Context, entityType, entityID stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	g := s.graphFor(entityType)
-	// Add replaces an existing node with the same key.
+	// coder/hnsw v0.6.1 Graph.Add replaces an existing key. The typical
+	// call path (HydrateChromem on a fresh store, or adding a brand-new book)
+	// only inserts new keys, so the built-in replace path is never exercised.
+	// Re-inserting existing keys has a library bug (HNSW-CRASH-2026-06-18)
+	// that is avoided structurally: NewServer loads the HNSW snapshot BEFORE
+	// PostInit so dedup.Engine.PostInit detects the populated store and skips
+	// HydrateChromem entirely. See internal/server/server.go and
+	// internal/dedup/lifecycle.go for the fix.
 	g.Add(hnsw.MakeNode(entityID, vec))
 	if meta == nil {
 		meta = map[string]string{}

--- a/internal/database/hnsw_embedding_store_test.go
+++ b/internal/database/hnsw_embedding_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-06-17
+// last-edited: 2026-06-18
 
 package database
 
@@ -330,4 +330,78 @@ func TestHNSW_RecallVsChromem(t *testing.T) {
 		t.Errorf("recall@%d vs exact = %.3f, want ≥ 0.80", k, recall)
 	}
 	t.Logf("HNSW recall@%d vs exact chromem = %.3f", k, recall)
+}
+
+// TestHNSW_SnapshotSkipsHydration is a regression test for HNSW-CRASH-2026-06-18.
+//
+// Production crash: on every restart with a saved snapshot, the service entered
+// a crash loop (restart #51). Sequence: NewServer called PostInit (which
+// launched HydrateChromem), then loaded the HNSW snapshot. HydrateChromem
+// re-inserted all ~38K existing keys into the already-populated graph, hitting a
+// bug in coder/hnsw v0.6.1: Delete+Add of an existing key can leave the graph
+// in a state where a node exists at layer L but not L-1. A subsequent Add finds
+// that node via the elevator and crashes at layer.nodes[elevator]=nil (addr=0x10
+// = Value field offset in layerNode, SIGSEGV).
+//
+// Fix: NewServer now loads the HNSW snapshot BEFORE PostInit (between Build and
+// PostInit). dedup.Engine.PostInit checks CountByType("book") > 0 and skips
+// HydrateChromem entirely. This test verifies the observable contract: after
+// Import, CountByType reports the loaded nodes so the lifecycle can detect and
+// skip hydration, and FindSimilar works correctly on the imported graph.
+func TestHNSW_SnapshotSkipsHydration(t *testing.T) {
+	const dim = 8
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(42))
+
+	// Build an initial store with enough nodes to produce a multi-layer graph.
+	s1 := NewHNSWEmbeddingStore(dim)
+	s1.newGraphRng = func() *rand.Rand { return rand.New(rand.NewSource(7)) }
+	ids := make([]string, 50)
+	vecs := make([][]float32, 50)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("book-%02d", i)
+		vecs[i] = unitVec(rng, dim)
+		if err := s1.Upsert(ctx, "book", ids[i], vecs[i], map[string]string{"k": "v"}); err != nil {
+			t.Fatalf("initial upsert %s: %v", ids[i], err)
+		}
+	}
+
+	// Export then Import — simulates the on-disk snapshot path.
+	dir := t.TempDir()
+	if err := s1.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	s2 := NewHNSWEmbeddingStore(dim)
+	s2.newGraphRng = func() *rand.Rand { return rand.New(rand.NewSource(7)) }
+	if err := s2.Import(dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// CountByType must be >0 after a successful Import so the lifecycle can
+	// detect the populated store and skip HydrateChromem.
+	n, err := s2.CountByType(ctx, "book")
+	if err != nil {
+		t.Fatalf("CountByType: %v", err)
+	}
+	if n != 50 {
+		t.Errorf("CountByType after import = %d, want 50", n)
+	}
+
+	// FindSimilar must work on the imported graph (snapshot is usable).
+	results, err := s2.FindSimilar(ctx, "book", vecs[0], 5, nil)
+	if err != nil {
+		t.Fatalf("FindSimilar after import: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("FindSimilar returned 0 results after import")
+	}
+
+	// New keys (not in snapshot) must still be insertable without crashing.
+	newVec := unitVec(rng, dim)
+	if err := s2.Upsert(ctx, "book", "new-book-99", newVec, nil); err != nil {
+		t.Fatalf("upsert new key after import: %v", err)
+	}
+	if got, _ := s2.CountByType(ctx, "book"); got != 51 {
+		t.Errorf("CountByType after new insert = %d, want 51", got)
+	}
 }

--- a/internal/dedup/lifecycle.go
+++ b/internal/dedup/lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/lifecycle.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3e4f5a6b-7c8d-9e0f-a1b2-c3d4e5f60718
-// last-edited: 2026-06-14
+// last-edited: 2026-06-18
 
 // Lifecycle methods on *dedup.Engine that the serviceregistry container
 // picks up via interface satisfaction. PostInit subscribes to lifecycle
@@ -112,12 +112,23 @@ func (de *Engine) PostInit(ctx context.Context, c *serviceregistry.Container) er
 	if chromemStore, ok := serviceregistry.TryGet[database.VectorANNStore](c, "chromemstore"); ok && chromemStore != nil {
 		de.SetChromemStore(chromemStore)
 		slog.Info("[INFO] vector ANN store active for dedup Layer 2")
+		// Check if the store is already populated (HNSW snapshot loaded before
+		// PostInit in NewServer — HNSW-CRASH-2026-06-18). Re-inserting existing
+		// keys into coder/hnsw v0.6.1 corrupts per-layer invariants and panics.
+		alreadyPopulated := false
+		if n, err := chromemStore.CountByType(ctx, "book"); err == nil && n > 0 {
+			alreadyPopulated = true
+			slog.Info("[dedup] vector ANN store already populated from snapshot, skipping hydration", "books", n)
+		}
+
 		if dedupChromemLazy() {
 			// Skip the eager hydrate. Chromem stays empty; FindSimilar in
 			// engine.go falls back to the SQLite linear-scan path via
 			// EmbeddingStore.FindSimilar (slower per-query but no upfront
 			// ~6GB heap from mirroring 42K book vectors into memory).
 			slog.Info("chromem hydrate skipped (DEDUP_CHROMEM_LAZY=true) — dedup FindSimilar will use SQLite linear-scan fallback")
+		} else if alreadyPopulated {
+			// Snapshot was loaded — nothing to hydrate.
 		} else {
 			// Hydrate asynchronously on the engine's bg-context.
 			// Add(1) under bgMu BEFORE launching so Stop can't race the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.30.0
+// version: 2.31.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-06-16
+// last-edited: 2026-06-18
 
 package server
 
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"log"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -418,6 +419,28 @@ func NewServer(store database.Store) *Server {
 		slog.Error("serviceregistry build", "err", err)
 		os.Exit(1)
 	}
+
+	// Load the HNSW snapshot BEFORE PostInit so dedup.Engine.PostInit can detect
+	// the populated store and skip HydrateChromem. Loading after PostInit caused a
+	// crash loop: HydrateChromem re-inserted all ~38K existing keys into the
+	// already-populated graph, triggering a nil-deref in coder/hnsw v0.6.1 when
+	// Delete+Add violates the per-layer node invariant (HNSW-CRASH-2026-06-18).
+	if config.AppConfig.DatabasePath != "" {
+		hnswDir := filepath.Join(filepath.Dir(config.AppConfig.DatabasePath), "hnsw")
+		server.hnswPersistDir = hnswDir
+		if raw, ok := serviceregistry.TryGet[database.VectorANNStore](regContainer, "chromemstore"); ok && raw != nil {
+			if hnswStore, ok := raw.(*database.HNSWEmbeddingStore); ok {
+				if err := hnswStore.Import(hnswDir); err != nil {
+					if !errors.Is(err, database.ErrNoHNSWSnapshot) {
+						slog.Warn("hnsw: import failed, will hydrate from PebbleDB", "err", err)
+					}
+				} else {
+					slog.Info("hnsw: loaded from on-disk snapshot", "dir", hnswDir)
+				}
+			}
+		}
+	}
+
 	if err := regContainer.PostInit(regCtx); err != nil {
 		slog.Error("serviceregistry postinit", "err", err)
 		os.Exit(1)

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,14 +1,13 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.34.0
+// version: 1.35.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-06-15
+// last-edited: 2026-06-18
 
 package server
 
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -257,27 +256,9 @@ func (s *Server) Start(cfg ServerConfig) error {
 		}
 	}
 
-	// Load HNSW snapshot from disk (skips PebbleDB hydration walk when available).
-	// NOTE: the chromem hydration goroutine is already running (launched in
-	// dedup.Engine.PostInit inside NewServer). If Import succeeds it pre-populates
-	// the graph; the concurrent hydration Upserts are serialized by the store's
-	// mutex and result in duplicate-but-correct inserts. A future task should gate
-	// hydration on snapshot availability to avoid the double-work.
-	if s.hnswPersistDir != "" {
-		if raw, ok := serviceregistry.TryGet[database.VectorANNStore](s.container, "chromemstore"); ok && raw != nil {
-			if hnswStore, ok := raw.(*database.HNSWEmbeddingStore); ok {
-				if err := hnswStore.Import(s.hnswPersistDir); err != nil {
-					if !errors.Is(err, database.ErrNoHNSWSnapshot) {
-						slog.Warn("hnsw: import failed, falling back to hydration", "err", err)
-					} else {
-						slog.Info("hnsw: no snapshot found, will hydrate from PebbleDB")
-					}
-				} else {
-					slog.Info("hnsw: loaded from on-disk snapshot", "dir", s.hnswPersistDir)
-				}
-			}
-		}
-	}
+	// HNSW snapshot is now loaded earlier, in NewServer (between Build and PostInit),
+	// so that dedup.Engine.PostInit can detect the populated store and skip the
+	// redundant HydrateChromem walk. Nothing to do here. (HNSW-CRASH-2026-06-18)
 
 	// Pre-warm facets cache (genres/languages) - lightweight, <1 second
 	go s.warmFacetsCache()


### PR DESCRIPTION
## Summary

Production crash loop (restart #51): nil pointer dereference in `coder/hnsw v0.6.1` during HNSW graph hydration at startup.

**Root cause**: `NewServer` called `PostInit` (which launched `HydrateChromem` goroutine) **before** loading the HNSW snapshot. `HydrateChromem` then re-inserted all ~38K existing keys into the already-populated graph. `coder/hnsw v0.6.1` has a bug where `Delete+Add` of an existing key can leave a node present at layer L but absent from layer L-1; a subsequent `Add` finds it via the elevator pointer and dereferences nil (`SIGSEGV addr=0x10` = `layerNode.Value` field offset).

**Fix (4 coordinated changes)**:
- **`server.go`**: load HNSW snapshot **between `Build()` and `PostInit()`**, so the store is populated before `dedup.Engine.PostInit` runs
- **`dedup/lifecycle.go`**: check `CountByType("book") > 0` before launching `HydrateChromem`; skip entirely if snapshot was loaded
- **`server_lifecycle.go`**: remove the now-redundant `Import` call from `Run()`
- **`hnsw_embedding_store.go`**: revert incorrect pre-delete workaround (introduced a different layer-invariant crash); add explanatory comment

## Test plan

- [x] `TestHNSW_SnapshotSkipsHydration` — new regression test verifying: after Import, `CountByType > 0` (lifecycle skips hydration) and `FindSimilar` works on imported graph
- [x] All 13 HNSW tests pass: `go test ./internal/database/ -run TestHNSW`
- [x] Full project builds clean: `go build ./...`
- [ ] Deploy to production and confirm restart counter stops incrementing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oxrQ7in6Ep86zic3L4Mbs