### PR TITLE
fix(dedup): C6 label stats — derive 'unlabeled' (Label:"" matched all)

### DIFF
--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
 // last-edited: 2026-06-19
 
@@ -65,18 +65,19 @@ func (h *Handler) GetDedupLabelStats(c *gin.Context) {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
 	}
+	// Count the explicit labels. NOTE: an empty Label means "no filter" (matches
+	// all), so "unlabeled" is DERIVED from total minus the explicit counts — a
+	// Label:"" query would wrongly return everything.
 	byLabel := map[string]int{}
-	for _, l := range []string{"true_dup", "not_dup", "unsure", ""} {
+	labeledSum := 0
+	for _, l := range []string{"true_dup", "not_dup", "unsure"} {
 		n, err := es.CountLabeledExamples(database.LabeledExampleFilter{Label: l})
 		if err != nil {
 			httputil.InternalError(c, "failed to count labels", err)
 			return
 		}
-		key := l
-		if key == "" {
-			key = "unlabeled"
-		}
-		byLabel[key] = n
+		byLabel[l] = n
+		labeledSum += n
 	}
 	bySource := map[string]int{}
 	for _, src := range []string{"human", "auto_high_conf", "rule", "itunes_attr", "llm_judge"} {
@@ -88,6 +89,7 @@ func (h *Handler) GetDedupLabelStats(c *gin.Context) {
 		bySource[src] = n
 	}
 	total, _ := es.CountLabeledExamples(database.LabeledExampleFilter{})
+	byLabel["unlabeled"] = total - labeledSum
 	httputil.RespondWithOK(c, gin.H{"total": total, "by_label": byLabel, "by_source": bySource})
 }
 

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -63,6 +63,35 @@ func TestListDedupLabels_FilterAndTotal(t *testing.T) {
 	}
 }
 
+func TestGetDedupLabelStats_UnlabeledDerived(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 1, "true_dup", "auto_high_conf")
+	seedLabel(t, d, 2, "not_dup", "rule")
+	seedLabel(t, d, 3, "", "rule") // features captured, no label yet
+
+	w := doReq(t, h.GetDedupLabelStats, http.MethodGet, "/api/v1/dedup/labels/stats", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Total   int            `json:"total"`
+			ByLabel map[string]int `json:"by_label"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.Total != 3 {
+		t.Fatalf("total=%d want 3", resp.Data.Total)
+	}
+	// The bug: by_label["unlabeled"] used a Label:"" query that matched ALL (3).
+	// It must be DERIVED: total - true_dup - not_dup - unsure = 3 - 1 - 1 - 0 = 1.
+	if resp.Data.ByLabel["unlabeled"] != 1 {
+		t.Errorf("unlabeled=%d want 1; by_label=%v", resp.Data.ByLabel["unlabeled"], resp.Data.ByLabel)
+	}
+}
+
 func TestOverrideDedupLabel_SetsHuman(t *testing.T) {
 	h, d := newHandler(t)
 	seedLabel(t, d, 7, "true_dup", "auto_high_conf")


### PR DESCRIPTION
GetDedupLabelStats counted `unlabeled` via `CountLabeledExamples(Label:"")`, but an empty `Label` filter means *no filter* (matches all), so the chip showed the **total** instead of the real unlabeled count. Now derived as `total - true_dup - not_dup - unsure`. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)