### PR TITLE
fix(database): adopt util.Normalize* for all author/series/title index keys (STR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.73.0 -->
+<!-- version: 3.74.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -8,6 +8,11 @@
 ## [Unreleased]
 
 ### Frontend
+
+#### June 23, 2026 — STR-3: adopt util.Normalize* for DB index keys
+
+- **`fix(database)`** STR-3 — Replaced `strings.ToLower(name)` (no TrimSpace) with `util.NormalizeAuthor`/`NormalizeTitle`/`NormalizeString` for all author, series, alias, role, playlist, and title index key construction in `pebble_store.go`. The missing TrimSpace caused names with leading/trailing whitespace (common from XML import or API input) to produce different keys on write vs. read, causing silent lookup misses.
+- **`fix(database)`** STR-3 — Adopted `util.NormalizeTitle` in `memdb_indexers.go` titleSortIndex and `util.NormalizeString` in `metadata_fetch_cache.go` cache key/source field; removed now-redundant `strings` import from indexers.
 
 #### June 23, 2026 — FE-8: real-server auth smoke test
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.31.0 -->
+<!-- version: 9.32.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1328,6 +1328,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **STR-4** — `BookDedup.tsx` 2907→145 lines: extracted `DedupAIReviewTab` (386 lines), `DedupEmbeddingTab` (1441 lines, embedding dedup with module-level cache + buildClusters), `DedupAcousticTab` (996 lines, acoustic dedup + `AcousticBookCard`/`AcousticBookMetadata` re-exports). Shipped PR #1585. TypeScript: 0 errors.
 - [x] **TOOL-1** — Large corpus LFS: already configured in `.gitattributes` (48 LFS objects, 1.7 GB). Fixed `mediainfo_test.go:889` hardcoded absolute path → `findRepoRootForMediainfo()` inline walk. Skip message updated to guide `git lfs pull`. Shipped PR #1586.
 - [x] **TOOL-3** — Demo recording isolated from default E2E: `chromium`/`webkit` projects now have `testIgnore: ['**/demo-*.spec.ts', '**/interactive-*.spec.ts']`; `chromium-record` is opt-in. `npm run test:e2e:demo` + `make test-e2e-demo` added.
+- [x] **STR-3** — DB index key normalization: `pebble_store.go` author/series/alias/role/playlist/title index keys replaced `strings.ToLower(name)` (no TrimSpace) with `util.NormalizeAuthor`/`NormalizeTitle`/`NormalizeString`. Names with leading/trailing whitespace (XML import, API) now produce consistent keys on write and read. Also adopted in `memdb_indexers.go` (titleSortIndex) and `metadata_fetch_cache.go`. 49 remaining inline patterns in other packages are style (already correct logic) — incremental adoption ongoing. Shipped PR #1600.
 - [x] **TOOL-7** — Fixed sleeps in E2E tests: `waitForTimeout(1000)` replaced with `waitForRequest(url)` in `dedup-operations.spec.ts` and `dedup.spec.ts`. `dynamic-ui-interactions.spec.ts` mock-handler delays retained (intentional latency simulation). Go backend `time.Sleep` calls are timing-sensitive and correct.
 - [x] **TOOL-8** — Manual smoke scripts wrapped as Makefile targets: `make manual-smoke`, `make smoke-create-books`, `make smoke-run-demo`.
 

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.17.0 -->
+<!-- version: 1.18.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -76,7 +76,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | ARCH-8 | Service registry uses globals and panicking string lookups | Sweep | ⬜ | P2. Typed service keys or generated accessors. |
 | STR-1 | Pagination helper missing — 376+ limit/offset/page callsites parsed independently | Structure | ✅ | `internal/server/pagination.go` created; pagination helper standardized (PR E #1578). |
 | STR-2 | AI retry duplicated in `openai_parser.go`, `metadata_llm_review.go`, `embedding_client.go` | Structure | ✅ | `internal/ai/retry.go` → `DoWithRetry` function; 4 sites migrated (PR E #1578). |
-| STR-3 | Path/string normalization scattered — 611 `ToLower/TrimSpace/Clean` callsites, subtle inconsistencies in author/series matching | Structure | ⬜ | P2. `internal/util/normalize.go` (proposed). Important for author name matching correctness. |
+| STR-3 | Path/string normalization scattered — 611 `ToLower/TrimSpace/Clean` callsites, subtle inconsistencies in author/series matching | Structure | ✅ Partial | `internal/util/normalize.go` already existed with 41 existing callers. Fixed the **correctness bug**: `pebble_store.go` author/series/alias/role/playlist index keys were using only `ToLower` (no TrimSpace) → names with whitespace produced wrong keys. Adopted `util.NormalizeTitle` in `memdb_indexers.go` and `util.NormalizeString` in `metadata_fetch_cache.go`. 49 remaining inline `ToLower+TrimSpace` patterns are style (already correct logic); incremental adoption ongoing. |
 
 ---
 

--- a/internal/database/memdb_indexers.go
+++ b/internal/database/memdb_indexers.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_indexers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000001
+// last-edited: 2026-06-23
 
 package database
 
@@ -8,9 +9,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/hashicorp/go-memdb"
+
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
 
 // Custom go-memdb indexers for our types. memdb ships with StringFieldIndex,
@@ -322,9 +324,9 @@ func (titleSortIndex) FromObject(obj interface{}) (bool, []byte, error) {
 	if !ok {
 		return false, nil, fmt.Errorf("titleSortIndex: expected *Book, got %T", obj)
 	}
-	key := strings.ToLower(strings.TrimSpace(b.Title))
+	key := util.NormalizeTitle(b.Title)
 	if key == "" && b.OriginalFilename != nil {
-		key = strings.ToLower(strings.TrimSpace(*b.OriginalFilename))
+		key = util.NormalizeTitle(*b.OriginalFilename)
 	}
 	if key == "" {
 		key = "~" // sort to end
@@ -341,7 +343,7 @@ func (titleSortIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("titleSortIndex: arg must be string, got %T", args[0])
 	}
-	return append([]byte(strings.ToLower(strings.TrimSpace(s))), 0), nil
+	return append([]byte(util.NormalizeTitle(s)), 0), nil
 }
 
 func (titleSortIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {

--- a/internal/database/metadata_fetch_cache.go
+++ b/internal/database/metadata_fetch_cache.go
@@ -1,7 +1,7 @@
 // file: internal/database/metadata_fetch_cache.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f
-// last-edited: 2026-05-05
+// last-edited: 2026-06-23
 
 package database
 
@@ -9,10 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/metrics"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
 
 // MetadataFetchCache caches external metadata API responses
@@ -58,7 +58,7 @@ type CachedMetadataEntry struct {
 // across restarts. Source names are lowercased to avoid
 // "Hardcover" vs "hardcover" drift.
 func metadataFetchCacheKey(bookID, source string) string {
-	return "metadata_fetch_cache:" + bookID + ":" + strings.ToLower(strings.TrimSpace(source))
+	return "metadata_fetch_cache:" + bookID + ":" + util.NormalizeString(source)
 }
 
 // GetCachedMetadataFetchWithMaxAge looks up a cache entry and enforces
@@ -132,7 +132,7 @@ func PutCachedMetadataFetch(store Store, bookID, source string, results json.Raw
 	}
 	entry := CachedMetadataEntry{
 		BookID:    bookID,
-		Source:    strings.ToLower(strings.TrimSpace(source)),
+		Source:    util.NormalizeString(source),
 		Results:   results,
 		BestScore: bestScore,
 		CachedAt:  time.Now().UTC(),

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.95.0
+// version: 1.96.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-06-23
 
@@ -489,7 +489,7 @@ func (p *PebbleStore) GetAuthorsByIDs(ids []int) (map[int]*Author, error) {
 
 func (p *PebbleStore) GetAuthorByName(name string) (*Author, error) {
 	// Use lowercase for case-insensitive lookup
-	indexKey := []byte(fmt.Sprintf("author:name:%s", strings.ToLower(name)))
+	indexKey := []byte(fmt.Sprintf("author:name:%s", util.NormalizeAuthor(name)))
 	value, closer, err := p.db.Get(indexKey)
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -531,7 +531,7 @@ func (p *PebbleStore) CreateAuthor(name string) (*Author, error) {
 	batch := p.db.NewBatch()
 	key := []byte(fmt.Sprintf("author:%d", id))
 	// Use lowercase for case-insensitive lookup
-	indexKey := []byte(fmt.Sprintf("author:name:%s", strings.ToLower(name)))
+	indexKey := []byte(fmt.Sprintf("author:name:%s", util.NormalizeAuthor(name)))
 
 	if err := batch.Set(key, data, nil); err != nil {
 		batch.Close()
@@ -565,7 +565,7 @@ func (p *PebbleStore) DeleteAuthor(id int) error {
 		batch.Close()
 		return fmt.Errorf("pebble Delete author:%d: %w", id, err)
 	}
-	if err := batch.Delete([]byte(fmt.Sprintf("author:name:%s", strings.ToLower(author.Name))), nil); err != nil {
+	if err := batch.Delete([]byte(fmt.Sprintf("author:name:%s", util.NormalizeAuthor(author.Name))), nil); err != nil {
 		batch.Close()
 		return fmt.Errorf("pebble Delete author:name: %w", err)
 	}
@@ -617,7 +617,7 @@ func (p *PebbleStore) UpdateAuthorName(id int, name string) error {
 
 	batch := p.db.NewBatch()
 	// Remove old name index
-	if err := batch.Delete([]byte(fmt.Sprintf("author:name:%s", strings.ToLower(author.Name))), nil); err != nil {
+	if err := batch.Delete([]byte(fmt.Sprintf("author:name:%s", util.NormalizeAuthor(author.Name))), nil); err != nil {
 		batch.Close()
 		return fmt.Errorf("pebble Delete author:name: %w", err)
 	}
@@ -634,7 +634,7 @@ func (p *PebbleStore) UpdateAuthorName(id int, name string) error {
 		return err
 	}
 	// Add new name index
-	if err := batch.Set([]byte(fmt.Sprintf("author:name:%s", strings.ToLower(name))), []byte(strconv.Itoa(id)), nil); err != nil {
+	if err := batch.Set([]byte(fmt.Sprintf("author:name:%s", util.NormalizeAuthor(name))), []byte(strconv.Itoa(id)), nil); err != nil {
 		batch.Close()
 		return err
 	}
@@ -718,7 +718,7 @@ func (p *PebbleStore) CreateAuthorAlias(authorID int, aliasName string, aliasTyp
 	}
 
 	// Check for duplicate
-	nameKey := fmt.Sprintf("author_alias:name:%s", strings.ToLower(aliasName))
+	nameKey := fmt.Sprintf("author_alias:name:%s", util.NormalizeAuthor(aliasName))
 	if _, closer, err := p.db.Get([]byte(nameKey)); err == nil {
 		closer.Close()
 		return nil, fmt.Errorf("alias %q already exists", aliasName)
@@ -782,7 +782,7 @@ func (p *PebbleStore) DeleteAuthorAlias(id int) error {
 		batch.Close()
 		return fmt.Errorf("pebble Delete author_alias:author index: %w", err)
 	}
-	if err := batch.Delete([]byte(fmt.Sprintf("author_alias:name:%s", strings.ToLower(alias.AliasName))), nil); err != nil {
+	if err := batch.Delete([]byte(fmt.Sprintf("author_alias:name:%s", util.NormalizeAuthor(alias.AliasName))), nil); err != nil {
 		batch.Close()
 		return fmt.Errorf("pebble Delete author_alias:name index: %w", err)
 	}
@@ -794,7 +794,7 @@ func (p *PebbleStore) DeleteAuthorAlias(id int) error {
 }
 
 func (p *PebbleStore) FindAuthorByAlias(aliasName string) (*Author, error) {
-	nameKey := []byte(fmt.Sprintf("author_alias:name:%s", strings.ToLower(aliasName)))
+	nameKey := []byte(fmt.Sprintf("author_alias:name:%s", util.NormalizeAuthor(aliasName)))
 	value, closer, err := p.db.Get(nameKey)
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -850,7 +850,7 @@ func (p *PebbleStore) deleteAuthorAliases(batch *pebble.Batch, authorID int) err
 			if err := batch.Delete([]byte(fmt.Sprintf("author_alias:%d", aliasID)), nil); err != nil {
 				return fmt.Errorf("pebble Delete author_alias:%d: %w", aliasID, err)
 			}
-			if err := batch.Delete([]byte(fmt.Sprintf("author_alias:name:%s", strings.ToLower(alias.AliasName))), nil); err != nil {
+			if err := batch.Delete([]byte(fmt.Sprintf("author_alias:name:%s", util.NormalizeAuthor(alias.AliasName))), nil); err != nil {
 				return fmt.Errorf("pebble Delete author_alias:name index: %w", err)
 			}
 		}
@@ -942,7 +942,7 @@ func (p *PebbleStore) GetSeriesByName(name string, authorID *int) (*Series, erro
 	}
 
 	// Use lowercase for case-insensitive lookup
-	indexKey := []byte(fmt.Sprintf("series:name:%s:%s", strings.ToLower(name), authorIDStr))
+	indexKey := []byte(fmt.Sprintf("series:name:%s:%s", util.NormalizeAuthor(name), authorIDStr))
 	value, closer, err := p.db.Get(indexKey)
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -989,7 +989,7 @@ func (p *PebbleStore) CreateSeries(name string, authorID *int) (*Series, error) 
 	batch := p.db.NewBatch()
 	key := []byte(fmt.Sprintf("series:%d", id))
 	// Use lowercase for case-insensitive lookup
-	indexKey := []byte(fmt.Sprintf("series:name:%s:%s", strings.ToLower(name), authorIDStr))
+	indexKey := []byte(fmt.Sprintf("series:name:%s:%s", util.NormalizeAuthor(name), authorIDStr))
 
 	if err := batch.Set(key, data, nil); err != nil {
 		batch.Close()
@@ -1020,7 +1020,7 @@ func (p *PebbleStore) DeleteSeries(id int) error {
 			if series.AuthorID != nil {
 				authorIDStr = strconv.Itoa(*series.AuthorID)
 			}
-			indexKey := []byte(fmt.Sprintf("series:name:%s:%s", strings.ToLower(series.Name), authorIDStr))
+			indexKey := []byte(fmt.Sprintf("series:name:%s:%s", util.NormalizeAuthor(series.Name), authorIDStr))
 			if err := p.db.Delete(indexKey, pebble.Sync); err != nil {
 				slog.Warn("pebble Delete series name index", "key", string(indexKey), "error", err)
 			}
@@ -1053,7 +1053,7 @@ func (p *PebbleStore) UpdateSeriesName(id int, name string) error {
 	if series.AuthorID != nil {
 		oldAuthorIDStr = strconv.Itoa(*series.AuthorID)
 	}
-	oldIndexKey := []byte(fmt.Sprintf("series:name:%s:%s", strings.ToLower(series.Name), oldAuthorIDStr))
+	oldIndexKey := []byte(fmt.Sprintf("series:name:%s:%s", util.NormalizeAuthor(series.Name), oldAuthorIDStr))
 	if err := p.db.Delete(oldIndexKey, pebble.Sync); err != nil {
 		slog.Warn("pebble Delete old series name index", "key", string(oldIndexKey), "error", err)
 	}
@@ -1069,7 +1069,7 @@ func (p *PebbleStore) UpdateSeriesName(id int, name string) error {
 	}
 
 	// Create new name index
-	newIndexKey := []byte(fmt.Sprintf("series:name:%s:%s", strings.ToLower(name), oldAuthorIDStr))
+	newIndexKey := []byte(fmt.Sprintf("series:name:%s:%s", util.NormalizeAuthor(name), oldAuthorIDStr))
 	idBytes := []byte(fmt.Sprintf("%d", id))
 	if err := p.db.Set(newIndexKey, idBytes, pebble.Sync); err != nil {
 		return err
@@ -1870,7 +1870,7 @@ func (p *PebbleStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]B
 		if err := json.Unmarshal(iter.Value(), &book); err != nil {
 			continue
 		}
-		if strings.ToLower(book.Title) != strings.ToLower(normalizedTitle) {
+		if util.NormalizeTitle(book.Title) != util.NormalizeTitle(normalizedTitle) {
 			continue
 		}
 		if filepath.Dir(book.FilePath) != dirPath {
@@ -2325,7 +2325,7 @@ func (p *PebbleStore) CreateNarrator(name string) (*Narrator, error) {
 	}
 
 	// Save name index
-	nameKey := []byte(fmt.Sprintf("narrator_name:%s", strings.ToLower(name)))
+	nameKey := []byte(fmt.Sprintf("narrator_name:%s", util.NormalizeAuthor(name)))
 	idData, _ := json.Marshal(nextID)
 	if err := p.db.Set(nameKey, idData, pebble.Sync); err != nil {
 		return nil, fmt.Errorf("pebble Set narrator name index: %w", err)
@@ -2360,7 +2360,7 @@ func (p *PebbleStore) GetNarratorByID(id int) (*Narrator, error) {
 }
 
 func (p *PebbleStore) GetNarratorByName(name string) (*Narrator, error) {
-	nameKey := []byte(fmt.Sprintf("narrator_name:%s", strings.ToLower(name)))
+	nameKey := []byte(fmt.Sprintf("narrator_name:%s", util.NormalizeAuthor(name)))
 	val, closer, err := p.db.Get(nameKey)
 	if err != nil {
 		if err == pebble.ErrNotFound {
@@ -3122,7 +3122,7 @@ func (p *PebbleStore) SearchBooks(query string, limit, offset int) ([]Book, erro
 			}
 			var a Author
 			if err := json.Unmarshal(authIter.Value(), &a); err == nil {
-				authorNames[a.ID] = strings.ToLower(a.Name)
+				authorNames[a.ID] = util.NormalizeAuthor(a.Name)
 			}
 		}
 	}
@@ -4933,7 +4933,7 @@ func (p *PebbleStore) GetRoleByID(id string) (*Role, error) {
 }
 
 func (p *PebbleStore) GetRoleByName(name string) (*Role, error) {
-	lower := strings.ToLower(name)
+	lower := util.NormalizeAuthor(name)
 	v, closer, err := p.db.Get([]byte("idx:role:name:" + lower))
 	if err == pebble.ErrNotFound {
 		return nil, nil
@@ -5042,7 +5042,7 @@ func (p *PebbleStore) DeleteRole(id string) error {
 		b.Close()
 		return err
 	}
-	if err := b.Delete([]byte("idx:role:name:"+strings.ToLower(r.Name)), nil); err != nil {
+	if err := b.Delete([]byte("idx:role:name:"+util.NormalizeAuthor(r.Name)), nil); err != nil {
 		b.Close()
 		return err
 	}
@@ -5071,7 +5071,7 @@ func (p *PebbleStore) CreateUserPlaylist(pl *UserPlaylist) (*UserPlaylist, error
 		}
 		pl.ID = id
 	}
-	lower := strings.ToLower(pl.Name)
+	lower := util.NormalizeString(pl.Name)
 	if v, closer, err := p.db.Get([]byte("idx:upl:name:" + lower)); err == nil {
 		existing := string(v)
 		closer.Close()
@@ -5135,7 +5135,7 @@ func (p *PebbleStore) GetUserPlaylist(id string) (*UserPlaylist, error) {
 }
 
 func (p *PebbleStore) GetUserPlaylistByName(name string) (*UserPlaylist, error) {
-	v, closer, err := p.db.Get([]byte("idx:upl:name:" + strings.ToLower(name)))
+	v, closer, err := p.db.Get([]byte("idx:upl:name:" + util.NormalizeAuthor(name)))
 	if err == pebble.ErrNotFound {
 		return nil, nil
 	}
@@ -5236,11 +5236,11 @@ func (p *PebbleStore) UpdateUserPlaylist(pl *UserPlaylist) error {
 		return err
 	}
 	if !strings.EqualFold(prev.Name, pl.Name) {
-		if err := b.Delete([]byte("idx:upl:name:"+strings.ToLower(prev.Name)), nil); err != nil {
+		if err := b.Delete([]byte("idx:upl:name:"+util.NormalizeString(prev.Name)), nil); err != nil {
 			b.Close()
 			return err
 		}
-		if err := b.Set([]byte("idx:upl:name:"+strings.ToLower(pl.Name)), []byte(pl.ID), nil); err != nil {
+		if err := b.Set([]byte("idx:upl:name:"+util.NormalizeString(pl.Name)), []byte(pl.ID), nil); err != nil {
 			b.Close()
 			return err
 		}
@@ -5286,7 +5286,7 @@ func (p *PebbleStore) DeleteUserPlaylist(id string) error {
 		b.Close()
 		return err
 	}
-	if err := b.Delete([]byte("idx:upl:name:"+strings.ToLower(pl.Name)), nil); err != nil {
+	if err := b.Delete([]byte("idx:upl:name:"+util.NormalizeString(pl.Name)), nil); err != nil {
 		b.Close()
 		return err
 	}


### PR DESCRIPTION
## Summary

- **Correctness bug**: `pebble_store.go` used `strings.ToLower(name)` without `TrimSpace` for all author, series, alias, role, and playlist index key construction. Names with leading/trailing whitespace (common in iTunes XML import or API input) produced different keys on write vs. read → silent lookup misses.
- **Fix**: replaced all index key sites with `util.NormalizeAuthor` / `util.NormalizeTitle` / `util.NormalizeString` (which apply `TrimSpace → ToLower`). The `internal/util` package was already imported.
- Also adopted `util.NormalizeTitle` in `memdb_indexers.go` (titleSortIndex) and `util.NormalizeString` in `metadata_fetch_cache.go`; removed now-unused `strings` import from indexers.
- 49 remaining inline `ToLower+TrimSpace` patterns in other packages are already correct (right operations, right order) — incremental adoption ongoing.

## Files changed

- `internal/database/pebble_store.go` — author/series/alias/role/playlist/title index keys (v1.95.0 → 1.96.0)
- `internal/database/memdb_indexers.go` — titleSortIndex; dropped `strings` import (v1.0.0 → 1.1.0)
- `internal/database/metadata_fetch_cache.go` — cache key + stored source field (v1.4.0 → 1.5.0)
- `docs/tracking/audit-remediation-2026-06.md`, `CHANGELOG.md`, `TODO.md` — status update

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go build ./internal/database/...` — clean
- [x] `GOEXPERIMENT=jsonv2 go test ./internal/database/... -short` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43