### PR TITLE
test(e2e): real-server auth smoke test (FE-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.72.0 -->
+<!-- version: 3.73.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Frontend
+
+#### June 23, 2026 — FE-8: real-server auth smoke test
+
+- **`test(e2e)`** FE-8 — Added `Authentication — Real Server Smoke` describe block to `auth-flow.spec.ts`. Hits live `/api/v1/auth/status`, runs first-run admin bootstrap against the real embedded server, and verifies the session cookie survives a page reload. Skips gracefully when DB already has users (local dev reuse).
 
 #### June 23, 2026 — FE-6: split useSettingsHandlers by domain
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.30.0 -->
+<!-- version: 9.31.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1253,6 +1253,7 @@ Bot-tasks: `docs/superpowers/bot-tasks/2026-04-30-*.md`.
 - [x] **FE-6 (audit)** `refactor/fe6-settings-handlers-split` — Done: `useSettingsHandlers.ts` (1259→936 lines) split into `useImportFolderHandlers`, `useBackupHandlers`, `useMetadataSourceHandlers`.
 - [x] **FE-7** `fix/frontend-remove-console-logs` — Done: no `console.log` calls in production source; only `console.error`/`console.warn` in catch blocks (appropriate).
 - [x] **FE-8** `fix/frontend-error-boundaries` — Done: `ErrorBoundary` wraps every page route in `App.tsx`.
+- [x] **FE-8 (audit)** `fix/fe8-real-server-smoke-test` — Done: real-server auth smoke test added to `auth-flow.spec.ts`; exercises first-run bootstrap + real session cookie against live webServer.
 - [x] **FE-9** `fix/frontend-localstorage-keys` — Done: `STORAGE_KEYS` constants exported from `lib/storageKeys.ts`.
 - [ ] **FE-10** [hold] `chore/frontend-coverage-thresholds` — Add Vitest coverage thresholds
   → [`2026-04-30-fe-10-coverage.md`](docs/superpowers/bot-tasks/2026-04-30-fe-10-coverage.md)

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.16.0 -->
+<!-- version: 1.17.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -91,7 +91,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | FE-5 | `Library.tsx` still a 3,333-line maintenance hotspot | Both | ✅ Partial | `useLibraryQuery` + `useLibrarySelection` extracted, 3,333→1,811 lines (PR L #1585). `useImportPaths` + `useLibraryOperations` deferred — P2. |
 | FE-6 | `useSettingsHandlers` passes too much mutable state through one hook | Sweep | ✅ | Extracted `useImportFolderHandlers` (212L), `useBackupHandlers` (167L), `useMetadataSourceHandlers` (121L). Main hook: 1259→936 lines (−26%). Return interface unchanged; Settings.tsx untouched. |
 | FE-7 | Sensitive one-time tokens remain rendered in React state after display | Sweep | ✅ | Token auto-clear after copy/timeout added (PR C #1576). |
-| FE-8 | E2E auth tests mock auth instead of exercising real cookie/CSRF | Sweep | ⬜ | Add one real-server smoke test. |
+| FE-8 | E2E auth tests mock auth instead of exercising real cookie/CSRF | Sweep | ✅ | Added `Authentication — Real Server Smoke` test to `auth-flow.spec.ts`. Calls live `/api/v1/auth/status`, exercises first-run bootstrap + real session cookie, verifies cookie survives reload. Skips safely if DB already has users (local reuse). |
 | STR-4 | `BookDedup.tsx` still ~3,656 lines | Structure | ✅ | Split into 3 tab components (DedupAIReviewTab, DedupEmbeddingTab, DedupAcousticTab); 2,907→145 lines (PR L #1585). |
 | STR-5 | `useAsyncAction` reduces but doesn't eliminate setLoading duplication (51 remaining) | Structure | ✅ Partial | Hook exists; 51 remaining callsites could adopt it incrementally. |
 

--- a/web/tests/e2e/auth-flow.spec.ts
+++ b/web/tests/e2e/auth-flow.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/auth-flow.spec.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9b9cd01d-ea34-4d87-bc84-f390b6ef10cd
-// last-edited: 2026-02-15
+// last-edited: 2026-06-23
 
 import { test, expect } from '@playwright/test';
 import { setupPhase2Interactive } from './utils/test-helpers';
@@ -71,6 +71,50 @@ test.describe('Authentication Flow', () => {
 
     await page.getByLabel('Password').fill('secretpass123');
     await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
+});
+
+// Real-server smoke test — exercises actual cookie/session flow against the
+// embedded Go server started by playwright.config.ts webServer. Skips if the
+// DB already has users (local reuse) so it doesn't conflict with CI fresh-DB
+// semantics.
+test.describe('Authentication — Real Server Smoke', () => {
+  test('first-run bootstrap creates admin account and sets real session cookie', async ({
+    page,
+    request,
+  }) => {
+    // Check live server auth status — no mocks used in this test.
+    const status = await request.get('/api/v1/auth/status');
+    if (!status.ok()) {
+      test.skip(true, 'Auth status endpoint unavailable — skipping real-server smoke test');
+      return;
+    }
+    const body = await status.json() as { requires_auth?: boolean; has_users?: boolean };
+    if (!body.requires_auth || body.has_users) {
+      test.skip(
+        true,
+        `Server already bootstrapped (requires_auth=${body.requires_auth}, has_users=${body.has_users}) — skip to avoid state pollution`
+      );
+      return;
+    }
+
+    // Fresh DB: exercise the real first-run path.
+    await page.goto('/login');
+    await expect(
+      page.getByRole('heading', { name: 'Create Admin Account' })
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.getByLabel('Username').fill('e2e-smoke-admin');
+    await page.getByLabel('Password').fill('e2e-smoke-pass-9');
+    await page.getByRole('button', { name: 'Create And Login' }).click();
+
+    // Real session cookie must be set — the redirect only works with a valid cookie.
+    await expect(page).toHaveURL(/\/dashboard$/, { timeout: 10000 });
+    await expect(page.getByLabel('logout')).toBeVisible();
+
+    // Confirm the session survives a reload (cookie persists across navigation).
+    await page.reload();
     await expect(page).toHaveURL(/\/dashboard$/);
   });
 });


### PR DESCRIPTION
## Summary

Adds a real-server smoke test to `auth-flow.spec.ts` that exercises the actual cookie/session flow — no mocks — against the embedded Go server started by `playwright.config.ts`'s `webServer`.

**What it tests:**
- Calls `/api/v1/auth/status` live to discover server state
- If auth is required + DB is fresh: runs the full first-run bootstrap (create admin account)
- Verifies the real session cookie is set (redirect to `/dashboard` lands correctly)
- Confirms cookie survives a `page.reload()` — this is the key real-server assertion the mocked tests can't make

**Safe for reuse:** gracefully skips if `has_users=true` (local dev where server is reused between runs).

## Test plan

- [ ] CI: fresh DB → smoke test runs and passes
- [ ] Local (reused server): smoke test skips with clear reason message
- [ ] Existing mocked auth tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43