### PR TITLE
fix(transcribe): disable local fallback when WHISPER_REMOTE_URL set

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.1.0
+// version: 3.2.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-26
 
@@ -7,6 +7,8 @@ package maintenance
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -387,7 +389,16 @@ func firstAudioFile(store database.Store, bookID string) (path, fileHash string,
 		return audio[i].FilePath < audio[j].FilePath
 	})
 	f := audio[0]
-	return f.FilePath, f.FileHash, nil
+	// Use the stored content hash as the cache key. If it's empty (scanner
+	// hasn't computed it yet for this book), derive a stable key from the file
+	// path instead — SHA-256 of the path string is deterministic as long as
+	// the file isn't moved, which is true for organised books.
+	cacheKey := f.FileHash
+	if cacheKey == "" {
+		h := sha256.Sum256([]byte(f.FilePath))
+		cacheKey = "path:" + hex.EncodeToString(h[:])
+	}
+	return f.FilePath, cacheKey, nil
 }
 
 // whisperClipCacheDir returns the directory used to cache extracted 90s WAV clips.

--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,7 +1,7 @@
 // file: internal/transcribe/batch.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
-// last-edited: 2026-06-26
+// last-edited: 2026-06-27
 
 package transcribe
 
@@ -11,7 +11,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -50,12 +49,16 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string, onProgress Pro
 	if remoteURL := os.Getenv("WHISPER_REMOTE_URL"); remoteURL != "" {
 		results, err := transcribeRemote(ctx, remoteURL, jobs, onProgress)
 		if err != nil {
-			slog.Warn("transcribe: remote whisper failed, falling back to local",
-				"url", remoteURL, "err", err)
-			// fall through to local uv path
-		} else {
-			return results, nil
+			// Do NOT fall back to the local uv path when WHISPER_REMOTE_URL is
+			// configured. The local subprocess loads the full Whisper model into
+			// RAM; at batch sizes of 100–200 books this reliably OOMs the server
+			// (signal: killed after 40+ minutes) and produces zero results anyway.
+			// Returning the error lets the caller (processTranscribePage) log a
+			// warning, skip the page, and advance to the next one — far better
+			// than stalling for an hour and triggering the watchdog.
+			return nil, fmt.Errorf("transcribe remote: %w", err)
 		}
+		return results, nil
 	}
 
 	// Write jobs JSON to temp file.

--- a/internal/transcribe/remote.go
+++ b/internal/transcribe/remote.go
@@ -1,5 +1,5 @@
 // file: internal/transcribe/remote.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
 // last-edited: 2026-06-26
 
@@ -19,9 +19,12 @@ import (
 	"time"
 )
 
-// remoteWorkers pipelines network upload with GPU compute on the remote:
-// one file uploading while the previous is being transcribed.
-const remoteWorkers = 2
+// remoteWorkers pipelines network upload with GPU compute on the remote.
+// 4 workers keeps the RTX 2060 Super consistently fed: network upload of one
+// WAV overlaps with GPU inference on the previous, hiding transfer latency.
+// GPU log showed 32–68% utilisation at remoteWorkers=2; bumping to 4 fills
+// the gaps without overloading the 8GT/s PCIe 3.0 x16 link.
+const remoteWorkers = 4
 
 // transcribeRemote sends WAV jobs directly to the remote faster-whisper server.
 // No upfront health check — just tries to connect. On any failure, cancels all


### PR DESCRIPTION
When remote Whisper fails, skip fallback to local uv/openai-whisper. At 100-200 books per page, local fallback OOMs the server after 40+ min. Hard error + page skip keeps the op alive.