### PR TITLE
feat(dedup): folder/file-count chip on candidate cards (DEDUP-FOLDER-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.43.0 -->
+<!-- version: 3.44.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-19 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Features
+
+#### June 19, 2026 — Dedup: folder/file-count chip on candidate cards (DEDUP-FOLDER-1)
+
+- Each dedup candidate card now shows a "Files" chip. Clicking it opens a popover that
+  lazily fetches the book's file list (`getBookFiles`) and lists each file's name,
+  format, size and duration with a count header — so a 197-file series is
+  distinguishable from a single file at a glance, without opening the compare drawer.
+- New `FolderFilesChip` component (own popover + lazy-load state); wired into
+  `UnifiedDedupTab` `renderBookCard`. Frontend-only; read-only API; best-effort.
 
 ### Fixes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.2.0 -->
+<!-- version: 9.3.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-19 -->
 
@@ -38,7 +38,7 @@ future agent) can scan the entire workspace in one page.
 - [ ] **CONS-2** Merge **Track B** (`feat/gold-labels-controls`) — 3-way `LabelToggle` (Dup/Unsure/Not), clickable rows, abbreviated paths in `DedupLabels.tsx`. After CONS-1: rebase, drop duplicate path-abbrev commits, keep only `af2d3313`, ship.
 - [ ] **CONS-3** Verify + merge stale fix branches if not already in main: `fix/1337-cleanup`, `fix/memory-leak-token`, `fix/triage-poll-org-ref`, `fix/hnsw-elevator-nil-deref` (check `git log origin/main | grep hnsw` first).
 - [ ] **CONS-4** **BookDedup.tsx row redesign** (dedup-ux task, 0 code written) — apply `renderBookCard` pattern (cover tall-left `alignSelf:'stretch'` w56 h100%, quality chip inline after title, larger title, remove bottom chip whitespace) to `renderBookSide` (~line 1057) in the 2907-line `web/src/pages/BookDedup.tsx`.
-- [ ] **CONS-5** = **DEDUP-FOLDER-1** (see Dedup UX section) — folder/file-count chip + lazy `getBookFiles` popover in `UnifiedDedupTab.tsx`.
+- [x] **CONS-5** = **DEDUP-FOLDER-1** — ✅ `FolderFilesChip` (lazy popover w/ file list, count, format/size/duration) wired into `UnifiedDedupTab` cards.
 - [ ] **CONS-6** **Track C** — metadata-compare tab in `CandidateCompareDrawer.tsx` (alongside Fingerprint tab): series/narrator/parts/duration/size/which-signal-fired, from `GET /api/v1/dedup/candidates/:id/breakdown`.
 - [ ] **CONS-7** = **DEDUP-KB-1** (see Dedup UX section) — keyboard shortcuts.
 - [x] **CONS-8** **Track D2** — ✅ code complete. Real root cause was iTunes import, NOT the scanner: `groupTracksByAlbum` empty-album fallback keyed per-chapter track name. Added `titleutil.StripChapterSuffix` to collapse trailing part markers (`Title – 11/23`) so chapter parts group into one book; `Book.Title` cleaned too. (`scanner.go groupFilesIntoBooks` was a red herring — only the FS walk uses it and its multi-file detection is already correct.)

--- a/web/src/components/dedup/FolderFilesChip.tsx
+++ b/web/src/components/dedup/FolderFilesChip.tsx
@@ -1,0 +1,144 @@
+// file: web/src/components/dedup/FolderFilesChip.tsx
+// version: 1.0.0
+// guid: 4a1c8e92-6d35-4b70-9f28-1e7a5c3d2b69
+// last-edited: 2026-06-19
+
+// FolderFilesChip shows a small "Files" chip on a dedup candidate card. Clicking
+// it opens a popover that lazily fetches the book's file list (getBookFiles) and
+// shows each file's name, format, size and duration with a count header — so the
+// user can tell a 197-file series from a single file without opening the drawer.
+
+import { useState, useCallback, type MouseEvent } from 'react';
+import {
+  Chip, Popover, Box, Typography, List, ListItem, CircularProgress, Tooltip,
+} from '@mui/material';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import { getBookFiles, type BookFile } from '../../services/api';
+
+interface FolderFilesChipProps {
+  bookId: string;
+  label?: string;
+}
+
+function basename(p: string): string {
+  if (!p) return '';
+  const parts = p.split('/');
+  return parts[parts.length - 1] || p;
+}
+
+function humanSize(bytes?: number): string {
+  if (!bytes || bytes <= 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function humanDuration(sec?: number): string {
+  if (!sec || sec <= 0) return '';
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${Math.floor(sec)}s`;
+}
+
+export function FolderFilesChip({ bookId, label = 'Files' }: FolderFilesChipProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [files, setFiles] = useState<BookFile[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const open = useCallback(
+    async (e: MouseEvent<HTMLElement>) => {
+      // Don't let the click bubble to the row (row click = select).
+      e.stopPropagation();
+      setAnchorEl(e.currentTarget);
+      if (files || loading) return; // lazy-load once
+      setLoading(true);
+      setError(null);
+      try {
+        const ctrl = new AbortController();
+        const res = await getBookFiles(bookId, { signal: ctrl.signal });
+        setFiles(res.files || []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load files');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [bookId, files, loading]
+  );
+
+  const close = useCallback(() => setAnchorEl(null), []);
+
+  const count = files?.length ?? 0;
+
+  return (
+    <>
+      <Tooltip title="Show files in this book">
+        <Chip
+          icon={<FolderOpenIcon />}
+          label={count > 0 ? `${count} ${label}` : label}
+          size="small"
+          variant="outlined"
+          clickable
+          onClick={open}
+        />
+      </Tooltip>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Box sx={{ p: 1.5, minWidth: 280, maxWidth: 560 }}>
+          {loading && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">Loading files…</Typography>
+            </Box>
+          )}
+          {error && (
+            <Typography variant="body2" color="error.main">{error}</Typography>
+          )}
+          {!loading && !error && files && (
+            <>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {count} {count === 1 ? 'file' : 'files'}
+              </Typography>
+              <List dense disablePadding sx={{ maxHeight: 320, overflow: 'auto' }}>
+                {files.map((f) => {
+                  const meta = [f.format, humanSize(f.file_size), humanDuration(f.duration)]
+                    .filter(Boolean)
+                    .join(' · ');
+                  return (
+                    <ListItem key={f.id} disableGutters sx={{ display: 'block', py: 0.25 }}>
+                      <Tooltip title={f.file_path} placement="bottom-start">
+                        <Typography
+                          variant="body2"
+                          sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: f.missing ? 'error.main' : 'text.primary' }}
+                          noWrap
+                        >
+                          {basename(f.file_path)}
+                        </Typography>
+                      </Tooltip>
+                      {meta && (
+                        <Typography variant="caption" color="text.secondary">{meta}</Typography>
+                      )}
+                    </ListItem>
+                  );
+                })}
+              </List>
+            </>
+          )}
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
 // last-edited: 2026-06-19
 
@@ -61,6 +61,7 @@ import { BandFilterBar, type BandCounts } from './BandFilterBar';
 import { ScoreBadgeRow } from './ScoreBadgeRow';
 import { CandidateCompareDrawer } from './CandidateCompareDrawer';
 import { BulkActionBar } from './BulkActionBar';
+import { FolderFilesChip } from './FolderFilesChip';
 
 // ---------- helpers ----------
 
@@ -211,6 +212,12 @@ function renderBookCard(book: Book | null | undefined, id: string, opts: BookCar
               {path}
             </Typography>
           </Tooltip>
+        )}
+
+        {!missing && (
+          <Box>
+            <FolderFilesChip bookId={id} />
+          </Box>
         )}
       </Stack>
     </Stack>

--- a/web/src/components/dedup/__tests__/FolderFilesChip.test.tsx
+++ b/web/src/components/dedup/__tests__/FolderFilesChip.test.tsx
@@ -1,0 +1,52 @@
+// file: web/src/components/dedup/__tests__/FolderFilesChip.test.tsx
+// version: 1.0.0
+// guid: 9c2e7a41-5b80-4d63-8f19-3a6d1c5e2b47
+// last-edited: 2026-06-19
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FolderFilesChip } from '../FolderFilesChip';
+import * as api from '../../../services/api';
+
+vi.mock('../../../services/api', () => ({
+  getBookFiles: vi.fn(),
+}));
+
+describe('FolderFilesChip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a files chip button', () => {
+    render(<FolderFilesChip bookId="BOOK1" />);
+    expect(screen.getByRole('button', { name: /files/i })).toBeInTheDocument();
+  });
+
+  it('lazy-loads and lists files with a count header on click', async () => {
+    vi.mocked(api.getBookFiles).mockResolvedValue({
+      count: 2,
+      files: [
+        { id: 'f1', book_id: 'BOOK1', file_path: '/books/At All Costs/01.m4b', format: 'm4b', file_size: 1048576, duration: 3600, missing: false },
+        { id: 'f2', book_id: 'BOOK1', file_path: '/books/At All Costs/02.m4b', format: 'm4b', file_size: 2097152, duration: 1800, missing: false },
+      ],
+    } as Awaited<ReturnType<typeof api.getBookFiles>>);
+
+    render(<FolderFilesChip bookId="BOOK1" />);
+    fireEvent.click(screen.getByRole('button', { name: /files/i }));
+
+    // Fetches exactly the requested book's files.
+    await waitFor(() => expect(api.getBookFiles).toHaveBeenCalledWith('BOOK1', expect.anything()));
+
+    // Lists each file's basename.
+    expect(await screen.findByText('01.m4b')).toBeInTheDocument();
+    expect(screen.getByText('02.m4b')).toBeInTheDocument();
+    // Count header reflects the number of files (popover header is lowercase
+    // "2 files"; the chip label is "2 Files" — exact match scopes to the header).
+    expect(screen.getByText('2 files')).toBeInTheDocument();
+  });
+
+  it('does not fetch until opened', () => {
+    render(<FolderFilesChip bookId="BOOK1" />);
+    expect(api.getBookFiles).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a "Files" chip to each dedup candidate card. Click → popover lazily fetches `getBookFiles` and lists each file (name, format, size, duration) with a count header — distinguishes a 197-file series from a single file at a glance.

- New `FolderFilesChip` (self-contained popover + lazy-load); wired into `UnifiedDedupTab` `renderBookCard`.
- Frontend-only, read-only API, best-effort (error → small message).
- 3 vitest tests; full suite **300/300**; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)