### PR TITLE
feat(ops): OpenSSH setup scripts for Windows GPU machine

### DIFF
--- a/scripts/setup-openssh-windows.ps1
+++ b/scripts/setup-openssh-windows.ps1
@@ -1,0 +1,47 @@
+# file: scripts/setup-openssh-windows.ps1
+# version: 1.0.0
+# guid: b3c4d5e6-f7a8-9012-bcde-234567890123
+# last-edited: 2026-06-27
+#
+# Run ONCE as Administrator on the Windows GPU machine (172.16.3.22).
+# Enables OpenSSH Server so you can SSH/SCP in from Mac or Linux.
+#
+#   Set-ExecutionPolicy Bypass -Scope Process -Force
+#   .\scripts\setup-openssh-windows.ps1
+
+#Requires -RunAsAdministrator
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Install OpenSSH Server (built-in optional feature since Win10 1809)
+$cap = Get-WindowsCapability -Online -Name "OpenSSH.Server*"
+if ($cap.State -ne "Installed") {
+    Write-Host "Installing OpenSSH.Server..."
+    Add-WindowsCapability -Online -Name "OpenSSH.Server~~~~0.0.1.0" | Out-Null
+}
+
+# Start service and set to auto-start
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+Write-Host "sshd running"
+
+# Firewall rule for port 22
+if (-not (Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -DisplayName "OpenSSH Server" `
+        -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+    Write-Host "Firewall rule created"
+}
+
+# Ensure the admin authorized_keys file exists with correct permissions.
+# Windows OpenSSH ignores ~/.ssh/authorized_keys for admin users and reads
+# from this central file instead.
+$keyFile = "C:\ProgramData\ssh\administrators_authorized_keys"
+if (-not (Test-Path $keyFile)) {
+    New-Item -Path $keyFile -ItemType File -Force | Out-Null
+}
+icacls $keyFile /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+Write-Host "administrators_authorized_keys ready at $keyFile"
+
+Write-Host ""
+Write-Host "Done. Now run scripts/setup-ssh-from-mac.sh on your Mac."
+Write-Host "sshd config: C:\ProgramData\ssh\sshd_config"

--- a/scripts/setup-ssh-from-mac.sh
+++ b/scripts/setup-ssh-from-mac.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# file: scripts/setup-ssh-from-mac.sh
+# version: 1.0.0
+# guid: c4d5e6f7-a8b9-0123-cdef-345678901234
+# last-edited: 2026-06-27
+#
+# Run on Mac AFTER setup-openssh-windows.ps1 has been run on Windows.
+# Generates an SSH key and installs it on the Windows machine.
+#
+#   bash scripts/setup-ssh-from-mac.sh
+#
+# You'll be prompted for your Windows password once, then never again.
+
+set -euo pipefail
+
+WIN_USER="jdfalk"
+WIN_IP="172.16.3.22"
+KEY="$HOME/.ssh/id_ed25519_windows"
+
+# Generate key if it doesn't exist
+if [[ ! -f "$KEY" ]]; then
+    ssh-keygen -t ed25519 -f "$KEY" -N "" -C "mac-to-windows-gpu"
+    echo "Generated $KEY"
+fi
+
+PUB=$(cat "${KEY}.pub")
+echo ""
+echo "Public key: $PUB"
+echo ""
+
+# Copy the key into the Windows admin authorized_keys file.
+# (ssh-copy-id puts it in ~/.ssh/authorized_keys which Windows OpenSSH
+# ignores for admin users — so we write to the correct location directly.)
+echo "Enter your Windows password when prompted..."
+ssh -o StrictHostKeyChecking=accept-new "${WIN_USER}@${WIN_IP}" \
+    "powershell -Command \"Add-Content 'C:\\ProgramData\\ssh\\administrators_authorized_keys' '${PUB}'\""
+
+echo ""
+echo "Testing passwordless connection..."
+ssh -i "$KEY" -o StrictHostKeyChecking=accept-new "${WIN_USER}@${WIN_IP}" "echo connected"
+
+echo ""
+echo "Add to ~/.ssh/config for convenience:"
+echo ""
+echo "  Host windows-gpu"
+echo "    HostName $WIN_IP"
+echo "    User $WIN_USER"
+echo "    IdentityFile $KEY"
+echo ""
+echo "Then: ssh windows-gpu, scp scripts/whisper_server.py windows-gpu:"


### PR DESCRIPTION
Two scripts to get passwordless SSH from Mac to the Windows GPU machine.

**`scripts/setup-openssh-windows.ps1`** — run as Administrator on 172.16.3.22:
- Installs `OpenSSH.Server` (built-in optional feature, no download)
- Starts `sshd`, sets Automatic startup, opens TCP 22 firewall
- Creates `C:\ProgramData\ssh\administrators_authorized_keys` with correct permissions (Windows admin users need keys here, not `~/.ssh/`)

**`scripts/setup-ssh-from-mac.sh`** — run on Mac:
- Generates `~/.ssh/id_ed25519_windows` if absent
- Writes the public key directly to `administrators_authorized_keys` (skips `ssh-copy-id` which puts it in the wrong location for admin users)
- Verifies passwordless connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01N8HKnuanxdr3NQj5stvy4P