### PR TITLE
fix(ops): in-memory atomic progress clock prevents false watchdog cancels

### DIFF
--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
-// last-edited: 2026-06-01
+// last-edited: 2026-06-22
 
 package registry
 
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -61,10 +62,19 @@ type dbReporter struct {
 
 	progressMu          sync.Mutex
 	progressCurrent     int
+	progressTotal       int
 	lastProgressMessage string
+	progressGen         atomic.Uint64 // incremented on every UpdateProgress; flush goroutine tracks last-flushed gen
 
 	// setCurrentItemFn, if non-nil, updates the runHandle's in-memory label.
 	setCurrentItemFn func(string)
+	// touchProgressFn, if non-nil, stamps the owning runHandle's lastProgressAt
+	// atomic nanosecond clock. Called at the very top of UpdateProgress before
+	// any lock or DB write, so the watchdog always sees a fresh timestamp even
+	// when UpdateOpProgressV2 is blocked behind PebbleDB compaction.
+	touchProgressFn      func()
+	synchronous          bool          // legacy: write DB on every UpdateProgress
+	progressFlushInterval time.Duration // how often lazy flush fires (0 = no lazy flush)
 
 	runCtx context.Context
 }
@@ -110,6 +120,8 @@ func (h *fanoutHandler) WithGroup(name string) slog.Handler {
 
 // NewDBReporterForTest is an exported wrapper around newDBReporter for use in
 // external _test packages. Do not use in production code.
+// NewDBReporterForTest creates a synchronous (legacy-mode) DB reporter for
+// tests that assert on immediate DB state after UpdateProgress.
 func NewDBReporterForTest(
 	runCtx context.Context,
 	opID, defID, plugin, traceID, spanID string,
@@ -117,7 +129,20 @@ func NewDBReporterForTest(
 	bus Bus,
 	logger *slog.Logger,
 ) Reporter {
-	return newDBReporter(runCtx, opID, defID, "", plugin, traceID, spanID, store, bus, nil, logger, nil)
+	return newDBReporter(runCtx, opID, defID, "", plugin, traceID, spanID, store, bus, nil, logger, nil, nil, 0, true)
+}
+
+// NewDBReporterForTestWithTouch creates a reporter with a custom touchFn for
+// tests that verify the in-memory atomic clock path.
+func NewDBReporterForTestWithTouch(
+	runCtx context.Context,
+	opID, defID, plugin, traceID, spanID string,
+	store database.OpsV2Store,
+	bus Bus,
+	logger *slog.Logger,
+	touchFn func(),
+) Reporter {
+	return newDBReporter(runCtx, opID, defID, "", plugin, traceID, spanID, store, bus, nil, logger, nil, touchFn, 0, false)
 }
 
 // newDBReporter creates a DB-backed Reporter.
@@ -125,6 +150,9 @@ func NewDBReporterForTest(
 // op_name attribute on every log line; empty falls back to defID.
 // setCurrentItemFn, if non-nil, is called by SetCurrentItem to update
 // the registry's in-memory runHandle without a DB write.
+// touchProgressFn, if non-nil, stamps the owning runHandle's atomic clock.
+// flushInterval controls lazy DB flush cadence (0 = disable lazy flush).
+// synchronous = true writes the DB on every UpdateProgress (legacy).
 func newDBReporter(
 	runCtx context.Context,
 	opID, defID, displayName, plugin, traceID, spanID string,
@@ -133,23 +161,29 @@ func newDBReporter(
 	activityRecorder ActivityRecorder,
 	logger *slog.Logger,
 	setCurrentItemFn func(string),
+	touchProgressFn func(),
+	flushInterval time.Duration,
+	synchronous bool,
 ) Reporter {
 	if displayName == "" {
 		displayName = defID
 	}
 	r := &dbReporter{
-		opID:             opID,
-		defID:            defID,
-		displayName:      displayName,
-		plugin:           plugin,
-		traceID:          traceID,
-		spanID:           spanID,
-		store:            store,
-		bus:              bus,
-		activityRecorder: activityRecorder,
-		flushCh:          make(chan struct{}, 1),
-		runCtx:           runCtx,
-		setCurrentItemFn: setCurrentItemFn,
+		opID:                  opID,
+		defID:                 defID,
+		displayName:           displayName,
+		plugin:                plugin,
+		traceID:               traceID,
+		spanID:                spanID,
+		store:                 store,
+		bus:                   bus,
+		activityRecorder:      activityRecorder,
+		flushCh:               make(chan struct{}, 1),
+		runCtx:                runCtx,
+		setCurrentItemFn:      setCurrentItemFn,
+		touchProgressFn:       touchProgressFn,
+		synchronous:           synchronous,
+		progressFlushInterval: flushInterval,
 	}
 
 	// Every log line emitted via reporter.Logger() inherits these attrs.
@@ -179,22 +213,55 @@ func newDBReporter(
 	return r
 }
 
-// flushLoop is the background goroutine that periodically flushes the log buffer.
+// flushLoop is the background goroutine that periodically flushes the log
+// buffer and, when lazy progress flushing is active, persists the in-memory
+// progress state to the DB for crash-recovery observability.
 func (r *dbReporter) flushLoop(ctx context.Context) {
-	ticker := time.NewTicker(250 * time.Millisecond)
-	defer ticker.Stop()
+	logTicker := time.NewTicker(250 * time.Millisecond)
+	defer logTicker.Stop()
+
+	// Wire lazy progress flush when not in synchronous mode.
+	var progressTickC <-chan time.Time
+	var progressTicker *time.Ticker
+	if !r.synchronous && r.progressFlushInterval > 0 {
+		progressTicker = time.NewTicker(r.progressFlushInterval)
+		progressTickC = progressTicker.C
+		defer progressTicker.Stop()
+	}
+
+	var lastFlushedGen uint64
 	for {
 		select {
 		case <-ctx.Done():
-			// Final flush on shutdown.
 			r.flushLogs()
+			r.flushProgressLazy(&lastFlushedGen) // terminal flush — final state persisted
 			return
-		case <-ticker.C:
+		case <-logTicker.C:
 			r.flushLogs()
 		case <-r.flushCh:
 			r.flushLogs()
+		case <-progressTickC:
+			r.flushProgressLazy(&lastFlushedGen)
 		}
 	}
+}
+
+// flushProgressLazy writes the current in-memory progress to the DB only when
+// it has changed since the last flush (tracked by generation counter).
+func (r *dbReporter) flushProgressLazy(lastFlushedGen *uint64) {
+	cur := r.progressGen.Load()
+	if cur == *lastFlushedGen {
+		return
+	}
+	r.progressMu.Lock()
+	current := r.progressCurrent
+	total := r.progressTotal
+	msg := r.lastProgressMessage
+	r.progressMu.Unlock()
+	if err := r.store.UpdateOpProgressV2(r.opID, current, total, msg); err != nil {
+		slog.Default().Warn("dbReporter: lazy progress flush failed", "op_id", r.opID, "error", err)
+	}
+	*lastFlushedGen = cur
 }
 
 // flushLogs drains logBuf to the DB.
@@ -236,14 +303,25 @@ func (r *dbReporter) flushLogs() {
 
 // UpdateProgress implements Reporter.
 func (r *dbReporter) UpdateProgress(current, total int, message string) error {
+	// Stamp the in-memory atomic clock first — before any lock or DB write.
+	// The watchdog reads this (lock-free) so it never fires due to a blocked
+	// UpdateOpProgressV2 call during PebbleDB L0 compaction.
+	if r.touchProgressFn != nil {
+		r.touchProgressFn()
+	}
+
 	r.progressMu.Lock()
 	last := r.lastProgressMessage
 	r.progressCurrent = current
+	r.progressTotal = total
 	r.lastProgressMessage = message
 	r.progressMu.Unlock()
+	r.progressGen.Add(1)
 
-	if err := r.store.UpdateOpProgressV2(r.opID, current, total, message); err != nil {
-		return err
+	if r.synchronous {
+		if err := r.store.UpdateOpProgressV2(r.opID, current, total, message); err != nil {
+			return err
+		}
 	}
 	if r.bus != nil {
 		_ = r.bus.Publish(r.runCtx, "op.updated", map[string]any{

--- a/internal/operations/registry/reporter_db_test.go
+++ b/internal/operations/registry/reporter_db_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter_db_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-05-06
+// last-edited: 2026-06-22
 
 package registry_test
 
@@ -10,6 +10,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -372,5 +373,37 @@ func TestReporterDB_AttrsAreIncludedInLog(t *testing.T) {
 	}
 	if !found {
 		t.Error("'with attrs' log entry not found")
+	}
+}
+
+// TestReporter_TouchProgressFnCalledOnUpdate verifies that the touchProgressFn
+// closure is called on every UpdateProgress call — proving the in-memory
+// atomic clock is stamped before any DB write can block.
+func TestReporter_TouchProgressFnCalledOnUpdate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var touchCount int64
+	touchFn := func() { atomic.AddInt64(&touchCount, 1) }
+
+	store := newFakeStore()
+	opID := "01TESTOPID000000000000002"
+	now := time.Now().UTC()
+	_ = store.InsertOperationV2(database.OperationV2Row{
+		ID: opID, DefID: "test.def", Plugin: "test-plugin",
+		TraceID: "trace-touch", SpanID: "span-touch", Status: "running",
+		Priority: 1, Params: "{}", QueuedAt: now,
+	})
+
+	rep := registry.NewDBReporterForTestWithTouch(ctx, opID, "test.def", "test-plugin",
+		"trace-touch", "span-touch", store, nil, slog.Default(), touchFn)
+
+	_ = rep.UpdateProgress(10, 100, "first")
+	_ = rep.UpdateProgress(20, 100, "second")
+	_ = rep.UpdateProgress(30, 100, "third")
+
+	got := atomic.LoadInt64(&touchCount)
+	if got != 3 {
+		t.Errorf("expected touchFn called 3 times, got %d", got)
 	}
 }

--- a/internal/operations/registry/subprocess.go
+++ b/internal/operations/registry/subprocess.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/subprocess.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b3c4d5e-6f7a-8901-bcde-f01234567890
-// last-edited: 2026-06-01
+// last-edited: 2026-06-22
 
 // Package registry — subprocess runner for Isolate=true operations.
 //
@@ -124,7 +124,9 @@ func RunChildMode(r *Registry) {
 
 	// Create reporter.
 	ctx := context.Background()
-	reporter := newDBReporter(ctx, opID, def.ID, def.DisplayName, def.Plugin, "", "", r.store, nil, r.activityRecorder, r.logger, nil)
+	// Subprocess runs in a separate process; no runHandle to stamp, so
+	// touchProgressFn is nil and synchronous mode preserves DB writes.
+	reporter := newDBReporter(ctx, opID, def.ID, def.DisplayName, def.Plugin, "", "", r.store, nil, r.activityRecorder, r.logger, nil, nil, 0, true)
 
 	// Run.
 	runErr := def.Run(ctx, hs.Params, reporter)

--- a/internal/operations/registry/types.go
+++ b/internal/operations/registry/types.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/types.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-06-13
+// last-edited: 2026-06-22
 
 // Package registry provides the UOS-02 in-memory OperationDef registry,
 // dispatcher, and in-process worker pool. See the spec at
@@ -48,6 +48,15 @@ type OperationDef struct {
 	// op is considered stuck and its context is canceled.
 	// Zero means "use default 5m".
 	ProgressTimeout time.Duration
+	// ProgressFlushInterval controls how often the lazy background goroutine
+	// persists the in-memory progress clock to the DB for crash-recovery
+	// observability. Zero or negative → default 30s. Greater than 5m → capped
+	// at 5m. Synchronous overrides this (no background flush needed).
+	ProgressFlushInterval time.Duration
+	// Synchronous, if true, writes last_progress_at to the database on every
+	// UpdateProgress call (legacy behaviour). Zero-value = false = in-memory
+	// atomic clock with lazy periodic DB flush.
+	Synchronous bool
 
 	// Concurrency. Required.
 	// ConcurrencyKey: ops with same non-empty key serialize; empty = no serialization.

--- a/internal/operations/registry/watchdog.go
+++ b/internal/operations/registry/watchdog.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/watchdog.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b3c4d5e-6f7a-8901-bcde-f01234567890
-// last-edited: 2026-05-06
+// last-edited: 2026-06-22
 
 package registry
 
@@ -82,11 +82,21 @@ func (r *Registry) watchdogCycle() {
 		if progressTimeout == 0 {
 			progressTimeout = defaultProgressTimeout
 		}
-		if row.LastProgressAt != nil && now.Sub(*row.LastProgressAt) > progressTimeout {
+		// Prefer the in-memory atomic clock over the DB row: if the reporter has
+		// stamped lastProgressAt (non-zero), use it — this avoids false-positive
+		// cancellations when UpdateOpProgressV2 is queued behind PebbleDB L0
+		// compaction. Fall back to the DB row only when the atomic is unset (zero).
+		var lastProgress time.Time
+		if ts := h.lastProgressAt.Load(); ts != 0 {
+			lastProgress = time.Unix(0, ts).UTC()
+		} else if row.LastProgressAt != nil {
+			lastProgress = *row.LastProgressAt
+		}
+		if !lastProgress.IsZero() && now.Sub(lastProgress) > progressTimeout {
 			r.writeStrike(h.id, def.ID, def.Plugin, "stuck",
-				fmt.Sprintf("no progress for %s (timeout=%s)", now.Sub(*row.LastProgressAt).Round(time.Second), progressTimeout))
+				fmt.Sprintf("no progress for %s (timeout=%s)", now.Sub(lastProgress).Round(time.Second), progressTimeout))
 			r.logger.Warn("registry: canceling stuck op", "op_id", h.id, "def_id", def.ID,
-				"idle_since", row.LastProgressAt)
+				"idle_since", lastProgress)
 			h.cancelIfActive()
 			continue // don't also check uncheckpointed for the same op
 		}

--- a/internal/operations/registry/watchdog_test.go
+++ b/internal/operations/registry/watchdog_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/watchdog_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4d5e6f7a-8b9c-0123-def0-1234567890ab
-// last-edited: 2026-05-06
+// last-edited: 2026-06-22
 
 package registry_test
 
@@ -108,6 +108,69 @@ func TestWatchdog_UncheckpointedOpGetsStrike(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Error("expected at least 1 uncheckpointed strike within 500ms, got 0")
+}
+
+// TestWatchdog_InMemoryClockPreventsFalseStuck verifies that the watchdog does
+// NOT fire when the in-memory atomic clock is fresh, even if the DB
+// last_progress_at row is stale — the scenario that occurs when
+// UpdateOpProgressV2 is blocked behind PebbleDB L0 compaction (Scenario A).
+//
+// The op calls UpdateProgress in a loop (keeping the atomic fresh) while the
+// test continuously backdates the DB row (simulating stuck DB writes).
+func TestWatchdog_InMemoryClockPreventsFalseStuck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 30 * time.Millisecond,
+	})
+
+	ready := make(chan struct{})
+	def := makeValidDef("test.wdog-atomic-fresh")
+	def.ResumePolicy = registry.ResumeDrop
+	def.ProgressTimeout = 100 * time.Millisecond
+	def.Run = func(runCtx context.Context, _ json.RawMessage, rep registry.Reporter) error {
+		// Signal that we're inside Run and about to start the loop.
+		close(ready)
+		// Keep calling UpdateProgress every 20ms so the atomic stays fresh.
+		// This simulates an op that is actively making progress but whose DB
+		// writes are queued/blocked.
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-runCtx.Done():
+				return runCtx.Err()
+			case <-ticker.C:
+				i++
+				_ = rep.UpdateProgress(i, 1000, "processing")
+			}
+		}
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.wdog-atomic-fresh", nil)
+	select {
+	case <-ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("op never entered Run")
+	}
+
+	// For 300ms, continuously backdate the DB row to simulate stuck DB writes.
+	// The op's UpdateProgress loop keeps the atomic fresh (every 20ms).
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		stale := time.Now().UTC().Add(-500 * time.Millisecond)
+		store.setLastProgressAt(opID, &stale)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if strikes := store.strikesOfKind(opID, "stuck"); len(strikes) > 0 {
+		t.Errorf("watchdog fired despite fresh in-memory progress clock (got %d stuck strikes)", len(strikes))
+	}
 }
 
 // TestWatchdog_InfiniteRestartForceDrop verifies that an op with resume_count≥3

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.6.0
+// version: 2.8.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-06-14
+// last-edited: 2026-06-22
 
 package registry
 
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
@@ -50,6 +51,10 @@ type runHandle struct {
 	abandoned      bool
 	currentItem    string
 	currentItemMu  sync.Mutex
+	// lastProgressAt is stamped by the reporter on every UpdateProgress call.
+	// Stored as Unix nanoseconds; zero means progress has never been reported.
+	// The watchdog reads this first (lock-free) before falling back to the DB row.
+	lastProgressAt atomic.Int64
 }
 
 // cancelIfActive cancels the run's context if it has been wired up.
@@ -173,12 +178,20 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 
 	r.logger.Info("registry: starting run", "op_id", qr.opID, "def_id", qr.defID)
 
-	// Build reporter (DB-backed). Pass a setter so SetCurrentItem updates
-	// the runHandle's in-memory currentItem without a DB write.
+	// Build reporter (DB-backed). Pass setItemFn so SetCurrentItem updates
+	// the runHandle's in-memory currentItem without a DB write. Pass touchFn
+	// so UpdateProgress stamps lastProgressAt atomically — the watchdog reads
+	// this instead of the DB row, preventing false-positive cancellations when
+	// UpdateOpProgressV2 is blocked behind PebbleDB compaction.
 	setItemFn := func(label string) { h.setCurrentItem(label) }
+	touchFn := func() { h.lastProgressAt.Store(time.Now().UnixNano()) }
+	flushInterval := def.ProgressFlushInterval
+	if flushInterval <= 0 || flushInterval > 5*time.Minute {
+		flushInterval = 30 * time.Second
+	}
 	reporter := newDBReporter(runCtx, qr.opID, qr.defID, def.DisplayName, qr.plugin,
 		"", "", // traceID / spanID loaded from DB row in future; empty for now
-		r.store, r.bus, r.activityRecorder, r.logger, setItemFn)
+		r.store, r.bus, r.activityRecorder, r.logger, setItemFn, touchFn, flushInterval, def.Synchronous)
 
 	// Canonical "operation started" log line, with all the tags downstream
 	// readers (op_log feed, activity-log enricher, digest aggregator) need

--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_reextract.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: 9c2f7a14-6d83-4e51-b0a9-2f5c8e1d4b67
-// last-edited: 2026-06-21
+// last-edited: 2026-06-22
 
 // Package maintenance — op maintenance.duration-reextract.
 //
@@ -188,7 +188,6 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		written       int // actual UpdateBook calls (apply mode)
 		examples      = make([]string, 0, exampleCap)
 		lastLog       = time.Now()
-		offset        int
 	)
 
 	heartbeat := func(force bool) {
@@ -205,196 +204,158 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		lastLog = time.Now()
 	}
 
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		// Keepalive goroutine: fires heartbeats every 60s while GetAllBooks
-		// blocks (e.g. during PebbleDB L0 compaction). Without it, the
-		// 5-minute stuck-op detector cancels us before the first page returns.
-		kaStop := make(chan struct{})
-		go func() {
-			tick := time.NewTicker(60 * time.Second)
-			defer tick.Stop()
-			for {
-				select {
-				case <-tick.C:
-					heartbeat(true)
-				case <-kaStop:
-					return
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
-		heartbeat(true)
-		books, err := store.GetAllBooks(pageSize, offset)
-		close(kaStop)
-		if err != nil {
-			return fmt.Errorf("GetAllBooks offset=%d: %w", offset, err)
-		}
-		if len(books) == 0 {
-			break
-		}
+	// errLimitReached signals PageBooks to stop iteration when params.Limit is hit.
+	// It is not propagated to the caller.
+	errLimitReached := fmt.Errorf("limit reached")
 
-		for i := range books {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			if params.Limit > 0 && examined >= params.Limit {
-				break
-			}
-			book := books[i]
-			examined++
-
-			// Compute the book's REAL duration. Multi-file books store audio across
-			// BookFiles (Book.FilePath may even be a directory); virtual single-file
-			// books carry it on Book.FilePath. We require EVERY present segment to
-			// yield a real (non-estimated) ffprobe duration, else the book total
-			// can't be trusted and we skip it.
-			segs, _ := store.GetBookFiles(book.ID)
-
-			var (
-				newDur      int
-				changedBFs  []database.BookFile
-				skip        bool
-				usedFfprobe bool // this book needed ≥1 ffprobe call (slow tail)
-			)
-
-			if len(segs) > 0 {
-				for si := range segs {
-					f := segs[si]
-					if f.FilePath == "" {
-						continue // pathless segment contributes nothing; tolerate
-					}
-					// v3 fast path: fingerprinting already measured and stored the real
-					// decode duration. Trust it as authoritative — no stat, no ffprobe.
-					// Only segments never fingerprinted fall through to the slow ffprobe
-					// path below.
-					var segDur int
-					if f.AcoustIDFingerprintDurationSec > 0 {
-						segDur = int(math.Round(f.AcoustIDFingerprintDurationSec))
-					} else {
-						usedFfprobe = true
-						info, mErr := extractWithTimeout(ctx, f.FilePath)
-						if mErr != nil || info == nil || info.Duration <= 0 {
-							readErr++
-							skip = true
-							break
-						}
-						if info.DurationEstimated {
-							estimated++
-							skip = true
-							break
-						}
-						segDur = info.Duration
-					}
-					newDur += segDur
-					if durationDiffMeaningful(f.Duration, segDur) {
-						nf := f
-						nf.Duration = segDur
-						changedBFs = append(changedBFs, nf)
-					}
-				}
-			} else {
-				// Virtual single-file book: no BookFile rows means no stored fingerprint
-				// duration, so always probe Book.FilePath directly.
-				usedFfprobe = true
-				if book.FilePath == "" {
-					noPath++
-					continue
-				}
-				info, mErr := extractWithTimeout(ctx, book.FilePath)
-				if mErr != nil || info == nil || info.Duration <= 0 {
-					readErr++
-					continue
-				}
-				if info.DurationEstimated {
-					estimated++
-					continue
-				}
-				newDur = info.Duration
-			}
-			if skip || newDur <= 0 {
-				continue
-			}
-			eligible++
-			if usedFfprobe {
-				ffprobeBooks++
-			} else {
-				fpBooks++
-			}
-
-			oldDur := 0
-			if book.Duration != nil {
-				oldDur = *book.Duration
-			}
-			if !durationDiffMeaningful(oldDur, newDur) && len(changedBFs) == 0 {
-				continue // book total + every segment already correct — idempotent skip
-			}
-			wouldChange++
-			if oldDur > 0 {
-				ratio := float64(newDur) / float64(oldDur)
-				if ratio >= 1.8 && ratio <= 2.2 {
-					roughlyDouble++
-				}
-			}
-			if len(examples) < exampleCap {
-				examples = append(examples, fmt.Sprintf("%s %ds→%ds (%d seg)", book.ID, oldDur, newDur, len(segs)))
-			}
-
-			if !params.DryRun {
-				// Correct each changed segment first. UpdateBookFile is full-replace,
-				// but segs came from pebble-direct GetBookFiles so every field incl.
-				// the fingerprint is intact; it also refreshes memdb.
-				for ci := range changedBFs {
-					cf := changedBFs[ci]
-					if uErr := store.UpdateBookFile(cf.ID, &cf); uErr != nil {
-						_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
-							"book %s seg %s: UpdateBookFile failed: %v", book.ID, cf.ID, uErr))
-						readErr++
-					}
-				}
-				if len(segs) > 0 {
-					// Canonical aggregator: sums the (now-corrected) segment durations
-					// into Book.Duration.
-					if rErr := store.RecomputeBookAggregates(book.ID); rErr != nil {
-						_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
-							"book %s: RecomputeBookAggregates failed: %v", book.ID, rErr))
-						readErr++
-						continue
-					}
-				} else {
-					full, gErr := store.GetBookByID(book.ID)
-					if gErr != nil || full == nil {
-						_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
-							"book %s: GetBookByID failed: %v", book.ID, gErr))
-						readErr++
-						continue
-					}
-					nd := newDur
-					full.Duration = &nd
-					if _, uErr := store.UpdateBook(book.ID, full); uErr != nil {
-						_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
-							"book %s: UpdateBook failed: %v", book.ID, uErr))
-						readErr++
-						continue
-					}
-				}
-				written++
-			}
-
-			heartbeat(false)
-		}
-
-		offset += len(books)
+	iterErr := sdk.PageBooks(ctx, store, reporter, pageSize, func(book database.Book) error {
 		if params.Limit > 0 && examined >= params.Limit {
-			break
+			return errLimitReached
 		}
-		if len(books) < pageSize {
-			break
+		examined++
+
+		// Compute the book's REAL duration. Multi-file books store audio across
+		// BookFiles (Book.FilePath may even be a directory); virtual single-file
+		// books carry it on Book.FilePath. We require EVERY present segment to
+		// yield a real (non-estimated) ffprobe duration, else the book total
+		// can't be trusted and we skip it.
+		segs, _ := store.GetBookFiles(book.ID)
+
+		var (
+			newDur      int
+			changedBFs  []database.BookFile
+			skip        bool
+			usedFfprobe bool // this book needed ≥1 ffprobe call (slow tail)
+		)
+
+		if len(segs) > 0 {
+			for si := range segs {
+				f := segs[si]
+				if f.FilePath == "" {
+					continue // pathless segment contributes nothing; tolerate
+				}
+				// v3 fast path: fingerprinting already measured and stored the real
+				// decode duration. Trust it as authoritative — no stat, no ffprobe.
+				// Only segments never fingerprinted fall through to the slow ffprobe
+				// path below.
+				var segDur int
+				if f.AcoustIDFingerprintDurationSec > 0 {
+					segDur = int(math.Round(f.AcoustIDFingerprintDurationSec))
+				} else {
+					usedFfprobe = true
+					info, mErr := extractWithTimeout(ctx, f.FilePath)
+					if mErr != nil || info == nil || info.Duration <= 0 {
+						readErr++
+						skip = true
+						break
+					}
+					if info.DurationEstimated {
+						estimated++
+						skip = true
+						break
+					}
+					segDur = info.Duration
+				}
+				newDur += segDur
+				if durationDiffMeaningful(f.Duration, segDur) {
+					nf := f
+					nf.Duration = segDur
+					changedBFs = append(changedBFs, nf)
+				}
+			}
+		} else {
+			// Virtual single-file book: no BookFile rows means no stored fingerprint
+			// duration, so always probe Book.FilePath directly.
+			usedFfprobe = true
+			if book.FilePath == "" {
+				noPath++
+				return nil
+			}
+			info, mErr := extractWithTimeout(ctx, book.FilePath)
+			if mErr != nil || info == nil || info.Duration <= 0 {
+				readErr++
+				return nil
+			}
+			if info.DurationEstimated {
+				estimated++
+				return nil
+			}
+			newDur = info.Duration
 		}
+		if skip || newDur <= 0 {
+			return nil
+		}
+		eligible++
+		if usedFfprobe {
+			ffprobeBooks++
+		} else {
+			fpBooks++
+		}
+
+		oldDur := 0
+		if book.Duration != nil {
+			oldDur = *book.Duration
+		}
+		if !durationDiffMeaningful(oldDur, newDur) && len(changedBFs) == 0 {
+			return nil // book total + every segment already correct — idempotent skip
+		}
+		wouldChange++
+		if oldDur > 0 {
+			ratio := float64(newDur) / float64(oldDur)
+			if ratio >= 1.8 && ratio <= 2.2 {
+				roughlyDouble++
+			}
+		}
+		if len(examples) < exampleCap {
+			examples = append(examples, fmt.Sprintf("%s %ds→%ds (%d seg)", book.ID, oldDur, newDur, len(segs)))
+		}
+
+		if !params.DryRun {
+			// Correct each changed segment first. UpdateBookFile is full-replace,
+			// but segs came from pebble-direct GetBookFiles so every field incl.
+			// the fingerprint is intact; it also refreshes memdb.
+			for ci := range changedBFs {
+				cf := changedBFs[ci]
+				if uErr := store.UpdateBookFile(cf.ID, &cf); uErr != nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s seg %s: UpdateBookFile failed: %v", book.ID, cf.ID, uErr))
+					readErr++
+				}
+			}
+			if len(segs) > 0 {
+				// Canonical aggregator: sums the (now-corrected) segment durations
+				// into Book.Duration.
+				if rErr := store.RecomputeBookAggregates(book.ID); rErr != nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s: RecomputeBookAggregates failed: %v", book.ID, rErr))
+					readErr++
+					return nil
+				}
+			} else {
+				full, gErr := store.GetBookByID(book.ID)
+				if gErr != nil || full == nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s: GetBookByID failed: %v", book.ID, gErr))
+					readErr++
+					return nil
+				}
+				nd := newDur
+				full.Duration = &nd
+				if _, uErr := store.UpdateBook(book.ID, full); uErr != nil {
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+						"book %s: UpdateBook failed: %v", book.ID, uErr))
+					readErr++
+					return nil
+				}
+			}
+			written++
+		}
+
 		heartbeat(false)
+		return nil
+	})
+	if iterErr != nil && iterErr != errLimitReached {
+		return fmt.Errorf("book scan: %w", iterErr)
 	}
 
 	verb := "would correct"

--- a/pkg/plugin/sdk/iterate.go
+++ b/pkg/plugin/sdk/iterate.go
@@ -1,0 +1,91 @@
+// file: pkg/plugin/sdk/iterate.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
+// last-edited: 2026-06-22
+
+package sdk
+
+import (
+	"context"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// BookStore is the narrow interface PageBooks needs — a paginated book reader.
+type BookStore interface {
+	GetAllBooks(limit, offset int) ([]database.Book, error)
+}
+
+// PageBooks calls fn for every book in the library, paging at pageSize.
+//
+// During each blocking GetAllBooks call, a keepalive goroutine fires
+// reporter.UpdateProgress every 60s so the stuck-op watchdog does not cancel
+// the operation while the DB read is in progress (Scenario B: memdb rebuild or
+// raidz2 full scan taking longer than ProgressTimeout).
+//
+// With the in-memory atomic clock fix in place, those UpdateProgress stamps
+// are lock-free and instant even under PebbleDB compaction.
+//
+// pageSize of 0 defaults to 500. fn returning a non-nil error stops iteration
+// and that error is returned; context cancellation is also checked between pages.
+func PageBooks(
+	ctx context.Context,
+	store BookStore,
+	reporter Reporter,
+	pageSize int,
+	fn func(database.Book) error,
+) error {
+	if pageSize <= 0 {
+		pageSize = 500
+	}
+	offset := 0
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Start keepalive goroutine only for the duration of the GetAllBooks call.
+		// close(stop) immediately after the call so we never over-stamp progress
+		// while fn is doing real work.
+		stop := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(60 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					_ = reporter.UpdateProgress(0, 0, "")
+				}
+			}
+		}()
+
+		books, err := store.GetAllBooks(pageSize, offset)
+		close(stop) // keepalive exits immediately after DB read completes
+
+		if err != nil {
+			return err
+		}
+		if len(books) == 0 {
+			return nil
+		}
+
+		for _, b := range books {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err := fn(b); err != nil {
+				return err
+			}
+		}
+
+		if len(books) < pageSize {
+			return nil // last page
+		}
+		offset += pageSize
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `maintenance.duration-reextract` was repeatedly cancelled by the stuck-op watchdog (5-minute threshold) due to two distinct scenarios — DB writes blocked by PebbleDB L0 compaction (Scenario A) and `GetAllBooks` blocking for 5+ minutes during memdb rebuild on raidz2 spinning disks (Scenario B)
- **Fix A**: `runHandle` gains `lastProgressAt atomic.Int64`; reporter's `touchProgressFn` closure stamps it on every `UpdateProgress` call *before* any lock or DB write; watchdog reads the atomic first (lock-free) and only falls back to the DB row when the atomic is zero
- **Fix B**: New `sdk.PageBooks` helper wraps pagination with a scoped keepalive goroutine (active only during each `GetAllBooks` call); `duration_reextract.go` replaces its manual pagination loop and keepalive goroutine with a single `sdk.PageBooks` call

## Changes

| File | Change |
|------|--------|
| `internal/operations/registry/types.go` | `OperationDef` gains `Synchronous bool` + `ProgressFlushInterval time.Duration` |
| `internal/operations/registry/worker.go` | `lastProgressAt atomic.Int64` on `runHandle`; `touchFn` + clamped `flushInterval` wired into reporter |
| `internal/operations/registry/reporter_db.go` | Stamps atomic in `UpdateProgress`; lazy flush goroutine (default 30s, configurable up to 5m); terminal flush on ctx cancel; `Synchronous` gate |
| `internal/operations/registry/watchdog.go` | Atomic fast-path check before DB `LastProgressAt` for stuck detection |
| `pkg/plugin/sdk/iterate.go` *(new)* | `PageBooks` — pagination + keepalive goroutine scoped to each `GetAllBooks` call |
| `internal/plugins/maintenance/duration_reextract.go` | Replaced manual pagination + keepalive with `sdk.PageBooks` |
| Tests | `TestWatchdog_InMemoryClockPreventsFalseStuck`, `TestReporter_TouchProgressFnCalledOnUpdate` |

## Test plan

- [x] `go test ./internal/operations/registry/... -count=1 -race` — all pass (25s)
- [x] `go test ./pkg/plugin/sdk/...` — all pass
- [x] `go test ./internal/plugins/maintenance/...` — all pass
- [x] `make build-api` — clean build
- [ ] Deploy to prod, re-enqueue `maintenance.duration-reextract` with `dryRun=false`, verify it completes all ~29K books without watchdog cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)