### PR TITLE
feat(library): combine selected books into one multi-file book

### DIFF
--- a/internal/merge/combine_test.go
+++ b/internal/merge/combine_test.go
@@ -1,0 +1,137 @@
+// file: internal/merge/combine_test.go
+// version: 1.0.0
+// guid: 2c8e4d1a-9f3b-4e6a-8b7c-1d2e3f4a5b6c
+// last-edited: 2026-06-21
+
+package merge
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestService_CombineBooks combines three single-file books into ONE multi-file
+// book on a chosen survivor. It covers both shapes a "single-file book" can take:
+//   - books with a real BookFile row (book1, book3)
+//   - a virtual book with only a FilePath and no BookFile row (book2, the survivor)
+//
+// Asserts: the survivor owns all three files, the two absorbed books are deleted,
+// external-id mappings are reassigned to the survivor, and the survivor's own
+// virtual file is materialized as a BookFile.
+func TestService_CombineBooks(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Survivor: virtual single-file book (FilePath only, no BookFile row).
+	survivor := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Chapter 02",
+		Format:   "mp3",
+		FilePath: "/tmp/book/ch02.mp3",
+	}
+	// book1: real BookFile row.
+	book1 := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Chapter 01",
+		Format:   "mp3",
+		FilePath: "/tmp/book/ch01.mp3",
+	}
+	// book3: real BookFile row.
+	book3 := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "Chapter 03",
+		Format:   "mp3",
+		FilePath: "/tmp/book/ch03.mp3",
+	}
+
+	for _, b := range []*database.Book{survivor, book1, book3} {
+		_, err := store.CreateBook(b)
+		require.NoError(t, err)
+	}
+
+	// Give book1 and book3 real BookFile rows.
+	file1 := &database.BookFile{ID: ulid.Make().String(), BookID: book1.ID, FilePath: book1.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(file1))
+	file3 := &database.BookFile{ID: ulid.Make().String(), BookID: book3.ID, FilePath: book3.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(file3))
+
+	// Map an external (iTunes) PID onto each absorbed book to verify reassignment.
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: "PID-1", BookID: book1.ID,
+	}))
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: "PID-3", BookID: book3.ID,
+	}))
+
+	ms := NewService(store)
+	res, err := ms.CombineBooks([]string{book1.ID, book3.ID, survivor.ID}, survivor.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, survivor.ID, res.PrimaryID)
+	// 3 files moved: survivor's materialized virtual file + book1's + book3's.
+	assert.Equal(t, 3, res.FilesMoved)
+	assert.Equal(t, 2, res.BooksDeleted)
+
+	// Survivor owns ALL three files now.
+	files, err := store.GetBookFiles(survivor.ID)
+	require.NoError(t, err)
+	assert.Len(t, files, 3, "survivor should own all 3 files")
+	paths := map[string]bool{}
+	for _, f := range files {
+		paths[f.FilePath] = true
+	}
+	assert.True(t, paths["/tmp/book/ch01.mp3"], "ch01 present")
+	assert.True(t, paths["/tmp/book/ch02.mp3"], "survivor own file materialized")
+	assert.True(t, paths["/tmp/book/ch03.mp3"], "ch03 present")
+
+	// The two absorbed books are gone.
+	b1, _ := store.GetBookByID(book1.ID)
+	assert.Nil(t, b1, "book1 should be hard-deleted")
+	b3, _ := store.GetBookByID(book3.ID)
+	assert.Nil(t, b3, "book3 should be hard-deleted")
+
+	// External-id mappings reassigned to the survivor.
+	if eid := AsExternalIDReassigner(store); eid != nil {
+		mappings, err := store.GetExternalIDsForBook(survivor.ID)
+		require.NoError(t, err)
+		got := map[string]bool{}
+		for _, m := range mappings {
+			got[m.ExternalID] = true
+		}
+		assert.True(t, got["PID-1"], "PID-1 reassigned to survivor")
+		assert.True(t, got["PID-3"], "PID-3 reassigned to survivor")
+	}
+}
+
+func TestService_CombineBooks_TooFew(t *testing.T) {
+	ms := NewService(nil)
+	_, err := ms.CombineBooks([]string{"one"}, "one")
+	require.Error(t, err)
+}
+
+func TestService_CombineBooks_RequiresPrimary(t *testing.T) {
+	ms := NewService(nil)
+	_, err := ms.CombineBooks([]string{"a", "b"}, "")
+	require.Error(t, err)
+}
+
+func TestService_CombineBooks_PrimaryNotInSet(t *testing.T) {
+	store := setupTestStore(t)
+	a := &database.Book{ID: ulid.Make().String(), Title: "A", Format: "mp3", FilePath: "/tmp/a.mp3"}
+	b := &database.Book{ID: ulid.Make().String(), Title: "B", Format: "mp3", FilePath: "/tmp/b.mp3"}
+	_, err := store.CreateBook(a)
+	require.NoError(t, err)
+	_, err = store.CreateBook(b)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	// primaryID resolves to a real book but is not part of bookIDs.
+	c := &database.Book{ID: ulid.Make().String(), Title: "C", Format: "mp3", FilePath: "/tmp/c.mp3"}
+	_, err = store.CreateBook(c)
+	require.NoError(t, err)
+	_, err = ms.CombineBooks([]string{a.ID, b.ID}, c.ID)
+	require.Error(t, err)
+}

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,5 +1,5 @@
 // file: internal/merge/service.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
 
 package merge
@@ -7,6 +7,7 @@ package merge
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -214,6 +215,151 @@ func (ms *Service) MergeBooks(bookIDs []string, primaryID string) (*Result, erro
 		VersionGroupID: versionGroupID,
 		MergedCount:    len(books),
 	}, nil
+}
+
+// CombineResult is the outcome of a CombineBooks call.
+type CombineResult struct {
+	PrimaryID    string `json:"primary_id"`
+	FilesMoved   int    `json:"files_moved"`
+	BooksDeleted int    `json:"books_deleted"`
+}
+
+// CombineBooks combines several books into ONE multi-file book — distinct from
+// MergeBooks, which links them as alternate VERSIONS in a version group. Every
+// selected book's audio files become real BookFiles on the survivor, and the
+// absorbed shells are hard-deleted. This is the manual analogue of the
+// shattered-book heal (applyFSRegroup): use it to reassemble tracks that were
+// imported as one book per file (e.g. an untagged folder of chapters).
+//
+// DB-only: files stay where they are on disk (most shattered sets are already in
+// one folder). Run organize afterward to physically co-locate if desired.
+//
+// The survivor keeps its own metadata (the caller picks primaryID); rename after.
+func (ms *Service) CombineBooks(bookIDs []string, primaryID string) (*CombineResult, error) {
+	if len(bookIDs) < 2 {
+		return nil, fmt.Errorf("need at least 2 books to combine")
+	}
+	if primaryID == "" {
+		return nil, fmt.Errorf("primary_id is required for combine")
+	}
+	survivor, err := ms.db.GetBookByID(primaryID)
+	if err != nil || survivor == nil {
+		return nil, fmt.Errorf("primary book %s not found", primaryID)
+	}
+	// Validate all IDs up front so a bad ID aborts before any mutation.
+	seen := map[string]bool{}
+	for _, id := range bookIDs {
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate book id %s", id)
+		}
+		seen[id] = true
+		b, err := ms.db.GetBookByID(id)
+		if err != nil || b == nil {
+			return nil, fmt.Errorf("book %s not found", id)
+		}
+	}
+	if !seen[primaryID] {
+		return nil, fmt.Errorf("primary_id %s not in book_ids", primaryID)
+	}
+
+	res := &CombineResult{PrimaryID: primaryID}
+	eidStore := AsExternalIDReassigner(ms.db)
+
+	// Materialize the survivor's own single-file (virtual-segment) audio as a
+	// BookFile so the combined book owns ALL its files explicitly.
+	res.FilesMoved += ms.ensureOwnFile(survivor)
+
+	for _, id := range bookIDs {
+		if id == primaryID {
+			continue
+		}
+		book, _ := ms.db.GetBookByID(id)
+		if book == nil {
+			continue
+		}
+
+		// Attach this book's files to the survivor.
+		files, _ := ms.db.GetBookFiles(id)
+		if len(files) > 0 {
+			ids := make([]string, len(files))
+			for i := range files {
+				ids[i] = files[i].ID
+			}
+			if err := ms.db.MoveBookFilesToBook(ids, id, survivor.ID); err != nil {
+				return nil, fmt.Errorf("move files %s->%s: %w", id, survivor.ID, err)
+			}
+			res.FilesMoved += len(files)
+		} else if book.FilePath != "" {
+			res.FilesMoved += ms.attachVirtualFile(book, survivor.ID)
+		}
+
+		// Reassign external IDs to the survivor.
+		if eidStore != nil {
+			if err := eidStore.ReassignExternalIDs(id, survivor.ID); err != nil {
+				slog.Warn("combine ReassignExternalIDs", "from", id, "to", survivor.ID, "err", err)
+			}
+		}
+
+		// Guard (mirrors applyFSRegroup): never delete a book that still owns
+		// files — that would orphan audio. After the move it must be empty.
+		if remaining, _ := ms.db.GetBookFiles(id); len(remaining) != 0 {
+			return nil, fmt.Errorf("book %s still owns %d files after move; aborting delete", id, len(remaining))
+		}
+		if err := ms.db.DeleteBook(id); err != nil {
+			return nil, fmt.Errorf("delete absorbed book %s: %w", id, err)
+		}
+		res.BooksDeleted++
+	}
+
+	if err := ms.db.RecomputeBookAggregates(survivor.ID); err != nil {
+		slog.Warn("combine RecomputeBookAggregates", "id", survivor.ID, "err", err)
+	}
+	slog.Info("combined books into one", "survivor", survivor.ID,
+		"files_moved", res.FilesMoved, "books_deleted", res.BooksDeleted)
+	return res, nil
+}
+
+// ensureOwnFile materializes a single-file book's FilePath as a BookFile when it
+// has no BookFile rows yet (the virtual-segment model). Returns files created (0/1).
+func (ms *Service) ensureOwnFile(b *database.Book) int {
+	if b.FilePath == "" {
+		return 0
+	}
+	if files, _ := ms.db.GetBookFiles(b.ID); len(files) > 0 {
+		return 0 // already materialized
+	}
+	return ms.attachVirtualFile(b, b.ID)
+}
+
+// attachVirtualFile creates (or reattaches) a BookFile at book.FilePath owned by
+// targetBookID. Reattach-safe per #1549: an existing row at that path is MOVED
+// (its BookID can't be changed in place — the primary key embeds it), never
+// duplicated. Returns files attached (0/1).
+func (ms *Service) attachVirtualFile(b *database.Book, targetBookID string) int {
+	existing, _ := ms.db.GetBookFileByPath(b.FilePath)
+	if existing != nil {
+		if existing.BookID != targetBookID {
+			if err := ms.db.MoveBookFilesToBook([]string{existing.ID}, existing.BookID, targetBookID); err != nil {
+				slog.Warn("combine reattach existing file", "path", b.FilePath, "err", err)
+				return 0
+			}
+		}
+		return 1
+	}
+	bf := &database.BookFile{
+		ID:       ulid.Make().String(),
+		BookID:   targetBookID,
+		FilePath: b.FilePath,
+		Format:   strings.TrimPrefix(strings.ToLower(filepath.Ext(b.FilePath)), "."),
+	}
+	if b.Duration != nil {
+		bf.Duration = *b.Duration
+	}
+	if err := ms.db.CreateBookFile(bf); err != nil {
+		slog.Warn("combine create file", "path", b.FilePath, "err", err)
+		return 0
+	}
+	return 1
 }
 
 // SoftDeleteBook marks a book as deleted using the MarkedForDeletion flag.

--- a/internal/server/handlers/duplicates/handler.go
+++ b/internal/server/handlers/duplicates/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/duplicates/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9f41f363-34fc-4ad2-b2f1-46d5ac0ba2f3
-// last-edited: 2026-06-03
+// last-edited: 2026-06-21
 
 // Package duplicates hosts the SQL-backed duplicate-detection HTTP handlers
 // extracted from the server package's duplicates_handlers.go: book / author /
@@ -319,6 +319,55 @@ func (h *Handler) MergeBooks(c *gin.Context) {
 	}
 
 	httputil.RespondWithSuccess(c, 202, op)
+}
+
+// CombineBooks combines several single-file books into ONE multi-file book on the
+// survivor (keep_id) and hard-deletes the absorbed shells. Distinct from
+// MergeBooks, which links them as alternate VERSIONS in a version group.
+// Synchronous — combine is a fast DB-only operation. POST /audiobooks/combine.
+func (h *Handler) CombineBooks(c *gin.Context) {
+	var req struct {
+		KeepID   string   `json:"keep_id" binding:"required"`
+		MergeIDs []string `json:"merge_ids" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondWithBadRequest(c, err.Error())
+		return
+	}
+
+	if len(req.MergeIDs) == 0 {
+		httputil.RespondWithBadRequest(c, "merge_ids must not be empty")
+		return
+	}
+
+	ms := h.getMergeService()
+	if ms == nil {
+		httputil.RespondWithInternalError(c, "merge service not initialized")
+		return
+	}
+
+	// Pass ALL ids (the absorbed books plus the survivor) and the survivor id.
+	result, err := ms.CombineBooks(append(req.MergeIDs, req.KeepID), req.KeepID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			httputil.RespondWithNotFound(c, "book", req.KeepID)
+		} else {
+			httputil.InternalError(c, "failed to combine books", err)
+		}
+		return
+	}
+
+	if h.dedupCache != nil {
+		h.dedupCache.Invalidate("book-dedup-scan")
+		h.dedupCache.Invalidate("book-duplicates")
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"message":       fmt.Sprintf("Combined %d files onto book; deleted %d shells", result.FilesMoved, result.BooksDeleted),
+		"primary_id":    result.PrimaryID,
+		"files_moved":   result.FilesMoved,
+		"books_deleted": result.BooksDeleted,
+	})
 }
 
 // ListDuplicateAuthors handles GET /authors/duplicates.

--- a/internal/server/handlers/duplicates/interfaces.go
+++ b/internal/server/handlers/duplicates/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/duplicates/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a04e0263-a6b1-42b9-9791-1b8b649004b5
-// last-edited: 2026-06-03
+// last-edited: 2026-06-21
 
 // Narrow dependency interfaces for the duplicates-domain HTTP handlers
 // (SQL-backed book/author/series duplicate detection, async merge / dismiss /
@@ -53,6 +53,10 @@ type DuplicatesStore interface {
 // controller without this package importing internal/server.
 type MergeService interface {
 	MergeBooks(bookIDs []string, primaryID string) (*merge.Result, error)
+	// CombineBooks combines several single-file books into ONE multi-file book
+	// on the survivor (primaryID) and hard-deletes the absorbed shells. Distinct
+	// from MergeBooks, which links them as alternate versions in a version group.
+	CombineBooks(bookIDs []string, primaryID string) (*merge.CombineResult, error)
 }
 
 // MetadataFetchService is the narrow *metafetch.Service subset used by

--- a/internal/server/handlers/duplicates/mocks/mock_merge_service.go
+++ b/internal/server/handlers/duplicates/mocks/mock_merge_service.go
@@ -36,6 +36,74 @@ func (_m *MockMergeService) EXPECT() *MockMergeService_Expecter {
 	return &MockMergeService_Expecter{mock: &_m.Mock}
 }
 
+// CombineBooks provides a mock function for the type MockMergeService
+func (_mock *MockMergeService) CombineBooks(bookIDs []string, primaryID string) (*merge.CombineResult, error) {
+	ret := _mock.Called(bookIDs, primaryID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CombineBooks")
+	}
+
+	var r0 *merge.CombineResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string, string) (*merge.CombineResult, error)); ok {
+		return returnFunc(bookIDs, primaryID)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string, string) *merge.CombineResult); ok {
+		r0 = returnFunc(bookIDs, primaryID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*merge.CombineResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string, string) error); ok {
+		r1 = returnFunc(bookIDs, primaryID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMergeService_CombineBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CombineBooks'
+type MockMergeService_CombineBooks_Call struct {
+	*mock.Call
+}
+
+// CombineBooks is a helper method to define mock.On call
+//   - bookIDs []string
+//   - primaryID string
+func (_e *MockMergeService_Expecter) CombineBooks(bookIDs any, primaryID any) *MockMergeService_CombineBooks_Call {
+	return &MockMergeService_CombineBooks_Call{Call: _e.mock.On("CombineBooks", bookIDs, primaryID)}
+}
+
+func (_c *MockMergeService_CombineBooks_Call) Run(run func(bookIDs []string, primaryID string)) *MockMergeService_CombineBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMergeService_CombineBooks_Call) Return(combineResult *merge.CombineResult, err error) *MockMergeService_CombineBooks_Call {
+	_c.Call.Return(combineResult, err)
+	return _c
+}
+
+func (_c *MockMergeService_CombineBooks_Call) RunAndReturn(run func(bookIDs []string, primaryID string) (*merge.CombineResult, error)) *MockMergeService_CombineBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MergeBooks provides a mock function for the type MockMergeService
 func (_mock *MockMergeService) MergeBooks(bookIDs []string, primaryID string) (*merge.Result, error) {
 	ret := _mock.Called(bookIDs, primaryID)
@@ -72,7 +140,7 @@ type MockMergeService_MergeBooks_Call struct {
 // MergeBooks is a helper method to define mock.On call
 //   - bookIDs []string
 //   - primaryID string
-func (_e *MockMergeService_Expecter) MergeBooks(bookIDs interface{}, primaryID interface{}) *MockMergeService_MergeBooks_Call {
+func (_e *MockMergeService_Expecter) MergeBooks(bookIDs any, primaryID any) *MockMergeService_MergeBooks_Call {
 	return &MockMergeService_MergeBooks_Call{Call: _e.mock.On("MergeBooks", bookIDs, primaryID)}
 }
 

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.9.0
+// version: 2.10.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-06-15
+// last-edited: 2026-06-21
 
 package server
 
@@ -881,6 +881,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	protected.GET("/authors/duplicates", s.perm(auth.PermLibraryView), duplicatesH.ListDuplicateAuthors)
 	protected.POST("/authors/duplicates/refresh", s.perm(auth.PermLibraryEditMetadata), duplicatesH.RefreshDuplicateAuthors)
 	protected.POST("/audiobooks/merge", s.perm(auth.PermLibraryEditMetadata), duplicatesH.MergeBooks)
+	protected.POST("/audiobooks/combine", s.perm(auth.PermLibraryEditMetadata), duplicatesH.CombineBooks)
 	protected.GET("/series/duplicates", s.perm(auth.PermLibraryView), duplicatesH.ListSeriesDuplicates)
 	protected.POST("/series/duplicates/refresh", s.perm(auth.PermLibraryEditMetadata), duplicatesH.RefreshSeriesDuplicates)
 	protected.POST("/series/deduplicate", s.perm(auth.PermLibraryEditMetadata), duplicatesH.DeduplicateSeriesHandler)

--- a/web/src/components/BatchToolbar.tsx
+++ b/web/src/components/BatchToolbar.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/BatchToolbar.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b5c6d7e8f9a0b
-// last-edited: 2026-04-30
+// last-edited: 2026-06-21
 
 import { Button, Chip, Box, Stack } from '@mui/material';
 
@@ -14,6 +14,7 @@ export interface BatchToolbarProps {
   onSaveToFilesClick: () => void;
   onOrganizeSelectedClick: () => void;
   onMergeAsVersionsClick: () => void;
+  onCombineIntoOneBookClick: () => void;
   onTagClick: () => void;
   onRateClick: () => void;
   onDeleteSelectedClick: () => void;
@@ -34,6 +35,7 @@ export const BatchToolbar = ({
   onSaveToFilesClick,
   onOrganizeSelectedClick,
   onMergeAsVersionsClick,
+  onCombineIntoOneBookClick,
   onTagClick,
   onRateClick,
   onDeleteSelectedClick,
@@ -91,6 +93,16 @@ export const BatchToolbar = ({
         disabled={selectedAudiobooksLength < 2}
       >
         Merge as Versions
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        color="primary"
+        onClick={onCombineIntoOneBookClick}
+        disabled={selectedAudiobooksLength < 2}
+        title="Combine the selected single-file books into ONE multi-file book (moves all files onto one survivor, deletes the rest). Distinct from Merge as Versions."
+      >
+        Combine into One Book
       </Button>
       <Button size="small" variant="outlined" onClick={onTagClick} disabled={!selectedCount}>
         Tag

--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
-// last-edited: 2026-05-11
+// last-edited: 2026-06-21
 
 import React from 'react';
 import {
@@ -95,6 +95,10 @@ interface LibraryDialogsProps {
   setMergePrimaryId: (id: string) => void;
   mergeInProgress: boolean;
   handleMergeAsVersions: () => void;
+  combineDialogOpen: boolean;
+  setCombineDialogOpen: (open: boolean) => void;
+  combineInProgress: boolean;
+  handleCombineIntoOneBook: () => void;
 
   // Batch delete dialog
   batchDeleteDialogOpen: boolean;
@@ -243,6 +247,10 @@ export const LibraryDialogs = ({
   setMergePrimaryId,
   mergeInProgress,
   handleMergeAsVersions,
+  combineDialogOpen,
+  setCombineDialogOpen,
+  combineInProgress,
+  handleCombineIntoOneBook,
   batchDeleteDialogOpen,
   setBatchDeleteDialogOpen,
   batchDeleteInProgress,
@@ -408,6 +416,50 @@ export const LibraryDialogs = ({
           disabled={mergeInProgress || !mergePrimaryId}
         >
           {mergeInProgress ? 'Merging...' : 'Merge'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+
+    <Dialog open={combineDialogOpen} onClose={() => setCombineDialogOpen(false)} maxWidth="sm" fullWidth>
+      <DialogTitle>Combine into One Book</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" gutterBottom>
+          Combine {selectedAudiobooks.length} books into a single multi-file book. Pick which book to keep as the survivor — its metadata is kept and all other files move onto it:
+        </Typography>
+        <Box sx={{ mt: 1 }}>
+          {selectedAudiobooks.map((book) => (
+            <FormControlLabel
+              key={book.id}
+              control={
+                <Checkbox
+                  checked={mergePrimaryId === book.id}
+                  onChange={() => setMergePrimaryId(book.id)}
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  <strong>{book.title}</strong>
+                  {book.author ? ` by ${book.author}` : ''}
+                  {book.file_path ? ` (${book.file_path.split('/').pop()})` : ''}
+                </Typography>
+              }
+            />
+          ))}
+        </Box>
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          The other {Math.max(selectedAudiobooks.length - 1, 0)} entries will be deleted and their files attached to the survivor. Unlike "Merge as Versions", this produces ONE book, not a version group. Files stay in place on disk.
+        </Alert>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setCombineDialogOpen(false)} disabled={combineInProgress}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleCombineIntoOneBook}
+          disabled={combineInProgress || !mergePrimaryId}
+        >
+          {combineInProgress ? 'Combining...' : 'Combine'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/web/src/components/library/LibraryToolbar.tsx
+++ b/web/src/components/library/LibraryToolbar.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryToolbar.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-15
+// last-edited: 2026-06-21
 
 import {
   Typography,
@@ -54,6 +54,7 @@ interface LibraryToolbarProps {
   onSaveToFiles: () => void;
   onOrganizeSelected: () => void;
   onMergeAsVersions: () => void;
+  onCombineIntoOneBook: () => void;
   onTagClick: () => void;
   onRateClick: () => void;
   onDeleteSelected: () => void;
@@ -96,6 +97,7 @@ export const LibraryToolbar = ({
   onSaveToFiles,
   onOrganizeSelected,
   onMergeAsVersions,
+  onCombineIntoOneBook,
   onTagClick,
   onRateClick,
   onDeleteSelected,
@@ -133,6 +135,7 @@ export const LibraryToolbar = ({
           onSaveToFilesClick={onSaveToFiles}
           onOrganizeSelectedClick={onOrganizeSelected}
           onMergeAsVersionsClick={onMergeAsVersions}
+          onCombineIntoOneBookClick={onCombineIntoOneBook}
           onTagClick={onTagClick}
           onRateClick={onRateClick}
           onDeleteSelectedClick={onDeleteSelected}

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.68.0
+// version: 1.69.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-05-20
+// last-edited: 2026-06-21
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -228,6 +228,8 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [batchDeleteInProgress, setBatchDeleteInProgress] = useState(false);
   const [batchRestoreInProgress, setBatchRestoreInProgress] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [combineDialogOpen, setCombineDialogOpen] = useState(false);
+  const [combineInProgress, setCombineInProgress] = useState(false);
   const [batchPlaylistOpen, setBatchPlaylistOpen] = useState(false);
   const [mergePrimaryId, setMergePrimaryId] = useState<string>('');
   // pendingFetchOpId tracks the in-flight metadata fetch so we can
@@ -1004,6 +1006,32 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     }
   };
 
+  // handleCombineIntoOneBook combines the selected single-file books into ONE
+  // multi-file book on the chosen survivor (mergePrimaryId), hard-deleting the
+  // absorbed shells. Distinct from handleMergeAsVersions (version-group merge).
+  const handleCombineIntoOneBook = async () => {
+    if (selectedAudiobooks.length < 2) return;
+    setCombineInProgress(true);
+    try {
+      const keepId = mergePrimaryId || selectedAudiobooks[0].id;
+      const mergeIds = selectedAudiobooks.filter((b) => b.id !== keepId).map((b) => b.id);
+      const result = await api.combineBooks(keepId, mergeIds);
+      toast(
+        `Combined ${result.files_moved} files into one book; removed ${result.books_deleted} entries.`,
+        'success',
+      );
+      setSelectedAudiobooks([]);
+      setCrossPageFilter(null);
+      setCombineDialogOpen(false);
+      await loadAudiobooks();
+    } catch (error) {
+      console.error('Failed to combine books:', error);
+      toast('Failed to combine books.', 'error');
+    } finally {
+      setCombineInProgress(false);
+    }
+  };
+
   const handlePurgeOne = async (book: Audiobook) => {
     setPurgingBookId(book.id);
     try {
@@ -1758,6 +1786,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         onSaveToFiles={() => { setBulkWriteBackResult(null); setBulkWriteBackRename(false); setBulkWriteBackDialogOpen(true); }}
         onOrganizeSelected={() => setBulkOrganizeDialogOpen(true)}
         onMergeAsVersions={() => { setMergePrimaryId(selectedAudiobooks[0]?.id || ''); setMergeDialogOpen(true); }}
+        onCombineIntoOneBook={() => { setMergePrimaryId(selectedAudiobooks[0]?.id || ''); setCombineDialogOpen(true); }}
         onTagClick={() => setBulkTagDialogOpen(true)}
         onRateClick={() => setBulkRatingDialogOpen(true)}
         onDeleteSelected={() => setBatchDeleteDialogOpen(true)}
@@ -1889,6 +1918,10 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           setMergePrimaryId={setMergePrimaryId}
           mergeInProgress={mergeInProgress}
           handleMergeAsVersions={handleMergeAsVersions}
+          combineDialogOpen={combineDialogOpen}
+          setCombineDialogOpen={setCombineDialogOpen}
+          combineInProgress={combineInProgress}
+          handleCombineIntoOneBook={handleCombineIntoOneBook}
           batchDeleteDialogOpen={batchDeleteDialogOpen}
           setBatchDeleteDialogOpen={setBatchDeleteDialogOpen}
           batchDeleteInProgress={batchDeleteInProgress}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.41.0
+// version: 2.42.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-06-19
+// last-edited: 2026-06-21
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -1433,6 +1433,32 @@ export async function mergeBooks(keepId: string, mergeIds: string[]): Promise<Op
     throw await buildApiError(response, 'Failed to merge books');
   }
   return response.json();
+}
+
+export interface CombineBooksResult {
+  primary_id: string;
+  files_moved: number;
+  books_deleted: number;
+  message?: string;
+}
+
+// combineBooks combines several single-file books into ONE multi-file book on the
+// survivor (keepId), hard-deleting the absorbed shells. Distinct from mergeBooks,
+// which links them as alternate versions in a version group. Synchronous.
+export async function combineBooks(
+  keepId: string,
+  mergeIds: string[],
+): Promise<CombineBooksResult> {
+  const response = await fetch(`${API_BASE}/audiobooks/combine`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ keep_id: keepId, merge_ids: mergeIds }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to combine books');
+  }
+  const body = await response.json();
+  return body.data ?? body;
 }
 
 // Book dedup scan — advanced duplicate detection with confidence levels


### PR DESCRIPTION
## What

Adds an end-to-end **"Combine into One Book"** action to the Library multi-select toolbar, built around the existing `merge.Service.CombineBooks` backend method.

## Distinct from "Merge as Versions"

| | Combine into One Book | Merge as Versions |
|---|---|---|
| Result | **ONE** multi-file book | A **version group** of alternates |
| Files | All moved onto the survivor as real `BookFile` rows | Left on their own books |
| Shells | Hard-deleted (after orphan-guard) | Soft-deleted, kept as alternate versions |
| Use case | Reassemble tracks imported as one-book-per-file (manual shattered-book heal) | Link duplicate editions/formats |

Combine is DB-only — files stay where they are on disk; run organize afterward to co-locate.

## Changes

**Backend**
- `duplicates.MergeService` interface gains `CombineBooks`; new `Handler.CombineBooks` (synchronous, `POST /audiobooks/combine`, binds `{keep_id, merge_ids}`; not-found → 404, else 500).
- Route wired in `wire_handlers.go` under `PermLibraryEditMetadata`.
- Regenerated `duplicates` `MockMergeService` (mockery) with the new method — Mock Freshness clean. (dedup/diagnostics `MergeService` interfaces are unchanged, so their mocks are untouched.)

**Frontend**
- `api.combineBooks(keepId, mergeIds)` mirroring `mergeBooks`.
- "Combine into One Book" toolbar button + survivor-pick dialog reusing the merge primary-pick pattern (`mergePrimaryId`).

## Test plan

`internal/merge/combine_test.go` against a real PebbleStore:
- 3 single-file books — two with real `BookFile` rows, one virtual (FilePath-only, also the survivor) — combine into 1 survivor owning all 3 files.
- Absorbed books hard-deleted; external-ID mappings reassigned to the survivor; survivor's own virtual file materialized.
- Guard cases: too-few IDs, missing primary, primary-not-in-set.

### Verification (local)
- `go build ./...` — pass
- `go vet ./internal/merge/ ./internal/server/handlers/duplicates/` — pass
- `go test ./internal/merge/` — 4/4 combine tests PASS
- `go test ./internal/server/handlers/duplicates/` — pass
- `npx tsc --noEmit` — pass; `npm run build` — built in 5.01s

🤖 Generated with [Claude Code](https://claude.com/claude-code)