### PR TITLE
fix(database): SearchBooks limit=0 returns all results; mark stale audit findings ✅ (PERF-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.63.0 -->
+<!-- version: 3.64.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-22 -->
+<!-- last-edited: 2026-06-23 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+#### June 23, 2026 — audit tracking cleanup + PERF-4 bug fix
+
+- **`fix(database)`** PERF-4 — `SearchBooks` with `limit=0` returned zero rows. Root cause: `len(filtered) < 0` is always false. Fixed by treating `limit==0` as "no limit" (standard Go convention). iTunes search panel now returns results when a search term is entered. Regression test `TestSearchBooksUnlimited` added.
+- **`docs`** SEC-3, SEC-4, SEC-9, FE-3 — tracking doc updated to ✅; all were already fixed in prior PRs (SEC-3/4 in PR A #1574; SEC-9 via `MaskSecrets()`; FE-3 via PR L #1585 which eliminated the stale code path).
 
 ### Security
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.21.0 -->
+<!-- version: 9.22.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-22 -->
+<!-- last-edited: 2026-06-23 -->
 
 # Project TODO
 
@@ -1311,6 +1311,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [ ] **ARCH-4b** — Migrate existing fan-out loops to `RunItems`: the 6 originally planned sites (`acoustid/backfill.go`, `acoustid/fingerprint_rescan.go`, `deluge/centralization.go`, `deluge/path_update.go`, `acoustid/lsh_backfill.go`, `acoustid/reset_all.go`) all have custom checkpointing, multi-counter, or resume-from-index logic that must be preserved. Each needs its own migration PR. Priority: medium (new code should use `RunItems` from day one).
 - [x] **PERF-2** — Batch upserts in `createBookFilesForBook`: N per-segment `UpsertBookFile` calls replaced with one `BatchUpsertBookFiles` call (shipped PR #1583). N→1 DB writes per book on first scan.
 - [ ] **PERF-2b** — Hash carry-forward: dedup check at `scanner.go:1885` re-hashes every segment file that `createBookFilesForBook` (line 1322) also hashes. Fix requires `saveBookToDatabase` to return a `map[string]string` (filePath→hash) and passing it to `createBookFilesForBook`. Blocked by `saveBook` function-variable API change.
+- [x] **PERF-4** — iTunes search `SearchBooks(search, 0, 0)` returned zero results: `limit=0` was checked as `len(filtered) < 0` (always false). Fixed in `pebble_store.go:3169` — `limit==0` now means "no limit". Regression test `TestSearchBooksUnlimited` added.
 - [x] **PERF-7** — `UpsertBookFile` memdb round-trip fingerprint data-loss: same preserve-on-empty guard as `BatchUpsertBookFiles` now applied. 3 regression tests in `pebble_bookfile_preserve_test.go`. Shipped PR (audit-remediation-p1).
 - [x] **SEC-7** — `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` stays accepted-risk per MED-1. Shipped PR (audit-remediation-p1).
 - [x] **SEC-2** — `WriteStartupReadOnlyKey bool` config flag (default true). Operators can set `write_startup_readonly_key: false` to suppress `.readonly-key` file creation. Bootstrap token unaffected. Shipped PR (audit-remediation-p1).

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,7 +1,7 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.6.0 -->
+<!-- version: 1.7.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
-<!-- last-edited: 2026-06-22 -->
+<!-- last-edited: 2026-06-23 -->
 
 # Audit Remediation Tracking — June 2026
 
@@ -36,13 +36,13 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 |---|---|---|---|---|
 | SEC-1 | `abk_...` API key committed in `docs/FINGERPRINT_E2E_TEST_REPORT.md:141` | Sweep | ⬜ | **Immediate.** Rotate key, replace with placeholder, add secret scanning to docs/. |
 | SEC-2 | Bootstrap/read-only credentials generated to plaintext files at startup | Sweep | ✅ | `Config.WriteStartupReadOnlyKey` bool (default true). Gated in `server_lifecycle.go`. Bootstrap token unchanged (emergency access). |
-| SEC-3 | Temp-login URLs trust inbound `Host` header | Sweep | ⬜ | `auth_temp_login.go:114`. Use configured canonical URL or Host allowlist. |
-| SEC-4 | No security-header middleware (CSP, frame-ancestors, nosniff, HSTS) | Sweep | ⬜ | Gap around `server_middleware.go:21`. |
+| SEC-3 | Temp-login URLs trust inbound `Host` header | Sweep | ✅ | Fixed in PR A (#1574): `auth_temp_login.go:108-116` uses `s.externalURL`; comment explicitly says "never trust the inbound Host header". |
+| SEC-4 | No security-header middleware (CSP, frame-ancestors, nosniff, HSTS) | Sweep | ✅ | Fixed in PR A (#1574): `securityHeadersMiddleware()` registered at `server.go:361`; sets nosniff, X-Frame-Options, HSTS (HTTPS only), Referrer-Policy. CSP intentionally omitted — React SPA requires inline styles. |
 | SEC-5 | Restore `verify=true` is a no-op; restore target is arbitrary absolute path | Sweep | ✅ | `pathvalidation.IsDangerousRoot` blocks system-dir targets; `verify=true` now logs a visible warning. Full checksum manifest deferred. Shipped PR #1584. |
 | SEC-6 | Factory reset deletes everything under `RootDir` without path validation | Sweep | ✅ | `pathvalidation.IsDangerousRoot` check added before library folder deletion; returns 400 + logs error if RootDir is a protected path. Shipped PR #1584. |
 | SEC-7 | `/metrics` and cache-stats endpoints unauthenticated | Sweep | ✅ | `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` kept as accepted-risk per MED-1 — standard Prometheus scrape endpoint, network-layer gating. |
-| SEC-8 | Docker build downloads unsigned tarballs, uses mutable base tags | Sweep | ⬜ | P2. Pin base digest, verify SHA256. |
-| SEC-9 | OpenAI key exposed to frontend runtime for validation | Sweep | ⬜ | P2. Move validation server-side. |
+| SEC-8 | Docker build downloads unsigned tarballs, uses mutable base tags | Sweep | ⬜ | P2. Pin `node:26-alpine`, `golang:1.26-alpine`, `alpine:3.24` to `@sha256:...` digests in `Dockerfile` + `Dockerfile.build-cgo`. Deferred — network-only change, no prod risk (internal network only). |
+| SEC-9 | OpenAI key exposed to frontend runtime for validation | Sweep | ✅ | `GetConfig` calls `MaskSecrets()` before responding; `update_service.go:37-55` masks all secret fields (OpenAI, AcoustID, Google Books, Hardcover, BasicAuth). Frontend only receives `***` masked value. |
 
 ---
 
@@ -53,9 +53,9 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | PERF-1 | Dedup full scan repeatedly sorts all candidate rows, caps at global top 50 — books with many candidates get incorrect results | Sweep | ⬜ | `dedup/engine.go:2032,404`, `embedding_store.go:608,663`. Add `ListCandidatesForEntity(entityType, bookID, status)` with index. |
 | PERF-2 | Multi-file import hashes/tags same files repeatedly, one `UpsertBookFile` per segment | Sweep | ⬜ | `scanner.go:1885,1307,1322,1327`. Carry hash/tag results forward; batch upserts; recompute aggregates once per book. |
 | PERF-3 | Library list has full-materialization escape hatches | Sweep | ⬜ | `audiobooks/service.go:856,1092,1286`. Push filters into `BookSummaryFilter`; add projections for common sorts. |
-| PERF-4 | iTunes search calls `SearchBooks(search, 0, 0)` — returns zero rows | Sweep | ⬜ | `handlers/itunes.go:693`. Add bounded iTunes-filtered search. |
+| PERF-4 | iTunes search calls `SearchBooks(search, 0, 0)` — returns zero rows | Sweep | ✅ | Root cause: `pebble_store.go:3169` `len(filtered) < limit` is always false when `limit=0`. Fixed: treat `limit==0` as "no limit". Regression test `TestSearchBooksUnlimited` added. |
 | PERF-5 | iTunes backfill: offset pagination, N+1 file reads, per-row writes | Sweep | ⬜ | `itunes/backfill.go:21,46,73`. Cursor iteration, batch file lookup, bulk writes. |
-| PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ⬜ | `server_search.go:63`. Add streaming/cursor book iteration. |
+| PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ⬜ | `server_search.go:63`. Deferred — requires `GetAllBooksFrom(afterID, limit)` cursor method on Store interface + mock regen. TODO comment added at call site. |
 | PERF-7 | Memdb projection is a monolith; strips `AcoustIDFingerprint` on round-trip | Sweep | ✅ | `UpsertBookFile` now has the same fingerprint-preserve guard as `BatchUpsertBookFiles`. 3 regression tests added in `pebble_bookfile_preserve_test.go`. |
 | PERF-8 | Backup walks live Pebble files directly | Sweep | ⬜ | P2. Use Pebble `Checkpoint` before archiving. |
 
@@ -85,7 +85,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 |---|---|---|---|---|
 | FE-1 | No centralized `apiFetch` wrapper — credentials, CSRF, error parsing, abort duplicated across `api.ts`, `activityApi.ts`, `readingApi.ts` | Sweep | ⬜ | `api.ts:891`, `activityApi.ts:141`, `readingApi.ts:62`. |
 | FE-2 | `ActivityLog` page-size changes can fetch stale data | Sweep | ⬜ | `ActivityLog.tsx:358,384,411`. Add `pageSize` to callback deps. |
-| FE-3 | Legacy `BookDedup` rows-per-page changes can fetch stale data | Sweep | ⬜ | `BookDedup.tsx:2249,2273`. Add dep or retire legacy tab. |
+| FE-3 | Legacy `BookDedup` rows-per-page changes can fetch stale data | Sweep | ✅ | Resolved by PR L (#1585): `BookDedup.tsx` reduced to 145 lines (pure tab router); the stale rows-per-page code was in the extracted tab components which were rewritten. |
 | FE-4 | `BookDetail` file/segment state stale across route-param changes | Sweep | ⬜ | `BookDetail.tsx:80,223`. Reset on `id` change. |
 | FE-5 | `Library.tsx` still a 3,333-line maintenance hotspot | Both | ⬜ | Extract `useLibraryQuery`, `useLibrarySelection`, `useImportPaths`, `useLibraryOperations`. |
 | FE-6 | `useSettingsHandlers` passes too much mutable state through one hook | Sweep | ⬜ | `useSettingsHandlers.ts:40`. Split by domain. |

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.94.0
+// version: 1.95.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-22
+// last-edited: 2026-06-23
 
 package database
 
@@ -3165,12 +3165,13 @@ func (p *PebbleStore) SearchBooks(query string, limit, offset int) ([]Book, erro
 		narratorMatch := book.Narrator != nil && strings.Contains(strings.ToLower(*book.Narrator), lowerQuery)
 
 		if titleMatch || authorMatch || narratorMatch {
-			// Apply pagination: only collect results in the requested range
-			if count >= offset && len(filtered) < limit {
+			// Apply pagination: only collect results in the requested range.
+			// limit == 0 means "no limit" (return all matches).
+			if count >= offset && (limit == 0 || len(filtered) < limit) {
 				filtered = append(filtered, book)
 			}
 			count++
-			if len(filtered) >= limit {
+			if limit > 0 && len(filtered) >= limit {
 				break
 			}
 		}

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
 
 package database
@@ -551,6 +551,32 @@ func TestPebbleSearchBooks(t *testing.T) {
 	// Assert
 	if len(results) < 3 {
 		t.Errorf("Expected at least 3 results for 'The', got %d", len(results))
+	}
+}
+
+// TestSearchBooksUnlimited verifies that limit=0 returns all matching results
+// (regression for PERF-4: count < 0 was always false, producing zero results).
+func TestSearchBooksUnlimited(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	for i := 0; i < 5; i++ {
+		_, err := store.CreateBook(&Book{
+			Title:    "Unlimited Test Book " + string(rune('A'+i)),
+			FilePath: "/test/unlimited/book" + string(rune('A'+i)) + ".mp3",
+		})
+		if err != nil {
+			t.Fatalf("create book %d: %v", i, err)
+		}
+	}
+
+	// limit=0 should return all 5 matches, not zero
+	results, err := store.SearchBooks("Unlimited Test", 0, 0)
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(results) < 5 {
+		t.Errorf("limit=0 should return all matches; got %d, want ≥5", len(results))
 	}
 }
 

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_search.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
-// last-edited: 2026-05-20
+// last-edited: 2026-06-23
 
 package server
 
@@ -69,6 +69,8 @@ func (s *Server) buildSearchIndexIfEmpty() {
 			return
 		default:
 		}
+		// TODO(PERF-6): replace with cursor-based GetAllBooksFrom(afterID, limit) once
+		// the Store interface gains that method — offset scans are O(offset) per page.
 		books, err := store.GetAllBooks(pageSize, offset)
 		if err != nil {
 			slog.Warn("search backfill GetAllBooks", "err", err)


### PR DESCRIPTION
## Summary

- **PERF-4 bug fix**: `SearchBooks(query, 0, 0)` in `pebble_store.go` returned zero results because `len(filtered) < 0` is always false. Fixed by treating `limit == 0` as "no limit" (standard Go convention). iTunes linked-panel search now works when a search term is typed. Regression test `TestSearchBooksUnlimited` added.
- **Tracking doc cleanup**: SEC-3, SEC-4, SEC-9, FE-3 marked ✅ — all were already fixed in prior PRs but the tracking doc wasn't updated.
- **PERF-6**: Deferred — cursor-based `GetAllBooksFrom` would require a Store interface change + mock regen. TODO comment added at call site.

## Files changed

| File | Change |
|---|---|
| `internal/database/pebble_store.go` | `limit==0` sentinel guard in `SearchBooks` |
| `internal/database/pebble_store_test.go` | `TestSearchBooksUnlimited` regression test |
| `internal/server/server_search.go` | TODO(PERF-6) comment at offset-scan call |
| `docs/tracking/audit-remediation-2026-06.md` | SEC-3/4/9, FE-3, PERF-4 marked ✅; PERF-6 note added |
| `TODO.md` | PERF-4 marked done |
| `CHANGELOG.md` | Fix entry added |

## Test plan

- [x] `TestSearchBooksUnlimited` — passes (was broken before fix)
- [x] `TestPebbleSearchBooks` — still passes (bounded search unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43