### PR TITLE
feat(dedup): UX overhaul — covers, zebra rows, click-select, page-size persistence, activity-log pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,29 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.40.0 -->
+<!-- version: 3.41.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-18 -->
+<!-- last-edited: 2026-06-19 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Features
+
+#### June 19, 2026 — Dedup UX overhaul (PR #1507)
+
+**Dedup candidate table:**
+- Book cover thumbnails (44×44) now show on every candidate row alongside title/path. Falls back to a placeholder box when no cover is stored.
+- Score/band/status chips moved inline to the top of the Book A cell — no more separate "Score/Band" and "Status" columns. Frees horizontal space for cover + path.
+- Alternating row background (zebra stripe) makes it much easier to track which row you're reading when scrolling through hundreds of candidates.
+- Click any row to select it; shift-click to range-select (same as a file manager). No checkbox required.
+- "Multi-select" toggle button in the toolbar shows/hides checkboxes for explicit bulk operations. Hidden by default to reclaim the column. State persists via `localStorage`.
+- Page size persists across navigation via `localStorage` (`dedup-page-size` key). Setting 250/page and clicking back no longer resets to 25.
+
+**Activity log:**
+- Expanding an op row now automatically pauses auto-refresh so log lines stop jumping away. A "Paused — row expanded" chip appears in the header with a "Follow log" action to resume without collapsing the row. Collapsing the row restores the previous refresh state.
+
+**Fingerprint visualizer (PR #1506):**
+- New "Fingerprint" tab in the candidate compare drawer renders both books' chromaprints as 32×64 bit-matrix heatmaps (frequency bits × time buckets). Amber cells overlay Book A showing differences vs Book B. Visual similarity percentage shown. Fetched lazily via `compareAcoustID` on first tab open.
 
 ### Fixes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 8.98.0 -->
+<!-- version: 8.99.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-18 -->
+<!-- last-edited: 2026-06-19 -->
 
 # Project TODO
 
@@ -19,12 +19,25 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🎯 Current Status — June 18, 2026
+## 🎯 Current Status — June 19, 2026
 
 **Library:** ~50K books (~10,891 organized + ~39K iTunes-imported) / 8,837 authors / 21,668 series
-**Production:** PebbleDB primary; Linux, HTTPS at prod server; stable (crash loop resolved 2026-06-18)
-**Latest activity:** HNSW-CRASH-2026-06-18 (2026-06-18, PR #1500): fixed production crash loop (restart #51) — HNSW snapshot now loaded before PostInit, HydrateChromem gated on CountByType>0; 38,987 books indexed from snapshot on first restart. Prior: SEC-AUDIT-12 closed (log+path injection guards, 87 CodeQL alerts resolved, PRs #1490–#1494); flaky DB tests fixed PR #1497.
+**Production:** PebbleDB primary; Linux, HTTPS at prod server; stable
+**Latest activity:** Dedup UX overhaul (PR #1507): book covers, inline badges, zebra rows, click-to-select + shift-click, localStorage page-size, multi-select toggle, activity log auto-pause on expand. Fingerprint visual (PR #1506): chromaprint bit-matrix in candidate drawer.
 **In flight:** CFG-2 (Settings UI reorg — frontend "second half") not started. Burndown bot dispatching test coverage tasks. EMB-UI-1 (Ollama download link) still open.
+
+---
+
+## 🖥️ Dedup UX — Open Items
+
+### Keyboard shortcuts (future)
+- [ ] **DEDUP-KB-1** Add keyboard shortcuts to dedup page for power users: `j`/`k` to navigate rows, `m` to merge, `d` to dismiss, `s` to select/deselect, `enter` to open compare drawer, `esc` to close drawer, `shift+a` select all on page. Goal: make it possible to clear a page of dedups without touching the mouse. Design: global `keydown` listener active when no input/dialog is focused; shortcuts displayed in a `?` help overlay.
+
+### Audible intro/outro false positives (backend investigation needed)
+- [ ] **DEDUP-INTRO-1** Investigate why Audible intro/outro clips ("Audible Opening Message", "Introduction") generate exact-match dedup candidates across unrelated books. Root cause: the exact layer fingerprints individual audio files and short intro clips have identical chromaprints across all books from the same publisher. Fix candidates: (a) filter candidates where both titles are known Audible boilerplate strings (title blocklist); (b) skip fingerprint comparison on files shorter than a configurable threshold (e.g. <60s); (c) check at the book level first — if books have different ISBNs/ASINs, don't flag file-level matches. Track prod volume: ~372K total candidates, many likely this class.
+
+### Folder chip + file hover list
+- [ ] **DEDUP-FOLDER-1** Add a "folder" chip to dedup candidate cards when the matched path is a directory (multi-file book). On hover/click, show a popover listing all files in that folder with their format, bitrate, size, duration. Helps distinguish "this is a 197-file m4b series" from "this is a single file" at a glance without opening the compare drawer.
 
 ---
 

--- a/web/src/components/dedup/CandidateCompareDrawer.tsx
+++ b/web/src/components/dedup/CandidateCompareDrawer.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/CandidateCompareDrawer.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: a6f7b8c9-d0e1-2345-fabc-af6789012345
 // last-edited: 2026-06-19
 
@@ -84,12 +84,12 @@ export function CandidateCompareDrawer({
 
     api
       .getDedupCandidateBreakdown(candidateId, ctrl.signal)
-      .then((resp) => {
+      .then((resp: DedupCandidateBreakdownResponse) => {
         if (!ctrl.signal.aborted) {
           setData(resp);
         }
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         if (!ctrl.signal.aborted) {
           setError(err instanceof Error ? err.message : 'Failed to load breakdown');
         }
@@ -289,7 +289,7 @@ export function CandidateCompareDrawer({
                     <AudioSamplePair
                       bookA={bookA}
                       bookB={bookB}
-                      onKeep={(winnerId) => handleMerge(winnerId)}
+                      onKeep={(winnerId: string | undefined) => handleMerge(winnerId)}
                     />
                   )}
                 </>
@@ -313,7 +313,7 @@ export function CandidateCompareDrawer({
             {/* Tabs: Files | Score Breakdown */}
             <Tabs
               value={activeTab}
-              onChange={(_, v) => setActiveTab(v)}
+              onChange={(_: unknown, v: number) => setActiveTab(v)}
               sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
             >
               <Tab label="Files" data-testid="drawer-tab-files" />

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
-// last-edited: 2026-06-17
+// last-edited: 2026-06-19
 
 // UnifiedDedupTab is the T017 single surface that replaces the separate Books /
 // Advanced-Scan / Acoustic tabs. It shows a paginated candidate table filtered
@@ -21,7 +21,7 @@
 //   - Timers cleared on unmount.
 //   - No module-level mutable state.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams, Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
@@ -56,6 +56,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 import * as api from '../../services/api';
 import type { Book, DedupCandidate, DedupBand, DedupStats } from '../../services/api';
 import { useOperationsStore } from '../../stores/useOperationsStore';
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 import { BandFilterBar, type BandCounts } from './BandFilterBar';
 import { ScoreBadgeRow } from './ScoreBadgeRow';
 import { CandidateCompareDrawer } from './CandidateCompareDrawer';
@@ -113,10 +114,24 @@ function renderBookCard(book: Book | null | undefined, id: string) {
   const missing = !book;
   const path = book?.file_path ?? '';
   const title = book?.title ?? '';
+  const coverUrl = book?.cover_url ?? '';
   const isGarbageTitle =
     !title || title.toUpperCase() === 'TITLE' || /^[0-9A-Z]{26}$/.test(title.trim());
   return (
-    <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+    <Stack direction="row" spacing={1} sx={{ minWidth: 0, alignItems: 'flex-start' }}>
+      {coverUrl && (
+        <Box
+          component="img"
+          src={coverUrl}
+          alt=""
+          loading="lazy"
+          sx={{ width: 44, height: 44, objectFit: 'cover', borderRadius: 0.5, flexShrink: 0, mt: 0.25 }}
+        />
+      )}
+      {!coverUrl && (
+        <Box sx={{ width: 44, height: 44, borderRadius: 0.5, flexShrink: 0, bgcolor: 'action.selected', mt: 0.25 }} />
+      )}
+      <Stack spacing={0.25} sx={{ minWidth: 0, flex: 1 }}>
       {missing ? (
         <Typography variant="body2" sx={{ color: 'error.main', fontStyle: 'italic' }}>
           (missing book — {id.slice(-8)})
@@ -164,6 +179,7 @@ function renderBookCard(book: Book | null | undefined, id: string) {
           </Typography>
         </Tooltip>
       )}
+      </Stack>
     </Stack>
   );
 }
@@ -189,7 +205,13 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
   // (both low-quality, need manual matching) — server-side filter.
   const [bothUnmatched, setBothUnmatched] = useState(false);
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(25);
+  const [rowsPerPage, setRowsPerPage] = useState<number>(() =>
+    parseInt(localStorage.getItem(STORAGE_KEYS.DEDUP_PAGE_SIZE) ?? '25', 10),
+  );
+  const [showMultiSelect, setShowMultiSelect] = useState<boolean>(
+    () => localStorage.getItem(STORAGE_KEYS.DEDUP_MULTI_SELECT) === 'true',
+  );
+  const lastClickedIdxRef = useRef<number | null>(null);
 
   // --- data state ---
   const [candidates, setCandidates] = useState<DedupCandidate[]>([]);
@@ -376,7 +398,28 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
     setSelected(new Set(filteredCandidates.map((c) => c.id)));
   };
 
-  const clearSelection = () => setSelected(new Set());
+  const clearSelection = () => {
+    setSelected(new Set());
+    lastClickedIdxRef.current = null;
+  };
+
+  // Click-to-select a row. Supports shift-click range selection.
+  const handleRowClick = (e: MouseEvent, id: number, idx: number) => {
+    // Don't steal clicks from buttons/links inside the row.
+    if ((e.target as HTMLElement).closest('a, button')) return;
+    if (e.shiftKey && lastClickedIdxRef.current !== null) {
+      const lo = Math.min(lastClickedIdxRef.current, idx);
+      const hi = Math.max(lastClickedIdxRef.current, idx);
+      setSelected((prev) => {
+        const next = new Set(prev);
+        filteredCandidates.slice(lo, hi + 1).forEach((c) => next.add(c.id));
+        return next;
+      });
+    } else {
+      toggleSelect(id);
+    }
+    lastClickedIdxRef.current = idx;
+  };
 
   // --- bulk actions ---
   const handleMergeSelected = async () => {
@@ -647,6 +690,22 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
             </Button>
           </span>
         </Tooltip>
+        <Box sx={{ flex: 1 }} />
+        <Tooltip title="Show checkboxes for bulk operations. Click any row to select; shift-click to range-select.">
+          <Button
+            size="small"
+            variant={showMultiSelect ? 'contained' : 'outlined'}
+            onClick={() => {
+              const next = !showMultiSelect;
+              setShowMultiSelect(next);
+              localStorage.setItem(STORAGE_KEYS.DEDUP_MULTI_SELECT, String(next));
+              if (!next) clearSelection();
+            }}
+            data-testid="multi-select-toggle"
+          >
+            {showMultiSelect ? 'Multi-select ON' : 'Multi-select'}
+          </Button>
+        </Tooltip>
       </Stack>
 
       {/* Band filter */}
@@ -744,58 +803,83 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
             <Table size="small">
               <TableHead>
                 <TableRow>
-                  <TableCell padding="checkbox">
-                    <Checkbox
-                      size="small"
-                      indeterminate={selected.size > 0 && selected.size < filteredCandidates.length}
-                      checked={
-                        filteredCandidates.length > 0 && selected.size === filteredCandidates.length
-                      }
-                      onChange={(e) => (e.target.checked ? selectAll() : clearSelection())}
-                    />
-                  </TableCell>
-                  <TableCell>Score / Band</TableCell>
+                  {showMultiSelect && (
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        size="small"
+                        indeterminate={selected.size > 0 && selected.size < filteredCandidates.length}
+                        checked={
+                          filteredCandidates.length > 0 && selected.size === filteredCandidates.length
+                        }
+                        onChange={(e) => (e.target.checked ? selectAll() : clearSelection())}
+                      />
+                    </TableCell>
+                  )}
                   <TableCell>Book A</TableCell>
                   <TableCell>Book B</TableCell>
-                  <TableCell align="center">Status</TableCell>
                   <TableCell align="center">Actions</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
-                {filteredCandidates.map((c) => {
+                {filteredCandidates.map((c, idx) => {
                   const busy = bulkBusy;
                   const bookA = c.book_a;
                   const bookB = c.book_b;
                   const qA = metadataQuality(bookA);
                   const qB = metadataQuality(bookB);
-                  // Recommend keeping the side with richer metadata. Ties (both
-                  // equal, or both missing) recommend neither.
                   const recommendA = qA > qB;
                   const recommendB = qB > qA;
+                  const isSelected = selected.has(c.id);
                   return (
                     <TableRow
                       key={c.id}
                       hover
-                      selected={selected.has(c.id)}
-                      sx={{ opacity: busy ? 0.7 : 1 }}
+                      selected={isSelected}
+                      onClick={(e) => handleRowClick(e, c.id, idx)}
+                      sx={{
+                        opacity: busy ? 0.7 : 1,
+                        cursor: 'pointer',
+                        // Zebra stripe: odd rows get a subtle tint for easier reading
+                        bgcolor: isSelected
+                          ? undefined
+                          : idx % 2 === 1
+                            ? 'action.hover'
+                            : 'transparent',
+                      }}
                     >
-                      <TableCell padding="checkbox">
-                        <Checkbox
-                          size="small"
-                          checked={selected.has(c.id)}
-                          onChange={() => toggleSelect(c.id)}
-                        />
-                      </TableCell>
-                      <TableCell sx={{ verticalAlign: 'top' }}>
-                        <ScoreBadgeRow
-                          band={c.band}
-                          score={c.score}
-                          layer={c.layer}
-                          similarity={c.similarity}
-                        />
-                      </TableCell>
-                      <TableCell sx={{ verticalAlign: 'top', minWidth: 280 }}>
+                      {showMultiSelect && (
+                        <TableCell padding="checkbox">
+                          <Checkbox
+                            size="small"
+                            checked={isSelected}
+                            onChange={() => toggleSelect(c.id)}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                        </TableCell>
+                      )}
+                      {/* Book A — badges (score/band/status) inline at top, then card */}
+                      <TableCell sx={{ verticalAlign: 'top', minWidth: 300 }}>
                         <Stack spacing={0.5}>
+                          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center">
+                            <ScoreBadgeRow
+                              band={c.band}
+                              score={c.score}
+                              layer={c.layer}
+                              similarity={c.similarity}
+                            />
+                            <Chip
+                              label={c.status}
+                              size="small"
+                              color={
+                                c.status === 'merged'
+                                  ? 'success'
+                                  : c.status === 'dismissed'
+                                    ? 'default'
+                                    : 'warning'
+                              }
+                              variant="outlined"
+                            />
+                          </Stack>
                           {renderBookCard(bookA, c.entity_a_id)}
                           <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
                             {qualityChip(qA)}
@@ -805,6 +889,7 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                           </Stack>
                         </Stack>
                       </TableCell>
+                      {/* Book B */}
                       <TableCell sx={{ verticalAlign: 'top', minWidth: 280 }}>
                         <Stack spacing={0.5}>
                           {renderBookCard(bookB, c.entity_b_id)}
@@ -815,20 +900,6 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                             )}
                           </Stack>
                         </Stack>
-                      </TableCell>
-                      <TableCell align="center" sx={{ verticalAlign: 'top' }}>
-                        <Chip
-                          label={c.status}
-                          size="small"
-                          color={
-                            c.status === 'merged'
-                              ? 'success'
-                              : c.status === 'dismissed'
-                                ? 'default'
-                                : 'warning'
-                          }
-                          variant="outlined"
-                        />
                       </TableCell>
                       <TableCell sx={{ verticalAlign: 'top' }}>
                         <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
@@ -899,7 +970,9 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
             }}
             rowsPerPage={rowsPerPage}
             onRowsPerPageChange={(e) => {
-              setRowsPerPage(parseInt(e.target.value, 10));
+              const val = parseInt(e.target.value, 10);
+              setRowsPerPage(val);
+              localStorage.setItem(STORAGE_KEYS.DEDUP_PAGE_SIZE, String(val));
               setPage(0);
               setSelected(new Set());
             }}

--- a/web/src/lib/storageKeys.ts
+++ b/web/src/lib/storageKeys.ts
@@ -1,7 +1,7 @@
 // file: web/src/lib/storageKeys.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c8a3d7b-2e1f-4a9c-b3d5-1e8f2a9c7d4b
-// last-edited: 2026-04-30
+// last-edited: 2026-06-19
 
 /** Centralised localStorage key constants. */
 export const STORAGE_KEYS = {
@@ -17,6 +17,8 @@ export const STORAGE_KEYS = {
   LIBRARY_RECENT_SEARCHES: 'library_recent_searches',
   METADATA_REVIEW_LANGUAGE_FILTER: 'metadata-review-language-filter',
   METADATA_REVIEW_PAGE_SIZE: 'metadata-review-page-size',
+  DEDUP_PAGE_SIZE: 'dedup-page-size',
+  DEDUP_MULTI_SELECT: 'dedup-multi-select',
 } as const;
 
 export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -167,6 +167,9 @@ export default function ActivityLog() {
   const [pinned, setPinned] = useState(() => localStorage.getItem(STORAGE_KEYS.ACTIVITY_OPS_PINNED) !== 'false');
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
   const [expandedOpId, setExpandedOpId] = useState<string | null>(searchParams.get('op'));
+  // pausedByExpand: true when auto-refresh was auto-paused because a row is
+  // expanded. Cleared when the row collapses or the user clicks "Follow log".
+  const pausedByExpandRef = useRef(false);
   const [opLogs, setOpLogs] = useState<string[]>([]);
   // opLogsLoaded distinguishes "haven't fetched yet" from "fetched, empty".
   // Without this, an op with zero logs shows "Loading logs..." forever.
@@ -223,6 +226,23 @@ export default function ActivityLog() {
     },
     [],
   );
+
+  // Auto-pause refresh when a row is expanded so log lines don't jump away.
+  // Restores the previous state when the row collapses, unless the user
+  // manually clicked "Follow log" (which clears pausedByExpandRef).
+  useEffect(() => {
+    if (expandedOpId !== null) {
+      if (autoRefresh) {
+        setAutoRefresh(false);
+        pausedByExpandRef.current = true;
+      }
+    } else if (pausedByExpandRef.current) {
+      setAutoRefresh(true);
+      pausedByExpandRef.current = false;
+    }
+  // intentionally omit autoRefresh — only trigger on expand/collapse transitions
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedOpId]);
 
   // Persist excluded sources
   useEffect(() => {
@@ -706,11 +726,27 @@ export default function ActivityLog() {
         <Typography variant="h4" sx={{ flexGrow: 1 }}>
           Activity
         </Typography>
+        {!isMobile && pausedByExpandRef.current && (
+          <Chip
+            label="Paused — row expanded"
+            size="small"
+            color="warning"
+            variant="outlined"
+            onDelete={() => {
+              pausedByExpandRef.current = false;
+              setAutoRefresh(true);
+            }}
+            deleteIcon={<span style={{ fontSize: '0.7rem', padding: '0 4px' }}>Follow log</span>}
+          />
+        )}
         {!isMobile && (
           <Button
             size="small"
             variant={autoRefresh ? 'contained' : 'outlined'}
-            onClick={() => setAutoRefresh(!autoRefresh)}
+            onClick={() => {
+              pausedByExpandRef.current = false;
+              setAutoRefresh(!autoRefresh);
+            }}
           >
             {autoRefresh ? 'Auto-refresh ON' : 'Auto-refresh OFF'}
           </Button>


### PR DESCRIPTION
## Commits

- `8d311e4` feat(dedup): UX overhaul — covers, zebra rows, click-select, page-size persistence, activity-log pause

## Changes

**Dedup candidate table:**
- Book cover thumbnails (44×44) on every candidate row; placeholder box when no cover stored
- Score/band/status chips moved inline to top of Book A cell — removes dedicated Score/Band and Status columns
- Zebra stripe alternating row backgrounds for easier row tracking at scale
- Click any row to select; shift-click for range selection (file-manager style)
- "Multi-select" toggle button in toolbar shows/hides checkboxes for bulk ops; hidden by default; state persists via localStorage
- Page size persists via `localStorage` (`dedup-page-size` key) — navigating back no longer resets to 25

**Activity log:**
- Expanding an op row auto-pauses auto-refresh so log lines stop jumping
- "Paused — row expanded" chip in header with "Follow log" one-click resume
- Collapsing the row restores previous refresh state

**TypeScript:**
- Fix implicit-any callback params in `CandidateCompareDrawer` (resp, err, winnerId, onChange)
- Add `DEDUP_PAGE_SIZE` + `DEDUP_MULTI_SELECT` keys to `storageKeys.ts`

**Docs:**
- TODO: DEDUP-KB-1 keyboard shortcuts, DEDUP-INTRO-1 Audible intro false positives, DEDUP-FOLDER-1 folder chip
- CHANGELOG: document all shipped features

## Test plan

- [ ] Navigate to dedup page, set page size to 250, click away and back — size preserved
- [ ] Verify book covers appear on candidate rows (or placeholder box if none)
- [ ] Click a row to select; shift-click another to range-select; verify zebra coloring
- [ ] Toggle "Multi-select" button — checkboxes appear/hide; state survives page reload
- [ ] In activity log, expand an op row — "Paused" chip appears; click "Follow log" — refresh resumes
- [ ] Collapse expanded row — refresh auto-resumes (no chip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)