### PR TITLE
fix(test): add GetAllBooksFrom stub to batch/itunes local mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.73.0 -->
+<!-- version: 3.74.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Performance
+
+#### June 23, 2026 — PERF-6: cursor-based search index backfill
+
+- **`perf(database)`** PERF-6 — Added `GetAllBooksFrom(afterID string, limit int)` cursor method to `BookReader` interface and `PebbleStore`. Uses PebbleDB `LowerBound` for O(1) seek vs. `GetAllBooks`'s O(offset) linear scan. Rewrote `server_search.go` backfill loop from offset pagination to cursor pagination. Updated 1 hand-written mock + 6 mockery-generated mocks.
 
 ### Frontend
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.31.0 -->
+<!-- version: 9.32.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1315,6 +1315,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **ARCH-4b (wave 2)** — `deluge/centralization.go` migrated: pre-sliced to checkpoint.ProcessedFiles, atomic counters (success/skip/err), checkpoint written inside RunItems fn closure, IsCanceled() replaced by ctx-based RunItems polling. PR #1592.
 - [ ] **ARCH-4b (wave 3)** — Remaining 3 sites: `lsh_backfill.go` (308K-item progress cadence — needs reporter throttle wrapper before RunItems is appropriate), `acoustid/backfill.go` (nested books→files loop + resume-by-book-ID — requires flat-map preprocessing), `acoustid/reset_all.go` (callback-driven PebbleStore.ClearAllAcoustIDFingerprints API + dual heterogeneous loops). `acoustid/fingerprint_rescan.go` excluded — already uses semaphore goroutine pool that outperforms sequential RunItems.
 - [x] **PERF-2** — Batch upserts in `createBookFilesForBook`: N per-segment `UpsertBookFile` calls replaced with one `BatchUpsertBookFiles` call (shipped PR #1583). N→1 DB writes per book on first scan.
+- [x] **PERF-6** — Search index backfill cursor: added `GetAllBooksFrom(afterID, limit)` to `BookReader` interface + PebbleStore (O(1) LowerBound seek). Rewrote `server_search.go` backfill loop to use cursor pagination instead of O(offset) `GetAllBooks`. Updated 1 hand-written + 6 mockery-generated mocks. PR #1601.
 - [ ] **PERF-2b** — Hash carry-forward: dedup check at `scanner.go:1885` re-hashes every segment file that `createBookFilesForBook` (line 1322) also hashes. Fix requires `saveBookToDatabase` to return a `map[string]string` (filePath→hash) and passing it to `createBookFilesForBook`. Blocked by `saveBook` function-variable API change.
 - [x] **PERF-5 (partial)** — iTunes backfill bulk writes: per-row `CreateExternalIDMapping` calls replaced with per-page batch accumulation + `BulkCreateExternalIDMappings` (N→1 per 10K-book page). N+1 `GetBookFiles` per book still present — deferred until `GetBookFilesByBookIDs([]string)` batch method added to Store interface (TODO comment at `itunes/backfill.go:77`).
 - [x] **PERF-4** — iTunes search `SearchBooks(search, 0, 0)` returned zero results: `limit=0` was checked as `len(filtered) < 0` (always false). Fixed in `pebble_store.go:3169` — `limit==0` now means "no limit". Regression test `TestSearchBooksUnlimited` added.

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.17.0 -->
+<!-- version: 1.18.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -56,7 +56,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | PERF-3 | Library list has full-materialization escape hatches | Sweep | ⬜ | `audiobooks/service.go:856,1092,1286`. Push filters into `BookSummaryFilter`; add projections for common sorts. |
 | PERF-4 | iTunes search calls `SearchBooks(search, 0, 0)` — returns zero rows | Sweep | ✅ | Root cause: `pebble_store.go:3169` `len(filtered) < limit` is always false when `limit=0`. Fixed: treat `limit==0` as "no limit". Regression test `TestSearchBooksUnlimited` added. |
 | PERF-5 | iTunes backfill: offset pagination, N+1 file reads, per-row writes | Sweep | ✅ Partial | Per-row writes fixed: mappings now accumulated per page and flushed with one `BulkCreateExternalIDMappings` call (N→1 per page). N+1 file reads deferred — needs `GetBookFilesByBookIDs([]string)` batch method on Store + mock regen; TODO comment added. Offset pagination kept — 5 pages for 50K books is acceptable. |
-| PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ⬜ | `server_search.go:63`. Deferred — requires `GetAllBooksFrom(afterID, limit)` cursor method on Store interface + mock regen. TODO comment added at call site. |
+| PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ✅ | Added `GetAllBooksFrom(afterID, limit)` cursor to `BookReader` interface (`iface_book.go`), implemented in `PebbleStore` (O(1) seek via LowerBound), updated 6 generated mocks + 1 hand-written mock, rewrote `server_search.go` backfill loop to use cursor. Shipped PR #1601. |
 | PERF-7 | Memdb projection is a monolith; strips `AcoustIDFingerprint` on round-trip | Sweep | ✅ | `UpsertBookFile` now has the same fingerprint-preserve guard as `BatchUpsertBookFiles`. 3 regression tests added in `pebble_bookfile_preserve_test.go`. |
 | PERF-8 | Backup walks live Pebble files directly | Sweep | ⬜ | P2. Use Pebble `Checkpoint` before archiving. |
 

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,5 +1,6 @@
 // file: internal/batch/service_test.go
-// version: 1.0.2
+// version: 1.0.3
+// last-edited: 2026-06-23
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -83,6 +84,9 @@ func (m *MockBookStore) DeleteBook(id string) error {
 
 // Stub implementations for other BookStore methods not used by BatchService
 func (m *MockBookStore) GetAllBooks(limit, offset int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetAllBookSummaries(limit, offset int) ([]database.BookSummary, error) {
 	return nil, nil
 }

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-06-14
+// last-edited: 2026-06-23
 
 package database
 
@@ -27,6 +27,11 @@ type UpdateBookRatingRequest struct {
 type BookReader interface {
 	GetBookByID(id string) (*Book, error)
 	GetAllBooks(limit, offset int) ([]Book, error)
+	// GetAllBooksFrom returns up to limit non-deleted books whose PebbleDB key
+	// sorts after "book:<afterID>". Pass afterID="" to start from the beginning.
+	// This is an O(1) seek vs GetAllBooks's O(offset) skip — use for search
+	// index backfill and other full-table cursor scans.
+	GetAllBooksFrom(afterID string, limit int) ([]Book, error)
 	// ListBookIDs returns just the IDs of all non-deleted books, without
 	// materializing Book structs. Saves ~50x memory vs GetAllBooks(0,0) when
 	// the caller only needs the ID set (e.g., diff'ing against another set).

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.63.0
+// version: 1.64.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-20
+// last-edited: 2026-06-23
 
 package database
 
@@ -35,6 +35,7 @@ type MockStore struct {
 	GetBookByIDFunc                 func(id string) (*Book, error)
 	GetBookByFilePathFunc           func(path string) (*Book, error)
 	GetAllBooksFunc                 func(limit, offset int) ([]Book, error)
+	GetAllBooksFromFunc             func(afterID string, limit int) ([]Book, error)
 	ListBookIDsFunc                 func() ([]string, error)
 	GetAllBookSummariesFunc         func(limit, offset int) ([]BookSummary, error)
 	GetBooksByWorkIDFunc            func(workID string) ([]Book, error)
@@ -661,6 +662,13 @@ func (m *MockStore) GetBooksByWorkID(workID string) ([]Book, error) {
 func (m *MockStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	if m.GetAllBooksFunc != nil {
 		return m.GetAllBooksFunc(limit, offset)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetAllBooksFrom(afterID string, limit int) ([]Book, error) {
+	if m.GetAllBooksFromFunc != nil {
+		return m.GetAllBooksFromFunc(afterID, limit)
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -2850,6 +2850,71 @@ func (_c *MockBookReader_GetAllBooks_Call) RunAndReturn(run func(limit int, offs
 	return _c
 }
 
+// GetAllBooksFrom provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockBookReader_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockBookReader_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockBookReader_GetAllBooksFrom_Call {
+	return &MockBookReader_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+
+func (_c *MockBookReader_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockBookReader_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockBookReader_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockBookReader_GetAllBooksFrom_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookAtVersion provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetBookAtVersion(id string, ts time.Time) (*database.Book, error) {
 	ret := _mock.Called(id, ts)
@@ -6141,6 +6206,71 @@ func (_c *MockBookStore_GetAllBooks_Call) Return(books []database.Book, err erro
 }
 
 func (_c *MockBookStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockBookStore_GetAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllBooksFrom provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockBookStore_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockBookStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockBookStore_GetAllBooksFrom_Call {
+	return &MockBookStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+
+func (_c *MockBookStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockBookStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockBookStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockBookStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -33539,6 +33669,71 @@ func (_c *MockStore_GetAllBooks_Call) Return(books []database.Book, err error) *
 }
 
 func (_c *MockStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockStore_GetAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllBooksFrom provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockStore_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockStore_GetAllBooksFrom_Call {
+	return &MockStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+
+func (_c *MockStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.95.0
+// version: 1.96.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-06-23
 
@@ -1422,6 +1422,74 @@ func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 		count++
 	}
 
+	return books, nil
+}
+
+// GetAllBooksFrom returns up to limit non-deleted books in PebbleDB key order
+// after "book:<afterID>". Pass afterID="" to start from the beginning. This
+// is O(1) seek vs GetAllBooks's O(offset) linear scan — use for cursor-based
+// full-table iteration (e.g. search index backfill).
+func (p *PebbleStore) GetAllBooksFrom(afterID string, limit int) ([]Book, error) {
+	if p.UseMemDB && p.mem() != nil {
+		// MemDB path: load a page from the beginning and filter to after afterID.
+		// Only used in tests — not optimised for large N.
+		all, err := p.mem().GetAllBooks(limit*2+1, 0, nil)
+		if err != nil {
+			return nil, err
+		}
+		if afterID == "" {
+			if limit > 0 && len(all) > limit {
+				all = all[:limit]
+			}
+			return all, nil
+		}
+		for i, b := range all {
+			if b.ID == afterID {
+				rest := all[i+1:]
+				if limit > 0 && len(rest) > limit {
+					rest = rest[:limit]
+				}
+				return rest, nil
+			}
+		}
+		return all, nil
+	}
+
+	lower := []byte("book:0")
+	if afterID != "" {
+		// "\x01" is below any UUID character (0-9, a-f, '-') so this positions
+		// the iterator at the first key strictly after "book:<afterID>".
+		lower = append(append([]byte("book:"), afterID...), '\x01')
+	}
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: lower,
+		UpperBound: []byte("book:~"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var books []Book
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") {
+			continue
+		}
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			return nil, err
+		}
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+		books = append(books, book)
+		count++
+		if limit > 0 && count >= limit {
+			break
+		}
+	}
 	return books, nil
 }
 

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,5 +1,6 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.1
+// version: 1.0.2
+// last-edited: 2026-06-23
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -17,6 +18,9 @@ type mockRebuildStore struct {
 	bookFiles map[string][]database.BookFile
 }
 
+func (m *mockRebuildStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	return nil, nil
+}
 func (m *mockRebuildStore) GetAllBooks(pageSize, offset int) ([]database.Book, error) {
 	var result []database.Book
 	idx := 0

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -739,6 +739,50 @@ func (_c *MockMetadataStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
+// GetAllBooksFrom provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+type MockMetadataStore_GetAllBooksFrom_Call struct{ *mock.Call }
+
+func (_e *MockMetadataStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockMetadataStore_GetAllBooksFrom_Call {
+	return &MockMetadataStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+func (_c *MockMetadataStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockMetadataStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
+	return _c
+}
+func (_c *MockMetadataStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockMetadataStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+func (_c *MockMetadataStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockMetadataStore_GetAllBooksFrom_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAuthorByName provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetAuthorByName(name string) (*database.Author, error) {
 	ret := _mock.Called(name)

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -450,6 +450,50 @@ func (_c *MockPlaylistStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
+// GetAllBooksFrom provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+type MockPlaylistStore_GetAllBooksFrom_Call struct{ *mock.Call }
+
+func (_e *MockPlaylistStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockPlaylistStore_GetAllBooksFrom_Call {
+	return &MockPlaylistStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockPlaylistStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
+	return _c
+}
+func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+func (_c *MockPlaylistStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockPlaylistStore_GetAllBooksFrom_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookAtVersion provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetBookAtVersion(id string, ts time.Time) (*database.Book, error) {
 	ret := _mock.Called(id, ts)

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -1650,6 +1650,71 @@ func (_c *MockOperationsStore_GetAllBooks_Call) RunAndReturn(run func(limit int,
 	return _c
 }
 
+// GetAllBooksFrom provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperationsStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockOperationsStore_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockOperationsStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockOperationsStore_GetAllBooksFrom_Call {
+	return &MockOperationsStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+
+func (_c *MockOperationsStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockOperationsStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockOperationsStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockOperationsStore_GetAllBooksFrom_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllSettings provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) GetAllSettings() ([]database.Setting, error) {
 	ret := _mock.Called()

--- a/internal/server/handlers/system/mocks/mock_system_store.go
+++ b/internal/server/handlers/system/mocks/mock_system_store.go
@@ -481,6 +481,50 @@ func (_c *MockSystemStore_GetAllBooks_Call) RunAndReturn(run func(limit int, off
 	return _c
 }
 
+// GetAllBooksFrom provides a mock function for the type MockSystemStore
+func (_mock *MockSystemStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+	ret := _mock.Called(afterID, limit)
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksFrom")
+	}
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
+		return returnFunc(afterID, limit)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
+		r0 = returnFunc(afterID, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(afterID, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+type MockSystemStore_GetAllBooksFrom_Call struct{ *mock.Call }
+
+func (_e *MockSystemStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockSystemStore_GetAllBooksFrom_Call {
+	return &MockSystemStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+}
+func (_c *MockSystemStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockSystemStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
+	return _c
+}
+func (_c *MockSystemStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockSystemStore_GetAllBooksFrom_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+func (_c *MockSystemStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockSystemStore_GetAllBooksFrom_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllSettings provides a mock function for the type MockSystemStore
 func (_mock *MockSystemStore) GetAllSettings() ([]database.Setting, error) {
 	ret := _mock.Called()

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_search.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
 // last-edited: 2026-06-23
 
@@ -61,7 +61,7 @@ func (s *Server) buildSearchIndexIfEmpty() {
 	start := time.Now()
 	indexed := 0
 	const pageSize = 500
-	offset := 0
+	afterID := ""
 	for {
 		select {
 		case <-s.bgCtx.Done():
@@ -69,11 +69,9 @@ func (s *Server) buildSearchIndexIfEmpty() {
 			return
 		default:
 		}
-		// TODO(PERF-6): replace with cursor-based GetAllBooksFrom(afterID, limit) once
-		// the Store interface gains that method — offset scans are O(offset) per page.
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksFrom(afterID, pageSize)
 		if err != nil {
-			slog.Warn("search backfill GetAllBooks", "err", err)
+			slog.Warn("search backfill GetAllBooksFrom", "err", err)
 			return
 		}
 		if len(books) == 0 {
@@ -93,7 +91,7 @@ func (s *Server) buildSearchIndexIfEmpty() {
 			}
 			indexed++
 		}
-		offset += len(books)
+		afterID = books[len(books)-1].ID
 		if len(books) < pageSize {
 			break
 		}


### PR DESCRIPTION
## Summary

Follow-up to #1601: two test-only local mocks were missing `GetAllBooksFrom` stubs after the interface addition.

- `internal/batch/service_test.go` — MockBookStore
- `internal/itunes/rebuild_test.go` — mockRebuildStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43