### PR TITLE
feat(maintenance): duration-reextract v3 — fingerprint-first backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.54.0 -->
+<!-- version: 3.55.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-21 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Changed
+
+#### June 21, 2026 — duration-reextract v3: fingerprint-first backfill
+
+- **`refactor(maintenance)`** — `maintenance.duration-reextract` upgraded to v3:
+  reads `BookFile.AcoustIDFingerprintDurationSec` (stored by fpcalc during whole-file
+  fingerprinting) as the authoritative per-segment duration — no stat, no subprocess.
+  ffprobe (`mediainfo.Extract`) is now the fallback only for the never-fingerprinted
+  tail (~275K files on fast path). The summary now reports `from-fingerprint=N
+  from-ffprobe=N` so a dry-run reveals the fast/slow split immediately. Trust
+  invariant and write path (UpdateBookFile + RecomputeBookAggregates) unchanged from
+  v2. Key insight: bad durations are a bounded historical stock (pre-PR #1555), not a
+  recurring flow — no tracking fields added. Design spec:
+  `docs/specs/2026-06-21-duration-reextract-v3-design.md`.
 
 ### Added
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.12.0 -->
+<!-- version: 9.13.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-21 -->
 
@@ -78,18 +78,17 @@ bottom of the review view so the last apply can be undone after the banner disap
 `POST /audiobooks/:id/metadata/undo-apply` / revert-to-snapshot. Investigate the review-matches
 component in `web/src/` first. NOT started.
 
-### AP-3 🔴 Duration extraction is fake (HALF/wrong durations) — feeds dedup + matching
-`internal/mediainfo/mediainfo.go` NEVER reads real duration: `dhowden/tag` doesn't expose it, so
-`Duration = fileSize ÷ bitrate` (line 88-93) with m4b bitrate DEFAULTING to 128 kbps (line 137).
-Real audiobooks ≈ 64 kbps → every m4b/m4a duration is ~2× too short (verified: Moons of Barsk
-403 MB shows 7h19m≈128k, real 14h46m≈61k). Poisons dedup duration-match + metadata scoring.
-- 🔵 FIX: read REAL duration. Best option — taglib `taglib_audioproperties_length` (already linked
-  via `internal/metadata/taglib_cgo.go`, accurate, no subprocess); fall back to ffprobe
-  (`internal/diagnosis/probe.go` already parses `format.duration`) when taglib can't.
-- 🔵 Then a re-extraction backfill op for existing rows (all current m4b/m4a durations are wrong).
-- 🔵 ARCH (AP-3b): consolidate the 3 duration paths — `internal/mediainfo` (estimate),
-  `internal/diagnosis/probe` (real ffprobe), external (Audible) — into ONE accurate extractor,
-  ideally surfaced through `internal/metadata` where it belongs.
+### AP-3 ✅ Duration extraction fixed — real durations now stored + backfill op shipped
+Fixed in PR #1555 (`internal/mediainfo`: calls ffprobe first, estimate only as flagged fallback).
+Both import paths now correct: filesystem scan uses `BuildFromTag`→`realDurationSec`; iTunes import
+uses `track.TotalTime/1000`. Backfill ops:
+- `maintenance.duration-backfill` — corrects iTunes ms→s inflated rows (CONS-16)
+- `maintenance.duration-reextract` v3 (Jun 21) — fingerprint-first; reads stored
+  `AcoustIDFingerprintDurationSec` (fast DB pass for ~275K fingerprinted files), ffprobe fallback
+  for residue. Design: `docs/specs/2026-06-21-duration-reextract-v3-design.md`.
+  Run dry-run first to verify counts, then `dryRun:false` to apply.
+- 🔵 ARCH (AP-3b): consolidate the 3 duration paths — `internal/mediainfo`, `internal/diagnosis/probe`,
+  external (Audible) — into ONE accurate extractor. Lower priority now that the extractor is fixed.
 
 ### AP-4 🟡 tag-backfill apply (lossless RawTags)
 RUNNING server-side `op_id=01KVN04C1WYZ4DFGYJGDDCFPC3` (was ~46% at last check, 0 read-err).

--- a/docs/specs/2026-06-21-duration-reextract-v3-design.md
+++ b/docs/specs/2026-06-21-duration-reextract-v3-design.md
@@ -1,0 +1,116 @@
+<!-- file: docs/specs/2026-06-21-duration-reextract-v3-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7f3a9c21-4e85-4b0d-9a2c-6d18f5e3b740 -->
+<!-- last-edited: 2026-06-21 -->
+
+# duration-reextract v3 — fingerprint-duration-first backfill
+
+## Problem
+
+Books imported before PR #1555 carry wrong `Book.Duration` values. The old
+`mediainfo` estimator derived duration from `fileSize ÷ assumed-bitrate`, which
+for m4b/m4a assumed 128 kbps and was routinely ~2× too short. Wrong durations
+poison dedup duration-matching (`checkDurationMatch`) and metadata scoring.
+
+The `maintenance.duration-reextract` op (v2) corrects this by re-reading the true
+duration via ffprobe — but it shells out **once per segment**, making a
+whole-library pass a multi-hour operation.
+
+## Key finding: this is a stock, not a flow
+
+Both live import paths already produce **real** durations, so nothing entering
+the library is wrong anymore:
+
+- **Filesystem scan/import** — `mediainfo.BuildFromTag` calls `realDurationSec`
+  (ffprobe) first and only falls back to the flagged estimate on failure
+  (`internal/mediainfo/mediainfo.go:128`, PR #1555).
+- **iTunes import** — uses iTunes's own `track.TotalTime / 1000`
+  (`internal/itunes/import.go:374`), a real measured value.
+
+So the bad durations are a **bounded historical backlog** (pre-#1555 scanned
+books), not a recurring inflow. The right shape is a **one-time drain**, not an
+ongoing scheduled re-scan. No `lastDurationScanTime`/`lastDurationFixTime`
+tracking fields are needed: "what still needs correcting" is derivable per book,
+and idempotency already exists via the diff tolerance.
+
+## The speedup: read the duration we already stored
+
+Fingerprinting already measured and stored a real per-file duration in
+`BookFile.AcoustIDFingerprintDurationSec` (float seconds). fpcalc produced it by
+decoding the whole file, so it is as authoritative as ffprobe — the field exists
+precisely *because* container metadata lies about duration. It is also
+memdb-safe (kept, not stripped). ~275K files have it.
+
+So v3 reads that stored value instead of re-running ffprobe, turning the fast
+majority of the backlog into a pure DB pass. ffprobe remains only for the
+residue (files never fingerprinted).
+
+## Goal
+
+Rework `maintenance.duration-reextract` to be fingerprint-duration-first:
+a fast DB pass for fingerprinted books, with inline ffprobe fallback (no cap)
+for the never-fingerprinted tail. One op corrects the whole backlog.
+
+Non-goals: no new persisted fields, no scheduled cadence, no change to the op
+ID, params, or write path.
+
+## Design
+
+### Per-segment duration source (priority order)
+
+1. **Fingerprint duration** — if `seg.AcoustIDFingerprintDurationSec > 0`, use
+   `round()` of it. No subprocess → fast.
+2. **ffprobe fallback** — else `mediainfo.Extract(seg.FilePath)`; trust only a
+   real result (`!DurationEstimated`). The `FingerprintFailedAt` tombstone does
+   **not** gate this: ffprobe can often read a container header even when
+   full-decode fingerprinting failed, and the worst case is simply skipping the
+   book.
+
+### Trust invariant (unchanged from v2)
+
+A book is corrected only when **every present segment** yields a real duration
+(fingerprint or real-ffprobe). Any missing / unreadable / estimated segment
+skips the whole book (counted, not half-written), so `Book.Duration` is never a
+partial sum.
+
+### Write path (unchanged from v2)
+
+- Changed segments → `UpdateBookFile` (full-replace on pebble-direct rows,
+  preserving the fingerprint per #1552, refreshing memdb per #1560).
+- Then `RecomputeBookAggregates(book.ID)` sums corrected segments into
+  `Book.Duration`.
+- Virtual single-file books (no `BookFile` rows) have no fingerprint field, so
+  they go straight to the ffprobe path and write `Book.Duration` directly.
+
+### What changes vs v2
+
+Only the per-segment "compute the real duration" block: add the fingerprint-first
+branch before the `mediainfo.Extract` fall-through. Everything else is retained:
+params (`dryRun` default true, `limit`), thresholds (`durationRelTolerance` 2%,
+`durationAbsToleranceS` 5s), heartbeat cadence, example capture, dry-run safety.
+
+### Telemetry
+
+Add two counters to the heartbeat + summary lines: `from-fingerprint=N` and
+`from-ffprobe=N`, so a dry-run immediately reveals how much of the backlog is the
+fast path vs the slow tail.
+
+## Testing
+
+Extend `internal/plugins/maintenance/duration_reextract_test.go`:
+
+- (a) Multi-file book where all segments have `AcoustIDFingerprintDurationSec`
+  → corrected with **zero** ffprobe calls.
+- (b) Mixed book (some segments fingerprinted, some not) → ffprobe fills the gaps.
+- (c) A segment with neither a real fingerprint nor a real ffprobe result →
+  whole book skipped.
+- (d) Idempotent re-run skips already-correct books.
+
+ffprobe is exercised via real `mediainfo.Extract` against fixtures, consistent
+with existing tests; fingerprint-sourced paths need no subprocess.
+
+## Rollback
+
+Dry-run is the default, so a bad run writes nothing. The change is confined to
+one file (`internal/plugins/maintenance/duration_reextract.go`) with the op ID
+and `Run` signature unchanged, so revert is a single-file `git revert`.

--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/duration_reextract.go
-// version: 2.0.0
+// version: 3.0.0
 // guid: 9c2f7a14-6d83-4e51-b0a9-2f5c8e1d4b67
 // last-edited: 2026-06-21
 
@@ -30,9 +30,21 @@
 // untrustworthy, so the whole book is skipped (counted) rather than half-written.
 // Book.Duration is what dedup's checkDurationMatch consumes.
 //
+// Source priority (v3): fingerprinting already measured and stored the real
+// decode duration in BookFile.AcoustIDFingerprintDurationSec for ~275K files. v3
+// reads that stored value FIRST and treats it as authoritative — no stat, no
+// ffprobe — so the fingerprinted majority of the backlog is a fast pure-DB pass.
+// ffprobe is the fallback only for never-fingerprinted segments (and virtual
+// single-file books, which have no BookFile row to carry the value). The summary
+// reports from-fingerprint vs from-ffprobe so a dry-run reveals the fast/slow
+// split. The FingerprintFailedAt tombstone does NOT gate the ffprobe fallback:
+// ffprobe can still read a container header even when full-decode fingerprinting
+// failed, and the worst case is simply skipping the book.
+//
 // Idempotent: a re-run finds already-corrected rows within tolerance and skips
-// them. Slow by design — it shells out to ffprobe once per segment — so it
-// heartbeats progress every ~15s and is cancellable.
+// them. The ffprobe tail is slow by design — it shells out once per
+// non-fingerprinted segment — so the op heartbeats progress every ~15s and is
+// cancellable.
 
 package maintenance
 
@@ -62,8 +74,8 @@ type durationReextractParams struct {
 // real duration differs from the stored value by more than BOTH a relative and an
 // absolute floor, so we never churn rows over sub-second rounding noise.
 const (
-	durationRelTolerance = 0.02 // 2%
-	durationAbsToleranceS = 5   // seconds
+	durationRelTolerance  = 0.02 // 2%
+	durationAbsToleranceS = 5    // seconds
 )
 
 // durationDiffMeaningful reports whether newDur differs from oldDur by enough to
@@ -84,11 +96,12 @@ func (p *Plugin) durationReextractDef() sdk.OperationDef {
 	return sdk.OperationDef{
 		ID:          "maintenance.duration-reextract",
 		Plugin:      "maintenance",
-		DisplayName: "Re-extract real book durations via ffprobe",
-		Description: "Re-reads the true audio-stream duration (ffprobe) for existing single-file books and " +
-			"corrects Book.Duration where the old fileSize÷bitrate estimate was wrong (PR #1555; m4b/m4a were ~2× too short). " +
-			"Never overwrites a real duration with an estimate, and skips files missing on disk. " +
-			"Default dry-run previews counts; set dryRun=false to apply. Slow: shells out to ffprobe per book.",
+		DisplayName: "Re-extract real book durations (fingerprint-first)",
+		Description: "Reads the real per-file duration already stored from fingerprinting (AcoustIDFingerprintDurationSec) first — a fast DB pass — " +
+			"and falls back to ffprobe only for never-fingerprinted files. Handles both multi-file and virtual single-file books. " +
+			"Corrects Book.Duration where the old fileSize÷bitrate estimate was wrong (PR #1555; m4b/m4a were ~2× too short). " +
+			"Never overwrites a real duration with an estimate, and skips books with any unreadable segment. " +
+			"Default dry-run previews counts (incl. fingerprint vs ffprobe split); set dryRun=false to apply.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.duration-reextract",
@@ -138,6 +151,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		estimated     int // ffprobe failed → estimate returned; never trusted/written
 		readErr       int // mediainfo.Extract returned an error
 		noPath        int // book has no single-file FilePath (multi-file; out of v1 scope)
+		fpBooks       int // eligible books fully sourced from stored fingerprint durations (fast path)
+		ffprobeBooks  int // eligible books that needed ≥1 ffprobe call (slow tail)
 		written       int // actual UpdateBook calls (apply mode)
 		examples      = make([]string, 0, exampleCap)
 		lastLog       = time.Now()
@@ -153,8 +168,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 			total = examined
 		}
 		_ = reporter.UpdateProgress(examined, total, fmt.Sprintf(
-			"examined=%d eligible=%d would-change=%d (~2x=%d) missing=%d est-skip=%d read-err=%d",
-			examined, eligible, wouldChange, roughlyDouble, missing, estimated, readErr))
+			"examined=%d eligible=%d (fp=%d ffprobe=%d) would-change=%d (~2x=%d) missing=%d est-skip=%d read-err=%d",
+			examined, eligible, fpBooks, ffprobeBooks, wouldChange, roughlyDouble, missing, estimated, readErr))
 		lastLog = time.Now()
 	}
 
@@ -188,9 +203,10 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 			segs, _ := store.GetBookFiles(book.ID)
 
 			var (
-				newDur     int
-				changedBFs []database.BookFile
-				skip       bool
+				newDur      int
+				changedBFs  []database.BookFile
+				skip        bool
+				usedFfprobe bool // this book needed ≥1 ffprobe call (slow tail)
 			)
 
 			if len(segs) > 0 {
@@ -199,31 +215,44 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 					if f.FilePath == "" {
 						continue // pathless segment contributes nothing; tolerate
 					}
-					if _, statErr := os.Stat(f.FilePath); statErr != nil {
-						missing++
-						skip = true
-						break
+					// v3 fast path: fingerprinting already measured and stored the real
+					// decode duration. Trust it as authoritative — no stat, no ffprobe.
+					// Only segments never fingerprinted fall through to the slow ffprobe
+					// path below.
+					var segDur int
+					if f.AcoustIDFingerprintDurationSec > 0 {
+						segDur = int(math.Round(f.AcoustIDFingerprintDurationSec))
+					} else {
+						usedFfprobe = true
+						if _, statErr := os.Stat(f.FilePath); statErr != nil {
+							missing++
+							skip = true
+							break
+						}
+						info, mErr := mediainfo.Extract(f.FilePath)
+						if mErr != nil || info == nil || info.Duration <= 0 {
+							readErr++
+							skip = true
+							break
+						}
+						if info.DurationEstimated {
+							estimated++
+							skip = true
+							break
+						}
+						segDur = info.Duration
 					}
-					info, mErr := mediainfo.Extract(f.FilePath)
-					if mErr != nil || info == nil || info.Duration <= 0 {
-						readErr++
-						skip = true
-						break
-					}
-					if info.DurationEstimated {
-						estimated++
-						skip = true
-						break
-					}
-					newDur += info.Duration
-					if durationDiffMeaningful(f.Duration, info.Duration) {
+					newDur += segDur
+					if durationDiffMeaningful(f.Duration, segDur) {
 						nf := f
-						nf.Duration = info.Duration
+						nf.Duration = segDur
 						changedBFs = append(changedBFs, nf)
 					}
 				}
 			} else {
-				// Virtual single-file book: probe Book.FilePath directly.
+				// Virtual single-file book: no BookFile rows means no stored fingerprint
+				// duration, so always probe Book.FilePath directly.
+				usedFfprobe = true
 				if book.FilePath == "" {
 					noPath++
 					continue
@@ -247,6 +276,11 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 				continue
 			}
 			eligible++
+			if usedFfprobe {
+				ffprobeBooks++
+			} else {
+				fpBooks++
+			}
 
 			oldDur := 0
 			if book.Duration != nil {
@@ -325,8 +359,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		verb = fmt.Sprintf("corrected %d;", written)
 	}
 	summary := fmt.Sprintf(
-		"examined=%d eligible=%d %s would-change=%d (~2x=%d) missing-on-disk=%d estimated-skipped=%d read-errors=%d no-filepath=%d | e.g. %s",
-		examined, eligible, verb, wouldChange, roughlyDouble, missing, estimated, readErr, noPath,
+		"examined=%d eligible=%d (from-fingerprint=%d from-ffprobe=%d) %s would-change=%d (~2x=%d) missing-on-disk=%d estimated-skipped=%d read-errors=%d no-filepath=%d | e.g. %s",
+		examined, eligible, fpBooks, ffprobeBooks, verb, wouldChange, roughlyDouble, missing, estimated, readErr, noPath,
 		strings.Join(examples, ", "))
 	_ = reporter.Log(slog.LevelInfo, summary)
 	total := totalBooks

--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -11,11 +11,12 @@
 // Every Book row imported before that fix still carries the wrong duration, which
 // poisons dedup duration-matching (checkDurationMatch) and metadata scoring.
 //
-// This op re-reads the real duration via mediainfo.Extract and corrects durations
-// when the new real value differs meaningfully from the stored one. It NEVER
-// overwrites a stored value with an ffprobe-fallback ESTIMATE
-// (DurationEstimated==true) and skips files missing on disk. Dry-run by default:
-// previews counts; set dryRun=false to apply.
+// This op re-derives the real duration and corrects durations when the new value
+// differs meaningfully from the stored one (see "Source priority (v3)" below for
+// where the real value comes from). It NEVER overwrites a stored value with an
+// ffprobe-fallback ESTIMATE (DurationEstimated==true) and skips books with any
+// unreadable segment. Dry-run by default: previews counts; set dryRun=false to
+// apply.
 //
 // Scope (v2): handles BOTH book layouts.
 //   - Multi-file books (audio across BookFiles; Book.FilePath may be a directory):
@@ -135,7 +136,7 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 	if countErr != nil || totalBooks <= 0 {
 		totalBooks = 0
 	}
-	_ = reporter.UpdateProgress(0, totalBooks, "Re-extracting real durations via ffprobe…")
+	_ = reporter.UpdateProgress(0, totalBooks, "Correcting real durations (fingerprint-first, ffprobe fallback)…")
 
 	const (
 		pageSize    = 500
@@ -144,7 +145,7 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 	)
 	var (
 		examined      int // books inspected
-		eligible      int // single-file books with a real, present file we could probe
+		eligible      int // books for which every segment yielded a real duration (fingerprint or ffprobe)
 		wouldChange   int // books whose real duration differs meaningfully
 		roughlyDouble int // subset where new ≈ 2× old (the m4b/m4a estimate bug signature)
 		missing       int // file path set but not on disk

--- a/internal/plugins/maintenance/duration_reextract_test.go
+++ b/internal/plugins/maintenance/duration_reextract_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/duration_reextract_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4a7d1e92-8c63-4f50-a1b8-3e6c9d2f5a04
 // last-edited: 2026-06-21
 
@@ -87,8 +87,8 @@ func TestDurationDiffMeaningful(t *testing.T) {
 		old, new int
 		want     bool
 	}{
-		{0, 100, true},     // no stored value, any real value is an improvement
-		{0, 0, false},      // nothing usable
+		{0, 100, true},      // no stored value, any real value is an improvement
+		{0, 0, false},       // nothing usable
 		{3600, 3600, false}, // identical
 		{3600, 3603, false}, // 3s — under both floors
 		{3600, 3700, true},  // 100s and ~2.8%
@@ -165,7 +165,7 @@ func TestDurationReextract_MultiFileMissingSegmentsSkipped(t *testing.T) {
 	writes := 0
 	books := []database.Book{{ID: "bm", Title: "Multi", FilePath: "/lib/Multi", Duration: intPtr(100)}}
 	store := &database.MockStore{
-		CountBooksFunc:  func() (int, error) { return len(books), nil },
+		CountBooksFunc: func() (int, error) { return len(books), nil },
 		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
 			if offset >= len(books) {
 				return nil, nil
@@ -187,5 +187,118 @@ func TestDurationReextract_MultiFileMissingSegmentsSkipped(t *testing.T) {
 	}
 	if writes != 0 {
 		t.Errorf("multi-file book with missing segments must be skipped, got %d writes", writes)
+	}
+}
+
+// TestDurationReextract_FingerprintDurationFirst is the v3 contract: when every
+// segment carries a stored fingerprint duration (AcoustIDFingerprintDurationSec),
+// the op corrects Book.Duration from those values WITHOUT touching the
+// filesystem. The segment paths below do not exist on disk — under the v2 logic
+// (os.Stat first) the whole book would be skipped, so a successful UpdateBookFile
+// proves the fingerprint-first fast path ran with zero ffprobe/stat calls. Only
+// the drifted segment is written; the already-correct one is left alone.
+func TestDurationReextract_FingerprintDurationFirst(t *testing.T) {
+	var written []database.BookFile
+	books := []database.Book{{ID: "bf", Title: "Fingerprinted", FilePath: "/lib/Fingerprinted", Duration: intPtr(120)}}
+	store := &database.MockStore{
+		CountBooksFunc: func() (int, error) { return len(books), nil },
+		GetAllBooksFunc: func(_, offset int) ([]database.Book, error) {
+			if offset >= len(books) {
+				return nil, nil
+			}
+			return books, nil
+		},
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				// Stored Duration wildly wrong (the estimate bug); fingerprint says 1800s.
+				{ID: "s1", BookID: "bf", FilePath: "/nonexistent/01.mp3", Duration: 50, AcoustIDFingerprintDurationSec: 1800.0},
+				// Stored Duration already within tolerance of the fingerprint value.
+				{ID: "s2", BookID: "bf", FilePath: "/nonexistent/02.mp3", Duration: 1801, AcoustIDFingerprintDurationSec: 1800.0},
+			}, nil
+		},
+		UpdateBookFileFunc: func(_ string, f *database.BookFile) error {
+			written = append(written, *f)
+			return nil
+		},
+	}
+	p := New(fakeDeps{store: store})
+	if err := p.runDurationReextract(context.Background(), mustReextractParams(t, false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(written) != 1 {
+		t.Fatalf("expected exactly 1 segment write (the drifted one), got %d", len(written))
+	}
+	if written[0].ID != "s1" {
+		t.Errorf("expected segment s1 to be corrected, got %q", written[0].ID)
+	}
+	if written[0].Duration != 1800 {
+		t.Errorf("corrected segment Duration = %d, want 1800 (rounded fingerprint)", written[0].Duration)
+	}
+}
+
+// TestDurationReextract_MixedFingerprintAndFfprobe verifies the fallback: a book
+// with one fingerprinted segment and one never-fingerprinted segment. The
+// fingerprinted segment is sourced from the stored value; the other must fall to
+// ffprobe. Here the ffprobe segment's file does not exist, so ffprobe fails and
+// the whole book is skipped (trust invariant) — proving the missing fingerprint
+// genuinely routed to the slow path rather than being silently treated as zero.
+func TestDurationReextract_MixedFingerprintAndFfprobe(t *testing.T) {
+	writes := 0
+	books := []database.Book{{ID: "bm", Title: "Mixed", FilePath: "/lib/Mixed", Duration: intPtr(120)}}
+	store := &database.MockStore{
+		CountBooksFunc: func() (int, error) { return len(books), nil },
+		GetAllBooksFunc: func(_, offset int) ([]database.Book, error) {
+			if offset >= len(books) {
+				return nil, nil
+			}
+			return books, nil
+		},
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{ID: "s1", BookID: "bm", FilePath: "/nonexistent/01.mp3", Duration: 50, AcoustIDFingerprintDurationSec: 1800.0},
+				{ID: "s2", BookID: "bm", FilePath: "/nonexistent/02.mp3", Duration: 50}, // no fingerprint → ffprobe → missing file
+			}, nil
+		},
+		UpdateBookFileFunc: func(_ string, _ *database.BookFile) error { writes++; return nil },
+		UpdateBookFunc:     func(_ string, b *database.Book) (*database.Book, error) { writes++; return b, nil },
+	}
+	p := New(fakeDeps{store: store})
+	if err := p.runDurationReextract(context.Background(), mustReextractParams(t, false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if writes != 0 {
+		t.Errorf("book with an unreadable non-fingerprinted segment must be skipped, got %d writes", writes)
+	}
+}
+
+// TestDurationReextract_FingerprintIdempotent verifies a re-run over already-correct
+// books writes nothing: every segment's stored Duration already matches its
+// fingerprint duration within tolerance, so there is nothing to correct.
+func TestDurationReextract_FingerprintIdempotent(t *testing.T) {
+	writes := 0
+	books := []database.Book{{ID: "bi", Title: "Correct", FilePath: "/lib/Correct", Duration: intPtr(3600)}}
+	store := &database.MockStore{
+		CountBooksFunc: func() (int, error) { return len(books), nil },
+		GetAllBooksFunc: func(_, offset int) ([]database.Book, error) {
+			if offset >= len(books) {
+				return nil, nil
+			}
+			return books, nil
+		},
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{ID: "s1", BookID: "bi", FilePath: "/nonexistent/01.mp3", Duration: 1800, AcoustIDFingerprintDurationSec: 1800.0},
+				{ID: "s2", BookID: "bi", FilePath: "/nonexistent/02.mp3", Duration: 1800, AcoustIDFingerprintDurationSec: 1800.0},
+			}, nil
+		},
+		UpdateBookFileFunc: func(_ string, _ *database.BookFile) error { writes++; return nil },
+		UpdateBookFunc:     func(_ string, b *database.Book) (*database.Book, error) { writes++; return b, nil },
+	}
+	p := New(fakeDeps{store: store})
+	if err := p.runDurationReextract(context.Background(), mustReextractParams(t, false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if writes != 0 {
+		t.Errorf("already-correct book must be skipped on re-run, got %d writes", writes)
 	}
 }


### PR DESCRIPTION
## Summary

- **v3 fingerprint-first fast path**: reads `BookFile.AcoustIDFingerprintDurationSec` (stored by fpcalc during whole-file fingerprinting) as the authoritative per-segment duration — no stat, no subprocess — for ~275K fingerprinted files. ffprobe (`mediainfo.Extract`) is the fallback only for never-fingerprinted files.
- **Trust invariant preserved**: a book is corrected only when every segment yields a real (non-estimated) duration. A single missing/unreadable segment skips the whole book.
- **Telemetry split**: dry-run summary now reports `from-fingerprint=N from-ffprobe=N` so the fast/slow split is visible before applying.
- **Design spec**: `docs/specs/2026-06-21-duration-reextract-v3-design.md`
- **9 tests** covering: fast path (nonexistent paths prove zero filesystem I/O), mixed fingerprint+ffprobe trust invariant, idempotency, dry-run safety, empty library, nil params.
- CHANGELOG.md and TODO.md updated (AP-3 marked resolved).

## Pre-existing test note

`internal/server` has a pre-existing bleve goroutine teardown timeout (~10min) that is unrelated to these changes (no files in `internal/server` were modified). All other packages pass.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/plugins/maintenance/... -count=1 -run TestDuration` — 9/9 pass
- [x] `go test $(go list ./... | grep -v internal/server$)` — all pass, no failures
- [ ] Prod dry-run: `maintenance.duration-reextract` with `dryRun: true` — verify `from-fingerprint` count is ~275K and no `~120s` durations in examples (would indicate fpcalc `-length` cap regression)
- [ ] Prod apply: `dryRun: false` after dry-run confirms correct split

🤖 Generated with [Claude Code](https://claude.com/claude-code)