### PR TITLE
feat(dedup): gold-labels review UI — 3-way toggle, abbreviated paths, clickable rows

### DIFF
--- a/web/src/components/dedup/LabelToggle.tsx
+++ b/web/src/components/dedup/LabelToggle.tsx
@@ -1,0 +1,62 @@
+// file: web/src/components/dedup/LabelToggle.tsx
+// version: 1.0.0
+// guid: 6f1b8d39-4a27-4c50-9e83-1d7a5c0b2e64
+// last-edited: 2026-06-19
+
+// LabelToggle is the 3-way segmented control for a dedup gold label:
+// [ Dup | Unsure | Not ]. The current label is highlighted (green / amber /
+// red). Selecting a value calls onChange; clicking the already-selected value
+// is a no-op (the override would be redundant).
+
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+
+export type DedupLabelValue = 'true_dup' | 'unsure' | 'not_dup' | '';
+
+interface LabelToggleProps {
+  value: DedupLabelValue | string;
+  onChange: (label: DedupLabelValue) => void;
+  disabled?: boolean;
+  size?: 'small' | 'medium';
+}
+
+const OPTIONS: Array<{ value: DedupLabelValue; label: string; color: string }> = [
+  { value: 'true_dup', label: 'Dup', color: 'success.main' },
+  { value: 'unsure', label: 'Unsure', color: 'warning.main' },
+  { value: 'not_dup', label: 'Not', color: 'error.main' },
+];
+
+export function LabelToggle({ value, onChange, disabled, size = 'small' }: LabelToggleProps) {
+  return (
+    <ToggleButtonGroup
+      exclusive
+      size={size}
+      value={value || null}
+      disabled={disabled}
+      onChange={(_, next) => {
+        // exclusive returns null when the selected button is re-clicked; ignore.
+        if (next) onChange(next as DedupLabelValue);
+      }}
+      aria-label="dedup label"
+    >
+      {OPTIONS.map((o) => (
+        <ToggleButton
+          key={o.value}
+          value={o.value}
+          aria-label={o.label}
+          sx={{
+            px: 1.5,
+            fontWeight: 600,
+            textTransform: 'none',
+            '&.Mui-selected': {
+              color: 'common.white',
+              bgcolor: o.color,
+              '&:hover': { bgcolor: o.color, filter: 'brightness(0.92)' },
+            },
+          }}
+        >
+          {o.label}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  );
+}

--- a/web/src/components/dedup/__tests__/LabelToggle.test.tsx
+++ b/web/src/components/dedup/__tests__/LabelToggle.test.tsx
@@ -1,0 +1,37 @@
+// file: web/src/components/dedup/__tests__/LabelToggle.test.tsx
+// version: 1.0.0
+// guid: 2a9d7e14-5c83-4b60-9f02-6e1a8c3d5b47
+// last-edited: 2026-06-19
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LabelToggle } from '../LabelToggle';
+
+describe('LabelToggle', () => {
+  it('renders the three label options', () => {
+    render(<LabelToggle value="" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /^dup$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unsure/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^not$/i })).toBeInTheDocument();
+  });
+
+  it('marks the current value as pressed', () => {
+    render(<LabelToggle value="true_dup" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /^dup$/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /^not$/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls onChange with the clicked value', () => {
+    const onChange = vi.fn();
+    render(<LabelToggle value="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /^not$/i }));
+    expect(onChange).toHaveBeenCalledWith('not_dup');
+  });
+
+  it('does not call onChange when clicking the already-selected value', () => {
+    const onChange = vi.fn();
+    render(<LabelToggle value="not_dup" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /^not$/i }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/DedupLabels.tsx
+++ b/web/src/pages/DedupLabels.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/DedupLabels.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e3a1c92-4b60-4d85-9f21-6a5e0c9d3f58
 // last-edited: 2026-06-19
 
@@ -12,8 +12,12 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   Box, Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead,
   TableRow, Chip, Select, MenuItem, FormControl, InputLabel, Button, Stack,
-  CircularProgress, Alert, Tooltip,
+  CircularProgress, Alert, Tooltip, Link as MuiLink,
 } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { LabelToggle } from '../components/dedup/LabelToggle';
+import { PathVarsLegend } from '../components/common/PathVarsLegend';
+import { formatPath, usePathVars, type PathVar } from '../utils/formatPath';
 
 const API_BASE = '/api/v1';
 
@@ -51,7 +55,52 @@ const sourceColor = (s: string): 'primary' | 'secondary' | 'info' | 'default' =>
 
 const PAGE = 50;
 
+// BookCell renders one side of a labeled pair: a clickable title that opens the
+// book, plus its abbreviated path (full path on hover).
+function BookCell({
+  bookId,
+  title,
+  path,
+  pathVars,
+  onOpen,
+}: {
+  bookId: string;
+  title?: string;
+  path?: string;
+  pathVars: PathVar[];
+  onOpen: (id: string) => void;
+}) {
+  return (
+    <Box sx={{ minWidth: 0, maxWidth: 360 }}>
+      <MuiLink
+        component="button"
+        type="button"
+        underline="hover"
+        onClick={() => onOpen(bookId)}
+        sx={{ fontWeight: 600, textAlign: 'left', display: 'block', cursor: 'pointer' }}
+        title={`Open "${title || bookId}"`}
+      >
+        {title || bookId}
+      </MuiLink>
+      {path && (
+        <Tooltip title={path} placement="bottom-start" componentsProps={{ tooltip: { sx: { maxWidth: 600 } } }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontFamily: 'monospace', fontSize: '0.65rem', display: 'block' }}
+            noWrap
+          >
+            {formatPath(path, pathVars)}
+          </Typography>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
 export default function DedupLabels() {
+  const navigate = useNavigate();
+  const pathVars = usePathVars();
   const [rows, setRows] = useState<LabeledExample[]>([]);
   const [total, setTotal] = useState(0);
   const [stats, setStats] = useState<LabelStats | null>(null);
@@ -91,6 +140,10 @@ export default function DedupLabels() {
 
   useEffect(() => { void loadStats(); }, [loadStats]);
   useEffect(() => { void load(); }, [load]);
+
+  // Opens the book detail page. Track C will upgrade this to the
+  // CandidateCompareDrawer for in-context side-by-side review.
+  const openBook = (bookId: string) => navigate(`/library/${bookId}`);
 
   const override = async (candidateId: number, label: string) => {
     try {
@@ -158,28 +211,29 @@ export default function DedupLabels() {
               <TableCell>Book A</TableCell>
               <TableCell>Book B</TableCell>
               <TableCell>Layer</TableCell>
-              <TableCell>Label</TableCell>
               <TableCell>Source</TableCell>
               <TableCell>Reason</TableCell>
-              <TableCell align="right">Override</TableCell>
+              <TableCell align="center">Label</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
-              <TableRow><TableCell colSpan={7} align="center"><CircularProgress size={24} sx={{ my: 2 }} /></TableCell></TableRow>
+              <TableRow><TableCell colSpan={6} align="center"><CircularProgress size={24} sx={{ my: 2 }} /></TableCell></TableRow>
             ) : rows.length === 0 ? (
-              <TableRow><TableCell colSpan={7} align="center"><Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>No labeled examples for this filter.</Typography></TableCell></TableRow>
+              <TableRow><TableCell colSpan={6} align="center"><Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>No labeled examples for this filter.</Typography></TableCell></TableRow>
             ) : rows.map((r) => (
               <TableRow key={r.candidate_id} hover>
-                <TableCell><Tooltip title={r.a?.primary_path || r.entity_a_id}><span>{r.a?.title || r.entity_a_id}</span></Tooltip></TableCell>
-                <TableCell><Tooltip title={r.b?.primary_path || r.entity_b_id}><span>{r.b?.title || r.entity_b_id}</span></Tooltip></TableCell>
+                <TableCell>
+                  <BookCell bookId={r.entity_a_id} title={r.a?.title} path={r.a?.primary_path} pathVars={pathVars} onOpen={openBook} />
+                </TableCell>
+                <TableCell>
+                  <BookCell bookId={r.entity_b_id} title={r.b?.title} path={r.b?.primary_path} pathVars={pathVars} onOpen={openBook} />
+                </TableCell>
                 <TableCell>{r.layer}</TableCell>
-                <TableCell><Chip size="small" color={labelColor(r.label)} label={r.label || 'unlabeled'} /></TableCell>
                 <TableCell><Chip size="small" variant="outlined" color={sourceColor(r.label_source)} label={r.label_source} /></TableCell>
-                <TableCell><Typography variant="caption">{r.label_reason}</Typography></TableCell>
-                <TableCell align="right">
-                  <Button size="small" color="success" onClick={() => void override(r.candidate_id, 'true_dup')}>dup</Button>
-                  <Button size="small" color="error" onClick={() => void override(r.candidate_id, 'not_dup')}>not</Button>
+                <TableCell><Typography variant="caption" color="text.secondary">{r.label_reason}</Typography></TableCell>
+                <TableCell align="center">
+                  <LabelToggle value={r.label} onChange={(label) => void override(r.candidate_id, label)} />
                 </TableCell>
               </TableRow>
             ))}
@@ -194,6 +248,8 @@ export default function DedupLabels() {
         </Typography>
         <Button disabled={offset + PAGE >= total} onClick={() => setOffset(offset + PAGE)}>Next</Button>
       </Stack>
+
+      <PathVarsLegend />
     </Box>
   );
 }

--- a/web/src/pages/__tests__/DedupLabels.test.tsx
+++ b/web/src/pages/__tests__/DedupLabels.test.tsx
@@ -1,0 +1,75 @@
+// file: web/src/pages/__tests__/DedupLabels.test.tsx
+// version: 1.0.0
+// guid: 4e0c7a92-8b15-4d63-9f20-3a6e1c8d5b09
+// last-edited: 2026-06-19
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DedupLabels from '../DedupLabels';
+
+const LIBROOT = '/mnt/bigdata/books/audiobook-organizer';
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+}
+
+const sampleRow = {
+  candidate_id: 42,
+  entity_a_id: 'BOOKA',
+  entity_b_id: 'BOOKB',
+  layer: 'exact',
+  label: 'unsure',
+  label_source: 'rule',
+  label_reason: 'part_vs_whole',
+  a: { title: 'Mistborn', primary_path: `${LIBROOT}/Sanderson/Mistborn/01.m4b` },
+  b: { title: 'Mistborn (CD)', primary_path: `${LIBROOT}/Sanderson/Mistborn-CD/01.m4b` },
+};
+
+describe('DedupLabels page', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/config')) return jsonResponse({ data: { config: { root_dir: LIBROOT } } });
+      if (url.includes('/dedup/labels/stats')) {
+        return jsonResponse({ data: { total: 1, by_label: { unsure: 1 }, by_source: { rule: 1 } } });
+      }
+      if (url.includes('/override')) return jsonResponse({ data: { status: 'updated' } });
+      if (url.includes('/dedup/labels')) return jsonResponse({ data: { labels: [sampleRow], total: 1 } });
+      return jsonResponse({ data: {} });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('renders the abbreviated library path for a labeled pair', async () => {
+    render(
+      <MemoryRouter>
+        <DedupLabels />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('$(libroot)/Sanderson/Mistborn/01.m4b')).toBeInTheDocument();
+  });
+
+  it('posts an override when a label toggle is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <DedupLabels />
+      </MemoryRouter>
+    );
+    await screen.findByText('Mistborn');
+    fireEvent.click(screen.getByRole('button', { name: /^not$/i }));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => String(u).includes('/dedup/labels/42/override'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({ label: 'not_dup' });
+    });
+  });
+});


### PR DESCRIPTION
Track B of the Gold Labels redesign.

- 3-way `LabelToggle` (Dup / Unsure / Not) replacing the clown-shoes buttons
- Clickable book rows that open the book
- Abbreviated paths via `formatPath` ($(libroot)/$(books)) with hover-full-path
- `PathVarsLegend` footer

Builds on path-abbrev (#1515, merged). 297/297 vitest green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)