### PR TITLE
feat(dedup): add dry-run exact-pending triage op (PH-2)

### DIFF
--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,0 +1,282 @@
+// file: internal/plugins/maintenance/dedup_triage.go
+// version: 1.0.0
+// guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
+// last-edited: 2026-06-24
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// TriageClass labels the inferred population of a dedup candidate.
+type TriageClass string
+
+const (
+	// TriageClassGenuine — file-hash, ISBN/ASIN, or metadata-source-hash signal
+	// present. These candidates represent real duplicates and must NOT be purged.
+	TriageClassGenuine TriageClass = "genuine"
+
+	// TriageClassStub — one or both books have no real audio (< 256 KiB file size
+	// with sub-5-second duration). The match was noise from an empty placeholder.
+	TriageClassStub TriageClass = "stub"
+
+	// TriageClassFragment — duration ratio between the two books is < 5%, suggesting
+	// one is a single iTunes chapter (fragment) matched against the full book.
+	// These are CONS-FRAG artifacts that survived PurgeStaleCandidates because they
+	// live in different directories.
+	TriageClassFragment TriageClass = "fragment"
+
+	// TriageClassTitleLeak — both books are iTunes imports, the candidate layer is
+	// "exact" (title match), and no hard signal (file-hash / ISBN / meta-hash) is
+	// present in the ScoreBreakdown. These are CONS-17 artifacts: the iTunes
+	// importer set every track's title to the first track's title, causing
+	// spurious title-identity matches across unrelated chapters.
+	TriageClassTitleLeak TriageClass = "title_leak"
+
+	// TriageClassUnknown — pre-T015 candidate with no ScoreBreakdown, or a
+	// combination of signals that doesn't fit the above buckets cleanly.
+	// These must be reviewed manually; they are never auto-purged.
+	TriageClassUnknown TriageClass = "unknown"
+)
+
+// TriageExample records minimal context on a sampled candidate for the report.
+type TriageExample struct {
+	CandidateID int64       `json:"candidate_id"`
+	BookAID     string      `json:"book_a_id"`
+	BookBID     string      `json:"book_b_id"`
+	BookATitle  string      `json:"book_a_title"`
+	BookBTitle  string      `json:"book_b_title"`
+	Layer       string      `json:"layer"`
+	Reason      string      `json:"reason"`
+}
+
+// TriagePopulation holds the count and up to 5 examples for one class.
+type TriagePopulation struct {
+	Class    TriageClass    `json:"class"`
+	Count    int            `json:"count"`
+	Examples []TriageExample `json:"examples,omitempty"`
+}
+
+// TriageReport is the output of the dry-run triage op.
+// It is logged as JSON at the end of the run and returned as op result data.
+type TriageReport struct {
+	ScannedAt      time.Time                    `json:"scanned_at"`
+	TotalScanned   int                          `json:"total_scanned"`
+	Populations    map[TriageClass]TriagePopulation `json:"populations"`
+	PurgeableCount int                          `json:"purgeable_count"`
+	KeepCount      int                          `json:"keep_count"`
+	ReviewCount    int                          `json:"review_count"`
+}
+
+// purgeableClasses are the populations safe to delete without human review.
+var purgeableClasses = map[TriageClass]bool{
+	TriageClassStub:      true,
+	TriageClassFragment:  true,
+	TriageClassTitleLeak: true,
+}
+
+// IsPurgeable reports whether cls is safe to delete without human review.
+func IsPurgeable(cls TriageClass) bool { return purgeableClasses[cls] }
+
+// minPlausibleAudioBytes is copied from internal/dedup/engine.go to avoid an
+// import cycle. Files smaller than this with sub-5-second duration are stubs.
+const minPlausibleAudioBytes = 256 * 1024
+
+// ClassifyCandidate classifies a dedup candidate into one of the four triage
+// populations. It returns the class and a short human-readable reason string.
+// a and b may be nil if the book was deleted; in that case it falls to unknown.
+func ClassifyCandidate(c database.DedupCandidate, a, b *database.Book) (TriageClass, string) {
+	if a == nil || b == nil {
+		return TriageClassUnknown, "one or both books missing"
+	}
+
+	// 1. Stub: either book has a tiny file + no real audio duration.
+	if isTriageStub(a) {
+		return TriageClassStub, fmt.Sprintf("book A (%s) is a byte-empty stub", a.ID)
+	}
+	if isTriageStub(b) {
+		return TriageClassStub, fmt.Sprintf("book B (%s) is a byte-empty stub", b.ID)
+	}
+
+	// 2. Hard signal in ScoreBreakdown → genuine duplicate.
+	if hasHardSignal(c) {
+		return TriageClassGenuine, hardSignalName(c)
+	}
+
+	// 3. Fragment-vs-full: duration ratio < 5%.
+	if cls, reason, ok := checkFragment(c, a, b); ok {
+		return cls, reason
+	}
+
+	// 4. Title-leak: both books are iTunes imports, layer = exact, no hard signal.
+	if a.ITunesPersistentID != nil && b.ITunesPersistentID != nil && c.Layer == "exact" {
+		return TriageClassTitleLeak, "both books are iTunes imports with exact-layer title match and no hard signal"
+	}
+
+	// 5. Pre-T015 (no ScoreBreakdown) or unclassifiable mixed signals.
+	if c.ScoreBreakdown == nil {
+		return TriageClassUnknown, "pre-T015 candidate, no ScoreBreakdown"
+	}
+	return TriageClassUnknown, fmt.Sprintf("layer=%s, no hard signal, signals=%s", c.Layer, signalList(c))
+}
+
+func isTriageStub(b *database.Book) bool {
+	if b.FileSize != nil && *b.FileSize < minPlausibleAudioBytes {
+		dur := 0
+		if b.Duration != nil {
+			dur = *b.Duration
+		}
+		if dur < 5 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHardSignal(c database.DedupCandidate) bool {
+	if c.ScoreBreakdown == nil {
+		return false
+	}
+	for _, sig := range c.ScoreBreakdown.Signals {
+		switch sig.Kind {
+		case unified.SigExactFile, unified.SigISBNASIN, unified.SigMetaSrcHash, unified.SigExactAcoustID:
+			return true
+		}
+	}
+	return false
+}
+
+func hardSignalName(c database.DedupCandidate) string {
+	if c.ScoreBreakdown == nil {
+		return ""
+	}
+	for _, sig := range c.ScoreBreakdown.Signals {
+		switch sig.Kind {
+		case unified.SigExactFile:
+			return "exact file-hash match"
+		case unified.SigISBNASIN:
+			return "ISBN/ASIN match"
+		case unified.SigMetaSrcHash:
+			return "same metadata source hash"
+		case unified.SigExactAcoustID:
+			return "exact AcoustID match"
+		}
+	}
+	return ""
+}
+
+func checkFragment(_ database.DedupCandidate, a, b *database.Book) (TriageClass, string, bool) {
+	durA, durB := 0, 0
+	if a.Duration != nil {
+		durA = *a.Duration
+	}
+	if b.Duration != nil {
+		durB = *b.Duration
+	}
+	if durA <= 0 || durB <= 0 {
+		return "", "", false
+	}
+	lo, hi := durA, durB
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	ratio := float64(lo) / float64(hi)
+	if ratio < 0.05 {
+		shortID := a.ID
+		if durB < durA {
+			shortID = b.ID
+		}
+		return TriageClassFragment, fmt.Sprintf(
+			"duration ratio %.1f%% (short book %s, %ds vs %ds) — CONS-FRAG artifact",
+			math.Round(ratio*1000)/10, shortID, lo, hi,
+		), true
+	}
+	return "", "", false
+}
+
+func signalList(c database.DedupCandidate) string {
+	if c.ScoreBreakdown == nil {
+		return "(none)"
+	}
+	var kinds []string
+	for _, sig := range c.ScoreBreakdown.Signals {
+		kinds = append(kinds, string(sig.Kind))
+	}
+	if len(kinds) == 0 {
+		return "(none)"
+	}
+	return strings.Join(kinds, ",")
+}
+
+// --- op definition ---
+
+func (p *Plugin) dedupExactTriageDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.dedup-exact-triage",
+		Plugin:          "maintenance",
+		DisplayName:     "Dedup exact-pending triage (dry-run)",
+		Description:     "Classifies all pending exact-layer dedup candidates into 4 populations (genuine/stub/fragment/title_leak) and reports counts. Dry-run only — no candidates are deleted.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.dedup-exact-triage",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Schedule:        nil,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead},
+		Run:             p.runDedupExactTriage,
+	}
+}
+
+func (p *Plugin) runDedupExactTriage(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	if !p.deps.HasDedupEngine() {
+		_ = reporter.Log(slog.LevelInfo, "Dedup engine not initialized, skipping exact triage")
+		return nil
+	}
+
+	_ = reporter.Log(slog.LevelInfo, "Starting exact-pending dedup triage (dry-run — no deletes)")
+	_ = reporter.UpdateProgress(0, 0, "Scanning candidates…")
+
+	report, err := p.deps.DedupTriageExactPending(ctx)
+	if err != nil {
+		return fmt.Errorf("triage scan: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(report.TotalScanned, report.TotalScanned, "Classification complete")
+
+	// Log per-population summaries.
+	for _, cls := range []TriageClass{
+		TriageClassGenuine, TriageClassStub, TriageClassFragment, TriageClassTitleLeak, TriageClassUnknown,
+	} {
+		pop := report.Populations[cls]
+		action := "KEEP"
+		if purgeableClasses[cls] {
+			action = "purgeable"
+		}
+		_ = reporter.Log(slog.LevelInfo,
+			fmt.Sprintf("%-12s  %5d candidates  [%s]", string(cls), pop.Count, action),
+		)
+	}
+
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"Summary: total=%d  purgeable=%d  keep=%d  review=%d",
+		report.TotalScanned, report.PurgeableCount, report.KeepCount, report.ReviewCount,
+	))
+
+	// Emit the full report as a structured log entry so the UI can surface it.
+	reportJSON, _ := json.MarshalIndent(report, "", "  ")
+	_ = reporter.Log(slog.LevelInfo, "Triage report (JSON)", slog.String("report", string(reportJSON)))
+
+	return nil
+}

--- a/internal/plugins/maintenance/dedup_triage_test.go
+++ b/internal/plugins/maintenance/dedup_triage_test.go
@@ -1,0 +1,166 @@
+// file: internal/plugins/maintenance/dedup_triage_test.go
+// version: 1.0.0
+// guid: 8f9a0b1c-2d3e-4f50-a6b7-c8d9e0f12345
+// last-edited: 2026-06-24
+
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+)
+
+func makeBook(id string, fileSize int64, duration int, itunesPID string) *database.Book {
+	b := &database.Book{ID: id, Title: "Book " + id}
+	if fileSize >= 0 {
+		b.FileSize = &fileSize
+	}
+	if duration >= 0 {
+		b.Duration = &duration
+	}
+	if itunesPID != "" {
+		b.ITunesPersistentID = &itunesPID
+	}
+	return b
+}
+
+func sig(kind unified.SignalKind) unified.Signal {
+	return unified.Signal{Kind: kind, Confidence: 0.99}
+}
+
+func withBreakdown(c database.DedupCandidate, signals ...unified.Signal) database.DedupCandidate {
+	c.ScoreBreakdown = &unified.UnifiedDedupScore{Signals: signals}
+	return c
+}
+
+func TestClassifyCandidate_Genuine_FileHash(t *testing.T) {
+	a := makeBook("a", 10*1024*1024, 3600, "")
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigExactFile))
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassGenuine {
+		t.Errorf("got %s (%s), want genuine", cls, reason)
+	}
+}
+
+func TestClassifyCandidate_Genuine_ISBN(t *testing.T) {
+	a := makeBook("a", 10*1024*1024, 3600, "")
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigISBNASIN))
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls != TriageClassGenuine {
+		t.Errorf("got %s, want genuine", cls)
+	}
+}
+
+func TestClassifyCandidate_Stub_TinyFile(t *testing.T) {
+	a := makeBook("a", 100, 1, "") // 100 bytes, 1s — byte-empty stub
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls != TriageClassStub {
+		t.Errorf("got %s, want stub", cls)
+	}
+}
+
+func TestClassifyCandidate_Stub_ZeroDuration(t *testing.T) {
+	a := makeBook("a", 1024, 0, "") // below threshold, no duration
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls != TriageClassStub {
+		t.Errorf("got %s, want stub", cls)
+	}
+}
+
+func TestClassifyCandidate_Stub_LargeFileRealDuration_NotStub(t *testing.T) {
+	// File within threshold but has real duration — not a stub
+	a := makeBook("a", 100*1024, 120, "") // 100 KiB but 2 min audio
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls == TriageClassStub {
+		t.Errorf("book with real duration should not be classified as stub")
+	}
+}
+
+func TestClassifyCandidate_Fragment_DurationRatio(t *testing.T) {
+	// Short: 2 min chapter vs 90 min full book = 2.2% ratio < 5%
+	a := makeBook("a", 5*1024*1024, 120, "itunes-pid-a")
+	b := makeBook("b", 100*1024*1024, 5400, "itunes-pid-b")
+	c := database.DedupCandidate{Layer: "exact"} // no ScoreBreakdown (pre-T015)
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassFragment {
+		t.Errorf("got %s (%s), want fragment", cls, reason)
+	}
+}
+
+func TestClassifyCandidate_Fragment_EqualDuration_NotFragment(t *testing.T) {
+	// Same duration — clearly not a fragment
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	b := makeBook("b", 5*1024*1024, 3600, "")
+	c := database.DedupCandidate{Layer: "exact"}
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls == TriageClassFragment {
+		t.Errorf("same-duration books should not be classified as fragment")
+	}
+}
+
+func TestClassifyCandidate_TitleLeak(t *testing.T) {
+	// Both iTunes, exact layer, no hard signal in breakdown
+	a := makeBook("a", 5*1024*1024, 3600, "itunes-pid-a")
+	b := makeBook("b", 5*1024*1024, 3600, "itunes-pid-b")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassTitleLeak {
+		t.Errorf("got %s (%s), want title_leak", cls, reason)
+	}
+}
+
+func TestClassifyCandidate_Unknown_NilBreakdown(t *testing.T) {
+	// Pre-T015: no ScoreBreakdown, not a stub or fragment
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	b := makeBook("b", 5*1024*1024, 3600, "")
+	c := database.DedupCandidate{Layer: "exact", ScoreBreakdown: nil}
+
+	cls, _ := ClassifyCandidate(c, a, b)
+	if cls != TriageClassUnknown {
+		t.Errorf("got %s, want unknown for pre-T015 candidate", cls)
+	}
+}
+
+func TestClassifyCandidate_MissingBook(t *testing.T) {
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	c := database.DedupCandidate{Layer: "exact"}
+
+	cls, _ := ClassifyCandidate(c, a, nil)
+	if cls != TriageClassUnknown {
+		t.Errorf("nil book should yield unknown, got %s", cls)
+	}
+}
+
+func TestIsPurgeable(t *testing.T) {
+	purge := []TriageClass{TriageClassStub, TriageClassFragment, TriageClassTitleLeak}
+	keep := []TriageClass{TriageClassGenuine, TriageClassUnknown}
+
+	for _, cls := range purge {
+		if !IsPurgeable(cls) {
+			t.Errorf("IsPurgeable(%s) = false, want true", cls)
+		}
+	}
+	for _, cls := range keep {
+		if IsPurgeable(cls) {
+			t.Errorf("IsPurgeable(%s) = true, want false", cls)
+		}
+	}
+}

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-05-19
+// last-edited: 2026-06-24
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -75,6 +75,12 @@ type ServerDeps interface {
 	CompactActivityLog(ctx context.Context,
 		compactionDays, changeDays, debugDays int,
 	) (compacted int, summarized int, pruned int, err error)
+
+	// DedupTriageExactPending scans all pending book dedup candidates,
+	// classifies each into one of four populations (genuine / stub / fragment /
+	// title_leak), and returns a TriageReport. No candidates are deleted.
+	// Returns an error if the embedding store is not initialised.
+	DedupTriageExactPending(ctx context.Context) (*TriageReport, error)
 
 	// ----- feature flags -----
 

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-06-21
+// last-edited: 2026-06-24
 
 package maintenance
 
@@ -60,6 +60,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// --- dedup ---
 		p.dedupLLMReviewDef(),
 		p.aiDedupBatchDef(),
+		p.dedupExactTriageDef(),
 
 		// --- batch poller ---
 		p.batchPollerDef(),

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,6 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
+// last-edited: 2026-06-24
 
 package maintenance
 
@@ -67,8 +68,11 @@ func (d fakeDeps) SweepArchivedBooks() int                         { return 0 }
 func (d fakeDeps) ActivityFlushOp(_ string)                        {}
 func (d fakeDeps) EnqueueWriteBack(_ string)                       {}
 func (d fakeDeps) PollBatch(_ context.Context) (int, error)        { return 0, nil }
-func (d fakeDeps) DedupLLMReview(_ context.Context) error          { return nil }
-func (d fakeDeps) InvalidateDedupCache()                           {}
+func (d fakeDeps) DedupLLMReview(_ context.Context) error { return nil }
+func (d fakeDeps) DedupTriageExactPending(_ context.Context) (*TriageReport, error) {
+	return &TriageReport{}, nil
+}
+func (d fakeDeps) InvalidateDedupCache() {}
 func (d fakeDeps) MetadataUpgradeRun(_ context.Context, _ int) (int, int, int, int, error) {
 	return 0, 0, 0, 0, nil
 }

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-05-19
+// last-edited: 2026-06-24
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -246,6 +246,103 @@ func (s *Server) EnqueueOp(ctx context.Context, defID string, params any) (strin
 		return "", fmt.Errorf("operations registry not initialized")
 	}
 	return s.opRegistry.EnqueueOp(ctx, defID, params)
+}
+
+// DedupTriageExactPending implements maintenance.ServerDeps. It pages all
+// pending book dedup candidates, classifies each via ClassifyCandidate, and
+// returns a TriageReport with per-population counts and up to 5 examples each.
+// No candidates are deleted regardless of their class.
+func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugin.TriageReport, error) {
+	if s.embeddingStore == nil {
+		return nil, fmt.Errorf("embedding store not initialized")
+	}
+
+	candidates, _, err := s.embeddingStore.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Limit:      1_000_000,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list candidates: %w", err)
+	}
+
+	// Memoize book lookups — a book may appear in many candidate pairs.
+	bookCache := make(map[string]*database.Book, len(candidates))
+	getBook := func(id string) *database.Book {
+		if b, ok := bookCache[id]; ok {
+			return b
+		}
+		b, _ := s.Store().GetBookByID(id)
+		bookCache[id] = b
+		return b
+	}
+
+	type popState struct {
+		count    int
+		examples []maintenanceplugin.TriageExample
+	}
+	pops := map[maintenanceplugin.TriageClass]*popState{
+		maintenanceplugin.TriageClassGenuine:   {},
+		maintenanceplugin.TriageClassStub:      {},
+		maintenanceplugin.TriageClassFragment:  {},
+		maintenanceplugin.TriageClassTitleLeak: {},
+		maintenanceplugin.TriageClassUnknown:   {},
+	}
+
+	for i := range candidates {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		c := candidates[i]
+		a := getBook(c.EntityAID)
+		b := getBook(c.EntityBID)
+
+		cls, reason := maintenanceplugin.ClassifyCandidate(c, a, b)
+		ps := pops[cls]
+		ps.count++
+		if len(ps.examples) < 5 {
+			titleA, titleB := "", ""
+			if a != nil {
+				titleA = a.Title
+			}
+			if b != nil {
+				titleB = b.Title
+			}
+			ps.examples = append(ps.examples, maintenanceplugin.TriageExample{
+				CandidateID: c.ID,
+				BookAID:     c.EntityAID,
+				BookBID:     c.EntityBID,
+				BookATitle:  titleA,
+				BookBTitle:  titleB,
+				Layer:       c.Layer,
+				Reason:      reason,
+			})
+		}
+	}
+
+	report := &maintenanceplugin.TriageReport{
+		ScannedAt:    time.Now(),
+		TotalScanned: len(candidates),
+		Populations:  make(map[maintenanceplugin.TriageClass]maintenanceplugin.TriagePopulation, len(pops)),
+	}
+	for cls, ps := range pops {
+		report.Populations[cls] = maintenanceplugin.TriagePopulation{
+			Class:    cls,
+			Count:    ps.count,
+			Examples: ps.examples,
+		}
+		switch {
+		case maintenanceplugin.IsPurgeable(cls):
+			report.PurgeableCount += ps.count
+		case cls == maintenanceplugin.TriageClassGenuine:
+			report.KeepCount += ps.count
+		default:
+			report.ReviewCount += ps.count
+		}
+	}
+	return report, nil
 }
 
 // WaitForOp implements maintenance.ServerDeps. It polls the database at 5-second


### PR DESCRIPTION
## Summary

- Adds `maintenance.dedup-exact-triage` — a **read-only** analysis op that classifies all pending book dedup candidates into 4 populations
- No candidates are deleted; this is the dry-run gate before any purge
- Adds `ClassifyCandidate()` + `IsPurgeable()` helpers in the maintenance package, tested with 10 unit tests

## Populations

| Class | Criteria | Action |
|-------|----------|--------|
| `genuine` | file-hash / ISBN / metadata-source-hash / exact-acoustid signal present | **KEEP** |
| `stub` | FileSize < 256 KiB **and** Duration < 5s for either book | purgeable |
| `fragment` | duration ratio < 5% (CONS-FRAG iTunes chapter artifact) | purgeable |
| `title_leak` | both iTunes imports, exact-layer, no hard signal (CONS-17 artifact) | purgeable |
| `unknown` | pre-T015 candidate with no ScoreBreakdown | manual review |

## Files changed

- `internal/plugins/maintenance/dedup_triage.go` — new op + classification logic
- `internal/plugins/maintenance/dedup_triage_test.go` — 10 unit tests
- `internal/plugins/maintenance/deps.go` — `DedupTriageExactPending` added to `ServerDeps`
- `internal/plugins/maintenance/plugin.go` — op registered
- `internal/server/server_maintenance_deps.go` — `*Server` implementation
- `internal/plugins/maintenance/title_backfill_test.go` — `fakeDeps` stub

## Test plan

- [x] 10 classifier unit tests — all pass
- [x] Full maintenance suite — passes
- [ ] Run `maintenance.dedup-exact-triage` on prod; review population breakdown before approving any purge

## Next step

After merge + deploy: enqueue the op on 172.16.2.30 and review the JSON report in the activity log. The purge wave (PH-2b) will be a separate PR after the user approves the breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v