### PR TITLE
feat(transcribe): content-hash WAV cache — src SHA-256 + clip SHA-256

### DIFF
--- a/internal/plugins/maintenance/extract_wav_clips.go
+++ b/internal/plugins/maintenance/extract_wav_clips.go
@@ -1,14 +1,17 @@
 // file: internal/plugins/maintenance/extract_wav_clips.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e1f2a3b4-c5d6-7890-abcd-ef1234567890
-// last-edited: 2026-06-27
+// last-edited: 2026-06-30
 
 package maintenance
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -26,7 +29,7 @@ func (p *Plugin) extractWAVClipsDef() sdk.OperationDef {
 		ID:              "maintenance.extract-wav-clips",
 		Plugin:          "maintenance",
 		DisplayName:     "Extract WAV clips for transcription cache",
-		Description:     "Extracts the first 90 seconds of each book's first audio file and saves the result in {library}/.wav-cache/{hash}.wav. Run this before 'Transcribe book intros' to pre-fill the clip cache so transcription runs spend zero time on ffmpeg extraction.",
+		Description:     "Extracts the first 90 seconds of each book's first audio file and saves the result in {library}/.wav-cache/{hash}.wav. Also hashes the source file and the extracted clip, persists the source SHA-256 to BookFile.FileHash (when missing), and creates a content-stable hardlink so the transcription cache survives organize path changes.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.extract-wav-clips",
@@ -85,7 +88,7 @@ func (p *Plugin) runExtractWAVClips(ctx context.Context, rawParams json.RawMessa
 			if gerr != nil || b == nil {
 				continue
 			}
-			src, cacheKey, _ := firstAudioFile(store, *b)
+			src, cacheKey, bookFileID, _ := firstAudioFile(store, *b)
 			if src == "" || cacheKey == "" {
 				continue
 			}
@@ -101,7 +104,7 @@ func (p *Plugin) runExtractWAVClips(ctx context.Context, rawParams json.RawMessa
 			}
 
 			wg.Add(1)
-			go func(bookID, src, dest string) {
+			go func(bookID, src, dest, cacheKey, bookFileID string) {
 				defer wg.Done()
 				sem <- struct{}{}
 				defer func() { <-sem }()
@@ -113,17 +116,48 @@ func (p *Plugin) runExtractWAVClips(ctx context.Context, rawParams json.RawMessa
 					dest,
 				)
 				out, ferr := ffCmd.CombinedOutput()
+
 				mu.Lock()
 				defer mu.Unlock()
+
 				if ferr != nil {
 					log.Warn("extract-wav-clips: ffmpeg failed",
 						"book_id", bookID, "file", src,
 						"err", ferr, "output", strings.TrimSpace(string(out)))
 					failed++
-				} else {
-					extracted++
+					return
 				}
-			}(bookID, src, dest)
+
+				extracted++
+
+				// Hash the extracted WAV clip (small: 90s × 16kHz × 2B ≈ 2.9MB).
+				wavHash, werr := hashFileSHA256(dest)
+				if werr != nil {
+					wavHash = ""
+				}
+
+				// Hash the full source audio file and use it as a content-stable
+				// cache key. This survives organize path renames because the key
+				// is derived from file content, not location.
+				srcHash, serr := hashFileSHA256(src)
+				if serr == nil && srcHash != "" && !strings.HasPrefix(cacheKey, srcHash) {
+					// Create a hardlink named by content hash — zero extra disk space.
+					contentDest := cachedClipPath(cacheDir, srcHash)
+					if _, statErr := os.Stat(contentDest); os.IsNotExist(statErr) {
+						_ = os.Link(dest, contentDest)
+					}
+					// Persist to DB so future transcription runs skip the slow path.
+					if bookFileID != "" {
+						_ = store.SetBookFileHash(bookFileID, srcHash)
+					}
+				}
+
+				log.Info("extract-wav-clips: extracted",
+					"book_id", bookID,
+					"src_sha256", srcHash,
+					"wav_sha256", wavHash,
+					"file", src)
+			}(bookID, src, dest, cacheKey, bookFileID)
 		}
 		wg.Wait()
 
@@ -146,4 +180,18 @@ func (p *Plugin) runExtractWAVClips(ctx context.Context, rawParams json.RawMessa
 	_ = reporter.UpdateProgress(1, 1,
 		fmt.Sprintf("Done — %d extracted, %d already cached, %d failed", extracted, skipped, failed))
 	return nil
+}
+
+// hashFileSHA256 returns the hex-encoded SHA-256 digest of the file at path.
+func hashFileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -307,7 +307,7 @@ func (p *Plugin) processTranscribePage(
 	}
 	jobs := make([]bookJob, 0, len(books))
 	for _, b := range books {
-		src, hash, _ := firstAudioFile(store, b)
+		src, hash, _, _ := firstAudioFile(store, b)
 		jobs = append(jobs, bookJob{book: b, audioSrc: src, fileHash: hash})
 	}
 
@@ -449,14 +449,15 @@ var audioExtSet = map[string]bool{
 	".flac": true, ".aac": true, ".ogg": true, ".wma": true,
 }
 
-// firstAudioFile returns the path and a stable cache key for the first audio
-// file of book. It checks BookFile records first (multi-track books); when none
-// exist it falls back to book.FilePath directly (single-file iTunes imports that
-// were ingested without individual BookFile rows — the ~17K gap in the cache).
-func firstAudioFile(store database.Store, book database.Book) (path, cacheKey string, err error) {
+// firstAudioFile returns the path, a stable cache key, and the BookFile ID for
+// the first audio file of book. The BookFile ID is empty when falling back to
+// the book-level FilePath (single-file iTunes imports with no BookFile rows).
+// Cache key priority: FileHash (content SHA-256) > fp:AcoustIDFingerprint >
+// path:SHA-256(FilePath) — path-keyed entries break when organize renames files.
+func firstAudioFile(store database.Store, book database.Book) (path, cacheKey, bookFileID string, err error) {
 	files, err := store.GetBookFiles(book.ID)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	var audio []database.BookFile
@@ -473,9 +474,9 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey st
 		fp := book.FilePath
 		if fp != "" && audioExtSet[strings.ToLower(filepath.Ext(fp))] {
 			h := sha256.Sum256([]byte(fp))
-			return fp, "path:" + hex.EncodeToString(h[:]), nil
+			return fp, "path:" + hex.EncodeToString(h[:]), "", nil
 		}
-		return "", "", nil
+		return "", "", "", nil
 	}
 
 	sort.Slice(audio, func(i, j int) bool {
@@ -487,9 +488,6 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey st
 		return audio[i].FilePath < audio[j].FilePath
 	})
 	f := audio[0]
-	// Prefer content-stable keys so the cache survives file moves (organize renames).
-	// Priority: FileHash (SHA-256 of content) > AcoustIDFingerprint (acoustic hash) >
-	// path hash (last resort; breaks when files are renamed/moved).
 	key := f.FileHash
 	if key == "" && len(f.AcoustIDFingerprint) > 0 {
 		key = "fp:" + hex.EncodeToString(f.AcoustIDFingerprint)
@@ -498,7 +496,7 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey st
 		h := sha256.Sum256([]byte(f.FilePath))
 		key = "path:" + hex.EncodeToString(h[:])
 	}
-	return f.FilePath, key, nil
+	return f.FilePath, key, f.ID, nil
 }
 
 // wavCacheDir returns the directory used to cache extracted 90s WAV clips.


### PR DESCRIPTION
## Summary

- After each successful ffmpeg extraction, hash both the extracted WAV clip and the full source audio file
- Create a hardlink `{srcHash}.wav` alongside the path-keyed entry — zero extra disk space, cache survives `organize` path renames forever
- Persist `src_sha256` to `BookFile.FileHash` via `SetBookFileHash` so the **next transcription run finds it via content hash without re-hashing**
- `firstAudioFile` now returns `bookFileID` (4th return) so callers can write back to DB after extraction

## Why this matters

The old cache used `path:{sha256(FilePath)}` keys. After `organize` renamed files and updated DB paths, none of the 45,790 cached WAVs were reachable. Content-hash keys survive any path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP