### PR TITLE
fix(transcribe): add setuptools for torch pkg_resources import

### DIFF
--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/batch.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 // last-edited: 2026-06-26
 
@@ -66,10 +66,13 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string) (map[string]Ba
 
 	// --python 3.11 is required: torch==2.0.1 has no wheels for python 3.12+.
 	// cu118 build supports CC 6.1 (GTX 1050 Ti); newer torch dropped sm_61.
+	// setuptools provides pkg_resources, which torch 2.0.x uses for version
+	// comparison. uv isolated envs don't include it by default.
 	cmd := exec.CommandContext(ctx, uvBin, "run",
 		"--python", "3.11",
 		"--with", "openai-whisper",
 		"--with", "torch==2.0.1+cu118",
+		"--with", "setuptools",
 		"python", scriptFile.Name(), "base.en", jobsFile.Name(),
 	)
 	// PyTorch wheel index for cu118 — supports CC 6.1 (Pascal) that newer


### PR DESCRIPTION
## Root cause

`torch==2.0.1` imports `pkg_resources` from `setuptools` in `torch_version.py` for version comparison. `uv` isolated environments don't include `setuptools` by default (Python 3.11+ removed it from stdlib), causing every batch Whisper call to fail at torch import time.

## Fix

Add `--with setuptools` to the `uv run` invocation.

## History

This is the third fix in the snap-uv debugging chain:
- PR #1633: `UV_CACHE_DIR` writable path + stderr capture
- PR #1634: non-snap uv binary via `resolveUVBin()`
- PR #1635: `resolveUVBin()` path `/home/jdfalk/uv` (`.local` is 700)
- **This PR**: `setuptools` for `pkg_resources`

## Test plan

- [ ] After merge + deploy: trigger `maintenance.transcribe-book-intros`
- [ ] Logs show `[batch_whisper] device=cuda model=base.en jobs=199`
- [ ] First page shows `Transcribed N/M books` (no page error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P