### PR TITLE
fix(dedup): exact emitters skip non-primary version-group members (candidate explosion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.36.0 -->
+<!-- version: 3.37.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-18 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixes
+
+#### June 18, 2026 — Dedup exact emitters skip non-primary version-group members (candidate-explosion fix)
+
+The exact-family candidate emitters (`checkExactFileHash`, `checkExactISBN`,
+`checkExactMetadataSourceHash`, `checkExactTitle`, `checkDurationMatch`) gated candidate
+books on `MarkedForDeletion` + `hasPlausibleAudio` but **not** `IsPrimaryVersion` — so
+every non-primary copy of a book got paired with its version-group siblings and with
+other books' copies. On prod this ballooned the `exact` layer to **387,597 pending
+candidates** against only **49,573 final books** (acoustid/embedding/llm combined were
+~1.4K). The embedding layer already gated on primary; the exact layer did not.
+
+- All six exact-layer writes now route through one gated helper,
+  `Engine.upsertExactCandidate`, which skips any pair where either side is a non-primary
+  version-group member. Centralizing the gate means a future emitter cannot reintroduce
+  the balloon without passing through it.
+- Regression guard `internal/dedup/engine_primary_gate_test.go`: non-primary members
+  never leak into a candidate; one final book + N copies yields **0** candidates (was
+  O(N²)); two primaries still pair normally.
+- Books with `IsPrimaryVersion == nil` are treated as primary (unchanged behavior).
+
+Follow-up (tracked as **DEDUP-CANDIDATE-EXPLOSION-2026-06-18**): the existing 387K stale
+exact candidates still need a one-time purge/rebuild against final books, and the
+upstream cause (why ~352K extra/chapter `books` rows exist) needs investigation. Do not
+run `dedup.mine-gold-labels --apply` until the candidate set is rebuilt.
 
 ### Features
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.31.0
+// version: 1.32.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-16
+// last-edited: 2026-06-18
 
 package dedup
 
@@ -738,15 +738,7 @@ func (de *Engine) handleFileHashMatch(book, other *database.Book, authorName str
 	}
 
 	// Create candidate even if we don't auto-merge
-	sim := 1.0
-	return false, de.embedStore.UpsertCandidate(database.DedupCandidate{
-		EntityType: "book",
-		EntityAID:  book.ID,
-		EntityBID:  other.ID,
-		Layer:      "exact",
-		Similarity: &sim,
-		Status:     "pending",
-	})
+	return false, de.upsertExactCandidate(book, other, "exact", 1.0)
 }
 
 // checkExactISBN finds all other books with a matching ISBN10, ISBN13, or ASIN
@@ -811,15 +803,7 @@ func (de *Engine) checkExactISBNIndexed(book *database.Book, bookISBN10, bookISB
 		if !hasPlausibleAudio(other) {
 			continue // stub / unscanned shell on the other side
 		}
-		sim := 1.0
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
-			EntityType: "book",
-			EntityAID:  book.ID,
-			EntityBID:  other.ID,
-			Layer:      "exact",
-			Similarity: &sim,
-			Status:     "pending",
-		}); err != nil {
+		if err := de.upsertExactCandidate(book, other, "exact", 1.0); err != nil {
 			slog.Error("dedup upsert ISBN candidate error", "err", err)
 		}
 	}
@@ -859,15 +843,7 @@ func (de *Engine) checkExactISBNScan(book *database.Book, bookISBN10, bookISBN13
 				matched = true
 			}
 			if matched {
-				sim := 1.0
-				if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
-					EntityType: "book",
-					EntityAID:  book.ID,
-					EntityBID:  other.ID,
-					Layer:      "exact",
-					Similarity: &sim,
-					Status:     "pending",
-				}); err != nil {
+				if err := de.upsertExactCandidate(book, other, "exact", 1.0); err != nil {
 					slog.Error("dedup upsert ISBN candidate error", "err", err)
 				}
 			}
@@ -903,15 +879,7 @@ func (de *Engine) checkExactMetadataSourceHash(book *database.Book) error {
 		if other.ID == book.ID {
 			continue
 		}
-		sim := 0.99
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
-			EntityType: "book",
-			EntityAID:  book.ID,
-			EntityBID:  other.ID,
-			Layer:      "metadata_hash",
-			Similarity: &sim,
-			Status:     "pending",
-		}); err != nil {
+		if err := de.upsertExactCandidate(book, other, "metadata_hash", 0.99); err != nil {
 			slog.Error("dedup upsert metadata-hash candidate error (book ↔ )", "book", book.ID, "other", other.ID, "err", err)
 		}
 	}
@@ -996,15 +964,7 @@ func (de *Engine) checkExactTitle(book *database.Book, authorName string) error 
 		if titlesDifferOnlyInDigits(normTitle, otherNormTitle) {
 			continue
 		}
-		sim := 1.0
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
-			EntityType: "book",
-			EntityAID:  book.ID,
-			EntityBID:  other.ID,
-			Layer:      "exact",
-			Similarity: &sim,
-			Status:     "pending",
-		}); err != nil {
+		if err := de.upsertExactCandidate(book, other, "exact", 1.0); err != nil {
 			slog.Error("dedup upsert title candidate error", "err", err)
 		}
 	}
@@ -1124,15 +1084,7 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 		// threshold (6 vs 3 in checkExactTitle) is OK here
 		// because duration is the strong signal.
 		if pct <= durationMatchTolerance && titleDist <= durationLevenshteinMax {
-			sim := 1.0
-			if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
-				EntityType: "book",
-				EntityAID:  book.ID,
-				EntityBID:  other.ID,
-				Layer:      "exact",
-				Similarity: &sim,
-				Status:     "pending",
-			}); err != nil {
+			if err := de.upsertExactCandidate(book, other, "exact", 1.0); err != nil {
 				slog.Error("dedup duration candidate upsert error", "err", err)
 				continue
 			}
@@ -1189,6 +1141,36 @@ const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
 // exact-title / ISBN emitters from flagging "100% duplicate" when one side is a
 // 32-byte stub or an unscanned shell. A large unscanned copy (real size, zero
 // duration) still qualifies — it is a genuine duplicate, not garbage.
+// isNonPrimaryVersion reports whether b is a non-primary member of a version
+// group. Such a book is, by construction, a known duplicate of its group's
+// primary — so it must never participate in dedup candidates. Pairing non-primary
+// members (with each other or with primaries) re-discovers duplicates the version
+// grouping already resolved and balloons the candidate set into the hundreds of
+// thousands. See DEDUP-CANDIDATE-EXPLOSION-2026-06-18.
+func isNonPrimaryVersion(b *database.Book) bool {
+	return b != nil && b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion
+}
+
+// upsertExactCandidate writes one exact-family dedup candidate (layer
+// "exact"/"metadata_hash"), skipping any pair where either side is a non-primary
+// version-group member. ALL exact emitters route through here so the primary gate
+// lives in exactly one place — a future emitter cannot reintroduce the balloon
+// without going through this guard. Returns the store error so callers that
+// propagate it keep their contract.
+func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim float64) error {
+	if isNonPrimaryVersion(a) || isNonPrimaryVersion(b) {
+		return nil
+	}
+	return de.embedStore.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  a.ID,
+		EntityBID:  b.ID,
+		Layer:      layer,
+		Similarity: &sim,
+		Status:     "pending",
+	})
+}
+
 func hasPlausibleAudio(book *database.Book) bool {
 	if book == nil {
 		return false

--- a/internal/dedup/engine_primary_gate_test.go
+++ b/internal/dedup/engine_primary_gate_test.go
@@ -1,0 +1,151 @@
+// file: internal/dedup/engine_primary_gate_test.go
+// version: 1.0.0
+// guid: 2f7b4c19-6d83-4e50-9a12-7c5e0a8b3d46
+// last-edited: 2026-06-18
+
+// Regression guard for DEDUP-CANDIDATE-EXPLOSION-2026-06-18: the exact-family
+// emitters must never produce a candidate that involves a NON-primary version-group
+// member. Non-primary members are already known duplicates of their group's primary,
+// so pairing them (with siblings or primaries) re-discovers resolved duplicates and
+// balloons the candidate set (observed: 387k exact candidates against ~49k final
+// books). Every exact emitter routes through Engine.upsertExactCandidate, which gates
+// on IsPrimaryVersion — these tests lock that invariant in place.
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// wireExactTitleOnly configures the mock so only the exact-title emitter can fire
+// (no file hash, ISBN, metadata-source-hash, or full-scan path) — isolating the
+// primary gate. books are returned by author for checkExactTitle.
+func wireExactTitleOnly(mock *database.MockStore, books map[string]*database.Book, byAuthor []database.Book) {
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
+		return &database.Author{ID: 1, Name: "Test Author"}, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return nil, nil }
+	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) { return nil, nil }
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) { return nil, nil }
+	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) { return byAuthor, nil }
+	mock.GetBooksByMetadataSourceHashFunc = func(h string) ([]database.Book, error) { return nil, nil }
+}
+
+func primaryBook(id, title string) *database.Book {
+	authorID, dur, primary := 1, 3600, true
+	return &database.Book{ID: id, Title: title, AuthorID: &authorID, Duration: &dur, IsPrimaryVersion: &primary}
+}
+
+func nonPrimaryBook(id, title string) *database.Book {
+	b := primaryBook(id, title)
+	np := false
+	b.IsPrimaryVersion = &np
+	return b
+}
+
+func pendingCandidates(t *testing.T, es *database.EmbeddingStore) []database.DedupCandidate {
+	t.Helper()
+	cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending"})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	return cands
+}
+
+// TestExactEmitters_SkipNonPrimaryVersions: A(primary), B(non-primary), C(primary),
+// all same title/author. Running CheckBook over each must pair the two PRIMARIES
+// (A↔C) but never involve the non-primary B.
+func TestExactEmitters_SkipNonPrimaryVersions(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+
+	a := primaryBook("BOOK_A", "Moby Dick")
+	b := nonPrimaryBook("BOOK_B", "Moby Dick")
+	c := primaryBook("BOOK_C", "Moby Dick")
+	byAuthor := []database.Book{*a, *b, *c}
+	wireExactTitleOnly(mock, map[string]*database.Book{"BOOK_A": a, "BOOK_B": b, "BOOK_C": c}, byAuthor)
+
+	for _, id := range []string{"BOOK_A", "BOOK_B", "BOOK_C"} {
+		if _, err := engine.CheckBook(context.Background(), id); err != nil {
+			t.Fatalf("CheckBook(%s): %v", id, err)
+		}
+	}
+
+	cands := pendingCandidates(t, es)
+	involvesNonPrimary := false
+	primaryPairFound := false
+	for _, c := range cands {
+		if c.EntityAID == "BOOK_B" || c.EntityBID == "BOOK_B" {
+			involvesNonPrimary = true
+		}
+		if (c.EntityAID == "BOOK_A" && c.EntityBID == "BOOK_C") || (c.EntityAID == "BOOK_C" && c.EntityBID == "BOOK_A") {
+			primaryPairFound = true
+		}
+	}
+	if involvesNonPrimary {
+		t.Errorf("non-primary BOOK_B leaked into a candidate; candidates=%+v", cands)
+	}
+	if !primaryPairFound {
+		t.Errorf("expected a primary↔primary candidate (BOOK_A↔BOOK_C); candidates=%+v", cands)
+	}
+}
+
+// TestExactEmitters_NoBalloonFromVersionCopies is the anti-balloon property: one
+// final book with N extra non-primary COPIES (1 primary + N non-primary, all same
+// title) must produce ZERO candidates — there is no second final book to pair with.
+// Pre-fix this produced O(N^2) within-group candidates.
+func TestExactEmitters_NoBalloonFromVersionCopies(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+
+	books := map[string]*database.Book{"PRIMARY": primaryBook("PRIMARY", "Dune")}
+	byAuthor := []database.Book{*books["PRIMARY"]}
+	ids := []string{"PRIMARY"}
+	for _, id := range []string{"COPY_1", "COPY_2", "COPY_3", "COPY_4"} {
+		nb := nonPrimaryBook(id, "Dune")
+		books[id] = nb
+		byAuthor = append(byAuthor, *nb)
+		ids = append(ids, id)
+	}
+	wireExactTitleOnly(mock, books, byAuthor)
+
+	for _, id := range ids {
+		if _, err := engine.CheckBook(context.Background(), id); err != nil {
+			t.Fatalf("CheckBook(%s): %v", id, err)
+		}
+	}
+
+	if cands := pendingCandidates(t, es); len(cands) != 0 {
+		t.Errorf("expected 0 candidates for one final book + copies, got %d: %+v", len(cands), cands)
+	}
+}
+
+// TestUpsertExactCandidate_GateUnit directly exercises the central gate so a future
+// emitter that routes through it is covered regardless of call path.
+func TestUpsertExactCandidate_GateUnit(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+	p1 := primaryBook("P1", "T")
+	p2 := primaryBook("P2", "T")
+	np := nonPrimaryBook("NP", "T")
+
+	if err := engine.upsertExactCandidate(p1, np, "exact", 1.0); err != nil {
+		t.Fatalf("upsert p1↔np: %v", err)
+	}
+	if err := engine.upsertExactCandidate(np, p1, "exact", 1.0); err != nil {
+		t.Fatalf("upsert np↔p1: %v", err)
+	}
+	if err := engine.upsertExactCandidate(p1, p2, "exact", 1.0); err != nil {
+		t.Fatalf("upsert p1↔p2: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Fatalf("expected exactly 1 candidate (primary↔primary), got %d: %+v", len(cands), cands)
+	}
+	if cands[0].EntityAID == "NP" || cands[0].EntityBID == "NP" {
+		t.Errorf("non-primary leaked: %+v", cands[0])
+	}
+}


### PR DESCRIPTION
## The bug

The exact-family candidate emitters (`checkExactFileHash`, `checkExactISBN`, `checkExactMetadataSourceHash`, `checkExactTitle`, `checkDurationMatch`) gated candidate books on `MarkedForDeletion` + `hasPlausibleAudio` — but **never `IsPrimaryVersion`**. So every non-primary copy of a book got paired with its version-group siblings (and other books' copies).

On prod this ballooned the `exact` layer to **387,597 pending candidates** against only **49,573 final books** (acoustid 1,028 / embedding 164 / llm 209 are sane). The embedding layer already gated on primary (`engine.go:262`); the exact layer didn't. This has bitten us repeatedly.

## The fix

All six exact-layer candidate writes now route through **one** gated helper, `Engine.upsertExactCandidate`, which skips any pair where either side is a non-primary version-group member. Centralizing the gate means a *future* emitter can't reintroduce the balloon without passing through it.

## Regression guard (the "never balloon again" part)

`internal/dedup/engine_primary_gate_test.go`:
- non-primary members never leak into a candidate (A primary, B non-primary, C primary → A↔C only);
- **one final book + N copies → 0 candidates** (pre-fix: O(N²) within-group pairs);
- two primaries still pair normally;
- direct unit test on the central gate.

`IsPrimaryVersion == nil` is treated as primary (unchanged behavior). Full `internal/dedup` suite green.

## Not in this PR (tracked: DEDUP-CANDIDATE-EXPLOSION-2026-06-18)

- One-time **purge/rebuild** of the 387K stale exact candidates against final books (data op).
- Investigate the upstream cause (~352K extra/chapter `books` rows vs 49,573 final).
- **Do not** run `dedup.mine-gold-labels --apply` until the candidate set is rebuilt.
- Separately: the scan-import **circuit breaker** (pause + confirm on > N new books) — your other ask, coming next.

## Test plan

`go test ./internal/dedup/` green; `go build ./...`; `go vet`; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)