### PR TITLE
fix(frontend): FE-2/3/4/7 stale deps and token-in-state

### DIFF
--- a/web/src/components/settings/APIKeysTab.tsx
+++ b/web/src/components/settings/APIKeysTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/APIKeysTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-fabc-456789012345
-// last-edited: 2026-06-19
+// last-edited: 2026-06-22
 
 import { useState, useEffect, useRef } from 'react';
 import {
@@ -191,10 +191,11 @@ export function APIKeysTab() {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      // Schedule reset with cleanup protection
+      // Schedule reset with cleanup protection; clear token from state after confirmation (FE-7).
       timeoutRef.current = setTimeout(() => {
         if (!isUnmountedRef.current) {
           setCopied(false);
+          setCreatedToken(null);
         }
         timeoutRef.current = null;
       }, 2000);

--- a/web/src/components/settings/TempLoginTab.tsx
+++ b/web/src/components/settings/TempLoginTab.tsx
@@ -1,12 +1,13 @@
 // file: web/src/components/settings/TempLoginTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
+// last-edited: 2026-06-22
 
 // Settings tab: pick a user, mint a 15-min single-use login URL,
 // copy it to the clipboard. Useful for signing yourself in on a new
 // phone / browser without typing a password.
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -31,6 +32,16 @@ export function TempLoginTab() {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<api.TempLoginTokenResponse | null>(null);
   const [error, setError] = useState('');
+  const clearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Auto-clear token from state 30s after display (FE-7).
+  useEffect(() => {
+    if (!result) return;
+    clearRef.current = setTimeout(() => setResult(null), 30_000);
+    return () => {
+      if (clearRef.current) clearTimeout(clearRef.current);
+    };
+  }, [result]);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,6 +86,8 @@ export function TempLoginTab() {
     try {
       await navigator.clipboard.writeText(result.login_url);
       toast('Login URL copied to clipboard', 'success');
+      if (clearRef.current) clearTimeout(clearRef.current);
+      setResult(null);
     } catch {
       toast('Could not copy — select the URL and copy manually', 'warning');
     }

--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.17.0
+// version: 2.18.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-17
+// last-edited: 2026-06-22
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -381,7 +381,7 @@ export default function ActivityLog() {
       setRefreshing(false);
       setLastUpdated(new Date());
     }
-  }, [typeFilter, levelFilter, operationId, sinceFilter, untilFilter, search, excludedSources, tiers, hideNoOp, tagFilter]);
+  }, [typeFilter, levelFilter, operationId, sinceFilter, untilFilter, search, excludedSources, tiers, hideNoOp, tagFilter, pageSize]);
 
   // Initial load + polling for active ops (3s when Activity page is mounted or
   // bell is open). The interval was unconditional before — toggling

--- a/web/src/pages/BookDedup.tsx
+++ b/web/src/pages/BookDedup.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDedup.tsx
-// version: 3.29.0
+// version: 3.30.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-book0dedup02
-// last-edited: 2026-06-11
+// last-edited: 2026-06-22
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSearchParams, useNavigate, Link as RouterLink } from 'react-router-dom';
@@ -2270,7 +2270,7 @@ function AcousticDedupTab() {
     } finally {
       setLoading(false);
     }
-  }, [page]);
+  }, [page, rowsPerPage]);
 
   useEffect(() => { loadCandidates(); }, [loadCandidates]);
 

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDetail.tsx
-// version: 1.50.1
+// version: 1.51.0
 // guid: 4d2f7c6a-1b3e-4c5d-8f7a-9b0c1d2e3f4a
-// last-edited: 2026-05-02
+// last-edited: 2026-06-22
 
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -217,6 +217,13 @@ export const BookDetail = () => {
       toast('Failed to link version', 'error');
     }
   };
+
+  // Reset file/segment state when navigating between books (FE-4).
+  useEffect(() => {
+    setSegmentsLoaded(false);
+    setBookFiles([]);
+    setSegments([]);
+  }, [id]);
 
   // Load book files from the canonical book_files endpoint.
   // Falls back to legacy segments endpoint if book_files is unavailable.


### PR DESCRIPTION
## Summary
- **FE-2** `ActivityLog`: `pageSize` was missing from `loadFeed` useCallback deps — changing page size used a stale closure and fetched with the old value
- **FE-3** `BookDedup`: `rowsPerPage` missing from `loadCandidates` deps — same stale-closure pattern
- **FE-4** `BookDetail`: navigating between books left `segmentsLoaded=true`, so the new book's files never loaded; reset effect on `id` change fixes this
- **FE-7** `TempLoginTab`/`APIKeysTab`: one-time tokens remained in React state indefinitely — `TempLoginTab` now auto-clears 30s after mint (and immediately on copy); `APIKeysTab` clears 2s after the copy-confirmed indicator resets

## Test plan
- [x] `make web-test` — 44 test files, 300 tests, all pass

Closes FE-2, FE-3, FE-4, FE-7 from `docs/tracking/audit-remediation-2026-06.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SraMucbUpin5Qf2EmH75bU