### PR TITLE
feat(dedup): C6 Gold Labels review UI — review the gold dataset in the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ pass), and validates the user-supplied path against configured import paths
 `PerformScan` (WalkDir handles a directory or a single file), so it goes through the same
 assembly + dedup + create pipeline. Trigger via `POST /operations/v2`
 `{"def_id":"library.import","params":{"path":"…"}}`.
+#### June 19, 2026 — C6: Gold Labels review UI (dedup feedback loop)
+
+The gold dataset is now reviewable in the UI. New **Gold Labels** page (`/dedup/labels`,
+sidebar entry) lists labeled dedup examples (the `dedup:label:` keyspace) filterable by
+label and `label_source`, with dataset-composition chips and one-click **human override**
+(sets `label_source=human`, which is gold and takes precedence).
+
+Backend: `GET /api/v1/dedup/labels` (filter + paginate), `GET /api/v1/dedup/labels/stats`
+(counts by label + source), `POST /api/v1/dedup/labels/:id/override`
+(`internal/server/handlers/dedup/label_review.go`). Tested in `label_review_test.go`.
 
 
 #### June 18, 2026 — Dedup feedback loop: in-house gold miner (`dedup.mine-gold-labels`)

--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,0 +1,161 @@
+// file: internal/server/handlers/dedup/label_review.go
+// version: 1.0.0
+// guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
+// last-edited: 2026-06-19
+
+package deduphandler
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
+)
+
+// ListDedupLabels handles GET /api/v1/dedup/labels — the gold-dataset review feed.
+// It returns labeled dedup examples (the dedup:label: keyspace) for the C6 review
+// UI, filterable by label / label_source / band / folder_relation / signature_relation,
+// paginated. The total is the unfiltered-by-page count for the same filters.
+func (h *Handler) ListDedupLabels(c *gin.Context) {
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+
+	filter := database.LabeledExampleFilter{
+		Label:             c.Query("label"),
+		LabelSource:       c.Query("label_source"),
+		Band:              c.Query("band"),
+		FolderRelation:    c.Query("folder_relation"),
+		SignatureRelation: c.Query("signature_relation"),
+		Limit:             clampAtoi(c.Query("limit"), 50, 1, 500),
+		Offset:            clampAtoi(c.Query("offset"), 0, 0, 1<<31),
+	}
+
+	items, err := es.ListLabeledExamples(filter)
+	if err != nil {
+		httputil.InternalError(c, "failed to list labeled examples", err)
+		return
+	}
+	// Total for the same filters, ignoring pagination.
+	countFilter := filter
+	countFilter.Limit, countFilter.Offset = 0, 0
+	total, err := es.CountLabeledExamples(countFilter)
+	if err != nil {
+		httputil.InternalError(c, "failed to count labeled examples", err)
+		return
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"labels": items,
+		"total":  total,
+		"limit":  filter.Limit,
+		"offset": filter.Offset,
+	})
+}
+
+// GetDedupLabelStats handles GET /api/v1/dedup/labels/stats — counts by label and by
+// label_source, so the review UI can show the dataset composition at a glance.
+func (h *Handler) GetDedupLabelStats(c *gin.Context) {
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+	byLabel := map[string]int{}
+	for _, l := range []string{"true_dup", "not_dup", "unsure", ""} {
+		n, err := es.CountLabeledExamples(database.LabeledExampleFilter{Label: l})
+		if err != nil {
+			httputil.InternalError(c, "failed to count labels", err)
+			return
+		}
+		key := l
+		if key == "" {
+			key = "unlabeled"
+		}
+		byLabel[key] = n
+	}
+	bySource := map[string]int{}
+	for _, src := range []string{"human", "auto_high_conf", "rule", "itunes_attr", "llm_judge"} {
+		n, err := es.CountLabeledExamples(database.LabeledExampleFilter{LabelSource: src})
+		if err != nil {
+			httputil.InternalError(c, "failed to count sources", err)
+			return
+		}
+		bySource[src] = n
+	}
+	total, _ := es.CountLabeledExamples(database.LabeledExampleFilter{})
+	httputil.RespondWithOK(c, gin.H{"total": total, "by_label": byLabel, "by_source": bySource})
+}
+
+// OverrideDedupLabel handles POST /api/v1/dedup/labels/:id/override — a human
+// reviewer setting/correcting the label on an example. The override always sets
+// label_source="human" (this is gold) and re-stamps DecidedAt, so reviewer
+// corrections take precedence over rule/auto-mined labels.
+func (h *Handler) OverrideDedupLabel(c *gin.Context) {
+	es := h.resolveEmbeddingStore()
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		httputil.RespondWithBadRequest(c, "invalid candidate id")
+		return
+	}
+	var body struct {
+		Label  string `json:"label"`
+		Reason string `json:"reason"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		httputil.RespondWithBadRequest(c, "invalid request body")
+		return
+	}
+	if body.Label != labelTrueDup && body.Label != labelNotDup && body.Label != "unsure" {
+		httputil.RespondWithBadRequest(c, "label must be one of true_dup, not_dup, unsure")
+		return
+	}
+
+	ex, err := es.GetLabeledExample(id)
+	if err != nil {
+		httputil.InternalError(c, "failed to load labeled example", err)
+		return
+	}
+	if ex == nil {
+		httputil.RespondWithNotFound(c, "labeled example", c.Param("id"))
+		return
+	}
+
+	ex.Label = body.Label
+	ex.LabelSource = labelSourceHuman
+	ex.LabelReason = body.Reason
+	if ex.LabelReason == "" {
+		ex.LabelReason = "ui_override"
+	}
+	ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := es.UpsertLabeledExample(*ex); err != nil {
+		httputil.InternalError(c, "failed to save label override", err)
+		return
+	}
+	httputil.RespondWithOK(c, gin.H{"status": "updated", "candidate_id": id, "label": ex.Label, "label_source": ex.LabelSource})
+}
+
+// clampAtoi parses s as an int, falling back to def, then clamps to [lo, hi].
+func clampAtoi(s string, def, lo, hi int) int {
+	v := def
+	if s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			v = n
+		}
+	}
+	if v < lo {
+		v = lo
+	}
+	if v > hi {
+		v = hi
+	}
+	return v
+}

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -1,0 +1,94 @@
+// file: internal/server/handlers/dedup/label_review_test.go
+// version: 1.0.0
+// guid: 8a3e1c46-9b20-4d75-8f31-2a6e0c9d5b39
+// last-edited: 2026-06-19
+
+package deduphandler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
+)
+
+func seedLabel(t *testing.T, d testDeps, candID int64, label, source string) {
+	t.Helper()
+	if err := d.es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: candID, EntityAID: "a", EntityBID: "b",
+		Layer: "exact", Label: label, LabelSource: source, LabelReason: "seed",
+	}); err != nil {
+		t.Fatalf("UpsertLabeledExample: %v", err)
+	}
+}
+
+func decodeLabels(t *testing.T, w *httptest.ResponseRecorder) (int, []map[string]any) {
+	t.Helper()
+	var resp struct {
+		Data struct {
+			Total  int              `json:"total"`
+			Labels []map[string]any `json:"labels"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+	return resp.Data.Total, resp.Data.Labels
+}
+
+func TestListDedupLabels_FilterAndTotal(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 1, "true_dup", "human")
+	seedLabel(t, d, 2, "not_dup", "rule")
+	seedLabel(t, d, 3, "true_dup", "auto_high_conf")
+
+	// No filter → all 3.
+	w := doReq(t, h.ListDedupLabels, http.MethodGet, "/api/v1/dedup/labels", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	total, items := decodeLabels(t, w)
+	if total != 3 || len(items) != 3 {
+		t.Fatalf("expected 3 labels, got total=%d len=%d", total, len(items))
+	}
+
+	// Filter by label_source=human → just 1.
+	w2 := doReq(t, h.ListDedupLabels, http.MethodGet, "/api/v1/dedup/labels?label_source=human", nil, nil)
+	total2, items2 := decodeLabels(t, w2)
+	if total2 != 1 || len(items2) != 1 {
+		t.Fatalf("expected 1 human label, got total=%d len=%d", total2, len(items2))
+	}
+}
+
+func TestOverrideDedupLabel_SetsHuman(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 7, "true_dup", "auto_high_conf")
+
+	w := doReq(t, h.OverrideDedupLabel, http.MethodPost, "/api/v1/dedup/labels/7/override",
+		map[string]string{"label": "not_dup", "reason": "reviewer says different book"},
+		gin.Params{{Key: "id", Value: "7"}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(7)
+	if err != nil || ex == nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if ex.Label != "not_dup" || ex.LabelSource != "human" {
+		t.Fatalf("override label=%q source=%q; want not_dup/human", ex.Label, ex.LabelSource)
+	}
+}
+
+func TestOverrideDedupLabel_RejectsBadLabel(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 9, "true_dup", "rule")
+	w := doReq(t, h.OverrideDedupLabel, http.MethodPost, "/api/v1/dedup/labels/9/override",
+		map[string]string{"label": "garbage"}, gin.Params{{Key: "id", Value: "9"}})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", w.Code)
+	}
+}

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -848,6 +848,10 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	protected.POST("/dedup/candidates/dismiss-cluster", s.perm(auth.PermLibraryEditMetadata), dedupH.DismissDedupCluster)
 	protected.POST("/dedup/candidates/remove-from-cluster", s.perm(auth.PermLibraryEditMetadata), dedupH.RemoveFromDedupCluster)
 	protected.GET("/dedup/candidates/series-summary", s.perm(auth.PermLibraryView), dedupH.ListDedupCandidateSeries)
+	// C6 — gold-dataset review (the dedup feedback-loop labels).
+	protected.GET("/dedup/labels", s.perm(auth.PermLibraryView), dedupH.ListDedupLabels)
+	protected.GET("/dedup/labels/stats", s.perm(auth.PermLibraryView), dedupH.GetDedupLabelStats)
+	protected.POST("/dedup/labels/:id/override", s.perm(auth.PermLibraryEditMetadata), dedupH.OverrideDedupLabel)
 	protected.POST("/dedup/candidates/merge-series", s.perm(auth.PermLibraryEditMetadata), dedupH.MergeDedupCandidateSeries)
 	protected.POST("/dedup/scan", s.perm(auth.PermScanTrigger), dedupH.TriggerDedupScan)
 	protected.POST("/dedup/scan-llm", s.perm(auth.PermScanTrigger), dedupH.TriggerDedupLLM)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,7 @@ const FileBrowser = lazy(() =>
 const BookDedup = lazy(() =>
   import('./pages/BookDedup').then((m) => ({ default: m.BookDedup }))
 );
+const DedupLabels = lazy(() => import('./pages/DedupLabels'));
 const Series = lazy(() =>
   import('./pages/Series').then((m) => ({ default: m.Series }))
 );
@@ -236,6 +237,7 @@ function App() {
               <Route path="/authors/dedup" element={<Navigate to="/dedup" replace />} />
               <Route path="/books/dedup" element={<Navigate to="/dedup" replace />} />
               <Route path="/dedup" element={<ErrorBoundary><BookDedup /></ErrorBoundary>} />
+              <Route path="/dedup/labels" element={<ErrorBoundary><DedupLabels /></ErrorBoundary>} />
               <Route path="/series" element={<ErrorBoundary><Series /></ErrorBoundary>} />
               <Route path="/authors" element={<ErrorBoundary><Authors /></ErrorBoundary>} />
               <Route path="/diagnostics" element={<ErrorBoundary><Diagnostics /></ErrorBoundary>} />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -60,6 +60,7 @@ const menuItems = [
   { text: 'Playlists', icon: <MenuBookIcon />, path: '/playlists' },
   { text: 'Activity', icon: <TimelineIcon />, path: '/activity' },
   { text: 'Dedup', icon: <MergeTypeIcon />, path: '/dedup' },
+  { text: 'Gold Labels', icon: <LibraryBooksIcon />, path: '/dedup/labels' },
   { text: 'Diagnostics', icon: <BugReportIcon />, path: '/diagnostics' },
   { text: 'System', icon: <MonitorIcon />, path: '/system' },
   { text: 'Users', icon: <PeopleIcon />, path: '/users' },

--- a/web/src/pages/DedupLabels.tsx
+++ b/web/src/pages/DedupLabels.tsx
@@ -1,0 +1,199 @@
+// file: web/src/pages/DedupLabels.tsx
+// version: 1.0.0
+// guid: 7e3a1c92-4b60-4d85-9f21-6a5e0c9d3f58
+// last-edited: 2026-06-19
+
+// DedupLabels — the C6 gold-dataset review page for the dedup feedback loop.
+// Lists labeled dedup examples (the dedup:label: keyspace), filterable by label
+// and label_source, with one-click human override. This is where the user reviews
+// the gold dataset that the classifier will train and validate on.
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box, Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead,
+  TableRow, Chip, Select, MenuItem, FormControl, InputLabel, Button, Stack,
+  CircularProgress, Alert, Tooltip,
+} from '@mui/material';
+
+const API_BASE = '/api/v1';
+
+interface BookFeatures {
+  title?: string;
+  primary_path?: string;
+  total_duration_sec?: number;
+}
+
+interface LabeledExample {
+  candidate_id: number;
+  entity_a_id: string;
+  entity_b_id: string;
+  layer: string;
+  band?: string;
+  label: string;
+  label_source: string;
+  label_reason?: string;
+  decided_at?: string;
+  a?: BookFeatures;
+  b?: BookFeatures;
+}
+
+interface LabelStats {
+  total: number;
+  by_label: Record<string, number>;
+  by_source: Record<string, number>;
+}
+
+const labelColor = (l: string): 'success' | 'error' | 'warning' | 'default' =>
+  l === 'true_dup' ? 'success' : l === 'not_dup' ? 'error' : l === 'unsure' ? 'warning' : 'default';
+
+const sourceColor = (s: string): 'primary' | 'secondary' | 'info' | 'default' =>
+  s === 'human' ? 'primary' : s === 'auto_high_conf' ? 'info' : s === 'rule' ? 'secondary' : 'default';
+
+const PAGE = 50;
+
+export default function DedupLabels() {
+  const [rows, setRows] = useState<LabeledExample[]>([]);
+  const [total, setTotal] = useState(0);
+  const [stats, setStats] = useState<LabelStats | null>(null);
+  const [labelFilter, setLabelFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadStats = useCallback(async () => {
+    try {
+      const r = await fetch(`${API_BASE}/dedup/labels/stats`);
+      if (r.ok) setStats((await r.json()).data);
+    } catch {
+      /* stats are best-effort */
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ limit: String(PAGE), offset: String(offset) });
+      if (labelFilter) params.set('label', labelFilter);
+      if (sourceFilter) params.set('label_source', sourceFilter);
+      const r = await fetch(`${API_BASE}/dedup/labels?${params}`);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const d = (await r.json()).data;
+      setRows(d.labels || []);
+      setTotal(d.total || 0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load labels');
+    } finally {
+      setLoading(false);
+    }
+  }, [labelFilter, sourceFilter, offset]);
+
+  useEffect(() => { void loadStats(); }, [loadStats]);
+  useEffect(() => { void load(); }, [load]);
+
+  const override = async (candidateId: number, label: string) => {
+    try {
+      const r = await fetch(`${API_BASE}/dedup/labels/${candidateId}/override`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label, reason: 'ui_override' }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      await load();
+      await loadStats();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Override failed');
+    }
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom>Dedup Gold Dataset</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Labeled duplicate-candidate examples the classifier trains and validates on.
+        Human overrides become gold (<code>label_source=human</code>) and take precedence.
+      </Typography>
+
+      {stats && (
+        <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
+          <Chip label={`total ${stats.total}`} />
+          {Object.entries(stats.by_label).map(([k, v]) => (
+            <Chip key={k} size="small" color={labelColor(k)} label={`${k}: ${v}`} variant="outlined" />
+          ))}
+          {Object.entries(stats.by_source).filter(([, v]) => v > 0).map(([k, v]) => (
+            <Chip key={k} size="small" color={sourceColor(k)} label={`${k}: ${v}`} />
+          ))}
+        </Stack>
+      )}
+
+      <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel>Label</InputLabel>
+          <Select label="Label" value={labelFilter} onChange={(e) => { setOffset(0); setLabelFilter(e.target.value); }}>
+            <MenuItem value="">All</MenuItem>
+            <MenuItem value="true_dup">true_dup</MenuItem>
+            <MenuItem value="not_dup">not_dup</MenuItem>
+            <MenuItem value="unsure">unsure</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel>Source</InputLabel>
+          <Select label="Source" value={sourceFilter} onChange={(e) => { setOffset(0); setSourceFilter(e.target.value); }}>
+            <MenuItem value="">All</MenuItem>
+            <MenuItem value="human">human (gold)</MenuItem>
+            <MenuItem value="auto_high_conf">auto_high_conf</MenuItem>
+            <MenuItem value="rule">rule</MenuItem>
+            <MenuItem value="llm_judge">llm_judge</MenuItem>
+          </Select>
+        </FormControl>
+      </Stack>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      <TableContainer component={Paper}>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>Book A</TableCell>
+              <TableCell>Book B</TableCell>
+              <TableCell>Layer</TableCell>
+              <TableCell>Label</TableCell>
+              <TableCell>Source</TableCell>
+              <TableCell>Reason</TableCell>
+              <TableCell align="right">Override</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow><TableCell colSpan={7} align="center"><CircularProgress size={24} sx={{ my: 2 }} /></TableCell></TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow><TableCell colSpan={7} align="center"><Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>No labeled examples for this filter.</Typography></TableCell></TableRow>
+            ) : rows.map((r) => (
+              <TableRow key={r.candidate_id} hover>
+                <TableCell><Tooltip title={r.a?.primary_path || r.entity_a_id}><span>{r.a?.title || r.entity_a_id}</span></Tooltip></TableCell>
+                <TableCell><Tooltip title={r.b?.primary_path || r.entity_b_id}><span>{r.b?.title || r.entity_b_id}</span></Tooltip></TableCell>
+                <TableCell>{r.layer}</TableCell>
+                <TableCell><Chip size="small" color={labelColor(r.label)} label={r.label || 'unlabeled'} /></TableCell>
+                <TableCell><Chip size="small" variant="outlined" color={sourceColor(r.label_source)} label={r.label_source} /></TableCell>
+                <TableCell><Typography variant="caption">{r.label_reason}</Typography></TableCell>
+                <TableCell align="right">
+                  <Button size="small" color="success" onClick={() => void override(r.candidate_id, 'true_dup')}>dup</Button>
+                  <Button size="small" color="error" onClick={() => void override(r.candidate_id, 'not_dup')}>not</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 2 }}>
+        <Button disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - PAGE))}>Prev</Button>
+        <Typography variant="body2">
+          {total === 0 ? '0' : `${offset + 1}–${Math.min(offset + PAGE, total)}`} of {total}
+        </Typography>
+        <Button disabled={offset + PAGE >= total} onClick={() => setOffset(offset + PAGE)}>Next</Button>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the "review the gold dataset in the UI" requirement of the feedback-loop goal. New **Gold Labels** page (`/dedup/labels`, sidebar entry) where the gold dataset (the `dedup:label:` keyspace) is reviewable: filter by label / `label_source`, see dataset-composition chips, and **one-click human override** (sets `label_source=human` — gold, takes precedence over rule/auto-mined labels).

## Backend (`internal/server/handlers/dedup/label_review.go`)

- `GET /api/v1/dedup/labels` — list `LabeledExample`s (filter `label`/`label_source`/`band`/`folder_relation`/`signature_relation`, paginated, returns `total`).
- `GET /api/v1/dedup/labels/stats` — counts by label and by source.
- `POST /api/v1/dedup/labels/:id/override` — human override (validates `true_dup`/`not_dup`/`unsure`, stamps `label_source=human`).

Tests: `label_review_test.go` (filter + total; override sets human; rejects bad label).

## Frontend

`web/src/pages/DedupLabels.tsx` (MUI table + filters + stats chips + override buttons), route in `App.tsx`, sidebar entry. **`tsc --noEmit` clean (0 errors).**

## Notes

This is the UI; a *meaningful* gold dataset still depends on the candidate-set cleanup (PRs #1504 merged + #1505) + the gold-miner apply. Backend `Go` tests pass; frontend typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)