### PR TITLE
feat(ops): unified checkpoint system — fix resume loop + RunItems + OpFreshness

### DIFF
--- a/internal/database/iface_ops_v2.go
+++ b/internal/database/iface_ops_v2.go
@@ -168,6 +168,10 @@ type OpsV2Store interface {
 	// UpsertOpStateV2 inserts or replaces a checkpoint row in op_state_v2.
 	UpsertOpStateV2(row OpStateV2Row) error
 
+	// UpdateOperationV2Params replaces the params blob on an operation row.
+	// Used by resumeRestart to inject checkpoint state before re-dispatch.
+	UpdateOperationV2Params(id string, params []byte) error
+
 	// ListOperationsV2Since returns all operations whose queued_at timestamp is
 	// at or after the given time, ordered by started_at DESC NULLS LAST,
 	// queued_at DESC. At most limit rows are returned (0 = use a safe default).

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.65.0
+// version: 1.66.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-23
+// last-edited: 2026-06-24
 
 package database
 
@@ -2611,6 +2611,7 @@ func (m *MockStore) IncrementResumeCountV2(_ string) error                  { re
 func (m *MockStore) InsertOpStrikeV2(_ OpStrikeV2Row) error                 { return nil }
 func (m *MockStore) GetOpStateV2(_ string) (*OpStateV2Row, error)           { return nil, nil }
 func (m *MockStore) DeleteOpStateV2(_ string) error                         { return nil }
+func (m *MockStore) UpdateOperationV2Params(_ string, _ []byte) error       { return nil }
 func (m *MockStore) UpdateOpProgressV2(_ string, _, _ int, _ string) error  { return nil }
 func (m *MockStore) UpdateOpPhaseV2(_ string, _ *string) error              { return nil }
 func (m *MockStore) UpdateOpCheckpointV2(_ string, _ int) error             { return nil }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -49374,6 +49374,60 @@ func (_c *MockStore_UpdateOperationStatus_Call) RunAndReturn(run func(id string,
 	return _c
 }
 
+// UpdateOperationV2Params provides a mock function for the type MockStore
+func (_mock *MockStore) UpdateOperationV2Params(id string, params []byte) error {
+	ret := _mock.Called(id, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateOperationV2Params")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = returnFunc(id, params)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_UpdateOperationV2Params_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateOperationV2Params'
+type MockStore_UpdateOperationV2Params_Call struct {
+	*mock.Call
+}
+
+// UpdateOperationV2Params is a helper method to define mock.On call
+//   - id string
+//   - params []byte
+func (_e *MockStore_Expecter) UpdateOperationV2Params(id interface{}, params interface{}) *MockStore_UpdateOperationV2Params_Call {
+	return &MockStore_UpdateOperationV2Params_Call{Call: _e.mock.On("UpdateOperationV2Params", id, params)}
+}
+
+func (_c *MockStore_UpdateOperationV2Params_Call) Run(run func(id string, params []byte)) *MockStore_UpdateOperationV2Params_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockStore_UpdateOperationV2Params_Call) Return(err error) *MockStore_UpdateOperationV2Params_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_UpdateOperationV2Params_Call) RunAndReturn(run func(string, []byte) error) *MockStore_UpdateOperationV2Params_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateOperationV2Status provides a mock function for the type MockStore
 func (_mock *MockStore) UpdateOperationV2Status(id string, status string, startedAt *time.Time, completedAt *time.Time, errMsg *string) error {
 	ret := _mock.Called(id, status, startedAt, completedAt, errMsg)

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -23671,6 +23671,60 @@ func (_c *MockOpsV2Store_UpdateOpProgressV2_Call) RunAndReturn(run func(id strin
 }
 
 // UpdateOperationV2Status provides a mock function for the type MockOpsV2Store
+// UpdateOperationV2Params provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) UpdateOperationV2Params(id string, params []byte) error {
+	ret := _mock.Called(id, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateOperationV2Params")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = returnFunc(id, params)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOpsV2Store_UpdateOperationV2Params_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateOperationV2Params'
+type MockOpsV2Store_UpdateOperationV2Params_Call struct {
+	*mock.Call
+}
+
+// UpdateOperationV2Params is a helper method to define mock.On call
+//   - id string
+//   - params []byte
+func (_e *MockOpsV2Store_Expecter) UpdateOperationV2Params(id interface{}, params interface{}) *MockOpsV2Store_UpdateOperationV2Params_Call {
+	return &MockOpsV2Store_UpdateOperationV2Params_Call{Call: _e.mock.On("UpdateOperationV2Params", id, params)}
+}
+
+func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) Run(run func(id string, params []byte)) *MockOpsV2Store_UpdateOperationV2Params_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
+		}
+		run(arg0, arg1)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) Return(err error) *MockOpsV2Store_UpdateOperationV2Params_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) RunAndReturn(run func(string, []byte) error) *MockOpsV2Store_UpdateOperationV2Params_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 func (_mock *MockOpsV2Store) UpdateOperationV2Status(id string, status string, startedAt *time.Time, completedAt *time.Time, errMsg *string) error {
 	ret := _mock.Called(id, status, startedAt, completedAt, errMsg)
 

--- a/internal/database/pebble_store_ops_v2.go
+++ b/internal/database/pebble_store_ops_v2.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_ops_v2.go
-// version: 3.3.0
+// version: 3.4.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-06-13
+// last-edited: 2026-06-24
 
 // pebble_store_ops_v2 implements OpsV2Store for PebbleDB (the primary production
 // database). Key schema (all prefixed with "opv2:"):
@@ -378,6 +378,22 @@ func (p *PebbleStore) GetOpStateV2(opID string) (*OpStateV2Row, error) {
 // DeleteOpStateV2 removes the state blob for an op.
 func (p *PebbleStore) DeleteOpStateV2(opID string) error {
 	return p.db.Delete(opv2StateKey(opID), pebble.Sync)
+}
+
+// UpdateOperationV2Params replaces the params blob on an operation row.
+// Used by resumeRestart to inject checkpoint state before re-dispatch.
+func (p *PebbleStore) UpdateOperationV2Params(id string, params []byte) error {
+	p.opsMu.Lock()
+	defer p.opsMu.Unlock()
+	var row OperationV2Row
+	if err := p.pebbleGetJSON(opv2OpKey(id), &row); err != nil {
+		return err
+	}
+	if row.ID == "" {
+		return fmt.Errorf("opv2: operation not found: %s", id)
+	}
+	row.Params = string(params)
+	return p.pebbleSetJSON(opv2OpKey(id), &row)
 }
 
 // AppendOpLogsV2 bulk-inserts log rows.

--- a/internal/operations/freshness/freshness.go
+++ b/internal/operations/freshness/freshness.go
@@ -1,0 +1,145 @@
+// file: internal/operations/freshness/freshness.go
+// version: 1.0.0
+// guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
+// last-edited: 2026-06-24
+
+// Package freshness provides per-item freshness stamps for background operations.
+//
+// Use OpFreshness when an operation needs to skip recently-processed items
+// across independent scheduled runs — for example, "skip this book if it was
+// fingerprinted within the last 7 days". This is distinct from reporter.Checkpoint
+// (which resumes a single crashed run) and from struct fields like DurationVerifiedAt
+// (which belong on the entity and are queryable from the library list).
+//
+// # When to use OpFreshness vs alternatives
+//
+//   - Use a struct field (DurationVerifiedAt, FingerprintFailedAt) when the stamp
+//     is meaningful to the library list, needs to be queryable from API filters,
+//     or semantically belongs to the entity model.
+//   - Use reporter.Checkpoint when resuming a single crashed run from its last
+//     committed position.
+//   - Use OpFreshness.Stamp when the stamp is an internal implementation detail
+//     of a background op that doesn't belong on the entity.
+package freshness
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// OpFreshness stores per-item timestamps for background operations.
+// All methods are safe for concurrent use.
+type OpFreshness interface {
+	// ShouldProcess returns true when the item needs processing:
+	//   - always true if force=true
+	//   - always true if no stamp exists for (op, itemID)
+	//   - true if the stamp is older than maxAge
+	//   - false otherwise (item is fresh, skip it)
+	ShouldProcess(op, itemID string, maxAge time.Duration, force bool) bool
+
+	// Stamp records that (op, itemID) was processed at now.
+	Stamp(op, itemID string) error
+
+	// StampBatch records that all itemIDs were processed at now in a single
+	// atomic Pebble batch. More efficient than calling Stamp N times.
+	StampBatch(op string, itemIDs []string) error
+
+	// ClearStamps removes all per-item stamps for op using a range delete,
+	// causing ShouldProcess to return true for every item on the next run.
+	// O(1) regardless of item count.
+	ClearStamps(op string) error
+}
+
+// PebbleFreshness implements OpFreshness backed by PebbleDB.
+//
+// Key layout: opck:{op}:item:{itemID} → 8-byte little-endian Unix nanoseconds.
+// The opck: prefix groups all freshness keys for easy range iteration/deletion.
+type PebbleFreshness struct {
+	db *pebble.DB
+}
+
+// NewPebbleFreshness creates a PebbleFreshness using the provided PebbleDB handle.
+// The DB must remain open for the lifetime of the returned value.
+func NewPebbleFreshness(db *pebble.DB) *PebbleFreshness {
+	return &PebbleFreshness{db: db}
+}
+
+func itemKey(op, itemID string) []byte {
+	return []byte("opck:" + op + ":item:" + itemID)
+}
+
+func itemPrefix(op string) []byte {
+	return []byte("opck:" + op + ":item:")
+}
+
+// ShouldProcess implements OpFreshness.
+func (f *PebbleFreshness) ShouldProcess(op, itemID string, maxAge time.Duration, force bool) bool {
+	if force {
+		return true
+	}
+	val, closer, err := f.db.Get(itemKey(op, itemID))
+	if err != nil {
+		// Not found or read error — process the item.
+		return true
+	}
+	defer closer.Close()
+	if len(val) < 8 {
+		return true
+	}
+	ns := int64(binary.LittleEndian.Uint64(val))
+	stamped := time.Unix(0, ns)
+	return time.Since(stamped) > maxAge
+}
+
+// Stamp implements OpFreshness.
+func (f *PebbleFreshness) Stamp(op, itemID string) error {
+	return f.db.Set(itemKey(op, itemID), encodeNow(), pebble.Sync)
+}
+
+// StampBatch implements OpFreshness.
+func (f *PebbleFreshness) StampBatch(op string, itemIDs []string) error {
+	if len(itemIDs) == 0 {
+		return nil
+	}
+	now := encodeNow()
+	b := f.db.NewBatch()
+	defer b.Close()
+	for _, id := range itemIDs {
+		if err := b.Set(itemKey(op, id), now, nil); err != nil {
+			return err
+		}
+	}
+	return b.Commit(pebble.Sync)
+}
+
+// ClearStamps implements OpFreshness using a range delete — O(1) regardless
+// of item count.
+func (f *PebbleFreshness) ClearStamps(op string) error {
+	prefix := itemPrefix(op)
+	end := prefixSuccessor(prefix)
+	return f.db.DeleteRange(prefix, end, pebble.Sync)
+}
+
+// encodeNow returns the current time as 8-byte little-endian Unix nanoseconds.
+func encodeNow() []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(time.Now().UnixNano()))
+	return buf
+}
+
+// prefixSuccessor returns the lexicographic successor of prefix for use as an
+// exclusive range-delete end key. Increments the last byte; if it overflows,
+// the prefix itself is the successor (no keys exist past it).
+func prefixSuccessor(prefix []byte) []byte {
+	end := make([]byte, len(prefix))
+	copy(end, prefix)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i]++
+		if end[i] != 0 {
+			return end
+		}
+	}
+	return end
+}

--- a/internal/operations/freshness/freshness_test.go
+++ b/internal/operations/freshness/freshness_test.go
@@ -1,0 +1,113 @@
+// file: internal/operations/freshness/freshness_test.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
+// last-edited: 2026-06-24
+
+package freshness_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/freshness"
+)
+
+func openTestDB(t *testing.T) *pebble.DB {
+	t.Helper()
+	db, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestShouldProcess_NoStamp(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	if !f.ShouldProcess("acoustid_backfill", "book-1", time.Hour, false) {
+		t.Error("expected true (no stamp), got false")
+	}
+}
+
+func TestShouldProcess_Fresh(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	if err := f.Stamp("acoustid_backfill", "book-1"); err != nil {
+		t.Fatal(err)
+	}
+	if f.ShouldProcess("acoustid_backfill", "book-1", time.Hour, false) {
+		t.Error("expected false (just stamped, within maxAge), got true")
+	}
+}
+
+func TestShouldProcess_Stale(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	if err := f.Stamp("acoustid_backfill", "book-1"); err != nil {
+		t.Fatal(err)
+	}
+	// maxAge of 0 means anything is stale.
+	if !f.ShouldProcess("acoustid_backfill", "book-1", 0, false) {
+		t.Error("expected true (stamp older than maxAge=0), got false")
+	}
+}
+
+func TestShouldProcess_Force(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	if err := f.Stamp("acoustid_backfill", "book-1"); err != nil {
+		t.Fatal(err)
+	}
+	if !f.ShouldProcess("acoustid_backfill", "book-1", time.Hour, true) {
+		t.Error("expected true (force=true always returns true), got false")
+	}
+}
+
+func TestStampBatch(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	ids := []string{"a", "b", "c"}
+	if err := f.StampBatch("lsh_backfill", ids); err != nil {
+		t.Fatalf("StampBatch: %v", err)
+	}
+	for _, id := range ids {
+		if f.ShouldProcess("lsh_backfill", id, time.Hour, false) {
+			t.Errorf("id %q: expected false (just batch-stamped), got true", id)
+		}
+	}
+	// Different op — stamps should be independent.
+	if !f.ShouldProcess("other_op", "a", time.Hour, false) {
+		t.Error("different op: expected true (not stamped), got false")
+	}
+}
+
+func TestClearStamps(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	ids := []string{"x", "y", "z"}
+	if err := f.StampBatch("op", ids); err != nil {
+		t.Fatalf("StampBatch: %v", err)
+	}
+	if err := f.ClearStamps("op"); err != nil {
+		t.Fatalf("ClearStamps: %v", err)
+	}
+	for _, id := range ids {
+		if !f.ShouldProcess("op", id, time.Hour, false) {
+			t.Errorf("id %q: expected true after ClearStamps, got false", id)
+		}
+	}
+}
+
+func TestStampBatch_Empty(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	if err := f.StampBatch("op", nil); err != nil {
+		t.Fatalf("StampBatch with nil: %v", err)
+	}
+	if err := f.StampBatch("op", []string{}); err != nil {
+		t.Fatalf("StampBatch with empty: %v", err)
+	}
+}
+
+func TestClearStamps_NoOp(t *testing.T) {
+	f := freshness.NewPebbleFreshness(openTestDB(t))
+	// ClearStamps on an op with no stamps should not error.
+	if err := f.ClearStamps("nonexistent_op"); err != nil {
+		t.Fatalf("ClearStamps on empty op: %v", err)
+	}
+}

--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
-// last-edited: 2026-06-22
+// last-edited: 2026-06-24
 
 package registry
 
@@ -10,9 +10,7 @@ package registry
 // before using Checkpoint with custom state types.
 
 import (
-	"bytes"
 	"context"
-	"encoding/gob"
 	"encoding/json"
 	"log/slog"
 	"sync"
@@ -397,12 +395,16 @@ func (r *dbReporter) Logger() *slog.Logger {
 }
 
 // Checkpoint implements Reporter.
-// It gob-encodes state and UPSERTs into op_state_v2, then updates
-// high_water_progress on operations_v2.
+// It JSON-encodes state (schema_version=2) and UPSERTs into op_state_v2,
+// then updates high_water_progress on operations_v2.
+//
+// Schema version 2 (JSON) is machine-readable by resumeRestart so the blob
+// can be merged back into the re-queued params on server restart — closing
+// the resume loop that schema version 1 (gob) left open. Existing v1 rows
+// in op_state_v2 are ignored by resumeRestart (treated as no checkpoint).
 func (r *dbReporter) Checkpoint(state any) error {
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	if err := enc.Encode(state); err != nil {
+	data, err := json.Marshal(state)
+	if err != nil {
 		return err
 	}
 
@@ -412,8 +414,8 @@ func (r *dbReporter) Checkpoint(state any) error {
 
 	stateRow := database.OpStateV2Row{
 		OperationID:   r.opID,
-		StateBlob:     buf.Bytes(),
-		SchemaVersion: 1,
+		StateBlob:     data,
+		SchemaVersion: 2,
 		WrittenAt:     time.Now().UTC(),
 	}
 	if err := r.store.UpsertOpStateV2(stateRow); err != nil {

--- a/internal/operations/registry/resume.go
+++ b/internal/operations/registry/resume.go
@@ -1,12 +1,13 @@
 // file: internal/operations/registry/resume.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3c4d5e6f-7a8b-9012-cdef-012345678901
-// last-edited: 2026-05-06
+// last-edited: 2026-06-24
 
 package registry
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -81,18 +82,36 @@ func (r *Registry) resumeAfterStartup(ctx context.Context) {
 	}
 }
 
-// resumeRestart increments resume_count, clears state if needed, resets the
-// DB row to status=queued, and signals the dispatcher. The dispatcher picks it
-// up via ListQueuedOperationsV2 on its next cycle — same path as a fresh enqueue.
-// State blob restoration is UOS-03's responsibility; initialState on queuedRun
-// is not yet consumed by executeRun, so direct-dispatch would add no value and
-// would race with the dispatcher re-queuing the same row.
+// resumeRestart increments resume_count, merges any saved checkpoint state
+// into the re-queued row's params, resets status to queued, and signals the
+// dispatcher. The dispatcher picks it up via ListQueuedOperationsV2 on its
+// next cycle — same path as a fresh enqueue.
+//
+// Checkpoint state (schema_version=2, JSON) is merged into params so that
+// the op's Run function receives it via json.Unmarshal(params, &state) on
+// the resumed run. Schema_version=1 (gob) blobs are ignored — the op
+// restarts from scratch once, which is safe for all idempotent ops.
 func (r *Registry) resumeRestart(ctx context.Context, row database.OperationV2Row, def OperationDef) {
 	_ = ctx // context used only for cancel guard; dispatcher started after us
 
 	if err := r.store.IncrementResumeCountV2(row.ID); err != nil {
 		r.logger.Warn("registry: resumeAfterStartup: failed to increment resume_count",
 			"op_id", row.ID, "error", err)
+	}
+
+	// Restore checkpoint state into params so Run can read it on resume.
+	if stateRow, err := r.store.GetOpStateV2(row.ID); err == nil &&
+		stateRow != nil && stateRow.SchemaVersion == 2 {
+		if merged, mergeErr := mergeJSONParams([]byte(row.Params), stateRow.StateBlob); mergeErr == nil {
+			if updateErr := r.store.UpdateOperationV2Params(row.ID, merged); updateErr != nil {
+				r.logger.Warn("registry: resumeAfterStartup: failed to merge checkpoint into params",
+					"op_id", row.ID, "error", updateErr)
+			} else {
+				row.Params = string(merged)
+				r.logger.Info("registry: resumeAfterStartup: merged checkpoint state into params",
+					"op_id", row.ID, "state_bytes", len(stateRow.StateBlob))
+			}
+		}
 	}
 
 	// Reset status to queued so the dispatcher picks it up normally.
@@ -108,6 +127,30 @@ func (r *Registry) resumeRestart(ctx context.Context, row database.OperationV2Ro
 	r.publishOpCreated(row, true)
 
 	r.pingDispatch()
+}
+
+// mergeJSONParams overlays checkpoint keys onto base params. Keys present in
+// overlay take precedence; keys present only in base are preserved. Both base
+// and overlay must be valid JSON objects (or empty/nil). Returns the merged
+// JSON. Pure function — no store calls.
+func mergeJSONParams(base, overlay []byte) ([]byte, error) {
+	merged := make(map[string]any)
+	if len(base) > 0 {
+		if err := json.Unmarshal(base, &merged); err != nil {
+			return nil, err
+		}
+	}
+	if len(overlay) == 0 {
+		return json.Marshal(merged)
+	}
+	var over map[string]any
+	if err := json.Unmarshal(overlay, &over); err != nil {
+		return nil, err
+	}
+	for k, v := range over {
+		merged[k] = v
+	}
+	return json.Marshal(merged)
 }
 
 // resumeRequeue clears state and re-inserts as a brand-new queued op.

--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-06-22
+// last-edited: 2026-06-24
 
 package registry
 
@@ -44,6 +44,16 @@ type RunItemsOptions struct {
 	// Label returns the SetCurrentItem / UpdateProgress label for item i of
 	// total. Defaults to "item <i+1>/<total>".
 	Label func(i, total int) string
+
+	// CheckpointFn, if non-nil, is called after each item completes
+	// successfully in SEQUENTIAL mode (Concurrency <= 1). The caller uses a
+	// closure to capture the current item's ID or any other state needed to
+	// build the checkpoint. Errors are logged but do not fail the item.
+	//
+	// Not called in concurrent mode — parallel writes to reporter.Checkpoint
+	// would race on the shared state blob. Use OpFreshness.Stamp instead for
+	// concurrent per-item checkpointing.
+	CheckpointFn func(ctx context.Context) error
 }
 
 // RunItems fans out fn over items, managing:
@@ -90,13 +100,14 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 	}
 
 	if opt.Concurrency == 1 {
-		return runItemsSeq(ctx, items, runOne, opt.ErrMode)
+		return runItemsSeq(ctx, items, runOne, opt)
 	}
 	return runItemsPar(ctx, items, runOne, opt)
 }
 
-// runItemsSeq runs items sequentially.
-func runItemsSeq[T any](ctx context.Context, items []T, runOne func(context.Context, int, T) error, mode ErrMode) error {
+// runItemsSeq runs items sequentially, calling opt.CheckpointFn after each
+// successful item when set.
+func runItemsSeq[T any](ctx context.Context, items []T, runOne func(context.Context, int, T) error, opt RunItemsOptions) error {
 	var errs []error
 	for i, item := range items {
 		select {
@@ -105,11 +116,14 @@ func runItemsSeq[T any](ctx context.Context, items []T, runOne func(context.Cont
 		default:
 		}
 		if err := runOne(ctx, i, item); err != nil {
-			if mode == ErrModeCollect {
+			if opt.ErrMode == ErrModeCollect {
 				errs = append(errs, err)
 				continue
 			}
 			return err
+		}
+		if opt.CheckpointFn != nil {
+			_ = opt.CheckpointFn(ctx) // errors are non-fatal; op continues
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/operations/registry/teststore_test.go
+++ b/internal/operations/registry/teststore_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/teststore_test.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
-// last-edited: 2026-06-14
+// last-edited: 2026-06-24
 
 package registry_test
 
@@ -373,6 +373,18 @@ func (f *fakeStore) UpsertOpStateV2(row database.OpStateV2Row) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.states[row.OperationID] = row
+	return nil
+}
+
+func (f *fakeStore) UpdateOperationV2Params(id string, params []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	op, ok := f.ops[id]
+	if !ok {
+		return nil // best-effort
+	}
+	op.Params = string(params)
+	f.ops[id] = op
 	return nil
 }
 

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-06-11
+// last-edited: 2026-06-24
 
 package acoustid
 
@@ -18,17 +18,15 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
-// BackfillParams encodes the checkpoint state for resumable backfill.
+// BackfillParams is the checkpoint state written by reporter.Checkpoint and
+// restored into params on ResumeRestart. RunItems drives the loop; progress
+// counters are handled by reporter.UpdateProgress.
 type BackfillParams struct {
 	LastProcessedBookID string `json:"last_processed_book_id,omitempty"`
-	Stats               struct {
-		Fingerprinted int `json:"fingerprinted"`
-		Skipped       int `json:"skipped"`
-		Failed        int `json:"failed"`
-	} `json:"stats"`
 }
 
 func (p *Plugin) backfillDef() sdk.OperationDef {
@@ -111,17 +109,16 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 		return nil
 	}
 
-	for i := startIdx; i < total; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	slice := books[startIdx:]
 
-		b := books[i]
-		files, err := p.store.GetBookFiles(b.ID)
-		if err != nil {
-			continue
+	// lastID is captured by both the item fn and CheckpointFn to thread the
+	// current book ID through without a shared struct that would need a mutex.
+	var lastID string
+
+	err = registry.RunItems(ctx, reporter, slice, func(ctx context.Context, b database.Book) error {
+		files, ferr := p.store.GetBookFiles(b.ID)
+		if ferr != nil {
+			return nil // non-fatal: skip this book
 		}
 
 		bookModified := false
@@ -139,25 +136,26 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 			}
 		}
 
-		// After fingerprinting all files for this book, synthesize the book signature
 		if bookModified || b.BookSigV1 == nil {
 			if err := synthesizeBookSignatureForBook(p.store, b.ID); err != nil {
 				reporter.Logger().Warn("synthesize book signature", "book_id", b.ID, "error", err)
 			}
 		}
 
-		if i%25 == 0 || i == total-1 {
-			prog.StepN(i+1,
-				fmt.Sprintf("Books %d/%d (fp=%d skip=%d fail=%d)", i+1, total, fingerprinted, skipped, failed))
-
-			// Checkpoint progress every 25 books for resumability
-			state.LastProcessedBookID = b.ID
-			state.Stats.Fingerprinted = fingerprinted
-			state.Stats.Skipped = skipped
-			state.Stats.Failed = failed
-			stateJSON, _ := json.Marshal(state)
-			_ = reporter.Checkpoint(stateJSON)
-		}
+		lastID = b.ID
+		return nil
+	}, registry.RunItemsOptions{
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Books %d/%d (fp=%d skip=%d fail=%d)",
+				startIdx+i+1, total, fingerprinted, skipped, failed)
+		},
+		CheckpointFn: func(ctx context.Context) error {
+			cp := BackfillParams{LastProcessedBookID: lastID}
+			return reporter.Checkpoint(cp)
+		},
+	})
+	if err != nil {
+		return err
 	}
 
 	prog.Done(fmt.Sprintf("Acoustid backfill complete: fingerprinted=%d skipped=%d failed=%d",

--- a/internal/plugins/acoustid/lsh_backfill.go
+++ b/internal/plugins/acoustid/lsh_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/lsh_backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c4d6e80-3b5a-4f9c-9b1d-7e8f0a2b4c6d
-// last-edited: 2026-05-30
+// last-edited: 2026-06-24
 
 package acoustid
 
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -91,47 +93,30 @@ func (p *Plugin) runLSHBackfill(ctx context.Context, _ json.RawMessage, reporter
 
 	var indexed, skippedNoFP, skippedAlreadyIndexed, failed int
 
-	for i := range files {
-		select {
-		case <-ctx.Done():
-			log.Info("acoustid lsh-backfill: cancelled",
-				"processed", i,
-				"indexed", indexed,
-				"skipped_no_fp", skippedNoFP,
-				"skipped_already_indexed", skippedAlreadyIndexed,
-				"failed", failed,
-				"elapsed", time.Since(startedAt).Round(time.Second))
-			return ctx.Err()
-		default:
-		}
-
-		f := files[i]
-
+	if err := registry.RunItems(ctx, reporter, files, func(ctx context.Context, f database.BookFile) error {
 		if len(f.AcoustIDFingerprint) == 0 {
 			skippedNoFP++
 		} else if hasChecker && checker.HasLSHIndex(f.ID) {
 			skippedAlreadyIndexed++
 		} else {
-			// Re-save the row so PebbleStore.writeBookFileSecondaryIndexes
-			// (added by the sibling pebble agent) writes the fpidx +
-			// fpidx_meta entries. We pass the row through unmodified —
-			// this is just a hook trigger.
+			// Re-save the row so PebbleStore.writeBookFileSecondaryIndexes writes
+			// the fpidx + fpidx_meta entries. Passed unmodified — just a hook trigger.
 			updated := f
 			if err := p.store.UpdateBookFile(f.ID, &updated); err != nil {
-				log.Warn("acoustid lsh-backfill: update failed",
-					"id", f.ID, "err", err)
+				log.Warn("acoustid lsh-backfill: update failed", "id", f.ID, "err", err)
 				failed++
 			} else {
 				indexed++
 			}
 		}
-
-		processed := i + 1
-		if processed%lshBackfillProgressEvery == 0 || processed == total {
-			prog.StepN(processed,
-				fmt.Sprintf("LSH backfill %d/%d (indexed=%d skip-no-fp=%d skip-existing=%d fail=%d)",
-					processed, total, indexed, skippedNoFP, skippedAlreadyIndexed, failed))
-		}
+		return nil
+	}, registry.RunItemsOptions{
+		Label: func(i, t int) string {
+			return fmt.Sprintf("LSH backfill %d/%d (indexed=%d skip-no-fp=%d skip-existing=%d fail=%d)",
+				i+1, t, indexed, skippedNoFP, skippedAlreadyIndexed, failed)
+		},
+	}); err != nil {
+		return err
 	}
 
 	log.Info("acoustid lsh-backfill: complete",


### PR DESCRIPTION
## Summary

- **Fixes the broken resume loop**: `reporter.Checkpoint` now writes JSON (schema_version=2) instead of gob; `resumeRestart` reads schema_version=2 blobs back and merges checkpoint keys into re-queued op params via `mergeJSONParams`. `UpdateOperationV2Params` added to `OpsV2Store` + `PebbleStore`.
- **Extends RunItems with checkpoint support**: `RunItemsOptions.CheckpointFn` (sequential-only, non-fatal) called after each successful item; caller uses closure to capture current item ID without making the options struct generic.
- **New `internal/operations/freshness` package**: `OpFreshness` interface + `PebbleFreshness` for cross-run per-item TTL stamps. Keys: `opck:{op}:item:{id}` → 8-byte LE nanoseconds; `ClearStamps` uses O(1) range delete.
- **ARCH-4b wave 3 (partial)**: `acoustid/backfill` migrated to `RunItems + CheckpointFn` — removes manual every-25-books checkpoint, `Stats` field dropped from `BackfillParams`; `acoustid/lsh_backfill` migrated to `RunItems` with `ResumeDrop` retained.

## Test plan

- [ ] `go test ./internal/operations/... ./internal/plugins/acoustid/...` — all pass
- [ ] `go build ./...` — clean
- [ ] Resume scenario: start a backfill, kill mid-run, restart — verify `LastProcessedBookID` in params and backfill resumes from that book (not from scratch)
- [ ] `OpFreshness.ShouldProcess` returns false for items stamped within maxAge, true after maxAge, always true when force=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43
