### PR TITLE
fix(itunes): collapse chapter-part tracks into one book (D2 — part-vs-full-book root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,30 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.42.0 -->
+<!-- version: 3.43.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-19 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixes
+
+#### June 19, 2026 — iTunes import: collapse chapter-part tracks into one book (D2)
+
+Root cause of the "individual book part vs full book" dedup candidate explosion
+(e.g. "At All Costs – 11/23", "13/23", "23/23" each imported as a separate book and
+paired at 100% against the full book).
+
+- `groupTracksByAlbum` (`internal/itunes/service/importer.go`): when a track has **no
+  album tag**, the grouping key fell back to the per-chapter track *name*. Because
+  `StripChapterPrefix` only strips *leading* markers, trailing part markers
+  ("Title – 11/23") survived → one book per chapter part.
+- Added `titleutil.StripChapterSuffix` (trailing `N/M`, `(N of M)`, `– N/M` markers;
+  preserves lone trailing numbers like "Catch 22"/"1984"). The empty-album fallback now
+  strips both leading and trailing markers, so all parts of one title collapse to a
+  single book. `Book.Title` is likewise cleaned.
+- Prevents **future** part-books; existing stale candidates are cleared separately by the
+  already-shipped `dedup.quarantine-chapter-artifacts` op.
 
 ### Features
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.1.0 -->
+<!-- version: 9.2.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-19 -->
 
@@ -41,7 +41,7 @@ future agent) can scan the entire workspace in one page.
 - [ ] **CONS-5** = **DEDUP-FOLDER-1** (see Dedup UX section) — folder/file-count chip + lazy `getBookFiles` popover in `UnifiedDedupTab.tsx`.
 - [ ] **CONS-6** **Track C** — metadata-compare tab in `CandidateCompareDrawer.tsx` (alongside Fingerprint tab): series/narrator/parts/duration/size/which-signal-fired, from `GET /api/v1/dedup/candidates/:id/breakdown`.
 - [ ] **CONS-7** = **DEDUP-KB-1** (see Dedup UX section) — keyboard shortcuts.
-- [ ] **CONS-8** **Track D2** — scanner `groupFilesIntoBooks` (`internal/scanner/scanner.go`): group chapter-part files (`N/M` / disc-number patterns) into one book instead of importing each as a separate book (root cause of part-vs-full-book candidates).
+- [x] **CONS-8** **Track D2** — ✅ code complete. Real root cause was iTunes import, NOT the scanner: `groupTracksByAlbum` empty-album fallback keyed per-chapter track name. Added `titleutil.StripChapterSuffix` to collapse trailing part markers (`Title – 11/23`) so chapter parts group into one book; `Book.Title` cleaned too. (`scanner.go groupFilesIntoBooks` was a red herring — only the FS walk uses it and its multi-file detection is already correct.)
 - [ ] **CONS-9** **Track D1** — `dedup.quarantine-chapter-artifacts` op misses unscanned (Duration=0) idents ("Opening Credits"/"Big Finish Ident"); dry-run finds only ~53. Fix selection predicate. **DRY-RUN ONLY; show list before apply.**
 - [ ] **CONS-10** **Track D3** — drain ~356K stale exact chapter-part candidates (run fixed quarantine op after D1/D2).
 - [ ] **CONS-11** **Track D4** — manual-import UI button (op `library.import` already merged/deployed; no frontend yet).

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -865,8 +865,12 @@ func (imp *Importer) groupTracksByAlbum(library *itunes.Library) []albumGroup {
 		artist := strings.TrimSpace(track.Artist)
 		album := strings.TrimSpace(track.Album)
 		if album == "" {
+			// No album tag: derive a stable grouping key from the track name.
+			// Strip both a leading marker ("(76/85) Title", "Chapter 03 - Title")
+			// AND a trailing one ("Title – 11/23") so every chapter part of the
+			// same book collapses into one group instead of one book per part.
 			trackName := strings.TrimSpace(track.Name)
-			stripped := stripChapterPrefix(trackName)
+			stripped := stripChapterSuffix(stripChapterPrefix(trackName))
 			if stripped != "" {
 				album = stripped
 			} else {
@@ -1118,10 +1122,11 @@ func (imp *Importer) buildBookFromAlbumGroup(group albumGroup, libraryPath strin
 	if title == "" {
 		// Album tag was empty/missing — falling back to the per-chapter track
 		// Name. iTunes audiobook tracks frequently have Names shaped like
-		// "(76/85) Tarkin: Star Wars (Unabridged)" — strip the chapter prefix
-		// so Book.Title doesn't carry a chapter number.
+		// "(76/85) Tarkin: Star Wars (Unabridged)" or "At All Costs – 11/23" —
+		// strip both leading and trailing chapter markers so Book.Title doesn't
+		// carry a chapter number.
 		// See docs/perf-audit-2026-05-29-g5-title-mismatch.md (MAYDEPLOY-G5a).
-		title = stripChapterPrefix(strings.TrimSpace(firstTrack.Name))
+		title = stripChapterSuffix(stripChapterPrefix(strings.TrimSpace(firstTrack.Name)))
 	}
 	if title == "" {
 		title = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))

--- a/internal/itunes/service/importer_test.go
+++ b/internal/itunes/service/importer_test.go
@@ -235,6 +235,33 @@ func TestGroupTracksByAlbum(t *testing.T) {
 	}
 }
 
+// TestGroupTracksByAlbum_EmptyAlbumChapterParts verifies that iTunes tracks with
+// NO album tag whose names carry a trailing part marker ("At All Costs – 11/23")
+// collapse into a single book group, rather than one book per chapter part.
+// This is the root cause of the part-vs-full-book dedup candidate explosion.
+func TestGroupTracksByAlbum_EmptyAlbumChapterParts(t *testing.T) {
+	library := &itunes.Library{
+		Tracks: map[string]*itunes.Track{
+			"1": {TrackID: 1, Name: "At All Costs – 11/23", Artist: "David Weber", Album: "", Kind: "Audiobook", TrackNumber: 11, DiscNumber: 1},
+			"2": {TrackID: 2, Name: "At All Costs – 13/23", Artist: "David Weber", Album: "", Kind: "Audiobook", TrackNumber: 13, DiscNumber: 1},
+			"3": {TrackID: 3, Name: "At All Costs – 23/23", Artist: "David Weber", Album: "", Kind: "Audiobook", TrackNumber: 23, DiscNumber: 1},
+		},
+	}
+
+	imp := newTestImporter()
+	groups := imp.groupTracksByAlbum(library)
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group (all chapter parts collapsed), got %d: %+v", len(groups), groups)
+	}
+	if groups[0].key != "David Weber|At All Costs" {
+		t.Errorf("group key = %q, want %q", groups[0].key, "David Weber|At All Costs")
+	}
+	if len(groups[0].tracks) != 3 {
+		t.Errorf("expected 3 tracks in the collapsed group, got %d", len(groups[0].tracks))
+	}
+}
+
 // TestGroupTracksByAlbum_MultiTrackBooks tests grouping with multi-track test data.
 func TestGroupTracksByAlbum_MultiTrackBooks(t *testing.T) {
 	library := &itunes.Library{

--- a/internal/itunes/service/strip_chapter_prefix.go
+++ b/internal/itunes/service/strip_chapter_prefix.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/strip_chapter_prefix.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 4d9e2f1a-7b6c-4e5f-8a3b-2c1d4e5f6a7b
 
 package itunesservice
@@ -13,4 +13,11 @@ import "github.com/falkcorp/audiobook-organizer/internal/titleutil"
 // Album tag to track.Name — when Album is present we trust it verbatim.
 func stripChapterPrefix(title string) string {
 	return titleutil.StripChapterPrefix(title)
+}
+
+// stripChapterSuffix delegates to titleutil.StripChapterSuffix. Used alongside
+// stripChapterPrefix in the empty-Album fallback so per-chapter track names with
+// a TRAILING part marker ("At All Costs – 11/23") collapse to one album key.
+func stripChapterSuffix(title string) string {
+	return titleutil.StripChapterSuffix(title)
 }

--- a/internal/titleutil/strip.go
+++ b/internal/titleutil/strip.go
@@ -1,5 +1,5 @@
 // file: internal/titleutil/strip.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e2a1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
 
 // Package titleutil provides shared helpers for normalising book titles.
@@ -50,6 +50,46 @@ func StripChapterPrefix(title string) string {
 	for _, re := range chapterPrefixPatterns {
 		if loc := re.FindStringIndex(s); loc != nil && loc[0] == 0 {
 			s = strings.TrimSpace(s[loc[1]:])
+			break
+		}
+	}
+	return s
+}
+
+// chapterSuffixPatterns matches a TRAILING part marker on an iTunes per-chapter
+// track Name, e.g. the reported "At All Costs – 11/23". Order matters — most
+// specific first. Each pattern is anchored at the end of the string.
+//
+// Every pattern requires an explicit N/M shape (two numbers, or "(N of M)"),
+// so a title ending in a lone number ("Catch 22", "1984") is left untouched.
+//
+//	"At All Costs – 11/23"   → "At All Costs"
+//	"At All Costs (11 of 23)"→ "At All Costs"
+//	"At All Costs 11/23"     → "At All Costs"
+var chapterSuffixPatterns = []*regexp.Regexp{
+	// Trailing "(11/23)" / "(11 of 23)" / "(1-2)" / "(1_2)"
+	regexp.MustCompile(`\s*\(\s*\d{1,4}\s*(?:of|[\s_\-/])\s*\d{1,4}\s*\)$`),
+	// Trailing delimiter then fraction: " – 11/23" / " - 13/23" / " : 1/23"
+	regexp.MustCompile(`\s*[-–—:]\s*\d{1,4}\s*/\s*\d{1,4}$`),
+	// Trailing "11 of 23"
+	regexp.MustCompile(`(?i)\s+\d{1,4}\s+of\s+\d{1,4}$`),
+	// Trailing bare fraction "11/23"
+	regexp.MustCompile(`\s+\d{1,4}\s*/\s*\d{1,4}$`),
+}
+
+// StripChapterSuffix removes a trailing part/chapter marker ("– 11/23",
+// "(11 of 23)", "11/23") from a book title. It exists so that iTunes
+// per-chapter track names with a TRAILING marker collapse to a single album
+// key (StripChapterPrefix only handles leading markers). Idempotent; only
+// strips an explicit N-of-M shape, so lone trailing numbers are preserved.
+func StripChapterSuffix(title string) string {
+	s := strings.TrimSpace(title)
+	if s == "" {
+		return s
+	}
+	for _, re := range chapterSuffixPatterns {
+		if loc := re.FindStringIndex(s); loc != nil && loc[1] == len(s) {
+			s = strings.TrimSpace(s[:loc[0]])
 			break
 		}
 	}

--- a/internal/titleutil/strip_test.go
+++ b/internal/titleutil/strip_test.go
@@ -1,5 +1,5 @@
 // file: internal/titleutil/strip_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f3b2c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 package titleutil_test
@@ -56,6 +56,50 @@ func TestStripChapterPrefix(t *testing.T) {
 		got := titleutil.StripChapterPrefix(tc.in)
 		if got != tc.want {
 			t.Errorf("StripChapterPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStripChapterSuffix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// The reported case: trailing "N/M" after an en-dash / hyphen.
+		{"At All Costs – 11/23", "At All Costs"},
+		{"At All Costs - 13/23", "At All Costs"},
+		{"At All Costs – 23/23", "At All Costs"},
+		{"At All Costs : 1/23", "At All Costs"},
+
+		// Trailing parenthesised forms.
+		{"At All Costs (11/23)", "At All Costs"},
+		{"At All Costs (11 of 23)", "At All Costs"},
+		{"At All Costs (1-2)", "At All Costs"},
+
+		// Trailing "N of M" / bare "N/M" without a delimiter.
+		{"At All Costs 11 of 23", "At All Costs"},
+		{"At All Costs 11/23", "At All Costs"},
+
+		// Clean titles — must be untouched.
+		{"The Hobbit", "The Hobbit"},
+		{"Tarkin: Star Wars (Unabridged)", "Tarkin: Star Wars (Unabridged)"},
+		{"A Tale of Two Cities", "A Tale of Two Cities"},
+		// A trailing year or lone number is NOT a part marker — keep it.
+		{"1984", "1984"},
+		{"Catch 22", "Catch 22"},
+
+		// Edge cases.
+		{"", ""},
+		{"   ", ""},
+		{"  At All Costs – 11/23  ", "At All Costs"},
+		// Idempotent.
+		{"At All Costs", "At All Costs"},
+	}
+
+	for _, tc := range cases {
+		got := titleutil.StripChapterSuffix(tc.in)
+		if got != tc.want {
+			t.Errorf("StripChapterSuffix(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem
Dedup UI showed individual chapter parts paired at 100% against the full book — e.g. `At All Costs – 11/23`, `13/23`, `23/23` each imported as a **separate book**.

## Root cause
`groupTracksByAlbum` (`internal/itunes/service/importer.go`): when an iTunes track has **no album tag**, the grouping key falls back to the per-chapter track *name*. `StripChapterPrefix` only strips *leading* markers, so trailing part markers (`Title – 11/23`) survived → one book per chapter part. (The scanner's `groupFilesIntoBooks` was a red herring — these books are iTunes-imported, not FS-walked.)

## Fix
- New `titleutil.StripChapterSuffix`: strips trailing `N/M`, `(N of M)`, `– N/M` markers; **preserves** lone trailing numbers (`Catch 22`, `1984`).
- Empty-album fallback strips both leading + trailing markers → chapter parts collapse to one book group. `Book.Title` cleaned likewise.

## Scope / safety
- Trailing strip runs **only** in the empty-album fallback (the chapter-part case), never when a real album tag is present — can't merge legitimately distinct albums.
- Prevents **future** part-books. Existing stale candidates are cleared by the already-shipped `dedup.quarantine-chapter-artifacts` op (drain run separately on prod).

## Tests
- `titleutil`: trailing-marker cases incl. idempotence + lone-number preservation.
- `TestGroupTracksByAlbum_EmptyAlbumChapterParts`: 3 empty-album parts → 1 group.
- Full `internal/titleutil` + `internal/itunes/service` packages green; gofmt/vet/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)