### PR TITLE
fix(transcribe): force --device cpu for GTX 1050 Ti compatibility

### DIFF
--- a/internal/transcribe/whisper.go
+++ b/internal/transcribe/whisper.go
@@ -85,6 +85,7 @@ func runPythonWhisper(ctx context.Context, wavPath string) (string, error) {
 		"--output_dir", outDir,
 		"--language", "en",
 		"--task", "transcribe",
+		"--device", "cpu", // GPU compatibility varies; CPU is universal and plenty fast for 30s clips
 	).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("python whisper: %w (%s)", err, strings.TrimSpace(string(out)))


### PR DESCRIPTION
Server's GTX 1050 Ti is CUDA CC 6.1; the PyTorch bundled with openai-whisper requires CC ≥ 7.5 and crashes on CUDA init. Adding `--device cpu` makes it universal and still fast for 30-second clips.

Tested on prod: full pipeline (ffmpeg → whisper) transcribed "Wish I Was Here by Jackie Kay, narrated by Anna Bentink..." correctly in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P