### PR TITLE
fix(transcribe): find uv at /home/jdfalk/uv (world-executable copy)

### DIFF
--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/batch.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 // last-edited: 2026-06-26
 
@@ -123,8 +123,11 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string) (map[string]Ba
 // typically drop. We prefer a non-snap install (e.g. installed via the
 // official uv installer to ~/.local/bin/uv) over the snap at /snap/bin/uv.
 func resolveUVBin() string {
+	// /home/jdfalk/.local has 700 perms — world-inaccessible to the audiobook
+	// service user. /home/jdfalk/uv is a copy with 755, world-executable.
+	// /usr/local/bin/uv would be ideal (requires root to install there).
 	candidates := []string{
-		"/home/jdfalk/.local/bin/uv",
+		"/home/jdfalk/uv",
 		"/usr/local/bin/uv",
 		"/opt/uv/bin/uv",
 	}


### PR DESCRIPTION
## Root cause

`/home/jdfalk/.local` has mode `700`, so the `audiobook` service user cannot traverse into it. `resolveUVBin()` was calling `os.Stat("/home/jdfalk/.local/bin/uv")` which returned `EACCES` → fell through to `exec.LookPath("uv")` → found `/snap/bin/uv` → snap-confine failure.

## Fix

- Copied `~/.local/bin/uv` to `/home/jdfalk/uv` with `chmod 755` (world-executable, done on server before this PR)
- `resolveUVBin()` now checks `/home/jdfalk/uv` first

## Long-term

Install uv to `/usr/local/bin/uv` (needs one-time `sudo cp /home/jdfalk/uv /usr/local/bin/uv`) — this PR unblocks tonight's bulk transcription run.

## Test plan

- [ ] After merge: `make deploy`, then check logs for `[batch_whisper] device=cuda`
- [ ] Verify first page completes without "page error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P