### PR TITLE
feat(metadata-review): always-visible Files list + persistent Undo

### DIFF
--- a/web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
+++ b/web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/audiobooks/BulkMetadataSearchDialog.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-06-21
 
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -19,6 +20,8 @@ import {
   IconButton,
   InputAdornment,
   LinearProgress,
+  List,
+  ListItem,
   Stack,
   Switch,
   TextField,
@@ -26,6 +29,7 @@ import {
   Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search.js';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen.js';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess.js';
 import HeadphonesIcon from '@mui/icons-material/Headphones.js';
@@ -35,7 +39,7 @@ import SkipNextIcon from '@mui/icons-material/SkipNext.js';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle.js';
 import UndoIcon from '@mui/icons-material/Undo.js';
 import type { Audiobook } from '../../types';
-import type { MetadataCandidate } from '../../services/api';
+import type { BookFile, MetadataCandidate } from '../../services/api';
 import * as api from '../../services/api';
 
 interface BulkMetadataSearchDialogProps {
@@ -76,6 +80,12 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / 1024).toFixed(0)} KB`;
 }
 
+function basename(p: string): string {
+  if (!p) return '';
+  const parts = p.split('/');
+  return parts[parts.length - 1] || p;
+}
+
 export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toast }: BulkMetadataSearchDialogProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [query, setQuery] = useState('');
@@ -95,6 +105,14 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
   const [skipApplied, setSkipApplied] = useState(false);
   const [sourceFilter, setSourceFilter] = useState<string | null>(null);
   const [sortResults, setSortResults] = useState<'score' | 'source'>('score');
+  // Files list for the current book — always shown so the user can confirm
+  // the file set even for single-file books. Eager-loaded on book change.
+  const [files, setFiles] = useState<BookFile[]>([]);
+  const [filesLoading, setFilesLoading] = useState(false);
+  const [filesExpanded, setFilesExpanded] = useState(false);
+  // Stack of book ids applied in this session so the persistent Undo button
+  // can revert the last apply even after navigating away / banner dismissal.
+  const [appliedStack, setAppliedStack] = useState<{ id: string; title: string }[]>([]);
 
   const handleToggleSkipApplied = (checked: boolean) => {
     setSkipApplied(checked);
@@ -144,6 +162,41 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
     }
   }, [open, currentIndex, currentBook, doSearch]);
 
+  // Eager-load the current book's files so the "N File(s)" control shows the
+  // real count without a click. One request per navigation — cheap because the
+  // dialog shows a single book at a time.
+  useEffect(() => {
+    if (!open || !currentBook?.id) return;
+    const controller = new AbortController();
+    setFiles([]);
+    setFilesExpanded(false);
+    setFilesLoading(true);
+    api
+      .getBookFiles(currentBook.id, { signal: controller.signal })
+      .then((res) => setFiles(res.files || []))
+      .catch(() => setFiles([]))
+      .finally(() => setFilesLoading(false));
+    return () => controller.abort();
+  }, [open, currentBook?.id]);
+
+  // Synthetic fallback so the Files control is never blank: if the API returns
+  // nothing, show "1 File" using the book's own path/size.
+  const displayFiles: BookFile[] = files.length > 0
+    ? files
+    : currentBook?.file_path
+      ? [{
+          id: `fallback-${currentBook.id}`,
+          book_id: currentBook.id,
+          file_path: currentBook.file_path,
+          file_size: currentBook.file_size_bytes ?? undefined,
+          format: currentBook.format ?? undefined,
+          missing: false,
+          created_at: '',
+          updated_at: '',
+        }]
+      : [];
+  const fileCount = Math.max(displayFiles.length, 1);
+
   const handleSearch = () => doSearch(query, authorQuery, narratorQuery, seriesQuery);
 
   const handleApplyAll = async (candidate: MetadataCandidate) => {
@@ -159,10 +212,12 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
             await api.undoLastApply(bookId);
             toast(`Undid metadata apply for "${bookTitle}"`, 'info');
             setBookStatuses((prev) => new Map(prev).set(bookId, 'pending'));
+            setAppliedStack((prev) => prev.filter((b) => b.id !== bookId));
           } catch { /* ignore */ }
         },
       });
       setBookStatuses((prev) => new Map(prev).set(bookId, 'applied'));
+      setAppliedStack((prev) => [...prev, { id: bookId, title: bookTitle }]);
       advanceToNext();
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Failed to apply metadata', 'error');
@@ -188,15 +243,36 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
             await api.undoLastApply(bookId);
             toast(`Undid metadata apply for "${bookTitle}"`, 'info');
             setBookStatuses((prev) => new Map(prev).set(bookId, 'pending'));
+            setAppliedStack((prev) => prev.filter((b) => b.id !== bookId));
           } catch { /* ignore */ }
         },
       });
       setBookStatuses((prev) => new Map(prev).set(bookId, 'applied'));
+      setAppliedStack((prev) => [...prev, { id: bookId, title: bookTitle }]);
       advanceToNext();
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Failed to apply metadata', 'error');
     } finally {
       setApplying(false);
+    }
+  };
+
+  // Undo the most-recently applied book in this session. Works after the
+  // success banner is gone and after navigating to other books, because it
+  // keys off the applied stack rather than the current book.
+  const handleUndoLastApplied = async () => {
+    const last = appliedStack[appliedStack.length - 1];
+    if (!last) return;
+    setUndoing(true);
+    try {
+      await api.undoLastApply(last.id);
+      toast(`Undid metadata apply for "${last.title}"`, 'success');
+      setBookStatuses((prev) => new Map(prev).set(last.id, 'pending'));
+      setAppliedStack((prev) => prev.slice(0, -1));
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to undo', 'error');
+    } finally {
+      setUndoing(false);
     }
   };
 
@@ -206,6 +282,7 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
       const resp = await api.undoLastApply(currentBook.id);
       toast(`Undid ${resp.undone_fields.length} field(s) for "${currentBook.title}"`, 'success');
       setBookStatuses((prev) => new Map(prev).set(currentBook.id, 'pending'));
+      setAppliedStack((prev) => prev.filter((b) => b.id !== currentBook.id));
     } catch (err) {
       toast(err instanceof Error ? err.message : 'Failed to undo', 'error');
     } finally {
@@ -241,6 +318,7 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
     }
     setCurrentIndex(0);
     setBookStatuses(new Map());
+    setAppliedStack([]);
     onClose();
   };
 
@@ -368,6 +446,49 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
                   iTunes: {currentBook.itunes_path}
                 </Typography>
               )}
+
+              {/* Always-visible Files control — shows even for single-file books
+                  so the user can confirm the file set. Mirrors the Library page's
+                  expandable "N Files" list. Stop click propagation so expanding
+                  the list doesn't trigger the card's cover-preview handler. */}
+              <Box sx={{ mt: 0.75 }} onClick={(e) => e.stopPropagation()}>
+                <Chip
+                  icon={filesLoading ? <CircularProgress size={14} /> : <FolderOpenIcon />}
+                  label={filesLoading ? 'Loading files…' : `${fileCount} File${fileCount === 1 ? '' : 's'}`}
+                  size="small"
+                  variant="outlined"
+                  clickable
+                  onClick={() => setFilesExpanded((v) => !v)}
+                  deleteIcon={filesExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  onDelete={() => setFilesExpanded((v) => !v)}
+                />
+                <Collapse in={filesExpanded}>
+                  <List dense disablePadding sx={{ mt: 0.5, maxHeight: 200, overflow: 'auto' }}>
+                    {displayFiles.map((f) => {
+                      const meta = [
+                        f.format,
+                        f.file_size != null && f.file_size > 0 ? formatFileSize(f.file_size) : null,
+                        f.duration != null && f.duration > 0 ? formatDuration(f.duration) : null,
+                      ].filter(Boolean).join(' · ');
+                      return (
+                        <ListItem key={f.id} disableGutters sx={{ display: 'block', py: 0.25 }}>
+                          <Tooltip title={f.file_path} placement="bottom-start">
+                            <Typography
+                              variant="caption"
+                              sx={{ fontFamily: 'monospace', display: 'block', color: f.missing ? 'error.main' : 'text.primary', wordBreak: 'break-all' }}
+                            >
+                              {basename(f.file_path)}
+                            </Typography>
+                          </Tooltip>
+                          {meta && (
+                            <Typography variant="caption" color="text.secondary">{meta}</Typography>
+                          )}
+                        </ListItem>
+                      );
+                    })}
+                  </List>
+                </Collapse>
+              </Box>
             </Box>
             {status === 'applied' && <Chip label="Applied" color="success" size="small" />}
             {status === 'skipped' && <Chip label="Skipped" size="small" variant="outlined" />}
@@ -606,6 +727,22 @@ export function BulkMetadataSearchDialog({ open, books, onClose, onComplete, toa
             >
               Undo
             </Button>
+          )}
+          {/* Persistent undo for the last applied book — remains usable after
+              the success banner is gone and after navigating to other books. */}
+          {appliedStack.length > 0 && (
+            <Tooltip title={`Undo last applied: "${appliedStack[appliedStack.length - 1].title}"`}>
+              <Button
+                color="warning"
+                startIcon={<UndoIcon />}
+                onClick={handleUndoLastApplied}
+                disabled={undoing}
+                size="small"
+                variant="contained"
+              >
+                {undoing ? 'Undoing…' : `Undo Last (${appliedStack.length})`}
+              </Button>
+            </Tooltip>
           )}
         </Stack>
         <Stack direction="row" spacing={1}>


### PR DESCRIPTION
## Summary

Two UX changes to the per-book "review metadata matches" card in `BulkMetadataSearchDialog.tsx` (the APPLY / REJECT / SKIP per-book reviewer), both requested by the user.

### 1. Always-visible Files control
- Adds a `N File(s)` chip to the current-book card that expands (Collapse) to show each file's basename + format/size/duration, mirroring the Library page's expandable file list.
- **Eager-loads** the file list via `getBookFiles(bookId)` on book change so the count is visible **without clicking** ("so we know it's working and it's predictable").
- **Always renders, even for single-file books.** If the API returns nothing, it falls back to a synthetic `1 File` built from the book's own `file_path` (+ `file_size_bytes`) so it is never blank.
- Click propagation is stopped so expanding the list doesn't trigger the card's cover-preview handler.

### 2. Persistent Undo
- Adds an `Undo Last (N)` button at the bottom of the review (DialogActions) that undoes the most-recently applied book via `undoLastApply`.
- Tracks applied books on a session-scoped stack (`appliedStack`), pushed inside both apply handlers **before** `advanceToNext()` — so undo works even though the current book has already advanced past the applied one.
- Stays visible/usable as long as there is a last-applied action this session (not tied to the transient snackbar). On undo it pops the stack and resets that book's status to `pending`.
- Existing per-book Undo, the snackbar Undo action, and dialog close all keep the stack consistent.

## Files changed
- `web/src/components/audiobooks/BulkMetadataSearchDialog.tsx` (version 1.3.0 → 1.4.0)

## API functions used
- Files: `api.getBookFiles(bookId, { signal })` → `{ files: BookFile[] }` (same call the Library page / dedup `FolderFilesChip` use)
- Undo: `api.undoLastApply(bookId)` → `POST /audiobooks/:id/undo-last-apply`

## Scope note — MetadataReviewDialog NOT changed
`MetadataReviewDialog.tsx` (title "Review Metadata Matches") is a multi-row table/grid, not a single-book card flow, so it has **no equivalent current-book card** to attach these two controls to. The user's description ("a per-book review with APPLY / REJECT / SKIP", "current-book card around lines 300-365") matches `BulkMetadataSearchDialog` exactly. I scoped the change to that file only. If the intended surface was actually `MetadataReviewDialog`, let me know and I'll port both features there.

## Verification
- `cd web && npm run build` — PASSED (`✓ built in 4.98s`, no type errors).
- `npx eslint src/components/audiobooks/BulkMetadataSearchDialog.tsx` — clean.
- No vitest tests exist for either dialog.
- **Not visually verified** (no running app in this environment).

## Manual test plan
1. Open the Library, select books, launch the per-book "Search Metadata" review dialog.
2. On the current-book card, confirm a `N Files` chip appears immediately (count shown without clicking), including for a single-file book (`1 File`).
3. Click the chip → file list expands showing basename + format/size/duration; click again to collapse. Confirm clicking it does NOT open the cover-preview lightbox.
4. Navigate Next/Previous → the Files count/list updates for each book.
5. Apply metadata to a book → it advances to the next book. Confirm `Undo Last (1)` appears at the bottom.
6. Navigate around / let the success snackbar disappear → confirm `Undo Last` is still there.
7. Click `Undo Last` → confirm the applied book reverts (status back to pending) and the counter decrements/disappears.
8. Apply several books, then undo them one at a time via `Undo Last` (LIFO order) and confirm each title in the tooltip matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)