### PR TITLE
fix(transcribe): stable path-hash WAV cache key + remoteWorkers 2→4

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-26
 
@@ -7,6 +7,8 @@ package maintenance
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -387,7 +389,16 @@ func firstAudioFile(store database.Store, bookID string) (path, fileHash string,
 		return audio[i].FilePath < audio[j].FilePath
 	})
 	f := audio[0]
-	return f.FilePath, f.FileHash, nil
+	// Use the stored content hash as the cache key. If it's empty (scanner
+	// hasn't computed it yet for this book), derive a stable key from the file
+	// path instead — SHA-256 of the path string is deterministic as long as
+	// the file isn't moved, which is true for organised books.
+	cacheKey := f.FileHash
+	if cacheKey == "" {
+		h := sha256.Sum256([]byte(f.FilePath))
+		cacheKey = "path:" + hex.EncodeToString(h[:])
+	}
+	return f.FilePath, cacheKey, nil
 }
 
 // whisperClipCacheDir returns the directory used to cache extracted 90s WAV clips.

--- a/internal/transcribe/remote.go
+++ b/internal/transcribe/remote.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/remote.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
 // last-edited: 2026-06-26
 
@@ -19,9 +19,12 @@ import (
 	"time"
 )
 
-// remoteWorkers pipelines network upload with GPU compute on the remote:
-// one file uploading while the previous is being transcribed.
-const remoteWorkers = 2
+// remoteWorkers pipelines network upload with GPU compute on the remote.
+// 4 workers keeps the RTX 2060 Super consistently fed: network upload of one
+// WAV overlaps with GPU inference on the previous, hiding transfer latency.
+// GPU log showed 32–68% utilisation at remoteWorkers=2; bumping to 4 fills
+// the gaps without overloading the 8GT/s PCIe 3.0 x16 link.
+const remoteWorkers = 4
 
 // transcribeRemote sends WAV jobs directly to the remote faster-whisper server.
 // No upfront health check — just tries to connect. On any failure, cancels all


### PR DESCRIPTION
## Summary

- **WAV cache fix**: `BookFile.FileHash` is empty for ~99% of books (scanner hash backfill only ran on organized books). Cache key was empty → clips written to tmpDir → deleted after each page → ffmpeg re-runs every book every restart. Fixed by falling back to `path:sha256(filePath)` — stable as long as the file doesn't move (true for organized books).

- **remoteWorkers 2→4**: GPU telemetry (attached nvidia-smi CSV + HWiNFO64 CSV) showed RTX 2060 Super at 32–68% utilization with 2 workers. The upload of one 90s WAV (~1.4MB) was leaving the GPU idle between books. 4 workers pipelines 3 concurrent uploads against GPU inference.

## Test plan
- [ ] Build passes (`make build-api`)
- [ ] WAV files accumulate in `/var/lib/audiobook-organizer/whisper-clips/` on re-run (previously only 3 files after 2,400 books)
- [ ] GPU utilization more consistent (target: sustained 60–80% instead of burst-hold pattern)
- [ ] Op resumes from checkpoint (LastBookID at book ~2,389)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P