### PR TITLE
docs(system): complete DOCS-1 system documentation (7 files, Mermaid diagrams)

### DIFF
--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -1,11 +1,11 @@
 <!-- file: docs/system/README.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 42030117-6ba8-4f26-a2c6-9b5f9014ef88 -->
-<!-- last-edited: 2026-06-28 -->
+<!-- last-edited: 2026-06-29 -->
 
 # System Documentation
 
-> **Status:** This index is a skeleton for the DOCS-1 workstream. The files listed below are in progress and will be added incrementally. Links will resolve once each document is written.
+> **Status:** DOCS-1 workstream complete. All 6 area documents are written and cross-linked below.
 
 Audiobook Organizer is a single-binary server (Go backend, React frontend) for scanning,
 normalizing, enriching, deduplicating, organizing, and serving audiobook

--- a/docs/system/api.md
+++ b/docs/system/api.md
@@ -1,0 +1,198 @@
+<!-- file: docs/system/api.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d4e5f6a7-b8c9-0123-def0-123456789012 -->
+<!-- last-edited: 2026-06-29 -->
+
+# HTTP API
+
+The Audiobook Organizer backend exposes a JSON REST API under `/api/v1/`. All endpoints require authentication except `/api/v1/auth/bootstrap` (first-run setup) and `/api/v1/auth/status`.
+
+## Authentication
+
+**All API calls must include:**
+```
+Authorization: Bearer <token>
+```
+
+Token types:
+- `abk_…` prefix — API key (persistent, programmatic access). Routed through API key validation.
+- Session token — short-lived cookie-backed token from browser login. Also accepted in `Authorization: Bearer`.
+
+**Never use `X-API-Key` header** — it is not supported.
+
+To obtain an API key:
+1. Bootstrap admin via `POST /api/v1/auth/bootstrap` (first-run only). Response: `{ "data": { "api_key": "abk_…" } }`
+2. Or: log in via browser, then `POST /api/v1/auth/api-keys` to create a persistent key.
+
+## Endpoint Reference
+
+### Library / Audiobooks
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/audiobooks` | List books with filtering and pagination |
+| `GET` | `/api/v1/audiobooks/:id` | Get single book with enrichment |
+| `PATCH` | `/api/v1/audiobooks/:id` | Update book metadata |
+| `DELETE` | `/api/v1/audiobooks/:id` | Soft-delete book |
+| `POST` | `/api/v1/audiobooks/batch-operations` | Per-item update / delete / restore |
+| `GET` | `/api/v1/audiobooks/:id/files` | List book file segments |
+| `GET` | `/api/v1/audiobooks/:id/cover` | Get cover art image |
+| `POST` | `/api/v1/audiobooks/:id/cover` | Upload/replace cover art |
+| `GET` | `/api/v1/audiobooks/:id/activity` | Activity log entries for a book |
+| `GET` | `/api/v1/audiobooks/:id/changelog` | Metadata changelog |
+
+#### Library List Query Parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `limit` | int | 20 | Max 1000 |
+| `offset` | int | 0 | Pagination offset |
+| `sort_by` | string | `title` | `title`, `author`, `duration`, `created_at`, `updated_at` |
+| `sort_order` | string | `asc` | `asc` or `desc` |
+| `is_primary_version` | bool | — | Filter to primary versions only |
+| `show_quarantined` | bool | false | Include quarantined books |
+| `author_id` | string | — | Filter by author ULID |
+| `series_id` | string | — | Filter by series ULID |
+| `search` | string | — | Full-text search query |
+| `review_status` | string | — | `matched`, `no_match`, `audio_confirmed` |
+| `has_cover` | bool | — | Filter by cover art presence |
+| `fingerprint_status` | string | — | `has_fingerprint`, `no_fingerprint` |
+
+### Authors and Series
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/authors` | List authors |
+| `GET` | `/api/v1/authors/:id` | Get author |
+| `PATCH` | `/api/v1/authors/:id` | Update author |
+| `DELETE` | `/api/v1/authors/:id` | Delete author |
+| `GET` | `/api/v1/series` | List series |
+| `GET` | `/api/v1/series/:id` | Get series |
+| `PATCH` | `/api/v1/series/:id` | Update series |
+
+### Metadata
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/audiobooks/:id/metadata/fetch` | Trigger metadata fetch for a book |
+| `POST` | `/api/v1/audiobooks/:id/metadata/apply` | Apply fetched metadata |
+| `GET` | `/api/v1/audiobooks/:id/metadata/candidates` | List scored metadata candidates |
+| `POST` | `/api/v1/metadata/batch-fetch` | Queue bulk metadata fetch |
+
+### Deduplication
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/dedup/candidates` | List dedup candidate pairs |
+| `POST` | `/api/v1/dedup/candidates/:id/resolve` | Resolve a candidate pair |
+| `GET` | `/api/v1/dedup/stats` | Dedup statistics |
+
+### Operations (v2)
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/operations/v2` | Launch an operation by def_id |
+| `GET` | `/api/v1/operations/v2` | List all operations (recent) |
+| `GET` | `/api/v1/operations/v2/:id` | Poll operation status |
+| `DELETE` | `/api/v1/operations/v2/:id` | Cancel operation |
+
+### Maintenance / Admin
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/admin/scan` | Trigger library scan |
+| `POST` | `/api/v1/admin/recompact-digests` | Recompact NutsDB activity digests |
+| `GET` | `/api/v1/admin/diagnostics` | Diagnostic ZIP export |
+| `POST` | `/api/v1/backup/create` | Create PebbleDB backup (checkpoint) |
+
+### Authentication
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/auth/bootstrap` | First-run admin setup |
+| `GET` | `/api/v1/auth/status` | Session status (unauthenticated OK) |
+| `POST` | `/api/v1/auth/login` | Login with username/password |
+| `POST` | `/api/v1/auth/logout` | Invalidate session |
+| `POST` | `/api/v1/auth/api-keys` | Create API key |
+| `GET` | `/api/v1/auth/api-keys` | List API keys |
+| `GET` | `/api/v1/auth/api-keys/:id` | Get API key |
+| `PATCH` | `/api/v1/auth/api-keys/:id` | Enable/disable key |
+| `DELETE` | `/api/v1/auth/api-keys/:id` | Revoke key |
+
+## Operations v2 Lifecycle
+
+Operations are long-running jobs (scan, transcription, dedup, organize, etc.) that run in the background with real-time progress reporting.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as POST /api/v1/operations/v2
+    participant DB as PebbleDB (opv2: keys)
+    participant Worker as Operation Worker
+
+    Client->>API: {"def_id": "maintenance.transcribe-book-intros", "params": {...}}
+    API->>DB: write opv2:<id> (queued) + opv2:act:<id>
+    API-->>Client: {"id": "<opULID>", "status": "queued"}
+
+    loop Poll until terminal
+        Client->>API: GET /api/v1/operations/v2/<id>
+        API->>DB: read opv2:<id>
+        API-->>Client: {"status": "running", "progress": {"done": 42, "total": 200}}
+    end
+
+    Worker->>DB: update opv2:<id> (running → completed/failed)
+    Worker->>DB: delete opv2:act:<id>
+
+    Client->>API: GET /api/v1/operations/v2/<id>
+    API-->>Client: {"status": "completed", "result": {...}}
+```
+
+### Known def_ids
+
+| def_id | Description |
+|---|---|
+| `maintenance.transcribe-book-intros` | Whisper intro transcription (`reparse_only` param supported) |
+| `maintenance.transcribe-book-intros` (reparse_only) | Re-parse stored transcripts only (no GPU/ffmpeg) |
+| `maintenance.dedup-exact-triage` | Classify dedup candidates (read-only, dry-run) |
+| `maintenance.dedup-auto-purge` | Purge confirmed purgeable dedup candidates |
+| `maintenance.itunes-heal` | Heal stale iTunes file paths after organize |
+| `maintenance.reconcile-scan` | Reconcile library paths vs. filesystem |
+| `maintenance.author-dedup-scan` | Scan for author near-duplicates |
+| `maintenance.window` | Nightly maintenance window (dispatches sub-ops) |
+| `library.bulk-write-back` | Bulk tag write-back to audio files |
+| `ai.author-review` | AI-assisted author dedup review |
+| `ai.author-merge-apply` | Apply AI author merge recommendations |
+
+## Response Conventions
+
+All responses use the envelope format:
+```json
+{
+  "data": { ... },
+  "error": null
+}
+```
+
+Errors:
+```json
+{
+  "data": null,
+  "error": "human-readable error message"
+}
+```
+
+Pagination responses include `total` alongside `data`:
+```json
+{
+  "data": [...],
+  "total": 10891,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+## Cross-references
+
+- Architecture (handler wiring): [architecture.md](architecture.md)
+- Pipelines (operation internals): [pipelines.md](pipelines.md)
+- Runbooks (deploy and ops): [runbooks.md](runbooks.md)

--- a/docs/system/architecture.md
+++ b/docs/system/architecture.md
@@ -1,0 +1,124 @@
+<!-- file: docs/system/architecture.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890 -->
+<!-- last-edited: 2026-06-29 -->
+
+# System Architecture
+
+Audiobook Organizer is a single-binary Go server that embeds a compiled React/TypeScript frontend via `//go:embed web/dist`. The same binary serves the UI, the REST API, and all background operations.
+
+## Runtime Shape
+
+```
+┌────────────────────────────────────────────────────────┐
+│  audiobook-organizer binary (linux/amd64)              │
+│                                                        │
+│  ┌──────────────┐   ┌─────────────────────────────┐   │
+│  │  Gin HTTP    │   │  React 18 / TypeScript UI    │   │
+│  │  server      │   │  (embedded via go:embed)     │   │
+│  └──────┬───────┘   └─────────────────────────────┘   │
+│         │                                              │
+│  ┌──────▼──────────────────────────────────────────┐  │
+│  │  Service Registry (serviceregistry.Container)   │  │
+│  │  KeyStore / KeyScan / KeyDedup / KeyOrganize … │  │
+│  └──────┬──────────────────────────────────────────┘  │
+│         │                                              │
+│  ┌──────▼───────────────────────────────────────────┐ │
+│  │  Domain Services                                  │ │
+│  │  audiobooks · scanner · organizer · dedup        │ │
+│  │  metafetch · matcher · fingerprint · tagger      │ │
+│  │  transcribe · search · activity · operations     │ │
+│  └──────┬───────────────────────────────────────────┘ │
+│         │                                              │
+│  ┌──────▼────────────────────────┐                    │
+│  │  Store Layer                  │                    │
+│  │  PebbleDB (primary)           │                    │
+│  │  memdb (in-memory query)      │                    │
+│  │  NutsDB (activity log)        │                    │
+│  └───────────────────────────────┘                    │
+└────────────────────────────────────────────────────────┘
+```
+
+## Component Overview
+
+```mermaid
+flowchart TD
+    Browser["Browser / React UI"] -->|"HTTPS REST"| GinHTTP["Gin HTTP Server\ninternal/server"]
+    GinHTTP --> AuthMW["Auth Middleware\n(Bearer abk_…)"]
+    AuthMW --> Handlers["HTTP Handlers\ninternal/server/handlers/"]
+    Handlers --> SvcReg["Service Registry\ninternal/serviceregistry"]
+    SvcReg --> AudiobookSvc["AudiobookService\ninternal/audiobooks"]
+    SvcReg --> ScanSvc["ScanService\ninternal/scanner"]
+    SvcReg --> DedupSvc["DedupService\ninternal/dedup"]
+    SvcReg --> OrgSvc["OrganizerService\ninternal/organizer"]
+    SvcReg --> MetaFetch["MetadataFetch\ninternal/metafetch"]
+    SvcReg --> OpHub["Operations Hub\ninternal/operations"]
+    AudiobookSvc --> Store["database.Store\ninternal/database"]
+    ScanSvc --> Store
+    DedupSvc --> Store
+    OrgSvc --> Store
+    MetaFetch --> Store
+    OpHub --> Store
+    Store --> Pebble["PebbleDB\n(primary KV store)"]
+    Store --> MemDB["memdb\n(in-memory query layer)"]
+    Store -->|"activity log"| NutsDB["NutsDB\n(activity tiers)"]
+    SvcReg --> Search["Bleve Full-text Search\ninternal/search"]
+    SvcReg --> Embeddings["Vector Embeddings\ninternal/database (HNSW)"]
+    SvcReg --> PluginReg["Plugin Registry\ninternal/plugin + internal/plugins"]
+    PluginReg --> MaintenancePlug["maintenance plugin\ninternal/plugins/maintenance"]
+    PluginReg --> DedupPlug["dedup plugin\ninternal/plugins/dedup"]
+    PluginReg --> DélugePlug["deluge plugin\ninternal/plugins/deluge"]
+```
+
+## Service Registry / Container Pattern
+
+All domain services are registered in `internal/serviceregistry` with string keys defined in `internal/serviceregistry/keys.go`. During server startup (`NewServer`), the registry resolves dependency order, calls `Build`, then `PostInit` before wiring HTTP handlers. The known keys are:
+
+| Key constant | Service |
+|---|---|
+| `KeyStore` | `database.Store` (PebbleDB-backed) |
+| `KeyScan` | Scanner / importer |
+| `KeyDedup` | Dedup engine |
+| `KeyOrganize` | File organizer |
+| `KeyMetaFetch` | Metadata fetch + scoring |
+| `KeyActivity` | Activity log service |
+| `KeyOpHub` | Operations hub (v2 registry) |
+| `KeyITunes` | iTunes XML sync |
+| `KeyConfig` | Configuration service |
+| `KeyWork` | Work-item / task queue |
+
+## Layer Responsibilities
+
+### HTTP Layer (`internal/server`)
+
+- Gin engine with CORS, security headers, session/cookie auth middleware
+- Routes split across per-domain files: `wire_auth_routes.go`, `wire_library_routes.go`, `wire_audiobooks_routes.go`, `wire_metadata_routes.go`, `wire_entities_routes.go`, `wire_operations_routes.go`, `wire_system_routes.go`, `wire_dedup_routes.go`, `wire_media_routes.go`
+- Handler instantiation stays in `wire_handlers.go`
+
+### Operations / Plugin System
+
+Long-running jobs run as v2 Operations registered via `opsregistry.OperationDef`. Plugins (`internal/plugin` SDK, `internal/plugins/*`) implement the `sdk.Plugin` interface and register their `OperationDef` entries at startup. The operation hub persists state to PebbleDB (`opv2:*` keys) and exposes `POST /api/v1/operations/v2` and `GET /api/v1/operations/v2/:id` for launch and polling.
+
+### AI / Embeddings
+
+- `internal/ai`: OpenAI batch job dispatch and universal batch poller
+- `internal/metafetch`: Multi-source metadata scoring (Open Library, Google Books, Audible scraper)
+- `internal/database`: local vector embeddings (bge-m3 via Ollama) stored in PebbleDB; optional HNSW index for fast ANN queries
+
+### Frontend Embedding
+
+The React UI is compiled by `npm run build` into `web/dist/`, then embedded at compile time via `//go:embed web/dist` with the `embed_frontend` build tag. The `make build` target handles both steps. `make build-api` skips the frontend build for faster backend iteration.
+
+## Build Tags
+
+| Tag | Effect |
+|---|---|
+| `embed_frontend` | Embeds `web/dist` into binary (required for production) |
+| _(none)_ | API-only binary; UI served from dev Vite server |
+
+## Cross-references
+
+- Storage details: [storage.md](storage.md)
+- Pipeline flows: [pipelines.md](pipelines.md)
+- HTTP API surface: [api.md](api.md)
+- Package inventory: [components.md](components.md)

--- a/docs/system/components.md
+++ b/docs/system/components.md
@@ -1,0 +1,177 @@
+<!-- file: docs/system/components.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f6a7b8c9-d0e1-2345-f012-345678901234 -->
+<!-- last-edited: 2026-06-29 -->
+
+# Component Inventory
+
+This document lists all backend packages in `internal/`, their responsibilities, and key types or entry points.
+
+## Package Map
+
+| Package | Responsibility | Key types / entry points |
+|---|---|---|
+| `acoustid` | AcoustID fingerprint submission and lookup | `Client`, `Lookup` |
+| `activity` | Activity log service (write events, query, compact) | `Service`, `Entry`, `DigestDetails` |
+| `ai` | OpenAI batch job dispatch; universal batch poller | `BatchPoller`, `JobDispatcher` |
+| `aiscan` | AI-driven audiobook scan result store | `AIJobStore`, `ScanResult` |
+| `audio` | Audio file utilities (duration, format detection) | `Info`, `GetDuration` |
+| `audiobooks` | Core AudiobookService: list, filter, get, update, delete | `Service`, split across `service_query.go`, `service_mutation.go`, `service_filtering.go`, `service_tags.go` |
+| `auth` | Session management, password hashing, API key CRUD | `SessionStore`, `APIKeyStore` |
+| `backup` | PebbleDB checkpoint backup; `Checkpointable` interface | `CreateBackupWithCheckpoint`, `Checkpointable` |
+| `batch` | OpenAI batch-job creation and result retrieval | `BatchClient` |
+| `cache` | Generic TTL-keyed in-memory cache | `Cache[K,V]` |
+| `config` | Server configuration struct hierarchy (7 sub-structs) | `Config`, `EmbeddingConfig`, `DedupConfig`, `ITunesConfig`, … |
+| `covers` | Cover art storage, SHA-256 dedup, history archival | `Store`, `WriteImage`, `DeduplicateCover` |
+| `database` | Store interfaces, PebbleDB impl, memdb, NutsDB, schema | `Store`, `PebbleStore`, `BookReader`, `BookWriter`, `OpsV2Store` |
+| `dedup` | Unified dedup scoring engine, LSH index, candidate management | `Engine`, `LSHIndex`, `Candidate`, `UnifiedScorer` |
+| `deluge` | Deluge torrent download integration and importer | `Client`, `Centralizer` |
+| `diagnosis` | Structured diagnostic result types | `Result`, `Finding` |
+| `diagnostics` | Diagnostic ZIP export and AI batch analysis | `Exporter`, `AnalyzeZIP` |
+| `download` | Generic HTTP download with progress tracking | `Downloader` |
+| `fileops` | Safe file move/copy/rename with copy-on-write | `MoveFile`, `CopyFile`, `SafeRename` |
+| `fingerprint` | fpcalc / Chromaprint fingerprint pipeline | `FingerprintFile`, `doFingerprintFile` |
+| `httputil` | Shared HTTP response helpers, error wrapping | `RespondJSON`, `RespondError` |
+| `importer` | Generic file importer (non-iTunes) | `Importer` |
+| `itunes` | iTunes XML parser, PID backfill, path translation (W:\ → /mnt/bigdata/books/) | `Parser`, `BackfillExternalIDs`, `HealPaths` |
+| `logger` | Structured slog wrapper with request context | `Logger`, `FromContext` |
+| `logging` | Log-level management and log-line formatting | `LevelSetter` |
+| `maintenance` | Plugin package: all maintenance OperationDefs (scan, organize, transcribe, dedup-triage, reconcile, …) | `Plugin`, multiple `*Def()` + `run*()` methods |
+| `matcher` | Fuzzy title/author matching for metadata scoring | `Score`, `NormalizeTitle`, `NormalizeAuthor` |
+| `mediainfo` | `mediainfo` CLI wrapper; extended format/codec metadata | `GetInfo`, `FileInfo` |
+| `merge` | Book merge/consolidation service | `Merger`, `MergeBooks` |
+| `metabatch` | Bulk metadata fetch queue and batch dispatch | `BatchQueue`, `Dispatcher` |
+| `metadata` | Metadata state tracking, apply pipeline, tag priority logic | `ApplyPipeline`, `isProtectedPath`, `MetadataState` |
+| `metafetch` | Multi-source metadata fetch (Open Library, Google Books, Audible) + scoring with transcription hints | `Fetcher`, `pickBestMatchFromScored`, `transcriptionHints` |
+| `metrics` | Prometheus metrics collection and NutsDB metrics store | `MetricsStore`, `Collector` |
+| `models` | Shared domain model types (not database-specific) | `AudiobookSummary`, `TagMap` |
+| `mtls` | mTLS bridge for subprocess isolation (Whisper, etc.) | `Bridge`, `Client` |
+| `openlibrary` | Open Library API client for ISBN/ASIN lookup | `Client`, `Search` |
+| `operations` | Operations v1 legacy types and `ProgressReporter` interface | `ProgressReporter`, `Operation` |
+| `organizer` | File rename/move according to configurable template | `Organize`, `PreviewOrganize`, `BuildPath` |
+| `pathutil` | Safe path utilities, import-path conflict detection | `IsUnder`, `IsDangerousRoot` |
+| `playlist` | Playlist CRUD and playback order management | `Service`, `Playlist`, `Item` |
+| `plugin` | Plugin SDK: `OperationDef`, `Reporter`, `Plugin` interface | `OperationDef`, `Plugin`, `Reporter` |
+| `plugins` | Plugin registry and built-in plugin loader | `Registry`, `Load` |
+| `policy` | Authorization policy (role checks) | `Policy`, `CanAdmin` |
+| `quarantine` | Quarantine zone: mark/unmark books for manual review | `Service`, `Quarantine` |
+| `readstatus` | Per-user book read/unread/in-progress status | `StatusStore` |
+| `realtime` | Server-Sent Events bus for live operation progress | `EventBus`, `Publish` |
+| `reconcile` | Path reconciliation (BookFile.FilePath vs. actual filesystem) | `Reconciler`, `ReconcileBook` |
+| `remux` | ffmpeg-based audio remux for format conversion | `Remux`, `Options` |
+| `scanner` | Filesystem scanner: walk, group, extract, upsert | `Scanner`, `ScanResult`, `DetectMultiFileGroup` |
+| `scheduler` | Cron-based scheduled operation dispatcher | `Scheduler`, `Schedule` |
+| `search` | Bleve full-text search index management | `Index`, `Search`, `IndexBook` |
+| `server` | Gin HTTP server, middleware, route wiring, serviceregistry wiring | `Server`, `NewServer`, `wireServerFromContainer` |
+| `serviceregistry` | Dependency-injection container for domain services | `Container`, `Get[T]`, keys in `keys.go` |
+| `sweep` | Bulk sweep utilities for large-library fan-out | `Sweep`, `RunItems[T]` |
+| `sysinfo` | System info (disk usage, OS, Go runtime stats) | `SystemInfo`, `DiskUsage` |
+| `tagger` | taglib-based tag read/write (standard + `AUDIOBOOK_ORGANIZER_*` custom tags) | `ExtractMetadata`, `WriteTagMap`, `WriteImage` |
+| `telemetry` | OpenTelemetry tracing setup | `Setup`, `Tracer` |
+| `titleutil` | Title normalization, subtitle stripping, sort-key generation | `NormalizeTitle`, `SortKey` |
+| `tools` | Developer CLI tools (reconcile-paths, etc.) | various `main` packages in `tools/cmd/` |
+| `transcode` | ffmpeg-based audio transcode (MP3/M4B/AAC target) | `Transcode`, `Options` |
+| `transcribe` | Whisper batch transcription: `TranscribeBatch`, `ParseAudiobookIntro`, embedded `batch_whisper.py` | `TranscribeBatch`, `ParseAudiobookIntro`, `IntroFields` |
+| `undo` | Undo-stack for reversible operations (tag write, rename) | `Stack`, `Push`, `Pop` |
+| `updater` | Auto-update checker and release download | `Updater`, `CheckLatest` |
+| `util` | String utilities: `NormalizeTitle`, `NormalizeAuthor`, `NormalizeString` | `NormalizeTitle`, `NormalizeAuthor` |
+| `versions` | Version-group management (multiple physical files of same book) | `GroupVersions`, `VersionGroup` |
+| `watcher` | Filesystem watcher for new-file notifications | `Watcher`, `Watch` |
+| `work` | Work-item queue for async DB operations | `Queue`, `WorkItem` |
+| `writeback` | Tag write-back coordinator: build tag map, call tagger, record changelog | `WriteBack`, `BuildFullTagMap` |
+
+## Dependency Flowchart
+
+```mermaid
+flowchart TD
+    subgraph HTTP
+        Server["server\n(Gin, middleware, routes)"]
+    end
+    subgraph Services
+        AudiobookSvc["audiobooks\nService"]
+        ScanSvc["scanner\nScanner"]
+        DedupSvc["dedup\nEngine"]
+        OrgSvc["organizer\nOrganize"]
+        MetaFetch["metafetch\nFetcher"]
+        Transcribe["transcribe\nTranscribeBatch"]
+        Activity["activity\nService"]
+        OpHub["operations\nProgressReporter"]
+    end
+    subgraph Store
+        Database["database\nStore / PebbleStore / memdb"]
+    end
+    subgraph DB
+        Pebble["PebbleDB"]
+        MemDB["memdb"]
+        NutsDB["NutsDB"]
+    end
+    subgraph Search_AI["Search + AI"]
+        Search["search\nBleve index"]
+        Embeddings["database\nHNSW / vector"]
+        AI["ai\nBatchPoller"]
+    end
+    subgraph Plugins
+        PluginReg["plugins\nRegistry"]
+        MaintenancePlug["maintenance\nPlugin"]
+        DedupPlug["dedup plugin"]
+    end
+    subgraph Shared
+        Tagger["tagger\nExtractMetadata / WriteTagMap"]
+        Matcher["matcher\nScore"]
+        Util["util / titleutil\nNormalize*"]
+        ServiceReg["serviceregistry\nContainer"]
+    end
+
+    Server --> ServiceReg
+    ServiceReg --> AudiobookSvc
+    ServiceReg --> ScanSvc
+    ServiceReg --> DedupSvc
+    ServiceReg --> OrgSvc
+    ServiceReg --> MetaFetch
+    ServiceReg --> Transcribe
+    ServiceReg --> Activity
+
+    AudiobookSvc --> Database
+    ScanSvc --> Database
+    ScanSvc --> Tagger
+    DedupSvc --> Database
+    OrgSvc --> Database
+    MetaFetch --> Database
+    MetaFetch --> Matcher
+    Transcribe --> Database
+    Activity --> NutsDB
+
+    Database --> Pebble
+    Database --> MemDB
+    Database --> Search
+    Database --> Embeddings
+
+    PluginReg --> MaintenancePlug
+    PluginReg --> DedupPlug
+    MaintenancePlug --> Database
+    MaintenancePlug --> Transcribe
+    DedupPlug --> Database
+
+    Matcher --> Util
+    Tagger --> Util
+```
+
+## Frontend Surfaces
+
+The React/TypeScript UI (`web/src/`) provides these main views:
+
+| Surface | Description |
+|---|---|
+| Library | Book list with column toggles, quick-filter presets, search, pagination (max 1000) |
+| Book detail | Metadata, files (format-grouped trays), iTunes linked panel, version group chip |
+| Tag comparison | Transposed table: tags as columns, sources as rows; resizable; snapshot dismiss |
+| Changelog | Timeline with revert buttons; clicking metadata_apply or tag_write shows snapshot diff |
+| Dedup | Unified dedup tab with candidate pairs, triage results, scoring breakdown |
+| Diagnostics | ZIP export, AI batch analysis, results review |
+| Activity log | Namespace-colored tag chips, click-to-filter, per-item timestamps, digest expansion |
+| Settings | Import paths, metadata sources, backup, config sub-structs (7 groups) |
+
+## Cross-references
+
+- Architecture overview: [architecture.md](architecture.md)
+- Incident history: [incidents.md](incidents.md)

--- a/docs/system/incidents.md
+++ b/docs/system/incidents.md
@@ -1,0 +1,150 @@
+<!-- file: docs/system/incidents.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a7b8c9d0-e1f2-3456-0123-456789012345 -->
+<!-- last-edited: 2026-06-29 -->
+
+# Incidents and Decisions
+
+This document records known failure modes, historical incidents, architectural decisions, and follow-up actions. Use it as a first stop when diagnosing unexpected behavior.
+
+## Incident Log
+
+### INC-01: memdb pagination cap (PR #1647)
+
+**Date:** 2026-06 (discovered during full-library job)
+**Component:** `internal/database` — `GetAllBooksFrom` memdb path
+**Root cause:** The cursor-pagination path in `GetAllBooksFrom` was silently capped at `2 * limit` (~400 books). For libraries with >400 books, jobs that iterated via `GetAllBooksFrom` would process only the first 400 books and silently stop. The tail of the library was never processed.
+**Fix (PR #1647):** Corrected the cursor accumulation logic; `GetAllBooksFrom` now iterates the full library. Tests added that verify mid-library books are returned.
+**Prevention:** For full-library jobs, prefer `ListBookIDs + RunItems[T]` over `GetAllBooksFrom`. Always verify results against mid-library books, not just head/tail.
+
+---
+
+### INC-02: Double-pagination bug — page 2 returns 0 items (PR #1660)
+
+**Date:** 2026-06-28
+**Component:** `internal/audiobooks` — `GetAudiobooks` service method
+**Root cause:** The light-pushdown path let memdb paginate (applying `offset` + `limit`), then the post-filter block re-sliced the already-paginated page using the original `offset` value. For page 2, `offset=20` applied to a slice that was already 20 items long → out-of-bounds → nil. Users saw page 1 = 10 items, page 2 = 0 items.
+**Fix (PR #1660):** Added a `didPushdown` flag that signals the post-filter block to skip the redundant re-slice. Also fixed the service list-cache key that formatted a `*bool` with `%v` (printed the pointer address, so cache never hit for primary-version queries). Pagination cap raised 500→1000; 1000 option added to UI.
+**Prevention:** Pushdown and post-filter pagination must be mutually exclusive. The `didPushdown` flag is the canonical guard.
+
+---
+
+### INC-03: Transcription parser producing garbage metadata
+
+**Date:** 2026-06-28 (fix PR #1661)
+**Component:** `internal/transcribe` — `ParseAudiobookIntro`
+**Root cause:** The original parser attempted to extract title/author/narrator from Whisper transcription text using a single regex pass. Publisher preambles (`Simon and Schuster audio presents Salem's Lot`) caused the full preamble to be captured as the title, and the author field consumed the entire acknowledgements section.
+**Fix (PR #1661):** Rewrote `ParseAudiobookIntro` as a staged extractor: (1) strip `[Publisher] presents` prefix, (2) split title on first `by`, (3) split author/narrator on `read by`, (4) truncate each name at the first prose boundary. 11-case table test. First prod run with `reparse_only=true` corrected ~80% of transcribed books.
+**Prevention:** Run `reparse_only=true` after any parser change to apply fixes to existing transcriptions cheaply.
+
+---
+
+### INC-04: Dedup false positives — boilerplate / short-clip / iTunes fragmentation (PRs #1528, #1529)
+
+**Date:** 2026-06-13 to 2026-06-19
+**Component:** `internal/dedup`, `internal/plugins/maintenance` (dedup-triage), `internal/itunes`
+**Root cause:** Three separate iTunes import bugs created ~380K false-positive dedup candidates:
+- **CONS-16:** iTunes importer stored file duration in milliseconds instead of dividing by 1000. Books appeared to be 1000× too long.
+- **CONS-17:** Books were titled after their first track (e.g. `"Chapter 1"`) instead of the album. These single-track "books" collided in the dedup engine.
+- **CONS-FRAG (PR #1528):** `groupTracksByAlbum` used `artist` as a grouping key, causing multi-narrator anthologies and albums with blank-artist parts to shatter into single-file "books" (the "6/47" false positive pattern).
+**Fix:** Forward fix for CONS-FRAG shipped + deployed (PR #1528). Blocking quarantine test fixed (PR #1529). CONS-16/17 drain blocked on a re-import of affected books.
+**Prevention:** Always use `(Album, Artist)` as the iTunes grouping key — never Album Artist or Composer (both are narrator-contaminated for audiobooks). Artist is 99.8% populated in iTunes data.
+
+---
+
+### INC-05: Cache warm-up memory bloat (~69 GB peak)
+
+**Date:** 2026-05 (discovered, fixed by 2026-05-20)
+**Component:** `internal/cache` — library counts warm-up
+**Root cause:** Cache warm-up stored full API response objects (including all enriched book metadata for 50K books) in a single in-memory cache entry. Peak RSS reached ~69 GB on the production server before OOM.
+**Fix:** Disabled the warm-up entirely. Memory settled at ~208 MB stable. The proper long-term fix (refactor cache to store minimal aggregates, not full response objects) is tracked in `project_cache_warmup_memory_fix.md`.
+**Prevention:** Never cache full API response blobs. Cache only minimal identifiers (IDs, counts) and re-hydrate on demand.
+
+---
+
+### INC-06: iTunes file path stale after organize run
+
+**Date:** 2026-06-26
+**Component:** `internal/itunes` — `BackfillExternalIDs`, file path tracking
+**Root cause:** An organize run moved ~19,922 iTunes-linked audio files into the organized library directory (`/mnt/bigdata/books/audiobook-organizer/`). The `BookFile.FilePath` records still pointed to the old import paths. `file_not_found` errors appeared for all affected iTunes tracks.
+**Fix (PR #1625):** New `maintenance.itunes-heal` op: parses iTunes XML as ground truth, builds a parallel filename index of the organized library, fans out 16 workers using `RunItems[T]` for O(1) map lookup + ZFS reflink per track. First run: 2,274 healed, 3,720 ambiguous, 5,349 not found on disk, 0 errors.
+**Prevention:** After any organize run, check for iTunes `file_not_found` errors in the activity log. Run `maintenance.itunes-heal` if present. Never dismiss iTunes `file_not_found` as "expected" — all files live on the NAS (172.16.2.30); zero Windows-local-only files exist.
+
+---
+
+## Architectural Decisions
+
+### DEC-01: PebbleDB as sole durable store
+
+**Date:** 2026-04
+**Decision:** PebbleDB (sorted KV) is the only production database. SQLite is available only for legacy opt-in. All new features must implement `PebbleStore` fully before shipping.
+**Rationale:** PebbleDB provides prefix-scan efficiency, atomic batch writes, built-in checkpoint/backup, and deterministic ULID key ordering. SQLite's row-level locking is unsuitable for the concurrent write patterns of the scanner and organizer.
+
+### DEC-02: memdb as query layer (not durable)
+
+**Date:** 2026-04
+**Decision:** `hashicorp/go-memdb` is populated at startup from PebbleDB and used for all hot-path queries. It is never written to independently; PebbleDB is always written first.
+**Rationale:** Avoids PebbleDB scan overhead for common list/filter queries. Trade-off: startup warmup (~30s for 50K books) and the `AcoustIDFingerprint` stripping footgun.
+
+### DEC-03: Operations v2 registry (UOS pattern)
+
+**Date:** 2026-05
+**Decision:** All long-running jobs are implemented as `OperationDef` entries registered with the v2 operations registry. HTTP API provides launch + poll. State persists to PebbleDB (`opv2:*` keys). Checkpoint support allows resume after server restart.
+**Rationale:** Replaces a tangled mix of goroutines, channels, and ad-hoc HTTP endpoints. Provides uniform progress reporting, cancellation, and history.
+
+---
+
+## Project Timeline
+
+```mermaid
+gantt
+    title Audiobook Organizer — Key Milestones (2026)
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+    section Infrastructure
+    PebbleDB migration complete          :done, 2026-04-01, 2026-04-15
+    Handler extraction (PR #1232-#1239)  :done, 2026-05-10, 2026-05-20
+    Memory leak fixes (PR #1076)         :done, 2026-05-20, 2026-05-21
+    Authors/Series cache                 :done, 2026-05-23, 2026-05-24
+
+    section Dedup
+    LSH index + 275K fingerprints        :done, 2026-06-01, 2026-06-11
+    Unified dedup tab live               :done, 2026-06-12, 2026-06-13
+    iTunes fragmentation fix (PR #1528)  :done, 2026-06-19, 2026-06-19
+    Dedup triage op (PR #1619)           :done, 2026-06-24, 2026-06-24
+
+    section Transcription
+    Batch Whisper op shipped             :done, 2026-06-26, 2026-06-26
+    Checkpoint + crash recovery (PR #1638) :done, 2026-06-26, 2026-06-26
+    Parser rewrite (PR #1661)            :done, 2026-06-28, 2026-06-28
+    reparse_only prod run (~80% fixed)   :done, 2026-06-28, 2026-06-29
+
+    section Audit Remediation (PRs A-M)
+    SEC / FE / PERF / STR / ARCH / TOOL :done, 2026-06-22, 2026-06-23
+
+    section Pagination
+    Library double-pagination fix (PR #1660) :done, 2026-06-28, 2026-06-28
+    memdb pagination cap fix (PR #1647)  :done, 2026-06-20, 2026-06-21
+```
+
+## Diagnostic Entry Points
+
+When investigating an issue, start here:
+
+| Symptom | First check |
+|---|---|
+| Page 2 of library returns 0 items | `didPushdown` flag in `service_filtering.go`; check `list-cache` key format |
+| iTunes book shows `file_not_found` | Run `maintenance.itunes-heal`; check `FilePath` vs actual disk path |
+| Dedup false positives | Run `maintenance.dedup-exact-triage`; check stub/fragment/title_leak counts |
+| High memory usage | Check cache warm-up (`internal/cache`); disable warm-ups if RSS > 2 GB |
+| Transcribed fields are wrong | Run `maintenance.transcribe-book-intros` with `reparse_only=true` |
+| Fingerprinting not progressing | Check `FingerprintFailedAt` on `BookFile`; fpcalc may need reinstall |
+| memdb shows stale counts | `InvalidateLibraryStats` should have been called; check for missed `UpdateBook` callers |
+| Operation stuck in "running" | Check `opv2:act:<id>` key exists; if server restarted mid-op, op may need manual cancel |
+
+## Cross-references
+
+- Component inventory: [components.md](components.md)
+- Architecture: [architecture.md](architecture.md)
+- Runbooks: [runbooks.md](runbooks.md)

--- a/docs/system/pipelines.md
+++ b/docs/system/pipelines.md
@@ -1,0 +1,148 @@
+<!-- file: docs/system/pipelines.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2c3d4e5-f6a7-8901-bcde-f01234567890 -->
+<!-- last-edited: 2026-06-29 -->
+
+# Data Pipelines
+
+This document describes the major data pipelines: how audiobooks flow from raw files on disk through scanning, metadata enrichment, fingerprinting, deduplication, organization, and transcription.
+
+## Pipeline Overview
+
+```mermaid
+flowchart LR
+    Disk["Disk\n(import paths)"] --> Scanner["Scanner\ninternal/scanner"]
+    Scanner --> ExtractMeta["Extract Metadata\n(taglib / mediainfo)"]
+    ExtractMeta --> DB["PebbleDB\n+ memdb"]
+    DB --> MetaFetch["Metadata Fetch\n(Open Library / Google Books)"]
+    MetaFetch --> MetaApply["Metadata Apply\n(runApplyPipeline)"]
+    MetaApply --> DB
+    DB --> Fingerprint["AcoustID Fingerprint\n(fpcalc + Chromaprint)"]
+    Fingerprint --> DB
+    DB --> Dedup["Dedup Engine\ninternal/dedup"]
+    Dedup --> DB
+    DB --> Organize["Organizer\ninternal/organizer"]
+    Organize --> Disk2["Organized Library\n(/mnt/bigdata/books/audiobook-organizer/)"]
+    DB --> Transcribe["Intro Transcription\n(Whisper / batch.py)"]
+    Transcribe --> DB
+```
+
+## Scan → Store Pipeline
+
+The scanner (`internal/scanner`) walks configured import paths, groups audio files into logical books (by album+artist tag, or filename sequence if tags are absent), extracts metadata via `taglib` and `mediainfo`, and upserts into PebbleDB via `saveBookToDatabase`.
+
+Key rules:
+- iTunes import paths are excluded from scanning (configured `SkipPaths`)
+- Multi-file dedup: `SegmentHashes` are carried forward to avoid re-hashing on the write pass (PERF-2b)
+- Books with no-tag sequential files are grouped by folder name as title (AP-5)
+
+```mermaid
+sequenceDiagram
+    participant Sched as Scheduler
+    participant Scanner as internal/scanner
+    participant FS as Filesystem
+    participant Tagger as internal/tagger
+    participant DB as PebbleDB + memdb
+
+    Sched->>Scanner: RunScan(ctx, reporter)
+    Scanner->>FS: walk import paths
+    FS-->>Scanner: file list
+    Scanner->>Tagger: ExtractMetadata(file)
+    Tagger-->>Scanner: tags (title, author, narrator, isbn…)
+    Scanner->>DB: UpsertBook + UpsertBookFiles (batch)
+    Scanner->>DB: InvalidateLibraryStats
+    Scanner-->>Sched: progress updates
+```
+
+## Metadata Fetch → Apply Pipeline
+
+After scan, books without curated metadata enter the metadata fetch queue. `internal/metafetch` queries Open Library, Google Books, and (optionally) an Audible scraper, scores candidates, and stores the best match.
+
+`runApplyPipeline` applies the fetched metadata:
+1. Checks `isProtectedPath` — aborts if book is in a protected location
+2. Calls `ensureLibraryCopy` + `syncMetadataToLibraryCopy` to get fresh data
+3. Writes curated fields to PebbleDB via `UpdateBook` (full column replacement)
+4. Enqueues ISBN enrichment (Open Library background goroutine)
+
+**Critical:** `UpdateBook` does a FULL column replacement. Always supply all fields or data will be wiped.
+
+**Tag priority for author:** `album_artist > artist > composer` (composer = narrator in audiobooks).
+
+## Metadata Review State Machine
+
+Books track their manual review status in `MetadataReviewStatus`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> nil: book created
+    nil --> matched: operator approves match
+    nil --> no_match: operator rejects all candidates
+    matched --> nil: operator clears review
+    no_match --> nil: operator clears review
+    matched --> audio_confirmed: transcription confirms title+author
+```
+
+Values: `null` (unreviewed), `"matched"` (operator approved), `"no_match"` (operator rejected), `"audio_confirmed"` (Whisper transcription confirms metadata).
+
+## Fingerprint Pipeline
+
+`internal/fingerprint` runs `fpcalc` (Chromaprint) on each audio file and submits to the AcoustID API. Results are stored in `BookFile.AcoustIDFingerprint` and `AcoustIDFingerprintDurationSec`.
+
+- Permanent-failure tombstone: if `fpcalc`/`ffmpeg` fails, `FingerprintFailedAt` is written; the LSH indexer skips these from re-enqueue
+- memdb strips `AcoustIDFingerprint` (large field); use `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has fingerprint"
+
+## Dedup Pipeline
+
+`internal/dedup` (unified scoring engine):
+1. LSH (Locality-Sensitive Hashing) indexes 275K+ fingerprints
+2. Candidate pairs are scored across multiple signals: exact file hash, ISBN/ASIN, metadata hash, AcoustID similarity, local embeddings (bge-m3)
+3. Results stored as dedup pairs in PebbleDB
+4. Triage op (`maintenance.dedup-exact-triage`) classifies pairs: genuine / stub / fragment / title_leak / unknown
+
+**Caution:** Purge ops are irreversible. Always run dry-run triage first.
+
+## Organization Pipeline
+
+`internal/organizer` moves/renames files according to a configurable template (e.g. `{Author}/{Series}/{Title}`). The `PR #1062` fix suppresses `{Title} - {Title}` doubled folder names.
+
+- Copy-on-write: `.bak-*` files with TTL cleanup via maintenance
+- Path history tracked in `book_path_history` (migration 35)
+- Cover art embedded during write-back via `taglib.WriteImage`; old covers archived to `covers/history/` with SHA-256 dedup
+
+## Transcription (Intro) Pipeline
+
+`maintenance.transcribe-book-intros` extracts the first 90 seconds of each book's first audio file and transcribes it using Whisper (`batch_whisper.py`, embedded via `//go:embed`).
+
+```mermaid
+sequenceDiagram
+    participant Op as transcribe-book-intros op
+    participant DB as PebbleDB
+    participant FFmpeg as ffmpeg workers (×4)
+    participant Whisper as batch_whisper.py (GPU)
+    participant Parser as ParseAudiobookIntro
+
+    Op->>DB: cursor-paginate books (200/page)
+    Op->>FFmpeg: extract 90s WAV per book (parallel)
+    FFmpeg-->>Op: WAV files
+    Op->>Whisper: TranscribeBatch(wavFiles)
+    Whisper-->>Op: transcription texts
+    Op->>Parser: ParseAudiobookIntro(text)
+    Parser-->>Op: IntroFields{Title, Author, Narrator}
+    Op->>DB: UpdateBook (TranscribedTitle/Author/Narrator, IntroTranscription, IntroTranscribedAt)
+    Op->>DB: reporter.Checkpoint(lastBookID)
+```
+
+Key params:
+- `reparse_only=true` — re-runs the parser on stored transcripts only (no ffmpeg/Whisper). Use to apply parser fixes to existing books cheaply.
+- Transcribed fields are stored separately from curated metadata (`TranscribedTitle` ≠ `Title`) so errors cannot overwrite manually curated data.
+- Model: `base.en` for bulk run; `small.en` for targeted re-runs on empty-parse books.
+
+## Background Scheduling
+
+`internal/scheduler` runs maintenance windows and scheduled operations. The `maintenance.window` op fires nightly and dispatches sub-ops: scan, fingerprint backfill, dedup sweep, cover art sync, activity compaction.
+
+## Cross-references
+
+- Architecture overview: [architecture.md](architecture.md)
+- HTTP API for launching ops: [api.md](api.md)
+- Storage layer: [storage.md](storage.md)

--- a/docs/system/runbooks.md
+++ b/docs/system/runbooks.md
@@ -1,0 +1,175 @@
+<!-- file: docs/system/runbooks.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e5f6a7b8-c9d0-1234-ef01-234567890123 -->
+<!-- last-edited: 2026-06-29 -->
+
+# Operator Runbooks
+
+This document collects operational procedures for building, deploying, recovering, and maintaining the Audiobook Organizer in production.
+
+**Production host:** `172.16.2.30` (Linux, x86_64/amd64, ZFS raidz2 + NVMe special vdev)
+
+## Deploy Runbook
+
+```mermaid
+flowchart TD
+    Start["Start: changes merged to main"] --> Pull["git pull origin main"]
+    Pull --> Build["make build\n(npm install + npm run build + go build -tags embed_frontend)"]
+    Build --> Verify["Verify binary: file audiobook-organizer"]
+    Verify --> SCP["make deploy\n(cross-compile linux/amd64 + scp to 172.16.2.30)"]
+    SCP --> Restart["ssh 172.16.2.30 'sudo systemctl restart audiobook-organizer'"]
+    Restart --> Smoke["Smoke: GET /api/v1/auth/status → 200"]
+    Smoke --> Done["Done"]
+
+    Build -->|"failure"| FixBuild["Fix build error\n(npm lint, go vet, etc.)"]
+    FixBuild --> Build
+```
+
+### Step-by-step
+
+1. Ensure you are on `main` with a clean working tree: `git status`
+2. Run the full build: `make build` — this runs `npm install`, `npm run build`, and `go build -tags embed_frontend -o audiobook-organizer`
+3. Deploy: `make deploy` — cross-compiles for linux/amd64 and copies to the server. Never substitute manual scp; always run `make deploy` verbatim.
+4. Restart the service: `ssh 172.16.2.30 'sudo systemctl restart audiobook-organizer'`
+5. Smoke check: `curl -s https://172.16.2.30/api/v1/auth/status` should return `{"data": {...}}`
+6. Monitor logs for 60 seconds: `ssh 172.16.2.30 'journalctl -u audiobook-organizer -f --since now'`
+
+For debug builds (verbose logging): use `make deploy-debug` instead of `make deploy`.
+
+### Systemd service
+
+The service is managed as `audiobook-organizer.service`. Server-specific config (env vars, ExecStart overrides) is in `deploy/local.conf` (gitignored) and deployed as a systemd drop-in at `/etc/systemd/system/audiobook-organizer.service.d/local.conf`.
+
+```bash
+# Service control
+sudo systemctl status audiobook-organizer
+sudo systemctl start audiobook-organizer
+sudo systemctl stop audiobook-organizer
+sudo systemctl restart audiobook-organizer
+
+# Reload drop-in config
+sudo systemctl daemon-reload
+sudo systemctl restart audiobook-organizer
+```
+
+## Reparse Intro Transcriptions (No GPU Required)
+
+Use when a parser fix has been shipped and you need to re-extract `TranscribedTitle/Author/Narrator` from already-stored transcription text without running Whisper again.
+
+```bash
+curl -X POST https://172.16.2.30/api/v1/operations/v2 \
+  -H "Authorization: Bearer abk_..." \
+  -H "Content-Type: application/json" \
+  -d '{"def_id":"maintenance.transcribe-book-intros","params":{"reparse_only":true}}'
+```
+
+Poll for completion:
+```bash
+# Get op ID from the POST response, then:
+curl -s https://172.16.2.30/api/v1/operations/v2/<OP_ID> \
+  -H "Authorization: Bearer abk_..."
+```
+
+Expected outcome: parser rewrites `TranscribedTitle/Author/Narrator` for all books with an existing `IntroTranscription`. No ffmpeg or GPU required. First prod run corrected ~80% of transcribed books.
+
+## Full Intro Transcription Run (GPU Required)
+
+Only run on the GPU machine (GTX 1050 Ti, sm_61). Requires the Windows GPU machine to be reachable from the server.
+
+```bash
+curl -X POST https://172.16.2.30/api/v1/operations/v2 \
+  -H "Authorization: Bearer abk_..." \
+  -H "Content-Type: application/json" \
+  -d '{"def_id":"maintenance.transcribe-book-intros","params":{}}'
+```
+
+- 200 books per page; 4 parallel ffmpeg workers extract 90s WAV per book
+- One Python/Whisper process per page (model loads once, not once per book)
+- Checkpoint written after each page; safe to restart server mid-run
+- Expected time: ~2–3h on GPU (vs. ~62h without batch mode)
+
+## Dedup Triage and Purge (Dry-Run First)
+
+**CAUTION:** Dedup purge ops are irreversible. Always run the triage op first and review the breakdown before authorizing purge.
+
+```bash
+# Step 1: dry-run triage (read-only)
+curl -X POST https://172.16.2.30/api/v1/operations/v2 \
+  -H "Authorization: Bearer abk_..." \
+  -d '{"def_id":"maintenance.dedup-exact-triage"}'
+
+# Review: check that the "genuine" count is reasonable and "stub"/"fragment"
+# counts match expectations before proceeding.
+
+# Step 2 (only after review): purge confirmed purgeable candidates
+# curl -X POST ... -d '{"def_id":"maintenance.dedup-auto-purge"}'
+```
+
+Purge skips books with iTunes persistent IDs (PID). Never auto-purge books linked to iTunes.
+
+## Backup and Restore
+
+### Create backup
+
+```bash
+curl -X POST https://172.16.2.30/api/v1/backup/create \
+  -H "Authorization: Bearer abk_..."
+```
+
+This uses PebbleDB's built-in checkpoint API (`PebbleStore.Checkpoint`) for a consistent point-in-time snapshot. The backup is written to the configured backup directory on the server.
+
+### Restore
+
+1. Stop the service: `sudo systemctl stop audiobook-organizer`
+2. Replace the PebbleDB directory: `cp -a /backup/audiobooks.pebble /var/lib/audiobook-organizer/audiobooks.pebble`
+3. Restart: `sudo systemctl start audiobook-organizer`
+4. Wait for memdb warmup (~30s on a 50K-book library)
+
+## memdb Warmup Recovery
+
+On server start, all books are loaded from PebbleDB into the in-memory query layer (memdb). For a 50K-book library, this takes approximately 30 seconds. During warmup:
+
+- The API is available but slow (some queries fall back to PebbleDB scans)
+- Library list pages may show incorrect counts until warmup completes
+- Do not restart the service again during warmup
+
+Check warmup progress in logs:
+```bash
+journalctl -u audiobook-organizer | grep "memdb"
+```
+
+## iTunes Path Heal
+
+If organize moved files and iTunes paths became stale (FilePath records no longer resolve):
+
+```bash
+curl -X POST https://172.16.2.30/api/v1/operations/v2 \
+  -H "Authorization: Bearer abk_..." \
+  -d '{"def_id":"maintenance.itunes-heal"}'
+```
+
+This op parses the iTunes XML, builds a filename index of the organized library, and heals stale paths using author/album/track-number signals. Idempotent (uses ZFS reflinks). First run healed 2,274 tracks; 0 errors.
+
+## Known CI Noise
+
+These CI issues are pre-existing and not caused by your changes:
+
+| Issue | Root cause | Action |
+|---|---|---|
+| Mock freshness drift (`mocks-check`) | `mockery` interface{}/any drift between mockery versions | Run `make mocks` to regenerate; commit if `make mocks-check` passes |
+| Flaky backup tests | Race between backup goroutine and test teardown | Rerun; if consistently failing, investigate lock ordering |
+| Flaky scan tests | Filesystem timing on slow CI runners | Rerun up to 3x before investigating |
+
+## API Key Reference
+
+- API keys are prefixed `abk_`
+- Obtain via browser login → Settings → API Keys, or via `POST /api/v1/auth/api-keys`
+- Bootstrap key (first-run): `POST /api/v1/auth/bootstrap` → `response.data.api_key`
+- Never commit API keys to source control
+- Credentials for CI are stored in the repository secrets, not in `.env` files
+
+## Cross-references
+
+- Build commands: [CLAUDE.md](../../CLAUDE.md)
+- Pipelines (operation internals): [pipelines.md](pipelines.md)
+- Storage (backup locations): [storage.md](storage.md)

--- a/docs/system/storage.md
+++ b/docs/system/storage.md
@@ -1,0 +1,222 @@
+<!-- file: docs/system/storage.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c3d4e5f6-a7b8-9012-cdef-012345678901 -->
+<!-- last-edited: 2026-06-29 -->
+
+# Storage Architecture
+
+Audiobook Organizer uses three complementary storage tiers: PebbleDB (durable primary KV store), memdb (in-process in-memory query layer populated at startup), and NutsDB (append-optimized activity log). An optional SQLite tier exists for legacy/opt-in use.
+
+## Storage Tiers at a Glance
+
+```mermaid
+graph TD
+    subgraph "Durability"
+        Pebble["PebbleDB\n/var/lib/audiobook-organizer/audiobooks.pebble\nSorted KV — primary source of truth"]
+        NutsDB["NutsDB\n/var/lib/audiobook-organizer/activity.nutsdb\nActivity log — append-optimized BTree buckets"]
+    end
+    subgraph "In-Process (non-durable)"
+        MemDB["memdb\n(hashicorp/go-memdb)\nIn-memory query index — rebuilt on startup"]
+    end
+    subgraph "Legacy / opt-in"
+        SQLite["SQLite\n(opt-in; legacy activity log)"]
+    end
+
+    Pebble -->|"startup load"| MemDB
+    Pebble --> NutsDB
+```
+
+## PebbleDB Key Conventions
+
+PebbleDB is a sorted key–value store. All keys use colon-delimited prefixes for prefix-scan efficiency. Values are JSON with a `version` field for forward compatibility. IDs are ULIDs (26-char Crockford base32, time-sortable).
+
+### Primary Entity Prefixes
+
+| Prefix | Entity | Notes |
+|---|---|---|
+| `meta:` | Global metadata and counters | Config blobs, startup flags |
+| `mig:` | Migration records | Applied migration IDs |
+| `u:` | Users | `u:<userULID>` |
+| `ua:` | User auth secrets/hashes | argon2id password hashes |
+| `sess:` | Sessions | Short-lived session tokens |
+| `pref:` | User preferences | Per-user config |
+| `authz:` | Role/permission maps | |
+| `a:` | Authors | `a:<authorULID>` |
+| `s:` | Series | `s:<seriesULID>` |
+| `w:` | Works | Logical title grouping across editions |
+| `b:` | Books | `b:<bookULID>` — primary audiobook entity |
+| `bf:` | Book file segments | Physical media files |
+| `bfi:` | Book→segment ordering index | |
+| `pl:` | Playlists | |
+| `pli:` | Playlist items | Ordered |
+| `playe:` | Playback events | Append-only log |
+| `playp:` | Playback progress | Latest snapshot per book |
+| `stats:` | Derived aggregates | e.g. `stats:library` |
+| `op:` | Operations (legacy v1) | |
+| `opl:` | Operation logs | |
+| `opv2:` | Operations v2 | `opv2:<opID>` — full state |
+| `opv2:act:` | Active operation set | `opv2:act:<opID>` → `""` (queued/running) |
+
+### Secondary Index Prefixes
+
+| Prefix pattern | Resolves to |
+|---|---|
+| `idx:user:username:<lower>` | `<userULID>` |
+| `idx:user:email:<lower>` | `<userULID>` |
+| `idx:author:name:<normalized>` | `<authorULID>` |
+| `idx:series:name:<normalized>` | `<seriesULID>` |
+| `idx:series:author:<authorULID>:<seriesULID>` | `1` |
+| `idx:book:author:<authorULID>:<bookULID>` | `1` |
+| `idx:book:series:<seriesULID>:<posPadded>:<bookULID>` | `1` |
+| `idx:book:title:<normalized>:<bookULID>` | `1` |
+| `idx:book:tag:<tagLower>:<bookULID>` | `1` |
+| `idx:book:isbn10:<isbn10norm>:<bookULID>` | `1` |
+| `idx:book:isbn13:<isbn13norm>:<bookULID>` | `1` |
+| `idx:work:title:<normalizedTitle>:author:<authorULID>` | `<workULID>` |
+| `idx:book:work:<workULID>:<bookULID>` | `1` |
+| `external_id_map` prefix | iTunes PID → bookULID mapping (migration 34) |
+
+### Cached Aggregate Pattern
+
+The library count aggregate (`stats:library`) uses a lazy dirty-flag pattern to avoid expensive full-library scans on every request:
+
+1. On write operations (`UpdateBook`, `DeleteBook`, etc.), `InvalidateLibraryStats` deletes the `stats:library` key (marks dirty)
+2. On read, if the key is missing (dirty) AND the min-recompute interval has elapsed (default 10 min, env `LIBRARY_COUNTS_CACHE_MIN_INTERVAL_SECONDS`), the store recomputes and writes the aggregate
+3. A `libraryCountsRecomputeMu` mutex prevents stampede when N callers simultaneously see a dirty cache
+
+## memdb In-Memory Query Layer
+
+At startup, PebbleDB data is loaded into `hashicorp/go-memdb` for O(1) index lookups without PebbleDB's scan overhead. The memdb schema (`internal/database/memdb_schema.go`) defines tables and indexes:
+
+### Tables
+
+| Table constant | Description |
+|---|---|
+| `books` | All books with their metadata |
+| `authors` | Author records |
+| `series` | Series records |
+| `book_files` | Physical file segments |
+| `narrators` | Narrator records |
+| `book_authors` | Book↔author join |
+| `book_narrators` | Book↔narrator join |
+| `import_paths` | Configured import directory paths |
+| `author_aliases` | Author name alias mappings |
+| `blocked_hashes` | File hashes blocked from import |
+
+### Key Indexes
+
+| Index | Table | Accelerates |
+|---|---|---|
+| `id` | all | Primary key lookup |
+| `title` | books | Title-based filtering and sort |
+| `author_id` | books | Author→books list |
+| `series_id` | books | Series→books list |
+| `book_id` | book_files | Book→segments |
+| `narrator_id` | book_narrators | Narrator→books |
+| `file_path` | book_files | Path dedup, file existence checks |
+| `file_hash` | book_files | Hash-based dedup |
+| `is_primary_version` | books | Primary-version filter |
+| `marked_for_deletion` | books | Soft-delete filtering |
+| `version_group_id` | books | Version group membership |
+| `itunes_persistent_id` | book_files | iTunes PID lookup |
+| `missing` | book_files | Missing-file report |
+| `path` | books | Library path dedup |
+| `enabled` | import_paths | Active import path list |
+| `alias_name` | author_aliases | Alias resolution |
+| `hash` | blocked_hashes | Blocked file detection |
+| `deluge_hash` | book_files | Deluge torrent hash |
+
+**Critical gotcha:** memdb strips `AcoustIDFingerprint` (large blob field) from `BookFile` rows. Use `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has fingerprint". See `stripBookFileForMemdb`.
+
+**Critical gotcha:** `GetAllBooksFrom` with the memdb path has cursor pagination that was silently capped at 2×limit (~400 books) before PR #1647. Use `ListBookIDs + RunItems` for full-library jobs; verify mid-library not just head/tail.
+
+## NutsDB Activity Log
+
+NutsDB stores the activity log in BTree buckets. The bucket naming convention:
+
+| Bucket pattern | Key format | Value |
+|---|---|---|
+| `act:<tier>` | `<20-digit-unix-nano>:<ulid>` | JSON `ActivityEntry` |
+| `act:op:<op_id>` | `<timekey>` | `<tier>:<timekey>` (op index) |
+| `act:bk:<book_id>` | `<timekey>` | `<tier>:<timekey>` (book index) |
+
+Tiers map to activity types (scan, organize, metadata_apply, tag_write, etc.). Daily digest compaction is performed by `CompactByDay` (also called via `POST /api/v1/admin/recompact-digests`).
+
+A dual-write adapter (`dual_write_activity_store.go`) bridges the legacy SQLite activity log during migration.
+
+## SQLite (opt-in legacy)
+
+SQLite is available for the legacy activity log. New deployments use NutsDB exclusively. The SQLite path is disabled by default and exists for backward compatibility with pre-NutsDB deployments.
+
+## Filesystem Assets
+
+Beyond the database, these filesystem paths are relevant:
+
+| Path | Contents |
+|---|---|
+| `/var/lib/audiobook-organizer/audiobooks.pebble` | PebbleDB data directory |
+| `/var/lib/audiobook-organizer/activity.nutsdb` | NutsDB activity log |
+| `/mnt/bigdata/books/audiobook-organizer/` | Organized audiobook library root |
+| `/mnt/bigdata/books/itunes/iTunes Library.xml` | iTunes XML (88K tracks / 11.7K albums) |
+| `covers/history/` | Archived cover art (SHA-256 dedup) |
+| `covers/dedup/{hash}.{ext}` | Identical covers stored once |
+
+## Entity Relationship Overview
+
+```mermaid
+erDiagram
+    BOOK {
+        string ID PK
+        string Title
+        string AuthorID FK
+        string SeriesID FK
+        string MetadataReviewStatus
+        string TranscribedTitle
+        string TranscribedAuthor
+        string TranscribedNarrator
+        string ISBN10
+        string ISBN13
+        bool IsPrimaryVersion
+        string VersionGroupID
+    }
+    AUTHOR {
+        string ID PK
+        string Name
+    }
+    SERIES {
+        string ID PK
+        string Name
+        string AuthorID FK
+    }
+    BOOK_FILE {
+        string ID PK
+        string BookID FK
+        string FilePath
+        string ITunesPath
+        string FileHash
+        string AcoustIDFingerprint
+        float64 AcoustIDFingerprintDurationSec
+        string ITunesPersistentID
+        timestamp FingerprintFailedAt
+    }
+    WORK {
+        string ID PK
+        string Title
+        string AuthorID FK
+    }
+    EXTERNAL_ID_MAP {
+        string ITunesPID PK
+        string BookID FK
+    }
+
+    BOOK }o--|| AUTHOR : "authored by"
+    BOOK }o--o| SERIES : "belongs to"
+    BOOK ||--o{ BOOK_FILE : "has segments"
+    BOOK }o--o| WORK : "edition of"
+    BOOK_FILE ||--o| EXTERNAL_ID_MAP : "mapped from iTunes PID"
+```
+
+## Cross-references
+
+- Architecture: [architecture.md](architecture.md)
+- API for querying storage: [api.md](api.md)


### PR DESCRIPTION
## Summary

Completes the system-docs workstream (DOCS-1) with 6 new area docs plus a README update:

- **architecture.md** — runtime shape, component flowchart (Mermaid), service registry key table, layer responsibilities, build tags
- **pipelines.md** — scan→store, metadata fetch→apply, transcription (Whisper batch), dedup, organizer; sequence diagram + state machine (Mermaid)
- **storage.md** — PebbleDB key conventions, memdb tables/indexes with gotchas, NutsDB buckets, cached-aggregate pattern, ER diagram (Mermaid)
- **api.md** — auth (Bearer only), endpoint reference table by resource, operations-v2 lifecycle sequence diagram (Mermaid), known def_ids
- **runbooks.md** — deploy flowchart (Mermaid), reparse-intros, full GPU transcription, dedup triage/purge, backup/restore, memdb warmup, iTunes heal, CI noise table
- **components.md** — 55-package inventory table, dependency flowchart (Mermaid), frontend surfaces
- **incidents.md** — 6 incidents (INC-01 through INC-06) + 3 architectural decisions + Gantt timeline (Mermaid) + diagnostic entry points

All docs are grounded in actual code (package names, function names, PR numbers, key conventions verified against source).

## Test plan

- [ ] Verify Mermaid diagrams render in GitHub preview (each file has at least one)
- [ ] Spot-check cross-links (architecture.md → storage.md, etc.) resolve to existing files
- [ ] Confirm file headers are present with version 1.0.0 and guid

Closes TASK-02 through TASK-07 from docs/agent-tasks/system-docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP