### PR TITLE
fix(test): resolve 4 pre-existing CI test failures

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,7 +1,7 @@
 // file: internal/backup/backup.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 8f9e0a1b-2c3d-4e5f-6a7b-8c9d0e1f2a3b
-// last-edited: 2026-06-23
+// last-edited: 2026-06-30
 
 package backup
 
@@ -140,7 +140,12 @@ func CreateBackup(databasePath, databaseType string, config BackupConfig) (*Back
 // flushes all in-flight writes and hard-links SST files into destDir, so the
 // archive is always internally consistent. Falls back to CreateBackup (live
 // walk) if the store does not implement Checkpointable (e.g. in tests).
-func CreateBackupWithCheckpoint(store Checkpointable, databaseType string, config BackupConfig) (*BackupInfo, error) {
+//
+// dbSourcePath is the original database path. Its basename is used as the root
+// entry in the tar archive so that restoring the archive recreates a directory
+// named after the source DB (e.g. "audiobooks.pebble/") rather than the random
+// checkpoint temp-dir name ("pebble-checkpoint-XYZ/").
+func CreateBackupWithCheckpoint(store Checkpointable, dbSourcePath, databaseType string, config BackupConfig) (*BackupInfo, error) {
 	if err := os.MkdirAll(config.BackupDir, 0775); err != nil {
 		return nil, fmt.Errorf("create backup dir: %w", err)
 	}
@@ -155,10 +160,24 @@ func CreateBackupWithCheckpoint(store Checkpointable, databaseType string, confi
 	if err := os.Remove(tmpDir); err != nil {
 		return nil, fmt.Errorf("remove pre-created checkpoint tmp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+
+	// Use a closure so the defer always removes whichever path is current.
+	cleanupDir := tmpDir
+	defer func() { os.RemoveAll(cleanupDir) }()
 
 	if err := store.Checkpoint(tmpDir); err != nil {
 		return nil, fmt.Errorf("pebble checkpoint: %w", err)
+	}
+
+	// Rename checkpoint dir to source DB basename so tar archive entries use
+	// the expected name. Restoring to a target then creates "target/test.pebble/"
+	// rather than "target/pebble-checkpoint-XYZ/".
+	if base := filepath.Base(dbSourcePath); base != "" && base != "." {
+		named := filepath.Join(filepath.Dir(tmpDir), base)
+		if renErr := os.Rename(tmpDir, named); renErr == nil {
+			cleanupDir = named
+			tmpDir = named
+		}
 	}
 
 	return CreateBackup(tmpDir, databaseType, config)

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.36.0
+// version: 1.37.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-28
+// last-edited: 2026-06-30
 
 package dedup
 
@@ -3078,6 +3078,12 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 		for _, f := range files {
 			if isBoilerplateTitle(f.Title) {
+				continue
+			}
+			// Skip files whose fingerprint duration is below the minimum — these
+			// are typically short publisher jingles or intro clips that appear on
+			// many unrelated books and produce false-positive pairs.
+			if knownShortFingerprintFile(f) {
 				continue
 			}
 			// Tier-0: whole-file LSH candidate set + Hamming refine.

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 8475f406-df31-4286-95b0-30787397603e
-// last-edited: 2026-06-23
+// last-edited: 2026-06-30
 
 // Package system hosts the system-level HTTP handlers extracted from the server
 // package: health, status, announcements, storage, logs, activity-log,
@@ -542,9 +542,13 @@ func (h *Handler) CreateBackup(c *gin.Context) {
 
 	var info *backup.BackupInfo
 	var err error
-	if store := h.resolveStore(); store != nil {
+	// Only use the Checkpointable (Pebble-native) path when the configured DB
+	// type is pebble. For sqlite (or any other type), fall through to the
+	// file-copy path so the source-path existence check runs and returns an
+	// appropriate error when the DB file is missing.
+	if store := h.resolveStore(); store != nil && dbType == "pebble" {
 		if cp, ok := store.(backup.Checkpointable); ok {
-			info, err = backup.CreateBackupWithCheckpoint(cp, dbType, backupConfig)
+			info, err = backup.CreateBackupWithCheckpoint(cp, dbPath, dbType, backupConfig)
 		} else {
 			info, err = backup.CreateBackup(dbPath, dbType, backupConfig)
 		}

--- a/internal/server/scan_edge_cases_test.go
+++ b/internal/server/scan_edge_cases_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/scan_edge_cases_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-3456-789012abcdef
 
 package server
@@ -196,8 +196,8 @@ func TestScanService_MultiChapterAudiobook(t *testing.T) {
 
 	books, err := env.Store.GetAllBooks(100, 0)
 	require.NoError(t, err)
-	// Scanner treats each file as a separate book
-	assert.Equal(t, 5, len(books), "each chapter file should be a separate book entry")
+	// Scanner groups all files in the same directory into one multi-chapter book.
+	assert.Equal(t, 1, len(books), "all chapter files under one directory should be one book")
 }
 
 func TestScanService_RealLibrivoxFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Four pre-existing test failures that were blocking CI, all caused by functions that existed but weren't wired into the right call path.

- **`TestAcoustIDScan_SkipsShortClipFingerprintMatch`** — `knownShortFingerprintFile()` existed but was never called from the `AcoustIDScan` inner loop; short publisher jingles (<60s fingerprint) were reaching the exact-match emit path and producing false candidates.
- **`TestBackupEndpointsErrors`** — handler used the `Checkpointable` (Pebble) backup path regardless of `dbType`; sqlite-configured test servers got HTTP 200 instead of 500 on missing DB because the Pebble checkpoint path bypasses the source-path existence check.
- **`TestRestoreBackup_Success`** — `CreateBackupWithCheckpoint` archived the checkpoint under a random `pebble-checkpoint-XYZ/` temp-dir name; restoring produced `target/pebble-checkpoint-XYZ/` not `target/test.pebble/` so the stat check failed. Fixed by renaming to `filepath.Base(dbPath)` before archiving.
- **`TestScanService_MultiChapterAudiobook`** — assertion expected 5 books (one per file) but the scanner correctly creates 1 book per directory for multi-chapter audiobooks; corrected the test expectation and comment.

## Test plan
- [x] `go test ./internal/dedup/ -run TestAcoustIDScan_SkipsShortClipFingerprintMatch` — PASS
- [x] `go test ./internal/server/ -run "TestBackupEndpointsErrors|TestRestoreBackup_Success|TestScanService_MultiChapterAudiobook"` — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP