### PR TITLE
feat(library): manual import button wired to library.import op

### DIFF
--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
-// last-edited: 2026-06-21
+// last-edited: 2026-06-28
 
 import React from 'react';
 import {
@@ -156,6 +156,16 @@ interface LibraryDialogsProps {
   importFileInProgress: boolean;
   handleImportFile: () => void;
 
+  // Manual import operation dialog
+  manualImportDialogOpen: boolean;
+  setManualImportDialogOpen: (open: boolean) => void;
+  manualImportPath: string;
+  setManualImportPath: (path: string) => void;
+  manualImportError: string | null;
+  manualImportInProgress: boolean;
+  manualImportOp: api.OperationV2 | null;
+  handleManualPathImport: () => void;
+
   // Bulk fetch dialog
   bulkFetchDialogOpen: boolean;
   handleCancelBulkFetch: () => void;
@@ -293,6 +303,14 @@ export const LibraryDialogs = ({
   setImportFileOrganize,
   importFileInProgress,
   handleImportFile,
+  manualImportDialogOpen,
+  setManualImportDialogOpen,
+  manualImportPath,
+  setManualImportPath,
+  manualImportError,
+  manualImportInProgress,
+  manualImportOp,
+  handleManualPathImport,
   bulkFetchDialogOpen,
   handleCancelBulkFetch,
   bulkFetchProgress,
@@ -778,6 +796,82 @@ export const LibraryDialogs = ({
           }
         >
           {importFileInProgress ? 'Importing\u2026' : 'Import'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+
+    <Dialog
+      open={manualImportDialogOpen}
+      onClose={() => {
+        if (!manualImportInProgress) {
+          setManualImportDialogOpen(false);
+        }
+      }}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>Manual import</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          autoFocus
+          margin="dense"
+          label="Absolute path"
+          value={manualImportPath}
+          onChange={(e) => setManualImportPath(e.target.value)}
+          placeholder="/path/to/audiobook-or-folder"
+          error={Boolean(manualImportError)}
+          helperText={manualImportError || 'Import one server path using the library.import operation.'}
+          disabled={manualImportInProgress}
+        />
+        {manualImportInProgress && (
+          <Box sx={{ mt: 2 }}>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+              <CircularProgress size={18} />
+              <Typography variant="body2" color="text.secondary">
+                {manualImportOp?.progress_message ||
+                  manualImportOp?.current_phase ||
+                  'Waiting for progress...'}
+              </Typography>
+            </Stack>
+            <LinearProgress
+              variant={(manualImportOp?.progress_total ?? 0) > 0 ? 'determinate' : 'indeterminate'}
+              value={
+                (manualImportOp?.progress_total ?? 0) > 0
+                  ? Math.round(
+                      ((manualImportOp?.progress_current ?? 0) /
+                        (manualImportOp?.progress_total ?? 1)) *
+                        100
+                    )
+                  : 0
+              }
+            />
+            {(manualImportOp?.progress_total ?? 0) > 0 && (
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+                {Math.round(
+                  ((manualImportOp?.progress_current ?? 0) /
+                    (manualImportOp?.progress_total ?? 1)) *
+                    100
+                )}
+                % ({manualImportOp?.progress_current ?? 0}/{manualImportOp?.progress_total ?? 0})
+              </Typography>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => setManualImportDialogOpen(false)}
+          disabled={manualImportInProgress}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleManualPathImport}
+          disabled={manualImportInProgress || !manualImportPath.trim()}
+        >
+          {manualImportInProgress ? 'Importing...' : 'Start import'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/web/src/components/library/LibraryToolbar.tsx
+++ b/web/src/components/library/LibraryToolbar.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryToolbar.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-21
+// last-edited: 2026-06-28
 
 import {
   Typography,
@@ -17,6 +17,7 @@ import {
 import {
   FilterList as FilterListIcon,
   Upload as UploadIcon,
+  DriveFolderUpload as ManualImportIcon,
   Delete as DeleteSweepIcon,
   Refresh as RefreshIcon,
 } from '@mui/icons-material';
@@ -60,6 +61,7 @@ interface LibraryToolbarProps {
   onDeleteSelected: () => void;
   onRestoreSelected: () => void;
   onManualImport: () => void;
+  onManualPathImport: () => void;
   onFilterOpen: () => void;
   onOrganizeLibrary: () => void;
   onFullRescan: () => void;
@@ -103,6 +105,7 @@ export const LibraryToolbar = ({
   onDeleteSelected,
   onRestoreSelected,
   onManualImport,
+  onManualPathImport,
   onFilterOpen,
   onOrganizeLibrary,
   onFullRescan,
@@ -151,6 +154,7 @@ export const LibraryToolbar = ({
         <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
           <Typography variant="h6" sx={{ mr: 1 }}>Library</Typography>
           <Button startIcon={<UploadIcon />} onClick={onManualImport} variant="contained" size="small">Import Files</Button>
+          <Button startIcon={<ManualImportIcon />} onClick={onManualPathImport} variant="outlined" size="small">Manual import</Button>
           <Button startIcon={<FilterListIcon />} onClick={onFilterOpen} variant="outlined" size="small">
             Filters{getActiveFilterCount() > 0 && <Chip label={getActiveFilterCount()} size="small" color="primary" sx={{ ml: 0.5, height: 18 }} />}
           </Button>

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,11 +1,11 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.2.0
+// version: 1.3.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
-// last-edited: 2026-05-08
+// last-edited: 2026-06-28
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Library } from './Library';
 import * as api from '../services/api';
 
@@ -65,7 +65,35 @@ vi.mock('../services/api', () => {
       message: 'import started',
       book: { id: 'id-1', title: 'Test Book', file_path: '/tmp/book.m4b' },
     }),
+    startLibraryImport: vi.fn().mockResolvedValue({ operation_id: 'op-manual-import' }),
+    getOperationV2: vi.fn().mockResolvedValue({
+      id: 'op-manual-import',
+      def_id: 'library.import',
+      plugin: 'library',
+      display_name: 'Manual Import',
+      status: 'completed',
+      priority: 10,
+      notify_level: 0,
+      progress_current: 1,
+      progress_total: 1,
+      progress_message: 'Imported /tmp/book.m4b',
+      current_phase: null,
+      current_item: null,
+      actor_user_id: null,
+      parent_id: null,
+      queued_at: '2026-01-01T00:00:00Z',
+      started_at: '2026-01-01T00:00:00Z',
+      completed_at: '2026-01-01T00:00:01Z',
+      error_message: null,
+      resume_count: 0,
+      trace_id: null,
+      span_id: null,
+    }),
   };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('Library import dialog', () => {
@@ -90,6 +118,41 @@ describe('Library import dialog', () => {
     const importFileMock = vi.mocked(api.importFile);
     await waitFor(() => {
       expect(importFileMock).toHaveBeenCalledWith('/tmp/book.m4b', true);
+    });
+  });
+
+  it('starts a manual library import operation and polls it to completion', async () => {
+    vi.useFakeTimers();
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Library />
+      </MemoryRouter>
+    );
+
+    const openButton = await screen.findByRole('button', {
+      name: /manual import/i,
+    });
+    fireEvent.click(openButton);
+
+    const pathField = await screen.findByLabelText(/absolute path/i);
+    fireEvent.change(pathField, { target: { value: '/tmp/book.m4b' } });
+
+    const submitButton = await screen.findByRole('button', { name: 'Start import' });
+    fireEvent.click(submitButton);
+
+    const startImportMock = vi.mocked(api.startLibraryImport);
+    await waitFor(() => {
+      expect(startImportMock).toHaveBeenCalledWith('/tmp/book.m4b');
+    });
+    expect(submitButton).toBeDisabled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await waitFor(() => {
+      expect(api.getOperationV2).toHaveBeenCalledWith('op-manual-import');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /manual import/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.70.0
+// version: 1.71.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-06-22
+// last-edited: 2026-06-28
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -232,6 +232,11 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [importFilePaths, setImportFilePaths] = useState<string[]>([]);
   const [importFileOrganize, setImportFileOrganize] = useState(true);
   const [importFileInProgress, setImportFileInProgress] = useState(false);
+  const [manualImportDialogOpen, setManualImportDialogOpen] = useState(false);
+  const [manualImportPath, setManualImportPath] = useState('');
+  const [manualImportError, setManualImportError] = useState<string | null>(null);
+  const [manualImportInProgress, setManualImportInProgress] = useState(false);
+  const [manualImportOp, setManualImportOp] = useState<api.OperationV2 | null>(null);
 
   // Per-action loading states for dynamic UI
   const [scanningAll, setScanningAll] = useState(false);
@@ -261,6 +266,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [bulkOrganizeError, setBulkOrganizeError] = useState<OrganizeErrorState | null>(null);
   const bulkOrganizeSnapshotRef = useRef<Map<string, Audiobook>>(new Map());
   const pollingCleanupRef = useRef<(() => void) | null>(null);
+  const manualImportPollCleanupRef = useRef<(() => void) | null>(null);
 
   // Cleanup polling on unmount
   useEffect(() => {
@@ -268,6 +274,10 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       if (pollingCleanupRef.current) {
         pollingCleanupRef.current();
         pollingCleanupRef.current = null;
+      }
+      if (manualImportPollCleanupRef.current) {
+        manualImportPollCleanupRef.current();
+        manualImportPollCleanupRef.current = null;
       }
     };
   }, []);
@@ -567,6 +577,13 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     setImportFileDialogOpen(true);
   };
 
+  const handleOpenManualPathImport = () => {
+    setManualImportPath('');
+    setManualImportError(null);
+    setManualImportOp(null);
+    setManualImportDialogOpen(true);
+  };
+
   const handleAddImportFilePath = () => {
     const trimmed = importFilePath.trim();
     if (!trimmed) return;
@@ -628,6 +645,87 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       toast(message, 'error');
     } finally {
       setImportFileInProgress(false);
+    }
+  };
+
+  const startManualImportPolling = (operationId: string) => {
+    if (manualImportPollCleanupRef.current) {
+      manualImportPollCleanupRef.current();
+    }
+
+    let cleanedUp = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const terminalStatuses = [
+      'completed',
+      'failed',
+      'canceled',
+      'interrupted_dropped',
+      'interrupted_restart',
+    ];
+
+    const poll = async () => {
+      try {
+        const op = await api.getOperationV2(operationId);
+        if (cleanedUp) return;
+        setManualImportOp(op);
+        if (terminalStatuses.includes(op.status)) {
+          setManualImportInProgress(false);
+          manualImportPollCleanupRef.current = null;
+          if (op.status === 'completed') {
+            toast('Manual import completed.', 'success');
+            setManualImportDialogOpen(false);
+            setManualImportPath('');
+            setManualImportError(null);
+            await loadAudiobooks();
+          } else {
+            const message = op.error_message || 'Manual import failed.';
+            setManualImportError(message);
+            toast(message, 'error');
+          }
+          return;
+        }
+        timeoutId = setTimeout(poll, 2000);
+      } catch (error) {
+        if (cleanedUp) return;
+        const message = error instanceof Error ? error.message : 'Failed to poll manual import.';
+        setManualImportInProgress(false);
+        setManualImportError(message);
+        toast(message, 'error');
+        manualImportPollCleanupRef.current = null;
+      }
+    };
+
+    timeoutId = setTimeout(poll, 2000);
+    manualImportPollCleanupRef.current = () => {
+      cleanedUp = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  };
+
+  const handleManualPathImport = async () => {
+    const path = manualImportPath.trim();
+    if (!path) {
+      setManualImportError('Enter an absolute path to import.');
+      return;
+    }
+
+    setManualImportInProgress(true);
+    setManualImportError(null);
+    setManualImportOp(null);
+    try {
+      const { operation_id: operationId } = await api.startLibraryImport(path);
+      if (!operationId) {
+        throw new Error('Manual import did not return an operation ID.');
+      }
+      toast('Manual import started.', 'info');
+      startManualImportPolling(operationId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to start manual import.';
+      setManualImportInProgress(false);
+      setManualImportError(message);
+      toast(message, 'error');
     }
   };
 
@@ -1585,6 +1683,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         onDeleteSelected={() => setBatchDeleteDialogOpen(true)}
         onRestoreSelected={handleBatchRestore}
         onManualImport={handleManualImport}
+        onManualPathImport={handleOpenManualPathImport}
         onFilterOpen={() => setFilterOpen(true)}
         onOrganizeLibrary={handleOrganizeLibrary}
         onFullRescan={handleFullRescan}
@@ -1757,6 +1856,14 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           setImportFileOrganize={setImportFileOrganize}
           importFileInProgress={importFileInProgress}
           handleImportFile={handleImportFile}
+          manualImportDialogOpen={manualImportDialogOpen}
+          setManualImportDialogOpen={setManualImportDialogOpen}
+          manualImportPath={manualImportPath}
+          setManualImportPath={setManualImportPath}
+          manualImportError={manualImportError}
+          manualImportInProgress={manualImportInProgress}
+          manualImportOp={manualImportOp}
+          handleManualPathImport={handleManualPathImport}
           bulkFetchDialogOpen={bulkFetchDialogOpen}
           handleCancelBulkFetch={handleCancelBulkFetch}
           bulkFetchProgress={bulkFetchProgress}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.45.0
+// version: 2.46.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-06-28
 
@@ -482,7 +482,9 @@ export async function getOperationV2(id: string): Promise<OperationV2> {
     throw await buildApiError(response, 'Failed to fetch operation');
   }
   const body = await response.json();
-  return body?.data?.operation ?? body?.operation;
+  const op = body?.data?.operation ?? body?.operation;
+  if (!op) throw new Error(`Unexpected response shape from GET /api/v1/operations/v2/${id}`);
+  return op as OperationV2;
 }
 
 // SSE event types emitted by the operations EventHub (UOS-06).

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -476,6 +476,15 @@ export async function getOperationTimeline(sinceMinutes = 15): Promise<Operation
   }
 }
 
+export async function getOperationV2(id: string): Promise<OperationV2> {
+  const response = await apiFetch(`${API_BASE}/operations/v2/${encodeURIComponent(id)}`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to fetch operation');
+  }
+  const body = await response.json();
+  return body?.data?.operation ?? body?.operation;
+}
+
 // SSE event types emitted by the operations EventHub (UOS-06).
 export type OperationSSEEventName =
   | 'op.created'
@@ -1770,6 +1779,22 @@ export async function startBulkMetadataFetch(
     if (!response.ok) throw await buildApiError(response, 'Failed to start bulk metadata fetch');
     const body = await response.json();
     return body?.data ?? { operation_id: '' };
+  });
+}
+
+export async function startLibraryImport(path: string): Promise<{ operation_id: string }> {
+  return wrapTrigger('library.import', async () => {
+    const response = await apiFetch(`${API_BASE}/operations/v2`, {
+      method: 'POST',
+      body: JSON.stringify({
+        def_id: 'library.import',
+        params: { path },
+      }),
+    });
+    if (!response.ok) throw await buildApiError(response, 'Failed to start manual import');
+    const body = await response.json();
+    const operationID = body?.op_id ?? body?.data?.op_id ?? body?.data?.operation_id ?? '';
+    return { operation_id: operationID };
   });
 }
 


### PR DESCRIPTION
Adds an Import button to the Library toolbar that opens a dialog and fires POST /api/v1/operations/v2 {def_id:"library.import"}. Wired through LibraryToolbar → LibraryDialogs → api.ts. CONS-11.