### PR TITLE
fix(mediainfo): read real duration via ffprobe (was a wrong-bitrate estimate, ~2x off)

### DIFF
--- a/internal/mediainfo/mediainfo.go
+++ b/internal/mediainfo/mediainfo.go
@@ -1,14 +1,19 @@
 // file: internal/mediainfo/mediainfo.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f1e2d3c4-b5a6-7c8d-9e0f-1a2b3c4d5e6f
 
 package mediainfo
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dhowden/tag"
 )
@@ -23,6 +28,39 @@ type MediaInfo struct {
 	Quality    string
 	Format     string
 	Duration   int
+	// DurationEstimated is true when Duration was derived from fileSize ÷ bitrate
+	// rather than read from the actual audio stream. Estimated durations are
+	// unreliable (esp. for m4b/AAC where the assumed bitrate is a default) and
+	// must NOT be trusted by dedup duration-matching or metadata scoring.
+	DurationEstimated bool
+}
+
+// ffprobeDurationTimeout bounds the per-file ffprobe call. ffprobe only reads the
+// container header, so this is generous even for large audiobooks.
+const ffprobeDurationTimeout = 20 * time.Second
+
+// realDurationSec reads the TRUE container duration via ffprobe (the stream's own
+// duration, not a filesize estimate). Returns ok=false when ffprobe is missing or
+// the file has no parseable duration, so the caller can fall back to a flagged
+// estimate. ffprobe is resolved from PATH, mirroring internal/diagnosis/probe.go.
+func realDurationSec(filePath string) (int, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), ffprobeDurationTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ffprobe",
+		"-v", "quiet",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		filePath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return 0, false // ffprobe missing or failed — caller estimates
+	}
+	secs, err := strconv.ParseFloat(strings.TrimSpace(stdout.String()), 64)
+	if err != nil || secs <= 0 {
+		return 0, false
+	}
+	return int(secs + 0.5), true
 }
 
 // Extract reads media information from an audio file.
@@ -83,13 +121,19 @@ func BuildFromTag(m tag.Metadata, filePath string, fileSize int64) *MediaInfo {
 		return result
 	}
 
-	// Estimate duration from file size and bitrate when the tag library
-	// doesn't provide it directly (which is most cases).
-	if info.Duration == 0 && info.Bitrate > 0 && fileSize > 0 {
-		// bitrate is in kbps; convert to bytes/sec then divide file size
-		bytesPerSec := (info.Bitrate * 1000) / 8
-		if bytesPerSec > 0 {
-			info.Duration = int(fileSize) / bytesPerSec
+	// The tag library does not expose real duration, so read it from the audio
+	// stream via ffprobe (accurate). Only if that fails do we fall back to a
+	// fileSize ÷ bitrate ESTIMATE — which for m4b/AAC uses a default bitrate and
+	// is routinely ~2× off — and we FLAG it so dedup/matching can distrust it.
+	if info.Duration == 0 {
+		if d, ok := realDurationSec(filePath); ok {
+			info.Duration = d
+		} else if info.Bitrate > 0 && fileSize > 0 {
+			bytesPerSec := (info.Bitrate * 1000) / 8
+			if bytesPerSec > 0 {
+				info.Duration = int(fileSize) / bytesPerSec
+				info.DurationEstimated = true
+			}
 		}
 	}
 
@@ -253,9 +297,16 @@ func inferFromFormat(filePath string, info *MediaInfo) (*MediaInfo, error) {
 		return nil, fmt.Errorf("unsupported format: %s", ext)
 	}
 
-	// Estimate duration from file size and bitrate
-	if info.Duration == 0 && info.Bitrate > 0 {
-		info.Duration = estimateDurationFromFile(filePath, info.Bitrate)
+	// Real duration first (ffprobe); estimate only as a flagged fallback.
+	if info.Duration == 0 {
+		if d, ok := realDurationSec(filePath); ok {
+			info.Duration = d
+		} else if info.Bitrate > 0 {
+			info.Duration = estimateDurationFromFile(filePath, info.Bitrate)
+			if info.Duration > 0 {
+				info.DurationEstimated = true
+			}
+		}
 	}
 
 	return info, nil

--- a/internal/mediainfo/mediainfo_test.go
+++ b/internal/mediainfo/mediainfo_test.go
@@ -1,7 +1,7 @@
 // file: internal/mediainfo/mediainfo_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a2b3c4d5-e6f7-8a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-01-21
+// last-edited: 2026-06-21
 
 package mediainfo
 
@@ -1230,5 +1230,33 @@ func TestExtractOGGInfo_WithMetadata(t *testing.T) {
 				t.Errorf("Expected 2 channels, got %d", info.Channels)
 			}
 		})
+	}
+}
+
+// realDurationSec must report ok=false (not crash) when ffprobe can't read the
+// file, so callers fall back to a flagged estimate.
+func TestRealDurationSec_MissingFile(t *testing.T) {
+	if _, ok := realDurationSec(filepath.Join(t.TempDir(), "nope.m4b")); ok {
+		t.Error("expected ok=false for a non-existent file")
+	}
+}
+
+// When the real duration can't be read (junk bytes ffprobe can't parse), the
+// fileSize÷bitrate fallback is used AND flagged DurationEstimated=true so dedup
+// and metadata scoring know not to trust it.
+func TestInferFromFormat_FlagsEstimatedDuration(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "junk.mp3")
+	if err := os.WriteFile(p, bytes.Repeat([]byte{0}, 200_000), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	info, err := inferFromFormat(p, &MediaInfo{})
+	if err != nil {
+		t.Fatalf("inferFromFormat: %v", err)
+	}
+	if info.Duration <= 0 {
+		t.Fatalf("expected an estimated duration > 0, got %d", info.Duration)
+	}
+	if !info.DurationEstimated {
+		t.Error("fallback estimate must set DurationEstimated=true")
 	}
 }


### PR DESCRIPTION
## The bug (poisons dedup + matching)
`internal/mediainfo` **never read the real audio duration**. `dhowden/tag` doesn't expose it, so `Duration` was *always* `fileSize ÷ bitrate`, and for m4b/m4a the bitrate **defaults to 128 kbps**. Real audiobooks are ~64 kbps → every m4b/m4a duration came out **~2× too short**.

Verified: "The Moons of Barsk" — 403 MB, shows **7h19m** (≈128 kbps), real length **14h46m** (≈61 kbps). Same for "The Zero Equation" (6h21m vs 12h49m).

This feeds `Book.Duration` (`scanner.go:794`), which `checkDurationMatch` (dedup) and metadata-match scoring both rely on — so the wrong durations were corrupting dedup and match confidence.

## Fix
Read the **true** container duration via `ffprobe -show_entries format=duration` (accurate; resolved from PATH like `diagnosis/probe.go`). The `fileSize÷bitrate` estimate is kept **only** as a fallback when ffprobe is unavailable, and is now **flagged** via the new `MediaInfo.DurationEstimated` so dedup/scoring can distrust it.

## Why not taglib (yet)
taglib `audioproperties_length` is in-process (no subprocess) and would be faster on big scans, but it's behind the `native_taglib` cgo build tag — wiring it as primary needs a hook to avoid a **CI-stub vs prod-cgo build divergence**. Tracked as a follow-up (TODO AP-3). ffprobe gives the same correctness now with zero build-tag risk.

## Follow-ups (TODO AP-3)
- taglib in-process duration as a speed optimization.
- A re-extract backfill op for the existing wrong durations already in the DB (dry-run→apply).
- Plumb `DurationEstimated` to `BookFile`/`Book` so dedup explicitly skips estimated values.

## Tests
`realDurationSec` returns ok=false for unreadable files; the estimate fallback sets `DurationEstimated=true`. Full `go test ./internal/mediainfo/ ./internal/scanner/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)