### PR TITLE
fix(test): portable corpus path in mediainfo_test (TOOL-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.61.0 -->
+<!-- version: 3.62.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+### Tests
+
+#### June 22, 2026 — fix hardcoded corpus path in mediainfo test (PR #1586)
+
+- **`fix(test)`** — `TestExtract_RealMP3File` used a hardcoded absolute path (`/Users/jdfalk/repos/.../`) that broke on any other machine. Replaced with `findRepoRootForMediainfo()` — an inline `go.mod` walk — so the test is portable. LFS already configured in `.gitattributes` (48 tracked audio files). Skip message now says "run git lfs pull to enable" instead of bare "not found".
 ### Refactor
 
 #### June 22, 2026 — frontend page decomposition: BookDedup + Library (PR #1585)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.19.0 -->
+<!-- version: 9.20.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -1314,7 +1314,8 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **SEC-5** — Restore target is arbitrary absolute path + `verify=true` is a no-op: `IsDangerousRoot` check added on `target_path`; `verify=true` logs a visible warning. Shipped PR #1584.
 - [x] **SEC-6** — Factory reset uses `RootDir` without validation: `IsDangerousRoot` check added before `os.RemoveAll` loop; returns 400 + logs error if RootDir is a protected system path. Shipped PR #1584.
 - [x] **FE-5 (audit)** — `Library.tsx` 2018→1811 lines: extracted `useLibraryQuery` (229 lines, book-fetch state + effects + auto-refresh) and `useLibrarySelection` (164 lines, selection state + handlers). Shipped PR #1585.
-- [x] **STR-4** — `BookDedup.tsx` 2907→145 lines: extracted `DedupAIReviewTab` (386 lines, AI pipeline tab), `DedupEmbeddingTab` (1441 lines, embedding dedup with module-level cache + buildClusters), `DedupAcousticTab` (996 lines, acoustic dedup + `AcousticBookCard`/`AcousticBookMetadata` re-exports). Shipped PR #1585. TypeScript: 0 errors.
+- [x] **STR-4** — `BookDedup.tsx` 2907→145 lines: extracted `DedupAIReviewTab` (386 lines), `DedupEmbeddingTab` (1441 lines, embedding dedup with module-level cache + buildClusters), `DedupAcousticTab` (996 lines, acoustic dedup + `AcousticBookCard`/`AcousticBookMetadata` re-exports). Shipped PR #1585. TypeScript: 0 errors.
+- [x] **TOOL-1** — Large corpus LFS: already configured in `.gitattributes` (48 LFS objects, 1.7 GB). Fixed `mediainfo_test.go:889` hardcoded absolute path → `findRepoRootForMediainfo()` inline walk. Skip message updated to guide `git lfs pull`. Shipped PR #1586.
 
 ---
 

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.4.0 -->
+<!-- version: 1.5.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-22 -->
 
@@ -203,4 +203,4 @@ This ordering respects dependencies and keeps each PR reviewable:
 | J | **Scanner batch pipeline** ✅ | PERF-2 batch upserts shipped PR #1583: `createBookFilesForBook` now collects all BookFiles then calls `BatchUpsertBookFiles` once (N→1 DB writes per book). Hash carry-forward (dedup check re-hashes same files at line 1885) deferred — needs `saveBookToDatabase` API change; documented as PERF-2b in TODO. | — |
 | K | **Security guardrails** ✅ | SEC-5 + SEC-6: `IsDangerousRoot` in pathvalidation, restore dangerous-root guard + verify warning, factory-reset dangerous-root guard. PR #1584. | — |
 | L | **Frontend page decomposition** ✅ | STR-4: BookDedup.tsx 2907→145 lines (3 tabs extracted: DedupAIReviewTab, DedupEmbeddingTab, DedupAcousticTab). FE-5: Library.tsx 2018→1811 lines (useLibraryQuery + useLibrarySelection hooks extracted). PR #1585. TypeScript: 0 errors. | F |
-| M | **Dataset strategy** | TOOL-1 optional large corpus | — |
+| M | **Dataset strategy** ✅ | TOOL-1: LFS already configured (`.gitattributes`). Fixed hardcoded absolute path in `mediainfo_test.go:889` (`falkcorp/...` → `findRepoRootForMediainfo()` walk). Skip message updated. PR #1586. | — |

--- a/internal/mediainfo/mediainfo_test.go
+++ b/internal/mediainfo/mediainfo_test.go
@@ -1,7 +1,7 @@
 // file: internal/mediainfo/mediainfo_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a2b3c4d5-e6f7-8a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-06-21
+// last-edited: 2026-06-22
 
 package mediainfo
 
@@ -884,12 +884,32 @@ func TestGetQualityTier_AboveBoundaries(t *testing.T) {
 	}
 }
 
+// findRepoRootForMediainfo walks up from cwd until it finds go.mod.
+func findRepoRootForMediainfo(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
 func TestExtract_RealMP3File(t *testing.T) {
-	// Use actual test file from testdata
-	testFile := "/Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer/testdata/audio/librivox/odyssey_butler_librivox/odyssey_01_homer_butler_64kb.mp3"
+	repoRoot := findRepoRootForMediainfo(t)
+	testFile := filepath.Join(repoRoot, "testdata", "audio", "librivox",
+		"odyssey_butler_librivox", "odyssey_01_homer_butler_64kb.mp3")
 
 	if _, err := os.Stat(testFile); os.IsNotExist(err) {
-		t.Skip("Test file not found")
+		t.Skip("Librivox corpus not present (LFS-on-demand; run git lfs pull to enable)")
 	}
 
 	info, err := Extract(testFile)


### PR DESCRIPTION
## Summary

- Fixes `TestExtract_RealMP3File` which used a hardcoded absolute path (`/Users/jdfalk/repos/github.com/falkcorp/audiobook-organizer/...`) — would fail on any CI runner or other developer's machine
- Replaced with `findRepoRootForMediainfo()` — an inline `go.mod` walk, zero external dependencies (no import cycle)
- Updated skip message to `"Librivox corpus not present (LFS-on-demand; run git lfs pull to enable)"` — guides developers rather than just saying "not found"

## Why not a bigger LFS migration?

Git LFS was already configured in `.gitattributes` for all audio extensions (`*.mp3`, `*.m4b`, `*.m4a`, `*.flac`). There are already 48 LFS-tracked files totaling ~1.7 GB. The corpus is already optional — you only download it if you run `git lfs pull`. This PR just fixes the broken portable path.

## Test plan

- [x] `go test ./internal/mediainfo/... -run TestExtract_RealMP3File -v` — PASS (LFS files present locally)
- [x] Test would now skip cleanly on CI without LFS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SraMucbUpin5Qf2EmH75bU