### PR TITLE
feat(transcribe): remote faster-whisper fallback via WHISPER_REMOTE_URL

### DIFF
--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/batch.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 // last-edited: 2026-06-26
 
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -25,17 +26,28 @@ type BatchResult struct {
 	Error string // non-empty means transcription failed for this item
 }
 
-// TranscribeBatch transcribes multiple WAV files in a single Python process,
-// loading the Whisper model only once. jobs maps an opaque key to a WAV path.
+// TranscribeBatch transcribes multiple WAV files. jobs maps an opaque key to a WAV path.
 //
-// Uses torch==2.0.1+cu118 so older NVIDIA cards (CC 6.1, e.g. GTX 1050 Ti)
-// get GPU acceleration; the Python script falls back to CPU automatically when
-// CUDA is absent or incompatible.
+// If WHISPER_REMOTE_URL is set (e.g. "http://192.168.1.x:8000"), jobs are sent
+// to the remote faster-whisper server running scripts/whisper_server.py. On any
+// failure the warning is logged and the function falls back to the local
+// uv/openai-whisper path.
 //
-// Requires uv on PATH.
+// Local path uses torch==2.0.1+cu118 for CC 6.1 GPU support (GTX 1050 Ti).
 func TranscribeBatch(ctx context.Context, jobs map[string]string) (map[string]BatchResult, error) {
 	if len(jobs) == 0 {
 		return nil, nil
+	}
+
+	if remoteURL := os.Getenv("WHISPER_REMOTE_URL"); remoteURL != "" {
+		results, err := transcribeRemote(ctx, remoteURL, jobs)
+		if err != nil {
+			slog.Warn("transcribe: remote whisper failed, falling back to local",
+				"url", remoteURL, "err", err)
+			// fall through to local uv path
+		} else {
+			return results, nil
+		}
 	}
 
 	// Write jobs JSON to temp file.

--- a/internal/transcribe/remote.go
+++ b/internal/transcribe/remote.go
@@ -1,0 +1,121 @@
+// file: internal/transcribe/remote.go
+// version: 1.0.0
+// guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
+// last-edited: 2026-06-26
+
+package transcribe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// remoteWorkers is the number of concurrent HTTP requests to the remote
+// whisper server. Two lets us pipeline network transfer with GPU compute
+// (one file uploading while the previous is being transcribed).
+const remoteWorkers = 2
+
+// transcribeRemote sends WAV jobs to a remote faster-whisper HTTP server.
+// If the server is unreachable or any request fails, returns an error so
+// the caller can fall back to local transcription.
+func transcribeRemote(ctx context.Context, remoteURL string, jobs map[string]string) (map[string]BatchResult, error) {
+	client := &http.Client{Timeout: 120 * time.Second}
+
+	type jobItem struct {
+		id      string
+		wavPath string
+	}
+	type resultItem struct {
+		id     string
+		result BatchResult
+		err    error
+	}
+
+	jobCh := make(chan jobItem, len(jobs))
+	for id, path := range jobs {
+		jobCh <- jobItem{id, path}
+	}
+	close(jobCh)
+
+	resultCh := make(chan resultItem, len(jobs))
+	var wg sync.WaitGroup
+	for range remoteWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobCh {
+				r, err := transcribeOneRemote(ctx, client, remoteURL, j.wavPath)
+				resultCh <- resultItem{id: j.id, result: r, err: err}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	results := make(map[string]BatchResult, len(jobs))
+	for item := range resultCh {
+		if item.err != nil {
+			return nil, fmt.Errorf("remote transcribe %s: %w", item.id, item.err)
+		}
+		results[item.id] = item.result
+	}
+	return results, nil
+}
+
+func transcribeOneRemote(ctx context.Context, client *http.Client, remoteURL, wavPath string) (BatchResult, error) {
+	f, err := os.Open(wavPath)
+	if err != nil {
+		return BatchResult{}, fmt.Errorf("open wav: %w", err)
+	}
+	defer f.Close()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	fw, err := mw.CreateFormFile("file", filepath.Base(wavPath))
+	if err != nil {
+		return BatchResult{}, err
+	}
+	if _, err := io.Copy(fw, f); err != nil {
+		return BatchResult{}, err
+	}
+	mw.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, remoteURL+"/transcribe", &body)
+	if err != nil {
+		return BatchResult{}, err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return BatchResult{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return BatchResult{}, fmt.Errorf("remote returned HTTP %d", resp.StatusCode)
+	}
+
+	var out struct {
+		Text  string  `json:"text"`
+		Error *string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return BatchResult{}, fmt.Errorf("decode response: %w", err)
+	}
+	if out.Error != nil && *out.Error != "" {
+		return BatchResult{Error: *out.Error}, nil
+	}
+	return BatchResult{Text: out.Text}, nil
+}

--- a/scripts/whisper_server.py
+++ b/scripts/whisper_server.py
@@ -1,0 +1,77 @@
+# file: scripts/whisper_server.py
+# version: 1.0.0
+# guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+# last-edited: 2026-06-26
+#
+# Remote Whisper transcription server for use with audiobook-organizer.
+# Run on a machine with a fast GPU to offload the bulk transcription op.
+#
+# Install:
+#   pip install faster-whisper fastapi "uvicorn[standard]"
+#
+# Run (defaults to base.en):
+#   python scripts/whisper_server.py [model]
+#   python scripts/whisper_server.py small.en
+#
+# Configure the Go service to use it:
+#   Add to deploy/local.conf:  Environment=WHISPER_REMOTE_URL=http://<this-machine-ip>:8000
+#   Then: make deploy
+#
+# Windows firewall: allow inbound TCP 8000 from your LAN subnet.
+
+import io
+import sys
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger("whisper_server")
+
+try:
+    import faster_whisper
+    from fastapi import FastAPI, File, UploadFile
+    from fastapi.responses import JSONResponse
+    import uvicorn
+except ImportError as e:
+    print(f"Missing dependency: {e}")
+    print("Install with: pip install faster-whisper fastapi \"uvicorn[standard]\"")
+    sys.exit(1)
+
+model_name = sys.argv[1] if len(sys.argv) > 1 else "base.en"
+log.info(f"Loading {model_name} (first run downloads ~150MB)...")
+
+model = faster_whisper.WhisperModel(
+    model_name,
+    device="cuda",
+    compute_type="float16",  # tensor cores on Turing+ (RTX series)
+)
+log.info(f"Ready — model={model_name} device=cuda compute=float16")
+
+app = FastAPI()
+
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    data = await file.read()
+    try:
+        segments, info = model.transcribe(
+            io.BytesIO(data),
+            language="en",
+            task="transcribe",
+            beam_size=5,
+            vad_filter=True,       # skip silent regions, speeds up short clips
+        )
+        text = " ".join(s.text for s in segments).strip()
+        log.info(f"transcribed {file.filename}: {len(text)} chars in {info.duration:.1f}s audio")
+        return {"text": text, "error": None}
+    except Exception as e:
+        log.error(f"transcription failed for {file.filename}: {e}")
+        return JSONResponse({"text": "", "error": str(e)}, status_code=200)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "model": model_name}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")


### PR DESCRIPTION
## Summary

Adds opt-in remote GPU transcription with automatic local fallback.

Set `WHISPER_REMOTE_URL=http://<windows-ip>:8000` in `deploy/local.conf` to use it. Unset = existing behavior, no change.

## How it works

```
Go op (Linux/1050 Ti)
  └── if WHISPER_REMOTE_URL set:
        POST WAV bytes ──LAN──► scripts/whisper_server.py (Windows/2060 Super)
        ← {"text": "...", "error": null}
      on ANY failure:
        log WARN + fall back to local uv/openai-whisper
```

- 2 concurrent HTTP workers pipeline upload with GPU compute
- Remote uses `faster-whisper` (CTranslate2, ~4× faster than openai-whisper) + `float16` on Turing tensor cores
- `vad_filter=True` skips silent regions — good for 30s intro clips
- `GET /health` endpoint for liveness checks

## Expected speedup (RTX 2060 Super vs GTX 1050 Ti)

| | Time/page (200 books) | Total (~55 pages) |
|---|---|---|
| Local 1050 Ti (current) | ~13 min | ~12 hr |
| Remote 2060 Super | ~2-3 min | ~2-2.5 hr |

## Setup on Windows

```powershell
pip install faster-whisper fastapi "uvicorn[standard]"
python scripts/whisper_server.py base.en
# Allow inbound TCP 8000 in Windows Firewall for LAN
```

Then in `deploy/local.conf` on the Linux server:
```ini
Environment=WHISPER_REMOTE_URL=http://192.168.x.x:8000
```

## Fallback behavior

If the Windows machine is off, unreachable, or returns an error on any job, a `WARN` is logged and the entire batch retries locally. No partial results are used from a failed remote call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P