### PR TITLE
fix(docker): pin base image SHA digests (SEC-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.64.0 -->
+<!-- version: 3.65.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -15,6 +15,10 @@
 - **`docs`** SEC-3, SEC-4, SEC-9, FE-3 — tracking doc updated to ✅; all were already fixed in prior PRs (SEC-3/4 in PR A #1574; SEC-9 via `MaskSecrets()`; FE-3 via PR L #1585 which eliminated the stale code path).
 
 ### Security
+
+#### June 23, 2026 — pin Docker base image SHA digests (SEC-8)
+
+- **`fix(docker)`** SEC-8 — All base images in `Dockerfile` and `Dockerfile.build-cgo` pinned to content-addressed manifest-list digests: `node:26-alpine@sha256:a2dc166a...`, `golang:1.26-alpine@sha256:3ad57304...`, `alpine:3.24@sha256:28bd5fe8...`. Builds are now reproducible and immune to tag mutation attacks. Refresh comment included in each Dockerfile.
 
 #### June 22, 2026 — P1 audit remediation: PERF-7, SEC-7, SEC-2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 # file: Dockerfile
-# version: 2.5.0
+# version: 2.6.0
 # guid: audiobook-organizer-dockerfile-production
+# last-edited: 2026-06-23
 
 # Multi-stage production Dockerfile for audiobook-organizer
 # Builds React frontend, embeds it into a statically-linked Go binary with
 # CGO enabled (for SQLite FTS5 support), produces a minimal container.
 
 # Stage 1: Build frontend
-FROM --platform=$BUILDPLATFORM node:26-alpine AS frontend-builder
+# SHA pinned 2026-06-23 (node:26-alpine manifest-list). Refresh with:
+#   docker buildx imagetools inspect node:26-alpine --format '{{.Manifest.Digest}}'
+FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606 AS frontend-builder
 
 WORKDIR /build/web
 
@@ -19,7 +22,8 @@ RUN npm run build
 
 # Stage 2: Build Go application with embedded frontend
 # Uses native platform (no cross-compile) so CGO works without cross-toolchain.
-FROM golang:1.26-alpine AS go-builder
+# SHA pinned 2026-06-23 (golang:1.26-alpine manifest-list).
+FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS go-builder
 
 WORKDIR /build
 
@@ -73,7 +77,8 @@ RUN CGO_ENABLED=1 go build \
     .
 
 # Stage 3: Minimal runtime image (scratch-compatible since binary is static)
-FROM alpine:3.24
+# SHA pinned 2026-06-23 (alpine:3.24 manifest-list).
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 RUN apk add --no-cache ca-certificates tzdata ffmpeg \
     && addgroup -g 1000 audiobook \

--- a/Dockerfile.build-cgo
+++ b/Dockerfile.build-cgo
@@ -1,6 +1,7 @@
 # file: Dockerfile.build-cgo
-# version: 1.0.0
+# version: 1.1.0
 # guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+# last-edited: 2026-06-23
 #
 # Builds a statically-linked CGO binary with native TagLib for Linux amd64/arm64.
 # Used by CI to produce downloadable release binaries.
@@ -9,14 +10,16 @@
 #   docker buildx build --platform linux/amd64 --build-arg APP_VERSION=v1.0.0 \
 #     -f Dockerfile.build-cgo --output type=local,dest=dist/ .
 
-FROM --platform=$BUILDPLATFORM node:26-alpine AS frontend-builder
+# SHA pinned 2026-06-23 (node:26-alpine manifest-list).
+FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606 AS frontend-builder
 WORKDIR /build/web
 COPY web/package*.json ./
 RUN npm ci --prefer-offline --no-audit
 COPY web/ ./
 RUN npm run build
 
-FROM golang:1.26-alpine AS go-builder
+# SHA pinned 2026-06-23 (golang:1.26-alpine manifest-list).
+FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS go-builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.22.0 -->
+<!-- version: 9.23.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1315,6 +1315,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **PERF-7** — `UpsertBookFile` memdb round-trip fingerprint data-loss: same preserve-on-empty guard as `BatchUpsertBookFiles` now applied. 3 regression tests in `pebble_bookfile_preserve_test.go`. Shipped PR (audit-remediation-p1).
 - [x] **SEC-7** — `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` stays accepted-risk per MED-1. Shipped PR (audit-remediation-p1).
 - [x] **SEC-2** — `WriteStartupReadOnlyKey bool` config flag (default true). Operators can set `write_startup_readonly_key: false` to suppress `.readonly-key` file creation. Bootstrap token unaffected. Shipped PR (audit-remediation-p1).
+- [x] **SEC-8** — Docker mutable base tags: `node:26-alpine`, `golang:1.26-alpine`, `alpine:3.24` pinned to manifest-list SHA digests in `Dockerfile` + `Dockerfile.build-cgo`. Refresh with `docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'`.
 - [x] **SEC-5** — Restore target is arbitrary absolute path + `verify=true` is a no-op: `IsDangerousRoot` check added on `target_path`; `verify=true` logs a visible warning. Shipped PR #1584.
 - [x] **SEC-6** — Factory reset uses `RootDir` without validation: `IsDangerousRoot` check added before `os.RemoveAll` loop; returns 400 + logs error if RootDir is a protected system path. Shipped PR #1584.
 - [x] **FE-5 (audit)** — `Library.tsx` 2018→1811 lines: extracted `useLibraryQuery` (229 lines, book-fetch state + effects + auto-refresh) and `useLibrarySelection` (164 lines, selection state + handlers). Shipped PR #1585.

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.7.0 -->
+<!-- version: 1.8.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -41,7 +41,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | SEC-5 | Restore `verify=true` is a no-op; restore target is arbitrary absolute path | Sweep | ✅ | `pathvalidation.IsDangerousRoot` blocks system-dir targets; `verify=true` now logs a visible warning. Full checksum manifest deferred. Shipped PR #1584. |
 | SEC-6 | Factory reset deletes everything under `RootDir` without path validation | Sweep | ✅ | `pathvalidation.IsDangerousRoot` check added before library folder deletion; returns 400 + logs error if RootDir is a protected path. Shipped PR #1584. |
 | SEC-7 | `/metrics` and cache-stats endpoints unauthenticated | Sweep | ✅ | `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` kept as accepted-risk per MED-1 — standard Prometheus scrape endpoint, network-layer gating. |
-| SEC-8 | Docker build downloads unsigned tarballs, uses mutable base tags | Sweep | ⬜ | P2. Pin `node:26-alpine`, `golang:1.26-alpine`, `alpine:3.24` to `@sha256:...` digests in `Dockerfile` + `Dockerfile.build-cgo`. Deferred — network-only change, no prod risk (internal network only). |
+| SEC-8 | Docker build downloads unsigned tarballs, uses mutable base tags | Sweep | ✅ | Pinned all base images to manifest-list SHA digests in `Dockerfile` and `Dockerfile.build-cgo` (2026-06-23). Refresh with `docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'`. |
 | SEC-9 | OpenAI key exposed to frontend runtime for validation | Sweep | ✅ | `GetConfig` calls `MaskSecrets()` before responding; `update_service.go:37-55` masks all secret fields (OpenAI, AcoustID, Google Books, Hardcover, BasicAuth). Frontend only receives `***` masked value. |
 
 ---


### PR DESCRIPTION
## Summary

- Pins `node:26-alpine`, `golang:1.26-alpine`, and `alpine:3.24` to content-addressed manifest-list SHA digests in both `Dockerfile` and `Dockerfile.build-cgo`
- Builds are now reproducible and immune to tag mutation (a compromised registry cannot swap the image under an existing tag)
- Each `FROM` line includes a comment showing the refresh command: `docker buildx imagetools inspect <image> --format '{{.Manifest.Digest}}'`

## Digests pinned (2026-06-23)

| Image | Digest |
|---|---|
| `node:26-alpine` | `sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606` |
| `golang:1.26-alpine` | `sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648` |
| `alpine:3.24` | `sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b` |

## Test plan

- [x] `Dockerfile` and `Dockerfile.build-cgo` lint clean
- [x] SHA digests fetched via `docker buildx imagetools inspect` (not guessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43