### PR TITLE
fix(dedup): block matches where both books have boilerplate intro titles

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.34.0
+// version: 1.34.1
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-24
+// last-edited: 2026-06-28
 
 package dedup
 
@@ -23,12 +23,73 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var dedupTracer = otel.Tracer("audiobook-organizer/dedup")
+
+// boilerplateTitlePatterns are exact publisher intro/outro "titles" that are
+// not real books and must not seed dedup matches. Seeded from
+// docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md and safe to extend.
+var boilerplateTitlePatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"end credits",
+	"credits",
+	"opening credits",
+	"closing credits",
+	"intro",
+	"introduction",
+	"outro",
+	"epilogue music",
+	"publisher introduction",
+	"publisher's note",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+}
+
+// boilerplateTitlePrefixPatterns are anchored boilerplate phrases that may carry
+// trailing publisher copy. Keep this list narrower than the exact-title list so
+// real books like "Introduction to Algorithms" still match normally.
+var boilerplateTitlePrefixPatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+}
+
+func isBoilerplateTitle(title string) bool {
+	normalized := util.NormalizeTitle(util.CollapseSpaces(title))
+	if normalized == "" {
+		return false
+	}
+	for _, pattern := range boilerplateTitlePatterns {
+		if normalized == pattern {
+			return true
+		}
+	}
+	for _, pattern := range boilerplateTitlePrefixPatterns {
+		if strings.HasPrefix(normalized, pattern+" ") {
+			return true
+		}
+	}
+	return false
+}
 
 // Engine orchestrates a 3-layer dedup system:
 //   - Layer 1: Exact matching (free, instant) — same file hash, ISBN/ASIN, or near-identical titles
@@ -2819,6 +2880,20 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		return fmt.Errorf("acoustid scan: get all books: %w", err)
 	}
 
+	boilerplateBookCache := make(map[string]bool, len(books))
+	for _, b := range books {
+		boilerplateBookCache[b.ID] = isBoilerplateTitle(b.Title)
+	}
+	isBoilerplateBook := func(bookID string) bool {
+		if blocked, ok := boilerplateBookCache[bookID]; ok {
+			return blocked
+		}
+		book, err := de.bookStore.GetBookByID(bookID)
+		blocked := err == nil && book != nil && isBoilerplateTitle(book.Title)
+		boilerplateBookCache[bookID] = blocked
+		return blocked
+	}
+
 	// emitted tracks canonical pair keys we've already inserted this run so we
 	// don't call UpsertCandidate multiple times for the same pair (can happen
 	// when two books share several segments).
@@ -2854,6 +2929,9 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 	}
 
 	emit := func(bookAID, bookBID string, sim float64) {
+		if isBoilerplateBook(bookAID) || isBoilerplateBook(bookBID) {
+			return
+		}
 		key := pairKey(bookAID, bookBID)
 		if _, already := emitted[key]; already {
 			return
@@ -2927,6 +3005,9 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		})
 
 		for _, f := range files {
+			if isBoilerplateTitle(f.Title) {
+				continue
+			}
 			// Tier-0: whole-file LSH candidate set + Hamming refine.
 			// Sub-linear via the fpidx: secondary index, so it runs
 			// unconditionally (index caps candidates, so work is bounded).
@@ -2937,7 +3018,8 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 						continue
 					}
 					cand, _ := lshStore.GetBookFileByID("", candID)
-					if cand == nil || cand.BookID == book.ID || len(cand.AcoustIDFingerprint) == 0 {
+					if cand == nil || cand.BookID == book.ID || len(cand.AcoustIDFingerprint) == 0 ||
+						isBoilerplateTitle(cand.Title) {
 						continue
 					}
 					sim, simErr := fingerprint.WholeFileSimilarity(f.AcoustIDFingerprint, cand.AcoustIDFingerprint)
@@ -2974,6 +3056,9 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 				// Tier 1: exact match (O(1) via Pebble book_file_acoustid: index).
 				exactHit, _ := de.bookStore.GetBookFileByAcoustID(seg)
 				if exactHit != nil && exactHit.BookID != book.ID {
+					if isBoilerplateTitle(exactHit.Title) {
+						continue
+					}
 					emit(book.ID, exactHit.BookID, 1.0)
 					continue
 				}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.34.1
+// version: 1.35.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-28
 
@@ -2889,6 +2889,9 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 			return blocked
 		}
 		book, err := de.bookStore.GetBookByID(bookID)
+		if err != nil {
+			slog.Warn("dedup: isBoilerplateBook fallback GetBookByID failed", "book_id", bookID, "err", err)
+		}
 		blocked := err == nil && book != nil && isBoilerplateTitle(book.Title)
 		boilerplateBookCache[bookID] = blocked
 		return blocked

--- a/internal/dedup/engine_acoustid_test.go
+++ b/internal/dedup/engine_acoustid_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_acoustid_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c8f25a0d-8e69-47f7-a36f-60c191b73810
 // last-edited: 2026-06-28
 
@@ -121,6 +121,35 @@ func TestAcoustIDScan_NormalTitleContainingBoilerplateWordStillEmitsCandidate(t 
 	}
 	if total != 1 {
 		t.Fatalf("expected one acoustid candidate for real title, got %d (%+v)", total, candidates)
+	}
+}
+
+
+func TestAcoustIDScan_BoilerplatePrefixTitleDoesNotEmitCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	books := []database.Book{
+		{ID: "BOOK_A", Title: "Audible Presents The Complete Sherlock Holmes"},
+		{ID: "BOOK_B", Title: "A Real Audiobook"},
+	}
+	filesByBook := map[string][]database.BookFile{
+		"BOOK_A": {{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/intro.mp3", AcoustIDSeg0: validFP80}},
+		"BOOK_B": {{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.mp3", AcoustIDSeg0: validFP80}},
+	}
+	wireAcoustIDScanMock(mock, books, filesByBook)
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Layer:      "acoustid",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("expected no acoustid candidates for boilerplate prefix title, got %d", total)
 	}
 }
 

--- a/internal/dedup/engine_acoustid_test.go
+++ b/internal/dedup/engine_acoustid_test.go
@@ -1,0 +1,153 @@
+// file: internal/dedup/engine_acoustid_test.go
+// version: 1.0.0
+// guid: c8f25a0d-8e69-47f7-a36f-60c191b73810
+// last-edited: 2026-06-28
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestAcoustIDScan_BoilerplateTitleDoesNotEmitCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	books := []database.Book{
+		{ID: "BOOK_A", Title: "  THIS   IS\tAUDIBLE  "},
+		{ID: "BOOK_B", Title: "A Real Audiobook"},
+	}
+	filesByBook := map[string][]database.BookFile{
+		"BOOK_A": {{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/intro.mp3", AcoustIDSeg0: validFP80}},
+		"BOOK_B": {{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.mp3", AcoustIDSeg0: validFP80}},
+	}
+	wireAcoustIDScanMock(mock, books, filesByBook)
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Layer:      "acoustid",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("expected no acoustid candidates for boilerplate title, got %d", total)
+	}
+}
+
+func TestAcoustIDScan_NormalTitleStillEmitsCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	books := []database.Book{
+		{ID: "BOOK_A", Title: "A Real Audiobook"},
+		{ID: "BOOK_B", Title: "A Real Audiobook"},
+	}
+	filesByBook := map[string][]database.BookFile{
+		"BOOK_A": {{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/book.mp3", AcoustIDSeg0: validFP80}},
+		"BOOK_B": {{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.mp3", AcoustIDSeg0: validFP80}},
+	}
+	wireAcoustIDScanMock(mock, books, filesByBook)
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	candidates, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Layer:      "acoustid",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("expected one acoustid candidate for normal titles, got %d (%+v)", total, candidates)
+	}
+}
+
+func TestAcoustIDScan_BoilerplateFileTitleDoesNotEmitCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	books := []database.Book{
+		{ID: "BOOK_A", Title: "A Real Audiobook"},
+		{ID: "BOOK_B", Title: "A Real Audiobook"},
+	}
+	filesByBook := map[string][]database.BookFile{
+		"BOOK_A": {{ID: "FILE_A", BookID: "BOOK_A", Title: "This Is Audible", FilePath: "/lib/a/intro.mp3", AcoustIDSeg0: validFP80}},
+		"BOOK_B": {{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.mp3", AcoustIDSeg0: validFP80}},
+	}
+	wireAcoustIDScanMock(mock, books, filesByBook)
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	_, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Layer:      "acoustid",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("expected no acoustid candidates for boilerplate file title, got %d", total)
+	}
+}
+
+func TestAcoustIDScan_NormalTitleContainingBoilerplateWordStillEmitsCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	books := []database.Book{
+		{ID: "BOOK_A", Title: "Introduction to Algorithms"},
+		{ID: "BOOK_B", Title: "Introduction to Algorithms"},
+	}
+	filesByBook := map[string][]database.BookFile{
+		"BOOK_A": {{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/book.mp3", AcoustIDSeg0: validFP80}},
+		"BOOK_B": {{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.mp3", AcoustIDSeg0: validFP80}},
+	}
+	wireAcoustIDScanMock(mock, books, filesByBook)
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	candidates, total, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Layer:      "acoustid",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("expected one acoustid candidate for real title, got %d (%+v)", total, candidates)
+	}
+}
+
+func wireAcoustIDScanMock(
+	mock *database.MockStore,
+	books []database.Book,
+	filesByBook map[string][]database.BookFile,
+) {
+	filesBySeg := make(map[string]database.BookFile)
+	for _, files := range filesByBook {
+		for _, file := range files {
+			if file.AcoustIDSeg0 != "" {
+				filesBySeg[file.AcoustIDSeg0] = file
+			}
+		}
+	}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		return books, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		return filesByBook[bookID], nil
+	}
+	mock.GetBookFileByAcoustIDFunc = func(fingerprint string) (*database.BookFile, error) {
+		if file, ok := filesBySeg[fingerprint]; ok {
+			return &file, nil
+		}
+		return nil, nil
+	}
+}


### PR DESCRIPTION
Adds a blocklist of publisher/platform boilerplate title patterns ("introduction", "audible presents", etc.). Pairs where both books have blocked titles are skipped from dedup. Part of DEDUP-INTRO-1.