### PR TITLE
fix(db): BatchUpsertBookFiles must not wipe AcoustID fingerprint on memdb round-trip

### DIFF
--- a/internal/database/pebble_bookfile_preserve_test.go
+++ b/internal/database/pebble_bookfile_preserve_test.go
@@ -1,0 +1,99 @@
+// file: internal/database/pebble_bookfile_preserve_test.go
+// version: 1.0.0
+// guid: 7e1a9c43-2b86-4d05-9f71-3c6e8a0d2b54
+// last-edited: 2026-06-21
+
+package database
+
+import (
+	"testing"
+)
+
+// BatchUpsertBookFiles must NOT wipe the raw AcoustID fingerprint when the
+// incoming row leaves it empty. This is the maintenance.tag-backfill footgun:
+// that op sources rows from the memdb view (GetAllBookFiles → stripBookFileForMemdb,
+// which nils AcoustIDFingerprint) and writes them back via BatchUpsertBookFiles.
+// Without the preserve-on-empty guard the whole-library backfill would erase the
+// ~275K-fingerprint library. GetBookFiles is pebble-direct so it reflects the
+// actually-stored row, not the stripped memdb copy.
+func TestBatchUpsertBookFiles_PreservesFingerprintOnEmptyIncoming(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, err := s.CreateBook(&Book{Title: "FP Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	path := "/lib/FP Book/01.m4b"
+	reason := "corrupt_audio"
+	if err := s.CreateBookFile(&BookFile{
+		BookID:                   book.ID,
+		FilePath:                 path,
+		FileHash:                 "deadbeef",
+		Duration:                 3600,
+		AcoustIDFingerprint:      []byte{1, 2, 3, 4, 5},
+		FingerprintFailureReason: &reason,
+	}); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	// Simulate a memdb-sourced backfill write: the row carries the fields memdb
+	// PRESERVES (FileHash, Duration) plus the new RawTags, but the fields memdb
+	// STRIPS (AcoustIDFingerprint, fingerprint diagnostics) are empty — exactly
+	// what tag-backfill feeds in.
+	if err := s.BatchUpsertBookFiles([]*BookFile{{
+		BookID:   book.ID,
+		FilePath: path,
+		FileHash: "deadbeef",
+		Duration: 3600,
+		RawTags:  map[string]string{"ALBUM": "FP Book", "TRACKNUMBER": "1"},
+	}}); err != nil {
+		t.Fatalf("BatchUpsertBookFiles: %v", err)
+	}
+
+	files, err := s.GetBookFiles(book.ID) // pebble-direct → the stored row
+	if err != nil || len(files) != 1 {
+		t.Fatalf("GetBookFiles: err=%v len=%d", err, len(files))
+	}
+	got := files[0]
+	if len(got.RawTags) != 2 {
+		t.Errorf("RawTags not written: %v", got.RawTags)
+	}
+	if string(got.AcoustIDFingerprint) != string([]byte{1, 2, 3, 4, 5}) {
+		t.Errorf("AcoustIDFingerprint WIPED: got %v, want [1 2 3 4 5]", got.AcoustIDFingerprint)
+	}
+	if got.FingerprintFailureReason == nil || *got.FingerprintFailureReason != reason {
+		t.Errorf("FingerprintFailureReason not preserved: %v", got.FingerprintFailureReason)
+	}
+	if got.FileHash != "deadbeef" {
+		t.Errorf("FileHash not preserved: %q", got.FileHash)
+	}
+}
+
+// A legitimate fingerprint WRITE (non-empty incoming) must still overwrite —
+// the preserve guard only fires when the incoming value is empty.
+func TestBatchUpsertBookFiles_OverwritesFingerprintWhenProvided(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, _ := s.CreateBook(&Book{Title: "FP Book 2"})
+	path := "/lib/FP Book 2/01.m4b"
+	if err := s.CreateBookFile(&BookFile{BookID: book.ID, FilePath: path, AcoustIDFingerprint: []byte{1, 1, 1}}); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+	if err := s.BatchUpsertBookFiles([]*BookFile{{
+		BookID: book.ID, FilePath: path, AcoustIDFingerprint: []byte{9, 9, 9, 9},
+	}}); err != nil {
+		t.Fatalf("BatchUpsertBookFiles: %v", err)
+	}
+	files, _ := s.GetBookFiles(book.ID)
+	if len(files) != 1 || string(files[0].AcoustIDFingerprint) != string([]byte{9, 9, 9, 9}) {
+		t.Errorf("fresh fingerprint not written: %v", files[0].AcoustIDFingerprint)
+	}
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.91.0
+// version: 1.92.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 package database
 
@@ -9868,6 +9868,28 @@ func (s *PebbleStore) BatchUpsertBookFiles(files []*BookFile) error {
 			file.BookID = existing.BookID
 			file.CreatedAt = existing.CreatedAt
 			file.UpdatedAt = now
+
+			// Preserve memdb-stripped heavy fields. A caller that sourced `file`
+			// from the memdb view (GetAllBookFiles → stripBookFileForMemdb) carries
+			// a nil AcoustIDFingerprint + nil fingerprint diagnostics. Writing that
+			// back verbatim would WIPE the raw chromaprint (~230 KB/file, expensive
+			// to recompute) on every row — a mass data-loss on any whole-library
+			// round-trip (e.g. maintenance.tag-backfill). Restore from the stored
+			// row whenever the incoming value is empty. The fingerprint WRITE path
+			// (internal/plugins/acoustid/backfill.go) always supplies a fresh
+			// non-empty value via UpdateBookFile, so this never blocks a real update.
+			if len(file.AcoustIDFingerprint) == 0 {
+				file.AcoustIDFingerprint = existing.AcoustIDFingerprint
+			}
+			if file.FingerprintFailureReason == nil {
+				file.FingerprintFailureReason = existing.FingerprintFailureReason
+			}
+			if file.FingerprintFailureDetail == nil {
+				file.FingerprintFailureDetail = existing.FingerprintFailureDetail
+			}
+			if file.FingerprintDiagnosticJSON == nil {
+				file.FingerprintDiagnosticJSON = existing.FingerprintDiagnosticJSON
+			}
 
 			if err := s.deleteBookFileSecondaryIndexes(batch, existing); err != nil {
 				batch.Close()


### PR DESCRIPTION
## Summary — latent mass-data-loss fix (blocks tag-backfill apply)
`BatchUpsertBookFiles` overwrites the stored row with the passed-in struct. But `GetAllBookFiles` returns the **memdb** view, and `stripBookFileForMemdb` nils `AcoustIDFingerprint` (the ~230 KB/file raw chromaprint) + the fingerprint diagnostics. So a whole-library round-trip that sources from `GetAllBookFiles` and writes via `BatchUpsertBookFiles` would **wipe the raw fingerprint on every row**.

`maintenance.tag-backfill` apply does exactly this round-trip — running it would have **destroyed the ~275K-fingerprint library**. The op had never been applied on prod (only a dry-run), so no damage occurred. This closes the footgun before the apply is ever run.

> Discovered during the post-#1548 tag-backfill apply gate (advisor-prompted code read): never inferred from grep, read the write loop.

## Fix
When updating an existing row, preserve `AcoustIDFingerprint` + `FingerprintFailureReason/Detail/DiagnosticJSON` from the stored row whenever the **incoming value is empty**. The fingerprint WRITE path (`acoustid/backfill.go`) always supplies a fresh non-empty value via `UpdateBookFile`, so this never blocks a real fingerprint update.

## Tests
- memdb-shaped upsert preserves fingerprint + diag + FileHash and still writes RawTags
- a non-empty incoming fingerprint still overwrites (guard only fires on empty)

## Follow-up
`UpsertBookFile` (singular) has the same full-replace shape; no current caller feeds it memdb-sourced rows, but the same guard should be considered. **After this merges + deploys, the tag-backfill apply is safe to run** (idempotent; skips populated rows).

Refs `docs/dedup-import-pipeline-audit.md` §1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)