### PR TITLE
feat(transcribe): durable quality gate — unparsed status + OnlyParsedTranscription filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.89.0 -->
+<!-- version: 3.90.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-06-30 -->
+<!-- last-edited: 2026-07-01 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features
+
+#### July 1, 2026 — Transcription quality gate: `unparsed` status + `OnlyParsedTranscription` filter
+
+- **`feat(operations)`** — Added `FilterSpec.OnlyParsedTranscription`. When set, a bulk operation's `SelectionSpec.Filter` resolves to only those primary books whose Whisper intro **parsed into a usable title** (`TranscribedTitle` non-empty), excluding the ~44% of transcriptions that produced raw text but no parseable title. This lets `library.bulk-metadata-fetch` (and any future filter-driven op) skip low-quality results without an upfront ID snapshot. **No backfill required:** the transcriber has always set `TranscribedTitle` only when a title parsed, so the filter is retroactively correct for books transcribed before this change.
+- **`feat(database)`** — Threaded `TranscribedTitle` through the `BookSummary` projection (both memdb and Pebble builders + the reverse `bookSummaryToBook` map) so it survives the summary-pushdown path that `GetAudiobooks` (and therefore `resolveFilterToBookIDs`) uses after PR #1660. Without this, the filter would resolve against summaries that never carried the field and silently return zero books. Guarded by `TestGetAudiobooks_CarriesTranscribedTitleThroughPushdown` (exercises the real service path) plus `TestStripBookForMemdb_PreservesTranscription`. Side benefit: `transcribed_title` now appears in the `/api/v1/audiobooks` list response.
+- **`feat(transcribe)`** — Split the transcription outcome: when Whisper returns non-empty text but `ParseAudiobookIntro` extracts no title, the book is now recorded as **`unparsed`** (new status + `TranscribeStats.Unparsed` counter) instead of `ok`. The raw transcript is still stored (usable via `reparse_only` after a future parser fix); only the parsed-title fields stay empty. `ok` now implies a parsed title, so the live `stats:transcribe` aggregate distinguishes genuinely-good transcriptions from the low-quality remainder.
+- Not yet deployed — merged to hold until the in-flight GPU re-transcribe run can be interrupted at a convenient time. The filter needs no data migration and works on first deploy.
 
 #### June 30, 2026 — Transcription observability: per-book outcome + stats aggregate + monitor (PRs #1693, #1694, #1695)
 

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package audiobooks
 
@@ -407,6 +407,7 @@ func bookSummaryToBook(summary database.BookSummary) database.Book {
 		Format:               summary.Format,
 		Duration:             summary.Duration,
 		Narrator:             summary.Narrator,
+		TranscribedTitle:     summary.TranscribedTitle,
 		OriginalFilename:     summary.OriginalFilename,
 		FileHash:             summary.FileHash,
 		FileSize:             summary.FileSize,

--- a/internal/audiobooks/transcribed_title_pushdown_test.go
+++ b/internal/audiobooks/transcribed_title_pushdown_test.go
@@ -1,0 +1,69 @@
+// file: internal/audiobooks/transcribed_title_pushdown_test.go
+// version: 1.0.0
+// guid: 8f3a1d62-4b09-4c7e-9a15-2e6c0b7d4f38
+// last-edited: 2026-07-01
+
+package audiobooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAudiobooks_CarriesTranscribedTitleThroughPushdown is the load-bearing
+// guard for FilterSpec.OnlyParsedTranscription. That filter runs in
+// resolveFilterToBookIDs against the Books returned by GetAudiobooks — which,
+// after PR #1660, resolves via the BookSummary pushdown (bookSummariesToBooks).
+// If TranscribedTitle isn't threaded through BookSummary, every returned Book
+// has a nil TranscribedTitle and the filter silently returns ZERO books.
+//
+// This exercises the ACTUAL service path (real PebbleStore + live memdb
+// pushdown), not the stripBookForMemdb projection in isolation, so it fails
+// loudly if the summary projection ever drops the field.
+func TestGetAudiobooks_CarriesTranscribedTitleThroughPushdown(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	primary := true
+	parsed := "Salem's Lot"
+
+	// Book WITH a parsed transcription title.
+	withTitle, err := ps.CreateBook(&database.Book{
+		Title:            "book-with-title",
+		IsPrimaryVersion: &primary,
+		TranscribedTitle: &parsed,
+	})
+	require.NoError(t, err)
+
+	// Book WITHOUT (raw-but-unparsed → TranscribedTitle nil).
+	without, err := ps.CreateBook(&database.Book{
+		Title:            "book-without-title",
+		IsPrimaryVersion: &primary,
+	})
+	require.NoError(t, err)
+
+	svc := NewAudiobookService(ps)
+	got, err := svc.GetAudiobooks(context.Background(), 1000, 0, "", nil, nil,
+		ListFilters{IsPrimaryVersion: &primary})
+	require.NoError(t, err)
+
+	byID := make(map[string]database.Book, len(got))
+	for _, b := range got {
+		byID[b.ID] = b
+	}
+
+	w, ok := byID[withTitle.ID]
+	require.True(t, ok, "book-with-title missing from GetAudiobooks result")
+	require.NotNil(t, w.TranscribedTitle,
+		"TranscribedTitle dropped by the summary pushdown — OnlyParsedTranscription would return zero books")
+	require.Equal(t, parsed, *w.TranscribedTitle)
+
+	wo, ok := byID[without.ID]
+	require.True(t, ok, "book-without-title missing from GetAudiobooks result")
+	require.Nil(t, wo.TranscribedTitle, "unparsed book must have nil TranscribedTitle")
+}

--- a/internal/database/memdb_strip_test.go
+++ b/internal/database/memdb_strip_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: e6f7a8b9-c0d1-4e2f-3a4b-5c6d7e8f9012
-// last-edited: 2026-06-11
+// last-edited: 2026-07-01
 
 package database
 
@@ -116,6 +116,50 @@ func TestStripBookFileForMemdb_NilsLargeFields(t *testing.T) {
 	}
 	if src.AcoustIDSeg0 != "AQADtAcSRY" {
 		t.Errorf("source mutated: AcoustIDSeg0 changed on src")
+	}
+}
+
+// TestStripBookForMemdb_PreservesTranscription is the correctness guard for
+// FilterSpec.OnlyParsedTranscription: the filter resolves against memdb-resident
+// Books (via GetAudiobooks), so it only works if stripBookForMemdb keeps the
+// transcription fields. This asserts Description is stripped (heavy) while
+// TranscribedTitle / TranscribeStatus / IntroTranscription survive. If a future
+// change adds these to the strip list, this test fails loudly before the filter
+// silently starts returning nothing.
+func TestStripBookForMemdb_PreservesTranscription(t *testing.T) {
+	desc := "a very long description that memdb strips to save RAM"
+	title := "Salem's Lot"
+	status := "ok"
+	intro := "Simon and Schuster audio presents Salem's Lot by Stephen King"
+
+	src := &Book{
+		ID:                 "bk-1",
+		Title:              "T",
+		Description:        &desc,
+		TranscribedTitle:   &title,
+		TranscribeStatus:   &status,
+		IntroTranscription: &intro,
+	}
+
+	stripped := stripBookForMemdb(src)
+	if stripped == nil {
+		t.Fatal("stripped is nil")
+	}
+	if stripped.Description != nil {
+		t.Errorf("Description should be stripped from memdb, got %q", *stripped.Description)
+	}
+	if stripped.TranscribedTitle == nil || *stripped.TranscribedTitle != title {
+		t.Errorf("TranscribedTitle must survive memdb strip (OnlyParsedTranscription depends on it), got %v", stripped.TranscribedTitle)
+	}
+	if stripped.TranscribeStatus == nil || *stripped.TranscribeStatus != status {
+		t.Errorf("TranscribeStatus must survive memdb strip, got %v", stripped.TranscribeStatus)
+	}
+	if stripped.IntroTranscription == nil || *stripped.IntroTranscription != intro {
+		t.Errorf("IntroTranscription must survive memdb strip, got %v", stripped.IntroTranscription)
+	}
+	// Source must not be mutated.
+	if src.Description == nil {
+		t.Error("source mutated: Description nil on src")
 	}
 }
 

--- a/internal/database/memdb_summaries.go
+++ b/internal/database/memdb_summaries.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_summaries.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000008
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package database
 
@@ -228,6 +228,7 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 			QuarantineReason:     b.QuarantineReason,
 			CoverURL:             b.CoverURL,
 			Narrator:             b.Narrator,
+			TranscribedTitle:     b.TranscribedTitle,
 			CreatedAt:            b.CreatedAt,
 			UpdatedAt:            b.UpdatedAt,
 			MetadataUpdatedAt:    b.MetadataUpdatedAt,

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.99.0
+// version: 1.100.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package database
 
@@ -1676,6 +1676,7 @@ func (p *PebbleStore) GetAllBookSummaries_Pebble(limit, offset int) ([]BookSumma
 			QuarantineReason:     b.QuarantineReason,
 			CoverURL:             b.CoverURL,
 			Narrator:             b.Narrator,
+			TranscribedTitle:     b.TranscribedTitle,
 			CreatedAt:            b.CreatedAt,
 			UpdatedAt:            b.UpdatedAt,
 			MetadataUpdatedAt:    b.MetadataUpdatedAt,

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.80.0
+// version: 2.81.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-06-24
+// last-edited: 2026-07-01
 
 package database
 
@@ -323,6 +323,12 @@ type BookSummary struct {
 	QuarantineReason     *string    `json:"quarantine_reason,omitempty"`
 	CoverURL             *string    `json:"cover_url,omitempty"`
 	Narrator             *string    `json:"narrator,omitempty"`
+	// TranscribedTitle is the Whisper-parsed intro title, carried in the
+	// summary projection so filter-pushdown callers (e.g.
+	// FilterSpec.OnlyParsedTranscription) can distinguish parsed from
+	// raw-but-unparsed transcriptions without a full-book fetch. Empty for the
+	// vast majority of books; nil unless the intro parsed into a title.
+	TranscribedTitle     *string    `json:"transcribed_title,omitempty"`
 	CreatedAt            *time.Time `json:"created_at,omitempty"`
 	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
 	MetadataUpdatedAt    *time.Time `json:"metadata_updated_at,omitempty"`

--- a/internal/database/transcribe_stats.go
+++ b/internal/database/transcribe_stats.go
@@ -1,7 +1,7 @@
 // file: internal/database/transcribe_stats.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7f2a9c14-3b6d-4e81-9a05-2c8e1d4f6b73
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 package database
 
@@ -33,8 +33,14 @@ type TranscribeStats struct {
 	// Per-outcome cumulative counts. Attempted = sum of the outcome buckets
 	// below; SkippedExisting is books skipped because they already had a
 	// transcript (only_missing mode) and were never attempted this run.
-	Attempted       int `json:"attempted"`
-	OK              int `json:"ok"`
+	Attempted int `json:"attempted"`
+	OK        int `json:"ok"`
+	// Unparsed counts books where Whisper returned non-empty text but
+	// ParseAudiobookIntro extracted no title. The raw transcript IS stored
+	// (usable via reparse_only), but TranscribedTitle stays empty, so these
+	// are excluded by FilterSpec.OnlyParsedTranscription. OK now implies a
+	// parsed title; Unparsed is the low-quality remainder.
+	Unparsed        int `json:"unparsed"`
 	SourceMissing   int `json:"source_file_missing"`
 	NoAudio         int `json:"no_audio"`
 	FFmpegError     int `json:"ffmpeg_error"`

--- a/internal/database/transcribe_stats_test.go
+++ b/internal/database/transcribe_stats_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/transcribe_stats_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c1f8a92-7d63-4b05-9e21-8f6a3c0d51e4
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 package database
 
@@ -37,7 +37,8 @@ func TestTranscribeStats_RoundTrip(t *testing.T) {
 		TotalBooks:    48763,
 		Attempted:     200,
 		OK:            5,
-		SourceMissing: 190,
+		Unparsed:      8,
+		SourceMissing: 182,
 		FFmpegError:   3,
 		WhisperError:  1,
 		Empty:         1,
@@ -54,7 +55,7 @@ func TestTranscribeStats_RoundTrip(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected stats after write, got nil")
 	}
-	if got.OK != 5 || got.SourceMissing != 190 || got.TotalBooks != 48763 {
+	if got.OK != 5 || got.Unparsed != 8 || got.SourceMissing != 182 || got.TotalBooks != 48763 {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
 	if !got.StartedAt.Equal(now) {

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -1,7 +1,7 @@
 // file: internal/operations/types.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: f1e2d3c4-b5a6-7890-abcd-ef1234567890
-// last-edited: 2026-05-16
+// last-edited: 2026-07-01
 //
 // SelectionSpec and related types for server-side bulk operation targeting.
 // A SelectionSpec describes which books an operation targets without requiring
@@ -33,6 +33,12 @@ type FilterSpec struct {
 	// "matched" candidate in the most-recent metadata_candidate_fetch result.
 	// Applied server-side after the primary filter; requires DB access.
 	OnlyUnmatched bool `json:"only_unmatched,omitempty"`
+	// OnlyParsedTranscription restricts the resolved set to books whose Whisper
+	// intro parsed into a usable title (TranscribedTitle non-empty), excluding
+	// raw-but-unparsed low-quality transcriptions. Because the transcriber only
+	// ever sets TranscribedTitle when a title was parsed, this works for books
+	// transcribed before the statusUnparsed split too — no backfill required.
+	OnlyParsedTranscription bool `json:"only_parsed_transcription,omitempty"`
 }
 
 // FieldFilter mirrors the server-side FieldFilter used for advanced search.

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.10.0
+// version: 3.11.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 package maintenance
 
@@ -547,7 +547,15 @@ func (p *Plugin) processTranscribePage(
 			p.applyOutcome(store, log, &book, statusEmpty, "whisper returned empty text", "", transcribe.IntroFields{}, now, accum)
 		default:
 			fields := transcribe.ParseAudiobookIntro(result.Text)
-			if p.applyOutcome(store, log, &book, statusOK, "", result.Text, fields, now, accum) {
+			// statusOK requires a parsed title. When Whisper returns text but
+			// the parser can't extract a title, store the raw transcript but
+			// mark it statusUnparsed so it's excluded by OnlyParsedTranscription
+			// and can be retried later via reparse_only after a parser fix.
+			outcome := statusOK
+			if fields.Title == "" {
+				outcome = statusUnparsed
+			}
+			if p.applyOutcome(store, log, &book, outcome, "", result.Text, fields, now, accum) {
 				processed++
 			}
 		}
@@ -557,11 +565,13 @@ func (p *Plugin) processTranscribePage(
 }
 
 // applyOutcome writes a book's transcription outcome and records it in the
-// aggregate. On statusOK it also stores the transcript and parsed fields. Writes
-// are change-guarded: a repeat of the SAME failure (same status + detail) skips
-// the UpdateBook so a re-run over ~45K stale-path books doesn't churn the DB.
-// statusOK always writes (a fresh transcript is new data). Returns true only
-// when the book was counted as a successful (ok) transcription.
+// aggregate. On statusOK/statusUnparsed it also stores the raw transcript (and,
+// for OK, the parsed fields). Writes are change-guarded: a repeat of the SAME
+// failure (same status + detail) skips the UpdateBook so a re-run over ~45K
+// stale-path books doesn't churn the DB. A transcript outcome (OK or Unparsed)
+// always writes — fresh transcript text is new data. Returns true when the book
+// produced a transcript this run (OK or Unparsed), which the caller counts as
+// processed.
 func (p *Plugin) applyOutcome(
 	store database.Store,
 	log interface {
@@ -578,8 +588,11 @@ func (p *Plugin) applyOutcome(
 
 	newDetail := strPtrOrNil(detail)
 
-	// Change-guard for failures: identical status+detail already stored → no write.
-	if status != statusOK &&
+	// A transcript outcome (OK or Unparsed) always carries fresh text and must
+	// write. Only pure failures are change-guarded: identical status+detail
+	// already stored → no write (avoids churning ~45K stale-path books on re-run).
+	hasTranscript := status == statusOK || status == statusUnparsed
+	if !hasTranscript &&
 		book.TranscribeStatus != nil && *book.TranscribeStatus == status &&
 		eqStrPtr(book.TranscribeError, newDetail) {
 		return false
@@ -590,9 +603,12 @@ func (p *Plugin) applyOutcome(
 	book.TranscribeStatus = &st
 	book.TranscribeError = newDetail
 
-	if status == statusOK {
+	if hasTranscript {
 		book.IntroTranscription = &text
 		book.IntroTranscribedAt = &now
+		// Parsed fields are set only when present. For statusUnparsed Title is
+		// empty by definition, leaving TranscribedTitle nil — which is exactly
+		// what OnlyParsedTranscription filters on.
 		if fields.Title != "" {
 			book.TranscribedTitle = &fields.Title
 		}
@@ -608,7 +624,7 @@ func (p *Plugin) applyOutcome(
 		log.Warn("transcribe: update failed", "book_id", book.ID, "status", status, "err", err)
 		return false
 	}
-	return status == statusOK
+	return hasTranscript
 }
 
 // ffmpegErrorTail returns the most diagnostic tail of ffmpeg stderr. ffmpeg

--- a/internal/plugins/maintenance/intro_transcribe_status_test.go
+++ b/internal/plugins/maintenance/intro_transcribe_status_test.go
@@ -1,0 +1,90 @@
+// file: internal/plugins/maintenance/intro_transcribe_status_test.go
+// version: 1.0.0
+// guid: 5a1c9e73-2b48-4f60-8d31-6c0af5b2e719
+// last-edited: 2026-07-01
+
+package maintenance
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
+)
+
+// newOutcomeStore returns a MockStore that captures every UpdateBook payload.
+func newOutcomeStore(written *[]database.Book) *database.MockStore {
+	return &database.MockStore{
+		UpdateBookFunc: func(_ string, b *database.Book) (*database.Book, error) {
+			*written = append(*written, *b)
+			return b, nil
+		},
+	}
+}
+
+// TestApplyOutcome_UnparsedStoresTranscriptButNoTitle verifies that when Whisper
+// returns text the parser can't title, applyOutcome stores the raw transcript,
+// leaves TranscribedTitle nil (so OnlyParsedTranscription excludes it), records
+// the Unparsed bucket, and still counts the book as processed.
+func TestApplyOutcome_UnparsedStoresTranscriptButNoTitle(t *testing.T) {
+	var written []database.Book
+	store := newOutcomeStore(&written)
+	p := New(fakeDeps{store: store})
+	accum := newTranscribeStatsAccum(nil, "op", 0, time.Now())
+	now := time.Now()
+
+	book := database.Book{ID: "b1"}
+	got := p.applyOutcome(store, slog.Default(), &book, statusUnparsed,
+		"", "mumbled words with no title structure", transcribe.IntroFields{}, now, accum)
+
+	if !got {
+		t.Fatal("unparsed transcript should count as processed (return true)")
+	}
+	if len(written) != 1 {
+		t.Fatalf("expected exactly 1 UpdateBook, got %d", len(written))
+	}
+	w := written[0]
+	if w.TranscribeStatus == nil || *w.TranscribeStatus != statusUnparsed {
+		t.Errorf("TranscribeStatus = %v, want %q", w.TranscribeStatus, statusUnparsed)
+	}
+	if w.IntroTranscription == nil || *w.IntroTranscription == "" {
+		t.Error("raw transcript must be stored for unparsed (needed by reparse_only)")
+	}
+	if w.TranscribedTitle != nil {
+		t.Errorf("TranscribedTitle must stay nil for unparsed, got %q", *w.TranscribedTitle)
+	}
+	if snap := accum.snapshot(); snap.Unparsed != 1 || snap.OK != 0 {
+		t.Errorf("accum: Unparsed=%d OK=%d, want Unparsed=1 OK=0", snap.Unparsed, snap.OK)
+	}
+}
+
+// TestApplyOutcome_OKStoresParsedTitle verifies the statusOK path stores the
+// parsed fields and increments OK (not Unparsed).
+func TestApplyOutcome_OKStoresParsedTitle(t *testing.T) {
+	var written []database.Book
+	store := newOutcomeStore(&written)
+	p := New(fakeDeps{store: store})
+	accum := newTranscribeStatsAccum(nil, "op", 0, time.Now())
+	now := time.Now()
+
+	book := database.Book{ID: "b2"}
+	fields := transcribe.IntroFields{Title: "Salem's Lot", Author: "Stephen King", Narrator: "Ron McClarty"}
+	got := p.applyOutcome(store, slog.Default(), &book, statusOK,
+		"", "Salem's Lot by Stephen King read by Ron McClarty", fields, now, accum)
+
+	if !got {
+		t.Fatal("ok transcript should count as processed (return true)")
+	}
+	w := written[0]
+	if w.TranscribedTitle == nil || *w.TranscribedTitle != "Salem's Lot" {
+		t.Errorf("TranscribedTitle = %v, want \"Salem's Lot\"", w.TranscribedTitle)
+	}
+	if w.TranscribedNarrator == nil || *w.TranscribedNarrator != "Ron McClarty" {
+		t.Errorf("TranscribedNarrator = %v, want \"Ron McClarty\"", w.TranscribedNarrator)
+	}
+	if snap := accum.snapshot(); snap.OK != 1 || snap.Unparsed != 0 {
+		t.Errorf("accum: OK=%d Unparsed=%d, want OK=1 Unparsed=0", snap.OK, snap.Unparsed)
+	}
+}

--- a/internal/plugins/maintenance/transcribe_stats_accum.go
+++ b/internal/plugins/maintenance/transcribe_stats_accum.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/transcribe_stats_accum.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d3b1e57-6a02-4c8f-b14d-7e9a2f5c08b1
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 package maintenance
 
@@ -15,7 +15,12 @@ import (
 // Per-book transcription outcome categories. These are written to
 // Book.TranscribeStatus and counted into the stats:transcribe aggregate.
 const (
-	statusOK            = "ok"
+	statusOK = "ok"
+	// statusUnparsed: Whisper returned non-empty text but ParseAudiobookIntro
+	// extracted no title. The raw transcript is still stored; only the parsed
+	// fields are absent. Distinct from statusOK so the aggregate and the
+	// OnlyParsedTranscription filter can exclude these low-quality results.
+	statusUnparsed      = "unparsed"
 	statusSourceMissing = "source_file_missing"
 	statusNoAudio       = "no_audio"
 	statusFFmpegError   = "ffmpeg_error"
@@ -56,6 +61,8 @@ func (a *transcribeStatsAccum) recordOutcome(status string, now time.Time) {
 	switch status {
 	case statusOK:
 		a.stats.OK++
+	case statusUnparsed:
+		a.stats.Unparsed++
 	case statusSourceMissing:
 		a.stats.SourceMissing++
 	case statusNoAudio:

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-06-21
+// last-edited: 2026-07-01
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -314,6 +314,9 @@ type bulkMetadataFetchV2Params = handlers.BulkMetadataFetchV2Params
 // version book IDs.  IsPrimaryVersion=true and quarantine exclusion are always
 // applied.  If f.OnlyUnmatched is set, books that already have a "matched"
 // candidate in the most-recent metadata_candidate_fetch result are removed.
+// If f.OnlyParsedTranscription is set, books whose Whisper intro produced no
+// parsed title (TranscribedTitle empty) are removed — this is safe against the
+// memdb projection because stripBookForMemdb does not clear TranscribedTitle.
 // Per-user FieldFilters are silently dropped (no user context in background ops).
 func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.FilterSpec) ([]string, error) {
 	trueVal := true
@@ -349,6 +352,10 @@ func (s *Server) resolveFilterToBookIDs(ctx context.Context, f operations.Filter
 	ids := make([]string, 0, len(books))
 	for _, b := range books {
 		if b.QuarantinedAt != nil {
+			continue
+		}
+		if f.OnlyParsedTranscription &&
+			(b.TranscribedTitle == nil || strings.TrimSpace(*b.TranscribedTitle) == "") {
 			continue
 		}
 		ids = append(ids, b.ID)


### PR DESCRIPTION
## Summary

Replaces the one-off ID snapshot used to scope the current metadata fetch with a durable, server-side way to target **only good-quality transcriptions** (skip the ~44% that produced raw Whisper text but no parseable title).

- **`operations`** — new `FilterSpec.OnlyParsedTranscription`: resolves to primary books with a non-empty `TranscribedTitle`. **No backfill** — the transcriber only ever set `TranscribedTitle` when a title parsed, so it's retroactively correct for books transcribed before this change.
- **`database`** — threaded `TranscribedTitle` through the `BookSummary` projection (memdb + Pebble builders + reverse `bookSummaryToBook` map) so it survives the summary-**pushdown** path that `GetAudiobooks`/`resolveFilterToBookIDs` use after #1660. Without this the filter would resolve against summaries missing the field and silently return **zero books**. Side benefit: `transcribed_title` now populates in the `/api/v1/audiobooks` list response (null→value, additive).
- **`transcribe`** — split the outcome: Whisper text with no parsed title → new status **`unparsed`** (+ `TranscribeStats.Unparsed`) instead of `ok`. Raw transcript still stored (usable via `reparse_only`); `ok` now implies a parsed title. `only_missing` keys on `IntroTranscription != ""`, so unparsed books are correctly treated as already-transcribed.

## Tests
- `TestGetAudiobooks_CarriesTranscribedTitleThroughPushdown` — integration guard through the **real** service path (PebbleStore + live memdb pushdown); fails loudly if the summary projection ever drops the field.
- `TestStripBookForMemdb_PreservesTranscription`, stats round-trip incl. `Unparsed`, `applyOutcome` ok-vs-unparsed behavior.
- Green locally: `internal/server` (471s), `internal/audiobooks` (37s), `internal/database`, `internal/plugins/maintenance`; vet clean.

## Deploy
**Hold** — merge only. Not deployed until the in-flight GPU re-transcribe op can be interrupted at a convenient time. The filter needs no migration and works on first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)