### PR TITLE
feat(transcribe): per-book outcome instrumentation + stats aggregate + monitor

### DIFF
--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -271,6 +271,20 @@ type Book struct {
 	TranscribedNarrator *string `json:"transcribed_narrator,omitempty"`
 	// IntroTranscribedAt is when IntroTranscription was last populated.
 	IntroTranscribedAt *time.Time `json:"intro_transcribed_at,omitempty"`
+	// TranscribeStatus records the outcome of the most recent transcription
+	// ATTEMPT for this book, written per-book by maintenance.transcribe-book-intros.
+	// One of: "ok", "source_file_missing", "no_audio", "ffmpeg_error",
+	// "whisper_error", "empty". This is the queryable drill-down field — count
+	// books by status to see exactly why transcription is/isn't producing data
+	// (e.g. how many books have stale FilePaths after an organize move).
+	TranscribeStatus *string `json:"transcribe_status,omitempty"`
+	// TranscribeError holds a short human-readable detail for a non-ok status —
+	// typically the tail of ffmpeg stderr or the Whisper error string. Empty on ok.
+	TranscribeError *string `json:"transcribe_error,omitempty"`
+	// TranscribeAttemptedAt is when the most recent transcription attempt ran
+	// (success OR failure), distinct from IntroTranscribedAt which only advances
+	// on a successful transcription.
+	TranscribeAttemptedAt *time.Time `json:"transcribe_attempted_at,omitempty"`
 	// Fingerprinting fields (computed, not stored in DB)
 	FingerprintStatus      string     `json:"fingerprint_status,omitempty"` // "none", "partial", "complete"
 	FingerprintedFileCount int        `json:"fingerprinted_file_count,omitempty"`

--- a/internal/database/transcribe_stats.go
+++ b/internal/database/transcribe_stats.go
@@ -1,0 +1,86 @@
+// file: internal/database/transcribe_stats.go
+// version: 1.0.0
+// guid: 7f2a9c14-3b6d-4e81-9a05-2c8e1d4f6b73
+// last-edited: 2026-06-30
+
+package database
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// statsTranscribeKey is the single PebbleDB key holding the live aggregate
+// counters for the most recent (or in-flight) transcription run. It is updated
+// incrementally by maintenance.transcribe-book-intros after each page so an
+// external monitor can read one key instead of scanning 48K book records or
+// scraping ephemeral op logs.
+const statsTranscribeKey = "stats:transcribe"
+
+// TranscribeStats is the live aggregate for a transcription run. Counts are
+// cumulative across the run identified by RunOpID. Persisted as JSON under
+// statsTranscribeKey. A monitor reads it via GET /api/v1/maintenance/transcribe-stats.
+type TranscribeStats struct {
+	RunOpID    string    `json:"run_op_id"`     // op that produced these counters
+	StartedAt  time.Time `json:"started_at"`    // when the run began
+	UpdatedAt  time.Time `json:"updated_at"`    // last counter write
+	Done       bool      `json:"done"`          // run finished (success or error)
+	TotalBooks int       `json:"total_books"`   // library size at run start
+
+	// Per-outcome cumulative counts. Attempted = sum of the outcome buckets
+	// below; SkippedExisting is books skipped because they already had a
+	// transcript (only_missing mode) and were never attempted this run.
+	Attempted       int `json:"attempted"`
+	OK              int `json:"ok"`
+	SourceMissing   int `json:"source_file_missing"`
+	NoAudio         int `json:"no_audio"`
+	FFmpegError     int `json:"ffmpeg_error"`
+	WhisperError    int `json:"whisper_error"`
+	Empty           int `json:"empty"`
+	SkippedExisting int `json:"skipped_existing"`
+	CacheHits       int `json:"cache_hits"`
+}
+
+// PutTranscribeStats writes the aggregate counters. Sync is intentional so a
+// monitor polling across a server restart still sees the last-known state.
+func (p *PebbleStore) PutTranscribeStats(s *TranscribeStats) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	if err := p.db.Set([]byte(statsTranscribeKey), data, pebble.Sync); err != nil {
+		slog.Error("pebble Set stats:transcribe", "error", err)
+		return err
+	}
+	return nil
+}
+
+// GetTranscribeStats reads the aggregate counters. Returns (nil, nil) when no
+// run has ever written them (key absent) so the caller can report "never run".
+func (p *PebbleStore) GetTranscribeStats() (*TranscribeStats, error) {
+	val, closer, err := p.db.Get([]byte(statsTranscribeKey))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	var s TranscribeStats
+	if err := json.Unmarshal(val, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// TranscribeStatsStore is the narrow capability interface satisfied by
+// *PebbleStore. The op and HTTP handler type-assert the concrete store to this
+// (mirroring the backup.Checkpointable pattern) so the store-wide Store
+// interface stays untouched.
+type TranscribeStatsStore interface {
+	PutTranscribeStats(*TranscribeStats) error
+	GetTranscribeStats() (*TranscribeStats, error)
+}

--- a/internal/database/transcribe_stats_test.go
+++ b/internal/database/transcribe_stats_test.go
@@ -1,0 +1,115 @@
+// file: internal/database/transcribe_stats_test.go
+// version: 1.0.0
+// guid: 4c1f8a92-7d63-4b05-9e21-8f6a3c0d51e4
+// last-edited: 2026-06-30
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestTranscribeStats_RoundTrip verifies the aggregate persists and reads back
+// through PebbleDB, and that an absent key yields (nil, nil) rather than an error.
+func TestTranscribeStats_RoundTrip(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	// Absent key → (nil, nil).
+	got, err := store.GetTranscribeStats()
+	if err != nil {
+		t.Fatalf("GetTranscribeStats on empty: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil stats before any write, got %+v", got)
+	}
+
+	now := time.Now().Truncate(time.Second)
+	want := &TranscribeStats{
+		RunOpID:       "run-1",
+		StartedAt:     now,
+		UpdatedAt:     now,
+		TotalBooks:    48763,
+		Attempted:     200,
+		OK:            5,
+		SourceMissing: 190,
+		FFmpegError:   3,
+		WhisperError:  1,
+		Empty:         1,
+		CacheHits:     2,
+	}
+	if err := store.PutTranscribeStats(want); err != nil {
+		t.Fatalf("PutTranscribeStats: %v", err)
+	}
+
+	got, err = store.GetTranscribeStats()
+	if err != nil {
+		t.Fatalf("GetTranscribeStats: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected stats after write, got nil")
+	}
+	if got.OK != 5 || got.SourceMissing != 190 || got.TotalBooks != 48763 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if !got.StartedAt.Equal(now) {
+		t.Fatalf("StartedAt mismatch: got %v want %v", got.StartedAt, now)
+	}
+}
+
+// TestTranscribeStatsStore_Interface confirms *PebbleStore satisfies the narrow
+// capability interface the op and handler type-assert to.
+func TestTranscribeStatsStore_Interface(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	var _ TranscribeStatsStore = store
+}
+
+// TestBook_TranscribeFields_RoundTrip verifies the new per-book outcome fields
+// persist through CreateBook/UpdateBook/GetBookByID (Book is JSON-marshaled
+// wholesale, so this guards against an accidental memdb strip of the fields).
+func TestBook_TranscribeFields_RoundTrip(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	b := &Book{ID: "bk1", Title: "T", Format: "mp3", FilePath: "/x/y.mp3"}
+	if _, err := store.CreateBook(b); err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	status := "source_file_missing"
+	detail := "source file not found: /x/y.mp3"
+	now := time.Now().Truncate(time.Second)
+	b.TranscribeStatus = &status
+	b.TranscribeError = &detail
+	b.TranscribeAttemptedAt = &now
+	if _, err := store.UpdateBook(b.ID, b); err != nil {
+		t.Fatalf("UpdateBook: %v", err)
+	}
+
+	got, err := store.GetBookByID("bk1")
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID: %v", err)
+	}
+	if got.TranscribeStatus == nil || *got.TranscribeStatus != status {
+		t.Fatalf("TranscribeStatus not persisted: %+v", got.TranscribeStatus)
+	}
+	if got.TranscribeError == nil || *got.TranscribeError != detail {
+		t.Fatalf("TranscribeError not persisted: %+v", got.TranscribeError)
+	}
+	if got.TranscribeAttemptedAt == nil || !got.TranscribeAttemptedAt.Equal(now) {
+		t.Fatalf("TranscribeAttemptedAt not persisted: %+v", got.TranscribeAttemptedAt)
+	}
+}

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.7.0
+// version: 3.8.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-30
 
@@ -132,6 +132,19 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	// (the whole point of batch mode: load the model once per 200 books).
 	pages := chunkIDs(allIDs[startIdx:], introTranscribePageSize)
 
+	// Live aggregate: the op records per-outcome counts into accum and flushes
+	// them to the stats:transcribe PebbleDB key after each page so an external
+	// monitor reads one key instead of scanning books or scraping op logs. The
+	// sink is best-effort — when the store doesn't implement TranscribeStatsStore
+	// (e.g. a test stub) counts are tracked in memory only.
+	var statsSink database.TranscribeStatsStore
+	if s, ok := store.(database.TranscribeStatsStore); ok {
+		statsSink = s
+	}
+	startedAt := time.Now()
+	accum := newTranscribeStatsAccum(statsSink, startedAt.Format(time.RFC3339), total, startedAt)
+	accum.flush(false) // initial write: monitor sees the run has started
+
 	// processed and lastID are written by concurrent page goroutines — must be
 	// thread-safe. processed uses atomic arithmetic; lastID uses a mutex because
 	// string assignment is not atomic (pointer + length, two words).
@@ -147,6 +160,7 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	// batches far more efficiently than one large serial one.
 	err = registry.RunItems(ctx, reporter, pages, func(ctx context.Context, ids []string) error {
 		books := make([]database.Book, 0, len(ids))
+		skipped := 0
 		for _, id := range ids {
 			b, gerr := store.GetBookByID(id)
 			if gerr != nil || b == nil {
@@ -156,11 +170,14 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 			lastID = id
 			lastIDMu.Unlock()
 			if onlyMissing && b.IntroTranscription != nil && *b.IntroTranscription != "" {
+				skipped++
 				continue // already transcribed — skip (cache still warm if re-run)
 			}
 			books = append(books, *b)
 		}
+		accum.recordSkipped(skipped)
 		if len(books) == 0 {
+			accum.flush(false)
 			return nil
 		}
 		// Per-book heartbeat: each completed book bumps the operation's progress
@@ -174,8 +191,9 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 			_ = reporter.UpdateProgress(cur, total,
 				fmt.Sprintf("Transcribing — %d/%d books", cur, total))
 		}
-		done := p.processTranscribePage(ctx, store, log, books, p.deps.RootDir(), onBook)
+		done := p.processTranscribePage(ctx, store, log, books, p.deps.RootDir(), onBook, accum)
 		cum := int(processed.Add(int64(done)))
+		accum.flush(false) // persist cumulative counts so the monitor sees live progress
 		log.Info("transcribe-book-intros: page complete",
 			"page_books", done, "cumulative_processed", cum, "total_books", total)
 		return nil
@@ -194,12 +212,23 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 		},
 	})
 	if err != nil {
+		// Mark the run done even on error so the monitor stops treating it as
+		// in-flight; the counts reflect whatever was processed before the error.
+		accum.flush(true)
 		return err
 	}
 
+	accum.flush(true)
+	st := accum.snapshot()
 	total64 := int(processed.Load())
-	log.Info("transcribe-book-intros: complete", "processed", total64, "total_books", total)
-	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf("Done — transcribed %d books", total64))
+	log.Info("transcribe-book-intros: complete",
+		"processed", total64, "total_books", total,
+		"ok", st.OK, "source_missing", st.SourceMissing, "no_audio", st.NoAudio,
+		"ffmpeg_error", st.FFmpegError, "whisper_error", st.WhisperError,
+		"empty", st.Empty, "skipped_existing", st.SkippedExisting, "cache_hits", st.CacheHits)
+	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf(
+		"Done — %d ok, %d source-missing, %d ffmpeg-err, %d whisper-err, %d empty (of %d total)",
+		st.OK, st.SourceMissing, st.FFmpegError, st.WhisperError, st.Empty, total))
 	return nil
 }
 
@@ -289,17 +318,28 @@ func chunkIDs(ids []string, size int) [][]string {
 // 1. Find the first audio file for each book.
 // 2. Extract 90-second WAVs in parallel with ffmpeg (cached on disk).
 // 3. Call TranscribeBatch once (single Python/Whisper process).
-// 4. Parse results and update all books.
+// 4. Parse results and write per-book outcome (status + parsed fields).
 // 5. Clean up temp WAVs (cached clips persist).
-// Returns the number of books successfully transcribed in this page. Errors are
-// logged and treated as non-fatal so one bad page never aborts the whole run.
+//
+// EVERY book in the page gets a TranscribeStatus written (change-guarded), so
+// the per-book field and the stats:transcribe aggregate together explain exactly
+// why transcription did or didn't produce data — the single most useful signal
+// being how many books fail with source_file_missing (stale FilePath after an
+// organize move).
+//
+// Returns the number of books successfully transcribed (status ok) in this page.
+// Errors are logged and treated as non-fatal so one bad page never aborts the run.
 func (p *Plugin) processTranscribePage(
 	ctx context.Context,
 	store database.Store,
-	log interface{ Info(string, ...any); Warn(string, ...any) },
+	log interface {
+		Info(string, ...any)
+		Warn(string, ...any)
+	},
 	books []database.Book,
 	rootDir string,
 	onBook transcribe.ProgressFunc,
+	accum *transcribeStatsAccum,
 ) (processed int) {
 	cacheDir := wavCacheDir(rootDir)
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
@@ -315,6 +355,12 @@ func (p *Plugin) processTranscribePage(
 	}
 	defer os.RemoveAll(tmpDir)
 
+	now := time.Now()
+	bookByID := make(map[string]database.Book, len(books))
+	for _, b := range books {
+		bookByID[b.ID] = b
+	}
+
 	// Step 1: find first audio file + file hash for each book (fast DB reads, serial).
 	type bookJob struct {
 		book     database.Book
@@ -327,20 +373,23 @@ func (p *Plugin) processTranscribePage(
 		jobs = append(jobs, bookJob{book: b, audioSrc: src, fileHash: hash})
 	}
 
-	// Step 2: extract WAVs in parallel with bounded ffmpeg workers.
-	// Cache hit: serve from cacheDir/{hash}.wav, skip ffmpeg entirely.
-	// Cache miss: write ffmpeg output directly to cacheDir/{hash}.wav (or tmpDir if no hash).
+	// Step 2: extract WAVs in parallel with bounded ffmpeg workers. Each
+	// goroutine owns its wavResults[idx] slot, so writes there are race-free.
+	// status carries the terminal extraction outcome ("" = WAV produced, defer
+	// to Whisper); detail carries the ffmpeg stderr tail for diagnosis.
 	type wavResult struct {
-		bookID   string
-		wavPath  string // empty on failure
+		bookID    string
+		wavPath   string // empty on failure
 		fromCache bool
+		status    string // "" | statusNoAudio | statusSourceMissing | statusFFmpegError
+		detail    string
 	}
 	wavResults := make([]wavResult, len(jobs))
 	sem := make(chan struct{}, introTranscribeFFWorkers)
 	var wg sync.WaitGroup
 	for i, j := range jobs {
 		if j.audioSrc == "" {
-			wavResults[i] = wavResult{bookID: j.book.ID}
+			wavResults[i] = wavResult{bookID: j.book.ID, status: statusNoAudio}
 			continue
 		}
 		wg.Add(1)
@@ -354,6 +403,13 @@ func (p *Plugin) processTranscribePage(
 					wavResults[idx] = wavResult{bookID: bookID, wavPath: cp, fromCache: true}
 					return
 				}
+			}
+
+			// Distinguish a stale FilePath (the dominant failure after organize
+			// moves files) from a real ffmpeg/codec error: stat the source first.
+			if _, statErr := os.Stat(src); statErr != nil {
+				wavResults[idx] = wavResult{bookID: bookID, status: statusSourceMissing, detail: "source file not found: " + src}
+				return
 			}
 
 			// Cache miss — run ffmpeg.
@@ -374,10 +430,10 @@ func (p *Plugin) processTranscribePage(
 				wavPath,
 			)
 			if out, err := ffCmd.CombinedOutput(); err != nil {
+				tail := ffmpegErrorTail(string(out))
 				log.Warn("transcribe: ffmpeg failed",
-					"book_id", bookID, "file", src,
-					"err", err, "output", strings.TrimSpace(string(out)))
-				wavResults[idx] = wavResult{bookID: bookID}
+					"book_id", bookID, "file", src, "err", err, "output", tail)
+				wavResults[idx] = wavResult{bookID: bookID, status: statusFFmpegError, detail: tail}
 				return
 			}
 			wavResults[idx] = wavResult{bookID: bookID, wavPath: wavPath}
@@ -393,6 +449,17 @@ func (p *Plugin) processTranscribePage(
 	}
 	if cacheHits > 0 {
 		log.Info("transcribe: clip cache hits", "hits", cacheHits, "total", len(wavResults))
+		accum.recordCacheHits(cacheHits)
+	}
+
+	// Record terminal extraction failures now (no Whisper needed for them).
+	wrByID := make(map[string]wavResult, len(wavResults))
+	for _, r := range wavResults {
+		wrByID[r.bookID] = r
+		if r.status != "" {
+			b := bookByID[r.bookID]
+			p.applyOutcome(store, log, &b, r.status, r.detail, "", transcribe.IntroFields{}, now, accum)
+		}
 	}
 
 	// Build the jobs map for TranscribeBatch (only books with valid WAVs).
@@ -410,34 +477,76 @@ func (p *Plugin) processTranscribePage(
 	log.Info("transcribe-book-intros: calling whisper batch", "jobs", len(batchJobs))
 	batchResults, err := transcribe.TranscribeBatch(ctx, batchJobs, onBook)
 	if err != nil {
+		// Whole-batch failure: every book that had a WAV is a whisper_error.
 		log.Warn("transcribe: whisper batch failed", "jobs", len(batchJobs), "err", err)
+		detail := truncateDetail(err.Error())
+		for bookID := range batchJobs {
+			b := bookByID[bookID]
+			p.applyOutcome(store, log, &b, statusWhisperError, detail, "", transcribe.IntroFields{}, now, accum)
+		}
 		return 0
 	}
 
-	// Step 4: parse results and update books.
-	// Build a lookup so we can find the Book struct by ID.
-	bookByID := make(map[string]database.Book, len(books))
-	for _, b := range books {
-		bookByID[b.ID] = b
+	// Step 4: write per-book outcome for every book that had a WAV submitted.
+	for bookID := range batchJobs {
+		book := bookByID[bookID]
+		result, ok := batchResults[bookID]
+		switch {
+		case !ok || result.Error != "":
+			detail := "no whisper result"
+			if ok {
+				detail = truncateDetail(result.Error)
+			}
+			log.Warn("transcribe: whisper error", "book_id", bookID, "err", detail)
+			p.applyOutcome(store, log, &book, statusWhisperError, detail, "", transcribe.IntroFields{}, now, accum)
+		case result.Text == "":
+			p.applyOutcome(store, log, &book, statusEmpty, "whisper returned empty text", "", transcribe.IntroFields{}, now, accum)
+		default:
+			fields := transcribe.ParseAudiobookIntro(result.Text)
+			if p.applyOutcome(store, log, &book, statusOK, "", result.Text, fields, now, accum) {
+				processed++
+			}
+		}
 	}
 
-	now := time.Now()
-	for bookID, result := range batchResults {
-		if result.Error != "" {
-			log.Warn("transcribe: whisper error", "book_id", bookID, "err", result.Error)
-			continue
-		}
-		text := result.Text
-		if text == "" {
-			continue
-		}
+	return processed
+}
 
-		book, ok := bookByID[bookID]
-		if !ok {
-			continue
-		}
+// applyOutcome writes a book's transcription outcome and records it in the
+// aggregate. On statusOK it also stores the transcript and parsed fields. Writes
+// are change-guarded: a repeat of the SAME failure (same status + detail) skips
+// the UpdateBook so a re-run over ~45K stale-path books doesn't churn the DB.
+// statusOK always writes (a fresh transcript is new data). Returns true only
+// when the book was counted as a successful (ok) transcription.
+func (p *Plugin) applyOutcome(
+	store database.Store,
+	log interface {
+		Info(string, ...any)
+		Warn(string, ...any)
+	},
+	book *database.Book,
+	status, detail, text string,
+	fields transcribe.IntroFields,
+	now time.Time,
+	accum *transcribeStatsAccum,
+) (ok bool) {
+	accum.recordOutcome(status, now)
 
-		fields := transcribe.ParseAudiobookIntro(text)
+	newDetail := strPtrOrNil(detail)
+
+	// Change-guard for failures: identical status+detail already stored → no write.
+	if status != statusOK &&
+		book.TranscribeStatus != nil && *book.TranscribeStatus == status &&
+		eqStrPtr(book.TranscribeError, newDetail) {
+		return false
+	}
+
+	book.TranscribeAttemptedAt = &now
+	st := status
+	book.TranscribeStatus = &st
+	book.TranscribeError = newDetail
+
+	if status == statusOK {
 		book.IntroTranscription = &text
 		book.IntroTranscribedAt = &now
 		if fields.Title != "" {
@@ -449,14 +558,40 @@ func (p *Plugin) processTranscribePage(
 		if fields.Narrator != "" {
 			book.TranscribedNarrator = &fields.Narrator
 		}
-		if _, err := store.UpdateBook(book.ID, &book); err != nil {
-			log.Warn("transcribe: update failed", "book_id", bookID, "err", err)
-			continue
-		}
-		processed++
 	}
 
-	return processed
+	if _, err := store.UpdateBook(book.ID, book); err != nil {
+		log.Warn("transcribe: update failed", "book_id", book.ID, "status", status, "err", err)
+		return false
+	}
+	return status == statusOK
+}
+
+// ffmpegErrorTail returns the most diagnostic tail of ffmpeg stderr. ffmpeg
+// prints a long build banner before the actual error; the real reason is on the
+// last non-empty line(s). Returns at most ~200 chars.
+func ffmpegErrorTail(out string) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	// Walk back to the last non-empty line — that's almost always the error.
+	last := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(lines[i]); s != "" {
+			last = s
+			break
+		}
+	}
+	return truncateDetail(last)
+}
+
+// truncateDetail caps a detail string so per-book error fields and the stats
+// blob stay small.
+func truncateDetail(s string) string {
+	s = strings.TrimSpace(s)
+	const max = 200
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
 }
 
 // audioExtSet is the set of extensions treated as playable audio by firstAudioFile.

--- a/internal/plugins/maintenance/transcribe_stats_accum.go
+++ b/internal/plugins/maintenance/transcribe_stats_accum.go
@@ -1,0 +1,110 @@
+// file: internal/plugins/maintenance/transcribe_stats_accum.go
+// version: 1.0.0
+// guid: 9d3b1e57-6a02-4c8f-b14d-7e9a2f5c08b1
+// last-edited: 2026-06-30
+
+package maintenance
+
+import (
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// Per-book transcription outcome categories. These are written to
+// Book.TranscribeStatus and counted into the stats:transcribe aggregate.
+const (
+	statusOK            = "ok"
+	statusSourceMissing = "source_file_missing"
+	statusNoAudio       = "no_audio"
+	statusFFmpegError   = "ffmpeg_error"
+	statusWhisperError  = "whisper_error"
+	statusEmpty         = "empty"
+)
+
+// transcribeStatsAccum is a thread-safe accumulator for the live transcription
+// aggregate. The 4 concurrent page goroutines all record outcomes into it; the
+// op flushes it to PebbleDB (via sink) after each page so a monitor can read
+// one key. sink may be nil when the store does not implement
+// database.TranscribeStatsStore — in that case the accumulator still tracks
+// counts in memory (used for the op's final log line) but never persists.
+type transcribeStatsAccum struct {
+	mu    sync.Mutex
+	stats database.TranscribeStats
+	sink  database.TranscribeStatsStore
+}
+
+func newTranscribeStatsAccum(sink database.TranscribeStatsStore, opID string, totalBooks int, startedAt time.Time) *transcribeStatsAccum {
+	return &transcribeStatsAccum{
+		sink: sink,
+		stats: database.TranscribeStats{
+			RunOpID:    opID,
+			StartedAt:  startedAt,
+			UpdatedAt:  startedAt,
+			TotalBooks: totalBooks,
+		},
+	}
+}
+
+// recordOutcome increments the bucket for one attempted book's status.
+func (a *transcribeStatsAccum) recordOutcome(status string, now time.Time) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stats.Attempted++
+	switch status {
+	case statusOK:
+		a.stats.OK++
+	case statusSourceMissing:
+		a.stats.SourceMissing++
+	case statusNoAudio:
+		a.stats.NoAudio++
+	case statusFFmpegError:
+		a.stats.FFmpegError++
+	case statusWhisperError:
+		a.stats.WhisperError++
+	case statusEmpty:
+		a.stats.Empty++
+	}
+	a.stats.UpdatedAt = now
+}
+
+// recordSkipped counts books skipped because they already have a transcript
+// (only_missing mode) and were never attempted this run.
+func (a *transcribeStatsAccum) recordSkipped(n int) {
+	a.mu.Lock()
+	a.stats.SkippedExisting += n
+	a.mu.Unlock()
+}
+
+// recordCacheHits counts WAV clips served from the on-disk cache (no ffmpeg).
+func (a *transcribeStatsAccum) recordCacheHits(n int) {
+	if n == 0 {
+		return
+	}
+	a.mu.Lock()
+	a.stats.CacheHits += n
+	a.mu.Unlock()
+}
+
+// flush persists the current counters. Safe to call concurrently. No-op when
+// sink is nil. markDone=true stamps the run as finished.
+func (a *transcribeStatsAccum) flush(markDone bool) {
+	if a.sink == nil {
+		return
+	}
+	a.mu.Lock()
+	if markDone {
+		a.stats.Done = true
+	}
+	snapshot := a.stats // copy under lock
+	a.mu.Unlock()
+	_ = a.sink.PutTranscribeStats(&snapshot)
+}
+
+// snapshot returns a copy of the current counters for logging.
+func (a *transcribeStatsAccum) snapshot() database.TranscribeStats {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.stats
+}

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/system/handler.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 8475f406-df31-4286-95b0-30787397603e
 // last-edited: 2026-06-30
 
@@ -903,4 +903,38 @@ func (h *Handler) GetQuickQueries(c *gin.Context) {
 	}
 
 	httputil.RespondWithOK(c, gin.H{"queries": results})
+}
+
+// GetTranscribeStats implements GET /api/v1/maintenance/transcribe-stats. It
+// returns the live aggregate counters written by maintenance.transcribe-book-intros
+// (stats:transcribe). A monitor polls this single endpoint instead of scanning
+// books or scraping op logs. Returns {data: null} when no run has ever written
+// stats (so the monitor reports "never run").
+func (h *Handler) GetTranscribeStats(c *gin.Context) {
+	store := h.resolveStore()
+	if store == nil {
+		httputil.RespondWithInternalError(c, "store unavailable")
+		return
+	}
+
+	var ts database.TranscribeStatsStore
+	if s, ok := store.(database.TranscribeStatsStore); ok {
+		ts = s
+	} else if uw, ok := store.(interface{ Unwrap() database.Store }); ok {
+		if s, ok2 := uw.Unwrap().(database.TranscribeStatsStore); ok2 {
+			ts = s
+		}
+	}
+	if ts == nil {
+		// Store does not support transcribe stats (e.g. SQLite in tests).
+		httputil.RespondWithOK(c, nil)
+		return
+	}
+
+	stats, err := ts.GetTranscribeStats()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "failed to read transcribe stats")
+		return
+	}
+	httputil.RespondWithOK(c, stats)
 }

--- a/internal/server/wire_system_routes.go
+++ b/internal/server/wire_system_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_system_routes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b8c9d0-e1f2-3456-abcd-789012345678
-// last-edited: 2026-06-23
+// last-edited: 2026-06-30
 
 package server
 
@@ -38,6 +38,7 @@ func (s *Server) wireSystemRoutes(
 	protected.POST("/backup/restore", s.perm(auth.PermSettingsManage), systemH.RestoreBackup)
 	protected.DELETE("/backup/:filename", s.perm(auth.PermSettingsManage), systemH.DeleteBackup)
 	protected.GET("/library/quick-queries", s.perm(auth.PermLibraryView), systemH.GetQuickQueries)
+	protected.GET("/maintenance/transcribe-stats", s.perm(auth.PermLibraryView), systemH.GetTranscribeStats)
 	protected.GET("/blocked-hashes", s.perm(auth.PermLibraryView), systemH.ListBlockedHashes)
 	protected.POST("/blocked-hashes", s.perm(auth.PermLibraryEditMetadata), systemH.AddBlockedHash)
 	protected.DELETE("/blocked-hashes/:hash", s.perm(auth.PermLibraryDelete), systemH.RemoveBlockedHash)

--- a/scripts/transcribe_monitor.py
+++ b/scripts/transcribe_monitor.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# file: scripts/transcribe_monitor.py
+# version: 1.0.0
+# guid: 2f7c4a91-8b03-4d6e-9a52-1c6e8f0b3d47
+# last-edited: 2026-06-30
+"""Transcription progress monitor + alerter.
+
+Polls the audiobook-organizer transcribe-stats aggregate
+(GET /api/v1/maintenance/transcribe-stats) on a fixed interval, writes one
+parseable JSONL metrics record per poll, prints a human summary, and raises
+ALERTs when:
+
+  * IDLE      — no run has ever produced stats, or the last run is marked done
+                and nothing new is happening (optionally auto-relaunch).
+  * STALL     — a run is in-flight but its counters haven't advanced for
+                --stall-secs (the GPU/op is stuck).
+  * NOPROGRESS— a run completed but produced almost no OK transcriptions
+                (the "did-nothing completion" pattern: mostly source_file_missing).
+  * WHISPER_DOWN — the Whisper server /health check fails.
+
+This is deliberately a STANDALONE script meant to run persistently on the
+always-up Linux server (systemd timer or a screen/tmux loop), NOT an agent
+background task. It checks far more often than a human and survives restarts
+because all state lives in the server-side stats:transcribe key.
+
+Auth: reads the API key from --token-file (default ./.api-token, format
+"api_key=abk_..."). The server speaks TLS on :8484; --insecure skips cert
+verification (self-signed prod cert).
+
+Examples:
+  # one-shot check (cron/systemd-timer friendly)
+  python3 transcribe_monitor.py --once
+
+  # continuous, poll every 30s, alert + auto-relaunch when idle
+  python3 transcribe_monitor.py --interval 30 --relaunch
+
+  # against prod explicitly
+  python3 transcribe_monitor.py --base https://172.16.2.30:8484 --insecure
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+
+def log_line(metrics_path, record):
+    """Append one JSONL metrics record."""
+    if not metrics_path:
+        return
+    try:
+        with open(metrics_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as e:
+        print(f"WARN: could not write metrics log {metrics_path}: {e}", file=sys.stderr)
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_token(token_file):
+    """Read 'api_key=abk_...' (or a bare token) from token_file."""
+    try:
+        with open(token_file) as f:
+            raw = f.read().strip()
+    except OSError as e:
+        print(f"FATAL: cannot read token file {token_file}: {e}", file=sys.stderr)
+        sys.exit(2)
+    if raw.startswith("api_key="):
+        return raw.split("=", 1)[1].strip()
+    return raw
+
+
+def http_get(url, token, insecure, timeout=15):
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    ctx = ssl._create_unverified_context() if insecure else None
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode())
+
+
+def http_post(url, token, insecure, body, timeout=15):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    ctx = ssl._create_unverified_context() if insecure else None
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode())
+
+
+def whisper_alive(whisper_url, timeout=5):
+    if not whisper_url:
+        return None  # not checked
+    try:
+        with urllib.request.urlopen(whisper_url.rstrip("/") + "/health", timeout=timeout) as resp:
+            body = json.loads(resp.read().decode())
+            return body.get("status") == "ok"
+    except Exception:
+        return False
+
+
+def fetch_stats(base, token, insecure):
+    """Return the stats dict, or None when the server reports no run yet."""
+    url = base.rstrip("/") + "/api/v1/maintenance/transcribe-stats"
+    body = http_get(url, token, insecure)
+    # RespondWithOK wraps the payload as {"data": <stats|null>}.
+    return body.get("data") if isinstance(body, dict) else body
+
+
+def relaunch_op(base, token, insecure):
+    url = base.rstrip("/") + "/api/v1/operations/v2"
+    return http_post(url, token, insecure, {
+        "def_id": "maintenance.transcribe-book-intros",
+        "params": {},
+    })
+
+
+def summarize(stats):
+    """One-line human summary of a stats dict."""
+    if not stats:
+        return "no run has produced stats yet"
+    s = stats
+    return (
+        f"attempted={s.get('attempted', 0)} ok={s.get('ok', 0)} "
+        f"src_missing={s.get('source_file_missing', 0)} "
+        f"ffmpeg_err={s.get('ffmpeg_error', 0)} whisper_err={s.get('whisper_error', 0)} "
+        f"no_audio={s.get('no_audio', 0)} empty={s.get('empty', 0)} "
+        f"skipped={s.get('skipped_existing', 0)} cache_hits={s.get('cache_hits', 0)} "
+        f"done={s.get('done', False)} total_books={s.get('total_books', 0)}"
+    )
+
+
+def progress_key(stats):
+    """A scalar that increases while a run makes progress, for stall detection."""
+    if not stats:
+        return -1
+    return sum(stats.get(k, 0) for k in (
+        "attempted", "ok", "source_file_missing", "ffmpeg_error",
+        "whisper_error", "no_audio", "empty", "skipped_existing",
+    ))
+
+
+def emit_alert(level, code, msg, alerts_path):
+    line = f"{now_iso()} ALERT[{level}] {code}: {msg}"
+    print(line, flush=True)
+    if alerts_path:
+        try:
+            with open(alerts_path, "a") as f:
+                f.write(line + "\n")
+        except OSError as e:
+            print(f"WARN: could not write alerts log {alerts_path}: {e}", file=sys.stderr)
+
+
+def run_once(args, token, state):
+    """Single poll. Mutates `state` (dict) for cross-poll stall tracking.
+    Returns the metrics record."""
+    ts = now_iso()
+    record: dict = {"ts": ts}
+
+    # Whisper health (optional).
+    w = whisper_alive(args.whisper_url)
+    record["whisper_ok"] = w
+    if w is False:
+        emit_alert("ERROR", "WHISPER_DOWN", f"{args.whisper_url}/health not ok", args.alerts_log)
+
+    # Stats.
+    try:
+        stats = fetch_stats(args.base, token, args.insecure)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError) as e:
+        emit_alert("ERROR", "API_UNREACHABLE", f"transcribe-stats fetch failed: {e}", args.alerts_log)
+        record["error"] = str(e)
+        log_line(args.metrics_log, record)
+        return record
+
+    record["stats"] = stats
+    print(f"{ts}  {summarize(stats)}", flush=True)
+
+    # --- alerting ---------------------------------------------------------
+    if not stats:
+        emit_alert("WARN", "IDLE", "no transcription run has ever produced stats", args.alerts_log)
+        if args.relaunch:
+            _try_relaunch(args, token, state, record)
+        log_line(args.metrics_log, record)
+        return record
+
+    done = bool(stats.get("done"))
+    ok = stats.get("ok", 0)
+    src_missing = stats.get("source_file_missing", 0)
+    attempted = stats.get("attempted", 0)
+    pk = progress_key(stats)
+
+    if done:
+        # Completed run. Flag the did-nothing pattern, then treat as idle.
+        if attempted > 0 and ok == 0:
+            emit_alert(
+                "WARN", "NOPROGRESS",
+                f"run completed with 0 ok of {attempted} attempted "
+                f"({src_missing} source_file_missing) — files likely moved (stale paths)",
+                args.alerts_log,
+            )
+        emit_alert("INFO", "IDLE", "last run is done; no transcription in flight", args.alerts_log)
+        if args.relaunch:
+            _try_relaunch(args, token, state, record)
+    else:
+        # In-flight run. Stall detection on the progress key.
+        last_pk = state.get("last_pk")
+        last_change = state.get("last_change_ts")
+        if last_pk is not None and pk == last_pk:
+            stalled_for = time.time() - (last_change or time.time())
+            record["stalled_for_sec"] = int(stalled_for)
+            if stalled_for >= args.stall_secs:
+                emit_alert(
+                    "ERROR", "STALL",
+                    f"counters unchanged for {int(stalled_for)}s (>= {args.stall_secs}s) "
+                    f"while run in-flight; op or GPU may be stuck",
+                    args.alerts_log,
+                )
+        else:
+            state["last_change_ts"] = time.time()
+        state["last_pk"] = pk
+
+    log_line(args.metrics_log, record)
+    return record
+
+
+def _try_relaunch(args, token, state, record):
+    """Relaunch the op, respecting a cooldown so we don't spam when every book
+    is stale-pathed (which would complete instantly and re-trigger IDLE)."""
+    last = state.get("last_relaunch_ts", 0)
+    if time.time() - last < args.relaunch_cooldown:
+        record["relaunch"] = "cooldown"
+        return
+    try:
+        resp = relaunch_op(args.base, token, args.insecure)
+        op_id = resp.get("op_id") if isinstance(resp, dict) else None
+        state["last_relaunch_ts"] = time.time()
+        record["relaunch"] = op_id or "ok"
+        emit_alert("INFO", "RELAUNCH", f"relaunched transcription op {op_id}", args.alerts_log)
+    except Exception as e:
+        record["relaunch"] = f"failed: {e}"
+        emit_alert("ERROR", "RELAUNCH_FAILED", str(e), args.alerts_log)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Transcription progress monitor + alerter")
+    ap.add_argument("--base", default=os.environ.get("ABK_BASE", "https://172.16.2.30:8484"),
+                    help="API base URL (default https://172.16.2.30:8484)")
+    ap.add_argument("--token-file", default=os.environ.get("ABK_TOKEN_FILE", ".api-token"),
+                    help="file with 'api_key=abk_...' (default ./.api-token)")
+    ap.add_argument("--whisper-url", default=os.environ.get("WHISPER_URL", "http://172.16.3.22:19847"),
+                    help="Whisper server base for /health check ('' to skip)")
+    ap.add_argument("--interval", type=int, default=30, help="poll interval seconds (default 30)")
+    ap.add_argument("--stall-secs", type=int, default=300,
+                    help="alert if in-flight counters unchanged this long (default 300)")
+    ap.add_argument("--metrics-log", default=os.environ.get("ABK_METRICS_LOG", "transcribe-metrics.jsonl"),
+                    help="JSONL metrics output path ('' to disable)")
+    ap.add_argument("--alerts-log", default=os.environ.get("ABK_ALERTS_LOG", "transcribe-alerts.log"),
+                    help="alerts output path ('' to disable)")
+    ap.add_argument("--relaunch", action="store_true",
+                    help="auto-relaunch the op when idle (respects --relaunch-cooldown)")
+    ap.add_argument("--relaunch-cooldown", type=int, default=900,
+                    help="min seconds between auto-relaunches (default 900)")
+    ap.add_argument("--insecure", action="store_true", default=False,
+                    help="skip TLS cert verification. Prod uses a self-signed cert, so "
+                         "you must pass --insecure (or add the server CA to the trust store). "
+                         "Off by default to avoid silently disabling verification.")
+    ap.add_argument("--once", action="store_true", help="run a single poll and exit")
+    args = ap.parse_args()
+
+    token = read_token(args.token_file)
+    state = {}
+
+    if args.once:
+        run_once(args, token, state)
+        return
+
+    print(f"{now_iso()} transcribe-monitor starting: base={args.base} interval={args.interval}s "
+          f"stall={args.stall_secs}s relaunch={args.relaunch}", flush=True)
+    while True:
+        try:
+            run_once(args, token, state)
+        except KeyboardInterrupt:
+            print("interrupted; exiting", flush=True)
+            return
+        except Exception as e:  # never let the loop die on an unexpected error
+            emit_alert("ERROR", "MONITOR_EXCEPTION", repr(e), args.alerts_log)
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/whisper-supervisor.ps1
+++ b/scripts/whisper-supervisor.ps1
@@ -1,0 +1,170 @@
+<#
+.SYNOPSIS
+    Supervises the faster-whisper transcription server on the Windows GPU box,
+    auto-restarting it on crash/exit while allowing deliberate stops for applying
+    changes (the "claude-loop" pattern).
+
+.DESCRIPTION
+    Runs `uv run whisper_server.py <model>` in a loop. When the process exits:
+      * If the STOP SENTINEL file exists -> deliberate stop; the supervisor exits.
+      * If the process exited with $StopExitCode -> deliberate stop; supervisor exits.
+      * Otherwise -> treated as a crash; logs it and restarts after $RestartDelaySec.
+
+    To apply a new whisper_server.py (or restart cleanly):
+      1. Create the sentinel:   New-Item C:\Users\jdfal\whisper-stop.flag
+      2. Stop the running server (Ctrl-C in its window, or Stop-Process).
+      3. The supervisor sees the sentinel, exits cleanly.
+      4. Pull/replace whisper_server.py, delete the sentinel, re-run this script.
+
+    All lifecycle events are appended to $LogPath with timestamps so the Linux
+    side (or a human) can tail/parse it.
+
+.PARAMETER ScriptPath
+    Path to whisper_server.py. Default: C:\Users\jdfal\whisper_server.py
+
+.PARAMETER Model
+    Whisper model name passed as argv[1]. Default: large-v2
+
+.PARAMETER Port
+    TCP port (WHISPER_PORT). Default: 19847
+
+.PARAMETER ComputeType
+    WHISPER_COMPUTE_TYPE. float16 for Turing+ (RTX), int8 for Pascal. Default: float16
+
+.PARAMETER SentinelPath
+    Stop sentinel file. When present, the supervisor exits instead of restarting.
+    Default: C:\Users\jdfal\whisper-stop.flag
+
+.PARAMETER LogPath
+    Lifecycle log. Default: C:\Users\jdfal\whisper-supervisor.log
+
+.PARAMETER RestartDelaySec
+    Seconds to wait before restarting after a crash. Default: 5
+
+.PARAMETER MaxRestarts
+    Crash-restart cap within $RestartWindowSec before giving up (prevents a hot
+    crash-loop from pegging the GPU box). 0 = unlimited. Default: 20
+
+.PARAMETER RestartWindowSec
+    Sliding window for MaxRestarts. Default: 600 (10 min)
+
+.EXAMPLE
+    # Normal supervised run (default settings)
+    powershell -ExecutionPolicy Bypass -File C:\Users\jdfal\whisper-supervisor.ps1
+
+.EXAMPLE
+    # Apply a new server build:
+    New-Item C:\Users\jdfal\whisper-stop.flag ; Stop-Process -Name python -Force
+    # ...replace whisper_server.py...
+    Remove-Item C:\Users\jdfal\whisper-stop.flag
+    powershell -ExecutionPolicy Bypass -File C:\Users\jdfal\whisper-supervisor.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ScriptPath      = "C:\Users\jdfal\whisper_server.py",
+    [string]$Model           = "large-v2",
+    [int]$Port               = 19847,
+    [string]$ComputeType     = "float16",
+    [string]$SentinelPath    = "C:\Users\jdfal\whisper-stop.flag",
+    [string]$LogPath         = "C:\Users\jdfal\whisper-supervisor.log",
+    [int]$RestartDelaySec    = 5,
+    [int]$StopExitCode       = 42,
+    [int]$MaxRestarts        = 20,
+    [int]$RestartWindowSec   = 600
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Log {
+    param([string]$Level, [string]$Message)
+    $ts = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ss.fffzzz")
+    $line = "$ts [$Level] $Message"
+    # Machine-parseable: ISO-8601 timestamp, bracketed level, free-text message.
+    Add-Content -Path $LogPath -Value $line
+    Write-Host $line
+}
+
+# Restart-rate bookkeeping: keep timestamps of recent crash-restarts so we can
+# trip the MaxRestarts circuit-breaker if the server is hot-looping.
+$restartTimes = New-Object System.Collections.ArrayList
+
+Write-Log "INFO" "supervisor starting: script=$ScriptPath model=$Model port=$Port compute=$ComputeType sentinel=$SentinelPath"
+
+# Resolve uv once. Prefer PATH; fall back to the standard per-user install dir.
+$uv = (Get-Command uv -ErrorAction SilentlyContinue)
+if ($uv) {
+    $uvExe = $uv.Source
+} elseif (Test-Path "$env:USERPROFILE\.local\bin\uv.exe") {
+    $uvExe = "$env:USERPROFILE\.local\bin\uv.exe"
+} else {
+    Write-Log "FATAL" "uv not found on PATH or in %USERPROFILE%\.local\bin. Install: https://docs.astral.sh/uv/"
+    exit 1
+}
+Write-Log "INFO" "using uv at $uvExe"
+
+if (-not (Test-Path $ScriptPath)) {
+    Write-Log "FATAL" "whisper_server.py not found at $ScriptPath"
+    exit 1
+}
+
+# A stale sentinel left over from a previous deliberate stop would make the
+# supervisor exit immediately. Clear it at startup so a fresh launch always runs.
+if (Test-Path $SentinelPath) {
+    Write-Log "WARN" "clearing stale stop-sentinel at startup: $SentinelPath"
+    Remove-Item $SentinelPath -Force
+}
+
+while ($true) {
+    # Honor a sentinel created between iterations (deliberate stop).
+    if (Test-Path $SentinelPath) {
+        Write-Log "INFO" "stop-sentinel present; exiting supervisor (deliberate stop)"
+        break
+    }
+
+    $env:WHISPER_PORT = "$Port"
+    $env:WHISPER_COMPUTE_TYPE = $ComputeType
+
+    Write-Log "INFO" "launching whisper server (uv run $ScriptPath $Model)"
+    $startedAt = Get-Date
+
+    # Start in this console so the user can Ctrl-C; capture the exit code.
+    $proc = Start-Process -FilePath $uvExe `
+        -ArgumentList @("run", $ScriptPath, $Model) `
+        -NoNewWindow -PassThru -Wait
+    $exitCode = $proc.ExitCode
+    $ranFor = [int]((Get-Date) - $startedAt).TotalSeconds
+
+    Write-Log "INFO" "whisper server exited: code=$exitCode ran_for_sec=$ranFor"
+
+    # Deliberate stop paths: sentinel appeared, or the agreed clean-exit code.
+    if (Test-Path $SentinelPath) {
+        Write-Log "INFO" "stop-sentinel present after exit; not restarting (deliberate stop)"
+        break
+    }
+    if ($exitCode -eq $StopExitCode) {
+        Write-Log "INFO" "server exited with stop-code $StopExitCode; not restarting (deliberate stop)"
+        break
+    }
+
+    # Crash path: record the restart and trip the breaker if hot-looping.
+    if ($MaxRestarts -gt 0) {
+        $now = Get-Date
+        [void]$restartTimes.Add($now)
+        # Drop timestamps outside the sliding window.
+        $cutoff = $now.AddSeconds(-$RestartWindowSec)
+        $recent = @($restartTimes | Where-Object { $_ -ge $cutoff })
+        $restartTimes.Clear()
+        foreach ($t in $recent) { [void]$restartTimes.Add($t) }
+        if ($recent.Count -ge $MaxRestarts) {
+            Write-Log "FATAL" "crash-loop breaker: $($recent.Count) restarts in ${RestartWindowSec}s (>= $MaxRestarts). Giving up. Investigate, then re-run the supervisor."
+            exit 1
+        }
+        Write-Log "WARN" "crash restart $($recent.Count)/$MaxRestarts within ${RestartWindowSec}s window"
+    }
+
+    Write-Log "WARN" "restarting in ${RestartDelaySec}s..."
+    Start-Sleep -Seconds $RestartDelaySec
+}
+
+Write-Log "INFO" "supervisor stopped."


### PR DESCRIPTION
## Why

The transcription op appeared to "do nothing." Root cause: organize moved files and left `BookFile.FilePath` **stale**, so ffmpeg can't find the source and the book is silently skipped. This was invisible — only ephemeral op logs (last 50 entries) showed it. My earlier concurrency PR (#1692) didn't touch this; the bottleneck was never parallelism.

## What

**Per-book outcome (the queryable field):** every attempted book now records `TranscribeStatus` ∈ {`ok`, `source_file_missing`, `no_audio`, `ffmpeg_error`, `whisper_error`, `empty`} + `TranscribeError` detail + `TranscribeAttemptedAt`. `source_file_missing` is detected via `os.Stat` **before** ffmpeg so stale paths are cleanly separated from real codec errors. Writes are change-guarded so a re-run over ~45K stale-path books doesn't churn the DB.

**Aggregate (one-key read):** `stats:transcribe` PebbleDB key, updated after each page by a thread-safe accumulator; served at `GET /api/v1/maintenance/transcribe-stats`.

**Monitor** (`scripts/transcribe_monitor.py`): polls the aggregate, writes JSONL metrics, alerts on `IDLE` / `STALL` / `NOPROGRESS` (did-nothing completion) / `WHISPER_DOWN`, optional `--relaunch` with cooldown. Built to run persistently on the server (systemd timer), not as an agent task.

**Supervisor** (`scripts/whisper-supervisor.ps1`): keeps `whisper_server.py` alive on the Windows GPU box; sentinel-file clean-stop for applying changes; crash-loop breaker.

## Verification

- `go build ./...` clean; `go vet` clean on touched packages
- New `transcribe_stats_test.go`: PebbleDB round-trip of the aggregate + per-book fields (guards against memdb stripping the new fields)
- `go test ./internal/plugins/maintenance/... ./internal/server/handlers/system/... ./internal/database/` — pass
- Python `py_compile` + PowerShell tokenize — clean

## Follow-up (not in this PR)

The actual fix to make transcription **produce data** is path reconciliation (update stale `FilePath`s to where organize moved the files). This PR makes the scale of that problem visible — after deploy, `transcribe-stats` will show exactly how many books are `source_file_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP