### PR TITLE
fix(transcribe): process entire library, not just first ~400 books

### DIFF
--- a/internal/database/pebble_books_pagination_test.go
+++ b/internal/database/pebble_books_pagination_test.go
@@ -1,0 +1,90 @@
+// file: internal/database/pebble_books_pagination_test.go
+// version: 1.0.0
+// guid: 7f2a9c14-3b6d-4e81-9a2c-0d5f1e8b4a37
+// last-edited: 2026-06-26
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAllBooksFrom_PaginatesPastDoubleLimit is a regression test for the
+// memdb-path bug where GetAllBooksFrom loaded only limit*2+1 books from the
+// start and searched for the cursor within that window. Cursor pagination
+// therefore stalled at the 2*limit boundary, so full-table backfills (intro
+// transcription, search index) only ever processed the first ~2 pages of the
+// library. See fix/transcribe-full-library.
+func TestGetAllBooksFrom_PaginatesPastDoubleLimit(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+	require.True(t, store.UseMemDB, "test must exercise the memdb path")
+	require.NotNil(t, store.mem(), "memdb must be published")
+
+	// Create enough books that the limit*2 boundary is well inside the set.
+	const total = 55
+	const pageSize = 10 // old cap was pageSize*2 = 20; 55 books exposes the bug
+
+	for i := 0; i < total; i++ {
+		b := &Book{
+			Title:    fmt.Sprintf("Book %03d", i),
+			FilePath: fmt.Sprintf("/tmp/book_%03d.m4b", i),
+		}
+		created, err := store.CreateBook(b)
+		require.NoError(t, err)
+		// Propagate into memdb so the memdb read path sees it (production does
+		// this write-through on every book mutation).
+		store.UpsertBookToMemDB(context.Background(), created)
+	}
+
+	// Walk the whole library via cursor pagination, exactly like the transcribe
+	// op and search backfill do.
+	seen := make(map[string]bool, total)
+	cursor := ""
+	pages := 0
+	for {
+		page, err := store.GetAllBooksFrom(cursor, pageSize)
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+		pages++
+		require.Less(t, pages, total, "pagination did not terminate")
+		for _, b := range page {
+			require.False(t, seen[b.ID], "book %s returned on more than one page", b.ID)
+			seen[b.ID] = true
+		}
+		if len(page) < pageSize {
+			break // last page
+		}
+		cursor = page[len(page)-1].ID
+	}
+
+	// The whole point: every book is reachable, not just the first 2*pageSize.
+	require.Equal(t, total, len(seen),
+		"expected all %d books across pages, got %d (old bug stopped at %d)",
+		total, len(seen), pageSize*2)
+}
+
+// TestGetAllBooksFrom_UnknownCursorEndsIteration verifies that a stale/unknown
+// cursor returns no rows (ending iteration) rather than restarting from the
+// top — which would loop forever.
+func TestGetAllBooksFrom_UnknownCursorEndsIteration(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	for i := 0; i < 5; i++ {
+		b := &Book{Title: fmt.Sprintf("B%d", i), FilePath: fmt.Sprintf("/tmp/b%d.m4b", i)}
+		created, err := store.CreateBook(b)
+		require.NoError(t, err)
+		store.UpsertBookToMemDB(context.Background(), created)
+	}
+
+	page, err := store.GetAllBooksFrom("zzzz-nonexistent-cursor", 10)
+	require.NoError(t, err)
+	require.Empty(t, page, "unknown cursor must end iteration, not restart")
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.97.0
+// version: 1.98.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-23
+// last-edited: 2026-06-26
 
 package database
 
@@ -1439,28 +1439,50 @@ func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 // full-table iteration (e.g. search index backfill).
 func (p *PebbleStore) GetAllBooksFrom(afterID string, limit int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
-		// MemDB path: load a page from the beginning and filter to after afterID.
-		// Only used in tests — not optimised for large N.
-		all, err := p.mem().GetAllBooks(limit*2+1, 0, nil)
+		// MemDB path. NOTE: this IS the production path — UseMemDB defaults to
+		// true. The previous implementation loaded only limit*2+1 books from the
+		// start and searched for afterID within that window, so cursor pagination
+		// silently stopped at the 2*limit boundary (e.g. page 3 of a 200-page
+		// scan returned nothing). Every full-table backfill that relied on this
+		// (intro transcription, search-index backfill) only ever processed the
+		// first ~2 pages of the library. See fix/transcribe-full-library.
+		//
+		// ListBookIDs walks the same memdb ID index as GetAllBooks and applies
+		// the same MarkedForDeletion filter, so the ID ordering is authoritative.
+		// Seek past afterID, then load the next `limit` books straight from
+		// Pebble (GetBookByID bypasses memdb but returns identical data).
+		ids, err := p.mem().ListBookIDs()
 		if err != nil {
 			return nil, err
 		}
-		if afterID == "" {
-			if limit > 0 && len(all) > limit {
-				all = all[:limit]
-			}
-			return all, nil
-		}
-		for i, b := range all {
-			if b.ID == afterID {
-				rest := all[i+1:]
-				if limit > 0 && len(rest) > limit {
-					rest = rest[:limit]
+		start := 0
+		if afterID != "" {
+			// Default to len(ids): an unknown/stale cursor ends iteration
+			// rather than restarting from the top (which would loop forever).
+			start = len(ids)
+			for i, id := range ids {
+				if id == afterID {
+					start = i + 1
+					break
 				}
-				return rest, nil
 			}
 		}
-		return all, nil
+		if start >= len(ids) {
+			return nil, nil
+		}
+		end := len(ids)
+		if limit > 0 && start+limit < end {
+			end = start + limit
+		}
+		books := make([]Book, 0, end-start)
+		for _, id := range ids[start:end] {
+			b, err := p.GetBookByID(id)
+			if err != nil || b == nil {
+				continue
+			}
+			books = append(books, *b)
+		}
+		return books, nil
 	}
 
 	lower := []byte("book:0")

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 2.4.0
+// version: 3.0.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-26
 
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -65,79 +66,120 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	onlyMissing := params.OnlyMissing == nil || *params.OnlyMissing
 
 	log := reporter.Logger()
-	log.Info("transcribe-book-intros: starting batch run",
-		"only_missing", onlyMissing, "page_size", introTranscribePageSize)
 
-	// Count total so we can report meaningful progress.
-	// We re-count mid-run only when needed; approximate is fine.
-	total := 0
-	processed := 0
-	cursor := params.LastBookID
+	// Load the FULL, ordered list of book IDs up front. This is the proven
+	// uncapped primitive (memdb ID-index walk). The previous implementation
+	// paginated via GetAllBooksFrom, whose memdb path silently stopped after
+	// 2*pageSize books — so only the first ~400 books of the library were ever
+	// transcribed. See fix/transcribe-full-library.
+	allIDs, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("list book ids: %w", err)
+	}
+	total := len(allIDs)
 
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		// Load one page of books from the cursor position.
-		page, err := store.GetAllBooksFrom(cursor, introTranscribePageSize)
-		if err != nil {
-			return fmt.Errorf("load books page: %w", err)
-		}
-		if len(page) == 0 {
-			break
-		}
-
-		// Filter to only books that need transcription.
-		var toProcess []database.Book
-		for _, b := range page {
-			if onlyMissing && b.IntroTranscription != nil && *b.IntroTranscription != "" {
-				continue
-			}
-			toProcess = append(toProcess, b)
-		}
-		total += len(page)
-
-		if len(toProcess) > 0 {
-			done, err := p.processTranscribePage(ctx, store, log, reporter, toProcess, processed, total)
-			processed += done
-			if err != nil {
-				// Non-fatal: log and continue to next page.
-				log.Warn("transcribe-book-intros: page error", "err", err)
+	// Resume support: skip past the last book ID checkpointed by a prior run.
+	startIdx := 0
+	if params.LastBookID != "" {
+		for i, id := range allIDs {
+			if id == params.LastBookID {
+				startIdx = i + 1
+				break
 			}
 		}
-
-		if len(page) < introTranscribePageSize {
-			break // last page
-		}
-		cursor = page[len(page)-1].ID
-		// Persist cursor after each completed page so a server restart resumes
-		// from here rather than scanning from book 0.
-		_ = reporter.Checkpoint(introTranscribeParams{
-			LastBookID:  cursor,
-			OnlyMissing: &onlyMissing,
-		})
 	}
 
-	log.Info("transcribe-book-intros: complete", "processed", processed)
+	log.Info("transcribe-book-intros: starting batch run",
+		"only_missing", onlyMissing, "total_books", total,
+		"start_index", startIdx, "page_size", introTranscribePageSize)
+
+	if startIdx >= total {
+		_ = reporter.UpdateProgress(1, 1, "Done — nothing to transcribe")
+		return nil
+	}
+
+	// Chunk the remaining IDs into pages. Each page → one Whisper batch process
+	// (the whole point of batch mode: load the model once per 200 books).
+	pages := chunkIDs(allIDs[startIdx:], introTranscribePageSize)
+
+	var processed int // cumulative books transcribed across all pages
+	var lastID string // last book ID seen — captured for the checkpoint closure
+
+	// RunItems drives the page loop, handling ctx cancellation, per-page
+	// progress, and checkpointing. The item is a PAGE of IDs (not a single
+	// book) so we keep one Whisper process per 200 books. Sequential by design:
+	// ffmpeg parallelism (16 workers) already lives inside processTranscribePage.
+	err = registry.RunItems(ctx, reporter, pages, func(ctx context.Context, ids []string) error {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			b, gerr := store.GetBookByID(id)
+			if gerr != nil || b == nil {
+				continue
+			}
+			lastID = id
+			if onlyMissing && b.IntroTranscription != nil && *b.IntroTranscription != "" {
+				continue // already transcribed — skip (cache still warm if re-run)
+			}
+			books = append(books, *b)
+		}
+		if len(books) == 0 {
+			return nil
+		}
+		done := p.processTranscribePage(ctx, store, log, books)
+		processed += done
+		log.Info("transcribe-book-intros: page complete",
+			"page_books", done, "cumulative_processed", processed, "total_books", total)
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   1,
+		ProgressTotal: len(pages),
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Page %d/%d — %d books transcribed", i+1, t, processed)
+		},
+		CheckpointFn: func(ctx context.Context) error {
+			om := onlyMissing
+			return reporter.Checkpoint(introTranscribeParams{LastBookID: lastID, OnlyMissing: &om})
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Info("transcribe-book-intros: complete", "processed", processed, "total_books", total)
 	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf("Done — transcribed %d books", processed))
 	return nil
 }
 
+// chunkIDs splits ids into consecutive slices of at most size elements.
+func chunkIDs(ids []string, size int) [][]string {
+	if size < 1 {
+		size = 1
+	}
+	chunks := make([][]string, 0, (len(ids)+size-1)/size)
+	for start := 0; start < len(ids); start += size {
+		end := start + size
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunks = append(chunks, ids[start:end])
+	}
+	return chunks
+}
+
 // processTranscribePage handles one page of books:
 // 1. Find the first audio file for each book.
-// 2. Extract 90-second WAVs in parallel with ffmpeg.
+// 2. Extract 90-second WAVs in parallel with ffmpeg (cached on disk).
 // 3. Call TranscribeBatch once (single Python/Whisper process).
 // 4. Parse results and update all books.
-// 5. Clean up temp WAVs.
+// 5. Clean up temp WAVs (cached clips persist).
+// Returns the number of books successfully transcribed in this page. Errors are
+// logged and treated as non-fatal so one bad page never aborts the whole run.
 func (p *Plugin) processTranscribePage(
 	ctx context.Context,
 	store database.Store,
 	log interface{ Info(string, ...any); Warn(string, ...any) },
-	reporter sdk.Reporter,
 	books []database.Book,
-	progressOffset, progressTotal int,
-) (processed int, err error) {
+) (processed int) {
 	cacheDir := whisperClipCacheDir()
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		log.Warn("transcribe: cannot create clip cache dir, running without cache", "dir", cacheDir, "err", err)
@@ -147,7 +189,8 @@ func (p *Plugin) processTranscribePage(
 	// tmpDir holds WAVs for books whose source file has no stored hash (no caching).
 	tmpDir, err := os.MkdirTemp("", "ao-transcribe-*")
 	if err != nil {
-		return 0, fmt.Errorf("create temp dir: %w", err)
+		log.Warn("transcribe: create temp dir failed", "err", err)
+		return 0
 	}
 	defer os.RemoveAll(tmpDir)
 
@@ -239,14 +282,15 @@ func (p *Plugin) processTranscribePage(
 		}
 	}
 	if len(batchJobs) == 0 {
-		return 0, nil
+		return 0
 	}
 
 	// Step 3: one Python/Whisper process for the whole page.
 	log.Info("transcribe-book-intros: calling whisper batch", "jobs", len(batchJobs))
 	batchResults, err := transcribe.TranscribeBatch(ctx, batchJobs)
 	if err != nil {
-		return 0, fmt.Errorf("whisper batch: %w", err)
+		log.Warn("transcribe: whisper batch failed", "jobs", len(batchJobs), "err", err)
+		return 0
 	}
 
 	// Step 4: parse results and update books.
@@ -291,12 +335,7 @@ func (p *Plugin) processTranscribePage(
 		processed++
 	}
 
-	_ = reporter.UpdateProgress(
-		progressOffset+processed,
-		progressTotal,
-		fmt.Sprintf("Transcribed %d/%d books", progressOffset+processed, progressTotal),
-	)
-	return processed, nil
+	return processed
 }
 
 // firstAudioFile returns the path and stored file hash of the first audio file


### PR DESCRIPTION
## The bug

`GetAllBooksFrom`'s **memdb branch** (the production path — `UseMemDB` defaults to true) loaded only `limit*2+1` books from the start of the library and searched for the cursor inside that window. Cursor pagination stalled at the `2*limit` boundary — page 3 of any scan returned nothing and the loop broke.

This silently capped:
- **intro-transcription op** at 400 books (of 29K+)
- **search-index backfill** (`server_search.go:72`) at the same boundary

The `// Only used in tests` comment was the false assumption that hid it.

## Fix

1. **`GetAllBooksFrom` memdb branch** now walks the full ordered `ListBookIDs` set, seeks past the cursor, and loads the next `limit` books from Pebble. Unknown cursor ends iteration instead of restarting.
2. **`runIntroTranscribe`** rewritten on the standard `RunItems` helper over `ListBookIDs`-derived pages — cancellation, progress, checkpoint/resume handled by the framework. WAV cache + 16-worker ffmpeg unchanged.
3. **Regression test** proves pagination reaches every book past the old `2*pageSize` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)