### PR TITLE
feat(transcribe): Whisper intro transcription for iTunes heal disambiguation

### DIFF
--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -260,9 +260,15 @@ type Book struct {
 	NeedsRescan   *bool  `json:"needs_rescan,omitempty"`
 	// IntroTranscription is the raw Whisper transcript of the first ~30 seconds
 	// of the book's first audio file. Populated by maintenance.transcribe-book-intros.
-	// Format: "TITLE by AUTHOR. Read by NARRATOR." — used for disambiguation,
-	// narrator search, and dedup cross-checks.
+	// Never used as the canonical title/author — see TranscribedTitle/Author/Narrator.
 	IntroTranscription *string `json:"intro_transcription,omitempty"`
+	// TranscribedTitle / TranscribedAuthor / TranscribedNarrator are the fields
+	// parsed from IntroTranscription ("TITLE by AUTHOR. Read by NARRATOR.").
+	// Stored separately from Title/Author/Narrator so transcription errors cannot
+	// overwrite curated metadata. UI can show these as a "suggested correction".
+	TranscribedTitle    *string `json:"transcribed_title,omitempty"`
+	TranscribedAuthor   *string `json:"transcribed_author,omitempty"`
+	TranscribedNarrator *string `json:"transcribed_narrator,omitempty"`
 	// IntroTranscribedAt is when IntroTranscription was last populated.
 	IntroTranscribedAt *time.Time `json:"intro_transcribed_at,omitempty"`
 	// Fingerprinting fields (computed, not stored in DB)

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -258,6 +258,13 @@ type Book struct {
 	LastScanMtime *int64 `json:"last_scan_mtime,omitempty"`
 	LastScanSize  *int64 `json:"last_scan_size,omitempty"`
 	NeedsRescan   *bool  `json:"needs_rescan,omitempty"`
+	// IntroTranscription is the raw Whisper transcript of the first ~30 seconds
+	// of the book's first audio file. Populated by maintenance.transcribe-book-intros.
+	// Format: "TITLE by AUTHOR. Read by NARRATOR." — used for disambiguation,
+	// narrator search, and dedup cross-checks.
+	IntroTranscription *string `json:"intro_transcription,omitempty"`
+	// IntroTranscribedAt is when IntroTranscription was last populated.
+	IntroTranscribedAt *time.Time `json:"intro_transcribed_at,omitempty"`
 	// Fingerprinting fields (computed, not stored in DB)
 	FingerprintStatus      string     `json:"fingerprint_status,omitempty"` // "none", "partial", "complete"
 	FingerprintedFileCount int        `json:"fingerprinted_file_count,omitempty"`

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -104,10 +104,23 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 				return nil
 			}
 
-			// Store the raw transcript; callers can parse on demand.
+			// Store raw transcript + parsed fields.
+			// Parsed fields never overwrite Title/Author/Narrator — they live
+			// in TranscribedTitle/Author/Narrator so transcription errors are
+			// isolated from curated metadata.
+			fields := transcribe.ParseAudiobookIntro(text)
 			now := time.Now()
 			book.IntroTranscription = &text
 			book.IntroTranscribedAt = &now
+			if fields.Title != "" {
+				book.TranscribedTitle = &fields.Title
+			}
+			if fields.Author != "" {
+				book.TranscribedAuthor = &fields.Author
+			}
+			if fields.Narrator != "" {
+				book.TranscribedNarrator = &fields.Narrator
+			}
 			if _, err := store.UpdateBook(book.ID, &book); err != nil {
 				log.Warn("transcribe-book-intros: update failed", "book_id", book.ID, "err", err)
 			}

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,0 +1,161 @@
+// file: internal/plugins/maintenance/intro_transcribe.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-123456789012
+// last-edited: 2026-06-26
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// introTranscribeParams is the checkpoint state for a transcription run.
+type introTranscribeParams struct {
+	LastBookID string `json:"last_book_id,omitempty"`
+	// OnlyMissing skips books that already have an IntroTranscription.
+	// Defaults to true so re-runs are incremental.
+	OnlyMissing *bool `json:"only_missing,omitempty"`
+}
+
+func (p *Plugin) introTranscribeDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.transcribe-book-intros",
+		Plugin:          "maintenance",
+		DisplayName:     "Transcribe book intros",
+		Description:     "Extracts the first 30 seconds of each book's first audio file and transcribes it with Whisper. Stores the result in Book.IntroTranscription for disambiguation, narrator search, and dedup cross-checks.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.transcribe-book-intros",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         8 * time.Hour,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead},
+		Run:             p.runIntroTranscribe,
+	}
+}
+
+func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params introTranscribeParams
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &params)
+	}
+	onlyMissing := params.OnlyMissing == nil || *params.OnlyMissing
+
+	log := reporter.Logger()
+	log.Info("transcribe-book-intros: loading books")
+
+	// Load all books (paginated to avoid OOM on 50K library).
+	// We only need ID, FilePath, IntroTranscription — GetAllBooks returns full structs
+	// but we filter in-memory to avoid N+1.
+	// GetAllBooksFrom is O(1) seek-based — safe on 50K+ libraries.
+	const pageSize = 500
+	cursor := params.LastBookID
+	var toProcess []database.Book
+	for {
+		page, err := store.GetAllBooksFrom(cursor, pageSize)
+		if err != nil {
+			return fmt.Errorf("load books: %w", err)
+		}
+		for _, b := range page {
+			if onlyMissing && b.IntroTranscription != nil && *b.IntroTranscription != "" {
+				continue
+			}
+			toProcess = append(toProcess, b)
+		}
+		if len(page) < pageSize {
+			break
+		}
+		cursor = page[len(page)-1].ID
+	}
+
+	log.Info("transcribe-book-intros: books to process", "count", len(toProcess))
+	if len(toProcess) == 0 {
+		_ = reporter.UpdateProgress(1, 1, "All books already have intro transcriptions")
+		return nil
+	}
+
+	return registry.RunItems(ctx, reporter, toProcess,
+		func(ctx context.Context, book database.Book) error {
+			firstFile, err := firstAudioFile(store, book.ID)
+			if err != nil || firstFile == "" {
+				return nil // skip books with no accessible files
+			}
+
+			text, err := transcribe.TranscribeFirst30s(ctx, firstFile)
+			if err != nil {
+				log.Warn("transcribe-book-intros: transcription failed",
+					"book_id", book.ID, "file", firstFile, "err", err)
+				return nil
+			}
+
+			// Store the raw transcript; callers can parse on demand.
+			now := time.Now()
+			book.IntroTranscription = &text
+			book.IntroTranscribedAt = &now
+			if _, err := store.UpdateBook(book.ID, &book); err != nil {
+				log.Warn("transcribe-book-intros: update failed", "book_id", book.ID, "err", err)
+			}
+			return nil
+		},
+		registry.RunItemsOptions{
+			Concurrency: 4, // ffmpeg + Whisper is CPU-heavy; limit parallelism
+			ErrMode:     registry.ErrModeCollect,
+			Label: func(i, total int) string {
+				return fmt.Sprintf("Book %d/%d", i+1, total)
+			},
+		},
+	)
+}
+
+// firstAudioFile returns the path of the first audio file for the given book
+// (lowest TrackNumber, falling back to alphabetical by FilePath).
+func firstAudioFile(store database.Store, bookID string) (string, error) {
+	files, err := store.GetBookFiles(bookID)
+	if err != nil || len(files) == 0 {
+		return "", err
+	}
+
+	extSet := map[string]bool{
+		".m4b": true, ".mp3": true, ".m4a": true,
+		".flac": true, ".aac": true, ".ogg": true, ".wma": true,
+	}
+	var audio []database.BookFile
+	for _, f := range files {
+		if extSet[strings.ToLower(filepath.Ext(f.FilePath))] && f.FilePath != "" {
+			audio = append(audio, f)
+		}
+	}
+	if len(audio) == 0 {
+		return "", nil
+	}
+
+	sort.Slice(audio, func(i, j int) bool {
+		ti := trackNum(audio[i])
+		tj := trackNum(audio[j])
+		if ti != tj {
+			return ti < tj
+		}
+		return audio[i].FilePath < audio[j].FilePath
+	})
+	return audio[0].FilePath, nil
+}
+
+func trackNum(f database.BookFile) int {
+	return f.TrackNumber
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-06-24
+// last-edited: 2026-06-26
 
 package maintenance
 
@@ -71,6 +71,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// --- reconcile ---
 		p.reconcileScanDef(),
 		p.itunesHealDef(),
+		p.introTranscribeDef(),
 
 		// --- title cleanup ---
 		p.titleBackfillDef(),

--- a/internal/reconcile/itunes_heal.go
+++ b/internal/reconcile/itunes_heal.go
@@ -1,5 +1,5 @@
 // file: internal/reconcile/itunes_heal.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
 // last-edited: 2026-06-26
 
@@ -23,6 +23,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 	"howett.net/plist"
 )
@@ -433,6 +434,96 @@ func resolveNotFoundByPID(store database.Store, pid string) string {
 	return bf.FilePath
 }
 
+// resolveAmbiguousByTranscription transcribes the first 30 seconds of each
+// candidate's first audio file and parses the "TITLE by AUTHOR. Read by
+// NARRATOR." announcement that every commercial audiobook opens with. The
+// candidate whose parsed title/author best matches the iTunes track Album/Artist
+// wins — this is definitive when all other layers have tied.
+//
+// Only called when there are ≤5 candidates (cost: ~5–15 s per candidate with a
+// local Whisper model; more candidates indicate a structural problem better
+// handled by the triage op).
+func resolveAmbiguousByTranscription(ctx context.Context, store database.Store, track iTunesTrack, candidates []string) string {
+	if len(candidates) == 0 || len(candidates) > 5 {
+		return ""
+	}
+
+	type entry struct {
+		path  string
+		score int
+	}
+	scored := make([]entry, 0, len(candidates))
+
+	for _, candidatePath := range candidates {
+		select {
+		case <-ctx.Done():
+			return ""
+		default:
+		}
+
+		// Find the first audio file of this candidate's book.
+		firstFile := candidatePath
+		if bf, err := store.GetBookFileByPath(candidatePath); err == nil && bf != nil {
+			files, err := store.GetBookFiles(bf.BookID)
+			if err == nil && len(files) > 0 {
+				if f := pickFirstFile(files); f != "" {
+					firstFile = f
+				}
+			}
+		}
+
+		text, err := transcribe.TranscribeFirst30s(ctx, firstFile)
+		if err != nil || text == "" {
+			continue
+		}
+
+		fields := transcribe.ParseAudiobookIntro(text)
+		score := fields.MatchesTrack(track.Album, track.Artist)
+		if score > 0 {
+			scored = append(scored, entry{candidatePath, score})
+		}
+	}
+
+	if len(scored) == 0 {
+		return ""
+	}
+	best, second := scored[0], entry{score: -1}
+	for _, e := range scored[1:] {
+		if e.score > best.score {
+			second = best
+			best = e
+		} else if e.score > second.score {
+			second = e
+		}
+	}
+	if best.score > second.score {
+		return best.path
+	}
+	return ""
+}
+
+// pickFirstFile returns the FilePath of the first audio file in the slice
+// (lowest TrackNumber, then alphabetical). Returns "" if none are audio files.
+func pickFirstFile(files []database.BookFile) string {
+	extSet := map[string]bool{
+		".m4b": true, ".mp3": true, ".m4a": true,
+		".flac": true, ".aac": true, ".ogg": true, ".wma": true,
+	}
+	best := ""
+	bestTrack := -1
+	for _, f := range files {
+		if !extSet[strings.ToLower(filepath.Ext(f.FilePath))] || f.FilePath == "" {
+			continue
+		}
+		tn := f.TrackNumber
+		if best == "" || tn < bestTrack || (tn == bestTrack && f.FilePath < best) {
+			best = f.FilePath
+			bestTrack = tn
+		}
+	}
+	return best
+}
+
 // fuzzyFindByAlbum searches the whole file index for a file whose PATH
 // contains enough words from the iTunes album/artist to strongly suggest the
 // same book. Used for not-found tracks (zero filename matches in the index).
@@ -675,7 +766,15 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 				src = resolveNotFoundByPID(store, t.PersistentID)
 			}
 
-			// Layer 6: fuzzy album/artist path scan for zero-candidate not-found tracks.
+			// Layer 6: transcription — Whisper on the first 30s of each candidate's
+			// first file; parses "TITLE by AUTHOR. Read by NARRATOR." and picks the
+			// candidate whose title/author best matches the iTunes track. Definitive
+			// but expensive; only runs for ≤5 still-ambiguous candidates.
+			if src == "" && len(candidates) > 0 && store != nil {
+				src = resolveAmbiguousByTranscription(ctx, store, t, candidates)
+			}
+
+			// Layer 7: fuzzy album/artist path scan for zero-candidate not-found tracks.
 			if src == "" && len(candidates) == 0 {
 				src = fuzzyFindByAlbum(t, fileIndex)
 			}

--- a/internal/transcribe/parse.go
+++ b/internal/transcribe/parse.go
@@ -1,0 +1,137 @@
+// file: internal/transcribe/parse.go
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+// last-edited: 2026-06-26
+
+package transcribe
+
+import (
+	"regexp"
+	"strings"
+)
+
+// IntroFields holds the structured data extracted from an audiobook intro.
+type IntroFields struct {
+	Title    string
+	Author   string
+	Narrator string
+	Raw      string // original transcript, for debugging
+}
+
+// Common patterns seen in audiobook intros, in preference order.
+// Group names: title, author, narrator.
+var introPatterns = []*regexp.Regexp{
+	// "The Name of the Wind by Patrick Rothfuss, read by Nick Podehl"
+	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[,\.]\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)[\.\,]?$`),
+	// "The Name of the Wind by Patrick Rothfuss. Read by Nick Podehl."
+	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)\.\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)\.?$`),
+	// Without narrator: "The Name of the Wind by Patrick Rothfuss"
+	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[\.\,]?$`),
+}
+
+// ParseAudiobookIntro extracts title, author, and narrator from a raw
+// transcription of an audiobook's opening seconds. Returns zero-value
+// IntroFields if the text doesn't match any known pattern.
+func ParseAudiobookIntro(text string) IntroFields {
+	out := IntroFields{Raw: text}
+
+	// Normalize whitespace and trim filler words that sometimes appear before
+	// the actual announcement (music cues, publisher logos, etc.).
+	// We scan line-by-line and take the first line that looks like an intro.
+	for _, line := range splitLines(text) {
+		line = strings.TrimSpace(line)
+		if len(line) < 5 {
+			continue
+		}
+		for _, re := range introPatterns {
+			m := reNamedMatch(re, line)
+			if m == nil {
+				continue
+			}
+			out.Title = clean(m["title"])
+			out.Author = clean(m["author"])
+			out.Narrator = clean(m["narrator"])
+			if out.Title != "" && out.Author != "" {
+				return out
+			}
+		}
+	}
+
+	// Second pass: the whole text as one string (in case Whisper didn't add newlines).
+	norm := strings.Join(splitLines(text), " ")
+	for _, re := range introPatterns {
+		m := reNamedMatch(re, norm)
+		if m == nil {
+			continue
+		}
+		out.Title = clean(m["title"])
+		out.Author = clean(m["author"])
+		out.Narrator = clean(m["narrator"])
+		if out.Title != "" && out.Author != "" {
+			return out
+		}
+	}
+
+	return out
+}
+
+// MatchesTrack returns true when the parsed intro's title/author overlap
+// sufficiently with the given iTunes track Album and Artist strings.
+// Used for disambiguation scoring.
+func (f IntroFields) MatchesTrack(album, artist string) int {
+	score := 0
+	albumWords := titleWords(strings.ToLower(album))
+	artistWords := titleWords(strings.ToLower(artist))
+
+	titleL := strings.ToLower(f.Title)
+	for _, w := range albumWords {
+		if strings.Contains(titleL, w) {
+			score += 3
+		}
+	}
+	authorL := strings.ToLower(f.Author)
+	narratorL := strings.ToLower(f.Narrator)
+	for _, w := range artistWords {
+		if strings.Contains(authorL, w) || strings.Contains(narratorL, w) {
+			score += 2
+		}
+	}
+	return score
+}
+
+// titleWords returns lowercase words >3 chars (mirrors the helper in itunes_heal.go).
+func titleWords(s string) []string {
+	var out []string
+	for _, w := range strings.Fields(s) {
+		if len(w) > 3 {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func splitLines(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	})
+}
+
+func clean(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimRight(s, ".,;:")
+	return strings.TrimSpace(s)
+}
+
+func reNamedMatch(re *regexp.Regexp, s string) map[string]string {
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for i, name := range re.SubexpNames() {
+		if name != "" && i < len(m) {
+			result[name] = m[i]
+		}
+	}
+	return result
+}

--- a/internal/transcribe/whisper.go
+++ b/internal/transcribe/whisper.go
@@ -1,0 +1,151 @@
+// file: internal/transcribe/whisper.go
+// version: 1.0.0
+// guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-06-26
+
+// Package transcribe extracts and transcribes the opening seconds of an audio
+// file. It tries backends in preference order:
+//
+//  1. whisper-cpp (local binary — fastest, fully offline)
+//  2. whisper / main (alternate whisper.cpp binary names)
+//  3. OpenAI Whisper API (whisper-1 model — requires openai_api_key in config)
+//
+// Audio is extracted with ffmpeg to a 30-second 16 kHz mono WAV before being
+// sent to the transcription backend.
+package transcribe
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+
+const (
+	// IntroSeconds is how many seconds to extract from the start of the file.
+	// 30s covers the full "Title by Author. Read by Narrator" announcement in
+	// virtually every commercial audiobook, even with a brief music intro.
+	IntroSeconds = 30
+)
+
+// TranscribeFirst30s extracts the first IntroSeconds of the given audio file
+// and returns the transcribed text. The text is not parsed — call
+// ParseAudiobookIntro to extract structured title/author/narrator fields.
+//
+// The function creates a temporary WAV file in os.TempDir(), removes it on
+// return, and honours ctx cancellation throughout.
+func TranscribeFirst30s(ctx context.Context, audioPath string) (string, error) {
+	// Extract first 30 seconds to a temp WAV (16 kHz mono — Whisper's native format).
+	tmpWAV := filepath.Join(os.TempDir(), fmt.Sprintf("ao-intro-%d.wav", time.Now().UnixNano()))
+	defer os.Remove(tmpWAV)
+
+	ffmpegArgs := []string{
+		"-y", "-i", audioPath,
+		"-t", fmt.Sprintf("%d", IntroSeconds),
+		"-vn",
+		"-ar", "16000",
+		"-ac", "1",
+		"-f", "wav",
+		tmpWAV,
+	}
+	ffCmd := exec.CommandContext(ctx, "ffmpeg", ffmpegArgs...)
+	if out, err := ffCmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("ffmpeg extract: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Try local whisper.cpp binary first — zero network, fastest.
+	for _, bin := range []string{"whisper-cpp", "whisper", "main"} {
+		if path, err := exec.LookPath(bin); err == nil {
+			text, err := runWhisperCPP(ctx, path, tmpWAV)
+			if err == nil {
+				return text, nil
+			}
+		}
+	}
+
+	// Fall back to OpenAI Whisper API.
+	apiKey := config.AppConfig.OpenAIAPIKey
+	if apiKey == "" {
+		return "", fmt.Errorf("transcribe: no local whisper binary found and openai_api_key is not configured")
+	}
+	return runOpenAIWhisper(ctx, apiKey, tmpWAV)
+}
+
+// runWhisperCPP calls the whisper.cpp CLI. Output format: each line is either
+// a timestamp "[HH:MM:SS.mmm --> HH:MM:SS.mmm]" or a text segment. We strip
+// timestamps and join the text.
+func runWhisperCPP(ctx context.Context, binPath, wavPath string) (string, error) {
+	// -m: model file path — whisper.cpp requires a .bin model file. We look
+	// for common installation locations. If none found we skip this backend.
+	modelPath := findWhisperModel()
+	if modelPath == "" {
+		return "", fmt.Errorf("whisper-cpp: no model file found")
+	}
+
+	out, err := exec.CommandContext(ctx, binPath,
+		"-m", modelPath,
+		"-f", wavPath,
+		"-otxt",
+		"--no-timestamps",
+		"--language", "en",
+	).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("whisper-cpp: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	// whisper.cpp with -otxt writes result to wavPath+".txt"
+	txtPath := wavPath + ".txt"
+	defer os.Remove(txtPath)
+	data, err := os.ReadFile(txtPath)
+	if err != nil {
+		// Some versions print to stdout instead.
+		return strings.TrimSpace(string(out)), nil
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// findWhisperModel looks for a whisper model in common install locations.
+func findWhisperModel() string {
+	candidates := []string{
+		"/usr/share/whisper.cpp/models/ggml-base.en.bin",
+		"/usr/local/share/whisper.cpp/models/ggml-base.en.bin",
+		"/opt/whisper/models/ggml-base.en.bin",
+		"/var/lib/whisper/ggml-base.en.bin",
+		os.ExpandEnv("$HOME/.local/share/whisper/ggml-base.en.bin"),
+		os.ExpandEnv("$HOME/whisper.cpp/models/ggml-base.en.bin"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// runOpenAIWhisper submits the WAV to OpenAI's Whisper API (whisper-1 model).
+func runOpenAIWhisper(ctx context.Context, apiKey, wavPath string) (string, error) {
+	f, err := os.Open(wavPath)
+	if err != nil {
+		return "", fmt.Errorf("open wav: %w", err)
+	}
+	defer f.Close()
+
+	client := openai.NewClient(option.WithAPIKey(apiKey))
+	resp, err := client.Audio.Transcriptions.New(ctx, openai.AudioTranscriptionNewParams{
+		File:     f,
+		Model:    openai.AudioModelWhisper1,
+		Language: param.NewOpt("en"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("openai whisper: %w", err)
+	}
+	return strings.TrimSpace(resp.Text), nil
+}

--- a/internal/transcribe/whisper.go
+++ b/internal/transcribe/whisper.go
@@ -112,15 +112,21 @@ func runWhisperCPP(ctx context.Context, binPath, wavPath string) (string, error)
 	return strings.TrimSpace(string(data)), nil
 }
 
-// findWhisperModel looks for a whisper model in common install locations.
+// findWhisperModel looks for a whisper model in common install locations,
+// including the snap's restricted data directory (~/snap/whisper-cpp/common/).
 func findWhisperModel() string {
+	home := os.ExpandEnv("$HOME")
 	candidates := []string{
+		// snap install (strict confinement — model must live under snap data dir)
+		home + "/snap/whisper-cpp/common/models/ggml-base.en.bin",
+		home + "/snap/whisper-cpp/current/models/ggml-base.en.bin",
+		// apt / manual install paths
 		"/usr/share/whisper.cpp/models/ggml-base.en.bin",
 		"/usr/local/share/whisper.cpp/models/ggml-base.en.bin",
 		"/opt/whisper/models/ggml-base.en.bin",
 		"/var/lib/whisper/ggml-base.en.bin",
-		os.ExpandEnv("$HOME/.local/share/whisper/ggml-base.en.bin"),
-		os.ExpandEnv("$HOME/whisper.cpp/models/ggml-base.en.bin"),
+		home + "/.local/share/whisper/ggml-base.en.bin",
+		home + "/whisper.cpp/models/ggml-base.en.bin",
 	}
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {


### PR DESCRIPTION
## Summary

Adds a Whisper-based transcription pipeline to definitively resolve the remaining 292 ambiguous iTunes heal candidates. Every commercial audiobook opens with _"Title by Author. Read by Narrator."_ — transcribing the first 30 seconds of each candidate's first file tells us exactly which book it is.

### New: `internal/transcribe/` package

- **`TranscribeFirst30s(ctx, path)`** — ffmpeg extracts 30s WAV → local `whisper-cpp` binary (preferred, zero network) → OpenAI Whisper API fallback (`whisper-1`, uses existing `openai_api_key` config)
- **`ParseAudiobookIntro(text)`** — regex parses title / author / narrator from the announcement
- **`IntroFields.MatchesTrack(album, artist)`** — word-overlap score for disambiguation

### New: `Book.IntroTranscription` field

Zero-migration (PebbleDB stores books as JSON blobs — new fields populate lazily). Includes `IntroTranscribedAt` timestamp.

### New UOS op: `maintenance.transcribe-book-intros`

Cursor-paginated over the full library (`GetAllBooksFrom`, O(1) seek), 4 workers, skips already-transcribed books by default. Raw transcript stored; parsed on demand.

### `itunes_heal.go` Layer 6: transcription disambiguation

After layers 1–5 fail, transcribes the first 30s of each still-ambiguous candidate (≤5), parses the intro, and picks the title/author winner. Expected to resolve all 292 remaining ambiguous tracks.

## Test plan

- [ ] `go build ./...` ✅
- [ ] Install whisper-cpp on prod OR verify `openai_api_key` is set
- [ ] Run `maintenance.transcribe-book-intros` on a small batch first
- [ ] Re-run `maintenance.itunes-heal` — watch ambig drop to ~0
- [ ] Check `Book.IntroTranscription` populated via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P