### PR TITLE
fix(transcribe): checkpoint cursor after each page for crash recovery

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-26
 
@@ -111,6 +111,12 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 			break // last page
 		}
 		cursor = page[len(page)-1].ID
+		// Persist cursor after each completed page so a server restart resumes
+		// from here rather than scanning from book 0.
+		_ = reporter.Checkpoint(introTranscribeParams{
+			LastBookID:  cursor,
+			OnlyMissing: &onlyMissing,
+		})
 	}
 
 	log.Info("transcribe-book-intros: complete", "processed", processed)


### PR DESCRIPTION
## Summary

- After each 200-book page completes, calls `reporter.Checkpoint(introTranscribeParams{LastBookID: cursor, OnlyMissing: &onlyMissing})`
- `resumeRestart` (already in the registry) merges the JSON blob into `rawParams` on server restart
- A resumed run picks up at the last completed page rather than scanning from book 0

## Safety model after this PR

| Tier | What | Recovery on crash |
|---|---|---|
| Per-book | `UpdateBook()` written immediately when page returns | Always preserved — skipped by `only_missing=true` |
| Per-page | Cursor checkpointed after each page | Resumed op starts from checkpoint, not book 0 |
| In-flight page | 200 books inside the Python batch | Re-processed on next run (idempotent) |

## Context

Identified while the first batch run was in progress (13 min/page, ~55 pages total). The uncheckpointed watchdog strikes in the log confirmed no checkpoint was being written. This fix lands while the run is in progress and will take effect on any future restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P