### PR TITLE
feat(ui): add Whisper Intro panel to book detail page

### DIFF
--- a/web/src/components/bookdetail/BookDetailInfoTab.tsx
+++ b/web/src/components/bookdetail/BookDetailInfoTab.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/bookdetail/BookDetailInfoTab.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1234-efab-345678901234
 // last-edited: 2026-05-02
 
@@ -21,6 +21,7 @@ import LabelIcon from '@mui/icons-material/Label.js';
 import type { Book, SegmentTags } from '../../services/api';
 import * as api from '../../services/api';
 import { formatDuration, formatBytes } from './bookDetailUtils';
+import { WhisperIntroPanel } from './WhisperIntroPanel';
 
 export interface BookDetailInfoTabProps {
   book: Book;
@@ -326,6 +327,8 @@ export const BookDetailInfoTab = ({
           )}
         </Paper>
       )}
+
+      <WhisperIntroPanel book={book} />
     </>
   );
 };

--- a/web/src/components/bookdetail/WhisperIntroPanel.tsx
+++ b/web/src/components/bookdetail/WhisperIntroPanel.tsx
@@ -1,0 +1,110 @@
+// file: web/src/components/bookdetail/WhisperIntroPanel.tsx
+// version: 1.0.0
+// guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
+// last-edited: 2026-06-26
+
+import { useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import MicIcon from '@mui/icons-material/Mic.js';
+import type { Book } from '../../services/api';
+
+interface Props {
+  book: Book;
+}
+
+export function WhisperIntroPanel({ book }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!book.intro_transcription && !book.intro_transcribed_at) return null;
+
+  const hasExtracted = book.transcribed_title || book.transcribed_author || book.transcribed_narrator;
+  const transcribedAt = book.intro_transcribed_at
+    ? new Date(book.intro_transcribed_at).toLocaleString()
+    : null;
+
+  const isShort = (book.intro_transcription?.length ?? 0) <= 20;
+
+  return (
+    <Accordion
+      expanded={expanded}
+      onChange={(_, v) => setExpanded(v)}
+      disableGutters
+      sx={{ mb: 3, '&:before': { display: 'none' }, borderRadius: 1, border: '1px solid', borderColor: 'divider' }}
+      elevation={0}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <MicIcon fontSize="small" color="action" />
+          <Typography variant="subtitle1" fontWeight={600}>
+            Whisper Intro
+          </Typography>
+          {isShort && (
+            <Tooltip title="Transcript is very short — may only have caught the Audible bumper">
+              <Chip label="short" size="small" color="warning" variant="outlined" />
+            </Tooltip>
+          )}
+          {!isShort && hasExtracted && (
+            <Chip label="parsed" size="small" color="success" variant="outlined" />
+          )}
+          {transcribedAt && (
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto', pr: 1 }}>
+              {transcribedAt}
+            </Typography>
+          )}
+        </Box>
+      </AccordionSummary>
+
+      <AccordionDetails>
+        {book.intro_transcription && (
+          <Box sx={{ mb: hasExtracted ? 2 : 0 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Raw Transcript
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                fontStyle: 'italic',
+                color: isShort ? 'warning.main' : 'text.primary',
+                bgcolor: 'action.hover',
+                borderRadius: 1,
+                p: 1.5,
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {book.intro_transcription}
+            </Typography>
+          </Box>
+        )}
+
+        {hasExtracted && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              Extracted
+            </Typography>
+            {[
+              { label: 'Title', value: book.transcribed_title },
+              { label: 'Author', value: book.transcribed_author },
+              { label: 'Narrator', value: book.transcribed_narrator },
+            ].map(({ label, value }) => value && (
+              <Box key={label} sx={{ display: 'flex', gap: 1.5, alignItems: 'baseline' }}>
+                <Typography variant="body2" color="text.secondary" sx={{ width: 64, flexShrink: 0 }}>
+                  {label}
+                </Typography>
+                <Typography variant="body2">{value}</Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.43.0
+// version: 2.44.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-06-22
 
@@ -148,6 +148,12 @@ export interface Book {
   // MATCH-1: metadata-source deduplication
   metadata_source_hash?: string | null;
   metadata_source_hash_duplicate_count?: number | null;
+  // Whisper intro transcription (maintenance.transcribe-book-intros op)
+  intro_transcription?: string | null;
+  transcribed_title?: string | null;
+  transcribed_author?: string | null;
+  transcribed_narrator?: string | null;
+  intro_transcribed_at?: string | null;
   // Book-level fingerprint signature (whole-file chromaprint synthesis)
   book_sig_v1?: string | null;
   book_sig_segments?: number | null;


### PR DESCRIPTION
## Summary

- New `WhisperIntroPanel` component: collapsible accordion on the Info tab
- Shows raw Whisper transcript, extracted title/author/narrator, transcription timestamp
- **"short" chip** (warning) when transcript ≤20 chars — likely only caught the Audible bumper
- **"parsed" chip** (success) when title/author/narrator were successfully extracted
- Hidden entirely if the book has never been transcribed

## Screenshots
Panel collapsed (shows chip status at a glance), expanded (full transcript + extracted fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P