### PR TITLE
fix(transcribe): correct Whisper-intro parsing (publisher prefix, read-by narrator, noise) + reparse mode

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -36,6 +36,12 @@ type introTranscribeParams struct {
 	// OnlyMissing skips books that already have an IntroTranscription.
 	// Defaults to true so re-runs are incremental.
 	OnlyMissing *bool `json:"only_missing,omitempty"`
+	// ReparseOnly re-runs ParseAudiobookIntro over the ALREADY-STORED
+	// IntroTranscription text and rewrites TranscribedTitle/Author/Narrator —
+	// no ffmpeg, no Whisper. Use after a parser fix to correct existing books
+	// (e.g. the "[Publisher] presents ..." / read-by extraction fix) without the
+	// cost of re-transcribing. Cheap: one GetBookByID + UpdateBook per book.
+	ReparseOnly *bool `json:"reparse_only,omitempty"`
 }
 
 func (p *Plugin) introTranscribeDef() sdk.OperationDef {
@@ -43,7 +49,7 @@ func (p *Plugin) introTranscribeDef() sdk.OperationDef {
 		ID:              "maintenance.transcribe-book-intros",
 		Plugin:          "maintenance",
 		DisplayName:     "Transcribe book intros",
-		Description:     "Extracts the first 90 seconds of each book's first audio file and transcribes it with Whisper. Stores the result in TranscribedTitle/Author/Narrator (separate from curated metadata) for disambiguation and dedup cross-checks. Uses batch mode: one Python process per page of 200 books loads the model once. 90s captures past Audible jingles/music intros that caused 30s clips to return only 'This is Audible.'",
+		Description:     "Extracts the first 90 seconds of each book's first audio file and transcribes it with Whisper. Stores the result in TranscribedTitle/Author/Narrator (separate from curated metadata) for disambiguation and dedup cross-checks. Uses batch mode: one Python process per page of 200 books loads the model once. 90s captures past Audible jingles/music intros that caused 30s clips to return only 'This is Audible.' Param reparse_only=true re-runs the parser over already-stored transcripts and rewrites the parsed fields with no ffmpeg/Whisper — use it to apply a parser fix to existing books cheaply.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.transcribe-book-intros",
@@ -74,8 +80,20 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 		_ = json.Unmarshal(rawParams, &params)
 	}
 	onlyMissing := params.OnlyMissing == nil || *params.OnlyMissing
+	reparseOnly := params.ReparseOnly != nil && *params.ReparseOnly
 
 	log := reporter.Logger()
+
+	// Reparse-only mode short-circuits the whole Whisper pipeline: it re-runs the
+	// parser over stored transcripts and rewrites the parsed fields. Used to apply
+	// a parser fix to existing books cheaply.
+	if reparseOnly {
+		ids, err := store.ListBookIDs()
+		if err != nil {
+			return fmt.Errorf("list book ids: %w", err)
+		}
+		return p.reparseStoredIntros(ctx, store, reporter, ids)
+	}
 
 	// Load the FULL, ordered list of book IDs up front. This is the proven
 	// uncapped primitive (memdb ID-index walk). The previous implementation
@@ -167,6 +185,72 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	log.Info("transcribe-book-intros: complete", "processed", processed, "total_books", total)
 	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf("Done — transcribed %d books", processed))
 	return nil
+}
+
+// reparseStoredIntros re-runs ParseAudiobookIntro over every book's stored
+// IntroTranscription and rewrites TranscribedTitle/Author/Narrator to the new
+// parse. No ffmpeg, no Whisper — used to apply a parser fix to existing data.
+// UpdateBook does full-column replacement, and GetBookByID returns the full
+// row, so only the three parsed fields change. IntroTranscribedAt is left
+// untouched (reparse is not a new transcription).
+func (p *Plugin) reparseStoredIntros(ctx context.Context, store interface {
+	ListBookIDs() ([]string, error)
+	GetBookByID(string) (*database.Book, error)
+	UpdateBook(string, *database.Book) (*database.Book, error)
+}, reporter sdk.Reporter, ids []string) error {
+	log := reporter.Logger()
+	total := len(ids)
+	var scanned, changed int
+	for i, id := range ids {
+		if i%500 == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			_ = reporter.UpdateProgress(i, total,
+				fmt.Sprintf("Reparsing intros — %d/%d (%d updated)", i, total, changed))
+		}
+		b, err := store.GetBookByID(id)
+		if err != nil || b == nil || b.IntroTranscription == nil || *b.IntroTranscription == "" {
+			continue
+		}
+		scanned++
+		f := transcribe.ParseAudiobookIntro(*b.IntroTranscription)
+		nt, na, nn := strPtrOrNil(f.Title), strPtrOrNil(f.Author), strPtrOrNil(f.Narrator)
+		if eqStrPtr(b.TranscribedTitle, nt) && eqStrPtr(b.TranscribedAuthor, na) && eqStrPtr(b.TranscribedNarrator, nn) {
+			continue // unchanged — skip the write
+		}
+		b.TranscribedTitle, b.TranscribedAuthor, b.TranscribedNarrator = nt, na, nn
+		if _, err := store.UpdateBook(b.ID, b); err != nil {
+			log.Warn("reparse-intros: update failed", "book_id", b.ID, "err", err)
+			continue
+		}
+		changed++
+	}
+	log.Info("reparse-intros: complete", "scanned", scanned, "changed", changed, "total_books", total)
+	_ = reporter.UpdateProgress(total, total,
+		fmt.Sprintf("Reparse complete — %d updated of %d transcribed (%d books)", changed, scanned, total))
+	return nil
+}
+
+// strPtrOrNil returns nil for empty/whitespace strings, else a pointer to the
+// trimmed value. Keeps cleared parse results out of the DB as NULL.
+func strPtrOrNil(s string) *string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// eqStrPtr reports whether two *string values are equal (both nil, or both set
+// to the same string).
+func eqStrPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // chunkIDs splits ids into consecutive slices of at most size elements.

--- a/internal/transcribe/parse.go
+++ b/internal/transcribe/parse.go
@@ -1,7 +1,7 @@
 // file: internal/transcribe/parse.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-26
+// last-edited: 2026-06-28
 
 package transcribe
 
@@ -18,32 +18,144 @@ type IntroFields struct {
 	Raw      string // original transcript, for debugging
 }
 
-// Common patterns seen in audiobook intros, in preference order.
-// Group names: title, author, narrator.
-var introPatterns = []*regexp.Regexp{
-	// "The Name of the Wind by Patrick Rothfuss, read by Nick Podehl"
-	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[,\.]\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)[\.\,]?$`),
-	// "The Name of the Wind by Patrick Rothfuss. Read by Nick Podehl."
-	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)\.\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)\.?$`),
-	// Without narrator: "The Name of the Wind by Patrick Rothfuss"
-	regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[\.\,]?$`),
+// Whisper transcripts of audiobook intros follow a consistent spoken grammar:
+//
+//	"[Publisher] (audio) presents [TITLE] by [AUTHOR]. Read by [NARRATOR]. <noise>"
+//
+// but Whisper rarely emits punctuation, so the old end-anchored regexes failed
+// and dumped the entire post-"by" acknowledgements wall into Author. We parse in
+// explicit stages instead: strip the credit prefix, split the title on the first
+// " by ", split author/narrator on "read by", then truncate each name field at
+// the first prose/acknowledgement boundary.
+var (
+	// "[Publisher] (audio) presents " — bounded to ~80 chars so a real title that
+	// happens to contain "presents" later isn't eaten.
+	presentsPrefixRe = regexp.MustCompile(`(?i)^.{0,80}?\b(?:audio\s+)?presents\b\s+`)
+
+	// Common junk openers captured by the 90s clip before the real announcement.
+	junkOpenerRe = regexp.MustCompile(`(?i)^(?:this is audible[.,]?\s+|audible hopes you enjoy[^.]*\.\s+|an audible original[.,]?\s+|brilliance audio[.,]?\s+)`)
+
+	// First standalone "by" separating title from author.
+	byRe = regexp.MustCompile(`(?i)\bby\b`)
+
+	// "read|narrated|performed by" separating author from narrator.
+	readByRe = regexp.MustCompile(`(?i)\b(?:read|narrated|performed)\s+by\b`)
+
+	// Strong boundary marking the end of a name and the start of prose/noise.
+	// Everything from here on is acknowledgements, blurb, or chapter text.
+	nameBoundaryRe = regexp.MustCompile(`(?i)\b(` +
+		`with an introduction|with a foreword|with an afterword|with a preface|` +
+		`introduction by|foreword by|afterword by|preface by|` +
+		`no one writes|and of course|and i would|i would like|would like to thank|` +
+		`this is a production|this is an? [\w']+ production|a production of|` +
+		`unabridged|abridged|copyright|all rights|published by|` +
+		`chapter one|chapter 1|prologue|part one|part 1` +
+		`)\b`)
+
+	wsRe = regexp.MustCompile(`\s+`)
+)
+
+// connectorWords are stripped from the trailing edge of a name field — they are
+// dangling joiners left behind after boundary truncation (e.g. "Stephen King and").
+var connectorWords = map[string]bool{
+	"and": true, "with": true, "by": true, "read": true, "the": true,
+	"a": true, "an": true, "for": true, "of": true, "to": true, "narrated": true,
+	"performed": true,
 }
 
 // ParseAudiobookIntro extracts title, author, and narrator from a raw
 // transcription of an audiobook's opening seconds. Returns zero-value
-// IntroFields if the text doesn't match any known pattern.
+// IntroFields if the text doesn't contain a recognizable "<title> by <author>"
+// announcement.
 func ParseAudiobookIntro(text string) IntroFields {
 	out := IntroFields{Raw: text}
 
-	// Normalize whitespace and trim filler words that sometimes appear before
-	// the actual announcement (music cues, publisher logos, etc.).
-	// We scan line-by-line and take the first line that looks like an intro.
-	for _, line := range splitLines(text) {
+	norm := collapseWS(strings.Join(splitLines(text), " "))
+	if norm == "" {
+		return out
+	}
+
+	// 1. Strip junk openers, then the "[Publisher] presents" credit prefix.
+	norm = junkOpenerRe.ReplaceAllString(norm, "")
+	norm = presentsPrefixRe.ReplaceAllString(norm, "")
+	norm = strings.TrimSpace(norm)
+
+	// 2. Split title from the rest on the FIRST standalone "by". Without the
+	// "<title> by <author>" grammar there is no trustworthy announcement — a 90s
+	// Whisper clip with no "by" is almost always a jingle/disclaimer ("This is
+	// Audible.") or chapter text, so we extract nothing rather than guess a title.
+	title, rest, hasBy := splitOnFirstRe(byRe, norm)
+	if !hasBy {
+		return out
+	}
+	out.Title = clean(title)
+
+	// 3. Split author (before "read by") from narrator (after).
+	author, narrator, hasReadBy := splitOnFirstRe(readByRe, rest)
+	out.Author = truncateName(author)
+	if hasReadBy {
+		out.Narrator = truncateName(narrator)
+	}
+
+	if out.Title != "" && out.Author != "" {
+		return out
+	}
+
+	// 4. Last-resort fallback: the old line-by-line / whole-text patterns, in
+	// case staged extraction produced nothing usable (e.g. an unusual intro).
+	if f := legacyPatternParse(text); f.Title != "" && f.Author != "" {
+		f.Raw = text
+		return f
+	}
+	return out
+}
+
+// truncateName trims a candidate name field down to just the name: it cuts at
+// the first prose/acknowledgement boundary, caps the word count (names are
+// short), and strips trailing connector words and punctuation.
+func truncateName(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Cut at the first strong boundary (start of acknowledgements / blurb).
+	if loc := nameBoundaryRe.FindStringIndex(s); loc != nil {
+		s = s[:loc[0]]
+	}
+	// Names are short; a long run is runaway noise. Cap to 6 words (allows a
+	// two-person "X Y and A B" credit).
+	fields := strings.Fields(s)
+	if len(fields) > 6 {
+		fields = fields[:6]
+	}
+	// Strip trailing dangling connectors left by the boundary cut.
+	for len(fields) > 0 {
+		last := strings.ToLower(strings.Trim(fields[len(fields)-1], ".,;:"))
+		if connectorWords[last] {
+			fields = fields[:len(fields)-1]
+			continue
+		}
+		break
+	}
+	return clean(strings.Join(fields, " "))
+}
+
+// legacyPatternParse is the previous regex-list approach, kept only as a
+// last-resort fallback for intros the staged parser can't handle.
+func legacyPatternParse(text string) IntroFields {
+	var out IntroFields
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[,\.]\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)[\.\,]?$`),
+		regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)\.\s+(?:read|narrated)\s+by\s+(?P<narrator>.+?)\.?$`),
+		regexp.MustCompile(`(?i)^(?P<title>.+?)\s+by\s+(?P<author>.+?)[\.\,]?$`),
+	}
+	candidates := append(splitLines(text), strings.Join(splitLines(text), " "))
+	for _, line := range candidates {
 		line = strings.TrimSpace(line)
 		if len(line) < 5 {
 			continue
 		}
-		for _, re := range introPatterns {
+		for _, re := range patterns {
 			m := reNamedMatch(re, line)
 			if m == nil {
 				continue
@@ -56,22 +168,6 @@ func ParseAudiobookIntro(text string) IntroFields {
 			}
 		}
 	}
-
-	// Second pass: the whole text as one string (in case Whisper didn't add newlines).
-	norm := strings.Join(splitLines(text), " ")
-	for _, re := range introPatterns {
-		m := reNamedMatch(re, norm)
-		if m == nil {
-			continue
-		}
-		out.Title = clean(m["title"])
-		out.Author = clean(m["author"])
-		out.Narrator = clean(m["narrator"])
-		if out.Title != "" && out.Author != "" {
-			return out
-		}
-	}
-
 	return out
 }
 
@@ -110,6 +206,21 @@ func titleWords(s string) []string {
 	return out
 }
 
+// splitOnFirstRe splits s at the first match of re. Returns the text before the
+// match, the text after it, and whether a match was found. When no match,
+// before=s, after="".
+func splitOnFirstRe(re *regexp.Regexp, s string) (before, after string, found bool) {
+	loc := re.FindStringIndex(s)
+	if loc == nil {
+		return s, "", false
+	}
+	return s[:loc[0]], s[loc[1]:], true
+}
+
+func collapseWS(s string) string {
+	return strings.TrimSpace(wsRe.ReplaceAllString(s, " "))
+}
+
 func splitLines(s string) []string {
 	return strings.FieldsFunc(s, func(r rune) bool {
 		return r == '\n' || r == '\r'
@@ -118,7 +229,7 @@ func splitLines(s string) []string {
 
 func clean(s string) string {
 	s = strings.TrimSpace(s)
-	s = strings.TrimRight(s, ".,;:")
+	s = strings.Trim(s, ".,;:")
 	return strings.TrimSpace(s)
 }
 

--- a/internal/transcribe/parse_test.go
+++ b/internal/transcribe/parse_test.go
@@ -1,0 +1,124 @@
+// file: internal/transcribe/parse_test.go
+// version: 1.0.0
+// guid: 4f8b1d6a-9c20-4e51-bb73-1a2c3d4e5f60
+// last-edited: 2026-06-28
+
+package transcribe
+
+import "testing"
+
+func TestParseAudiobookIntro(t *testing.T) {
+	// The real failing case from prod (book 01KNDBS8BC5D7Y6ARC9K74JY1T).
+	salemsLot := "Simon and Schuster audio presents Salem's Lot by Stephen King " +
+		"Read by Ron McClarty with an introduction by Stephen King No one writes a " +
+		"long novel alone and I would like to take a moment of your time to thank some " +
+		"of the people who helped with this one G Everett McCutchen of Hamden Academy " +
+		"for his practical suggestions and encouragement Dr. John Pearson of Old Town, " +
+		"Maine, medical examiner of Penobscot County, and member in good standing of " +
+		"that most excellent medical specialty general practice. Father Renald Halley " +
+		"of St. John's Catholic Church in Bangor, Maine, and of course my wife, whose " +
+		"criticism is as tough and unflinching as ever. Although the town surrounding " +
+		"Salem's lot are very real, Salem's lot exists wholly in the author's " +
+		"imagination. and any resemblance between the people who live there and the " +
+		"people who live in the real world is coincidental and unintended. I first " +
+		"read Dracula when I was 9 or 10"
+
+	cases := []struct {
+		name                          string
+		text                          string
+		wantTitle, wantAuthor, wantNr string
+	}{
+		{
+			name:       "salems_lot_publisher_presents_readby_then_acknowledgements",
+			text:       salemsLot,
+			wantTitle:  "Salem's Lot",
+			wantAuthor: "Stephen King",
+			wantNr:     "Ron McClarty",
+		},
+		{
+			name:       "publisher_audio_presents",
+			text:       "Penguin Random House Audio presents The Martian by Andy Weir Read by R.C. Bray",
+			wantTitle:  "The Martian",
+			wantAuthor: "Andy Weir",
+			wantNr:     "R.C. Bray",
+		},
+		{
+			name:       "bare_presents_no_audio_word",
+			text:       "Macmillan presents Project Hail Mary by Andy Weir narrated by Ray Porter",
+			wantTitle:  "Project Hail Mary",
+			wantAuthor: "Andy Weir",
+			wantNr:     "Ray Porter",
+		},
+		{
+			name:       "no_publisher_clean_readby",
+			text:       "The Name of the Wind by Patrick Rothfuss Read by Nick Podehl",
+			wantTitle:  "The Name of the Wind",
+			wantAuthor: "Patrick Rothfuss",
+			wantNr:     "Nick Podehl",
+		},
+		{
+			name:       "comma_punctuated_classic_case",
+			text:       "The Hobbit by J.R.R. Tolkien, read by Rob Inglis.",
+			wantTitle:  "The Hobbit",
+			wantAuthor: "J.R.R. Tolkien",
+			wantNr:     "Rob Inglis",
+		},
+		{
+			name:       "narrator_followed_by_introduction_noise",
+			text:       "Dune by Frank Herbert read by Scott Brick with an introduction by the author and a note on pronunciation",
+			wantTitle:  "Dune",
+			wantAuthor: "Frank Herbert",
+			wantNr:     "Scott Brick",
+		},
+		{
+			name:       "author_trailing_noise_no_readby",
+			text:       "On Writing by Stephen King No one writes a long novel alone and I would like to thank everyone",
+			wantTitle:  "On Writing",
+			wantAuthor: "Stephen King",
+			wantNr:     "",
+		},
+		{
+			name:       "performed_by_variant",
+			text:       "Lincoln in the Bardo by George Saunders performed by a full cast",
+			wantTitle:  "Lincoln in the Bardo",
+			wantAuthor: "George Saunders",
+			wantNr:     "a full cast",
+		},
+		{
+			name:       "two_narrators_with_and",
+			text:       "Good Omens by Neil Gaiman read by Martin Jarvis and Peter Serafinowicz",
+			wantTitle:  "Good Omens",
+			wantAuthor: "Neil Gaiman",
+			wantNr:     "Martin Jarvis and Peter Serafinowicz",
+		},
+		{
+			name:       "empty_input",
+			text:       "",
+			wantTitle:  "",
+			wantAuthor: "",
+			wantNr:     "",
+		},
+		{
+			name:       "no_by_at_all_title_only",
+			text:       "This is Audible.",
+			wantTitle:  "",
+			wantAuthor: "",
+			wantNr:     "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseAudiobookIntro(tc.text)
+			if got.Title != tc.wantTitle {
+				t.Errorf("Title  = %q, want %q", got.Title, tc.wantTitle)
+			}
+			if got.Author != tc.wantAuthor {
+				t.Errorf("Author = %q, want %q", got.Author, tc.wantAuthor)
+			}
+			if got.Narrator != tc.wantNr {
+				t.Errorf("Narrator = %q, want %q", got.Narrator, tc.wantNr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The Whisper-intro parser dumped garbage into the transcribed fields. Real data, book `01KNDBS8BC5D7Y6ARC9K74JY1T` ("Salem's Lot"):

| Field | Before |
|---|---|
| Title | `Simon and Schuster audio presents Salem's Lot` |
| Author | `Stephen King Read by Ron McClarty with an introduction by Stephen King No one writes a long novel alone … I first read Dracula when I was 9 or 10` |
| Narrator | *(empty)* |

**Root cause** (`internal/transcribe/parse.go`): the three `introPatterns` required the narrator at end-of-string with punctuation before "read by". Whisper emits no punctuation, so real intros fell through to the bare `^title by author$` pattern — the publisher prefix stayed in the title, the author swallowed everything after "by", and the narrator was never extracted.

## Fix

Rewrote `ParseAudiobookIntro` as a **staged extractor**:
1. normalize whitespace
2. strip junk openers + the `[Publisher] (audio) presents` credit prefix (bounded so a real title isn't eaten)
3. split title from the rest on the first standalone `by`
4. split author/narrator on `read|narrated|performed by`
5. `truncateName` each field at the first prose boundary (`with an introduction`, `no one writes`, `copyright`, `chapter one`, …), cap word count, trim trailing connectors

No `by` grammar → extract nothing (a jingle/disclaimer clip isn't a title). The old regex list is kept as a last-resort fallback.

| Field | After |
|---|---|
| Title | `Salem's Lot` |
| Author | `Stephen King` |
| Narrator | `Ron McClarty` |

## Reparse existing data

Added `reparse_only=true` to `maintenance.transcribe-book-intros`: re-runs the parser over already-stored `IntroTranscription` and rewrites the parsed fields with **no ffmpeg/Whisper** — corrects the whole library cheaply (one `GetBookByID`+`UpdateBook` per changed book, skips unchanged, leaves `IntroTranscribedAt` untouched).

## Tests

`internal/transcribe/parse_test.go` — 11 cases incl. the verbatim Salem's Lot transcript, publisher variants (`X presents`, `X audio presents`, bare `presents`), `narrated`/`performed by`, comma-punctuated classic, narrator-then-introduction-noise, two-narrator, trailing-acknowledgements, and junk-only. `go vet` + `go test ./internal/transcribe/ ./internal/plugins/maintenance/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)