### PR TITLE
feat(dedup): in-house gold miner op (dedup.mine-gold-labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.35.0 -->
+<!-- version: 3.36.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-18 -->
 
@@ -8,6 +8,24 @@
 ## [Unreleased]
 
 ### Features
+
+#### June 18, 2026 — Dedup feedback loop: in-house gold miner (`dedup.mine-gold-labels`)
+
+New UOS op that seeds the dedup tuning dataset with **high-confidence positive labels**
+mined from in-house ground truth — the positive counterpart to `dedup.dataset-backfill`'s
+rule-based negatives and the live human merge/dismiss capture.
+
+For each pending candidate it labels `true_dup` (`label_source="auto_high_conf"`) when the
+two books share a **file hash** (identical bytes — definitive), an **AcoustID recording id**,
+or an **ASIN/ISBN** (gated on plausible audio on both sides so two metadata stubs sharing an
+id are never mislabeled). Signals fire in descending confidence order; reuses each
+candidate's own id (no synthetic rows).
+
+- Pure, unit-tested matcher `dataset.MineHighConfidenceDup` (`internal/dedup/dataset/highconf.go`).
+- **Dry-run by default**; `apply=true` is idempotent. Trigger via the generic op route
+  (`{"def_id":"dedup.mine-gold-labels","params":{"apply":true}}`).
+- These are high-precision but NOT human gold — the classifier treats them as weak/strong
+  supervision and validates only on `label_source="human"` labels.
 
 #### June 18, 2026 — Dedup feedback loop, Slice A: capture human merge/dismiss as gold labels
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 8.96.0 -->
+<!-- version: 8.97.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-18 -->
 
@@ -268,6 +268,13 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   merge snapshots features pre-merge. Hooked: single merge, single dismiss, bulk merge,
   cluster dismiss. **Follow-up (deferred):** cluster-merge + series-merge capture (need
   pre-merge snapshot reordering); `RemoveFromDedupCluster` → not_dup capture.
+- [x] **C-gold / gold miner** In-house high-confidence positive miner: op `dedup.mine-gold-labels`
+  (`internal/plugins/dedup/mine_gold_labels.go`) labels pending candidates `true_dup`
+  (`label_source="auto_high_conf"`) when the two books share a file hash, AcoustID recording id,
+  or ASIN/ISBN (audio-gated). Pure matcher `dataset.MineHighConfidenceDup`
+  (`internal/dedup/dataset/highconf.go`), 7 unit tests + 2 op e2e tests. Dry-run default;
+  reuses candidate ids (no synthetic rows). Complements `dedup.dataset-backfill` (rule negatives)
+  + human capture. **Not yet run on prod** — dry-run first via `{"def_id":"dedup.mine-gold-labels","params":{}}`.
 - [ ] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path
   so each new candidate automatically gets a feature snapshot + deterministic label on
   creation (no separate backfill needed going forward).

--- a/internal/dedup/dataset/highconf.go
+++ b/internal/dedup/dataset/highconf.go
@@ -1,0 +1,134 @@
+// file: internal/dedup/dataset/highconf.go
+// version: 1.0.0
+// guid: 3b9e1c70-8d42-4a16-9f53-7c2e6a8b1d04
+// last-edited: 2026-06-18
+
+package dataset
+
+import "github.com/falkcorp/audiobook-organizer/internal/database"
+
+// MineHighConfidenceDup detects high-precision DUPLICATE signals between two books
+// that the rule Classify() does not emit as positives. It is the positive-label
+// counterpart to Classify's negative catchers, used by the dedup.mine-gold-labels
+// op to seed the tuning dataset with auto-mined true_dup labels
+// (label_source="auto_high_conf") from in-house ground truth.
+//
+// Returns (label="true_dup", reason, fires=true) on the FIRST signal that fires,
+// in descending order of confidence; ("", "", false) if none fires.
+//
+// Signals (highest confidence first):
+//  1. shared file hash      — identical bytes; a definitive duplicate (no audio gate)
+//  2. shared AcoustID recording id — implies both sides were fingerprinted from real audio
+//  3. shared ASIN/ISBN13/ISBN10    — strong identity, gated on plausible audio on BOTH
+//     sides so two metadata-only stubs sharing an id are never mislabeled
+func MineHighConfidenceDup(a, b *database.Book, aFiles, bFiles []database.BookFile) (label, reason string, fires bool) {
+	if a == nil || b == nil {
+		return "", "", false
+	}
+	if h := sharedFileHash(a, aFiles, b, bFiles); h != "" {
+		return "true_dup", "shared file hash " + shortHash(h), true
+	}
+	if rid := sharedRecordingID(aFiles, bFiles); rid != "" {
+		return "true_dup", "shared acoustid recording " + rid, true
+	}
+	if sidePlausibleAudioRaw(aFiles) && sidePlausibleAudioRaw(bFiles) {
+		if id := sharedExternalID(a, b); id != "" {
+			return "true_dup", "shared " + id, true
+		}
+	}
+	return "", "", false
+}
+
+// sharedFileHash returns a non-empty file hash present on both books (book-level
+// FileHash or any BookFile.FileHash), or "" if there is no overlap.
+func sharedFileHash(a *database.Book, aFiles []database.BookFile, b *database.Book, bFiles []database.BookFile) string {
+	set := make(map[string]struct{})
+	if a.FileHash != nil && *a.FileHash != "" {
+		set[*a.FileHash] = struct{}{}
+	}
+	for i := range aFiles {
+		if aFiles[i].FileHash != "" {
+			set[aFiles[i].FileHash] = struct{}{}
+		}
+	}
+	if b.FileHash != nil && *b.FileHash != "" {
+		if _, ok := set[*b.FileHash]; ok {
+			return *b.FileHash
+		}
+	}
+	for i := range bFiles {
+		if h := bFiles[i].FileHash; h != "" {
+			if _, ok := set[h]; ok {
+				return h
+			}
+		}
+	}
+	return ""
+}
+
+// sharedRecordingID returns an AcoustID online recording id present on a file of
+// each book, or "" if none is shared.
+func sharedRecordingID(aFiles, bFiles []database.BookFile) string {
+	set := make(map[string]struct{})
+	for i := range aFiles {
+		if id := aFiles[i].AcoustIDOnlineRecordingID; id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	for i := range bFiles {
+		if id := bFiles[i].AcoustIDOnlineRecordingID; id != "" {
+			if _, ok := set[id]; ok {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// sharedExternalID returns a labeled (kind + value) external identifier shared by
+// both books, preferring ASIN > ISBN13 > ISBN10. Returns "" if none is shared.
+func sharedExternalID(a, b *database.Book) string {
+	if v := bothEqual(a.ASIN, b.ASIN); v != "" {
+		return "ASIN " + v
+	}
+	if v := bothEqual(a.ISBN13, b.ISBN13); v != "" {
+		return "ISBN13 " + v
+	}
+	if v := bothEqual(a.ISBN10, b.ISBN10); v != "" {
+		return "ISBN10 " + v
+	}
+	return ""
+}
+
+// bothEqual returns the shared value when both pointers are non-nil, non-empty,
+// and equal; otherwise "".
+func bothEqual(x, y *string) string {
+	if x != nil && y != nil && *x != "" && *x == *y {
+		return *x
+	}
+	return ""
+}
+
+// sidePlausibleAudioRaw reports whether a book side shows evidence of real audio:
+// any file with positive duration, or a file at/above the stub floor. Mirrors the
+// engine/rules plausible-audio signal but operates on raw BookFiles.
+func sidePlausibleAudioRaw(files []database.BookFile) bool {
+	for i := range files {
+		f := &files[i]
+		if f.AcoustIDFingerprintDurationSec > 0 || f.Duration > 0 {
+			return true
+		}
+		if f.FileSize >= minPlausibleAudioBytes {
+			return true
+		}
+	}
+	return false
+}
+
+// shortHash truncates a hash for human-readable reasons.
+func shortHash(h string) string {
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}

--- a/internal/dedup/dataset/highconf_test.go
+++ b/internal/dedup/dataset/highconf_test.go
@@ -1,0 +1,99 @@
+// file: internal/dedup/dataset/highconf_test.go
+// version: 1.0.0
+// guid: 6d2a8f31-0c54-4b29-8e17-9a3b5c7d2e60
+// last-edited: 2026-06-18
+
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func strp(s string) *string { return &s }
+
+func TestMineHighConfidenceDup_SharedFileHash(t *testing.T) {
+	a := &database.Book{Title: "A"}
+	b := &database.Book{Title: "B"}
+	aFiles := []database.BookFile{{FilePath: "/a.m4b", FileHash: "deadbeefcafe0001", FileSize: 5 << 20}}
+	bFiles := []database.BookFile{{FilePath: "/b.m4b", FileHash: "deadbeefcafe0001", FileSize: 5 << 20}}
+
+	label, reason, fires := MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if !fires || label != "true_dup" {
+		t.Fatalf("expected true_dup fire; got label=%q fires=%v", label, fires)
+	}
+	if want := "shared file hash deadbeefcafe"; reason != want {
+		t.Errorf("reason=%q want %q", reason, want)
+	}
+}
+
+func TestMineHighConfidenceDup_SharedRecordingID(t *testing.T) {
+	a := &database.Book{Title: "A"}
+	b := &database.Book{Title: "B"}
+	aFiles := []database.BookFile{{FilePath: "/a.m4b", AcoustIDOnlineRecordingID: "rec-123", FileSize: 5 << 20}}
+	bFiles := []database.BookFile{{FilePath: "/b.m4b", AcoustIDOnlineRecordingID: "rec-123", FileSize: 5 << 20}}
+
+	label, reason, fires := MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if !fires || label != "true_dup" {
+		t.Fatalf("expected true_dup; got label=%q fires=%v reason=%q", label, fires, reason)
+	}
+	if reason != "shared acoustid recording rec-123" {
+		t.Errorf("reason=%q", reason)
+	}
+}
+
+func TestMineHighConfidenceDup_SharedASIN_WithAudio(t *testing.T) {
+	a := &database.Book{Title: "A", ASIN: strp("B00ABC")}
+	b := &database.Book{Title: "B", ASIN: strp("B00ABC")}
+	// Both sides have plausible audio (positive duration).
+	aFiles := []database.BookFile{{FilePath: "/a.m4b", Duration: 3600}}
+	bFiles := []database.BookFile{{FilePath: "/b.m4b", Duration: 3600}}
+
+	label, reason, fires := MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if !fires || label != "true_dup" || reason != "shared ASIN B00ABC" {
+		t.Fatalf("expected shared ASIN true_dup; got label=%q reason=%q fires=%v", label, reason, fires)
+	}
+}
+
+func TestMineHighConfidenceDup_SharedASIN_NoAudio_DoesNotFire(t *testing.T) {
+	a := &database.Book{Title: "A", ASIN: strp("B00ABC")}
+	b := &database.Book{Title: "B", ASIN: strp("B00ABC")}
+	// Stub sides: zero duration AND sub-floor file size → not plausible audio.
+	aFiles := []database.BookFile{{FilePath: "/a.m4b", FileSize: 100}}
+	bFiles := []database.BookFile{{FilePath: "/b.m4b", FileSize: 100}}
+
+	_, _, fires := MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if fires {
+		t.Fatal("shared ASIN on two stubs must NOT fire (audio gate)")
+	}
+}
+
+func TestMineHighConfidenceDup_NoSignal(t *testing.T) {
+	a := &database.Book{Title: "A", ASIN: strp("B001")}
+	b := &database.Book{Title: "B", ASIN: strp("B002")}
+	aFiles := []database.BookFile{{FilePath: "/a.m4b", FileHash: "h1", Duration: 3600}}
+	bFiles := []database.BookFile{{FilePath: "/b.m4b", FileHash: "h2", Duration: 3600}}
+
+	if _, _, fires := MineHighConfidenceDup(a, b, aFiles, bFiles); fires {
+		t.Fatal("distinct hashes/ids must not fire")
+	}
+}
+
+func TestMineHighConfidenceDup_NilBooks(t *testing.T) {
+	if _, _, fires := MineHighConfidenceDup(nil, nil, nil, nil); fires {
+		t.Fatal("nil books must not fire")
+	}
+}
+
+// Priority: file-hash beats ASIN when both present.
+func TestMineHighConfidenceDup_HashBeatsASIN(t *testing.T) {
+	a := &database.Book{ASIN: strp("B00X")}
+	b := &database.Book{ASIN: strp("B00X")}
+	aFiles := []database.BookFile{{FileHash: "samehash00000", Duration: 60}}
+	bFiles := []database.BookFile{{FileHash: "samehash00000", Duration: 60}}
+	_, reason, fires := MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if !fires || reason[:6] != "shared" || reason != "shared file hash samehash0000" {
+		t.Fatalf("expected file-hash reason to win; got %q fires=%v", reason, fires)
+	}
+}

--- a/internal/plugins/dedup/mine_gold_labels.go
+++ b/internal/plugins/dedup/mine_gold_labels.go
@@ -1,0 +1,148 @@
+// file: internal/plugins/dedup/mine_gold_labels.go
+// version: 1.0.0
+// guid: 8f4c2a16-5d70-4e93-bc28-1a6e9d3b7c52
+// last-edited: 2026-06-18
+
+// Package dedup — op dedup.mine-gold-labels (dedup tuning dataset, positive miner).
+//
+// Iterates pending candidates and labels the high-confidence DUPLICATES that the
+// rule Classify() does not catch as positives — pairs that share a file hash, an
+// AcoustID recording id, or an ASIN/ISBN (with audio on both sides). Each firing
+// candidate gets a LabeledExample written with label_source="auto_high_conf" and
+// label="true_dup", reusing the candidate's own id (no synthetic rows).
+//
+// This complements dedup.dataset-backfill (which mines rule-based NEGATIVES) and
+// the live human-capture path (merge/dismiss → label_source="human"): together they
+// seed the tuning dataset. These auto-mined labels are high precision but NOT human
+// gold — the classifier should treat them as weak/strong supervision and validate
+// only on human labels.
+//
+// Dry-run by default: reports counts, writes nothing. apply=true is idempotent
+// (UpsertLabeledExample overwrites), so re-running is safe.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+type mineGoldLabelsParams struct {
+	// Apply, if true, writes the mined true_dup labels. Default false (dry-run).
+	Apply bool `json:"apply"`
+}
+
+func (p *Plugin) mineGoldLabelsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.mine-gold-labels",
+		Plugin:      "dedup",
+		DisplayName: "Mine high-confidence dedup labels",
+		Description: "Labels pending candidates that share a file hash, AcoustID recording id, or " +
+			"ASIN/ISBN as true_dup (label_source=auto_high_conf), seeding the tuning dataset with " +
+			"in-house positive ground truth. Dry-run by default.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.mine-gold-labels",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runMineGoldLabels,
+	}
+}
+
+func (p *Plugin) runMineGoldLabels(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	var params mineGoldLabelsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	reporter.Logger().Info("mine-gold-labels start", "apply", params.Apply)
+
+	_ = reporter.UpdateProgress(0, 2, "Loading pending candidates…")
+	cands, _, err := p.embeddingStore.ListCandidates(database.CandidateFilter{Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list candidates: %w", err)
+	}
+	reporter.Logger().Info("mine-gold-labels: candidates loaded", "count", len(cands))
+
+	adapter := builderAdapter{store: p.store}
+	var examined, mined, written, errs int
+
+	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Mining %d candidates…", len(cands)))
+	for i := range cands {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		c := cands[i]
+		examined++
+		if examined%1000 == 0 {
+			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Mined %d/%d…", examined, len(cands)))
+		}
+
+		a, aErr := adapter.GetBook(c.EntityAID)
+		b, bErr := adapter.GetBook(c.EntityBID)
+		if aErr != nil || bErr != nil || a == nil || b == nil {
+			errs++
+			continue
+		}
+		aFiles, afErr := adapter.GetBookFiles(c.EntityAID)
+		bFiles, bfErr := adapter.GetBookFiles(c.EntityBID)
+		if afErr != nil || bfErr != nil {
+			errs++
+			continue
+		}
+
+		label, reason, fires := dataset.MineHighConfidenceDup(a, b, aFiles, bFiles)
+		if !fires {
+			continue
+		}
+		mined++
+
+		if params.Apply {
+			ex, buildErr := dataset.BuildExample(adapter, c)
+			if buildErr != nil {
+				errs++
+				reporter.Logger().Warn("mine-gold-labels: build example failed", "candidate_id", c.ID, "error", buildErr)
+				continue
+			}
+			ex.Label = label
+			ex.LabelSource = "auto_high_conf"
+			ex.LabelReason = reason
+			ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+			if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
+				errs++
+				reporter.Logger().Error("mine-gold-labels: upsert error", "candidate_id", c.ID, "error", err)
+				continue
+			}
+			written++
+		}
+	}
+
+	summary := fmt.Sprintf("examined=%d mined=%d written=%d errs=%d (apply=%v)", examined, mined, written, errs, params.Apply)
+	reporter.Logger().Info("mine-gold-labels complete", "summary", summary)
+	if !params.Apply {
+		_ = reporter.UpdateProgress(2, 2, fmt.Sprintf("Dry-run — %d of %d candidates are high-confidence true_dup. Pass apply=true to write.", mined, examined))
+	} else {
+		_ = reporter.UpdateProgress(2, 2, fmt.Sprintf("Complete — wrote %d true_dup labels. %s", written, summary))
+	}
+	return nil
+}

--- a/internal/plugins/dedup/mine_gold_labels_test.go
+++ b/internal/plugins/dedup/mine_gold_labels_test.go
@@ -1,0 +1,118 @@
+// file: internal/plugins/dedup/mine_gold_labels_test.go
+// version: 1.0.0
+// guid: c5a71e38-9b20-4d64-8f12-3e6a9c7b2d05
+// last-edited: 2026-06-18
+
+// End-to-end test for the dedup.mine-gold-labels op against a real PebbleStore +
+// EmbeddingStore: a candidate whose two books share a file hash is labeled
+// true_dup/auto_high_conf on apply; a candidate with no shared signal is not.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func createBookWithHashedFile(t *testing.T, pebble *database.PebbleStore, title, fileHash string) string {
+	t.Helper()
+	b := &database.Book{Title: title, FilePath: "/audio/" + title + ".m4b"}
+	created, err := pebble.CreateBook(b)
+	if err != nil {
+		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	if err := pebble.CreateBookFile(&database.BookFile{
+		BookID:   created.ID,
+		FilePath: "/audio/" + title + ".m4b",
+		FileHash: fileHash,
+		FileSize: 5 << 20,
+		Duration: 3600,
+	}); err != nil {
+		t.Fatalf("CreateBookFile %q: %v", title, err)
+	}
+	return created.ID
+}
+
+func candidateID(t *testing.T, es *database.EmbeddingStore, aID, bID string) int64 {
+	t.Helper()
+	sim := 0.9
+	if err := es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: aID, EntityBID: bID, Layer: "embedding", Similarity: &sim, Status: "pending",
+	}); err != nil {
+		t.Fatalf("UpsertCandidate: %v", err)
+	}
+	ca, cb := aID, bID
+	if ca > cb {
+		ca, cb = cb, ca
+	}
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Status: "pending", Limit: 100})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	for _, c := range cands {
+		if c.EntityAID == ca && c.EntityBID == cb {
+			return c.ID
+		}
+	}
+	t.Fatal("candidate not found")
+	return 0
+}
+
+func TestMineGoldLabels_ApplyLabelsSharedHashTrueDup(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// Pair 1: shared file hash → high-confidence true_dup.
+	dupA := createBookWithHashedFile(t, pebble, "MobyA", "sharedhash0000ff")
+	dupB := createBookWithHashedFile(t, pebble, "MobyB", "sharedhash0000ff")
+	dupCand := candidateID(t, es, dupA, dupB)
+
+	// Pair 2: distinct hashes, no shared id → no signal.
+	nonA := createBookWithHashedFile(t, pebble, "OtherC", "hashC1111")
+	nonB := createBookWithHashedFile(t, pebble, "OtherD", "hashD2222")
+	nonCand := candidateID(t, es, nonA, nonB)
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	if err := p.runMineGoldLabels(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runMineGoldLabels: %v", err)
+	}
+
+	// The shared-hash candidate is labeled true_dup / auto_high_conf.
+	ex, err := es.GetLabeledExample(dupCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(dup): %v", err)
+	}
+	if ex == nil {
+		t.Fatal("expected a label for the shared-hash candidate, got nil")
+	}
+	if ex.Label != "true_dup" || ex.LabelSource != "auto_high_conf" {
+		t.Fatalf("label=%q source=%q; want true_dup/auto_high_conf", ex.Label, ex.LabelSource)
+	}
+
+	// The no-signal candidate is NOT labeled.
+	if ex2, err := es.GetLabeledExample(nonCand); err != nil {
+		t.Fatalf("GetLabeledExample(non): %v", err)
+	} else if ex2 != nil {
+		t.Fatalf("expected no label for the no-signal candidate, got %+v", ex2)
+	}
+}
+
+func TestMineGoldLabels_DryRunWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+	a := createBookWithHashedFile(t, pebble, "MobyA", "samehashaaaa")
+	b := createBookWithHashedFile(t, pebble, "MobyB", "samehashaaaa")
+	cand := candidateID(t, es, a, b)
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	if err := p.runMineGoldLabels(context.Background(), json.RawMessage(`{}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runMineGoldLabels dry-run: %v", err)
+	}
+	if ex, err := es.GetLabeledExample(cand); err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	} else if ex != nil {
+		t.Fatal("dry-run must write nothing")
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -68,6 +68,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.embReencodeDef(),       // T021: float16+zstd re-encode op
 		p.bookfileSegDropDef(),   // T020: drop AcoustID segment fields from stored values
 		p.datasetBackfillDef(),   // C4: label + suppress residual pending candidates
+		p.mineGoldLabelsDef(),    // gold miner: auto-label high-confidence true_dup positives
 		p.checkBookDef(),         // M4: per-book dedup check via dependency scheduler
 		p.buildISBNIndexDef(),    // T022: ISBN/ASIN secondary index backfill
 		p.reembedEmbeddingsDef(), // Part B: re-embed corpus when the embedding model changes


### PR DESCRIPTION
## Summary

Adds the **in-house gold miner** for the dedup feedback loop — the positive-label counterpart to `dedup.dataset-backfill` (rule negatives) and the live human merge/dismiss capture (Slice A, PR #1501).

For each pending candidate, op `dedup.mine-gold-labels` writes a `true_dup` `LabeledExample` (`label_source="auto_high_conf"`) when the two books share, in descending confidence order:
1. a **file hash** — identical bytes, a definitive duplicate (no audio gate)
2. an **AcoustID recording id** — implies both were fingerprinted from real audio
3. an **ASIN/ISBN13/ISBN10** — gated on plausible audio on **both** sides, so two metadata-only stubs sharing an id are never mislabeled

It reuses each candidate's own id (no synthetic rows) and is **dry-run by default** (`apply=true` is idempotent).

## Why

The classifier needs positive ground truth, and `Classify()` only emits one positive (whole-book signature). This mines the *free* in-house positives (hash/recording-id/ASIN-ISBN) that are high precision. They are **not** human gold — the classifier will treat them as weak/strong supervision and validate only on `label_source="human"`.

## Files

- `internal/dedup/dataset/highconf.go` — pure `MineHighConfidenceDup` matcher.
- `internal/plugins/dedup/mine_gold_labels.go` — the UOS op.
- `internal/plugins/dedup/plugin.go` — registration.

## Test plan

- `go test ./internal/dedup/dataset/` — 7 unit tests (each signal, audio gate, priority, nils).
- `go test ./internal/plugins/dedup/` — 2 end-to-end tests over a real Pebble + EmbeddingStore (shared-hash pair labeled true_dup/auto_high_conf; no-signal pair not labeled; dry-run writes nothing).
- `go build ./...`, `go vet`, `gofmt` — clean.
- Post-deploy: dry-run on prod (`{"def_id":"dedup.mine-gold-labels","params":{}}`) to report how many pending candidates are high-confidence positives before any `apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)