### PR TITLE
docs(agent-tasks): manual AI-agent task package + orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.86.0 -->
+<!-- version: 3.87.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-26 -->
+<!-- last-edited: 2026-06-28 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features
+
+#### June 28, 2026 — Library pagination, transcription parser + matching, agent-task package (PRs #1660, #1661)
+
+- **`fix(library)`** (PR #1660) — Repaired the "page 2 of all books returns 0 items" bug. Root cause was **double pagination**: the light-pushdown path let memdb paginate, then the post-filter block re-sliced the already-paginated page by the original offset (out of bounds for a ≤limit slice), so any offset>0 collapsed to nil. Fixed via a `didPushdown` flag (clears `hasPostFilters` only when the store actually filtered+paginated). Also fixed the service list-cache key that formatted a `*bool` with `%v` (printed the pointer address → cache never hit for primary queries). Verified on prod: page 2 = 20 (was 0), page 1 = 20 (was 10), 500 = 500.
+- **`fix(library)`** (PR #1660) — Pushed quarantine exclusion into the indexed scan (`BookSummaryFilter.ExcludeQuarantined`) so a page of N returns N non-quarantined books and the count matches items (previously quarantined rows were dropped AFTER pagination → short pages, count≠items). Raised the shared pagination cap 500→1000 + a 1000 option in the library items-per-page selector.
+- **`feat(metafetch)`** (PR #1660) — Wired the audio-derived `TranscribedTitle/Author/Narrator` into metadata **discovery**: fallback query construction when curated metadata is garbage/empty, a last-resort transcribed-title search, and a scoring boost (exact normalized title ×2.0, substring ×1.4, author ×1.6, narrator ×1.4) via a backward-compatible `transcriptionHints` param on `pickBestMatchFromScored`.
+- **`fix(transcribe)`** (PR #1661) — Rewrote `ParseAudiobookIntro` as a staged extractor (strip `[Publisher] presents` prefix → split title on first `by` → split author/narrator on `read by` → truncate each name at the first prose boundary). Fixes the Salem's Lot case: Title `Simon and Schuster audio presents Salem's Lot`→`Salem's Lot`, Author (entire acknowledgements wall)→`Stephen King`, Narrator ``→`Ron McClarty`. 11-case table test.
+- **`feat(transcribe)`** (PR #1661) — Added `reparse_only=true` to `maintenance.transcribe-book-intros`: re-runs the parser over already-stored transcripts and rewrites the parsed fields with no ffmpeg/Whisper. First prod run corrected ~80% of transcribed books.
+- **`docs(agent-tasks)`** — Added `docs/agent-tasks/`: a self-contained, in-repo manual task package (weak-model-proof, worktree-disciplined, portable generic-subagent roster) with a portable multi-agent orchestration pattern (`ORCHESTRATION.md` + `run-sweep.sh`) and four workstreams — transcription-matching (5 tasks), dedup-intro-falsepositive (4), dedup-ui (5), system-docs (DOCS-1, 7 tasks).
 
 #### June 26, 2026 — Batch Whisper dep pins + crash-recovery checkpoint (PRs #1637, #1638)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.45.0 -->
+<!-- version: 9.46.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-06-26 -->
+<!-- last-edited: 2026-06-28 -->
 
 # Project TODO
 
@@ -10,12 +10,37 @@ Details live in the linked files; this file exists so anyone (you, me, a
 future agent) can scan the entire workspace in one page.
 
 **Sources indexed here:**
+- [`docs/agent-tasks/`](docs/agent-tasks/) — **manual AI-agent task package** (run by hand, not the burndown bot): self-contained briefs + orchestration scripts
 - [`docs/backlog-2026-04-10.md`](docs/backlog-2026-04-10.md) — 1725-line working list, ranked by category
 - [`docs/superpowers/plans/`](docs/superpowers/plans/) — implementation plans per feature
 - [`docs/superpowers/specs/`](docs/superpowers/specs/) — design specs per feature
 - [`docs/implementation-guide.md`](docs/implementation-guide.md) — integration guide for open items
 - [`docs/codebase-evaluation.md`](docs/codebase-evaluation.md) — 2026-04-30 codebase audit (12 issue groups, 38 bot-tasks)
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
+
+---
+
+## 🤖 Agent Task Package — [`docs/agent-tasks/`](docs/agent-tasks/) (added June 28, 2026)
+
+Hand-run, weak-model-proof task briefs (worktree-disciplined, portable subagent
+roster, multi-agent orchestration scripts). Use these instead of the unreliable
+TODO→GitHub-issues bot.
+
+- 🔵 **transcription-matching/** (TOP PRIORITY) — 5 tasks: search-path hints, apply auto-confirm, upgrade-confidence gate, batch auto-match, dedup tiebreaker. Extends the shipped transcription→discovery wiring into the rest of matching.
+- 🔵 **dedup-intro-falsepositive/** (DEDUP-INTRO-1) — 4 tasks: investigate, skip sub-60s clip fingerprints, boilerplate-title blocklist, ISBN/ASIN gate. Kills ~372K intro/outro false positives.
+- 🔵 **dedup-ui/** (CONS-4/6/11, C6, DEDUP-KB-1) — 5 frontend tasks: row redesign, metadata-compare tab, manual-import button, label-review panel, keyboard shortcuts.
+- 🔵 **system-docs/** (DOCS-1) — 7 tasks producing ≥9 docs / ≥7 Mermaid diagrams under `docs/system/`.
+
+### ✅ Shipped June 28, 2026 (PRs #1660, #1661)
+
+- 🟢 **Library pagination** — page-2-returns-0 (double-pagination) FIXED; "500 means 500" honored; quarantine pushed into the indexed scan; cap 500→1000. Verified on prod.
+- 🟢 **Transcription discovery wiring** — `hintsFromBook`/`transcriptionBoost` in fetch + scoring.
+- 🟢 **Whisper intro parser** — staged extractor (publisher prefix, read-by narrator, noise truncation); `reparse_only` op corrected existing data on prod.
+
+### 🐛 Known flaky CI (pre-existing, capture-and-fix later)
+
+- 🔴 **Mock Freshness** check fails on every branch — `mockery` version drift (`interface{}`→`any`). Needs the pinned mockery version regenerated/committed.
+- 🔴 `TestBackupEndpointsErrors`, `TestScanService_MultiChapterAudiobook` — flaky/environment-sensitive (fail on `main` too). Diagnose root cause; don't rerun-and-ignore.
 
 ---
 

--- a/docs/agent-tasks/ORCHESTRATION.md
+++ b/docs/agent-tasks/ORCHESTRATION.md
@@ -1,0 +1,92 @@
+<!-- file: docs/agent-tasks/ORCHESTRATION.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1c9d8e7f-3a2b-4c50-9e81-6f7a8b9c0d12 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Orchestration — running many task-agents in parallel
+
+This is the portable, tool-agnostic version of the coordinator pattern this repo
+uses for `/parallel-sweep`. It lets you run several `TASK-*.md` agents at once
+without them stepping on each other, then merge them one at a time with automatic
+sibling rebasing.
+
+The model is **coordinator + workers**:
+
+- **Workers** are AI agents, one per task, each confined to its own git worktree.
+  Workers only read/write code and run tests. **Workers never run `git push`,
+  `gh pr ...`, or merge** — they report "done" and hand back.
+- **The coordinator** (you, or a stronger agent) owns all git/gh: it creates the
+  worktrees, gates each finished worker on a local build/test, opens+merges the
+  PR, and rebases the still-open siblings after each merge.
+
+```mermaid
+flowchart TD
+    C[Coordinator] -->|1 worktree + branch per task| W1[Worker: task A]
+    C --> W2[Worker: task B]
+    C --> W3[Worker: task C]
+    W1 -->|reports done| G1{local build+test pass?}
+    W2 -->|reports done| G2{local build+test pass?}
+    W3 -->|reports done| G3{local build+test pass?}
+    G1 -->|yes| M[Coordinator: PR + rebase-merge]
+    G2 -->|yes| M
+    G3 -->|yes| M
+    M -->|after each merge| R[Rebase open siblings onto origin/main]
+    R -->|conflict| CR[conflict-resolution subagent]
+    R -->|clean| M
+```
+
+## Why this shape
+
+| Risk | Mitigation |
+|------|------------|
+| Two agents edit the same file → corrupt merges | One worktree per task; each agent is told to stay inside its worktree path. |
+| Agent pushes/merges half-done work | Only the coordinator touches git/gh. Workers are report-only. |
+| Sibling branches drift from main and rot | After every merge, rebase all open siblings onto `origin/main`. |
+| A weak worker model wanders | Each task is fully self-contained with explicit acceptance criteria; the coordinator rejects a "done" that fails the local gate. |
+| Tasks have dependencies | Run dependent tasks in waves (see each workstream's `run.sh` order). Don't start a task whose `Depends on:` isn't merged yet. |
+
+## Step-by-step (manual coordinator)
+
+1. **Pick a wave** of independent tasks (no unmet `Depends on:`). Good first
+   wave for transcription-matching: `TASK-01` + `TASK-05` (independent);
+   `TASK-04` depends on `TASK-02`.
+2. **Create worktrees + prompt files**: run `./run-sweep.sh <workstream> <TASK-id>...`
+   (see below). It makes `.worktrees/<slug>` per task and writes a
+   `*.agent-prompt.txt` you paste into each agent.
+3. **Dispatch** one agent per prompt file. Let them run concurrently.
+4. **Gate** each finished worker:
+   ```bash
+   cd .worktrees/<slug>
+   go build ./... && go test ./<changed-pkgs>/ -count=1
+   ```
+   If red, send the agent back with the failure output. If green, continue.
+5. **Merge** (coordinator only):
+   ```bash
+   git -C .worktrees/<slug> push -u origin <branch>
+   gh pr create --fill && gh pr merge <n> --rebase
+   ```
+6. **Rebase siblings** after each merge:
+   ```bash
+   for wt in .worktrees/*; do
+     git -C "$wt" fetch origin main -q && git -C "$wt" rebase origin/main || {
+       echo "CONFLICT in $wt — hand to a conflict-resolution subagent"; }
+   done
+   ```
+7. **Repeat** for the next wave.
+
+## Dependency waves per workstream
+
+- **transcription-matching**: wave1 = TASK-01, TASK-05; wave2 = TASK-02, TASK-03;
+  wave3 = TASK-04 (needs TASK-02).
+- **dedup-intro-falsepositive**: wave1 = TASK-01 (investigate, read-only) →
+  then TASK-02, TASK-03, TASK-04 in parallel.
+- **dedup-ui**: all five are independent — one wave, up to 5 in parallel.
+- **system-docs**: TASK-01 (outline) first → remaining doc tasks in parallel.
+
+## If you have a stronger agentic tool
+
+You can let a single strong "coordinator agent" do steps 2–7 autonomously: give
+it this file plus the workstream's `run.sh`, and tell it to act as the
+coordinator (own all git/gh, dispatch worker subagents per task, gate on local
+tests, merge, rebase siblings). The workers it spawns should be the cheap
+capability tiers from the roster in `README.md`.

--- a/docs/agent-tasks/README.md
+++ b/docs/agent-tasks/README.md
@@ -1,0 +1,138 @@
+<!-- file: docs/agent-tasks/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a1e0c44-9d2b-4f08-bc31-2e5a6b7c8d90 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Agent Task Package
+
+This folder is a **self-contained, manually-run work queue**. Each `TASK-*.md`
+file is a complete, copy-pasteable brief that a single AI agent — even a weak one
+(Haiku, an older GPT) — can execute end to end without any other context.
+
+You (the human) drive it: pick a task, paste it into an AI agent, let it work,
+review, merge. The `ORCHESTRATION.md` + `run-sweep.sh` show how to run several
+tasks in parallel on isolated git worktrees.
+
+> This is **not** the automated burndown bot (TODO.md → GitHub issues). These are
+> in-repo markdown briefs for hands-on runs.
+
+## Workstreams (run in priority order)
+
+| # | Folder | What | Priority |
+|---|--------|------|----------|
+| B | [`transcription-matching/`](transcription-matching/) | Wire the audio-transcription fields into the metadata **matching** system | **P1 — do first** |
+| C | [`dedup-intro-falsepositive/`](dedup-intro-falsepositive/) | Kill the ~372K dedup false positives from identical short intro/outro audio | P2 |
+| D | [`dedup-ui/`](dedup-ui/) | Five small dedup/library frontend tasks | P2 |
+| E | [`system-docs/`](system-docs/) | Comprehensive system documentation (≥9 files, ≥7 Mermaid diagrams) | P3 |
+
+Each workstream folder has its own `README.md` (overview + dependency graph),
+numbered `TASK-NN-*.md` files, an `orchestration.md`, and a `run.sh`.
+
+## How to run ONE task (the simple path)
+
+1. Open the `TASK-*.md` file.
+2. Paste its **entire contents** into a fresh AI agent session, prefixed with:
+   *"You are an autonomous coding agent. Execute this task exactly. Do not skip
+   the START HERE setup. Stop and report if any acceptance criterion fails."*
+3. When the agent reports done, review its PR and merge it.
+
+## How to run MANY tasks in parallel
+
+See [`ORCHESTRATION.md`](ORCHESTRATION.md) and run [`run-sweep.sh`](run-sweep.sh).
+It creates one git worktree per task and emits a ready-to-paste prompt file for
+each, so you can fan several agents out at once without them colliding.
+
+## Generic subagent roster (portable — no project-specific agent names)
+
+Every task names a **recommended subagent by capability**, so it works with any
+AI tool. Map these to whatever your tool calls them:
+
+| Role | Use for | Typical model tier |
+|------|---------|--------------------|
+| **code-exploration subagent** | read-only: find files, trace call paths, map a subsystem before editing | cheap/fast |
+| **go-backend subagent** | implement Go changes in `internal/**` | mid |
+| **frontend subagent** | implement React/TypeScript in `web/src/**` | mid |
+| **test-writing subagent** | author Go `_test.go` / Vitest / Playwright tests | mid |
+| **code-auditing subagent** | review a diff for bugs, security, convention violations | strong |
+| **documentation subagent** | write/restructure markdown docs + Mermaid diagrams | mid |
+| **conflict-resolution subagent** | resolve git rebase conflicts, preserving both intents | strong |
+
+A task may suggest splitting itself: e.g. *"first a code-exploration subagent to
+confirm the insertion point, then a go-backend subagent to implement, then a
+test-writing subagent."* Follow that split when the task is large.
+
+## Universal protocol — EVERY task obeys these
+
+Each task repeats the critical bits inline (weak models don't follow links), but
+here is the canonical version.
+
+### 1. Worktree + fresh base (NON-NEGOTIABLE)
+
+Never edit on `main`. Never edit in the primary checkout. Always:
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+SLUG=<task-slug>                                                 # from the task file
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/$SLUG" -b "<branch-from-task>" origin/main
+cd "$REPO/.worktrees/$SLUG"
+git rebase origin/main      # ensure a fresh base before any edits
+```
+
+When finished, clean up: `git -C "$REPO" worktree remove "$REPO/.worktrees/$SLUG"`.
+
+### 2. File version headers (MANDATORY)
+
+Every file you create or modify must carry an updated header. Bump the version
+and `last-edited` on **every** change.
+
+- **Go files** (first lines, before `package`):
+  ```go
+  // file: internal/pkg/name.go
+  // version: 1.2.3
+  // guid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  // last-edited: YYYY-MM-DD
+  ```
+- **All other files** (md/yaml/json/ts/tsx/sh) use HTML/line comments with the
+  same four fields. Keep an existing file's `guid`; only generate a new one for a
+  brand-new file.
+
+### 3. Commit + PR + merge
+
+- Conventional commit: `type(scope): summary` (feat/fix/refactor/test/docs/chore/perf/ci).
+- End every commit body with:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  ```
+- `gh pr create` then `gh pr merge <n> --rebase` (this repo uses rebase/FF, never squash).
+
+### 4. Build + test gate (before opening a PR)
+
+```bash
+go build ./...
+go test ./<changed-packages>/ -count=1     # exact packages named in the task
+# frontend tasks also: cd web && npm run build && npm test
+```
+
+> **Known CI noise (not your fault, do not chase):** the **Mock Freshness** check
+> fails on every branch due to a `mockery` version drift (`interface{}`→`any`);
+> and `TestBackupEndpointsErrors` / `TestScanService_MultiChapterAudiobook` are
+> pre-existing flaky tests. Your gate is your changed packages passing locally.
+> See [`dedup-intro-falsepositive/`](dedup-intro-falsepositive/) sibling note and
+> the `flaky-tests` follow-up in this repo's TODO.md.
+
+## Definition of Done (every task)
+
+- [ ] Worked in a worktree branched off fresh `origin/main`.
+- [ ] All acceptance criteria in the task file are checked.
+- [ ] Changed-package tests pass locally; new behavior has a test.
+- [ ] File headers bumped on every touched file.
+- [ ] Conventional commit with the Co-Authored-By trailer.
+- [ ] PR opened and rebase-merged.
+- [ ] Worktree removed.
+
+## Coding standards
+
+Org standards live in the `.standards/` submodule and `.github/instructions/`.
+Key Go/TS rules and the file-header spec are referenced from each task. When in
+doubt, match the surrounding code's style.

--- a/docs/agent-tasks/dedup-intro-falsepositive/README.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/README.md
@@ -1,0 +1,50 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a4b6c8e0-2d4f-4a6b-8c0d-3e5f7a9b1c3d -->
+<!-- last-edited: 2026-06-28 -->
+
+# Workstream C — Kill Audible intro/outro dedup false positives
+
+**Problem (TODO.md DEDUP-INTRO-1):** the exact dedup layer fingerprints
+individual audio files. Short publisher intro/outro clips ("This is Audible…",
+jingles, brand stings) produce **identical chromaprints across unrelated books
+from the same publisher**, so dedup pairs them as duplicates. Estimated up to
+~372K candidate pairs are polluted by this class.
+
+The fix is layered defense — none alone is sufficient:
+1. **Don't fingerprint-match tiny clips** (a <60s file is almost always an
+   intro/outro, not a book).
+2. **Blocklist known boilerplate titles** so they never seed an exact match.
+3. **Gate file matches at the book level** by ISBN/ASIN — if two books have
+   different ISBNs/ASINs, a shared short-clip fingerprint must not merge them.
+
+## Tasks & order
+
+```mermaid
+flowchart LR
+    T1[TASK-01 investigate / quantify] --> T2[TASK-02 skip short-clip FP]
+    T1 --> T3[TASK-03 title blocklist]
+    T1 --> T4[TASK-04 book-level ISBN/ASIN gate]
+```
+
+| Task | Title | Priority | Effort | Depends on |
+|------|-------|----------|--------|-----------|
+| TASK-01 | Investigate & quantify the false-positive class (read-only) | P1 | M | — |
+| TASK-02 | Skip fingerprint compare on short clips (<60s) | P2 | M | TASK-01 |
+| TASK-03 | Title blocklist for publisher boilerplate | P3 | S | TASK-01 |
+| TASK-04 | Book-level ISBN/ASIN gate before file match | P2 | M | TASK-01 |
+
+Do TASK-01 first (read-only) — its findings tune the thresholds/lists in the
+others. Then TASK-02/03/04 can run in parallel.
+
+## Where the code lives (verify before editing)
+
+- `internal/dedup/` — dedup engine, `book_dedup.go`, `engine.go`, the exact
+  fingerprint layer. Tests: `internal/dedup/*_test.go`.
+- Fingerprint data: `BookFile.AcoustIDFingerprint*` fields; duration is on the
+  `BookFile`/`Book`. The LSH secondary index drives exact-layer matches.
+- Use a **code-exploration subagent** to map the exact-layer match path before
+  changing thresholds:
+  ```bash
+  grep -rn "exact\|AcoustID\|fingerprint\|LSH\|chromaprint\|DurationSec" internal/dedup/ | head -40
+  ```

--- a/docs/agent-tasks/dedup-intro-falsepositive/TASK-01-investigate.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/TASK-01-investigate.md
@@ -1,0 +1,94 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/TASK-01-investigate.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b5c7d9e1-3e5f-4b7c-9d1e-4f6a8b0c2d4e -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-01 — Investigate & quantify the intro/outro false-positive class
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** code-exploration
+subagent (read-only) · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+This task is **read-only / analysis** — it produces a short findings doc, not code
+changes. Still work in a worktree so the findings doc can be committed:
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/di-investigate" -b agent/di-investigate origin/main
+cd "$REPO/.worktrees/di-investigate"
+git rebase origin/main
+```
+
+## Goal
+
+Produce a precise picture of the intro/outro false-positive class so TASK-02/03/04
+use correct thresholds and lists. Answer, with numbers and exact code paths:
+
+1. **Where** does the exact dedup layer turn a shared file fingerprint into a
+   candidate pair? (function + file:line in `internal/dedup/`.)
+2. **How many** current candidate pairs are explained by short files? Bucket the
+   files participating in exact matches by duration (`<30s`, `30–60s`, `60–120s`,
+   `>120s`).
+3. **Which titles** recur on the short-clip side (publisher boilerplate to
+   blocklist in TASK-03)?
+4. **Do paired books differ by ISBN/ASIN?** Sample candidate pairs and report how
+   often the two books have different ISBN10/ISBN13/ASIN (supports TASK-04).
+5. Recommended thresholds/lists for TASK-02 (duration cutoff), TASK-03 (title
+   blocklist), TASK-04 (which id fields to compare).
+
+## How to gather (read-only)
+
+- Map the code path:
+  ```bash
+  grep -rn "exact\|AcoustID\|chromaprint\|LSH\|DurationSec\|GetDuplicate" internal/dedup/ | head -60
+  ```
+- If a read-only query/CLI exists for dedup candidates or AcoustID stats, use it
+  (e.g. an existing `GetAcoustIDStats` or a dedup candidates endpoint). Do NOT
+  mutate anything. Do NOT run anything against production unless the operator
+  explicitly tells you to; prefer reading code + existing reports.
+- If you cannot get live counts safely, document the EXACT query/endpoint the
+  operator should run, and provide expected output shape.
+
+## Deliverable
+
+Write `docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md` with:
+- the exact match-path call chain (file:line),
+- the duration histogram (or the precise query to produce it),
+- the recurring boilerplate titles,
+- the ISBN/ASIN-mismatch rate among sampled pairs,
+- concrete recommended values for TASK-02 (cutoff seconds), TASK-03 (title list),
+  TASK-04 (id fields + behavior).
+
+Include the standard markdown file header (file/version/guid/last-edited).
+
+## Acceptance criteria
+
+- [ ] `FINDINGS.md` exists with all five answers, each backed by a code path or a query.
+- [ ] No source/behaviour changes (analysis only).
+- [ ] Recommended thresholds/lists are concrete (numbers + strings), not vague.
+
+## Commit message
+
+```
+docs(dedup): investigate intro/outro fingerprint false-positive class
+
+Findings doc quantifying the short-clip dedup false positives: match-path call
+chain, file-duration histogram, recurring boilerplate titles, and ISBN/ASIN
+mismatch rate among paired books. Feeds the TASK-02/03/04 fixes.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/di-investigate
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `FINDINGS.md` already exists and answers all five, this is done. Rollback = delete the doc.

--- a/docs/agent-tasks/dedup-intro-falsepositive/TASK-02-skip-short-clip-fingerprint.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/TASK-02-skip-short-clip-fingerprint.md
@@ -1,0 +1,98 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/TASK-02-skip-short-clip-fingerprint.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c6d8e0f2-4f60-4c8d-9e2f-5a7b9c1d3e5f -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-02 — Skip fingerprint compare on short clips (<60s)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** go-backend subagent ·
+**Depends on:** TASK-01 (use its recommended cutoff)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/di-skip-shortclip" -b agent/di-skip-shortclip origin/main
+cd "$REPO/.worktrees/di-skip-shortclip"
+git rebase origin/main
+```
+
+## Goal
+
+Stop the exact dedup layer from treating short audio files as evidence of a
+duplicate book. A file under the cutoff (default **60s**, or TASK-01's value) is
+almost always a publisher intro/outro, not book content — so its fingerprint must
+not produce or strengthen a candidate pair.
+
+## Background (verify before editing)
+
+- The exact-layer match path identified in TASK-01 (function + file:line in
+  `internal/dedup/`). Duration is available as
+  `BookFile.AcoustIDFingerprintDurationSec` (the memdb-safe proxy) and/or the
+  file/book duration. Confirm which field is reliably populated on the match path:
+  ```bash
+  grep -rn "DurationSec\|Duration\b\|AcoustIDFingerprintDurationSec" internal/dedup/ internal/database/ | head
+  ```
+
+## Step-by-step
+
+1. Add a constant near the exact-layer code:
+   ```go
+   // minFingerprintMatchSeconds: files shorter than this are publisher
+   // intro/outro clips, not book content — their fingerprints must not seed or
+   // strengthen a duplicate pair. See dedup-intro-falsepositive FINDINGS.md.
+   const minFingerprintMatchSeconds = 60
+   ```
+2. In the exact-layer compare, skip any file whose duration is `> 0` and
+   `< minFingerprintMatchSeconds`. Treat unknown/zero duration as NOT-short (don't
+   over-skip) — only skip when we positively know it's short.
+3. Make sure the skip happens BEFORE the pair is emitted, so short clips never
+   create candidates.
+4. Log a debug counter of skipped short-clip files per scan.
+5. Bump file headers.
+
+## How to test
+
+`internal/dedup/*_test.go`: two books sharing a 20s-fingerprint file produce NO
+candidate pair; two books sharing a 2-hour-fingerprint file still pair; a file
+with unknown duration is not skipped.
+
+```bash
+go build ./...
+go test ./internal/dedup/ -count=1
+go vet ./internal/dedup/
+```
+
+## Acceptance criteria
+
+- [ ] Files with known duration `< 60s` (or TASK-01 cutoff) are excluded from exact-layer matching.
+- [ ] Unknown/zero-duration files are NOT skipped (no over-exclusion).
+- [ ] Long files still match as before.
+- [ ] Tests cover short-skip / long-match / unknown-keep; `go test ./internal/dedup/` green; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+fix(dedup): skip exact-layer fingerprint match on sub-60s clips
+
+Short publisher intro/outro files share identical chromaprints across unrelated
+books and flooded dedup with false positives. Exclude files with a known
+duration under 60s from the exact-layer compare; unknown durations are kept.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/di-skip-shortclip
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a sub-60s skip already exists in the exact layer, this is done. Rollback =
+revert the commit (dedup returns to matching all durations).

--- a/docs/agent-tasks/dedup-intro-falsepositive/TASK-03-title-blocklist.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/TASK-03-title-blocklist.md
@@ -1,0 +1,99 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/TASK-03-title-blocklist.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d7e9f1a3-5071-4d9e-9f30-6b8c0d2e4f60 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-03 — Title blocklist for publisher boilerplate
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** go-backend subagent ·
+**Depends on:** TASK-01 (use its recurring-title list)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/di-title-blocklist" -b agent/di-title-blocklist origin/main
+cd "$REPO/.worktrees/di-title-blocklist"
+git rebase origin/main
+```
+
+## Goal
+
+Some short clips are stored as their own "books" with boilerplate titles ("This
+is Audible", "Audible hopes you have enjoyed this program", brand stings). These
+should never seed a dedup match. Add a small, well-commented blocklist of
+boilerplate title patterns and exclude matching books from the exact dedup layer.
+
+## Background (verify before editing)
+
+- Use the recurring-title list from TASK-01's `FINDINGS.md` as the seed.
+- Find where a book/file enters the exact dedup layer (TASK-01) and where the
+  title is available there.
+- A normalized compare helper likely exists (`util.NormalizeTitle` in
+  `internal/util/normalize.go`); reuse it for case/whitespace-insensitive matching.
+
+## Step-by-step
+
+1. Add a blocklist (slice of lowercased substrings or a small regexp), e.g.:
+   ```go
+   // boilerplateTitlePatterns: publisher intro/outro "titles" that are not real
+   // books and must not seed dedup matches. Seeded from FINDINGS.md.
+   var boilerplateTitlePatterns = []string{
+       "this is audible",
+       "audible hopes you",
+       "an audible original",
+       // ... add the rest from FINDINGS.md
+   }
+   ```
+2. Add a helper `isBoilerplateTitle(title string) bool` using normalized
+   substring matching.
+3. In the exact dedup layer, skip a book/file whose title is boilerplate before
+   emitting a candidate.
+4. Keep the list small and commented; note in a code comment that it's seeded
+   from `FINDINGS.md` and can be extended.
+5. Bump file headers.
+
+## How to test
+
+`internal/dedup/*_test.go`: a book titled "This is Audible" does not pair with
+anything; a normal book is unaffected; matching is case/whitespace-insensitive.
+
+```bash
+go build ./...
+go test ./internal/dedup/ -count=1
+go vet ./internal/dedup/
+```
+
+## Acceptance criteria
+
+- [ ] Boilerplate-titled books are excluded from exact-layer matching.
+- [ ] Matching is normalized (case/whitespace-insensitive).
+- [ ] Normal titles unaffected; tests cover boilerplate-skip + normal-keep.
+- [ ] `go test ./internal/dedup/` green; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+fix(dedup): blocklist publisher boilerplate titles from exact matching
+
+Books whose title is publisher intro/outro boilerplate ("This is Audible", …)
+are not real books and must not seed dedup pairs. Adds a small normalized
+title blocklist (seeded from FINDINGS.md) applied in the exact layer.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/di-title-blocklist
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a boilerplate-title blocklist already gates the exact layer, this is done.
+Rollback = revert the commit.

--- a/docs/agent-tasks/dedup-intro-falsepositive/TASK-04-booklevel-isbn-gate.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/TASK-04-booklevel-isbn-gate.md
@@ -1,0 +1,102 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/TASK-04-booklevel-isbn-gate.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e8f0a2b4-6182-4e0f-9a41-7c9d1e3f5071 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-04 — Book-level ISBN/ASIN gate before file match
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** go-backend subagent ·
+**Depends on:** TASK-01 (mismatch-rate evidence)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/di-isbn-gate" -b agent/di-isbn-gate origin/main
+cd "$REPO/.worktrees/di-isbn-gate"
+git rebase origin/main
+```
+
+## Goal
+
+A shared file fingerprint should not merge two books that are provably different
+editions/titles. Add a book-level gate: if the two books in a candidate pair have
+**different, both-present** ISBN10/ISBN13/ASIN, drop the pair regardless of a
+shared short-clip fingerprint. Identifiers are authoritative; a shared jingle is
+not.
+
+## Background (verify before editing)
+
+- `Book` carries `ISBN10`, `ISBN13`, `ASIN` (see `internal/database/store.go`).
+- There is likely an ISBN/ASIN secondary index and helpers
+  (`derefStrISBN`, `writeISBNIndexRows`, `GetBookIDsByISBNASIN`) in
+  `internal/database/pebble_store.go`. Find compare helpers:
+  ```bash
+  grep -rn "ISBN10\|ISBN13\|ASIN\|derefStrISBN\|GetBookIDsByISBN" internal/database/ internal/dedup/ | head
+  ```
+- Apply at the candidate-emit point identified in TASK-01.
+
+## Step-by-step
+
+1. Add a helper:
+   ```go
+   // identifiersConflict reports whether a and b have a definitive, both-present
+   // identifier mismatch (different ISBN13, or different ISBN10, or different
+   // ASIN). Missing identifiers are NOT a conflict (return false).
+   func identifiersConflict(a, b *database.Book) bool { ... }
+   ```
+   Compare each of ISBN13/ISBN10/ASIN only when BOTH books have that field set
+   (normalize: trim, strip hyphens, uppercase ASIN). Any one definitive mismatch
+   → true.
+2. In the exact dedup layer, after a pair is formed but before it's emitted, drop
+   the pair when `identifiersConflict(a, b)` is true.
+3. Be conservative: when identifiers are missing on either side, do NOT drop
+   (let the other layers decide).
+4. Log a debug counter of pairs dropped by the identifier gate.
+5. Bump file headers.
+
+## How to test
+
+`internal/dedup/*_test.go`: two books with different ISBN13s sharing a fingerprint
+do NOT pair; two books with the same ISBN13 still pair; two books where one lacks
+an ISBN still pair (no over-gating).
+
+```bash
+go build ./...
+go test ./internal/dedup/ -count=1
+go vet ./internal/dedup/
+```
+
+## Acceptance criteria
+
+- [ ] Pairs with a definitive both-present ISBN13/ISBN10/ASIN mismatch are dropped.
+- [ ] Missing identifiers never cause a drop (conservative).
+- [ ] Identifier compare is normalized (hyphens/case).
+- [ ] Tests cover mismatch-drop / match-keep / missing-keep; `go test ./internal/dedup/` green; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+fix(dedup): drop candidate pairs with conflicting ISBN/ASIN identifiers
+
+A shared short-clip fingerprint must not merge two books that have different,
+both-present ISBN13/ISBN10/ASIN — identifiers are authoritative. Missing
+identifiers never gate (conservative).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/di-isbn-gate
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If an ISBN/ASIN conflict gate already exists on the exact layer, this is done.
+Rollback = revert the commit.

--- a/docs/agent-tasks/dedup-intro-falsepositive/orchestration.md
+++ b/docs/agent-tasks/dedup-intro-falsepositive/orchestration.md
@@ -1,0 +1,32 @@
+<!-- file: docs/agent-tasks/dedup-intro-falsepositive/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f9a1b3c5-7293-4f10-9b52-8d0e2f406182 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Orchestration — dedup-intro-falsepositive workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first.
+
+## Waves
+
+```mermaid
+flowchart LR
+    T1[TASK-01 investigate] --> T2[TASK-02 skip short clips]
+    T1 --> T3[TASK-03 title blocklist]
+    T1 --> T4[TASK-04 ISBN/ASIN gate]
+```
+
+- **Wave 1**: TASK-01 (read-only investigation) — run alone, merge its
+  `FINDINGS.md` first so the others can use its thresholds/lists.
+- **Wave 2** (parallel): TASK-02, TASK-03, TASK-04.
+
+These three edit `internal/dedup/` and may lightly conflict — after the first of
+them merges, rebase the other two onto `origin/main` (hand conflicts to a
+conflict-resolution subagent) before continuing.
+
+## Run it
+
+```bash
+./run.sh 01          # investigation first
+./run.sh 02 03 04    # after FINDINGS.md merged
+```

--- a/docs/agent-tasks/dedup-intro-falsepositive/run.sh
+++ b/docs/agent-tasks/dedup-intro-falsepositive/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/dedup-intro-falsepositive/run.sh
+# version: 1.0.0
+# guid: 0a1b2c3d-8304-4021-9c63-9e1f30417293
+# last-edited: 2026-06-28
+#
+# Thin wrapper over ../run-sweep.sh for the dedup-intro-falsepositive workstream.
+#   ./run.sh         # show waves, set up wave 1 (TASK-01 investigation)
+#   ./run.sh 02 03 04
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+
+cat <<'EOF'
+dedup-intro-falsepositive waves:
+  Wave 1: 01 investigate (read-only; merge FINDINGS.md first)
+  Wave 2 (parallel): 02 skip-short-clip, 03 title-blocklist, 04 isbn-gate
+EOF
+
+if [[ $# -gt 0 ]]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+echo; echo "Setting up Wave 1 (01 investigate)…"; echo
+exec "$HERE/../run-sweep.sh" "$WS" 01

--- a/docs/agent-tasks/dedup-ui/README.md
+++ b/docs/agent-tasks/dedup-ui/README.md
@@ -1,0 +1,35 @@
+<!-- file: docs/agent-tasks/dedup-ui/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1b2c3d4e-9405-4132-9d74-0f2031428304 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Workstream D — Dedup & library UI tasks
+
+Five independent React/TypeScript front-end tasks from TODO.md (CONS-4, CONS-6,
+CONS-11, C6, DEDUP-KB-1). Each is self-contained — run all five in parallel.
+
+| Task | TODO id | Title | Priority | Effort |
+|------|---------|-------|----------|--------|
+| TASK-01 | CONS-4 | BookDedup row redesign | P2 | M |
+| TASK-02 | CONS-6 | Metadata-compare tab in compare drawer | P2 | M |
+| TASK-03 | CONS-11 | Manual-import button on Library | P2 | S |
+| TASK-04 | C6 | Dedup label review panel | P3 | M |
+| TASK-05 | DEDUP-KB-1 | Keyboard shortcuts for dedup page | P3 | S |
+
+All are independent → one wave, up to 5 agents in parallel. See `orchestration.md`.
+
+## Front-end ground rules (all tasks)
+
+- Code lives under `web/src/`. Build + test:
+  ```bash
+  cd web && npm install && npm run build && npm test
+  ```
+- Match the existing component style (Material UI, hooks). Reuse existing API
+  helpers (e.g. the `apiFetch` wrapper) rather than raw `fetch`.
+- Recommended subagent: **frontend subagent**; optionally a **code-exploration
+  subagent** first to locate the component and its props.
+- Bump the file-header (`<!-- file/version/guid/last-edited -->`) on every `.tsx`/`.ts` you touch.
+- Verify any API path against the backend before wiring it:
+  ```bash
+  grep -rn "dedup/candidates\|operations/v2\|dedup:label" internal/server/ | head
+  ```

--- a/docs/agent-tasks/dedup-ui/TASK-01-bookdedup-row-redesign.md
+++ b/docs/agent-tasks/dedup-ui/TASK-01-bookdedup-row-redesign.md
@@ -1,0 +1,85 @@
+<!-- file: docs/agent-tasks/dedup-ui/TASK-01-bookdedup-row-redesign.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2c3d4e5f-0516-4243-9e85-103142539405 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-01 — BookDedup row redesign (CONS-4)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** frontend subagent ·
+**Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dui-row-redesign" -b agent/dui-row-redesign origin/main
+cd "$REPO/.worktrees/dui-row-redesign"
+git rebase origin/main
+```
+
+## Goal
+
+Apply the existing `renderBookCard` visual pattern to `renderBookSide` in the
+dedup comparison so both sides of a candidate look consistent: tall left-aligned
+cover, the quality chip inline after the title, and no dead whitespace below the
+chip.
+
+## Background (verify before editing)
+
+- Find the component and the two render functions:
+  ```bash
+  grep -rn "renderBookSide\|renderBookCard" web/src/components/dedup/BookDedup.tsx
+  ```
+  (`BookDedup.tsx` is large; `renderBookSide` is roughly mid-file. Use grep, not line numbers.)
+- Compare the markup/sx of `renderBookCard` (the desired look) with
+  `renderBookSide` (the one to fix).
+
+## Step-by-step
+
+1. In `renderBookSide`, make the cover tall and left-aligned:
+   `alignSelf: 'stretch'`, fixed width (~56px), `height: '100%'` — matching `renderBookCard`.
+2. Move the quality/score chip to sit **inline after the title** (not on its own row below).
+3. Remove the empty space under the chip (trim the trailing spacer/Box).
+4. Keep all data/handlers identical — this is purely layout.
+5. Bump the file header.
+
+## How to test
+
+```bash
+cd web && npm run build && npm test
+```
+Manually (optional): run the dev server, open the dedup page, confirm both sides
+match `renderBookCard` and there's no whitespace gap.
+
+## Acceptance criteria
+
+- [ ] `renderBookSide` cover is tall/left-aligned like `renderBookCard`.
+- [ ] Quality chip renders inline after the title.
+- [ ] No empty whitespace below the chip.
+- [ ] `npm run build` + `npm test` pass; no behavior/data changes.
+- [ ] File header bumped.
+
+## Commit message
+
+```
+feat(dedup-ui): align BookDedup row layout with renderBookCard (CONS-4)
+
+renderBookSide now uses the tall left-aligned cover, inline quality chip, and
+trimmed whitespace from renderBookCard so both sides of a candidate match.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/dui-row-redesign
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `renderBookSide` already mirrors `renderBookCard`, this is done. Rollback =
+revert the commit.

--- a/docs/agent-tasks/dedup-ui/TASK-02-metadata-compare-tab.md
+++ b/docs/agent-tasks/dedup-ui/TASK-02-metadata-compare-tab.md
@@ -1,0 +1,93 @@
+<!-- file: docs/agent-tasks/dedup-ui/TASK-02-metadata-compare-tab.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d4e5f60-1627-4354-9f96-214253649516 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-02 — Metadata-compare tab in the candidate compare drawer (CONS-6)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** frontend subagent
+(code-exploration subagent first to confirm the API shape) · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dui-metadata-tab" -b agent/dui-metadata-tab origin/main
+cd "$REPO/.worktrees/dui-metadata-tab"
+git rebase origin/main
+```
+
+## Goal
+
+Add a **Metadata** tab to the dedup candidate compare drawer, alongside the
+existing Fingerprint tab, showing a side-by-side compare of series / narrator /
+parts / duration / file size and **which signal fired** for the candidate. Data
+comes from `GET /api/v1/dedup/candidates/:id/breakdown`.
+
+## Background (verify before editing)
+
+- Component: `web/src/components/dedup/CandidateCompareDrawer.tsx` (has the
+  Fingerprint tab today). Confirm:
+  ```bash
+  grep -rn "Tab\|Fingerprint\|breakdown\|/dedup/candidates" web/src/components/dedup/CandidateCompareDrawer.tsx
+  ```
+- Confirm the breakdown endpoint exists and its response shape:
+  ```bash
+  grep -rn "dedup/candidates/.*breakdown\|Breakdown" internal/server/ | head
+  ```
+  If the endpoint does NOT exist, STOP and report — this task assumes it does
+  (TODO.md CONS-6 says "wire from GET …/breakdown").
+
+## Step-by-step
+
+1. Add a new tab next to Fingerprint. Reuse the existing tab/panel pattern in the
+   drawer.
+2. Fetch the breakdown for the current candidate via the existing API helper
+   (e.g. `apiFetch`), with loading + error states matching sibling components.
+3. Render a two-column compare: series, narrator, parts/segment count, duration,
+   file size — left book vs right book — plus a row/badge showing which signal
+   fired (exact / fuzzy / embedding / etc., from the breakdown payload).
+4. Highlight differing fields (e.g. subtle background) so mismatches are obvious.
+5. Bump the file header.
+
+## How to test
+
+```bash
+cd web && npm run build && npm test
+```
+Add/extend a component test if the drawer has tests; otherwise verify build +
+manual smoke (open a candidate, switch to the Metadata tab, see the compare).
+
+## Acceptance criteria
+
+- [ ] New Metadata tab present alongside Fingerprint.
+- [ ] Fetches `/dedup/candidates/:id/breakdown` via the standard API helper, with loading/error states.
+- [ ] Side-by-side series/narrator/parts/duration/size + which-signal-fired.
+- [ ] Differing fields visually distinguished.
+- [ ] `npm run build` + `npm test` pass; file header bumped.
+
+## Commit message
+
+```
+feat(dedup-ui): metadata-compare tab in candidate drawer (CONS-6)
+
+Adds a Metadata tab beside Fingerprint showing side-by-side series/narrator/
+parts/duration/size and which dedup signal fired, sourced from
+GET /api/v1/dedup/candidates/:id/breakdown.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/dui-metadata-tab
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a Metadata tab already exists in the drawer, this is done. Rollback = revert
+the commit.

--- a/docs/agent-tasks/dedup-ui/TASK-03-manual-import-button.md
+++ b/docs/agent-tasks/dedup-ui/TASK-03-manual-import-button.md
@@ -1,0 +1,92 @@
+<!-- file: docs/agent-tasks/dedup-ui/TASK-03-manual-import-button.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4e5f6071-2738-4465-9a07-325364759627 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-03 — Manual-import button on the Library page (CONS-11)
+
+**Priority:** P2 · **Effort:** S · **Recommended subagent:** frontend subagent ·
+**Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dui-manual-import" -b agent/dui-manual-import origin/main
+cd "$REPO/.worktrees/dui-manual-import"
+git rebase origin/main
+```
+
+## Goal
+
+Add a button + small dialog on the Library page that lets the operator import a
+single path on demand: it POSTs a `library.import` operation and polls it to
+completion, showing progress.
+
+## Background (verify before editing)
+
+- Library page + toolbar: `web/src/pages/Library.tsx`,
+  `web/src/components/library/LibraryToolbar.tsx`.
+- Operation trigger API: `POST /api/v1/operations/v2` with body
+  `{ "def_id": "library.import", "params": { "path": "<abs path>" } }`; poll
+  `GET /api/v1/operations/v2/:id`. Confirm the def id + params:
+  ```bash
+  grep -rn "library.import\|def_id\|operations/v2" internal/server/ internal/plugins/ | head
+  ```
+  If the def id differs, use the real one and note it in the PR.
+- Reuse any existing operation-trigger/poll hook or the `apiFetch` helper. Look
+  for a sibling that already launches ops from the UI:
+  ```bash
+  grep -rn "operations/v2\|def_id" web/src | head
+  ```
+
+## Step-by-step
+
+1. Add a "Manual import" button to the Library toolbar.
+2. On click, open a dialog with a single text field for an absolute path (+ basic
+   validation that it's non-empty).
+3. On submit, POST the `library.import` op with `{ path }`, then poll the op id;
+   show progress (spinner/percent) and a final success/error toast.
+4. Disable the submit while in flight; close the dialog on success.
+5. Bump the file header on every touched file.
+
+## How to test
+
+```bash
+cd web && npm run build && npm test
+```
+Manual smoke: open Library, click Manual import, submit a path, see progress →
+done.
+
+## Acceptance criteria
+
+- [ ] Manual-import button + dialog on the Library page.
+- [ ] Submits `POST /api/v1/operations/v2 {def_id:"library.import", params:{path}}` and polls to completion.
+- [ ] Progress + success/error feedback; submit disabled while running.
+- [ ] Reuses existing API helper/op hook (no raw fetch if a wrapper exists).
+- [ ] `npm run build` + `npm test` pass; file headers bumped.
+
+## Commit message
+
+```
+feat(library-ui): manual single-path import button + dialog (CONS-11)
+
+Adds a Library toolbar button that POSTs a library.import operation for an
+operator-entered path and polls it to completion with progress feedback.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/dui-manual-import
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a manual-import control already exists on Library, this is done. Rollback =
+revert the commit.

--- a/docs/agent-tasks/dedup-ui/TASK-04-label-review-panel.md
+++ b/docs/agent-tasks/dedup-ui/TASK-04-label-review-panel.md
@@ -1,0 +1,90 @@
+<!-- file: docs/agent-tasks/dedup-ui/TASK-04-label-review-panel.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5f607182-3849-4576-9b18-436475869738 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-04 — Dedup label review panel (C6)
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** frontend subagent
+(code-exploration subagent first to find/confirm the labels API) · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dui-label-review" -b agent/dui-label-review origin/main
+cd "$REPO/.worktrees/dui-label-review"
+git rebase origin/main
+```
+
+## Goal
+
+A web panel listing dedup label examples (the `dedup:label:*` store), filterable
+by `label`, `label_source`, and `band`, where a human can **override** a label
+and set `label_source=human`.
+
+## Background (verify before editing)
+
+- Find the dedup-labels API (list + update) and its fields:
+  ```bash
+  grep -rn "dedup:label\|DedupLabel\|label_source\|/dedup/labels\|GetDedupLabels" internal/server/ internal/database/ | head
+  ```
+  There may already be a `DedupLabels` page/component:
+  ```bash
+  grep -rln "DedupLabels\|dedup.*label" web/src | head
+  ```
+  If a labels list/update endpoint does NOT exist, STOP and report — note that the
+  backend endpoint is a prerequisite (capture it as a backend follow-up task).
+- Reuse an existing table component if present (the repo has a
+  `ConfigurableTable`); reuse the `apiFetch` helper.
+
+## Step-by-step
+
+1. Add (or extend) a panel/page that lists dedup label examples in a table.
+2. Add filter controls for `label`, `label_source`, and `band` (dropdowns/inputs
+   driving query params).
+3. Per-row action: override the label; on save, PUT/PATCH the label with
+   `label_source=human`. Reflect the change in the table.
+4. Loading/empty/error states matching sibling pages.
+5. Bump file headers.
+
+## How to test
+
+```bash
+cd web && npm run build && npm test
+```
+Manual smoke: open the panel, filter, override a label, confirm it persists +
+shows `label_source=human`.
+
+## Acceptance criteria
+
+- [ ] Panel lists `dedup:label:*` examples in a table.
+- [ ] Filter by label / label_source / band works.
+- [ ] Human override saves with `label_source=human` and updates the row.
+- [ ] Reuses existing table + API helper; loading/error states present.
+- [ ] `npm run build` + `npm test` pass; file headers bumped.
+
+## Commit message
+
+```
+feat(dedup-ui): dedup label review + human-override panel (C6)
+
+Lists dedup:label:* examples filterable by label/label_source/band and lets a
+human override a label (sets label_source=human).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/dui-label-review
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a label-review panel with override already exists, this is done. Rollback =
+revert the commit.

--- a/docs/agent-tasks/dedup-ui/TASK-05-keyboard-shortcuts.md
+++ b/docs/agent-tasks/dedup-ui/TASK-05-keyboard-shortcuts.md
@@ -1,0 +1,94 @@
+<!-- file: docs/agent-tasks/dedup-ui/TASK-05-keyboard-shortcuts.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 60718293-4950-4687-9c29-547586970849 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-05 — Keyboard shortcuts for the dedup page (DEDUP-KB-1)
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** frontend subagent ·
+**Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dui-kbd-shortcuts" -b agent/dui-kbd-shortcuts origin/main
+cd "$REPO/.worktrees/dui-kbd-shortcuts"
+git rebase origin/main
+```
+
+## Goal
+
+Add keyboard navigation to the dedup page so a reviewer can work without the
+mouse, with a `?` help overlay listing the shortcuts.
+
+Shortcuts:
+- `j` / `k` — move to next / previous row
+- `m` — merge the focused candidate
+- `d` — dismiss the focused candidate
+- `s` — select / deselect the focused row
+- `Enter` — open the compare drawer for the focused row
+- `Esc` — close the drawer
+- `Shift+A` — select all on the current page
+- `?` — toggle a help overlay listing all shortcuts
+
+## Background (verify before editing)
+
+- Dedup page + the handlers the shortcuts trigger (merge/dismiss/select/open):
+  ```bash
+  grep -rn "onMerge\|onDismiss\|onSelect\|openDrawer\|CompareDrawer\|BookDedup" web/src/components/dedup/ | head
+  ```
+  Wire each shortcut to the **existing** handler — do not reimplement merge/dismiss.
+
+## Step-by-step
+
+1. Add a global `keydown` listener (effect with cleanup) active only when no
+   input/textarea/dialog is focused (guard with
+   `document.activeElement` tag check) so typing in fields isn't hijacked.
+2. Track the "focused row" index in component state; `j`/`k` move it (clamp to
+   range); scroll the focused row into view.
+3. Map each key to the existing handler for the focused candidate.
+4. Add a `?`-toggled help overlay (a Dialog/Popover) listing the shortcuts.
+5. Bump file headers.
+
+## How to test
+
+```bash
+cd web && npm run build && npm test
+```
+Manual smoke: open dedup page, use j/k to move, m/d/s, Enter/Esc, Shift+A, ? for
+help. Confirm typing in a text field does NOT trigger shortcuts.
+
+## Acceptance criteria
+
+- [ ] All listed shortcuts work and call the existing handlers.
+- [ ] Shortcuts are suppressed while an input/textarea/dialog is focused.
+- [ ] `?` shows a help overlay listing the shortcuts.
+- [ ] Listener is cleaned up on unmount (no leak).
+- [ ] `npm run build` + `npm test` pass; file headers bumped.
+
+## Commit message
+
+```
+feat(dedup-ui): keyboard shortcuts + help overlay for dedup page (DEDUP-KB-1)
+
+Adds j/k navigation, m/d/s actions, Enter/Esc drawer control, Shift+A select-all,
+and a ?-toggled help overlay, wired to existing handlers and suppressed while
+inputs are focused.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/dui-kbd-shortcuts
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If the dedup page already has a keydown listener with these shortcuts, this is
+done. Rollback = revert the commit.

--- a/docs/agent-tasks/dedup-ui/orchestration.md
+++ b/docs/agent-tasks/dedup-ui/orchestration.md
@@ -1,0 +1,34 @@
+<!-- file: docs/agent-tasks/dedup-ui/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 71829304-5061-4798-9d30-658697081950 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Orchestration — dedup-ui workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first.
+
+## Waves
+
+All five tasks are independent → **one wave, up to 5 agents in parallel**.
+
+```mermaid
+flowchart LR
+    T1[TASK-01 row redesign]
+    T2[TASK-02 metadata tab]
+    T3[TASK-03 manual import]
+    T4[TASK-04 label review]
+    T5[TASK-05 keyboard shortcuts]
+```
+
+TASK-01 and TASK-05 both touch the dedup page/components and may lightly
+conflict; after the first merges, rebase the other onto `origin/main`.
+
+## Run it
+
+```bash
+./run.sh            # set up all five
+./run.sh 01 03 05   # subset
+```
+
+Per task, gate with `cd web && npm run build && npm test`, then push/PR/merge as
+coordinator and rebase siblings.

--- a/docs/agent-tasks/dedup-ui/run.sh
+++ b/docs/agent-tasks/dedup-ui/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/dedup-ui/run.sh
+# version: 1.0.0
+# guid: 82930415-6172-4809-9e41-769708192061
+# last-edited: 2026-06-28
+#
+# Thin wrapper over ../run-sweep.sh for the dedup-ui workstream.
+# All five tasks are independent — one wave.
+#   ./run.sh            # set up all five
+#   ./run.sh 01 03 05   # subset
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+
+cat <<'EOF'
+dedup-ui: all five tasks independent (one wave, up to 5 parallel):
+  01 bookdedup-row-redesign   02 metadata-compare-tab   03 manual-import-button
+  04 label-review-panel       05 keyboard-shortcuts
+Gate each with: cd web && npm run build && npm test
+EOF
+
+echo
+exec "$HERE/../run-sweep.sh" "$WS" "$@"

--- a/docs/agent-tasks/run-sweep.sh
+++ b/docs/agent-tasks/run-sweep.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/run-sweep.sh
+# version: 1.0.0
+# guid: 9e0f1a2b-4c3d-4e60-af71-2b3c4d5e6f70
+# last-edited: 2026-06-28
+#
+# Portable coordinator helper: for each requested TASK in a workstream, create an
+# isolated git worktree branched off a fresh origin/main and emit a ready-to-paste
+# agent prompt file. Tool-agnostic — it does NOT call any specific AI CLI; you
+# paste the generated prompt into whatever agent you use.
+#
+# Usage:
+#   ./run-sweep.sh <workstream> [TASK-id ...]
+#   ./run-sweep.sh transcription-matching            # all tasks in the workstream
+#   ./run-sweep.sh transcription-matching 01 05      # only TASK-01 and TASK-05
+#
+# It NEVER pushes or merges. After agents finish, you (the coordinator) gate on
+# `go build ./... && go test`, then push/PR/merge, then rebase siblings.
+# See ORCHESTRATION.md.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Repo root = three levels up from docs/agent-tasks/run-sweep.sh
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKSTREAM="${1:-}"
+
+if [[ -z "$WORKSTREAM" || ! -d "$HERE/$WORKSTREAM" ]]; then
+  echo "usage: $0 <workstream> [TASK-id ...]" >&2
+  echo "workstreams:" >&2
+  find "$HERE" -mindepth 1 -maxdepth 1 -type d -printf '  %f\n' >&2
+  exit 1
+fi
+shift || true
+
+# Resolve the task files: explicit ids, or all TASK-*.md in the workstream.
+declare -a TASK_FILES
+if [[ $# -gt 0 ]]; then
+  for id in "$@"; do
+    f=$(find "$HERE/$WORKSTREAM" -maxdepth 1 -name "TASK-${id}-*.md" | head -1)
+    [[ -n "$f" ]] || { echo "no TASK-${id}-*.md in $WORKSTREAM" >&2; exit 1; }
+    TASK_FILES+=("$f")
+  done
+else
+  while IFS= read -r f; do TASK_FILES+=("$f"); done \
+    < <(find "$HERE/$WORKSTREAM" -maxdepth 1 -name 'TASK-*.md' | sort)
+fi
+
+git -C "$REPO" fetch origin -q
+
+PROMPT_DIR="$HERE/.prompts"
+mkdir -p "$PROMPT_DIR"
+
+for task in "${TASK_FILES[@]}"; do
+  base="$(basename "$task" .md)"            # e.g. TASK-01-search-path-hints
+  slug="${WORKSTREAM}-${base#TASK-*-}"      # e.g. transcription-matching-search-path-hints
+  slug="$(echo "$slug" | tr -cs 'a-zA-Z0-9-' '-' | sed 's/-\+/-/g;s/^-//;s/-$//')"
+  branch="agent/${slug}"
+  wt="$REPO/.worktrees/${slug}"
+
+  if git -C "$REPO" worktree list --porcelain | grep -q "worktree $wt$"; then
+    echo "• worktree exists: $wt (skipping create)"
+  else
+    git -C "$REPO" worktree add "$wt" -b "$branch" origin/main >/dev/null
+    echo "• created worktree $wt on $branch"
+  fi
+  git -C "$wt" rebase origin/main -q || true
+
+  prompt="$PROMPT_DIR/${slug}.agent-prompt.txt"
+  {
+    echo "You are an autonomous coding agent. Execute the task below EXACTLY."
+    echo "Work ONLY inside this worktree: $wt"
+    echo "Your branch ($branch) is already created and rebased on origin/main."
+    echo "Do NOT run git push, gh, or merge — when finished, STOP and report a"
+    echo "summary plus the exact files you changed. Stop immediately and report if"
+    echo "any acceptance criterion fails."
+    echo
+    echo "===== TASK ($base) ====="
+    cat "$task"
+  } > "$prompt"
+  echo "  → prompt: $prompt"
+done
+
+echo
+echo "Next steps (coordinator):"
+echo "  1. Paste each .agent-prompt.txt into a separate agent session."
+echo "  2. When an agent reports done:  cd <worktree> && go build ./... && go test ./<pkgs>/ -count=1"
+echo "  3. If green:  git -C <worktree> push -u origin <branch> && gh pr create --fill && gh pr merge <n> --rebase"
+echo "  4. After each merge, rebase open siblings:  for wt in $REPO/.worktrees/*; do git -C \"\$wt\" fetch origin main -q && git -C \"\$wt\" rebase origin/main; done"
+echo "  5. Clean up merged worktrees:  git -C $REPO worktree remove <worktree>"

--- a/docs/agent-tasks/system-docs/README.md
+++ b/docs/agent-tasks/system-docs/README.md
@@ -1,0 +1,53 @@
+<!-- file: docs/agent-tasks/system-docs/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 93041526-7283-491a-9f52-87a819203172 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Workstream E — Comprehensive system documentation (DOCS-1)
+
+Produce a high-quality documentation set for the audiobook-organizer under
+`docs/system/`. Target (TODO.md DOCS-1): **≥9 files and ≥7 Mermaid diagrams**
+spanning flowchart, sequence, state-machine, and (where useful) Gantt/ER types.
+Model: the `falkcorp/burndown-tasks/docs` gold standard.
+
+These are **documentation** tasks (no production code changes). Recommended
+subagent: **documentation subagent** (a **code-exploration subagent** first to
+gather accurate detail). Each task writes one area's doc(s) with at least one
+Mermaid diagram and is committed independently.
+
+## Tasks & order
+
+```mermaid
+flowchart LR
+    T1[TASK-01 outline + index] --> T2[TASK-02 architecture]
+    T1 --> T3[TASK-03 data flow + pipelines]
+    T1 --> T4[TASK-04 storage + schema]
+    T1 --> T5[TASK-05 API surface]
+    T1 --> T6[TASK-06 ops runbooks]
+    T1 --> T7[TASK-07 component inventory + incident history]
+```
+
+| Task | Doc(s) produced | Diagram type |
+|------|-----------------|--------------|
+| TASK-01 | `docs/system/README.md` (index + outline) | flowchart (site map) |
+| TASK-02 | `docs/system/architecture.md` | flowchart (component graph) |
+| TASK-03 | `docs/system/pipelines.md` (scan→organize→metadata→dedup→fingerprint) | sequence + state machine |
+| TASK-04 | `docs/system/storage.md` (PebbleDB/NutsDB/memdb, key formats) | ER/flowchart |
+| TASK-05 | `docs/system/api.md` (HTTP surface, operations v2) | sequence |
+| TASK-06 | `docs/system/runbooks.md` (deploy, reparse, dedup drain, recovery) | flowchart |
+| TASK-07 | `docs/system/components.md` + `docs/system/incidents.md` | flowchart + timeline/Gantt |
+
+That's 8 task-produced files + this index = **9 files**, and ≥7 diagrams across
+them. TASK-01 first (defines the index every other doc links into); TASK-02..07
+then run in parallel.
+
+## Accuracy rules (all tasks)
+
+- **Verify against code**, don't invent. Cross-check existing docs:
+  `docs/AI-REFERENCE.md`, `docs/database-architecture.md`,
+  `docs/database-pebble-schema.md`, and the specs under `docs/specs/`.
+- Every file carries the standard header (`<!-- file/version/guid/last-edited -->`).
+- Mermaid blocks must render (fenced ```mermaid). Keep diagrams readable
+  (≤~25 nodes); split if larger.
+- Link between docs with relative paths; keep the index (`docs/system/README.md`)
+  authoritative.

--- a/docs/agent-tasks/system-docs/TASK-01-outline-index.md
+++ b/docs/agent-tasks/system-docs/TASK-01-outline-index.md
@@ -1,0 +1,76 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-01-outline-index.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a4152637-8394-4a2b-9063-98b920314283 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-01 — System docs index + outline
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** documentation
+subagent · **Depends on:** none (do this first)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-index" -b agent/sd-index origin/main
+cd "$REPO/.worktrees/sd-index"
+git rebase origin/main
+```
+
+## Goal
+
+Create `docs/system/README.md` — the index that every other system doc links
+into. It lists the planned docs (architecture, pipelines, storage, api, runbooks,
+components, incidents), each with a one-line summary, and includes a site-map
+Mermaid flowchart. This locks the structure so TASK-02..07 can run in parallel
+without colliding on naming.
+
+## Step-by-step
+
+1. Skim existing docs to anchor the structure: `docs/AI-REFERENCE.md`,
+   `docs/database-architecture.md`, `docs/database-pebble-schema.md`, and
+   `ls docs/specs/ | sort -r | head`.
+2. Create `docs/system/README.md` with the standard header and:
+   - a 1-paragraph "what this system is",
+   - a table of the system docs with one-line summaries and relative links,
+   - a **site-map Mermaid flowchart** showing how the docs relate.
+3. Create empty-but-headed stub files is NOT required — the other tasks create
+   their own files. Just make sure your index links to the agreed filenames:
+   `architecture.md`, `pipelines.md`, `storage.md`, `api.md`, `runbooks.md`,
+   `components.md`, `incidents.md`.
+
+## How to test
+
+Render-check the Mermaid block (any Mermaid live editor) and confirm links use
+the agreed filenames. No code build needed.
+
+## Acceptance criteria
+
+- [ ] `docs/system/README.md` exists with header, intro, doc table, and a site-map Mermaid flowchart.
+- [ ] Links use the agreed filenames for TASK-02..07.
+- [ ] Mermaid renders.
+
+## Commit message
+
+```
+docs(system): add system-docs index + site map (DOCS-1)
+
+Index for the comprehensive system documentation set: doc table with summaries,
+relative links to the planned area docs, and a site-map Mermaid flowchart.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-index
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `docs/system/README.md` already exists with the index, this is done. Rollback
+= delete the file.

--- a/docs/agent-tasks/system-docs/TASK-02-architecture.md
+++ b/docs/agent-tasks/system-docs/TASK-02-architecture.md
@@ -1,0 +1,69 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-02-architecture.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b5263748-9405-4b3c-9174-09203142539a -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-02 — Architecture overview doc
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent (code-exploration subagent first) · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-architecture" -b agent/sd-architecture origin/main
+cd "$REPO/.worktrees/sd-architecture"
+git rebase origin/main
+```
+
+## Goal
+
+Write `docs/system/architecture.md`: the high-level architecture — Go backend
+(Gin) + embedded React/TS frontend, the service registry/container, the store
+layers (PebbleDB primary, NutsDB activity log, memdb query layer), search
+(Bleve), embeddings/HNSW, the operations/plugin system. Include a **component
+graph Mermaid flowchart**.
+
+## Gather (verify against code)
+
+- `docs/AI-REFERENCE.md` (architecture overview, package map) — primary source.
+- `internal/server/` (server lifecycle, registry wiring), `internal/serviceregistry/`,
+  `internal/database/` (PebbleStore, MemStore), `internal/search/`, `internal/metafetch/`,
+  `internal/dedup/`, `internal/plugins/`.
+  ```bash
+  sed -n '1,80p' docs/AI-REFERENCE.md
+  grep -rn "IncludeGroup\|ServiceDef\|OperationDef" internal/server/ internal/serviceregistry/ | head
+  ```
+
+## Required content
+
+- One paragraph per major subsystem (backend, frontend, store, search, AI/embeddings, ops/plugins).
+- A **Mermaid flowchart** of the component graph (HTTP → handlers → services → store; bg workers; plugins).
+- A short "request lifecycle" note (how a library list request flows).
+- Links back to `README.md` (index) and forward to `storage.md`, `pipelines.md`, `api.md`.
+
+## Acceptance criteria
+
+- [ ] `docs/system/architecture.md` exists with header, subsystem sections, and a component-graph Mermaid flowchart.
+- [ ] Claims are grounded in `docs/AI-REFERENCE.md` + code (no invented components).
+- [ ] Cross-links to sibling docs; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): architecture overview + component graph (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-architecture && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Exists already → done. Rollback = delete the file.

--- a/docs/agent-tasks/system-docs/TASK-03-pipelines.md
+++ b/docs/agent-tasks/system-docs/TASK-03-pipelines.md
@@ -1,0 +1,67 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-03-pipelines.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c6374859-0516-4c4d-9285-1031425360ab -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-03 — Pipelines doc (scan → organize → metadata → dedup → fingerprint)
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent (code-exploration subagent first) · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-pipelines" -b agent/sd-pipelines origin/main
+cd "$REPO/.worktrees/sd-pipelines"
+git rebase origin/main
+```
+
+## Goal
+
+Write `docs/system/pipelines.md`: the end-to-end data pipelines — scan → metadata
+extract → organize → metadata fetch/apply → fingerprint → dedup, plus the
+transcription intro pipeline. Include a **sequence diagram** of the scan→apply
+flow and a **state-machine diagram** of a book's metadata-review lifecycle
+(`nil` → `matched`/`no_match`).
+
+## Gather (verify against code)
+
+- `internal/scanner/`, `internal/metafetch/` (fetch/apply), `internal/dedup/`,
+  `internal/fingerprint/`, `internal/plugins/maintenance/intro_transcribe.go`,
+  `internal/transcribe/parse.go`.
+  ```bash
+  grep -rn "func.*Scan\|FetchMetadataForBook\|ApplyMetadataCandidate\|ScanBookDuplicates\|ComputeFingerprint" internal/ | head
+  ```
+
+## Required content
+
+- A prose walkthrough of each stage and what it reads/writes.
+- A **Mermaid sequence diagram**: import path → scanner → metadata → store → UI.
+- A **Mermaid state diagram**: `MetadataReviewStatus` lifecycle.
+- The transcription path: 90s clip → Whisper → `ParseAudiobookIntro` → Transcribed* fields → matching boosts (link to the agent-tasks transcription-matching workstream).
+- Cross-links to `architecture.md`, `storage.md`.
+
+## Acceptance criteria
+
+- [ ] `docs/system/pipelines.md` with header, stage walkthrough, a sequence diagram, AND a state-machine diagram (2 diagrams).
+- [ ] Grounded in code; cross-linked; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): pipelines (scan→metadata→dedup→fingerprint) + diagrams (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-pipelines && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Exists already → done. Rollback = delete the file.

--- a/docs/agent-tasks/system-docs/TASK-04-storage-schema.md
+++ b/docs/agent-tasks/system-docs/TASK-04-storage-schema.md
@@ -1,0 +1,69 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-04-storage-schema.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d7485960-1627-4d5e-9396-2142536071bc -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-04 — Storage & schema doc
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent (code-exploration subagent first) · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-storage" -b agent/sd-storage origin/main
+cd "$REPO/.worktrees/sd-storage"
+git rebase origin/main
+```
+
+## Goal
+
+Write `docs/system/storage.md`: the storage architecture — PebbleDB (primary
+k/v), the memdb in-memory query layer (go-memdb indexes), NutsDB activity log,
+optional SQLite tier, key-format conventions, and the cached-aggregate +
+dirty-flag pattern. Include an **ER-style or flowchart Mermaid diagram** of the
+core entities (Book, BookFile, Author, Series, Narrator) and the index layers.
+
+## Gather (verify against code/docs)
+
+- `docs/database-architecture.md`, `docs/database-pebble-schema.md` (primary).
+- `internal/database/store.go` (models), `pebble_store.go`, `memdb_schema.go`,
+  `memdb_summaries.go`.
+  ```bash
+  sed -n '1,60p' docs/database-pebble-schema.md
+  grep -rn "memIdx\|memTable\|counter:\|book:work:\|external_id_map" internal/database/ | head
+  ```
+
+## Required content
+
+- PebbleDB key conventions (with real prefixes), the memdb index list and what
+  each accelerates, NutsDB activity buckets, SQLite opt-in.
+- The cached-aggregate + dirty-flag pattern (e.g. `stats:library`).
+- A **Mermaid diagram** of core entities + index layers.
+- Cross-links to `architecture.md`, `pipelines.md`.
+
+## Acceptance criteria
+
+- [ ] `docs/system/storage.md` with header, key-format tables, memdb index list, a Mermaid entity/index diagram.
+- [ ] Key prefixes match the code/`database-pebble-schema.md`.
+- [ ] Cross-linked; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): storage + schema (Pebble/memdb/NutsDB) + diagram (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-storage && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Exists already → done. Rollback = delete the file.

--- a/docs/agent-tasks/system-docs/TASK-05-api-surface.md
+++ b/docs/agent-tasks/system-docs/TASK-05-api-surface.md
@@ -1,0 +1,69 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-05-api-surface.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e8596071-2738-4e6f-9407-25364750 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-05 — API surface doc
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent (code-exploration subagent first) · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-api" -b agent/sd-api origin/main
+cd "$REPO/.worktrees/sd-api"
+git rebase origin/main
+```
+
+## Goal
+
+Write `docs/system/api.md`: the HTTP API surface — auth model
+(`Authorization: Bearer abk_…`), the main resource endpoints
+(`/api/v1/audiobooks`, authors, series, dedup, metadata), and the **operations v2**
+async pattern (`POST /api/v1/operations/v2` → poll `GET …/:id`). Include a
+**sequence diagram** of launching + polling an operation.
+
+## Gather (verify against code)
+
+- Route wiring: `internal/server/wire_handlers.go`, the handler sub-packages
+  under `internal/server/handlers/`, `internal/server/operations_v2_handlers.go`.
+  ```bash
+  grep -rn "router\.\(GET\|POST\|PUT\|DELETE\)\|/api/v1" internal/server/ | head -60
+  grep -rn "operations/v2\|def_id" internal/server/operations_v2_handlers.go
+  ```
+- Auth: search for the bearer/api-key middleware.
+
+## Required content
+
+- Auth section (header format; never `X-API-Key`).
+- A table of key endpoints grouped by resource (method, path, purpose, key params).
+- The operations-v2 lifecycle + a **Mermaid sequence diagram** (client → POST op → poll → result).
+- Note common query params for the library list (limit/offset cap 1000, sort_by, is_primary_version, show_quarantined).
+- Cross-links to `architecture.md`, `pipelines.md`.
+
+## Acceptance criteria
+
+- [ ] `docs/system/api.md` with header, auth, endpoint table, operations-v2 sequence diagram.
+- [ ] Endpoints/paths verified against route wiring.
+- [ ] Cross-linked; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): API surface + operations-v2 sequence (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-api && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Exists already → done. Rollback = delete the file.

--- a/docs/agent-tasks/system-docs/TASK-06-ops-runbooks.md
+++ b/docs/agent-tasks/system-docs/TASK-06-ops-runbooks.md
@@ -1,0 +1,68 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-06-ops-runbooks.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f9607182-3849-4f60-9518-364758 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-06 — Operations runbooks doc
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-runbooks" -b agent/sd-runbooks origin/main
+cd "$REPO/.worktrees/sd-runbooks"
+git rebase origin/main
+```
+
+## Goal
+
+Write `docs/system/runbooks.md`: concrete operator runbooks — build/deploy
+(`make build`/`make deploy`/`make deploy-debug`), the systemd drop-in pattern,
+the transcription `reparse_only` op, dedup drain, backups/restore, and recovery
+(memdb warmup, server restart). Include a **deploy flowchart**.
+
+## Gather (verify against code/repo)
+
+- `Makefile` targets (`grep -E '^[a-z-]+:' Makefile`), `deploy/` (service file,
+  drop-in), `CLAUDE.md` (deploy + workflow rules), and the maintenance ops:
+  ```bash
+  grep -E '^[a-zA-Z_-]+:' Makefile | head -40
+  grep -rn "reparse_only\|transcribe-book-intros\|auto-purge\|RecompactDigests" internal/plugins/ | head
+  ```
+- Production facts (host, paths) are in `CLAUDE.md` / repo docs — do NOT invent
+  secrets or tokens; reference how to obtain them, never embed them.
+
+## Required content
+
+- Deploy runbook (build → cross-compile → scp → systemd restart) + a **Mermaid flowchart**.
+- Reparse-intros runbook: `POST /api/v1/operations/v2 {def_id:"maintenance.transcribe-book-intros", params:{reparse_only:true}}`.
+- Backup/restore, dedup drain (with the data-loss caution from TODO.md CONS-10), and memdb-warmup recovery notes.
+- A short "known CI noise" note (mock-freshness drift; flaky backup/scan tests).
+
+## Acceptance criteria
+
+- [ ] `docs/system/runbooks.md` with header, ≥4 runbooks, and a deploy Mermaid flowchart.
+- [ ] Commands match the Makefile/ops; no secrets embedded.
+- [ ] Cross-linked to `architecture.md`; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): operations runbooks + deploy flowchart (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-runbooks && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Exists already → done. Rollback = delete the file.

--- a/docs/agent-tasks/system-docs/TASK-07-components-incidents.md
+++ b/docs/agent-tasks/system-docs/TASK-07-components-incidents.md
@@ -1,0 +1,70 @@
+<!-- file: docs/agent-tasks/system-docs/TASK-07-components-incidents.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0a718293-4950-407 1-9629-475869 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-07 — Component inventory + incident history
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** documentation
+subagent (code-exploration subagent first) · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/sd-components" -b agent/sd-components origin/main
+cd "$REPO/.worktrees/sd-components"
+git rebase origin/main
+```
+
+## Goal
+
+Write **two** files:
+1. `docs/system/components.md` — an inventory of the `internal/**` packages: one
+   row per package with its responsibility and key types/entry points. Include a
+   **package-dependency Mermaid flowchart** (grouped by layer).
+2. `docs/system/incidents.md` — a curated incident/decision history distilled
+   from `CHANGELOG.md` and the specs: notable bugs, root causes, and fixes
+   (memdb pagination cap, double-pagination, transcription parser, dedup
+   false-positives, cache warm-up memory bloat). Include a **timeline/Gantt-style
+   Mermaid diagram** of major milestones.
+
+## Gather (verify against repo)
+
+```bash
+find internal -maxdepth 1 -type d | sort
+sed -n '1,120p' CHANGELOG.md
+ls docs/specs/ | sort -r | head -20
+```
+
+## Required content
+
+- `components.md`: package table + a **Mermaid flowchart** of inter-package deps (layered: handlers → services → store; plus search/AI/plugins).
+- `incidents.md`: ≥6 incidents/decisions with root cause + fix + PR refs, and a **Mermaid timeline/gantt** of milestones.
+- Cross-link both into `README.md` (index) and `architecture.md`.
+
+## Acceptance criteria
+
+- [ ] `docs/system/components.md` (package inventory + dependency flowchart).
+- [ ] `docs/system/incidents.md` (≥6 incidents + a timeline/gantt diagram).
+- [ ] Two distinct Mermaid diagrams total; grounded in CHANGELOG/specs/code.
+- [ ] Cross-linked; Mermaid renders.
+
+## Commit message
+
+```
+docs(system): component inventory + incident history + diagrams (DOCS-1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/sd-components && gh pr create --fill && gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Both files exist already → done. Rollback = delete the files.

--- a/docs/agent-tasks/system-docs/orchestration.md
+++ b/docs/agent-tasks/system-docs/orchestration.md
@@ -1,0 +1,33 @@
+<!-- file: docs/agent-tasks/system-docs/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1b829304-5061-4182-973a-586970 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Orchestration — system-docs workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first.
+
+## Waves
+
+```mermaid
+flowchart LR
+    T1[TASK-01 index] --> T2[TASK-02 architecture]
+    T1 --> T3[TASK-03 pipelines]
+    T1 --> T4[TASK-04 storage]
+    T1 --> T5[TASK-05 api]
+    T1 --> T6[TASK-06 runbooks]
+    T1 --> T7[TASK-07 components+incidents]
+```
+
+- **Wave 1**: TASK-01 (index) — merge first so the others link into agreed names.
+- **Wave 2** (parallel): TASK-02..07. They write distinct files → low conflict
+  risk (only the index links, already set by TASK-01).
+
+Each is docs-only — gate is "Mermaid renders + links resolve", no code build.
+
+## Run it
+
+```bash
+./run.sh 01            # index first
+./run.sh 02 03 04 05 06 07
+```

--- a/docs/agent-tasks/system-docs/run.sh
+++ b/docs/agent-tasks/system-docs/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/system-docs/run.sh
+# version: 1.0.0
+# guid: 2c930415-6172-4293-984b-697081
+# last-edited: 2026-06-28
+#
+# Thin wrapper over ../run-sweep.sh for the system-docs workstream.
+#   ./run.sh 01                  # index first
+#   ./run.sh 02 03 04 05 06 07   # area docs in parallel
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+
+cat <<'EOF'
+system-docs waves (DOCS-1 target: >=9 files, >=7 Mermaid diagrams):
+  Wave 1: 01 index (merge first)
+  Wave 2 (parallel): 02 architecture, 03 pipelines, 04 storage, 05 api,
+                     06 runbooks, 07 components+incidents
+EOF
+
+if [[ $# -gt 0 ]]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+echo; echo "Setting up Wave 1 (01 index)…"; echo
+exec "$HERE/../run-sweep.sh" "$WS" 01

--- a/docs/agent-tasks/transcription-matching/README.md
+++ b/docs/agent-tasks/transcription-matching/README.md
@@ -1,0 +1,64 @@
+<!-- file: docs/agent-tasks/transcription-matching/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2d4f6a80-1b3c-4e5f-9a0b-7c8d9e0f1a2b -->
+<!-- last-edited: 2026-06-28 -->
+
+# Workstream B — Wire transcription into matching (TOP PRIORITY)
+
+Each audiobook can carry **audio-derived** fields parsed from the first 90s of
+narration (Whisper): `Book.TranscribedTitle`, `Book.TranscribedAuthor`,
+`Book.TranscribedNarrator` (`internal/database/store.go` ~line 269). These are
+ground truth pulled from the book itself, so when an external metadata candidate
+matches them, that is strong evidence the candidate is correct.
+
+**Already shipped (do NOT redo):** the *discovery / auto-fetch* path already uses
+these fields — `hintsFromBook`, `transcriptionBoost`, and the variadic
+`transcriptionHints` on `pickBestMatchFromScored` in
+`internal/metafetch/service_scoring.go`, plus fallback query construction in
+`internal/metafetch/service_fetch.go`. The parser that fills the fields was also
+fixed (`internal/transcribe/parse.go`, staged extractor) and a `reparse_only`
+op exists on `maintenance.transcribe-book-intros`.
+
+These tasks extend that wiring into the rest of the **matching** surface:
+manual search, apply/auto-confirm, the upgrade job, batch auto-apply, and dedup.
+
+## Tasks & dependency graph
+
+```mermaid
+flowchart LR
+    T1[TASK-01 search-path hints] --> T4[TASK-04 batch auto-match]
+    T2[TASK-02 apply auto-confirm] --> T4
+    T3[TASK-03 upgrade-confidence signal]
+    T5[TASK-05 dedup tiebreaker]
+```
+
+| Task | Title | Priority | Effort | Depends on |
+|------|-------|----------|--------|-----------|
+| TASK-01 | Search-path transcription hints | P1 | S | — |
+| TASK-02 | Apply auto-confirm on exact transcription match | P1 | M | — |
+| TASK-03 | Upgrade-confidence transcription signal | P2 | M | — |
+| TASK-04 | Batch auto-match operation | P1 | L | TASK-02 |
+| TASK-05 | Dedup tiebreaker via transcription | P3 | M | — |
+
+Run wave 1 (TASK-01, TASK-05) and wave 2 (TASK-02, TASK-03) in parallel;
+TASK-04 last (needs TASK-02). See `orchestration.md`.
+
+## Shared reference — scoring constants & helpers
+
+From `internal/metafetch/service_scoring.go` (verify before editing — line numbers drift):
+
+| Symbol | Meaning |
+|--------|---------|
+| `f1MinScore = 0.35` | min score for the F1 base tier |
+| `config.AppConfig.MetadataScoring.EmbeddingBestMatch` | min score for the embedding tier |
+| `transcriptionHints{title, author, narrator}` | the audio-derived hints struct |
+| `hintsFromBook(book *database.Book) transcriptionHints` | extracts + drops garbage |
+| `transcriptionBoost(score, r, hints)` | ×2.0 exact title / ×1.4 substring / ×1.6 author / ×1.4 narrator |
+| `pickBestMatchFromScored(..., hints ...transcriptionHints)` | variadic; hints optional |
+| `containsCI(a, b)` | case-insensitive substring both-ways |
+
+`MetadataReviewStatus` values: `nil` (unreviewed) · `"matched"` · `"no_match"`.
+Tests for this area go in `internal/metafetch/transcription_match_test.go`.
+
+> **Tag**: in TODO.md these correspond to the "wire transcription into matching"
+> initiative (TRANSCR-MATCH-1..5).

--- a/docs/agent-tasks/transcription-matching/TASK-01-search-path-hints.md
+++ b/docs/agent-tasks/transcription-matching/TASK-01-search-path-hints.md
@@ -1,0 +1,133 @@
+<!-- file: docs/agent-tasks/transcription-matching/TASK-01-search-path-hints.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3e5f7a91-2c4d-4f60-ab1c-8d9e0f1a2b3c -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-01 — Search-path transcription hints
+
+**Priority:** P1 · **Effort:** S · **Recommended subagent:** go-backend subagent
+(optionally a code-exploration subagent first to confirm the line numbers) ·
+**Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/tm-search-path-hints" -b agent/tm-search-path-hints origin/main
+cd "$REPO/.worktrees/tm-search-path-hints"
+git rebase origin/main
+```
+Do all work inside that worktree. Never edit `main` or the primary checkout.
+
+## Goal
+
+The **automatic** metadata fetch already boosts candidates that match a book's
+audio-derived (transcribed) title/author/narrator. The **manual search** path
+(the search dialog) does NOT — it scores candidates without the transcription
+hints, so a user searching a book with good transcription gets worse ranking than
+the auto-fetch would. Make the manual search path pass the same hints into
+scoring so both paths rank identically.
+
+## Background (verify line numbers — they drift)
+
+- `internal/metafetch/service_search.go` — `SearchMetadataForBook` /
+  `SearchMetadataForBookWithOptions` build a candidate list and score each
+  candidate inline (around lines 304–415: author ×1.5 / ×0.7, narrator ×1.3,
+  series ×1.4, audiobook ×1.15/0.85). These inline multipliers do NOT include the
+  transcription boost.
+- `internal/metafetch/service_scoring.go` already has the reusable helpers:
+  - `hintsFromBook(book *database.Book) transcriptionHints`
+  - `transcriptionBoost(score float64, r metadata.BookMetadata, h transcriptionHints) float64`
+  - `(transcriptionHints).empty() bool`
+- The manual search path has the `*database.Book` in scope (it loads the book by
+  id), so you can call `hintsFromBook(book)` there.
+
+Use the **code-exploration subagent** or `grep -n` to confirm:
+```bash
+grep -n "func (mfs \*Service) SearchMetadataForBook" internal/metafetch/service_search.go
+grep -n "score \*= 1.5\|score \*= 1.3\|narrator\|audiobook" internal/metafetch/service_search.go
+grep -n "func hintsFromBook\|func transcriptionBoost\|func (th transcriptionHints) empty" internal/metafetch/service_scoring.go
+```
+
+## Exact files to change
+
+- `internal/metafetch/service_search.go` — apply the transcription boost in the
+  inline scoring loop.
+- `internal/metafetch/transcription_match_test.go` — add a test (or a new
+  `service_search_transcription_test.go`).
+
+## Step-by-step
+
+1. In `service_search.go`, find where the book is resolved and where each
+   candidate's score is adjusted inline (the block with the `*= 1.5` author
+   boost etc.). Just before/after the narrator multiplier, compute the hints once
+   (outside the per-candidate loop):
+   ```go
+   th := hintsFromBook(book)   // book is the *database.Book already in scope
+   ```
+2. Inside the per-candidate loop, after the existing narrator/audiobook
+   multipliers and before the candidate's score is finalized, add:
+   ```go
+   if !th.empty() {
+       score = transcriptionBoost(score, candidate, th)
+   }
+   ```
+   Use the same candidate variable name already in the loop (likely `r` or
+   `result`); match the existing style.
+3. If the function does not currently have the `*database.Book` in scope (only a
+   bookID), load it once via `mfs.db.GetBookByID(id)` near the top and reuse it.
+   Do NOT add a DB call inside the per-candidate loop.
+4. Bump the file header `version` + `last-edited` on every file you touch.
+
+## How to test
+
+Add a test asserting that, given two candidates where the lower-base-score one
+matches the transcribed title, the transcription-matching candidate wins via the
+manual search path. Mirror the existing cases in
+`internal/metafetch/transcription_match_test.go`.
+
+```bash
+go build ./...
+go test ./internal/metafetch/ -count=1
+go vet ./internal/metafetch/
+```
+
+## Acceptance criteria
+
+- [ ] Manual search scoring applies `transcriptionBoost` when hints are present.
+- [ ] Hints are computed once per search, not once per candidate (no per-candidate DB calls).
+- [ ] New test proves a transcription-matching candidate is preferred in the search path.
+- [ ] `go test ./internal/metafetch/ -count=1` passes; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+feat(metafetch): apply transcription boost in the manual search path
+
+The auto-fetch path already boosts candidates matching a book's audio-derived
+title/author/narrator; the manual search dialog did not. Compute hintsFromBook
+once per search and apply transcriptionBoost in the inline candidate scoring so
+both paths rank identically.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/tm-search-path-hints
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency
+
+If `service_search.go` already calls `transcriptionBoost`/`hintsFromBook` in its
+scoring loop, this task is already done — verify the test exists and stop.
+
+## Rollback
+
+Revert the single commit; the change is additive and isolated to the search
+scoring loop.

--- a/docs/agent-tasks/transcription-matching/TASK-02-apply-auto-confirm.md
+++ b/docs/agent-tasks/transcription-matching/TASK-02-apply-auto-confirm.md
@@ -1,0 +1,121 @@
+<!-- file: docs/agent-tasks/transcription-matching/TASK-02-apply-auto-confirm.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4f60718a-3d5e-4071-bc2d-9e0f1a2b3c4d -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-02 — Apply auto-confirm on exact transcription match
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** go-backend subagent,
+then test-writing subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/tm-apply-auto-confirm" -b agent/tm-apply-auto-confirm origin/main
+cd "$REPO/.worktrees/tm-apply-auto-confirm"
+git rebase origin/main
+```
+
+## Goal
+
+When metadata is applied to a book and the chosen candidate **exactly matches the
+transcription** (audio-derived title + author), record that the match is
+audio-confirmed. This raises trust in the result and lets a later batch job
+(TASK-04) auto-apply such matches without human review. The apply path currently
+sets `MetadataReviewStatus = "matched"` for any user-applied candidate with no
+notion of *why* it matched.
+
+## Background (verify line numbers — they drift)
+
+- `internal/metafetch/service_apply.go` — `ApplyMetadataCandidate(id, candidate, fields)`
+  applies a candidate and sets `MetadataReviewStatus = "matched"` (around lines
+  520–535). Find it:
+  ```bash
+  grep -n "func (mfs \*Service) ApplyMetadataCandidate\|MetadataReviewStatus" internal/metafetch/service_apply.go
+  ```
+- Reuse the matching helpers from `internal/metafetch/service_scoring.go`:
+  `hintsFromBook`, `containsCI`, and `util.NormalizeTitle` (in
+  `internal/util/normalize.go`) for exact normalized title comparison.
+
+## Design decision (you choose the exact mechanism)
+
+The book has no dedicated "match source" column. Pick ONE, simplest-first:
+
+- **(A) Provenance/notes** — if the apply path already writes a provenance or
+  `VersionNotes`/metadata-source record, append an `audio_confirmed` marker there.
+- **(B) New boolean field** — add `Book.MetadataAudioConfirmed *bool` to
+  `internal/database/store.go`, set it true on exact transcription match. Heavier
+  (touches the model + memdb projection); only do this if (A) has no natural home.
+
+Prefer (A). Whatever you choose, the **observable behavior** is: an exact
+transcription match during apply is recorded so TASK-04 can query it.
+
+## Step-by-step
+
+1. In `ApplyMetadataCandidate`, after the candidate is chosen and before/where
+   `MetadataReviewStatus` is set, compute:
+   ```go
+   th := hintsFromBook(book)
+   audioConfirmed := !th.empty() &&
+       th.title != "" && util.NormalizeTitle(candidate.Title) == util.NormalizeTitle(th.title) &&
+       (th.author == "" || containsCI(candidate.Author, th.author))
+   ```
+   (Title must match exactly-normalized; author, when present, must be a
+   case-insensitive substring match.)
+2. When `audioConfirmed`, record the marker via your chosen mechanism (A or B).
+   Keep `MetadataReviewStatus = "matched"` as today.
+3. Add a slog line: `slog.Info("metadata apply: audio-confirmed match", "book_id", id, "title", candidate.Title)`.
+4. Bump file headers.
+
+## How to test
+
+`internal/metafetch/` test (new `service_apply_transcription_test.go` or extend
+existing apply tests). Assert: applying a candidate whose title equals the
+transcribed title records the audio-confirmed marker; applying a non-matching
+candidate does not.
+
+```bash
+go build ./...
+go test ./internal/metafetch/ ./internal/database/ -count=1
+go vet ./internal/metafetch/
+```
+
+## Acceptance criteria
+
+- [ ] Exact normalized transcribed-title match (+ author substring when present) is detected at apply time.
+- [ ] An audio-confirmed marker is durably recorded (mechanism A or B).
+- [ ] Non-matching applies are unaffected (still `"matched"`, no marker).
+- [ ] Tests cover both branches; `go test` green; `go vet` clean.
+- [ ] If you added a DB field, the memdb projection + `UpdateBook` full-column write still round-trip it (see `internal/database/memdb_summaries.go`).
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+feat(metafetch): record audio-confirmed metadata matches on apply
+
+When an applied candidate exactly matches the book's audio-derived (transcribed)
+title and author, mark the match as audio-confirmed so a later batch job can
+auto-apply such high-trust matches without human review.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/tm-apply-auto-confirm
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency
+
+If an audio-confirmed marker is already written on apply, this is done.
+
+## Rollback
+
+Revert the commit. If you added a DB field (option B), no migration is needed —
+the field is optional/omitempty and defaults to nil.

--- a/docs/agent-tasks/transcription-matching/TASK-03-upgrade-confidence-signal.md
+++ b/docs/agent-tasks/transcription-matching/TASK-03-upgrade-confidence-signal.md
@@ -1,0 +1,109 @@
+<!-- file: docs/agent-tasks/transcription-matching/TASK-03-upgrade-confidence-signal.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5071829b-4e6f-4182-bc3e-0f1a2b3c4d5e -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-03 — Upgrade-confidence transcription signal
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** go-backend subagent ·
+**Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/tm-upgrade-confidence" -b agent/tm-upgrade-confidence origin/main
+cd "$REPO/.worktrees/tm-upgrade-confidence"
+git rebase origin/main
+```
+
+## Goal
+
+The metadata-upgrade job auto-applies a better candidate only when its score
+clears a fixed gate (`MinUpgradeConfidence = 0.90`). When the candidate also
+**matches the book's transcription exactly**, that is independent corroboration —
+so allow a lower score (e.g. 0.85) for transcription-confirmed candidates. This
+upgrades more correct books automatically without lowering the bar globally.
+
+## Background (verify line numbers — they drift)
+
+- `internal/metabatch/upgrade.go` — `MetadataUpgradeService.tryUpgradeBook`
+  decides whether to upgrade. The constant `MinUpgradeConfidence = 0.90` (~line
+  67) gates it; the decision block is ~line 150. Find them:
+  ```bash
+  grep -n "MinUpgradeConfidence\|func.*tryUpgradeBook\|score\b" internal/metabatch/upgrade.go
+  ```
+- Reuse `hintsFromBook` + exact-title compare (`util.NormalizeTitle`) and
+  `containsCI` from `internal/metafetch/`. If they are unexported, either export a
+  small helper or replicate the tiny comparison locally (don't import test code).
+
+## Step-by-step
+
+1. Define a second, lower threshold near the existing constant:
+   ```go
+   // MinUpgradeConfidenceWithTranscription relaxes the gate when the candidate
+   // independently matches the book's audio-derived title/author.
+   const MinUpgradeConfidenceWithTranscription = 0.85
+   ```
+2. In `tryUpgradeBook`, compute whether the candidate matches the transcription
+   (exact normalized title; author substring when present), using `hintsFromBook`.
+3. Change the gate so the effective threshold is the lower one when transcription
+   confirms:
+   ```go
+   gate := MinUpgradeConfidence
+   if transcriptionConfirms {
+       gate = MinUpgradeConfidenceWithTranscription
+   }
+   if score < gate { /* skip upgrade as before */ }
+   ```
+4. Log which gate was used: `slog.Debug("upgrade gate", "book_id", id, "score", score, "gate", gate, "transcription_confirms", transcriptionConfirms)`.
+5. Bump file headers.
+
+## How to test
+
+`internal/metabatch/` test: a candidate with score 0.87 that matches the
+transcription IS upgraded; the same score WITHOUT a transcription match is NOT;
+a 0.95 candidate is upgraded regardless. Mirror existing upgrade tests.
+
+```bash
+go build ./...
+go test ./internal/metabatch/ -count=1
+go vet ./internal/metabatch/
+```
+
+## Acceptance criteria
+
+- [ ] Transcription-confirmed candidates use the 0.85 gate; others keep 0.90.
+- [ ] Exact normalized title match required (+ author substring when present).
+- [ ] Tests cover 0.87-with-transcription (upgrade), 0.87-without (skip), 0.95 (upgrade).
+- [ ] `go test ./internal/metabatch/ -count=1` green; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+feat(metabatch): relax upgrade gate for transcription-confirmed candidates
+
+A candidate that independently matches the book's audio-derived title/author is
+corroborated, so allow a 0.85 upgrade score for it (vs the global 0.90) without
+lowering the bar for unconfirmed candidates.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/tm-upgrade-confidence
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency
+
+If a transcription-aware gate already exists in `tryUpgradeBook`, this is done.
+
+## Rollback
+
+Revert the commit; the change only affects the upgrade-decision threshold.

--- a/docs/agent-tasks/transcription-matching/TASK-04-batch-auto-match.md
+++ b/docs/agent-tasks/transcription-matching/TASK-04-batch-auto-match.md
@@ -1,0 +1,134 @@
+<!-- file: docs/agent-tasks/transcription-matching/TASK-04-batch-auto-match.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6182930a-5f70-4293-bc4f-1a2b3c4d5e6f -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-04 — Batch auto-match operation
+
+**Priority:** P1 · **Effort:** L · **Recommended subagent:** code-exploration
+subagent first (map the op + apply plumbing), then go-backend subagent, then
+test-writing subagent · **Depends on:** TASK-02 (apply auto-confirm)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/tm-batch-auto-match" -b agent/tm-batch-auto-match origin/main
+cd "$REPO/.worktrees/tm-batch-auto-match"
+git rebase origin/main
+```
+
+> Do not start until TASK-02 is merged — this builds on the audio-confirmed apply.
+
+## Goal
+
+Add an **operation** that walks the library and, for every unreviewed book whose
+best metadata candidate both (a) scores above a threshold AND (b) exactly matches
+the transcription, **auto-applies** it and marks it `matched` (audio-confirmed).
+This turns the new transcription signal into bulk, hands-off metadata correction.
+It must be **dry-run-gated** (report what it would do) before applying.
+
+## Background (verify before editing)
+
+- Operation definitions live in the plugins/registry. A good model is
+  `internal/plugins/maintenance/intro_transcribe.go` — see `introTranscribeDef()`
+  (an `sdk.OperationDef`) and `runIntroTranscribe`, including the `RunItems`
+  fan-out and checkpointing. Copy that shape.
+  ```bash
+  grep -rn "sdk.OperationDef\|registry.RunItems\|ListBookIDs" internal/plugins/maintenance/intro_transcribe.go
+  ```
+- Apply logic: `internal/metafetch/service_apply.go` `ApplyMetadataCandidate`
+  (extended by TASK-02). Fetch-and-score: `FetchMetadataForBook` /
+  `bestTitleMatchForBook` in `internal/metafetch/`.
+- Books: `store.ListBookIDs()` → full ordered id list (the uncapped primitive);
+  `store.GetBookByID(id)`. Reuse `hintsFromBook` + exact-title compare.
+
+## Step-by-step
+
+1. **Explore first** (code-exploration subagent): confirm how an op is registered
+   (the `Def()` + `Run` pattern), how `RunItems` drives a paged/checkpointed loop,
+   and the exact signature to apply a candidate to a book.
+2. Add a new op, e.g. `maintenance.auto-match-transcribed`, with params:
+   ```go
+   type autoMatchParams struct {
+       DryRun     *bool   `json:"dry_run,omitempty"`   // default true
+       MinScore   float64 `json:"min_score,omitempty"` // default e.g. 0.75
+       LastBookID string  `json:"last_book_id,omitempty"` // checkpoint
+   }
+   ```
+   Default `DryRun=true`. Default `MinScore` to a conservative value (0.75).
+3. For each book with a non-garbage transcription and `MetadataReviewStatus == nil`:
+   - fetch + score candidates (reuse the existing fetch/score path),
+   - take the best candidate; require `score >= MinScore` AND exact normalized
+     transcribed-title match (+ author substring when present),
+   - if `DryRun`: log/count "would apply <candidate> to <book>",
+   - else: call `ApplyMetadataCandidate` and rely on TASK-02 to mark it
+     audio-confirmed.
+4. Use `RunItems` for paging, checkpointing (`LastBookID`), progress, and ctx
+   cancellation — mirror `runIntroTranscribe`. Set a sane `ProgressTimeout`.
+5. Emit a final summary log: scanned / eligible / applied (or would-apply).
+6. Register the op in the same place the maintenance ops are registered.
+7. Bump file headers.
+
+## Safety
+
+- **Dry-run by default.** The op must NOT mutate anything unless `dry_run=false`
+  is explicitly passed.
+- Only touch books with `MetadataReviewStatus == nil` (never override a human
+  `no_match` or an existing `matched`).
+- Respect ctx cancellation and checkpoint so a long run can resume.
+
+## How to test
+
+`internal/plugins/maintenance/` (or wherever the op lives): a fake/in-memory
+store with a few books — one with a transcription matching a high-score
+candidate (applied when dry_run=false; only counted when dry_run=true), one with
+no transcription (skipped), one already `matched` (skipped).
+
+```bash
+go build ./...
+go test ./internal/plugins/maintenance/ ./internal/metafetch/ -count=1
+go vet ./...
+```
+
+## Acceptance criteria
+
+- [ ] New op registered and discoverable via the operations API.
+- [ ] Defaults to dry-run; applies only when `dry_run=false`.
+- [ ] Applies only to `MetadataReviewStatus == nil` books with an exact transcription match above `min_score`.
+- [ ] Paged + checkpointed via `RunItems`; cancellable; final summary logged.
+- [ ] Tests cover apply / dry-run-count / skip-no-transcription / skip-already-reviewed.
+- [ ] `go test` green for changed packages; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+feat(maintenance): auto-match-transcribed batch operation (dry-run gated)
+
+Walks the library and auto-applies the best metadata candidate to unreviewed
+books whose candidate exactly matches the audio-derived transcription above a
+score threshold. Dry-run by default; checkpointed + cancellable via RunItems.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/tm-batch-auto-match
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency
+
+Re-running with the same params is safe: already-`matched` books are skipped, and
+the checkpoint (`LastBookID`) resumes a partial run. Verify an op named
+`auto-match-transcribed` doesn't already exist before adding it.
+
+## Rollback
+
+Revert the commit. No data migration. If a dry-run-false run applied bad
+metadata, the existing metadata revert/changelog tooling can undo per-book.

--- a/docs/agent-tasks/transcription-matching/TASK-05-dedup-tiebreaker.md
+++ b/docs/agent-tasks/transcription-matching/TASK-05-dedup-tiebreaker.md
@@ -1,0 +1,111 @@
+<!-- file: docs/agent-tasks/transcription-matching/TASK-05-dedup-tiebreaker.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7293a40b-6081-43a4-bc50-2b3c4d5e6f70 -->
+<!-- last-edited: 2026-06-28 -->
+
+# TASK-05 — Dedup tiebreaker via transcription
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** code-exploration
+subagent first, then go-backend subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/tm-dedup-tiebreaker" -b agent/tm-dedup-tiebreaker origin/main
+cd "$REPO/.worktrees/tm-dedup-tiebreaker"
+git rebase origin/main
+```
+
+## Goal
+
+Dedup groups books by metadata similarity at a fuzzy threshold (~0.85). For
+**borderline** pairs (just under/over the line), the audio-derived transcribed
+title/author is a strong independent signal: if two candidate-duplicate books
+have matching transcribed titles, raise confidence they ARE duplicates; if their
+transcribed titles clearly differ, lower it (they're distinct books that merely
+share fuzzy metadata). Use transcription as a tiebreaker, not as a primary
+grouping key.
+
+## Background (verify line numbers — they drift)
+
+- `internal/dedup/book_dedup.go` — `ScanBookDuplicates` runs a three-tier scan;
+  the metadata fuzzy tier calls something like
+  `store.GetDuplicateBooksByMetadata(0.85)` (~lines 78–84). Find it:
+  ```bash
+  grep -n "func.*ScanBookDuplicates\|GetDuplicateBooksByMetadata\|0.85\|threshold" internal/dedup/book_dedup.go
+  ```
+- The transcribed fields are on `Book` (`TranscribedTitle`, `TranscribedAuthor`).
+  Reuse a normalized-title compare (`util.NormalizeTitle`) and `containsCI`.
+- Tests: `internal/dedup/book_dedup_test.go`.
+
+## Step-by-step
+
+1. **Explore first**: confirm where borderline metadata pairs are produced and
+   what data each pair carries (do both books' transcribed fields reach this
+   point, or must you load them via `GetBookByID`?). Decide the cheapest place to
+   apply the tiebreaker.
+2. Define a small helper, e.g.:
+   ```go
+   // transcriptionAgreement returns +1 if both books' transcribed titles match,
+   // -1 if both are present and clearly differ, 0 if unknown (missing data).
+   func transcriptionAgreement(a, b *database.Book) int { ... }
+   ```
+   Use exact normalized title match for +1; present-but-different for -1; any
+   missing/garbage transcribed title → 0 (no signal).
+3. Apply it to borderline pairs only (e.g. similarity in [0.80, 0.88]): promote a
+   +1 pair to a higher-confidence band / keep it; demote a -1 pair (drop or flag).
+   Do NOT change behavior for pairs far from the threshold.
+4. Keep it conservative — when in doubt (0), leave the existing decision intact.
+5. Bump file headers.
+
+## How to test
+
+`internal/dedup/book_dedup_test.go`: a borderline pair with matching transcribed
+titles is kept/promoted; a borderline pair with clearly different transcribed
+titles is demoted/dropped; a pair with missing transcription is unchanged.
+
+```bash
+go build ./...
+go test ./internal/dedup/ -count=1
+go vet ./internal/dedup/
+```
+
+## Acceptance criteria
+
+- [ ] Transcription agreement only affects borderline pairs (near the threshold).
+- [ ] Matching transcribed titles raise confidence; clearly-different lower it.
+- [ ] Missing/garbage transcription = no change (signal = 0).
+- [ ] Tests cover promote / demote / no-signal; `go test ./internal/dedup/` green; `go vet` clean.
+- [ ] File headers bumped.
+
+## Commit message
+
+```
+feat(dedup): transcription tiebreaker for borderline metadata pairs
+
+For dedup candidate pairs near the fuzzy threshold, use the audio-derived
+transcribed title as an independent signal: matching titles raise duplicate
+confidence, clearly-different titles lower it. Conservative — no effect when
+transcription is missing or pairs are far from the threshold.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/tm-dedup-tiebreaker
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency
+
+If `book_dedup.go` already consults transcribed fields for borderline pairs, this
+is done.
+
+## Rollback
+
+Revert the commit; dedup grouping returns to metadata-only.

--- a/docs/agent-tasks/transcription-matching/orchestration.md
+++ b/docs/agent-tasks/transcription-matching/orchestration.md
@@ -1,0 +1,44 @@
+<!-- file: docs/agent-tasks/transcription-matching/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 83a4b50c-7192-44b5-9c61-3c4d5e6f7081 -->
+<!-- last-edited: 2026-06-28 -->
+
+# Orchestration — transcription-matching workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This
+file only adds the workstream-specific wave order.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      T1[TASK-01 search hints]
+      T5[TASK-05 dedup tiebreaker]
+    end
+    subgraph Wave2
+      T2[TASK-02 apply auto-confirm]
+      T3[TASK-03 upgrade gate]
+    end
+    subgraph Wave3
+      T4[TASK-04 batch auto-match]
+    end
+    T2 --> T4
+```
+
+- **Wave 1** (parallel, independent): TASK-01, TASK-05.
+- **Wave 2** (parallel, independent): TASK-02, TASK-03.
+- **Wave 3** (after TASK-02 merged): TASK-04.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/
+./run.sh                 # prints wave order + sets up worktrees for wave 1
+./run.sh 01 05           # wave 1 only
+./run.sh 02 03           # wave 2 (after wave 1 merged + siblings rebased)
+./run.sh 04              # wave 3 (after TASK-02 merged)
+```
+
+After each wave: gate each worktree (`go build ./... && go test ./internal/metafetch/ -count=1`),
+push/PR/merge as coordinator, then rebase remaining siblings onto `origin/main`.

--- a/docs/agent-tasks/transcription-matching/run.sh
+++ b/docs/agent-tasks/transcription-matching/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/transcription-matching/run.sh
+# version: 1.0.0
+# guid: 94b5c61d-8203-44c6-9d72-4d5e6f708192
+# last-edited: 2026-06-28
+#
+# Thin wrapper over ../run-sweep.sh for the transcription-matching workstream.
+# Prints the dependency wave order, then delegates worktree+prompt creation.
+#   ./run.sh            # show waves, set up wave 1 (TASK-01, TASK-05)
+#   ./run.sh 02 03      # set up specific tasks by id
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+
+cat <<'EOF'
+transcription-matching waves (respect Depends on:):
+  Wave 1 (parallel): 01 search-path-hints, 05 dedup-tiebreaker
+  Wave 2 (parallel): 02 apply-auto-confirm, 03 upgrade-confidence
+  Wave 3 (after 02): 04 batch-auto-match
+EOF
+
+if [[ $# -gt 0 ]]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+echo; echo "Setting up Wave 1 (01, 05)…"; echo
+exec "$HERE/../run-sweep.sh" "$WS" 01 05


### PR DESCRIPTION
## What

Adds `docs/agent-tasks/` — a **self-contained, in-repo manual task package** you run by hand (feed each brief to an AI agent, even a weak one), distinct from the unreliable TODO→GitHub-issues burndown bot.

## Contents

- **`README.md`** — generic, portable subagent roster (code-exploration / go-backend / frontend / test-writing / code-auditing / documentation / conflict-resolution), the mandatory worktree+rebase protocol repeated inline, file-header rules, and a Definition of Done.
- **`ORCHESTRATION.md` + `run-sweep.sh`** — a portable, tool-agnostic multi-agent coordinator pattern (one worktree per task, workers report-only, coordinator owns git/gh + local `make ci` gate + sibling rebase). The script creates worktrees and emits ready-to-paste agent prompts; it never pushes or merges.
- **Four workstreams**, each with a `README.md` (overview + Mermaid dependency graph), numbered self-contained `TASK-NN-*.md` files, `orchestration.md`, and `run.sh`:
  - **`transcription-matching/`** (TOP PRIORITY) — 5 tasks: search-path hints, apply auto-confirm, upgrade-confidence gate, batch auto-match, dedup tiebreaker.
  - **`dedup-intro-falsepositive/`** — 4 tasks (investigate → short-clip skip / title blocklist / ISBN-ASIN gate) for the ~372K intro/outro false positives.
  - **`dedup-ui/`** — 5 frontend tasks (row redesign, metadata tab, manual import, label review, keyboard shortcuts).
  - **`system-docs/`** — 7 tasks producing the DOCS-1 set (≥9 docs, ≥7 Mermaid diagrams) under `docs/system/`.

Every task is weak-model-proof: explicit START-HERE worktree/rebase commands, exact `file:line` references, copy-pasteable steps, test commands, checkbox acceptance criteria, an exact commit message, and idempotency/rollback notes.

## Tracking

- `TODO.md` — adds the Agent Task Package section, records the June 28 pagination/transcription ship, and captures the known flaky CI (mock-freshness drift, backup/scan tests).
- `CHANGELOG.md` — June 28 entry prepended.

Docs-only; all `run.sh`/`run-sweep.sh` are `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)