### PR TITLE
test(e2e): replace waitForTimeout with waitForRequest (TOOL-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.70.0 -->
+<!-- version: 3.71.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Tooling
+
+#### June 23, 2026 — TOOL-7: replace fixed sleeps in E2E tests
+
+- **`test(e2e)`** TOOL-7 — `waitForTimeout(1000)` replaced with `waitForRequest(url)` in `dedup-operations.spec.ts` and `dedup.spec.ts`. Tests now respond to actual network activity instead of arbitrary delays.
 
 #### June 23, 2026 — TOOL-3 demo isolation + TOOL-8 smoke targets
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.28.0 -->
+<!-- version: 9.29.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1326,6 +1326,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **STR-4** — `BookDedup.tsx` 2907→145 lines: extracted `DedupAIReviewTab` (386 lines), `DedupEmbeddingTab` (1441 lines, embedding dedup with module-level cache + buildClusters), `DedupAcousticTab` (996 lines, acoustic dedup + `AcousticBookCard`/`AcousticBookMetadata` re-exports). Shipped PR #1585. TypeScript: 0 errors.
 - [x] **TOOL-1** — Large corpus LFS: already configured in `.gitattributes` (48 LFS objects, 1.7 GB). Fixed `mediainfo_test.go:889` hardcoded absolute path → `findRepoRootForMediainfo()` inline walk. Skip message updated to guide `git lfs pull`. Shipped PR #1586.
 - [x] **TOOL-3** — Demo recording isolated from default E2E: `chromium`/`webkit` projects now have `testIgnore: ['**/demo-*.spec.ts', '**/interactive-*.spec.ts']`; `chromium-record` is opt-in. `npm run test:e2e:demo` + `make test-e2e-demo` added.
+- [x] **TOOL-7** — Fixed sleeps in E2E tests: `waitForTimeout(1000)` replaced with `waitForRequest(url)` in `dedup-operations.spec.ts` and `dedup.spec.ts`. `dynamic-ui-interactions.spec.ts` mock-handler delays retained (intentional latency simulation). Go backend `time.Sleep` calls are timing-sensitive and correct.
 - [x] **TOOL-8** — Manual smoke scripts wrapped as Makefile targets: `make manual-smoke`, `make smoke-create-books`, `make smoke-run-demo`.
 
 ---

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.14.0 -->
+<!-- version: 1.15.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -107,7 +107,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | TOOL-4 | Testing docs and actual CI gates disagree (80% vs 30% coverage claims) | Sweep | ✅ | Docs aligned with actual CI thresholds (PR B #1575). |
 | TOOL-5 | Generated mocks still large despite per-handler split | Sweep | ⬜ | P2. Prefer narrow hand-written fakes for new code. |
 | TOOL-6 | Generated Playwright report tracked in git | Sweep | ✅ | `/playwright-report/` untracked, added to `.gitignore` (PR B #1575). |
-| TOOL-7 | Fixed sleeps in tests | Sweep | ⬜ | P2. Use locator/API waits and injected clocks. |
+| TOOL-7 | Fixed sleeps in tests | Sweep | ✅ Partial | `waitForTimeout(1000)` replaced with `waitForRequest(url)` in `dedup-operations.spec.ts:128` and `dedup.spec.ts:174`. `dynamic-ui-interactions.spec.ts` sleeps are in mock route handlers (intentional simulated latency, not polling) — correctly left as-is. Remaining Go backend sleeps (`time.Sleep`) are timing-sensitive (TTL expiry, timestamp ordering) and cannot be replaced with state checks. |
 | TOOL-8 | Manual smoke scripts not integrated into Makefile | Sweep | ✅ | `make manual-smoke`, `make smoke-create-books`, `make smoke-run-demo` targets added to Makefile. |
 
 ---

--- a/web/tests/e2e/dedup-operations.spec.ts
+++ b/web/tests/e2e/dedup-operations.spec.ts
@@ -1,6 +1,7 @@
 // file: web/tests/e2e/dedup-operations.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b
+// last-edited: 2026-06-23
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -125,7 +126,8 @@ test.describe('Production Company Resolution', () => {
     await page.waitForLoadState('networkidle');
 
     await page.getByRole('button', { name: /find real author/i }).first().click();
-    await page.waitForTimeout(1000);
+    // Wait for the API request rather than sleeping — avoids flakiness under load.
+    await page.waitForRequest(req => req.url().includes('/resolve-production'));
     expect(resolveCallCount).toBeGreaterThan(0);
   });
 });

--- a/web/tests/e2e/dedup.spec.ts
+++ b/web/tests/e2e/dedup.spec.ts
@@ -1,6 +1,7 @@
 // file: web/tests/e2e/dedup.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+// last-edited: 2026-06-23
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -170,8 +171,8 @@ test.describe('Author Dedup', () => {
 
     await page.getByRole('button', { name: /find real author/i }).first().click();
 
-    // Wait for the API call to complete
-    await page.waitForTimeout(1000);
+    // Wait for the API request rather than sleeping — avoids flakiness under load.
+    await page.waitForRequest(req => req.url().includes('/resolve-production'));
     expect(resolveCallCount).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## Summary

Replaces 2 `waitForTimeout(1000)` fixed sleeps in E2E tests with `waitForRequest(url)` — tests now wait for actual network activity instead of arbitrary 1-second delays.

**Changed:**
- `dedup-operations.spec.ts:128` — after clicking "Find Real Author", wait for the `/resolve-production` request instead of sleeping 1s
- `dedup.spec.ts:174` — same pattern, same fix

**Left as-is:** `dynamic-ui-interactions.spec.ts` — all `setTimeout` calls are inside mock route handlers simulating server latency (intentional, tests UI loading states like spinners and disabled buttons).

**Left as-is:** Go backend `time.Sleep` calls in tests — these are testing TTL expiry, timestamp ordering, and cache invalidation timing; they cannot be replaced with state-check waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43