### PR TITLE
fix(dedup): gate exact emitters against chapter cross-pairs + delete-on-suppress backstop

### DIFF
--- a/internal/dedup/chapter_sibling.go
+++ b/internal/dedup/chapter_sibling.go
@@ -1,0 +1,72 @@
+// file: internal/dedup/chapter_sibling.go
+// version: 1.0.0
+// guid: c1d4e7a2-9b35-4f80-8e16-2a7c0d5b9f43
+// last-edited: 2026-06-21
+
+// Package dedup — same-physical-book detection for emit-time suppression.
+//
+// The exact-layer emitters (checkExactTitle, checkDurationMatch) historically
+// cross-paired the chapters of ONE multi-file audiobook against each other,
+// because every chapter shares the same album-derived Title + author. That fed
+// the 380K candidate explosion (.claude/notes/shattered-books-inventory.md).
+//
+// The existing same_dir_multi_file guard (filepath.Dir(a) == filepath.Dir(b))
+// only catches chapters stored as multiple FILES in ONE folder. It MISSES the
+// "shattered" layout where each chapter is its own subdir —
+// `<Book>/<Book> - 1/f`, `<Book>/<Book> - 2/f` — whose parent dirs DIFFER. That
+// is exactly why purge-stale only cleared ~8% of the backlog. chapterSiblings
+// closes that gap: two paths are chapter siblings when both live in a
+// `<prefix> - N` chapter dir, sharing the same grandparent AND the same prefix.
+
+package dedup
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// chapterDirNameRe matches a chapter subdir basename like "Cage of Souls - 15":
+// "<prefix> - <number>". Mirrors itunesservice.chapterDirRe (kept local to avoid
+// a dedup→itunes/service import edge purely for a regex).
+var chapterDirNameRe = regexp.MustCompile(`^(.*) - \d+$`)
+
+// chapterDirParts returns the grandparent dir and the book-title prefix for a
+// file inside a "<prefix> - N" chapter dir. ok=false when it isn't one.
+func chapterDirParts(fp string) (grandparent, prefix string, ok bool) {
+	dir := filepath.Dir(fp)
+	m := chapterDirNameRe.FindStringSubmatch(filepath.Base(dir))
+	if m == nil || strings.TrimSpace(m[1]) == "" {
+		return "", "", false
+	}
+	return filepath.Dir(dir), strings.TrimSpace(m[1]), true
+}
+
+// chapterSiblings reports whether two file paths are chapter subdirs of the SAME
+// shattered book: both live in a "<prefix> - N" dir, under the same grandparent,
+// with the same prefix. Two genuinely-distinct books in sibling dirs (different
+// prefixes, e.g. "Book A - 1" vs "Book B - 2") are NOT siblings and pass through.
+func chapterSiblings(aPath, bPath string) bool {
+	if aPath == "" || bPath == "" {
+		return false
+	}
+	ag, ap, aok := chapterDirParts(aPath)
+	bg, bp, bok := chapterDirParts(bPath)
+	return aok && bok && ag == bg && strings.EqualFold(ap, bp)
+}
+
+// sameMultiFileBook reports whether two books are parts of ONE physical
+// multi-file audiobook — either chapters in the same folder (same parent dir) or
+// chapters shattered across `<prefix> - N` sibling subdirs. Such pairs must
+// never be emitted as duplicate candidates.
+func sameMultiFileBook(a, b *database.Book) bool {
+	if a.FilePath == "" || b.FilePath == "" {
+		return false
+	}
+	if filepath.Dir(a.FilePath) == filepath.Dir(b.FilePath) {
+		return true
+	}
+	return chapterSiblings(a.FilePath, b.FilePath)
+}

--- a/internal/dedup/chapter_sibling_test.go
+++ b/internal/dedup/chapter_sibling_test.go
@@ -1,0 +1,151 @@
+// file: internal/dedup/chapter_sibling_test.go
+// version: 1.0.0
+// guid: e3a8c7d1-4b62-4f90-9a05-7c2e1d8b6f54
+// last-edited: 2026-06-21
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func chapterBook(id, title, path string) *database.Book {
+	b := primaryBook(id, title)
+	b.FilePath = path
+	return b
+}
+
+func TestChapterSiblings(t *testing.T) {
+	base := "/lib/Brandon Sanderson/Elantris - Elantris"
+	tests := []struct {
+		name, a, b string
+		want       bool
+	}{
+		{"shattered siblings same grandparent+prefix", base + "/Elantris - 1/01.mp3", base + "/Elantris - 2/01.mp3", true},
+		{"same parent dir (multi-file in one folder)", base + "/01.mp3", base + "/02.mp3", false}, // caught by same-parent, not chapterSiblings
+		{"different prefixes under same grandparent", "/lib/A/Book A - 1/f.mp3", "/lib/A/Book B - 2/f.mp3", false},
+		{"different grandparents", "/lib/A/Elantris - 1/f.mp3", "/lib/B/Elantris - 2/f.mp3", false},
+		{"not a chapter dir", "/lib/A/Elantris/f.mp3", "/lib/A/Elantris/g.mp3", false},
+		{"empty path", "", base + "/Elantris - 2/01.mp3", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chapterSiblings(tt.a, tt.b); got != tt.want {
+				t.Errorf("chapterSiblings(%q,%q)=%v want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSameMultiFileBook(t *testing.T) {
+	base := "/lib/Author/Cage of Souls - Cage of Souls"
+	// same parent dir
+	a := &database.Book{FilePath: base + "/01.mp3"}
+	b := &database.Book{FilePath: base + "/02.mp3"}
+	if !sameMultiFileBook(a, b) {
+		t.Error("same parent dir should be sameMultiFileBook")
+	}
+	// shattered siblings
+	c := &database.Book{FilePath: base + "/Cage of Souls - 1/01.mp3"}
+	d := &database.Book{FilePath: base + "/Cage of Souls - 2/01.mp3"}
+	if !sameMultiFileBook(c, d) {
+		t.Error("shattered siblings should be sameMultiFileBook")
+	}
+	// genuine cross-dir duplicate — must NOT be suppressed
+	e := &database.Book{FilePath: "/lib/A/Mistborn/Mistborn.m4b"}
+	f := &database.Book{FilePath: "/lib/B/Mistborn (2)/Mistborn.m4b"}
+	if sameMultiFileBook(e, f) {
+		t.Error("genuine cross-dir duplicate must NOT be sameMultiFileBook")
+	}
+}
+
+func TestPairEligibility_SuppressesChapterSiblings(t *testing.T) {
+	base := "/lib/Author/Cage of Souls - Cage of Souls"
+	a := &database.Book{ID: "A", Title: "Cage of Souls", FilePath: base + "/Cage of Souls - 1/01.mp3"}
+	b := &database.Book{ID: "B", Title: "Cage of Souls", FilePath: base + "/Cage of Souls - 2/01.mp3"}
+	ok, sup := PairEligibility(a, b)
+	if ok {
+		t.Fatalf("chapter siblings should be ineligible, got eligible")
+	}
+	found := false
+	for _, s := range sup {
+		if s == "same_dir_multi_file" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("suppressors = %v, want same_dir_multi_file", sup)
+	}
+}
+
+// Emitter must NOT cross-pair chapter siblings of one shattered book.
+func TestExactEmitters_SuppressChapterSiblings(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+	base := "/lib/Brandon Sanderson/Elantris - Elantris"
+	a := chapterBook("A", "Elantris", base+"/Elantris - 1/01.mp3")
+	b := chapterBook("B", "Elantris", base+"/Elantris - 2/01.mp3")
+	byAuthor := []database.Book{*a, *b}
+	wireExactTitleOnly(mock, map[string]*database.Book{"A": a, "B": b}, byAuthor)
+
+	for _, id := range []string{"A", "B"} {
+		if _, err := engine.CheckBook(context.Background(), id); err != nil {
+			t.Fatalf("CheckBook(%s): %v", id, err)
+		}
+	}
+	if cands := pendingCandidates(t, es); len(cands) != 0 {
+		t.Errorf("chapter siblings produced %d candidates, want 0: %+v", len(cands), cands)
+	}
+}
+
+// Emitter MUST still emit for a genuine cross-directory same-title duplicate.
+func TestExactEmitters_EmitCrossDirDuplicate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+	x := chapterBook("X", "Mistborn", "/lib/A/Mistborn/Mistborn.m4b")
+	y := chapterBook("Y", "Mistborn", "/lib/B/Mistborn (2)/Mistborn.m4b")
+	byAuthor := []database.Book{*x, *y}
+	wireExactTitleOnly(mock, map[string]*database.Book{"X": x, "Y": y}, byAuthor)
+
+	for _, id := range []string{"X", "Y"} {
+		if _, err := engine.CheckBook(context.Background(), id); err != nil {
+			t.Fatalf("CheckBook(%s): %v", id, err)
+		}
+	}
+	cands := pendingCandidates(t, es)
+	if len(cands) == 0 {
+		t.Fatalf("genuine cross-dir duplicate produced 0 candidates, want ≥1")
+	}
+}
+
+// Backstop: a suppressible pending candidate (chapter siblings) that already exists
+// must be DELETED by the unified pass, not merely skipped.
+func TestUnifiedPass_DeletesSuppressedChapterSiblingCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	base := "/lib/Author/Elantris - Elantris"
+	a := chapterBook("A", "Elantris", base+"/Elantris - 1/01.mp3")
+	b := chapterBook("B", "Elantris", base+"/Elantris - 2/01.mp3")
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return map[string]*database.Book{"A": a, "B": b}[id], nil
+	}
+	mock.GetBookFilesFunc = func(string) ([]database.BookFile, error) { return nil, nil }
+
+	// Seed a pending candidate for the sibling pair (upsert does not apply the
+	// emit-time same-dir guard, so it inserts — exactly the residual we must purge).
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("seed candidate: %v", err)
+	}
+	if len(pendingCandidates(t, es)) != 1 {
+		t.Fatalf("setup: expected 1 seeded candidate")
+	}
+
+	if err := engine.runUnifiedScoringForBook(context.Background(), a, "Author"); err != nil {
+		t.Fatalf("runUnifiedScoringForBook: %v", err)
+	}
+	if cands := pendingCandidates(t, es); len(cands) != 0 {
+		t.Errorf("backstop should have deleted the suppressed candidate, got %d: %+v", len(cands), cands)
+	}
+}

--- a/internal/dedup/eligibility.go
+++ b/internal/dedup/eligibility.go
@@ -37,8 +37,6 @@
 package dedup
 
 import (
-	"path/filepath"
-
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
@@ -100,11 +98,12 @@ func PairEligibility(a, b *database.Book) (ok bool, suppressors []string) {
 	}
 
 	// Guard 3 — same_dir_multi_file
-	// Extracted verbatim from findSimilarBooks (engine.go:920-922).
-	// Multi-file audiobooks split into chapters and stored in the same folder
-	// produce identical embeddings — suppress before any collector runs.
-	if a.FilePath != "" && b.FilePath != "" &&
-		filepath.Dir(a.FilePath) == filepath.Dir(b.FilePath) {
+	// Originally from findSimilarBooks (engine.go:920-922): chapters split into
+	// multiple files in ONE folder produce identical embeddings. Extended to also
+	// catch the "shattered" layout where each chapter is its own "<prefix> - N"
+	// subdir (different parent dirs, same grandparent + prefix) — the layout that
+	// the old same-parent-only guard missed (purge-stale cleared only ~8%).
+	if sameMultiFileBook(a, b) {
 		suppressors = append(suppressors, "same_dir_multi_file")
 	}
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -414,7 +414,14 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 
 	// Build the set of other-book IDs this book is paired with in the current
 	// embedding + LSH candidate set.  This is the candidate pool for MetaFuzzy.
-	var embeddingCandIDs []string
+	// Keep each pair's candidate-record ID so the eligibility backstop below can
+	// DELETE a suppressed pair (e.g. a chapter cross-pair) rather than merely
+	// skip re-scoring it — otherwise the row persists forever.
+	type candRef struct {
+		otherID string
+		candID  int64
+	}
+	var embeddingCandIDs []candRef
 	for _, c := range candidates {
 		if c.EntityAID != book.ID && c.EntityBID != book.ID {
 			continue
@@ -423,7 +430,7 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		if c.EntityBID == book.ID {
 			otherID = c.EntityAID
 		}
-		embeddingCandIDs = append(embeddingCandIDs, otherID)
+		embeddingCandIDs = append(embeddingCandIDs, candRef{otherID: otherID, candID: c.ID})
 	}
 
 	if len(embeddingCandIDs) == 0 {
@@ -441,18 +448,26 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	// Get the book's files once for acoustid collectors.
 	bookFiles, _ := de.bookStore.GetBookFiles(book.ID)
 
-	for _, candID := range embeddingCandIDs {
+	for _, ref := range embeddingCandIDs {
+		candID := ref.otherID
 		otherBook, err := de.bookStore.GetBookByID(candID)
 		if err != nil || otherBook == nil {
 			continue
 		}
 
-		// 1. Eligibility pre-filter.
+		// 1. Eligibility pre-filter. A suppressed pair (chapter cross-pair, same
+		// version group, distinct series volume) is not just skipped — it is
+		// DELETED, so it can't survive re-scoring forever. This is the backstop
+		// for any emitter (incl. LSH/AcoustID) that lacks the emit-time guard.
 		ok, suppressors := PairEligibility(book, otherBook)
 		if !ok {
-			slog.Debug("dedup unified: suppressed pair",
+			slog.Debug("dedup unified: suppressed pair → delete",
 				"book", book.ID, "other", candID,
-				"suppressors", suppressors)
+				"cand", ref.candID, "suppressors", suppressors)
+			if err := de.embedStore.DeleteCandidate(ref.candID); err != nil {
+				slog.Debug("dedup unified: delete suppressed candidate failed",
+					"cand", ref.candID, "err", err)
+			}
 			continue
 		}
 
@@ -928,6 +943,13 @@ func (de *Engine) checkExactTitle(book *database.Book, authorName string) error 
 		if !hasPlausibleAudio(other) {
 			continue // stub / unscanned shell on the other side
 		}
+		// Prevention: never cross-pair the chapters of ONE physical multi-file
+		// book (same folder, or shattered across "<prefix> - N" sibling subdirs).
+		// This was the 380K-explosion vector. Cheap filepath compare before the
+		// O(title-length) Levenshtein, so it also trims per-author O(M²) cost.
+		if sameMultiFileBook(book, other) {
+			continue
+		}
 		otherForms := de.allNormalizedTitleForms(other)
 		// Closest-form distance: a match exists if ANY form of book is
 		// within Levenshtein 2 of ANY form of other. Alt titles let the
@@ -1040,6 +1062,11 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 			continue
 		}
 		if !hasUsableTitle(other.Title) {
+			continue
+		}
+		// Prevention: chapters of ONE multi-file book share near-identical
+		// durations and the album-derived title — never emit them as a pair.
+		if sameMultiFileBook(book, other) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
Closes the **dedup-side recurrence vector** behind the 380K candidate explosion. The exact-layer emitters (`checkExactTitle`, `checkDurationMatch`) had no same-folder guard at emission, so they cross-paired the chapters of one multi-file audiobook (shared album-derived title + author).

The existing `same_dir_multi_file` guard only compared **parent dirs**, so it missed the *shattered* layout where each chapter is its own `<prefix> - N` subdir (different parents, shared grandparent) — which is exactly why `purge-stale` cleared only ~8% of the backlog.

## Changes
- **`chapter_sibling.go`**: `sameMultiFileBook(a,b)` = same parent dir **OR** chapter siblings (both in `<prefix> - N` dirs, same grandparent + prefix). Genuinely distinct books in sibling dirs (different prefixes) pass through.
- `checkExactTitle` + `checkDurationMatch`: skip such pairs at **emit time** (cheap `filepath` compare before Levenshtein → also trims per-author O(M²) cost).
- `PairEligibility` Guard 3 extended to recognize chapter siblings.
- `runUnifiedScoringForBook`: **deletes** suppressed pairs (was Debug+continue) — so LSH/AcoustID or any future emitter can't leave a chapter cross-pair pending forever. Preserves each pair's candidate-record ID for the delete.

## Tests
`chapterSiblings` table, `sameMultiFileBook`, PairEligibility suppression, emitter suppresses siblings, emitter **still emits** cross-dir dups, unified-pass backstop deletes a seeded suppressible candidate. Full `go test ./internal/dedup/` green.

Refs `docs/dedup-import-pipeline-audit.md` §2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)