### PR TITLE
feat(pathutil): path abbreviation helper ($(libroot)/$(books)) — Track A

### DIFF
--- a/docs/specs/2026-06-19-gold-labels-review-ui-and-path-abbrev-design.md
+++ b/docs/specs/2026-06-19-gold-labels-review-ui-and-path-abbrev-design.md
@@ -1,0 +1,190 @@
+<!-- file: docs/specs/2026-06-19-gold-labels-review-ui-and-path-abbrev-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3c8e1d57-9a42-4b6f-bd03-7e15a9c2f640 -->
+<!-- last-edited: 2026-06-19 -->
+
+# Gold Labels Review UI + Path Abbreviation — Design
+
+## Goal
+
+Bring the dedup **Gold Labels** review page (`/dedup/labels`,
+`web/src/pages/DedupLabels.tsx`, backend
+`internal/server/handlers/dedup/label_review.go`) up to the visual/quality bar set
+by `CandidateCompareDrawer`, and clear the documented dedup follow-ups. The work is
+split into four independent tracks, each shipping as its own PR (or several small
+PRs). More, smaller PRs are preferred over fewer large ones.
+
+The visual/quality reference for all UI work is
+`web/src/components/dedup/CandidateCompareDrawer.tsx` (the dedup picker with the
+fingerprint tab).
+
+## Background / current state
+
+- Each gold-label row carries a `candidate_id`. The existing endpoint
+  `GET /api/v1/dedup/candidates/:id/breakdown` returns full `book_a` / `book_b`
+  detail plus `score_breakdown.signals` — the same payload `CandidateCompareDrawer`
+  already renders. Req #3 (metadata-compare) is therefore largely a *reuse* of
+  existing infrastructure rather than new plumbing.
+- Path display today is ad-hoc: `FileInfoCompare.tsx` has a local `truncatePath`
+  that strips at the literal marker `audiobook-organizer/`; there is an unused
+  `filesCommonDir` helper at `internal/server/server_middleware.go:63`.
+- The dedup gold dataset on prod has ~5,946 labeled examples (1,153 true_dup,
+  4,092 not_dup, 701 unlabeled, 248 auto_high_conf). The page is live but needs the
+  fixes below.
+
+## Decisions (confirmed with user)
+
+1. **Compare UX**: reuse `CandidateCompareDrawer` (drawer now, inline expansion
+   considered later only if row-by-row review feels slow).
+2. **Label control**: 3-way segmented toggle `[ Dup | Unsure | Not ]`.
+3. **PR scope**: four separate tracks (A–D), each its own PR, split into smaller
+   PRs as convenient.
+4. **`books` variable**: derived as `filepath.Dir(RootDir)` — no new config field.
+5. **Tracks B and C are split** even though both touch the gold-labels page
+   (B = label control + path display + clickable rows; C = drawer integration +
+   extra judging fields).
+
+---
+
+## Track A — Path abbreviation helper (foundational, app-wide)
+
+### Variables (most-specific first)
+
+| Var          | Value                                              | Example render                              |
+|--------------|----------------------------------------------------|---------------------------------------------|
+| `$(libroot)` | `config.AppConfig.RootDir` (`/mnt/bigdata/books/audiobook-organizer`) | `$(libroot)/Sanderson/Mistborn/01.m4b` |
+| `$(books)`   | `filepath.Dir(RootDir)` (`/mnt/bigdata/books`)     | `$(books)/itunes/iTunes Media/x.m4a`        |
+| (none)       | anything else                                       | full path, or common-prefix-stripped        |
+
+Checked `libroot` first so the more-specific prefix wins; a path under `libroot` is
+never rendered as `$(books)/audiobook-organizer/...`.
+
+The abbreviation token (`$(libroot)`, `$(books)`) is rendered **literally** as a
+visible signal that the path is abbreviated. In React this is plain string text; in
+any markdown/terminal context the `$(...)` is escaped so it prints verbatim.
+
+### Backend
+
+New package `internal/pathutil/abbreviate.go`:
+
+```go
+// AbbreviatePath returns p with the most-specific known root replaced by a
+// literal $(var) token. Roots are checked libroot-first.
+func AbbreviatePath(p string) string
+
+// PathVars returns the {name, value} pairs in match order, for the UI legend
+// and for the frontend formatter to stay in sync with the backend.
+func PathVars() []PathVar
+```
+
+- Roots are read from `config.AppConfig.RootDir` at call time (handles hot-reload).
+- The unused `filesCommonDir` logic folds in here as the "strip a sensible common
+  prefix" fallback for multi-file books, becoming a real call site instead of dead
+  code. The old `filesCommonDir` is removed (or made a thin wrapper) and its one
+  intended use is rewired to the new helper.
+
+### Frontend
+
+`web/src/utils/formatPath.ts`:
+
+- `formatPath(path: string, vars: PathVar[]): string` — mirrors the backend rules.
+- `usePathVars()` — reads `{libroot, books}` once from the existing config
+  (`GET /config` exposes `RootDir`; `books` derived as the parent) and caches it, so
+  there is a single source of truth shared with the backend ordering.
+- `<PathVarsLegend />` — renders the footer:
+  `Information: $(libroot) = /mnt/bigdata/books/audiobook-organizer · $(books) = /mnt/bigdata/books`.
+
+Replaces the local `truncatePath` in `FileInfoCompare.tsx` and is then spread to the
+highest-traffic path displays (file lists, book detail, dedup tabs) incrementally.
+
+### Naming
+
+`libroot` and `books` — short and clear. `libroot` over `library-root`; `books`
+over `booksdir`.
+
+### Test strategy (A)
+
+- Go table tests for `AbbreviatePath`: libroot match, books match, libroot-wins-over-books,
+  unrelated path, trailing-slash, exact-root, empty.
+- Vitest for `formatPath`: same cases, parity with Go expectations.
+
+---
+
+## Track B — Gold Labels: real label control + paths + clickable rows (req #2)
+
+- Replace the two text buttons (`dup` / `not`) with an MUI `ToggleButtonGroup`:
+  **[ Dup | Unsure | Not ]**, current label highlighted (green / amber / red).
+  Setting a value calls the existing override endpoint (which already writes
+  `label_source=human`).
+- File name + abbreviated path via the Track-A `formatPath`; **hover shows the full
+  path** (Tooltip), preserving current behavior.
+- Title / file cells become **clickable → open the book**: opens the Track-C drawer
+  (preferred) or navigates to `/library/:id` as a fallback before C lands.
+- Tighten table density toward the `CandidateCompareDrawer` bar.
+
+### Test strategy (B)
+
+- Vitest: toggle renders current label as selected; clicking a value POSTs the
+  override and optimistically updates; tooltip carries full path; row click fires the
+  open handler.
+
+---
+
+## Track C — Gold Labels: metadata-compare drawer (req #3)
+
+- Row click opens the existing `CandidateCompareDrawer` keyed by `candidate_id`
+  (it already fetches `/breakdown` → files + score breakdown + fingerprint +
+  open-book).
+- Extend the compare with the extra judging fields: **series, narrator,
+  parts/file-count, total duration, total size, and which signal fired**
+  (`score_breakdown.signals[].kind / evidence`, `primary` flag). Most exist in the
+  breakdown payload already; surface the missing ones (series / narrator) by widening
+  `DedupBookDetail` + the breakdown handler. Because the drawer is shared, the dedup
+  picker gains the richer fields too.
+
+### Test strategy (C)
+
+- Go: breakdown handler returns the widened fields (series_name, narrator_name).
+- Vitest: drawer opens from a gold-labels row; new fields render; existing
+  CandidateCompareDrawer tests stay green.
+
+---
+
+## Track D — Backend dedup fixes (req #4), each its own PR
+
+- **D1 — `quarantine-chapter-artifacts` root cause.** Dry-run currently finds only
+  53 books and misses the unscanned (`Duration=0`) "Opening Credits" / "Big Finish
+  Ident" idents despite the v2 unscanned-branch. Instrument the dry-run to log *why*
+  each candidate book is skipped; confirm whether the cause is normalized-title
+  bucketing or `GetBookFiles` via memdb returning ≠1 for `Duration=0` idents; fix.
+  **Dry-run only — the list is shown to the user before any apply.**
+- **D2 — Scanner prevention.** `groupFilesIntoBooks` (`internal/scanner/scanner.go`)
+  stops emitting standalone books for single-file short segments that sit alongside a
+  multi-file book — the real upstream cause of the candidate balloon.
+- **D3 — Drain stale exact candidates.** Once D1/D2 criteria are right, drain the
+  remaining ~356K stale exact candidates.
+- **D4 — Manual-import UI button.** Frontend for the already-merged+deployed
+  `library.import` op (folder / file picker).
+
+### Test strategy (D)
+
+- D1: unit test that an unscanned single-file ident with a colliding title is
+  selected by the dry-run; regression for the previously-missed branch.
+- D2: scanner test that a single-file short segment beside a multi-file book is not
+  emitted as a standalone book.
+- D4: Vitest for the import button + picker; backend already tested.
+
+---
+
+## Rollback
+
+- Tracks A–C are additive UI/helper changes; rollback = revert the PR. The path
+  helper has no data effects.
+- Track D1 is dry-run only (no writes). D2 changes scan output going forward only
+  (no migration). D3 is the only data-mutating step and is gated behind explicit
+  user confirmation with the list shown first.
+
+## Build order
+
+A → B → C → D1 → D2 → D3 → D4. A is foundational (B/C consume it). D items are
+independent of A–C and can interleave, but D3 depends on D1+D2.

--- a/internal/pathutil/abbreviate.go
+++ b/internal/pathutil/abbreviate.go
@@ -1,0 +1,65 @@
+// file: internal/pathutil/abbreviate.go
+// version: 1.0.0
+// guid: 4a7d2e91-3c58-4b06-9f2a-1d8e6b07c534
+// last-edited: 2026-06-19
+
+// Package pathutil renders filesystem paths in a short, readable form for the
+// UI by replacing known library roots with literal $(var) tokens. The same
+// rules are mirrored by the frontend formatter (web/src/utils/formatPath.ts);
+// PathVars is the single source of truth for the root values both sides use.
+package pathutil
+
+import (
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+)
+
+// PathVar is a named library root used for abbreviation. Value is the absolute
+// path prefix; Name is the short token shown in its place (e.g. "libroot").
+type PathVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// Abbreviate replaces the most-specific matching root in p with a literal
+// $(name) token. vars are checked in the order given, so callers must list the
+// most-specific root first (e.g. libroot before books, since libroot is nested
+// under books). Empty-valued vars are skipped so they never match everything.
+// Paths matching no var are returned unchanged.
+func Abbreviate(p string, vars []PathVar) string {
+	for _, v := range vars {
+		if v.Value == "" {
+			continue
+		}
+		if p == v.Value {
+			return "$(" + v.Name + ")"
+		}
+		if strings.HasPrefix(p, v.Value+"/") {
+			return "$(" + v.Name + ")" + p[len(v.Value):]
+		}
+	}
+	return p
+}
+
+// PathVars returns the configured library roots in match order (most-specific
+// first): libroot = config RootDir, books = its parent directory.
+func PathVars() []PathVar {
+	root := strings.TrimRight(config.AppConfig.RootDir, "/")
+	if root == "" {
+		return nil
+	}
+	books := root
+	if i := strings.LastIndex(root, "/"); i > 0 {
+		books = root[:i]
+	}
+	return []PathVar{
+		{Name: "libroot", Value: root},
+		{Name: "books", Value: books},
+	}
+}
+
+// AbbreviatePath abbreviates p using the configured library roots.
+func AbbreviatePath(p string) string {
+	return Abbreviate(p, PathVars())
+}

--- a/internal/pathutil/abbreviate_test.go
+++ b/internal/pathutil/abbreviate_test.go
@@ -1,0 +1,83 @@
+// file: internal/pathutil/abbreviate_test.go
+// version: 1.0.0
+// guid: 9b1f4e2a-6c83-4d07-a5e1-2f9c8b4d6071
+// last-edited: 2026-06-19
+
+package pathutil
+
+import "testing"
+
+func TestAbbreviate(t *testing.T) {
+	// libroot is intentionally *under* books so we can prove the
+	// most-specific-first ordering: a path under libroot must never render
+	// as $(books)/audiobook-organizer/...
+	vars := []PathVar{
+		{Name: "libroot", Value: "/mnt/bigdata/books/audiobook-organizer"},
+		{Name: "books", Value: "/mnt/bigdata/books"},
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "path under libroot",
+			in:   "/mnt/bigdata/books/audiobook-organizer/Sanderson/Mistborn/01.m4b",
+			want: "$(libroot)/Sanderson/Mistborn/01.m4b",
+		},
+		{
+			name: "path under books but not libroot",
+			in:   "/mnt/bigdata/books/itunes/iTunes Media/x.m4a",
+			want: "$(books)/itunes/iTunes Media/x.m4a",
+		},
+		{
+			name: "libroot wins over books for a libroot path",
+			in:   "/mnt/bigdata/books/audiobook-organizer/Author/book.m4b",
+			want: "$(libroot)/Author/book.m4b",
+		},
+		{
+			name: "exact libroot",
+			in:   "/mnt/bigdata/books/audiobook-organizer",
+			want: "$(libroot)",
+		},
+		{
+			name: "exact books",
+			in:   "/mnt/bigdata/books",
+			want: "$(books)",
+		},
+		{
+			name: "unrelated path unchanged",
+			in:   "/var/lib/audiobook-organizer/audiobooks.pebble",
+			want: "/var/lib/audiobook-organizer/audiobooks.pebble",
+		},
+		{
+			name: "sibling that shares a name prefix is not a match",
+			in:   "/mnt/bigdata/books-archive/x.m4b",
+			want: "/mnt/bigdata/books-archive/x.m4b",
+		},
+		{
+			name: "empty path",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Abbreviate(tc.in, vars); got != tc.want {
+				t.Errorf("Abbreviate(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// An empty var value must never swallow every path (would turn "" into a
+// prefix match for everything).
+func TestAbbreviate_SkipsEmptyVarValue(t *testing.T) {
+	vars := []PathVar{{Name: "libroot", Value: ""}}
+	in := "/some/path/file.m4b"
+	if got := Abbreviate(in, vars); got != in {
+		t.Errorf("Abbreviate(%q) with empty var = %q, want unchanged", in, got)
+	}
+}

--- a/internal/pathutil/commondir.go
+++ b/internal/pathutil/commondir.go
@@ -1,0 +1,35 @@
+// file: internal/pathutil/commondir.go
+// version: 1.0.0
+// guid: 7c0b3f49-5a26-4d18-9e72-0b8d4a6c2f51
+// last-edited: 2026-06-19
+
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// CommonDir returns the deepest directory that contains all of the given file
+// paths. With a single file it returns that file's directory; with no shared
+// ancestor it returns "/". Returns "" for empty input. This is the shared-prefix
+// fallback used when a path matches no named library root.
+//
+// (Folded in from the previously-unused server.filesCommonDir helper so the
+// logic lives in one place instead of being hardcoded at call sites.)
+func CommonDir(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	common := filepath.Dir(paths[0])
+	for _, p := range paths[1:] {
+		dir := filepath.Dir(p)
+		for common != dir && !strings.HasPrefix(dir, common+string(filepath.Separator)) {
+			common = filepath.Dir(common)
+			if common == "/" || common == "." {
+				return common
+			}
+		}
+	}
+	return common
+}

--- a/internal/pathutil/commondir_test.go
+++ b/internal/pathutil/commondir_test.go
@@ -1,0 +1,49 @@
+// file: internal/pathutil/commondir_test.go
+// version: 1.0.0
+// guid: 1e6c9a07-2d54-4b38-8f01-7a2e5c9d4b63
+// last-edited: 2026-06-19
+
+package pathutil
+
+import "testing"
+
+func TestCommonDir(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{
+			name: "single file returns its dir",
+			in:   []string{"/mnt/books/Author/Book/01.m4b"},
+			want: "/mnt/books/Author/Book",
+		},
+		{
+			name: "files in same dir",
+			in:   []string{"/mnt/books/Author/Book/01.m4b", "/mnt/books/Author/Book/02.m4b"},
+			want: "/mnt/books/Author/Book",
+		},
+		{
+			name: "files in nested subdirs share the ancestor",
+			in:   []string{"/mnt/books/Author/Book/cd1/01.m4b", "/mnt/books/Author/Book/cd2/01.m4b"},
+			want: "/mnt/books/Author/Book",
+		},
+		{
+			name: "no shared dir falls back to root",
+			in:   []string{"/a/x.m4b", "/b/y.m4b"},
+			want: "/",
+		},
+		{
+			name: "empty input",
+			in:   nil,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CommonDir(tc.in); got != tc.want {
+				t.Errorf("CommonDir(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server_middleware.go
+++ b/internal/server/server_middleware.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_middleware.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 6a093405-441a-4c14-a9c5-46326ea767c1
-// last-edited: 2026-06-16
+// last-edited: 2026-06-19
 
 package server
 
@@ -13,9 +13,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func corsMiddleware() gin.HandlerFunc {
@@ -58,23 +58,6 @@ func corsMiddleware() gin.HandlerFunc {
 
 		c.Next()
 	}
-}
-
-func filesCommonDir(files []database.BookFile) string {
-	if len(files) == 0 {
-		return ""
-	}
-	common := filepath.Dir(files[0].FilePath)
-	for _, f := range files[1:] {
-		fDir := filepath.Dir(f.FilePath)
-		for common != fDir && !strings.HasPrefix(fDir, common+string(filepath.Separator)) {
-			common = filepath.Dir(common)
-			if common == "/" || common == "." {
-				return common
-			}
-		}
-	}
-	return common
 }
 
 // isProtectedPath is now a method on *Server so it uses the server's

--- a/web/src/components/common/PathVarsLegend.tsx
+++ b/web/src/components/common/PathVarsLegend.tsx
@@ -1,0 +1,33 @@
+// file: web/src/components/common/PathVarsLegend.tsx
+// version: 1.0.0
+// guid: 8b4e0d27-1c93-4a56-9f70-2e6a5c8d1b34
+// last-edited: 2026-06-19
+
+// PathVarsLegend renders the expansion key for abbreviated paths, e.g.
+//   Information: $(libroot) = /mnt/bigdata/books/audiobook-organizer · $(books) = /mnt/bigdata/books
+// Place at the bottom of any page that shows abbreviated paths.
+
+import { Typography } from '@mui/material';
+import { usePathVars, type PathVar } from '../../utils/formatPath';
+
+interface PathVarsLegendProps {
+  /** Override the vars (defaults to the shared config-derived vars). */
+  vars?: PathVar[];
+}
+
+export function PathVarsLegend({ vars }: PathVarsLegendProps) {
+  const loaded = usePathVars();
+  const list = vars ?? loaded;
+  if (list.length === 0) return null;
+  return (
+    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+      Information:{' '}
+      {list.map((v, i) => (
+        <span key={v.name}>
+          {i > 0 && ' · '}
+          <code>{`$(${v.name})`}</code> = {v.value}
+        </span>
+      ))}
+    </Typography>
+  );
+}

--- a/web/src/components/dedup/FileInfoCompare.tsx
+++ b/web/src/components/dedup/FileInfoCompare.tsx
@@ -1,13 +1,14 @@
 // file: web/src/components/dedup/FileInfoCompare.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: e4d5f6a7-b8c9-0123-defa-ed4567890123
-// last-edited: 2026-06-10
+// last-edited: 2026-06-19
 
 // FileInfoCompare renders a side-by-side comparison of two books' file lists.
 // Used inside CandidateCompareDrawer.
 
 import { Box, Chip, Divider, Stack, Tooltip, Typography } from '@mui/material';
 import type { DedupBookDetail } from '../../services/api';
+import { formatPath, usePathVars, type PathVar } from '../../utils/formatPath';
 
 function formatBytes(bytes: number | undefined): string {
   if (bytes == null) return '';
@@ -24,18 +25,13 @@ function formatDuration(seconds: number | undefined): string {
   return `${m}m`;
 }
 
-function truncatePath(path: string): string {
-  const marker = 'audiobook-organizer/';
-  const idx = path.indexOf(marker);
-  return idx >= 0 ? path.slice(idx + marker.length) : path;
-}
-
 interface BookFilesColumnProps {
   book: DedupBookDetail;
   label: string;
+  pathVars: PathVar[];
 }
 
-function BookFilesColumn({ book, label }: BookFilesColumnProps) {
+function BookFilesColumn({ book, label, pathVars }: BookFilesColumnProps) {
   return (
     <Box sx={{ flex: 1, minWidth: 0 }}>
       <Typography
@@ -84,7 +80,7 @@ function BookFilesColumn({ book, label }: BookFilesColumnProps) {
                   sx={{ fontFamily: 'monospace', fontSize: '0.65rem', display: 'block' }}
                   noWrap
                 >
-                  {truncatePath(f.file_path)}
+                  {formatPath(f.file_path, pathVars)}
                 </Typography>
                 <Stack direction="row" spacing={0.5} sx={{ mt: 0.25 }}>
                   {f.format && (
@@ -127,6 +123,7 @@ interface FileInfoCompareProps {
 }
 
 export function FileInfoCompare({ bookA, bookB }: FileInfoCompareProps) {
+  const pathVars = usePathVars();
   return (
     <Stack
       direction="row"
@@ -135,8 +132,8 @@ export function FileInfoCompare({ bookA, bookB }: FileInfoCompareProps) {
       sx={{ alignItems: 'flex-start' }}
       data-testid="file-info-compare"
     >
-      <BookFilesColumn book={bookA} label="Book A" />
-      <BookFilesColumn book={bookB} label="Book B" />
+      <BookFilesColumn book={bookA} label="Book A" pathVars={pathVars} />
+      <BookFilesColumn book={bookB} label="Book B" pathVars={pathVars} />
     </Stack>
   );
 }

--- a/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
+++ b/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
-// version: 1.2.0
+// version: 1.2.1
 // guid: d4e5f6a7-b8c9-0123-defa-444567890123
 // last-edited: 2026-06-19
 
@@ -71,6 +71,9 @@ function renderInRouter() {
 describe('UnifiedDedupTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // UnifiedDedupTab persists multi-select / page-size to localStorage and
+    // reads them on init; clear between tests so the suite is order-independent.
+    localStorage.clear();
     // Default: fetch returns an empty candidate list.
     vi.mocked(api.getDedupCandidates).mockResolvedValue({
       candidates: [],
@@ -189,12 +192,15 @@ describe('UnifiedDedupTab', () => {
       expect(screen.getByText(bookATitle)).toBeInTheDocument();
     });
 
-    // Checkboxes are hidden by default.
-    expect(screen.queryByRole('checkbox')).toBeNull();
+    // Row-selection checkboxes are hidden by default. (The toolbar's
+    // "Both need manual matching" filter checkbox is always present, so we
+    // assert the count grows once multi-select adds per-row checkboxes rather
+    // than asserting zero checkboxes.)
+    const baseline = screen.queryAllByRole('checkbox').length;
 
-    // Enable multi-select — checkboxes should appear.
+    // Enable multi-select — per-row checkboxes should appear.
     fireEvent.click(screen.getByTestId('multi-select-toggle'));
-    expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(baseline);
   });
 
   it('shows rescore dialog when rescore button clicked', async () => {

--- a/web/src/utils/__tests__/formatPath.test.ts
+++ b/web/src/utils/__tests__/formatPath.test.ts
@@ -1,0 +1,63 @@
+// file: web/src/utils/__tests__/formatPath.test.ts
+// version: 1.0.0
+// guid: c2f7a9e3-6b40-4d18-9a52-1e7c3d8b0f64
+// last-edited: 2026-06-19
+
+import { describe, it, expect } from 'vitest';
+import { formatPath, derivePathVars } from '../formatPath';
+
+const vars = [
+  { name: 'libroot', value: '/mnt/bigdata/books/audiobook-organizer' },
+  { name: 'books', value: '/mnt/bigdata/books' },
+];
+
+describe('formatPath', () => {
+  it('abbreviates a path under libroot', () => {
+    expect(formatPath('/mnt/bigdata/books/audiobook-organizer/Sanderson/Mistborn/01.m4b', vars)).toBe(
+      '$(libroot)/Sanderson/Mistborn/01.m4b'
+    );
+  });
+
+  it('abbreviates a path under books but not libroot', () => {
+    expect(formatPath('/mnt/bigdata/books/itunes/iTunes Media/x.m4a', vars)).toBe(
+      '$(books)/itunes/iTunes Media/x.m4a'
+    );
+  });
+
+  it('prefers libroot over books (most-specific wins)', () => {
+    expect(formatPath('/mnt/bigdata/books/audiobook-organizer/A/b.m4b', vars)).toBe('$(libroot)/A/b.m4b');
+  });
+
+  it('returns exact root as the bare token', () => {
+    expect(formatPath('/mnt/bigdata/books/audiobook-organizer', vars)).toBe('$(libroot)');
+    expect(formatPath('/mnt/bigdata/books', vars)).toBe('$(books)');
+  });
+
+  it('leaves unrelated paths unchanged', () => {
+    expect(formatPath('/var/lib/audiobook-organizer/db.pebble', vars)).toBe(
+      '/var/lib/audiobook-organizer/db.pebble'
+    );
+  });
+
+  it('does not match a sibling that only shares a name prefix', () => {
+    expect(formatPath('/mnt/bigdata/books-archive/x.m4b', vars)).toBe('/mnt/bigdata/books-archive/x.m4b');
+  });
+
+  it('skips empty-valued vars so they never match everything', () => {
+    expect(formatPath('/some/path.m4b', [{ name: 'libroot', value: '' }])).toBe('/some/path.m4b');
+  });
+});
+
+describe('derivePathVars', () => {
+  it('derives libroot from rootDir and books from its parent', () => {
+    expect(derivePathVars('/mnt/bigdata/books/audiobook-organizer')).toEqual(vars);
+  });
+
+  it('strips a trailing slash from rootDir', () => {
+    expect(derivePathVars('/mnt/bigdata/books/audiobook-organizer/')).toEqual(vars);
+  });
+
+  it('returns empty for an empty rootDir', () => {
+    expect(derivePathVars('')).toEqual([]);
+  });
+});

--- a/web/src/utils/formatPath.ts
+++ b/web/src/utils/formatPath.ts
@@ -1,0 +1,81 @@
+// file: web/src/utils/formatPath.ts
+// version: 1.0.0
+// guid: 5d9a2c84-7e61-4f30-b8a2-0c6f1e9d4a72
+// last-edited: 2026-06-19
+
+// Path abbreviation for the UI: replace known library roots with literal
+// $(var) tokens so paths render short. Mirrors the backend rules in
+// internal/pathutil/abbreviate.go — keep the two in sync.
+
+import { useEffect, useState } from 'react';
+import { getConfig } from '../services/api';
+
+export interface PathVar {
+  name: string;
+  value: string;
+}
+
+/**
+ * formatPath replaces the most-specific matching root in `path` with a literal
+ * `$(name)` token. `vars` are checked in order, so the caller must list the
+ * most-specific root first (libroot before books). Empty-valued vars are
+ * skipped so they never match everything. Unmatched paths are returned as-is.
+ */
+export function formatPath(path: string, vars: PathVar[]): string {
+  for (const v of vars) {
+    if (!v.value) continue;
+    if (path === v.value) return `$(${v.name})`;
+    if (path.startsWith(v.value + '/')) return `$(${v.name})` + path.slice(v.value.length);
+  }
+  return path;
+}
+
+/**
+ * derivePathVars builds the abbreviation vars from the library root dir:
+ * libroot = rootDir (trailing slash stripped), books = its parent directory.
+ */
+export function derivePathVars(rootDir: string): PathVar[] {
+  const root = rootDir.replace(/\/+$/, '');
+  if (!root) return [];
+  const i = root.lastIndexOf('/');
+  const books = i > 0 ? root.slice(0, i) : root;
+  return [
+    { name: 'libroot', value: root },
+    { name: 'books', value: books },
+  ];
+}
+
+// Single shared fetch of the config so every consumer of usePathVars reuses one
+// request rather than each refetching /config.
+let cachedVarsPromise: Promise<PathVar[]> | null = null;
+
+function loadPathVars(): Promise<PathVar[]> {
+  if (!cachedVarsPromise) {
+    cachedVarsPromise = getConfig()
+      .then((cfg) => derivePathVars(cfg.root_dir || ''))
+      .catch(() => {
+        // On failure, don't poison the cache — allow a later retry.
+        cachedVarsPromise = null;
+        return [];
+      });
+  }
+  return cachedVarsPromise;
+}
+
+/**
+ * usePathVars returns the abbreviation vars (libroot/books), loaded once from
+ * config and shared across all callers. Empty until loaded.
+ */
+export function usePathVars(): PathVar[] {
+  const [vars, setVars] = useState<PathVar[]>([]);
+  useEffect(() => {
+    let alive = true;
+    void loadPathVars().then((v) => {
+      if (alive) setVars(v);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return vars;
+}


### PR DESCRIPTION
## Track A — Path abbreviation (foundational)

First of four tracks bringing the dedup **Gold Labels** review UI up to the `CandidateCompareDrawer` bar. Spec: `docs/specs/2026-06-19-gold-labels-review-ui-and-path-abbrev-design.md`.

Renders filesystem paths short by replacing known library roots with literal `$(var)` tokens, checked most-specific-first so a libroot path never renders as `$(books)/audiobook-organizer/...`.

### Backend — `internal/pathutil`
- `Abbreviate(path, vars)` / `PathVars()` / `AbbreviatePath(path)` — `libroot` = config `RootDir`, `books` = its parent dir (no new config field).
- `CommonDir(paths)` — folds in the previously **unused** `server.filesCommonDir` as the shared-prefix fallback (dead code removed).

### Frontend
- `web/src/utils/formatPath.ts` — `formatPath`/`derivePathVars` mirroring the backend rules + `usePathVars()` hook (single shared `/config` fetch, cached).
- `PathVarsLegend` component for the `Information: $(libroot) = … · $(books) = …` footer.
- `FileInfoCompare` now uses `formatPath` instead of the hardcoded `'audiobook-organizer/'` marker.

### Tests
- Go table tests: libroot-wins-over-books, exact-root, sibling-prefix non-match, empty-var guard, common dir.
- vitest: `formatPath`/`derivePathVars` (10 cases). Full dedup component suite green (31 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)