### PR TITLE
fix(metadata): skip chapter-fragment books in matcher (no more 101% nonsense matches)

### DIFF
--- a/internal/metadata/chapter_fragment.go
+++ b/internal/metadata/chapter_fragment.go
@@ -1,0 +1,72 @@
+// file: internal/metadata/chapter_fragment.go
+// version: 1.0.0
+// guid: 7d2f1a4c-9b6e-4c0a-8f31-2e5a9c1d3b67
+// last-edited: 2026-06-21
+
+package metadata
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Chapter-fragment detection — context.
+//
+// "Shattered" audiobooks were imported into the library as one book PER CHAPTER:
+// each chapter is its own Book row with a title like "06 Chapter 6", a single
+// short mp3, and a path like
+//
+//	.../Metro 2034/Metro 2034 - 06 Chapter 6/06 Chapter 6/06 Chapter 6 - Metro 2034 - read by narrator.mp3
+//
+// When the bulk metadata matcher searches a catalog (Audible / OpenLibrary /
+// etc.) for a title like "06 Chapter 6" it confidently matches a RANDOM catalog
+// entry at ~100%+ confidence (e.g. "06 Chapter 6" -> some 2026 public-domain
+// "Daniel Boone" book at 101%). Applying that writes garbage onto every chapter.
+//
+// IsLikelyChapterFragment is a CONSERVATIVE, title-pattern-only guard so callers
+// can skip catalog search/matching for these obvious fragments. It must avoid
+// false positives on real books, so it deliberately keys only on the title
+// (never on duration — legitimate short books exist).
+
+var (
+	// "06 Chapter 6", "01 - Track 1", "12. Part 3", "3 disc 2"
+	// A leading number, optional separator, then a chapter/track keyword.
+	chapterFragNumberThenWord = regexp.MustCompile(`(?i)^\d{1,3}\s*[-.]?\s*(?:chapter|track|part|disc|cd|section)\b`)
+
+	// "Chapter 6", "Track 1", "Part 2", "Disc 2", "CD 3", "Section 4"
+	// A chapter/track keyword that MUST be followed by a number. Requiring the
+	// trailing number is what keeps real titles like "Part of Your World" and
+	// "Discworld" out of the net.
+	chapterFragWordThenNumber = regexp.MustCompile(`(?i)^(?:chapter|track|part|disc|cd|section)\s*\d+\b`)
+
+	// Pure zero-padded numeric titles like "06", "01", "012".
+	// A leading zero is REQUIRED so bare years/numbers that are legitimate
+	// titles ("1984", "2001", "451") are NOT treated as fragments.
+	chapterFragZeroPadded = regexp.MustCompile(`^0\d*$`)
+)
+
+// IsLikelyChapterFragment reports whether title looks like a single-chapter
+// fragment of a shattered audiobook (see file-level doc comment). It is
+// intentionally conservative: only obvious chapter/track-style titles match,
+// so legitimate books are never suppressed from metadata matching.
+//
+// TRUE examples:  "06 Chapter 6", "Chapter 6", "01 - Track 1", "Disc 2", "06"
+// FALSE examples: "The Moons of Barsk", "Metro 2034", "1984",
+//
+//	"Part of Your World", "Discworld", "Catch-22"
+func IsLikelyChapterFragment(title string) bool {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return false
+	}
+	if chapterFragNumberThenWord.MatchString(t) {
+		return true
+	}
+	if chapterFragWordThenNumber.MatchString(t) {
+		return true
+	}
+	if chapterFragZeroPadded.MatchString(t) {
+		return true
+	}
+	return false
+}

--- a/internal/metadata/chapter_fragment_test.go
+++ b/internal/metadata/chapter_fragment_test.go
@@ -1,0 +1,54 @@
+// file: internal/metadata/chapter_fragment_test.go
+// version: 1.0.0
+// guid: 3a9c0e21-6f48-4b7d-95a2-1c8f0d4e7b52
+// last-edited: 2026-06-21
+
+package metadata
+
+import "testing"
+
+func TestIsLikelyChapterFragment(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// --- Chapter fragments: must be TRUE ---
+		{"number then chapter", "06 Chapter 6", true},
+		{"bare chapter", "Chapter 6", true},
+		{"number dash track", "01 - Track 1", true},
+		{"number dot track", "01. Track 1", true},
+		{"disc with number", "Disc 2", true},
+		{"cd with number", "CD 3", true},
+		{"section with number", "Section 4", true},
+		{"part with number", "Part 2", true},
+		{"number then part", "12 Part 3", true},
+		{"zero padded two digit", "06", true},
+		{"zero padded one digit", "01", true},
+		{"zero padded three digit", "012", true},
+		{"lowercase chapter", "chapter 12", true},
+
+		// --- Real books: must be FALSE ---
+		{"real title moons", "The Moons of Barsk", false},
+		{"real title metro", "Metro 2034", false},
+		{"year title 1984", "1984", false},
+		{"year title 2001", "2001", false},
+		{"bare number 451", "451", false},
+		{"part of your world", "Part of Your World", false},
+		{"discworld", "Discworld", false},
+		{"catch 22", "Catch-22", false},
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"chapter no number", "Chapter House Dune", false},
+		{"section no number", "Sectional Sofas", false},
+		{"track no number", "Off the Beaten Track", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLikelyChapterFragment(tc.title); got != tc.want {
+				t.Errorf("IsLikelyChapterFragment(%q) = %v, want %v", tc.title, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-05-11
+// last-edited: 2026-06-21
 //
 // HTTP handlers for the metadata candidate batch fetch / apply pipeline.
 // Pure service types and logic live in internal/metabatch.
@@ -23,6 +23,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metabatch"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 )
@@ -195,6 +196,19 @@ func (s *Server) fetchCandidateForBook(
 	}
 
 	bookInfo := metabatch.BuildCandidateBookInfo(store, book)
+
+	// Skip obvious chapter fragments of shattered audiobooks (e.g. a book
+	// titled "06 Chapter 6"). Searching a catalog for these matches a random
+	// entry at ~100%+ confidence and writes garbage onto every chapter, so we
+	// short-circuit BEFORE any external search and surface a clear skipped
+	// status instead of a bogus "matched" candidate.
+	if metadata.IsLikelyChapterFragment(book.Title) {
+		return CandidateResult{
+			Book:   bookInfo,
+			Status: "skipped",
+			Error:  "skipped: chapter fragment",
+		}
+	}
 
 	// Wait for rate limiter before making external requests.
 	if err := limiter.Wait(ctx); err != nil {

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-06-03
+// last-edited: 2026-06-21
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -168,6 +168,27 @@ func (s *Server) runBulkMetadataFetchAll(
 
 		bookID := w.book.ID
 		currentAuthor := w.authorName
+
+		// Skip obvious chapter fragments of shattered audiobooks (e.g. a book
+		// titled "06 Chapter 6"). Searching the catalog for these confidently
+		// matches a random entry, so we record a skipped status and never hit
+		// the API or cache a bogus result.
+		if metadata.IsLikelyChapterFragment(w.book.Title) {
+			_ = store.CreateOperationResult(&database.OperationResult{
+				OperationID: opID,
+				BookID:      bookID,
+				ResultJSON:  `{"status":"skipped_fragment","source":""}`,
+				Status:      "skipped_fragment",
+			})
+			notFound++
+			n := atomic.AddInt64(&completed, 1)
+			if i%50 == 0 || int(n) == totalBooks {
+				_ = progress.UpdateProgress(int(n), totalBooks,
+					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+			}
+			continue
+		}
+
 		searchTitle := stripChapterFromTitle(w.book.Title)
 
 		var metaResults []metadata.BookMetadata
@@ -499,6 +520,26 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 			return ctx.Err()
 		}
 		bookID := w.book.ID
+
+		// Skip obvious chapter fragments of shattered audiobooks (see
+		// runBulkMetadataFetchAll for the rationale): never search or cache a
+		// bogus catalog match for a title like "06 Chapter 6".
+		if metadata.IsLikelyChapterFragment(w.book.Title) {
+			_ = store.CreateOperationResult(&database.OperationResult{
+				OperationID: opID,
+				BookID:      bookID,
+				ResultJSON:  `{"status":"skipped_fragment","source":""}`,
+				Status:      "skipped_fragment",
+			})
+			notFound++
+			n := atomic.AddInt64(&completed, 1)
+			if i%50 == 0 || int(n) == totalBooks {
+				_ = progress.UpdateProgress(int(n), totalBooks,
+					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+			}
+			continue
+		}
+
 		searchTitle := stripChapterFromTitle(w.book.Title)
 
 		var metaResults []metadata.BookMetadata


### PR DESCRIPTION
## The bug

"Shattered" audiobooks were imported as one book **per chapter** — e.g. a book titled `06 Chapter 6`, a single short mp3, path like `.../Metro 2034/Metro 2034 - 06 Chapter 6/06 Chapter 6/06 Chapter 6 - Metro 2034 - read by narrator.mp3`.

The bulk metadata matcher then confidently matched each chapter fragment to a **random** catalog (Audible/OpenLibrary) entry at ~100%+ confidence — e.g. `06 Chapter 6` → a 2026 public-domain "Daniel Boone" book at 101%. On apply this wrote garbage metadata onto every chapter.

## The fix

New conservative helper `metadata.IsLikelyChapterFragment(title)` (in `internal/metadata/chapter_fragment.go`), applied at the per-book seams **before any catalog search**, so a fragment is skipped instead of producing a bogus high-confidence candidate:

- `fetchCandidateForBook` (the review-UI candidate path that produces the 101% "matched" result) → returns `Status: "skipped"` with `error_message: "skipped: chapter fragment"`. **This is the primary seam for the reported bug.**
- `runBulkMetadataFetchAll` / `runBulkMetadataFetchForBookIDs` (bulk fetch/cache path) → write an OperationResult with `Status: "skipped_fragment"` and never call `PutCachedMetadataFetch`.

## The heuristic (conservative, title-only)

Keys **only on the title** — never on duration, because real short books exist. A title is a fragment when it matches one of:

1. `(?i)^\d{1,3}\s*[-.]?\s*(?:chapter|track|part|disc|cd|section)\b` — "06 Chapter 6", "01 - Track 1"
2. `(?i)^(?:chapter|track|part|disc|cd|section)\s*\d+\b` — "Chapter 6", "Disc 2"
3. `^0\d*$` — zero-padded pure number ("06", "01")

### False-positive guards

- Both keyword forms **require an adjacent digit**, so `Part of Your World`, `Discworld`, `Chapter House Dune`, `Off the Beaten Track` stay **FALSE**.
- The pure-number rule **requires a leading zero**, so year/number titles `1984`, `2001`, `451` stay **FALSE** (a zero-padded "06" is a fragment; a bare "1984" is a real title).

## Test plan

`internal/metadata/chapter_fragment_test.go` — 26-case table-driven test.

TRUE: `06 Chapter 6`, `Chapter 6`, `01 - Track 1`, `Disc 2`, `CD 3`, `Section 4`, `Part 2`, `06`, `012`, …
FALSE: `The Moons of Barsk`, `Metro 2034`, `1984`, `2001`, `451`, `Part of Your World`, `Discworld`, `Catch-22`, `Chapter House Dune`, …

Verified locally:
- `go build ./...` — clean
- `go vet ./internal/metadata/ ./internal/server/` — clean
- `go test ./internal/metadata/` — ok (all 26 cases pass)
- `go test ./internal/server/...` — ok (all packages pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)