### PR TITLE
fix(dedup): skip fingerprint matching on short clips (<60s)

### DIFF
--- a/internal/dedup/collectors_acoustid.go
+++ b/internal/dedup/collectors_acoustid.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_acoustid.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b3c841-d9e2-4f15-88a0-5bc12e347f6d
-// last-edited: 2026-06-10
+// last-edited: 2026-06-28
 
 // Package dedup — acoustic-ID collector family (fable5 T013).
 //
@@ -95,6 +95,12 @@ func CollectExactAcoustID(
 	if queryFile == nil {
 		return nil, nil
 	}
+	if knownShortFingerprintFile(*queryFile) {
+		slog.Debug("dedup/collectors_acoustid: exact lookup skipped short clip fingerprint",
+			"file_id", queryFile.ID,
+			"duration_sec", queryFile.AcoustIDFingerprintDurationSec)
+		return nil, nil
+	}
 	segs := [7]string{
 		queryFile.AcoustIDSeg0,
 		queryFile.AcoustIDSeg1,
@@ -128,6 +134,13 @@ func CollectExactAcoustID(
 			continue
 		}
 		if hit == nil || hit.BookID == queryBookID || seen[hit.BookID] {
+			continue
+		}
+		if knownShortFingerprintFile(*hit) {
+			slog.Debug("dedup/collectors_acoustid: exact lookup hit skipped short clip fingerprint",
+				"file_id", queryFile.ID,
+				"hit_file_id", hit.ID,
+				"hit_duration_sec", hit.AcoustIDFingerprintDurationSec)
 			continue
 		}
 		seen[hit.BookID] = true
@@ -231,6 +244,12 @@ func CollectLSHAcoustID(
 		// Nothing to probe — caller should log at the appropriate level.
 		return nil, nil
 	}
+	if knownShortFingerprintFile(*queryFile) {
+		slog.Debug("dedup/collectors_acoustid: lsh probe skipped short clip fingerprint",
+			"file_id", queryFile.ID,
+			"duration_sec", queryFile.AcoustIDFingerprintDurationSec)
+		return nil, nil
+	}
 
 	// Gate: skip with INFO when the index has never been built.  This is the
 	// permanent replacement for the ACOUSTID_FUZZY_ENABLED env variable — when
@@ -293,6 +312,13 @@ func CollectLSHAcoustID(
 		if len(candFile.AcoustIDFingerprint) == 0 {
 			// Candidate was indexed but fingerprint was subsequently cleared —
 			// skip; stale index entry, harmless.
+			continue
+		}
+		if knownShortFingerprintFile(*candFile) {
+			slog.Debug("dedup/collectors_acoustid: lsh candidate skipped short clip fingerprint",
+				"file_id", queryFile.ID,
+				"cand_file_id", candFile.ID,
+				"cand_duration_sec", candFile.AcoustIDFingerprintDurationSec)
 			continue
 		}
 

--- a/internal/dedup/collectors_acoustid_test.go
+++ b/internal/dedup/collectors_acoustid_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_acoustid_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c4d952-e0f3-5a26-99b1-6cd23f458g7e
-// last-edited: 2026-06-10
+// last-edited: 2026-06-28
 
 package dedup
 
@@ -132,6 +132,52 @@ func TestCollectExactAcoustID_HitEmitsSignal(t *testing.T) {
 	}
 	if sigs[0].Confidence != 0.99 {
 		t.Errorf("expected confidence 0.99, got %v", sigs[0].Confidence)
+	}
+}
+
+func TestCollectExactAcoustID_ShortQuerySkipped(t *testing.T) {
+	queryFile := &database.BookFile{
+		ID:                             "qfile1",
+		BookID:                         "bookA",
+		AcoustIDSeg0:                   validFP80,
+		AcoustIDFingerprintDurationSec: 20,
+	}
+	candidateFile := &database.BookFile{
+		ID:                             "cfile1",
+		BookID:                         "bookB",
+		AcoustIDFingerprintDurationSec: 7200,
+	}
+	store := &stubExactStore{m: map[string]*database.BookFile{validFP80: candidateFile}}
+
+	sigs, err := CollectExactAcoustID(store, queryFile, "bookA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Fatalf("expected 0 signals for short query fingerprint, got %d", len(sigs))
+	}
+}
+
+func TestCollectExactAcoustID_ShortHitSkipped(t *testing.T) {
+	queryFile := &database.BookFile{
+		ID:                             "qfile1",
+		BookID:                         "bookA",
+		AcoustIDSeg0:                   validFP80,
+		AcoustIDFingerprintDurationSec: 7200,
+	}
+	candidateFile := &database.BookFile{
+		ID:                             "cfile1",
+		BookID:                         "bookB",
+		AcoustIDFingerprintDurationSec: 20,
+	}
+	store := &stubExactStore{m: map[string]*database.BookFile{validFP80: candidateFile}}
+
+	sigs, err := CollectExactAcoustID(store, queryFile, "bookA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sigs) != 0 {
+		t.Fatalf("expected 0 signals for short hit fingerprint, got %d", len(sigs))
 	}
 }
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -91,6 +91,11 @@ func isBoilerplateTitle(title string) bool {
 	return false
 }
 
+// minFingerprintMatchSeconds: files shorter than this are publisher
+// intro/outro clips, not book content — their fingerprints must not seed or
+// strengthen a duplicate pair. See dedup-intro-falsepositive FINDINGS.md.
+const minFingerprintMatchSeconds = 60
+
 // Engine orchestrates a 3-layer dedup system:
 //   - Layer 1: Exact matching (free, instant) — same file hash, ISBN/ASIN, or near-identical titles
 //   - Layer 2: Embedding similarity (cheap, ~250ms) — cosine similarity of OpenAI embeddings
@@ -3076,6 +3081,11 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	slog.Info("[dedup] acoustid scan complete books scanned, candidate pair(s) emitted", "total", total, "emitted_count", len(emitted))
 	return nil
+}
+
+func knownShortFingerprintFile(f database.BookFile) bool {
+	return f.AcoustIDFingerprintDurationSec > 0 &&
+		f.AcoustIDFingerprintDurationSec < minFingerprintMatchSeconds
 }
 
 // bestSeg returns the first non-empty segment string from a BookFile,

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_test.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
-// last-edited: 2026-06-16
+// last-edited: 2026-06-28
 
 package dedup
 
@@ -49,6 +49,88 @@ func setupTestEngine(t *testing.T) (*Engine, *database.MockStore, *database.Embe
 }
 
 // strPtr is defined in helpers_test.go
+
+func runAcoustIDScanSharedSegment(
+	t *testing.T,
+	durationA float64,
+	durationB float64,
+) []database.DedupCandidate {
+	t.Helper()
+
+	engine, mock, es := setupTestEngine(t)
+	bookA := database.Book{ID: "BOOK_A", Title: "Book A"}
+	bookB := database.Book{ID: "BOOK_B", Title: "Book B"}
+	fileA := database.BookFile{
+		ID:                             "FILE_A",
+		BookID:                         "BOOK_A",
+		FilePath:                       "/library/a/book.m4b",
+		AcoustIDSeg0:                   validFP80,
+		AcoustIDFingerprintDurationSec: durationA,
+	}
+	fileB := database.BookFile{
+		ID:                             "FILE_B",
+		BookID:                         "BOOK_B",
+		FilePath:                       "/library/b/book.m4b",
+		AcoustIDSeg0:                   validFP80,
+		AcoustIDFingerprintDurationSec: durationB,
+	}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		return []database.Book{bookA, bookB}, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "BOOK_A":
+			return []database.BookFile{fileA}, nil
+		case "BOOK_B":
+			return []database.BookFile{fileB}, nil
+		default:
+			return nil, nil
+		}
+	}
+	mock.GetBookFileByAcoustIDFunc = func(fp string) (*database.BookFile, error) {
+		if fp != validFP80 {
+			return nil, nil
+		}
+		return &fileB, nil
+	}
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+	candidates, _, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	return candidates
+}
+
+func TestAcoustIDScan_SkipsShortClipFingerprintMatch(t *testing.T) {
+	candidates := runAcoustIDScanSharedSegment(t, 20, 20)
+	if len(candidates) != 0 {
+		t.Fatalf("expected no candidate for shared short clip fingerprint, got %d: %+v", len(candidates), candidates)
+	}
+}
+
+func TestAcoustIDScan_LongFingerprintMatchStillPairs(t *testing.T) {
+	candidates := runAcoustIDScanSharedSegment(t, 7200, 7200)
+	if len(candidates) != 1 {
+		t.Fatalf("expected one candidate for shared long fingerprint, got %d: %+v", len(candidates), candidates)
+	}
+	if candidates[0].Layer != "acoustid" {
+		t.Fatalf("candidate layer = %q, want acoustid", candidates[0].Layer)
+	}
+}
+
+func TestAcoustIDScan_UnknownFingerprintDurationKeepsMatch(t *testing.T) {
+	candidates := runAcoustIDScanSharedSegment(t, 0, 0)
+	if len(candidates) != 1 {
+		t.Fatalf("expected one candidate for unknown fingerprint duration, got %d: %+v", len(candidates), candidates)
+	}
+}
 
 func TestEngine_ExactMatch_FileHash(t *testing.T) {
 	engine, mock, es := setupTestEngine(t)


### PR DESCRIPTION
Intro/outro clips under 60s are excluded from AcoustID fingerprint matching. These short shared clips (Audible intros, publisher spots) are the primary source of dedup false positives. Part of DEDUP-INTRO-1.