### PR TITLE
fix(library): repair page-2 pagination, 500-means-500, + transcription discovery

### DIFF
--- a/internal/audiobooks/list_pagination_test.go
+++ b/internal/audiobooks/list_pagination_test.go
@@ -1,0 +1,125 @@
+// file: internal/audiobooks/list_pagination_test.go
+// version: 1.0.0
+// guid: 7c1e9b42-3a6d-4f01-9d8e-2b5c6a7e1f04
+// last-edited: 2026-06-28
+
+package audiobooks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPaginationStore builds a real PebbleStore (memdb pushdown active) with
+// `n` primary, title-sorted books whose titles are zero-padded so A→Z order is
+// deterministic ("Book 0001" … "Book NNNN"). Draining warmupDone first ensures
+// memdb is published before CreateBook write-through populates it.
+func seedPaginationStore(t *testing.T, n int) (*AudiobookService, []string) {
+	t.Helper()
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+
+	// Drain the async warmup so memPtr is published (empty); subsequent
+	// CreateBook calls write through into the live memdb.
+	ps.WaitForWarmup()
+
+	primary := true
+	wantTitles := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		title := fmt.Sprintf("Book %04d", i)
+		wantTitles = append(wantTitles, title)
+		_, err := ps.CreateBook(&database.Book{
+			Title:            title,
+			IsPrimaryVersion: &primary,
+		})
+		require.NoError(t, err)
+	}
+	return NewAudiobookService(ps), wantTitles
+}
+
+// TestGetAudiobooks_TitlePrimaryPagination is the regression test for the
+// library "page 2 returns 0 items" bug. The light-pushdown path paginated in
+// the store, then the post-filter block re-paginated the already-sliced page
+// using the original offset — so any offset>0 returned nothing.
+func TestGetAudiobooks_TitlePrimaryPagination(t *testing.T) {
+	const total = 60
+	svc, want := seedPaginationStore(t, total)
+	ctx := context.Background()
+	primary := true
+	filt := ListFilters{IsPrimaryVersion: &primary, SortBy: "title", SortOrder: "asc"}
+
+	pageSize := 20
+	for page := 0; page < total/pageSize; page++ {
+		off := page * pageSize
+		got, err := svc.GetAudiobooks(ctx, pageSize, off, "", nil, nil, filt)
+		require.NoError(t, err)
+		require.Lenf(t, got, pageSize, "page %d (offset %d) must return %d books", page, off, pageSize)
+		for i, b := range got {
+			require.Equalf(t, want[off+i], b.Title,
+				"page %d row %d: titles must be contiguous in sort order", page, i)
+		}
+	}
+}
+
+// unwrapStore mimics the production indexedStore decorator: it embeds a
+// database.Store and exposes Unwrap() so the pushdown's single-level Unwrap can
+// reach the concrete PebbleStore underneath. This proves the fix holds for the
+// real production store shape (service store is wrapped, not bare).
+type unwrapStore struct {
+	database.Store
+}
+
+func (u unwrapStore) Unwrap() database.Store { return u.Store }
+
+// TestGetAudiobooks_TitlePrimaryPagination_WrappedStore is the production-shape
+// variant: the service's store is a decorator, and pushdown must reach the
+// PebbleStore via Unwrap(). Without that, summariesPushdown would fall back to
+// the unfiltered path and pagination would break differently.
+func TestGetAudiobooks_TitlePrimaryPagination_WrappedStore(t *testing.T) {
+	const total = 60
+	svcInner, want := seedPaginationStore(t, total)
+	// Re-wrap the same underlying store in a decorator and rebuild the service.
+	svc := NewAudiobookService(unwrapStore{Store: svcInner.store.(database.Store)})
+	ctx := context.Background()
+	primary := true
+	filt := ListFilters{IsPrimaryVersion: &primary, SortBy: "title", SortOrder: "asc"}
+
+	pageSize := 20
+	for page := 0; page < total/pageSize; page++ {
+		off := page * pageSize
+		got, err := svc.GetAudiobooks(ctx, pageSize, off, "", nil, nil, filt)
+		require.NoError(t, err)
+		require.Lenf(t, got, pageSize, "wrapped: page %d (offset %d) must return %d books", page, off, pageSize)
+		for i, b := range got {
+			require.Equalf(t, want[off+i], b.Title,
+				"wrapped: page %d row %d: titles must be contiguous", page, i)
+		}
+	}
+}
+
+// TestGetAudiobooks_LargePageSize covers requirement #3: "if I set 500 it
+// should load 500 books". Also asserts offset=pageSize returns the next slice.
+func TestGetAudiobooks_LargePageSize(t *testing.T) {
+	const total = 1000
+	svc, want := seedPaginationStore(t, total)
+	ctx := context.Background()
+	primary := true
+	filt := ListFilters{IsPrimaryVersion: &primary, SortBy: "title", SortOrder: "asc"}
+
+	first, err := svc.GetAudiobooks(ctx, 500, 0, "", nil, nil, filt)
+	require.NoError(t, err)
+	require.Len(t, first, 500, "page size 500 at offset 0 must return 500 books")
+	require.Equal(t, want[0], first[0].Title)
+	require.Equal(t, want[499], first[499].Title)
+
+	second, err := svc.GetAudiobooks(ctx, 500, 500, "", nil, nil, filt)
+	require.NoError(t, err)
+	require.Len(t, second, 500, "page size 500 at offset 500 must return the next 500 books")
+	require.Equal(t, want[500], second[0].Title)
+	require.Equal(t, want[999], second[499].Title)
+}

--- a/internal/audiobooks/list_pagination_test.go
+++ b/internal/audiobooks/list_pagination_test.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/list_pagination_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c1e9b42-3a6d-4f01-9d8e-2b5c6a7e1f04
 // last-edited: 2026-06-28
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/stretchr/testify/require"
@@ -122,4 +123,70 @@ func TestGetAudiobooks_LargePageSize(t *testing.T) {
 	require.Len(t, second, 500, "page size 500 at offset 500 must return the next 500 books")
 	require.Equal(t, want[500], second[0].Title)
 	require.Equal(t, want[999], second[499].Title)
+}
+
+// TestGetAudiobooks_ExcludeQuarantined verifies quarantine exclusion is pushed
+// into the scan: a page of N returns N NON-quarantined books (not N-minus-the-
+// quarantined-in-window), and the count matches the items. Every 3rd book is
+// quarantined here, so without pushdown a 30-page would return ~20.
+func TestGetAudiobooks_ExcludeQuarantined(t *testing.T) {
+	const total = 90
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	primary := true
+	quarantined := 0
+	for i := 0; i < total; i++ {
+		b := &database.Book{
+			Title:            fmt.Sprintf("Book %04d", i),
+			IsPrimaryVersion: &primary,
+		}
+		if i%3 == 0 {
+			now := time.Now()
+			reason := "test"
+			b.QuarantinedAt = &now
+			b.QuarantineReason = &reason
+			quarantined++
+		}
+		_, err := ps.CreateBook(b)
+		require.NoError(t, err)
+	}
+	svc := NewAudiobookService(ps)
+	ctx := context.Background()
+	wantVisible := total - quarantined // 60
+
+	filt := ListFilters{
+		IsPrimaryVersion:   &primary,
+		SortBy:             "title",
+		SortOrder:          "asc",
+		ExcludeQuarantined: true,
+	}
+
+	// Page of 30 must be 30 non-quarantined books — not short-changed by the
+	// quarantined rows that fall in the [0,30) title window.
+	page, err := svc.GetAudiobooks(ctx, 30, 0, "", nil, nil, filt)
+	require.NoError(t, err)
+	require.Len(t, page, 30, "page must be filled with non-quarantined books")
+	for _, b := range page {
+		require.Nil(t, b.QuarantinedAt, "no quarantined book may appear")
+	}
+
+	// Count must agree with the visible total (count != items was the bug).
+	count, err := svc.CountAudiobooksFiltered(ctx, filt)
+	require.NoError(t, err)
+	require.Equal(t, wantVisible, count, "count must exclude quarantined to match items")
+
+	// Paging through must surface exactly wantVisible books, all unique.
+	seen := map[string]struct{}{}
+	for off := 0; off < wantVisible; off += 30 {
+		pg, err := svc.GetAudiobooks(ctx, 30, off, "", nil, nil, filt)
+		require.NoError(t, err)
+		for _, b := range pg {
+			require.Nil(t, b.QuarantinedAt)
+			seen[b.ID] = struct{}{}
+		}
+	}
+	require.Len(t, seen, wantVisible, "paging must surface every non-quarantined book exactly once")
 }

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -447,14 +447,15 @@ func bookSummariesToBooks(summaries []database.BookSummary) []database.Book {
 // boolean is what lets the caller safely SKIP the post-filter re-pagination:
 // re-slicing an already-paginated page by the original offset is what made
 // "page 2" (any offset>0) return zero rows.
-func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *bool, sortBy string, sortAscending bool) (summaries []database.BookSummary, didPushdown bool, err error) {
+func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *bool, sortBy string, sortAscending, excludeQuarantined bool) (summaries []database.BookSummary, didPushdown bool, err error) {
 	type filteredSummaryStore interface {
 		GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
 	}
 	filter := database.BookSummaryFilter{
-		IsPrimaryVersion: isPrimary,
-		SortBy:           sortBy,
-		SortAscending:    sortAscending,
+		IsPrimaryVersion:   isPrimary,
+		SortBy:             sortBy,
+		SortAscending:      sortAscending,
+		ExcludeQuarantined: excludeQuarantined,
 	}
 	if fs, ok := svc.store.(filteredSummaryStore); ok {
 		s, e := fs.GetAllBookSummariesFiltered(limit, offset, filter)
@@ -704,11 +705,12 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 	}
 
 	bsf := database.BookSummaryFilter{
-		IsPrimaryVersion: f.IsPrimaryVersion,
-		LibraryState:     libraryState,
-		ReviewStatus:     reviewStatus,
-		RestrictToIDs:    restrictIDs,
-		Predicate:        predicate,
+		IsPrimaryVersion:   f.IsPrimaryVersion,
+		ExcludeQuarantined: f.ExcludeQuarantined,
+		LibraryState:       libraryState,
+		ReviewStatus:       reviewStatus,
+		RestrictToIDs:      restrictIDs,
+		Predicate:          predicate,
 	}
 	if f.SortBy == "title" {
 		bsf.SortBy = "title"

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-06-23
+// last-edited: 2026-06-28
 
 package audiobooks
 
@@ -439,7 +439,15 @@ func bookSummariesToBooks(summaries []database.BookSummary) []database.Book {
 // by the store. Mock-friendly: when the store lacks
 // GetAllBookSummariesFiltered, falls back to GetAllBookSummaries(limit,
 // offset) — preserves the pre-pushdown test contract.
-func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *bool, sortBy string, sortAscending bool) ([]database.BookSummary, error) {
+//
+// Returns didPushdown=true when the store applied the IsPrimary/title filter
+// itself and already paginated the result (production memdb path). false means
+// the store fell back to the unfiltered GetAllBookSummaries path — the caller
+// must keep the in-memory post-filter pass so IsPrimary is still applied. This
+// boolean is what lets the caller safely SKIP the post-filter re-pagination:
+// re-slicing an already-paginated page by the original offset is what made
+// "page 2" (any offset>0) return zero rows.
+func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *bool, sortBy string, sortAscending bool) (summaries []database.BookSummary, didPushdown bool, err error) {
 	type filteredSummaryStore interface {
 		GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
 	}
@@ -449,14 +457,17 @@ func (svc *AudiobookService) summariesPushdown(limit, offset int, isPrimary *boo
 		SortAscending:    sortAscending,
 	}
 	if fs, ok := svc.store.(filteredSummaryStore); ok {
-		return fs.GetAllBookSummariesFiltered(limit, offset, filter)
+		s, e := fs.GetAllBookSummariesFiltered(limit, offset, filter)
+		return s, true, e
 	}
 	if uw, ok := svc.store.(interface{ Unwrap() database.Store }); ok {
 		if fs, ok2 := uw.Unwrap().(filteredSummaryStore); ok2 {
-			return fs.GetAllBookSummariesFiltered(limit, offset, filter)
+			s, e := fs.GetAllBookSummariesFiltered(limit, offset, filter)
+			return s, true, e
 		}
 	}
-	return svc.store.GetAllBookSummaries(limit, offset)
+	s, e := svc.store.GetAllBookSummaries(limit, offset)
+	return s, false, e
 }
 
 // summariesPushdownFiltered runs the full pushdown — every filter the

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-06-23
+// last-edited: 2026-06-28
 
 package audiobooks
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -83,15 +84,32 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 		// full-scan.
 		sortAsc := !strings.EqualFold(f.SortOrder, "desc")
 		if !hasHeavyPostFilters {
-			cacheKey := fmt.Sprintf("all:%d:%d:p=%v:sb=%s:asc=%v",
-				limit, offset, f.IsPrimaryVersion, f.SortBy, sortAsc)
+			// primaryKey renders the *bool as a stable token. Formatting the
+			// pointer itself with %v prints its memory address, which is unique
+			// per request — so the cache key never matched and the list cache
+			// never hit for is_primary_version queries (every library page).
+			primaryKey := "nil"
+			if f.IsPrimaryVersion != nil {
+				primaryKey = strconv.FormatBool(*f.IsPrimaryVersion)
+			}
+			cacheKey := fmt.Sprintf("all:%d:%d:p=%s:sb=%s:asc=%v",
+				limit, offset, primaryKey, f.SortBy, sortAsc)
 			if cached, ok := svc.listCache.Get(cacheKey); ok {
 				return cached, nil
 			}
-			summaries, sErr := svc.summariesPushdown(storeLimit, storeOffset, f.IsPrimaryVersion, f.SortBy, sortAsc)
+			summaries, didPushdown, sErr := svc.summariesPushdown(storeLimit, storeOffset, f.IsPrimaryVersion, f.SortBy, sortAsc)
 			if sErr == nil && summaries != nil {
 				books = bookSummariesToBooks(summaries)
 				svc.listCache.Set(cacheKey, books)
+			}
+			// When the store applied the filter AND paginated, the page is
+			// final. Running the post-filter block would re-slice this
+			// already-paginated page by the original offset — which is out of
+			// bounds for a ≤limit slice, so every offset>0 ("page 2") returned
+			// zero rows. Skip it. If the store fell back to the unfiltered path
+			// (didPushdown=false), keep the post-filter so IsPrimary is applied.
+			if didPushdown {
+				hasPostFilters = false
 			}
 		} else {
 			// Heavy-filter pushdown: build a BookSummaryFilter that

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -92,12 +92,12 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			if f.IsPrimaryVersion != nil {
 				primaryKey = strconv.FormatBool(*f.IsPrimaryVersion)
 			}
-			cacheKey := fmt.Sprintf("all:%d:%d:p=%s:sb=%s:asc=%v",
-				limit, offset, primaryKey, f.SortBy, sortAsc)
+			cacheKey := fmt.Sprintf("all:%d:%d:p=%s:sb=%s:asc=%v:noq=%v",
+				limit, offset, primaryKey, f.SortBy, sortAsc, f.ExcludeQuarantined)
 			if cached, ok := svc.listCache.Get(cacheKey); ok {
 				return cached, nil
 			}
-			summaries, didPushdown, sErr := svc.summariesPushdown(storeLimit, storeOffset, f.IsPrimaryVersion, f.SortBy, sortAsc)
+			summaries, didPushdown, sErr := svc.summariesPushdown(storeLimit, storeOffset, f.IsPrimaryVersion, f.SortBy, sortAsc, f.ExcludeQuarantined)
 			if sErr == nil && summaries != nil {
 				books = bookSummariesToBooks(summaries)
 				svc.listCache.Set(cacheKey, books)

--- a/internal/audiobooks/service_types.go
+++ b/internal/audiobooks/service_types.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_types.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a3f9b2c1-d4e5-6f70-8a9b-0c1d2e3f4a5b
-// last-edited: 2026-06-23
+// last-edited: 2026-06-28
 
 package audiobooks
 
@@ -77,9 +77,14 @@ type FieldFilter struct {
 // ListFilters holds optional filters for listing audiobooks.
 type ListFilters struct {
 	IsPrimaryVersion *bool
-	LibraryState     string
-	Tag              string
-	Tags             []string
+	// ExcludeQuarantined drops quarantined books during the indexed scan so
+	// pagination counts the post-quarantine set (a 500-page returns 500
+	// non-quarantined books, and the total count matches). Set by the HTTP
+	// layer from the inverse of ?show_quarantined.
+	ExcludeQuarantined bool
+	LibraryState       string
+	Tag                string
+	Tags               []string
 	SortBy           string        // column sort key
 	SortOrder        string        // "asc" or "desc"
 	FieldFilters     []FieldFilter // advanced field-specific filters (book-global)

--- a/internal/database/memdb_summaries.go
+++ b/internal/database/memdb_summaries.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_summaries.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000008
+// last-edited: 2026-06-28
 
 package database
 
@@ -29,6 +30,13 @@ type BookSummaryFilter struct {
 	// SortAscending controls iteration direction when SortBy is set.
 	// True (or zero value with SortBy=="title") = A→Z; false = Z→A.
 	SortAscending bool
+
+	// ExcludeQuarantined, when true, drops rows whose QuarantinedAt is set.
+	// Applied in-loop BEFORE offset/limit so pagination counts the post-
+	// quarantine set — a page of N returns N non-quarantined books, and the
+	// matching count (CountBookSummaries) agrees. The HTTP layer sets this from
+	// the inverse of ?show_quarantined.
+	ExcludeQuarantined bool
 
 	// LibraryState, if non-empty, restricts to books with this LibraryState
 	// (case-sensitive equality, e.g. "organized" / "imported" / "suspicious").
@@ -166,6 +174,9 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 		// In-loop filter pushdowns. Each predicate is O(1) per row; the
 		// loop body short-circuits on the first miss, so adding filters
 		// can only reduce work, never add it.
+		if f.ExcludeQuarantined && b.QuarantinedAt != nil {
+			continue
+		}
 		if f.LibraryState != "" {
 			ls := ""
 			if b.LibraryState != nil {
@@ -296,6 +307,9 @@ func (m *MemStore) CountBookSummaries(f BookSummaryFilter) (int, error) {
 			if isDel != requireDeleted {
 				continue
 			}
+		}
+		if f.ExcludeQuarantined && b.QuarantinedAt != nil {
+			continue
 		}
 		if f.LibraryState != "" {
 			ls := ""

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.98.0
+// version: 1.99.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-26
+// last-edited: 2026-06-28
 
 package database
 
@@ -1619,6 +1619,9 @@ func (p *PebbleStore) GetAllBookSummariesFiltered(limit, offset int, f BookSumma
 			if eff != *f.IsPrimaryVersion {
 				continue
 			}
+		}
+		if f.ExcludeQuarantined && s.QuarantinedAt != nil {
+			continue
 		}
 		filtered = append(filtered, s)
 	}

--- a/internal/httputil/parse.go
+++ b/internal/httputil/parse.go
@@ -1,7 +1,7 @@
 // file: internal/httputil/parse.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-01
+// last-edited: 2026-06-28
 
 package httputil
 
@@ -65,7 +65,12 @@ func ParseQueryString(c *gin.Context, key string) string {
 }
 
 // ParsePaginationParams parses limit, offset, and search from query params.
-// Defaults: limit=50, max=500, offset=0.
+// Defaults: limit=50, max=1000, offset=0.
+//
+// The cap exists so a malformed/hostile ?limit= can't force a huge projection,
+// but it must be high enough to honor the library "items per page" selector
+// (max option 1000). Below 1000 the page would silently return fewer rows than
+// the user asked for.
 func ParsePaginationParams(c *gin.Context) PaginationParams {
 	limit := ParseQueryInt(c, "limit", 50)
 	offset := ParseQueryInt(c, "offset", 0)
@@ -73,8 +78,8 @@ func ParsePaginationParams(c *gin.Context) PaginationParams {
 	if limit < 1 {
 		limit = 50
 	}
-	if limit > 500 {
-		limit = 500
+	if limit > 1000 {
+		limit = 1000
 	}
 	if offset < 0 {
 		offset = 0

--- a/internal/httputil/parse_test.go
+++ b/internal/httputil/parse_test.go
@@ -1,0 +1,49 @@
+// file: internal/httputil/parse_test.go
+// version: 1.0.0
+// guid: 5e2a7c91-8b04-4d6f-a1c3-9f0e2d4b6a18
+// last-edited: 2026-06-28
+
+package httputil
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func paginationCtx(t *testing.T, query string) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/?"+query, nil)
+	return c
+}
+
+func TestParsePaginationParams_Cap(t *testing.T) {
+	cases := []struct {
+		name      string
+		query     string
+		wantLimit int
+		wantOff   int
+	}{
+		{"default", "", 50, 0},
+		{"explicit 500 honored", "limit=500", 500, 0},
+		{"explicit 1000 honored", "limit=1000", 1000, 0},
+		{"above cap clamped to 1000", "limit=5000", 1000, 0},
+		{"below 1 falls to default", "limit=0", 50, 0},
+		{"negative offset zeroed", "limit=20&offset=-5", 20, 0},
+		{"offset preserved", "limit=20&offset=40", 20, 40},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := ParsePaginationParams(paginationCtx(t, tc.query))
+			if p.Limit != tc.wantLimit {
+				t.Errorf("limit = %d, want %d", p.Limit, tc.wantLimit)
+			}
+			if p.Offset != tc.wantOff {
+				t.Errorf("offset = %d, want %d", p.Offset, tc.wantOff)
+			}
+		})
+	}
+}

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
-// last-edited: 2026-05-05
+// last-edited: 2026-06-28
 
 package metafetch
 
@@ -80,6 +80,24 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		currentNarrator = *book.Narrator
 	}
 
+	// Transcription fallback: when the curated title/author/narrator is missing
+	// or garbage, fall back to what Whisper heard in the book's own intro
+	// ("TITLE by AUTHOR. Read by NARRATOR."). These are stored separately so a
+	// noisy transcript never overwrites curated metadata, but for discovery they
+	// are the best available query terms for an otherwise-unsearchable book.
+	th := hintsFromBook(book)
+	if IsGarbageValue(searchTitle) || strings.TrimSpace(searchTitle) == "" {
+		if th.title != "" {
+			searchTitle = th.title
+		}
+	}
+	if currentAuthor == "" && th.author != "" {
+		currentAuthor = th.author
+	}
+	if currentNarrator == "" && th.narrator != "" {
+		currentNarrator = th.narrator
+	}
+
 	var lastErr error
 	for _, src := range sources {
 		var results []metadata.BookMetadata
@@ -154,6 +172,23 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 				}
 			}
 
+			// Last resort: the audio-derived (transcribed) title, when it differs
+			// from everything tried above. For books with bad/empty curated titles
+			// the intro narration ("TITLE by AUTHOR") is often the only term that
+			// finds the right edition. Pair it with the transcribed author when we
+			// have one for a tighter match.
+			if len(results) == 0 && th.title != "" && th.title != searchTitle && th.title != book.Title {
+				if th.author != "" {
+					results, searchErr = src.SearchByTitleAndAuthor(context.Background(), th.title, th.author)
+				}
+				if len(results) == 0 {
+					results, searchErr = src.SearchByTitle(context.Background(), th.title)
+				}
+				if searchErr != nil {
+					lastErr = searchErr
+				}
+			}
+
 			// Write non-empty results to cache so future fetch/search calls
 			// for this book+source can skip the external API entirely.
 			if len(results) > 0 {
@@ -170,7 +205,13 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		}
 		if len(results) > 0 {
 			// Score all results and pick the best; reject if below quality threshold.
-			scored := mfs.bestTitleMatchForBook(book, results, currentAuthor, currentNarrator, searchTitle, book.Title)
+			// Pass the transcribed title too (when present) so its significant
+			// words contribute to F1 base scoring alongside the curated title.
+			scoreTitles := []string{searchTitle, book.Title}
+			if th.title != "" {
+				scoreTitles = append(scoreTitles, th.title)
+			}
+			scored := mfs.bestTitleMatchForBook(book, results, currentAuthor, currentNarrator, scoreTitles...)
 			if len(scored) == 0 {
 								slog.Debug("all results rejected by quality scorer for", "name", src.Name(), "count", len(results), "value", searchTitle)
 				continue // try next source

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
-// last-edited: 2026-05-01
+// last-edited: 2026-06-28
 
 package metafetch
 
@@ -11,6 +11,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -257,6 +258,51 @@ func computeDurationScore(bookDurationSec, candidateDurationSec int) float64 {
 // bonuses or author/narrator multipliers. This keeps the package-level
 // bestTitleMatchWithContext bit-for-bit equivalent to its pre-refactor
 // implementation, which the existing test suite locks in.
+// transcriptionHints carries the audio-derived (Whisper) title/author/narrator
+// for a book. These come from the book's own intro narration, so a candidate
+// that matches them is strong evidence of a correct match. Empty fields are
+// ignored. Passed optionally (variadic) so existing callers stay unchanged.
+type transcriptionHints struct {
+	title, author, narrator string
+}
+
+func (th transcriptionHints) empty() bool {
+	return th.title == "" && th.author == "" && th.narrator == ""
+}
+
+// containsCI reports whether a contains b (or vice-versa), case-insensitively.
+// Mirrors the substring-both-ways comparison the curated author/narrator boosts
+// already use, so transcription matching behaves consistently.
+func containsCI(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	al, bl := strings.ToLower(a), strings.ToLower(b)
+	return strings.Contains(al, bl) || strings.Contains(bl, al)
+}
+
+// transcriptionBoost multiplies score when a candidate matches the audio-derived
+// fields. Multipliers stack on top of the curated-field boosts; scores are
+// intentionally NOT clamped — bonuses add on top (see scoring memo). An exact
+// (normalized) transcribed-title match is the strongest signal because the title
+// is read aloud verbatim in the intro.
+func transcriptionBoost(score float64, r metadata.BookMetadata, th transcriptionHints) float64 {
+	if th.title != "" && r.Title != "" {
+		if util.NormalizeTitle(r.Title) == util.NormalizeTitle(th.title) {
+			score *= 2.0
+		} else if containsCI(r.Title, th.title) {
+			score *= 1.4
+		}
+	}
+	if th.author != "" && containsCI(r.Author, th.author) {
+		score *= 1.6
+	}
+	if th.narrator != "" && containsCI(r.Narrator, th.narrator) {
+		score *= 1.4
+	}
+	return score
+}
+
 func pickBestMatchFromScored(
 	results []metadata.BookMetadata,
 	baseScores []float64,
@@ -264,8 +310,14 @@ func pickBestMatchFromScored(
 	searchWords map[string]bool,
 	bookAuthor, bookNarrator string,
 	bookDurationSec int,
+	hints ...transcriptionHints,
 ) []metadata.BookMetadata {
 	const f1MinScore = 0.35
+
+	var th transcriptionHints
+	if len(hints) > 0 {
+		th = hints[0]
+	}
 
 	minScore := f1MinScore
 	if baseTier != "f1" {
@@ -321,6 +373,13 @@ func pickBestMatchFromScored(
 			score *= 1.15
 		} else {
 			score *= 0.85
+		}
+
+		// Transcription-match boost: when the candidate matches the book's own
+		// audio-derived title/author/narrator, that is strong evidence of a
+		// correct match. No-op when no transcription hints were supplied.
+		if !th.empty() {
+			score = transcriptionBoost(score, r, th)
 		}
 
 		// Duration-based scoring: compare candidate runtime against the book's
@@ -441,7 +500,28 @@ func (mfs *Service) bestTitleMatchForBook(
 	if book.Duration != nil {
 		bookDurationSec = *book.Duration
 	}
-	return pickBestMatchFromScored(results, baseScores, baseTier, searchWords, bookAuthor, bookNarrator, bookDurationSec)
+	return pickBestMatchFromScored(results, baseScores, baseTier, searchWords, bookAuthor, bookNarrator, bookDurationSec, hintsFromBook(book))
+}
+
+// hintsFromBook extracts the audio-derived transcription fields from a book for
+// transcription-match scoring. Garbage values are dropped so a noisy transcript
+// can't skew the boost.
+func hintsFromBook(book *database.Book) transcriptionHints {
+	clean := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		s := strings.TrimSpace(*p)
+		if s == "" || IsGarbageValue(s) {
+			return ""
+		}
+		return s
+	}
+	return transcriptionHints{
+		title:    clean(book.TranscribedTitle),
+		author:   clean(book.TranscribedAuthor),
+		narrator: clean(book.TranscribedNarrator),
+	}
 }
 
 // rerankTopK asks the LLM scorer to re-judge the ambiguous top candidates

--- a/internal/metafetch/transcription_match_test.go
+++ b/internal/metafetch/transcription_match_test.go
@@ -1,0 +1,90 @@
+// file: internal/metafetch/transcription_match_test.go
+// version: 1.0.0
+// guid: 9d3f1a6c-2b85-4e07-bc41-7a8e0f2d5c39
+// last-edited: 2026-06-28
+
+package metafetch
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPickBestMatch_TranscriptionBoost verifies the audio-derived transcription
+// hints steer the scorer toward the candidate that matches what Whisper heard in
+// the intro — even when a non-matching candidate has a higher base score.
+func TestPickBestMatch_TranscriptionBoost(t *testing.T) {
+	t.Run("transcribed_title_match_wins_over_higher_base", func(t *testing.T) {
+		results := []metadata.BookMetadata{
+			{Title: "The Wrong Book", Author: "A", Narrator: "N"},
+			{Title: "The Way of Kings", Author: "A", Narrator: "N"},
+		}
+		// The wrong book has the higher base score; the transcription pulls the
+		// right one ahead via the ×2.0 exact-title multiplier.
+		scores := []float64{0.9, 0.6}
+		words := SignificantWords("The Way of Kings")
+		th := transcriptionHints{title: "The Way of Kings"}
+
+		matched := pickBestMatchFromScored(results, scores, "f1", words, "", "", 0, th)
+		require.NotEmpty(t, matched)
+		assert.Equal(t, "The Way of Kings", matched[0].Title)
+	})
+
+	t.Run("transcribed_author_match_boosts", func(t *testing.T) {
+		results := []metadata.BookMetadata{
+			{Title: "Mistborn", Author: "Wrong Author", Narrator: "N"},
+			{Title: "Mistborn", Author: "Brandon Sanderson", Narrator: "N"},
+		}
+		scores := []float64{0.8, 0.7}
+		words := SignificantWords("Mistborn")
+		th := transcriptionHints{author: "Brandon Sanderson"}
+
+		matched := pickBestMatchFromScored(results, scores, "f1", words, "", "", 0, th)
+		require.NotEmpty(t, matched)
+		assert.Equal(t, "Brandon Sanderson", matched[0].Author)
+	})
+
+	t.Run("no_hints_leaves_behavior_unchanged", func(t *testing.T) {
+		results := []metadata.BookMetadata{
+			{Title: "Mistborn", Author: "Brandon Sanderson"},
+			{Title: "Elantris", Author: "Brandon Sanderson"},
+		}
+		scores := []float64{0.9, 0.5}
+		words := SignificantWords("Mistborn")
+
+		// Empty variadic (no hints) and an explicit-empty hint must both match
+		// the pre-feature result: highest base score wins.
+		withoutArg := pickBestMatchFromScored(results, scores, "f1", words, "", "", 0)
+		withEmpty := pickBestMatchFromScored(results, scores, "f1", words, "", "", 0, transcriptionHints{})
+		require.NotEmpty(t, withoutArg)
+		require.NotEmpty(t, withEmpty)
+		assert.Equal(t, "Mistborn", withoutArg[0].Title)
+		assert.Equal(t, withoutArg[0].Title, withEmpty[0].Title)
+	})
+}
+
+func TestContainsCI(t *testing.T) {
+	assert.True(t, containsCI("Brandon Sanderson", "sanderson"))
+	assert.True(t, containsCI("sanderson", "Brandon Sanderson")) // both-ways
+	assert.False(t, containsCI("Brandon Sanderson", "Tolkien"))
+	assert.False(t, containsCI("", "x"))
+	assert.False(t, containsCI("x", ""))
+}
+
+func TestHintsFromBook_DropsGarbage(t *testing.T) {
+	good := "The Way of Kings"
+	garbage := "Unknown" // matches IsGarbageValue blocklist
+	empty := "   "
+	th := hintsFromBook(&database.Book{
+		TranscribedTitle:    &good,
+		TranscribedAuthor:   &garbage,
+		TranscribedNarrator: &empty,
+	})
+	assert.Equal(t, "The Way of Kings", th.title)
+	assert.Equal(t, "", th.author, "garbage transcribed author must be dropped")
+	assert.Equal(t, "", th.narrator, "blank transcribed narrator must be dropped")
+}

--- a/internal/server/audiobooks_helpers.go
+++ b/internal/server/audiobooks_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/audiobooks_helpers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 439aa827-edea-481d-8918-ddacd2c140b7
-// last-edited: 2026-06-03
+// last-edited: 2026-06-28
 
 // Server-package helpers relocated out of audiobooks_handlers.go when the
 // audiobooks HTTP handlers were extracted into the handlers/audiobooks
@@ -41,11 +41,22 @@ import (
 // buildListResponse closure) and the startup cache warmer so both produce
 // identical results.
 func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset int, search string, authorID, seriesID *int, filters ListFilters, showQuarantined bool) (gin.H, error) {
+	// Push quarantine exclusion DOWN into the indexed scan (and the count) so a
+	// page of N returns N non-quarantined books and totalCount agrees. Dropping
+	// quarantined rows AFTER pagination (as this used to) made a 500-page return
+	// fewer than 500 and made count != items.
+	if !showQuarantined {
+		filters.ExcludeQuarantined = true
+	}
+
 	books, err := s.audiobookService.GetAudiobooks(ctx, limit, offset, search, authorID, seriesID, filters)
 	if err != nil {
 		return nil, err
 	}
 
+	// Safety net for the degraded (memdb-down) read path, where the Pebble
+	// fallback does not honor ExcludeQuarantined. In the normal memdb path the
+	// scan already excluded these, so this drops nothing.
 	if !showQuarantined {
 		filtered := books[:0]
 		for _, b := range books {
@@ -78,7 +89,7 @@ func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset i
 	}
 
 	totalCount := len(enriched)
-	hasFilters := filters.IsPrimaryVersion != nil || filters.LibraryState != "" || filters.Tag != "" || len(filters.Tags) > 0
+	hasFilters := filters.IsPrimaryVersion != nil || filters.ExcludeQuarantined || filters.LibraryState != "" || filters.Tag != "" || len(filters.Tags) > 0
 	if search == "" && authorID == nil && seriesID == nil {
 		if hasFilters {
 			if tc, err := s.audiobookService.CountAudiobooksFiltered(ctx, filters); err == nil {

--- a/internal/server/error_handler_test.go
+++ b/internal/server/error_handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/error_handler_test.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 6e7f8a9b-0c1d-2e3f-4a5b-6c7d8e9f0a1b
-// last-edited: 2026-05-05
+// last-edited: 2026-06-28
 
 package server
 
@@ -183,7 +183,7 @@ func TestParsePaginationParams(t *testing.T) {
 		{
 			name:       "limit exceeds max",
 			queryStr:   "/?limit=20000",
-			wantLimit:  500,
+			wantLimit:  1000,
 			wantOffset: 0,
 			wantSearch: "",
 		},

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.5.1
+// version: 1.5.2
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-23
+// last-edited: 2026-06-28
 
 import {
   Typography,
@@ -388,6 +388,7 @@ export const LibraryBookGrid = ({
               <MenuItem value={100}>100</MenuItem>
               <MenuItem value={250}>250</MenuItem>
               <MenuItem value={500}>500</MenuItem>
+              <MenuItem value={1000}>1000</MenuItem>
             </TextField>
             {totalPages > 1 && (
               <Pagination


### PR DESCRIPTION
## Summary

Fixes the user-reported library bug — **clicking page 2 of "all books" returns 0 items** — plus two adjacent issues, and wires audio transcription into metadata discovery.

### 1. Page-2 pagination (double pagination)
The light-pushdown path in `GetAudiobooks` lets memdb paginate (returning exactly the requested page), but `sort_by=title` / `is_primary_version` set `hasPostFilters=true`, so the post-filter block **re-sliced the already-paginated page by the original offset** — out of bounds for a ≤limit slice, so any offset>0 collapsed to nil. Smoking gun: `limit=500&offset=499 → 1`, `offset=500 → 0`.

Fix: `summariesPushdown` returns `didPushdown`; the caller clears `hasPostFilters` only when the store actually filtered+paginated (mirrors the heavy path). Also fixes the service list-cache key that formatted a `*bool` with `%v` (printed the pointer address → cache never hit for primary queries).

### 2. "500 means 500"
Raised the shared pagination cap 500→1000 (+ a 1000 option in the library items-per-page selector), and pushed **quarantine exclusion into the indexed scan** (`BookSummaryFilter.ExcludeQuarantined`) so a page of N returns N non-quarantined books and `count` matches `items`. Previously quarantined rows were dropped *after* pagination → short pages and count≠items.

### 3. Transcription → discovery
`Book.TranscribedTitle/Author/Narrator` (Whisper intro transcription) now feed the automatic metadata discovery pipeline:
- **Query construction**: fall back to transcribed values when curated title/author/narrator is empty/garbage; last-resort transcribed-title (+author) search attempt; transcribed title added to the scorer's significant-word set.
- **Scoring**: backward-compatible variadic `transcriptionHints` on `pickBestMatchFromScored`; a candidate matching the transcription is boosted (exact normalized title ×2.0, substring ×1.4, author ×1.6, narrator ×1.4), stacking on curated-field multipliers. Garbage transcripts dropped via `hintsFromBook`.

## Tests
- Real-PebbleStore (memdb pushdown) regression: contiguous title order across pages for **bare and production-shape wrapped (`Unwrap`) stores**; 500/500 large-page slices; `ParsePaginationParams` cap.
- Quarantine: every-3rd-book quarantined → 30-page stays full, count == visible total, paging surfaces each non-quarantined book once.
- Transcription boost steers past a higher-base-score non-match; no-hints path unchanged; garbage-dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)