### PR TITLE
feat(scanner): coalesce shattered chapter-subdir siblings at scan time (flag OFF)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,6 +282,14 @@ type Config struct {
 	// averages below this duration, they are consolidated into one book record.
 	// Default 10. Set to 0 to disable consolidation.
 	ChapterConsolidationThresholdMin int `json:"chapter_consolidation_threshold_min"`
+	// CoalesceShatteredSiblings enables a scan-time post-pass that merges
+	// single-file books shattered across "<prefix> - N" sibling chapter subdirs
+	// (the layout that produced the 380K dedup-candidate explosion) into ONE
+	// multi-file book — the scan-time analogue of maintenance.fs-regroup-xml.
+	// DEFAULT OFF: the existing library is already healed; enable on a canary
+	// before turning on by default. Path-based + the prefix⊆parent precision
+	// guard (excludes flat dumps and series volumes); no extra tag I/O.
+	CoalesceShatteredSiblings bool `json:"coalesce_shattered_siblings"`
 	// Background operation timeout in minutes (0 disables timeout)
 	OperationTimeoutMinutes int `json:"operation_timeout_minutes"`
 	// MinBookSizeBytes: single-file books below this size are flagged as suspicious and
@@ -772,6 +780,7 @@ func InitConfig() {
 			// Performance
 			ConcurrentScans:                  viper.GetInt("concurrent_scans"),
 			ChapterConsolidationThresholdMin: viper.GetInt("chapter_consolidation_threshold_min"),
+			CoalesceShatteredSiblings:        viper.GetBool("coalesce_shattered_siblings"),
 			OperationTimeoutMinutes:          viper.GetInt("operation_timeout_minutes"),
 			MinBookSizeBytes:                 viper.GetInt64("min_book_size_bytes"),
 			APIRateLimitPerMinute:            viper.GetInt("api_rate_limit_per_minute"),

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -469,6 +469,19 @@ func ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) (
 	}
 
 	wg.Wait()
+
+	// Prevention post-pass: groupFilesIntoBooks runs per-leaf-dir, so a book laid
+	// out as one chapter per "<prefix> - N" subdir shatters into one book per
+	// chapter. Coalesce those siblings into one multi-file book before persisting.
+	// Path-based + prefix⊆parent guard; gated OFF by default (see CoalesceShatteredSiblings).
+	if config.AppConfig.CoalesceShatteredSiblings {
+		before := len(books)
+		books = coalesceShatteredSiblings(books)
+		if len(books) != before {
+			slog.Info("scanner shattered-sibling coalesce", "books_before", before, "books_after", len(books))
+		}
+	}
+
 	return books, nil
 }
 

--- a/internal/scanner/shattered_coalesce.go
+++ b/internal/scanner/shattered_coalesce.go
@@ -1,0 +1,137 @@
+// file: internal/scanner/shattered_coalesce.go
+// version: 1.0.0
+// guid: 9b4e2a17-6c08-4d35-8f91-3a7d05c2e6b4
+// last-edited: 2026-06-21
+
+// Package scanner — scan-time prevention of the "shattered book" defect.
+//
+// The scanner groups files PER LEAF DIRECTORY (groupFilesIntoBooks runs once per
+// dir), so a book laid out as one chapter per subdir —
+// `<Book>/<Book> - 1/f`, `<Book>/<Book> - 2/f`, … — produces one standalone
+// single-file Book per chapter. That shattered ~1,075 real books into ~35,577
+// records and fed the 380K dedup-candidate explosion. The data was healed by
+// maintenance.fs-regroup-xml; coalesceShatteredSiblings is the scan-time analogue
+// that stops the defect from being re-persisted on the next scan.
+//
+// It is PATH-BASED (no tag I/O — album/track tags aren't read until ProcessBooks)
+// and reuses the heal's exact precision guard: group single-file books by
+// (grandparent dir, chapter prefix) where the chapter dir matches "<prefix> - N",
+// accepting a group ONLY when the prefix is a substring of the parent folder name
+// (`Cage of Souls - Cage of Souls/Cage of Souls - N/`). That excludes flat dumps
+// (`abooks/Throne of Jade 01/…`) and series volumes (`Author/Series - N/file`),
+// both of which must NOT be merged — validated in production by the heal.
+//
+// Gated by config.AppConfig.CoalesceShatteredSiblings (default OFF).
+
+package scanner
+
+import (
+	"log/slog"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// shatterChapterDirRe matches a chapter subdir basename "<prefix> - <number>".
+// Mirrors itunesservice.chapterDirRe.
+var shatterChapterDirRe = regexp.MustCompile(`^(.*) - (\d+)$`)
+
+// shatterChapterParts returns the grandparent dir, book-title prefix, and chapter
+// number for a file inside a "<prefix> - N" chapter dir. ok=false otherwise.
+func shatterChapterParts(fp string) (parent, prefix string, num int, ok bool) {
+	chapterDir := filepath.Dir(fp)
+	m := shatterChapterDirRe.FindStringSubmatch(filepath.Base(chapterDir))
+	if m == nil || strings.TrimSpace(m[1]) == "" {
+		return "", "", 0, false
+	}
+	n, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", "", 0, false
+	}
+	return filepath.Dir(chapterDir), strings.TrimSpace(m[1]), n, true
+}
+
+// normShatterPrefix lowercases and strips non-alphanumerics — matches
+// itunesservice.normTitle so the prefix⊆parent guard behaves identically to the
+// production-validated heal (distinct from this package's space-joined
+// normForCompare).
+func normShatterPrefix(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// coalesceShatteredSiblings merges single-file books that are chapters of one
+// shattered book (sibling "<prefix> - N" subdirs under a book-named folder) into
+// ONE multi-file Book with SegmentFiles ordered by chapter number. All other
+// books pass through untouched. Returns the input unchanged when nothing merges.
+func coalesceShatteredSiblings(books []Book) []Book {
+	type key struct{ parent, prefix string }
+	groups := map[key][]int{}
+	for i := range books {
+		b := &books[i]
+		if len(b.SegmentFiles) > 0 || b.FilePath == "" {
+			continue // already multi-file, or no path to reason about
+		}
+		parent, prefix, _, ok := shatterChapterParts(b.FilePath)
+		if !ok {
+			continue
+		}
+		k := key{parent, prefix}
+		groups[k] = append(groups[k], i)
+	}
+	if len(groups) == 0 {
+		return books
+	}
+
+	merged := make([]bool, len(books))
+	coalesced := map[int]Book{} // first-member index → coalesced book
+	for k, idxs := range groups {
+		if len(idxs) < 2 {
+			continue // a lone chapter is not a shattered book
+		}
+		// Precision guard: the book folder must be named after the book.
+		if !strings.Contains(normShatterPrefix(filepath.Base(k.parent)), normShatterPrefix(k.prefix)) {
+			continue
+		}
+		sort.SliceStable(idxs, func(a, b int) bool {
+			_, _, na, _ := shatterChapterParts(books[idxs[a]].FilePath)
+			_, _, nb, _ := shatterChapterParts(books[idxs[b]].FilePath)
+			return na < nb
+		})
+		segs := make([]string, len(idxs))
+		for j, idx := range idxs {
+			segs[j] = books[idx].FilePath
+			merged[idx] = true
+		}
+		coalesced[idxs[0]] = Book{
+			FilePath:     segs[0],
+			Format:       strings.ToLower(filepath.Ext(segs[0])),
+			SegmentFiles: segs,
+		}
+		slog.Info("scanner coalesced shattered siblings",
+			"book", k.prefix, "chapters", len(segs), "dir", k.parent)
+	}
+	if len(coalesced) == 0 {
+		return books
+	}
+
+	out := make([]Book, 0, len(books))
+	for i := range books {
+		if cb, ok := coalesced[i]; ok {
+			out = append(out, cb)
+			continue
+		}
+		if merged[i] {
+			continue
+		}
+		out = append(out, books[i])
+	}
+	return out
+}

--- a/internal/scanner/shattered_coalesce_test.go
+++ b/internal/scanner/shattered_coalesce_test.go
@@ -1,0 +1,129 @@
+// file: internal/scanner/shattered_coalesce_test.go
+// version: 1.0.0
+// guid: 4c7e9a02-8d31-4b65-9f80-1a3c6d2e7b59
+// last-edited: 2026-06-21
+
+package scanner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func sf(path string) Book { return Book{FilePath: path} }
+
+// Shattered chapters (sibling "<prefix> - N" dirs under a book-named folder)
+// collapse into ONE multi-file book with ordered segments.
+func TestCoalesce_ShatteredMergesToOneBook(t *testing.T) {
+	base := "/lib/Adrian Tchaikovsky/Cage of Souls - Cage of Souls"
+	in := []Book{
+		sf(base + "/Cage of Souls - 1/01.mp3"),
+		sf(base + "/Cage of Souls - 2/01.mp3"),
+		sf(base + "/Cage of Souls - 3/01.mp3"),
+	}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 1 {
+		t.Fatalf("got %d books, want 1: %+v", len(out), out)
+	}
+	want := []string{
+		base + "/Cage of Souls - 1/01.mp3",
+		base + "/Cage of Souls - 2/01.mp3",
+		base + "/Cage of Souls - 3/01.mp3",
+	}
+	if !reflect.DeepEqual(out[0].SegmentFiles, want) {
+		t.Errorf("segments = %v, want %v", out[0].SegmentFiles, want)
+	}
+}
+
+// Segments must be ordered by NUMERIC chapter number, not lexical.
+func TestCoalesce_OrdersChaptersNumerically(t *testing.T) {
+	base := "/lib/A/Elantris - Elantris"
+	in := []Book{
+		sf(base + "/Elantris - 11/f.mp3"),
+		sf(base + "/Elantris - 2/f.mp3"),
+		sf(base + "/Elantris - 1/f.mp3"),
+		sf(base + "/Elantris - 10/f.mp3"),
+	}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 1 {
+		t.Fatalf("got %d books, want 1", len(out))
+	}
+	want := []string{
+		base + "/Elantris - 1/f.mp3",
+		base + "/Elantris - 2/f.mp3",
+		base + "/Elantris - 10/f.mp3",
+		base + "/Elantris - 11/f.mp3",
+	}
+	if !reflect.DeepEqual(out[0].SegmentFiles, want) {
+		t.Errorf("segments = %v, want numeric order %v", out[0].SegmentFiles, want)
+	}
+}
+
+// Flat dumps (`abooks/<Book> - N/`) — prefix NOT a substring of the parent folder
+// — must NOT be merged (the books are unrelated, sharing only a dump directory).
+func TestCoalesce_FlatDumpNotMerged(t *testing.T) {
+	in := []Book{
+		sf("/mnt/bigdata/books/abooks/Throne of Jade - 1/f.mp3"),
+		sf("/mnt/bigdata/books/abooks/Throne of Jade - 2/f.mp3"),
+	}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 2 {
+		t.Errorf("flat dump merged (got %d, want 2 untouched): %+v", len(out), out)
+	}
+}
+
+// Series volumes stored as `Author/Series - N/file` — parent is the author dir,
+// not a book-named folder — must NOT be merged (would destroy distinct volumes).
+func TestCoalesce_SeriesVolumesNotMerged(t *testing.T) {
+	in := []Book{
+		sf("/lib/Brandon Sanderson/Stormlight - 1/book.m4b"),
+		sf("/lib/Brandon Sanderson/Stormlight - 2/book.m4b"),
+		sf("/lib/Brandon Sanderson/Stormlight - 3/book.m4b"),
+	}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 3 {
+		t.Errorf("series volumes merged (got %d, want 3 untouched): %+v", len(out), out)
+	}
+}
+
+// A box set with two DISTINCT books under one folder must coalesce into TWO
+// books (each book's own chapters), never cross-merge into one.
+func TestCoalesce_BoxSetDistinctPrefixesSeparate(t *testing.T) {
+	base := "/lib/Author/Apex Ascended - Apex Ascended"
+	in := []Book{
+		sf(base + "/Apex Ascended - 1/f.mp3"),
+		sf(base + "/Apex Ascended - 2/f.mp3"),
+		// a different book that happens to share the grandparent but a distinct prefix
+		sf("/lib/Author/Other Book - Other Book/Other Book - 1/f.mp3"),
+		sf("/lib/Author/Other Book - Other Book/Other Book - 2/f.mp3"),
+	}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 2 {
+		t.Fatalf("got %d books, want 2 (one per distinct prefix): %+v", len(out), out)
+	}
+	for _, b := range out {
+		if len(b.SegmentFiles) != 2 {
+			t.Errorf("book %q has %d segments, want 2", b.FilePath, len(b.SegmentFiles))
+		}
+	}
+}
+
+// A lone chapter (single member of a group) is not a shattered book.
+func TestCoalesce_LoneChapterNotMerged(t *testing.T) {
+	in := []Book{sf("/lib/A/Solo - Solo/Solo - 1/f.mp3")}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 1 || len(out[0].SegmentFiles) != 0 {
+		t.Errorf("lone chapter altered: %+v", out)
+	}
+}
+
+// Already-multi-file books pass through untouched; unrelated books are preserved.
+func TestCoalesce_PassThroughNonCandidates(t *testing.T) {
+	multi := Book{FilePath: "/lib/A/Book/01.mp3", SegmentFiles: []string{"/lib/A/Book/01.mp3", "/lib/A/Book/02.mp3"}}
+	other := sf("/lib/A/Standalone/whole.m4b")
+	in := []Book{multi, other}
+	out := coalesceShatteredSiblings(in)
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2", len(out))
+	}
+}


### PR DESCRIPTION
## Summary
Scan-time **prevention** for the shattered-book defect (the root cause of the 380K dedup-candidate explosion). `groupFilesIntoBooks` runs per-leaf-directory, so a book laid out as one chapter per `<prefix> - N` subdir shatters into one single-file book per chapter. The existing data was healed by `maintenance.fs-regroup-xml`; this stops the defect from being **re-persisted** on the next scan.

## Why not "group by album tag"
The audit's first idea (group `groupFilesIntoBooks` by album) is a **no-op for this bug**: the album-equal chapter files live in *separate sibling dirs* and never enter one `groupFilesIntoBooks` call — and the album tag isn't even on the `Book` at `ScanDirectoryParallel` time (it's read later in `ProcessBooks`). So the fix is a **post-pass** above the per-dir boundary, and it's **path-based** (zero extra tag I/O).

## How
`coalesceShatteredSiblings` (post-pass in `ScanDirectoryParallel`) groups single-file books by `(grandparent, chapter prefix)` and merges only when `prefix ⊆ parent-folder-name` — the production-validated guard that excludes flat dumps (`abooks/`) and series volumes (`Author/Series - N/`). Reuses the heal's exact `normTitle` semantics.

**Gated by `config.CoalesceShatteredSiblings`, DEFAULT OFF** — zero behavior change until enabled on a canary.

## Tests
shattered→1 book, numeric chapter ordering, flat-dump NOT merged, series volumes NOT merged, box-set distinct prefixes stay separate, lone chapter untouched, already-multi-file passthrough. Full `go test ./internal/scanner/ ./internal/config/` green.

Refs `docs/dedup-import-pipeline-audit.md` §1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)