### PR TITLE
feat(itunes-regroup): duration-bucket single-file books

### DIFF
--- a/internal/itunes/service/regroup_plan.go
+++ b/internal/itunes/service/regroup_plan.go
@@ -1,11 +1,14 @@
 // file: internal/itunes/service/regroup_plan.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-06-20
 
 package itunesservice
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // PIDLoc is the current DB location of one iTunes track PID.
 type PIDLoc struct {
@@ -17,8 +20,10 @@ type PIDLoc struct {
 // target book for a group. Built once from a DB read-snapshot; never mutated.
 type BookMeta struct {
 	ID                   string
+	Title                string
 	IsPrimary            bool
 	FileCount            int   // total BookFiles currently on this book
+	DurationSec          int   // book aggregate duration (seconds)
 	EnrichScore          int   // richer = preferred survivor (ISBN, description, …)
 	CreatedAtUnix        int64 // older = preferred survivor (tiebreak)
 	VersionGroupID       string
@@ -77,6 +82,15 @@ type RegroupPlan struct {
 	CompleteGroups         int
 	PartialGroups          int
 	SingleFileChapterBooks int
+
+	// Single-file-chapter books bucketed by duration, to separate TRUE lone
+	// chapters (short) from COMPLETE single-file books that merely share an album
+	// tag with un-imported siblings (long). SFCExamples holds a few short-bucket
+	// "title (dur)" samples for eyeballing.
+	SFCShort    int // < 15min — likely a true chapter or intro/credit clip
+	SFCMid      int // 15-90min — novella / long chapter / short book (ambiguous)
+	SFCLong     int // >= 90min — a COMPLETE book (false alarm: series entry)
+	SFCExamples []string
 }
 
 // PlanRegroup computes the frozen heal plan: assign each group exactly one target
@@ -118,11 +132,29 @@ func PlanRegroup(groups []HealGroup, snap Snapshot) RegroupPlan {
 				plan.PartialGroups++
 			}
 		}
-		// Lone single-file books that are really one chapter of a multi-track book.
+		// Lone single-file books that are really one chapter of a multi-track book,
+		// bucketed by duration so true chapters (short) separate from complete
+		// single-file books sharing an album tag (long).
 		if len(g.PIDs) > 1 {
 			for _, loc := range resolved {
-				if b, ok := snap.Books[loc.BookID]; ok && b.FileCount == 1 {
-					singleFileChapters[loc.BookID] = struct{}{}
+				b, ok := snap.Books[loc.BookID]
+				if !ok || b.FileCount != 1 {
+					continue
+				}
+				if _, seen := singleFileChapters[loc.BookID]; seen {
+					continue
+				}
+				singleFileChapters[loc.BookID] = struct{}{}
+				switch {
+				case b.DurationSec < 900:
+					plan.SFCShort++
+					if len(plan.SFCExamples) < 12 {
+						plan.SFCExamples = append(plan.SFCExamples, fmt.Sprintf("%q (%ds)", b.Title, b.DurationSec))
+					}
+				case b.DurationSec < 5400:
+					plan.SFCMid++
+				default:
+					plan.SFCLong++
 				}
 			}
 		}

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-20
 
@@ -99,8 +99,11 @@ func (p *Plugin) runITunesRegroup(ctx context.Context, raw json.RawMessage, repo
 		plan.FreshBooks, len(plan.DeleteBooks), plan.PIDsResolved, plan.PIDsUnresolved)
 	_ = reporter.Log(slog.LevelInfo, "PLAN: "+summary)
 	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
-		"COMPLETENESS: complete-groups=%d partial-groups=%d (missing some tracks) single-file-chapter-books=%d (lone 1-file books that are really one chapter of a multi-track book)",
+		"COMPLETENESS: complete-groups=%d partial-groups=%d (missing some tracks) single-file-in-multitrack-album=%d",
 		plan.CompleteGroups, plan.PartialGroups, plan.SingleFileChapterBooks))
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"SINGLE-FILE BY DURATION: <15min(true chapter/clip)=%d  15-90min(ambiguous)=%d  >=90min(COMPLETE book, false alarm)=%d | short examples: %s",
+		plan.SFCShort, plan.SFCMid, plan.SFCLong, strings.Join(plan.SFCExamples, "; ")))
 
 	if params.DryRun {
 		examples := regroupExamples(plan, 8)
@@ -130,8 +133,10 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 
 	// Pass 1: all books → per-book fields + version-group non-primary membership.
 	type partialMeta struct {
+		title     string
 		isPrimary bool
 		enrich    int
+		duration  int
 		createdAt int64
 		vgID      string
 	}
@@ -157,7 +162,11 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 				vg = *b.VersionGroupID
 			}
 			isPrimary := b.IsPrimaryVersion != nil && *b.IsPrimaryVersion
-			meta[b.ID] = partialMeta{isPrimary: isPrimary, enrich: enrichScore(b), createdAt: b.CreatedAt.Unix(), vgID: vg}
+			dur := 0
+			if b.Duration != nil {
+				dur = *b.Duration
+			}
+			meta[b.ID] = partialMeta{title: b.Title, isPrimary: isPrimary, enrich: enrichScore(b), duration: dur, createdAt: b.CreatedAt.Unix(), vgID: vg}
 			if vg != "" && !isPrimary {
 				vgNonPrimary[vg] = true
 			}
@@ -188,8 +197,10 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 	for id, pm := range meta {
 		snap.Books[id] = itunesservice.BookMeta{
 			ID:                   id,
+			Title:                pm.title,
 			IsPrimary:            pm.isPrimary,
 			FileCount:            fileCount[id],
+			DurationSec:          pm.duration,
 			EnrichScore:          pm.enrich,
 			CreatedAtUnix:        pm.createdAt,
 			VersionGroupID:       pm.vgID,


### PR DESCRIPTION
Separates true lone chapters from complete single-file books (series entries) and clips by bucketing the single-file-in-multitrack-album population by corrected duration (<15min / 15-90min / >=90min) with examples. Run after duration-backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)