### PR TITLE
feat(ops): work-item execution contract — RunItems[T] generic fan-out helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.57.0 -->
+<!-- version: 3.58.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-22 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+#### June 22, 2026 — work-item execution contract (PR #1579)
+
+- **`feat(ops)`** — `internal/operations/registry/run_items.go`: new `RunItems[T any]` standalone generic function providing standardized fan-out over any item slice:
+  - `ctx.Done()` polling between items (both sequential and parallel modes)
+  - `reporter.SetCurrentItem(label)` heartbeat per item (watchdog-safe)
+  - `reporter.UpdateProgress(i+1, total, label)` after each item
+  - Per-item timeout via `RunItemsOptions.PerItemTimeout` (generalizes the ad-hoc `os.Stat` timeout from #1562)
+  - Worker-pool concurrency via `RunItemsOptions.Concurrency`
+  - Fail-fast or best-effort error semantics via `ErrMode` (`ErrModeFail` / `ErrModeCollect`)
+  - Custom label function via `RunItemsOptions.Label`
+- 9 unit tests covering sequential, parallel, fail-fast, collect, per-item timeout, context cancellation, empty slice, and custom label
+- Design spec: `docs/specs/2026-06-22-work-item-contract.md`
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.15.0 -->
+<!-- version: 9.16.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -1303,6 +1303,12 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
   ✅ NormalizePath, NormalizeTitle, NormalizeAuthor, NormalizeString, CollapseSpaces; 45 call-chain replacements across 5 files
 - [x] **STRUCT-13** — Finish splitting `BookDetail.tsx` (2773 lines) into sub-components *(completed)*
   ✅ See STRUCT-9 above — BookDetail.tsx reduced to 1073 lines
+
+#### ARCH — Architecture (June 2026 audit)
+
+- [x] **ARCH-3** — Unified op-launch helpers: `launchOp` (operations handler) and `launchLegacyOp` (duplicates handler) shipped PR #1577. Eliminates enqueue boilerplate across 11 callers.
+- [x] **ARCH-4** — Work-item contract: `RunItems[T]` standalone generic function + `ErrMode`/`RunItemsOptions` + 9 unit tests shipped PR #1579. Eliminates ctx.Done/UpdateProgress/SetCurrentItem boilerplate in new fan-out ops.
+- [ ] **ARCH-4b** — Migrate existing fan-out loops to `RunItems`: the 6 originally planned sites (`acoustid/backfill.go`, `acoustid/fingerprint_rescan.go`, `deluge/centralization.go`, `deluge/path_update.go`, `acoustid/lsh_backfill.go`, `acoustid/reset_all.go`) all have custom checkpointing, multi-counter, or resume-from-index logic that must be preserved. Each needs its own migration PR. Priority: medium (new code should use `RunItems` from day one).
 
 ---
 

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -199,7 +199,7 @@ This ordering respects dependencies and keeps each PR reviewable:
 | F | **Frontend API wrapper** | FE-1 `apiFetch`, credentials/CSRF/error/abort | — |
 | G | **Operation launch helper** | ARCH-3 unified enqueue helper | ARCH-2 partially |
 | H | **Work-item contract design** | Design doc + open question resolution | G |
-| I | **Work-item contract implementation** | `ItemConcurrency` + `Reporter.RunItems` + migrate 6 fan-out sites | H |
+| I | **Work-item contract implementation** ✅ | `RunItems[T]` standalone generic fn + `ErrMode`/`RunItemsOptions` + 9 unit tests (PR #1579). Note: the 6 listed fan-out sites all have custom checkpointing/multi-counter/resume-from-index logic that cannot be replaced without regression — documented as future follow-up in TODO `ARCH-4b`. | H |
 | J | **Scanner batch pipeline** | PERF-2 hash/tag carry-forward, batch upserts | — |
 | K | **Security guardrails** | SEC-5 restore validation, SEC-6 factory-reset path check | — |
 | L | **Frontend page decomposition** | FE-5 Library.tsx hooks, STR-4 BookDedup split | F |

--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,0 +1,161 @@
+// file: internal/operations/registry/run_items.go
+// version: 1.0.0
+// guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
+// last-edited: 2026-06-22
+
+package registry
+
+// Work-item execution contract — see docs/specs/2026-06-22-work-item-contract.md
+//
+// Generic methods cannot be declared on interfaces in Go, so RunItems is a
+// package-level generic function that accepts a Reporter rather than a method.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ErrMode controls error collection behaviour in RunItems.
+type ErrMode int
+
+const (
+	// ErrModeFail cancels remaining items on the first error (default).
+	ErrModeFail ErrMode = iota
+	// ErrModeCollect runs all items and returns a joined error of all failures.
+	ErrModeCollect
+)
+
+// RunItemsOptions configures a RunItems call. All fields are optional.
+type RunItemsOptions struct {
+	// Concurrency is the worker-pool size. 0 or 1 = sequential (default).
+	Concurrency int
+
+	// PerItemTimeout wraps each item's context with this deadline when > 0.
+	PerItemTimeout time.Duration
+
+	// ErrMode controls whether the first error cancels remaining items
+	// (ErrModeFail, default) or all items run and errors are joined
+	// (ErrModeCollect).
+	ErrMode ErrMode
+
+	// Label returns the SetCurrentItem / UpdateProgress label for item i of
+	// total. Defaults to "item <i+1>/<total>".
+	Label func(i, total int) string
+}
+
+// RunItems fans out fn over items, managing:
+//   - ctx.Done() polling between items
+//   - reporter.SetCurrentItem label per item
+//   - reporter.UpdateProgress after each item
+//   - per-item timeout (RunItemsOptions.PerItemTimeout)
+//   - worker-pool concurrency (RunItemsOptions.Concurrency)
+//   - error semantics (ErrModeFail or ErrModeCollect)
+//
+// Returns nil when all items succeed.
+// Returns ctx.Err() on context cancellation.
+// Returns the first item error on ErrModeFail, or errors.Join on ErrModeCollect.
+func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...RunItemsOptions) error {
+	var opt RunItemsOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	if opt.Concurrency < 1 {
+		opt.Concurrency = 1
+	}
+	total := len(items)
+	if total == 0 {
+		return nil
+	}
+
+	lbl := opt.Label
+	if lbl == nil {
+		lbl = func(i, total int) string { return fmt.Sprintf("item %d/%d", i+1, total) }
+	}
+
+	runOne := func(ctx context.Context, i int, item T) error {
+		itemCtx := ctx
+		if opt.PerItemTimeout > 0 {
+			var cancel context.CancelFunc
+			itemCtx, cancel = context.WithTimeout(ctx, opt.PerItemTimeout)
+			defer cancel()
+		}
+		l := lbl(i, total)
+		r.SetCurrentItem(l)
+		err := fn(itemCtx, item)
+		_ = r.UpdateProgress(i+1, total, l)
+		return err
+	}
+
+	if opt.Concurrency == 1 {
+		return runItemsSeq(ctx, items, runOne, opt.ErrMode)
+	}
+	return runItemsPar(ctx, items, runOne, opt)
+}
+
+// runItemsSeq runs items sequentially.
+func runItemsSeq[T any](ctx context.Context, items []T, runOne func(context.Context, int, T) error, mode ErrMode) error {
+	var errs []error
+	for i, item := range items {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if err := runOne(ctx, i, item); err != nil {
+			if mode == ErrModeCollect {
+				errs = append(errs, err)
+				continue
+			}
+			return err
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// runItemsPar runs items with a worker pool of size opt.Concurrency.
+func runItemsPar[T any](ctx context.Context, items []T, runOne func(context.Context, int, T) error, opt RunItemsOptions) error {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, opt.Concurrency)
+	var mu sync.Mutex
+	var errs []error
+	var wg sync.WaitGroup
+
+	for i, item := range items {
+		// Check for cancellation before acquiring a worker slot.
+		select {
+		case <-cancelCtx.Done():
+			wg.Wait()
+			if len(errs) > 0 {
+				return errors.Join(errs...)
+			}
+			return ctx.Err()
+		case sem <- struct{}{}:
+		}
+
+		wg.Add(1)
+		i, item := i, item
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := runOne(cancelCtx, i, item); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+				if opt.ErrMode == ErrModeFail {
+					cancel()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return ctx.Err()
+}

--- a/internal/operations/registry/run_items_test.go
+++ b/internal/operations/registry/run_items_test.go
@@ -1,0 +1,224 @@
+// file: internal/operations/registry/run_items_test.go
+// version: 1.0.0
+// guid: b3c4d5e6-f7a8-9012-bcde-f34567890123
+// last-edited: 2026-06-22
+
+package registry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// stubReporterForItems is a minimal Reporter for RunItems tests.
+type stubReporterForItems struct {
+	progressCalls atomic.Int32
+	currentItems  []string
+	mu            sync.Mutex
+}
+
+func (s *stubReporterForItems) UpdateProgress(current, total int, message string) error {
+	s.progressCalls.Add(1)
+	return nil
+}
+func (s *stubReporterForItems) SetCurrentItem(label string) {
+	s.mu.Lock()
+	s.currentItems = append(s.currentItems, label)
+	s.mu.Unlock()
+}
+func (s *stubReporterForItems) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
+func (s *stubReporterForItems) Logger() *slog.Logger                             { return slog.Default() }
+func (s *stubReporterForItems) Checkpoint(_ any) error                           { return nil }
+func (s *stubReporterForItems) IsCanceled() bool                                 { return false }
+func (s *stubReporterForItems) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, s)
+}
+func (s *stubReporterForItems) Trigger(_ context.Context, _ string, _ any) error { return nil }
+
+func TestRunItems_Sequential_AllSucceed(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := []int{1, 2, 3}
+	var processed []int
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		processed = append(processed, n)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(processed) != 3 {
+		t.Fatalf("expected 3 items processed, got %d", len(processed))
+	}
+	if int(r.progressCalls.Load()) != 3 {
+		t.Fatalf("expected 3 progress calls, got %d", r.progressCalls.Load())
+	}
+}
+
+func TestRunItems_Sequential_FailFast(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := []int{1, 2, 3}
+	var processed []int
+	errStop := errors.New("stop")
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		processed = append(processed, n)
+		if n == 2 {
+			return errStop
+		}
+		return nil
+	})
+	if !errors.Is(err, errStop) {
+		t.Fatalf("expected errStop, got %v", err)
+	}
+	if len(processed) != 2 {
+		t.Fatalf("expected 2 items processed (fail on 2nd), got %d", len(processed))
+	}
+}
+
+func TestRunItems_Sequential_CollectErrors(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := []int{1, 2, 3}
+	errA := errors.New("err-1")
+	errC := errors.New("err-3")
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		if n == 1 {
+			return errA
+		}
+		if n == 3 {
+			return errC
+		}
+		return nil
+	}, registry.RunItemsOptions{ErrMode: registry.ErrModeCollect})
+	if err == nil {
+		t.Fatal("expected a joined error")
+	}
+	if !errors.Is(err, errA) {
+		t.Errorf("expected errA in joined error")
+	}
+	if !errors.Is(err, errC) {
+		t.Errorf("expected errC in joined error")
+	}
+	if int(r.progressCalls.Load()) != 3 {
+		t.Fatalf("all 3 items should have been processed, got %d progress calls", r.progressCalls.Load())
+	}
+}
+
+func TestRunItems_Parallel_AllSucceed(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := make([]int, 20)
+	for i := range items {
+		items[i] = i
+	}
+	var count atomic.Int32
+	err := registry.RunItems(context.Background(), r, items, func(_ context.Context, n int) error {
+		count.Add(1)
+		return nil
+	}, registry.RunItemsOptions{Concurrency: 4})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int(count.Load()) != 20 {
+		t.Fatalf("expected 20 items, got %d", count.Load())
+	}
+}
+
+func TestRunItems_Parallel_FailFast_CancelsRemaining(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := make([]int, 100)
+	for i := range items {
+		items[i] = i
+	}
+	errBoom := errors.New("boom")
+	var count atomic.Int32
+	err := registry.RunItems(context.Background(), r, items, func(ctx context.Context, n int) error {
+		count.Add(1)
+		if n == 0 {
+			return errBoom
+		}
+		// Simulate slow work — will be cancelled by ctx.Done()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		}
+	}, registry.RunItemsOptions{Concurrency: 4, ErrMode: registry.ErrModeFail})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if count.Load() >= 100 {
+		t.Fatalf("expected fewer than 100 items to run; got %d", count.Load())
+	}
+}
+
+func TestRunItems_PerItemTimeout(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := []int{1}
+	err := registry.RunItems(context.Background(), r, items, func(ctx context.Context, n int) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+			return nil
+		}
+	}, registry.RunItemsOptions{PerItemTimeout: 10 * time.Millisecond})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestRunItems_ContextCancellation(t *testing.T) {
+	r := &stubReporterForItems{}
+	ctx, cancel := context.WithCancel(context.Background())
+	items := make([]int, 100)
+	var count atomic.Int32
+	cancel() // pre-cancel
+	err := registry.RunItems(ctx, r, items, func(_ context.Context, _ int) error {
+		count.Add(1)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if count.Load() > 0 {
+		t.Fatalf("no items should have run with a pre-cancelled ctx, got %d", count.Load())
+	}
+}
+
+func TestRunItems_EmptyItems(t *testing.T) {
+	r := &stubReporterForItems{}
+	err := registry.RunItems(context.Background(), r, []string{}, func(_ context.Context, _ string) error {
+		return errors.New("should not be called")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for empty slice: %v", err)
+	}
+}
+
+func TestRunItems_CustomLabel(t *testing.T) {
+	r := &stubReporterForItems{}
+	items := []string{"a", "b"}
+	_ = registry.RunItems(context.Background(), r, items, func(_ context.Context, _ string) error {
+		return nil
+	}, registry.RunItemsOptions{
+		Label: func(i, total int) string { return fmt.Sprintf("processing %d of %d", i+1, total) },
+	})
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.currentItems) != 2 {
+		t.Fatalf("expected 2 SetCurrentItem calls, got %d", len(r.currentItems))
+	}
+	if r.currentItems[0] != "processing 1 of 2" {
+		t.Errorf("unexpected label: %q", r.currentItems[0])
+	}
+}


### PR DESCRIPTION
## Summary

- New `RunItems[T any]` standalone generic function in `internal/operations/registry/run_items.go`
- `ErrMode` type (`ErrModeFail` / `ErrModeCollect`) and `RunItemsOptions` struct
- 9 unit tests covering all option paths
- Design spec at `docs/specs/2026-06-22-work-item-contract.md` (shipped in PR H)

## What it eliminates

Every fan-out operation currently reimplements ~40-60 lines of:
- `select { case <-ctx.Done(): ... }` polling
- `reporter.SetCurrentItem(label)` heartbeat (watchdog-safe)
- `reporter.UpdateProgress(i+1, total, msg)` after each item
- Manual semaphore + WaitGroup for parallel work

## Why standalone function, not interface method

Generic methods cannot be declared on Go interfaces (compile error). `RunItems[T any](ctx, r Reporter, items []T, fn)` as a package-level function is the canonical Go idiom for generic utilities that operate on interface values.

## Fan-out site migrations (follow-up: ARCH-4b)

The 6 originally planned sites (`acoustid/backfill.go`, `acoustid/fingerprint_rescan.go`, `deluge/centralization.go`, `deluge/path_update.go`, `acoustid/lsh_backfill.go`, `acoustid/reset_all.go`) all have custom checkpointing, multi-counter aggregation, or resume-from-index logic. Replacing them with `RunItems` would silently remove that behavior. Each is documented as a separate migration in `TODO.md` (ARCH-4b). New fan-out code should use `RunItems` from day one.

## Test plan

- [x] `go build ./internal/operations/registry/...` — clean
- [x] `go test ./internal/operations/registry/... -run TestRunItems` — 9/9 pass
- [x] `go test ./internal/operations/registry/...` — full suite pass (22s)
- [x] `make build-api` — full backend clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SraMucbUpin5Qf2EmH75bU