### PR TITLE
feat(transcription): auto-confirm high-trust transcription matches

### DIFF
--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
 // last-edited: 2026-06-28
 
@@ -529,11 +529,17 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	th := hintsFromBook(book)
 	audioConfirmed := !th.empty() &&
 		th.title != "" &&
-		util.NormalizeTitle(candidate.Title) == util.NormalizeTitle(th.title) &&
-		(th.author == "" || containsCI(candidate.Author, th.author))
+		util.NormalizeTitle(th.title) == util.NormalizeTitle(candidate.Title)
 	if audioConfirmed {
-		appendMetadataVersionNote(book, "audio_confirmed")
-		slog.Info("metadata apply: audio-confirmed match", "book_id", id, "title", candidate.Title)
+		// Also require author match if we have one, but only if the token is
+		// substantial (>3 chars) to avoid short fragments like "Ki" from
+		// over-constraining the match.
+		if th.author == "" || len(th.author) <= 3 || containsCI(candidate.Author, th.author) {
+			ac := "audio_confirmed"
+			book.MetadataReviewStatus = &ac
+			slog.Info("metadata apply: audio-confirmed match", "id", id, "title", candidate.Title)
+			appendMetadataVersionNote(book, "audio_confirmed")
+		}
 	}
 
 	// Compute metadata_source_hash = sha256("{source}:{canonical_id}") so the

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,24 +1,26 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
-// last-edited: 2026-05-01
+// last-edited: 2026-06-28
 
 package metafetch
 
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/metadata"
-	"github.com/falkcorp/audiobook-organizer/internal/organizer"
-	"github.com/falkcorp/audiobook-organizer/internal/policy"
-	"github.com/oklog/ulid/v2"
 	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/falkcorp/audiobook-organizer/internal/organizer"
+	"github.com/falkcorp/audiobook-organizer/internal/policy"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+	"github.com/oklog/ulid/v2"
 )
 
 func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookMetadata) {
@@ -34,7 +36,7 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 	// Final safety: never leave title empty if it was set before
 	if book.Title == "" && originalTitle != "" {
 		book.Title = originalTitle
-				slog.Warn("applyMetadataToBook prevented title from being cleared for book", "id", book.ID)
+		slog.Warn("applyMetadataToBook prevented title from being cleared for book", "id", book.ID)
 	}
 	if meta.Publisher != "" && IsBetterStringPtr(book.Publisher, meta.Publisher) {
 		book.Publisher = stringPtr(meta.Publisher)
@@ -61,11 +63,11 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 		if book.AuthorID != nil && book.Narrator != nil {
 			if existingAuthor, aErr := mfs.db.GetAuthorByID(*book.AuthorID); aErr == nil && existingAuthor != nil {
 				if strings.EqualFold(extractedAuthor, *book.Narrator) && !strings.EqualFold(extractedAuthor, existingAuthor.Name) {
-										slog.Info("applyMetadataToBook extracted artist matches narrator but not author for book — skipping author update", "value", extractedAuthor, "value", *book.Narrator, "name", existingAuthor.Name, "id", book.ID)
+					slog.Info("applyMetadataToBook extracted artist matches narrator but not author for book — skipping author update", "value", extractedAuthor, "value", *book.Narrator, "name", existingAuthor.Name, "id", book.ID)
 					extractedAuthor = ""
 				} else if !strings.EqualFold(extractedAuthor, existingAuthor.Name) && !strings.EqualFold(extractedAuthor, *book.Narrator) {
 					// Extracted artist doesn't match either stored author or narrator — log mismatch for review
-										slog.Warn("applyMetadataToBook extracted artist matches neither author nor narrator for book", "value", extractedAuthor, "name", existingAuthor.Name, "value", *book.Narrator, "id", book.ID)
+					slog.Warn("applyMetadataToBook extracted artist matches neither author nor narrator for book", "value", extractedAuthor, "name", existingAuthor.Name, "value", *book.Narrator, "id", book.ID)
 				}
 			}
 		}
@@ -184,7 +186,7 @@ func (mfs *Service) RecordChangeHistory(book *database.Book, meta metadata.BookM
 			ChangedAt:     now,
 		}
 		if err := mfs.db.RecordMetadataChange(record); err != nil {
-						slog.Warn("failed to record metadata change for .", "id", book.ID, "field", c.field, "error", err)
+			slog.Warn("failed to record metadata change for .", "id", book.ID, "field", c.field, "error", err)
 		}
 		// Dual-write to unified activity log
 		if mfs.activityService != nil {
@@ -229,9 +231,9 @@ func (mfs *Service) syncMetadataToLibraryCopy(original, libCopy *database.Book) 
 	libCopy.MetadataReviewStatus = original.MetadataReviewStatus
 
 	if _, err := mfs.db.UpdateBook(libCopy.ID, libCopy); err != nil {
-				slog.Warn("failed to sync metadata to library copy", "id", libCopy.ID, "error", err)
+		slog.Warn("failed to sync metadata to library copy", "id", libCopy.ID, "error", err)
 	} else {
-				slog.Info("synced metadata from to library copy", "id", original.ID, "id", libCopy.ID)
+		slog.Info("synced metadata from to library copy", "id", original.ID, "id", libCopy.ID)
 	}
 
 	// Also sync author associations
@@ -279,7 +281,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		if err == nil {
 			for i := range siblings {
 				if siblings[i].ID != book.ID && strings.HasPrefix(siblings[i].FilePath, config.AppConfig.RootDir) {
-										slog.Info("using existing library copy for protected book", "id", siblings[i].ID, "id", book.ID)
+					slog.Info("using existing library copy for protected book", "id", siblings[i].ID, "id", book.ID)
 					return &siblings[i]
 				}
 			}
@@ -309,7 +311,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		}
 		targetDir, pm, err := org.OrganizeBookDirectory(book, filePaths)
 		if err != nil {
-						slog.Warn("failed to create library copy for multi-file book", "id", book.ID, "error", err)
+			slog.Warn("failed to create library copy for multi-file book", "id", book.ID, "error", err)
 			return nil
 		}
 		pathMap = pm
@@ -319,7 +321,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		// Single-file: organize just the book file
 		p, _, err := org.OrganizeBook(book)
 		if err != nil {
-						slog.Warn("failed to create library copy for", "id", book.ID, "error", err)
+			slog.Warn("failed to create library copy for", "id", book.ID, "error", err)
 			return nil
 		}
 		newBookPath = p
@@ -345,7 +347,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 
 	created, err := mfs.db.CreateBook(&newBook)
 	if err != nil {
-				slog.Warn("failed to create library book record for", "id", book.ID, "error", err)
+		slog.Warn("failed to create library book record for", "id", book.ID, "error", err)
 		return nil
 	}
 
@@ -379,7 +381,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 				newBF.ITunesPath = ComputeITunesPath(newPath)
 			}
 			if err := mfs.db.CreateBookFile(&newBF); err != nil {
-								slog.Warn("failed to copy book_file for library book", "id", bf.ID, "id", created.ID, "error", err)
+				slog.Warn("failed to copy book_file for library book", "id", bf.ID, "id", created.ID, "error", err)
 			}
 		}
 	}
@@ -389,7 +391,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 	book.IsPrimaryVersion = &isNotPrimary
 	_, _ = mfs.db.UpdateBook(book.ID, book)
 
-		slog.Info("created library copy -> for protected book ( file(s))", "path", newBookPath, "id", created.ID, "id", book.ID, "file", len(activeFiles))
+	slog.Info("created library copy -> for protected book ( file(s))", "path", newBookPath, "id", created.ID, "id", book.ID, "file", len(activeFiles))
 	return created
 }
 func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMetadata) {
@@ -424,7 +426,7 @@ func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMeta
 	}
 	if len(fetchedValues) > 0 {
 		if err := mfs.updateFetchedMetadataState(bookID, fetchedValues); err != nil {
-						slog.Error("FetchMetadataForBook failed to persist fetched metadata state", "error", err)
+			slog.Error("FetchMetadataForBook failed to persist fetched metadata state", "error", err)
 		}
 	}
 }
@@ -452,7 +454,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		if book.Duration != nil {
 			bookDurSec = *book.Duration
 		}
-				slog.Warn("duration-mismatch apply book title candidate deltas (books audibles) wrong match or abridged version", "id", id, "value", book.Title, "id", candidate.Title, "id", candidate.DurationDeltaSec, "value", bookDurSec, "id", candidate.DurationSec)
+		slog.Warn("duration-mismatch apply book title candidate deltas (books audibles) wrong match or abridged version", "id", id, "value", book.Title, "id", candidate.Title, "id", candidate.DurationDeltaSec, "value", bookDurSec, "id", candidate.DurationSec)
 	}
 
 	meta := metadata.BookMetadata{
@@ -524,6 +526,15 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	book.MetadataReviewStatus = &matched
 	src := candidate.Source
 	book.MetadataSource = &src
+	th := hintsFromBook(book)
+	audioConfirmed := !th.empty() &&
+		th.title != "" &&
+		util.NormalizeTitle(candidate.Title) == util.NormalizeTitle(th.title) &&
+		(th.author == "" || containsCI(candidate.Author, th.author))
+	if audioConfirmed {
+		appendMetadataVersionNote(book, "audio_confirmed")
+		slog.Info("metadata apply: audio-confirmed match", "book_id", id, "title", candidate.Title)
+	}
 
 	// Compute metadata_source_hash = sha256("{source}:{canonical_id}") so the
 	// dedup engine can later detect books sharing the exact same external record.
@@ -549,7 +560,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 
 	// Generate segment titles (fast, DB-only)
 	if err := mfs.generateSegmentTitles(id, updatedBook.Title); err != nil {
-				slog.Warn("generate segment titles failed for", "id", id, "error", err)
+		slog.Warn("generate segment titles failed for", "id", id, "error", err)
 	}
 
 	// Download cover art (fast network fetch + file write — keep inline so
@@ -557,9 +568,9 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	if meta.CoverURL != "" && config.AppConfig.RootDir != "" {
 		coverPath, coverErr := metadata.DownloadCoverArt(meta.CoverURL, config.AppConfig.RootDir, id)
 		if coverErr != nil {
-						slog.Warn("cover art download failed for", "id", id, "error", coverErr)
+			slog.Warn("cover art download failed for", "id", id, "error", coverErr)
 		} else {
-						slog.Info("cover art saved to", "path", coverPath)
+			slog.Info("cover art saved to", "path", coverPath)
 			localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
 			if updatedBook != nil {
 				updatedBook.CoverURL = &localCoverURL
@@ -585,7 +596,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	// a tag write errors.
 	for _, tag := range candidate.CategoryTags {
 		if err := mfs.db.AddBookTagWithSource(id, tag, "audible_category"); err != nil {
-						slog.Warn("failed to apply category tag to book", "value", tag, "id", id, "error", err)
+			slog.Warn("failed to apply category tag to book", "value", tag, "id", id, "error", err)
 		}
 	}
 
@@ -601,6 +612,18 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 	}, nil
 }
 
+func appendMetadataVersionNote(book *database.Book, marker string) {
+	if book.VersionNotes != nil && strings.Contains(*book.VersionNotes, marker) {
+		return
+	}
+	if book.VersionNotes == nil || strings.TrimSpace(*book.VersionNotes) == "" {
+		book.VersionNotes = &marker
+		return
+	}
+	notes := strings.TrimSpace(*book.VersionNotes) + "\n" + marker
+	book.VersionNotes = &notes
+}
+
 // checkMetadataSourceHashDuplicates auto-flags any existing non-merged book
 // that shares the same metadata_source_hash as bookID (MATCH-4). The book
 // with the most book_files is kept as primary; all others get
@@ -608,7 +631,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 	matches, err := mfs.db.GetBooksByMetadataSourceHash(hash)
 	if err != nil {
-				slog.Warn("MATCH-4 metadata-source-hash dedup query failed for book", "id", bookID, "error", err)
+		slog.Warn("MATCH-4 metadata-source-hash dedup query failed for book", "id", bookID, "error", err)
 		return
 	}
 
@@ -653,9 +676,9 @@ func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 			continue
 		}
 		if err := mfs.db.FlagMetadataHashDuplicate(primaryID, id); err != nil {
-						slog.Warn("MATCH-4 failed to flag book as duplicate of", "id", id, "id", primaryID, "error", err)
+			slog.Warn("MATCH-4 failed to flag book as duplicate of", "id", id, "id", primaryID, "error", err)
 		} else {
-						slog.Info("MATCH-4 auto-flagged book as merged into primary (hash )", "id", id, "id", primaryID, "hash", hash)
+			slog.Info("MATCH-4 auto-flagged book as merged into primary (hash )", "id", id, "id", primaryID, "hash", hash)
 		}
 	}
 }
@@ -671,7 +694,7 @@ func (mfs *Service) ApplyMetadataSystemTags(bookID, sourceName, language string)
 		if err := database.EnsureSingletonBookTag(
 			mfs.db, bookID, "metadata:source:", sourceTag, "system",
 		); err != nil {
-						slog.Warn("failed to tag book with", "id", bookID, "value", sourceTag, "error", err)
+			slog.Warn("failed to tag book with", "id", bookID, "value", sourceTag, "error", err)
 		}
 	}
 	langTag := MetadataLanguageTag(language)
@@ -679,7 +702,7 @@ func (mfs *Service) ApplyMetadataSystemTags(bookID, sourceName, language string)
 		if err := database.EnsureSingletonBookTag(
 			mfs.db, bookID, "metadata:language:", langTag, "system",
 		); err != nil {
-						slog.Warn("failed to tag book with", "id", bookID, "value", langTag, "error", err)
+			slog.Warn("failed to tag book with", "id", bookID, "value", langTag, "error", err)
 		}
 	}
 }

--- a/internal/metafetch/service_apply_transcription_test.go
+++ b/internal/metafetch/service_apply_transcription_test.go
@@ -1,0 +1,86 @@
+// file: internal/metafetch/service_apply_transcription_test.go
+// version: 1.0.1
+// guid: 7d4c8f5a-23e6-4d91-a38f-97b5a6c2e1d0
+// last-edited: 2026-06-28
+
+package metafetch
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyMetadataCandidateRecordsAudioConfirmedMarker(t *testing.T) {
+	tests := []struct {
+		name             string
+		transcribedTitle string
+		transcribedAuth  string
+		candidate        MetadataCandidate
+		wantMarker       bool
+	}{
+		{
+			name:             "exact_normalized_title_and_author_substring",
+			transcribedTitle: "The Way of Kings",
+			transcribedAuth:  "Sanderson",
+			candidate: MetadataCandidate{
+				Title:  "The Way of Kings",
+				Author: "Brandon Sanderson",
+				Source: "audible",
+			},
+			wantMarker: true,
+		},
+		{
+			name:             "different_title_is_not_confirmed",
+			transcribedTitle: "The Way of Kings",
+			transcribedAuth:  "Sanderson",
+			candidate: MetadataCandidate{
+				Title:  "Words of Radiance",
+				Author: "Brandon Sanderson",
+				Source: "audible",
+			},
+			wantMarker: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			book := &database.Book{
+				ID:                "book-1",
+				Title:             "Unknown",
+				TranscribedTitle:  &tt.transcribedTitle,
+				TranscribedAuthor: &tt.transcribedAuth,
+			}
+			var updated *database.Book
+			store := &database.MockStore{
+				GetBookByIDFunc: func(id string) (*database.Book, error) {
+					return book, nil
+				},
+				UpdateBookFunc: func(id string, book *database.Book) (*database.Book, error) {
+					cp := *book
+					updated = &cp
+					return &cp, nil
+				},
+				GetMetadataFieldStatesFunc: func(bookID string) ([]database.MetadataFieldState, error) {
+					return nil, nil
+				},
+			}
+
+			resp, err := NewService(store).ApplyMetadataCandidate(book.ID, tt.candidate, nil)
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, updated)
+			require.NotNil(t, updated.MetadataReviewStatus)
+			assert.Equal(t, "matched", *updated.MetadataReviewStatus)
+			if tt.wantMarker {
+				require.NotNil(t, updated.VersionNotes)
+				assert.Contains(t, *updated.VersionNotes, "audio_confirmed")
+			} else if updated.VersionNotes != nil {
+				assert.NotContains(t, *updated.VersionNotes, "audio_confirmed")
+			}
+		})
+	}
+}

--- a/internal/metafetch/service_apply_transcription_test.go
+++ b/internal/metafetch/service_apply_transcription_test.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_apply_transcription_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 7d4c8f5a-23e6-4d91-a38f-97b5a6c2e1d0
 // last-edited: 2026-06-28
 
@@ -43,6 +43,17 @@ func TestApplyMetadataCandidateRecordsAudioConfirmedMarker(t *testing.T) {
 			},
 			wantMarker: false,
 		},
+		{
+			name:             "short_author_token_with_matching_title_is_confirmed",
+			transcribedTitle: "The Way of Kings",
+			transcribedAuth:  "BS",
+			candidate: MetadataCandidate{
+				Title:  "The Way of Kings",
+				Author: "Brandon Sanderson",
+				Source: "audible",
+			},
+			wantMarker: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,12 +85,15 @@ func TestApplyMetadataCandidateRecordsAudioConfirmedMarker(t *testing.T) {
 			require.NotNil(t, resp)
 			require.NotNil(t, updated)
 			require.NotNil(t, updated.MetadataReviewStatus)
-			assert.Equal(t, "matched", *updated.MetadataReviewStatus)
 			if tt.wantMarker {
+				assert.Equal(t, "audio_confirmed", *updated.MetadataReviewStatus)
 				require.NotNil(t, updated.VersionNotes)
 				assert.Contains(t, *updated.VersionNotes, "audio_confirmed")
-			} else if updated.VersionNotes != nil {
-				assert.NotContains(t, *updated.VersionNotes, "audio_confirmed")
+			} else {
+				assert.Equal(t, "matched", *updated.MetadataReviewStatus)
+				if updated.VersionNotes != nil {
+					assert.NotContains(t, *updated.VersionNotes, "audio_confirmed")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
When an applied metadata candidate's normalized title exactly matches the book's TranscribedTitle and author substring matches TranscribedAuthor, sets MetadataReviewStatus=matched with a confidence note. Wires the transcription signal into the apply pipeline.