### PR TITLE
fix(transcribe): hash AcoustID fingerprint before using as WAV cache filename

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.5.0
+// version: 3.6.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-30
 
@@ -490,7 +490,10 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey, b
 	f := audio[0]
 	key := f.FileHash
 	if key == "" && len(f.AcoustIDFingerprint) > 0 {
-		key = "fp:" + hex.EncodeToString(f.AcoustIDFingerprint)
+		// Hash the fingerprint — raw fingerprints are 400–2000 bytes;
+		// hex-encoding them directly exceeds the 255-byte Linux filename limit.
+		fpHash := sha256.Sum256(f.AcoustIDFingerprint)
+		key = "fp:" + hex.EncodeToString(fpHash[:])
 	}
 	if key == "" {
 		h := sha256.Sum256([]byte(f.FilePath))


### PR DESCRIPTION
## Root cause

`firstAudioFile` in `intro_transcribe.go` was building `fp:` cache keys by
directly hex-encoding raw `AcoustIDFingerprint` bytes:

```go
key = "fp:" + hex.EncodeToString(f.AcoustIDFingerprint)
```

AcoustID fingerprints are compressed chromaprint binaries — typically 400–2000 bytes.
Hex-encoding produces 800–4000 character strings, which exceed the 255-byte Linux
filename limit. `ffmpeg` exited with code 220 ("File name too long") for every book
that had a fingerprint, causing **88% of WAV extraction attempts to fail**.

The remaining 12% (457 books) had already-cached `path:` keys from a prior run
and were being skipped as existing — so 0 new extractions were happening.

## Fix

Hash the fingerprint with SHA-256 before hex-encoding:

```go
fpHash := sha256.Sum256(f.AcoustIDFingerprint)
key = "fp:" + hex.EncodeToString(fpHash[:])
```

This produces a stable 64-character hex key regardless of fingerprint size,
and is consistent with how `path:` keys already work (SHA-256 of the path string).

## Test plan

- [x] `go build ./internal/plugins/maintenance/` — passes
- [ ] Deploy and relaunch `extract-wav-clips` op; confirm `extracted` counter climbs (was stuck at 0)
- [ ] Spot-check: `ls .wav-cache/ | grep "^fp:" | head -3` → filenames ≤ 255 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP