### PR TITLE
fix(fs-regroup): reattach pre-existing BookFiles to survivor (delete-skipped data loss)

### DIFF
--- a/docs/dedup-import-pipeline-audit.md
+++ b/docs/dedup-import-pipeline-audit.md
@@ -1,0 +1,269 @@
+<!-- file: docs/dedup-import-pipeline-audit.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d95f6a1c-45d5-4c5d-b9c7-0b479ae25c0a -->
+<!-- last-edited: 2026-06-21 -->
+
+# Dedup + Import Pipeline Audit — Recurrence Prevention & Optimization
+
+**Date:** 2026-06-21 · **Author:** agent-driven audit (post PR #1548 shattered-book heal)
+**Scope:** `internal/dedup/`, `internal/plugins/dedup/`, `internal/scanner/`,
+`internal/itunes/service/`, plus the `maintenance.fs-regroup-xml` apply path.
+
+> Companion to `.claude/notes/shattered-books-inventory.md` (the pre-heal root-cause
+> inventory) and memory `project_itunes_grouping_key`.
+
+---
+
+## 0. Executive summary
+
+The shattered-book heal (PR #1548) removed 20,247 chapter-junk records and cut the
+exact-layer dedup backlog from 380,515 → 10,859 candidates. This audit answers the two
+**recurrence-prevention** questions and surfaces the scaling problems that made the
+explosion expensive.
+
+**The two prevention findings (load-bearing):**
+
+1. **Import side — the shatter is _cross-directory_.** `groupFilesIntoBooks` runs
+   per-leaf-directory, so a per-chapter-subdir layout yields one 1-file book per chapter.
+   **Changing its grouping key to "album" fixes nothing** — the album-equal files live in
+   separate sibling dirs and never enter the same `files` slice. The fix must live one
+   level up, in `ScanDirectoryParallel`, as a sibling-coalescing post-pass.
+
+2. **Dedup side — the exact emitters have _no same-dir gate at emission_.** `checkExactTitle`
+   and `checkDurationMatch` can re-create chapter cross-pairs at any time; the only
+   folder-aware suppression today is reactive (`PairEligibility` skips re-scoring but does
+   not delete; `PurgeStaleCandidates` deletes but is a manual cleanup op). A future
+   shatter (or the still-unfixed title-leak importer bug) regenerates the explosion.
+
+**The residual (10,859) is four populations, not one** — a blanket purge would destroy the
+genuine-duplicate review signal. See §3.
+
+---
+
+## 1. Import pipeline (scanner + iTunes importer)
+
+### 1.1 ROOT CAUSE of the shatter — cross-directory (P0)
+
+`internal/scanner/scanner.go`:
+- `ScanDirectoryParallel` (`:427-468`) walks the tree, collects each directory into `dirs`
+  (`:364-419`), then for **each** directory spawns a goroutine that `os.ReadDir`s only the
+  files **directly in that dir** (subdirs skipped, `:443-445`) and calls
+  `groupFilesIntoBooks(audioFiles)` **once per directory** (`:460`).
+- `groupFilesIntoBooks` (`:1514`) early-returns `if len(files) <= 1` (`:1515`).
+
+For the shattered layout `Author/<Book>/<Book> - N/47.mp3`, each `<Book> - N/` dir holds
+exactly **one** file → 1-element slice → early return → **one standalone Book per chapter**.
+
+`groupFilesIntoBooks`'s internal album grouping (`:1561-1647`) only fires on multiple files
+**in one folder** — it solves the opposite problem ("mixed albums in one folder"), so
+album-keying it is a **no-op for this bug**.
+
+### 1.2 PREVENTION — sibling-coalescing post-pass in `ScanDirectoryParallel` (P0)
+
+PR #1548 made this newly feasible: the `album` tag + real track/disc are now captured per
+file, giving a cross-directory merge key.
+
+**Recommended algorithm (post-pass, smaller blast radius than re-architecting the walk):**
+
+```
+After per-dir goroutines produce `books`, run a serial post-pass:
+1. Candidates = single-file Books whose parent dir is a child of a common grandparent
+   (sibling chapter dirs).
+2. Group candidates by (grandparent_dir, normalized album).
+   - album empty/missing → DO NOT merge by album. Fall back to filename-sequence
+     detection only (a sibling-dir variant of DetectMultiFileGroup; the `<Book> - N`
+     dir names already match extractSeqNumber patterns). NEVER derive the key from the
+     parent-folder name alone (recreates the importer CONS-17b "every GRRM book →
+     'George R. R. Martin'" bug).
+3. Over-merge guard: require a ≥75% album quorum (matches DetectMultiFileGroup's
+   TagQuorum) AND the importer's trackNumbersCleanDistinct check (importer.go:930):
+   merge only when per-file track numbers form a clean DISTINCT sequence. Repeated/zero
+   track numbers ⇒ leave split (signature of distinct books sharing a generic album).
+4. Merge survivors into one Book{ SegmentFiles: [...sorted by disc,track...] }.
+5. Gate behind a config flag + dry-run (like other risky scanner behaviors).
+```
+
+**Reuse, don't reinvent:** the importer already solved the identical over-merge risk —
+`groupTracksByAlbum` (`importer.go:867`), `albumGroupKey` (`:913`),
+`trackNumbersCleanDistinct` (`:930`), `splitOverMergedGroup` (`:950`). Lift that pattern.
+
+> **Doc correction:** memory's "(Album, Artist) ONLY" identity key is **stale** for the
+> importer. Post-CONS-FRAG the importer keys **album-only** when album is present
+> (`albumGroupKey:914-916`), keeping artist only as a guard for the no-album fallback.
+> Update memory `project_itunes_grouping_key` accordingly.
+
+### 1.3 Per-file tag read I/O cost (#1548) (P1)
+
+`createBookFilesForBook` (`scanner.go:1229-1331`) now does, per segment file:
+`metadata.ExtractMetadata` (`:1294`, full open+parse) **plus** `ComputeFileHash`
+(`:1309`, open+read up to 20 MB). The grouping phase also opens each file
+(`quickReadMultiFileInfo :1534`, `quickReadAlbum :1564/:1591`) → **~3 opens/file** across a
+full scan. On a 35K-file scan the hash reads dominate (hundreds of GB read).
+
+**Fix — deduplicate opens, not batch:** route segment reads through `ProcessFile`
+(`process_file.go:41`, one open → meta+mediainfo+hash) and reuse grouping-phase tags in
+`createBookFilesForBook`. Net ~3 → ~1 open/file. Directory-level parallelism already exists.
+
+### 1.4 Grouping gates (P2)
+
+- `DetectMultiFileGroup` (`scanner.go:1531`): N≥3, sequential naming, ≥75% tag quorum.
+  No duration gate.
+- `consolidateChapterGroups` (`chapter_consolidation.go:44-143`, no-album fallback): has a
+  duration gate (`:108-128`) — only consolidates short files.
+- These gates are filename/duration-based and **per-directory**; the cross-dir post-pass
+  should add the importer's track-number-distinctness gate.
+
+---
+
+## 2. Dedup pipeline
+
+### 2.1 PREVENTION — same-dir gate at emission (P0)
+
+`internal/dedup/engine.go`:
+- All exact emitters persist via `upsertExactCandidate` (`:1160`); its only guard is
+  `isNonPrimaryVersion` (`:1161`). **No same-folder suppression.**
+- `checkExactTitle` (`:902`) + `checkDurationMatch` (`:1014`) are the two that cross-pair
+  chapters (shared leaked title / similar duration). The same-dir signal is available at
+  emit time (`book.FilePath` → `filepath.Dir`) and is already used elsewhere
+  (`findSimilarBooks :1394`, `eligibility.go:106`, `PurgeStaleCandidates :2280`).
+- The unified re-score pass loads pending pairs (`:407`), and the suppressible branch at
+  **`:452-457` is `slog.Debug` + `continue` — no delete.** So same-dir pairs persist.
+
+**Fix (two complementary):**
+- **(a) Preventive, targeted (recommended):** add a same-parent-dir guard to
+  `checkExactTitle` and `checkDurationMatch` specifically. **Do NOT** add a blanket guard
+  in `upsertExactCandidate` — it also routes file-hash/ISBN/metadata-hash, where a same-dir
+  pair can be a *legitimate* duplicate (two identical files in one folder). If a single
+  chokepoint is preferred, make it **layer-aware** (suppress same-dir only for exact
+  title/duration).
+- **(b) Backstop:** at `:452-457`, change `continue` → `DeleteCandidate(c.ID)` then
+  `continue`, so the unified pass deletes any suppressible pair from any emitter (catches
+  future emitters + LSH/AcoustID chapter pairs too).
+
+### 2.2 O(N·P) — unified pass reloads the full pending table per book (P1)
+
+`runUnifiedScoringForBook` (`:407-410`) loads **all** pending candidates per book (no
+per-book/entity filter), then linearly scans them (`:415-427`). Full scan = O(N·P);
+at N=29,308, P≈10,859 ≈ **318M row-scans/scan**; during an explosion P grows → effectively
+quadratic. **Fix:** add an entity-ID predicate to `CandidateFilter` (or a
+`book:dedup:cand:<id>` index) so each book loads only its own pairs → O(N·K).
+*(Verify the candidate-store API supports an entity filter before implementing.)*
+
+### 2.3 N+1 — book-only collectors re-run inside the per-candidate loop (P1)
+
+`engine.go:444-554`: `CollectExactFileHash` (`:463`), `CollectISBNASIN` (`:473`),
+`CollectMetaSrcHash` (`:482`), `CollectDuration` (`:521`) depend only on `book` but run
+**inside** the `for candID` loop. `CollectISBNASIN` (`collectors_exact.go:148`) does a full
+O(N) `GetAllBooks` batch scan → O(K·N) per book. **Fix:** hoist all four out of the loop,
+build `map[otherID][]Signal` once per book.
+
+### 2.4 Per-author O(M²) emitters (P1/P2)
+
+`checkExactTitle` (`:913` `GetBooksByAuthorID` + `:920` inner loop) and `checkDurationMatch`
+(`:1025`+`:1034`) are O(M²) per author — pathological for a synthetic author aggregating
+thousands of chapter-books. `checkExactISBN` already has an indexed fast path (`:770-811`).
+The same-dir guard from §2.1(a) short-circuits the dominant pathological pairs cheaply
+(compare `filepath.Dir` before Levenshtein). Severity depends on whether the heal
+redistributed the synthetic authors.
+
+### 2.5 purge-stale ≤100K/pass cap (P2)
+
+`engine.go:2195-2199`: `ListCandidates{Status:"pending", Limit:100000}`, single page, no
+offset loop. Cap is real; bounds memory/runtime for the interactive op (10-min timeout,
+`purge_stale.go:28-46`). Currently latent (P≈10,859 < 100K). During the 380K explosion a
+single pass cleaned only the first 100K (why the heal needed 4 passes). **Fix:** either
+paginate-read accumulating stale IDs then batch-delete (a naive `offset += 100000` loop
+re-fetches survivors forever — wrong), **or** raise the cap to 1M (precedent:
+`dataset_backfill.go:100` uses `Limit: 1_000_000`) with chunked deletes. Prefer raising.
+
+### 2.6 Signature oracle + LSH do NOT suppress chapter pairs today
+
+`book_signature_scan.go` is a separate manual op (not wired into `dedup.full-scan`) and
+emits its own `book_signature` layer with no folder awareness. LSH/AcoustID collectors
+(`collectors_acoustid.go`) operate on per-file fingerprints with no same-folder awareness.
+The §2.1(b) delete-on-suppress backstop would also neutralize any chapter pairs these raise.
+
+---
+
+## 3. Residual characterization — the 10,859 exact-pending (fresh, post-heal)
+
+Read-only sample of n=151 pairs spread across the full range (both books fetched per pair;
+`.claude/notes/characterize_residual.py`). The composition **flipped** vs the pre-heal 380K:
+
+| Bucket | Pre-heal (380K) | Post-heal (10,859) |
+|---|---|---|
+| Chapter-sibling (same grandparent) | 69% | **17%** |
+| Different-tree (cross-location) | ~17% | **83%** |
+| Fragment-vs-full (duration ratio < 0.5) | 8% | **14%** |
+
+Reading the actual pairs, the residual is **four distinct populations**:
+
+1. **Genuine duplicate editions** — e.g. `Equilibrium` and `Darkness Beyond` (ratio 1.0,
+   byte-identical filesize, different folders), two real copies of `The Bands of Mourning`.
+   → **KEEP for the review UI. Do NOT purge.** This is the dedup feature working.
+2. **Fragment-vs-full leftovers (~14%)** — full `.m4b` vs a single `Chapter 67.mp3`
+   (`Disquiet Gods`, `Sun Eater`). → needs an absolute fragment-floor rule (purge the
+   stray chapter candidate, or attach it).
+3. **Title-leak FALSE pairs** — the `"Opening Credits"` / `"Intro"` / `"Big Finish Ident"`
+   cluster (dur=0): *different* books (`Backyard Dungeon 4` vs `Made in Hell 3`) sharing a
+   junk leaked title. → purgeable; **root cause = the title-leak importer bug (CONS-17,
+   memory `project_duration_ms_and_title_leak`)** — fix upstream so it can't regenerate.
+4. **Stub / empty records** — `fs=11` / `fs=91` bytes paired with a real book
+   (`Kushiel's Mercy`, `The Finder Chronicles [02]`). → cleanup (these never had real audio).
+
+**Implication:** differentiated handling, not a blanket purge. Populations #3 and #4 trace
+to upstream importer bugs the prevention work should also close.
+
+---
+
+## 4. The delete-skipped edge case = a real data-completeness bug
+
+`maintenance.fs-regroup-xml` apply (`internal/plugins/maintenance/fs_regroup_xml.go`):
+`applyFSRegroup` (`:203`). The delete-guard (`:277-281`) refuses to delete a shell that
+still owns ≥1 BookFile — **correct** defensive behavior. The bug is upstream in the attach
+step (`:231-251`): it calls `UpsertBookFile` with `BookID: survivor.ID` but
+`FilePath: m.FilePath`. `UpsertBookFile` (`pebble_store.go:9799-9827`) **matches by path**
+(`:9812-9817`) and on match **preserves the existing row's BookID** (`:9824-9826`) — it does
+NOT reassign.
+
+- Shell with FileCount==0 (path only on `Book.FilePath`, no row) → `CreateBookFile` →
+  attaches to survivor → shell empty → deleted. **(the 595 healed)**
+- Shell with FileCount==1 (already had a materialized BookFile row) → path-match keeps the
+  old BookID → file **stays on the shell** → guard sees non-empty → **delete-skipped.**
+  **(the 3)** — and the **survivor is silently missing that chapter's audio.**
+
+**Verdict: apply bug, not benign.** Fix: explicit reattach/move (set `BookFile.BookID =
+survivor.ID` for the matched row) instead of relying on `UpsertBookFile`. The WS2
+store-mocked test must replicate `UpsertBookFile`'s path-match-preserves-BookID semantics or
+it proves nothing (see §5).
+
+---
+
+## 5. Prioritized work plan
+
+| Pri | Item | Where | Track |
+|---|---|---|---|
+| **P0** | Same-dir gate on title/duration emitters + delete-on-suppress backstop | `engine.go:902,1014,452` | code |
+| **P0** | Cross-dir sibling-coalescing post-pass (shatter prevention) | `scanner.go:427` | code |
+| **P0** | Fix `applyFSRegroup` attach (explicit reattach) + heal the 1 residual | `fs_regroup_xml.go:231` | code+op |
+| **P1** | `applyFSRegroup` store-mocked unit test + E2E shattered fixture | new tests | code |
+| **P1** | Per-book candidate filter (kill O(N·P)) | `engine.go:407` | code |
+| **P1** | Hoist book-only collectors out of per-candidate loop | `engine.go:444-554` | code |
+| **P1** | Dedup #1548 read: route `createBookFilesForBook` through `ProcessFile` | `scanner.go:1294` | code |
+| **P1** | tag-backfill apply (lossless whole library) | op | op |
+| **P2** | Differentiated residual disposition (fragment-floor; purge title-leak/stub) | new op | op |
+| **P2** | purge-stale: raise cap to 1M w/ chunked delete | `engine.go:2195` | code |
+| **P2** | Per-author O(M²) short-circuit via same-dir | `engine.go:913,1025` | code |
+
+---
+
+## 6. Open verification items (flagged by the auditors)
+
+- Confirm `CandidateFilter` / candidate-store supports an entity-ID predicate before the
+  §2.2 fix.
+- Confirm `DeleteCandidate` is safe to call mid-scan inside `runUnifiedScoringForBook`
+  (candidates already materialized into a slice → appears safe).
+- The "why exactly 3" provenance of the one-file shells is a hypothesis; the FileCount 0/1
+  split is forced by the prod numbers and is certain.
+- Empirical scan open-count (3 is a static worst case; scan-cache `shouldSkipFile:289` may
+  skip unchanged files on rescans).

--- a/internal/plugins/maintenance/fs_regroup_xml.go
+++ b/internal/plugins/maintenance/fs_regroup_xml.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/fs_regroup_xml.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7d2a9c14-3e86-4b50-9f71-2c8e0a6d4b95
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 // Package maintenance — op maintenance.fs-regroup-xml.
 //
@@ -233,16 +233,54 @@ func (p *Plugin) applyFSRegroup(ctx context.Context, store database.Store, targe
 			if fi, serr := os.Stat(m.FilePath); serr == nil {
 				size = fi.Size()
 			}
+			format := strings.TrimPrefix(strings.ToLower(filepath.Ext(m.FilePath)), ".")
+			// Explicit REATTACH (not UpsertBookFile): a member shell may already own a
+			// materialized BookFile row at this path (FileCount==1). UpsertBookFile matches
+			// by path and PRESERVES the existing row's BookID (pebble_store.go:9824-9825),
+			// which would leave the file orphaned on the shell — the shell then fails the
+			// delete-guard (delete-skipped) AND the survivor silently loses that chapter's
+			// audio. So if a row exists, MOVE it to the survivor (preserving its
+			// RawTags/hashes — the BookFile primary key embeds the bookID, so an in-place
+			// UpdateBookFile cannot change owners; MoveBookFilesToBook re-keys it), then set
+			// the chapter track order (which also syncs memdb). Otherwise create a fresh row.
+			existing, _ := store.GetBookFileByPath(m.FilePath)
+			if existing != nil {
+				if existing.BookID != survivor.ID {
+					if err := store.MoveBookFilesToBook([]string{existing.ID}, existing.BookID, survivor.ID); err != nil {
+						_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("reattach file %s -> %s failed: %v", m.FilePath, survivor.ID, err))
+						errCount++
+						continue
+					}
+				}
+				existing.BookID = survivor.ID
+				existing.TrackNumber = order + 1
+				if existing.Duration == 0 {
+					existing.Duration = m.DurationSec
+				}
+				if existing.FileSize == 0 {
+					existing.FileSize = size
+				}
+				if existing.Format == "" {
+					existing.Format = format
+				}
+				if err := store.UpdateBookFile(existing.ID, existing); err != nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("set track order %s -> %s failed: %v", m.FilePath, survivor.ID, err))
+					errCount++
+					continue
+				}
+				filesAttached++
+				continue
+			}
 			bf := &database.BookFile{
 				ID:          ulid.Make().String(),
 				BookID:      survivor.ID,
 				FilePath:    m.FilePath,
-				Format:      strings.TrimPrefix(strings.ToLower(filepath.Ext(m.FilePath)), "."),
+				Format:      format,
 				FileSize:    size,
 				Duration:    m.DurationSec,
 				TrackNumber: order + 1,
 			}
-			if err := store.UpsertBookFile(bf); err != nil {
+			if err := store.CreateBookFile(bf); err != nil {
 				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("attach file %s -> %s failed: %v", m.FilePath, survivor.ID, err))
 				errCount++
 				continue

--- a/internal/plugins/maintenance/fs_regroup_xml_test.go
+++ b/internal/plugins/maintenance/fs_regroup_xml_test.go
@@ -1,0 +1,250 @@
+// file: internal/plugins/maintenance/fs_regroup_xml_test.go
+// version: 1.0.0
+// guid: 2a7c5e91-8d34-4b6f-a012-9f3e7c1d56ab
+// last-edited: 2026-06-21
+
+package maintenance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+)
+
+// resultLog returns the final "APPLIED — …" summary the apply path logs.
+func resultLog(t *testing.T, logs []string) string {
+	t.Helper()
+	for i := len(logs) - 1; i >= 0; i-- {
+		if strings.HasPrefix(logs[i], "APPLIED —") {
+			return logs[i]
+		}
+	}
+	t.Fatalf("no APPLIED summary in logs: %v", logs)
+	return ""
+}
+
+// Happy path: shattered members that own NO BookFile rows (the virtual-segment model,
+// the 595 healed on prod). Survivor gains a BookFile per member; shells are deleted.
+func TestApplyFSRegroup_HappyPath_ZeroFileShells(t *testing.T) {
+	s := regroupStore(t)
+	survivor := seedBook(t, s, "") // title empty — prefix becomes the title
+	shellA := seedBook(t, s, "")
+	shellB := seedBook(t, s, "")
+
+	base := "/lib/Adrian Tchaikovsky/Cage of Souls - Cage of Souls"
+	target := itunesservice.FSRegroupTarget{
+		BookFolder: base,
+		Title:      "Cage of Souls",
+		SurvivorID: survivor,
+		Members: []itunesservice.FSBook{
+			{ID: survivor, FilePath: base + "/Cage of Souls - 1/01.mp3", DurationSec: 1200},
+			{ID: shellA, FilePath: base + "/Cage of Souls - 2/01.mp3", DurationSec: 1300},
+			{ID: shellB, FilePath: base + "/Cage of Souls - 3/01.mp3", DurationSec: 1400},
+		},
+	}
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	if err := p.applyFSRegroup(context.Background(), s, []itunesservice.FSRegroupTarget{target}, 0, rep); err != nil {
+		t.Fatalf("applyFSRegroup: %v", err)
+	}
+
+	files, _ := s.GetBookFiles(survivor)
+	if len(files) != 3 {
+		t.Fatalf("survivor has %d files, want 3", len(files))
+	}
+	if b, _ := s.GetBookByID(shellA); b != nil {
+		t.Errorf("shellA not deleted")
+	}
+	if b, _ := s.GetBookByID(shellB); b != nil {
+		t.Errorf("shellB not deleted")
+	}
+	if sb, _ := s.GetBookByID(survivor); sb == nil || sb.Title != "Cage of Souls" || sb.FilePath != base {
+		t.Errorf("survivor title/path = %v, want 'Cage of Souls' @ %q", sb, base)
+	}
+	if r := resultLog(t, rep.logs); !strings.Contains(r, "delete-skipped=0") || !strings.Contains(r, "healed=1") {
+		t.Errorf("result = %q, want healed=1 delete-skipped=0", r)
+	}
+}
+
+// REGRESSION (the #1548 delete-skipped bug): a non-survivor member that ALREADY owns a
+// materialized BookFile row at its path (FileCount==1). The old code called UpsertBookFile,
+// which path-matches and preserves the shell's BookID — leaving the file on the shell, so
+// the delete-guard skipped it AND the survivor silently lost that chapter's audio. The fix
+// reattaches the existing row to the survivor, so the shell empties and is deleted.
+func TestApplyFSRegroup_ReattachesOneFileShell(t *testing.T) {
+	s := regroupStore(t)
+	survivor := seedBook(t, s, "")
+	shell := seedBook(t, s, "")
+
+	base := "/lib/Brandon Sanderson/Elantris - Elantris"
+	shellPath := base + "/Elantris - 2/01.mp3"
+	// Pre-seed a BookFile row OWNED BY THE SHELL at the shell's chapter path.
+	if err := s.CreateBookFile(&database.BookFile{BookID: shell, FilePath: shellPath, Duration: 999}); err != nil {
+		t.Fatalf("seed shell file: %v", err)
+	}
+
+	target := itunesservice.FSRegroupTarget{
+		BookFolder: base,
+		Title:      "Elantris",
+		SurvivorID: survivor,
+		Members: []itunesservice.FSBook{
+			{ID: survivor, FilePath: base + "/Elantris - 1/01.mp3", DurationSec: 1200},
+			{ID: shell, FilePath: shellPath, DurationSec: 1300},
+		},
+	}
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	if err := p.applyFSRegroup(context.Background(), s, []itunesservice.FSRegroupTarget{target}, 0, rep); err != nil {
+		t.Fatalf("applyFSRegroup: %v", err)
+	}
+
+	// The pre-existing file must have MOVED to the survivor (not stayed on the shell).
+	sfiles, _ := s.GetBookFiles(survivor)
+	if len(sfiles) != 2 {
+		t.Fatalf("survivor has %d files, want 2 (own + reattached)", len(sfiles))
+	}
+	if sh, _ := s.GetBookFiles(shell); len(sh) != 0 {
+		t.Errorf("shell still owns %d files, want 0 (reattach failed → would orphan audio)", len(sh))
+	}
+	if b, _ := s.GetBookByID(shell); b != nil {
+		t.Errorf("shell not deleted (delete-skipped bug regressed)")
+	}
+	// The reattached row must preserve its identity (the move keeps the existing row).
+	moved, _ := s.GetBookFileByPath(shellPath)
+	if moved == nil || moved.BookID != survivor {
+		t.Errorf("reattached row = %v, want BookID=%s", moved, survivor)
+	}
+	if r := resultLog(t, rep.logs); !strings.Contains(r, "delete-skipped=0") {
+		t.Errorf("result = %q, want delete-skipped=0", r)
+	}
+}
+
+// Integration: a real shattered folder layout (Cage of Souls / N) routed through the
+// PURE planner guard (GroupShatteredBooks, prefix⊆parent) and then the apply path,
+// collapsing N chapter shells into ONE survivor book.
+func TestFSRegroup_ShatteredFolder_HealsToOneBook(t *testing.T) {
+	s := regroupStore(t)
+	base := "/lib/Adrian Tchaikovsky/Cage of Souls - Cage of Souls"
+	var fsbooks []itunesservice.FSBook
+	var ids []string
+	for i := 1; i <= 4; i++ {
+		id := seedBook(t, s, "")
+		ids = append(ids, id)
+		fsbooks = append(fsbooks, itunesservice.FSBook{
+			ID:        id,
+			FilePath:  base + "/Cage of Souls - " + itoa(i) + "/01.mp3",
+			IsPrimary: true,
+		})
+	}
+
+	targets, st := itunesservice.GroupShatteredBooks(fsbooks)
+	if len(targets) != 1 {
+		t.Fatalf("planner produced %d targets, want 1 (stats: %+v)", len(targets), st)
+	}
+	if targets[0].Title != "Cage of Souls" {
+		t.Errorf("title = %q, want 'Cage of Souls'", targets[0].Title)
+	}
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	if err := p.applyFSRegroup(context.Background(), s, targets, 0, rep); err != nil {
+		t.Fatalf("applyFSRegroup: %v", err)
+	}
+
+	survivors := 0
+	for _, id := range ids {
+		if b, _ := s.GetBookByID(id); b != nil {
+			survivors++
+		}
+	}
+	if survivors != 1 {
+		t.Fatalf("%d books remain, want 1 (shattered → 1)", survivors)
+	}
+	files, _ := s.GetBookFiles(targets[0].SurvivorID)
+	if len(files) != 4 {
+		t.Errorf("survivor has %d files, want 4", len(files))
+	}
+}
+
+// itoa avoids importing strconv for a single tiny use.
+func itoa(n int) string { return string(rune('0' + n)) }
+
+// External-id mappings on a shell must be reassigned to the survivor before the shell
+// is deleted (so iTunes PID linkage survives the heal).
+func TestApplyFSRegroup_ReassignsExternalIDs(t *testing.T) {
+	s := regroupStore(t)
+	survivor := seedBook(t, s, "")
+	shell := seedBook(t, s, "")
+	if err := s.CreateExternalIDMapping(&database.ExternalIDMapping{Source: "itunes", ExternalID: "PID-X", BookID: shell}); err != nil {
+		t.Fatalf("seed ext-id: %v", err)
+	}
+
+	base := "/lib/Author/Book - Book"
+	target := itunesservice.FSRegroupTarget{
+		BookFolder: base,
+		Title:      "Book",
+		SurvivorID: survivor,
+		Members: []itunesservice.FSBook{
+			{ID: survivor, FilePath: base + "/Book - 1/01.mp3", DurationSec: 100},
+			{ID: shell, FilePath: base + "/Book - 2/01.mp3", DurationSec: 200},
+		},
+	}
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	if err := p.applyFSRegroup(context.Background(), s, []itunesservice.FSRegroupTarget{target}, 0, rep); err != nil {
+		t.Fatalf("applyFSRegroup: %v", err)
+	}
+	if id, _ := s.GetBookByExternalID("itunes", "PID-X"); id != survivor {
+		t.Errorf("PID-X -> %q, want survivor %q", id, survivor)
+	}
+	if b, _ := s.GetBookByID(shell); b != nil {
+		t.Errorf("shell not deleted after ext-id reassign")
+	}
+}
+
+// When ext-id reassignment FAILS, the shell must be skip-counted and NOT deleted
+// (so its mappings aren't orphaned). Forced via a mock that errors on reassign.
+func TestApplyFSRegroup_ExtIDErrorSkipsDelete(t *testing.T) {
+	survivor := &database.Book{ID: "surv"}
+	deleted := map[string]bool{}
+	mock := &database.MockStore{
+		GetBookByIDFunc:        func(id string) (*database.Book, error) { return survivor, nil },
+		GetBookFileByPathFunc:  func(string) (*database.BookFile, error) { return nil, nil },
+		CreateBookFileFunc:     func(*database.BookFile) error { return nil },
+		UpdateBookFunc:         func(_ string, b *database.Book) (*database.Book, error) { return b, nil },
+		GetExternalIDsForBookFunc: func(string) ([]database.ExternalIDMapping, error) {
+			return []database.ExternalIDMapping{{ExternalID: "p", BookID: "shell"}}, nil
+		},
+		ReassignExternalIDsFunc: func(_, _ string) error { return context.DeadlineExceeded },
+		GetBookFilesFunc:        func(string) ([]database.BookFile, error) { return nil, nil },
+		DeleteBookFunc:          func(id string) error { deleted[id] = true; return nil },
+	}
+
+	base := "/lib/A/B - B"
+	target := itunesservice.FSRegroupTarget{
+		BookFolder: base, Title: "B", SurvivorID: "surv",
+		Members: []itunesservice.FSBook{
+			{ID: "surv", FilePath: base + "/B - 1/01.mp3"},
+			{ID: "shell", FilePath: base + "/B - 2/01.mp3"},
+		},
+	}
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	// A reassign failure is skip-counted (delete-skipped), not an errCount → apply returns nil.
+	if err := p.applyFSRegroup(context.Background(), mock, []itunesservice.FSRegroupTarget{target}, 0, rep); err != nil {
+		t.Fatalf("applyFSRegroup: %v", err)
+	}
+	if deleted["shell"] {
+		t.Errorf("shell deleted despite ext-id reassign failure (orphans mappings)")
+	}
+	if r := resultLog(t, rep.logs); !strings.Contains(r, "delete-skipped=1") {
+		t.Errorf("result = %q, want delete-skipped=1", r)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a silent **data-completeness bug** in the `maintenance.fs-regroup-xml` apply path discovered while characterizing the 3 `delete-skipped` shells from the PR #1548 prod heal.

The attach loop used `UpsertBookFile`, which matches by path and **preserves the existing row's BookID** (`pebble_store.go:9824-9825`). When a member shell already owned a materialized BookFile row (`FileCount==1`), the file was never moved to the survivor → the shell failed the delete-guard (counted as `delete-skipped`) **and the survivor silently lost that chapter's audio**.

## Fix
Explicit reattach: if a row exists at the path, move it to the survivor via `MoveBookFilesToBook` (the BookFile primary key embeds the bookID, so in-place `UpdateBookFile` can't change owners), then set the chapter track order. Moving in place **preserves the row's RawTags/hashes** — more lossless than the old rebuild.

## Tests (apply path previously had none)
- happy-path zero-file shells
- **one-file-shell reattach regression** (locks the bug)
- ext-id reassignment to survivor
- ext-id-error → delete-skip branch (mock)
- planner→apply integration: shattered folder → 1 book

## Docs
Adds `docs/dedup-import-pipeline-audit.md` — the agent-driven dedup+import pipeline audit + post-heal residual characterization (10,859 candidates are 4 distinct populations) that motivates the follow-up PRs.

## Test plan
`go test ./internal/plugins/maintenance/ ./internal/itunes/service/` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)