### PR TITLE
fix(itunes-regroup): entanglement check after move computation

### DIFF
--- a/internal/itunes/service/regroup_plan.go
+++ b/internal/itunes/service/regroup_plan.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/regroup_plan.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-20
 
@@ -105,9 +105,32 @@ func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 			continue
 		}
 
-		// Version-entanglement guard: if any book holding this group's files is
-		// part of a version group with non-primary members, skip (conservative
-		// v1 — auto-merging could orphan or mis-merge curated versions).
+		// Pick the target: the best UNCLAIMED book among the holders, then compute
+		// the moves needed to gather this group's files onto it.
+		target, fresh := pickTarget(resolved, snap, claimed)
+		var moves []FileMove
+		for i, loc := range resolved {
+			if loc.BookID != target {
+				moves = append(moves, FileMove{PID: resolvedPIDs[i], FileID: loc.FileID, From: loc.BookID})
+			}
+		}
+
+		// Already correct: all of this group's files are on one existing book.
+		// Nothing moves, so version entanglement is IRRELEVANT (nothing to orphan
+		// or mis-merge) — claim the book and count it correct, never skip it.
+		// (Checking entanglement BEFORE this point is the bug that made ~95% of
+		// groups falsely skip merely for touching a version-grouped book.)
+		if len(moves) == 0 && !fresh {
+			act.Target = target
+			claimed[target] = true
+			plan.AlreadyCorrect++
+			plan.Groups = append(plan.Groups, act)
+			continue
+		}
+
+		// Moves ARE needed. Only now does entanglement matter: auto-merging could
+		// orphan or mis-merge curated versions (or genuine alternate editions), so
+		// skip (conservative v1). This count is "entangled AND would-move".
 		if entangledAmong(resolved, snap) {
 			act.Entangled = true
 			plan.EntangledSkipped++
@@ -115,29 +138,15 @@ func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 			continue
 		}
 
-		// Pick the target: the best UNCLAIMED book among the holders. If every
-		// holder is already claimed by an earlier group, allocate a fresh book.
-		target, fresh := pickTarget(resolved, snap, claimed)
 		act.Target = target
 		act.FreshBook = fresh
+		act.Moves = moves
 		if fresh {
 			plan.FreshBooks++
 		} else {
 			claimed[target] = true
 		}
-
-		// Emit a move for every resolved PID whose file is not already on target.
-		for i, loc := range resolved {
-			if loc.BookID != target {
-				act.Moves = append(act.Moves, FileMove{PID: resolvedPIDs[i], FileID: loc.FileID, From: loc.BookID})
-			}
-		}
-
-		if len(act.Moves) == 0 && !fresh {
-			plan.AlreadyCorrect++
-		} else {
-			plan.Consolidated++
-		}
+		plan.Consolidated++
 		plan.Groups = append(plan.Groups, act)
 	}
 

--- a/internal/itunes/service/regroup_plan_test.go
+++ b/internal/itunes/service/regroup_plan_test.go
@@ -166,6 +166,22 @@ func TestPlanRegroup_VersionEntangledSkipped(t *testing.T) {
 	}
 }
 
+func TestPlanRegroup_EntangledButAlreadyCorrect_NotSkipped(t *testing.T) {
+	// All of the group's PIDs are already on ONE book that happens to be version-
+	// entangled. Zero moves → entanglement is irrelevant → AlreadyCorrect, NOT
+	// skipped. (Regression guard for the check-ordering bug that falsely skipped
+	// ~95% of groups merely for touching a version-grouped book.)
+	groups := []HealGroup{{Title: "Solo", PIDs: []string{"p1", "p2"}}}
+	snap := mkSnap(
+		map[string]PIDLoc{"p1": {FileID: "f1", BookID: "B1"}, "p2": {FileID: "f2", BookID: "B1"}},
+		map[string]BookMeta{"B1": {ID: "B1", FileCount: 2, VersionGroupID: "vg1", HasNonPrimaryMembers: true}},
+	)
+	p := PlanRegroup(groups, snap)
+	if p.AlreadyCorrect != 1 || p.EntangledSkipped != 0 {
+		t.Fatalf("AlreadyCorrect=%d EntangledSkipped=%d, want 1/0", p.AlreadyCorrect, p.EntangledSkipped)
+	}
+}
+
 func TestPlanRegroup_UnresolvedPIDs(t *testing.T) {
 	// p3 is in the XML group but absent from the DB → counted unresolved; the
 	// resolved p1,p2 still consolidate.

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-20
 
@@ -85,7 +85,7 @@ func (p *Plugin) runITunesRegroup(ctx context.Context, raw json.RawMessage, repo
 	groups := itunesservice.GroupLibraryForHeal(lib)
 
 	_ = reporter.UpdateProgress(1, 4, fmt.Sprintf("Phase 2/4: snapshotting DB for %d target groups…", len(groups)))
-	snap, err := p.buildRegroupSnapshot(ctx, store, groups, reporter)
+	snap, err := p.buildRegroupSnapshot(ctx, store, reporter)
 	if err != nil {
 		return err
 	}
@@ -114,84 +114,87 @@ func (p *Plugin) runITunesRegroup(ctx context.Context, raw json.RawMessage, repo
 	return nil
 }
 
-// buildRegroupSnapshot reads the immutable DB state the planner reasons over:
-// the current location of every group PID, and metadata for each book holding
-// them (including version-group entanglement). No mutation.
-func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store, groups []itunesservice.HealGroup, reporter sdk.Reporter) (itunesservice.Snapshot, error) {
+// buildRegroupSnapshot reads the immutable DB state the planner reasons over via
+// TWO bulk in-memory scans — all books once, all book files once — instead of
+// tens of thousands of per-PID / per-book point queries (which made the dry-run
+// take >10min on a 65K/308K library). The file scan yields PID→location directly
+// from BookFile.ITunesPersistentID, so no per-PID lookups are needed. No mutation.
+func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store, reporter sdk.Reporter) (itunesservice.Snapshot, error) {
 	snap := itunesservice.Snapshot{
 		PIDLoc: make(map[string]itunesservice.PIDLoc),
 		Books:  make(map[string]itunesservice.BookMeta),
 	}
-	vgNonPrimary := make(map[string]bool) // version-group id -> has a non-primary member
-	seenPID := make(map[string]bool)
 
-	var processed int
-	for _, g := range groups {
+	// Pass 1: all books → per-book fields + version-group non-primary membership.
+	type partialMeta struct {
+		isPrimary bool
+		enrich    int
+		createdAt int64
+		vgID      string
+	}
+	meta := make(map[string]partialMeta)
+	vgNonPrimary := make(map[string]bool) // version-group id -> has a non-primary member
+	const page = 1000
+	off := 0
+	for {
 		if ctx.Err() != nil {
 			return snap, ctx.Err()
 		}
-		for _, pid := range g.PIDs {
-			if seenPID[pid] {
-				continue
+		books, err := store.GetAllBooks(page, off)
+		if err != nil {
+			return snap, fmt.Errorf("GetAllBooks offset=%d: %w", off, err)
+		}
+		if len(books) == 0 {
+			break
+		}
+		for i := range books {
+			b := &books[i]
+			vg := ""
+			if b.VersionGroupID != nil {
+				vg = *b.VersionGroupID
 			}
-			seenPID[pid] = true
+			isPrimary := b.IsPrimaryVersion != nil && *b.IsPrimaryVersion
+			meta[b.ID] = partialMeta{isPrimary: isPrimary, enrich: enrichScore(b), createdAt: b.CreatedAt.Unix(), vgID: vg}
+			if vg != "" && !isPrimary {
+				vgNonPrimary[vg] = true
+			}
+		}
+		off += len(books)
+		_ = reporter.UpdateProgress(1, 4, fmt.Sprintf("Phase 2/4: scanned %d books…", off))
+		if len(books) < page {
+			break
+		}
+	}
 
-			f, ferr := store.GetBookFileByPID(pid)
-			if ferr != nil || f == nil || f.BookID == "" {
-				continue // unresolved: PID in XML but not in DB
-			}
+	// Pass 2: all book files → PID→location + per-book file counts.
+	files, err := store.GetAllBookFiles()
+	if err != nil {
+		return snap, fmt.Errorf("GetAllBookFiles: %w", err)
+	}
+	fileCount := make(map[string]int, len(meta))
+	for i := range files {
+		f := &files[i]
+		fileCount[f.BookID]++
+		if pid := strings.TrimSpace(f.ITunesPersistentID); pid != "" && f.BookID != "" {
 			snap.PIDLoc[pid] = itunesservice.PIDLoc{FileID: f.ID, BookID: f.BookID}
-
-			if _, ok := snap.Books[f.BookID]; !ok {
-				if meta, ok := bookMeta(store, f.BookID, vgNonPrimary); ok {
-					snap.Books[f.BookID] = meta
-				}
-			}
-		}
-		processed++
-		if processed%2000 == 0 {
-			_ = reporter.UpdateProgress(1, 4, fmt.Sprintf("Phase 2/4: snapshotted %d/%d groups…", processed, len(groups)))
 		}
 	}
+
+	// Assemble book meta (only books that actually exist; planner only reads the
+	// ones referenced by resolved PIDs).
+	for id, pm := range meta {
+		snap.Books[id] = itunesservice.BookMeta{
+			ID:                   id,
+			IsPrimary:            pm.isPrimary,
+			FileCount:            fileCount[id],
+			EnrichScore:          pm.enrich,
+			CreatedAtUnix:        pm.createdAt,
+			VersionGroupID:       pm.vgID,
+			HasNonPrimaryMembers: pm.vgID != "" && vgNonPrimary[pm.vgID],
+		}
+	}
+	_ = reporter.UpdateProgress(2, 4, fmt.Sprintf("Phase 2/4: snapshot ready (%d books, %d PID locations)", len(snap.Books), len(snap.PIDLoc)))
 	return snap, nil
-}
-
-// bookMeta loads one book's planner metadata, resolving version-group
-// entanglement (cached per group id).
-func bookMeta(store database.Store, bookID string, vgNonPrimary map[string]bool) (itunesservice.BookMeta, bool) {
-	b, err := store.GetBookByID(bookID)
-	if err != nil || b == nil {
-		return itunesservice.BookMeta{}, false
-	}
-	files, _ := store.GetBookFiles(bookID)
-	vgID := ""
-	if b.VersionGroupID != nil {
-		vgID = *b.VersionGroupID
-	}
-	hasNonPrimary := false
-	if vgID != "" {
-		if v, ok := vgNonPrimary[vgID]; ok {
-			hasNonPrimary = v
-		} else {
-			members, _ := store.GetBooksByVersionGroup(vgID)
-			for i := range members {
-				if members[i].IsPrimaryVersion == nil || !*members[i].IsPrimaryVersion {
-					hasNonPrimary = true
-					break
-				}
-			}
-			vgNonPrimary[vgID] = hasNonPrimary
-		}
-	}
-	return itunesservice.BookMeta{
-		ID:                   b.ID,
-		IsPrimary:            b.IsPrimaryVersion != nil && *b.IsPrimaryVersion,
-		FileCount:            len(files),
-		EnrichScore:          enrichScore(b),
-		CreatedAtUnix:        b.CreatedAt.Unix(),
-		VersionGroupID:       vgID,
-		HasNonPrimaryMembers: hasNonPrimary,
-	}, true
 }
 
 // enrichScore counts populated enrichment fields so the planner prefers the

--- a/internal/plugins/maintenance/itunes_regroup_test.go
+++ b/internal/plugins/maintenance/itunes_regroup_test.go
@@ -56,7 +56,7 @@ func TestITunesRegroupApply_MergeAndDelete(t *testing.T) {
 	rep := &fakeReporter{}
 	groups := []itunesservice.HealGroup{{Title: "Merged Book", PIDs: []string{"p1", "p2"}}}
 
-	snap, err := p.buildRegroupSnapshot(context.Background(), s, groups, rep)
+	snap, err := p.buildRegroupSnapshot(context.Background(), s, rep)
 	if err != nil {
 		t.Fatalf("buildRegroupSnapshot: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestITunesRegroupApply_DeleteGuardSkipsResidualExtID(t *testing.T) {
 	p := &Plugin{}
 	rep := &fakeReporter{}
 	groups := []itunesservice.HealGroup{{Title: "Merged Book", PIDs: []string{"p1", "p2"}}}
-	snap, _ := p.buildRegroupSnapshot(context.Background(), s, groups, rep)
+	snap, _ := p.buildRegroupSnapshot(context.Background(), s, rep)
 	plan := itunesservice.PlanRegroup(groups, snap)
 
 	survivor := plan.Groups[0].Target


### PR DESCRIPTION
Planner checked version-entanglement *before* computing moves, so groups needing **zero** moves (already correct) were counted `EntangledSkipped` just for touching a version-grouped book — 94.8% false-skip on prod, making the heal a no-op. A zero-move group is `AlreadyCorrect` regardless of entanglement (nothing moves ⇒ nothing to orphan). Now entanglement only gates groups that actually need a move, so the metric becomes the real "entangled AND would-move" gate number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)