### PR TITLE
fix(dedup): remove fragment from purgeable triage classes

### DIFF
--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/dedup_triage.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
 // last-edited: 2026-06-24
 
@@ -82,9 +82,11 @@ type TriageReport struct {
 }
 
 // purgeableClasses are the populations safe to delete without human review.
+// TriageClassFragment is intentionally excluded: duration-data quality issues
+// (CONS-17 books with unverified ms-stored durations) mean fragment candidates
+// require manual review before any purge is authorised.
 var purgeableClasses = map[TriageClass]bool{
 	TriageClassStub:      true,
-	TriageClassFragment:  true,
 	TriageClassTitleLeak: true,
 }
 

--- a/internal/plugins/maintenance/dedup_triage_test.go
+++ b/internal/plugins/maintenance/dedup_triage_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/dedup_triage_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8f9a0b1c-2d3e-4f50-a6b7-c8d9e0f12345
 // last-edited: 2026-06-24
 
@@ -167,8 +167,8 @@ func TestClassifyCandidate_MissingBook(t *testing.T) {
 }
 
 func TestIsPurgeable(t *testing.T) {
-	purge := []TriageClass{TriageClassStub, TriageClassFragment, TriageClassTitleLeak}
-	keep := []TriageClass{TriageClassGenuine, TriageClassUnknown}
+	purge := []TriageClass{TriageClassStub, TriageClassTitleLeak}
+	keep := []TriageClass{TriageClassGenuine, TriageClassFragment, TriageClassUnknown}
 
 	for _, cls := range purge {
 		if !IsPurgeable(cls) {


### PR DESCRIPTION
Fragment candidates need manual review before any purge. The CONS-17 ms-duration bug means the classifier cannot yet reliably tell a real CONS-FRAG chapter artifact from a genuine duplicate pair where one book has a corrupt (unverified) duration value.

`TriageClassFragment` removed from `purgeableClasses`. Fragments are now reported in the triage output for visibility but blocked from any auto-purge path. The fragment purge wave will be a separate explicitly-gated step, deferred until CONS-17 books are fully corrected.

`TestIsPurgeable` updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0195svPHWE64Wbu7U6qCxT6v