### PR TITLE
feat(dedup): capture human merge/dismiss as gold labels (feedback loop Slice A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,31 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.34.0 -->
+<!-- version: 3.35.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-18 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Features
+
+#### June 18, 2026 — Dedup feedback loop, Slice A: capture human merge/dismiss as gold labels
+
+First slice of the self-improving dedup feedback loop. When a user **merges** or
+**dismisses** a dedup candidate, the decision is now captured as a gold ground-truth
+`LabeledExample` (`label_source="human"`) in the existing `dedup:label:` keyspace —
+`true_dup` on merge, `not_dup` on dismiss. These are the human labels the planned
+dedup classifier will train and validate on.
+
+- Reuses `dataset.BuildExample` for the feature snapshot, so live captures are
+  identical to the `dedup.dataset-backfill` op's.
+- **Best-effort:** any capture failure is logged and swallowed — it can never block or
+  fail the user's merge/dismiss action.
+- **Merge timing:** the feature snapshot is taken *before* the merge runs, because a
+  merge absorbs/deletes one side (after which the book can't be loaded).
+- Hooked into single merge, single dismiss, bulk merge, and cluster dismiss. Cluster-
+  merge and series-merge capture are a tracked follow-up (need pre-merge snapshot
+  reordering); C5 live-capture-on-upsert and the gold miner are subsequent slices.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,35 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.33.0 -->
+<!-- version: 3.34.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-17 -->
+<!-- last-edited: 2026-06-18 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Bug Fixes
+
+#### June 18, 2026 — HNSW-CRASH-2026-06-18: fix crash loop on restart (PR #1500)
+
+Production was crash-looping (restart counter #51) with a nil-pointer dereference
+in `coder/hnsw v0.6.1` during startup. Root cause: initialization ordering — the
+server called `PostInit` (launching `HydrateChromem`) **before** loading the HNSW
+snapshot. `HydrateChromem` then re-inserted all 38,987 existing keys into the
+already-populated graph, triggering a library bug where `Delete+Add` of an existing
+key leaves the graph in an inconsistent state (node present at layer L, absent from
+layer L-1), causing a SIGSEGV on the next insertion (addr=0x10 = `layerNode.Value`
+field offset).
+
+Fix: `NewServer` now loads the HNSW snapshot between `Build()` and `PostInit()`.
+`dedup.Engine.PostInit` checks `CountByType("book") > 0` and skips `HydrateChromem`
+entirely when the snapshot is already loaded. Confirmed stable in production with
+38,987 books indexed from snapshot on first restart.
+
+- `internal/server/server.go`: load HNSW snapshot between `Build()` and `PostInit()`
+- `internal/dedup/lifecycle.go`: gate HydrateChromem on `CountByType("book") == 0`
+- `internal/server/server_lifecycle.go`: remove now-redundant `Import` call from `Run()`
+- `internal/database/hnsw_embedding_store.go`: revert incorrect pre-delete workaround; document the library bug
+- Regression test: `TestHNSW_SnapshotSkipsHydration`
 
 ### Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.95.0 -->
+<!-- version: 8.96.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-18 -->
 
@@ -262,6 +262,12 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   `unrelated`, `same_dir`, `a_ancestor_of_b`, `b_ancestor_of_a`. The `sibling_parts`
   value (same parent, different child dirs matching a series pattern) is planned but not
   yet implemented.
+- [x] **C-human / Slice A** Human label capture: merging or dismissing a dedup candidate now
+  writes a gold `LabeledExample` (`label_source="human"`, `true_dup`/`not_dup`) via
+  `internal/server/handlers/dedup/label_capture.go`. Best-effort (never blocks the action);
+  merge snapshots features pre-merge. Hooked: single merge, single dismiss, bulk merge,
+  cluster dismiss. **Follow-up (deferred):** cluster-merge + series-merge capture (need
+  pre-merge snapshot reordering); `RemoveFromDedupCluster` → not_dup capture.
 - [ ] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path
   so each new candidate automatically gets a feature snapshot + deterministic label on
   creation (no separate backfill needed going forward).

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.94.0 -->
+<!-- version: 8.95.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-17 -->
+<!-- last-edited: 2026-06-18 -->
 
 # Project TODO
 
@@ -19,12 +19,12 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — June 16, 2026
+## 🎯 Current Status — June 18, 2026
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
-**Production:** PebbleDB primary; Linux, HTTPS at prod server
-**Latest activity:** Repo hygiene + red-CI fix (2026-06-17): pruned 51 stale worktrees (55→4) and ~97 merged branches (106→4); fixed the long-red `Frontend Unit Tests` CI job (stale `UnifiedDedupTab` assertions); bumped the full `-race` test timeout (root-caused an `internal/server` timeout). Prior: CFG-1 Waves 1–8 complete (PRs #1468–#1484) — all 77 flat config fields nested into 7 sub-structs; `GetConfig` secret-masking bug fixed; WebUI config API documented at `docs/reference/config-api-shape.md`.
-**In flight:** Burndown bot dispatching test coverage tasks (#79–#109), FE-10 (Vitest coverage thresholds). EMB-UI-1 (Ollama download link) still open.
+**Production:** PebbleDB primary; Linux, HTTPS at prod server; stable (crash loop resolved 2026-06-18)
+**Latest activity:** HNSW-CRASH-2026-06-18 (2026-06-18, PR #1500): fixed production crash loop (restart #51) — HNSW snapshot now loaded before PostInit, HydrateChromem gated on CountByType>0; 38,987 books indexed from snapshot on first restart. Prior: SEC-AUDIT-12 closed (log+path injection guards, 87 CodeQL alerts resolved, PRs #1490–#1494); flaky DB tests fixed PR #1497.
+**In flight:** CFG-2 (Settings UI reorg — frontend "second half") not started. Burndown bot dispatching test coverage tasks. EMB-UI-1 (Ollama download link) still open.
 
 ---
 

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -991,6 +991,8 @@ func (h *Handler) BulkMergeDedupCandidates(c *gin.Context) {
 	merged := 0
 
 	for _, cand := range candidates {
+		// Snapshot features before the merge absorbs one side (best-effort).
+		labelExample := h.snapshotCandidateExample(&cand)
 		_, mergeErr := h.mergeService.MergeBooks([]string{cand.EntityAID, cand.EntityBID}, "")
 		if mergeErr != nil {
 			failures = append(failures, failure{CandidateID: cand.ID, Reason: mergeErr.Error()})
@@ -1004,6 +1006,8 @@ func (h *Handler) BulkMergeDedupCandidates(c *gin.Context) {
 			slog.Info("dedup bulk merge candidate merged but status update failed", "cand", cand.ID, "err", err)
 		}
 		merged++
+		// Capture the user's bulk merge as a gold true_dup label (best-effort).
+		h.recordHumanLabel(labelExample, labelTrueDup, labelReasonUserMerge)
 	}
 
 	slog.Info("dedup bulk merge complete merged, failed out of matched", "merged", merged, "failures_count", len(failures), "total", total)
@@ -1162,6 +1166,8 @@ func (h *Handler) DismissDedupCluster(c *gin.Context) {
 			continue
 		}
 		dismissed++
+		// Capture each dismissed pair as a gold not_dup label (best-effort).
+		h.recordHumanLabel(h.snapshotCandidateExample(&cand), labelNotDup, labelReasonUserDismiss)
 	}
 	slog.Info("dedup cluster dismiss dismissed candidate row(s) across books", "dismissed", dismissed, "count", len(body.BookIDs))
 	h.markDuplicatesFlaggedDirty("dismiss_cluster")
@@ -1337,6 +1343,10 @@ func (h *Handler) MergeDedupCandidate(c *gin.Context) {
 		return
 	}
 
+	// Snapshot the feature example BEFORE the merge: MergeBooks absorbs/deletes one
+	// side, after which the snapshot can no longer load that book. Best-effort.
+	labelExample := h.snapshotCandidateExample(candidate)
+
 	var result interface{}
 	if candidate.EntityType == "book" && h.mergeService != nil {
 		mergeResult, mergeErr := h.mergeService.MergeBooks([]string{candidate.EntityAID, candidate.EntityBID}, keepID)
@@ -1405,6 +1415,9 @@ func (h *Handler) MergeDedupCandidate(c *gin.Context) {
 		"candidate_id": id,
 	}))
 
+	// Capture the user's merge as a gold true_dup label (best-effort).
+	h.recordHumanLabel(labelExample, labelTrueDup, labelReasonUserMerge)
+
 	httputil.RespondWithOK(c, gin.H{"status": "merged", "result": result, "keep_id": keepID})
 }
 
@@ -1428,6 +1441,9 @@ func (h *Handler) DismissDedupCandidate(c *gin.Context) {
 		return
 	}
 	h.markDuplicatesFlaggedDirty("dismiss_candidate")
+
+	// Capture the user's dismiss as a gold not_dup label (best-effort).
+	h.captureHumanLabelByID(id, labelNotDup, labelReasonUserDismiss)
 
 	httputil.RespondWithOK(c, gin.H{"status": "dismissed"})
 }

--- a/internal/server/handlers/dedup/handler_test.go
+++ b/internal/server/handlers/dedup/handler_test.go
@@ -363,6 +363,7 @@ func TestMergeDedupCandidateSeries_NoMergeSvc(t *testing.T) {
 
 func TestBulkMergeDedupCandidates(t *testing.T) {
 	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
 	insertCandidate(t, d.es, "book-a", "book-b")
 	d.merge.EXPECT().MergeBooks(mock.Anything, mock.Anything).Return(&merge.Result{PrimaryID: "book-a"}, nil).Once()
 	w := doReq(t, h.BulkMergeDedupCandidates, http.MethodPost, "/api/v1/dedup/candidates/bulk-merge", map[string]any{}, nil)
@@ -408,6 +409,7 @@ func TestMergeDedupCluster_TooFew(t *testing.T) {
 
 func TestDismissDedupCluster(t *testing.T) {
 	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
 	insertCandidate(t, d.es, "id1", "id2")
 	w := doReq(t, h.DismissDedupCluster, http.MethodPost, "/api/v1/dedup/candidates/dismiss-cluster",
 		map[string][]string{"book_ids": {"id1", "id2"}}, nil)
@@ -463,6 +465,7 @@ func TestMergeDedupCandidate_KeepIDInvalid(t *testing.T) {
 
 func TestMergeDedupCandidate_MergeSuccess(t *testing.T) {
 	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
 	id, aID, bID := insertCandidate(t, d.es, "book-aaa", "book-bbb")
 	d.merge.EXPECT().MergeBooks([]string{aID, bID}, "").Return(&merge.Result{PrimaryID: aID}, nil).Once()
 	d.engine.EXPECT().CleanupCandidatesAfterMerge(mock.Anything).Return(0).Once()
@@ -484,6 +487,7 @@ func TestMergeDedupCandidate_KeepIDEcho(t *testing.T) {
 	for _, side := range []string{"A", "B"} {
 		t.Run(side, func(t *testing.T) {
 			h, d := newHandler(t)
+			allowLabelCaptureReads(d)
 			id, aID, bID := insertCandidate(t, d.es, "book-aaa", "book-bbb")
 			keep := aID
 			if side == "B" {
@@ -515,6 +519,7 @@ func TestMergeDedupCandidate_KeepIDEcho(t *testing.T) {
 
 func TestMergeDedupCandidate_AlreadyMergedConflict(t *testing.T) {
 	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
 	id, aID, bID := insertCandidate(t, d.es, "book-aaa", "book-bbb")
 	d.merge.EXPECT().MergeBooks([]string{aID, bID}, "").
 		Return(nil, errNotFound{}).Once()
@@ -532,6 +537,7 @@ func (errNotFound) Error() string { return "book book-aaa not found" }
 
 func TestDismissDedupCandidate(t *testing.T) {
 	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
 	id, _, _ := insertCandidate(t, d.es, "book-aaa", "book-bbb")
 	w := doReq(t, h.DismissDedupCandidate, http.MethodPost,
 		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/dismiss", nil,

--- a/internal/server/handlers/dedup/label_capture.go
+++ b/internal/server/handlers/dedup/label_capture.go
@@ -1,0 +1,107 @@
+// file: internal/server/handlers/dedup/label_capture.go
+// version: 1.0.0
+// guid: 7c1d9e42-3a8b-4f60-9c21-5e0a7b2d6f48
+// last-edited: 2026-06-18
+
+package deduphandler
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+)
+
+// Human-decision dedup labels. When a user merges or dismisses a candidate we
+// capture the decision as a gold ground-truth LabeledExample (label_source =
+// labelSourceHuman). These are the labels the dedup tuning classifier trains and
+// validates on — see [[project-dedup-tuning]]. Capture is always best-effort: a
+// failure is logged and swallowed so it can never block the user's action.
+const (
+	labelTrueDup = "true_dup"
+	labelNotDup  = "not_dup"
+
+	labelSourceHuman = "human"
+
+	labelReasonUserMerge   = "user_merge"
+	labelReasonUserDismiss = "user_dismiss"
+)
+
+// builderStoreAdapter bridges the handler's DedupStore (GetBookByID) onto
+// dataset.BuilderStore (GetBook), which the feature builder expects. Mirrors the
+// builderAdapter in the dedup.dataset-backfill op so the feature snapshot is
+// computed identically here and in the backfill.
+type builderStoreAdapter struct{ s DedupStore }
+
+func (b builderStoreAdapter) GetBook(id string) (*database.Book, error) { return b.s.GetBookByID(id) }
+func (b builderStoreAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
+	return b.s.GetBookFiles(id)
+}
+
+// snapshotCandidateExample builds the feature snapshot for a candidate pair.
+//
+// For a MERGE it MUST be called BEFORE the merge executes: a merge absorbs and
+// deletes one side, after which BuildExample can no longer load that book and the
+// snapshot would fail. For a dismiss both books still exist, so timing is free.
+//
+// Best-effort: returns nil (after logging) on any failure so the caller's
+// merge/dismiss flow is never blocked.
+func (h *Handler) snapshotCandidateExample(cand *database.DedupCandidate) *database.LabeledExample {
+	if cand == nil {
+		return nil
+	}
+	store := h.resolveStore()
+	if store == nil {
+		slog.Warn("dedup label capture: no store; skipping snapshot", "candidate_id", cand.ID)
+		return nil
+	}
+	ex, err := dataset.BuildExample(builderStoreAdapter{store}, *cand)
+	if err != nil {
+		slog.Warn("dedup label capture: build example failed",
+			"candidate_id", cand.ID, "entity_a", cand.EntityAID, "entity_b", cand.EntityBID, "error", err)
+		return nil
+	}
+	return &ex
+}
+
+// recordHumanLabel finalizes a pre-built example with a human ground-truth label
+// and persists it to the dedup:label keyspace. Best-effort: a nil example (the
+// snapshot failed upstream) or a write error is logged and swallowed.
+func (h *Handler) recordHumanLabel(ex *database.LabeledExample, label, reason string) {
+	if ex == nil {
+		return
+	}
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		slog.Warn("dedup label capture: no embedding store; dropping label", "candidate_id", ex.CandidateID)
+		return
+	}
+	ex.Label = label
+	ex.LabelSource = labelSourceHuman
+	ex.LabelReason = reason
+	ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := es.UpsertLabeledExample(*ex); err != nil {
+		slog.Warn("dedup label capture: upsert failed", "candidate_id", ex.CandidateID, "error", err)
+		return
+	}
+	slog.Info("dedup label capture: recorded human label",
+		"candidate_id", ex.CandidateID, "label", label, "reason", reason,
+		"entity_a", ex.EntityAID, "entity_b", ex.EntityBID)
+}
+
+// captureHumanLabelByID fetches the candidate, snapshots it, and records the label
+// in one best-effort call. Use this ONLY for dismiss-style actions where both books
+// still exist; for merges, snapshot before the merge and recordHumanLabel after.
+func (h *Handler) captureHumanLabelByID(candidateID int64, label, reason string) {
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		return
+	}
+	cand, err := es.GetCandidateByID(candidateID)
+	if err != nil || cand == nil {
+		slog.Warn("dedup label capture: candidate lookup failed", "candidate_id", candidateID, "error", err)
+		return
+	}
+	h.recordHumanLabel(h.snapshotCandidateExample(cand), label, reason)
+}

--- a/internal/server/handlers/dedup/label_capture_test.go
+++ b/internal/server/handlers/dedup/label_capture_test.go
@@ -1,0 +1,110 @@
+// file: internal/server/handlers/dedup/label_capture_test.go
+// version: 1.0.0
+// guid: 9b3d1f57-4c20-4e8a-bf16-2a7e9c5d013a
+// last-edited: 2026-06-18
+
+package deduphandler_test
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/mock"
+)
+
+// allowLabelCaptureReads lets the best-effort label-capture path call the
+// DedupStore book readers any number of times (including zero) without failing
+// the strict testify mock. Returns books with one sizeable file so BuildExample
+// produces a populated example.
+func allowLabelCaptureReads(d testDeps) {
+	d.store.EXPECT().GetBookByID(mock.Anything).
+		Return(&database.Book{ID: "x", Title: "T"}, nil).Maybe()
+	d.store.EXPECT().GetBookFiles(mock.Anything).
+		Return([]database.BookFile{{FilePath: "/lib/a.m4b", FileSize: 5 << 20, Duration: 3600}}, nil).Maybe()
+}
+
+func TestDismissDedupCandidate_RecordsHumanNotDupLabel(t *testing.T) {
+	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
+	id, _, _ := insertCandidate(t, d.es, "book-aaa", "book-bbb")
+
+	w := doReq(t, h.DismissDedupCandidate, http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/dismiss", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(id)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if ex == nil {
+		t.Fatal("expected a labeled example after dismiss, got nil")
+	}
+	if ex.Label != "not_dup" || ex.LabelSource != "human" || ex.LabelReason != "user_dismiss" {
+		t.Fatalf("label=%q source=%q reason=%q; want not_dup/human/user_dismiss", ex.Label, ex.LabelSource, ex.LabelReason)
+	}
+	if ex.DecidedAt == "" {
+		t.Error("expected DecidedAt to be stamped")
+	}
+}
+
+func TestMergeDedupCandidate_RecordsHumanTrueDupLabel(t *testing.T) {
+	h, d := newHandler(t)
+	allowLabelCaptureReads(d)
+	id, aID, bID := insertCandidate(t, d.es, "book-aaa", "book-bbb")
+	d.merge.EXPECT().MergeBooks([]string{aID, bID}, "").Return(&merge.Result{PrimaryID: aID}, nil).Once()
+	d.engine.EXPECT().CleanupCandidatesAfterMerge(mock.Anything).Return(0).Once()
+
+	w := doReq(t, h.MergeDedupCandidate, http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/merge", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(id)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if ex == nil {
+		t.Fatal("expected a labeled example after merge, got nil")
+	}
+	if ex.Label != "true_dup" || ex.LabelSource != "human" || ex.LabelReason != "user_merge" {
+		t.Fatalf("label=%q source=%q reason=%q; want true_dup/human/user_merge", ex.Label, ex.LabelSource, ex.LabelReason)
+	}
+}
+
+// TestDismissDedupCandidate_LabelCaptureBestEffort proves capture failure (the
+// store cannot resolve the books) never breaks the dismiss action: the request
+// still succeeds and simply no label is written.
+func TestDismissDedupCandidate_LabelCaptureBestEffort(t *testing.T) {
+	h, d := newHandler(t)
+	d.store.EXPECT().GetBookByID(mock.Anything).Return(nil, assertErr{}).Maybe()
+	d.store.EXPECT().GetBookFiles(mock.Anything).Return(nil, assertErr{}).Maybe()
+	id, _, _ := insertCandidate(t, d.es, "book-aaa", "book-bbb")
+
+	w := doReq(t, h.DismissDedupCandidate, http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/dismiss", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 even when capture fails; body=%s", w.Code, w.Body.String())
+	}
+	// A build error means no example is written — and crucially, no panic/500.
+	ex, err := d.es.GetLabeledExample(id)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if ex != nil {
+		t.Fatalf("expected no label when capture failed, got %+v", ex)
+	}
+}
+
+type assertErr struct{}
+
+func (assertErr) Error() string { return "store unavailable" }


### PR DESCRIPTION
## Summary

First slice of the self-improving dedup feedback loop (see TODO **C-human / Slice A**). It closes the highest-leverage gap: the system now **learns from the user's own merge/dismiss decisions**.

When a user merges or dismisses a dedup candidate, the decision is captured as a **gold ground-truth `LabeledExample`** (`label_source="human"`) in the existing `dedup:label:` keyspace — `true_dup` on merge, `not_dup` on dismiss. These are the human labels the planned dedup classifier will train and (crucially) **validate** on.

## Design

- **New** `internal/server/handlers/dedup/label_capture.go` — `builderStoreAdapter` (DedupStore→`dataset.BuilderStore`), `snapshotCandidateExample`, `recordHumanLabel`, `captureHumanLabelByID`. Reuses `dataset.BuildExample`, so live captures produce the **same feature snapshot** as the `dedup.dataset-backfill` op.
- **Best-effort:** any capture failure is logged and swallowed — it can **never** block or fail the user's merge/dismiss action.
- **Merge timing (correctness):** the feature snapshot is taken **before** `MergeBooks` runs, because a merge absorbs/deletes one side, after which the book can no longer be loaded.
- **Hooked into:** single merge, single dismiss, bulk merge, cluster dismiss.

## Scope / follow-ups

- Deferred (tracked in TODO): cluster-merge + series-merge capture (need pre-merge snapshot reordering); `RemoveFromDedupCluster` → not_dup.
- Subsequent slices: C5 live-capture-on-upsert, the in-house gold miner, review/override UI + JSONL export (Slice B), and the pure-Go classifier (Slice C).

## Test plan

- `go test ./internal/server/handlers/dedup/` — green (new `label_capture_test.go` asserts `true_dup`/`not_dup` human labels written + best-effort no-op on capture failure; existing merge/dismiss tests updated with store-read expectations).
- `go build ./...`, `go vet ./internal/server/handlers/dedup/`, `gofmt` — clean.
- Post-deploy: dismiss a candidate on prod → confirm a `human`/`not_dup` label is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)