### PR TITLE
feat(maintenance): duration-reextract op — re-read real durations via ffprobe

### DIFF
--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -1,0 +1,267 @@
+// file: internal/plugins/maintenance/duration_reextract.go
+// version: 1.0.0
+// guid: 9c2f7a14-6d83-4e51-b0a9-2f5c8e1d4b67
+// last-edited: 2026-06-21
+
+// Package maintenance — op maintenance.duration-reextract.
+//
+// PR #1555 fixed internal/mediainfo to read the TRUE audio-stream duration via
+// ffprobe instead of the old fileSize÷assumed-bitrate estimate. The old estimator
+// assumed 128 kbps for m4b/m4a, so those durations were routinely ~2× too short.
+// Every Book row imported before that fix still carries the wrong duration, which
+// poisons dedup duration-matching (checkDurationMatch) and metadata scoring.
+//
+// This op re-reads the real duration for existing single-file books via
+// mediainfo.Extract and corrects Book.Duration when the new real value differs
+// meaningfully from the stored one. It NEVER overwrites a stored value with an
+// ffprobe-fallback ESTIMATE (DurationEstimated==true) and skips files missing on
+// disk. Dry-run by default: previews counts; set dryRun=false to apply.
+//
+// Scope (v1): Book.Duration only — that is the field dedup's checkDurationMatch
+// consumes. Per-file BookFile.Duration re-extraction (for multi-file books) is a
+// follow-up; it requires the same DurationEstimated guard applied per BookFile
+// and a BatchUpsertBookFiles write (safe since PR #1552 preserve-on-empty), but
+// is deferred to keep this op's blast radius small and reviewable.
+//
+// Idempotent: a re-run finds the already-corrected rows within tolerance and
+// skips them. Slow by design — it shells out to ffprobe once per book — so it
+// heartbeats progress every ~15s and is cancellable.
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/mediainfo"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+type durationReextractParams struct {
+	DryRun bool `json:"dryRun"`
+	// Limit caps the number of books examined in one run (0 = no cap). Useful for
+	// a bounded first pass over a large library.
+	Limit int `json:"limit"`
+}
+
+// durationChangeThresholds: a book is corrected only when the freshly extracted
+// real duration differs from the stored value by more than BOTH a relative and an
+// absolute floor, so we never churn rows over sub-second rounding noise.
+const (
+	durationRelTolerance = 0.02 // 2%
+	durationAbsToleranceS = 5   // seconds
+)
+
+// durationDiffMeaningful reports whether newDur differs from oldDur by enough to
+// warrant a write: >2% AND >5s. Both floors must be exceeded.
+func durationDiffMeaningful(oldDur, newDur int) bool {
+	if oldDur <= 0 {
+		return newDur > 0 // no usable stored value — any real value is an improvement
+	}
+	delta := int(math.Abs(float64(newDur - oldDur)))
+	if delta <= durationAbsToleranceS {
+		return false
+	}
+	rel := float64(delta) / float64(oldDur)
+	return rel > durationRelTolerance
+}
+
+func (p *Plugin) durationReextractDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.duration-reextract",
+		Plugin:      "maintenance",
+		DisplayName: "Re-extract real book durations via ffprobe",
+		Description: "Re-reads the true audio-stream duration (ffprobe) for existing single-file books and " +
+			"corrects Book.Duration where the old fileSize÷bitrate estimate was wrong (PR #1555; m4b/m4a were ~2× too short). " +
+			"Never overwrites a real duration with an estimate, and skips files missing on disk. " +
+			"Default dry-run previews counts; set dryRun=false to apply. Slow: shells out to ffprobe per book.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.duration-reextract",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         120 * time.Minute,
+		Schedule:        nil,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runDurationReextract,
+	}
+}
+
+func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := durationReextractParams{DryRun: true} // safe default
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if params.DryRun {
+		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no changes will be written")
+	}
+
+	totalBooks, countErr := store.CountBooks()
+	if countErr != nil || totalBooks <= 0 {
+		totalBooks = 0
+	}
+	_ = reporter.UpdateProgress(0, totalBooks, "Re-extracting real durations via ffprobe…")
+
+	const (
+		pageSize    = 500
+		logInterval = 15 * time.Second
+		exampleCap  = 5
+	)
+	var (
+		examined      int // books inspected
+		eligible      int // single-file books with a real, present file we could probe
+		wouldChange   int // books whose real duration differs meaningfully
+		roughlyDouble int // subset where new ≈ 2× old (the m4b/m4a estimate bug signature)
+		missing       int // file path set but not on disk
+		estimated     int // ffprobe failed → estimate returned; never trusted/written
+		readErr       int // mediainfo.Extract returned an error
+		noPath        int // book has no single-file FilePath (multi-file; out of v1 scope)
+		written       int // actual UpdateBook calls (apply mode)
+		examples      = make([]string, 0, exampleCap)
+		lastLog       = time.Now()
+		offset        int
+	)
+
+	heartbeat := func(force bool) {
+		if !force && time.Since(lastLog) < logInterval {
+			return
+		}
+		total := totalBooks
+		if total == 0 {
+			total = examined
+		}
+		_ = reporter.UpdateProgress(examined, total, fmt.Sprintf(
+			"examined=%d eligible=%d would-change=%d (~2x=%d) missing=%d est-skip=%d read-err=%d",
+			examined, eligible, wouldChange, roughlyDouble, missing, estimated, readErr))
+		lastLog = time.Now()
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		books, err := store.GetAllBooks(pageSize, offset)
+		if err != nil {
+			return fmt.Errorf("GetAllBooks offset=%d: %w", offset, err)
+		}
+		if len(books) == 0 {
+			break
+		}
+
+		for i := range books {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if params.Limit > 0 && examined >= params.Limit {
+				break
+			}
+			book := books[i]
+			examined++
+
+			if book.FilePath == "" {
+				noPath++
+				continue
+			}
+			if _, statErr := os.Stat(book.FilePath); statErr != nil {
+				missing++
+				continue
+			}
+
+			info, mErr := mediainfo.Extract(book.FilePath)
+			if mErr != nil || info == nil {
+				readErr++
+				continue
+			}
+			if info.Duration <= 0 {
+				readErr++
+				continue
+			}
+			if info.DurationEstimated {
+				// ffprobe failed; this is a filesize estimate — never trust it to
+				// overwrite a stored duration.
+				estimated++
+				continue
+			}
+			eligible++
+
+			oldDur := 0
+			if book.Duration != nil {
+				oldDur = *book.Duration
+			}
+			if !durationDiffMeaningful(oldDur, info.Duration) {
+				continue // already correct within tolerance — idempotent skip
+			}
+			wouldChange++
+			if oldDur > 0 {
+				ratio := float64(info.Duration) / float64(oldDur)
+				if ratio >= 1.8 && ratio <= 2.2 {
+					roughlyDouble++
+				}
+			}
+			if len(examples) < exampleCap {
+				examples = append(examples, fmt.Sprintf("%s %ds→%ds", book.ID, oldDur, info.Duration))
+			}
+
+			if !params.DryRun {
+				// Full-replacement write: fetch the full book and update only Duration.
+				full, gErr := store.GetBookByID(book.ID)
+				if gErr != nil || full == nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s: GetBookByID failed: %v", book.ID, gErr))
+					readErr++
+					continue
+				}
+				newDur := info.Duration
+				full.Duration = &newDur
+				if _, uErr := store.UpdateBook(book.ID, full); uErr != nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s: UpdateBook failed: %v", book.ID, uErr))
+					readErr++
+					continue
+				}
+				written++
+			}
+
+			heartbeat(false)
+		}
+
+		offset += len(books)
+		if params.Limit > 0 && examined >= params.Limit {
+			break
+		}
+		if len(books) < pageSize {
+			break
+		}
+		heartbeat(false)
+	}
+
+	verb := "would correct"
+	if !params.DryRun {
+		verb = fmt.Sprintf("corrected %d;", written)
+	}
+	summary := fmt.Sprintf(
+		"examined=%d eligible=%d %s would-change=%d (~2x=%d) missing-on-disk=%d estimated-skipped=%d read-errors=%d no-filepath=%d | e.g. %s",
+		examined, eligible, verb, wouldChange, roughlyDouble, missing, estimated, readErr, noPath,
+		strings.Join(examples, ", "))
+	_ = reporter.Log(slog.LevelInfo, summary)
+	total := totalBooks
+	if total == 0 {
+		total = examined
+	}
+	_ = reporter.UpdateProgress(total, total, summary)
+	return nil
+}

--- a/internal/plugins/maintenance/duration_reextract_test.go
+++ b/internal/plugins/maintenance/duration_reextract_test.go
@@ -1,0 +1,158 @@
+// file: internal/plugins/maintenance/duration_reextract_test.go
+// version: 1.0.0
+// guid: 4a7d1e92-8c63-4f50-a1b8-3e6c9d2f5a04
+// last-edited: 2026-06-21
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func mustReextractParams(t *testing.T, dryRun bool, limit int) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(durationReextractParams{DryRun: dryRun, Limit: limit})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	return b
+}
+
+// newReextractPlugin wires a MockStore over a fixed book slice. updates records
+// every UpdateBook call so apply-path tests can assert writes.
+func newReextractPlugin(books []database.Book) (*Plugin, *[]database.Book) {
+	updates := make([]database.Book, 0)
+	byID := make(map[string]database.Book, len(books))
+	for _, b := range books {
+		byID[b.ID] = b
+	}
+	store := &database.MockStore{
+		CountBooksFunc: func() (int, error) { return len(books), nil },
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			if offset >= len(books) {
+				return nil, nil
+			}
+			end := offset + limit
+			if end > len(books) {
+				end = len(books)
+			}
+			return books[offset:end], nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b, ok := byID[id]
+			if !ok {
+				return nil, nil
+			}
+			cp := b
+			return &cp, nil
+		},
+		UpdateBookFunc: func(_ string, b *database.Book) (*database.Book, error) {
+			updates = append(updates, *b)
+			return b, nil
+		},
+	}
+	return New(fakeDeps{store: store}), &updates
+}
+
+func intPtr(v int) *int { return &v }
+
+// TestDurationReextract_Registered verifies the op def carries the expected ID,
+// capabilities, and dry-run-friendly defaults.
+func TestDurationReextract_Registered(t *testing.T) {
+	p := New(fakeDeps{store: &database.MockStore{}})
+	def := p.durationReextractDef()
+	if def.ID != "maintenance.duration-reextract" {
+		t.Errorf("def ID = %q, want maintenance.duration-reextract", def.ID)
+	}
+	if def.ConcurrencyKey != "maintenance.duration-reextract" {
+		t.Errorf("ConcurrencyKey = %q", def.ConcurrencyKey)
+	}
+	if !def.Cancellable {
+		t.Error("op must be cancellable")
+	}
+	if def.Run == nil {
+		t.Error("op Run must be set")
+	}
+}
+
+// TestDurationDiffMeaningful exercises the tolerance gate (>2% AND >5s).
+func TestDurationDiffMeaningful(t *testing.T) {
+	cases := []struct {
+		old, new int
+		want     bool
+	}{
+		{0, 100, true},     // no stored value, any real value is an improvement
+		{0, 0, false},      // nothing usable
+		{3600, 3600, false}, // identical
+		{3600, 3603, false}, // 3s — under both floors
+		{3600, 3700, true},  // 100s and ~2.8%
+		{3600, 7200, true},  // exactly double (the m4b bug signature)
+		{1000, 1004, false}, // 4s, under abs floor even though >0.2%
+		{100, 110, true},    // 10s and 10%
+	}
+	for _, c := range cases {
+		if got := durationDiffMeaningful(c.old, c.new); got != c.want {
+			t.Errorf("durationDiffMeaningful(%d,%d) = %v, want %v", c.old, c.new, got, c.want)
+		}
+	}
+}
+
+// TestDurationReextract_DryRunWritesNothing runs the full dry-run path over a
+// real on-disk file and confirms no UpdateBook calls occur. The temp file is not
+// valid audio, so mediainfo.Extract yields a read path that exercises the op's
+// error/skip accounting — the contract under test is "dry run never writes".
+func TestDurationReextract_DryRunWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "book.m4b")
+	if err := os.WriteFile(fp, []byte("not real audio but present on disk"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	books := []database.Book{
+		{ID: "b1", Title: "Present file", FilePath: fp, Duration: intPtr(100)},
+		{ID: "b2", Title: "Missing file", FilePath: filepath.Join(dir, "gone.m4b"), Duration: intPtr(100)},
+		{ID: "b3", Title: "No path", FilePath: ""},
+	}
+	p, updates := newReextractPlugin(books)
+
+	if err := p.runDurationReextract(context.Background(), mustReextractParams(t, true, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("dry-run returned error: %v", err)
+	}
+	if len(*updates) != 0 {
+		t.Errorf("dry run must write nothing, got %d UpdateBook calls", len(*updates))
+	}
+}
+
+// TestDurationReextract_NilParamsDefaultsDryRun verifies nil params -> dryRun=true.
+func TestDurationReextract_NilParamsDefaultsDryRun(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "book.m4b")
+	if err := os.WriteFile(fp, []byte("present"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	books := []database.Book{{ID: "b1", FilePath: fp, Duration: intPtr(100)}}
+	p, updates := newReextractPlugin(books)
+
+	if err := p.runDurationReextract(context.Background(), nil, &fakeReporter{}); err != nil {
+		t.Fatalf("nil-params run returned error: %v", err)
+	}
+	if len(*updates) != 0 {
+		t.Errorf("nil params must default to dry run, got %d writes", len(*updates))
+	}
+}
+
+// TestDurationReextract_EmptyLibrary verifies a clean exit with no books.
+func TestDurationReextract_EmptyLibrary(t *testing.T) {
+	p, updates := newReextractPlugin(nil)
+	if err := p.runDurationReextract(context.Background(), mustReextractParams(t, false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("empty-library run returned error: %v", err)
+	}
+	if len(*updates) != 0 {
+		t.Errorf("empty library must write nothing, got %d writes", len(*updates))
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-06-20
+// last-edited: 2026-06-21
 
 package maintenance
 
@@ -75,6 +75,9 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 		// --- duration repair ---
 		p.durationBackfillDef(),
+
+		// --- duration re-extract (real ffprobe duration; PR #1555) ---
+		p.durationReextractDef(),
 
 		// --- iTunes re-group heal (CONS-FRAG) ---
 		p.itunesRegroupDef(),


### PR DESCRIPTION
## What

Adds a new dry-run-gated UOS maintenance op **`maintenance.duration-reextract`** that re-reads the TRUE audio-stream duration (via ffprobe / `mediainfo.Extract`) for existing single-file books and corrects `Book.Duration` where the old estimate was wrong.

- Iterates all books paged via `store.GetAllBooks(limit, offset)`.
- For each book with a single-file `FilePath` that exists on disk, calls `mediainfo.Extract`.
- Updates `Book.Duration` only when the new **real** value (`DurationEstimated == false`) differs by **>2% AND >5s** from the stored value.
- **Never** overwrites a stored duration with an ffprobe-fallback estimate; **skips** files missing on disk (counted).
- Apply path uses full-book `UpdateBook` (fetch full row, set only Duration) — no partial-Book construction.
- Idempotent (re-running skips already-correct rows), cancellable, 120min timeout, unique ConcurrencyKey, `CapLibraryRead`+`CapLibraryWrite`.
- Heartbeats progress every ~15s (ffprobe-per-file is slow on a big library).

## Why

PR #1555 fixed `internal/mediainfo` to read real duration via ffprobe (new `DurationEstimated` flag). The old code assumed 128kbps for m4b/m4a, so those durations were routinely ~2× too short. Every existing Book row still has the OLD wrong duration, which feeds dedup duration-matching (`checkDurationMatch`) and metadata scoring — these must be re-extracted.

## Scope (v1)

Updates **`Book.Duration` only** — the field dedup's `checkDurationMatch` consumes. Per-file `BookFile.Duration` re-extraction (multi-file books) is documented as a follow-up in the op's doc comment (would need the same `DurationEstimated` guard per file + `BatchUpsertBookFiles`, safe since PR #1552 preserve-on-empty, but deferred to keep the blast radius small).

## Test plan

New `internal/plugins/maintenance/duration_reextract_test.go` (real `PebbleStore`-style `MockStore` + existing `fakeReporter`):
- `TestDurationReextract_Registered` — def ID/concurrency-key/cancellable/Run wired.
- `TestDurationDiffMeaningful` — tolerance gate table.
- `TestDurationReextract_DryRunWritesNothing` — full dry-run over a real on-disk file: zero `UpdateBook` calls.
- `TestDurationReextract_NilParamsDefaultsDryRun` — nil params default to dry run.
- `TestDurationReextract_EmptyLibrary` — clean exit, no writes.

Verified: `go build ./...`, `go test ./internal/plugins/maintenance/ ./internal/mediainfo/`, `go vet ./internal/plugins/maintenance/` all pass.

## Prod rollout

**Dry-run by default.** Run dry-run → review the reported counts (especially `~2x` magnitude and `missing-on-disk` / `estimated-skipped`) → only then run with `dryRun=false` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)