### PR TITLE
feat(scanner): group untagged sequential files into one book (AP-5)

### DIFF
--- a/internal/scanner/integration_format_test.go
+++ b/internal/scanner/integration_format_test.go
@@ -1,6 +1,7 @@
 // file: internal/scanner/integration_format_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-06-24
 
 package scanner
 
@@ -74,8 +75,17 @@ func TestIntegrationRealWorldMixedFormats(t *testing.T) {
 		t.Fatalf("Integration scan failed: %v", err)
 	}
 
-	if len(books) != totalFiles {
-		t.Errorf("Expected %d total files, got %d", totalFiles, len(books))
+	// AP-5: "Author B/Book 2 - MP3" contains Chapter 01-03.mp3 with no tags
+	// but sequential names — they are now grouped into ONE multi-file book
+	// instead of 3 shattered single-file books. Expected book count = 11:
+	//   Author A: 1 (m4b)
+	//   Author B: 1 (multi-file, Chapter 01-03.mp3 → SegmentFiles)
+	//   Author C: 2 (Part 1 + Part 2 m4a — no sequential pattern match)
+	//   Author D: 4 (Track01-04.flac — "TrackNN" not a pattern-quorum match)
+	//   Author E: 3 (Intro.mp3 + Main.m4b + Bonus.m4a — mixed formats, no group)
+	expectedBooks := totalFiles - 2 // 13 - 2: Chapter 02 + Chapter 03 absorbed
+	if len(books) != expectedBooks {
+		t.Errorf("Expected %d total books, got %d", expectedBooks, len(books))
 	}
 
 	// Verify format distribution
@@ -92,7 +102,7 @@ func TestIntegrationRealWorldMixedFormats(t *testing.T) {
 
 	expectedCounts := map[string]int{
 		".m4b":  2, // Book 1 + Book 5 Main
-		".mp3":  4, // Book 2 (3) + Book 5 Intro
+		".mp3":  2, // Book 2 as multi-file (1) + Book 5 Intro (1)
 		".m4a":  3, // Book 3 (2) + Book 5 Bonus
 		".flac": 4, // Book 4
 	}

--- a/internal/scanner/multifile_detector.go
+++ b/internal/scanner/multifile_detector.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/multifile_detector.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a3e4c8b-1d2f-4a5b-9c6d-8e0f1a2b3c4d
-// last-edited: 2026-05-29
+// last-edited: 2026-06-24
 
 // Package scanner — multi-file audiobook detection.
 //
@@ -177,7 +177,8 @@ func majorityValue(values []string) (string, int) {
 //   - detected numbers are dense in [min..max]:
 //     #detected / (max-min+1) >= cfg.DensityRatio
 //   - ≥ cfg.TagQuorum fraction of files share the same non-empty
-//     normalized album OR album_artist
+//     normalized album OR album_artist; OR all files have empty album AND
+//     album_artist (AP-5: untagged tracks are grouped by sequential name alone)
 //
 // The detector does NO file IO; the caller pre-extracts tag metadata.
 func DetectMultiFileGroup(files []MultiFileInfo, cfg MultiFileDetectionConfig) (bool, []MultiFileInfo) {
@@ -277,7 +278,11 @@ func DetectMultiFileGroup(files []MultiFileInfo, cfg MultiFileDetectionConfig) (
 	if required < 1 {
 		required = 1
 	}
-	tagAgrees := albumCount >= required || artistCount >= required
+	// AP-5: when ALL files lack album and album_artist tags the silence is
+	// uniform, not a sign of tag conflict. Sequential filenames alone are
+	// sufficient evidence — the scanner will use the folder name as the title.
+	allTagsAbsent := albumCount == 0 && artistCount == 0
+	tagAgrees := albumCount >= required || artistCount >= required || allTagsAbsent
 	if !tagAgrees {
 		return false, files
 	}

--- a/internal/scanner/multifile_detector_test.go
+++ b/internal/scanner/multifile_detector_test.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/multifile_detector_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9b4f5d2c-3e6a-4b7c-8d9e-0f1a2b3c4d5e
-// last-edited: 2026-05-29
+// last-edited: 2026-06-24
 
 package scanner
 
@@ -232,5 +232,42 @@ func TestDetectMultiFileGroup_RejectsSparseNumbers(t *testing.T) {
 	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
 	if ok {
 		t.Fatalf("expected NEGATIVE detection for sparse numbering (1, 2, 500)")
+	}
+}
+
+func TestDetectMultiFileGroup_NoTagsGroupedBySequentialName(t *testing.T) {
+	// AP-5: files with no album / album_artist tags at all but clear sequential
+	// naming — e.g. "Assimil Japanese With Ease Audio/06 - X.mp3". The tag
+	// quorum cannot be satisfied (no tags), but tag silence is uniform, not a
+	// sign of tag conflict.  Sequential names are sufficient evidence.
+	files := []MultiFileInfo{
+		mk("06 - Lesson Six.mp3", "", ""),
+		mk("07 - Lesson Seven.mp3", "", ""),
+		mk("08 - Lesson Eight.mp3", "", ""),
+		mk("09 - Lesson Nine.mp3", "", ""),
+		mk("10 - Lesson Ten.mp3", "", ""),
+	}
+	ok, sorted := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatal("expected positive detection for untagged sequential files (AP-5)")
+	}
+	if len(sorted) != len(files) {
+		t.Fatalf("expected %d sorted files, got %d", len(files), len(sorted))
+	}
+}
+
+func TestDetectMultiFileGroup_MixedTagsStillGroupedByArtistQuorum(t *testing.T) {
+	// Conflicting album tags but consistent album_artist: artist quorum passes.
+	// This verifies that the AP-5 allTagsAbsent path doesn't break the existing
+	// quorum path when some tags are present.
+	files := []MultiFileInfo{
+		mk("01.mp3", "Album A", "Same Author"),
+		mk("02.mp3", "Album B", "Same Author"),
+		mk("03.mp3", "Album C", "Same Author"),
+		mk("04.mp3", "Album D", "Same Author"),
+	}
+	ok, _ := DetectMultiFileGroup(files, DefaultMultiFileConfig())
+	if !ok {
+		t.Fatal("expected positive detection when album_artist quorum passes despite varying album tags")
 	}
 }


### PR DESCRIPTION
## Summary

- **`DetectMultiFileGroup`** now groups files when ALL album and album_artist tags are absent. Previously the 75% tag-quorum check would fail for completely untagged files even when sequential names (e.g. `06 - Lesson Six.mp3`, `07 - Lesson Seven.mp3`) made the grouping obvious. Universally absent tags are not a tag conflict — sequential filenames alone are sufficient.
- Conflicting tags (some files say "Album A", others say "Album B") are still rejected.
- The scanner uses the directory name as the book title for no-tag groups (existing fallback path).

**Root cause fixed:** `Assimil Japanese With Ease Audio/06 - X.mp3`, `07 - Y.mp3`, etc. each imported as their own Book because `albumCount == 0 && artistCount == 0` caused the quorum check to fail even though steps 1–3 (sequential pattern + density) all passed.

## Test plan

- [x] `TestDetectMultiFileGroup_NoTagsGroupedBySequentialName` — 5 untagged sequential .mp3 → 1 multi-file book
- [x] `TestDetectMultiFileGroup_MixedTagsStillGroupedByArtistQuorum` — conflicting album but same artist → still grouped (pre-existing path unchanged)
- [x] `TestDetectMultiFileGroup_RejectsDisagreeingAlbums` — both album + albumArtist conflict → still rejected
- [x] `TestIntegrationRealWorldMixedFormats` updated — Chapter 01-03.mp3 with no tags now → 1 multi-file book (was 3 shattered books)
- [x] `go test ./internal/scanner/... -short` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v