### PR TITLE
refactor(database): centralize optional store capability resolution (ARCH-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.76.0 -->
+<!-- version: 3.77.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-23 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Architecture
+
+#### June 23, 2026 — ARCH-6: centralized storecap helpers
+
+- **`refactor(database)`** ARCH-6 — Added `database.GetOpsV2(store Store) OpsV2Store` and `database.GetAIJobs(store Store) AIJobsStore` in `internal/database/storecap.go`. Both helpers handle the nil-guard and walk any `Unwrap()` decorator chain (same pattern as `errors.As`). Updated 5 call sites in `wire_handlers.go`, `registry_wire.go`, `operations_v2_handlers.go`, `batch_poller.go`, and `handlers/ai.go` to use the canonical helpers. `UnwrapAIJobsStore` now delegates to `database.GetAIJobs` for backward compat.
 
 ### Performance
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.34.0 -->
+<!-- version: 9.35.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-23 -->
 
@@ -1317,6 +1317,7 @@ Bot-tasks at [`docs/superpowers/bot-tasks/2026-05-01-struct-*.md`](docs/superpow
 - [x] **PERF-2** — Batch upserts in `createBookFilesForBook`: N per-segment `UpsertBookFile` calls replaced with one `BatchUpsertBookFiles` call (shipped PR #1583). N→1 DB writes per book on first scan.
 - [x] **PERF-6** — Search index backfill cursor: added `GetAllBooksFrom(afterID, limit)` to `BookReader` interface + PebbleStore (O(1) LowerBound seek). Rewrote `server_search.go` backfill loop to use cursor pagination instead of O(offset) `GetAllBooks`. Updated 1 hand-written + 6 mockery-generated mocks. PR #1601.
 - [x] **PERF-2b** — Hash carry-forward: added `Book.SegmentHashes map[string]string`; `saveBookToDatabase` dedup loop writes computed hashes back; `createBookFilesForBook` accepts `knownHashes ...map[string]string` variadic (no signature change to `saveBook` function variable); call site at line 850 passes `books[idx].SegmentHashes`. PR #1605.
+- [x] **ARCH-6** — Optional store capabilities discovered ad hoc: `database.GetOpsV2(store)` + `database.GetAIJobs(store)` added to `internal/database/storecap.go`. Both walk the `Unwrap()` decorator chain (mirrors `errors.As`). 5 ad-hoc type-assertion sites replaced; `UnwrapAIJobsStore` in `handlers/ai.go` delegates to `GetAIJobs` for backward compat. PR #1606.
 - [x] **PERF-5 (partial)** — iTunes backfill bulk writes: per-row `CreateExternalIDMapping` calls replaced with per-page batch accumulation + `BulkCreateExternalIDMappings` (N→1 per 10K-book page). N+1 `GetBookFiles` per book still present — deferred until `GetBookFilesByBookIDs([]string)` batch method added to Store interface (TODO comment at `itunes/backfill.go:77`).
 - [x] **PERF-4** — iTunes search `SearchBooks(search, 0, 0)` returned zero results: `limit=0` was checked as `len(filtered) < 0` (always false). Fixed in `pebble_store.go:3169` — `limit==0` now means "no limit". Regression test `TestSearchBooksUnlimited` added.
 - [x] **PERF-3** — Library list full-materialization escape hatches: removed non-title sort and fingerprint/coverage early-returns from `buildBookSummaryFilterWithLookupCount`. Both now push predicates into `BookSummaryFilter`; non-title sorts fetch all filtered books (not 68K unfiltered), letting the service sort+paginate in-memory on the smaller set. PR #1604.

--- a/docs/tracking/audit-remediation-2026-06.md
+++ b/docs/tracking/audit-remediation-2026-06.md
@@ -1,5 +1,5 @@
 <!-- file: docs/tracking/audit-remediation-2026-06.md -->
-<!-- version: 1.20.0 -->
+<!-- version: 1.21.0 -->
 <!-- guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f -->
 <!-- last-edited: 2026-06-23 -->
 <!-- Note: per-finding table synced to PR delivery table on 2026-06-23 -->
@@ -71,7 +71,7 @@ These Structure Audit findings were addressed in the May–June refactor wave be
 | ARCH-3 | Operation enqueue boilerplate duplicated across handlers | Sweep | ✅ | `launchOp` / `launchLegacyOp` helpers extracted; 11 enqueue boilerplate sites eliminated (PR G #1577). |
 | ARCH-4 | Config legacy remap machinery repeats by group | Sweep | ✅ | `applyLegacyRemaps` + `configRemapGroups` table in `update_service.go`. 6 per-group functions eliminated; all remap logic in one place. 13 tests updated. |
 | ARCH-5 | `AudiobookService` is a god service | Sweep | ⬜ | P2. Split query/mutation/tags/delete/compatibility. |
-| ARCH-6 | Optional store capabilities discovered ad hoc | Sweep | ⬜ | P2. Add `storecap` helpers. |
+| ARCH-6 | Optional store capabilities discovered ad hoc | Sweep | ✅ | `database.GetOpsV2` + `GetAIJobs` in `storecap.go`; 5 sites updated; `UnwrapAIJobsStore` delegates. PR #1606. |
 | ARCH-7 | Compatibility surfaces scattered across 6+ files | Sweep | ⬜ | P2. Create compatibility registry with owner/removal condition. |
 | ARCH-8 | Service registry uses globals and panicking string lookups | Sweep | ⬜ | P2. Typed service keys or generated accessors. |
 | STR-1 | Pagination helper missing — 376+ limit/offset/page callsites parsed independently | Structure | ✅ | `internal/server/pagination.go` created; pagination helper standardized (PR E #1578). |

--- a/internal/database/storecap.go
+++ b/internal/database/storecap.go
@@ -1,0 +1,44 @@
+// file: internal/database/storecap.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-06-23
+
+package database
+
+// GetOpsV2 resolves the OpsV2Store capability from store, walking any Unwrap()
+// decorator chain. Returns nil if store is nil or no layer satisfies OpsV2Store.
+//
+// Use this instead of scattering `store.(database.OpsV2Store)` type assertions.
+func GetOpsV2(store Store) OpsV2Store {
+	type unwrapper interface{ Unwrap() Store }
+	for store != nil {
+		if v2, ok := store.(OpsV2Store); ok {
+			return v2
+		}
+		u, ok := store.(unwrapper)
+		if !ok {
+			break
+		}
+		store = u.Unwrap()
+	}
+	return nil
+}
+
+// GetAIJobs resolves the AIJobsStore capability from store, walking any Unwrap()
+// decorator chain. Returns nil if store is nil or no layer satisfies AIJobsStore.
+//
+// Use this instead of scattering `store.(database.AIJobsStore)` type assertions.
+func GetAIJobs(store Store) AIJobsStore {
+	type unwrapper interface{ Unwrap() Store }
+	for store != nil {
+		if aij, ok := store.(AIJobsStore); ok {
+			return aij
+		}
+		u, ok := store.(unwrapper)
+		if !ok {
+			break
+		}
+		store = u.Unwrap()
+	}
+	return nil
+}

--- a/internal/server/batch_poller.go
+++ b/internal/server/batch_poller.go
@@ -1,6 +1,7 @@
 // file: internal/server/batch_poller.go
-// version: 1.5.1
+// version: 1.6.0
 // guid: f8a1b2c3-d4e5-6789-abcd-0123456789ab
+// last-edited: 2026-06-23
 
 package server
 
@@ -200,8 +201,8 @@ func (s *Server) registerBatchPollerHandlers() {
 				Err:      r.Error,
 			})
 		}
-		store, ok := s.Store().(database.AIJobsStore)
-		if !ok {
+		store := database.GetAIJobs(s.Store())
+		if store == nil {
 			return fmt.Errorf("aijobs: store does not implement AIJobsStore")
 		}
 		return aijobs.Dispatch(ctx, store, batchID, results)

--- a/internal/server/handlers/ai.go
+++ b/internal/server/handlers/ai.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/ai.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6ccf0c64-9654-46c5-aed0-584943acb1c5
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // AIHandler hosts the AI HTTP endpoints extracted from the server package:
 // filename parsing, OpenAI / metadata-source connection tests, per-book AI
@@ -701,8 +701,8 @@ func (h *AIHandler) ListAIJobs(c *gin.Context) {
 		offset = 0
 	}
 
-	store, ok := UnwrapAIJobsStore(h.store)
-	if !ok {
+	store := database.GetAIJobs(h.store)
+	if store == nil {
 		httputil.RespondWithInternalError(c, "store does not implement AIJobsStore")
 		return
 	}
@@ -716,23 +716,11 @@ func (h *AIHandler) ListAIJobs(c *gin.Context) {
 	}{Jobs: jobs})
 }
 
-// UnwrapAIJobsStore peels Store decorator layers (anything with Unwrap()) until
-// it finds one that satisfies database.AIJobsStore, mirroring the errors.As()
-// pattern. Exported (relocated from server.unwrapAIJobsStore) so it remains
-// callable from package handlers.
+// UnwrapAIJobsStore peels Store decorator layers until it finds one satisfying
+// database.AIJobsStore. Delegates to database.GetAIJobs; kept for API compat.
 func UnwrapAIJobsStore(s database.Store) (database.AIJobsStore, bool) {
-	type unwrapper interface{ Unwrap() database.Store }
-	for s != nil {
-		if aij, ok := s.(database.AIJobsStore); ok {
-			return aij, true
-		}
-		u, ok := s.(unwrapper)
-		if !ok {
-			break
-		}
-		s = u.Unwrap()
-	}
-	return nil, false
+	aij := database.GetAIJobs(s)
+	return aij, aij != nil
 }
 
 // AIReviewGroupsMode is the Groups mode of the AI author review: local

--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/operations_v2_handlers.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-05-08
+// last-edited: 2026-06-23
 
 // UOS-06: SSE event hub, /operations/timeline, single-op introspection,
 // cancel, trigger-op, and /op-defs endpoints.
@@ -263,14 +263,7 @@ func (s *Server) handleOperationsSSE(c *gin.Context) {
 // opsV2Store returns the OpsV2Store from the server's composite Store, or nil
 // if the store does not implement it.
 func (s *Server) opsV2Store() database.OpsV2Store {
-	if s.Store() == nil {
-		return nil
-	}
-	st, ok := s.Store().(database.OpsV2Store)
-	if !ok {
-		return nil
-	}
-	return st
+	return database.GetOpsV2(s.Store())
 }
 
 // displayNameFor looks up the human-readable display name for a def ID.

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,6 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.14.0
-// last-edited: 2026-06-16
+// version: 1.15.0
+// last-edited: 2026-06-23
 
 package server
 
@@ -116,10 +116,7 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			store := serviceregistry.Get[database.Store](c, "store")
-			if s, ok := store.(database.AIJobsStore); ok {
-				return s, nil
-			}
-			return database.AIJobsStore(nil), nil
+			return database.GetAIJobs(store), nil
 		},
 	})
 

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.11.0
+// version: 2.12.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-06-22
+// last-edited: 2026-06-23
 
 package server
 
@@ -159,12 +159,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	}
 
 	// Resolve the opsV2 store from the composite store (nil if unsupported).
-	var opsV2 database.OpsV2Store
-	if st := s.Store(); st != nil {
-		if v2, ok := st.(database.OpsV2Store); ok {
-			opsV2 = v2
-		}
-	}
+	opsV2 := database.GetOpsV2(s.Store())
 	opsV2H := handlers.NewOperationsV2Handler(opsV2, opReg, opEventHub)
 
 	// Operations domain handler (scan/organize/optimize/transcode triggers,


### PR DESCRIPTION
## Summary

- Added `database.GetOpsV2(store Store) OpsV2Store` and `database.GetAIJobs(store Store) AIJobsStore` in `internal/database/storecap.go`
- Both helpers nil-guard the store and walk any `Unwrap()` decorator chain (same pattern as `errors.As`) — future wrapped/instrumented stores are handled automatically
- Replaced 5 ad-hoc `if v, ok := store.(database.XxxStore); ok { ... }` patterns scattered across `wire_handlers.go`, `registry_wire.go`, `operations_v2_handlers.go`, `batch_poller.go`, and `handlers/ai.go`
- `handlers.UnwrapAIJobsStore` (exported, in use by existing callers) delegates to `database.GetAIJobs` — no API break

## Why

ARCH-6 from the June 2026 audit: "Optional store capabilities discovered ad hoc." Each file used a slightly different pattern (some with nil guards, some without; some with Unwrap chaining, some with direct assertion). Centralizing ensures consistent behavior and makes it trivial to add future capabilities.

## Test plan

- [ ] `GOEXPERIMENT=jsonv2 go build ./...` — passes (verified)
- [ ] `make test` — existing tests cover all updated callers

## Audit remediation

Completes ARCH-6 from `docs/tracking/audit-remediation-2026-06.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43