### PR TITLE
feat(dedup): redesign candidate card layout + clean up score badges

### DIFF
--- a/web/src/components/dedup/ScoreBadgeRow.tsx
+++ b/web/src/components/dedup/ScoreBadgeRow.tsx
@@ -1,12 +1,12 @@
 // file: web/src/components/dedup/ScoreBadgeRow.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c2b3d4e5-f6a7-8901-bcde-cb2345678901
-// last-edited: 2026-06-10
+// last-edited: 2026-06-19
 
 // ScoreBadgeRow renders a compact row of band + score chips for a candidate.
 // Used inside the candidate table and the comparison drawer header.
 
-import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material';
+import { Chip, Stack, Tooltip } from '@mui/material';
 import type { DedupBand } from '../../services/api';
 import { BAND_CONFIG } from './BandFilterBar';
 
@@ -17,8 +17,9 @@ interface ScoreBadgeRowProps {
   similarity?: number;
 }
 
-const LAYER_COLORS: Record<string, 'error' | 'primary' | 'secondary' | 'default'> = {
-  exact: 'error',
+// Non-exact layers are shown since they're distinctive. "exact" is omitted —
+// when everything in view is exact it adds no information and wastes space.
+const NOTABLE_LAYER_COLORS: Record<string, 'primary' | 'secondary' | 'default'> = {
   embedding: 'primary',
   llm: 'secondary',
 };
@@ -26,52 +27,44 @@ const LAYER_COLORS: Record<string, 'error' | 'primary' | 'secondary' | 'default'
 export function ScoreBadgeRow({ band, score, layer, similarity }: ScoreBadgeRowProps) {
   const bandCfg = band ? BAND_CONFIG[band as DedupBand] : null;
 
+  // Prefer the composite score; fall back to raw similarity percentage.
+  const scoreLabel =
+    score != null
+      ? `${score.toFixed(0)}%`
+      : similarity != null
+        ? `${(similarity * 100).toFixed(0)}%`
+        : null;
+
+  const scoreTooltip =
+    score != null
+      ? `Composite score: ${score.toFixed(1)} / 100`
+      : similarity != null
+        ? `Raw similarity: ${(similarity * 100).toFixed(1)}%`
+        : '';
+
   return (
     <Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" useFlexGap>
       {bandCfg && (
         <Tooltip title={bandCfg.description}>
-          <Chip
-            label={bandCfg.label}
-            size="small"
-            color={bandCfg.color}
-            variant="filled"
-          />
+          <Chip label={bandCfg.label} size="small" color={bandCfg.color} variant="filled" />
         </Tooltip>
       )}
       {band && !bandCfg && (
         <Chip label={String(band)} size="small" variant="outlined" />
       )}
-      {score != null && (
-        <Tooltip title={`Composite score: ${score.toFixed(1)} / 100`}>
-          <Box
-            component="span"
-            sx={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              bgcolor: 'action.hover',
-              borderRadius: 1,
-              px: 0.75,
-              py: 0.25,
-            }}
-          >
-            <Typography variant="caption" fontWeight={600}>
-              {score.toFixed(0)}
-            </Typography>
-          </Box>
+      {scoreLabel && (
+        <Tooltip title={scoreTooltip}>
+          <Chip label={scoreLabel} size="small" variant="outlined" color="default" />
         </Tooltip>
       )}
-      {layer && (
+      {/* Only show layer when it's something non-obvious (not "exact") */}
+      {layer && layer !== 'exact' && layer in NOTABLE_LAYER_COLORS && (
         <Chip
           label={layer}
           size="small"
-          color={LAYER_COLORS[layer] ?? 'default'}
+          color={NOTABLE_LAYER_COLORS[layer]}
           variant="outlined"
         />
-      )}
-      {similarity != null && score == null && (
-        <Typography variant="caption" color="text.secondary">
-          {(similarity * 100).toFixed(1)}%
-        </Typography>
       )}
     </Stack>
   );

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
 // last-edited: 2026-06-19
 
@@ -21,7 +21,7 @@
 //   - Timers cleared on unmount.
 //   - No module-level mutable state.
 
-import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type MouseEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams, Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
@@ -104,13 +104,21 @@ function qualityChip(score: number) {
   return <Chip label="Poor metadata" size="small" color="error" variant="outlined" />;
 }
 
-// renderBookCard shows a candidate book's title (linking to its detail page) and
-// file path. The title falls back to a muted ULID tail when the book row is
-// missing (merged/deleted/orphaned candidate) and is shown in orange when the
-// stored title is itself garbage — the case the user kept hitting in the raw-ULID
-// table. Path lives under the title so identical/missing titles can still be
-// disambiguated.
-function renderBookCard(book: Book | null | undefined, id: string) {
+interface BookCardOpts {
+  /** Score/band/status chips rendered above the title — only supplied for Book A. */
+  badgesNode?: ReactNode;
+  /** Quality chip shown inline after the title. */
+  qualityChipNode?: ReactNode;
+  /** "★ Recommended keep" chip shown inline after quality. */
+  recommendedNode?: ReactNode;
+}
+
+// renderBookCard renders a candidate book with:
+//   • cover on the LEFT spanning full row height
+//   • score/status badges above the title (Book A only, via badgesNode)
+//   • title (bigger) + quality chip inline on the same line
+//   • author + monospace path below
+function renderBookCard(book: Book | null | undefined, id: string, opts: BookCardOpts = {}) {
   const missing = !book;
   const path = book?.file_path ?? '';
   const title = book?.title ?? '';
@@ -118,67 +126,92 @@ function renderBookCard(book: Book | null | undefined, id: string) {
   const isGarbageTitle =
     !title || title.toUpperCase() === 'TITLE' || /^[0-9A-Z]{26}$/.test(title.trim());
   return (
-    <Stack direction="row" spacing={1} sx={{ minWidth: 0, alignItems: 'flex-start' }}>
-      {coverUrl && (
-        <Box
-          component="img"
-          src={coverUrl}
-          alt=""
-          loading="lazy"
-          sx={{ width: 44, height: 44, objectFit: 'cover', borderRadius: 0.5, flexShrink: 0, mt: 0.25 }}
-        />
-      )}
-      {!coverUrl && (
-        <Box sx={{ width: 44, height: 44, borderRadius: 0.5, flexShrink: 0, bgcolor: 'action.selected', mt: 0.25 }} />
-      )}
-      <Stack spacing={0.25} sx={{ minWidth: 0, flex: 1 }}>
-      {missing ? (
-        <Typography variant="body2" sx={{ color: 'error.main', fontStyle: 'italic' }}>
-          (missing book — {id.slice(-8)})
-        </Typography>
-      ) : (
-        <Link
-          component={RouterLink}
-          to={`/library/${id}`}
-          underline="hover"
-          sx={{
-            color: isGarbageTitle ? 'warning.main' : 'primary.main',
-            fontWeight: 500,
-            fontSize: '0.95rem',
-            textTransform: 'none',
-            textAlign: 'left',
-            display: 'block',
-            whiteSpace: 'normal',
-            wordBreak: 'break-word',
-            fontStyle: isGarbageTitle ? 'italic' : 'normal',
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {isGarbageTitle ? title || '(no title)' : title}
-        </Link>
-      )}
-      {book?.author_name && (
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          {book.author_name}
-        </Typography>
-      )}
-      {path && (
-        <Tooltip title={path} placement="bottom-start">
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'text.secondary',
-              fontFamily: 'monospace',
-              fontSize: '0.72rem',
-              lineHeight: 1.2,
-              wordBreak: 'break-all',
-              opacity: 0.75,
-            }}
-          >
-            {path}
+    <Stack direction="row" alignItems="stretch" spacing={1.5} sx={{ minWidth: 0 }}>
+      {/* Cover — left-anchored, full row height */}
+      <Box
+        sx={{
+          width: 56,
+          flexShrink: 0,
+          borderRadius: 0.5,
+          overflow: 'hidden',
+          alignSelf: 'stretch',
+          minHeight: 68,
+          bgcolor: 'action.selected',
+        }}
+      >
+        {coverUrl && (
+          <Box
+            component="img"
+            src={coverUrl}
+            alt=""
+            loading="lazy"
+            sx={{ width: 56, height: '100%', objectFit: 'cover', display: 'block' }}
+          />
+        )}
+      </Box>
+
+      {/* Text content */}
+      <Stack spacing={0.4} sx={{ minWidth: 0, flex: 1 }}>
+        {/* Badges row — only rendered when supplied (Book A) */}
+        {opts.badgesNode && (
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center">
+            {opts.badgesNode}
+          </Stack>
+        )}
+
+        {/* Title + inline quality + recommended chips */}
+        <Stack direction="row" alignItems="center" flexWrap="wrap" spacing={0.5} useFlexGap>
+          {missing ? (
+            <Typography variant="body1" sx={{ color: 'error.main', fontStyle: 'italic' }}>
+              (missing book — {id.slice(-8)})
+            </Typography>
+          ) : (
+            <Link
+              component={RouterLink}
+              to={`/library/${id}`}
+              underline="hover"
+              sx={{
+                color: isGarbageTitle ? 'warning.main' : 'primary.main',
+                fontWeight: 600,
+                fontSize: '1rem',
+                textTransform: 'none',
+                textAlign: 'left',
+                whiteSpace: 'normal',
+                wordBreak: 'break-word',
+                fontStyle: isGarbageTitle ? 'italic' : 'normal',
+              }}
+              onClick={(e: MouseEvent) => e.stopPropagation()}
+            >
+              {isGarbageTitle ? title || '(no title)' : title}
+            </Link>
+          )}
+          {opts.qualityChipNode}
+          {opts.recommendedNode}
+        </Stack>
+
+        {book?.author_name && (
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            {book.author_name}
           </Typography>
-        </Tooltip>
-      )}
+        )}
+
+        {path && (
+          <Tooltip title={path} placement="bottom-start">
+            <Typography
+              variant="caption"
+              sx={{
+                color: 'text.secondary',
+                fontFamily: 'monospace',
+                fontSize: '0.72rem',
+                lineHeight: 1.2,
+                wordBreak: 'break-all',
+                opacity: 0.75,
+              }}
+            >
+              {path}
+            </Typography>
+          </Tooltip>
+        )}
       </Stack>
     </Stack>
   );
@@ -857,49 +890,45 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                           />
                         </TableCell>
                       )}
-                      {/* Book A — badges (score/band/status) inline at top, then card */}
-                      <TableCell sx={{ verticalAlign: 'top', minWidth: 300 }}>
-                        <Stack spacing={0.5}>
-                          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center">
-                            <ScoreBadgeRow
-                              band={c.band}
-                              score={c.score}
-                              layer={c.layer}
-                              similarity={c.similarity}
-                            />
-                            <Chip
-                              label={c.status}
-                              size="small"
-                              color={
-                                c.status === 'merged'
-                                  ? 'success'
-                                  : c.status === 'dismissed'
-                                    ? 'default'
-                                    : 'warning'
-                              }
-                              variant="outlined"
-                            />
-                          </Stack>
-                          {renderBookCard(bookA, c.entity_a_id)}
-                          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                            {qualityChip(qA)}
-                            {recommendA && (
-                              <Chip label="★ Recommended keep" size="small" color="primary" />
-                            )}
-                          </Stack>
-                        </Stack>
+                      {/* Book A: cover left + score badges above title + quality chip inline */}
+                      <TableCell sx={{ verticalAlign: 'middle', minWidth: 300 }}>
+                        {renderBookCard(bookA, c.entity_a_id, {
+                          badgesNode: (
+                            <>
+                              <ScoreBadgeRow
+                                band={c.band}
+                                score={c.score}
+                                layer={c.layer}
+                                similarity={c.similarity}
+                              />
+                              <Chip
+                                label={c.status}
+                                size="small"
+                                color={
+                                  c.status === 'merged'
+                                    ? 'success'
+                                    : c.status === 'dismissed'
+                                      ? 'default'
+                                      : 'warning'
+                                }
+                                variant="outlined"
+                              />
+                            </>
+                          ),
+                          qualityChipNode: qualityChip(qA),
+                          recommendedNode: recommendA ? (
+                            <Chip label="★ Recommended keep" size="small" color="primary" />
+                          ) : undefined,
+                        })}
                       </TableCell>
-                      {/* Book B */}
-                      <TableCell sx={{ verticalAlign: 'top', minWidth: 280 }}>
-                        <Stack spacing={0.5}>
-                          {renderBookCard(bookB, c.entity_b_id)}
-                          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                            {qualityChip(qB)}
-                            {recommendB && (
-                              <Chip label="★ Recommended keep" size="small" color="primary" />
-                            )}
-                          </Stack>
-                        </Stack>
+                      {/* Book B: cover left + quality chip inline */}
+                      <TableCell sx={{ verticalAlign: 'middle', minWidth: 280 }}>
+                        {renderBookCard(bookB, c.entity_b_id, {
+                          qualityChipNode: qualityChip(qB),
+                          recommendedNode: recommendB ? (
+                            <Chip label="★ Recommended keep" size="small" color="primary" />
+                          ) : undefined,
+                        })}
                       </TableCell>
                       <TableCell sx={{ verticalAlign: 'top' }}>
                         <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>


### PR DESCRIPTION
## Commits

- `3b9bc0d` feat(dedup): redesign candidate card layout + clean up score badges

## Changes

**Card layout:**
- Cover image spans full row height on the LEFT of both Book A and Book B cells
- Score/band/status badges sit above the title in the content block (Book A only)
- Title font bumped to 1rem/600 weight; quality chip (Partial metadata, etc.) sits inline after the title on the same line
- Recommended keep chip also inline — no stray bottom row
- `verticalAlign` changed to `'middle'` so the cover stretch works correctly

**ScoreBadgeRow:**
- Score/similarity promoted from bare `Box` to a real `Chip` (picks up theme tokens)
- Format unified: shows as `X%` for both composite score and raw similarity
- `exact` layer chip hidden — it's the default for all current candidates, adds zero info
- Non-default layers (`embedding`, `llm`) still shown as distinct colored chips

## Test plan

- [ ] Dedup page: cover image is on the far left, spanning full row height
- [ ] Title is larger, quality chip (Partial/Poor/Rich metadata) appears inline after title
- [ ] Score shows as `100%` chip instead of bare number; no `[exact]` chip visible
- [ ] `embedding` or `llm` layer candidates still show their layer chip
- [ ] Book B cell has same cover-left layout, no score badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)