### PR TITLE
feat(maintenance): auto-match-transcribed batch operation (dry-run gated)

### DIFF
--- a/internal/plugins/maintenance/auto_match_transcribed.go
+++ b/internal/plugins/maintenance/auto_match_transcribed.go
@@ -1,0 +1,221 @@
+// file: internal/plugins/maintenance/auto_match_transcribed.go
+// version: 1.0.0
+// guid: 7a3b5c1d-2e4f-6a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-06-29
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// autoMatchTranscribedParams is the checkpoint/input state for a
+// maintenance.auto-match-transcribed run.
+type autoMatchTranscribedParams struct {
+	// LastBookID is the resume checkpoint. On restart, processing skips every
+	// book whose ID comes before (and including) this value in ListBookIDs order.
+	LastBookID string `json:"last_book_id,omitempty"`
+	// DryRun defaults to true when nil. The op MUST NOT mutate any book unless
+	// this is explicitly set to false.
+	DryRun *bool `json:"dry_run,omitempty"`
+	// MinScore is the minimum candidate score required to qualify for apply.
+	// Defaults to 0.75 when ≤0. Scores are uncapped (transcription boosts can
+	// push them above 1.0), so 0.75 sits well above a random token-overlap hit.
+	MinScore float64 `json:"min_score,omitempty"`
+}
+
+func (p *Plugin) autoMatchTranscribedDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:             "maintenance.auto-match-transcribed",
+		Plugin:         "maintenance",
+		DisplayName:    "Auto-match transcribed books",
+		Description:    "Walks the library and auto-applies the best metadata candidate to unreviewed books whose audio-derived transcription exactly matches a search result above a configurable score threshold. Dry-run by default — pass dry_run=false to apply. Checkpointed and cancellable.",
+		ResumePolicy:   sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey: "maintenance.auto-match-transcribed",
+		Cancellable:    true,
+		Timeout:        12 * time.Hour,
+		Run:            p.runAutoMatchTranscribed,
+	}
+}
+
+func (p *Plugin) runAutoMatchTranscribed(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if !p.deps.HasMetadataFetchService() {
+		return fmt.Errorf("metadata fetch service not initialized; cannot run auto-match-transcribed")
+	}
+
+	var params autoMatchTranscribedParams
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &params)
+	}
+
+	// Default dry_run to true — safety first.
+	dryRun := params.DryRun == nil || *params.DryRun
+
+	// Default min_score to 0.75.
+	minScore := params.MinScore
+	if minScore <= 0 {
+		minScore = 0.75
+	}
+
+	log := reporter.Logger()
+
+	allIDs, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("list book ids: %w", err)
+	}
+	total := len(allIDs)
+
+	// Resume: find where to restart from the checkpoint.
+	startIdx := 0
+	if params.LastBookID != "" {
+		for i, id := range allIDs {
+			if id == params.LastBookID {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+
+	log.Info("auto-match-transcribed: starting",
+		"dry_run", dryRun, "min_score", minScore,
+		"total_books", total, "start_index", startIdx)
+
+	if startIdx >= total {
+		_ = reporter.UpdateProgress(total, total, "nothing to process — already at end")
+		return nil
+	}
+
+	var scanned, eligible, applied int
+
+	// lastID tracks the most-recently visited book for checkpoint writes.
+	lastID := params.LastBookID
+
+	err = registry.RunItems(ctx, reporter, allIDs[startIdx:], func(ctx context.Context, id string) error {
+		scanned++
+		b, getErr := store.GetBookByID(id)
+		if getErr != nil || b == nil {
+			return nil // non-fatal: skip missing / deleted books
+		}
+		lastID = id
+
+		// Only touch books that have never been reviewed.
+		if b.MetadataReviewStatus != nil {
+			return nil
+		}
+		// Must have an audio-derived title to search with.
+		if b.TranscribedTitle == nil || *b.TranscribedTitle == "" {
+			return nil
+		}
+
+		transTitle := *b.TranscribedTitle
+		transAuthor := ""
+		if b.TranscribedAuthor != nil {
+			transAuthor = *b.TranscribedAuthor
+		}
+
+		candTitle, candAuthor, score, found, searchErr := p.deps.SearchTranscriptionCandidate(
+			ctx, id, transTitle, transAuthor,
+		)
+		if searchErr != nil {
+			log.Warn("auto-match-transcribed: search failed",
+				"book_id", id, "err", searchErr)
+			return nil // non-fatal: move on to next book
+		}
+		if !found {
+			return nil
+		}
+
+		// Gate 1: candidate score must meet the threshold.
+		if score < minScore {
+			return nil
+		}
+
+		// Gate 2: normalized title must exactly match the transcribed title.
+		// This is the same normalization used by ApplyMetadataCandidate's
+		// audio-confirm path (TASK-02), ensuring the two checks agree.
+		if util.NormalizeTitle(candTitle) != util.NormalizeTitle(transTitle) {
+			return nil
+		}
+
+		// Gate 3: if the transcribed author is substantial (>3 chars), require
+		// that it appears inside the candidate author or vice versa. Mirrors the
+		// containsCI guard in service_scoring.go so the gate never fires on a
+		// short/empty token.
+		if len(transAuthor) > 3 {
+			al := strings.ToLower(candAuthor)
+			tl := strings.ToLower(transAuthor)
+			if !strings.Contains(al, tl) && !strings.Contains(tl, al) {
+				return nil
+			}
+		}
+
+		// All gates passed — this book is eligible.
+		eligible++
+
+		if dryRun {
+			log.Info("auto-match-transcribed: would-apply",
+				"book_id", id, "db_title", b.Title,
+				"candidate", candTitle, "score", score)
+			return nil // no mutation in dry-run
+		}
+
+		if applyErr := p.deps.ApplyTranscriptionCandidate(ctx, id, candTitle, candAuthor); applyErr != nil {
+			log.Warn("auto-match-transcribed: apply failed",
+				"book_id", id, "candidate", candTitle, "err", applyErr)
+			return nil // non-fatal: continue with remaining books
+		}
+		log.Info("auto-match-transcribed: applied",
+			"book_id", id, "db_title", b.Title, "candidate", candTitle, "score", score)
+		applied++
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:    1,
+		ProgressTotal:  total,
+		ProgressOffset: startIdx,
+		Label: func(i, t int) string {
+			return fmt.Sprintf("auto-match %d/%d — eligible: %d, applied: %d",
+				startIdx+i+1, t, eligible, applied)
+		},
+		CheckpointFn: func(_ context.Context) error {
+			dr := dryRun
+			return reporter.Checkpoint(autoMatchTranscribedParams{
+				LastBookID: lastID,
+				DryRun:     &dr,
+				MinScore:   minScore,
+			})
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	var summary string
+	if dryRun {
+		summary = fmt.Sprintf(
+			"auto-match-transcribed complete (dry-run): scanned %d, eligible %d, would-apply %d",
+			scanned, eligible, eligible,
+		)
+	} else {
+		summary = fmt.Sprintf(
+			"auto-match-transcribed complete: scanned %d, eligible %d, applied %d",
+			scanned, eligible, applied,
+		)
+	}
+	log.Info(summary)
+	_ = reporter.UpdateProgress(total, total, summary)
+	return nil
+}

--- a/internal/plugins/maintenance/auto_match_transcribed_test.go
+++ b/internal/plugins/maintenance/auto_match_transcribed_test.go
@@ -1,0 +1,200 @@
+// file: internal/plugins/maintenance/auto_match_transcribed_test.go
+// version: 1.0.0
+// guid: 3f7e9b2a-5c8d-4e1f-a0b3-6d9c2e5f8a1b
+// last-edited: 2026-06-29
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// autoMatchDeps wraps fakeDeps and overrides SearchTranscriptionCandidate and
+// ApplyTranscriptionCandidate so tests can inject results and count calls.
+type autoMatchDeps struct {
+	fakeDeps
+	searchFn func(ctx context.Context, bookID, transTitle, transAuthor string) (string, string, float64, bool, error)
+	applyFn  func(ctx context.Context, bookID, candTitle, candAuthor string) error
+	// call counters
+	searchCalled int
+	applyCalled  int
+}
+
+func (d *autoMatchDeps) SearchTranscriptionCandidate(ctx context.Context, bookID, transTitle, transAuthor string) (string, string, float64, bool, error) {
+	d.searchCalled++
+	if d.searchFn != nil {
+		return d.searchFn(ctx, bookID, transTitle, transAuthor)
+	}
+	return "", "", 0, false, nil
+}
+
+func (d *autoMatchDeps) ApplyTranscriptionCandidate(ctx context.Context, bookID, candTitle, candAuthor string) error {
+	d.applyCalled++
+	if d.applyFn != nil {
+		return d.applyFn(ctx, bookID, candTitle, candAuthor)
+	}
+	return nil
+}
+
+func (d *autoMatchDeps) HasMetadataFetchService() bool { return true }
+
+// ptr helpers
+
+func boolPtr(b bool) *bool   { return &b }
+func strPtr(s string) *string { return &s }
+
+// newAutoMatchPlugin builds a Plugin + MockStore wired to the given books.
+func newAutoMatchPlugin(books []database.Book, deps *autoMatchDeps) *Plugin {
+	store := &database.MockStore{
+		ListBookIDsFunc: func() ([]string, error) {
+			ids := make([]string, len(books))
+			for i, b := range books {
+				ids[i] = b.ID
+			}
+			return ids, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			for i := range books {
+				if books[i].ID == id {
+					return &books[i], nil
+				}
+			}
+			return nil, nil
+		},
+	}
+	deps.fakeDeps = fakeDeps{store: store}
+	return New(deps)
+}
+
+func autoMatchParams(dryRun bool, minScore float64) json.RawMessage {
+	b, _ := json.Marshal(autoMatchTranscribedParams{
+		DryRun:   boolPtr(dryRun),
+		MinScore: minScore,
+	})
+	return b
+}
+
+// TestAutoMatchTranscribed_Apply verifies that a book with a high-score
+// transcription match is applied when dry_run=false, and that
+// ApplyTranscriptionCandidate is called exactly once.
+func TestAutoMatchTranscribed_Apply(t *testing.T) {
+	trans := "The Name of the Wind"
+	author := "Patrick Rothfuss"
+	books := []database.Book{
+		{
+			ID:              "b1",
+			Title:           "Name Wind",
+			TranscribedTitle: strPtr(trans),
+			TranscribedAuthor: strPtr(author),
+			// MetadataReviewStatus == nil → eligible
+		},
+	}
+
+	deps := &autoMatchDeps{
+		searchFn: func(_ context.Context, _, _, _ string) (string, string, float64, bool, error) {
+			// Return exact title match with score above default 0.75 threshold.
+			return trans, author, 1.8, true, nil
+		},
+	}
+	p := newAutoMatchPlugin(books, deps)
+
+	if err := p.runAutoMatchTranscribed(context.Background(), autoMatchParams(false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.searchCalled != 1 {
+		t.Errorf("expected 1 search call, got %d", deps.searchCalled)
+	}
+	if deps.applyCalled != 1 {
+		t.Errorf("expected 1 apply call (dry_run=false), got %d", deps.applyCalled)
+	}
+}
+
+// TestAutoMatchTranscribed_DryRunNoApply verifies that a matching book is NOT
+// applied when dry_run=true — ApplyTranscriptionCandidate must be called 0 times.
+func TestAutoMatchTranscribed_DryRunNoApply(t *testing.T) {
+	trans := "The Name of the Wind"
+	author := "Patrick Rothfuss"
+	books := []database.Book{
+		{
+			ID:                "b1",
+			Title:             "Name Wind",
+			TranscribedTitle:  strPtr(trans),
+			TranscribedAuthor: strPtr(author),
+		},
+	}
+
+	deps := &autoMatchDeps{
+		searchFn: func(_ context.Context, _, _, _ string) (string, string, float64, bool, error) {
+			return trans, author, 1.8, true, nil
+		},
+	}
+	p := newAutoMatchPlugin(books, deps)
+
+	if err := p.runAutoMatchTranscribed(context.Background(), autoMatchParams(true, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.applyCalled != 0 {
+		t.Errorf("dry-run must not call Apply, got %d apply calls", deps.applyCalled)
+	}
+	// Search was still called — we evaluate the candidate even in dry-run.
+	if deps.searchCalled != 1 {
+		t.Errorf("expected 1 search call in dry-run, got %d", deps.searchCalled)
+	}
+}
+
+// TestAutoMatchTranscribed_NoTranscriptionSkipped verifies that books without a
+// TranscribedTitle are skipped entirely — neither search nor apply is called.
+func TestAutoMatchTranscribed_NoTranscriptionSkipped(t *testing.T) {
+	books := []database.Book{
+		{
+			ID:    "b1",
+			Title: "Some Untranscribed Book",
+			// TranscribedTitle == nil → no audio signal → skip
+		},
+	}
+
+	deps := &autoMatchDeps{}
+	p := newAutoMatchPlugin(books, deps)
+
+	if err := p.runAutoMatchTranscribed(context.Background(), autoMatchParams(false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.searchCalled != 0 {
+		t.Errorf("books without TranscribedTitle must be skipped: got %d search calls", deps.searchCalled)
+	}
+	if deps.applyCalled != 0 {
+		t.Errorf("books without TranscribedTitle must be skipped: got %d apply calls", deps.applyCalled)
+	}
+}
+
+// TestAutoMatchTranscribed_AlreadyReviewedSkipped verifies that books with a
+// non-nil MetadataReviewStatus are skipped — no search, no apply.
+func TestAutoMatchTranscribed_AlreadyReviewedSkipped(t *testing.T) {
+	status := "matched"
+	trans := "Already Matched Book"
+	books := []database.Book{
+		{
+			ID:                   "b1",
+			Title:                "Already Matched Book",
+			TranscribedTitle:     strPtr(trans),
+			MetadataReviewStatus: &status, // already reviewed → must be skipped
+		},
+	}
+
+	deps := &autoMatchDeps{}
+	p := newAutoMatchPlugin(books, deps)
+
+	if err := p.runAutoMatchTranscribed(context.Background(), autoMatchParams(false, 0), &fakeReporter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.searchCalled != 0 {
+		t.Errorf("already-reviewed books must be skipped: got %d search calls", deps.searchCalled)
+	}
+	if deps.applyCalled != 0 {
+		t.Errorf("already-reviewed books must be skipped: got %d apply calls", deps.applyCalled)
+	}
+}

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-06-24
+// last-edited: 2026-06-29
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -65,6 +65,28 @@ type ServerDeps interface {
 	InvalidateDedupCache()
 	// MetadataUpgradeRun runs the metadata upgrade scan up to limit books.
 	MetadataUpgradeRun(ctx context.Context, limit int) (checked, upgraded, skipped, errs int, err error)
+	// SearchTranscriptionCandidate finds the top-scoring metadata candidate for
+	// bookID using transTitle as the query. The returned score may exceed 1.0
+	// (uncapped scale with transcription boosts applied). Returns found=false
+	// when no candidates exist or the service is unavailable. The caller is
+	// responsible for applying score/title/author gates on the returned values.
+	SearchTranscriptionCandidate(
+		ctx context.Context,
+		bookID string,
+		transTitle string,
+		transAuthor string,
+	) (title string, author string, score float64, found bool, err error)
+	// ApplyTranscriptionCandidate applies the top metadata candidate whose
+	// title matches candTitle to the given book, re-fetching via the cached
+	// search path. Relies on TASK-02 audio-confirm logic to set
+	// MetadataReviewStatus="audio_confirmed" when the candidate title matches
+	// the book's transcribed title.
+	ApplyTranscriptionCandidate(
+		ctx context.Context,
+		bookID string,
+		candTitle string,
+		candAuthor string,
+	) error
 	// OptimizeAIScanStore optimizes the AI scan store (no-op if nil).
 	OptimizeAIScanStore() error
 	// OptimizeOLStore optimizes the OpenLibrary cache store (no-op if nil).

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-06-26
+// last-edited: 2026-06-29
 
 package maintenance
 
@@ -56,6 +56,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.metadataRefreshDef(),
 		p.metadataUpgradeDef(),
 		p.isbnEnrichmentDef(),
+		p.autoMatchTranscribedDef(),
 
 		// --- dedup ---
 		p.dedupLLMReviewDef(),

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-06-24
+// last-edited: 2026-06-29
 
 package maintenance
 
@@ -98,6 +98,10 @@ func (d fakeDeps) EnqueueOp(_ context.Context, _ string, _ any) (string, error) 
 	return "", nil
 }
 func (d fakeDeps) WaitForOp(_ context.Context, _ string) error { return nil }
+func (d fakeDeps) SearchTranscriptionCandidate(_ context.Context, _, _, _ string) (string, string, float64, bool, error) {
+	return "", "", 0, false, nil
+}
+func (d fakeDeps) ApplyTranscriptionCandidate(_ context.Context, _, _, _ string) error { return nil }
 
 var _ ServerDeps = fakeDeps{}
 

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-06-24
+// last-edited: 2026-06-29
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -343,6 +343,53 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		}
 	}
 	return report, nil
+}
+
+// SearchTranscriptionCandidate implements maintenance.ServerDeps.
+// It searches for the top-scoring metadata candidate using transTitle as the
+// query, optionally narrowed by transAuthor. Returns (title, author, score,
+// true, nil) when at least one candidate is found; (‟", "", 0, false, nil)
+// when the service is unavailable or no results exist; and a non-nil error
+// only on a hard failure from the metadata service.
+func (s *Server) SearchTranscriptionCandidate(_ context.Context, bookID, transTitle, transAuthor string) (string, string, float64, bool, error) {
+	if s.metadataFetchService == nil {
+		return "", "", 0, false, nil
+	}
+	var hints []string
+	if transAuthor != "" {
+		hints = append(hints, transAuthor)
+	}
+	resp, err := s.metadataFetchService.SearchMetadataForBook(bookID, transTitle, hints...)
+	if err != nil || resp == nil || len(resp.Results) == 0 {
+		return "", "", 0, false, err
+	}
+	best := resp.Results[0]
+	return best.Title, best.Author, best.Score, true, nil
+}
+
+// ApplyTranscriptionCandidate implements maintenance.ServerDeps.
+// It re-fetches candidates for the book (cache-backed, so a second call for
+// the same title is effectively instant) and applies the top result via
+// ApplyMetadataCandidate. TASK-02 audio-confirm logic sets
+// MetadataReviewStatus="audio_confirmed" when the candidate title matches the
+// book's transcribed title.
+func (s *Server) ApplyTranscriptionCandidate(_ context.Context, bookID, candTitle, candAuthor string) error {
+	if s.metadataFetchService == nil {
+		return fmt.Errorf("metadata fetch service not initialized")
+	}
+	var hints []string
+	if candAuthor != "" {
+		hints = append(hints, candAuthor)
+	}
+	resp, err := s.metadataFetchService.SearchMetadataForBook(bookID, candTitle, hints...)
+	if err != nil {
+		return fmt.Errorf("re-search before apply for book %s: %w", bookID, err)
+	}
+	if resp == nil || len(resp.Results) == 0 {
+		return fmt.Errorf("no candidates found when applying for book %s", bookID)
+	}
+	_, err = s.metadataFetchService.ApplyMetadataCandidate(bookID, resp.Results[0], nil)
+	return err
 }
 
 // WaitForOp implements maintenance.ServerDeps. It polls the database at 5-second


### PR DESCRIPTION
## Summary

- Adds `maintenance.auto-match-transcribed` operation that walks the full library and auto-applies the best metadata candidate to books whose audio-derived transcription exactly matches a search result above a configurable score threshold
- Dry-run by default (`dry_run=false` required to mutate); checkpointed and cancellable via `RunItems`
- Adds `SearchTranscriptionCandidate` + `ApplyTranscriptionCandidate` to `ServerDeps` (2-method split so the gate logic and dryRun branch live in testable op code, not in the delegation layer)

## Gate logic (all three must pass to qualify)

1. **Score ≥ min_score** (default 0.75; scores are uncapped — transcription boosts can push to 1.8+)
2. **`NormalizeTitle(candTitle) == NormalizeTitle(transTitle)`** — exact normalized match
3. **Author containsCI guard** (if `len(transAuthor) > 3`, either `candAuthor ⊇ transAuthor` or vice versa)

## Safety

- `DryRun=true` by default — no mutations without explicit `dry_run=false`
- Only touches books with `MetadataReviewStatus == nil`
- Respects context cancellation; checkpoints `LastBookID` via `RunItems.CheckpointFn`
- `ApplyMetadataCandidate` (TASK-02) sets `MetadataReviewStatus="audio_confirmed"` when transcription matches

## Test plan

- [x] `TestAutoMatchTranscribed_Apply` — high-score match, `dry_run=false` → `applyCalled=1`
- [x] `TestAutoMatchTranscribed_DryRunNoApply` — same candidate, `dry_run=true` → `applyCalled=0`
- [x] `TestAutoMatchTranscribed_NoTranscriptionSkipped` — nil `TranscribedTitle` → search and apply never called
- [x] `TestAutoMatchTranscribed_AlreadyReviewedSkipped` — non-nil `MetadataReviewStatus` → search and apply never called
- [x] `go build ./...` clean
- [x] `go test ./internal/plugins/maintenance/ ./internal/metafetch/ -count=1` green (4/4 new + all prior)
- [x] `go vet ./...` clean

## Depends on

TASK-02 (apply auto-confirm) — already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP