### PR TITLE
feat(itunes-regroup): completeness metrics (partial + single-file-chapter)

### DIFF
--- a/internal/itunes/service/regroup_plan.go
+++ b/internal/itunes/service/regroup_plan.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/regroup_plan.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-20
 
@@ -61,12 +61,22 @@ type RegroupPlan struct {
 
 	// Metrics (for the dry-run model-validation report).
 	TotalGroups      int
-	AlreadyCorrect   int // target already holds exactly the group's resolved PIDs
+	AlreadyCorrect   int // group's resolved PIDs already all on one book (may be PARTIAL)
 	Consolidated     int // groups requiring ≥1 move
 	EntangledSkipped int
 	FreshBooks       int
 	PIDsResolved     int
 	PIDsUnresolved   int
+
+	// Completeness metrics — distinguish "correctly grouped" from "only partially
+	// present". A group is PARTIAL when some of its XML PIDs resolve in the DB and
+	// some do not: the book(s) holding it are missing tracks. CompleteGroups have
+	// every XML PID present. SingleFileChapterBooks is the count of distinct books
+	// that (a) hold ≥1 PID of a multi-track group and (b) have exactly one file —
+	// i.e. lone single-file "books" that are really one chapter of a larger book.
+	CompleteGroups         int
+	PartialGroups          int
+	SingleFileChapterBooks int
 }
 
 // PlanRegroup computes the frozen heal plan: assign each group exactly one target
@@ -80,7 +90,8 @@ type RegroupPlan struct {
 // silently retitling it.
 func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 	plan := RegroupPlan{TotalGroups: len(groups)}
-	claimed := make(map[string]bool, len(groups)) // existing books already taken as a target
+	claimed := make(map[string]bool, len(groups))   // existing books already taken as a target
+	singleFileChapters := make(map[string]struct{}) // distinct single-file books in multi-track groups
 
 	for _, g := range groups {
 		act := GroupAction{Title: g.Title}
@@ -98,6 +109,23 @@ func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 		}
 		plan.PIDsResolved += len(resolved)
 		plan.PIDsUnresolved += len(act.Unresolved)
+
+		// Completeness: did every XML track for this group make it into the DB?
+		if len(resolved) > 0 {
+			if len(resolved) == len(g.PIDs) {
+				plan.CompleteGroups++
+			} else {
+				plan.PartialGroups++
+			}
+		}
+		// Lone single-file books that are really one chapter of a multi-track book.
+		if len(g.PIDs) > 1 {
+			for _, loc := range resolved {
+				if b, ok := snap.Books[loc.BookID]; ok && b.FileCount == 1 {
+					singleFileChapters[loc.BookID] = struct{}{}
+				}
+			}
+		}
 
 		if len(resolved) == 0 {
 			// Nothing in the DB to heal for this group (book never imported).
@@ -150,6 +178,7 @@ func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 		plan.Groups = append(plan.Groups, act)
 	}
 
+	plan.SingleFileChapterBooks = len(singleFileChapters)
 	plan.DeleteBooks = projectEmptyBooks(plan.Groups, snap)
 	return plan
 }

--- a/internal/itunes/service/regroup_plan_test.go
+++ b/internal/itunes/service/regroup_plan_test.go
@@ -200,6 +200,37 @@ func TestPlanRegroup_UnresolvedPIDs(t *testing.T) {
 	}
 }
 
+func TestPlanRegroup_CompletenessMetrics(t *testing.T) {
+	// "Complete": both PIDs present on a 2-file book. "Partial": only 1 of 3 PIDs
+	// present, on a single-file book — a lone chapter of a multi-track book.
+	groups := []HealGroup{
+		{Title: "Complete", PIDs: []string{"a1", "a2"}},
+		{Title: "Partial", PIDs: []string{"b1", "b2", "b3"}},
+	}
+	snap := mkSnap(
+		map[string]PIDLoc{
+			"a1": {FileID: "fa1", BookID: "BA"}, "a2": {FileID: "fa2", BookID: "BA"},
+			"b1": {FileID: "fb1", BookID: "BB"}, // b2, b3 unresolved (not imported)
+		},
+		map[string]BookMeta{
+			"BA": {ID: "BA", FileCount: 2},
+			"BB": {ID: "BB", FileCount: 1},
+		},
+	)
+	p := PlanRegroup(groups, snap)
+	if p.CompleteGroups != 1 || p.PartialGroups != 1 {
+		t.Fatalf("complete=%d partial=%d, want 1/1", p.CompleteGroups, p.PartialGroups)
+	}
+	if p.SingleFileChapterBooks != 1 {
+		t.Fatalf("single-file-chapter books=%d, want 1 (BB)", p.SingleFileChapterBooks)
+	}
+	// Both are "already-correct" by the move metric (resolved PIDs each on one book)
+	// — proving already-correct ≠ complete.
+	if p.AlreadyCorrect != 2 {
+		t.Fatalf("already-correct=%d, want 2 (partial still counts as no-move)", p.AlreadyCorrect)
+	}
+}
+
 func TestPlanRegroup_Deterministic(t *testing.T) {
 	groups := []HealGroup{
 		{Title: "Alpha", PIDs: []string{"p1", "p2", "p3"}},

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-20
 
@@ -98,6 +98,9 @@ func (p *Plugin) runITunesRegroup(ctx context.Context, raw json.RawMessage, repo
 		plan.TotalGroups, plan.AlreadyCorrect, plan.Consolidated, plan.EntangledSkipped,
 		plan.FreshBooks, len(plan.DeleteBooks), plan.PIDsResolved, plan.PIDsUnresolved)
 	_ = reporter.Log(slog.LevelInfo, "PLAN: "+summary)
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"COMPLETENESS: complete-groups=%d partial-groups=%d (missing some tracks) single-file-chapter-books=%d (lone 1-file books that are really one chapter of a multi-track book)",
+		plan.CompleteGroups, plan.PartialGroups, plan.SingleFileChapterBooks))
 
 	if params.DryRun {
 		examples := regroupExamples(plan, 8)


### PR DESCRIPTION
`already-correct` only checks that a group's *resolved* PIDs sit on one book — not that all its tracks are present. So a 6-of-47-track partial book counted as already-correct. Adds `CompleteGroups`/`PartialGroups` + `SingleFileChapterBooks` (lone 1-file books that are really one chapter) to the dry-run report, to answer 'do we have single-file books that are really a chapter?'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)