### PR TITLE
refactor(handlers): remove unnecessary lazy store providers (ARCH-1)

### DIFF
--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Package audiobookshandler hosts the main library list / CRUD HTTP handlers
 // extracted from the server package's audiobooks_handlers.go: book listing
@@ -39,12 +39,11 @@
 //
 // As a result package audiobookshandler never imports package server.
 //
-// The store is reached through a LAZY PROVIDER CLOSURE (getStore) so a value
-// swapped after wireHandlers (a router-integration test swaps server.store
-// post-wire) is still observed at request time, mirroring the dedup /
-// duplicates / system handler getStore seam. The interface-typed service deps
-// are wire-time snapshots (assigned once before setupRoutes, never swapped),
-// each guarded against typed-nil boxing by the controller in wire_handlers.go.
+// The store is a WIRE-TIME SNAPSHOT (assigned once in New, never swapped after
+// that). The interface-typed service deps are also wire-time snapshots, each
+// guarded against typed-nil boxing by the controller in wire_handlers.go.
+// The write-back batcher is the sole exception: it remains a lazy provider
+// closure because integration tests swap server.writeBackBatcher post-wire.
 
 package audiobookshandler
 
@@ -76,15 +75,13 @@ const facetsCacheKey = "all"
 
 // Handler hosts the audiobooks-domain HTTP endpoints.
 type Handler struct {
-	// getStore resolves the database store lazily, at request time. The original
-	// handlers read s.Store() at call time (late binding), and a router
-	// integration test swaps server.store AFTER wiring to inject a mock — so
-	// snapshotting the store at wire time would capture the pre-swap store. The
-	// provider returns the concrete store value (un-stripped) so the handlers'
-	// inline type assertions (Unwrap / ListBooksWithFileErrors /
+	// store is the wire-time snapshot of the database store. All handlers read
+	// from this field directly (no lazy provider needed — no post-wire swap for
+	// this package's store). The concrete store value (un-stripped) is preserved
+	// so the handlers' inline type assertions (Unwrap / ListBooksWithFileErrors /
 	// GetAllBookIDsForQuickQuery / GetBookFilesForIDs / InvalidateLibraryStats)
 	// still resolve against the dynamic type.
-	getStore func() AudiobooksStore
+	store AudiobooksStore
 
 	audiobookService AudiobookService
 	audiobookUpdater AudiobookUpdater
@@ -143,7 +140,7 @@ type Handler struct {
 
 // New constructs an audiobooks Handler from its dependencies.
 func New(
-	getStore func() AudiobooksStore,
+	store AudiobooksStore,
 	audiobookService AudiobookService,
 	audiobookUpdater AudiobookUpdater,
 	getWriteBack func() WriteBackEnqueuer,
@@ -163,7 +160,7 @@ func New(
 	publishEvent func(ctx context.Context, event plugin.Event),
 ) *Handler {
 	return &Handler{
-		getStore:             getStore,
+		store:                store,
 		audiobookService:     audiobookService,
 		audiobookUpdater:     audiobookUpdater,
 		getWriteBack:         getWriteBack,
@@ -182,15 +179,6 @@ func New(
 		getExternalIDStore:   getExternalIDStore,
 		publishEvent:         publishEvent,
 	}
-}
-
-// resolveStore returns the live store via the lazy provider, or nil if no
-// provider was supplied or the provider yields nil.
-func (h *Handler) resolveStore() AudiobooksStore {
-	if h.getStore == nil {
-		return nil
-	}
-	return h.getStore()
 }
 
 // resolveWriteBack returns the live write-back batcher via the lazy provider, or
@@ -218,7 +206,7 @@ func ptrStr(p *string) string {
 // no_isbn / duplicates_flagged) fast-path, then the filtered list pipeline with
 // the list cache (skipped when per-user filters are active).
 func (h *Handler) ListAudiobooks(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 
 	// Parse pagination parameters
 	params := httputil.ParsePaginationParams(c)
@@ -527,7 +515,7 @@ func (h *Handler) PurgeSoftDeletedAudiobooks(c *gin.Context) {
 // in the DB to match physical reality. POST /audiobooks/:id/rescan.
 func (h *Handler) RescanAudiobook(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -649,7 +637,7 @@ func (h *Handler) CountAudiobooks(c *gin.Context) {
 // distinct genres and languages for filter dropdowns. Results are cached for 5
 // minutes and pre-warmed at startup (warmFacetsCache stays in package server).
 func (h *Handler) AudiobookFacets(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return

--- a/internal/server/handlers/audiobooks/handler_crud.go
+++ b/internal/server/handlers/audiobooks/handler_crud.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_crud.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f0f10bf-7554-4af5-b2d2-ce0a6af6b46e
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Write-side CRUD + batch endpoints for the audiobooks domain: update
 // (full-column replacement with change-history recording + file write-back),
@@ -32,7 +32,7 @@ import (
 // the file, enqueues iTunes write-back, and invalidates caches.
 func (h *Handler) UpdateAudiobook(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 
 	var payload map[string]any
 	if err := c.ShouldBindJSON(&payload); err != nil {

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_files.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 82f8d1f7-46d5-4ead-b5c1-ba796fd785f9
-// last-edited: 2026-06-17
+// last-edited: 2026-06-23
 
 // File / segment endpoints for the audiobooks domain: segment listing,
 // book-file listing + patch, track-info extraction, relocate, and segment
@@ -49,7 +49,7 @@ func relocateTargetAllowed(store AudiobooksStore, absPath string) bool {
 // segments for a multi-file audiobook in the legacy BookSegment JSON shape.
 func (h *Handler) ListAudiobookSegments(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -100,7 +100,7 @@ func (h *Handler) ListAudiobookSegments(c *gin.Context) {
 // check. GET /audiobooks/:id/files.
 func (h *Handler) ListBookFiles(c *gin.Context) {
 	bookID := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -167,7 +167,7 @@ func (h *Handler) PatchBookFile(c *gin.Context) {
 	bookID := c.Param("id")
 	fileID := c.Param("file_id")
 
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -211,7 +211,7 @@ func (h *Handler) PatchBookFile(c *gin.Context) {
 // segments. POST /audiobooks/:id/extract-track-info.
 func (h *Handler) ExtractTrackInfo(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -324,7 +324,7 @@ func (h *Handler) ExtractTrackInfo(c *gin.Context) {
 // POST /audiobooks/:id/relocate.
 func (h *Handler) RelocateBookFiles(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -433,7 +433,7 @@ func (h *Handler) RelocateBookFiles(c *gin.Context) {
 func (h *Handler) GetSegmentTags(c *gin.Context) {
 	id := c.Param("id")
 	segmentId := c.Param("segmentId")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return

--- a/internal/server/handlers/audiobooks/handler_metadata.go
+++ b/internal/server/handlers/audiobooks/handler_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_metadata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 591661c3-5e87-4559-9a08-3203eec4fb68
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Metadata-history / undo / field-state / path-history / external-id /
 // changelog / changes endpoints for the audiobooks domain. Split out of
@@ -26,7 +26,7 @@ import (
 // GetBookMetadataHistory handles GET /audiobooks/:id/metadata-history.
 func (h *Handler) GetBookMetadataHistory(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -65,7 +65,7 @@ func (h *Handler) GetAudiobookFieldStates(c *gin.Context) {
 func (h *Handler) GetFieldMetadataHistory(c *gin.Context) {
 	id := c.Param("id")
 	field := c.Param("field")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -91,7 +91,7 @@ func (h *Handler) GetFieldMetadataHistory(c *gin.Context) {
 func (h *Handler) UndoMetadataChange(c *gin.Context) {
 	id := c.Param("id")
 	field := c.Param("field")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -158,7 +158,7 @@ func (h *Handler) UndoMetadataChange(c *gin.Context) {
 // for a book. POST /audiobooks/:id/undo-last-apply.
 func (h *Handler) UndoLastApply(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -266,7 +266,7 @@ func (h *Handler) UndoLastApply(c *gin.Context) {
 // GetBookPathHistory handles GET /audiobooks/:id/path-history.
 func (h *Handler) GetBookPathHistory(c *gin.Context) {
 	id := c.Param("id")
-	history, err := h.resolveStore().GetBookPathHistory(id)
+	history, err := h.store.GetBookPathHistory(id)
 	if err != nil {
 		httputil.RespondWithOK(c, gin.H{"history": []any{}})
 		return
@@ -321,7 +321,7 @@ func (h *Handler) GetBookChangelog(c *gin.Context) {
 // GET /audiobooks/:id/changes.
 func (h *Handler) GetBookChanges(c *gin.Context) {
 	id := c.Param("id")
-	changes, err := h.resolveStore().GetBookChanges(id)
+	changes, err := h.store.GetBookChanges(id)
 	if err != nil {
 		httputil.InternalError(c, "failed to get book changes", err)
 		return

--- a/internal/server/handlers/audiobooks/handler_tags.go
+++ b/internal/server/handlers/audiobooks/handler_tags.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_tags.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: ff2e3609-5ce3-4414-a18b-976d21b929fb
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Tag read/write, alternative-title CRUD, and batch tag-update endpoints for
 // the audiobooks domain. Split out of handler.go for readability; one Handler,
@@ -77,7 +77,7 @@ func (h *Handler) GetBookTagsDetailed(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "book id is required")
 		return
 	}
-	tags, err := h.resolveStore().GetBookTagsDetailed(id)
+	tags, err := h.store.GetBookTagsDetailed(id)
 	if err != nil {
 		httputil.RespondWithInternalError(c, err.Error())
 		return
@@ -95,7 +95,7 @@ func (h *Handler) GetBookAlternativeTitles(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "id is required")
 		return
 	}
-	alts, err := h.resolveStore().GetBookAlternativeTitles(id)
+	alts, err := h.store.GetBookAlternativeTitles(id)
 	if err != nil {
 		httputil.InternalError(c, "failed to get alternative titles", err)
 		return
@@ -123,7 +123,7 @@ func (h *Handler) AddBookAlternativeTitle(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "title is required")
 		return
 	}
-	store := h.resolveStore()
+	store := h.store
 	// Confirm the book exists before inserting — avoids orphan alt
 	// title rows for deleted books.
 	if book, err := store.GetBookByID(id); err != nil || book == nil {
@@ -152,7 +152,7 @@ func (h *Handler) RemoveBookAlternativeTitle(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "title is required")
 		return
 	}
-	store := h.resolveStore()
+	store := h.store
 	if err := store.RemoveBookAlternativeTitle(id, body.Title); err != nil {
 		httputil.InternalError(c, "failed to remove alternative title", err)
 		return

--- a/internal/server/handlers/audiobooks/handler_test.go
+++ b/internal/server/handlers/audiobooks/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5cd764d5-8036-425c-842e-c49d0d44acec
-// last-edited: 2026-06-17
+// last-edited: 2026-06-23
 
 // Tests for the audiobooks-domain handlers (main library list / CRUD). The
 // store / audiobook-service / updater / write-back / metadata-state /
@@ -87,7 +87,7 @@ func newHandler(t *testing.T) (*audiobookshandler.Handler, testDeps) {
 	rec := &recorders{}
 
 	h := audiobookshandler.New(
-		func() audiobookshandler.AudiobooksStore { return store },
+		store,
 		svc,
 		updater,
 		func() audiobookshandler.WriteBackEnqueuer { return writeBack },

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/handler.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: d1b9e024-d28c-4d62-8f90-96d7064559c4
-// last-edited: 2026-06-13
+// last-edited: 2026-06-23
 
 // Package deduphandler hosts the dedup-domain HTTP handlers extracted from the
 // server package: dedup candidate / cluster / series listing, merge / dismiss /
@@ -15,13 +15,11 @@
 // wrap *Server methods which stay in package server (they are shared with other
 // domains). As a result package deduphandler never imports package server.
 //
-// The store and the embedding store are reached through LAZY PROVIDER CLOSURES
-// (getStore / getEmbeddingStore) so a value swapped after wireHandlers (a
-// router-integration test swaps server.store post-wire) is still observed at
-// request time, mirroring the system handler's getStore seam. opRegistry /
-// mergeService / dedupEngine are interface snapshots taken at wire time (they
-// are assigned once in registry_wire, before setupRoutes, and never swapped),
-// each guarded against typed-nil boxing by the controller.
+// The store and the embedding store are WIRE-TIME SNAPSHOTS (assigned once in
+// New, never swapped after that). opRegistry / mergeService / dedupEngine are
+// also interface snapshots taken at wire time (assigned once in registry_wire,
+// before setupRoutes, and never swapped), each guarded against typed-nil boxing
+// by the controller.
 //
 // NAME NOTE: this package is `deduphandler` (dir internal/server/handlers/dedup/)
 // to avoid clashing with the dedup ENGINE package internal/dedup, imported here
@@ -49,19 +47,14 @@ import (
 
 // Handler hosts the dedup-domain HTTP endpoints.
 type Handler struct {
-	// getStore resolves the database store lazily, at request time. The original
-	// handlers read s.Store() at call time (late binding), and a router
-	// integration test swaps server.store AFTER wiring to inject a mock — so
-	// snapshotting the store at wire time would capture the pre-swap store and
-	// miss the mock's expectations. The provider performs the typed-nil guard.
-	getStore func() DedupStore
+	// store is the wire-time snapshot of the database store. All handlers read
+	// from this field directly (no lazy provider needed).
+	store DedupStore
 
-	// getEmbeddingStore resolves the concrete *database.EmbeddingStore lazily, at
-	// request time. The original handlers read s.embeddingStore at call time and
-	// nil-checked it; the provider performs the nil-check (a nil concrete pointer
-	// stays nil, no interface boxing involved). Concrete pointer (not interface)
-	// because EmbeddingStore is a clean db type under heavy multi-method use.
-	getEmbeddingStore func() *database.EmbeddingStore
+	// embeddingStore is the wire-time snapshot of the concrete
+	// *database.EmbeddingStore. Concrete pointer (not interface) because
+	// EmbeddingStore is a clean db type under heavy multi-method use.
+	embeddingStore *database.EmbeddingStore
 
 	// opRegistry backs the scan-trigger endpoints. Interface snapshot guarded by
 	// the controller against typed-nil boxing so the in-method `== nil` guards
@@ -89,8 +82,8 @@ type Handler struct {
 
 // New constructs a dedup Handler from its dependencies.
 func New(
-	getStore func() DedupStore,
-	getEmbeddingStore func() *database.EmbeddingStore,
+	store DedupStore,
+	embeddingStore *database.EmbeddingStore,
 	opRegistry OperationsRegistry,
 	mergeService MergeService,
 	dedupEngine DedupEngine,
@@ -98,32 +91,14 @@ func New(
 	markDuplicatesFlaggedDirty func(reason string),
 ) *Handler {
 	return &Handler{
-		getStore:                   getStore,
-		getEmbeddingStore:          getEmbeddingStore,
+		store:                      store,
+		embeddingStore:             embeddingStore,
 		opRegistry:                 opRegistry,
 		mergeService:               mergeService,
 		dedupEngine:                dedupEngine,
 		publishEvent:               publishEvent,
 		markDuplicatesFlaggedDirty: markDuplicatesFlaggedDirty,
 	}
-}
-
-// resolveStore returns the live store via the lazy provider, or nil if no
-// provider was supplied or the provider yields nil.
-func (h *Handler) resolveStore() DedupStore {
-	if h.getStore == nil {
-		return nil
-	}
-	return h.getStore()
-}
-
-// resolveEmbeddingStore returns the live *database.EmbeddingStore via the lazy
-// provider, or nil if no provider was supplied or it yields nil.
-func (h *Handler) resolveEmbeddingStore() *database.EmbeddingStore {
-	if h.getEmbeddingStore == nil {
-		return nil
-	}
-	return h.getEmbeddingStore()
 }
 
 // ListDedupCandidates handles GET /api/v1/dedup/candidates.
@@ -149,7 +124,7 @@ func (h *Handler) resolveEmbeddingStore() *database.EmbeddingStore {
 // field (the composite 0–100 value). "band" is already part of
 // DedupCandidate. "score_breakdown" is omitted unless include_breakdown=true.
 func (h *Handler) ListDedupCandidates(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -216,7 +191,7 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 	// slips through (race, missed delete, crash between cleanup runs),
 	// the UI never shows a candidate that would 404 when clicked.
 	// Non-book entities (e.g. author) skip the existence check.
-	store := h.resolveStore()
+	store := h.store
 	// bookCache memoises GetBookByID across both referenced IDs of every
 	// candidate. A miss is recorded as a nil entry so we never re-query a
 	// known-dead ID. The cached *database.Book doubles as the include_books
@@ -359,7 +334,7 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 // Returns 404 when the candidate ID is not found.
 // Returns 503 when the embedding store is unavailable.
 func (h *Handler) GetDedupCandidateBreakdown(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -383,7 +358,7 @@ func (h *Handler) GetDedupCandidateBreakdown(c *gin.Context) {
 	}
 
 	// Fetch both books and their files for the side-by-side comparison view.
-	store := h.resolveStore()
+	store := h.store
 	type bookDetail struct {
 		*database.Book
 		Files []database.BookFile `json:"files"`
@@ -468,7 +443,7 @@ func (h *Handler) RescoreDedupCandidates(c *gin.Context) {
 // entity_b_id, entity_b_title, entity_b_author,
 // llm_verdict, llm_reason, created_at, updated_at.
 func (h *Handler) ExportDedupCandidates(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -509,7 +484,7 @@ func (h *Handler) ExportDedupCandidates(c *gin.Context) {
 	// memoized so a book that appears in multiple candidates is only
 	// fetched once. Books-only for now — authors export would need the
 	// author table which we can add later if needed.
-	store := h.resolveStore()
+	store := h.store
 	type enriched struct {
 		title  string
 		author string
@@ -660,7 +635,7 @@ type dedupSeriesSummary struct {
 // from every summary — they're cross-series and don't fit the
 // "series-aware bulk merge" workflow.
 func (h *Handler) ListDedupCandidateSeries(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -677,7 +652,7 @@ func (h *Handler) ListDedupCandidateSeries(c *gin.Context) {
 	}
 
 	// Memoize book → series_id lookups across candidates.
-	store := h.resolveStore()
+	store := h.store
 	bookSeries := make(map[string]int, len(cands)*2)
 	lookup := func(id string) int {
 		if v, ok := bookSeries[id]; ok {
@@ -777,7 +752,7 @@ func (h *Handler) ListDedupCandidateSeries(c *gin.Context) {
 // a scope, not a selector. If the user wants those pairs merged, they
 // can use the regular Merge Filtered action.
 func (h *Handler) MergeDedupCandidateSeries(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -806,7 +781,7 @@ func (h *Handler) MergeDedupCandidateSeries(c *gin.Context) {
 	}
 
 	// Filter to same-series candidates only.
-	store := h.resolveStore()
+	store := h.store
 	bookSeries := make(map[string]int, len(cands)*2)
 	lookup := func(id string) int {
 		if v, ok := bookSeries[id]; ok {
@@ -905,7 +880,7 @@ func (h *Handler) MergeDedupCandidateSeries(c *gin.Context) {
 
 // GetDedupStats handles GET /api/v1/dedup/stats.
 func (h *Handler) GetDedupStats(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -935,7 +910,7 @@ func (h *Handler) GetDedupStats(c *gin.Context) {
 // Safety: caller should confirm with the user before invoking, because
 // this is destructive and irreversible.
 func (h *Handler) BulkMergeDedupCandidates(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1032,7 +1007,7 @@ func (h *Handler) BulkMergeDedupCandidates(c *gin.Context) {
 // merged together as one logical group rather than one pairwise merge at a
 // time (which would fight the version-group state mid-way).
 func (h *Handler) MergeDedupCluster(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1123,7 +1098,7 @@ func (h *Handler) MergeDedupCluster(c *gin.Context) {
 // as status=dismissed. No books are modified — this just removes the pair
 // from the pending queue.
 func (h *Handler) DismissDedupCluster(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1199,7 +1174,7 @@ func (h *Handler) DismissDedupCluster(c *gin.Context) {
 // Accepts both singular and plural forms for backwards compatibility.
 // If both are provided, they're merged into a single set.
 func (h *Handler) RemoveFromDedupCluster(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1303,7 +1278,7 @@ func (h *Handler) RemoveFromDedupCluster(c *gin.Context) {
 
 // MergeDedupCandidate handles POST /api/v1/dedup/candidates/:id/merge.
 func (h *Handler) MergeDedupCandidate(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1423,7 +1398,7 @@ func (h *Handler) MergeDedupCandidate(c *gin.Context) {
 
 // DismissDedupCandidate handles POST /api/v1/dedup/candidates/:id/dismiss.
 func (h *Handler) DismissDedupCandidate(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -1673,7 +1648,7 @@ type AcoustIDCompareResponse struct {
 // HandleCompareAcoustID handles POST /api/v1/audiobooks/:id/compare-acoustid?other=<bookID2>.
 // Computes per-segment fingerprint comparison between two books' primary files.
 func (h *Handler) HandleCompareAcoustID(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	idA := c.Param("id")
 	idB := c.Query("other")
 	if idB == "" {

--- a/internal/server/handlers/dedup/handler_test.go
+++ b/internal/server/handlers/dedup/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/handler_test.go
-// version: 1.3.2
+// version: 1.4.0
 // guid: 6d8011eb-bed6-430b-959e-2a2b0738ffbc
-// last-edited: 2026-06-12
+// last-edited: 2026-06-23
 
 // Tests for the dedup-domain handlers. The embedding store is exercised through
 // a REAL pebble-backed *database.EmbeddingStore (it is a concrete db type the
@@ -74,11 +74,9 @@ func newHandler(t *testing.T, opts ...func(*handlerCfg)) (*deduphandler.Handler,
 	publishedN := 0
 	dirtyReasons := []string{}
 
-	var getEmbed func() *database.EmbeddingStore
+	var embedArg *database.EmbeddingStore
 	if cfg.hasEmbed {
-		getEmbed = func() *database.EmbeddingStore { return es }
-	} else {
-		getEmbed = func() *database.EmbeddingStore { return nil }
+		embedArg = es
 	}
 
 	var regArg deduphandler.OperationsRegistry
@@ -95,8 +93,8 @@ func newHandler(t *testing.T, opts ...func(*handlerCfg)) (*deduphandler.Handler,
 	}
 
 	h := deduphandler.New(
-		func() deduphandler.DedupStore { return store },
-		getEmbed,
+		store,
+		embedArg,
 		regArg,
 		mergeArg,
 		engineArg,

--- a/internal/server/handlers/dedup/label_capture.go
+++ b/internal/server/handlers/dedup/label_capture.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/label_capture.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c1d9e42-3a8b-4f60-9c21-5e0a7b2d6f48
-// last-edited: 2026-06-18
+// last-edited: 2026-06-23
 
 package deduphandler
 
@@ -51,7 +51,7 @@ func (h *Handler) snapshotCandidateExample(cand *database.DedupCandidate) *datab
 	if cand == nil {
 		return nil
 	}
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		slog.Warn("dedup label capture: no store; skipping snapshot", "candidate_id", cand.ID)
 		return nil
@@ -72,7 +72,7 @@ func (h *Handler) recordHumanLabel(ex *database.LabeledExample, label, reason st
 	if ex == nil {
 		return
 	}
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		slog.Warn("dedup label capture: no embedding store; dropping label", "candidate_id", ex.CandidateID)
 		return
@@ -94,7 +94,7 @@ func (h *Handler) recordHumanLabel(ex *database.LabeledExample, label, reason st
 // in one best-effort call. Use this ONLY for dismiss-style actions where both books
 // still exist; for merges, snapshot before the merge and recordHumanLabel after.
 func (h *Handler) captureHumanLabelByID(candidateID int64, label, reason string) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		return
 	}

--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
-// last-edited: 2026-06-19
+// last-edited: 2026-06-23
 
 package deduphandler
 
@@ -19,7 +19,7 @@ import (
 // UI, filterable by label / label_source / band / folder_relation / signature_relation,
 // paginated. The total is the unfiltered-by-page count for the same filters.
 func (h *Handler) ListDedupLabels(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -60,7 +60,7 @@ func (h *Handler) ListDedupLabels(c *gin.Context) {
 // GetDedupLabelStats handles GET /api/v1/dedup/labels/stats — counts by label and by
 // label_source, so the review UI can show the dataset composition at a glance.
 func (h *Handler) GetDedupLabelStats(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return
@@ -98,7 +98,7 @@ func (h *Handler) GetDedupLabelStats(c *gin.Context) {
 // label_source="human" (this is gold) and re-stamps DecidedAt, so reviewer
 // corrections take precedence over rule/auto-mined labels.
 func (h *Handler) OverrideDedupLabel(c *gin.Context) {
-	es := h.resolveEmbeddingStore()
+	es := h.embeddingStore
 	if es == nil {
 		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
 		return

--- a/internal/server/handlers/duplicates/handler.go
+++ b/internal/server/handlers/duplicates/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/duplicates/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9f41f363-34fc-4ad2-b2f1-46d5ac0ba2f3
-// last-edited: 2026-06-22
+// last-edited: 2026-06-23
 
 // Package duplicates hosts the SQL-backed duplicate-detection HTTP handlers
 // extracted from the server package's duplicates_handlers.go: book / author /
@@ -21,13 +21,10 @@
 // passes thin closures over them. As a result package duplicates never imports
 // package server.
 //
-// The store is reached through a LAZY PROVIDER CLOSURE (getStore) so a value
-// swapped after wireHandlers (a router-integration test swaps server.store
-// post-wire) is still observed at request time, mirroring the dedup / system
-// handler getStore seam. opRegistry / mergeService / audiobookService /
-// metadataFetchService are interface snapshots taken at wire time (assigned once
-// before setupRoutes, never swapped), each guarded against typed-nil boxing by
-// the controller.
+// The store is a WIRE-TIME SNAPSHOT (assigned once in New, never swapped after
+// that). opRegistry / mergeService / audiobookService / metadataFetchService are
+// also interface snapshots taken at wire time (assigned once before setupRoutes,
+// never swapped), each guarded against typed-nil boxing by the controller.
 
 package duplicates
 
@@ -43,13 +40,9 @@ import (
 
 // Handler hosts the duplicates-domain HTTP endpoints.
 type Handler struct {
-	// getStore resolves the database store lazily, at request time. The original
-	// handlers read s.Store() at call time (late binding), and a router
-	// integration test swaps server.store AFTER wiring to inject a mock — so
-	// snapshotting the store at wire time would capture the pre-swap store. The
-	// provider performs the typed-nil guard (s.Store() returns the database.Store
-	// interface, so a nil store stays a nil interface).
-	getStore func() DuplicatesStore
+	// store is the wire-time snapshot of the database store. All handlers read
+	// from this field directly (no lazy provider needed).
+	store DuplicatesStore
 
 	// dedupCache is the concrete *cache.Cache[gin.H] the original handlers read /
 	// wrote directly (book-duplicates / author-duplicates / series-duplicates /
@@ -100,7 +93,7 @@ type Handler struct {
 
 // New constructs a duplicates Handler from its dependencies.
 func New(
-	getStore func() DuplicatesStore,
+	store DuplicatesStore,
 	dedupCache *cache.Cache[gin.H],
 	opRegistry OperationsRegistry,
 	audiobookService AudiobookService,
@@ -111,7 +104,7 @@ func New(
 	seriesNormalizePreview func() any,
 ) *Handler {
 	return &Handler{
-		getStore:                  getStore,
+		store:                     store,
 		dedupCache:                dedupCache,
 		opRegistry:                opRegistry,
 		audiobookService:          audiobookService,
@@ -121,15 +114,6 @@ func New(
 		computeSeriesPrunePreview: computeSeriesPrunePreview,
 		seriesNormalizePreview:    seriesNormalizePreview,
 	}
-}
-
-// resolveStore returns the live store via the lazy provider, or nil if no
-// provider was supplied or the provider yields nil.
-func (h *Handler) resolveStore() DuplicatesStore {
-	if h.getStore == nil {
-		return nil
-	}
-	return h.getStore()
 }
 
 // ListDuplicateAudiobooks handles GET /audiobooks/duplicates.
@@ -183,7 +167,7 @@ func (h *Handler) launchLegacyOp(c *gin.Context, defID, legacyType, detail strin
 		httputil.RespondWithInternalError(c, "operation registry not initialized")
 		return false
 	}
-	store := h.resolveStore()
+	store := h.store
 	legacyID := ulid.Make().String()
 	d := detail
 	op, err := store.CreateOperation(legacyID, legacyType, &d)
@@ -260,7 +244,7 @@ func (h *Handler) DismissBookDuplicateGroup(c *gin.Context) {
 		return
 	}
 
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -293,7 +277,7 @@ func (h *Handler) MergeBooks(c *gin.Context) {
 		return
 	}
 
-	store := h.resolveStore()
+	store := h.store
 	keepBook, err := store.GetBookByID(req.KeepID)
 	if err != nil || keepBook == nil {
 		httputil.RespondWithNotFound(c, "book", req.KeepID)
@@ -479,7 +463,7 @@ func (h *Handler) DeduplicateSeriesHandler(c *gin.Context) {
 // SeriesPrunePreview returns a dry-run preview of the series auto-prune.
 // GET /series/prune/preview.
 func (h *Handler) SeriesPrunePreview(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -518,7 +502,7 @@ func (h *Handler) MergeSeriesGroup(c *gin.Context) {
 		return
 	}
 
-	store := h.resolveStore()
+	store := h.store
 	keepSeries, err := store.GetSeriesByID(req.KeepID)
 	if err != nil || keepSeries == nil {
 		httputil.RespondWithNotFound(c, "series", "")
@@ -536,7 +520,7 @@ func (h *Handler) MergeSeriesGroup(c *gin.Context) {
 // name-normalization pass would do, with no database writes.
 // GET /series/normalize/preview.
 func (h *Handler) SeriesNormalizePreview(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -548,7 +532,7 @@ func (h *Handler) SeriesNormalizePreview(c *gin.Context) {
 // SeriesNormalize enqueues an async operation that renames/merges contaminated
 // series and re-organizes affected books in place. POST /series/normalize.
 func (h *Handler) SeriesNormalize(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return

--- a/internal/server/handlers/duplicates/handler_test.go
+++ b/internal/server/handlers/duplicates/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/duplicates/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 62637af9-347f-4f38-b42b-d90ff3ab3654
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Tests for the duplicates-domain handlers. The store / merge-service /
 // audiobook-service / metadata-fetch-service / operations-registry deps are
@@ -98,7 +98,7 @@ func newHandler(t *testing.T, opts ...func(*cfg)) (*duplicates.Handler, testDeps
 	}
 
 	h := duplicates.New(
-		func() duplicates.DuplicatesStore { return store },
+		store,
 		dc,
 		regArg,
 		audArg,

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -36,13 +36,12 @@
 //
 // As a result package metadatahandler never imports package server.
 //
-// The store and the write-back batcher are reached through LAZY PROVIDER
-// CLOSURES (getStore / getWriteBack) so values swapped after wireHandlers (a
-// router-integration test swaps server.store / server.writeBackBatcher
-// post-wire) are still observed at request time, mirroring the audiobooks /
-// duplicates seams. The interface-typed service deps (metadataFetchService,
-// opRegistry, fileIOPool) are wire-time snapshots, each guarded against
-// typed-nil boxing by the controller in wire_handlers.go.
+// The store is a WIRE-TIME SNAPSHOT (assigned once in New, never swapped after
+// that). The write-back batcher remains a lazy provider closure because
+// integration tests swap server.writeBackBatcher post-wire. The interface-typed
+// service deps (metadataFetchService, opRegistry, fileIOPool) are wire-time
+// snapshots, each guarded against typed-nil boxing by the controller in
+// wire_handlers.go.
 
 package metadatahandler
 
@@ -71,14 +70,12 @@ import (
 
 // Handler hosts the metadata-domain HTTP endpoints.
 type Handler struct {
-	// getStore resolves the database store lazily, at request time. The original
-	// handlers read s.Store() at call time (late binding), and a router
-	// integration test swaps server.store AFTER wiring to inject a mock — so
-	// snapshotting the store at wire time would capture the pre-swap store. The
-	// provider returns a value typed MetadataStore (which embeds
-	// database.BookStore) so the handler can pass it straight to
-	// metadata.BatchUpdateMetadata / metadata.ImportMetadata.
-	getStore func() MetadataStore
+	// store is the wire-time snapshot of the database store. All handlers read
+	// from this field directly (no lazy provider needed — no post-wire swap for
+	// this package's store). Typed MetadataStore (which embeds database.BookStore)
+	// so the handler can pass it straight to metadata.BatchUpdateMetadata /
+	// metadata.ImportMetadata.
+	store MetadataStore
 
 	metadataFetchService MetadataFetchService
 
@@ -135,7 +132,7 @@ type Handler struct {
 
 // New constructs a metadata Handler from its dependencies.
 func New(
-	getStore func() MetadataStore,
+	store MetadataStore,
 	metadataFetchService MetadataFetchService,
 	getWriteBack func() WriteBackEnqueuer,
 	opRegistry OperationsRegistry,
@@ -148,7 +145,7 @@ func New(
 	publishEvent func(ctx context.Context, event plugin.Event),
 ) *Handler {
 	return &Handler{
-		getStore:                   getStore,
+		store:                      store,
 		metadataFetchService:       metadataFetchService,
 		getWriteBack:               getWriteBack,
 		opRegistry:                 opRegistry,
@@ -160,15 +157,6 @@ func New(
 		updateFetchedMetadataState: updateFetchedMetadataState,
 		publishEvent:               publishEvent,
 	}
-}
-
-// resolveStore returns the live store via the lazy provider, or nil if no
-// provider was supplied or the provider yields nil.
-func (h *Handler) resolveStore() MetadataStore {
-	if h.getStore == nil {
-		return nil
-	}
-	return h.getStore()
 }
 
 // resolveWriteBack returns the live write-back batcher via the lazy provider, or
@@ -227,7 +215,7 @@ type batchSaveOpParams struct {
 
 // batchUpdateMetadata handles batch metadata updates with validation
 func (h *Handler) batchUpdateMetadataImpl(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -292,7 +280,7 @@ func (h *Handler) validateMetadataImpl(c *gin.Context) {
 
 // exportMetadata exports all audiobook metadata
 func (h *Handler) exportMetadataImpl(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -317,7 +305,7 @@ func (h *Handler) exportMetadataImpl(c *gin.Context) {
 
 // importMetadata imports audiobook metadata
 func (h *Handler) importMetadataImpl(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -389,7 +377,7 @@ func (h *Handler) searchMetadataImpl(c *gin.Context) {
 func (h *Handler) fetchAudiobookMetadataImpl(c *gin.Context) {
 	id := c.Param("id")
 
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -432,7 +420,7 @@ func (h *Handler) fetchAudiobookMetadataImpl(c *gin.Context) {
 // alternative-search, not a re-read of the same query.
 func (h *Handler) searchAudiobookMetadataImpl(c *gin.Context) {
 	id := c.Param("id")
-	if h.resolveStore() == nil {
+	if h.store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
@@ -525,7 +513,7 @@ func decodeCachedCandidates(entry *metafetch.MetadataCandidateCache) []metafetch
 // applyAudiobookMetadata handles POST /api/v1/audiobooks/:id/apply-metadata.
 func (h *Handler) applyAudiobookMetadataImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -597,7 +585,7 @@ func (h *Handler) applyAudiobookMetadataImpl(c *gin.Context) {
 // markAudiobookNoMatch handles POST /api/v1/audiobooks/:id/mark-no-match.
 func (h *Handler) markAudiobookNoMatchImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -622,7 +610,7 @@ func (h *Handler) markAudiobookNoMatchImpl(c *gin.Context) {
 // handleGetMetadataRejections handles GET /api/v1/audiobooks/:id/metadata-rejections.
 func (h *Handler) handleGetMetadataRejectionsImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -642,7 +630,7 @@ func (h *Handler) handleGetMetadataRejectionsImpl(c *gin.Context) {
 // It restores a book to a previous CoW version snapshot via the store layer.
 func (h *Handler) revertAudiobookMetadataImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -676,7 +664,7 @@ func (h *Handler) revertAudiobookMetadataImpl(c *gin.Context) {
 // Returns copy-on-write version snapshots from the store layer.
 func (h *Handler) listBookCOWVersionsImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -695,7 +683,7 @@ func (h *Handler) listBookCOWVersionsImpl(c *gin.Context) {
 // Prunes old copy-on-write version snapshots, keeping the most recent N.
 func (h *Handler) pruneBookCOWVersionsImpl(c *gin.Context) {
 	id := c.Param("id")
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -731,7 +719,7 @@ func (h *Handler) writeBackAudiobookMetadataImpl(c *gin.Context) {
 	}
 	_ = c.ShouldBindJSON(&body)
 
-	store := h.resolveStore()
+	store := h.store
 	book, err := store.GetBookByID(id)
 	if err != nil || book == nil {
 		httputil.RespondWithNotFound(c, "audiobook", "")
@@ -779,7 +767,7 @@ func (h *Handler) writeBackAudiobookMetadataImpl(c *gin.Context) {
 // bulkFetchMetadata fetches external metadata for multiple audiobooks and applies
 // fields only when they are missing and not manually overridden or locked.
 func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -1091,7 +1079,7 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 // It creates an async operation that writes metadata tags and renames files
 // for all books matching the provided filters (or all organized/imported books).
 func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
@@ -1217,7 +1205,7 @@ func (h *Handler) batchWriteBackAudiobooksImpl(c *gin.Context) {
 		return
 	}
 
-	store := h.resolveStore()
+	store := h.store
 	doOrganize := req.Organize || req.Rename
 
 	// Create a supervisor operation for tracking
@@ -1409,7 +1397,7 @@ func (h *Handler) handleUpdateBookRatingImpl(c *gin.Context) {
 		}
 	}
 
-	store := h.resolveStore()
+	store := h.store
 	if store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return

--- a/internal/server/handlers/metadata/handler_test.go
+++ b/internal/server/handlers/metadata/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d31ef73-7c7a-4c3b-a840-01b0865023d7
-// last-edited: 2026-06-03
+// last-edited: 2026-06-23
 
 // Tests for the metadata-domain handlers. The store / metadata-fetch-service /
 // write-back-enqueuer / operations-registry / file-io-pool deps are generated
@@ -96,7 +96,7 @@ func newHandler(t *testing.T, opts ...func(*cfg)) (*metadatahandler.Handler, tes
 	}
 
 	h := metadatahandler.New(
-		func() metadatahandler.MetadataStore { return store },
+		store,
 		mfsArg,
 		func() metadatahandler.WriteBackEnqueuer {
 			if cf.hasWB {

--- a/internal/server/handlers_integration_test.go
+++ b/internal/server/handlers_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers_integration_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-06-10
+// last-edited: 2026-06-23
 
 package server
 
@@ -153,7 +153,7 @@ func newAudiobooksHandler(s *Server) *audiobookshandler.Handler {
 		abChangelog = s.changelogService
 	}
 	return audiobookshandler.New(
-		func() audiobookshandler.AudiobooksStore { return s.Store() },
+		s.Store(),
 		abSvc,
 		abUpdater,
 		func() audiobookshandler.WriteBackEnqueuer {

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_handlers.go
-// version: 2.12.0
+// version: 2.13.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
 // last-edited: 2026-06-23
 
@@ -313,8 +313,8 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		dedupEng = s.dedupEngine
 	}
 	dedupH := deduphandler.New(
-		func() deduphandler.DedupStore { return s.Store() },
-		func() *database.EmbeddingStore { return s.embeddingStore },
+		s.Store(),
+		s.embeddingStore,
 		dedupOpReg,
 		dedupMergeSvc,
 		dedupEng,
@@ -355,7 +355,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		dupMetadataSvc = s.metadataFetchService
 	}
 	duplicatesH := duplicates.New(
-		func() duplicates.DuplicatesStore { return s.Store() },
+		s.Store(),
 		s.dedupCache,
 		dupOpReg,
 		dupAudiobookSvc,
@@ -503,7 +503,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		abChangelog = s.changelogService
 	}
 	audiobooksH := audiobookshandler.New(
-		func() audiobookshandler.AudiobooksStore { return s.Store() },
+		s.Store(),
 		abSvc,
 		abUpdater,
 		// Lazy provider: server.writeBackBatcher is swapped post-wire by
@@ -564,13 +564,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		mdFileIOPool = s.fileIOPool
 	}
 	metadataH := metadatahandler.New(
-		func() metadatahandler.MetadataStore {
-			st := s.Store()
-			if st == nil {
-				return nil
-			}
-			return st
-		},
+		s.Store(),
 		mdMetaFetch,
 		// Lazy provider: server.writeBackBatcher is swapped post-wire by
 		// integration tests and the original handlers read it at request time, so


### PR DESCRIPTION
## Summary

- Removes 4 unnecessary `getStore func() XxxStore` lazy provider closures from the audiobooks, metadata, dedup, and duplicates handler packages
- Replaces them with direct wire-time store snapshots (field `store XxxStore` assigned once in `New()`)
- Removes the now-unused `resolveStore()` / `resolveEmbeddingStore()` helper methods
- Updates `wire_handlers.go` to pass `s.Store()` / `s.embeddingStore` directly instead of closures
- Updates all test `New()` call sites to pass concrete values instead of closures

**What is preserved (intentionally kept lazy):**
- `system.Handler.getStore` — a router integration test swaps `server.store` post-wire for blocked-hashes routes (`TestBlockedHashes_CRUD`)
- `audiobooks.Handler.getWriteBack` and `metadata.Handler.getWriteBack` — integration tests swap `server.writeBackBatcher` post-wire

## Files changed (16)

| File | Change |
|------|--------|
| `handlers/audiobooks/handler.go` | `getStore func()` → `store` field; remove `resolveStore()` |
| `handlers/audiobooks/handler_{crud,files,metadata,tags}.go` | `resolveStore()` → `h.store` (21 sites) |
| `handlers/metadata/handler.go` | `getStore func()` → `store` field; remove `resolveStore()` (17 sites) |
| `handlers/dedup/handler.go` | `getStore/getEmbeddingStore` funcs → `store/embeddingStore` fields |
| `handlers/dedup/label_{capture,review}.go` | `resolveStore/resolveEmbeddingStore()` → direct fields |
| `handlers/duplicates/handler.go` | `getStore func()` → `store` field; remove `resolveStore()` (8 sites) |
| `wire_handlers.go` | Pass `s.Store()` / `s.embeddingStore` directly to 4 `New()` calls |
| `*_test.go` (5 files) | Update test `New()` call sites |

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go build ./...` — clean
- [x] All handler package tests pass: audiobooks, metadata, dedup, duplicates, system, operations, entities, tools, middleware
- [x] `TestBlockedHashes_CRUD` passes (system lazy store preserved)
- [ ] `TestPipeline_FetchMetadata_MultiSourceFallback` times out at 120s — **pre-existing flaky test** (unchanged file, hits external metadata APIs); not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43