### PR TITLE
refactor(config): centralize legacy key remap machinery (ARCH-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.67.0 -->
+<!-- version: 3.68.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Refactor
+
+#### June 23, 2026 — ARCH-4: config remap table centralization
+
+- **`refactor(config)`** ARCH-4 — 6 per-group `remap*Keys` functions in `update_service.go` replaced with `configRemapGroups` table + generic `applyLegacyRemaps`. Single source of truth: adding a new legacy-key migration needs one `legacyRemapGroup` entry, not a new function. 13 tests updated to use the unified helper.
 
 #### June 23, 2026 — ARCH-4b wave 2: deluge/centralization.go → RunItems (ARCH-4b)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.25.0 -->
+<!-- version: 9.26.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1308,6 +1308,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 
 - [x] **ARCH-3** — Unified op-launch helpers: `launchOp` (operations handler) and `launchLegacyOp` (duplicates handler) shipped PR #1577. Eliminates enqueue boilerplate across 11 callers.
 - [x] **ARCH-4** — Work-item contract: `RunItems[T]` standalone generic function + `ErrMode`/`RunItemsOptions` + 9 unit tests shipped PR #1579. Eliminates ctx.Done/UpdateProgress/SetCurrentItem boilerplate in new fan-out ops.
+- [x] **ARCH-4 (remap centralization)** — Config remap machinery: 6 per-group `remap*Keys` functions in `update_service.go` replaced with `configRemapGroups` table + generic `applyLegacyRemaps`. Single source of truth — adding new legacy-key groups requires one entry, not a new function. PR #1594.
 - [x] **ARCH-4b (wave 1)** — `deluge/path_update.go` migrated to `registry.RunItems[database.BookVersion]` with `ErrModeCollect`. `updated` counter via `atomic.Int64`. PR #1591.
 - [x] **ARCH-4b (wave 2)** — `deluge/centralization.go` migrated: pre-sliced to checkpoint.ProcessedFiles, atomic counters (success/skip/err), checkpoint written inside RunItems fn closure, IsCanceled() replaced by ctx-based RunItems polling. PR #1592.
 - [ ] **ARCH-4b (wave 3)** — Remaining 3 sites: `lsh_backfill.go` (308K-item progress cadence — needs reporter throttle wrapper before RunItems is appropriate), `acoustid/backfill.go` (nested books→files loop + resume-by-book-ID — requires flat-map preprocessing), `acoustid/reset_all.go` (callback-driven PebbleStore.ClearAllAcoustIDFingerprints API + dual heterogeneous loops). `acoustid/fingerprint_rescan.go` excluded — already uses semaphore goroutine pool that outperforms sequential RunItems.

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.11.0 -->
+<!-- version: 1.12.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -69,7 +69,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | ARCH-1 | Handler extraction preserved Server coupling (lazy providers, injected closures, server-private helpers) | Sweep | ⬜ | `handlers/audiobooks/handler.go:77`, `handlers/metadata/handler.go:72`, etc. Introduce domain application services; handlers become HTTP adapters. |
 | ARCH-2 | `wire_handlers.go` is an overloaded composition root + route registry | Sweep | ⬜ | `wire_handlers.go:31`, typed-nil guards at `:145,170,226`. Split per-domain route modules. |
 | ARCH-3 | Operation enqueue boilerplate duplicated across handlers | Sweep | ✅ | `launchOp` / `launchLegacyOp` helpers extracted; 11 enqueue boilerplate sites eliminated (PR G #1577). |
-| ARCH-4 | Config legacy remap machinery repeats by group | Sweep | ⬜ | `config/update_service.go:70,102,138,170,206`. Centralize remap tables. P2 — CFG struct-nesting refactor (PRs #1464–#1485) restructured fields but did not centralize remap tables. |
+| ARCH-4 | Config legacy remap machinery repeats by group | Sweep | ✅ | `applyLegacyRemaps` + `configRemapGroups` table in `update_service.go`. 6 per-group functions eliminated; all remap logic in one place. 13 tests updated. |
 | ARCH-5 | `AudiobookService` is a god service | Sweep | ⬜ | P2. Split query/mutation/tags/delete/compatibility. |
 | ARCH-6 | Optional store capabilities discovered ad hoc | Sweep | ⬜ | P2. Add `storecap` helpers. |
 | ARCH-7 | Compatibility surfaces scattered across 6+ files | Sweep | ⬜ | P2. Create compatibility registry with owner/removal condition. |

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence_test.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-06-16
+// last-edited: 2026-06-23
 
 package config
 
@@ -863,7 +863,7 @@ func TestRemapEmbeddingKeys_FlatKeys(t *testing.T) {
 		"embedding_dimensions": float64(1024),
 		"root_dir":             "/data",
 	}
-	result := remapEmbeddingKeys(payload)
+	result := applyLegacyRemaps(payload)
 
 	emb, ok := result["embedding"].(map[string]any)
 	require.True(t, ok)
@@ -881,7 +881,7 @@ func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
 		"embedding_enabled": false,
 		"embedding":         map[string]any{"model": "bge-m3"},
 	}
-	result := remapEmbeddingKeys(payload)
+	result := applyLegacyRemaps(payload)
 	emb := result["embedding"].(map[string]any)
 	assert.Equal(t, false, emb["enabled"])
 	assert.Equal(t, "bge-m3", emb["model"])
@@ -889,7 +889,7 @@ func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
 
 func TestRemapEmbeddingKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapEmbeddingKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
@@ -936,7 +936,7 @@ func TestRemapDedupKeys_FlatKeys(t *testing.T) {
 		"dedup_review_model":        "gpt-5-mini",
 		"root_dir":                  "/data",
 	}
-	result := remapDedupKeys(payload)
+	result := applyLegacyRemaps(payload)
 	d, ok := result["dedup"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(0.95), d["book_high_threshold"])
@@ -947,7 +947,7 @@ func TestRemapDedupKeys_FlatKeys(t *testing.T) {
 
 func TestRemapDedupKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapDedupKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
@@ -995,7 +995,7 @@ func TestRemapMetadataScoringKeys_FlatKeys(t *testing.T) {
 		"write_backup_before_tag_write":      false,
 		"root_dir":                           "/data",
 	}
-	result := remapMetadataScoringKeys(payload)
+	result := applyLegacyRemaps(payload)
 	ms, ok := result["metadata_scoring"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, true, ms["embedding_enabled"])
@@ -1006,7 +1006,7 @@ func TestRemapMetadataScoringKeys_FlatKeys(t *testing.T) {
 
 func TestRemapMetadataScoringKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapMetadataScoringKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
@@ -1055,7 +1055,7 @@ func TestRemapITunesKeys_FlatKeys(t *testing.T) {
 		"itl_write_back_enabled": false,
 		"root_dir":               "/data",
 	}
-	result := remapITunesKeys(payload)
+	result := applyLegacyRemaps(payload)
 	it, ok := result["itunes"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, true, it["sync_enabled"])
@@ -1066,7 +1066,7 @@ func TestRemapITunesKeys_FlatKeys(t *testing.T) {
 
 func TestRemapITunesKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapITunesKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
@@ -1113,7 +1113,7 @@ func TestRemapMaintenanceKeys_FlatKeys(t *testing.T) {
 		"acoustid_online_lookup_nightly_limit": float64(500),
 		"root_dir":                             "/data",
 	}
-	result := remapMaintenanceKeys(payload)
+	result := applyLegacyRemaps(payload)
 	m, ok := result["maintenance"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, false, m["enabled"])
@@ -1124,7 +1124,7 @@ func TestRemapMaintenanceKeys_FlatKeys(t *testing.T) {
 
 func TestRemapMaintenanceKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapMaintenanceKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
@@ -1233,7 +1233,7 @@ func TestRemapAutoUpdateKeys_FlatKeys(t *testing.T) {
 		"auto_update_channel": "beta",
 		"root_dir":            "/data",
 	}
-	result := remapAutoUpdateKeys(payload)
+	result := applyLegacyRemaps(payload)
 	au, ok := result["auto_update"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, false, au["enabled"])
@@ -1244,6 +1244,6 @@ func TestRemapAutoUpdateKeys_FlatKeys(t *testing.T) {
 
 func TestRemapAutoUpdateKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
-	result := remapAutoUpdateKeys(payload)
+	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,7 +1,7 @@
 // file: internal/config/update_service.go
-// version: 3.8.0
+// version: 3.9.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
-// last-edited: 2026-06-16
+// last-edited: 2026-06-23
 
 package config
 
@@ -67,44 +67,25 @@ var secretFieldKeys = []string{
 // immutableFieldKeys cannot be changed at runtime and are rejected if present.
 var immutableFieldKeys = []string{"database_type", "enable_sqlite"}
 
-// remapEmbeddingKeys translates legacy flat embedding keys in a config update
-// payload to the nested EmbeddingConfig format. Merges into any existing
-// "embedding" sub-object to avoid zeroing sibling fields.
-// Remove this shim once the frontend sends nested keys.
-func remapEmbeddingKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+// legacyRemapGroup defines a single flat→nested config migration shim.
+// Remove entries (and their keys) once the frontend sends nested keys directly.
+type legacyRemapGroup struct {
+	groupKey     string
+	flatToNested map[string]string
+}
+
+// configRemapGroups is the single source of truth for all flat→nested config
+// key translations in UpdateConfig. Adding a new group here is sufficient —
+// no per-group function required.
+var configRemapGroups = []legacyRemapGroup{
+	{groupKey: "embedding", flatToNested: map[string]string{
 		"embedding_enabled":    "enabled",
 		"embedding_model":      "model",
 		"embedding_dimensions": "dimensions",
 		"embedding_base_url":   "base_url",
 		"vector_index_backend": "vector_backend",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
-		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["embedding"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
-		}
-	} else {
-		payload["embedding"] = nested
-	}
-	return payload
-}
-
-// remapDedupKeys translates legacy flat dedup keys in a config update payload
-// to the nested DedupConfig format. Merges into any existing "dedup" sub-object
-// to avoid zeroing sibling fields.
-// Remove this shim once the frontend sends nested keys.
-func remapDedupKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+	}},
+	{groupKey: "dedup", flatToNested: map[string]string{
 		"dedup_book_high_threshold":             "book_high_threshold",
 		"dedup_book_low_threshold":              "book_low_threshold",
 		"dedup_author_high_threshold":           "author_high_threshold",
@@ -114,31 +95,8 @@ func remapDedupKeys(payload map[string]any) map[string]any {
 		"dedup_llm_auto_merge_high_confidence": "llm_auto_merge_high_confidence",
 		"dedup_on_import_via_scheduler":         "on_import_via_scheduler",
 		"dedup_review_model":                    "review_model",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
-		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["dedup"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
-		}
-	} else {
-		payload["dedup"] = nested
-	}
-	return payload
-}
-
-// remapMetadataScoringKeys translates legacy flat metadata scoring keys to nested format.
-// Remove this shim once the frontend sends nested keys.
-func remapMetadataScoringKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+	}},
+	{groupKey: "metadata_scoring", flatToNested: map[string]string{
 		"metadata_embedding_scoring_enabled": "embedding_enabled",
 		"metadata_embedding_min_score":       "embedding_min_score",
 		"metadata_embedding_best_match_min":  "embedding_best_match",
@@ -146,33 +104,8 @@ func remapMetadataScoringKeys(payload map[string]any) map[string]any {
 		"metadata_llm_rerank_epsilon":        "llm_rerank_epsilon",
 		"metadata_llm_rerank_top_k":          "llm_rerank_top_k",
 		"write_backup_before_tag_write":      "write_backup_before",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
-		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["metadata_scoring"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
-		}
-	} else {
-		payload["metadata_scoring"] = nested
-	}
-	return payload
-}
-
-// remapITunesKeys translates legacy flat iTunes keys in a config update payload
-// to the nested ITunesConfig format. Merges into any existing "itunes" sub-object
-// to avoid zeroing sibling fields.
-// Remove this shim once the frontend sends nested keys.
-func remapITunesKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+	}},
+	{groupKey: "itunes", flatToNested: map[string]string{
 		"itunes_sync_enabled":       "sync_enabled",
 		"itunes_sync_interval":      "sync_interval",
 		"itl_write_back_enabled":    "write_back_enabled",
@@ -182,33 +115,8 @@ func remapITunesKeys(payload map[string]any) map[string]any {
 		"itunes_path_trim_enabled":  "path_trim_enabled",
 		"itunes_windows_root_path":  "windows_root_path",
 		"itunes_media_root":         "media_root",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
-		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["itunes"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
-		}
-	} else {
-		payload["itunes"] = nested
-	}
-	return payload
-}
-
-// remapMaintenanceKeys translates legacy flat maintenance_window_* keys in a config
-// update payload to the nested MaintenanceConfig format. Merges into any existing
-// "maintenance" sub-object to avoid zeroing sibling fields.
-// Remove this shim once the frontend sends nested keys.
-func remapMaintenanceKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+	}},
+	{groupKey: "maintenance", flatToNested: map[string]string{
 		"maintenance_window_enabled":                "enabled",
 		"maintenance_window_start":                  "window_start",
 		"maintenance_window_end":                    "window_end",
@@ -226,52 +134,38 @@ func remapMaintenanceKeys(payload map[string]any) map[string]any {
 		"maintenance_window_library_size_refresh":   "library_size_refresh",
 		"maintenance_window_acoustid_online_lookup": "acoustid_online_lookup",
 		"acoustid_online_lookup_nightly_limit":      "acoustid_nightly_limit",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
-		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["maintenance"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
-		}
-	} else {
-		payload["maintenance"] = nested
-	}
-	return payload
-}
-
-// remapAutoUpdateKeys translates legacy flat auto_update_* keys to nested AutoUpdateConfig format.
-func remapAutoUpdateKeys(payload map[string]any) map[string]any {
-	flatToNested := map[string]string{
+	}},
+	{groupKey: "auto_update", flatToNested: map[string]string{
 		"auto_update_enabled":       "enabled",
 		"auto_update_channel":       "channel",
 		"auto_update_check_minutes": "check_minutes",
 		"auto_update_window_start":  "window_start",
 		"auto_update_window_end":    "window_end",
-	}
-	nested := make(map[string]any)
-	for flat, short := range flatToNested {
-		if v, ok := payload[flat]; ok {
-			nested[short] = v
-			delete(payload, flat)
+	}},
+}
+
+// applyLegacyRemaps applies all configRemapGroups to payload, translating any
+// legacy flat keys to their nested equivalents. Existing sub-objects are merged
+// rather than replaced, so partial payloads don't zero sibling fields.
+func applyLegacyRemaps(payload map[string]any) map[string]any {
+	for _, g := range configRemapGroups {
+		nested := make(map[string]any)
+		for flat, short := range g.flatToNested {
+			if v, ok := payload[flat]; ok {
+				nested[short] = v
+				delete(payload, flat)
+			}
 		}
-	}
-	if len(nested) == 0 {
-		return payload
-	}
-	if existing, ok := payload["auto_update"].(map[string]any); ok {
-		for k, v := range nested {
-			existing[k] = v
+		if len(nested) == 0 {
+			continue
 		}
-	} else {
-		payload["auto_update"] = nested
+		if existing, ok := payload[g.groupKey].(map[string]any); ok {
+			for k, v := range nested {
+				existing[k] = v
+			}
+		} else {
+			payload[g.groupKey] = nested
+		}
 	}
 	return payload
 }
@@ -328,20 +222,11 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 		delete(filtered, k)
 	}
 
-	// Translate any legacy flat embedding keys to the nested EmbeddingConfig format.
-	filtered = remapEmbeddingKeys(filtered)
-	// Translate any legacy flat dedup keys to the nested DedupConfig format.
-	filtered = remapDedupKeys(filtered)
-	// Translate any legacy flat metadata scoring keys to the nested MetadataScoringConfig format.
-	filtered = remapMetadataScoringKeys(filtered)
-	// Translate any legacy flat iTunes keys to the nested ITunesConfig format.
-	filtered = remapITunesKeys(filtered)
-	// Translate any legacy flat maintenance_window_* keys to the nested MaintenanceConfig format.
-	filtered = remapMaintenanceKeys(filtered)
-	// Translate any legacy flat scheduled_* keys to the nested ScheduledTasksConfig format.
+	// Translate all legacy flat keys to their nested group equivalents.
+	// configRemapGroups is the single source of truth; remapScheduledKeys handles
+	// the deeper two-level nesting that the generic helper doesn't cover.
+	filtered = applyLegacyRemaps(filtered)
 	filtered = remapScheduledKeys(filtered)
-	// Translate any legacy flat auto_update_* keys to the nested AutoUpdateConfig format.
-	filtered = remapAutoUpdateKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.
 	// Any field in Config with a matching json tag is set automatically.


### PR DESCRIPTION
## Summary

Eliminates 6 near-identical remap*Keys functions in update_service.go, replacing with configRemapGroups table + applyLegacyRemaps helper. Tests updated. go test passes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43