### PR TITLE
feat(dedup-ui): metadata compare tab in CandidateCompareDrawer

### DIFF
--- a/web/src/components/dedup/CandidateCompareDrawer.tsx
+++ b/web/src/components/dedup/CandidateCompareDrawer.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/CandidateCompareDrawer.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: a6f7b8c9-d0e1-2345-fabc-af6789012345
-// last-edited: 2026-06-19
+// last-edited: 2026-06-28
 
 // CandidateCompareDrawer is a right-side Drawer that shows a full side-by-side
 // comparison of the two books in a dedup candidate, plus the score breakdown.
@@ -13,6 +13,7 @@ import {
   Alert,
   Box,
   Button,
+  Chip,
   CircularProgress,
   Divider,
   Drawer,
@@ -29,7 +30,12 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useNavigate } from 'react-router-dom';
 import * as api from '../../services/api';
-import type { AcoustIDCompareResponse, DedupCandidateBreakdownResponse } from '../../services/api';
+import type {
+  AcoustIDCompareResponse,
+  DedupBookDetail,
+  DedupCandidateBreakdownResponse,
+  DedupSignal,
+} from '../../services/api';
 import { ScoreBadgeRow } from './ScoreBadgeRow';
 import { ScoreBreakdownPanel } from './ScoreBreakdownPanel';
 import { FileInfoCompare } from './FileInfoCompare';
@@ -44,6 +50,182 @@ interface CandidateCompareDrawerProps {
   onMerged?: (candidateId: number, keepId?: string) => void;
   /** Called after a dismiss action. */
   onDismissed?: (candidateId: number) => void;
+}
+
+const SIGNAL_LABELS: Record<string, string> = {
+  exact_file: 'Exact file hash',
+  exact_acoustid: 'Exact AcoustID',
+  isbn_asin: 'ISBN/ASIN',
+  lsh_acoustid: 'LSH AcoustID',
+  embedding_high: 'Embedding (high)',
+  metadata_hash: 'Metadata hash',
+  metadata_fuzzy: 'Metadata fuzzy',
+  embedding_med: 'Embedding (medium)',
+  duration: 'Duration match',
+  folder_path: 'Folder path',
+};
+
+function formatBytes(bytes: number | undefined): string {
+  if (bytes == null) return 'Unknown';
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function formatDuration(seconds: number | undefined): string {
+  if (seconds == null) return 'Unknown';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatPartCount(count: number): string {
+  return `${count} ${count === 1 ? 'part' : 'parts'}`;
+}
+
+function normalizeCompareValue(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+function totalFileSize(book: DedupBookDetail): number | undefined {
+  const fileTotal = book.files?.reduce((sum, file) => sum + (file.file_size ?? 0), 0) ?? 0;
+  return fileTotal > 0 ? fileTotal : book.file_size;
+}
+
+function totalDuration(book: DedupBookDetail): number | undefined {
+  return book.duration ?? book.files?.reduce((sum, file) => sum + (file.duration ?? 0), 0);
+}
+
+function signalLabel(signal: DedupSignal): string {
+  return SIGNAL_LABELS[signal.kind] ?? signal.kind.replace(/_/g, ' ');
+}
+
+interface MetadataCompareRowProps {
+  id: string;
+  label: string;
+  left: string;
+  right: string;
+}
+
+function MetadataCompareRow({ id, label, left, right }: MetadataCompareRowProps) {
+  const different = normalizeCompareValue(left) !== normalizeCompareValue(right);
+  return (
+    <Box
+      data-testid={`metadata-row-${id}`}
+      data-different={different ? 'true' : 'false'}
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', sm: '140px minmax(0, 1fr) minmax(0, 1fr)' },
+        gap: { xs: 0.75, sm: 1 },
+        alignItems: 'stretch',
+        p: 1,
+        borderRadius: 1,
+        bgcolor: different ? 'warning.light' : 'transparent',
+        color: different ? 'warning.contrastText' : 'inherit',
+      }}
+    >
+      <Typography variant="caption" fontWeight={700} color={different ? 'inherit' : 'text.secondary'}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
+        {left}
+      </Typography>
+      <Typography variant="body2" sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
+        {right}
+      </Typography>
+    </Box>
+  );
+}
+
+interface MetadataComparePanelProps {
+  bookA: DedupBookDetail;
+  bookB: DedupBookDetail;
+  signals: DedupSignal[];
+}
+
+function MetadataComparePanel({ bookA, bookB, signals }: MetadataComparePanelProps) {
+  const rows: MetadataCompareRowProps[] = [
+    {
+      id: 'series',
+      label: 'Series',
+      left: bookA.series_name ?? (bookA.series_id != null ? `Series #${bookA.series_id}` : 'None'),
+      right: bookB.series_name ?? (bookB.series_id != null ? `Series #${bookB.series_id}` : 'None'),
+    },
+    {
+      id: 'narrator',
+      label: 'Narrator',
+      left: bookA.narrator ?? 'Unknown',
+      right: bookB.narrator ?? 'Unknown',
+    },
+    {
+      id: 'parts',
+      label: 'Parts',
+      left: formatPartCount(bookA.files?.length ?? 0),
+      right: formatPartCount(bookB.files?.length ?? 0),
+    },
+    {
+      id: 'duration',
+      label: 'Duration',
+      left: formatDuration(totalDuration(bookA)),
+      right: formatDuration(totalDuration(bookB)),
+    },
+    {
+      id: 'file-size',
+      label: 'File size',
+      left: formatBytes(totalFileSize(bookA)),
+      right: formatBytes(totalFileSize(bookB)),
+    },
+  ];
+
+  return (
+    <Stack spacing={1.5} data-testid="metadata-compare-panel">
+      <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+        <Typography variant="caption" fontWeight={700} color="text.secondary">
+          Signals fired
+        </Typography>
+        {signals.length > 0 ? (
+          signals.map((signal) => (
+            <Tooltip key={signal.kind} title={signal.evidence || signal.kind}>
+              <Chip
+                label={signalLabel(signal)}
+                size="small"
+                color={signal.primary ? 'primary' : 'default'}
+                variant={signal.primary ? 'filled' : 'outlined'}
+              />
+            </Tooltip>
+          ))
+        ) : (
+          <Typography variant="caption" color="text.disabled" fontStyle="italic">
+            No signal data available.
+          </Typography>
+        )}
+      </Stack>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '140px minmax(0, 1fr) minmax(0, 1fr)' },
+          gap: { xs: 0.5, sm: 1 },
+          px: 1,
+        }}
+      >
+        <Box />
+        <Typography variant="caption" color="text.secondary" fontWeight={700}>
+          Book A
+        </Typography>
+        <Typography variant="caption" color="text.secondary" fontWeight={700}>
+          Book B
+        </Typography>
+      </Box>
+
+      <Stack spacing={0.5}>
+        {rows.map((row) => (
+          <MetadataCompareRow key={row.id} {...row} />
+        ))}
+      </Stack>
+    </Stack>
+  );
 }
 
 export function CandidateCompareDrawer({
@@ -113,11 +295,11 @@ export function CandidateCompareDrawer({
     };
   }, []);
 
-  // Lazy-load fingerprint comparison when the Fingerprint tab (index 2) is first opened.
+  // Lazy-load fingerprint comparison when the Fingerprint tab (index 3) is first opened.
   useEffect(() => {
     const bA = data?.book_a;
     const bB = data?.book_b;
-    if (activeTab !== 2 || !bA || !bB || fpData || fpLoading) return;
+    if (activeTab !== 3 || !bA || !bB || fpData || fpLoading) return;
     fpAbortRef.current?.abort();
     const ctrl = new AbortController();
     fpAbortRef.current = ctrl;
@@ -310,7 +492,7 @@ export function CandidateCompareDrawer({
 
             <Divider sx={{ mb: 2 }} />
 
-            {/* Tabs: Files | Score Breakdown */}
+            {/* Tabs: Files | Score Breakdown | Metadata | Fingerprint */}
             <Tabs
               value={activeTab}
               onChange={(_: unknown, v: number) => setActiveTab(v)}
@@ -318,6 +500,7 @@ export function CandidateCompareDrawer({
             >
               <Tab label="Files" data-testid="drawer-tab-files" />
               <Tab label="Score Breakdown" data-testid="drawer-tab-breakdown" />
+              <Tab label="Metadata" data-testid="drawer-tab-metadata" />
               <Tab label="Fingerprint" data-testid="drawer-tab-fingerprint" />
             </Tabs>
 
@@ -339,7 +522,20 @@ export function CandidateCompareDrawer({
               </Typography>
             )}
 
-            {activeTab === 2 && (
+            {activeTab === 2 && bookA && bookB && (
+              <MetadataComparePanel
+                bookA={bookA}
+                bookB={bookB}
+                signals={candidate?.score_breakdown?.signals ?? []}
+              />
+            )}
+            {activeTab === 2 && (!bookA || !bookB) && (
+              <Typography color="text.secondary" variant="body2">
+                Book metadata unavailable.
+              </Typography>
+            )}
+
+            {activeTab === 3 && (
               <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, pt: 1 }}>
                 {fpLoading && <CircularProgress size={32} />}
                 {!fpLoading && fpData && fpData.segment_scores.length > 0 && (

--- a/web/src/components/dedup/CandidateCompareDrawer.tsx
+++ b/web/src/components/dedup/CandidateCompareDrawer.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/CandidateCompareDrawer.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: a6f7b8c9-d0e1-2345-fabc-af6789012345
 // last-edited: 2026-06-28
 
@@ -85,7 +85,7 @@ function formatPartCount(count: number): string {
 }
 
 function normalizeCompareValue(value: string): string {
-  return value.trim().toLocaleLowerCase();
+  return value.trim().toLowerCase();
 }
 
 function totalFileSize(book: DedupBookDetail): number | undefined {
@@ -186,7 +186,7 @@ function MetadataComparePanel({ bookA, bookB, signals }: MetadataComparePanelPro
         </Typography>
         {signals.length > 0 ? (
           signals.map((signal) => (
-            <Tooltip key={signal.kind} title={signal.evidence || signal.kind}>
+            <Tooltip key={signal.kind} title={signal.evidence}>
               <Chip
                 label={signalLabel(signal)}
                 size="small"

--- a/web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
+++ b/web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4d5e6f7-a8b9-0123-cdef-cd4567890123
 // last-edited: 2026-06-28
 
@@ -130,5 +130,21 @@ describe('CandidateCompareDrawer', () => {
     const seriesRow = screen.getByTestId('metadata-row-series');
     expect(seriesRow).toHaveAttribute('data-different', 'true');
     expect(within(seriesRow).getByText('Series')).toBeInTheDocument();
+  });
+
+  it('renders "Book metadata unavailable." when book_a is null and Metadata tab is active', async () => {
+    const breakdownNullA = {
+      ...breakdown,
+      book_a: null as unknown as typeof breakdown.book_a,
+    };
+    vi.mocked(api.getDedupCandidateBreakdown).mockResolvedValue(breakdownNullA);
+
+    renderDrawer();
+
+    expect(await screen.findByTestId('drawer-tab-metadata')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('drawer-tab-metadata'));
+
+    expect(await screen.findByText('Book metadata unavailable.')).toBeInTheDocument();
+    expect(screen.queryByTestId('metadata-compare-panel')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
+++ b/web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
@@ -1,0 +1,134 @@
+// file: web/src/components/dedup/__tests__/CandidateCompareDrawer.test.tsx
+// version: 1.0.0
+// guid: c4d5e6f7-a8b9-0123-cdef-cd4567890123
+// last-edited: 2026-06-28
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CandidateCompareDrawer } from '../CandidateCompareDrawer';
+import * as api from '../../../services/api';
+import type { DedupCandidateBreakdownResponse } from '../../../services/api';
+
+vi.mock('../../../services/api', () => ({
+  compareAcoustID: vi.fn(),
+  dismissDedupCandidate: vi.fn(),
+  getConfig: vi.fn().mockResolvedValue({ root_dir: '/library' }),
+  getDedupCandidateBreakdown: vi.fn(),
+  mergeDedupCandidate: vi.fn(),
+}));
+
+const breakdown: DedupCandidateBreakdownResponse = {
+  candidate: {
+    id: 42,
+    entity_type: 'book',
+    entity_a_id: 'book-a',
+    entity_b_id: 'book-b',
+    layer: 'embedding',
+    similarity: 0.94,
+    status: 'pending',
+    created_at: '2026-06-28T00:00:00Z',
+    updated_at: '2026-06-28T00:00:00Z',
+    band: 'HIGH',
+    score: 91.4,
+    score_breakdown: {
+      score: 91.4,
+      band: 'HIGH',
+      formula: 'v2',
+      signals: [
+        {
+          kind: 'metadata_fuzzy',
+          value: 0.91,
+          weight: 80,
+          evidence: 'Title, narrator, and series are close matches',
+          primary: true,
+        },
+        {
+          kind: 'duration',
+          value: 0.73,
+          weight: 20,
+          evidence: 'Durations are close',
+          primary: false,
+        },
+      ],
+    },
+  },
+  book_a: {
+    id: 'book-a',
+    title: 'The City We Became',
+    author_name: 'N. K. Jemisin',
+    series_id: 12,
+    series_name: 'Great Cities',
+    duration: 3610,
+    files: [
+      {
+        id: 'file-a-1',
+        file_path: '/library/city-a.m4b',
+        file_size: 734003200,
+        duration: 3610,
+      },
+      {
+        id: 'file-a-2',
+        file_path: '/library/city-a-bonus.m4b',
+        file_size: 1048576,
+        duration: 60,
+      },
+    ],
+  },
+  book_b: {
+    id: 'book-b',
+    title: 'The City We Became',
+    author_name: 'N. K. Jemisin',
+    series_id: 13,
+    series_name: 'Great Cities: Deluxe',
+    duration: 4200,
+    files: [
+      {
+        id: 'file-b-1',
+        file_path: '/library/city-b.m4b',
+        file_size: 838860800,
+        duration: 4200,
+      },
+    ],
+  },
+};
+
+function renderDrawer() {
+  return render(
+    <MemoryRouter>
+      <CandidateCompareDrawer candidateId={42} onClose={vi.fn()} />
+    </MemoryRouter>
+  );
+}
+
+describe('CandidateCompareDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getDedupCandidateBreakdown).mockResolvedValue(breakdown);
+  });
+
+  it('renders a Metadata tab with side-by-side metadata and primary signals', async () => {
+    renderDrawer();
+
+    expect(await screen.findByTestId('drawer-tab-metadata')).toBeInTheDocument();
+    expect(api.getDedupCandidateBreakdown).toHaveBeenCalledWith(42, expect.any(AbortSignal));
+
+    fireEvent.click(screen.getByTestId('drawer-tab-metadata'));
+
+    expect(await screen.findByTestId('metadata-compare-panel')).toBeInTheDocument();
+    expect(screen.getByText('Metadata fuzzy')).toBeInTheDocument();
+    expect(screen.getByText('Duration match')).toBeInTheDocument();
+    expect(screen.getByText('Great Cities')).toBeInTheDocument();
+    expect(screen.getByText('Great Cities: Deluxe')).toBeInTheDocument();
+    expect(screen.getByText('2 parts')).toBeInTheDocument();
+    expect(screen.getByText('1 part')).toBeInTheDocument();
+    expect(screen.getByText('1h 0m')).toBeInTheDocument();
+    expect(screen.getByText('1h 10m')).toBeInTheDocument();
+    expect(screen.getByText('701.0MB')).toBeInTheDocument();
+    expect(screen.getByText('800.0MB')).toBeInTheDocument();
+
+    const seriesRow = screen.getByTestId('metadata-row-series');
+    expect(seriesRow).toHaveAttribute('data-different', 'true');
+    expect(within(seriesRow).getByText('Series')).toBeInTheDocument();
+  });
+});

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.44.0
+// version: 2.45.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-06-22
+// last-edited: 2026-06-28
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -5536,8 +5536,10 @@ export interface DedupBookDetail {
   author_name?: string;
   series_id?: number | null;
   series_name?: string;
+  narrator?: string;
   format?: string;
   duration?: number;
+  file_size?: number;
   file_path?: string;
   cover_url?: string;
   files: Array<{


### PR DESCRIPTION
Adds a Compare tab to CandidateCompareDrawer showing side-by-side metadata for dedup candidates. Wires GET /api/v1/dedup/candidates/:id/breakdown. CONS-6.