### PR TITLE
fix(dedup): gate intro matches by book identifiers (ISBN/ASIN)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.35.0
+// version: 1.36.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-06-28
 
@@ -1296,7 +1296,8 @@ func normalizedIDConflict(a, b *string, normalize func(string) string) bool {
 }
 
 func normalizeISBN(v string) string {
-	return strings.ReplaceAll(strings.TrimSpace(v), "-", "")
+	s := strings.ReplaceAll(strings.TrimSpace(v), "-", "")
+	return strings.ReplaceAll(s, " ", "")
 }
 
 func normalizeASIN(v string) string {
@@ -2998,6 +2999,7 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 			return
 		}
 		if identifiersConflict(bookForIdentifierGate(bookAID), bookForIdentifierGate(bookBID)) {
+			emitted[key] = struct{}{}
 			identifierGateDrops++
 			return
 		}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -542,6 +542,15 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		if err != nil || otherBook == nil {
 			continue
 		}
+		if identifiersConflict(book, otherBook) {
+			slog.Debug("dedup unified: identifier-conflicting pair → delete",
+				"book", book.ID, "other", candID, "cand", ref.candID)
+			if err := de.embedStore.DeleteCandidate(ref.candID); err != nil {
+				slog.Debug("dedup unified: delete identifier-conflicting candidate failed",
+					"cand", ref.candID, "err", err)
+			}
+			continue
+		}
 
 		// 1. Eligibility pre-filter. A suppressed pair (chapter cross-pair, same
 		// version group, distinct series volume) is not just skipped — it is
@@ -1251,6 +1260,11 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 	if isNonPrimaryVersion(a) || isNonPrimaryVersion(b) {
 		return nil
 	}
+	if identifiersConflict(a, b) {
+		slog.Debug("dedup exact candidate dropped by identifier gate",
+			"book_a", a.ID, "book_b", b.ID, "layer", layer)
+		return nil
+	}
 	return de.embedStore.UpsertCandidate(database.DedupCandidate{
 		EntityType: "book",
 		EntityAID:  a.ID,
@@ -1259,6 +1273,34 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 		Similarity: &sim,
 		Status:     "pending",
 	})
+}
+
+// identifiersConflict reports whether a and b have a definitive, both-present
+// identifier mismatch. Missing identifiers are conservative and never conflict.
+func identifiersConflict(a, b *database.Book) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return normalizedIDConflict(a.ISBN13, b.ISBN13, normalizeISBN) ||
+		normalizedIDConflict(a.ISBN10, b.ISBN10, normalizeISBN) ||
+		normalizedIDConflict(a.ASIN, b.ASIN, normalizeASIN)
+}
+
+func normalizedIDConflict(a, b *string, normalize func(string) string) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	normalizedA := normalize(*a)
+	normalizedB := normalize(*b)
+	return normalizedA != "" && normalizedB != "" && normalizedA != normalizedB
+}
+
+func normalizeISBN(v string) string {
+	return strings.ReplaceAll(strings.TrimSpace(v), "-", "")
+}
+
+func normalizeASIN(v string) string {
+	return strings.ToUpper(strings.TrimSpace(v))
 }
 
 func hasPlausibleAudio(book *database.Book) bool {
@@ -2879,6 +2921,10 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 	if err != nil {
 		return fmt.Errorf("acoustid scan: get all books: %w", err)
 	}
+	booksByID := make(map[string]*database.Book, len(books))
+	for i := range books {
+		booksByID[books[i].ID] = &books[i]
+	}
 
 	boilerplateBookCache := make(map[string]bool, len(books))
 	for _, b := range books {
@@ -2931,12 +2977,28 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		return dir
 	}
 
+	identifierGateDrops := 0
+	bookForIdentifierGate := func(bookID string) *database.Book {
+		if b := booksByID[bookID]; b != nil {
+			return b
+		}
+		b, err := de.bookStore.GetBookByID(bookID)
+		if err != nil || b == nil {
+			return nil
+		}
+		booksByID[bookID] = b
+		return b
+	}
 	emit := func(bookAID, bookBID string, sim float64) {
 		if isBoilerplateBook(bookAID) || isBoilerplateBook(bookBID) {
 			return
 		}
 		key := pairKey(bookAID, bookBID)
 		if _, already := emitted[key]; already {
+			return
+		}
+		if identifiersConflict(bookForIdentifierGate(bookAID), bookForIdentifierGate(bookBID)) {
+			identifierGateDrops++
 			return
 		}
 		// Suppress when both books' files live in the same directory: those
@@ -3074,7 +3136,10 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		}
 	}
 
-	slog.Info("[dedup] acoustid scan complete books scanned, candidate pair(s) emitted", "total", total, "emitted_count", len(emitted))
+	slog.Info("[dedup] acoustid scan complete books scanned, candidate pair(s) emitted",
+		"total", total,
+		"emitted_count", len(emitted),
+		"identifier_gate_dropped_count", identifierGateDrops)
 	return nil
 }
 

--- a/internal/dedup/engine_identifier_gate_test.go
+++ b/internal/dedup/engine_identifier_gate_test.go
@@ -1,0 +1,149 @@
+// file: internal/dedup/engine_identifier_gate_test.go
+// version: 1.0.0
+// guid: 6e6934a1-44e9-45a5-b789-c71b541d7f74
+// last-edited: 2026-06-28
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestIdentifiersConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *database.Book
+		b    *database.Book
+		want bool
+	}{
+		{
+			name: "different both-present ISBN13 conflicts after hyphen normalization",
+			a:    &database.Book{ISBN13: strPtr("978-0-00-000001-1")},
+			b:    &database.Book{ISBN13: strPtr("9780000000028")},
+			want: true,
+		},
+		{
+			name: "same normalized ISBN13 keeps pair",
+			a:    &database.Book{ISBN13: strPtr("978-0-00-000001-1")},
+			b:    &database.Book{ISBN13: strPtr("9780000000011")},
+			want: false,
+		},
+		{
+			name: "missing identifier is conservative and keeps pair",
+			a:    &database.Book{ISBN13: strPtr("9780000000011")},
+			b:    &database.Book{},
+			want: false,
+		},
+		{
+			name: "same ASIN keeps pair after case normalization",
+			a:    &database.Book{ASIN: strPtr("b00case001")},
+			b:    &database.Book{ASIN: strPtr("B00CASE001")},
+			want: false,
+		},
+		{
+			name: "different both-present ASIN conflicts after case normalization",
+			a:    &database.Book{ASIN: strPtr("b00case001")},
+			b:    &database.Book{ASIN: strPtr("B00CASE002")},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := identifiersConflict(tt.a, tt.b); got != tt.want {
+				t.Fatalf("identifiersConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpsertExactCandidate_DropsConflictingIdentifiers(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	conflictA := primaryBook("CONFLICT_A", "Shared Intro")
+	conflictA.ISBN13 = strPtr("978-0-00-000001-1")
+	conflictB := primaryBook("CONFLICT_B", "Shared Intro")
+	conflictB.ISBN13 = strPtr("9780000000028")
+	sameA := primaryBook("SAME_A", "Shared Intro")
+	sameA.ISBN13 = strPtr("978-0-00-000003-5")
+	sameB := primaryBook("SAME_B", "Shared Intro")
+	sameB.ISBN13 = strPtr("9780000000035")
+	missingA := primaryBook("MISSING_A", "Shared Intro")
+	missingA.ISBN13 = strPtr("9780000000042")
+	missingB := primaryBook("MISSING_B", "Shared Intro")
+
+	if err := engine.upsertExactCandidate(conflictA, conflictB, "acoustid", 1.0); err != nil {
+		t.Fatalf("upsert conflict pair: %v", err)
+	}
+	if err := engine.upsertExactCandidate(sameA, sameB, "acoustid", 1.0); err != nil {
+		t.Fatalf("upsert same-id pair: %v", err)
+	}
+	if err := engine.upsertExactCandidate(missingA, missingB, "acoustid", 1.0); err != nil {
+		t.Fatalf("upsert missing-id pair: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 2 {
+		t.Fatalf("expected same-id and missing-id pairs only, got %d: %+v", len(cands), cands)
+	}
+	for _, c := range cands {
+		if c.EntityAID == "CONFLICT_A" || c.EntityBID == "CONFLICT_A" ||
+			c.EntityAID == "CONFLICT_B" || c.EntityBID == "CONFLICT_B" {
+			t.Fatalf("conflicting ISBN13 pair leaked into candidates: %+v", c)
+		}
+	}
+}
+
+func TestAcoustIDScan_DropsConflictingIdentifiers(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := primaryBook("BOOK_A", "Shared Intro A")
+	bookA.ISBN13 = strPtr("9780000000011")
+	bookB := primaryBook("BOOK_B", "Shared Intro B")
+	bookB.ISBN13 = strPtr("9780000000028")
+	books := map[string]*database.Book{"BOOK_A": bookA, "BOOK_B": bookB}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		if offset > 0 {
+			return nil, nil
+		}
+		return []database.Book{*bookA, *bookB}, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return books[id], nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		return []database.BookFile{{
+			ID:           "FILE_" + bookID,
+			BookID:       bookID,
+			FilePath:     "/library/" + bookID + "/intro.mp3",
+			AcoustIDSeg0: validFP80,
+			AcoustIDSeg1: "different-" + bookID,
+			AcoustIDSeg2: "different2-" + bookID,
+			AcoustIDSeg3: "different3-" + bookID,
+			AcoustIDSeg4: "different4-" + bookID,
+			AcoustIDSeg5: "different5-" + bookID,
+			AcoustIDSeg6: "different6-" + bookID,
+		}}, nil
+	}
+	mock.GetBookFileByAcoustIDFunc = func(fp string) (*database.BookFile, error) {
+		if fp != validFP80 {
+			return nil, nil
+		}
+		return &database.BookFile{
+			ID:       "FILE_BOOK_B",
+			BookID:   "BOOK_B",
+			FilePath: "/library/BOOK_B/intro.mp3",
+		}, nil
+	}
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+	if cands := pendingCandidates(t, es); len(cands) != 0 {
+		t.Fatalf("expected conflicting ISBN13s to drop shared-fingerprint pair, got %+v", cands)
+	}
+}

--- a/internal/dedup/engine_identifier_gate_test.go
+++ b/internal/dedup/engine_identifier_gate_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_identifier_gate_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6e6934a1-44e9-45a5-b789-c71b541d7f74
 // last-edited: 2026-06-28
 
@@ -48,6 +48,12 @@ func TestIdentifiersConflict(t *testing.T) {
 			a:    &database.Book{ASIN: strPtr("b00case001")},
 			b:    &database.Book{ASIN: strPtr("B00CASE002")},
 			want: true,
+		},
+		{
+			name: "nil book a is conservative",
+			a:    nil,
+			b:    &database.Book{ISBN13: strPtr("9780000000011")},
+			want: false,
 		},
 	}
 


### PR DESCRIPTION
Gates acoustic fingerprint dedup matches using ISBN-13 and ASIN — books with conflicting identifiers are skipped even if fingerprints match. Part of DEDUP-INTRO-1 false-positive reduction.