### PR TITLE
perf(maintenance): skip ffprobe for non-iTunes segments with stored durations

### DIFF
--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/duration_reextract.go
-// version: 3.7.0
+// version: 3.8.0
 // guid: 9c2f7a14-6d83-4e51-b0a9-2f5c8e1d4b67
 // last-edited: 2026-06-24
 
@@ -175,6 +175,7 @@ type bookProcessResult struct {
 	changedBFs       []database.BookFile
 	eligible         bool
 	usedFfprobe      bool
+	usedStoredDur    bool // used stored segment Duration instead of ffprobe (non-iTunes fast path)
 	wouldChange      bool
 	roughDouble      bool
 	readErr          bool
@@ -214,6 +215,13 @@ func processBookForReextract(ctx context.Context, store database.Store, book dat
 			var segDur int
 			if f.AcoustIDFingerprintDurationSec > 0 {
 				segDur = int(math.Round(f.AcoustIDFingerprintDurationSec))
+			} else if f.ITunesPersistentID == "" && book.ITunesPersistentID == nil && f.Duration > 0 {
+				// Stored-duration fast path: non-iTunes segment with a known Duration.
+				// The iTunes-ms bug (durations stored as milliseconds instead of seconds)
+				// only affects iTunes-imported segments; organized-library files have
+				// durations measured by the scanner and can be trusted without ffprobe.
+				segDur = f.Duration
+				res.usedStoredDur = true
 			} else {
 				usedFfprobe = true
 				info, mErr := extractWithTimeout(ctx, f.FilePath)
@@ -332,8 +340,9 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		estimated     int
 		readErr       int
 		noPath        int
-		fpBooks       int
-		ffprobeBooks  int
+		fpBooks        int
+		ffprobeBooks   int
+		storedDurBooks int
 		written        int
 		examples      = make([]string, 0, exampleCap)
 		lastLog       = time.Now()
@@ -348,8 +357,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 			total = examined
 		}
 		_ = reporter.UpdateProgress(examined, total, fmt.Sprintf(
-			"examined=%d eligible=%d (fp=%d ffprobe=%d) would-change=%d (~2x=%d) est-skip=%d read-err=%d",
-			examined, eligible, fpBooks, ffprobeBooks, wouldChange, roughlyDouble, estimated, readErr))
+			"examined=%d eligible=%d (fp=%d stored=%d ffprobe=%d) would-change=%d (~2x=%d) est-skip=%d read-err=%d",
+			examined, eligible, fpBooks, storedDurBooks, ffprobeBooks, wouldChange, roughlyDouble, estimated, readErr))
 		lastLog = time.Now()
 	}
 
@@ -426,6 +435,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		eligible++
 		if res.usedFfprobe {
 			ffprobeBooks++
+		} else if res.usedStoredDur {
+			storedDurBooks++
 		} else {
 			fpBooks++
 		}
@@ -497,8 +508,8 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		verb = fmt.Sprintf("corrected %d;", written)
 	}
 	summary := fmt.Sprintf(
-		"examined=%d eligible=%d (from-fingerprint=%d from-ffprobe=%d) %s would-change=%d (~2x=%d) estimated-skipped=%d read-errors=%d no-filepath=%d | e.g. %s",
-		examined, eligible, fpBooks, ffprobeBooks, verb, wouldChange, roughlyDouble, estimated, readErr, noPath,
+		"examined=%d eligible=%d (from-fingerprint=%d from-stored=%d from-ffprobe=%d) %s would-change=%d (~2x=%d) estimated-skipped=%d read-errors=%d no-filepath=%d | e.g. %s",
+		examined, eligible, fpBooks, storedDurBooks, ffprobeBooks, verb, wouldChange, roughlyDouble, estimated, readErr, noPath,
 		strings.Join(examples, ", "))
 	_ = reporter.Log(slog.LevelInfo, summary)
 	total := totalBooks

--- a/internal/plugins/maintenance/duration_reextract_test.go
+++ b/internal/plugins/maintenance/duration_reextract_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_reextract_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 4a7d1e92-8c63-4f50-a1b8-3e6c9d2f5a04
-// last-edited: 2026-06-22
+// last-edited: 2026-06-24
 
 package maintenance
 
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
@@ -238,15 +239,15 @@ func TestDurationReextract_FingerprintDurationFirst(t *testing.T) {
 	}
 }
 
-// TestDurationReextract_MixedFingerprintAndFfprobe verifies the fallback: a book
-// with one fingerprinted segment and one never-fingerprinted segment. The
-// fingerprinted segment is sourced from the stored value; the other must fall to
-// ffprobe. Here the ffprobe segment's file does not exist, so ffprobe fails and
-// the whole book is skipped (trust invariant) — proving the missing fingerprint
-// genuinely routed to the slow path rather than being silently treated as zero.
+// TestDurationReextract_MixedFingerprintAndFfprobe verifies the ffprobe fallback
+// for iTunes-linked segments: one fingerprinted segment + one iTunes segment
+// without a fingerprint. The iTunes segment falls through to ffprobe; its file
+// is missing, so the whole book is skipped (trust invariant).
 func TestDurationReextract_MixedFingerprintAndFfprobe(t *testing.T) {
 	writes := 0
-	books := []database.Book{{ID: "bm", Title: "Mixed", FilePath: "/lib/Mixed", Duration: intPtr(120)}}
+	itunesPID := "itunes-pid-mixed"
+	bookPID := itunesPID
+	books := []database.Book{{ID: "bm", Title: "Mixed", FilePath: "/lib/Mixed", Duration: intPtr(120), ITunesPersistentID: &bookPID}}
 	store := &database.MockStore{
 		CountAllBooksFunc: func() (int, error) { return len(books), nil },
 		GetAllBooksFunc: func(_, offset int) ([]database.Book, error) {
@@ -258,7 +259,8 @@ func TestDurationReextract_MixedFingerprintAndFfprobe(t *testing.T) {
 		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
 			return []database.BookFile{
 				{ID: "s1", BookID: "bm", FilePath: "/nonexistent/01.mp3", Duration: 50, AcoustIDFingerprintDurationSec: 1800.0},
-				{ID: "s2", BookID: "bm", FilePath: "/nonexistent/02.mp3", Duration: 50}, // no fingerprint → ffprobe → missing file
+				// iTunes segment, no fingerprint → must fall back to ffprobe → missing file → skip
+				{ID: "s2", BookID: "bm", FilePath: "/nonexistent/02.mp3", Duration: 50, ITunesPersistentID: itunesPID},
 			}, nil
 		},
 		UpdateBookFileFunc: func(_ string, _ *database.BookFile) error { writes++; return nil },
@@ -269,7 +271,7 @@ func TestDurationReextract_MixedFingerprintAndFfprobe(t *testing.T) {
 		t.Fatalf("run: %v", err)
 	}
 	if writes != 0 {
-		t.Errorf("book with an unreadable non-fingerprinted segment must be skipped, got %d writes", writes)
+		t.Errorf("book with an unreadable iTunes segment must be skipped, got %d writes", writes)
 	}
 }
 
@@ -319,6 +321,90 @@ func TestDurationReextract_ParallelWorkers_AllBooksProcessed(t *testing.T) {
 	}
 	if len(written) != n {
 		t.Errorf("parallel run wrote %d segments, want %d", len(written), n)
+	}
+}
+
+// TestProcessBookForReextract_StoredDuration_NonITunes verifies opt-2: when a
+// segment has no fingerprint AND is not iTunes-linked (f.ITunesPersistentID==""
+// and book.ITunesPersistentID==nil), the stored segment Duration is used without
+// shelling out to ffprobe. The file path does not exist on disk, so any ffprobe
+// attempt would produce a readErr and classify the book as ineligible. A result
+// of eligible=true proves the stored-duration path ran instead.
+func TestProcessBookForReextract_StoredDuration_NonITunes(t *testing.T) {
+	store := &database.MockStore{
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				// no fingerprint, no iTunes PID, stored Duration=1800, file absent
+				{ID: "s1", FilePath: "/nonexistent/01.mp3", Duration: 1800},
+			}, nil
+		},
+	}
+	book := database.Book{ID: "b1", Duration: intPtr(100)}
+	res := processBookForReextract(context.Background(), store, book, time.Time{})
+
+	if !res.eligible {
+		t.Fatalf("expected eligible=true (stored duration used), got eligible=false readErr=%v", res.readErr)
+	}
+	if res.usedFfprobe {
+		t.Error("non-iTunes segment with stored Duration must not use ffprobe")
+	}
+	if res.newDur != 1800 {
+		t.Errorf("newDur = %d, want 1800 (stored segment Duration)", res.newDur)
+	}
+	if !res.wouldChange {
+		t.Error("book.Duration=100 vs computed=1800 must set wouldChange=true")
+	}
+}
+
+// TestProcessBookForReextract_StoredDuration_ITunes still routes to ffprobe:
+// a segment that is iTunes-linked (ITunesPersistentID!="") may have the ms-bug
+// duration and must be verified via ffprobe rather than trusting the stored value.
+// Missing file → ffprobe fails → readErr, not eligible.
+func TestProcessBookForReextract_StoredDuration_ITunes(t *testing.T) {
+	pid := "itunes-pid-001"
+	store := &database.MockStore{
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{ID: "s1", FilePath: "/nonexistent/01.mp3", Duration: 1800, ITunesPersistentID: pid},
+			}, nil
+		},
+	}
+	bookPID := pid
+	book := database.Book{ID: "b1", Duration: intPtr(100), ITunesPersistentID: &bookPID}
+	res := processBookForReextract(context.Background(), store, book, time.Time{})
+
+	if res.eligible {
+		t.Error("iTunes segment must go through ffprobe; file missing → not eligible")
+	}
+	if !res.readErr {
+		t.Error("expected readErr=true (iTunes segment, missing file, ffprobe failed)")
+	}
+}
+
+// TestProcessBookForReextract_StoredDuration_BookITunesLinked verifies that a
+// segment without its own ITunesPersistentID still falls back to ffprobe when
+// the BOOK is iTunes-linked (book.ITunesPersistentID!=nil). Some organized-library
+// books are matched to an iTunes entry but the segment files themselves don't carry
+// the PID; the book-level field is the definitive iTunes guard.
+func TestProcessBookForReextract_StoredDuration_BookITunesLinked(t *testing.T) {
+	pid := "book-itunes-pid"
+	store := &database.MockStore{
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				// segment has no iTunes PID, but the BOOK is iTunes-linked
+				{ID: "s1", FilePath: "/nonexistent/01.mp3", Duration: 1800},
+			}, nil
+		},
+	}
+	bookPID := pid
+	book := database.Book{ID: "b1", Duration: intPtr(100), ITunesPersistentID: &bookPID}
+	res := processBookForReextract(context.Background(), store, book, time.Time{})
+
+	if res.eligible {
+		t.Error("book-level iTunes link must prevent stored-duration shortcut; file missing → not eligible")
+	}
+	if !res.readErr {
+		t.Error("expected readErr=true (book iTunes-linked, missing file, ffprobe failed)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- For segments with no AcoustID fingerprint, if neither the segment nor the book is iTunes-linked, uses the stored `Duration` field directly instead of shelling out to ffprobe
- The iTunes-ms bug (durations in milliseconds) only affects iTunes-imported files — organized library files have reliable stored durations
- Adds `stored=N` telemetry field to both heartbeat and final summary log lines
- Updates `TestDurationReextract_MixedFingerprintAndFfprobe` to use an iTunes PID on the non-fingerprinted segment (preserves "ffprobe path for iTunes segments" contract)
- Adds 3 new unit tests directly on `processBookForReextract`: non-iTunes fast path, iTunes still-ffprobe, and book-level iTunes link guard

## Impact

Converts ~9K ffprobe subprocess calls per full scan into in-memory reads for non-iTunes libraries. With 4 workers and ~1s per ffprobe call, this saves ~37min of wall-clock time on the ffprobe tail.

## Test plan

- [x] `TestProcessBookForReextract_StoredDuration_NonITunes` — non-iTunes, stored dur used, file missing, eligible=true
- [x] `TestProcessBookForReextract_StoredDuration_ITunes` — iTunes segment, still ffprobe, file missing → readErr
- [x] `TestProcessBookForReextract_StoredDuration_BookITunesLinked` — book iTunes-linked, still ffprobe even if segment PID empty
- [x] Full `./internal/plugins/maintenance/...` suite with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v