### PR TITLE
fix(dedup): quarantine chapter-file-as-book artifacts (drain candidate explosion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.37.0 -->
+<!-- version: 3.38.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-18 -->
 
@@ -8,6 +8,20 @@
 ## [Unreleased]
 
 ### Fixes
+
+#### June 19, 2026 — dedup.quarantine-chapter-artifacts: drain chapter-file-as-book candidates
+
+New maintenance op that drains the dedup candidate explosion at its source. Root cause
+(confirmed): the scanner's mixed-directory album grouping (`groupFilesIntoBooks`) emits a
+STANDALONE book for every single-file album group, so segment files (idents, "Opening
+Credits", intros) with distinct tags became standalone books whose generic titles collide
+library-wide. The exact-title emitter cross-paired them into ~356K bogus candidates (the
+primary-version-gate fix only removed ~31K non-primary ones).
+
+The op soft-deletes (recoverable; `MarkedForDeletion`) a book only when ALL hold: its
+normalized title is shared by ≥ N other books (default 5), it is a single-file book, and
+that file's duration is positive and below a threshold (default 1200s). Dry-run by default.
+
 
 #### June 18, 2026 — Dedup exact emitters skip non-primary version-group members (candidate-explosion fix)
 

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -69,6 +69,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.bookfileSegDropDef(),   // T020: drop AcoustID segment fields from stored values
 		p.datasetBackfillDef(),   // C4: label + suppress residual pending candidates
 		p.mineGoldLabelsDef(),    // gold miner: auto-label high-confidence true_dup positives
+		p.quarantineChapterArtifactsDef(), // drain chapter-file-as-book artifacts (candidate explosion)
 		p.checkBookDef(),         // M4: per-book dedup check via dependency scheduler
 		p.buildISBNIndexDef(),    // T022: ISBN/ASIN secondary index backfill
 		p.reembedEmbeddingsDef(), // Part B: re-embed corpus when the embedding model changes

--- a/internal/plugins/dedup/quarantine_chapter_artifacts.go
+++ b/internal/plugins/dedup/quarantine_chapter_artifacts.go
@@ -1,0 +1,189 @@
+// file: internal/plugins/dedup/quarantine_chapter_artifacts.go
+// version: 1.0.0
+// guid: 1d7a4f92-3c60-4e85-9b21-6a5e8c0d3f47
+// last-edited: 2026-06-19
+
+// Package dedup — op dedup.quarantine-chapter-artifacts.
+//
+// Drains the candidate explosion at its source: chapter/segment files that the
+// scanner imported as STANDALONE books (idents, "Opening Credits", intro tracks)
+// with generic titles that collide across hundreds of audiobooks. Those generic
+// titles get cross-paired by the exact-title emitter into hundreds of thousands of
+// bogus candidates (DEDUP-CANDIDATE-EXPLOSION-2026-06-18).
+//
+// A book is treated as a chapter artifact when ALL hold:
+//   - its normalized title is shared by >= MinTitleCollisions OTHER books
+//     (a real book title is not held by 5+ books; "Opening Credits" is held by many);
+//   - it is a SINGLE-file book (not a multi-file audiobook);
+//   - that single file's duration is positive and below MaxDurationSec
+//     (a genuine short story is not also title-colliding with 5+ books).
+//
+// Action is SOFT-delete (MarkedForDeletion) — recoverable, not a hard delete.
+// Dry-run by default: reports what it WOULD quarantine and writes nothing.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+type quarantineChapterParams struct {
+	Apply              bool `json:"apply"`
+	MinTitleCollisions int  `json:"min_title_collisions,omitempty"` // default 5
+	MaxDurationSec     int  `json:"max_duration_sec,omitempty"`     // default 1200 (20 min)
+}
+
+func (p *Plugin) quarantineChapterArtifactsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.quarantine-chapter-artifacts",
+		Plugin:      "dedup",
+		DisplayName: "Quarantine chapter-file artifacts",
+		Description: "Soft-deletes single short books whose generic title collides with many others " +
+			"(idents/credits/intros the scanner imported as standalone books). Dry-run by default.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.quarantine-chapter-artifacts",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runQuarantineChapterArtifacts,
+	}
+}
+
+func (p *Plugin) runQuarantineChapterArtifacts(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+	params := quarantineChapterParams{MinTitleCollisions: 5, MaxDurationSec: 1200}
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	if params.MinTitleCollisions < 2 {
+		params.MinTitleCollisions = 5
+	}
+	if params.MaxDurationSec <= 0 {
+		params.MaxDurationSec = 1200
+	}
+	reporter.Logger().Info("quarantine-chapter-artifacts start",
+		"apply", params.Apply, "min_collisions", params.MinTitleCollisions, "max_duration_sec", params.MaxDurationSec)
+
+	_ = reporter.UpdateProgress(0, 3, "Loading library…")
+	books, err := p.store.GetAllBooks(0, 0)
+	if err != nil {
+		return fmt.Errorf("get all books: %w", err)
+	}
+
+	// Pass 1: count books per normalized title (skip empty titles / already soft-deleted).
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Counting title collisions over %d books…", len(books)))
+	titleCount := make(map[string]int, len(books))
+	for i := range books {
+		b := &books[i]
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		norm := util.NormalizeTitle(b.Title)
+		if norm == "" {
+			continue
+		}
+		titleCount[norm]++
+	}
+
+	// Pass 2: identify chapter artifacts among the colliding-title books.
+	_ = reporter.UpdateProgress(2, 3, "Identifying chapter artifacts…")
+	type artifact struct {
+		ID    string
+		Title string
+	}
+	var artifacts []artifact
+	sampleByTitle := make(map[string]int)
+	examined := 0
+	for i := range books {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		b := &books[i]
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		norm := util.NormalizeTitle(b.Title)
+		if norm == "" || titleCount[norm] < params.MinTitleCollisions {
+			continue
+		}
+		examined++
+		files, ferr := p.store.GetBookFiles(b.ID)
+		if ferr != nil || len(files) != 1 {
+			continue // multi-file audiobook (or unreadable) — not a single-segment artifact
+		}
+		dur := files[0].AcoustIDFingerprintDurationSec
+		if dur <= 0 {
+			dur = float64(files[0].Duration)
+		}
+		if dur <= 0 || dur >= float64(params.MaxDurationSec) {
+			continue // unscanned or long — leave it alone (conservative)
+		}
+		artifacts = append(artifacts, artifact{ID: b.ID, Title: b.Title})
+		sampleByTitle[b.Title]++
+	}
+
+	// Build a short, human-readable sample of the offending titles.
+	type tc struct {
+		Title string
+		N     int
+	}
+	samples := make([]tc, 0, len(sampleByTitle))
+	for t, n := range sampleByTitle {
+		samples = append(samples, tc{t, n})
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i].N > samples[j].N })
+	sampleStr := ""
+	for i := 0; i < len(samples) && i < 10; i++ {
+		sampleStr += fmt.Sprintf("%q×%d ", samples[i].Title, samples[i].N)
+	}
+
+	quarantined := 0
+	if params.Apply {
+		now := time.Now()
+		for _, a := range artifacts {
+			if reporter.IsCanceled() {
+				return context.Canceled
+			}
+			full, gerr := p.store.GetBookByID(a.ID)
+			if gerr != nil || full == nil {
+				continue
+			}
+			marked := true
+			full.MarkedForDeletion = &marked
+			full.MarkedForDeletionAt = &now
+			if _, uerr := p.store.UpdateBook(full.ID, full); uerr != nil {
+				reporter.Logger().Error("quarantine soft-delete error", "book_id", a.ID, "error", uerr)
+				continue
+			}
+			quarantined++
+		}
+	}
+
+	summary := fmt.Sprintf("examined=%d artifacts=%d quarantined=%d (apply=%v) top: %s",
+		examined, len(artifacts), quarantined, params.Apply, sampleStr)
+	reporter.Logger().Info("quarantine-chapter-artifacts complete", "summary", summary)
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
+			"Dry-run — %d chapter-artifact book(s) would be soft-deleted. Pass apply=true to quarantine. Top: %s",
+			len(artifacts), sampleStr))
+	} else {
+		_ = reporter.UpdateProgress(3, 3, fmt.Sprintf("Soft-deleted %d chapter-artifact book(s). %s", quarantined, summary))
+	}
+	return nil
+}

--- a/internal/plugins/dedup/quarantine_chapter_artifacts_test.go
+++ b/internal/plugins/dedup/quarantine_chapter_artifacts_test.go
@@ -1,0 +1,87 @@
+// file: internal/plugins/dedup/quarantine_chapter_artifacts_test.go
+// version: 1.0.0
+// guid: 9c2e7a14-5b80-4d36-8f21-3a6e0c9d5b18
+// last-edited: 2026-06-19
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// mkBook creates a book with one file of the given duration, at a unique path.
+func mkBook(t *testing.T, pebble *database.PebbleStore, title string, idx, durationSec int) string {
+	t.Helper()
+	path := fmt.Sprintf("/audio/%s-%d.m4b", title, idx)
+	created, err := pebble.CreateBook(&database.Book{Title: title, FilePath: path})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	if err := pebble.CreateBookFile(&database.BookFile{
+		BookID: created.ID, FilePath: path, Duration: durationSec, FileSize: 1 << 20,
+	}); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+	return created.ID
+}
+
+func isMarkedDeleted(t *testing.T, pebble *database.PebbleStore, id string) bool {
+	t.Helper()
+	b, err := pebble.GetBookByID(id)
+	if err != nil || b == nil {
+		t.Fatalf("GetBookByID(%s): %v", id, err)
+	}
+	return b.MarkedForDeletion != nil && *b.MarkedForDeletion
+}
+
+func TestQuarantineChapterArtifacts(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	p := &Plugin{store: pebble}
+
+	// 5 short single-file "Opening Credits" books → chapter artifacts (title collides ≥5).
+	var artifactIDs []string
+	for i := 0; i < 5; i++ {
+		artifactIDs = append(artifactIDs, mkBook(t, pebble, "Opening Credits", i, 30))
+	}
+	// A long single-file book with the SAME title → NOT an artifact (not short).
+	longID := mkBook(t, pebble, "Opening Credits", 99, 36000)
+	// A unique-title short single-file book → NOT an artifact (no collision).
+	uniqueID := mkBook(t, pebble, "A Real Short Story", 0, 30)
+
+	run := func(apply bool) {
+		body := `{}`
+		if apply {
+			body = `{"apply":true}`
+		}
+		if err := p.runQuarantineChapterArtifacts(context.Background(), json.RawMessage(body), &fakeReporter{}); err != nil {
+			t.Fatalf("run(apply=%v): %v", apply, err)
+		}
+	}
+
+	// Dry-run writes nothing.
+	run(false)
+	for _, id := range artifactIDs {
+		if isMarkedDeleted(t, pebble, id) {
+			t.Fatalf("dry-run soft-deleted %s — must write nothing", id)
+		}
+	}
+
+	// Apply soft-deletes only the 5 colliding short single-file books.
+	run(true)
+	for _, id := range artifactIDs {
+		if !isMarkedDeleted(t, pebble, id) {
+			t.Errorf("expected artifact %s to be soft-deleted", id)
+		}
+	}
+	if isMarkedDeleted(t, pebble, longID) {
+		t.Error("long book (same title) must NOT be quarantined")
+	}
+	if isMarkedDeleted(t, pebble, uniqueID) {
+		t.Error("unique-title book must NOT be quarantined")
+	}
+}


### PR DESCRIPTION
## What & why

Drains the **356K** exact-candidate balloon at its source. After the primary-version gate fix (PR #1504) only removed ~31K (non-primary copies), the dominant remainder is **chapter/segment files imported as standalone books** — idents, intros, `"Opening Credits"` — whose generic titles collide across hundreds of audiobooks and get cross-paired by the exact-title emitter.

**Confirmed root cause:** `scanner.go` `groupFilesIntoBooks` emits a standalone book for every single-file album group in a mixed directory, so a tagged segment becomes its own book titled e.g. "Opening Credits".

## The op

`dedup.quarantine-chapter-artifacts` **soft-deletes** (recoverable; `MarkedForDeletion`) a book only when **all** hold:
- its normalized title is shared by **≥ N** other books (default **5** — a real title isn't held by 5+ books);
- it is a **single-file** book (not a multi-file audiobook);
- that file's duration is **positive and < threshold** (default **1200s**).

**Dry-run by default** — reports the count + the top offending titles before anything is written. Params: `apply`, `min_title_collisions`, `max_duration_sec`.

## Test

`quarantine_chapter_artifacts_test.go`: 5 colliding short single-file books are quarantined on apply; a long same-title book and a unique-title book are left alone; dry-run writes nothing.

## Follow-up

The **scanner prevention** (don't emit standalone books for single-file short segments alongside a multi-file book) is the upstream fix — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)