### PR TITLE
perf(itunes): batch external ID writes in backfill (PERF-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.68.0 -->
+<!-- version: 3.69.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Performance
+
+#### June 23, 2026 — iTunes backfill bulk writes (PERF-5)
+
+- **`perf(itunes)`** PERF-5 — `BackfillExternalIDs` now accumulates mappings per page and flushes with a single `BulkCreateExternalIDMappings` call, reducing DB writes from O(N) to O(pages). N+1 `GetBookFiles` read deferred (TODO at `itunes/backfill.go:77`).
 
 ### Refactor
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.26.0 -->
+<!-- version: 9.27.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1314,6 +1314,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [ ] **ARCH-4b (wave 3)** — Remaining 3 sites: `lsh_backfill.go` (308K-item progress cadence — needs reporter throttle wrapper before RunItems is appropriate), `acoustid/backfill.go` (nested books→files loop + resume-by-book-ID — requires flat-map preprocessing), `acoustid/reset_all.go` (callback-driven PebbleStore.ClearAllAcoustIDFingerprints API + dual heterogeneous loops). `acoustid/fingerprint_rescan.go` excluded — already uses semaphore goroutine pool that outperforms sequential RunItems.
 - [x] **PERF-2** — Batch upserts in `createBookFilesForBook`: N per-segment `UpsertBookFile` calls replaced with one `BatchUpsertBookFiles` call (shipped PR #1583). N→1 DB writes per book on first scan.
 - [ ] **PERF-2b** — Hash carry-forward: dedup check at `scanner.go:1885` re-hashes every segment file that `createBookFilesForBook` (line 1322) also hashes. Fix requires `saveBookToDatabase` to return a `map[string]string` (filePath→hash) and passing it to `createBookFilesForBook`. Blocked by `saveBook` function-variable API change.
+- [x] **PERF-5 (partial)** — iTunes backfill bulk writes: per-row `CreateExternalIDMapping` calls replaced with per-page batch accumulation + `BulkCreateExternalIDMappings` (N→1 per 10K-book page). N+1 `GetBookFiles` per book still present — deferred until `GetBookFilesByBookIDs([]string)` batch method added to Store interface (TODO comment at `itunes/backfill.go:77`).
 - [x] **PERF-4** — iTunes search `SearchBooks(search, 0, 0)` returned zero results: `limit=0` was checked as `len(filtered) < 0` (always false). Fixed in `pebble_store.go:3169` — `limit==0` now means "no limit". Regression test `TestSearchBooksUnlimited` added.
 - [x] **PERF-7** — `UpsertBookFile` memdb round-trip fingerprint data-loss: same preserve-on-empty guard as `BatchUpsertBookFiles` now applied. 3 regression tests in `pebble_bookfile_preserve_test.go`. Shipped PR (audit-remediation-p1).
 - [x] **SEC-7** — `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` stays accepted-risk per MED-1. Shipped PR (audit-remediation-p1).

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.12.0 -->
+<!-- version: 1.13.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -55,7 +55,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | PERF-2 | Multi-file import hashes/tags same files repeatedly, one `UpsertBookFile` per segment | Sweep | ✅ Partial | Batch upserts shipped (PR J #1583): N→1 `BatchUpsertBookFiles` per book. Hash carry-forward (PERF-2b) blocked — needs `saveBookToDatabase` API change. |
 | PERF-3 | Library list has full-materialization escape hatches | Sweep | ⬜ | `audiobooks/service.go:856,1092,1286`. Push filters into `BookSummaryFilter`; add projections for common sorts. |
 | PERF-4 | iTunes search calls `SearchBooks(search, 0, 0)` — returns zero rows | Sweep | ✅ | Root cause: `pebble_store.go:3169` `len(filtered) < limit` is always false when `limit=0`. Fixed: treat `limit==0` as "no limit". Regression test `TestSearchBooksUnlimited` added. |
-| PERF-5 | iTunes backfill: offset pagination, N+1 file reads, per-row writes | Sweep | ⬜ | `itunes/backfill.go:21,46,73`. Cursor iteration, batch file lookup, bulk writes. |
+| PERF-5 | iTunes backfill: offset pagination, N+1 file reads, per-row writes | Sweep | ✅ Partial | Per-row writes fixed: mappings now accumulated per page and flushed with one `BulkCreateExternalIDMappings` call (N→1 per page). N+1 file reads deferred — needs `GetBookFilesByBookIDs([]string)` batch method on Store + mock regen; TODO comment added. Offset pagination kept — 5 pages for 50K books is acceptable. |
 | PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ⬜ | `server_search.go:63`. Deferred — requires `GetAllBooksFrom(afterID, limit)` cursor method on Store interface + mock regen. TODO comment added at call site. |
 | PERF-7 | Memdb projection is a monolith; strips `AcoustIDFingerprint` on round-trip | Sweep | ✅ | `UpsertBookFile` now has the same fingerprint-preserve guard as `BatchUpsertBookFiles`. 3 regression tests added in `pebble_bookfile_preserve_test.go`. |
 | PERF-8 | Backup walks live Pebble files directly | Sweep | ⬜ | P2. Use Pebble `Checkpoint` before archiving. |

--- a/internal/itunes/backfill.go
+++ b/internal/itunes/backfill.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/backfill.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b8c9d0e1-f2a3-b4c5-d6e7-f8a9b0c1d2e3
+// last-edited: 2026-06-23
 
 package itunes
 
@@ -54,6 +55,10 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 		if err != nil || len(books) == 0 {
 			break
 		}
+
+		// Accumulate per-page so we can flush with a single bulk write rather
+		// than one CreateExternalIDMapping call per book/file (PERF-5).
+		var batch []database.ExternalIDMapping
 		for _, book := range books {
 			if err := ctx.Err(); err != nil {
 				slog.Info("external ID backfill canceled mid-batch after mappings", "backfilled", backfilled, "err", err)
@@ -61,31 +66,35 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 			}
 			// Book-level PID
 			if book.ITunesPersistentID != nil && *book.ITunesPersistentID != "" {
-				_ = store.CreateExternalIDMapping(&database.ExternalIDMapping{
+				batch = append(batch, database.ExternalIDMapping{
 					Source:     "itunes",
 					ExternalID: *book.ITunesPersistentID,
 					BookID:     book.ID,
 				})
-				backfilled++
 			}
 
 			// BookFile-level PIDs (catches split books, multi-file books, etc.)
+			// TODO(PERF-5): replace with a batch GetBookFilesByBookIDs call to
+			// eliminate the N+1 file read. Requires a new Store interface method.
 			files, fErr := store.GetBookFiles(book.ID)
 			if fErr != nil {
 				continue
 			}
 			for _, f := range files {
 				if f.ITunesPersistentID != "" {
-					_ = store.CreateExternalIDMapping(&database.ExternalIDMapping{
+					batch = append(batch, database.ExternalIDMapping{
 						Source:     "itunes",
 						ExternalID: f.ITunesPersistentID,
 						BookID:     book.ID,
 						FilePath:   f.FilePath,
 						Provenance: "backfill_v4",
 					})
-					backfilled++
 				}
 			}
+		}
+		if len(batch) > 0 {
+			_ = store.BulkCreateExternalIDMappings(batch)
+			backfilled += len(batch)
 		}
 		offset += 10000
 	}


### PR DESCRIPTION
## Summary

`BackfillExternalIDs` was calling `CreateExternalIDMapping` once per book and once per BookFile with an iTunes PID — potentially 50K+ individual DB write round-trips for a 50K-book library.

Fix: accumulate mappings into a per-page `[]ExternalIDMapping` slice, flush with one `BulkCreateExternalIDMappings` call at end of each 10K-book page. Result: 5 bulk writes instead of 50K+ individual ones.

**Remaining:** N+1 `GetBookFiles(book.ID)` read (one per book) documented with `TODO(PERF-5)` comment at `itunes/backfill.go:77`. Deferred until `GetBookFilesByBookIDs([]string)` batch method is added to the Store interface.

Note: this backfill runs at most once (idempotent via `external_id_backfill_v4_done` setting), so the production impact is during initial migration only.

## Test plan

- [x] `go test ./internal/itunes/...` passes
- [x] Build clean: `go build ./internal/itunes/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43