### PR TITLE
perf(transcribe): raise ffmpeg concurrency to 48 (one per server core)

### DIFF
--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.8.1
+// version: 3.9.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-06-30
 
@@ -28,8 +28,11 @@ import (
 
 const (
 	introTranscribePageSize  = 200
-	introTranscribeFFWorkers = 8  // parallel ffmpeg per page; 4 pages run concurrently → 32 total
-	introTranscribePageConc  = 4  // pages processed in parallel (ffmpeg overlaps with Whisper GPU)
+	introTranscribeFFWorkers = 8 // parallel ffmpeg per page; 6 pages run concurrently → 48 total
+	introTranscribePageConc  = 6 // pages in parallel: 48 concurrent ffmpeg (= server core count)
+	//                              and 6 concurrent Whisper batches to keep the GPU saturated.
+	//                              Tuned for the 48-core prod server (172.16.2.30); audio decode
+	//                              is I/O-light so one ffmpeg per core is the practical ceiling.
 )
 
 // introTranscribeParams is the checkpoint state for a transcription run.


### PR DESCRIPTION
Prod server has 48 cores at ~5.8 load but the op only ran 32 concurrent ffmpeg. Bump `pageConc` 4→6 → 48 concurrent ffmpeg (= core count) + 6 concurrent Whisper batches to saturate the single GPU. Supports the full `only_missing=false` re-extraction now in flight (cache had only 3,585 of ~48K WAVs because prior runs skipped already-transcribed books).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGi9tyZWDffg1mawtWbTNP