### PR TITLE
perf(dedup): PERF-1 entity secondary index for O(k) candidate lookup

### DIFF
--- a/internal/database/embedding_candidates_test.go
+++ b/internal/database/embedding_candidates_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/embedding_candidates_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: f3e2d1c0-b9a8-4765-8e7d-6f5c4b3a2190
+// last-edited: 2026-06-22
 
 package database
 
@@ -536,4 +537,71 @@ func TestCanonicalizeCandidates_Cleanup(t *testing.T) {
 			"all rows should have entity_a_id <= entity_b_id after canonicalize, got (%s, %s)",
 			c.EntityAID, c.EntityBID)
 	}
+}
+
+func TestListCandidatesForEntity(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// book "b1" is paired with b2 and b3; b2 and b3 also have a pair with each other.
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Similarity: floatPtr(0.95), Status: "pending"}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b1", EntityBID: "b3", Layer: "embedding", Similarity: floatPtr(0.80), Status: "dismissed"}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b2", EntityBID: "b3", Layer: "embedding", Similarity: floatPtr(0.70), Status: "pending"}))
+
+	// b1 appears in 2 pairs; filtered by status it's 1.
+	all, err := store.ListCandidatesForEntity("book", "b1", "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2, "b1 is in 2 pairs")
+
+	pending, err := store.ListCandidatesForEntity("book", "b1", "pending")
+	require.NoError(t, err)
+	assert.Len(t, pending, 1)
+	assert.Equal(t, "pending", pending[0].Status)
+
+	// b2 appears in 2 pairs (b1-b2 and b2-b3).
+	b2All, err := store.ListCandidatesForEntity("book", "b2", "")
+	require.NoError(t, err)
+	assert.Len(t, b2All, 2)
+
+	// Entity with no pairs returns empty slice, not error.
+	none, err := store.ListCandidatesForEntity("book", "bX", "")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+func TestBackfillEntityIndex(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Write two candidates via the normal path (entity index is written automatically).
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending"}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b3", EntityBID: "b4", Layer: "embedding", Status: "pending"}))
+
+	// BackfillEntityIndex is idempotent — running twice should not error or duplicate.
+	n1, err := store.BackfillEntityIndex()
+	require.NoError(t, err)
+	assert.Equal(t, 2, n1)
+
+	n2, err := store.BackfillEntityIndex()
+	require.NoError(t, err)
+	assert.Equal(t, 2, n2)
+
+	// Entity index lookups should still return correct results after backfill.
+	got, err := store.ListCandidatesForEntity("book", "b1", "")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+}
+
+func TestDeleteCandidate_CleansEntityIndex(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending"}))
+
+	before, err := store.ListCandidatesForEntity("book", "b1", "")
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	require.NoError(t, store.DeleteCandidate(before[0].ID))
+
+	after, err := store.ListCandidatesForEntity("book", "b1", "")
+	require.NoError(t, err)
+	assert.Empty(t, after, "entity index entries should be removed on delete")
 }

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.3.1
-// last-edited: 2026-06-13
+// version: 2.4.0
+// last-edited: 2026-06-22
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -76,14 +76,16 @@ func init() {
 //	emb:c:<model>:<textHash>        → raw float32 blob  (content-hash cache)
 //	dedup:r:<id16hex>               → candRec JSON      (dedup candidate)
 //	dedup:p:<type>:<aID>:<bID>      → id16hex           (pair uniqueness index)
+//	dedup:e:<type>:<entityID>:<id16hex> → empty         (entity secondary index — both sides)
 //	dedup:seq                       → [8]byte LE int64  (auto-increment counter)
 //	dedup:label:<id16hex>           → LabeledExample JSON   (dataset labels)
 const (
-	embVecPfx    = "emb:v:"
-	embCachePfx  = "emb:c:"
-	dedupRecPfx  = "dedup:r:"
-	dedupPairPfx = "dedup:p:"
-	dedupSeqKey  = "dedup:seq"
+	embVecPfx      = "emb:v:"
+	embCachePfx    = "emb:c:"
+	dedupRecPfx    = "dedup:r:"
+	dedupPairPfx   = "dedup:p:"
+	dedupEntityPfx = "dedup:e:"
+	dedupSeqKey    = "dedup:seq"
 )
 
 // embRec is the stored value for a vector embedding.
@@ -431,6 +433,13 @@ func dedupPairKey(entityType, aID, bID string) []byte {
 	return []byte(dedupPairPfx + entityType + ":" + aID + ":" + bID)
 }
 
+// dedupEntityKey builds a secondary-index key for one side of a candidate pair.
+// Both entity_a and entity_b get their own entry so prefix-scanning
+// "dedup:e:<type>:<entityID>:" yields all candidates for that entity in O(k).
+func dedupEntityKey(entityType, entityID string, id int64) []byte {
+	return []byte(fmt.Sprintf("%s%s:%s:%016x", dedupEntityPfx, entityType, entityID, id))
+}
+
 // nextID reads and increments the sequential counter. Must be called with s.mu held.
 // The new counter value is written into the supplied batch so counter + record land atomically.
 func (s *EmbeddingStore) nextID(b *pebble.Batch) (int64, error) {
@@ -509,6 +518,13 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 		if err := b.Set(pairKey, []byte(fmt.Sprintf("%016x", id)), nil); err != nil {
 			return err
 		}
+		// Entity secondary index — both sides, so prefix-scan by entity is O(k).
+		if err := b.Set(dedupEntityKey(c.EntityType, c.EntityAID, id), nil, nil); err != nil {
+			return err
+		}
+		if err := b.Set(dedupEntityKey(c.EntityType, c.EntityBID, id), nil, nil); err != nil {
+			return err
+		}
 		return b.Commit(pebble.Sync)
 	}
 
@@ -571,6 +587,13 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 		return fmt.Errorf("marshal updated candidate: %w", err)
 	}
 	if err := b.Set(dedupRecKey(id), data, nil); err != nil {
+		return err
+	}
+	// Idempotent: ensure entity index entries exist (backfills pre-index records).
+	if err := b.Set(dedupEntityKey(existing.EntityType, existing.EntityAID, id), nil, nil); err != nil {
+		return err
+	}
+	if err := b.Set(dedupEntityKey(existing.EntityType, existing.EntityBID, id), nil, nil); err != nil {
 		return err
 	}
 	return b.Commit(pebble.Sync)
@@ -676,6 +699,97 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 	return all[start:end], total, nil
 }
 
+// ListCandidatesForEntity returns all dedup candidates that involve the given
+// entity on either side, using the "dedup:e:" secondary index for O(k) lookup
+// instead of a full-table scan. status="" returns all statuses.
+func (s *EmbeddingStore) ListCandidatesForEntity(entityType, entityID, status string) ([]DedupCandidate, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	prefix := []byte(dedupEntityPfx + entityType + ":" + entityID + ":")
+	upper := prefixUpperBound(prefix)
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, fmt.Errorf("entity index scan: %w", err)
+	}
+	defer iter.Close()
+
+	pfxLen := len(dedupEntityPfx) + len(entityType) + 1 + len(entityID) + 1
+	var results []DedupCandidate
+	for iter.First(); iter.Valid(); iter.Next() {
+		idHex := string(iter.Key()[pfxLen:])
+		id, err := strconv.ParseInt(idHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		val, closer, err := s.db.Get(dedupRecKey(id))
+		if err == pebble.ErrNotFound {
+			continue // stale index entry — tolerated, cleaned up on next UpsertCandidate
+		}
+		if err != nil {
+			return nil, fmt.Errorf("entity candidate fetch %d: %w", id, err)
+		}
+		var rec candRec
+		unmarshalErr := json.Unmarshal(val, &rec)
+		closer.Close()
+		if unmarshalErr != nil {
+			continue
+		}
+		if status != "" && rec.Status != status {
+			continue
+		}
+		results = append(results, candRecToCandidate(id, rec))
+	}
+	if err := iter.Error(); err != nil {
+		return nil, fmt.Errorf("entity candidate scan: %w", err)
+	}
+	return results, nil
+}
+
+// BackfillEntityIndex writes "dedup:e:" index entries for any candidate that
+// was stored before the entity index was introduced. Safe to call repeatedly —
+// writes are idempotent. Returns the number of candidates processed.
+func (s *EmbeddingStore) BackfillEntityIndex() (int, error) {
+	if err := s.checkClosed(); err != nil {
+		return 0, err
+	}
+	prefix := []byte(dedupRecPfx)
+	upper := prefixUpperBound(prefix)
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return 0, fmt.Errorf("backfill entity index scan: %w", err)
+	}
+	defer iter.Close()
+
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		idHex := string(iter.Key())[len(dedupRecPfx):]
+		id, err := strconv.ParseInt(idHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		var rec candRec
+		if err := json.Unmarshal(iter.Value(), &rec); err != nil {
+			continue
+		}
+		b := s.db.NewBatch()
+		_ = b.Set(dedupEntityKey(rec.EntityType, rec.EntityAID, id), nil, nil)
+		_ = b.Set(dedupEntityKey(rec.EntityType, rec.EntityBID, id), nil, nil)
+		if err := b.Commit(pebble.Sync); err != nil {
+			b.Close()
+			return count, fmt.Errorf("backfill entity index write %d: %w", id, err)
+		}
+		b.Close()
+		count++
+	}
+	if err := iter.Error(); err != nil {
+		return count, fmt.Errorf("backfill entity index: %w", err)
+	}
+	return count, nil
+}
+
 // UpdateCandidateStatus updates the status of a single candidate by ID.
 func (s *EmbeddingStore) UpdateCandidateStatus(id int64, status string) error {
 	return s.updateCandidate(id, func(rec *candRec) {
@@ -751,6 +865,8 @@ func (s *EmbeddingStore) DeleteCandidate(id int64) error {
 	defer b.Close()
 	_ = b.Delete(dedupRecKey(id), nil)
 	_ = b.Delete(dedupPairKey(rec.EntityType, rec.EntityAID, rec.EntityBID), nil)
+	_ = b.Delete(dedupEntityKey(rec.EntityType, rec.EntityAID, id), nil)
+	_ = b.Delete(dedupEntityKey(rec.EntityType, rec.EntityBID, id), nil)
 	return b.Commit(pebble.Sync)
 }
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.32.0
+// version: 1.33.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-18
+// last-edited: 2026-06-22
 
 package dedup
 
@@ -401,31 +401,22 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		return nil
 	}
 
-	// Load the embedding candidates that findSimilarBooks just wrote for this
-	// book.  We iterate only these (embedding top-K) rather than all pending
-	// candidates to avoid O(N²) cost and to satisfy the MetaFuzzy constraint.
-	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
-		EntityType: "book",
-		Status:     "pending",
-	})
+	// Load pending candidates for this specific book via the entity secondary
+	// index — O(k) where k is candidates for this book, not O(N) over all rows.
+	bookCandidates, err := de.embedStore.ListCandidatesForEntity("book", book.ID, "pending")
 	if err != nil {
 		return fmt.Errorf("runUnifiedScoringForBook: list candidates: %w", err)
 	}
 
-	// Build the set of other-book IDs this book is paired with in the current
-	// embedding + LSH candidate set.  This is the candidate pool for MetaFuzzy.
+	// Build the set of other-book IDs this book is paired with.
 	// Keep each pair's candidate-record ID so the eligibility backstop below can
-	// DELETE a suppressed pair (e.g. a chapter cross-pair) rather than merely
-	// skip re-scoring it — otherwise the row persists forever.
+	// DELETE a suppressed pair rather than merely skip re-scoring it.
 	type candRef struct {
 		otherID string
 		candID  int64
 	}
 	var embeddingCandIDs []candRef
-	for _, c := range candidates {
-		if c.EntityAID != book.ID && c.EntityBID != book.ID {
-			continue
-		}
+	for _, c := range bookCandidates {
 		otherID := c.EntityBID
 		if c.EntityBID == book.ID {
 			otherID = c.EntityAID
@@ -503,7 +494,7 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		}
 
 		// Embedding signal from existing candidate row (avoid re-scanning).
-		for _, c := range candidates {
+		for _, c := range bookCandidates {
 			if (c.EntityAID == book.ID && c.EntityBID == candID) ||
 				(c.EntityBID == book.ID && c.EntityAID == candID) {
 				if c.Similarity != nil && c.Layer == "embedding" {


### PR DESCRIPTION
## Summary
- Adds `dedup:e:<type>:<entityID>:<id16hex>` secondary index to PebbleDB so candidate lookups by entity are O(k) instead of O(N full scan)
- `ListCandidatesForEntity(type, entityID, status)` prefix-scans the entity index directly
- `UpsertCandidate` writes entity index entries for both sides atomically (new path), and idempotently on update (backfills pre-index records)
- `DeleteCandidate` removes entity index entries in the same batch
- `BackfillEntityIndex()` migrates records created before this index
- `runUnifiedScoringForBook` (hot path) switched from `ListCandidates({EntityType:"book", Status:"pending"})` + in-memory per-book filter → `ListCandidatesForEntity("book", book.ID, "pending")`

## Test plan
- [x] 3 new regression tests: `TestListCandidatesForEntity`, `TestBackfillEntityIndex`, `TestDeleteCandidate_CleansEntityIndex` — all pass
- [x] Full `./internal/database/...` suite — pass
- [x] `make build-api` — clean

Closes PERF-1 from `docs/tracking/audit-remediation-2026-06.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SraMucbUpin5Qf2EmH75bU