### PR TITLE
feat(merge): add title/author/narrator override to Combine into One Book

### DIFF
--- a/internal/merge/combine_test.go
+++ b/internal/merge/combine_test.go
@@ -67,7 +67,7 @@ func TestService_CombineBooks(t *testing.T) {
 	}))
 
 	ms := NewService(store)
-	res, err := ms.CombineBooks([]string{book1.ID, book3.ID, survivor.ID}, survivor.ID)
+	res, err := ms.CombineBooks([]string{book1.ID, book3.ID, survivor.ID}, survivor.ID, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, survivor.ID, res.PrimaryID)
@@ -108,13 +108,13 @@ func TestService_CombineBooks(t *testing.T) {
 
 func TestService_CombineBooks_TooFew(t *testing.T) {
 	ms := NewService(nil)
-	_, err := ms.CombineBooks([]string{"one"}, "one")
+	_, err := ms.CombineBooks([]string{"one"}, "one", nil)
 	require.Error(t, err)
 }
 
 func TestService_CombineBooks_RequiresPrimary(t *testing.T) {
 	ms := NewService(nil)
-	_, err := ms.CombineBooks([]string{"a", "b"}, "")
+	_, err := ms.CombineBooks([]string{"a", "b"}, "", nil)
 	require.Error(t, err)
 }
 
@@ -132,6 +132,6 @@ func TestService_CombineBooks_PrimaryNotInSet(t *testing.T) {
 	c := &database.Book{ID: ulid.Make().String(), Title: "C", Format: "mp3", FilePath: "/tmp/c.mp3"}
 	_, err = store.CreateBook(c)
 	require.NoError(t, err)
-	_, err = ms.CombineBooks([]string{a.ID, b.ID}, c.ID)
+	_, err = ms.CombineBooks([]string{a.ID, b.ID}, c.ID, nil)
 	require.Error(t, err)
 }

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,6 +1,7 @@
 // file: internal/merge/service.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
+// last-edited: 2026-06-30
 
 package merge
 
@@ -224,6 +225,15 @@ type CombineResult struct {
 	BooksDeleted int    `json:"books_deleted"`
 }
 
+// CombineOverride holds optional metadata fields to apply to the survivor book
+// after all files have been reassigned. Only non-empty strings take effect;
+// omitting a field leaves the survivor's existing value untouched.
+type CombineOverride struct {
+	Title    string `json:"title,omitempty"`
+	Author   string `json:"author,omitempty"`
+	Narrator string `json:"narrator,omitempty"`
+}
+
 // CombineBooks combines several books into ONE multi-file book — distinct from
 // MergeBooks, which links them as alternate VERSIONS in a version group. Every
 // selected book's audio files become real BookFiles on the survivor, and the
@@ -234,8 +244,9 @@ type CombineResult struct {
 // DB-only: files stay where they are on disk (most shattered sets are already in
 // one folder). Run organize afterward to physically co-locate if desired.
 //
-// The survivor keeps its own metadata (the caller picks primaryID); rename after.
-func (ms *Service) CombineBooks(bookIDs []string, primaryID string) (*CombineResult, error) {
+// override is optional: non-empty fields overwrite the survivor's metadata after
+// the combine. Leave it nil or empty to keep the survivor's existing metadata.
+func (ms *Service) CombineBooks(bookIDs []string, primaryID string, override *CombineOverride) (*CombineResult, error) {
 	if len(bookIDs) < 2 {
 		return nil, fmt.Errorf("need at least 2 books to combine")
 	}
@@ -314,6 +325,48 @@ func (ms *Service) CombineBooks(bookIDs []string, primaryID string) (*CombineRes
 	if err := ms.db.RecomputeBookAggregates(survivor.ID); err != nil {
 		slog.Warn("combine RecomputeBookAggregates", "id", survivor.ID, "err", err)
 	}
+
+	// Apply metadata overrides to the survivor. UpdateBook does a full column
+	// replacement, so we re-fetch after the aggregate recompute and patch only
+	// the non-empty override fields.
+	if override != nil && (override.Title != "" || override.Author != "" || override.Narrator != "") {
+		fresh, err := ms.db.GetBookByID(primaryID)
+		if err == nil && fresh != nil {
+			if override.Title != "" {
+				fresh.Title = override.Title
+			}
+			if override.Narrator != "" {
+				fresh.Narrator = &override.Narrator
+			}
+			if _, err := ms.db.UpdateBook(fresh.ID, fresh); err != nil {
+				slog.Warn("combine override UpdateBook", "id", fresh.ID, "err", err)
+			} else {
+				slog.Info("combine applied metadata override", "id", fresh.ID,
+					"title", override.Title, "narrator", override.Narrator)
+			}
+		}
+		// Author resolution: find or create by name, then link to the survivor.
+		if override.Author != "" {
+			author, err := ms.db.GetAuthorByName(override.Author)
+			if err == nil && author == nil {
+				author, err = ms.db.CreateAuthor(override.Author)
+			}
+			if err == nil && author != nil {
+				_ = ms.db.SetBookAuthors(primaryID, []database.BookAuthor{
+					{BookID: primaryID, AuthorID: author.ID, Role: "author", Position: 0},
+				})
+				// Also set AuthorID on the book row for backward compat.
+				if b, err2 := ms.db.GetBookByID(primaryID); err2 == nil && b != nil {
+					b.AuthorID = &author.ID
+					_, _ = ms.db.UpdateBook(b.ID, b)
+				}
+			}
+			if err != nil {
+				slog.Warn("combine override author", "name", override.Author, "err", err)
+			}
+		}
+	}
+
 	slog.Info("combined books into one", "survivor", survivor.ID,
 		"files_moved", res.FilesMoved, "books_deleted", res.BooksDeleted)
 	return res, nil

--- a/internal/server/handlers/duplicates/handler.go
+++ b/internal/server/handlers/duplicates/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/duplicates/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9f41f363-34fc-4ad2-b2f1-46d5ac0ba2f3
-// last-edited: 2026-06-23
+// last-edited: 2026-06-30
 
 // Package duplicates hosts the SQL-backed duplicate-detection HTTP handlers
 // extracted from the server package's duplicates_handlers.go: book / author /
@@ -35,6 +35,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -299,6 +300,10 @@ func (h *Handler) CombineBooks(c *gin.Context) {
 	var req struct {
 		KeepID   string   `json:"keep_id" binding:"required"`
 		MergeIDs []string `json:"merge_ids" binding:"required"`
+		// Override is optional. Non-empty fields overwrite the survivor's metadata
+		// after all files are reassigned. Useful when none of the source books has
+		// the correct title/author (e.g. every file was titled after its chapter).
+		Override *merge.CombineOverride `json:"override,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		httputil.RespondWithBadRequest(c, err.Error())
@@ -317,7 +322,7 @@ func (h *Handler) CombineBooks(c *gin.Context) {
 	}
 
 	// Pass ALL ids (the absorbed books plus the survivor) and the survivor id.
-	result, err := ms.CombineBooks(append(req.MergeIDs, req.KeepID), req.KeepID)
+	result, err := ms.CombineBooks(append(req.MergeIDs, req.KeepID), req.KeepID, req.Override)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			httputil.RespondWithNotFound(c, "book", req.KeepID)

--- a/internal/server/handlers/duplicates/interfaces.go
+++ b/internal/server/handlers/duplicates/interfaces.go
@@ -56,7 +56,7 @@ type MergeService interface {
 	// CombineBooks combines several single-file books into ONE multi-file book
 	// on the survivor (primaryID) and hard-deletes the absorbed shells. Distinct
 	// from MergeBooks, which links them as alternate versions in a version group.
-	CombineBooks(bookIDs []string, primaryID string) (*merge.CombineResult, error)
+	CombineBooks(bookIDs []string, primaryID string, override *merge.CombineOverride) (*merge.CombineResult, error)
 }
 
 // MetadataFetchService is the narrow *metafetch.Service subset used by

--- a/internal/server/handlers/duplicates/mocks/mock_merge_service.go
+++ b/internal/server/handlers/duplicates/mocks/mock_merge_service.go
@@ -37,8 +37,8 @@ func (_m *MockMergeService) EXPECT() *MockMergeService_Expecter {
 }
 
 // CombineBooks provides a mock function for the type MockMergeService
-func (_mock *MockMergeService) CombineBooks(bookIDs []string, primaryID string) (*merge.CombineResult, error) {
-	ret := _mock.Called(bookIDs, primaryID)
+func (_mock *MockMergeService) CombineBooks(bookIDs []string, primaryID string, override *merge.CombineOverride) (*merge.CombineResult, error) {
+	ret := _mock.Called(bookIDs, primaryID, override)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CombineBooks")
@@ -46,18 +46,18 @@ func (_mock *MockMergeService) CombineBooks(bookIDs []string, primaryID string) 
 
 	var r0 *merge.CombineResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string, string) (*merge.CombineResult, error)); ok {
-		return returnFunc(bookIDs, primaryID)
+	if returnFunc, ok := ret.Get(0).(func([]string, string, *merge.CombineOverride) (*merge.CombineResult, error)); ok {
+		return returnFunc(bookIDs, primaryID, override)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]string, string) *merge.CombineResult); ok {
-		r0 = returnFunc(bookIDs, primaryID)
+	if returnFunc, ok := ret.Get(0).(func([]string, string, *merge.CombineOverride) *merge.CombineResult); ok {
+		r0 = returnFunc(bookIDs, primaryID, override)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*merge.CombineResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func([]string, string) error); ok {
-		r1 = returnFunc(bookIDs, primaryID)
+	if returnFunc, ok := ret.Get(1).(func([]string, string, *merge.CombineOverride) error); ok {
+		r1 = returnFunc(bookIDs, primaryID, override)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -72,11 +72,12 @@ type MockMergeService_CombineBooks_Call struct {
 // CombineBooks is a helper method to define mock.On call
 //   - bookIDs []string
 //   - primaryID string
-func (_e *MockMergeService_Expecter) CombineBooks(bookIDs any, primaryID any) *MockMergeService_CombineBooks_Call {
-	return &MockMergeService_CombineBooks_Call{Call: _e.mock.On("CombineBooks", bookIDs, primaryID)}
+//   - override *merge.CombineOverride
+func (_e *MockMergeService_Expecter) CombineBooks(bookIDs any, primaryID any, override any) *MockMergeService_CombineBooks_Call {
+	return &MockMergeService_CombineBooks_Call{Call: _e.mock.On("CombineBooks", bookIDs, primaryID, override)}
 }
 
-func (_c *MockMergeService_CombineBooks_Call) Run(run func(bookIDs []string, primaryID string)) *MockMergeService_CombineBooks_Call {
+func (_c *MockMergeService_CombineBooks_Call) Run(run func(bookIDs []string, primaryID string, override *merge.CombineOverride)) *MockMergeService_CombineBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 []string
 		if args[0] != nil {
@@ -86,10 +87,11 @@ func (_c *MockMergeService_CombineBooks_Call) Run(run func(bookIDs []string, pri
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		run(
-			arg0,
-			arg1,
-		)
+		var arg2 *merge.CombineOverride
+		if args[2] != nil {
+			arg2 = args[2].(*merge.CombineOverride)
+		}
+		run(arg0, arg1, arg2)
 	})
 	return _c
 }
@@ -99,7 +101,7 @@ func (_c *MockMergeService_CombineBooks_Call) Return(combineResult *merge.Combin
 	return _c
 }
 
-func (_c *MockMergeService_CombineBooks_Call) RunAndReturn(run func(bookIDs []string, primaryID string) (*merge.CombineResult, error)) *MockMergeService_CombineBooks_Call {
+func (_c *MockMergeService_CombineBooks_Call) RunAndReturn(run func(bookIDs []string, primaryID string, override *merge.CombineOverride) (*merge.CombineResult, error)) *MockMergeService_CombineBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/web/src/components/library/LibraryDialogs.tsx
+++ b/web/src/components/library/LibraryDialogs.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryDialogs.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: d4e5f6a7-b8c9-0123-def0-234567890123
-// last-edited: 2026-06-28
+// last-edited: 2026-06-30
 
 import React from 'react';
 import {
@@ -98,6 +98,12 @@ interface LibraryDialogsProps {
   combineDialogOpen: boolean;
   setCombineDialogOpen: (open: boolean) => void;
   combineInProgress: boolean;
+  combineOverrideTitle: string;
+  setCombineOverrideTitle: (v: string) => void;
+  combineOverrideAuthor: string;
+  setCombineOverrideAuthor: (v: string) => void;
+  combineOverrideNarrator: string;
+  setCombineOverrideNarrator: (v: string) => void;
   handleCombineIntoOneBook: () => void;
 
   // Batch delete dialog
@@ -260,6 +266,12 @@ export const LibraryDialogs = ({
   combineDialogOpen,
   setCombineDialogOpen,
   combineInProgress,
+  combineOverrideTitle,
+  setCombineOverrideTitle,
+  combineOverrideAuthor,
+  setCombineOverrideAuthor,
+  combineOverrideNarrator,
+  setCombineOverrideNarrator,
   handleCombineIntoOneBook,
   batchDeleteDialogOpen,
   setBatchDeleteDialogOpen,
@@ -465,8 +477,37 @@ export const LibraryDialogs = ({
           ))}
         </Box>
         <Alert severity="warning" sx={{ mt: 1 }}>
-          The other {Math.max(selectedAudiobooks.length - 1, 0)} entries will be deleted and their files attached to the survivor. Unlike "Merge as Versions", this produces ONE book, not a version group. Files stay in place on disk.
+          The other {Math.max(selectedAudiobooks.length - 1, 0)} entries will be deleted and their files attached to the survivor. Unlike &quot;Merge as Versions&quot;, this produces ONE book, not a version group. Files stay in place on disk.
         </Alert>
+        <Typography variant="body2" sx={{ mt: 2, mb: 0.5, color: 'text.secondary' }}>
+          Override metadata (optional — leave blank to keep the survivor&apos;s existing values):
+        </Typography>
+        <Stack spacing={1.5}>
+          <TextField
+            label="Title"
+            size="small"
+            fullWidth
+            value={combineOverrideTitle}
+            onChange={(e) => setCombineOverrideTitle(e.target.value)}
+            placeholder="e.g. Salem's Lot"
+          />
+          <TextField
+            label="Author"
+            size="small"
+            fullWidth
+            value={combineOverrideAuthor}
+            onChange={(e) => setCombineOverrideAuthor(e.target.value)}
+            placeholder="e.g. Stephen King"
+          />
+          <TextField
+            label="Narrator"
+            size="small"
+            fullWidth
+            value={combineOverrideNarrator}
+            onChange={(e) => setCombineOverrideNarrator(e.target.value)}
+            placeholder="e.g. Ron McClarty"
+          />
+        </Stack>
       </DialogContent>
       <DialogActions>
         <Button onClick={() => setCombineDialogOpen(false)} disabled={combineInProgress}>

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.71.0
+// version: 1.72.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-06-28
+// last-edited: 2026-06-30
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -218,6 +218,9 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [combineDialogOpen, setCombineDialogOpen] = useState(false);
   const [combineInProgress, setCombineInProgress] = useState(false);
+  const [combineOverrideTitle, setCombineOverrideTitle] = useState('');
+  const [combineOverrideAuthor, setCombineOverrideAuthor] = useState('');
+  const [combineOverrideNarrator, setCombineOverrideNarrator] = useState('');
   const [batchPlaylistOpen, setBatchPlaylistOpen] = useState(false);
   const [mergePrimaryId, setMergePrimaryId] = useState<string>('');
   // pendingFetchOpId tracks the in-flight metadata fetch so we can
@@ -906,13 +909,19 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       const keepId = mergePrimaryId || selectedAudiobooks[0].id;
       const mergeIds = selectedAudiobooks.filter((b) => b.id !== keepId).map((b) => b.id);
-      const result = await api.combineBooks(keepId, mergeIds);
+      const override = (combineOverrideTitle || combineOverrideAuthor || combineOverrideNarrator)
+        ? { title: combineOverrideTitle || undefined, author: combineOverrideAuthor || undefined, narrator: combineOverrideNarrator || undefined }
+        : undefined;
+      const result = await api.combineBooks(keepId, mergeIds, override);
       toast(
         `Combined ${result.files_moved} files into one book; removed ${result.books_deleted} entries.`,
         'success',
       );
       setSelectedAudiobooks([]);
       setCrossPageFilter(null);
+      setCombineOverrideTitle('');
+      setCombineOverrideAuthor('');
+      setCombineOverrideNarrator('');
       setCombineDialogOpen(false);
       await loadAudiobooks();
     } catch (error) {
@@ -1813,6 +1822,12 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           combineDialogOpen={combineDialogOpen}
           setCombineDialogOpen={setCombineDialogOpen}
           combineInProgress={combineInProgress}
+          combineOverrideTitle={combineOverrideTitle}
+          setCombineOverrideTitle={setCombineOverrideTitle}
+          combineOverrideAuthor={combineOverrideAuthor}
+          setCombineOverrideAuthor={setCombineOverrideAuthor}
+          combineOverrideNarrator={combineOverrideNarrator}
+          setCombineOverrideNarrator={setCombineOverrideNarrator}
           handleCombineIntoOneBook={handleCombineIntoOneBook}
           batchDeleteDialogOpen={batchDeleteDialogOpen}
           setBatchDeleteDialogOpen={setBatchDeleteDialogOpen}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.46.0
+// version: 2.47.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-06-28
+// last-edited: 2026-06-30
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -1460,17 +1460,26 @@ export interface CombineBooksResult {
   message?: string;
 }
 
+export interface CombineOverride {
+  title?: string;
+  author?: string;
+  narrator?: string;
+}
+
 // combineBooks combines several single-file books into ONE multi-file book on the
 // survivor (keepId), hard-deleting the absorbed shells. Distinct from mergeBooks,
 // which links them as alternate versions in a version group. Synchronous.
+// override is optional: non-empty fields overwrite the survivor's metadata after
+// the combine (useful when all source books have per-chapter titles).
 export async function combineBooks(
   keepId: string,
   mergeIds: string[],
+  override?: CombineOverride,
 ): Promise<CombineBooksResult> {
   const response = await apiFetch(`${API_BASE}/audiobooks/combine`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ keep_id: keepId, merge_ids: mergeIds }),
+    body: JSON.stringify({ keep_id: keepId, merge_ids: mergeIds, override: override ?? null }),
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to combine books');


### PR DESCRIPTION
## Summary

- Adds optional `CombineOverride` struct (`title`, `author`, `narrator`) to `CombineBooks` — non-empty fields are applied to the survivor after the combine completes
- Solves the use case where all source books have per-chapter titles and no single book has correct metadata: user can now type the real title/author/narrator directly in the Combine dialog
- Author override follows the correct `GetAuthorByName` → `CreateAuthor` → `SetBookAuthors` + `UpdateBook(AuthorID)` pattern (not a direct struct field assignment, since `Book.Author` is `db:"-"`)
- State is cleared on successful combine (not on cancel), so values survive accidental dialog dismissal

## Changed files

| File | Change |
|------|--------|
| `internal/merge/service.go` | `CombineOverride` struct; updated `CombineBooks` signature; override application block |
| `internal/merge/combine_test.go` | All 4 `CombineBooks` calls updated with `nil` override arg |
| `internal/server/handlers/duplicates/interfaces.go` | `MergeService.CombineBooks` interface updated |
| `internal/server/handlers/duplicates/handler.go` | Request struct + `merge` import + call site |
| `internal/server/handlers/duplicates/mocks/mock_merge_service.go` | Mock updated to match new signature |
| `web/src/services/api.ts` | `CombineOverride` interface + optional `override` param to `combineBooks()` |
| `web/src/components/library/LibraryDialogs.tsx` | Three optional TextField inputs in Combine dialog |
| `web/src/pages/Library.tsx` | State vars + props threaded to dialog + API call |

## Test plan

- [ ] `go test ./internal/merge/... ./internal/server/handlers/duplicates/...` — passes
- [ ] `npx tsc --noEmit` in `web/` — 0 errors
- [ ] UI: open Combine dialog, type title/author/narrator, confirm → survivor updated correctly
- [ ] UI: leave fields blank → survivor metadata unchanged (existing behavior)
- [ ] UI: cancel with fields filled → values persist if dialog re-opened (not cleared on cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP