### PR TITLE
fix(transcribe): use AcoustID fingerprint as cache key, disable VAD

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-06-27
+// last-edited: 2026-06-30
 
 package maintenance
 
@@ -487,7 +487,13 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey st
 		return audio[i].FilePath < audio[j].FilePath
 	})
 	f := audio[0]
+	// Prefer content-stable keys so the cache survives file moves (organize renames).
+	// Priority: FileHash (SHA-256 of content) > AcoustIDFingerprint (acoustic hash) >
+	// path hash (last resort; breaks when files are renamed/moved).
 	key := f.FileHash
+	if key == "" && len(f.AcoustIDFingerprint) > 0 {
+		key = "fp:" + hex.EncodeToString(f.AcoustIDFingerprint)
+	}
 	if key == "" {
 		h := sha256.Sum256([]byte(f.FilePath))
 		key = "path:" + hex.EncodeToString(h[:])

--- a/scripts/whisper_server.py
+++ b/scripts/whisper_server.py
@@ -1,5 +1,5 @@
 # file: scripts/whisper_server.py
-# version: 2.3.0
+# version: 2.4.0
 # guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 # last-edited: 2026-06-30
 #
@@ -89,7 +89,7 @@ def _do_transcribe(data: bytes, filename: str) -> dict:
                 language="en",
                 task="transcribe",
                 batch_size=16,
-                vad_filter=True,
+                vad_filter=False,
             )
         else:
             segments, info = model.transcribe(
@@ -97,7 +97,7 @@ def _do_transcribe(data: bytes, filename: str) -> dict:
                 language="en",
                 task="transcribe",
                 beam_size=5,
-                vad_filter=True,
+                vad_filter=False,
             )
         text = " ".join(s.text for s in segments).strip()
         log.info(f"transcribed {filename}: {len(text)} chars, {info.duration:.1f}s audio")


### PR DESCRIPTION
## Summary

- **VAD filter disabled** (`vad_filter=False`): `BatchedInferencePipeline` was classifying every audio chunk as non-speech and stripping the entire clip before Whisper ran — every transcription returned 0 chars. `large-v2` handles mixed audio (music intros + speech) without pre-filtering.

- **Cache key priority fixed**: path-hash keys break when organize renames/moves files. New priority: `FileHash` > `AcoustIDFingerprint` (content-stable acoustic hash) > `path:{sha256}` (last resort). The 46K pre-extracted WAV clips in `.wav-cache/` that were path-keyed can now be addressed by acoustic fingerprint, surviving file moves.

## Test plan
- [ ] Start Windows whisper server: `$env:WHISPER_PORT="19847"; uv run C:\Users\jdfal\whisper_server.py large-v2`
- [ ] Launch transcription op — verify Windows server log shows chars > 0
- [ ] Confirm `TranscribedTitle` written to DB for books with fingerprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP