### PR TITLE
fix(ops): RunItems ProgressOffset/ProgressTotal for sub-slice progress

### DIFF
--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-06-24
+// last-edited: 2026-06-25
 
 package registry
 
@@ -54,6 +54,17 @@ type RunItemsOptions struct {
 	// would race on the shared state blob. Use OpFreshness.Stamp instead for
 	// concurrent per-item checkpointing.
 	CheckpointFn func(ctx context.Context) error
+
+	// ProgressOffset shifts UpdateProgress current values by this amount.
+	// Use when iterating a sub-slice of a larger set so the progress bar
+	// shows position within the full set rather than within the slice.
+	// Example: startIdx=1000, total=5000 → item 0 reports 1001/5000.
+	ProgressOffset int
+
+	// ProgressTotal overrides the denominator passed to UpdateProgress.
+	// Defaults to len(items) when zero. Set to the full collection size
+	// when iterating a sub-slice (pairs with ProgressOffset).
+	ProgressTotal int
 }
 
 // RunItems fans out fn over items, managing:
@@ -80,9 +91,14 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 		return nil
 	}
 
+	progTotal := total
+	if opt.ProgressTotal > 0 {
+		progTotal = opt.ProgressTotal
+	}
+
 	lbl := opt.Label
 	if lbl == nil {
-		lbl = func(i, total int) string { return fmt.Sprintf("item %d/%d", i+1, total) }
+		lbl = func(i, total int) string { return fmt.Sprintf("item %d/%d", opt.ProgressOffset+i+1, total) }
 	}
 
 	runOne := func(ctx context.Context, i int, item T) error {
@@ -92,10 +108,10 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 			itemCtx, cancel = context.WithTimeout(ctx, opt.PerItemTimeout)
 			defer cancel()
 		}
-		l := lbl(i, total)
+		l := lbl(i, progTotal)
 		r.SetCurrentItem(l)
 		err := fn(itemCtx, item)
-		_ = r.UpdateProgress(i+1, total, l)
+		_ = r.UpdateProgress(opt.ProgressOffset+i+1, progTotal, l)
 		return err
 	}
 

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-06-24
+// last-edited: 2026-06-25
 
 package acoustid
 
@@ -145,9 +145,11 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 		lastID = b.ID
 		return nil
 	}, registry.RunItemsOptions{
+		ProgressOffset: startIdx,
+		ProgressTotal:  total,
 		Label: func(i, t int) string {
 			return fmt.Sprintf("Books %d/%d (fp=%d skip=%d fail=%d)",
-				startIdx+i+1, total, fingerprinted, skipped, failed)
+				i+1, t, fingerprinted, skipped, failed)
 		},
 		CheckpointFn: func(ctx context.Context) error {
 			cp := BackfillParams{LastProcessedBookID: lastID}


### PR DESCRIPTION
## Summary

- Adds `ProgressOffset` and `ProgressTotal` to `RunItemsOptions`
- `UpdateProgress` now reports `offset+i+1` out of `ProgressTotal` (falls back to `len(items)` when zero)
- Default label also incorporates the offset, so callers without a custom `Label` func get correct numbers too
- `acoustid/backfill` passes `startIdx` / full book count — progress bar now shows e.g. 22,000/48,774 on a resumed run instead of 1/26,774

## Test plan
- [ ] `go test ./internal/operations/registry/... ./internal/plugins/acoustid/...` passes
- [ ] On prod: trigger backfill, watch `progress_current`/`progress_total` on the op row reflect absolute book position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HohsNFFnhKGDDmksubXH43