### PR TITLE
fix(dedup): quarantine-chapter-artifacts also catches unscanned idents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ no-ops while `mem()==nil`), then warmup published a memdb missing those rows —
 as order-dependent `TestPebbleGetAllAuthors`-class flakes ("Expected 3 authors, got 2")
 under the full `-race` suite, repeatedly blocking unrelated PRs. Verified: the flaky test
 is green over `-race -count=40`; full `internal/database -short -race` green.
+#### June 19, 2026 — quarantine-chapter-artifacts: also catch UNSCANNED idents
+
+The first version required positive duration, but the dominant offenders ("Opening
+Credits", "Big Finish Ident") are UNSCANNED mp3 segments (duration=0) — so a prod dry-run
+found only 53 books. Now unscanned single-file books are caught when their title collides
+with >= MinTitleCollisionsUnscanned (default 10, a higher bar than the scanned-short
+threshold of 5). Long single files are still never touched. Dry-run by default.
 
 
 #### June 19, 2026 — dedup.quarantine-chapter-artifacts: drain chapter-file-as-book candidates

--- a/internal/plugins/dedup/quarantine_chapter_artifacts.go
+++ b/internal/plugins/dedup/quarantine_chapter_artifacts.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/quarantine_chapter_artifacts.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d7a4f92-3c60-4e85-9b21-6a5e8c0d3f47
 // last-edited: 2026-06-19
 
@@ -15,8 +15,10 @@
 //   - its normalized title is shared by >= MinTitleCollisions OTHER books
 //     (a real book title is not held by 5+ books; "Opening Credits" is held by many);
 //   - it is a SINGLE-file book (not a multi-file audiobook);
-//   - that single file's duration is positive and below MaxDurationSec
-//     (a genuine short story is not also title-colliding with 5+ books).
+//   - and either its single file is short (0 < duration < MaxDurationSec), OR it is
+//     UNSCANNED (duration unknown — most idents/credits are) AND the title collides
+//     with >= MinTitleCollisionsUnscanned books (a higher bar, since duration can't
+//     confirm it's a segment). Long single files are never touched.
 //
 // Action is SOFT-delete (MarkedForDeletion) — recoverable, not a hard delete.
 // Dry-run by default: reports what it WOULD quarantine and writes nothing.
@@ -35,8 +37,13 @@ import (
 
 type quarantineChapterParams struct {
 	Apply              bool `json:"apply"`
-	MinTitleCollisions int  `json:"min_title_collisions,omitempty"` // default 5
+	MinTitleCollisions int  `json:"min_title_collisions,omitempty"` // default 5 (scanned short books)
 	MaxDurationSec     int  `json:"max_duration_sec,omitempty"`     // default 1200 (20 min)
+	// MinTitleCollisionsUnscanned is the (higher) collision bar for UNSCANNED
+	// single-file books (duration unknown). Most chapter idents/credits are
+	// unscanned mp3 segments, so they MUST be reachable — but a higher bar avoids
+	// quarantining a few unscanned copies of a genuine book. Default 10.
+	MinTitleCollisionsUnscanned int `json:"min_title_collisions_unscanned,omitempty"`
 }
 
 func (p *Plugin) quarantineChapterArtifactsDef() sdk.OperationDef {
@@ -60,7 +67,7 @@ func (p *Plugin) runQuarantineChapterArtifacts(ctx context.Context, rawParams js
 	if p.store == nil {
 		return fmt.Errorf("main store not available")
 	}
-	params := quarantineChapterParams{MinTitleCollisions: 5, MaxDurationSec: 1200}
+	params := quarantineChapterParams{MinTitleCollisions: 5, MaxDurationSec: 1200, MinTitleCollisionsUnscanned: 10}
 	if len(rawParams) > 0 {
 		if err := json.Unmarshal(rawParams, &params); err != nil {
 			return fmt.Errorf("parse params: %w", err)
@@ -71,6 +78,12 @@ func (p *Plugin) runQuarantineChapterArtifacts(ctx context.Context, rawParams js
 	}
 	if params.MaxDurationSec <= 0 {
 		params.MaxDurationSec = 1200
+	}
+	if params.MinTitleCollisionsUnscanned < params.MinTitleCollisions {
+		params.MinTitleCollisionsUnscanned = params.MinTitleCollisions
+		if params.MinTitleCollisionsUnscanned < 10 {
+			params.MinTitleCollisionsUnscanned = 10
+		}
 	}
 	reporter.Logger().Info("quarantine-chapter-artifacts start",
 		"apply", params.Apply, "min_collisions", params.MinTitleCollisions, "max_duration_sec", params.MaxDurationSec)
@@ -131,8 +144,18 @@ func (p *Plugin) runQuarantineChapterArtifacts(ctx context.Context, rawParams js
 		if dur <= 0 {
 			dur = float64(files[0].Duration)
 		}
-		if dur <= 0 || dur >= float64(params.MaxDurationSec) {
-			continue // unscanned or long — leave it alone (conservative)
+		switch {
+		case dur >= float64(params.MaxDurationSec):
+			continue // long — a real audiobook, never an artifact
+		case dur > 0:
+			// Scanned + short: the ≥ MinTitleCollisions gate above is enough.
+		default:
+			// Unscanned (duration unknown — most idents/credits are unscanned mp3
+			// segments). Require the higher collision bar so we don't quarantine a
+			// few unscanned copies of a genuine book.
+			if titleCount[norm] < params.MinTitleCollisionsUnscanned {
+				continue
+			}
 		}
 		artifacts = append(artifacts, artifact{ID: b.ID, Title: b.Title})
 		sampleByTitle[b.Title]++

--- a/internal/plugins/dedup/quarantine_chapter_artifacts_test.go
+++ b/internal/plugins/dedup/quarantine_chapter_artifacts_test.go
@@ -85,3 +85,35 @@ func TestQuarantineChapterArtifacts(t *testing.T) {
 		t.Error("unique-title book must NOT be quarantined")
 	}
 }
+
+// TestQuarantineChapterArtifacts_UnscannedIdents: unscanned (duration=0) segments
+// like "Big Finish Ident" are the dominant offenders. They are caught only when the
+// title collides with >= MinTitleCollisionsUnscanned (10) books; fewer unscanned
+// copies of a genuine book are left alone.
+func TestQuarantineChapterArtifacts_UnscannedIdents(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	p := &Plugin{store: pebble}
+
+	var identIDs []string
+	for i := 0; i < 10; i++ { // 10 unscanned "Big Finish Ident" → over the unscanned bar
+		identIDs = append(identIDs, mkBook(t, pebble, "Big Finish Ident", i, 0))
+	}
+	var nicheIDs []string
+	for i := 0; i < 5; i++ { // 5 unscanned "Niche Title" → under the unscanned bar (10)
+		nicheIDs = append(nicheIDs, mkBook(t, pebble, "Niche Title", i, 0))
+	}
+
+	if err := p.runQuarantineChapterArtifacts(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	for _, id := range identIDs {
+		if !isMarkedDeleted(t, pebble, id) {
+			t.Errorf("expected unscanned ident %s (10 collisions) to be quarantined", id)
+		}
+	}
+	for _, id := range nicheIDs {
+		if isMarkedDeleted(t, pebble, id) {
+			t.Errorf("5 unscanned copies (< 10) must NOT be quarantined: %s", id)
+		}
+	}
+}


### PR DESCRIPTION
First version required positive duration, but the dominant offenders ("Opening Credits", "Big Finish Ident") are **unscanned** mp3 segments (`duration=0`) — so the prod dry-run found only **53** books (wrong ones). Now unscanned single-file books are caught at a **higher** collision bar (`MinTitleCollisionsUnscanned`, default **10**) so a few unscanned copies of a real book are spared. Long single files still never touched. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)