### PR TITLE
fix(transcribe): stop watchdog cancelling transcription mid-batch

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-26
 
@@ -48,6 +48,14 @@ func (p *Plugin) introTranscribeDef() sdk.OperationDef {
 		Cancellable:     true,
 		Isolate:         false,
 		Timeout:         10 * time.Hour,
+		// A page of 200 books sent to the (remote GPU or local) Whisper backend
+		// can take several minutes to return. The default 5-minute no-progress
+		// watchdog would cancel the op mid-batch — which it did, repeatedly,
+		// cutting off in-flight requests to the remote GPU. Per-book progress
+		// (see TranscribeBatch onProgress) normally ticks every ~1-2s on the
+		// remote path; this generous timeout is the backstop for the local
+		// single-subprocess fallback, which is silent until it completes.
+		ProgressTimeout: 30 * time.Minute,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead},
 		Run:             p.runIntroTranscribe,
 	}
@@ -125,7 +133,16 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 		if len(books) == 0 {
 			return nil
 		}
-		done := p.processTranscribePage(ctx, store, log, books)
+		// Per-book heartbeat: each completed book bumps the operation's progress
+		// clock so the watchdog sees liveness during a multi-minute batch (the
+		// old code only reported once per page and got cancelled mid-batch).
+		// base is the cumulative count before this page; d is books done within it.
+		base := processed
+		onBook := func(d, _ int) {
+			_ = reporter.UpdateProgress(base+d, total,
+				fmt.Sprintf("Transcribing — %d/%d books", base+d, total))
+		}
+		done := p.processTranscribePage(ctx, store, log, books, onBook)
 		processed += done
 		log.Info("transcribe-book-intros: page complete",
 			"page_books", done, "cumulative_processed", processed, "total_books", total)
@@ -179,6 +196,7 @@ func (p *Plugin) processTranscribePage(
 	store database.Store,
 	log interface{ Info(string, ...any); Warn(string, ...any) },
 	books []database.Book,
+	onBook transcribe.ProgressFunc,
 ) (processed int) {
 	cacheDir := whisperClipCacheDir()
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
@@ -287,7 +305,7 @@ func (p *Plugin) processTranscribePage(
 
 	// Step 3: one Python/Whisper process for the whole page.
 	log.Info("transcribe-book-intros: calling whisper batch", "jobs", len(batchJobs))
-	batchResults, err := transcribe.TranscribeBatch(ctx, batchJobs)
+	batchResults, err := transcribe.TranscribeBatch(ctx, batchJobs, onBook)
 	if err != nil {
 		log.Warn("transcribe: whisper batch failed", "jobs", len(batchJobs), "err", err)
 		return 0

--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/batch.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
 // last-edited: 2026-06-26
 
@@ -26,21 +26,29 @@ type BatchResult struct {
 	Error string // non-empty means transcription failed for this item
 }
 
+// ProgressFunc is an optional callback invoked after each book finishes
+// transcribing on the remote path. done is the number completed so far, total
+// the batch size. Callers use it to emit per-book progress — critical so the
+// operation watchdog sees liveness during a multi-minute batch instead of
+// cancelling it for "no progress". May be nil.
+type ProgressFunc func(done, total int)
+
 // TranscribeBatch transcribes multiple WAV files. jobs maps an opaque key to a WAV path.
 //
 // If WHISPER_REMOTE_URL is set (e.g. "http://192.168.1.x:8000"), jobs are sent
 // to the remote faster-whisper server running scripts/whisper_server.py. On any
 // failure the warning is logged and the function falls back to the local
-// uv/openai-whisper path.
+// uv/openai-whisper path. onProgress (if non-nil) fires per book on the remote
+// path; the local single-subprocess path reports only on completion.
 //
 // Local path uses torch==2.0.1+cu118 for CC 6.1 GPU support (GTX 1050 Ti).
-func TranscribeBatch(ctx context.Context, jobs map[string]string) (map[string]BatchResult, error) {
+func TranscribeBatch(ctx context.Context, jobs map[string]string, onProgress ProgressFunc) (map[string]BatchResult, error) {
 	if len(jobs) == 0 {
 		return nil, nil
 	}
 
 	if remoteURL := os.Getenv("WHISPER_REMOTE_URL"); remoteURL != "" {
-		results, err := transcribeRemote(ctx, remoteURL, jobs)
+		results, err := transcribeRemote(ctx, remoteURL, jobs, onProgress)
 		if err != nil {
 			slog.Warn("transcribe: remote whisper failed, falling back to local",
 				"url", remoteURL, "err", err)
@@ -133,6 +141,12 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string) (map[string]Ba
 			r.Error = *v.Error
 		}
 		results[k] = r
+	}
+	// The local subprocess returns all results at once, so we can only report
+	// completion (not per-book). The op def's generous ProgressTimeout covers
+	// the silent gap during a local-fallback batch.
+	if onProgress != nil {
+		onProgress(len(results), len(jobs))
 	}
 	return results, nil
 }

--- a/internal/transcribe/remote.go
+++ b/internal/transcribe/remote.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/remote.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
 // last-edited: 2026-06-26
 
@@ -27,7 +27,7 @@ const remoteWorkers = 2
 // No upfront health check — just tries to connect. On any failure, cancels all
 // in-flight requests immediately and returns an error so the caller falls back
 // to local transcription.
-func transcribeRemote(ctx context.Context, remoteURL string, jobs map[string]string) (map[string]BatchResult, error) {
+func transcribeRemote(ctx context.Context, remoteURL string, jobs map[string]string, onProgress ProgressFunc) (map[string]BatchResult, error) {
 	client := &http.Client{Timeout: 120 * time.Second}
 
 	// Child context so we can cancel all workers the moment any request fails.
@@ -72,11 +72,18 @@ func transcribeRemote(ctx context.Context, remoteURL string, jobs map[string]str
 	}()
 
 	results := make(map[string]BatchResult, len(jobs))
+	total := len(jobs)
 	for item := range resultCh {
 		if item.err != nil {
 			return nil, fmt.Errorf("remote transcribe %s: %w", item.id, item.err)
 		}
 		results[item.id] = item.result
+		// Single-goroutine drain loop, so onProgress is called sequentially —
+		// no extra synchronization needed. This per-book tick is what keeps the
+		// operation watchdog alive during a long batch.
+		if onProgress != nil {
+			onProgress(len(results), total)
+		}
 	}
 	return results, nil
 }


### PR DESCRIPTION
## Symptom

Every transcription run died at the 5-minute mark:
```
watchdog: "no progress for 5m8s (timeout=5m0s)" → canceling stuck op
→ remote whisper: context canceled
```
The remote GPU (Windows box) looked idle because we kept cancelling its in-flight requests.

## Cause

A 200-book Whisper batch takes minutes to return, but the op reported progress only **once per page**. The default 5-minute no-progress watchdog fired mid-batch and cancelled everything.

## Fix

1. **`ProgressTimeout: 30m`** on the op def — backstop for the local single-subprocess fallback (silent until done).
2. **Per-book progress callback** (`transcribe.ProgressFunc`) threaded `TranscribeBatch → transcribeRemote`. On the remote path it fires after each book, stamping the progress clock every ~1-2s — keeps the watchdog alive **and** shows live `books N/total` throughput.

Only the no-progress "stuck" strike cancels; "uncheckpointed" is observability-only, so per-page checkpointing stays sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)