### PR TITLE
fix(dedup): guard triage fragment classifier against CONS-17 durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.82.0 -->
+<!-- version: 3.83.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-06-24 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Features
+
+#### June 24, 2026 — PH-2: dedup exact-pending triage op (PR #1619)
+
+- **`feat(dedup)`** PH-2 — Adds `maintenance.dedup-exact-triage`, a **read-only** dry-run op that classifies all pending book dedup candidates into five populations: `genuine` (file-hash / ISBN / metadata-hash / exact-acoustid → KEEP), `stub` (FileSize < 256 KiB + Duration < 5s → purgeable), `fragment` (duration ratio < 5%, CONS-FRAG artifact → purgeable), `title_leak` (both iTunes, exact-layer, no hard signal, CONS-17 artifact → purgeable), `unknown` (pre-T015 / unclassifiable → manual review). No candidates are deleted by this op. The purge wave (PH-2b) is a separate PR gated on the user reviewing the reported breakdown. 10 unit tests cover all classification branches.
 
 #### June 24, 2026 — AP-5: no-tag sequential grouping (PR #1618)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.40.0 -->
+<!-- version: 9.41.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-06-24 -->
 
@@ -42,11 +42,12 @@ cancel tail) — re-enqueue pending. Tag-backfill 98% complete (308K/314K), re-e
 > Session handoff: `.remember/remember.md`.
 
 - [x] **PH-1** ✅ Tag-backfill completed 314,893/314,893 (op `01KVQVAZK0TH0FRFPNMMBYJKJQ`, 2026-06-22). Lossless-library goal done.
-- [ ] **PH-2 (P2)** Differentiated residual-triage op — the 10,859 exact-pending are 4
-      populations (genuine dups KEEP / fragment-vs-full / title-leak-false / byte-empty stubs).
-      Purge only the junk; never blanket-purge. Own dry-run + advisor gate. Audit §3.
+- [ ] **PH-2 (P2)** Differentiated residual-triage op (PR #1619 merged, deployed).
+      `maintenance.dedup-exact-triage` shipped: classifies all pending candidates into
+      genuine/stub/fragment/title_leak/unknown. **Next: enqueue on prod and review the
+      population breakdown. Purge wave (PH-2b) is a separate PR — never blanket-purge.**
 - [x] **PH-3 (P1/P2)** ✅ Dedup perf shipped in PR #1617: O(N²)→O(1) embedding map, hoisted book-only collectors, purge cap 100K→1M.
-- [ ] **PH-4** 5 prefix-not-in-parent flat-dump folders — decide v2 looser guard or leave.
+- [x] **PH-4** ✅ Decision: LEAVE the `strings.Contains(normTitle(parent), normTitle(prefix))` guard as-is. Weakening the string test risks silent mis-merges across tens of thousands of iTunes books for only 5 edge cases. These 5 folders can be fixed manually via AP-1 "Combine into one book". No code change needed.
 - [x] **PH-5** ✅ `UpsertBookFile` preserve-on-empty guard already added in PR #1587 (PERF-7). AcoustIDFingerprint, FingerprintFailureReason/Detail/DiagnosticJSON all preserved on nil/empty incoming fields.
 
 ---

--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/dedup_triage.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
 // last-edited: 2026-06-24
 
@@ -34,7 +34,9 @@ const (
 	// TriageClassFragment — duration ratio between the two books is < 5%, suggesting
 	// one is a single iTunes chapter (fragment) matched against the full book.
 	// These are CONS-FRAG artifacts that survived PurgeStaleCandidates because they
-	// live in different directories.
+	// live in different directories. Only classified as fragment when neither book
+	// shows a CONS-17 suspect duration (> maxPlausibleAudioSeconds with no
+	// DurationVerifiedAt stamp) — otherwise falls through to unknown.
 	TriageClassFragment TriageClass = "fragment"
 
 	// TriageClassTitleLeak — both books are iTunes imports, the candidate layer is
@@ -92,6 +94,11 @@ func IsPurgeable(cls TriageClass) bool { return purgeableClasses[cls] }
 // minPlausibleAudioBytes is copied from internal/dedup/engine.go to avoid an
 // import cycle. Files smaller than this with sub-5-second duration are stubs.
 const minPlausibleAudioBytes = 256 * 1024
+
+// maxPlausibleAudioSeconds is the upper bound for a sane audiobook duration.
+// Any unverified book exceeding this almost certainly has its duration stored
+// as milliseconds (CONS-17 iTunes-importer bug). 360 000 s = 100 hours.
+const maxPlausibleAudioSeconds = 360_000
 
 // ClassifyCandidate classifies a dedup candidate into one of the four triage
 // populations. It returns the class and a short human-readable reason string.
@@ -176,7 +183,23 @@ func hardSignalName(c database.DedupCandidate) string {
 	return ""
 }
 
+// isCons17Suspect returns true when a book's stored duration looks like it was
+// saved in milliseconds rather than seconds (CONS-17 iTunes-importer bug) and
+// the duration-reextract op has not yet corrected it.
+func isCons17Suspect(b *database.Book) bool {
+	return b.Duration != nil &&
+		*b.Duration > maxPlausibleAudioSeconds &&
+		b.DurationVerifiedAt == nil
+}
+
 func checkFragment(_ database.DedupCandidate, a, b *database.Book) (TriageClass, string, bool) {
+	// Guard: if either book looks like a CONS-17 ms-stored-as-seconds victim, the
+	// raw duration numbers are unreliable — skip fragment classification entirely
+	// and let the caller fall through to unknown.
+	if isCons17Suspect(a) || isCons17Suspect(b) {
+		return "", "", false
+	}
+
 	durA, durB := 0, 0
 	if a.Duration != nil {
 		durA = *a.Duration

--- a/internal/plugins/maintenance/dedup_triage_test.go
+++ b/internal/plugins/maintenance/dedup_triage_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/dedup_triage_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f9a0b1c-2d3e-4f50-a6b7-c8d9e0f12345
 // last-edited: 2026-06-24
 
@@ -100,6 +100,23 @@ func TestClassifyCandidate_Fragment_DurationRatio(t *testing.T) {
 	cls, reason := ClassifyCandidate(c, a, b)
 	if cls != TriageClassFragment {
 		t.Errorf("got %s (%s), want fragment", cls, reason)
+	}
+}
+
+func TestClassifyCandidate_Fragment_Cons17Suspect_NotFragment(t *testing.T) {
+	// CONS-17: one book has an astronomically large duration (stored as ms instead
+	// of seconds) with no DurationVerifiedAt. The ratio looks tiny (<5%) but the
+	// duration data is unreliable — must fall through to unknown, not fragment.
+	a := makeBook("a", 50*1024*1024, 31431, "")   // correct: ~8.7h
+	b := makeBook("b", 50*1024*1024, 31430435, "") // CONS-17: 31430435s = 364 days
+	c := database.DedupCandidate{Layer: "exact"}
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls == TriageClassFragment {
+		t.Errorf("CONS-17 suspect book must not be classified as fragment, got fragment (%s)", reason)
+	}
+	if cls != TriageClassUnknown {
+		t.Errorf("CONS-17 suspect book should fall to unknown, got %s (%s)", cls, reason)
 	}
 }
 


### PR DESCRIPTION
## Problem

`maintenance.dedup-exact-triage` (PR #1619) classifies candidates as `fragment` when the duration ratio between two books is < 5%. When that op ran on prod today (op `01KVXJBXYH016D32G29VNAWH7J`), it reported **418 purgeable fragments** — but inspection showed some are false positives.

Books affected by the CONS-17 iTunes-importer bug (duration stored as milliseconds instead of seconds) show impossibly large Duration values (e.g., `31,430,435s` = 364 days). The `duration-reextract` op has corrected most of these (it stamps `DurationVerifiedAt`), but **unfixed books remain** — either because their file paths changed post-regroup or are otherwise inaccessible to ffprobe.

**Example false positive:**
- Book A: `31,431s` (verified ✅) — Fortress of Shadows, 8.7 hours
- Book B: `31,430,435s` (unverified ❌) — same book, duration stored as ms = 8.7 hours
- Ratio: 0.1% → classified `fragment` → **would have been deleted**

These are genuine duplicate pairs, not CONS-FRAG chapter artifacts.

## Fix

`isCons17Suspect(b *database.Book) bool`: returns true when `Duration > 360_000s` (100h ceiling — no real audiobook exceeds this) **AND** `DurationVerifiedAt == nil`. `checkFragment` bails out immediately if either book is a CONS-17 suspect, letting the candidate fall to `TriageClassUnknown` for manual review instead of `TriageClassFragment` for auto-purge.

## Impact on the 418 fragments

Re-running the triage op after this fix will produce a lower fragment count (the genuine duplicates with corrupt durations will move to `unknown`), and a cleaner fragment set that is genuinely safe to purge.

## Test

`TestClassifyCandidate_Fragment_Cons17Suspect_NotFragment` — verifies that a pair where one book has `31,430,435s` (no `DurationVerifiedAt`) is classified `unknown`, not `fragment`.

## Test plan
- [x] `go test ./internal/plugins/maintenance/... -run TestClassify` — 11/11 pass
- [x] Full maintenance suite passes
- [ ] Re-run `maintenance.dedup-exact-triage` on prod after deploy and compare new fragment count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v