### PR TITLE
refactor(frontend): split useSettingsHandlers by domain (FE-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.71.0 -->
+<!-- version: 3.72.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Frontend
+
+#### June 23, 2026 — FE-6: split useSettingsHandlers by domain
+
+- **`refactor(frontend)`** FE-6 — `useSettingsHandlers.ts` (1259 lines) split into three domain-scoped sub-hooks: `useImportFolderHandlers`, `useBackupHandlers`, `useMetadataSourceHandlers`. Main hook reduced to 936 lines (−26%). Return interface and Settings.tsx consumer unchanged.
 
 ### Tooling
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.29.0 -->
+<!-- version: 9.30.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1250,6 +1250,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
   → [`2026-04-30-fe-4-settings-general.md`](docs/superpowers/bot-tasks/2026-04-30-fe-4-settings-general.md)
 - [x] **FE-5** `refactor/settings-paths-tab` — Done: `PathsSettingsTab.tsx` extracted.
 - [x] **FE-6** `refactor/settings-metadata-tab` — Done: `MetadataSettingsTab.tsx` extracted.
+- [x] **FE-6 (audit)** `refactor/fe6-settings-handlers-split` — Done: `useSettingsHandlers.ts` (1259→936 lines) split into `useImportFolderHandlers`, `useBackupHandlers`, `useMetadataSourceHandlers`.
 - [x] **FE-7** `fix/frontend-remove-console-logs` — Done: no `console.log` calls in production source; only `console.error`/`console.warn` in catch blocks (appropriate).
 - [x] **FE-8** `fix/frontend-error-boundaries` — Done: `ErrorBoundary` wraps every page route in `App.tsx`.
 - [x] **FE-9** `fix/frontend-localstorage-keys` — Done: `STORAGE_KEYS` constants exported from `lib/storageKeys.ts`.

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.15.0 -->
+<!-- version: 1.16.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -89,7 +89,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | FE-3 | Legacy `BookDedup` rows-per-page changes can fetch stale data | Sweep | ✅ | Resolved by PR L (#1585): `BookDedup.tsx` reduced to 145 lines (pure tab router); the stale rows-per-page code was in the extracted tab components which were rewritten. |
 | FE-4 | `BookDetail` file/segment state stale across route-param changes | Sweep | ✅ | Reset on `id` change added (PR C #1576). |
 | FE-5 | `Library.tsx` still a 3,333-line maintenance hotspot | Both | ✅ Partial | `useLibraryQuery` + `useLibrarySelection` extracted, 3,333→1,811 lines (PR L #1585). `useImportPaths` + `useLibraryOperations` deferred — P2. |
-| FE-6 | `useSettingsHandlers` passes too much mutable state through one hook | Sweep | ⬜ | `useSettingsHandlers.ts:40`. Split by domain. P2. |
+| FE-6 | `useSettingsHandlers` passes too much mutable state through one hook | Sweep | ✅ | Extracted `useImportFolderHandlers` (212L), `useBackupHandlers` (167L), `useMetadataSourceHandlers` (121L). Main hook: 1259→936 lines (−26%). Return interface unchanged; Settings.tsx untouched. |
 | FE-7 | Sensitive one-time tokens remain rendered in React state after display | Sweep | ✅ | Token auto-clear after copy/timeout added (PR C #1576). |
 | FE-8 | E2E auth tests mock auth instead of exercising real cookie/CSRF | Sweep | ⬜ | Add one real-server smoke test. |
 | STR-4 | `BookDedup.tsx` still ~3,656 lines | Structure | ✅ | Split into 3 tab components (DedupAIReviewTab, DedupEmbeddingTab, DedupAcousticTab); 2,907→145 lines (PR L #1585). |

--- a/web/src/hooks/useBackupHandlers.ts
+++ b/web/src/hooks/useBackupHandlers.ts
@@ -1,0 +1,167 @@
+// file: web/src/hooks/useBackupHandlers.ts
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-06-23
+
+import type { Dispatch, SetStateAction } from 'react';
+import * as api from '../services/api';
+
+type BackupNotice = { severity: 'success' | 'error' | 'info'; message: string } | null;
+
+export interface UseBackupHandlersParams {
+  setBackups: Dispatch<SetStateAction<api.BackupInfo[]>>;
+  setBackupNotice: Dispatch<SetStateAction<BackupNotice>>;
+  setBackupsLoading: Dispatch<SetStateAction<boolean>>;
+  setRestoreTarget: Dispatch<SetStateAction<api.BackupInfo | null>>;
+  setRestoreDialogOpen: Dispatch<SetStateAction<boolean>>;
+  setRestoreInProgress: Dispatch<SetStateAction<boolean>>;
+  setDeleteBackupTarget: Dispatch<SetStateAction<api.BackupInfo | null>>;
+  setDeleteBackupInProgress: Dispatch<SetStateAction<boolean>>;
+  setCreateBackupInProgress: Dispatch<SetStateAction<boolean>>;
+  setNewFolderPath: Dispatch<SetStateAction<string>>;
+  restoreTarget: api.BackupInfo | null;
+  restoreVerify: boolean;
+  deleteBackupTarget: api.BackupInfo | null;
+}
+
+export interface UseBackupHandlersReturn {
+  loadBackups: () => Promise<void>;
+  handleCreateBackup: () => Promise<void>;
+  handleRequestRestore: (backup: api.BackupInfo) => void;
+  handleConfirmRestore: () => Promise<void>;
+  handleRequestDeleteBackup: (backup: api.BackupInfo) => void;
+  handleConfirmDeleteBackup: () => Promise<void>;
+  handleFolderBrowserSelect: (path: string, isDir: boolean) => void;
+}
+
+export function useBackupHandlers(
+  params: UseBackupHandlersParams
+): UseBackupHandlersReturn {
+  const {
+    setBackups,
+    setBackupNotice,
+    setBackupsLoading,
+    setRestoreTarget,
+    setRestoreDialogOpen,
+    setRestoreInProgress,
+    setDeleteBackupTarget,
+    setDeleteBackupInProgress,
+    setCreateBackupInProgress,
+    setNewFolderPath,
+    restoreTarget,
+    restoreVerify,
+    deleteBackupTarget,
+  } = params;
+
+  const loadBackups = async () => {
+    setBackupsLoading(true);
+    try {
+      const data = await api.listBackups();
+      const sorted = [...(data.backups || [])].sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      );
+      setBackups(sorted);
+    } catch (error) {
+      console.error('Failed to load backups:', error);
+      setBackupNotice({
+        severity: 'error',
+        message: 'Failed to load backups.',
+      });
+    } finally {
+      setBackupsLoading(false);
+    }
+  };
+
+  const handleCreateBackup = async () => {
+    setCreateBackupInProgress(true);
+    setBackupNotice(null);
+    try {
+      await api.createBackup();
+      setBackupNotice({
+        severity: 'success',
+        message: 'Backup created successfully.',
+      });
+      await loadBackups();
+    } catch (error) {
+      console.error('Failed to create backup:', error);
+      setBackupNotice({
+        severity: 'error',
+        message: 'Failed to create backup.',
+      });
+    } finally {
+      setCreateBackupInProgress(false);
+    }
+  };
+
+  const handleRequestRestore = (backup: api.BackupInfo) => {
+    setRestoreTarget(backup);
+    setRestoreDialogOpen(true);
+  };
+
+  const handleConfirmRestore = async () => {
+    if (!restoreTarget) return;
+    setRestoreInProgress(true);
+    setBackupNotice(null);
+    try {
+      await api.restoreBackup(restoreTarget.filename, restoreVerify);
+      setBackupNotice({
+        severity: 'success',
+        message: 'Backup restored successfully.',
+      });
+      setRestoreDialogOpen(false);
+      window.location.reload();
+    } catch (error) {
+      console.error('Failed to restore backup:', error);
+      setBackupNotice({
+        severity: 'error',
+        message: 'Backup file is corrupt.',
+      });
+    } finally {
+      setRestoreInProgress(false);
+    }
+  };
+
+  const handleRequestDeleteBackup = (backup: api.BackupInfo) => {
+    setDeleteBackupTarget(backup);
+  };
+
+  const handleConfirmDeleteBackup = async () => {
+    if (!deleteBackupTarget) return;
+    setDeleteBackupInProgress(true);
+    setBackupNotice(null);
+    try {
+      await api.deleteBackup(deleteBackupTarget.filename);
+      setBackupNotice({
+        severity: 'success',
+        message: 'Backup deleted successfully.',
+      });
+      setDeleteBackupTarget(null);
+      await loadBackups();
+    } catch (error) {
+      console.error('Failed to delete backup:', error);
+      setBackupNotice({
+        severity: 'error',
+        message: 'Failed to delete backup.',
+      });
+    } finally {
+      setDeleteBackupInProgress(false);
+    }
+  };
+
+  const handleFolderBrowserSelect = (path: string, isDir: boolean) => {
+    if (isDir) {
+      setNewFolderPath(path);
+    }
+  };
+
+  return {
+    loadBackups,
+    handleCreateBackup,
+    handleRequestRestore,
+    handleConfirmRestore,
+    handleRequestDeleteBackup,
+    handleConfirmDeleteBackup,
+    handleFolderBrowserSelect,
+  };
+}

--- a/web/src/hooks/useImportFolderHandlers.ts
+++ b/web/src/hooks/useImportFolderHandlers.ts
@@ -1,0 +1,212 @@
+// file: web/src/hooks/useImportFolderHandlers.ts
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-06-23
+
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import * as api from '../services/api';
+import type { ScanStatus, ScanErrorTarget } from './useSettingsHandlers';
+
+export interface UseImportFolderHandlersParams {
+  setImportFolders: Dispatch<SetStateAction<api.ImportPath[]>>;
+  setScanStatuses: Dispatch<SetStateAction<Record<number, ScanStatus>>>;
+  setCancelScanTarget: Dispatch<SetStateAction<api.ImportPath | null>>;
+  setScanErrorTarget: Dispatch<SetStateAction<ScanErrorTarget | null>>;
+  setNewFolderPath: Dispatch<SetStateAction<string>>;
+  setShowFolderBrowser: Dispatch<SetStateAction<boolean>>;
+  setAddFolderDialogOpen: Dispatch<SetStateAction<boolean>>;
+  scanIntervalsRef: MutableRefObject<Record<number, number>>;
+  cancelScanTarget: api.ImportPath | null;
+  scanStatuses: Record<number, ScanStatus>;
+  newFolderPath: string;
+}
+
+export interface UseImportFolderHandlersReturn {
+  loadImportFolders: () => Promise<void>;
+  handleAddImportFolder: () => Promise<void>;
+  handleRemoveImportFolder: (id: number) => Promise<void>;
+  handleScanImportFolder: (folder: api.ImportPath) => Promise<void>;
+  handleRequestCancelScan: (folder: api.ImportPath) => void;
+  handleConfirmCancelScan: () => Promise<void>;
+  handleViewScanErrors: (folder: api.ImportPath, status: ScanStatus) => void;
+}
+
+export function useImportFolderHandlers(
+  params: UseImportFolderHandlersParams
+): UseImportFolderHandlersReturn {
+  const {
+    setImportFolders,
+    setScanStatuses,
+    setCancelScanTarget,
+    setScanErrorTarget,
+    setNewFolderPath,
+    setShowFolderBrowser,
+    setAddFolderDialogOpen,
+    scanIntervalsRef,
+    cancelScanTarget,
+    scanStatuses,
+    newFolderPath,
+  } = params;
+
+  const loadImportFolders = async () => {
+    try {
+      const folders = await api.getImportPaths();
+      setImportFolders(folders);
+    } catch (error) {
+      console.error('Failed to load import folders:', error);
+    }
+  };
+
+  const handleAddImportFolder = async () => {
+    if (!newFolderPath.trim()) return;
+    try {
+      const folder = await api.addImportPath(
+        newFolderPath,
+        newFolderPath.split('/').pop() || 'Import Folder'
+      );
+      setImportFolders((prev) => [...prev, folder]);
+      setNewFolderPath('');
+      setShowFolderBrowser(false);
+      setAddFolderDialogOpen(false);
+    } catch (error) {
+      console.error('Failed to add import folder:', error);
+    }
+  };
+
+  const handleRemoveImportFolder = async (id: number) => {
+    try {
+      await api.removeImportPath(id);
+      setImportFolders((prev) => prev.filter((f) => f.id !== id));
+    } catch (error) {
+      console.error('Failed to remove import folder:', error);
+    }
+  };
+
+  const handleScanImportFolder = async (folder: api.ImportPath) => {
+    setScanStatuses((prev) => ({
+      ...prev,
+      [folder.id]: {
+        status: 'scanning',
+        scanned: 0,
+        total: prev[folder.id]?.total || 0,
+      },
+    }));
+
+    let total = 50;
+    let errors: string[] = [];
+    let operationId: string | undefined;
+
+    try {
+      const response = await api.startScan(folder.path);
+      if (typeof response.total === 'number') {
+        total = response.total;
+      }
+      if (Array.isArray(response.errors)) {
+        errors = response.errors;
+      }
+      operationId = response.id;
+    } catch (error) {
+      console.error('Failed to scan import folder:', error);
+      const message =
+        error instanceof Error ? error.message : 'Scan failed.';
+      setScanStatuses((prev) => ({
+        ...prev,
+        [folder.id]: {
+          status: 'error',
+          scanned: 0,
+          total: 0,
+          errors: [message],
+        },
+      }));
+      return;
+    }
+
+    setScanStatuses((prev) => ({
+      ...prev,
+      [folder.id]: {
+        status: 'scanning',
+        scanned: 0,
+        total,
+        operationId,
+        errors,
+      },
+    }));
+
+    let scanned = 0;
+    const increment = Math.max(1, Math.ceil(total / 10));
+    if (scanIntervalsRef.current[folder.id]) {
+      window.clearInterval(scanIntervalsRef.current[folder.id]);
+    }
+    const interval = window.setInterval(() => {
+      scanned += increment;
+      setScanStatuses((prev) => ({
+        ...prev,
+        [folder.id]: {
+          status: scanned >= total ? 'complete' : 'scanning',
+          scanned: Math.min(scanned, total),
+          total,
+          operationId,
+          errors,
+        },
+      }));
+      if (scanned >= total) {
+        window.clearInterval(interval);
+        delete scanIntervalsRef.current[folder.id];
+      }
+    }, 300);
+
+    scanIntervalsRef.current[folder.id] = interval;
+  };
+
+  const handleRequestCancelScan = (folder: api.ImportPath) => {
+    setCancelScanTarget(folder);
+  };
+
+  const handleConfirmCancelScan = async () => {
+    if (!cancelScanTarget) return;
+    const target = cancelScanTarget;
+    setCancelScanTarget(null);
+    const status = scanStatuses[target.id];
+    if (!status) return;
+    const interval = scanIntervalsRef.current[target.id];
+    if (interval) {
+      window.clearInterval(interval);
+      delete scanIntervalsRef.current[target.id];
+    }
+    if (status.operationId) {
+      try {
+        await api.cancelOperation(status.operationId);
+      } catch (error) {
+        console.error('Failed to cancel scan operation:', error);
+      }
+    }
+    setScanStatuses((prev) => ({
+      ...prev,
+      [target.id]: {
+        ...status,
+        status: 'cancelled',
+      },
+    }));
+  };
+
+  const handleViewScanErrors = (
+    folder: api.ImportPath,
+    status: ScanStatus
+  ) => {
+    if (!status.errors?.length) return;
+    setScanErrorTarget({
+      path: folder.path,
+      errors: status.errors,
+    });
+  };
+
+  return {
+    loadImportFolders,
+    handleAddImportFolder,
+    handleRemoveImportFolder,
+    handleScanImportFolder,
+    handleRequestCancelScan,
+    handleConfirmCancelScan,
+    handleViewScanErrors,
+  };
+}

--- a/web/src/hooks/useMetadataSourceHandlers.ts
+++ b/web/src/hooks/useMetadataSourceHandlers.ts
@@ -1,0 +1,121 @@
+// file: web/src/hooks/useMetadataSourceHandlers.ts
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-123456789012
+// last-edited: 2026-06-23
+
+import type { Dispatch, SetStateAction } from 'react';
+import * as api from '../services/api';
+import type { SettingsState } from '../pages/Settings';
+
+type SourceTestStatus = Record<
+  string,
+  { testing: boolean; result?: { success: boolean; message?: string; error?: string } }
+>;
+
+export interface UseMetadataSourceHandlersParams {
+  settings: SettingsState;
+  setSettings: Dispatch<SetStateAction<SettingsState>>;
+  setSaved: Dispatch<SetStateAction<boolean>>;
+  setSourceTestStatus: Dispatch<SetStateAction<SourceTestStatus>>;
+}
+
+export interface UseMetadataSourceHandlersReturn {
+  handleSourceToggle: (sourceId: string) => void;
+  handleTestMetadataSource: (sourceId: string) => Promise<void>;
+  handleCredentialChange: (sourceId: string, field: string, value: string) => void;
+  handleSourceReorder: (sourceId: string, direction: 'up' | 'down') => void;
+}
+
+export function useMetadataSourceHandlers(
+  params: UseMetadataSourceHandlersParams
+): UseMetadataSourceHandlersReturn {
+  const { settings, setSettings, setSaved, setSourceTestStatus } = params;
+
+  const handleSourceToggle = (sourceId: string) => {
+    setSettings((prev) => ({
+      ...prev,
+      metadataSources: prev.metadataSources.map((source) =>
+        source.id === sourceId
+          ? { ...source, enabled: !source.enabled }
+          : source
+      ),
+    }));
+    setSaved(false);
+  };
+
+  const handleTestMetadataSource = async (sourceId: string) => {
+    const source = settings.metadataSources.find((s) => s.id === sourceId);
+    const apiKey = source?.credentials?.apiKey || '';
+    if (!apiKey) {
+      setSourceTestStatus((prev) => ({
+        ...prev,
+        [sourceId]: { testing: false, result: { success: false, error: 'No API key entered' } },
+      }));
+      return;
+    }
+    setSourceTestStatus((prev) => ({
+      ...prev,
+      [sourceId]: { testing: true },
+    }));
+    try {
+      const result = await api.testMetadataSource(sourceId, apiKey);
+      setSourceTestStatus((prev) => ({
+        ...prev,
+        [sourceId]: { testing: false, result },
+      }));
+    } catch (err) {
+      setSourceTestStatus((prev) => ({
+        ...prev,
+        [sourceId]: { testing: false, result: { success: false, error: String(err) } },
+      }));
+    }
+  };
+
+  const handleCredentialChange = (
+    sourceId: string,
+    field: string,
+    value: string
+  ) => {
+    setSettings((prev) => ({
+      ...prev,
+      metadataSources: prev.metadataSources.map((source) =>
+        source.id === sourceId
+          ? {
+              ...source,
+              credentials: { ...source.credentials, [field]: value },
+            }
+          : source
+      ),
+    }));
+    setSaved(false);
+  };
+
+  const handleSourceReorder = (sourceId: string, direction: 'up' | 'down') => {
+    setSettings((prev) => {
+      const sources = [...prev.metadataSources];
+      const index = sources.findIndex((s) => s.id === sourceId);
+      if (index === -1) return prev;
+
+      const targetIndex = direction === 'up' ? index - 1 : index + 1;
+      if (targetIndex < 0 || targetIndex >= sources.length) return prev;
+
+      const temp = sources[index].priority;
+      sources[index] = {
+        ...sources[index],
+        priority: sources[targetIndex].priority,
+      };
+      sources[targetIndex] = { ...sources[targetIndex], priority: temp };
+      sources.sort((a, b) => a.priority - b.priority);
+
+      return { ...prev, metadataSources: sources };
+    });
+    setSaved(false);
+  };
+
+  return {
+    handleSourceToggle,
+    handleTestMetadataSource,
+    handleCredentialChange,
+    handleSourceReorder,
+  };
+}

--- a/web/src/hooks/useSettingsHandlers.ts
+++ b/web/src/hooks/useSettingsHandlers.ts
@@ -1,12 +1,15 @@
 // file: web/src/hooks/useSettingsHandlers.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: b8c9d0e1-f2a3-4567-bcde-678901234567
-// last-edited: 2026-06-19
+// last-edited: 2026-06-23
 
 import { ChangeEvent } from 'react';
 import { NavigateFunction } from 'react-router-dom';
 import * as api from '../services/api';
 import type { SettingsState } from '../pages/Settings';
+import { useImportFolderHandlers } from './useImportFolderHandlers';
+import { useBackupHandlers } from './useBackupHandlers';
+import { useMetadataSourceHandlers } from './useMetadataSourceHandlers';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -341,356 +344,45 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
   // Import folder management
   // -------------------------------------------------------------------------
 
-  const loadImportFolders = async () => {
-    try {
-      const folders = await api.getImportPaths();
-      setImportFolders(folders);
-    } catch (error) {
-      console.error('Failed to load import folders:', error);
-    }
-  };
+  // ── Import folder management (extracted to useImportFolderHandlers) ──────
+  const importFolderHandlers = useImportFolderHandlers({
+    setImportFolders,
+    setScanStatuses,
+    setCancelScanTarget,
+    setScanErrorTarget,
+    setNewFolderPath,
+    setShowFolderBrowser,
+    setAddFolderDialogOpen,
+    scanIntervalsRef,
+    cancelScanTarget,
+    scanStatuses,
+    newFolderPath,
+  });
 
-  const handleAddImportFolder = async () => {
-    if (!newFolderPath.trim()) return;
-    try {
-      const folder = await api.addImportPath(
-        newFolderPath,
-        newFolderPath.split('/').pop() || 'Import Folder'
-      );
-      setImportFolders((prev) => [...prev, folder]);
-      setNewFolderPath('');
-      setShowFolderBrowser(false);
-      setAddFolderDialogOpen(false);
-    } catch (error) {
-      console.error('Failed to add import folder:', error);
-    }
-  };
+  // ── Backup management (extracted to useBackupHandlers) ───────────────────
+  const backupHandlers = useBackupHandlers({
+    setBackups,
+    setBackupNotice,
+    setBackupsLoading,
+    setRestoreTarget,
+    setRestoreDialogOpen,
+    setRestoreInProgress,
+    setDeleteBackupTarget,
+    setDeleteBackupInProgress,
+    setCreateBackupInProgress,
+    setNewFolderPath,
+    restoreTarget,
+    restoreVerify,
+    deleteBackupTarget,
+  });
 
-  const handleRemoveImportFolder = async (id: number) => {
-    try {
-      await api.removeImportPath(id);
-      setImportFolders((prev) => prev.filter((f) => f.id !== id));
-    } catch (error) {
-      console.error('Failed to remove import folder:', error);
-    }
-  };
-
-  const handleScanImportFolder = async (folder: api.ImportPath) => {
-    setScanStatuses((prev) => ({
-      ...prev,
-      [folder.id]: {
-        status: 'scanning',
-        scanned: 0,
-        total: prev[folder.id]?.total || 0,
-      },
-    }));
-
-    let total = 50;
-    let errors: string[] = [];
-    let operationId: string | undefined;
-
-    try {
-      const response = await api.startScan(folder.path);
-      if (typeof response.total === 'number') {
-        total = response.total;
-      }
-      if (Array.isArray(response.errors)) {
-        errors = response.errors;
-      }
-      operationId = response.id;
-    } catch (error) {
-      console.error('Failed to scan import folder:', error);
-      const message =
-        error instanceof Error ? error.message : 'Scan failed.';
-      setScanStatuses((prev) => ({
-        ...prev,
-        [folder.id]: {
-          status: 'error',
-          scanned: 0,
-          total: 0,
-          errors: [message],
-        },
-      }));
-      return;
-    }
-
-    setScanStatuses((prev) => ({
-      ...prev,
-      [folder.id]: {
-        status: 'scanning',
-        scanned: 0,
-        total,
-        operationId,
-        errors,
-      },
-    }));
-
-    let scanned = 0;
-    const increment = Math.max(1, Math.ceil(total / 10));
-    // Clear any existing interval for this folder
-    if (scanIntervalsRef.current[folder.id]) {
-      window.clearInterval(scanIntervalsRef.current[folder.id]);
-    }
-    const interval = window.setInterval(() => {
-      scanned += increment;
-      setScanStatuses((prev) => ({
-        ...prev,
-        [folder.id]: {
-          status: scanned >= total ? 'complete' : 'scanning',
-          scanned: Math.min(scanned, total),
-          total,
-          operationId,
-          errors,
-        },
-      }));
-      if (scanned >= total) {
-        window.clearInterval(interval);
-        delete scanIntervalsRef.current[folder.id];
-      }
-    }, 300);
-
-    scanIntervalsRef.current[folder.id] = interval;
-  };
-
-  const handleRequestCancelScan = (folder: api.ImportPath) => {
-    setCancelScanTarget(folder);
-  };
-
-  const handleConfirmCancelScan = async () => {
-    if (!cancelScanTarget) return;
-    const target = cancelScanTarget;
-    setCancelScanTarget(null);
-    const status = scanStatuses[target.id];
-    if (!status) return;
-    const interval = scanIntervalsRef.current[target.id];
-    if (interval) {
-      window.clearInterval(interval);
-      delete scanIntervalsRef.current[target.id];
-    }
-    if (status.operationId) {
-      try {
-        await api.cancelOperation(status.operationId);
-      } catch (error) {
-        console.error('Failed to cancel scan operation:', error);
-      }
-    }
-    setScanStatuses((prev) => ({
-      ...prev,
-      [target.id]: {
-        ...status,
-        status: 'cancelled',
-      },
-    }));
-  };
-
-  const handleViewScanErrors = (
-    folder: api.ImportPath,
-    status: ScanStatus
-  ) => {
-    if (!status.errors?.length) return;
-    setScanErrorTarget({
-      path: folder.path,
-      errors: status.errors,
-    });
-  };
-
-  // -------------------------------------------------------------------------
-  // Backup management
-  // -------------------------------------------------------------------------
-
-  const loadBackups = async () => {
-    setBackupsLoading(true);
-    try {
-      const data = await api.listBackups();
-      const sorted = [...(data.backups || [])].sort(
-        (a, b) =>
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-      setBackups(sorted);
-    } catch (error) {
-      console.error('Failed to load backups:', error);
-      setBackupNotice({
-        severity: 'error',
-        message: 'Failed to load backups.',
-      });
-    } finally {
-      setBackupsLoading(false);
-    }
-  };
-
-  const handleCreateBackup = async () => {
-    setCreateBackupInProgress(true);
-    setBackupNotice(null);
-    try {
-      await api.createBackup();
-      setBackupNotice({
-        severity: 'success',
-        message: 'Backup created successfully.',
-      });
-      await loadBackups();
-    } catch (error) {
-      console.error('Failed to create backup:', error);
-      setBackupNotice({
-        severity: 'error',
-        message: 'Failed to create backup.',
-      });
-    } finally {
-      setCreateBackupInProgress(false);
-    }
-  };
-
-  const handleRequestRestore = (backup: api.BackupInfo) => {
-    setRestoreTarget(backup);
-    setRestoreDialogOpen(true);
-  };
-
-  const handleConfirmRestore = async () => {
-    if (!restoreTarget) return;
-    setRestoreInProgress(true);
-    setBackupNotice(null);
-    try {
-      await api.restoreBackup(restoreTarget.filename, restoreVerify);
-      setBackupNotice({
-        severity: 'success',
-        message: 'Backup restored successfully.',
-      });
-      setRestoreDialogOpen(false);
-      window.location.reload();
-    } catch (error) {
-      console.error('Failed to restore backup:', error);
-      setBackupNotice({
-        severity: 'error',
-        message: 'Backup file is corrupt.',
-      });
-    } finally {
-      setRestoreInProgress(false);
-    }
-  };
-
-  const handleRequestDeleteBackup = (backup: api.BackupInfo) => {
-    setDeleteBackupTarget(backup);
-  };
-
-  const handleConfirmDeleteBackup = async () => {
-    if (!deleteBackupTarget) return;
-    setDeleteBackupInProgress(true);
-    setBackupNotice(null);
-    try {
-      await api.deleteBackup(deleteBackupTarget.filename);
-      setBackupNotice({
-        severity: 'success',
-        message: 'Backup deleted successfully.',
-      });
-      setDeleteBackupTarget(null);
-      await loadBackups();
-    } catch (error) {
-      console.error('Failed to delete backup:', error);
-      setBackupNotice({
-        severity: 'error',
-        message: 'Failed to delete backup.',
-      });
-    } finally {
-      setDeleteBackupInProgress(false);
-    }
-  };
-
-  // -------------------------------------------------------------------------
-  // Folder browser for import path dialog
-  // -------------------------------------------------------------------------
-
-  const handleFolderBrowserSelect = (path: string, isDir: boolean) => {
-    if (isDir) {
-      setNewFolderPath(path);
-    }
-  };
-
-  // -------------------------------------------------------------------------
-  // Metadata source management
-  // -------------------------------------------------------------------------
-
-  const handleSourceToggle = (sourceId: string) => {
-    setSettings((prev) => ({
-      ...prev,
-      metadataSources: prev.metadataSources.map((source) =>
-        source.id === sourceId
-          ? { ...source, enabled: !source.enabled }
-          : source
-      ),
-    }));
-    setSaved(false);
-  };
-
-  const handleTestMetadataSource = async (sourceId: string) => {
-    const source = settings.metadataSources.find((s) => s.id === sourceId);
-    const apiKey = source?.credentials?.apiKey || '';
-    if (!apiKey) {
-      setSourceTestStatus((prev) => ({
-        ...prev,
-        [sourceId]: { testing: false, result: { success: false, error: 'No API key entered' } },
-      }));
-      return;
-    }
-    setSourceTestStatus((prev) => ({
-      ...prev,
-      [sourceId]: { testing: true },
-    }));
-    try {
-      const result = await api.testMetadataSource(sourceId, apiKey);
-      setSourceTestStatus((prev) => ({
-        ...prev,
-        [sourceId]: { testing: false, result },
-      }));
-    } catch (err) {
-      setSourceTestStatus((prev) => ({
-        ...prev,
-        [sourceId]: { testing: false, result: { success: false, error: String(err) } },
-      }));
-    }
-  };
-
-  const handleCredentialChange = (
-    sourceId: string,
-    field: string,
-    value: string
-  ) => {
-    setSettings((prev) => ({
-      ...prev,
-      metadataSources: prev.metadataSources.map((source) =>
-        source.id === sourceId
-          ? {
-              ...source,
-              credentials: { ...source.credentials, [field]: value },
-            }
-          : source
-      ),
-    }));
-    setSaved(false);
-  };
-
-  const handleSourceReorder = (sourceId: string, direction: 'up' | 'down') => {
-    setSettings((prev) => {
-      const sources = [...prev.metadataSources];
-      const index = sources.findIndex((s) => s.id === sourceId);
-      if (index === -1) return prev;
-
-      const targetIndex = direction === 'up' ? index - 1 : index + 1;
-      if (targetIndex < 0 || targetIndex >= sources.length) return prev;
-
-      // Swap priorities
-      const temp = sources[index].priority;
-      sources[index] = {
-        ...sources[index],
-        priority: sources[targetIndex].priority,
-      };
-      sources[targetIndex] = { ...sources[targetIndex], priority: temp };
-
-      // Sort by priority
-      sources.sort((a, b) => a.priority - b.priority);
-
-      return { ...prev, metadataSources: sources };
-    });
-    setSaved(false);
-  };
+  // ── Metadata source management (extracted to useMetadataSourceHandlers) ──
+  const metadataSourceHandlers = useMetadataSourceHandlers({
+    settings,
+    setSettings,
+    setSaved,
+    setSourceTestStatus,
+  });
 
   // -------------------------------------------------------------------------
   // Save / reset
@@ -1223,24 +915,9 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
     handleBrowserSelect,
     handleBrowserConfirm,
     handleBrowserCancel,
-    loadImportFolders,
-    handleAddImportFolder,
-    handleRemoveImportFolder,
-    handleScanImportFolder,
-    handleRequestCancelScan,
-    handleConfirmCancelScan,
-    handleViewScanErrors,
-    loadBackups,
-    handleCreateBackup,
-    handleRequestRestore,
-    handleConfirmRestore,
-    handleRequestDeleteBackup,
-    handleConfirmDeleteBackup,
-    handleFolderBrowserSelect,
-    handleSourceToggle,
-    handleTestMetadataSource,
-    handleCredentialChange,
-    handleSourceReorder,
+    ...importFolderHandlers,
+    ...backupHandlers,
+    ...metadataSourceHandlers,
     handleSave,
     handleReset,
     handleAddExtension,


### PR DESCRIPTION
## Summary

Extracts 3 domain-scoped sub-hooks from the 1259-line `useSettingsHandlers` god hook:

| Hook | Lines | Responsibility |
|---|---|---|
| `useImportFolderHandlers` | 212 | Add/remove/scan import folder management, cancel/error dialogs |
| `useBackupHandlers` | 167 | Create/restore/delete backup lifecycle, folder browser select |
| `useMetadataSourceHandlers` | 121 | Source toggle/test/reorder/credentials |

`useSettingsHandlers` now calls the three sub-hooks and spreads their results: 1259 → **936 lines** (−26%). The `UseSettingsHandlersReturn` interface is **unchanged** — `Settings.tsx` requires zero modifications.

## Design

The sub-hooks use the "handler provider" pattern — they receive typed `Dispatch<SetStateAction<T>>` setters as params rather than owning internal state. This matches the existing architecture where all state lives in `Settings.tsx` and flows down.

TypeScript compilation clean (`tsc --noEmit` passes with no errors).

## Test plan

- [ ] `make web-test` — vitest unit tests pass
- [ ] Settings page loads, import folder add/remove/scan works
- [ ] Backup create/restore/delete works
- [ ] Metadata source toggle/test/reorder works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43