### PR TITLE
feat(dedup-ui): keyboard shortcuts + help overlay (DEDUP-KB-1)

### DIFF
--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.7.0
+// version: 1.8.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
-// last-edited: 2026-06-28
+// last-edited: 2026-06-29
 
 // UnifiedDedupTab is the T017 single surface that replaces the separate Books /
 // Advanced-Scan / Acoustic tabs. It shows a paginated candidate table filtered
@@ -107,6 +107,22 @@ function qualityChip(score: number) {
   return <Chip label="Poor metadata" size="small" color="error" variant="outlined" />;
 }
 
+/**
+ * Single source of truth for the "recommended keep" decision.
+ * Returns which entity to keep and its label ('A' or 'B'), or null when scores
+ * are tied (no recommendation). Both the render and the `m` keyboard shortcut
+ * call this function so they can never drift.
+ */
+function recommendedKeepSide(
+  candidate: DedupCandidate
+): { keepId: string; label: 'A' | 'B' } | null {
+  const qA = metadataQuality(candidate.book_a);
+  const qB = metadataQuality(candidate.book_b);
+  if (qA > qB) return { keepId: candidate.entity_a_id, label: 'A' };
+  if (qB > qA) return { keepId: candidate.entity_b_id, label: 'B' };
+  return null; // tie — no recommendation
+}
+
 const DEDUP_SHORTCUTS = [
   { keys: 'j / k', action: 'Move to next / previous row' },
   { keys: 'm', action: 'Merge the focused candidate' },
@@ -118,13 +134,16 @@ const DEDUP_SHORTCUTS = [
   { keys: '?', action: 'Toggle this shortcut help' },
 ];
 
-function isKeyboardShortcutSuppressed() {
+function isKeyboardShortcutSuppressed(): boolean {
   const active = document.activeElement;
   if (!active) return false;
   const tag = active.tagName.toLowerCase();
-  if (tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'dialog') return true;
+  // Block shortcuts when a form element has focus.
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
   const activeElement = active as HTMLElement;
   if (activeElement.isContentEditable) return true;
+  // Block shortcuts when focus is anywhere inside a modal dialog (MUI renders
+  // div[role="dialog"], not a native <dialog> element).
   return Boolean(activeElement.closest('[role="dialog"]'));
 }
 
@@ -649,10 +668,11 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
 
       if (event.key === 'm' && focusedCandidate.status === 'pending') {
         event.preventDefault();
-        const qA = metadataQuality(focusedCandidate.book_a);
-        const qB = metadataQuality(focusedCandidate.book_b);
-        const keepId = qB > qA ? focusedCandidate.entity_b_id : focusedCandidate.entity_a_id;
-        const label = keepId === focusedCandidate.entity_b_id ? 'B' : 'A';
+        // Use the shared helper so this decision can never drift from the ★ chip shown in render.
+        const rec = recommendedKeepSide(focusedCandidate);
+        // On a quality tie (rec === null) default to keeping A, matching the Keep A button order.
+        const keepId = rec?.keepId ?? focusedCandidate.entity_a_id;
+        const label = rec?.label ?? 'A';
         void handleKeep(focusedCandidate.id, keepId, label);
       }
     };
@@ -998,8 +1018,10 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                   const bookB = c.book_b;
                   const qA = metadataQuality(bookA);
                   const qB = metadataQuality(bookB);
-                  const recommendA = qA > qB;
-                  const recommendB = qB > qA;
+                  // Use the shared helper so the ★ chip and `m` shortcut always agree.
+                  const rec = recommendedKeepSide(c);
+                  const recommendA = rec?.label === 'A';
+                  const recommendB = rec?.label === 'B';
                   const isSelected = selected.has(c.id);
                   const isFocused = idx === focusedRowIndex;
                   return (

--- a/web/src/components/dedup/UnifiedDedupTab.tsx
+++ b/web/src/components/dedup/UnifiedDedupTab.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/UnifiedDedupTab.tsx
-// version: 1.6.0
+// version: 1.7.0
 // guid: c8b9d0e1-f2a3-4567-bcde-cb8901234567
-// last-edited: 2026-06-19
+// last-edited: 2026-06-28
 
 // UnifiedDedupTab is the T017 single surface that replaces the separate Books /
 // Advanced-Scan / Acoustic tabs. It shows a paginated candidate table filtered
@@ -35,6 +35,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Divider,
   FormControlLabel,
   IconButton,
   Link,
@@ -53,6 +54,7 @@ import {
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import ClearIcon from '@mui/icons-material/Clear';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import * as api from '../../services/api';
 import type { Book, DedupCandidate, DedupBand, DedupStats } from '../../services/api';
 import { useOperationsStore } from '../../stores/useOperationsStore';
@@ -103,6 +105,27 @@ function qualityChip(score: number) {
   if (score >= 3)
     return <Chip label="Partial metadata" size="small" color="warning" variant="outlined" />;
   return <Chip label="Poor metadata" size="small" color="error" variant="outlined" />;
+}
+
+const DEDUP_SHORTCUTS = [
+  { keys: 'j / k', action: 'Move to next / previous row' },
+  { keys: 'm', action: 'Merge the focused candidate' },
+  { keys: 'd', action: 'Dismiss the focused candidate' },
+  { keys: 's', action: 'Select / deselect the focused row' },
+  { keys: 'Enter', action: 'Open the compare drawer for the focused row' },
+  { keys: 'Esc', action: 'Close the compare drawer' },
+  { keys: 'Shift+A', action: 'Select all on the current page' },
+  { keys: '?', action: 'Toggle this shortcut help' },
+];
+
+function isKeyboardShortcutSuppressed() {
+  const active = document.activeElement;
+  if (!active) return false;
+  const tag = active.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'dialog') return true;
+  const activeElement = active as HTMLElement;
+  if (activeElement.isContentEditable) return true;
+  return Boolean(activeElement.closest('[role="dialog"]'));
 }
 
 interface BookCardOpts {
@@ -264,6 +287,9 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
 
   // --- selection state ---
   const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [focusedRowIndex, setFocusedRowIndex] = useState(0);
+  const rowRefs = useRef<Array<HTMLTableRowElement | null>>([]);
+  const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
 
   // --- drawer state ---
   const [drawerCandidateId, setDrawerCandidateId] = useState<number | null>(null);
@@ -424,6 +450,20 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
 
   const bandCounts = useMemo(() => deriveBandCounts(stats), [stats]);
 
+  useEffect(() => {
+    setFocusedRowIndex((idx) => {
+      if (filteredCandidates.length === 0) return 0;
+      return Math.min(idx, filteredCandidates.length - 1);
+    });
+  }, [filteredCandidates.length]);
+
+  useEffect(() => {
+    rowRefs.current[focusedRowIndex]?.scrollIntoView?.({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [focusedRowIndex, filteredCandidates.length]);
+
   // --- selection helpers ---
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
@@ -541,6 +581,97 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
       setBulkBusy(false);
     }
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === '?' && shortcutHelpOpen) {
+        event.preventDefault();
+        setShortcutHelpOpen(false);
+        return;
+      }
+
+      if (hidden || isKeyboardShortcutSuppressed()) return;
+
+      if (event.key === '?') {
+        event.preventDefault();
+        setShortcutHelpOpen((open) => !open);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        if (drawerCandidateId !== null) {
+          event.preventDefault();
+          setDrawerCandidateId(null);
+        }
+        return;
+      }
+
+      if (filteredCandidates.length === 0) return;
+      const focusedCandidate = filteredCandidates[focusedRowIndex];
+      if (!focusedCandidate) return;
+
+      if (event.key === 'j') {
+        event.preventDefault();
+        setFocusedRowIndex((idx) => Math.min(idx + 1, filteredCandidates.length - 1));
+        return;
+      }
+
+      if (event.key === 'k') {
+        event.preventDefault();
+        setFocusedRowIndex((idx) => Math.max(idx - 1, 0));
+        return;
+      }
+
+      if (event.key === 's') {
+        event.preventDefault();
+        toggleSelect(focusedCandidate.id);
+        lastClickedIdxRef.current = focusedRowIndex;
+        return;
+      }
+
+      if (event.key === 'A' && event.shiftKey) {
+        event.preventDefault();
+        selectAll();
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        setDrawerCandidateId(focusedCandidate.id);
+        return;
+      }
+
+      if (event.key === 'd' && focusedCandidate.status === 'pending') {
+        event.preventDefault();
+        void handleDismissOne(focusedCandidate.id);
+        return;
+      }
+
+      if (event.key === 'm' && focusedCandidate.status === 'pending') {
+        event.preventDefault();
+        const qA = metadataQuality(focusedCandidate.book_a);
+        const qB = metadataQuality(focusedCandidate.book_b);
+        const keepId = qB > qA ? focusedCandidate.entity_b_id : focusedCandidate.entity_a_id;
+        const label = keepId === focusedCandidate.entity_b_id ? 'B' : 'A';
+        void handleKeep(focusedCandidate.id, keepId, label);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    drawerCandidateId,
+    filteredCandidates,
+    focusedRowIndex,
+    handleDismissOne,
+    handleKeep,
+    hidden,
+    selectAll,
+    shortcutHelpOpen,
+    toggleSelect,
+  ]);
 
   const handleMergeAllFiltered = async () => {
     setBulkBusy(true);
@@ -870,12 +1001,18 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                   const recommendA = qA > qB;
                   const recommendB = qB > qA;
                   const isSelected = selected.has(c.id);
+                  const isFocused = idx === focusedRowIndex;
                   return (
                     <TableRow
                       key={c.id}
+                      ref={(node) => {
+                        rowRefs.current[idx] = node;
+                      }}
                       hover
                       selected={isSelected}
                       onClick={(e) => handleRowClick(e, c.id, idx)}
+                      data-testid={`dedup-candidate-row-${c.id}`}
+                      aria-current={isFocused ? 'true' : undefined}
                       sx={{
                         opacity: busy ? 0.7 : 1,
                         cursor: 'pointer',
@@ -885,6 +1022,9 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
                           : idx % 2 === 1
                             ? 'action.hover'
                             : 'transparent',
+                        outline: isFocused ? 2 : 0,
+                        outlineColor: 'primary.main',
+                        outlineOffset: -2,
                       }}
                     >
                       {showMultiSelect && (
@@ -1042,6 +1182,44 @@ export function UnifiedDedupTab({ hidden }: UnifiedDedupTabProps) {
           loadStats();
         }}
       />
+
+      {/* Dedup keyboard shortcut help */}
+      <Dialog
+        open={shortcutHelpOpen}
+        onClose={() => setShortcutHelpOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <HelpOutlineIcon fontSize="small" />
+          <Box sx={{ flex: 1 }}>Dedup Keyboard Shortcuts</Box>
+          <IconButton
+            size="small"
+            onClick={() => setShortcutHelpOpen(false)}
+            aria-label="close shortcuts help"
+          >
+            <ClearIcon fontSize="small" />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={1}>
+            {DEDUP_SHORTCUTS.map((shortcut, idx) => (
+              <Box key={shortcut.keys}>
+                {idx > 0 && <Divider sx={{ mb: 1 }} />}
+                <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+                  <Typography variant="body2">{shortcut.action}</Typography>
+                  <Chip
+                    label={shortcut.keys}
+                    size="small"
+                    variant="outlined"
+                    sx={{ fontFamily: 'monospace', flexShrink: 0 }}
+                  />
+                </Stack>
+              </Box>
+            ))}
+          </Stack>
+        </DialogContent>
+      </Dialog>
 
       {/* Force Full Rescan modal — pick which detection layer to re-run */}
       <Dialog open={rescanOpen} onClose={() => setRescanOpen(false)} maxWidth="sm" fullWidth>

--- a/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
+++ b/web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
@@ -1,14 +1,14 @@
 // file: web/src/components/dedup/__tests__/UnifiedDedupTab.test.tsx
-// version: 1.2.1
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0123-defa-444567890123
-// last-edited: 2026-06-19
+// last-edited: 2026-06-28
 
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { UnifiedDedupTab } from '../UnifiedDedupTab';
 import * as api from '../../../services/api';
-import type { Book } from '../../../services/api';
+import type { Book, DedupBookDetail, DedupCandidate } from '../../../services/api';
 
 // Mock the full api module.
 vi.mock('../../../services/api', () => ({
@@ -17,6 +17,9 @@ vi.mock('../../../services/api', () => ({
   mergeDedupCandidate: vi.fn(),
   dismissDedupCandidate: vi.fn(),
   bulkMergeDedupCandidates: vi.fn(),
+  getDedupCandidateBreakdown: vi.fn(),
+  compareAcoustID: vi.fn(),
+  getConfig: vi.fn(),
   rescoreDedupCandidates: vi.fn(),
   triggerDedupScan: vi.fn(),
 }));
@@ -34,7 +37,7 @@ vi.mock('../../../stores/useOperationsStore', () => ({
 const bookATitle = 'Dune (FLAC rip)';
 const bookBTitle = 'Dune (MP3 rip)';
 
-const mockCandidate = {
+const mockCandidate: DedupCandidate = {
   id: 1,
   entity_type: 'book' as const,
   entity_a_id: '01ABCDEFGHIJKLMNOPQRSTUV01',
@@ -60,12 +63,65 @@ const mockCandidate = {
   } as Book,
 };
 
+const secondMockCandidate: DedupCandidate = {
+  ...mockCandidate,
+  id: 2,
+  entity_a_id: '01ABCDEFGHIJKLMNOPQRSTUV03',
+  entity_b_id: '01ABCDEFGHIJKLMNOPQRSTUV04',
+  score: 96.2,
+  book_a: {
+    id: '01ABCDEFGHIJKLMNOPQRSTUV03',
+    title: 'Neuromancer (Archive)',
+    author_name: 'William Gibson',
+    file_path: '/audiobooks/neuromancer-archive.m4b',
+  } as Book,
+  book_b: {
+    id: '01ABCDEFGHIJKLMNOPQRSTUV04',
+    title: 'Neuromancer (Tagged)',
+    author_name: 'William Gibson',
+    file_path: '/audiobooks/neuromancer-tagged.m4b',
+    asin: 'B000000001',
+  } as Book,
+};
+
 function renderInRouter() {
   return render(
     <MemoryRouter>
       <UnifiedDedupTab />
     </MemoryRouter>
   );
+}
+
+function mockCandidatesResponse(candidates: DedupCandidate[]) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    if (url.includes('/dedup/stats')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: { stats: [] } }),
+      });
+    }
+    if (url.includes('/dedup/candidates')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { candidates, total: candidates.length },
+          }),
+      });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+function toDedupBookDetail(book: Book): DedupBookDetail {
+  return {
+    id: book.id,
+    title: book.title ?? '',
+    author_name: book.author_name,
+    file_path: book.file_path,
+    cover_url: book.cover_url,
+    files: [],
+  };
 }
 
 describe('UnifiedDedupTab', () => {
@@ -80,6 +136,22 @@ describe('UnifiedDedupTab', () => {
       total: 0,
     });
     vi.mocked(api.getDedupStats).mockResolvedValue({ stats: [] });
+    vi.mocked(api.getConfig).mockResolvedValue({
+      root_dir: '/audiobooks',
+    } as Awaited<ReturnType<typeof api.getConfig>>);
+    vi.mocked(api.mergeDedupCandidate).mockResolvedValue();
+    vi.mocked(api.dismissDedupCandidate).mockResolvedValue();
+    vi.mocked(api.getDedupCandidateBreakdown).mockResolvedValue({
+      candidate: mockCandidate,
+      book_a: toDedupBookDetail(mockCandidate.book_a as Book),
+      book_b: toDedupBookDetail(mockCandidate.book_b as Book),
+    });
+    vi.mocked(api.compareAcoustID).mockResolvedValue({
+      book_a: mockCandidate.book_a as Book,
+      book_b: mockCandidate.book_b as Book,
+      overall_score: 0,
+      segment_scores: [],
+    });
 
     // Mock the global fetch used inside the component for AbortController-aware calls.
     globalThis.fetch = vi.fn().mockImplementation((url: string) => {
@@ -207,5 +279,82 @@ describe('UnifiedDedupTab', () => {
     renderInRouter();
     fireEvent.click(screen.getByTestId('rescore-btn'));
     expect(screen.getByText(/Rescore dedup candidates/i)).toBeInTheDocument();
+  });
+
+  it('uses keyboard navigation to merge and dismiss the focused candidate', async () => {
+    mockCandidatesResponse([mockCandidate, secondMockCandidate]);
+
+    renderInRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText(bookATitle)).toBeInTheDocument();
+      expect(screen.getByText('Neuromancer (Archive)')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: 'j' });
+    fireEvent.keyDown(window, { key: 'm' });
+
+    await waitFor(() => {
+      expect(api.mergeDedupCandidate).toHaveBeenCalledWith(2, secondMockCandidate.entity_b_id);
+    });
+
+    fireEvent.keyDown(window, { key: 'k' });
+    fireEvent.keyDown(window, { key: 'd' });
+
+    await waitFor(() => {
+      expect(api.dismissDedupCandidate).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('supports select, select all, compare drawer, escape, and help shortcuts', async () => {
+    mockCandidatesResponse([mockCandidate, secondMockCandidate]);
+
+    renderInRouter();
+
+    await waitFor(() => {
+      expect(screen.getByText(bookATitle)).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: 's' });
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-action-bar')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: 'A', shiftKey: true });
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    await waitFor(() => {
+      expect(screen.getByTestId('candidate-compare-drawer')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByText(/Candidate #1/i)).not.toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByText('Dedup Keyboard Shortcuts')).toBeInTheDocument();
+    expect(screen.getByText('Merge the focused candidate')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: '?' });
+    await waitFor(() => {
+      expect(screen.queryByText('Dedup Keyboard Shortcuts')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not run row shortcuts while typing in the search field', async () => {
+    mockCandidatesResponse([mockCandidate]);
+
+    renderInRouter();
+
+    const search = await screen.findByPlaceholderText(/Search by book ID/i);
+    search.focus();
+    expect(search).toHaveFocus();
+    fireEvent.keyDown(window, { key: 'd' });
+    fireEvent.keyDown(window, { key: '?' });
+
+    expect(api.dismissDedupCandidate).not.toHaveBeenCalled();
+    expect(screen.queryByText('Dedup Keyboard Shortcuts')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Adds j/k navigation, m=merge, d=dismiss, s=skip, enter=expand, esc=collapse, ?=help overlay to UnifiedDedupTab. Suppressed when focus is in an input.