### PR TITLE
perf(scanner): batch BookFile upserts — N per-segment writes → 1 per book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.58.0 -->
+<!-- version: 3.59.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-22 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Performance
+
+#### June 22, 2026 — scanner batch pipeline: N→1 DB writes per book on first scan (PR #1583)
+
+- **`perf(scanner)`** — `createBookFilesForBook` now collects all `BookFile` records for a book and calls `BatchUpsertBookFiles` once (single PebbleDB batch write) instead of calling `UpsertBookFile` per segment file. For a 40-chapter book this reduces DB round-trips from 40 to 1 during initial scan.
 
 ### Added
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.16.0 -->
+<!-- version: 9.17.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -1309,6 +1309,8 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **ARCH-3** — Unified op-launch helpers: `launchOp` (operations handler) and `launchLegacyOp` (duplicates handler) shipped PR #1577. Eliminates enqueue boilerplate across 11 callers.
 - [x] **ARCH-4** — Work-item contract: `RunItems[T]` standalone generic function + `ErrMode`/`RunItemsOptions` + 9 unit tests shipped PR #1579. Eliminates ctx.Done/UpdateProgress/SetCurrentItem boilerplate in new fan-out ops.
 - [ ] **ARCH-4b** — Migrate existing fan-out loops to `RunItems`: the 6 originally planned sites (`acoustid/backfill.go`, `acoustid/fingerprint_rescan.go`, `deluge/centralization.go`, `deluge/path_update.go`, `acoustid/lsh_backfill.go`, `acoustid/reset_all.go`) all have custom checkpointing, multi-counter, or resume-from-index logic that must be preserved. Each needs its own migration PR. Priority: medium (new code should use `RunItems` from day one).
+- [x] **PERF-2** — Batch upserts in `createBookFilesForBook`: N per-segment `UpsertBookFile` calls replaced with one `BatchUpsertBookFiles` call (shipped PR #1583). N→1 DB writes per book on first scan.
+- [ ] **PERF-2b** — Hash carry-forward: dedup check at `scanner.go:1885` re-hashes every segment file that `createBookFilesForBook` (line 1322) also hashes. Fix requires `saveBookToDatabase` to return a `map[string]string` (filePath→hash) and passing it to `createBookFilesForBook`. Blocked by `saveBook` function-variable API change.
 
 ---
 

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -200,7 +200,7 @@ This ordering respects dependencies and keeps each PR reviewable:
 | G | **Operation launch helper** | ARCH-3 unified enqueue helper | ARCH-2 partially |
 | H | **Work-item contract design** | Design doc + open question resolution | G |
 | I | **Work-item contract implementation** ✅ | `RunItems[T]` standalone generic fn + `ErrMode`/`RunItemsOptions` + 9 unit tests (PR #1579). Note: the 6 listed fan-out sites all have custom checkpointing/multi-counter/resume-from-index logic that cannot be replaced without regression — documented as future follow-up in TODO `ARCH-4b`. | H |
-| J | **Scanner batch pipeline** | PERF-2 hash/tag carry-forward, batch upserts | — |
+| J | **Scanner batch pipeline** ✅ | PERF-2 batch upserts shipped PR #1583: `createBookFilesForBook` now collects all BookFiles then calls `BatchUpsertBookFiles` once (N→1 DB writes per book). Hash carry-forward (dedup check re-hashes same files at line 1885) deferred — needs `saveBookToDatabase` API change; documented as PERF-2b in TODO. | — |
 | K | **Security guardrails** | SEC-5 restore validation, SEC-6 factory-reset path check | — |
 | L | **Frontend page decomposition** | FE-5 Library.tsx hooks, STR-4 BookDedup split | F |
 | M | **Dataset strategy** | TOOL-1 optional large corpus | — |

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.44.0
+// version: 1.45.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-06-19
+// last-edited: 2026-06-22
 
 package scanner
 
@@ -1282,6 +1282,7 @@ func createBookFilesForBook(bookFilePath string, segmentFiles []string, scanLog 
 		}
 	}
 
+	bfs := make([]*database.BookFile, 0, len(segmentFiles))
 	for i, filePath := range segmentFiles {
 		trackNum := i + 1
 		ext := strings.ToLower(filepath.Ext(filePath))
@@ -1324,8 +1325,12 @@ func createBookFilesForBook(bookFilePath string, segmentFiles []string, scanLog 
 			bf.OriginalFileHash = h
 		}
 
-		if serr := getStore().UpsertBookFile(bf); serr != nil {
-			scanLog.Warn("failed to upsert book file for %s: %v", filePath, serr)
+		bfs = append(bfs, bf)
+	}
+
+	if len(bfs) > 0 {
+		if serr := getStore().BatchUpsertBookFiles(bfs); serr != nil {
+			scanLog.Warn("failed to batch upsert book files for book %s: %v", dbBook.ID, serr)
 		}
 	}
 

--- a/internal/scanner/unit_test.go
+++ b/internal/scanner/unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/unit_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-06-01
+// last-edited: 2026-06-22
 
 package scanner
 
@@ -1586,7 +1586,7 @@ func TestCreateBookFilesForBookWithStore(t *testing.T) {
 		FilePath: bookPath,
 	}, nil)
 	store.EXPECT().GetBookFiles("book-1").Return(nil, nil) // no existing files
-	store.EXPECT().UpsertBookFile(mock.Anything).Return(nil)
+	store.EXPECT().BatchUpsertBookFiles(mock.Anything).Return(nil)
 	store.EXPECT().UpdateBook("book-1", mock.Anything).Return(nil, nil) // normalize FilePath
 
 	oldExts := config.AppConfig.SupportedExtensions
@@ -1646,7 +1646,7 @@ func TestCreateBookFilesWithSegmentFiles(t *testing.T) {
 		FilePath: tmp,
 	}, nil)
 	store.EXPECT().GetBookFiles("book-2").Return(nil, nil)
-	store.EXPECT().UpsertBookFile(mock.Anything).Return(nil).Times(2)
+	store.EXPECT().BatchUpsertBookFiles(mock.Anything).Return(nil)
 
 	createBookFilesForBook(tmp, []string{seg1, seg2}, defaultLog)
 }


### PR DESCRIPTION
## Summary

- `createBookFilesForBook` in `internal/scanner/scanner.go` previously called `UpsertBookFile` for every segment file individually (N PebbleDB writes per book on first scan)
- Now collects all `BookFile` records, then calls `BatchUpsertBookFiles` once (1 atomic PebbleDB batch write per book)
- For a 40-chapter audiobook: 40 writes → 1 write per scan

## What's deferred (PERF-2b)

The dedup check at `scanner.go:1885` re-hashes the same segment files that `createBookFilesForBook` at line 1322 also hashes (double-SHA256 of all files). Fixing this requires changing `saveBookToDatabase`'s return type to carry hashes forward — documented as `PERF-2b` in TODO.

## Test plan

- [x] `go test ./internal/scanner/...` — all tests pass (including 2 updated mock expectations)
- [x] `make build-api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SraMucbUpin5Qf2EmH75bU