### PR TITLE
fix(test): add CountAllBooks to handler mocks; fix apiFetch assertions

### DIFF
--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -89,6 +89,59 @@ func (_c *MockMetadataStore_AddMetadataRejection_Call) RunAndReturn(run func(r d
 	return _c
 }
 
+// CountAllBooks provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) CountAllBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAllBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockMetadataStore_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockMetadataStore_Expecter) CountAllBooks() *MockMetadataStore_CountAllBooks_Call {
+	return &MockMetadataStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockMetadataStore_CountAllBooks_Call) Run(run func()) *MockMetadataStore_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_CountAllBooks_Call) Return(n int, err error) *MockMetadataStore_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockMetadataStore_CountAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountPrimaryBooks provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) CountPrimaryBooks() (int, error) {
 	ret := _mock.Called()

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -95,6 +95,59 @@ func (_c *MockPlaylistStore_ClearUserPositions_Call) RunAndReturn(run func(userI
 	return _c
 }
 
+// CountAllBooks provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) CountAllBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAllBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlaylistStore_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockPlaylistStore_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockPlaylistStore_Expecter) CountAllBooks() *MockPlaylistStore_CountAllBooks_Call {
+	return &MockPlaylistStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockPlaylistStore_CountAllBooks_Call) Run(run func()) *MockPlaylistStore_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_CountAllBooks_Call) Return(n int, err error) *MockPlaylistStore_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockPlaylistStore_CountAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountPrimaryBooks provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) CountPrimaryBooks() (int, error) {
 	ret := _mock.Called()

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/App.test.tsx
-// version: 1.0.8
+// version: 1.0.9
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
-// last-edited: 2026-05-08
+// last-edited: 2026-06-24
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -48,6 +48,16 @@ vi.mock('./services/api', () => ({
   getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
   getAppVersion: vi.fn().mockResolvedValue('1.0.0-test'),
   getOperationTimeline: vi.fn().mockResolvedValue([]),
+  getSystemStorage: vi.fn().mockResolvedValue({
+    path: '/',
+    total_bytes: 1000000,
+    used_bytes: 500000,
+    free_bytes: 500000,
+    percent_used: 50,
+    quota_enabled: false,
+    quota_percent: 0,
+    user_quotas_enabled: false,
+  }),
   openOperationsSSE: vi.fn().mockReturnValue({
     close: vi.fn(),
     addEventListener: vi.fn(),

--- a/web/src/services/api.test.ts
+++ b/web/src/services/api.test.ts
@@ -1,6 +1,7 @@
 // file: src/services/api.test.ts
-// version: 1.3.0
+// version: 1.3.1
 // guid: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+// last-edited: 2026-06-24
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
@@ -59,7 +60,7 @@ describe('api import paths', () => {
         book_count: 0,
       },
     ]);
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/import-paths');
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/import-paths', expect.any(Object));
   });
 
   it('addImportPath returns created import path', async () => {
@@ -124,9 +125,7 @@ describe('api import paths', () => {
     mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
 
     await removeImportPath(4);
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/import-paths/4', {
-      method: 'DELETE',
-    });
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/import-paths/4', expect.objectContaining({ method: 'DELETE' }));
   });
 
   it('bulkFetchMetadata posts book ids and returns response', async () => {
@@ -157,11 +156,10 @@ describe('api import paths', () => {
     const response = await bulkFetchMetadata(['id-1', 'id-2'], false);
     expect(response.updated_count).toBe(1);
     expect(response.total_count).toBe(2);
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/metadata/bulk-fetch', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/metadata/bulk-fetch', expect.objectContaining({
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ book_ids: ['id-1', 'id-2'], only_missing: false }),
-    });
+    }));
   });
 
   it('batchWriteBackMetadata posts book ids and rename flag', async () => {
@@ -186,10 +184,9 @@ describe('api import paths', () => {
     const response = await batchWriteBackMetadata(['id-1', 'id-2'], true);
     expect(response.written).toBe(2);
     expect(response.renamed).toBe(1);
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/audiobooks/batch-write-back', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/audiobooks/batch-write-back', expect.objectContaining({
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ book_ids: ['id-1', 'id-2'], organize: true, force: false }),
-    });
+    }));
   });
 });


### PR DESCRIPTION
## Summary

- **MockMetadataStore / MockPlaylistStore** were missing `CountAllBooks` after it was added to `database.BookStore` — caused `go vet` and `go test` to fail with \"missing method CountAllBooks\". Added full mockery-format method + Expecter scaffold to both mocks.
- **App.test.tsx**: added `getSystemStorage` to the api mock (the `QuotaTab` component calls it at render time; the missing export threw at test startup).
- **api.test.ts**: updated 4 fetch call assertions from exact-match to `expect.objectContaining`/`expect.any(Object)` after the `apiFetch` wrapper (PR #1580) added `credentials: 'include'` + a `Headers` instance to every call, making the old assertions fail.

## Test plan

- [x] `go vet ./internal/server/handlers/...` — clean
- [x] `go test ./internal/server/handlers/... -short` — all pass
- [x] `npx vitest run src/services/api.test.ts` — 6/6 pass (was 4 failures)
- [ ] CI: Mock Freshness, Frontend Unit Tests, Go Vet & Build should all go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v