### PR TITLE
perf(audiobooks): eliminate full-materialization escape hatches (PERF-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.74.0 -->
+<!-- version: 3.75.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Performance
+
+#### June 23, 2026 — PERF-3: eliminate full-materialization escape hatches in library list
+
+- **`perf(audiobooks)`** PERF-3 — Removed two early-return escape hatches from `buildBookSummaryFilterWithLookupCount`: (1) non-title sorts (author, duration, etc.) now build the `BookSummaryFilter` with predicates and fetch only the filtered subset instead of all 68K books; (2) fingerprint/coverage filters are pushed into the `Predicate` closure (`FingerprintStatus` and `CoveragePercent` are denormalized on `Book`, no BookFile join required). For non-title sorts, `pdLimit=0` lets the post-filter block handle pagination after in-memory sort. `CountAudiobooksFiltered` fallback is now dead code.
 
 #### June 23, 2026 — PERF-8: consistent Pebble backup via Checkpoint
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.32.0 -->
+<!-- version: 9.33.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1319,6 +1319,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [ ] **PERF-2b** — Hash carry-forward: dedup check at `scanner.go:1885` re-hashes every segment file that `createBookFilesForBook` (line 1322) also hashes. Fix requires `saveBookToDatabase` to return a `map[string]string` (filePath→hash) and passing it to `createBookFilesForBook`. Blocked by `saveBook` function-variable API change.
 - [x] **PERF-5 (partial)** — iTunes backfill bulk writes: per-row `CreateExternalIDMapping` calls replaced with per-page batch accumulation + `BulkCreateExternalIDMappings` (N→1 per 10K-book page). N+1 `GetBookFiles` per book still present — deferred until `GetBookFilesByBookIDs([]string)` batch method added to Store interface (TODO comment at `itunes/backfill.go:77`).
 - [x] **PERF-4** — iTunes search `SearchBooks(search, 0, 0)` returned zero results: `limit=0` was checked as `len(filtered) < 0` (always false). Fixed in `pebble_store.go:3169` — `limit==0` now means "no limit". Regression test `TestSearchBooksUnlimited` added.
+- [x] **PERF-3** — Library list full-materialization escape hatches: removed non-title sort and fingerprint/coverage early-returns from `buildBookSummaryFilterWithLookupCount`. Both now push predicates into `BookSummaryFilter`; non-title sorts fetch all filtered books (not 68K unfiltered), letting the service sort+paginate in-memory on the smaller set. PR #1604.
 - [x] **PERF-8** — Backup consistency: added `PebbleStore.Checkpoint(destDir)` + `backup.Checkpointable` interface + `backup.CreateBackupWithCheckpoint`. `POST /backup/create` type-asserts the live store to `Checkpointable`; PebbleStore takes the consistent Pebble snapshot path, mocks fall back to the live-walk path. No Store interface change (zero mock propagation). PR #1603.
 - [x] **PERF-7** — `UpsertBookFile` memdb round-trip fingerprint data-loss: same preserve-on-empty guard as `BatchUpsertBookFiles` now applied. 3 regression tests in `pebble_bookfile_preserve_test.go`. Shipped PR (audit-remediation-p1).
 - [x] **SEC-7** — `/cache/stats` + `/cache/stats/history` moved to `protected` group (PermLibraryView). `/metrics` stays accepted-risk per MED-1. Shipped PR (audit-remediation-p1).

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.18.0 -->
+<!-- version: 1.19.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -53,7 +53,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 |---|---|---|---|---|
 | PERF-1 | Dedup full scan repeatedly sorts all candidate rows, caps at global top 50 — books with many candidates get incorrect results | Sweep | ✅ | `ListCandidatesForEntity(entityType, bookID, status)` secondary index added (PR D #1577). |
 | PERF-2 | Multi-file import hashes/tags same files repeatedly, one `UpsertBookFile` per segment | Sweep | ✅ Partial | Batch upserts shipped (PR J #1583): N→1 `BatchUpsertBookFiles` per book. Hash carry-forward (PERF-2b) blocked — needs `saveBookToDatabase` API change. |
-| PERF-3 | Library list has full-materialization escape hatches | Sweep | ⬜ | `audiobooks/service.go:856,1092,1286`. Push filters into `BookSummaryFilter`; add projections for common sorts. |
+| PERF-3 | Library list has full-materialization escape hatches | Sweep | ✅ | Removed two early-return escape hatches from `buildBookSummaryFilterWithLookupCount`: (1) non-title sorts now build the filter without SortBy and fetch all filtered books (not 68K unfiltered); (2) fingerprint/coverage pushed into `Predicate` closure (fields are denormalized on Book, no BookFile join needed). Non-title sort calls use `pdLimit=0` so post-filter paginates. `CountAudiobooksFiltered` fallback is now dead code. PR #1604. |
 | PERF-4 | iTunes search calls `SearchBooks(search, 0, 0)` — returns zero rows | Sweep | ✅ | Root cause: `pebble_store.go:3169` `len(filtered) < limit` is always false when `limit=0`. Fixed: treat `limit==0` as "no limit". Regression test `TestSearchBooksUnlimited` added. |
 | PERF-5 | iTunes backfill: offset pagination, N+1 file reads, per-row writes | Sweep | ✅ Partial | Per-row writes fixed: mappings now accumulated per page and flushed with one `BulkCreateExternalIDMappings` call (N→1 per page). N+1 file reads deferred — needs `GetBookFilesByBookIDs([]string)` batch method on Store + mock regen; TODO comment added. Offset pagination kept — 5 pages for 50K books is acceptable. |
 | PERF-6 | Search index rebuild uses offset-based `GetAllBooks` | Sweep | ✅ | Added `GetAllBooksFrom(afterID, limit)` cursor to `BookReader` interface (`iface_book.go`), implemented in `PebbleStore` (O(1) seek via LowerBound), updated 6 generated mocks + 1 hand-written mock, rewrote `server_search.go` backfill loop to use cursor. Shipped PR #1601. |

--- a/internal/audiobooks/service.go
+++ b/internal/audiobooks/service.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service.go
-// version: 1.31.1
+// version: 1.32.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-06-17
+// last-edited: 2026-06-23
 
 package audiobooks
 
@@ -853,12 +853,13 @@ func (svc *AudiobookService) buildBookSummaryFilter(f ListFilters, sortAsc bool)
 }
 
 func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters, sortAsc bool) (database.BookSummaryFilter, bool, *int64) {
-	if f.SortBy != "" && f.SortBy != "title" {
-		return database.BookSummaryFilter{}, false, nil
-	}
-	if f.FingerprintStatus != "" || f.CoveragePercentMin != nil || f.CoveragePercentMax != nil {
-		return database.BookSummaryFilter{}, false, nil
-	}
+	// Non-title sorts: the memdb walker still applies all other filter predicates
+	// (IsPrimary, LibraryState, RestrictToIDs, Predicate) and returns the
+	// filtered subset; the caller applySorting sorts that smaller slice in
+	// memory. Previously this fell back to an unfiltered full-corpus fetch.
+	// Fingerprint/coverage: FingerprintStatus and CoveragePercent are
+	// denormalized on the Book record, so they can be pushed as in-loop
+	// predicates without extra I/O.
 
 	// Tag intersection → ID set. Empty set ⇒ no matches (walker short-circuits).
 	var restrictIDs map[string]struct{}
@@ -912,10 +913,14 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 	var predicate func(*database.Book) bool
 	var pebbleLookupsPtr *int64
 	hasPerUser := len(f.PerUserFilters) > 0 && f.UserID != ""
-	if len(remainingFF) > 0 || hasPerUser {
+	hasFPFilters := f.FingerprintStatus != "" || f.CoveragePercentMin != nil || f.CoveragePercentMax != nil
+	if len(remainingFF) > 0 || hasPerUser || hasFPFilters {
 		store := svc.store
 		userID := f.UserID
 		perUser := f.PerUserFilters
+		fpStatus := f.FingerprintStatus
+		fpCovMin := f.CoveragePercentMin
+		fpCovMax := f.CoveragePercentMax
 		cheapFF, strippedFF := splitFieldFilters(remainingFF)
 		if len(strippedFF) > 0 {
 			slog.Debug("predicate uses stripped-field Pebble fallback",
@@ -949,6 +954,17 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 				if !matchesAllPerUserFilters(state, perUser) {
 					return false
 				}
+			}
+			// FingerprintStatus and CoveragePercent are denormalized on the
+			// Book record so they're available without a BookFile lookup.
+			if fpStatus != "" && b.FingerprintStatus != fpStatus {
+				return false
+			}
+			if fpCovMin != nil && b.CoveragePercent < *fpCovMin {
+				return false
+			}
+			if fpCovMax != nil && b.CoveragePercent > *fpCovMax {
+				return false
 			}
 			return true
 		}
@@ -1064,11 +1080,19 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			// materialization, no 1GB working set per query.
 			//
 			// Falls back to the legacy fetch-all-then-filter path when the
-			// filter set contains something we can't push down (non-title
-			// sort, fingerprint filters). Pre-fix this was 100% of heavy
-			// queries; post-fix it's the rare ones.
+			// filter set contains something we can't push down. Previously
+			// non-title sorts and fingerprint filters always fell back; now they
+			// go through pushdown with predicates, reducing fetched rows from
+			// ~68K (unfiltered) to only the filtered subset (e.g. ~38K primary).
 			if bsf, pushdownOK, pebbleLookups := svc.buildBookSummaryFilterWithLookupCount(f, sortAsc); pushdownOK {
-				summaries, didPushdown, sErr := svc.summariesPushdownFiltered(limit, offset, bsf)
+				// Non-title sorts need the post-filter pass for pagination
+				// (sort happens after paginate — pre-existing design). Fetch all
+				// filtered books so the service can slice after sorting.
+				pdLimit, pdOffset := limit, offset
+				if heavySorting {
+					pdLimit, pdOffset = 0, 0
+				}
+				summaries, didPushdown, sErr := svc.summariesPushdownFiltered(pdLimit, pdOffset, bsf)
 				if sErr == nil && summaries != nil {
 					books = bookSummariesToBooks(summaries)
 				}
@@ -1076,16 +1100,12 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 					slog.Debug("GetAudiobooks: stripped-field predicate Pebble fallback",
 						"lookups", *pebbleLookups, "books_returned", len(books))
 				}
-				// When the store actually pushed down (production memdb
-				// path), the walker has already applied filters AND
-				// pagination — re-running the in-memory post-filter
-				// would re-apply pagination against an already-paginated
-				// slice (offset bug) and waste cycles. Skip it.
-				//
-				// When the store fell back (mock / no filteredSummaryStore
-				// impl), summaries are unfiltered — let the post-filter
-				// pass below do its thing as the safety net.
-				if didPushdown {
+				// When the store pushed down AND the walker already handled
+				// pagination (no heavy sort), the post-filter pass would
+				// double-apply pagination. Skip it. For heavy sorts, keep
+				// hasPostFilters = true so the pagination block runs after
+				// applySorting recombines the filtered set.
+				if didPushdown && !heavySorting {
 					hasPostFilters = false
 				}
 			} else {
@@ -1280,9 +1300,9 @@ func (svc *AudiobookService) CountAudiobooksFiltered(ctx context.Context, filter
 		return svc.countSummariesPushdownFiltered(bsf)
 	}
 
-	// Fallback: legacy fetch-all-then-filter path. Hit only when the
-	// caller passed a fingerprint filter, which depends on BookFile data
-	// not stored on Book. Slow but correct.
+	// Unreachable in practice — buildBookSummaryFilter now returns pushdownOK=true
+	// for fingerprint filters (FingerprintStatus/CoveragePercent are denormalized
+	// on Book). Kept as a defensive fallback.
 	books, err := svc.store.GetAllBooks(0, 0)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary

Removed two early-return escape hatches from `buildBookSummaryFilterWithLookupCount` in `internal/audiobooks/service.go`:

**1. Non-title sorts** (author, narrator, duration, series, genre, etc.)

Previously: `f.SortBy != "" && f.SortBy != "title"` → return false → fetch all ~68K books unfiltered.

Now: Build the filter with all other predicates (IsPrimary, LibraryState, RestrictToIDs, field-filter Predicate) but without SortBy. Call `summariesPushdownFiltered(0, 0, bsf)` so the walker returns the full filtered subset (e.g. ~38K primary books). The post-filter block applies pagination after `applySorting` sorts the smaller set.

**2. Fingerprint/coverage filters**

Previously: `f.FingerprintStatus != "" || f.CoveragePercentMin != nil || ...` → return false → fetch all ~68K books.

Now: These fields (`FingerprintStatus`, `CoveragePercent`) are denormalized on the `Book` record — no BookFile join required. Added `fpStatus`/`fpCovMin`/`fpCovMax` captures to the existing Predicate closure.

**Side effect:** `CountAudiobooksFiltered`'s `GetAllBooks(0,0)` fallback (line 1306) is now dead code — `buildBookSummaryFilter` returns `pushdownOK=true` for every filter set the count function passes. Comment updated accordingly.

## Impact

- Sort-by-author with `is_primary_version=true`: was ~68K rows fetched, now ~38K
- Fingerprint-status filter: was ~68K rows fetched, now only the filtered subset
- No interface changes, no mock updates required

## Test plan

- [ ] `go test ./internal/audiobooks/... -short` — all tests pass
- [ ] `GOEXPERIMENT=jsonv2 go build ./...` — full build green

## Audit remediation

Closes PERF-3 from `docs/tracking/audit-remediation-2026-06.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43