### PR TITLE
fix(ops): re-add opv2:q: index key when transitioning running→queued

### DIFF
--- a/internal/database/pebble_store_ops_v2.go
+++ b/internal/database/pebble_store_ops_v2.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_ops_v2.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-06-24
 
@@ -221,9 +221,13 @@ func (p *PebbleStore) UpdateOperationV2Status(id, status string, startedAt, comp
 		return err
 	}
 
-	// Remove from queue index if it was queued.
-	if oldStatus == "queued" {
+	// Maintain queue index.
+	if oldStatus == "queued" && status != "queued" {
 		_ = p.db.Delete(opv2QueueKey(row.Priority, row.QueuedAt, id), pebble.Sync)
+	} else if status == "queued" && oldStatus != "queued" {
+		// resumeRestart transitions running→queued; must re-add the index entry
+		// or ListQueuedOperationsV2 never sees the op and it stalls forever.
+		_ = p.db.Set(opv2QueueKey(row.Priority, row.QueuedAt, id), []byte(id), pebble.Sync)
 	}
 	// Maintain active set.
 	if status == "running" {


### PR DESCRIPTION
## Root cause

`UpdateOperationV2Status` maintained the `opv2:q:` secondary index correctly in one direction (queued→running: delete key) but never wrote it back when going the other way (running→queued). 

`resumeRestart` calls this function on every service restart to re-queue in-flight ops. The op row got `status="queued"` but had no `opv2:q:` index entry — making it permanently invisible to `ListQueuedOperationsV2` (which scans that prefix). The dispatcher ticked every 100ms and never saw the op.

## Fix

One conditional added: when `status == "queued" && oldStatus != "queued"`, write the index key.

## Impact

Every op that was in-flight when the service was killed/restarted would stall forever in "queued" state after the restart. This was masked because short-lived ops (scheduler maintenance) finished before the next restart, but long-running ops like `maintenance.transcribe-book-intros` always stalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P